### PR TITLE
fix: import stage colors from constants

### DIFF
--- a/app/features/Habits/components/HabitSettingsModal.tsx
+++ b/app/features/Habits/components/HabitSettingsModal.tsx
@@ -14,7 +14,8 @@ import DateTimePicker, { type DateTimePickerEvent } from '@react-native-communit
 import EmojiSelector from 'react-native-emoji-selector';
 
 import type { Habit, HabitSettingsModalProps } from '../Habits.types';
-import { calculateNetEnergy, STAGE_COLORS, DAYS_OF_WEEK } from '../HabitsScreen';
+import { calculateNetEnergy, DAYS_OF_WEEK } from '../HabitsScreen';
+import { STAGE_COLORS } from '../../../constants/stageColors';
 
 import styles from '../Habits.styles';
 


### PR DESCRIPTION
## Summary
- import STAGE_COLORS from constants in HabitSettingsModal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 53 problems (52 errors, 1 warning))*

------
https://chatgpt.com/codex/tasks/task_e_68a8121857fc8322a97cb8a760fb3369