### PR TITLE
style: format HabitsScreen second half

### DIFF
--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -1,103 +1,131 @@
 // HabitsScreen.tsx
 
-import React, { useState, useEffect } from "react";
-import {
-  View,
-  Text,
-  FlatList,
-  TouchableOpacity,
-  Alert,
-} from "react-native";
+import React, { useState, useEffect } from 'react';
+import { View, Text, FlatList, TouchableOpacity, Alert } from 'react-native';
 import * as Notifications from 'expo-notifications';
 
 import GoalModal from './components/GoalModal';
-import HabitSettingsModal from "./components/HabitSettingsModal"
-import StatsModal from "./components/StatsModal";
-import MissedDaysModal from "./components/MissedDaysModal";
-import OnboardingModal from "./components/OnboardingModal";
-import ReorderHabitsModal from "./components/ReorderHabitsModal";
-import HabitTile from "./HabitTile";
+import HabitSettingsModal from './components/HabitSettingsModal';
+import StatsModal from './components/StatsModal';
+import MissedDaysModal from './components/MissedDaysModal';
+import OnboardingModal from './components/OnboardingModal';
+import ReorderHabitsModal from './components/ReorderHabitsModal';
+import HabitTile from './HabitTile';
 
-import { HABIT_DEFAULTS } from "./HabitDefaults";
-import {
-    Habit,
-    Goal,
-    HabitStatsData,
-    OnboardingHabit,
-    Completion,
-} from "./Habits.types"
+import { HABIT_DEFAULTS } from './HabitDefaults';
+import { Habit, Goal, HabitStatsData, OnboardingHabit, Completion } from './Habits.types';
 
-import styles from "./Habits.styles"
+import styles from './Habits.styles';
 
 //------------------
 // Constants & Helpers
 //------------------
 
 export const STAGE_ORDER = [
-  "Beige",
-  "Purple",
-  "Red",
-  "Blue",
-  "Orange",
-  "Green",
-  "Yellow",
-  "Turquoise",
-  "Ultraviolet",
-  "Clear Light",
+  'Beige',
+  'Purple',
+  'Red',
+  'Blue',
+  'Orange',
+  'Green',
+  'Yellow',
+  'Turquoise',
+  'Ultraviolet',
+  'Clear Light',
 ];
 
 export const getTierColor = (tier: string) => {
-    switch (tier) {
-    case "low":
-        return "#bc845d";
-    case "clear":
-        return "#807f66";
-    case "stretch":
-        return "#b0ae91";
+  switch (tier) {
+    case 'low':
+      return '#bc845d';
+    case 'clear':
+      return '#807f66';
+    case 'stretch':
+      return '#b0ae91';
     default:
-        return "#dad9d4";
-    }
+      return '#dad9d4';
+  }
 };
 
 export const STAGE_COLORS: Record<string, string> = {
-  "Beige": "#d8cbb8",
-  "Purple": "#a093c6",
-  "Red": "#cc5b5b",
-  "Blue": "#6fa3d3",
-  "Orange": "#f29f67",
-  "Green": "#6fcf97",
-  "Yellow": "#f2e96d",
-  "Turquoise": "#50c9c3",
-  "Ultraviolet": "#8e44ad",
-  "Clear Light": "#ffffff",
+  Beige: '#d8cbb8',
+  Purple: '#a093c6',
+  Red: '#cc5b5b',
+  Blue: '#6fa3d3',
+  Orange: '#f29f67',
+  Green: '#6fcf97',
+  Yellow: '#f2e96d',
+  Turquoise: '#50c9c3',
+  Ultraviolet: '#8e44ad',
+  'Clear Light': '#ffffff',
 };
 
 // Victory color - shown when Clear goal is met and moving to Stretch goal
-export const VICTORY_COLOR = "#27ae60";
+export const VICTORY_COLOR = '#27ae60';
 
 export const DEFAULT_ICONS = [
-  "🧘", "🏃", "💧", "🥗", "💪", "📱", "🍷", "☕", "🎨", "💼",
-  "🧠", "🌱", "🌞", "🌙", "📚", "✍️", "🤔", "🗣️", "👥", "❤️"
+  '🧘',
+  '🏃',
+  '💧',
+  '🥗',
+  '💪',
+  '📱',
+  '🍷',
+  '☕',
+  '🎨',
+  '💼',
+  '🧠',
+  '🌱',
+  '🌞',
+  '🌙',
+  '📚',
+  '✍️',
+  '🤔',
+  '🗣️',
+  '👥',
+  '❤️',
 ];
 
 export const TARGET_UNITS = [
-  "minutes", "hours", "reps", "sets", "cups", "liters", "ml", "oz", "pages", "sessions",
-  "steps", "calories", "times", "units", "mg", "g", "kg", "lbs", "points", "days"
+  'minutes',
+  'hours',
+  'reps',
+  'sets',
+  'cups',
+  'liters',
+  'ml',
+  'oz',
+  'pages',
+  'sessions',
+  'steps',
+  'calories',
+  'times',
+  'units',
+  'mg',
+  'g',
+  'kg',
+  'lbs',
+  'points',
+  'days',
 ];
 
