### PR TITLE
fix: correct STAGE_COLORS import path

### DIFF
--- a/app/features/Habits/components/GoalModal.tsx
+++ b/app/features/Habits/components/GoalModal.tsx
@@ -15,7 +15,6 @@ import styles from '../Habits.styles';
 import type { Goal, GoalModalProps, EditableGoalProps, Habit } from '../Habits.types';
 import {
   calculateProgressIncrements,
-  STAGE_COLORS,
   TARGET_UNITS,
   FREQUENCY_UNITS,
   DAYS_OF_WEEK,
@@ -23,6 +22,7 @@ import {
   getGoalTarget,
   getTierColor,
 } from '../HabitsScreen';
+import { STAGE_COLORS } from '../../../constants/stageColors';
 
 // Constant for golden glow color to match with HabitTile
 const GOLDEN_GLOW_COLOR = 'rgba(255, 215, 0, 0.6)';


### PR DESCRIPTION
## Summary
- import STAGE_COLORS from constants rather than HabitsScreen in GoalModal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 52 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a81042d9f88322bc584cbe788a46e9