### PR TITLE
refactor: derive habit progress from completions

### DIFF
--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+module.exports = {
+  presets: ['babel-preset-expo'],
+};

--- a/app/eslint.config.cjs
+++ b/app/eslint.config.cjs
@@ -11,7 +11,17 @@ const path = require('node:path');
 
 module.exports = tseslint.config(
   // Ignore build artifacts
-  { ignores: ['node_modules/', 'dist/', 'build/', 'coverage/', 'android/', 'ios/'] },
+  {
+    ignores: [
+      'node_modules/',
+      'dist/',
+      'build/',
+      'coverage/',
+      'android/',
+      'ios/',
+      'babel.config.js',
+    ],
+  },
 
   {
     files: ['**/*.{ts,tsx,js,jsx}'],

--- a/app/features/Habits/HabitDefaults.tsx
+++ b/app/features/Habits/HabitDefaults.tsx
@@ -10,7 +10,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 7,
     energy_return: 9,
     start_date: new Date(2025, 3, 1),
-    progress: 0,
     goals: [
       {
         id: 1,
@@ -53,7 +52,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 6,
     energy_return: 8,
     start_date: new Date(2025, 3, 5),
-    progress: 0,
     goals: [
       {
         id: 4,
@@ -96,7 +94,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 4,
     energy_return: 5,
     start_date: new Date(2025, 3, 10),
-    progress: 0,
     goals: [
       {
         id: 7,
@@ -139,7 +136,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 5,
     energy_return: 8,
     start_date: new Date(2025, 2, 25),
-    progress: 0,
     goals: [
       {
         id: 10,
@@ -182,7 +178,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 8,
     energy_return: 9,
     start_date: new Date(2025, 3, 15),
-    progress: 0,
     goals: [
       {
         id: 13,
@@ -225,7 +220,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 7,
     energy_return: 8,
     start_date: new Date(2025, 2, 20),
-    progress: 0,
     goals: [
       {
         id: 16,
@@ -268,7 +262,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 3,
     energy_return: 6,
     start_date: new Date(2025, 3, 8),
-    progress: 0,
     goals: [
       {
         id: 19,
@@ -311,7 +304,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 5,
     energy_return: 7,
     start_date: new Date(2025, 2, 28),
-    progress: 0,
     goals: [
       {
         id: 22,
@@ -354,7 +346,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 4,
     energy_return: 7,
     start_date: new Date(2025, 2, 15),
-    progress: 0,
     goals: [
       {
         id: 25,
@@ -397,7 +388,6 @@ export const HABIT_DEFAULTS: Habit[] = [
     energy_cost: 5,
     energy_return: 8,
     start_date: new Date(2025, 2, 5),
-    progress: 0,
     goals: [
       {
         id: 28,

--- a/app/features/Habits/Habits.types.ts
+++ b/app/features/Habits/Habits.types.ts
@@ -11,7 +11,15 @@ export interface Habit {
   streak: number;
   energy_cost: number;
   energy_return: number;
-  progress: number;
+  /**
+   * Total progress toward the habit goals.
+   *
+   * This value is derived from the sum of all completion units
+   * recorded in the `completions` array and should not be set
+   * directly. It is kept optional to encourage calculating the
+   * current progress programmatically via `calculateHabitProgress`.
+   */
+  progress?: number;
   start_date: Date;
   goals: Goal[];
   completions?: Completion[];

--- a/app/features/Habits/__tests__/HabitsScreen.test.ts
+++ b/app/features/Habits/__tests__/HabitsScreen.test.ts
@@ -1,0 +1,176 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { STAGE_COLORS } from '../../../constants/stageColors';
+import type { Habit, Goal } from '../Habits.types';
+import {
+  calculateHabitProgress,
+  calculateProgressPercentage,
+  getGoalTier,
+  getProgressBarColor,
+  VICTORY_COLOR,
+} from '../HabitUtils';
+
+describe('habit progress utilities', () => {
+  const additiveGoals: Goal[] = [
+    {
+      id: 1,
+      tier: 'low',
+      title: 'low',
+      target: 1,
+      target_unit: 'units',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+    {
+      id: 2,
+      tier: 'clear',
+      title: 'clear',
+      target: 2,
+      target_unit: 'units',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+    {
+      id: 3,
+      tier: 'stretch',
+      title: 'stretch',
+      target: 3,
+      target_unit: 'units',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+  ];
+
+  const subtractiveGoals: Goal[] = [
+    {
+      id: 4,
+      tier: 'low',
+      title: 'low',
+      target: 300,
+      target_unit: 'mg',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    },
+    {
+      id: 5,
+      tier: 'clear',
+      title: 'clear',
+      target: 200,
+      target_unit: 'mg',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    },
+    {
+      id: 6,
+      tier: 'stretch',
+      title: 'stretch',
+      target: 0,
+      target_unit: 'mg',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    },
+  ];
+
+  it('sums completion units for habit progress', () => {
+    const habit: Habit = {
+      id: 1,
+      stage: 'Beige',
+      name: 'Test',
+      icon: '🔥',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: additiveGoals,
+      completions: [
+        { id: 1, timestamp: new Date(), completed_units: 1 },
+        { id: 2, timestamp: new Date(), completed_units: 2.5 },
+      ],
+    };
+
+    expect(calculateHabitProgress(habit)).toBeCloseTo(3.5);
+  });
+
+  it('offsets progress percentage after clear goal for additive habits', () => {
+    const habit: Habit = {
+      id: 2,
+      stage: 'Beige',
+      name: 'Additive',
+      icon: '🔥',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: additiveGoals,
+      completions: [{ id: 1, timestamp: new Date(), completed_units: 2 }],
+    };
+
+    const { currentGoal, nextGoal } = getGoalTier(habit);
+    const percentage = calculateProgressPercentage(habit, currentGoal, nextGoal);
+    expect(percentage).toBeCloseTo(33);
+  });
+
+  it('calculates progress percentage for subtractive habits', () => {
+    const habit: Habit = {
+      id: 3,
+      stage: 'Blue',
+      name: 'Subtractive',
+      icon: '❄️',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: subtractiveGoals,
+      completions: [{ id: 1, timestamp: new Date(), completed_units: 150 }],
+    };
+
+    const { currentGoal, nextGoal } = getGoalTier(habit);
+    const percentage = calculateProgressPercentage(habit, currentGoal, nextGoal);
+    expect(percentage).toBeCloseTo(50);
+  });
+
+  it('uses victory color until stretch goal is broken for subtractive habits', () => {
+    const baseHabit: Habit = {
+      id: 4,
+      stage: 'Blue',
+      name: 'Subtractive',
+      icon: '❄️',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: subtractiveGoals,
+      completions: [],
+    };
+
+    const goodTier = getGoalTier(baseHabit);
+    expect(
+      getProgressBarColor(
+        baseHabit,
+        goodTier.currentGoal,
+        goodTier.nextGoal,
+        goodTier.completedAllGoals,
+      ),
+    ).toBe(VICTORY_COLOR);
+
+    const brokenHabit = {
+      ...baseHabit,
+      completions: [{ id: 1, timestamp: new Date(), completed_units: 1 }],
+    };
+    const brokenTier = getGoalTier(brokenHabit);
+    expect(
+      getProgressBarColor(
+        brokenHabit,
+        brokenTier.currentGoal,
+        brokenTier.nextGoal,
+        brokenTier.completedAllGoals,
+      ),
+    ).toBe(STAGE_COLORS[brokenHabit.stage]);
+  });
+});

--- a/app/features/Habits/components/GoalModal.tsx
+++ b/app/features/Habits/components/GoalModal.tsx
@@ -14,15 +14,13 @@ import {
 import { STAGE_COLORS } from '../../../constants/stageColors';
 import styles from '../Habits.styles';
 import type { Goal, GoalModalProps, EditableGoalProps, Habit } from '../Habits.types';
+import { TARGET_UNITS, FREQUENCY_UNITS, DAYS_OF_WEEK } from '../HabitsScreen';
 import {
   calculateProgressIncrements,
-  TARGET_UNITS,
-  FREQUENCY_UNITS,
-  DAYS_OF_WEEK,
   calculateHabitProgress,
   getGoalTarget,
   getTierColor,
-} from '../HabitsScreen';
+} from '../HabitUtils';
 
 // Constant for golden glow color to match with HabitTile
 const GOLDEN_GLOW_COLOR = 'rgba(255, 215, 0, 0.6)';
@@ -34,7 +32,7 @@ const GOLDEN_GLOW_COLOR = 'rgba(255, 215, 0, 0.6)';
  * @returns Progress percentage (0-100)
  */
 const calculateGoalProgress = (goal: Goal, habit: Habit): number => {
-  const totalProgress = habit.progress || calculateHabitProgress(habit);
+  const totalProgress = calculateHabitProgress(habit);
   const targetValue = getGoalTarget(goal);
 
   if (goal.is_additive) {
@@ -52,7 +50,7 @@ const calculateGoalProgress = (goal: Goal, habit: Habit): number => {
  * @returns True if goal is achieved
  */
 const isGoalAchieved = (goal: Goal, habit: Habit): boolean => {
-  const totalProgress = habit.progress || calculateHabitProgress(habit);
+  const totalProgress = calculateHabitProgress(habit);
   const targetValue = getGoalTarget(goal);
 
   if (goal.is_additive) {
@@ -320,7 +318,7 @@ const EditableGoal = ({
 
         {/* Progress text showing progress vs target */}
         <Text style={styles.goalProgressText}>
-          {habit.progress || 0} / {goal.target} {goal.target_unit}
+          {calculateHabitProgress(habit)} / {goal.target} {goal.target_unit}
           {achieved && ' (Achieved!)'}
         </Text>
       </View>
@@ -394,7 +392,7 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
   };
 
   // Calculate total habit progress for display
-  const totalProgress = habit.progress || calculateHabitProgress(habit);
+  const totalProgress = calculateHabitProgress(habit);
 
   // Sort goals by tier for consistent display order
   const sortedGoals = [...habit.goals].sort((a, b) => {

--- a/app/features/Habits/components/ReorderHabitsModal.tsx
+++ b/app/features/Habits/components/ReorderHabitsModal.tsx
@@ -6,7 +6,7 @@ import DraggableFlatList from 'react-native-draggable-flatlist';
 import { STAGE_COLORS } from '../../../constants/stageColors';
 import styles from '../Habits.styles';
 import type { Habit, ReorderHabitsModalProps } from '../Habits.types';
-import { STAGE_ORDER } from '../HabitsScreen';
+import { STAGE_ORDER } from '../HabitUtils';
 
 export const ReorderHabitsModal = ({
   visible,


### PR DESCRIPTION
## Summary
- compute habit progress from completion history
- clarify progress bar behavior for additive vs subtractive goals
- cover habit progress utilities with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d0aff43483229af3b8239fb7e584