-export const FREQUENCY_UNITS = [
-  "per_day", "per_week", "per_month", "per_session"
-];
+export const FREQUENCY_UNITS = ['per_day', 'per_week', 'per_month', 'per_session'];
 
 export const DAYS_OF_WEEK = [
-  "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
 ];
 
 // Sample default habits – these might be loaded or saved to AsyncStorage
-const DEFAULT_HABITS: Habit[] = HABIT_DEFAULTS.map(habit => ({
+const DEFAULT_HABITS: Habit[] = HABIT_DEFAULTS.map((habit) => ({
   ...habit,
   revealed: true,
-  completions: [] // Initialize empty completions array
+  completions: [], // Initialize empty completions array
 }));
 
 // Register for push notifications
@@ -123,7 +151,7 @@ const registerForPushNotificationsAsync = async (): Promise<string | undefined> 
 // Schedule a notification for a habit using its defined time and frequency
 const scheduleHabitNotification = async (
   habit: Habit,
-  notificationTime: string
+  notificationTime: string,
 ): Promise<string> => {
   const [hours, minutes] = notificationTime.split(':').map(Number);
   let trigger: any;
@@ -132,7 +160,11 @@ const scheduleHabitNotification = async (
     trigger = { hour: hours, minute: minutes, repeats: true };
   } else if (habit.notificationFrequency === 'weekly') {
     trigger = { weekday: 1, hour: hours, minute: minutes, repeats: true };
-  } else if (habit.notificationFrequency === 'custom' && habit.notificationDays && habit.notificationDays.length > 0) {
+  } else if (
+    habit.notificationFrequency === 'custom' &&
+    habit.notificationDays &&
+    habit.notificationDays.length > 0
+  ) {
     // For the custom frequency, we'll schedule multiple notifications
     const notificationIds: string[] = [];
 
@@ -174,11 +206,15 @@ const updateHabitNotifications = async (habit: Habit): Promise<string[]> => {
   if (!habit.id) return [];
   if (habit.notificationIds && habit.notificationIds.length > 0) {
     await Promise.all(
-      habit.notificationIds.map(id => Notifications.cancelScheduledNotificationAsync(id))
+      habit.notificationIds.map((id) => Notifications.cancelScheduledNotificationAsync(id)),
     );
   }
 
-  if (habit.notificationFrequency === 'off' || !habit.notificationTimes || habit.notificationTimes.length === 0) {
+  if (
+    habit.notificationFrequency === 'off' ||
+    !habit.notificationTimes ||
+    habit.notificationTimes.length === 0
+  ) {
     return [];
   }
 
@@ -214,68 +250,70 @@ export const calculateProgressIncrements = (goal: Goal): number[] => {
   }
 };
 
-export const getGoalTier = (habit: Habit): {
-    currentGoal: Goal,
-    nextGoal: Goal | null,
-    completedAllGoals: boolean
-  } => {
-    const sortedGoals = [...habit.goals].sort((a, b) => {
-      const tierOrder = { 'low': 1, 'clear': 2, 'stretch': 3 };
-      return tierOrder[a.tier] - tierOrder[b.tier];
-    });
+export const getGoalTier = (
+  habit: Habit,
+): {
+  currentGoal: Goal;
+  nextGoal: Goal | null;
+  completedAllGoals: boolean;
+} => {
+  const sortedGoals = [...habit.goals].sort((a, b) => {
+    const tierOrder = { low: 1, clear: 2, stretch: 3 };
+    return tierOrder[a.tier] - tierOrder[b.tier];
+  });
 
-    const totalProgress = calculateHabitProgress(habit);
-    let currentGoal = sortedGoals[0];
-    let nextGoal: Goal | null = null;
-    let completedAllGoals = false;
+  const totalProgress = calculateHabitProgress(habit);
+  let currentGoal = sortedGoals[0];
+  let nextGoal: Goal | null = null;
+  let completedAllGoals = false;
 
-    // For additive goals - find which goal tier we're currently working on
-    if (currentGoal.is_additive) {
-      if (totalProgress >= getGoalTarget(sortedGoals[2])) {
-        // We've completed all goals including stretch
-        currentGoal = sortedGoals[2];
-        completedAllGoals = true;
-      } else if (totalProgress >= getGoalTarget(sortedGoals[1])) {
-        // We're working on the stretch goal
-        currentGoal = sortedGoals[1];
-        nextGoal = sortedGoals[2];
-      } else if (totalProgress >= getGoalTarget(sortedGoals[0])) {
-        // We've completed the low goal, working on clear goal
-        currentGoal = sortedGoals[0];
-        nextGoal = sortedGoals[1];
-      } else {
-        // We're still working on the low goal
-        currentGoal = sortedGoals[0];
-        // Don't set nextGoal to sortedGoals[0], keep it null for the lowest tier
-      }
+  // For additive goals - find which goal tier we're currently working on
+  if (currentGoal.is_additive) {
+    if (totalProgress >= getGoalTarget(sortedGoals[2])) {
+      // We've completed all goals including stretch
+      currentGoal = sortedGoals[2];
+      completedAllGoals = true;
+    } else if (totalProgress >= getGoalTarget(sortedGoals[1])) {
+      // We're working on the stretch goal
+      currentGoal = sortedGoals[1];
+      nextGoal = sortedGoals[2];
+    } else if (totalProgress >= getGoalTarget(sortedGoals[0])) {
+      // We've completed the low goal, working on clear goal
+      currentGoal = sortedGoals[0];
+      nextGoal = sortedGoals[1];
     } else {
-      // For subtractive goals - find which goal tier we're currently at
-      // For subtractive, lower target is better (e.g., 0 drinks is better than 3)
-      const lowTarget = getGoalTarget(sortedGoals[0]);
-      const clearTarget = getGoalTarget(sortedGoals[1]);
-      const stretchTarget = getGoalTarget(sortedGoals[2]);
-
-      if (totalProgress <= stretchTarget) {
-        // We're at or better than the stretch goal
-        currentGoal = sortedGoals[2];
-        completedAllGoals = true;
-      } else if (totalProgress <= clearTarget) {
-        // We're at or better than the clear goal
-        currentGoal = sortedGoals[1];
-        nextGoal = sortedGoals[2];
-      } else if (totalProgress <= lowTarget) {
-        // We're at or better than the low goal
-        currentGoal = sortedGoals[0];
-        nextGoal = sortedGoals[1];
-      } else {
-        // We haven't reached any goal yet
-        currentGoal = sortedGoals[0];
-        // Don't set nextGoal to sortedGoals[0], keep it null if no goal is reached
-      }
+      // We're still working on the low goal
+      currentGoal = sortedGoals[0];
+      // Don't set nextGoal to sortedGoals[0], keep it null for the lowest tier
     }
+  } else {
+    // For subtractive goals - find which goal tier we're currently at
+    // For subtractive, lower target is better (e.g., 0 drinks is better than 3)
+    const lowTarget = getGoalTarget(sortedGoals[0]);
+    const clearTarget = getGoalTarget(sortedGoals[1]);
+    const stretchTarget = getGoalTarget(sortedGoals[2]);
 
-    return { currentGoal, nextGoal, completedAllGoals };
-  };
+    if (totalProgress <= stretchTarget) {
+      // We're at or better than the stretch goal
+      currentGoal = sortedGoals[2];
+      completedAllGoals = true;
+    } else if (totalProgress <= clearTarget) {
+      // We're at or better than the clear goal
+      currentGoal = sortedGoals[1];
+      nextGoal = sortedGoals[2];
+    } else if (totalProgress <= lowTarget) {
+      // We're at or better than the low goal
+      currentGoal = sortedGoals[0];
+      nextGoal = sortedGoals[1];
+    } else {
+      // We haven't reached any goal yet
+      currentGoal = sortedGoals[0];
+      // Don't set nextGoal to sortedGoals[0], keep it null if no goal is reached
+    }
+  }
+
+  return { currentGoal, nextGoal, completedAllGoals };
+};
 
 // Calculate the target value for a goal based on frequency
 export const getGoalTarget = (goal: Goal): number => {
@@ -288,12 +326,12 @@ export const getGoalTarget = (goal: Goal): number => {
 
   // For per_week goals, divide by 7 to get daily equivalent
   if (goal.frequency_unit === 'per_week') {
-    return goal.target / 7 * goal.frequency;
+    return (goal.target / 7) * goal.frequency;
   }
 
   // For per_month goals, divide by 30 to get daily equivalent (approximation)
   if (goal.frequency_unit === 'per_month') {
-    return goal.target / 30 * goal.frequency;
+    return (goal.target / 30) * goal.frequency;
   }
 
   // Default case
@@ -314,7 +352,7 @@ export const calculateHabitProgress = (habit: Habit): number => {
 export const calculateProgressPercentage = (
   habit: Habit,
   currentGoal: Goal,
-  nextGoal: Goal | null
+  nextGoal: Goal | null,
 ): number => {
   const totalProgress = calculateHabitProgress(habit);
   const isAdditive = currentGoal.is_additive;
@@ -331,7 +369,10 @@ export const calculateProgressPercentage = (
         // If we're past the clear goal and working on stretch
         if (totalProgress >= currentTarget) {
           // Percentage between clear and stretch goals
-          return Math.min(100, ((totalProgress - currentTarget) / (nextTarget - currentTarget)) * 100 + 33);
+          return Math.min(
+            100,
+            ((totalProgress - currentTarget) / (nextTarget - currentTarget)) * 100 + 33,
+          );
         }
       }
 
@@ -339,7 +380,10 @@ export const calculateProgressPercentage = (
       if (currentGoal.tier === 'low' && nextGoal.tier === 'clear') {
         // If we're past the low goal and working on clear
         if (totalProgress >= currentTarget) {
-          return Math.min(100, ((totalProgress - currentTarget) / (nextTarget - currentTarget)) * 100);
+          return Math.min(
+            100,
+            ((totalProgress - currentTarget) / (nextTarget - currentTarget)) * 100,
+          );
         }
       }
     }
@@ -370,7 +414,7 @@ export const getProgressBarColor = (
   habit: Habit,
   currentGoal: Goal,
   nextGoal: Goal | null,
-  completedAllGoals: boolean
+  completedAllGoals: boolean,
 ): string => {
   const isAdditive = currentGoal.is_additive;
   const totalProgress = calculateHabitProgress(habit);
@@ -383,8 +427,12 @@ export const getProgressBarColor = (
   // For additive goals
   if (isAdditive) {
     // If we're working on the stretch goal (after completing clear)
-    if (nextGoal && currentGoal.tier === 'clear' && nextGoal.tier === 'stretch' &&
-        totalProgress >= getGoalTarget(currentGoal)) {
+    if (
+      nextGoal &&
+      currentGoal.tier === 'clear' &&
+      nextGoal.tier === 'stretch' &&
+      totalProgress >= getGoalTarget(currentGoal)
+    ) {
       return VICTORY_COLOR;
     }
 
@@ -422,9 +470,9 @@ const HabitsScreen = () => {
   // Recalculate progress for all habits
   useEffect(() => {
     // This effect ensures progress is properly calculated from completions
-    const updatedHabits = habits.map(habit => ({
+    const updatedHabits = habits.map((habit) => ({
       ...habit,
-      progress: calculateHabitProgress(habit)
+      progress: calculateHabitProgress(habit),
     }));
 
     setHabits(updatedHabits);
@@ -435,9 +483,12 @@ const HabitsScreen = () => {
     setHabits((prev) =>
       prev.map((h) =>
         h.id === habitId
-          ? { ...h, goals: h.goals.map((goal) => (goal.id === updatedGoal.id ? updatedGoal : goal)) }
-          : h
-      )
+          ? {
+              ...h,
+              goals: h.goals.map((goal) => (goal.id === updatedGoal.id ? updatedGoal : goal)),
+            }
+          : h,
+      ),
     );
   };
 
@@ -453,23 +504,25 @@ const HabitsScreen = () => {
           const newCompletion: Completion = {
             id: Math.random(), // Generate a unique ID in a real app
             timestamp: now,
-            completed_units: amount
+            completed_units: amount,
           };
 
           // Add the new completion to the array
-          const updatedCompletions = h.completions ? [...h.completions, newCompletion] : [newCompletion];
+          const updatedCompletions = h.completions
+            ? [...h.completions, newCompletion]
+            : [newCompletion];
 
           // Calculate new total progress from all completions
           const newProgress = updatedCompletions.reduce(
             (sum, completion) => sum + completion.completed_units,
-            0
+            0,
           );
 
           // Get current goal info
           const { currentGoal, nextGoal } = getGoalTier({
             ...h,
             progress: newProgress,
-            completions: updatedCompletions
+            completions: updatedCompletions,
           });
 
           // Check if we should show achievement alert
@@ -477,32 +530,40 @@ const HabitsScreen = () => {
             const currentTarget = getGoalTarget(currentGoal);
 
             // If just achieved the low goal
-            if (h.progress < currentTarget && newProgress >= currentTarget && currentGoal.tier === 'low') {
+            if (
+              h.progress < currentTarget &&
+              newProgress >= currentTarget &&
+              currentGoal.tier === 'low'
+            ) {
               Alert.alert(
-                "Goal Achieved!",
-                `You've reached your Low Goal for ${h.name}! Keep going for the Clear Goal.`
+                'Goal Achieved!',
+                `You've reached your Low Goal for ${h.name}! Keep going for the Clear Goal.`,
               );
             }
 
             // If just achieved the clear goal
-            if (nextGoal &&
-                currentGoal.tier === 'clear' &&
-                h.progress < getGoalTarget(currentGoal) &&
-                newProgress >= getGoalTarget(currentGoal)) {
+            if (
+              nextGoal &&
+              currentGoal.tier === 'clear' &&
+              h.progress < getGoalTarget(currentGoal) &&
+              newProgress >= getGoalTarget(currentGoal)
+            ) {
               Alert.alert(
-                "Clear Goal Achieved!",
-                `Congratulations! You've reached your Clear Goal for ${h.name}! Now aim for the Stretch Goal!`
+                'Clear Goal Achieved!',
+                `Congratulations! You've reached your Clear Goal for ${h.name}! Now aim for the Stretch Goal!`,
               );
             }
 
             // If just achieved the stretch goal
-            if (nextGoal &&
-                currentGoal.tier === 'stretch' &&
-                h.progress < getGoalTarget(currentGoal) &&
-                newProgress >= getGoalTarget(currentGoal)) {
+            if (
+              nextGoal &&
+              currentGoal.tier === 'stretch' &&
+              h.progress < getGoalTarget(currentGoal) &&
+              newProgress >= getGoalTarget(currentGoal)
+            ) {
               Alert.alert(
-                "Stretch Goal Achieved!",
-                `Amazing! You've reached your Stretch Goal for ${h.name}!`
+                'Stretch Goal Achieved!',
+                `Amazing! You've reached your Stretch Goal for ${h.name}!`,
               );
             }
           }
@@ -512,19 +573,17 @@ const HabitsScreen = () => {
             streak: newStreak,
             last_completion_date: now,
             progress: newProgress,
-            completions: updatedCompletions
+            completions: updatedCompletions,
           };
         }
         return h;
-      })
+      }),
     );
   };
 
   // Update habit details
   const handleUpdateHabit = (updatedHabit: Habit) => {
-    setHabits((prev) =>
-      prev.map((h) => (h.id === updatedHabit.id ? updatedHabit : h))
-    );
+    setHabits((prev) => prev.map((h) => (h.id === updatedHabit.id ? updatedHabit : h)));
   };
 
   // Delete a habit
@@ -547,10 +606,10 @@ const HabitsScreen = () => {
   const generateStatsForHabit = (habit: Habit): HabitStatsData => {
     // For demonstration purposes - in a real app, calculate based on habit.completions
     return {
-      dates: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+      dates: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
       values: [1, 2, 3, 2, 4, 1, 0],
       completionsByDay: [1, 1, 1, 1, 1, 0, 0],
-      dayLabels: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+      dayLabels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
       longestStreak: habit.streak || 5,
       totalCompletions: habit.completions?.length || 12,
       completionRate: 0.75,
@@ -559,14 +618,14 @@ const HabitsScreen = () => {
 
   // Handle backfilling missed days
   const handleBackfillMissedDays = (habitId: number, days: Date[]) => {
-    setHabits(prev =>
-      prev.map(habit => {
+    setHabits((prev) =>
+      prev.map((habit) => {
         if (habit.id === habitId) {
           // Create completion entries for each missed day
-          const newCompletions = days.map(day => ({
+          const newCompletions = days.map((day) => ({
             id: Math.random(), // Generate a unique ID in a real app
             timestamp: day,
-            completed_units: 1 // Default to 1 unit per missed day
+            completed_units: 1, // Default to 1 unit per missed day
           }));
 
           const updatedCompletions = habit.completions
@@ -576,7 +635,7 @@ const HabitsScreen = () => {
           // Recalculate total progress
           const newProgress = updatedCompletions.reduce(
             (sum, completion) => sum + completion.completed_units,
-            0
+            0,
           );
 
           return {
@@ -584,18 +643,18 @@ const HabitsScreen = () => {
             streak: habit.streak + days.length,
             last_completion_date: new Date(),
             completions: updatedCompletions,
-            progress: newProgress
+            progress: newProgress,
           };
         }
         return habit;
-      })
+      }),
     );
   };
 
   // Reset habit to a new start date
   const handleSetNewStartDate = (habitId: number, newDate: Date) => {
-    setHabits(prev =>
-      prev.map(habit => {
+    setHabits((prev) =>
+      prev.map((habit) => {
         if (habit.id === habitId) {
           return {
             ...habit,
@@ -603,11 +662,11 @@ const HabitsScreen = () => {
             streak: 0,
             last_completion_date: undefined,
             completions: [], // Reset completions
-            progress: 0
+            progress: 0,
           };
         }
         return habit;
-      })
+      }),
     );
   };
 
@@ -619,43 +678,43 @@ const HabitsScreen = () => {
       id: index + 1,
       streak: 0,
       progress: 0,
-      revealed: habit.stage === "Beige", // Only reveal Beige stage habits initially
+      revealed: habit.stage === 'Beige', // Only reveal Beige stage habits initially
       completions: [], // Initialize empty completions array
       goals: [
         {
           id: index * 3 + 1,
           title: `Low goal for ${habit.name}`,
-          tier: "low" as "low",
+          tier: 'low' as 'low',
           target: 1,
-          target_unit: "units",
+          target_unit: 'units',
           frequency: 1,
-          frequency_unit: "per_day",
+          frequency_unit: 'per_day',
           is_additive: true,
-          progress: 0
+          progress: 0,
         },
         {
           id: index * 3 + 2,
           title: `Clear goal for ${habit.name}`,
-          tier: "clear" as "clear",
+          tier: 'clear' as 'clear',
           target: 2,
-          target_unit: "units",
+          target_unit: 'units',
           frequency: 1,
-          frequency_unit: "per_day",
+          frequency_unit: 'per_day',
           is_additive: true,
-          progress: 0
+          progress: 0,
         },
         {
           id: index * 3 + 3,
           title: `Stretch goal for ${habit.name}`,
-          tier: "stretch" as "stretch",
+          tier: 'stretch' as 'stretch',
           target: 3,
-          target_unit: "units",
+          target_unit: 'units',
           frequency: 1,
-          frequency_unit: "per_day",
+          frequency_unit: 'per_day',
           is_additive: true,
-          progress: 0
-        }
-      ]
+          progress: 0,
+        },
+      ],
     }));
 
     setHabits(fullHabits);
@@ -684,7 +743,7 @@ const HabitsScreen = () => {
   return (
     <View style={styles.container}>
       <FlatList
-        data={habits.filter(h => h.revealed)} // Only show revealed habits
+        data={habits.filter((h) => h.revealed)} // Only show revealed habits
         keyExtractor={(item) => (item.id ? item.id.toString() : Math.random().toString())}
         renderItem={renderHabitTile}
         numColumns={2}
@@ -695,9 +754,7 @@ const HabitsScreen = () => {
         style={styles.energyScaffoldingButton}
         onPress={() => setOnboardingVisible(true)}
       >
-        <Text style={styles.energyScaffoldingButtonText}>
-          Perform Energy Scaffolding
-        </Text>
+        <Text style={styles.energyScaffoldingButtonText}>Perform Energy Scaffolding</Text>
       </TouchableOpacity>
 
       {/* Modals */}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,24 @@
+import js from '@eslint/js';
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "@eslint/js": "^9.32.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^9.32.0"
+  },
+  "name": "adepthood",
+  "private": true,
+  "version": "0.1.0"
+}


### PR DESCRIPTION
## Summary
- format remaining HabitsScreen portion with Prettier settings
- add minimal ESLint flat config and TypeScript dependencies

## Testing
- `npx prettier package.json eslint.config.mjs app/features/Habits/HabitsScreen.tsx --check --no-config --single-quote --trailing-comma all --semi --arrow-parens always --bracket-spacing --print-width 100`
- `npx eslint app/features/Habits/HabitsScreen.tsx` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a69a4b62c483229c99dba16f5ef31e