### PR TITLE
ci: point frontend workflow to app directory

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -3,12 +3,12 @@ name: Frontend CI
 on:
   push:
     paths:
-      - "frontend/**"
+      - "app/**"
       - ".github/workflows/frontend-ci.yml"
       - ".pre-commit-config.yaml"
   pull_request:
     paths:
-      - "frontend/**"
+      - "app/**"
       - ".github/workflows/frontend-ci.yml"
       - ".pre-commit-config.yaml"
 
@@ -22,26 +22,26 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: "frontend/.nvmrc"
+          node-version-file: "app/.nvmrc"
           cache: "npm"
-          cache-dependency-path: "frontend/package-lock.json"
+          cache-dependency-path: "app/package.json"
 
       - name: Install dependencies
-        working-directory: frontend
+        working-directory: app
         run: npm ci || npm install
 
       - name: Lint
-        working-directory: frontend
+        working-directory: app
         run: npx eslint . --max-warnings=0
 
       - name: Type-check
-        working-directory: frontend
+        working-directory: app
         run: npx tsc -p tsconfig.json --noEmit
 
       - name: Format check
-        working-directory: frontend
+        working-directory: app
         run: npx prettier -c .
 
       - name: Tests
-        working-directory: frontend
+        working-directory: app
         run: npx jest --passWithNoTests


### PR DESCRIPTION
## Summary
- fix frontend workflow paths to use the `app` directory and existing `.nvmrc`

## Testing
- `pre-commit run --files .github/workflows/frontend-ci.yml` *(fails: npm registry 403 for commitlint)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b6e922608322b02a5041ac8eb738