### PR TITLE
chore: add sqlmodel and pydantic to backend requirements

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -7,3 +7,5 @@ pre-commit
 pytest
 pytest-cov
 ruff
+pydantic
+sqlmodel

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ fastapi
 uvicorn
 pydantic
 sqlalchemy
+sqlmodel
 asyncpg
 pytest
 pytest-asyncio


### PR DESCRIPTION
## Summary
- declare sqlmodel runtime dependency
- track pydantic and sqlmodel in dev requirements

## Testing
- `./.venv/bin/python3 -m pre_commit run --files backend/requirements.txt backend/requirements-dev.txt` *(fails: KeyboardInterrupt in pip-audit)*
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6b66cfbcc8322b0bd9304d7378f74