### PR TITLE
feat(habits): refine progress bar with milestones

### DIFF
--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Alert, Text, TouchableOpacity, View } from 'react-native';
+import React, { useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
 
 import { STAGE_COLORS } from '../../constants/stageColors';
 import { spacing } from '../../Sources/design/DesignSystem';
@@ -21,6 +21,8 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
   const formatGoalTooltip = (g: Goal) =>
     `${g.target} ${g.target_unit} ${g.frequency_unit.replace('_', ' ')}`;
   const stageColor = STAGE_COLORS[habit.stage];
+
+  const [tooltip, setTooltip] = useState<null | 'low' | 'clear' | 'stretch'>(null);
 
   const lowGoal = habit.goals.find((g) => g.tier === 'low');
   const clearGoal = habit.goals.find((g) => g.tier === 'clear');
@@ -146,18 +148,11 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
             }}
           />
           {lowGoal && lowMarker >= 0 && (
-            <TouchableOpacity
+            <View
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(lowMarker)}%`,
                 top: -6 + barHeight / 2,
-                width: 12,
-                height: 12,
-                borderRadius: 6,
-                backgroundColor: '#fffdf7',
-                borderWidth: 2,
-                borderColor: getTierColor('low'),
-                zIndex: 1,
                 transform: [
                   {
                     translateX:
@@ -168,23 +163,50 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                           : -6,
                   },
                 ],
+                zIndex: 1,
+                alignItems: 'center',
               }}
-              onLongPress={() => Alert.alert('Low Grit', formatGoalTooltip(lowGoal))}
-            />
+            >
+              {tooltip === 'low' && (
+                <View
+                  testID="tooltip-low"
+                  style={{
+                    position: 'absolute',
+                    bottom: 16,
+                    backgroundColor: '#fffdf7',
+                    borderWidth: 1,
+                    borderColor: getTierColor('low'),
+                    borderRadius: 4,
+                    paddingHorizontal: 4,
+                    paddingVertical: 2,
+                  }}
+                >
+                  <Text style={{ fontSize: spacing(1.5, scale), color: '#333' }}>
+                    {formatGoalTooltip(lowGoal)}
+                  </Text>
+                </View>
+              )}
+              <TouchableOpacity
+                testID="marker-low"
+                onPressIn={() => setTooltip('low')}
+                onPressOut={() => setTooltip(null)}
+                style={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: 6,
+                  backgroundColor: '#fffdf7',
+                  borderWidth: 2,
+                  borderColor: getTierColor('low'),
+                }}
+              />
+            </View>
           )}
           {clearGoal && clearMarker >= 0 && (
-            <TouchableOpacity
+            <View
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(clearMarker)}%`,
                 top: -6 + barHeight / 2,
-                width: 12,
-                height: 12,
-                borderRadius: 6,
-                backgroundColor: '#fffdf7',
-                borderWidth: 2,
-                borderColor: getTierColor('clear'),
-                zIndex: 2,
                 transform: [
                   {
                     translateX:
@@ -195,23 +217,50 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                           : -6,
                   },
                 ],
+                zIndex: 2,
+                alignItems: 'center',
               }}
-              onLongPress={() => Alert.alert('Clear Goal', formatGoalTooltip(clearGoal))}
-            />
+            >
+              {tooltip === 'clear' && (
+                <View
+                  testID="tooltip-clear"
+                  style={{
+                    position: 'absolute',
+                    bottom: 16,
+                    backgroundColor: '#fffdf7',
+                    borderWidth: 1,
+                    borderColor: getTierColor('clear'),
+                    borderRadius: 4,
+                    paddingHorizontal: 4,
+                    paddingVertical: 2,
+                  }}
+                >
+                  <Text style={{ fontSize: spacing(1.5, scale), color: '#333' }}>
+                    {formatGoalTooltip(clearGoal)}
+                  </Text>
+                </View>
+              )}
+              <TouchableOpacity
+                testID="marker-clear"
+                onPressIn={() => setTooltip('clear')}
+                onPressOut={() => setTooltip(null)}
+                style={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: 6,
+                  backgroundColor: '#fffdf7',
+                  borderWidth: 2,
+                  borderColor: getTierColor('clear'),
+                }}
+              />
+            </View>
           )}
           {stretchGoal && stretchMarker >= 0 && hasCleared && (
-            <TouchableOpacity
+            <View
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(stretchMarker)}%`,
                 top: -6 + barHeight / 2,
-                width: 12,
-                height: 12,
-                borderRadius: 6,
-                backgroundColor: '#fffdf7',
-                borderWidth: 2,
-                borderColor: getTierColor('stretch'),
-                zIndex: 3,
                 transform: [
                   {
                     translateX:
@@ -222,9 +271,43 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                           : -6,
                   },
                 ],
+                zIndex: 3,
+                alignItems: 'center',
               }}
-              onLongPress={() => Alert.alert('Stretch Goal', formatGoalTooltip(stretchGoal))}
-            />
+            >
+              {tooltip === 'stretch' && (
+                <View
+                  testID="tooltip-stretch"
+                  style={{
+                    position: 'absolute',
+                    bottom: 16,
+                    backgroundColor: '#fffdf7',
+                    borderWidth: 1,
+                    borderColor: getTierColor('stretch'),
+                    borderRadius: 4,
+                    paddingHorizontal: 4,
+                    paddingVertical: 2,
+                  }}
+                >
+                  <Text style={{ fontSize: spacing(1.5, scale), color: '#333' }}>
+                    {formatGoalTooltip(stretchGoal)}
+                  </Text>
+                </View>
+              )}
+              <TouchableOpacity
+                testID="marker-stretch"
+                onPressIn={() => setTooltip('stretch')}
+                onPressOut={() => setTooltip(null)}
+                style={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: 6,
+                  backgroundColor: '#fffdf7',
+                  borderWidth: 2,
+                  borderColor: getTierColor('stretch'),
+                }}
+              />
+            </View>
           )}
         </View>
         <View style={{ position: 'relative', marginTop: spacing(0.5, scale) }}>

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -188,7 +188,15 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                     paddingVertical: 2,
                   }}
                 >
-                  <Text style={{ fontSize: spacing(1.5, scale), color: '#333' }}>
+                  <Text
+                    style={{
+                      fontSize: spacing(1.5, scale),
+                      color: '#333',
+                      fontFamily: 'serif',
+                      fontStyle: 'italic',
+                      letterSpacing: 0.5,
+                    }}
+                  >
                     {formatGoalTooltip(lowGoal)}
                   </Text>
                 </View>
@@ -246,7 +254,15 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                     paddingVertical: 2,
                   }}
                 >
-                  <Text style={{ fontSize: spacing(1.5, scale), color: '#333' }}>
+                  <Text
+                    style={{
+                      fontSize: spacing(1.5, scale),
+                      color: '#333',
+                      fontFamily: 'serif',
+                      fontStyle: 'italic',
+                      letterSpacing: 0.5,
+                    }}
+                  >
                     {formatGoalTooltip(clearGoal)}
                   </Text>
                 </View>
@@ -304,7 +320,15 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                     paddingVertical: 2,
                   }}
                 >
-                  <Text style={{ fontSize: spacing(1.5, scale), color: '#333' }}>
+                  <Text
+                    style={{
+                      fontSize: spacing(1.5, scale),
+                      color: '#333',
+                      fontFamily: 'serif',
+                      fontStyle: 'italic',
+                      letterSpacing: 0.5,
+                    }}
+                  >
                     {formatGoalTooltip(stretchGoal)}
                   </Text>
                 </View>
@@ -331,7 +355,7 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
         </View>
         <View style={{ position: 'relative', marginTop: spacing(0.5, scale) }}>
           {lowGoal && lowMarker >= 0 && (
-            <Text
+            <View
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(lowMarker)}%`,
@@ -345,16 +369,17 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                           : -6,
                   },
                 ],
-                fontSize: spacing(1.5, scale),
-                color: getTierColor('low'),
                 zIndex: 1,
+                backgroundColor: '#fffdf7',
+                paddingHorizontal: 2,
+                borderRadius: 2,
               }}
             >
-              LG
-            </Text>
+              <Text style={{ fontSize: spacing(1.5, scale), color: getTierColor('low') }}>LG</Text>
+            </View>
           )}
           {clearGoal && clearMarker >= 0 && (
-            <Text
+            <View
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(clearMarker)}%`,
@@ -368,16 +393,19 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                           : -6,
                   },
                 ],
-                fontSize: spacing(1.5, scale),
-                color: getTierColor('clear'),
                 zIndex: 2,
+                backgroundColor: '#fffdf7',
+                paddingHorizontal: 2,
+                borderRadius: 2,
               }}
             >
-              CG
-            </Text>
+              <Text style={{ fontSize: spacing(1.5, scale), color: getTierColor('clear') }}>
+                CG
+              </Text>
+            </View>
           )}
           {stretchGoal && stretchMarker >= 0 && hasCleared && (
-            <Text
+            <View
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(stretchMarker)}%`,
@@ -391,13 +419,16 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                           : -6,
                   },
                 ],
-                fontSize: spacing(1.5, scale),
-                color: getTierColor('stretch'),
                 zIndex: 3,
+                backgroundColor: '#fffdf7',
+                paddingHorizontal: 2,
+                borderRadius: 2,
               }}
             >
