### PR TITLE
fix: import STAGE_COLORS from constants

### DIFF
--- a/app/features/Habits/components/MissedDaysModal.tsx
+++ b/app/features/Habits/components/MissedDaysModal.tsx
@@ -3,7 +3,7 @@ import { Modal, Text, TouchableOpacity, View } from 'react-native';
 import { Calendar } from 'react-native-calendars';
 import type { DateData } from 'react-native-calendars';
 
-import { STAGE_COLORS } from '../HabitsScreen';
+import { STAGE_COLORS } from '../../../constants/stageColors';
 import type { MissedDaysModalProps } from '../Habits.types';
 
 import styles from '../Habits.styles';


### PR DESCRIPTION
### Summary
- fix STAGE_COLORS import path in MissedDaysModal to reference shared constants file

### Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors in existing files)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: multiple type errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68a8127e2c9c8322863e69a7eb6aa2b8