### PR TITLE
chore: lint HabitsScreen imports

### DIFF
--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -1,109 +1,149 @@
 // HabitsScreen.tsx
 
-import React, { useState, useEffect } from "react";
-import {
-  View,
-  Text,
-  FlatList,
-  TouchableOpacity,
-  Alert,
-} from "react-native";
 import * as Notifications from 'expo-notifications';
+import React, { useEffect, useState } from 'react';
+import { Alert, FlatList, Text, TouchableOpacity, View } from 'react-native';
 
 import GoalModal from './components/GoalModal';
-import HabitSettingsModal from "./components/HabitSettingsModal"
-import StatsModal from "./components/StatsModal";
-import MissedDaysModal from "./components/MissedDaysModal";
-import OnboardingModal from "./components/OnboardingModal";
-import ReorderHabitsModal from "./components/ReorderHabitsModal";
-import HabitTile from "./HabitTile";
-
-import { HABIT_DEFAULTS } from "./HabitDefaults";
-import {
-    Habit,
-    Goal,
-    HabitStatsData,
-    OnboardingHabit,
-    Completion,
-} from "./Habits.types"
-
-import styles from "./Habits.styles"
+import HabitSettingsModal from './components/HabitSettingsModal';
+import MissedDaysModal from './components/MissedDaysModal';
+import OnboardingModal from './components/OnboardingModal';
+import ReorderHabitsModal from './components/ReorderHabitsModal';
+import StatsModal from './components/StatsModal';
+import { HABIT_DEFAULTS } from './HabitDefaults';
+import HabitTile from './HabitTile';
+import styles from './Habits.styles';
+import type {
+  Completion,
+  Goal,
+  Habit,
+  HabitStatsData,
+  OnboardingHabit,
+} from './Habits.types';
 
 //------------------
 // Constants & Helpers
 //------------------
 
 export const STAGE_ORDER = [
-  "Beige",
-  "Purple",
-  "Red",
-  "Blue",
-  "Orange",
-  "Green",
-  "Yellow",
-  "Turquoise",
-  "Ultraviolet",
-  "Clear Light",
+  'Beige',
+  'Purple',
+  'Red',
+  'Blue',
+  'Orange',
+  'Green',
+  'Yellow',
+  'Turquoise',
+  'Ultraviolet',
+  'Clear Light',
 ];
 
 export const getTierColor = (tier: string) => {
-    switch (tier) {
-    case "low":
-        return "#bc845d";
-    case "clear":
-        return "#807f66";
-    case "stretch":
-        return "#b0ae91";
+  switch (tier) {
+    case 'low':
+      return '#bc845d';
+    case 'clear':
+      return '#807f66';
+    case 'stretch':
+      return '#b0ae91';
     default:
-        return "#dad9d4";
-    }
+      return '#dad9d4';
+  }
 };
 
 export const STAGE_COLORS: Record<string, string> = {
-  "Beige": "#d8cbb8",
-  "Purple": "#a093c6",
-  "Red": "#cc5b5b",
-  "Blue": "#6fa3d3",
-  "Orange": "#f29f67",
-  "Green": "#6fcf97",
-  "Yellow": "#f2e96d",
-  "Turquoise": "#50c9c3",
-  "Ultraviolet": "#8e44ad",
-  "Clear Light": "#ffffff",
+  Beige: '#d8cbb8',
+  Purple: '#a093c6',
+  Red: '#cc5b5b',
+  Blue: '#6fa3d3',
+  Orange: '#f29f67',
+  Green: '#6fcf97',
+  Yellow: '#f2e96d',
+  Turquoise: '#50c9c3',
+  Ultraviolet: '#8e44ad',
+  'Clear Light': '#ffffff',
 };
 
 // Victory color - shown when Clear goal is met and moving to Stretch goal
