### PR TITLE
chore: ensure pre-commit installs in setup

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -11,6 +11,10 @@ pip install --upgrade pip
 pip install -r backend/requirements.txt
 pip install -r backend/requirements-dev.txt
 
+echo "⬇️ Installing pre-commit..."
+# Some environments may skip dev dependencies; ensure pre-commit is present.
+pip install pre-commit
+
 echo "📦 Installing Node dependencies..."
 if [ -d app ]; then
   if [ -f app/package-lock.json ]; then


### PR DESCRIPTION
## Summary
- ensure dev-setup installs pre-commit so hooks run even if dev dependencies are skipped

## Testing
- `pre-commit run --files dev-setup.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6be01e55c8322bdb60dae258b0023