### PR TITLE
fix: remove unused screen width constant

### DIFF
--- a/app/features/Habits/Habits.styles.ts
+++ b/app/features/Habits/Habits.styles.ts
@@ -89,7 +89,7 @@ const BORDER_RADIUS = {
 };
 
 // Device dimensions (for responsive layouts)
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
 //------------------
 // Styles (modernized mystical minimalist style)


### PR DESCRIPTION
## Summary
- remove unused `SCREEN_WIDTH` from Habits styles to satisfy ESLint

## Testing
- `pre-commit run --files app/features/Habits/Habits.styles.ts` *(fails: TypeScript errors in other files)*
- `cd app && npx eslint features/Habits/Habits.styles.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8b53ea1c4832298ae19ff39fdb6c7