### PR TITLE
fix: correct stage color import

### DIFF
--- a/app/features/Habits/components/ReorderHabitsModal.tsx
+++ b/app/features/Habits/components/ReorderHabitsModal.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import { View, Text, TouchableOpacity, Modal, Platform } from 'react-native';
 import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import React, { useEffect, useState } from 'react';
+import { Modal, Platform, Text, TouchableOpacity, View } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 
-import type { Habit, ReorderHabitsModalProps } from '../Habits.types';
-import { STAGE_ORDER, STAGE_COLORS } from '../HabitsScreen';
+import { STAGE_COLORS } from '../../../constants/stageColors';
 import styles from '../Habits.styles';
+import type { Habit, ReorderHabitsModalProps } from '../Habits.types';
+import { STAGE_ORDER } from '../HabitsScreen';
 
 export const ReorderHabitsModal = ({
   visible,


### PR DESCRIPTION
## Summary
- import STAGE_COLORS from constants instead of HabitsScreen

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint features/Habits/components/ReorderHabitsModal.tsx --format json --max-warnings=0`
- `npx tsc -p app/tsconfig.json --noEmit` (fails: Module './HabitsScreen' has no exported member 'STAGE_COLORS', and other existing type errors)


------
https://chatgpt.com/codex/tasks/task_e_68a812a67c008322af6eb55227d6515a