-              SG
-            </Text>
+              <Text style={{ fontSize: spacing(1.5, scale), color: getTierColor('stretch') }}>
+                SG
+              </Text>
+            </View>
           )}
         </View>
       </View>

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -5,7 +5,7 @@ import { STAGE_COLORS } from '../../constants/stageColors';
 import { spacing } from '../../Sources/design/DesignSystem';
 import useResponsive from '../../Sources/design/useResponsive';
 
-import type { HabitTileProps } from './Habits.types';
+import type { HabitTileProps, Goal } from './Habits.types';
 import {
   getProgressPercentage,
   clampPercentage,
@@ -17,6 +17,8 @@ import {
 
 export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) => {
   const { width, height, columns, scale, gridGutter } = useResponsive();
+  const formatGoalTooltip = (g: Goal) =>
+    `${g.target} ${g.target_unit} ${g.frequency_unit.replace('_', ' ')}`;
   const stageColor = STAGE_COLORS[habit.stage];
 
   const lowGoal = habit.goals.find((g) => g.tier === 'low');
@@ -133,6 +135,14 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
             position: 'relative',
           }}
         >
+          <View
+            testID="progress-fill"
+            style={{
+              height: '100%',
+              width: `${progressPercentage}%`,
+              backgroundColor: progressBarColor,
+            }}
+          />
           {lowGoal && lowMarker >= 0 && (
             <TouchableOpacity
               style={{
@@ -142,13 +152,19 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                 bottom: 0,
                 width: 2,
                 backgroundColor: getTierColor('low'),
+                zIndex: 1,
+                transform: [
+                  {
+                    translateX:
+                      clampPercentage(lowMarker) === 0
+                        ? 0
+                        : clampPercentage(lowMarker) === 100
+                          ? -2
+                          : -1,
+                  },
+                ],
               }}
-              onLongPress={() =>
-                Alert.alert(
-                  'Low Goal',
-                  `${lowGoal.target} ${lowGoal.target_unit} ${lowGoal.frequency_unit}`,
-                )
-              }
+              onLongPress={() => Alert.alert('Low Grit', formatGoalTooltip(lowGoal))}
             />
           )}
           {clearGoal && clearMarker >= 0 && (
@@ -160,13 +176,19 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                 bottom: 0,
                 width: 2,
                 backgroundColor: getTierColor('clear'),
+                zIndex: 2,
+                transform: [
+                  {
+                    translateX:
+                      clampPercentage(clearMarker) === 0
+                        ? 0
+                        : clampPercentage(clearMarker) === 100
+                          ? -2
+                          : -1,
+                  },
+                ],
               }}
-              onLongPress={() =>
-                Alert.alert(
-                  'Clear Goal',
-                  `${clearGoal.target} ${clearGoal.target_unit} ${clearGoal.frequency_unit}`,
-                )
-              }
+              onLongPress={() => Alert.alert('Clear Goal', formatGoalTooltip(clearGoal))}
             />
           )}
           {stretchGoal && stretchMarker >= 0 && (
@@ -178,23 +200,21 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                 bottom: 0,
                 width: 2,
                 backgroundColor: getTierColor('stretch'),
+                zIndex: 3,
+                transform: [
+                  {
+                    translateX:
+                      clampPercentage(stretchMarker) === 0
+                        ? 0
+                        : clampPercentage(stretchMarker) === 100
+                          ? -2
+                          : -1,
+                  },
+                ],
               }}
-              onLongPress={() =>
-                Alert.alert(
-                  'Stretch Goal',
-                  `${stretchGoal.target} ${stretchGoal.target_unit} ${stretchGoal.frequency_unit}`,
-                )
-              }
+              onLongPress={() => Alert.alert('Stretch Goal', formatGoalTooltip(stretchGoal))}
             />
           )}
-          <View
-            testID="progress-fill"
-            style={{
-              height: '100%',
-              width: `${progressPercentage}%`,
-              backgroundColor: progressBarColor,
-            }}
-          />
         </View>
         <View style={{ position: 'relative', marginTop: spacing(0.5, scale) }}>
           {lowGoal && lowMarker >= 0 && (
@@ -202,9 +222,19 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(lowMarker)}%`,
-                transform: [{ translateX: -6 }],
+                transform: [
+                  {
+                    translateX:
+                      clampPercentage(lowMarker) === 0
+                        ? 0
+                        : clampPercentage(lowMarker) === 100
+                          ? -12
+                          : -6,
+                  },
+                ],
                 fontSize: spacing(1.5, scale),
                 color: getTierColor('low'),
+                zIndex: 1,
               }}
             >
               LG
@@ -215,9 +245,19 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(clearMarker)}%`,
-                transform: [{ translateX: -6 }],
+                transform: [
+                  {
+                    translateX:
+                      clampPercentage(clearMarker) === 0
+                        ? 0
+                        : clampPercentage(clearMarker) === 100
+                          ? -12
+                          : -6,
+                  },
+                ],
                 fontSize: spacing(1.5, scale),
                 color: getTierColor('clear'),
+                zIndex: 2,
               }}
             >
               CG
@@ -228,9 +268,19 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(stretchMarker)}%`,
-                transform: [{ translateX: -6 }],
+                transform: [
+                  {
+                    translateX:
+                      clampPercentage(stretchMarker) === 0
+                        ? 0
+                        : clampPercentage(stretchMarker) === 100
+                          ? -12
+                          : -6,
+                  },
+                ],
                 fontSize: spacing(1.5, scale),
                 color: getTierColor('stretch'),
+                zIndex: 3,
               }}
             >
               SG

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -14,12 +14,17 @@ import {
   getProgressBarColor,
   getTierColor,
   isGoalAchieved,
+  calculateHabitProgress,
 } from './HabitUtils';
 
 export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) => {
   const { width, height, columns, scale, gridGutter } = useResponsive();
-  const formatGoalTooltip = (g: Goal) =>
-    `${g.target} ${g.target_unit} ${g.frequency_unit.replace('_', ' ')}`;
+  const formatGoalTooltip = (g: Goal) => {
+    const label =
+      g.tier === 'low' ? 'Low Grit' : g.tier === 'clear' ? 'Clear Goal' : 'Stretch Goal';
+    const progress = calculateHabitProgress(habit);
+    return `${label}: ${progress}/${g.target} ${g.target_unit}`;
+  };
   const stageColor = STAGE_COLORS[habit.stage];
 
   const [tooltip, setTooltip] = useState<null | 'low' | 'clear' | 'stretch'>(null);
@@ -130,23 +135,25 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
       )}
 
       <View style={{ marginTop: spacing(1, scale) }}>
-        <View
-          style={{
-            height: barHeight,
-            backgroundColor: '#eee',
-            borderRadius: barHeight / 2,
-            overflow: 'hidden',
-            position: 'relative',
-          }}
-        >
+        <View style={{ height: barHeight, position: 'relative' }}>
           <View
-            testID="progress-fill"
             style={{
               height: '100%',
-              width: `${progressPercentage}%`,
-              backgroundColor: progressBarColor,
+              backgroundColor: '#eee',
+              borderRadius: barHeight / 2,
+              overflow: 'hidden',
             }}
-          />
+          >
+            <View
+              testID="progress-fill"
+              style={{
+                height: '100%',
+                width: `${progressPercentage}%`,
+                backgroundColor: progressBarColor,
+                borderRadius: barHeight / 2,
+              }}
+            />
+          </View>
           {lowGoal && lowMarker >= 0 && (
             <View
               style={{
@@ -190,6 +197,10 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                 testID="marker-low"
                 onPressIn={() => setTooltip('low')}
                 onPressOut={() => setTooltip(null)}
+                // @ts-ignore react-native-web hover props
+                onMouseEnter={() => setTooltip('low')}
+                // @ts-ignore react-native-web hover props
+                onMouseLeave={() => setTooltip(null)}
                 style={{
                   width: 12,
                   height: 12,
@@ -244,6 +255,10 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                 testID="marker-clear"
                 onPressIn={() => setTooltip('clear')}
                 onPressOut={() => setTooltip(null)}
+                // @ts-ignore react-native-web hover props
+                onMouseEnter={() => setTooltip('clear')}
+                // @ts-ignore react-native-web hover props
+                onMouseLeave={() => setTooltip(null)}
                 style={{
                   width: 12,
                   height: 12,
@@ -298,6 +313,10 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                 testID="marker-stretch"
                 onPressIn={() => setTooltip('stretch')}
                 onPressOut={() => setTooltip(null)}
+                // @ts-ignore react-native-web hover props
+                onMouseEnter={() => setTooltip('stretch')}
+                // @ts-ignore react-native-web hover props
+                onMouseLeave={() => setTooltip(null)}
                 style={{
                   width: 12,
                   height: 12,

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Text, TouchableOpacity, View } from 'react-native';
 
 import { STAGE_COLORS } from '../../constants/stageColors';
 import { spacing } from '../../Sources/design/DesignSystem';
@@ -7,7 +7,7 @@ import useResponsive from '../../Sources/design/useResponsive';
 
 import type { HabitTileProps } from './Habits.types';
 import {
-  calculateProgressPercentage,
+  getProgressPercentage,
   clampPercentage,
   getGoalTier,
   getMarkerPositions,
@@ -24,9 +24,7 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
   const stretchGoal = habit.goals.find((g) => g.tier === 'stretch');
 
   const { currentGoal, nextGoal, completedAllGoals } = getGoalTier(habit);
-  const progressPercentage = clampPercentage(
-    calculateProgressPercentage(habit, currentGoal, nextGoal),
-  );
+  const progressPercentage = clampPercentage(getProgressPercentage(habit, currentGoal, nextGoal));
   const progressBarColor = getProgressBarColor(habit);
   const hasCompletedGoal = completedAllGoals || progressPercentage >= 100;
   const streakText =
@@ -136,7 +134,7 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
           }}
         >
           {lowGoal && lowMarker >= 0 && (
-            <View
+            <TouchableOpacity
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(lowMarker)}%`,
@@ -145,10 +143,16 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                 width: 2,
                 backgroundColor: getTierColor('low'),
               }}
