### PR TITLE
chore: tidy GoalModal formatting and types

### DIFF
--- a/app/features/Habits/components/GoalModal.tsx
+++ b/app/features/Habits/components/GoalModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -9,10 +9,15 @@ import {
   TouchableWithoutFeedback,
   ScrollView,
   Alert,
-} from "react-native";
+} from 'react-native';
 
-import styles from "../Habits.styles"
-import { Goal, GoalModalProps, EditableGoalProps, Habit } from "../Habits.types"
+import styles from '../Habits.styles';
+import type {
+  Goal,
+  GoalModalProps,
+  EditableGoalProps,
+  Habit,
+} from '../Habits.types';
 import {
   calculateProgressIncrements,
   STAGE_COLORS,
@@ -22,10 +27,10 @@ import {
   calculateHabitProgress,
   getGoalTarget,
   getTierColor,
-} from "../HabitsScreen";
+} from '../HabitsScreen';
 
 // Constant for golden glow color to match with HabitTile
-const GOLDEN_GLOW_COLOR = "rgba(255, 215, 0, 0.6)";
+const GOLDEN_GLOW_COLOR = 'rgba(255, 215, 0, 0.6)';
 
 /**
  * Calculate progress for a specific goal based on habit's total progress
@@ -41,7 +46,7 @@ const calculateGoalProgress = (goal: Goal, habit: Habit): number => {
     return Math.min((totalProgress / targetValue) * 100, 100);
   } else {
     // For subtractive goals, start at 100% and decrease with progress
-    return Math.max(0, 100 - ((totalProgress / targetValue) * 100));
+    return Math.max(0, 100 - (totalProgress / targetValue) * 100);
   }
 };
 
@@ -65,10 +70,16 @@ const isGoalAchieved = (goal: Goal, habit: Habit): boolean => {
 /**
  * Editable goal component to display and modify a habit goal
  */
-const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & { habit: Habit }) => {
+const EditableGoal = ({
+  goal,
+  habit,
+  onUpdate,
+  isEditing,
+}: EditableGoalProps & { habit: Habit }) => {
   const [editedGoal, setEditedGoal] = useState<Goal>({ ...goal });
   const [showTargetUnitDropdown, setShowTargetUnitDropdown] = useState(false);
-  const [showFrequencyUnitDropdown, setShowFrequencyUnitDropdown] = useState(false);
+  const [showFrequencyUnitDropdown, setShowFrequencyUnitDropdown] =
+    useState(false);
   const [showDaysSelection, setShowDaysSelection] = useState(false);
 
   // Reset edited goal when goal or editing status changes
@@ -76,7 +87,7 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
     setEditedGoal({ ...goal });
   }, [goal, isEditing]);
 
-  const handleChange = (field: keyof Goal, value: any) => {
+  const handleChange = (field: keyof Goal, value: Goal[keyof Goal]) => {
     setEditedGoal((prev) => ({ ...prev, [field]: value }));
   };
 
@@ -97,11 +108,11 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
     const currentDays = editedGoal.days_of_week || [];
     if (currentDays.includes(day)) {
       handleChange(
-        "days_of_week",
-        currentDays.filter(d => d !== day)
+        'days_of_week',
+        currentDays.filter((d) => d !== day),
       );
     } else {
-      handleChange("days_of_week", [...currentDays, day]);
+      handleChange('days_of_week', [...currentDays, day]);
     }
   };
 
@@ -113,13 +124,13 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
           backgroundColor: getTierColor(goal.tier),
           borderWidth: achieved ? 2 : 0,
           borderColor: achieved ? GOLDEN_GLOW_COLOR : 'transparent',
-        }
+        },
       ]}
     >
       <View style={styles.goalHeader}>
         <Text style={styles.goalTier}>
           {goal.tier.toUpperCase()}
