### PR TITLE
fix: correct STAGE_COLORS import in HabitSettingsModal

### DIFF
--- a/app/features/Habits/components/HabitSettingsModal.tsx
+++ b/app/features/Habits/components/HabitSettingsModal.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -10,13 +11,12 @@ import {
   ScrollView,
   Switch,
 } from 'react-native';
-import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import EmojiSelector from 'react-native-emoji-selector';
 
-import type { Habit, HabitSettingsModalProps } from '../Habits.types';
-import { calculateNetEnergy, STAGE_COLORS, DAYS_OF_WEEK } from '../HabitsScreen';
-
+import { STAGE_COLORS } from '../../../constants/stageColors';
 import styles from '../Habits.styles';
+import type { Habit, HabitSettingsModalProps } from '../Habits.types';
+import { calculateNetEnergy, DAYS_OF_WEEK } from '../HabitsScreen';
 
 export const HabitSettingsModal = ({
   visible,


### PR DESCRIPTION
## Summary
- fix STAGE_COLORS import path in HabitSettingsModal
- remove unused import and reorder imports for linting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: import/order violations across app)*
- `npx eslint features/Habits/components/HabitSettingsModal.tsx`
- `npx tsc --noEmit` *(fails: 33 errors in 8 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a81249ca7483229c02ff1d9224bedf