+              onLongPress={() =>
+                Alert.alert(
+                  'Low Goal',
+                  `${lowGoal.target} ${lowGoal.target_unit} ${lowGoal.frequency_unit}`,
+                )
+              }
             />
           )}
           {clearGoal && clearMarker >= 0 && (
-            <View
+            <TouchableOpacity
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(clearMarker)}%`,
@@ -157,10 +161,16 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                 width: 2,
                 backgroundColor: getTierColor('clear'),
               }}
+              onLongPress={() =>
+                Alert.alert(
+                  'Clear Goal',
+                  `${clearGoal.target} ${clearGoal.target_unit} ${clearGoal.frequency_unit}`,
+                )
+              }
             />
           )}
           {stretchGoal && stretchMarker >= 0 && (
-            <View
+            <TouchableOpacity
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(stretchMarker)}%`,
@@ -169,6 +179,12 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                 width: 2,
                 backgroundColor: getTierColor('stretch'),
               }}
+              onLongPress={() =>
+                Alert.alert(
+                  'Stretch Goal',
+                  `${stretchGoal.target} ${stretchGoal.target_unit} ${stretchGoal.frequency_unit}`,
+                )
+              }
             />
           )}
           <View
@@ -179,6 +195,47 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
               backgroundColor: progressBarColor,
             }}
           />
+        </View>
+        <View style={{ position: 'relative', marginTop: spacing(0.5, scale) }}>
+          {lowGoal && lowMarker >= 0 && (
+            <Text
+              style={{
+                position: 'absolute',
+                left: `${clampPercentage(lowMarker)}%`,
+                transform: [{ translateX: -6 }],
+                fontSize: spacing(1.5, scale),
+                color: getTierColor('low'),
+              }}
+            >
+              LG
+            </Text>
+          )}
+          {clearGoal && clearMarker >= 0 && (
+            <Text
+              style={{
+                position: 'absolute',
+                left: `${clampPercentage(clearMarker)}%`,
+                transform: [{ translateX: -6 }],
+                fontSize: spacing(1.5, scale),
+                color: getTierColor('clear'),
+              }}
+            >
+              CG
+            </Text>
+          )}
+          {stretchGoal && stretchMarker >= 0 && (
+            <Text
+              style={{
+                position: 'absolute',
+                left: `${clampPercentage(stretchMarker)}%`,
+                transform: [{ translateX: -6 }],
+                fontSize: spacing(1.5, scale),
+                color: getTierColor('stretch'),
+              }}
+            >
+              SG
+            </Text>
+          )}
         </View>
       </View>
     </TouchableOpacity>

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -13,6 +13,7 @@ import {
   getMarkerPositions,
   getProgressBarColor,
   getTierColor,
+  isGoalAchieved,
 } from './HabitUtils';
 
 export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) => {
@@ -43,6 +44,7 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
     clear: clearMarker,
     stretch: stretchMarker,
   } = getMarkerPositions(lowGoal, clearGoal, stretchGoal);
+  const hasCleared = clearGoal ? isGoalAchieved(clearGoal, habit) : false;
 
   return (
     <TouchableOpacity
@@ -148,10 +150,13 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(lowMarker)}%`,
-                top: 0,
-                bottom: 0,
-                width: 2,
-                backgroundColor: getTierColor('low'),
+                top: -6 + barHeight / 2,
+                width: 12,
+                height: 12,
+                borderRadius: 6,
+                backgroundColor: '#fffdf7',
+                borderWidth: 2,
+                borderColor: getTierColor('low'),
                 zIndex: 1,
                 transform: [
                   {
@@ -159,8 +164,8 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                       clampPercentage(lowMarker) === 0
                         ? 0
                         : clampPercentage(lowMarker) === 100
-                          ? -2
-                          : -1,
+                          ? -12
+                          : -6,
                   },
                 ],
               }}
@@ -172,10 +177,13 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(clearMarker)}%`,
-                top: 0,
-                bottom: 0,
-                width: 2,
-                backgroundColor: getTierColor('clear'),
+                top: -6 + barHeight / 2,
+                width: 12,
+                height: 12,
+                borderRadius: 6,
+                backgroundColor: '#fffdf7',
+                borderWidth: 2,
+                borderColor: getTierColor('clear'),
                 zIndex: 2,
                 transform: [
                   {
@@ -183,23 +191,26 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                       clampPercentage(clearMarker) === 0
                         ? 0
                         : clampPercentage(clearMarker) === 100
-                          ? -2
-                          : -1,
+                          ? -12
+                          : -6,
                   },
                 ],
               }}
               onLongPress={() => Alert.alert('Clear Goal', formatGoalTooltip(clearGoal))}
             />
           )}
