### PR TITLE
fix eslint issues in GoalModal

### DIFF
--- a/app/features/Habits/components/GoalModal.tsx
+++ b/app/features/Habits/components/GoalModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -11,6 +11,7 @@ import {
   Alert,
 } from 'react-native';
 
+import { STAGE_COLORS } from '../../../constants/stageColors';
 import styles from '../Habits.styles';
 import type { Goal, GoalModalProps, EditableGoalProps, Habit } from '../Habits.types';
 import {
@@ -22,7 +23,6 @@ import {
   getGoalTarget,
   getTierColor,
 } from '../HabitsScreen';
-import { STAGE_COLORS } from '../../../constants/stageColors';
 
 // Constant for golden glow color to match with HabitTile
 const GOLDEN_GLOW_COLOR = 'rgba(255, 215, 0, 0.6)';


### PR DESCRIPTION
## Summary
- fix GoalModal import order and remove unused `useRef`

## Testing
- `pre-commit run --files app/features/Habits/components/GoalModal.tsx` *(fails: multiple eslint and typecheck errors in unrelated files)*
- `cd app && npx eslint features/Habits/components/GoalModal.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a8b5ac22dc8322886a1097b78f319e