### PR TITLE
fix: initialize safe-area context and Reanimated

### DIFF
--- a/app/@types/react-test-renderer.d.ts
+++ b/app/@types/react-test-renderer.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-test-renderer';

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,16 +1,19 @@
 // app/App.tsx
 
 import React from 'react';
-import { SafeAreaView, StatusBar, StyleSheet } from 'react-native';
+import { StatusBar, StyleSheet } from 'react-native';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 import HabitsScreen from './features/Habits/HabitsScreen';
 
 export default function App(): React.JSX.Element {
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <StatusBar barStyle="dark-content" />
-      <HabitsScreen />
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.safeArea}>
+        <StatusBar barStyle="dark-content" />
+        <HabitsScreen />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 }
 

--- a/app/Sources/design/DesignSystem.ts
+++ b/app/Sources/design/DesignSystem.ts
@@ -1,0 +1,39 @@
+export const breakpoints = { xs: 0, sm: 360, md: 600, lg: 900, xl: 1200 } as const;
+
+const BASE_SPACING = 8;
+export const spacing = (n: number, scale = 1): number => n * BASE_SPACING * scale;
+
+export const radius = {
+  sm: 4,
+  md: 8,
+  lg: 16,
+} as const;
+
+export const elevation = {
+  sm: 1,
+  md: 3,
+  lg: 6,
+} as const;
+
+export const border = {
+  width: 1,
+  color: '#ddd',
+} as const;
+
+export const typography = (width: number) => {
+  const base =
+    width < breakpoints.sm
+      ? 14
+      : width < breakpoints.md
+        ? 16
+        : width < breakpoints.lg
+          ? 18
+          : width < breakpoints.xl
+            ? 20
+            : 22;
+  return {
+    title: base * 1.4,
+    body: base,
+    caption: base * 0.8,
+  } as const;
+};

--- a/app/Sources/design/useResponsive.ts
+++ b/app/Sources/design/useResponsive.ts
@@ -1,0 +1,33 @@
+import { useWindowDimensions } from 'react-native';
+
+import { breakpoints, spacing } from './DesignSystem';
+
+export const useResponsive = () => {
+  const { width, height } = useWindowDimensions();
+  const isXS = width < breakpoints.sm;
+  const isSM = width >= breakpoints.sm && width < breakpoints.md;
+  const isMD = width >= breakpoints.md && width < breakpoints.lg;
+  const isLG = width >= breakpoints.lg && width < breakpoints.xl;
+  const isXL = width >= breakpoints.xl;
+
+  const baseScale = isXS ? 0.85 : isSM ? 0.9 : isMD ? 1 : isLG ? 1.1 : 1.2;
+  const heightScale = height < 700 ? 0.85 : 1;
+  const scale = baseScale * heightScale;
+  const columns = width > height ? 2 : 1;
+  const gridGutter = spacing(2, scale);
+
+  return {
+    width,
+    height,
+    isXS,
+    isSM,
+    isMD,
+    isLG,
+    isXL,
+    columns,
+    gridGutter,
+    scale,
+  } as const;
+};
+
+export default useResponsive;

--- a/app/Sources/design/useResponsive.ts
+++ b/app/Sources/design/useResponsive.ts
@@ -14,7 +14,7 @@ export const useResponsive = () => {
   const heightScale = height < 700 ? 0.85 : 1;
   const scale = baseScale * heightScale;
   const columns = width > height ? 2 : 1;
-  const gridGutter = spacing(2, scale);
+  const gridGutter = spacing(1, scale);
 
   return {
     width,

--- a/app/__tests__/App.bootstrap.test.tsx
+++ b/app/__tests__/App.bootstrap.test.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable import/order, @typescript-eslint/no-explicit-any */
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it, jest } from '@jest/globals';
+import React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import renderer from 'react-test-renderer';
+
+import App from '../App';
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: (jest.fn() as any).mockResolvedValue({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn() as any,
+  getExpoPushTokenAsync: (jest.fn() as any).mockResolvedValue({ data: 'token' }),
+  scheduleNotificationAsync: jest.fn() as any,
+  cancelScheduledNotificationAsync: jest.fn() as any,
+}));
+
+jest.mock('../features/Habits/components/GoalModal', () => () => null);
+jest.mock('../features/Habits/components/HabitSettingsModal', () => () => null);
+jest.mock('../features/Habits/components/MissedDaysModal', () => () => null);
+jest.mock('../features/Habits/components/OnboardingModal', () => () => null);
+jest.mock('../features/Habits/components/ReorderHabitsModal', () => () => null);
+jest.mock('../features/Habits/components/StatsModal', () => () => null);
+
+describe('App bootstrap', () => {
+  it('includes SafeAreaProvider at the root', () => {
+    const tree = renderer.create(<App />).root;
+    expect(tree.findAllByType(SafeAreaProvider).length).toBeGreaterThan(0);
+  });
+
+  it('imports react-native-reanimated before app bootstrap', () => {
+    const indexPath = path.join(__dirname, '..', 'index.ts');
+    const content = fs.readFileSync(indexPath, 'utf8');
+    expect(content.trim().startsWith("import 'react-native-reanimated'")).toBe(true);
+  });
+});

--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
 module.exports = {
   presets: ['babel-preset-expo'],
+  plugins: ['react-native-reanimated/plugin'],
 };

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -148,9 +148,9 @@ export const HabitTile = ({
           transform: [{ scale: scaleAnim }],
           borderWidth: hasCompletedGoal ? 2 : 1,
           borderColor: stageColor,
-          margin: spacing(1, scale),
-          padding: spacing(3, scale),
-          minHeight: spacing(14, scale),
+          margin: spacing(0.5, scale),
+          padding: spacing(2, scale),
+          minHeight: spacing(8, scale),
         },
       ]}
     >

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -1,42 +1,23 @@
-import { MoreHorizontal, Edit, CheckCircle, BarChart } from 'lucide-react';
-import React, { useEffect, useRef, useState } from 'react';
-import { Animated, Platform, Text, TouchableOpacity, View } from 'react-native';
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
 
 import { STAGE_COLORS } from '../../constants/stageColors';
 import { spacing } from '../../Sources/design/DesignSystem';
 import useResponsive from '../../Sources/design/useResponsive';
 
-import styles from './Habits.styles';
-import type { Goal, HabitTileProps } from './Habits.types';
+import type { HabitTileProps } from './Habits.types';
 import {
   calculateProgressPercentage,
+  clampPercentage,
   getGoalTier,
+  getMarkerPositions,
   getProgressBarColor,
   getTierColor,
-  getMarkerPositions,
-  clampPercentage,
 } from './HabitUtils';
 