-          {stretchGoal && stretchMarker >= 0 && (
+          {stretchGoal && stretchMarker >= 0 && hasCleared && (
             <TouchableOpacity
               style={{
                 position: 'absolute',
                 left: `${clampPercentage(stretchMarker)}%`,
-                top: 0,
-                bottom: 0,
-                width: 2,
-                backgroundColor: getTierColor('stretch'),
+                top: -6 + barHeight / 2,
+                width: 12,
+                height: 12,
+                borderRadius: 6,
+                backgroundColor: '#fffdf7',
+                borderWidth: 2,
+                borderColor: getTierColor('stretch'),
                 zIndex: 3,
                 transform: [
                   {
@@ -207,8 +218,8 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
                       clampPercentage(stretchMarker) === 0
                         ? 0
                         : clampPercentage(stretchMarker) === 100
-                          ? -2
-                          : -1,
+                          ? -12
+                          : -6,
                   },
                 ],
               }}
@@ -263,7 +274,7 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
               CG
             </Text>
           )}
-          {stretchGoal && stretchMarker >= 0 && (
+          {stretchGoal && stretchMarker >= 0 && hasCleared && (
             <Text
               style={{
                 position: 'absolute',

--- a/app/features/Habits/HabitUtils.ts
+++ b/app/features/Habits/HabitUtils.ts
@@ -30,6 +30,12 @@ export const getTierColor = (tier: 'low' | 'clear' | 'stretch') => {
 
 export const clampPercentage = (value: number): number => Math.min(100, Math.max(0, value));
 
+export const isGoalAchieved = (goal: Goal, habit: Habit): boolean => {
+  const totalProgress = calculateHabitProgress(habit);
+  const targetValue = getGoalTarget(goal);
+  return goal.is_additive ? totalProgress >= targetValue : totalProgress <= targetValue;
+};
+
 export const getMarkerPositions = (
   lowGoal?: Goal,
   clearGoal?: Goal,

--- a/app/features/Habits/HabitUtils.ts
+++ b/app/features/Habits/HabitUtils.ts
@@ -145,7 +145,12 @@ export const getGoalTier = (
   return { currentGoal, nextGoal, completedAllGoals };
 };
 
-export const calculateProgressPercentage = (
+// Returns current progress as a percentage between 0 and 100.
+//
+// The calculation supports both additive (e.g. "do X more") and
+// subtractive (e.g. "drink X less") habit types. The function also
+// ensures progress never overflows beyond the 0-100 range.
+export const getProgressPercentage = (
   habit: Habit,
   currentGoal: Goal,
   nextGoal: Goal | null,

--- a/app/features/Habits/HabitUtils.ts
+++ b/app/features/Habits/HabitUtils.ts
@@ -1,6 +1,6 @@
 import { STAGE_COLORS } from '../../constants/stageColors';
 
-import type { Goal, Habit } from './Habits.types';
+import type { Goal, Habit, Completion } from './Habits.types';
 
 export const STAGE_ORDER = [
   'Beige',
@@ -203,4 +203,26 @@ export const getProgressPercentage = (
 
 export const getProgressBarColor = (habit: Habit): string => {
   return STAGE_COLORS[habit.stage] ?? '#000';
+};
+
+// Logs a number of units for the given habit. Multiple logs can occur within
+// the same day; however, the streak counter will only increment once per
+// calendar day. Returns the updated habit object.
+export const logHabitUnits = (habit: Habit, amount: number, date: Date = new Date()): Habit => {
+  const alreadyLoggedToday =
+    habit.last_completion_date &&
+    new Date(habit.last_completion_date).toDateString() === date.toDateString();
+
+  const completion: Completion = {
+    id: Math.random(),
+    timestamp: date,
+    completed_units: amount,
+  };
+
+  return {
+    ...habit,
+    streak: alreadyLoggedToday ? habit.streak : habit.streak + 1,
+    last_completion_date: date,
+    completions: habit.completions ? [...habit.completions, completion] : [completion],
+  };
 };

--- a/app/features/Habits/Habits.styles.ts
+++ b/app/features/Habits/Habits.styles.ts
@@ -545,19 +545,19 @@ export const styles = StyleSheet.create({
   },
   currentIcon: {
     fontSize: 24,
-    marginRight: SPACING.sm,
   },
   iconButtonText: {
     color: COLORS.secondary,
     fontWeight: '500',
   },
   emojiSelectorContainer: {
-    height: 250,
+    height: 200,
     marginVertical: SPACING.md,
     borderWidth: 1,
     borderColor: '#ddd',
     borderRadius: BORDER_RADIUS.md,
     overflow: 'hidden',
+    backgroundColor: '#fff',
   },
 
   // ===== Reorder Button =====
@@ -1180,8 +1180,8 @@ export const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-    backgroundColor: COLORS.background.card,
-    height: 300,
+    backgroundColor: '#fff',
+    height: 280,
     borderTopLeftRadius: BORDER_RADIUS.xl,
     borderTopRightRadius: BORDER_RADIUS.xl,
     ...SHADOWS.large,

--- a/app/features/Habits/Habits.types.ts
+++ b/app/features/Habits/Habits.types.ts
@@ -75,6 +75,7 @@ export interface GoalModalProps {
   onClose: () => void;
   onUpdateGoal: (_habitId: number, _updatedGoal: Goal) => void;
   onLogUnit: (_habitId: number, _amount: number) => void;
+  onUpdateHabit: (_updatedHabit: Habit) => void;
 }
 
 export interface StatsModalProps {

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -545,6 +545,7 @@ const HabitsScreen = () => {
         onClose={() => setGoalModalVisible(false)}
         onUpdateGoal={handleUpdateGoal}
         onLogUnit={handleLogUnit}
+        onUpdateHabit={handleUpdateHabit}
       />
       <StatsModal
         visible={statsModalVisible}

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -267,6 +267,7 @@ const HabitsScreen = () => {
 
   // Log progress units for a habit
   const handleLogUnit = (habitId: number, amount: number) => {
+    let updated: Habit | null = null;
     setHabits((prev) =>
       prev.map((h) => {
         if (h.id !== habitId) return h;
@@ -274,6 +275,7 @@ const HabitsScreen = () => {
         const updatedHabit = logHabitUnits(h, amount);
         const newProgress = calculateHabitProgress(updatedHabit);
         const { currentGoal, nextGoal } = getGoalTier(updatedHabit);
+        updated = updatedHabit;
 
         if (currentGoal.is_additive) {
           const currentTarget = getGoalTarget(currentGoal);
@@ -311,6 +313,9 @@ const HabitsScreen = () => {
         return updatedHabit;
       }),
     );
+    if (selectedHabit?.id === habitId && updated) {
+      setSelectedHabit(updated);
+    }
   };
 
   // Update habit details

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -251,8 +251,15 @@ const HabitsScreen = () => {
     setHabits((prev) =>
       prev.map((h) => {
         if (h.id === habitId) {
-          const newStreak = h.streak + 1;
           const now = new Date();
+
+          // Prevent logging more than once per calendar day
+          const lastDate = h.last_completion_date ? new Date(h.last_completion_date) : undefined;
+          if (lastDate && lastDate.toDateString() === now.toDateString()) {
+            return h;
+          }
+
+          const newStreak = h.streak + 1;
 
           // Create a new completion record
           const newCompletion: Completion = {

--- a/app/features/Habits/__tests__/GoalModal.test.tsx
+++ b/app/features/Habits/__tests__/GoalModal.test.tsx
@@ -122,3 +122,28 @@ describe('GoalModal progress', () => {
     expect(parseFloat(updatedFill.props.style.width)).toBeCloseTo(33.33, 1);
   });
 });
+
+describe('GoalModal tooltips', () => {
+  it('shows tooltip when hovering over markers', () => {
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    const lowMarker = testRenderer.root.findByProps({ testID: 'modal-marker-low' });
+    renderer.act(() => {
+      lowMarker.props.onMouseEnter();
+    });
+    expect(testRenderer.root.findByProps({ testID: 'modal-tooltip-low' })).toBeTruthy();
+    renderer.act(() => {
+      lowMarker.props.onMouseLeave();
+    });
+    expect(() => testRenderer.root.findByProps({ testID: 'modal-tooltip-low' })).toThrow();
+  });
+});

--- a/app/features/Habits/__tests__/GoalModal.test.tsx
+++ b/app/features/Habits/__tests__/GoalModal.test.tsx
@@ -1,0 +1,87 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+/* eslint-disable import/order */
+import { jest } from '@jest/globals';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { GoalModal } from '../components/GoalModal';
+import type { Habit, Goal } from '../Habits.types';
+
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+const sampleGoals: Goal[] = [
+  {
+    id: 1,
+    tier: 'low',
+    title: 'low',
+    target: 1,
+    target_unit: 'units',
+    frequency: 1,
+    frequency_unit: 'per_day',
+    is_additive: true,
+  },
+  {
+    id: 2,
+    tier: 'clear',
+    title: 'clear',
+    target: 2,
+    target_unit: 'units',
+    frequency: 1,
+    frequency_unit: 'per_day',
+    is_additive: true,
+  },
+  {
+    id: 3,
+    tier: 'stretch',
+    title: 'stretch',
+    target: 3,
+    target_unit: 'units',
+    frequency: 1,
+    frequency_unit: 'per_day',
+    is_additive: true,
+  },
+];
+
+const sampleHabit: Habit = {
+  id: 1,
+  stage: 'Beige',
+  name: 'Test',
+  icon: '🔥',
+  streak: 0,
+  energy_cost: 0,
+  energy_return: 0,
+  start_date: new Date(),
+  goals: sampleGoals,
+  completions: [],
+};
+
+describe('GoalModal hook order', () => {
+  it('renders without crashing when habit becomes available', () => {
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={null}
+        onClose={() => {}}
+        onUpdateGoal={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    expect(() => {
+      renderer.act(() => {
+        testRenderer.update(
+          <GoalModal
+            visible
+            habit={sampleHabit}
+            onClose={() => {}}
+            onUpdateGoal={() => {}}
+            onLogUnit={() => {}}
+            onUpdateHabit={() => {}}
+          />,
+        );
+      });
+    }).not.toThrow();
+  });
+});

--- a/app/features/Habits/__tests__/GoalModal.test.tsx
+++ b/app/features/Habits/__tests__/GoalModal.test.tsx
@@ -7,6 +7,7 @@ import renderer from 'react-test-renderer';
 
 import { GoalModal } from '../components/GoalModal';
 import type { Habit, Goal } from '../Habits.types';
+import { logHabitUnits } from '../HabitUtils';
 
 jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
 
@@ -83,5 +84,41 @@ describe('GoalModal hook order', () => {
         );
       });
     }).not.toThrow();
+  });
+});
+
+describe('GoalModal progress', () => {
+  it('shows stretch marker and updates progress fill when habit changes', () => {
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    expect(testRenderer.root.findByProps({ testID: 'modal-marker-stretch' })).toBeTruthy();
+    const initialFill = testRenderer.root.findByProps({ testID: 'modal-progress-fill' });
+    expect(initialFill.props.style.width).toBe('0%');
+
+    const updatedHabit = logHabitUnits(sampleHabit, 1);
+    renderer.act(() => {
+      testRenderer.update(
+        <GoalModal
+          visible
+          habit={updatedHabit}
+          onClose={() => {}}
+          onUpdateGoal={() => {}}
+          onLogUnit={() => {}}
+          onUpdateHabit={() => {}}
+        />,
+      );
+    });
+
+    const updatedFill = testRenderer.root.findByProps({ testID: 'modal-progress-fill' });
+    expect(parseFloat(updatedFill.props.style.width)).toBeCloseTo(33.33, 1);
   });
 });

--- a/app/features/Habits/__tests__/HabitTileTooltip.test.tsx
+++ b/app/features/Habits/__tests__/HabitTileTooltip.test.tsx
@@ -1,0 +1,68 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+/* eslint-disable import/order */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { HabitTile } from '../HabitTile';
+import type { Habit } from '../Habits.types';
+
+const habit: Habit = {
+  id: 1,
+  stage: 'Beige',
+  name: 'Water',
+  icon: '💧',
+  streak: 0,
+  energy_cost: 0,
+  energy_return: 0,
+  start_date: new Date(),
+  goals: [
+    {
+      title: 'Low',
+      tier: 'low',
+      target: 10,
+      target_unit: 'oz',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+    {
+      title: 'Clear',
+      tier: 'clear',
+      target: 20,
+      target_unit: 'oz',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+    {
+      title: 'Stretch',
+      tier: 'stretch',
+      target: 30,
+      target_unit: 'oz',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+  ],
+  completions: [{ id: 1, timestamp: new Date(), completed_units: 5 }],
+};
+
+describe('HabitTile tooltips', () => {
+  it('shows tooltip on hover', () => {
+    const component = renderer.create(
+      <HabitTile habit={habit} onOpenGoals={() => {}} onLongPress={() => {}} />,
+    );
+
+    const marker = component.root.findByProps({ testID: 'marker-clear' });
+    expect(() => component.root.findByProps({ testID: 'tooltip-clear' })).toThrow();
+    renderer.act(() => {
+      marker.props.onMouseEnter();
+    });
+    expect(component.root.findByProps({ testID: 'tooltip-clear' })).toBeTruthy();
+    renderer.act(() => {
+      marker.props.onMouseLeave();
+    });
+    expect(() => component.root.findByProps({ testID: 'tooltip-clear' })).toThrow();
+  });
+});

--- a/app/features/Habits/__tests__/HabitUtils.test.ts
+++ b/app/features/Habits/__tests__/HabitUtils.test.ts
@@ -1,7 +1,13 @@
 /* eslint-env jest */
 /* global describe, test, expect */
 import type { Habit, Goal } from '../Habits.types';
-import { getProgressPercentage, getMarkerPositions, getGoalTier } from '../HabitUtils';
+import {
+  getProgressPercentage,
+  getMarkerPositions,
+  getGoalTier,
+  calculateHabitProgress,
+  logHabitUnits,
+} from '../HabitUtils';
 
 describe('HabitUtils', () => {
   const baseHabit = {
@@ -172,5 +178,93 @@ describe('HabitUtils', () => {
     expect(pos.low).toBe(100);
     expect(Math.round(pos.clear)).toBe(38);
     expect(pos.stretch).toBe(0);
+  });
+
+  test('logHabitUnits accumulates progress and increments streak once per day', () => {
+    const goals: Goal[] = [
+      {
+        id: 1,
+        tier: 'low',
+        title: 'low',
+        target: 5,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 2,
+        tier: 'clear',
+        title: 'clear',
+        target: 10,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 3,
+        tier: 'stretch',
+        title: 'stretch',
+        target: 15,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+    ];
+    let habit: Habit = { ...baseHabit, goals, completions: [], streak: 0 };
+    const day = new Date('2023-01-01T08:00:00');
+    habit = logHabitUnits(habit, 3, day);
+    expect(calculateHabitProgress(habit)).toBe(3);
+    expect(habit.streak).toBe(1);
+    habit = logHabitUnits(habit, 4, new Date('2023-01-01T12:00:00'));
+    expect(calculateHabitProgress(habit)).toBe(7);
+    expect(habit.streak).toBe(1);
+    habit = logHabitUnits(habit, 2, new Date('2023-01-02T09:00:00'));
+    expect(calculateHabitProgress(habit)).toBe(9);
+    expect(habit.streak).toBe(2);
+  });
+
+  test('logHabitUnits supports subtractive habits', () => {
+    const goals: Goal[] = [
+      {
+        id: 1,
+        tier: 'low',
+        title: 'low',
+        target: 10,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 2,
+        tier: 'clear',
+        title: 'clear',
+        target: 5,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 3,
+        tier: 'stretch',
+        title: 'stretch',
+        target: 2,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+    ];
+    let habit: Habit = { ...baseHabit, goals, completions: [], streak: 0 };
+    habit = logHabitUnits(habit, 4, new Date('2023-01-01T08:00:00'));
+    habit = logHabitUnits(habit, 3, new Date('2023-01-01T12:00:00'));
+    expect(calculateHabitProgress(habit)).toBe(7);
+    expect(habit.streak).toBe(1);
+    habit = logHabitUnits(habit, 1, new Date('2023-01-02T09:00:00'));
+    expect(habit.streak).toBe(2);
   });
 });

--- a/app/features/Habits/__tests__/HabitUtils.test.ts
+++ b/app/features/Habits/__tests__/HabitUtils.test.ts
@@ -1,0 +1,176 @@
+/* eslint-env jest */
+/* global describe, test, expect */
+import type { Habit, Goal } from '../Habits.types';
+import { getProgressPercentage, getMarkerPositions, getGoalTier } from '../HabitUtils';
+
+describe('HabitUtils', () => {
+  const baseHabit = {
+    id: 1,
+    name: 'Test',
+    icon: '🔥',
+    stage: 'Beige',
+    streak: 0,
+    energy_cost: 0,
+    energy_return: 0,
+    start_date: new Date(),
+  } as const;
+
+  test('getProgressPercentage additive clamps at 100', () => {
+    const goals: Goal[] = [
+      {
+        id: 1,
+        tier: 'low',
+        title: 'low',
+        target: 2,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 2,
+        tier: 'clear',
+        title: 'clear',
+        target: 4,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 3,
+        tier: 'stretch',
+        title: 'stretch',
+        target: 6,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+    ];
+    const habit: Habit = {
+      ...baseHabit,
+      goals,
+      completions: [{ id: 1, timestamp: new Date(), completed_units: 7 }],
+    };
+    const { currentGoal, nextGoal } = getGoalTier(habit);
+    expect(getProgressPercentage(habit, currentGoal, nextGoal)).toBe(100);
+  });
+
+  test('getProgressPercentage subtractive returns proportion', () => {
+    const goals: Goal[] = [
+      {
+        id: 1,
+        tier: 'low',
+        title: 'low',
+        target: 10,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 2,
+        tier: 'clear',
+        title: 'clear',
+        target: 5,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 3,
+        tier: 'stretch',
+        title: 'stretch',
+        target: 2,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+    ];
+    const habit: Habit = {
+      ...baseHabit,
+      goals,
+      completions: [{ id: 1, timestamp: new Date(), completed_units: 6 }],
+    };
+    const { currentGoal, nextGoal } = getGoalTier(habit);
+    const pct = getProgressPercentage(habit, currentGoal, nextGoal);
+    expect(Math.round(pct)).toBe(50);
+  });
+
+  test('getMarkerPositions additive', () => {
+    const low: Goal = {
+      id: 1,
+      tier: 'low',
+      title: 'low',
+      target: 2,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    };
+    const clear: Goal = {
+      id: 2,
+      tier: 'clear',
+      title: 'clear',
+      target: 4,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    };
+    const stretch: Goal = {
+      id: 3,
+      tier: 'stretch',
+      title: 'stretch',
+      target: 6,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    };
+    const pos = getMarkerPositions(low, clear, stretch);
+    expect(pos.low).toBeCloseTo(50);
+    expect(pos.clear).toBe(100);
+    expect(pos.stretch).toBe(100);
+  });
+
+  test('getMarkerPositions subtractive', () => {
+    const low: Goal = {
+      id: 1,
+      tier: 'low',
+      title: 'low',
+      target: 10,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    };
+    const clear: Goal = {
+      id: 2,
+      tier: 'clear',
+      title: 'clear',
+      target: 5,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    };
+    const stretch: Goal = {
+      id: 3,
+      tier: 'stretch',
+      title: 'stretch',
+      target: 2,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    };
+    const pos = getMarkerPositions(low, clear, stretch);
+    expect(pos.low).toBe(100);
+    expect(Math.round(pos.clear)).toBe(38);
+    expect(pos.stretch).toBe(0);
+  });
+});

--- a/app/features/Habits/__tests__/HabitsScreen.test.ts
+++ b/app/features/Habits/__tests__/HabitsScreen.test.ts
@@ -4,7 +4,7 @@ import { STAGE_COLORS } from '../../../constants/stageColors';
 import type { Habit, Goal } from '../Habits.types';
 import {
   calculateHabitProgress,
-  calculateProgressPercentage,
+  getProgressPercentage,
   getGoalTier,
   getProgressBarColor,
   getMarkerPositions,
@@ -113,7 +113,7 @@ describe('habit progress utilities', () => {
     };
 
     const { currentGoal, nextGoal } = getGoalTier(habit);
-    const percentage = calculateProgressPercentage(habit, currentGoal, nextGoal);
+    const percentage = getProgressPercentage(habit, currentGoal, nextGoal);
     expect(percentage).toBeCloseTo(33);
   });
 
@@ -132,7 +132,7 @@ describe('habit progress utilities', () => {
     };
 
     const { currentGoal, nextGoal } = getGoalTier(habit);
-    const percentage = calculateProgressPercentage(habit, currentGoal, nextGoal);
+    const percentage = getProgressPercentage(habit, currentGoal, nextGoal);
     expect(percentage).toBeCloseTo(50);
   });
 

--- a/app/features/Habits/components/GoalModal.tsx
+++ b/app/features/Habits/components/GoalModal.tsx
@@ -1,360 +1,155 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
-  View,
-  Text,
-  Pressable,
-  TouchableOpacity,
-  Modal,
-  TextInput,
-  TouchableWithoutFeedback,
-  ScrollView,
   Alert,
+  Modal,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+  PanResponder,
 } from 'react-native';
+import type { LayoutChangeEvent, ViewStyle, TextStyle } from 'react-native';
+import EmojiSelector from 'react-native-emoji-selector';
 
 import { STAGE_COLORS } from '../../../constants/stageColors';
 import styles from '../Habits.styles';
-import type { Goal, GoalModalProps, EditableGoalProps, Habit } from '../Habits.types';
-import { TARGET_UNITS, FREQUENCY_UNITS, DAYS_OF_WEEK } from '../HabitsScreen';
+import type { GoalModalProps } from '../Habits.types';
 import {
-  calculateHabitProgress,
-  getGoalTarget,
-  getTierColor,
   getGoalTier,
   getMarkerPositions,
-  getProgressPercentage,
   getProgressBarColor,
+  getProgressPercentage,
   clampPercentage,
+  getTierColor,
+  getGoalTarget,
+  isGoalAchieved,
 } from '../HabitUtils';
 
-// Constant for golden glow color to match with HabitTile
-const GOLDEN_GLOW_COLOR = 'rgba(255, 215, 0, 0.6)';
-const formatGoal = (g: Goal) =>
-  `${g.target} ${g.target_unit} ${g.frequency_unit.replace('_', ' ')}`;
+const bubbleStyle = (color: string, leftPct: number): ViewStyle => ({
+  position: 'absolute',
+  // @ts-ignore percentage positioning not typed
+  left: `${clampPercentage(leftPct)}%`,
+  top: -6,
+  width: 12,
+  height: 12,
+  borderRadius: 6,
+  backgroundColor: '#fffdf7',
+  borderWidth: 2,
+  borderColor: color,
+  transform: [
+    {
+      translateX: clampPercentage(leftPct) === 0 ? 0 : clampPercentage(leftPct) === 100 ? -12 : -6,
+    },
+  ],
+});
 
-/**
- * Determine if a goal has been achieved
- * @param goal The goal to check
- * @param habit The parent habit containing the progress data
- * @returns True if goal is achieved
- */
-const isGoalAchieved = (goal: Goal, habit: Habit): boolean => {
-  const totalProgress = calculateHabitProgress(habit);
-  const targetValue = getGoalTarget(goal);
+const labelStyle = (color: string, leftPct: number): TextStyle => ({
+  position: 'absolute',
+  // @ts-ignore percentage positioning not typed
+  left: `${clampPercentage(leftPct)}%`,
+  transform: [
+    {
+      translateX: clampPercentage(leftPct) === 0 ? 0 : clampPercentage(leftPct) === 100 ? -12 : -6,
+    },
+  ],
+  fontSize: 10,
+  color,
+});
 
-  if (goal.is_additive) {
-    return totalProgress >= targetValue;
-  } else {
-    return totalProgress <= targetValue;
-  }
-};
-
-/**
- * Editable goal component to display and modify a habit goal
- */
-const EditableGoal = ({
-  goal,
+export const GoalModal = ({
+  visible,
   habit,
-  onUpdate,
-  isEditing,
-}: EditableGoalProps & { habit: Habit }) => {
-  const [editedGoal, setEditedGoal] = useState<Goal>({ ...goal });
-  const [showTargetUnitDropdown, setShowTargetUnitDropdown] = useState(false);
-  const [showFrequencyUnitDropdown, setShowFrequencyUnitDropdown] = useState(false);
-  const [showDaysSelection, setShowDaysSelection] = useState(false);
-
-  // Reset edited goal when goal or editing status changes
-  useEffect(() => {
-    setEditedGoal({ ...goal });
-  }, [goal, isEditing]);
-
-  const handleChange = (field: keyof Goal, value: Goal[keyof Goal]) => {
-    setEditedGoal((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const handleSave = () => {
-    onUpdate(editedGoal);
-  };
-
-  // Check if goal is achieved
-  const achieved = isGoalAchieved(goal, habit);
-
-  const toggleDaySelection = (day: string) => {
-    const currentDays = editedGoal.days_of_week || [];
-    if (currentDays.includes(day)) {
-      handleChange(
-        'days_of_week',
-        currentDays.filter((d) => d !== day),
-      );
-    } else {
-      handleChange('days_of_week', [...currentDays, day]);
-    }
-  };
-
-  return (
-    <View
-      style={[
-        styles.goalItem,
-        {
-          backgroundColor: getTierColor(goal.tier),
-          borderWidth: achieved ? 2 : 0,
-          borderColor: achieved ? GOLDEN_GLOW_COLOR : 'transparent',
-        },
-      ]}
-    >
-      <View style={styles.goalHeader}>
-        <Text style={styles.goalTier}>
-          {goal.tier.toUpperCase()}
-          {achieved && ' ✓'}
-        </Text>
-        {isEditing && (
-          <TouchableOpacity onPress={handleSave} style={styles.saveButton}>
-            <Text style={styles.saveButtonText}>Save</Text>
-          </TouchableOpacity>
-        )}
-      </View>
-
-      {isEditing ? (
-        <TextInput
-          style={styles.goalTitleInput}
-          value={editedGoal.title}
-          onChangeText={(text) => handleChange('title', text)}
-          placeholder="Goal title"
-        />
-      ) : (
-        <Text style={styles.goalTitle}>{goal.title}</Text>
-      )}
-
-      <View style={styles.goalDetailsContainer}>
-        {isEditing ? (
-          <>
-            <View style={styles.editRow}>
-              <Text style={styles.editLabel}>Target:</Text>
-              <TextInput
-                style={styles.editInput}
-                value={editedGoal.target.toString()}
-                onChangeText={(text) => handleChange('target', parseFloat(text) || 0)}
-                keyboardType="numeric"
-              />
-
-              <TouchableOpacity
-                style={styles.unitDropdownButton}
-                onPress={() => setShowTargetUnitDropdown(!showTargetUnitDropdown)}
-              >
-                <Text>{editedGoal.target_unit || 'Select unit'}</Text>
-              </TouchableOpacity>
-
-              {showTargetUnitDropdown && (
-                <ScrollView style={styles.dropdown} keyboardShouldPersistTaps="handled">
-                  {TARGET_UNITS.map((unit) => (
-                    <TouchableOpacity
-                      key={unit}
-                      style={styles.dropdownItem}
-                      onPress={() => {
-                        handleChange('target_unit', unit);
-                        setShowTargetUnitDropdown(false);
-                      }}
-                    >
-                      <Text>{unit}</Text>
-                    </TouchableOpacity>
-                  ))}
-                </ScrollView>
-              )}
-            </View>
-
-            <View style={styles.editRow}>
-              <Text style={styles.editLabel}>Frequency:</Text>
-              <TextInput
-                style={styles.editInput}
-                value={editedGoal.frequency.toString()}
-                onChangeText={(text) => handleChange('frequency', parseFloat(text) || 0)}
-                keyboardType="numeric"
-              />
-
-              <TouchableOpacity
-                style={styles.unitDropdownButton}
-                onPress={() => setShowFrequencyUnitDropdown(!showFrequencyUnitDropdown)}
-              >
-                <Text>{editedGoal.frequency_unit.replace('_', ' ') || 'Select frequency'}</Text>
-              </TouchableOpacity>
-
-              {showFrequencyUnitDropdown && (
-                <ScrollView style={styles.dropdown} keyboardShouldPersistTaps="handled">
-                  {FREQUENCY_UNITS.map((unit) => (
-                    <TouchableOpacity
-                      key={unit}
-                      style={styles.dropdownItem}
-                      onPress={() => {
-                        handleChange('frequency_unit', unit);
-                        setShowFrequencyUnitDropdown(false);
-                      }}
-                    >
-                      <Text>{unit.replace('_', ' ')}</Text>
-                    </TouchableOpacity>
-                  ))}
-                </ScrollView>
-              )}
-            </View>
-
-            {editedGoal.frequency_unit === 'per_week' && (
-              <View style={styles.editRow}>
-                <Text style={styles.editLabel}>Days:</Text>
-                <TouchableOpacity
-                  style={styles.daysSelectorButton}
-                  onPress={() => setShowDaysSelection(!showDaysSelection)}
-                >
-                  <Text>
-                    {editedGoal.days_of_week && editedGoal.days_of_week.length > 0
-                      ? editedGoal.days_of_week.map((d) => d.substring(0, 3)).join(', ')
-                      : 'Select days'}
-                  </Text>
-                </TouchableOpacity>
-
-                {showDaysSelection && (
-                  <View style={styles.daysSelector}>
-                    {DAYS_OF_WEEK.map((day) => (
-                      <TouchableOpacity
-                        key={day}
-                        style={[
-                          styles.dayOption,
-                          (editedGoal.days_of_week || []).includes(day) && styles.selectedDayOption,
-                        ]}
-                        onPress={() => toggleDaySelection(day)}
-                      >
-                        <Text style={styles.dayOptionText}>{day.substring(0, 3)}</Text>
-                      </TouchableOpacity>
-                    ))}
-                  </View>
-                )}
-              </View>
-            )}
-
-            <View style={styles.editRow}>
-              <Text style={styles.editLabel}>Type:</Text>
-              <Pressable
-                style={[
-                  styles.toggleButton,
-                  {
-                    backgroundColor: editedGoal.is_additive ? '#4CAF50' : '#ccc',
-                  },
-                ]}
-                onPress={() => handleChange('is_additive', true)}
-              >
-                <Text style={styles.toggleText}>Additive</Text>
-              </Pressable>
-              <Pressable
-                style={[
-                  styles.toggleButton,
-                  {
-                    backgroundColor: !editedGoal.is_additive ? '#F44336' : '#ccc',
-                  },
-                ]}
-                onPress={() => handleChange('is_additive', false)}
-              >
-                <Text style={styles.toggleText}>Subtractive</Text>
-              </Pressable>
-            </View>
-          </>
-        ) : (
-          <Text style={styles.goalDetails}>
-            {goal.is_additive ? 'At least' : 'No more than'} {goal.target} {goal.target_unit},{' '}
-            {goal.frequency} {goal.frequency_unit.replace('_', ' ')}
-            {goal.days_of_week &&
-              goal.days_of_week.length > 0 &&
-              ` on ${goal.days_of_week.map((d) => d.substring(0, 3)).join(', ')}`}
-          </Text>
-        )}
-      </View>
-
-      {/* Progress removed in favor of unified bar at top */}
-    </View>
-  );
-};
-
-/**
- * Main GoalModal component to display and manage habit goals
- */
-export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: GoalModalProps) => {
-  const [activeGoal, setActiveGoal] = useState<Goal | null>(null);
-  const [isEditing, setIsEditing] = useState(false);
+  onClose,
+  onUpdateGoal,
+  onLogUnit,
+  onUpdateHabit,
+}: GoalModalProps) => {
   const [logAmount, setLogAmount] = useState('1');
-  const [goalVisible, setGoalVisible] = useState<Record<number, boolean>>({});
-
-  // Initialize all goals to be visible initially
-  useEffect(() => {
-    if (habit && visible) {
-      const visibilityMap: Record<number, boolean> = {};
-      habit.goals.forEach((goal, index) => {
-        visibilityMap[index] = true;
-      });
-      setGoalVisible(visibilityMap);
-    }
-  }, [habit, visible]);
-
-  // Reset state when modal is closed
-  useEffect(() => {
-    if (!visible) {
-      setIsEditing(false);
-      setActiveGoal(null);
-      setLogAmount('1');
-    }
-  }, [visible]);
+  const [showEmojiSelector, setShowEmojiSelector] = useState(false);
+  const barWidth = useRef(0);
+  const [lowMarker, setLowMarker] = useState(0);
+  const [clearMarker, setClearMarker] = useState(0);
 
   if (!habit) return null;
-
-  const handleUpdateGoal = (updatedGoal: Goal) => {
-    if (habit.id && updatedGoal.id) {
-      onUpdateGoal(habit.id, updatedGoal);
-      setIsEditing(false);
-    }
-  };
-
-  const handleLogUnit = () => {
-    if (habit.id) {
-      const amount = parseFloat(logAmount) || 1;
-      onLogUnit(habit.id, amount);
-      setLogAmount('1');
-
-      // Show a feedback alert
-      Alert.alert(
-        'Progress Logged',
-        `Added ${amount} ${amount === 1 ? 'unit' : 'units'} to ${habit.name}`,
-        [{ text: 'OK', onPress: () => {} }],
-      );
-    }
-  };
-
-  const handleEditGoal = (goal: Goal) => {
-    setActiveGoal(goal);
-    setIsEditing(true);
-  };
-
-  const toggleGoalVisibility = (index: number) => {
-    setGoalVisible((prev) => ({
-      ...prev,
-      [index]: !prev[index],
-    }));
-  };
-
-  // Calculate total habit progress for display
-  const totalProgress = calculateHabitProgress(habit);
 
   const lowGoal = habit.goals.find((g) => g.tier === 'low');
   const clearGoal = habit.goals.find((g) => g.tier === 'clear');
   const stretchGoal = habit.goals.find((g) => g.tier === 'stretch');
   const { currentGoal, nextGoal } = getGoalTier(habit);
   const progressPercentage = clampPercentage(getProgressPercentage(habit, currentGoal, nextGoal));
-  const {
-    low: lowMarker,
-    clear: clearMarker,
-    stretch: stretchMarker,
-  } = getMarkerPositions(lowGoal, clearGoal, stretchGoal);
   const progressBarColor = getProgressBarColor(habit);
+  const markers = getMarkerPositions(lowGoal, clearGoal, stretchGoal);
+  const stretchMarker = markers.stretch;
 
-  // Sort goals by tier for consistent display order
-  const sortedGoals = [...habit.goals].sort((a, b) => {
-    const tierOrder = { low: 1, clear: 2, stretch: 3 };
-    return tierOrder[a.tier] - tierOrder[b.tier];
-  });
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    setLowMarker(markers.low);
+    setClearMarker(markers.clear);
+  }, [markers.low, markers.clear]);
+
+  const handleBarLayout = (e: LayoutChangeEvent) => {
+    barWidth.current = e.nativeEvent.layout.width;
+  };
+
+  const confirmUpdate = (tier: 'low' | 'clear', percent: number) => {
+    const goal = tier === 'low' ? lowGoal : clearGoal;
+    if (!goal || !habit.id) return;
+    const stretchTarget = stretchGoal ? getGoalTarget(stretchGoal) : goal.target;
+    const newTarget = Math.max(1, Math.round((percent / 100) * stretchTarget));
+    Alert.alert(
+      tier === 'low' ? 'Edit Low Goal' : 'Edit Clear Goal',
+      `Edit the ${tier === 'low' ? 'Low Grit' : 'Clear Goal'} to be ${newTarget} ${goal.target_unit} ${goal.frequency_unit.replace(
+        '_',
+        ' ',
+      )}?`,
+      [
+        {
+          text: 'No',
+          style: 'cancel',
+          onPress: () => {
+            if (tier === 'low') setLowMarker(markers.low);
+            else setClearMarker(markers.clear);
+          },
+        },
+        {
+          text: 'Yes',
+          onPress: () => onUpdateGoal(habit.id!, { ...goal, target: newTarget }),
+        },
+      ],
+    );
+  };
+
+  const createPanResponder = (tier: 'low' | 'clear') =>
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onPanResponderMove: (_, gesture) => {
+        const init = tier === 'low' ? markers.low : markers.clear;
+        const percent = (((init / 100) * barWidth.current + gesture.dx) / barWidth.current) * 100;
+        if (tier === 'low') {
+          setLowMarker(Math.min(clampPercentage(percent), clearMarker - 5));
+        } else {
+          setClearMarker(Math.max(clampPercentage(percent), lowMarker + 5));
+        }
+      },
+      onPanResponderRelease: () => {
+        const percent = tier === 'low' ? lowMarker : clearMarker;
+        confirmUpdate(tier, percent);
+      },
+    });
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const lowPan = useRef(createPanResponder('low')).current;
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const clearPan = useRef(createPanResponder('clear')).current;
+
+  const handleLogUnit = () => {
+    if (habit.id) {
+      const amount = parseFloat(logAmount) || 1;
+      onLogUnit(habit.id, amount);
+      setLogAmount('1');
+    }
+  };
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
@@ -363,30 +158,31 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
           <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
             <View style={[styles.modalContent, { borderTopColor: STAGE_COLORS[habit.stage] }]}>
               <View style={styles.modalHeader}>
-                <Text style={styles.modalTitle}>
-                  {habit.name} <Text style={styles.iconLarge}>{habit.icon}</Text>
-                </Text>
-                <Text style={styles.streakBadge}>
-                  {habit.streak} {habit.streak === 1 ? 'day' : 'days'}
-                </Text>
+                <Text style={styles.modalTitle}>{habit.name}</Text>
+                <TouchableOpacity onPress={() => setShowEmojiSelector(true)}>
+                  <Text style={styles.iconLarge}>{habit.icon}</Text>
+                </TouchableOpacity>
                 <TouchableOpacity onPress={onClose} style={styles.closeButton}>
                   <Text style={styles.closeButtonText}>×</Text>
                 </TouchableOpacity>
               </View>
 
-              {/* Habit summary section */}
-              <View style={styles.habitSummary}>
-                <Text style={styles.habitSummaryText}>
-                  Total Progress: {totalProgress} {sortedGoals[0]?.target_unit || 'units'}
-                </Text>
-                <Text style={styles.habitSummaryText}>
-                  Energy: Cost {habit.energy_cost} · Return {habit.energy_return} · Net{' '}
-                  {habit.energy_return - habit.energy_cost}
-                </Text>
-              </View>
+              {showEmojiSelector && (
+                <View style={styles.emojiSelectorContainer}>
+                  <EmojiSelector
+                    onEmojiSelected={(emoji) => {
+                      onUpdateHabit({ ...habit, icon: emoji });
+                      setShowEmojiSelector(false);
+                    }}
+                    showSearchBar
+                    columns={6}
+                    // @ts-ignore react-native-emoji-selector missing emojiSize typing
+                    emojiSize={28}
+                  />
+                </View>
+              )}
 
-              {/* Unified progress bar with markers */}
-              <View style={{ marginVertical: 16 }}>
+              <View style={{ marginVertical: 16 }} onLayout={handleBarLayout}>
                 <View
                   style={{
                     height: 12,
@@ -404,179 +200,31 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
                     }}
                   />
                   {lowGoal && (
-                    <TouchableOpacity
-                      style={{
-                        position: 'absolute',
-                        left: `${clampPercentage(lowMarker)}%`,
-                        top: 0,
-                        bottom: 0,
-                        width: 2,
-                        backgroundColor: getTierColor('low'),
-                        zIndex: 1,
-                        transform: [
-                          {
-                            translateX:
-                              clampPercentage(lowMarker) === 0
-                                ? 0
-                                : clampPercentage(lowMarker) === 100
-                                  ? -2
-                                  : -1,
-                          },
-                        ],
-                      }}
-                      onPress={() => handleEditGoal(lowGoal)}
-                      onLongPress={() => Alert.alert('Low Grit', formatGoal(lowGoal))}
+                    <View
+                      {...lowPan.panHandlers}
+                      style={bubbleStyle(getTierColor('low'), lowMarker)}
                     />
                   )}
                   {clearGoal && (
-                    <TouchableOpacity
-                      style={{
-                        position: 'absolute',
-                        left: `${clampPercentage(clearMarker)}%`,
-                        top: 0,
-                        bottom: 0,
-                        width: 2,
-                        backgroundColor: getTierColor('clear'),
-                        zIndex: 2,
-                        transform: [
-                          {
-                            translateX:
-                              clampPercentage(clearMarker) === 0
-                                ? 0
-                                : clampPercentage(clearMarker) === 100
-                                  ? -2
-                                  : -1,
-                          },
-                        ],
-                      }}
-                      onPress={() => handleEditGoal(clearGoal)}
-                      onLongPress={() => Alert.alert('Clear Goal', formatGoal(clearGoal))}
+                    <View
+                      {...clearPan.panHandlers}
+                      style={bubbleStyle(getTierColor('clear'), clearMarker)}
                     />
                   )}
-                  {stretchGoal && (
-                    <TouchableOpacity
-                      style={{
-                        position: 'absolute',
-                        left: `${clampPercentage(stretchMarker)}%`,
-                        top: 0,
-                        bottom: 0,
-                        width: 2,
-                        backgroundColor: getTierColor('stretch'),
-                        zIndex: 3,
-                        transform: [
-                          {
-                            translateX:
-                              clampPercentage(stretchMarker) === 0
-                                ? 0
-                                : clampPercentage(stretchMarker) === 100
-                                  ? -2
-                                  : -1,
-                          },
-                        ],
-                      }}
-                      onPress={() => handleEditGoal(stretchGoal)}
-                      onLongPress={() => Alert.alert('Stretch Goal', formatGoal(stretchGoal))}
-                    />
+                  {stretchGoal && isGoalAchieved(clearGoal!, habit) && (
+                    <View style={bubbleStyle(getTierColor('stretch'), stretchMarker)} />
                   )}
                 </View>
                 <View style={{ position: 'relative', marginTop: 4 }}>
-                  {lowGoal && (
-                    <Text
-                      style={{
-                        position: 'absolute',
-                        left: `${clampPercentage(lowMarker)}%`,
-                        transform: [
-                          {
-                            translateX:
-                              clampPercentage(lowMarker) === 0
-                                ? 0
-                                : clampPercentage(lowMarker) === 100
-                                  ? -12
-                                  : -6,
-                          },
-                        ],
-                        fontSize: 10,
-                        color: getTierColor('low'),
-                        zIndex: 1,
-                      }}
-                    >
-                      LG
-                    </Text>
-                  )}
+                  {lowGoal && <Text style={labelStyle(getTierColor('low'), lowMarker)}>LG</Text>}
                   {clearGoal && (
-                    <Text
-                      style={{
-                        position: 'absolute',
-                        left: `${clampPercentage(clearMarker)}%`,
-                        transform: [
-                          {
-                            translateX:
-                              clampPercentage(clearMarker) === 0
-                                ? 0
-                                : clampPercentage(clearMarker) === 100
-                                  ? -12
-                                  : -6,
-                          },
-                        ],
-                        fontSize: 10,
-                        color: getTierColor('clear'),
-                        zIndex: 2,
-                      }}
-                    >
-                      CG
-                    </Text>
+                    <Text style={labelStyle(getTierColor('clear'), clearMarker)}>CG</Text>
                   )}
-                  {stretchGoal && (
-                    <Text
-                      style={{
-                        position: 'absolute',
-                        left: `${clampPercentage(stretchMarker)}%`,
-                        transform: [
-                          {
-                            translateX:
-                              clampPercentage(stretchMarker) === 0
-                                ? 0
-                                : clampPercentage(stretchMarker) === 100
-                                  ? -12
-                                  : -6,
-                          },
-                        ],
-                        fontSize: 10,
-                        color: getTierColor('stretch'),
-                        zIndex: 3,
-                      }}
-                    >
-                      SG
-                    </Text>
+                  {stretchGoal && isGoalAchieved(clearGoal!, habit) && (
+                    <Text style={labelStyle(getTierColor('stretch'), stretchMarker)}>SG</Text>
                   )}
                 </View>
               </View>
-
-              <ScrollView style={styles.goalsContainer}>
-                {sortedGoals.map((goal, index) => (
-                  <View key={index}>
-                    <TouchableOpacity
-                      style={styles.goalHeaderToggle}
-                      onPress={() => toggleGoalVisibility(index)}
-                    >
-                      <Text style={styles.goalHeaderToggleText}>
-                        {goal.tier.toUpperCase()} GOAL {goalVisible[index] ? '▼' : '►'}
-                      </Text>
-                    </TouchableOpacity>
-
-                    {goalVisible[index] && (
-                      <TouchableOpacity onPress={() => handleEditGoal(goal)}>
-                        <EditableGoal
-                          goal={goal}
-                          habit={habit}
-                          onUpdate={handleUpdateGoal}
-                          isEditing={isEditing && activeGoal?.id === goal.id}
-                        />
-                      </TouchableOpacity>
-                    )}
-                  </View>
-                ))}
-              </ScrollView>
 
               <View style={styles.actionButtons}>
                 <View style={styles.logUnitContainer}>
@@ -590,14 +238,6 @@ export const GoalModal = ({ visible, habit, onClose, onUpdateGoal, onLogUnit }: 
                     <Text style={styles.logUnitButtonText}>Log Units</Text>
                   </TouchableOpacity>
                 </View>
-                <TouchableOpacity
-                  style={styles.editButton}
-                  onPress={() => setIsEditing(!isEditing)}
-                >
-                  <Text style={styles.editButtonText}>
-                    {isEditing ? 'Done Editing' : 'Edit Goals'}
-                  </Text>
-                </TouchableOpacity>
               </View>
             </View>
           </TouchableWithoutFeedback>

--- a/app/features/Habits/components/GoalModal.tsx
+++ b/app/features/Habits/components/GoalModal.tsx
@@ -71,18 +71,20 @@ export const GoalModal = ({
   const [lowMarker, setLowMarker] = useState(0);
   const [clearMarker, setClearMarker] = useState(0);
 
-  if (!habit) return null;
-
-  const lowGoal = habit.goals.find((g) => g.tier === 'low');
-  const clearGoal = habit.goals.find((g) => g.tier === 'clear');
-  const stretchGoal = habit.goals.find((g) => g.tier === 'stretch');
-  const { currentGoal, nextGoal } = getGoalTier(habit);
-  const progressPercentage = clampPercentage(getProgressPercentage(habit, currentGoal, nextGoal));
-  const progressBarColor = getProgressBarColor(habit);
+  const lowGoal = habit?.goals.find((g) => g.tier === 'low');
+  const clearGoal = habit?.goals.find((g) => g.tier === 'clear');
+  const stretchGoal = habit?.goals.find((g) => g.tier === 'stretch');
+  const { currentGoal, nextGoal } = habit
+    ? getGoalTier(habit)
+    : { currentGoal: lowGoal || null, nextGoal: clearGoal || null };
+  const progressPercentage =
+    habit && currentGoal
+      ? clampPercentage(getProgressPercentage(habit, currentGoal, nextGoal ?? null))
+      : 0;
+  const progressBarColor = habit ? getProgressBarColor(habit) : '#eee';
   const markers = getMarkerPositions(lowGoal, clearGoal, stretchGoal);
   const stretchMarker = markers.stretch;
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     setLowMarker(markers.low);
     setClearMarker(markers.clear);
@@ -94,7 +96,7 @@ export const GoalModal = ({
 
   const confirmUpdate = (tier: 'low' | 'clear', percent: number) => {
     const goal = tier === 'low' ? lowGoal : clearGoal;
-    if (!goal || !habit.id) return;
+    if (!goal || !habit?.id) return;
     const stretchTarget = stretchGoal ? getGoalTarget(stretchGoal) : goal.target;
     const newTarget = Math.max(1, Math.round((percent / 100) * stretchTarget));
     Alert.alert(
@@ -138,18 +140,18 @@ export const GoalModal = ({
       },
     });
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const lowPan = useRef(createPanResponder('low')).current;
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const clearPan = useRef(createPanResponder('clear')).current;
 
   const handleLogUnit = () => {
-    if (habit.id) {
+    if (habit?.id) {
       const amount = parseFloat(logAmount) || 1;
       onLogUnit(habit.id, amount);
       setLogAmount('1');
     }
   };
+
+  if (!habit) return null;
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>

--- a/app/features/Habits/components/HabitSettingsModal.tsx
+++ b/app/features/Habits/components/HabitSettingsModal.tsx
@@ -145,12 +145,8 @@ export const HabitSettingsModal = ({
 
             <View style={styles.settingRow}>
               <Text style={styles.settingLabel}>Icon:</Text>
-              <TouchableOpacity
-                style={styles.iconSelectorButton}
-                onPress={() => setShowEmojiSelector(!showEmojiSelector)}
-              >
+              <TouchableOpacity onPress={() => setShowEmojiSelector(!showEmojiSelector)}>
                 <Text style={styles.currentIcon}>{editedHabit.icon}</Text>
-                <Text style={styles.iconButtonText}>Change</Text>
               </TouchableOpacity>
             </View>
 
@@ -162,7 +158,9 @@ export const HabitSettingsModal = ({
                     setShowEmojiSelector(false);
                   }}
                   showSearchBar
-                  columns={8}
+                  columns={6}
+                  // @ts-ignore react-native-emoji-selector typing
+                  emojiSize={28}
                   placeholder="Search emoji..."
                 />
               </View>

--- a/app/features/Habits/components/OnboardingModal.tsx
+++ b/app/features/Habits/components/OnboardingModal.tsx
@@ -271,7 +271,9 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
           <EmojiSelector
             onEmojiSelected={(emoji) => updateHabitIcon(selectedHabitIndex, emoji)}
             showSearchBar
-            columns={8}
+            columns={6}
+            // @ts-ignore react-native-emoji-selector typing
+            emojiSize={28}
           />
         </View>
       )}


### PR DESCRIPTION
## Summary
- refactor habit progress bar with color-coded markers and milestone labels
- clamp habit logging to one completion per day
- add unit tests for progress percentage and marker positioning

## Testing
- `npm test`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68accc07d39c8322bff9e2daf01cd0fb