-export const VICTORY_COLOR = "#27ae60";
+export const VICTORY_COLOR = '#27ae60';
 
 export const DEFAULT_ICONS = [
-  "🧘", "🏃", "💧", "🥗", "💪", "📱", "🍷", "☕", "🎨", "💼",
-  "🧠", "🌱", "🌞", "🌙", "📚", "✍️", "🤔", "🗣️", "👥", "❤️"
+  '🧘',
+  '🏃',
+  '💧',
+  '🥗',
+  '💪',
+  '📱',
+  '🍷',
+  '☕',
+  '🎨',
+  '💼',
+  '🧠',
+  '🌱',
+  '🌞',
+  '🌙',
+  '📚',
+  '✍️',
+  '🤔',
+  '🗣️',
+  '👥',
+  '❤️',
 ];
 
 export const TARGET_UNITS = [
-  "minutes", "hours", "reps", "sets", "cups", "liters", "ml", "oz", "pages", "sessions",
-  "steps", "calories", "times", "units", "mg", "g", "kg", "lbs", "points", "days"
+  'minutes',
+  'hours',
+  'reps',
+  'sets',
+  'cups',
+  'liters',
+  'ml',
+  'oz',
+  'pages',
+  'sessions',
+  'steps',
+  'calories',
+  'times',
+  'units',
+  'mg',
+  'g',
+  'kg',
+  'lbs',
+  'points',
+  'days',
 ];
 
 export const FREQUENCY_UNITS = [
-  "per_day", "per_week", "per_month", "per_session"
+  'per_day',
+  'per_week',
+  'per_month',
+  'per_session',
 ];
 
 export const DAYS_OF_WEEK = [
-  "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
 ];
 
 // Sample default habits – these might be loaded or saved to AsyncStorage
