### PR TITLE
fix: correct STAGE_COLORS import in MissedDaysModal

### DIFF
--- a/app/features/Habits/components/MissedDaysModal.tsx
+++ b/app/features/Habits/components/MissedDaysModal.tsx
@@ -3,10 +3,9 @@ import { Modal, Text, TouchableOpacity, View } from 'react-native';
 import { Calendar } from 'react-native-calendars';
 import type { DateData } from 'react-native-calendars';
 
-import { STAGE_COLORS } from '../HabitsScreen';
-import type { MissedDaysModalProps } from '../Habits.types';
-
+import { STAGE_COLORS } from '../../../constants/stageColors';
 import styles from '../Habits.styles';
+import type { MissedDaysModalProps } from '../Habits.types';
 
 export const MissedDaysModal = ({
   visible,


### PR DESCRIPTION
## Summary
- fix STAGE_COLORS import to use constants file

## Testing
- `npx eslint features/Habits/components/MissedDaysModal.tsx`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8122fe49c83229f5bbea93aacde27