### PR TITLE
fix StatsModal STAGE_COLORS import

### DIFF
--- a/app/features/Habits/components/StatsModal.tsx
+++ b/app/features/Habits/components/StatsModal.tsx
@@ -3,9 +3,9 @@ import { View, Text, Dimensions, TouchableOpacity, Modal, ScrollView } from 'rea
 import { Calendar, type MarkingProps } from 'react-native-calendars';
 import { LineChart, BarChart } from 'react-native-chart-kit';
 
+import { STAGE_COLORS } from '../../../constants/stageColors';
 import styles from '../Habits.styles';
 import type { StatsModalProps } from '../Habits.types';
-import { STAGE_COLORS } from '../HabitsScreen';
 
 export const StatsModal = ({ visible, habit, stats, onClose }: StatsModalProps) => {
   const [selectedTab, setSelectedTab] = useState('calendar');


### PR DESCRIPTION
## Summary
- fix StatsModal STAGE_COLORS import to reference shared stageColors constant

## Testing
- `npx eslint features/Habits/components/StatsModal.tsx`
- `npx tsc -p tsconfig.json --noEmit` *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a812cbcfb883228ffab138913e6458