-const DEFAULT_HABITS: Habit[] = HABIT_DEFAULTS.map(habit => ({
+const DEFAULT_HABITS: Habit[] = HABIT_DEFAULTS.map((habit) => ({
   ...habit,
   revealed: true,
-  completions: [] // Initialize empty completions array
+  completions: [], // Initialize empty completions array
 }));
 
 // Register for push notifications
-const registerForPushNotificationsAsync = async (): Promise<string | undefined> => {
+const registerForPushNotificationsAsync = async (): Promise<
+  string | undefined
+> => {
   try {
-    const { status: existingStatus } = await Notifications.getPermissionsAsync();
+    const { status: existingStatus } =
+      await Notifications.getPermissionsAsync();
     let finalStatus = existingStatus;
     if (existingStatus !== 'granted') {
       const { status } = await Notifications.requestPermissionsAsync();
@@ -123,22 +163,31 @@ const registerForPushNotificationsAsync = async (): Promise<string | undefined> 
 // Schedule a notification for a habit using its defined time and frequency
 const scheduleHabitNotification = async (
   habit: Habit,
-  notificationTime: string
+  notificationTime: string,
 ): Promise<string> => {
   const [hours, minutes] = notificationTime.split(':').map(Number);
-  let trigger: any;
+  let trigger: Notifications.NotificationTriggerInput;
 
   if (habit.notificationFrequency === 'daily') {
     trigger = { hour: hours, minute: minutes, repeats: true };
   } else if (habit.notificationFrequency === 'weekly') {
     trigger = { weekday: 1, hour: hours, minute: minutes, repeats: true };
-  } else if (habit.notificationFrequency === 'custom' && habit.notificationDays && habit.notificationDays.length > 0) {
+  } else if (
+    habit.notificationFrequency === 'custom' &&
+    habit.notificationDays &&
+    habit.notificationDays.length > 0
+  ) {
     // For the custom frequency, we'll schedule multiple notifications
     const notificationIds: string[] = [];
 
     for (const day of habit.notificationDays) {
       const weekday = DAYS_OF_WEEK.indexOf(day) + 1; // 1-7, where 1 is Monday
-      const customTrigger = { weekday, hour: hours, minute: minutes, repeats: true };
+      const customTrigger = {
+        weekday,
+        hour: hours,
+        minute: minutes,
+        repeats: true,
+      };
 
       const id = await Notifications.scheduleNotificationAsync({
         content: {
@@ -174,18 +223,27 @@ const updateHabitNotifications = async (habit: Habit): Promise<string[]> => {
   if (!habit.id) return [];
   if (habit.notificationIds && habit.notificationIds.length > 0) {
     await Promise.all(
-      habit.notificationIds.map(id => Notifications.cancelScheduledNotificationAsync(id))
+      habit.notificationIds.map((id) =>
+        Notifications.cancelScheduledNotificationAsync(id),
+      ),
     );
   }
 
-  if (habit.notificationFrequency === 'off' || !habit.notificationTimes || habit.notificationTimes.length === 0) {
+  if (
+    habit.notificationFrequency === 'off' ||
+    !habit.notificationTimes ||
+    habit.notificationTimes.length === 0
+  ) {
     return [];
   }
 
   const notificationIds: string[] = [];
 
   for (const notificationTime of habit.notificationTimes) {
-    const notificationId = await scheduleHabitNotification(habit, notificationTime);
+    const notificationId = await scheduleHabitNotification(
+      habit,
+      notificationTime,
+    );
     notificationIds.push(notificationId);
   }
 
@@ -193,7 +251,10 @@ const updateHabitNotifications = async (habit: Habit): Promise<string[]> => {
 };
 
 // Calculate net energy for a habit
-export const calculateNetEnergy = (cost: number, returnValue: number): number => {
+export const calculateNetEnergy = (
+  cost: number,
+  returnValue: number,
+): number => {
   return returnValue - cost;
 };
 
@@ -206,7 +267,9 @@ export const calculateProgressIncrements = (goal: Goal): number[] => {
   } else if (target <= 10) {
     return Array.from({ length: 5 }, (_, i) => ((i + 1) * target) / 5);
   } else if (target <= 100) {
-    return Array.from({ length: 5 }, (_, i) => Math.ceil(((i + 1) * target) / 5));
+    return Array.from({ length: 5 }, (_, i) =>
+      Math.ceil(((i + 1) * target) / 5),
+    );
   } else {
     // For very large targets, show 5 evenly spaced markers
     const increment = Math.ceil(target / 5);
@@ -214,68 +277,70 @@ export const calculateProgressIncrements = (goal: Goal): number[] => {
   }
 };
 
-export const getGoalTier = (habit: Habit): {
-    currentGoal: Goal,
-    nextGoal: Goal | null,
-    completedAllGoals: boolean
-  } => {
-    const sortedGoals = [...habit.goals].sort((a, b) => {
-      const tierOrder = { 'low': 1, 'clear': 2, 'stretch': 3 };
-      return tierOrder[a.tier] - tierOrder[b.tier];
-    });
+export const getGoalTier = (
+  habit: Habit,
+): {
+  currentGoal: Goal;
+  nextGoal: Goal | null;
+  completedAllGoals: boolean;
+} => {
+  const sortedGoals = [...habit.goals].sort((a, b) => {
+    const tierOrder = { low: 1, clear: 2, stretch: 3 };
+    return tierOrder[a.tier] - tierOrder[b.tier];
+  });
 
-    const totalProgress = calculateHabitProgress(habit);
-    let currentGoal = sortedGoals[0];
-    let nextGoal: Goal | null = null;
-    let completedAllGoals = false;
+  const totalProgress = calculateHabitProgress(habit);
+  let currentGoal = sortedGoals[0];
+  let nextGoal: Goal | null = null;
+  let completedAllGoals = false;
 
-    // For additive goals - find which goal tier we're currently working on
-    if (currentGoal.is_additive) {
-      if (totalProgress >= getGoalTarget(sortedGoals[2])) {
-        // We've completed all goals including stretch
-        currentGoal = sortedGoals[2];
-        completedAllGoals = true;
-      } else if (totalProgress >= getGoalTarget(sortedGoals[1])) {
-        // We're working on the stretch goal
-        currentGoal = sortedGoals[1];
-        nextGoal = sortedGoals[2];
-      } else if (totalProgress >= getGoalTarget(sortedGoals[0])) {
-        // We've completed the low goal, working on clear goal
-        currentGoal = sortedGoals[0];
-        nextGoal = sortedGoals[1];
-      } else {
-        // We're still working on the low goal
-        currentGoal = sortedGoals[0];
-        // Don't set nextGoal to sortedGoals[0], keep it null for the lowest tier
-      }
+  // For additive goals - find which goal tier we're currently working on
+  if (currentGoal.is_additive) {
+    if (totalProgress >= getGoalTarget(sortedGoals[2])) {
+      // We've completed all goals including stretch
+      currentGoal = sortedGoals[2];
+      completedAllGoals = true;
+    } else if (totalProgress >= getGoalTarget(sortedGoals[1])) {
+      // We're working on the stretch goal
+      currentGoal = sortedGoals[1];
+      nextGoal = sortedGoals[2];
+    } else if (totalProgress >= getGoalTarget(sortedGoals[0])) {
+      // We've completed the low goal, working on clear goal
+      currentGoal = sortedGoals[0];
+      nextGoal = sortedGoals[1];
     } else {
-      // For subtractive goals - find which goal tier we're currently at
-      // For subtractive, lower target is better (e.g., 0 drinks is better than 3)
-      const lowTarget = getGoalTarget(sortedGoals[0]);
-      const clearTarget = getGoalTarget(sortedGoals[1]);
-      const stretchTarget = getGoalTarget(sortedGoals[2]);
-
-      if (totalProgress <= stretchTarget) {
-        // We're at or better than the stretch goal
-        currentGoal = sortedGoals[2];
-        completedAllGoals = true;
-      } else if (totalProgress <= clearTarget) {
-        // We're at or better than the clear goal
-        currentGoal = sortedGoals[1];
-        nextGoal = sortedGoals[2];
-      } else if (totalProgress <= lowTarget) {
-        // We're at or better than the low goal
-        currentGoal = sortedGoals[0];
-        nextGoal = sortedGoals[1];
-      } else {
-        // We haven't reached any goal yet
-        currentGoal = sortedGoals[0];
-        // Don't set nextGoal to sortedGoals[0], keep it null if no goal is reached
-      }
+      // We're still working on the low goal
+      currentGoal = sortedGoals[0];
+      // Don't set nextGoal to sortedGoals[0], keep it null for the lowest tier
     }
+  } else {
+    // For subtractive goals - find which goal tier we're currently at
+    // For subtractive, lower target is better (e.g., 0 drinks is better than 3)
+    const lowTarget = getGoalTarget(sortedGoals[0]);
+    const clearTarget = getGoalTarget(sortedGoals[1]);
+    const stretchTarget = getGoalTarget(sortedGoals[2]);
 
-    return { currentGoal, nextGoal, completedAllGoals };
-  };
+    if (totalProgress <= stretchTarget) {
+      // We're at or better than the stretch goal
+      currentGoal = sortedGoals[2];
+      completedAllGoals = true;
+    } else if (totalProgress <= clearTarget) {
+      // We're at or better than the clear goal
+      currentGoal = sortedGoals[1];
+      nextGoal = sortedGoals[2];
+    } else if (totalProgress <= lowTarget) {
+      // We're at or better than the low goal
+      currentGoal = sortedGoals[0];
+      nextGoal = sortedGoals[1];
+    } else {
+      // We haven't reached any goal yet
+      currentGoal = sortedGoals[0];
+      // Don't set nextGoal to sortedGoals[0], keep it null if no goal is reached
+    }
+  }
+
+  return { currentGoal, nextGoal, completedAllGoals };
+};
 
 // Calculate the target value for a goal based on frequency
 export const getGoalTarget = (goal: Goal): number => {
@@ -288,12 +353,12 @@ export const getGoalTarget = (goal: Goal): number => {
 
   // For per_week goals, divide by 7 to get daily equivalent
   if (goal.frequency_unit === 'per_week') {
-    return goal.target / 7 * goal.frequency;
+    return (goal.target / 7) * goal.frequency;
   }
 
   // For per_month goals, divide by 30 to get daily equivalent (approximation)
   if (goal.frequency_unit === 'per_month') {
-    return goal.target / 30 * goal.frequency;
+    return (goal.target / 30) * goal.frequency;
   }
 
   // Default case


### PR DESCRIPTION
## Summary
- reorder HabitsScreen imports and convert type-only imports
- prefer single quotes and semicolons for constants
- type notification triggers with expo notifications

## Testing
- `npx prettier --no-config --single-quote --trailing-comma all --arrow-parens always --write app/features/Habits/HabitsScreen.tsx`
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a69a2dbee8832280906f46283cb005