### PR TITLE
fix: ensure date string key for marked dates

### DIFF
--- a/app/features/Habits/components/MissedDaysModal.tsx
+++ b/app/features/Habits/components/MissedDaysModal.tsx
@@ -4,9 +4,8 @@ import { Calendar } from 'react-native-calendars';
 import type { DateData } from 'react-native-calendars';
 
 import { STAGE_COLORS } from '../../../constants/stageColors';
-import type { MissedDaysModalProps } from '../Habits.types';
-
 import styles from '../Habits.styles';
+import type { MissedDaysModalProps } from '../Habits.types';
 
 export const MissedDaysModal = ({
   visible,
@@ -40,6 +39,8 @@ export const MissedDaysModal = ({
     }
   };
 
+  const selectedDateString = selectedDate.toISOString().split('T')[0]!;
+
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
       <View style={styles.modalOverlay}>
@@ -56,7 +57,7 @@ export const MissedDaysModal = ({
             <Calendar
               onDayPress={handleDateSelect}
               markedDates={{
-                [selectedDate.toISOString().split('T')[0]]: {
+                [selectedDateString]: {
                   selected: true,
                   selectedColor: STAGE_COLORS[habit.stage],
                 },


### PR DESCRIPTION
## Summary
- fix `MissedDaysModal` calendar marking with explicit date string key

## Testing
- `npx tsc`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8bef03a4c8322b5c4cb360afeea33