-          {achieved && " ✓"}
+          {achieved && ' ✓'}
         </Text>
         {isEditing && (
           <TouchableOpacity onPress={handleSave} style={styles.saveButton}>
@@ -132,8 +143,8 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
         <TextInput
           style={styles.goalTitleInput}
           value={editedGoal.title}
-          onChangeText={(text) => handleChange("title", text)}
-          placeholder="Goal title"
+          onChangeText={(text) => handleChange('title', text)}
+          placeholder='Goal title'
         />
       ) : (
         <Text style={styles.goalTitle}>{goal.title}</Text>
@@ -147,25 +158,32 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
               <TextInput
                 style={styles.editInput}
                 value={editedGoal.target.toString()}
-                onChangeText={(text) => handleChange("target", parseFloat(text) || 0)}
-                keyboardType="numeric"
+                onChangeText={(text) =>
+                  handleChange('target', parseFloat(text) || 0)
+                }
+                keyboardType='numeric'
               />
 
               <TouchableOpacity
                 style={styles.unitDropdownButton}
-                onPress={() => setShowTargetUnitDropdown(!showTargetUnitDropdown)}
+                onPress={() =>
+                  setShowTargetUnitDropdown(!showTargetUnitDropdown)
+                }
               >
-                <Text>{editedGoal.target_unit || "Select unit"}</Text>
+                <Text>{editedGoal.target_unit || 'Select unit'}</Text>
               </TouchableOpacity>
 
               {showTargetUnitDropdown && (
-                <ScrollView style={styles.dropdown} keyboardShouldPersistTaps="handled">
+                <ScrollView
+                  style={styles.dropdown}
+                  keyboardShouldPersistTaps='handled'
+                >
                   {TARGET_UNITS.map((unit) => (
                     <TouchableOpacity
                       key={unit}
                       style={styles.dropdownItem}
                       onPress={() => {
-                        handleChange("target_unit", unit);
+                        handleChange('target_unit', unit);
                         setShowTargetUnitDropdown(false);
                       }}
                     >
@@ -181,36 +199,46 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
               <TextInput
                 style={styles.editInput}
                 value={editedGoal.frequency.toString()}
-                onChangeText={(text) => handleChange("frequency", parseFloat(text) || 0)}
-                keyboardType="numeric"
+                onChangeText={(text) =>
+                  handleChange('frequency', parseFloat(text) || 0)
+                }
+                keyboardType='numeric'
               />
 
               <TouchableOpacity
                 style={styles.unitDropdownButton}
-                onPress={() => setShowFrequencyUnitDropdown(!showFrequencyUnitDropdown)}
+                onPress={() =>
+                  setShowFrequencyUnitDropdown(!showFrequencyUnitDropdown)
+                }
               >
-                <Text>{editedGoal.frequency_unit.replace("_", " ") || "Select frequency"}</Text>
+                <Text>
+                  {editedGoal.frequency_unit.replace('_', ' ') ||
+                    'Select frequency'}
+                </Text>
               </TouchableOpacity>
 
               {showFrequencyUnitDropdown && (
-                <ScrollView style={styles.dropdown} keyboardShouldPersistTaps="handled">
+                <ScrollView
+                  style={styles.dropdown}
+                  keyboardShouldPersistTaps='handled'
+                >
                   {FREQUENCY_UNITS.map((unit) => (
                     <TouchableOpacity
                       key={unit}
                       style={styles.dropdownItem}
                       onPress={() => {
-                        handleChange("frequency_unit", unit);
+                        handleChange('frequency_unit', unit);
                         setShowFrequencyUnitDropdown(false);
                       }}
                     >
-                      <Text>{unit.replace("_", " ")}</Text>
+                      <Text>{unit.replace('_', ' ')}</Text>
                     </TouchableOpacity>
                   ))}
                 </ScrollView>
               )}
             </View>
 
-            {editedGoal.frequency_unit === "per_week" && (
+            {editedGoal.frequency_unit === 'per_week' && (
               <View style={styles.editRow}>
                 <Text style={styles.editLabel}>Days:</Text>
                 <TouchableOpacity
@@ -218,9 +246,12 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
                   onPress={() => setShowDaysSelection(!showDaysSelection)}
                 >
                   <Text>
-                    {editedGoal.days_of_week && editedGoal.days_of_week.length > 0
-                      ? editedGoal.days_of_week.map(d => d.substring(0, 3)).join(", ")
-                      : "Select days"}
+                    {editedGoal.days_of_week &&
+                    editedGoal.days_of_week.length > 0
+                      ? editedGoal.days_of_week
+                          .map((d) => d.substring(0, 3))
+                          .join(', ')
+                      : 'Select days'}
                   </Text>
                 </TouchableOpacity>
 
@@ -231,11 +262,14 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
                         key={day}
                         style={[
                           styles.dayOption,
-                          (editedGoal.days_of_week || []).includes(day) && styles.selectedDayOption
+                          (editedGoal.days_of_week || []).includes(day) &&
+                            styles.selectedDayOption,
                         ]}
                         onPress={() => toggleDaySelection(day)}
                       >
-                        <Text style={styles.dayOptionText}>{day.substring(0, 3)}</Text>
+                        <Text style={styles.dayOptionText}>
+                          {day.substring(0, 3)}
+                        </Text>
                       </TouchableOpacity>
                     ))}
                   </View>
@@ -246,14 +280,28 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
             <View style={styles.editRow}>
               <Text style={styles.editLabel}>Type:</Text>
               <Pressable
-                style={[styles.toggleButton, { backgroundColor: editedGoal.is_additive ? "#4CAF50" : "#ccc" }]}
-                onPress={() => handleChange("is_additive", true)}
+                style={[
+                  styles.toggleButton,
+                  {
+                    backgroundColor: editedGoal.is_additive
+                      ? '#4CAF50'
+                      : '#ccc',
+                  },
+                ]}
+                onPress={() => handleChange('is_additive', true)}
               >
                 <Text style={styles.toggleText}>Additive</Text>
               </Pressable>
               <Pressable
-                style={[styles.toggleButton, { backgroundColor: !editedGoal.is_additive ? "#F44336" : "#ccc" }]}
-                onPress={() => handleChange("is_additive", false)}
+                style={[
+                  styles.toggleButton,
+                  {
+                    backgroundColor: !editedGoal.is_additive
+                      ? '#F44336'
+                      : '#ccc',
+                  },
+                ]}
+                onPress={() => handleChange('is_additive', false)}
               >
                 <Text style={styles.toggleText}>Subtractive</Text>
               </Pressable>
@@ -261,11 +309,12 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
           </>
         ) : (
           <Text style={styles.goalDetails}>
-            {goal.is_additive ? "At least" : "No more than"} {goal.target} {goal.target_unit},{" "}
-            {goal.frequency} {goal.frequency_unit.replace("_", " ")}
-            {goal.days_of_week && goal.days_of_week.length > 0 &&
-              ` on ${goal.days_of_week.map(d => d.substring(0, 3)).join(", ")}`
-            }
+            {goal.is_additive ? 'At least' : 'No more than'} {goal.target}{' '}
+            {goal.target_unit}, {goal.frequency}{' '}
+            {goal.frequency_unit.replace('_', ' ')}
+            {goal.days_of_week &&
+              goal.days_of_week.length > 0 &&
+              ` on ${goal.days_of_week.map((d) => d.substring(0, 3)).join(', ')}`}
           </Text>
         )}
       </View>
@@ -284,8 +333,8 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
                     left: `${position}%`,
                     height: 7,
                     width: 2,
-                    backgroundColor: 'rgba(0,0,0,0.4)'
-                  }
+                    backgroundColor: 'rgba(0,0,0,0.4)',
+                  },
                 ]}
               />
             );
@@ -297,8 +346,10 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
               {
                 width: `${progressPercentage}%`,
                 height: 12, // Thicker progress bar
-                backgroundColor: achieved ? GOLDEN_GLOW_COLOR : STAGE_COLORS[habit.stage],
-              }
+                backgroundColor: achieved
+                  ? GOLDEN_GLOW_COLOR
+                  : STAGE_COLORS[habit.stage],
+              },
             ]}
           />
         </View>