-// Constants
-const TOOLTIP_DISPLAY_TIME = 2000; // 2 seconds to display tooltip
-
-export const HabitTile = ({
-  habit,
-  onOpenGoals,
-  onLogUnit,
-  onOpenStats,
-  onLongPress,
-}: HabitTileProps) => {
+export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) => {
   const { scale } = useResponsive();
-  const backgroundColor = '#f8f8f8'; // Neutral background for all habits
   const stageColor = STAGE_COLORS[habit.stage];
-  const scaleAnim = useRef(new Animated.Value(1)).current;
-  const [showMarkerTooltip, setShowMarkerTooltip] = useState<Goal['tier'] | null>(null);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [goalAchievedMessage, setGoalAchievedMessage] = useState('');
-  const fadeAnim = useRef(new Animated.Value(0)).current;
-
-  const isMobile = Platform.OS === 'ios' || Platform.OS === 'android';
 
   const lowGoal = habit.goals.find((g) => g.tier === 'low');
   const clearGoal = habit.goals.find((g) => g.tier === 'clear');
@@ -47,402 +28,119 @@ export const HabitTile = ({
     calculateProgressPercentage(habit, currentGoal, nextGoal),
   );
   const progressBarColor = getProgressBarColor(habit);
-  const progressBarWidth = progressPercentage / 100;
   const hasCompletedGoal = completedAllGoals || progressPercentage >= 100;
+  const streakText =
+    `${habit.streak} days${hasCompletedGoal ? ' — Achieved Today!' : ''}`.toUpperCase();
 
-  // Show flash message when a clear goal is achieved
-  useEffect(() => {
-    if (goalAchievedMessage) {
-      Animated.sequence([
-        Animated.timing(fadeAnim, {
-          toValue: 1,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.delay(2000),
-        Animated.timing(fadeAnim, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-      ]).start(() => {
-        setGoalAchievedMessage('');
-      });
-    }
-  }, [goalAchievedMessage, fadeAnim]);
-
-  // Animation functions
-  const animateIn = () => {
-    Animated.spring(scaleAnim, {
-      toValue: 0.97,
-      friction: 5,
-      tension: 100,
-      useNativeDriver: true,
-    }).start();
-  };
-
-  const animateOut = () => {
-    Animated.spring(scaleAnim, {
-      toValue: 1,
-      friction: 5,
-      tension: 100,
-      useNativeDriver: true,
-    }).start();
-  };
-
-  // Handlers
-  const handlePressIn = () => {
-    if (!habit.revealed) return;
-    animateIn();
-  };
-
-  const handlePressOut = () => {
-    if (!habit.revealed) return;
-    animateOut();
-  };
-
-  const handlePress = () => {
-    if (!habit.revealed) return;
-    onOpenGoals();
-  };
+  const barHeight = Math.max(8, spacing(2, scale));
 
   const {
-    low: lowMarkerPosition,
-    clear: clearMarkerPosition,
-    stretch: stretchMarkerPosition,
+    low: lowMarker,
+    clear: clearMarker,
+    stretch: stretchMarker,
   } = getMarkerPositions(lowGoal, clearGoal, stretchGoal);
 
-  // Show action menu (for mobile)
-  const toggleMenu = () => {
-    setIsMenuOpen(!isMenuOpen);
-  };
-
-  // Show marker tooltip on hover/press
-  const showMarkerInfo = (tier: Goal['tier']) => {
-    setShowMarkerTooltip(tier);
-
-    // Auto-hide tooltip after a delay
-    setTimeout(() => {
-      setShowMarkerTooltip(null);
-    }, TOOLTIP_DISPLAY_TIME);
-  };
-
-  // Format the marker tooltip text
-  const getMarkerTooltipText = (tier: Goal['tier']) => {
-    const goal = tier === 'low' ? lowGoal : tier === 'clear' ? clearGoal : stretchGoal;
-
-    if (!goal) return '';
-
-    // Create descriptive tooltip
-    return `${tier.charAt(0).toUpperCase() + tier.slice(1)} Goal: ${goal.target} ${goal.target_unit} ${goal.frequency_unit}`;
-  };
-
   return (
-    <Animated.View
+    <TouchableOpacity
       testID="habit-tile"
-      style={[
-        styles.tile,
-        {
-          backgroundColor,
-          opacity: habit.revealed ? 1 : 0.5,
-          transform: [{ scale: scaleAnim }],
-          borderWidth: hasCompletedGoal ? 2 : 1,
-          borderColor: stageColor,
-          margin: spacing(0.5, scale),
-          padding: spacing(2, scale),
-          minHeight: spacing(8, scale),
-        },
-      ]}
+      style={{
+        borderWidth: 1,
+        borderColor: stageColor,
+        padding: spacing(1, scale),
+        margin: spacing(0.5, scale),
+        minHeight: spacing(6, scale),
+        borderRadius: spacing(1, scale),
+        backgroundColor: '#f8f8f8',
+      }}
+      onPress={onOpenGoals}
+      onLongPress={onLongPress}
     >
-      {/* Achievement Flash Message */}
-      {goalAchievedMessage && (
-        <Animated.View
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            backgroundColor: stageColor,
-            padding: 8,
-            borderTopLeftRadius: 12,
-            borderTopRightRadius: 12,
-            opacity: fadeAnim,
-            zIndex: 10,
-            alignItems: 'center',
-          }}
-        >
-          <Text style={{ fontWeight: 'bold', color: '#333' }}>{goalAchievedMessage}</Text>
-        </Animated.View>
-      )}
-
-      {/* Mobile Menu */}
-      {isMobile && (
-        <TouchableOpacity
-          style={{
-            position: 'absolute',
-            top: 8,
-            right: 8,
-            zIndex: 5,
-          }}
-          onPress={toggleMenu}
-        >
-          <MoreHorizontal size={22} color="#333" />
-        </TouchableOpacity>
-      )}
-
-      {/* Mobile Menu Popup */}
-      {isMobile && isMenuOpen && (
-        <View
-          style={{
-            position: 'absolute',
-            top: 36,
-            right: 8,
-            backgroundColor: 'white',
-            borderRadius: 8,
-            padding: 8,
-            zIndex: 10,
-            ...styles.menuShadow,
-            borderWidth: 1,
-            borderColor: '#eee',
-          }}
-        >
-          <TouchableOpacity
-            style={{ flexDirection: 'row', alignItems: 'center', padding: 8 }}
-            onPress={() => {
-              onOpenStats();
-              setIsMenuOpen(false);
-            }}
-          >
-            <BarChart size={18} color="#333" style={{ marginRight: 8 }} />
-            <Text>Stats</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={{ flexDirection: 'row', alignItems: 'center', padding: 8 }}
-            onPress={() => {
-              onLongPress();
-              setIsMenuOpen(false);
-            }}
-          >
-            <Edit size={18} color="#333" style={{ marginRight: 8 }} />
-            <Text>Edit</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={{ flexDirection: 'row', alignItems: 'center', padding: 8 }}
-            onPress={() => {
-              onLogUnit();
-              setIsMenuOpen(false);
-            }}
-          >
-            <CheckCircle size={18} color="#333" style={{ marginRight: 8 }} />
-            <Text>Log</Text>
-          </TouchableOpacity>
-        </View>
-      )}
-
-      {/* Desktop Action Icons */}
-      {!isMobile && (
-        <View
-          style={{
-            position: 'absolute',
-            top: 8,
-            right: 8,
-            flexDirection: 'row',
-            zIndex: 5,
-          }}
-        >
-          <TouchableOpacity style={{ padding: 6 }} onPress={onOpenStats}>
-            <BarChart size={18} color="#333" />
-          </TouchableOpacity>
-
-          <TouchableOpacity style={{ padding: 6 }} onPress={onLongPress}>
-            <Edit size={18} color="#333" />
-          </TouchableOpacity>
-
-          <TouchableOpacity style={{ padding: 6 }} onPress={onLogUnit}>
-            <CheckCircle size={18} color="#333" />
-          </TouchableOpacity>
-        </View>
-      )}
-
-      {/* Main tile content */}
-      <TouchableOpacity
-        onPress={handlePress}
-        onPressIn={handlePressIn}
-        onPressOut={handlePressOut}
-        style={{ width: '100%', alignItems: 'center' }}
-      >
-        <Text style={[styles.icon, { fontSize: 32 * scale }]}>{habit.icon}</Text>
+      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <Text style={{ fontSize: spacing(3, scale), marginRight: spacing(1, scale) }}>
+          {habit.icon}
+        </Text>
         <Text
-          style={[styles.name, { color: habit.revealed ? '#333' : '#aaa', fontSize: 16 * scale }]}
+          style={{
+            flex: 1,
+            fontSize: spacing(2, scale),
+            fontWeight: '700',
+            textTransform: 'uppercase',
+          }}
         >
           {habit.name}
         </Text>
+        <Text
+          style={[
+            { fontSize: spacing(1.5, scale), textTransform: 'uppercase' },
+            hasCompletedGoal && {
+              backgroundColor: stageColor,
+              color: '#fff',
+              paddingHorizontal: spacing(0.5, scale),
+              borderRadius: spacing(0.5, scale),
+            },
+          ]}
+        >
+          {streakText}
+        </Text>
+      </View>
 
-        {habit.revealed && (
-          <View style={styles.streakContainer}>
-            <Text style={styles.streakText}>
-              {habit.streak} {habit.streak === 1 ? 'day' : 'days'}
-            </Text>
-          </View>
-        )}
-
-        {/* Progress Bar */}
-        {habit.revealed && lowGoal && (
-          <View style={[styles.progressBarContainer, { marginTop: spacing(1.5, scale) }]}>
+      <View style={{ marginTop: spacing(1, scale) }}>
+        <View
+          style={{
+            height: barHeight,
+            backgroundColor: '#eee',
+            borderRadius: barHeight / 2,
+            overflow: 'hidden',
+            position: 'relative',
+          }}
+        >
+          {lowGoal && lowMarker >= 0 && (
             <View
-              style={[styles.progressBar, { height: Math.max(8, 10 * scale), overflow: 'visible' }]}
-            >
-              {/* Goal markers with improved visibility and correct positioning */}
-              {lowGoal && lowMarkerPosition >= 0 && (
-                <TouchableOpacity
-                  style={[
-                    styles.goalMarker,
-                    {
-                      left: `${clampPercentage(lowMarkerPosition)}%`,
-                      height: Math.max(16, spacing(2, scale)),
-                      width: 4,
-                      top: -2,
-                      backgroundColor: getTierColor('low'),
-                      borderRadius: 2,
-                    },
-                  ]}
-                  hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
-                  onPress={() => showMarkerInfo('low')}
-                />
-              )}
-
-              {clearGoal && clearMarkerPosition >= 0 && (
-                <TouchableOpacity
-                  style={[
-                    styles.goalMarker,
-                    {
-                      left: `${clampPercentage(clearMarkerPosition)}%`,
-                      height: Math.max(16, spacing(2, scale)),
-                      width: 4,
-                      top: -2,
-                      backgroundColor: getTierColor('clear'),
-                      borderRadius: 2,
-                    },
-                  ]}
-                  hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
-                  onPress={() => showMarkerInfo('clear')}
-                />
-              )}
-
-              {stretchGoal && stretchMarkerPosition >= 0 && (
-                <TouchableOpacity
-                  style={[
-                    styles.goalMarker,
-                    {
-                      left: `${clampPercentage(stretchMarkerPosition)}%`,
-                      height: Math.max(16, spacing(2, scale)),
-                      width: 4,
-                      top: -2,
-                      backgroundColor: getTierColor('stretch'),
-                      borderRadius: 2,
-                    },
-                  ]}
-                  hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
-                  onPress={() => showMarkerInfo('stretch')}
-                />
-              )}
-
-              {/* Enhanced marker tooltips */}
-              {showMarkerTooltip && (
-                <View
-                  style={{
-                    position: 'absolute',
-                    top: -40,
-                    left:
-                      showMarkerTooltip === 'low'
-                        ? `${clampPercentage(lowMarkerPosition)}%`
-                        : showMarkerTooltip === 'clear'
-                          ? `${clampPercentage(clearMarkerPosition)}%`
-                          : `${clampPercentage(stretchMarkerPosition)}%`,
-                    transform: [
-                      {
-                        translateX:
-                          (showMarkerTooltip === 'low'
-                            ? lowMarkerPosition
-                            : showMarkerTooltip === 'clear'
-                              ? clearMarkerPosition
-                              : stretchMarkerPosition) < 10
-                            ? 0
-                            : (showMarkerTooltip === 'low'
-                                  ? lowMarkerPosition
-                                  : showMarkerTooltip === 'clear'
-                                    ? clearMarkerPosition
-                                    : stretchMarkerPosition) > 90
-                              ? -100
-                              : -50,
-                      },
-                    ],
-                    backgroundColor: 'rgba(0,0,0,0.8)',
-                    padding: 8,
-                    borderRadius: 4,
-                    zIndex: 10,
-                    minWidth: 120,
-                    alignItems: 'center',
-                  }}
-                >
-                  <Text style={{ color: 'white', fontSize: 12 }}>
-                    {getMarkerTooltipText(showMarkerTooltip)}
-                  </Text>
-                </View>
-              )}
-
-              {/* Progress fill */}
-              <View
-                testID="progress-fill"
-                style={[
-                  styles.progressBarFill,
-                  {
-                    width: `${progressBarWidth * 100}%`,
-                    backgroundColor: progressBarColor,
-                    height: '100%',
-                  },
-                ]}
-              />
-            </View>
-          </View>
-        )}
-
-        {/* Achievement indicator */}
-        {hasCompletedGoal ? (
+              style={{
+                position: 'absolute',
+                left: `${clampPercentage(lowMarker)}%`,
+                top: 0,
+                bottom: 0,
+                width: 2,
+                backgroundColor: getTierColor('low'),
+              }}
+            />
+          )}
+          {clearGoal && clearMarker >= 0 && (
+            <View
+              style={{
+                position: 'absolute',
+                left: `${clampPercentage(clearMarker)}%`,
+                top: 0,
+                bottom: 0,
+                width: 2,
+                backgroundColor: getTierColor('clear'),
+              }}
+            />
+          )}
+          {stretchGoal && stretchMarker >= 0 && (
+            <View
+              style={{
+                position: 'absolute',
+                left: `${clampPercentage(stretchMarker)}%`,
+                top: 0,
+                bottom: 0,
+                width: 2,
+                backgroundColor: getTierColor('stretch'),
+              }}
+            />
+          )}
           <View
+            testID="progress-fill"
             style={{
-              marginTop: 3,
-              marginBottom: 10,
-              borderRadius: 4,
-              paddingHorizontal: 6,
-              paddingVertical: 2,
+              height: '100%',
+              width: `${progressPercentage}%`,
               backgroundColor: progressBarColor,
             }}
-          >
-            <Text
-              style={{
-                fontSize: 12,
-                fontWeight: 'bold',
-                color: '#ffffff',
-                textShadowColor: '#000',
-                textShadowOffset: { width: 1, height: 1 },
-                textShadowRadius: 2,
-              }}
-            >
-              Goal Achieved!
-            </Text>
-          </View>
-        ) : (
-          <View
-            style={{
-              paddingVertical: spacing(1, scale),
-            }}
-          ></View>
-        )}
-      </TouchableOpacity>
-    </Animated.View>
+          />
+        </View>
+      </View>
+    </TouchableOpacity>
   );
 };
 

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Animated, Platform, Text, TouchableOpacity, View } from 'react-native';
 
 import { STAGE_COLORS } from '../../constants/stageColors';
+import { spacing } from '../../Sources/design/DesignSystem';
+import useResponsive from '../../Sources/design/useResponsive';
 
 import styles from './Habits.styles';
 import type { Goal, HabitTileProps } from './Habits.types';
@@ -11,6 +13,8 @@ import {
   getGoalTier,
   getProgressBarColor,
   getTierColor,
+  getMarkerPositions,
+  clampPercentage,
 } from './HabitUtils';
 
 // Constants
@@ -23,6 +27,7 @@ export const HabitTile = ({
   onOpenStats,
   onLongPress,
 }: HabitTileProps) => {
+  const { scale } = useResponsive();
   const backgroundColor = '#f8f8f8'; // Neutral background for all habits
   const stageColor = STAGE_COLORS[habit.stage];
   const scaleAnim = useRef(new Animated.Value(1)).current;
@@ -38,8 +43,10 @@ export const HabitTile = ({
   const stretchGoal = habit.goals.find((g) => g.tier === 'stretch');
 
   const { currentGoal, nextGoal, completedAllGoals } = getGoalTier(habit);
-  const progressPercentage = calculateProgressPercentage(habit, currentGoal, nextGoal);
-  const progressBarColor = getProgressBarColor(habit, currentGoal, nextGoal, completedAllGoals);
+  const progressPercentage = clampPercentage(
+    calculateProgressPercentage(habit, currentGoal, nextGoal),
+  );
+  const progressBarColor = getProgressBarColor(habit);
   const progressBarWidth = progressPercentage / 100;
   const hasCompletedGoal = completedAllGoals || progressPercentage >= 100;
 
@@ -99,51 +106,11 @@ export const HabitTile = ({
     onOpenGoals();
   };
 
-  // Calculate marker positions
-  // For additive goals, normalize against clearGoal
-  // For subtractive goals, normalize against lowGoal (the leftmost marker)
-  const getMarkerPositions = () => {
-    if (!lowGoal) return { low: 0, clear: 0, stretch: 0 };
-
-    if (lowGoal.is_additive) {
-      // For additive goals, if there's a clear goal, use it as the base
-      if (clearGoal) {
-        const lowPosition = (lowGoal.target / clearGoal.target) * 100;
-        // Clear goal is always at 100% of the progress bar
-        const clearPosition = 100;
-        // Stretch goal is beyond the visible bar
-        const stretchPosition = stretchGoal ? 100 : 0;
-
-        return { low: lowPosition, clear: clearPosition, stretch: stretchPosition };
-      }
-      // If no clear goal, just use low goal
-      else {
-        return { low: 100, clear: 0, stretch: 0 };
-      }
-    }
-    // For subtractive goals
-    else {
-      if (lowGoal) {
-        const maxTarget = lowGoal.target;
-        const minTarget = stretchGoal ? stretchGoal.target : 0;
-        const normalize = (value: number) => ((value - minTarget) / (maxTarget - minTarget)) * 100;
-
-        const stretchPosition = 0; // best at far left
-        const clearPosition = clearGoal ? normalize(clearGoal.target) : 50;
-        const lowPosition = 100; // worst at far right
-
-        return { low: lowPosition, clear: clearPosition, stretch: stretchPosition };
-      } else {
-        return { low: 0, clear: 0, stretch: 0 };
-      }
-    }
-  };
-
   const {
     low: lowMarkerPosition,
     clear: clearMarkerPosition,
     stretch: stretchMarkerPosition,
-  } = getMarkerPositions();
+  } = getMarkerPositions(lowGoal, clearGoal, stretchGoal);
 
   // Show action menu (for mobile)
   const toggleMenu = () => {
@@ -172,6 +139,7 @@ export const HabitTile = ({
 
   return (
     <Animated.View
+      testID="habit-tile"
       style={[
         styles.tile,
         {
@@ -179,7 +147,10 @@ export const HabitTile = ({
           opacity: habit.revealed ? 1 : 0.5,
           transform: [{ scale: scaleAnim }],
           borderWidth: hasCompletedGoal ? 2 : 1,
-          borderColor: hasCompletedGoal ? stageColor : '#ddd',
+          borderColor: stageColor,
+          margin: spacing(1, scale),
+          padding: spacing(3, scale),
+          minHeight: spacing(14, scale),
         },
       ]}
     >
@@ -302,8 +273,12 @@ export const HabitTile = ({
         onPressOut={handlePressOut}
         style={{ width: '100%', alignItems: 'center' }}
       >
-        <Text style={styles.icon}>{habit.icon}</Text>
-        <Text style={[styles.name, { color: habit.revealed ? '#333' : '#aaa' }]}>{habit.name}</Text>
+        <Text style={[styles.icon, { fontSize: 32 * scale }]}>{habit.icon}</Text>
+        <Text
+          style={[styles.name, { color: habit.revealed ? '#333' : '#aaa', fontSize: 16 * scale }]}
+        >
+          {habit.name}
+        </Text>
 
         {habit.revealed && (
           <View style={styles.streakContainer}>
@@ -315,17 +290,9 @@ export const HabitTile = ({
 
         {/* Progress Bar */}
         {habit.revealed && lowGoal && (
-          <View style={[styles.progressBarContainer, { marginTop: 12 }]}>
+          <View style={[styles.progressBarContainer, { marginTop: spacing(1.5, scale) }]}>
             <View
-              style={[
-                styles.progressBar,
-                {
-                  height: 12,
-                  backgroundColor: '#eee',
-                  borderRadius: 6,
-                  overflow: 'visible',
-                },
-              ]}
+              style={[styles.progressBar, { height: Math.max(8, 10 * scale), overflow: 'visible' }]}
             >
               {/* Goal markers with improved visibility and correct positioning */}
               {lowGoal && lowMarkerPosition >= 0 && (
@@ -333,14 +300,15 @@ export const HabitTile = ({
                   style={[
                     styles.goalMarker,
                     {
-                      left: `${lowMarkerPosition}%`,
-                      height: 16,
+                      left: `${clampPercentage(lowMarkerPosition)}%`,
+                      height: Math.max(16, spacing(2, scale)),
                       width: 4,
                       top: -2,
                       backgroundColor: getTierColor('low'),
                       borderRadius: 2,
                     },
                   ]}
+                  hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
                   onPress={() => showMarkerInfo('low')}
                 />
               )}
@@ -350,14 +318,15 @@ export const HabitTile = ({
                   style={[
                     styles.goalMarker,
                     {
-                      left: `${clearMarkerPosition}%`,
-                      height: 16,
+                      left: `${clampPercentage(clearMarkerPosition)}%`,
+                      height: Math.max(16, spacing(2, scale)),
                       width: 4,
                       top: -2,
                       backgroundColor: getTierColor('clear'),
                       borderRadius: 2,
                     },
                   ]}
+                  hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
                   onPress={() => showMarkerInfo('clear')}
                 />
               )}
@@ -367,14 +336,15 @@ export const HabitTile = ({
                   style={[
                     styles.goalMarker,
                     {
-                      left: `${stretchMarkerPosition}%`,
-                      height: 16,
+                      left: `${clampPercentage(stretchMarkerPosition)}%`,
+                      height: Math.max(16, spacing(2, scale)),
                       width: 4,
                       top: -2,
                       backgroundColor: getTierColor('stretch'),
                       borderRadius: 2,
                     },
                   ]}
+                  hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
                   onPress={() => showMarkerInfo('stretch')}
                 />
               )}
@@ -387,11 +357,28 @@ export const HabitTile = ({
                     top: -40,
                     left:
                       showMarkerTooltip === 'low'
-                        ? `${lowMarkerPosition}%`
+                        ? `${clampPercentage(lowMarkerPosition)}%`
                         : showMarkerTooltip === 'clear'
-                          ? `${clearMarkerPosition}%`
-                          : `${stretchMarkerPosition}%`,
-                    transform: [{ translateX: -50 }],
+                          ? `${clampPercentage(clearMarkerPosition)}%`
+                          : `${clampPercentage(stretchMarkerPosition)}%`,
+                    transform: [
+                      {
+                        translateX:
+                          (showMarkerTooltip === 'low'
+                            ? lowMarkerPosition
+                            : showMarkerTooltip === 'clear'
+                              ? clearMarkerPosition
+                              : stretchMarkerPosition) < 10
+                            ? 0
+                            : (showMarkerTooltip === 'low'
+                                  ? lowMarkerPosition
+                                  : showMarkerTooltip === 'clear'
+                                    ? clearMarkerPosition
+                                    : stretchMarkerPosition) > 90
+                              ? -100
+                              : -50,
+                      },
+                    ],
                     backgroundColor: 'rgba(0,0,0,0.8)',
                     padding: 8,
                     borderRadius: 4,
@@ -408,6 +395,7 @@ export const HabitTile = ({
 
               {/* Progress fill */}
               <View
+                testID="progress-fill"
                 style={[
                   styles.progressBarFill,
                   {
@@ -449,7 +437,7 @@ export const HabitTile = ({
         ) : (
           <View
             style={{
-              paddingVertical: 15,
+              paddingVertical: spacing(1, scale),
             }}
           ></View>
         )}

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -16,7 +16,7 @@ import {
 } from './HabitUtils';
 
 export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) => {
-  const { scale } = useResponsive();
+  const { width, height, columns, scale, gridGutter } = useResponsive();
   const stageColor = STAGE_COLORS[habit.stage];
 
   const lowGoal = habit.goals.find((g) => g.tier === 'low');
@@ -33,6 +33,10 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
     `${habit.streak} days${hasCompletedGoal ? ' — Achieved Today!' : ''}`.toUpperCase();
 
   const barHeight = Math.max(8, spacing(2, scale));
+  const rows = columns === 2 ? 5 : 10;
+  const tileMinHeight = height / rows - 2 * spacing(1, scale) - gridGutter;
+  const tileWidth = width / columns;
+  const iconInline = columns === 1 || tileWidth < 400;
 
   const {
     low: lowMarker,
@@ -44,45 +48,82 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
     <TouchableOpacity
       testID="habit-tile"
       style={{
+        flex: 1,
         borderWidth: 1,
         borderColor: stageColor,
         padding: spacing(1, scale),
-        margin: spacing(0.5, scale),
-        minHeight: spacing(6, scale),
+        margin: gridGutter / 2,
+        minHeight: tileMinHeight,
         borderRadius: spacing(1, scale),
         backgroundColor: '#f8f8f8',
       }}
       onPress={onOpenGoals}
       onLongPress={onLongPress}
     >
-      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-        <Text style={{ fontSize: spacing(3, scale), marginRight: spacing(1, scale) }}>
-          {habit.icon}
-        </Text>
-        <Text
-          style={{
-            flex: 1,
-            fontSize: spacing(2, scale),
-            fontWeight: '700',
-            textTransform: 'uppercase',
-          }}
-        >
-          {habit.name}
-        </Text>
-        <Text
-          style={[
-            { fontSize: spacing(1.5, scale), textTransform: 'uppercase' },
-            hasCompletedGoal && {
-              backgroundColor: stageColor,
-              color: '#fff',
-              paddingHorizontal: spacing(0.5, scale),
-              borderRadius: spacing(0.5, scale),
-            },
-          ]}
-        >
-          {streakText}
-        </Text>
-      </View>
+      {iconInline ? (
+        <View testID="habit-header" style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <Text style={{ fontSize: spacing(3, scale), marginRight: spacing(1, scale) }}>
+            {habit.icon}
+          </Text>
+          <Text
+            style={{
+              flex: 1,
+              fontSize: spacing(2, scale),
+              fontWeight: '700',
+              textTransform: 'uppercase',
+            }}
+          >
+            {habit.name}
+          </Text>
+          <Text
+            style={[
+              { fontSize: spacing(1.5, scale), textTransform: 'uppercase' },
+              hasCompletedGoal && {
+                backgroundColor: stageColor,
+                color: '#fff',
+                paddingHorizontal: spacing(0.5, scale),
+                borderRadius: spacing(0.5, scale),
+              },
+            ]}
+          >
+            {streakText}
+          </Text>
+        </View>
+      ) : (
+        <>
+          <View
+            testID="habit-icon-top"
+            style={{ alignItems: 'center', marginBottom: spacing(1, scale) }}
+          >
+            <Text style={{ fontSize: spacing(4, scale) }}>{habit.icon}</Text>
+          </View>
+          <View testID="habit-header" style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <Text
+              style={{
+                flex: 1,
+                fontSize: spacing(2, scale),
+                fontWeight: '700',
+                textTransform: 'uppercase',
+              }}
+            >
+              {habit.name}
+            </Text>
+            <Text
+              style={[
+                { fontSize: spacing(1.5, scale), textTransform: 'uppercase' },
+                hasCompletedGoal && {
+                  backgroundColor: stageColor,
+                  color: '#fff',
+                  paddingHorizontal: spacing(0.5, scale),
+                  borderRadius: spacing(0.5, scale),
+                },
+              ]}
+            >
+              {streakText}
+            </Text>
+          </View>
+        </>
+      )}
 
       <View style={{ marginTop: spacing(1, scale) }}>
         <View

--- a/app/features/Habits/Habits.styles.ts
+++ b/app/features/Habits/Habits.styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet, Dimensions } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 //------------------
 // Theme Configuration (easier to maintain and change)
@@ -89,7 +89,6 @@ const BORDER_RADIUS = {
 };
 
 // Device dimensions (for responsive layouts)
-const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
 //------------------
 // Styles (modernized mystical minimalist style)
@@ -105,7 +104,6 @@ export const styles = StyleSheet.create({
   },
   habitsGrid: {
     justifyContent: 'space-between',
-    paddingBottom: 70, // Space for the energy scaffolding button
   },
 
   // ===== Habit Tiles =====
@@ -118,7 +116,6 @@ export const styles = StyleSheet.create({
     justifyContent: 'center',
     position: 'relative',
     ...SHADOWS.medium,
-    height: SCREEN_HEIGHT * 0.175,
   },
   glowEffect: {
     ...StyleSheet.absoluteFillObject,
@@ -1359,6 +1356,7 @@ export const styles = StyleSheet.create({
     backgroundColor: '#eee',
     borderRadius: 6,
     overflow: 'hidden',
+    position: 'relative',
   },
   markerTooltip: {
     position: 'absolute',

--- a/app/features/Habits/Habits.types.ts
+++ b/app/features/Habits/Habits.types.ts
@@ -93,8 +93,6 @@ export interface EditableGoalProps {
 export interface HabitTileProps {
   habit: Habit;
   onOpenGoals: () => void;
-  onLogUnit: () => void;
-  onOpenStats: () => void;
   onLongPress: () => void;
 }
 

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -2,7 +2,11 @@
 
 import * as Notifications from 'expo-notifications';
 import React, { useEffect, useState } from 'react';
-import { Alert, FlatList, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, FlatList, Text, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { spacing } from '../../Sources/design/DesignSystem';
+import useResponsive from '../../Sources/design/useResponsive';
 
 import GoalModal from './components/GoalModal';
 import HabitSettingsModal from './components/HabitSettingsModal';
@@ -448,6 +452,8 @@ const HabitsScreen = () => {
   };
 
   // Render a habit tile
+  const { columns, gridGutter, scale } = useResponsive();
+
   const renderHabitTile = ({ item }: { item: Habit }) => (
     <HabitTile
       habit={item}
@@ -468,13 +474,21 @@ const HabitsScreen = () => {
   );
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={[styles.container, { padding: spacing(3, scale) }]}>
       <FlatList
-        data={habits.filter((h) => h.revealed)} // Only show revealed habits
-        keyExtractor={(item) => (item.id ? item.id.toString() : Math.random().toString())}
+        testID="habits-list"
+        data={habits.filter((h) => h.revealed)}
+        keyExtractor={(item) => item.id?.toString() ?? item.name}
         renderItem={renderHabitTile}
-        numColumns={2}
-        contentContainerStyle={styles.habitsGrid}
+        numColumns={columns}
+        columnWrapperStyle={columns > 1 ? { gap: gridGutter } : undefined}
+        contentContainerStyle={[
+          styles.habitsGrid,
+          {
+            padding: gridGutter / 2,
+            paddingBottom: gridGutter / 2,
+          },
+        ]}
       />
 
       <TouchableOpacity
@@ -526,7 +540,7 @@ const HabitsScreen = () => {
         onClose={() => setOnboardingVisible(false)}
         onSaveHabits={handleOnboardingSave}
       />
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -454,7 +454,8 @@ const HabitsScreen = () => {
   };
 
   // Render a habit tile
-  const { columns, gridGutter, scale } = useResponsive();
+  const { columns, gridGutter, scale, isLG, isXL } = useResponsive();
+  const screenPadding = spacing(isLG || isXL ? 2 : 1, scale);
 
   const renderHabitTile = ({ item }: { item: Habit }) => (
     <HabitTile
@@ -471,7 +472,7 @@ const HabitsScreen = () => {
   );
 
   return (
-    <SafeAreaView style={[styles.container, { padding: spacing(1, scale) }]}>
+    <SafeAreaView style={[styles.container, { padding: screenPadding }]}>
       <View style={{ alignItems: 'flex-end' }}>
         <TouchableOpacity
           onPress={() => setMenuVisible((v) => !v)}

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -1,8 +1,9 @@
 // HabitsScreen.tsx
 
 import * as Notifications from 'expo-notifications';
+import { MoreHorizontal } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
-import { Alert, FlatList, Text, TouchableOpacity } from 'react-native';
+import { Alert, FlatList, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { spacing } from '../../Sources/design/DesignSystem';
@@ -218,6 +219,7 @@ export const calculateNetEnergy = (cost: number, returnValue: number): number =>
 const HabitsScreen = () => {
   const [habits, setHabits] = useState<Habit[]>(DEFAULT_HABITS);
   const [selectedHabit, setSelectedHabit] = useState<Habit | null>(null);
+  const [menuVisible, setMenuVisible] = useState(false);
   const [goalModalVisible, setGoalModalVisible] = useState(false);
   const [statsModalVisible, setStatsModalVisible] = useState(false);
   const [settingsModalVisible, setSettingsModalVisible] = useState(false);
@@ -461,11 +463,6 @@ const HabitsScreen = () => {
         setSelectedHabit(item);
         setGoalModalVisible(true);
       }}
-      onLogUnit={() => handleLogUnit(item.id!, 1)}
-      onOpenStats={() => {
-        setSelectedHabit(item);
-        setStatsModalVisible(true);
-      }}
       onLongPress={() => {
         setSelectedHabit(item);
         setSettingsModalVisible(true);
@@ -475,6 +472,56 @@ const HabitsScreen = () => {
 
   return (
     <SafeAreaView style={[styles.container, { padding: spacing(1, scale) }]}>
+      <View style={{ alignItems: 'flex-end' }}>
+        <TouchableOpacity
+          onPress={() => setMenuVisible((v) => !v)}
+          style={{ padding: spacing(1, scale) }}
+        >
+          <MoreHorizontal size={spacing(3, scale)} />
+        </TouchableOpacity>
+        {menuVisible && (
+          <View
+            style={{
+              position: 'absolute',
+              top: spacing(5, scale),
+              right: spacing(1, scale),
+              backgroundColor: '#fff',
+              padding: spacing(1, scale),
+              borderRadius: spacing(1, scale),
+              elevation: 2,
+            }}
+          >
+            <TouchableOpacity
+              onPress={() => {
+                if (selectedHabit) handleLogUnit(selectedHabit.id!, 1);
+                setMenuVisible(false);
+              }}
+              style={{ paddingVertical: spacing(0.5, scale) }}
+            >
+              <Text>Quick Log</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => {
+                if (selectedHabit) setStatsModalVisible(true);
+                setMenuVisible(false);
+              }}
+              style={{ paddingVertical: spacing(0.5, scale) }}
+            >
+              <Text>Stats</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => {
+                if (selectedHabit) setSettingsModalVisible(true);
+                setMenuVisible(false);
+              }}
+              style={{ paddingVertical: spacing(0.5, scale) }}
+            >
+              <Text>Edit</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+
       <FlatList
         key={`cols-${columns}`}
         testID="habits-list"

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -474,7 +474,7 @@ const HabitsScreen = () => {
   );
 
   return (
-    <SafeAreaView style={[styles.container, { padding: spacing(3, scale) }]}>
+    <SafeAreaView style={[styles.container, { padding: spacing(1, scale) }]}>
       <FlatList
         testID="habits-list"
         data={habits.filter((h) => h.revealed)}

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -476,6 +476,7 @@ const HabitsScreen = () => {
   return (
     <SafeAreaView style={[styles.container, { padding: spacing(1, scale) }]}>
       <FlatList
+        key={`cols-${columns}`}
         testID="habits-list"
         data={habits.filter((h) => h.revealed)}
         keyExtractor={(item) => item.id?.toString() ?? item.name}

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -475,6 +475,7 @@ const HabitsScreen = () => {
     <SafeAreaView style={[styles.container, { padding: screenPadding }]}>
       <View style={{ alignItems: 'flex-end' }}>
         <TouchableOpacity
+          testID="overflow-menu-toggle"
           onPress={() => setMenuVisible((v) => !v)}
           style={{ padding: spacing(1, scale) }}
         >
@@ -482,6 +483,7 @@ const HabitsScreen = () => {
         </TouchableOpacity>
         {menuVisible && (
           <View
+            testID="overflow-menu"
             style={{
               position: 'absolute',
               top: spacing(5, scale),
@@ -490,6 +492,7 @@ const HabitsScreen = () => {
               padding: spacing(1, scale),
               borderRadius: spacing(1, scale),
               elevation: 2,
+              zIndex: 1000,
             }}
           >
             <TouchableOpacity

--- a/app/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/app/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -63,6 +63,9 @@ describe('HabitsScreen responsive layout', () => {
 
         const maxTileHeight = (height * expectedColumns) / 10;
         expect(tileHeight).toBeLessThanOrEqual(maxTileHeight);
+        if (expectedColumns === 2) {
+          expect(style.flex).toBe(1);
+        }
         expect(colorValues).toContain(style.borderColor);
 
         const fill = t.findByProps({ testID: 'progress-fill' });
@@ -72,6 +75,14 @@ describe('HabitsScreen responsive layout', () => {
         expect(val).toBeLessThanOrEqual(100);
         expect(fillStyle.backgroundColor).toBe(style.borderColor);
       });
+
+      const iconTopExpected = expectedColumns === 2 && w / expectedColumns >= 400;
+      const iconTopNodes = tree.findAllByProps({ testID: 'habit-icon-top' });
+      if (iconTopExpected) {
+        expect(iconTopNodes.length).toBeGreaterThan(0);
+      } else {
+        expect(iconTopNodes.length).toBe(0);
+      }
     });
   });
 

--- a/app/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/app/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest, describe, afterEach, it, expect } from '@jest/globals';
+
+import { STAGE_COLORS } from '../../../constants/stageColors';
+
+const HabitsScreen = require('../HabitsScreen').default;
+
+const renderer = require('react-test-renderer');
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: (jest.fn() as any).mockResolvedValue({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn() as any,
+  scheduleNotificationAsync: jest.fn() as any,
+  cancelScheduledNotificationAsync: jest.fn() as any,
+  getExpoPushTokenAsync: (jest.fn() as any).mockResolvedValue({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: any }) => <>{children}</>,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/StatsModal', () => () => null);
+
+const widths = [320, 390, 600, 900, 1200];
+
+describe('HabitsScreen responsive layout', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  widths.forEach((w) => {
+    it(`renders correctly at width ${w}`, () => {
+      const height = w > 800 ? 600 : 800;
+      jest
+        .spyOn(require('react-native'), 'useWindowDimensions')
+        .mockReturnValue({ width: w, height, scale: 1, fontScale: 1 });
+
+      const tree = renderer.create(<HabitsScreen />).root;
+      const list = tree.findByProps({ testID: 'habits-list' });
+      const expectedColumns = w > height ? 2 : 1;
+      expect(list.props.numColumns).toBe(expectedColumns);
+      expect(list.props.horizontal).not.toBe(true);
+
+      const tiles = tree.findAllByProps({ testID: 'habit-tile' });
+      const colorValues = Object.values(STAGE_COLORS);
+
+      tiles.forEach((t: any) => {
+        const style = Array.isArray(t.props.style) ? t.props.style[1] : t.props.style;
+        expect(style.minHeight).toBeLessThanOrEqual(height / 5);
+        expect(colorValues).toContain(style.borderColor);
+
+        const fill = t.findByProps({ testID: 'progress-fill' });
+        const fillStyle = Array.isArray(fill.props.style) ? fill.props.style[1] : fill.props.style;
+        const val = parseFloat(fillStyle.width);
+        expect(val).toBeGreaterThanOrEqual(0);
+        expect(val).toBeLessThanOrEqual(100);
+        expect(fillStyle.backgroundColor).toBe(style.borderColor);
+      });
+    });
+  });
+});

--- a/app/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/app/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -61,7 +61,8 @@ describe('HabitsScreen responsive layout', () => {
         const tileHeight =
           (style.minHeight ?? 0) + 2 * (style.padding ?? 0) + 2 * (style.margin ?? 0);
 
-        expect(tileHeight).toBeLessThanOrEqual(height / 5);
+        const maxTileHeight = (height * expectedColumns) / 10;
+        expect(tileHeight).toBeLessThanOrEqual(maxTileHeight);
         expect(colorValues).toContain(style.borderColor);
 
         const fill = t.findByProps({ testID: 'progress-fill' });

--- a/app/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/app/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -107,4 +107,24 @@ describe('HabitsScreen responsive layout', () => {
     const secondList = testRenderer.root.findByType(FlatList);
     expect(secondList.props.numColumns).toBe(1);
   });
+
+  it('renders overflow menu above tiles', () => {
+    jest
+      .spyOn(require('react-native'), 'useWindowDimensions')
+      .mockReturnValue({ width: 900, height: 600, scale: 1, fontScale: 1 });
+
+    const testRenderer = renderer.create(<HabitsScreen />);
+    const toggle = testRenderer.root.findByProps({ testID: 'overflow-menu-toggle' });
+
+    renderer.act(() => {
+      toggle.props.onPress();
+    });
+
+    const menu = testRenderer.root.findByProps({ testID: 'overflow-menu' });
+    const style = Array.isArray(menu.props.style)
+      ? menu.props.style.reduce((acc: any, s: any) => ({ ...acc, ...s }), {})
+      : menu.props.style;
+
+    expect(style.zIndex).toBeGreaterThan(0);
+  });
 });

--- a/app/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/app/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -54,8 +54,14 @@ describe('HabitsScreen responsive layout', () => {
       const colorValues = Object.values(STAGE_COLORS);
 
       tiles.forEach((t: any) => {
-        const style = Array.isArray(t.props.style) ? t.props.style[1] : t.props.style;
-        expect(style.minHeight).toBeLessThanOrEqual(height / 5);
+        const style = Array.isArray(t.props.style)
+          ? t.props.style.reduce((acc: any, s: any) => ({ ...acc, ...s }), {})
+          : t.props.style;
+
+        const tileHeight =
+          (style.minHeight ?? 0) + 2 * (style.padding ?? 0) + 2 * (style.margin ?? 0);
+
+        expect(tileHeight).toBeLessThanOrEqual(height / 5);
         expect(colorValues).toContain(style.borderColor);
 
         const fill = t.findByProps({ testID: 'progress-fill' });

--- a/app/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/app/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -73,4 +73,26 @@ describe('HabitsScreen responsive layout', () => {
       });
     });
   });
+
+  it('remounts list when column count changes', () => {
+    const dimSpy = jest
+      .spyOn(require('react-native'), 'useWindowDimensions')
+      .mockReturnValue({ width: 900, height: 600, scale: 1, fontScale: 1 });
+
+    const { FlatList } = require('react-native');
+    const testRenderer = renderer.create(<HabitsScreen />);
+    const firstList = testRenderer.root.findByType(FlatList);
+    expect(firstList.props.numColumns).toBe(2);
+
+    dimSpy.mockReturnValue({ width: 320, height: 800, scale: 1, fontScale: 1 });
+
+    expect(() => {
+      renderer.act(() => {
+        testRenderer.update(<HabitsScreen />);
+      });
+    }).not.toThrow();
+
+    const secondList = testRenderer.root.findByType(FlatList);
+    expect(secondList.props.numColumns).toBe(1);
+  });
 });

--- a/app/features/Habits/__tests__/HabitsScreen.test.ts
+++ b/app/features/Habits/__tests__/HabitsScreen.test.ts
@@ -7,7 +7,8 @@ import {
   calculateProgressPercentage,
   getGoalTier,
   getProgressBarColor,
-  VICTORY_COLOR,
+  getMarkerPositions,
+  clampPercentage,
 } from '../HabitUtils';
 
 describe('habit progress utilities', () => {
@@ -135,8 +136,8 @@ describe('habit progress utilities', () => {
     expect(percentage).toBeCloseTo(50);
   });
 
-  it('uses victory color until stretch goal is broken for subtractive habits', () => {
-    const baseHabit: Habit = {
+  it('returns the stage color for progress bars', () => {
+    const habit: Habit = {
       id: 4,
       stage: 'Blue',
       name: 'Subtractive',
@@ -149,28 +150,26 @@ describe('habit progress utilities', () => {
       completions: [],
     };
 
-    const goodTier = getGoalTier(baseHabit);
-    expect(
-      getProgressBarColor(
-        baseHabit,
-        goodTier.currentGoal,
-        goodTier.nextGoal,
-        goodTier.completedAllGoals,
-      ),
-    ).toBe(VICTORY_COLOR);
+    expect(getProgressBarColor(habit)).toBe(STAGE_COLORS[habit.stage]);
+  });
 
-    const brokenHabit = {
-      ...baseHabit,
-      completions: [{ id: 1, timestamp: new Date(), completed_units: 1 }],
-    };
-    const brokenTier = getGoalTier(brokenHabit);
-    expect(
-      getProgressBarColor(
-        brokenHabit,
-        brokenTier.currentGoal,
-        brokenTier.nextGoal,
-        brokenTier.completedAllGoals,
-      ),
-    ).toBe(STAGE_COLORS[brokenHabit.stage]);
+  it('clamps percentage values between 0 and 100', () => {
+    expect(clampPercentage(150)).toBe(100);
+    expect(clampPercentage(-20)).toBe(0);
+  });
+
+  it('computes marker positions for additive goals', () => {
+    const [low, clear, stretch] = additiveGoals;
+    const pos = getMarkerPositions(low, clear, stretch);
+    expect(pos.low).toBeCloseTo(50);
+    expect(pos.clear).toBe(100);
+  });
+
+  it('computes marker positions for subtractive goals', () => {
+    const [low, clear, stretch] = subtractiveGoals;
+    const pos = getMarkerPositions(low, clear, stretch);
+    expect(pos.low).toBe(100);
+    expect(pos.stretch).toBe(0);
+    expect(pos.clear).toBeGreaterThan(0);
   });
 });

--- a/app/index.ts
+++ b/app/index.ts
@@ -1,3 +1,4 @@
+import 'react-native-reanimated';
 import { registerRootComponent } from 'expo';
 
 import App from './App';


### PR DESCRIPTION
## Summary
- wrap root app with SafeAreaProvider
- initialize react-native-reanimated via entry import and Babel plugin
- add bootstrap tests to ensure SafeAreaProvider and reanimated import remain
- compress habit tiles and apply stage-colored borders and progress bars
- scale layout with viewport height so all ten habits fit on screen

## Testing
- `npm --prefix app test`


------
https://chatgpt.com/codex/tasks/task_e_68ab953a101883229ae7b5b1c8747dd4