### PR TITLE
fix: clean up MissedDaysModal imports and types

### DIFF
--- a/app/features/Habits/components/MissedDaysModal.tsx
+++ b/app/features/Habits/components/MissedDaysModal.tsx
@@ -1,90 +1,94 @@
-import React, { useState } from "react";
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  Modal,
-} from "react-native";
+import React, { useState } from 'react';
+import { Modal, Text, TouchableOpacity, View } from 'react-native';
 import { Calendar } from 'react-native-calendars';
+import type { DateData } from 'react-native-calendars';
 
-import { STAGE_COLORS } from "../HabitsScreen";
-import {
-    MissedDaysModalProps
-} from "../Habits.types"
+import { STAGE_COLORS } from '../HabitsScreen';
+import type { MissedDaysModalProps } from '../Habits.types';
 
-import styles from "../Habits.styles"
+import styles from '../Habits.styles';
 
 export const MissedDaysModal = ({
-    visible,
-    habit,
-    missedDays,
-    onClose,
-    onBackfill,
-    onNewStartDate,
-  }: MissedDaysModalProps) => {
-    const [showCalendar, setShowCalendar] = useState(false);
-    const [selectedDate, setSelectedDate] = useState(new Date());
-    if (!habit || missedDays.length === 0) return null;
+  visible,
+  habit,
+  missedDays,
+  onClose,
+  onBackfill,
+  onNewStartDate,
+}: MissedDaysModalProps) => {
+  const [showCalendar, setShowCalendar] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  if (!habit || missedDays.length === 0) return null;
 
-    const handleBackfill = () => {
-      if (habit.id) {
-        onBackfill(habit.id, missedDays);
-        onClose();
-      }
-    };
-
-    const handleSelectNewDate = () => {
-      setShowCalendar(true);
-    };
-
-    const handleDateSelect = (date: any) => {
-      setSelectedDate(new Date(date.dateString));
-      setShowCalendar(false);
-      if (habit.id) {
-        onNewStartDate(habit.id, new Date(date.dateString));
-        onClose();
-      }
-    };
-
-    return (
-      <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-        <View style={styles.modalOverlay}>
-          <View style={styles.missedDaysContent}>
-            <Text style={styles.missedDaysTitle}>Missed you!</Text>
-            <Text style={styles.missedDaysSubtitle}>
-              We missed {missedDays.length} day{missedDays.length !== 1 ? "s" : ""} for "{habit.name}".
-            </Text>
-            <Text style={styles.missedDaysQuestion}>
-              Did you keep up with "{habit.name}" while you were gone?
-            </Text>
-            {showCalendar ? (
-              <Calendar
-                onDayPress={handleDateSelect}
-                markedDates={{
-                  [selectedDate.toISOString().split("T")[0]]: {
-                    selected: true,
-                    selectedColor: STAGE_COLORS[habit.stage],
-                  },
-                }}
-                minDate={new Date().toISOString()}
-              />
-            ) : (
-              <View style={styles.missedDaysButtons}>
-                <TouchableOpacity style={[styles.missedDaysButton, styles.yesButton]} onPress={handleBackfill}>
-                  <Text style={styles.missedDaysButtonText}>Yes, I did it!</Text>
-                </TouchableOpacity>
-                <TouchableOpacity style={[styles.missedDaysButton, styles.resetButton]} onPress={handleSelectNewDate}>
-                  <Text style={styles.missedDaysButtonText}>Set new start date</Text>
-                </TouchableOpacity>
-                <TouchableOpacity style={[styles.missedDaysButton, styles.cancelButton]} onPress={onClose}>
-                  <Text style={styles.missedDaysButtonText}>Just continue</Text>
-                </TouchableOpacity>
-              </View>
-            )}
-          </View>
-        </View>
-      </Modal>
-    );
+  const handleBackfill = () => {
+    if (habit.id) {
+      onBackfill(habit.id, missedDays);
+      onClose();
+    }
   };
 
-export default MissedDaysModal
+  const handleSelectNewDate = () => {
+    setShowCalendar(true);
+  };
+
+  const handleDateSelect = (date: DateData) => {
+    setSelectedDate(new Date(date.dateString));
+    setShowCalendar(false);
+    if (habit.id) {
+      onNewStartDate(habit.id, new Date(date.dateString));
+      onClose();
+    }
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.modalOverlay}>
+        <View style={styles.missedDaysContent}>
+          <Text style={styles.missedDaysTitle}>Missed you!</Text>
+          <Text style={styles.missedDaysSubtitle}>
+            We missed {missedDays.length} day
+            {missedDays.length !== 1 ? 's' : ''} for '{habit.name}'.
+          </Text>
+          <Text style={styles.missedDaysQuestion}>
+            Did you keep up with '{habit.name}' while you were gone?
+          </Text>
+          {showCalendar ? (
+            <Calendar
+              onDayPress={handleDateSelect}
+              markedDates={{
+                [selectedDate.toISOString().split('T')[0]]: {
+                  selected: true,
+                  selectedColor: STAGE_COLORS[habit.stage],
+                },
+              }}
+              minDate={new Date().toISOString()}
+            />
+          ) : (
+            <View style={styles.missedDaysButtons}>
+              <TouchableOpacity
+                style={[styles.missedDaysButton, styles.yesButton]}
+                onPress={handleBackfill}
+              >
+                <Text style={styles.missedDaysButtonText}>Yes, I did it!</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.missedDaysButton, styles.resetButton]}
+                onPress={handleSelectNewDate}
+              >
+                <Text style={styles.missedDaysButtonText}>Set new start date</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.missedDaysButton, styles.cancelButton]}
+                onPress={onClose}
+              >
+                <Text style={styles.missedDaysButtonText}>Just continue</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default MissedDaysModal;


### PR DESCRIPTION
## Summary
- refactor MissedDaysModal to use type-only imports and strict DateData type
- format MissedDaysModal with Prettier and single quotes

## Testing
- `npx prettier --write features/Habits/components/MissedDaysModal.tsx --single-quote --trailing-comma all --print-width 100 --semi --no-config`
- `npx eslint features/Habits/components/MissedDaysModal.tsx` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a69ada13ac832281fc6e3c867c7adb