@@ -306,7 +357,7 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
         {/* Progress text showing progress vs target */}
         <Text style={styles.goalProgressText}>
           {habit.progress || 0} / {goal.target} {goal.target_unit}
-          {achieved && " (Achieved!)"}
+          {achieved && ' (Achieved!)'}
         </Text>
       </View>
     </View>
@@ -316,11 +367,19 @@ const EditableGoal = ({ goal, habit, onUpdate, isEditing }: EditableGoalProps & 
 /**
  * Main GoalModal component to display and manage habit goals
  */
-export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: GoalModalProps) => {
+export const GoalModal = ({
+  visible,
+  habit,
+  onClose,
+  onUpdateGoal,
+  onLogUnit,
+}: GoalModalProps) => {
   const [activeGoal, setActiveGoal] = useState<Goal | null>(null);
   const [isEditing, setIsEditing] = useState(false);
-  const [logAmount, setLogAmount] = useState("1");
-  const [goalVisible, setGoalVisible] = useState<{[key: number]: boolean}>({});
+  const [logAmount, setLogAmount] = useState('1');
+  const [goalVisible, setGoalVisible] = useState<{ [key: number]: boolean }>(
+    {},
+  );
 
   // Initialize all goals to be visible initially
   useEffect(() => {
@@ -338,7 +397,7 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
     if (!visible) {
       setIsEditing(false);
       setActiveGoal(null);
-      setLogAmount("1");
+      setLogAmount('1');
     }
   }, [visible]);
 
@@ -355,13 +414,13 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
     if (habit.id) {
       const amount = parseFloat(logAmount) || 1;
       onLogUnit(habit.id, amount);
-      setLogAmount("1");
+      setLogAmount('1');
 
       // Show a feedback alert
       Alert.alert(
-        "Progress Logged",
+        'Progress Logged',
         `Added ${amount} ${amount === 1 ? 'unit' : 'units'} to ${habit.name}`,
-        [{ text: "OK", onPress: () => {} }]
+        [{ text: 'OK', onPress: () => {} }],
       );
     }
   };
@@ -372,9 +431,9 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
   };
 
   const toggleGoalVisibility = (index: number) => {
-    setGoalVisible(prev => ({
+    setGoalVisible((prev) => ({
       ...prev,
-      [index]: !prev[index]
+      [index]: !prev[index],
     }));
   };
 
@@ -383,22 +442,33 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
 
   // Sort goals by tier for consistent display order
   const sortedGoals = [...habit.goals].sort((a, b) => {
-    const tierOrder = { 'low': 1, 'clear': 2, 'stretch': 3 };
+    const tierOrder = { low: 1, clear: 2, stretch: 3 };
     return tierOrder[a.tier] - tierOrder[b.tier];
   });
 
   return (
-    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+    <Modal
+      visible={visible}
+      transparent
+      animationType='slide'
+      onRequestClose={onClose}
+    >
       <TouchableWithoutFeedback onPress={onClose}>
         <View style={styles.modalOverlay}>
           <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
-            <View style={[styles.modalContent, { borderTopColor: STAGE_COLORS[habit.stage] }]}>
+            <View
+              style={[
+                styles.modalContent,
+                { borderTopColor: STAGE_COLORS[habit.stage] },
+              ]}
+            >
               <View style={styles.modalHeader}>
                 <Text style={styles.modalTitle}>
-                  {habit.name} <Text style={styles.iconLarge}>{habit.icon}</Text>
+                  {habit.name}{' '}
+                  <Text style={styles.iconLarge}>{habit.icon}</Text>
                 </Text>
                 <Text style={styles.streakBadge}>
-                  {habit.streak} {habit.streak === 1 ? "day" : "days"}
+                  {habit.streak} {habit.streak === 1 ? 'day' : 'days'}
                 </Text>
                 <TouchableOpacity onPress={onClose} style={styles.closeButton}>
                   <Text style={styles.closeButtonText}>×</Text>
@@ -408,10 +478,13 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
               {/* Habit summary section */}
               <View style={styles.habitSummary}>
                 <Text style={styles.habitSummaryText}>
-                  Total Progress: {totalProgress} {sortedGoals[0]?.target_unit || 'units'}
+                  Total Progress: {totalProgress}{' '}
+                  {sortedGoals[0]?.target_unit || 'units'}
                 </Text>
                 <Text style={styles.habitSummaryText}>
-                  Energy: Cost {habit.energy_cost} · Return {habit.energy_return} · Net {habit.energy_return - habit.energy_cost}
+                  Energy: Cost {habit.energy_cost} · Return{' '}
+                  {habit.energy_return} · Net{' '}
+                  {habit.energy_return - habit.energy_cost}
                 </Text>
               </View>
 
@@ -423,14 +496,13 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
                       onPress={() => toggleGoalVisibility(index)}
                     >
                       <Text style={styles.goalHeaderToggleText}>
-                        {goal.tier.toUpperCase()} GOAL {goalVisible[index] ? '▼' : '►'}
+                        {goal.tier.toUpperCase()} GOAL{' '}
+                        {goalVisible[index] ? '▼' : '►'}
                       </Text>
                     </TouchableOpacity>
 
                     {goalVisible[index] && (
-                      <TouchableOpacity
-                        onPress={() => handleEditGoal(goal)}
-                      >
+                      <TouchableOpacity onPress={() => handleEditGoal(goal)}>
                         <EditableGoal
                           goal={goal}
                           habit={habit}
@@ -449,7 +521,7 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
                     style={styles.logUnitInput}
                     value={logAmount}
                     onChangeText={setLogAmount}
-                    keyboardType="numeric"
+                    keyboardType='numeric'
                   />
                   <TouchableOpacity
                     style={styles.logUnitButton}
@@ -463,7 +535,7 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
                   onPress={() => setIsEditing(!isEditing)}
                 >
                   <Text style={styles.editButtonText}>
-                    {isEditing ? "Done Editing" : "Edit Goals"}
+                    {isEditing ? 'Done Editing' : 'Edit Goals'}
                   </Text>
                 </TouchableOpacity>
               </View>


### PR DESCRIPTION
## Summary
- type-only import for Goal-related types and add missing semicolons
- specify Goal value type in handleChange
- format GoalModal with Prettier using single quotes

## Testing
- `npx prettier features/Habits/components/GoalModal.tsx --write --no-config --single-quote --jsx-single-quote --trailing-comma all --semi --arrow-parens always --bracket-spacing true`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a69aa22e648322aaee80b36e4b340d