### PR TITLE
Add pydantic mypy extra to dev requirements

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -7,5 +7,5 @@ pre-commit
 pytest
 pytest-cov
 ruff
-pydantic
+pydantic[mypy]
 sqlmodel


### PR DESCRIPTION
## Summary
- ensure `pydantic.mypy` plugin is available by adding `pydantic[mypy]` to backend dev requirements

## Testing
- `pytest`
- `pre-commit run --files backend/requirements-dev.txt` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6c554894483229efb28733bc5ebeb