### PR TITLE
feat: enhance energy scaffolding icons

### DIFF
--- a/app/features/Habits/EnergyUtils.ts
+++ b/app/features/Habits/EnergyUtils.ts
@@ -1,0 +1,3 @@
+export const calculateNetEnergy = (cost: number, returnValue: number): number => {
+  return returnValue - cost;
+};

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -18,6 +18,7 @@ import {
 export const HabitTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: HabitTileProps) => {
   const { width, height, columns, scale, gridGutter } = useResponsive();
   const stageColor = STAGE_COLORS[habit.stage];
+  const isUpcoming = new Date(habit.start_date) > new Date();
 
   const lowGoal = habit.goals.find((g) => g.tier === 'low');
   const clearGoal = habit.goals.find((g) => g.tier === 'clear');
@@ -56,6 +57,7 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: Habi
         minHeight: tileMinHeight,
         borderRadius: spacing(1, scale),
         backgroundColor: '#f8f8f8',
+        opacity: isUpcoming ? 0.4 : 1,
       }}
       onPress={onOpenGoals}
       onLongPress={onLongPress}

--- a/app/features/Habits/HabitTile.tsx
+++ b/app/features/Habits/HabitTile.tsx
@@ -15,7 +15,7 @@ import {
   getTierColor,
 } from './HabitUtils';
 
-export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) => {
+export const HabitTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: HabitTileProps) => {
   const { width, height, columns, scale, gridGutter } = useResponsive();
   const stageColor = STAGE_COLORS[habit.stage];
 
@@ -62,7 +62,11 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
     >
       {iconInline ? (
         <View testID="habit-header" style={{ flexDirection: 'row', alignItems: 'center' }}>
-          <Text style={{ fontSize: spacing(3, scale), marginRight: spacing(1, scale) }}>
+          <Text
+            style={{ fontSize: spacing(3, scale), marginRight: spacing(1, scale) }}
+            onPress={onIconPress}
+            testID="habit-icon"
+          >
             {habit.icon}
           </Text>
           <Text
@@ -95,7 +99,13 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress }: HabitTileProps) =
             testID="habit-icon-top"
             style={{ alignItems: 'center', marginBottom: spacing(1, scale) }}
           >
-            <Text style={{ fontSize: spacing(4, scale) }}>{habit.icon}</Text>
+            <Text
+              style={{ fontSize: spacing(4, scale) }}
+              onPress={onIconPress}
+              testID="habit-icon-top-text"
+            >
+              {habit.icon}
+            </Text>
           </View>
           <View testID="habit-header" style={{ flexDirection: 'row', alignItems: 'center' }}>
             <Text

--- a/app/features/Habits/Habits.styles.ts
+++ b/app/features/Habits/Habits.styles.ts
@@ -1176,16 +1176,11 @@ export const styles = StyleSheet.create({
 
   // ===== Emoji Picker =====
   emojiPickerModal: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    bottom: 0,
     backgroundColor: COLORS.background.card,
-    height: 300,
-    borderTopLeftRadius: BORDER_RADIUS.xl,
-    borderTopRightRadius: BORDER_RADIUS.xl,
+    width: '90%',
+    maxHeight: 300,
+    borderRadius: BORDER_RADIUS.xl,
     ...SHADOWS.large,
-    zIndex: 1000,
   },
   emojiPickerHeader: {
     flexDirection: 'row',

--- a/app/features/Habits/Habits.types.ts
+++ b/app/features/Habits/Habits.types.ts
@@ -67,6 +67,8 @@ export interface OnboardingHabit {
   energy_return: number;
   stage: string;
   start_date: Date;
+  costEntered?: boolean;
+  returnEntered?: boolean;
 }
 
 export interface GoalModalProps {
@@ -94,6 +96,7 @@ export interface HabitTileProps {
   habit: Habit;
   onOpenGoals: () => void;
   onLongPress: () => void;
+  onIconPress?: () => void;
 }
 
 export interface HabitSettingsModalProps {
@@ -104,6 +107,7 @@ export interface HabitSettingsModalProps {
   onDelete: (_habitId: number) => void;
   onOpenReorderModal: (_habits: Habit[]) => void;
   allHabits: Habit[];
+  startWithEmojiPicker?: boolean;
 }
 
 export interface MissedDaysModalProps {

--- a/app/features/Habits/Habits.types.ts
+++ b/app/features/Habits/Habits.types.ts
@@ -123,6 +123,7 @@ export interface OnboardingModalProps {
   visible: boolean;
   onClose: () => void;
   onSaveHabits: (_habits: OnboardingHabit[]) => void;
+  initialStep?: number;
 }
 
 export interface ReorderHabitsModalProps {

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -410,7 +410,7 @@ const HabitsScreen = () => {
       ...habit,
       id: index + 1,
       streak: 0,
-      revealed: habit.stage === 'Beige', // Only reveal Beige stage habits initially
+      revealed: true,
       completions: [], // Initialize empty completions array
       goals: [
         {
@@ -531,7 +531,7 @@ const HabitsScreen = () => {
       <FlatList
         key={`cols-${columns}`}
         testID="habits-list"
-        data={habits.filter((h) => h.revealed)}
+        data={habits}
         keyExtractor={(item) => item.id?.toString() ?? item.name}
         renderItem={renderHabitTile}
         numColumns={columns}

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -535,12 +535,15 @@ const HabitsScreen = () => {
         keyExtractor={(item) => item.id?.toString() ?? item.name}
         renderItem={renderHabitTile}
         numColumns={columns}
-        columnWrapperStyle={columns > 1 ? { gap: gridGutter } : undefined}
+        columnWrapperStyle={
+          columns > 1 ? { gap: gridGutter, flexDirection: 'row-reverse' } : undefined
+        }
         contentContainerStyle={[
           styles.habitsGrid,
           {
             padding: gridGutter / 2,
             paddingBottom: gridGutter / 2,
+            flexDirection: 'column-reverse',
           },
         ]}
       />

--- a/app/features/Habits/HabitsScreen.tsx
+++ b/app/features/Habits/HabitsScreen.tsx
@@ -205,11 +205,6 @@ const updateHabitNotifications = async (habit: Habit): Promise<string[]> => {
   return notificationIds;
 };
 
-// Calculate net energy for a habit
-export const calculateNetEnergy = (cost: number, returnValue: number): number => {
-  return returnValue - cost;
-};
-
 // Calculate progress increments for a goal based on its target
 
 //------------------
@@ -223,6 +218,7 @@ const HabitsScreen = () => {
   const [goalModalVisible, setGoalModalVisible] = useState(false);
   const [statsModalVisible, setStatsModalVisible] = useState(false);
   const [settingsModalVisible, setSettingsModalVisible] = useState(false);
+  const [openSettingsWithEmoji, setOpenSettingsWithEmoji] = useState(false);
   const [reorderModalVisible, setReorderModalVisible] = useState(false);
   const [missedDaysModalVisible, setMissedDaysModalVisible] = useState(false);
   const [onboardingVisible, setOnboardingVisible] = useState(habits.length === 0);
@@ -466,6 +462,12 @@ const HabitsScreen = () => {
       }}
       onLongPress={() => {
         setSelectedHabit(item);
+        setOpenSettingsWithEmoji(false);
+        setSettingsModalVisible(true);
+      }}
+      onIconPress={() => {
+        setSelectedHabit(item);
+        setOpenSettingsWithEmoji(true);
         setSettingsModalVisible(true);
       }}
     />
@@ -567,11 +569,15 @@ const HabitsScreen = () => {
       <HabitSettingsModal
         visible={settingsModalVisible}
         habit={selectedHabit}
-        onClose={() => setSettingsModalVisible(false)}
+        onClose={() => {
+          setSettingsModalVisible(false);
+          setOpenSettingsWithEmoji(false);
+        }}
         onUpdate={handleUpdateHabit}
         onDelete={handleDeleteHabit}
         onOpenReorderModal={handleOpenReorderModal}
         allHabits={habits}
+        startWithEmojiPicker={openSettingsWithEmoji}
       />
       <ReorderHabitsModal
         visible={reorderModalVisible}

--- a/app/features/Habits/OnboardingUtils.ts
+++ b/app/features/Habits/OnboardingUtils.ts
@@ -1,3 +1,19 @@
+export const STAGE_SEQUENCE = [
+  'Beige',
+  'Purple',
+  'Red',
+  'Blue',
+  'Orange',
+  'Green',
+  'Yellow',
+  'Turquoise',
+  'Ultraviolet',
+  'Clear Light',
+];
+
+export const getStageByIndex = (index: number): string =>
+  STAGE_SEQUENCE[index % STAGE_SEQUENCE.length]!;
+
 export const getStaggeredStartDate = (base: Date, index: number): Date => {
   const offsetDays = index < 8 ? index * 21 : 7 * 21 + (index - 7) * 42;
   const d = new Date(base);

--- a/app/features/Habits/OnboardingUtils.ts
+++ b/app/features/Habits/OnboardingUtils.ts
@@ -1,0 +1,6 @@
+export const getStaggeredStartDate = (base: Date, index: number): Date => {
+  const offsetDays = index < 8 ? index * 21 : 7 * 21 + (index - 7) * 42;
+  const d = new Date(base);
+  d.setDate(d.getDate() + offsetDays);
+  return d;
+};

--- a/app/features/Habits/__tests__/EnergyUtils.test.ts
+++ b/app/features/Habits/__tests__/EnergyUtils.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 
 import { calculateNetEnergy } from '../EnergyUtils';
-import { getStaggeredStartDate } from '../OnboardingUtils';
+import { getStaggeredStartDate, getStageByIndex } from '../OnboardingUtils';
 
 describe('energy utilities', () => {
   it('calculates net energy as return minus cost', () => {
@@ -16,5 +16,11 @@ describe('energy utilities', () => {
     const diff10 = (tenth.getTime() - ninth.getTime()) / (1000 * 60 * 60 * 24);
     expect(diff9).toBe(189);
     expect(diff10).toBe(42);
+  });
+
+  it('assigns stages in fixed sequence', () => {
+    expect(getStageByIndex(0)).toBe('Beige');
+    expect(getStageByIndex(1)).toBe('Purple');
+    expect(getStageByIndex(9)).toBe('Clear Light');
   });
 });

--- a/app/features/Habits/__tests__/EnergyUtils.test.ts
+++ b/app/features/Habits/__tests__/EnergyUtils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { calculateNetEnergy } from '../EnergyUtils';
+import { getStaggeredStartDate } from '../OnboardingUtils';
+
+describe('energy utilities', () => {
+  it('calculates net energy as return minus cost', () => {
+    expect(calculateNetEnergy(3, 10)).toBe(7);
+  });
+
+  it('staggered start dates follow 21/42 day pattern', () => {
+    const base = new Date('2025-01-01');
+    const ninth = getStaggeredStartDate(base, 8);
+    const tenth = getStaggeredStartDate(base, 9);
+    const diff9 = (ninth.getTime() - base.getTime()) / (1000 * 60 * 60 * 24);
+    const diff10 = (tenth.getTime() - ninth.getTime()) / (1000 * 60 * 60 * 24);
+    expect(diff9).toBe(189);
+    expect(diff10).toBe(42);
+  });
+});

--- a/app/features/Habits/__tests__/HabitsScreen.layout.test.tsx
+++ b/app/features/Habits/__tests__/HabitsScreen.layout.test.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable import/order, @typescript-eslint/no-explicit-any */
+import { describe, it, expect, jest } from '@jest/globals';
+import React from 'react';
+import renderer from 'react-test-renderer';
+import HabitsScreen from '../HabitsScreen';
+
+void React;
+
+// Mock external modules
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: (jest.fn() as any).mockResolvedValue({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn() as any,
+  getExpoPushTokenAsync: (jest.fn() as any).mockResolvedValue({ data: 'token' }),
+  scheduleNotificationAsync: jest.fn() as any,
+  cancelScheduledNotificationAsync: jest.fn() as any,
+}));
+
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/StatsModal', () => () => null);
+
+// Force responsive hook to a predictable grid
+jest.mock('../../../Sources/design/useResponsive', () => () => ({
+  columns: 2,
+  gridGutter: 0,
+  scale: 1,
+  width: 400,
+  height: 800,
+  isLG: false,
+  isXL: false,
+}));
+
+describe('HabitsScreen layout', () => {
+  it('renders habits bottom-up with reversed rows and columns', () => {
+    const tree = renderer.create(<HabitsScreen />).root;
+    const list = tree.findByProps({ testID: 'habits-list' });
+    const contentStyle = Array.isArray(list.props.contentContainerStyle)
+      ? Object.assign({}, ...list.props.contentContainerStyle)
+      : list.props.contentContainerStyle;
+    expect(contentStyle.flexDirection).toBe('column-reverse');
+    expect(list.props.columnWrapperStyle.flexDirection).toBe('row-reverse');
+  });
+});

--- a/app/features/Habits/__tests__/OnboardingModal.test.tsx
+++ b/app/features/Habits/__tests__/OnboardingModal.test.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable import/order */
+import { describe, it, expect, jest } from '@jest/globals';
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { OnboardingModal } from '../components/OnboardingModal';
+
+void React;
+
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
+jest.mock('../HabitsScreen', () => ({ DEFAULT_ICONS: ['😀'] }));
+
+jest.mock('@react-native-community/datetimepicker', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return ({ testID }: { testID?: string }) => <Text testID={testID}>picker</Text>;
+});
+
+describe('OnboardingModal date picker', () => {
+  it('shows a date picker when start date button is pressed', () => {
+    const testRenderer = renderer.create(
+      <OnboardingModal visible initialStep={4} onClose={() => null} onSaveHabits={() => null} />,
+    );
+    const root = testRenderer.root;
+    expect(root.findAllByProps({ testID: 'start-date-picker' }).length).toBe(0);
+    renderer.act(() => {
+      root.findByProps({ testID: 'start-date-button' }).props.onPress();
+    });
+    expect(root.findAllByProps({ testID: 'start-date-picker' }).length).toBeGreaterThan(0);
+  });
+});

--- a/app/features/Habits/components/HabitSettingsModal.tsx
+++ b/app/features/Habits/components/HabitSettingsModal.tsx
@@ -14,9 +14,10 @@ import {
 import EmojiSelector from 'react-native-emoji-selector';
 
 import { STAGE_COLORS } from '../../../constants/stageColors';
+import { calculateNetEnergy } from '../EnergyUtils';
 import styles from '../Habits.styles';
 import type { Habit, HabitSettingsModalProps } from '../Habits.types';
-import { calculateNetEnergy, DAYS_OF_WEEK } from '../HabitsScreen';
+import { DAYS_OF_WEEK } from '../HabitsScreen';
 
 export const HabitSettingsModal = ({
   visible,
@@ -26,6 +27,7 @@ export const HabitSettingsModal = ({
   onDelete,
   onOpenReorderModal,
   allHabits,
+  startWithEmojiPicker,
 }: HabitSettingsModalProps) => {
   const [editedHabit, setEditedHabit] = useState<Habit | null>(null);
   const [showTimePicker, setShowTimePicker] = useState(false);
@@ -35,7 +37,10 @@ export const HabitSettingsModal = ({
 
   useEffect(() => {
     setEditedHabit(habit ? { ...habit } : null);
-  }, [habit, visible]);
+    if (startWithEmojiPicker) {
+      setShowEmojiSelector(true);
+    }
+  }, [habit, visible, startWithEmojiPicker]);
 
   if (!editedHabit) return null;
 
@@ -145,13 +150,13 @@ export const HabitSettingsModal = ({
 
             <View style={styles.settingRow}>
               <Text style={styles.settingLabel}>Icon:</Text>
-              <TouchableOpacity
-                style={styles.iconSelectorButton}
+              <Text
+                style={styles.currentIcon}
                 onPress={() => setShowEmojiSelector(!showEmojiSelector)}
+                testID="settings-icon"
               >
-                <Text style={styles.currentIcon}>{editedHabit.icon}</Text>
-                <Text style={styles.iconButtonText}>Change</Text>
-              </TouchableOpacity>
+                {editedHabit.icon}
+              </Text>
             </View>
 
             {showEmojiSelector && (

--- a/app/features/Habits/components/HabitSettingsModal.tsx
+++ b/app/features/Habits/components/HabitSettingsModal.tsx
@@ -127,40 +127,252 @@ export const HabitSettingsModal = ({
   const netEnergy = calculateNetEnergy(editedHabit.energy_cost, editedHabit.energy_return);
 
   return (
-    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <View style={styles.modalOverlay}>
-        <View
-          style={[styles.settingsModalContent, { borderTopColor: STAGE_COLORS[editedHabit.stage] }]}
-        >
-          <View style={styles.modalHeader}>
-            <Text style={styles.modalTitle}>Edit Habit</Text>
-            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-              <Text style={styles.closeButtonText}>×</Text>
-            </TouchableOpacity>
-          </View>
-          <ScrollView style={styles.settingsContainer}>
-            <View style={styles.settingRow}>
-              <Text style={styles.settingLabel}>Name:</Text>
-              <TextInput
-                style={styles.settingInput}
-                value={editedHabit.name}
-                onChangeText={(text) => handleChange('name', text)}
-              />
+    <>
+      <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+        <View style={styles.modalOverlay}>
+          <View
+            style={[
+              styles.settingsModalContent,
+              { borderTopColor: STAGE_COLORS[editedHabit.stage] },
+            ]}
+          >
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>Edit Habit</Text>
+              <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+                <Text style={styles.closeButtonText}>×</Text>
+              </TouchableOpacity>
             </View>
+            <ScrollView style={styles.settingsContainer}>
+              <View style={styles.settingRow}>
+                <Text style={styles.settingLabel}>Name:</Text>
+                <TextInput
+                  style={styles.settingInput}
+                  value={editedHabit.name}
+                  onChangeText={(text) => handleChange('name', text)}
+                />
+              </View>
 
-            <View style={styles.settingRow}>
-              <Text style={styles.settingLabel}>Icon:</Text>
-              <Text
-                style={styles.currentIcon}
-                onPress={() => setShowEmojiSelector(!showEmojiSelector)}
-                testID="settings-icon"
+              <View style={styles.settingRow}>
+                <Text style={styles.settingLabel}>Icon:</Text>
+                <Text
+                  style={styles.currentIcon}
+                  onPress={() => setShowEmojiSelector(!showEmojiSelector)}
+                  testID="settings-icon"
+                >
+                  {editedHabit.icon}
+                </Text>
+              </View>
+
+              <View style={styles.settingRow}>
+                <Text style={styles.settingLabel}>Stage:</Text>
+                <Text style={styles.settingValue}>{editedHabit.stage}</Text>
+              </View>
+
+              <TouchableOpacity
+                style={styles.reorderButton}
+                onPress={() => onOpenReorderModal(allHabits)}
               >
-                {editedHabit.icon}
-              </Text>
-            </View>
+                <Text style={styles.reorderButtonText}>Reorder Habits</Text>
+              </TouchableOpacity>
 
-            {showEmojiSelector && (
-              <View style={styles.emojiSelectorContainer}>
+              <View style={styles.settingRow}>
+                <Text style={styles.settingLabel}>Energy Rating:</Text>
+              </View>
+
+              <View style={styles.energyContainer}>
+                <View style={styles.energyHeader}>
+                  <Text style={styles.energyHeaderText}>Cost</Text>
+                  <Text style={styles.energyHeaderText}>Return</Text>
+                  <Text style={styles.energyHeaderText}>Net</Text>
+                </View>
+
+                <View style={styles.energyRow}>
+                  <TextInput
+                    style={styles.energyInput}
+                    value={editedHabit.energy_cost.toString()}
+                    onChangeText={(text) => {
+                      const value = parseInt(text) || 0;
+                      if (value >= -10 && value <= 10) {
+                        handleChange('energy_cost', value);
+                      }
+                    }}
+                    keyboardType="numeric"
+                  />
+                  <TextInput
+                    style={styles.energyInput}
+                    value={editedHabit.energy_return.toString()}
+                    onChangeText={(text) => {
+                      const value = parseInt(text) || 0;
+                      if (value >= -10 && value <= 10) {
+                        handleChange('energy_return', value);
+                      }
+                    }}
+                    keyboardType="numeric"
+                  />
+                  <Text style={styles.netEnergyValue}>{netEnergy}</Text>
+                </View>
+
+                <View style={styles.validationNote}>
+                  <Text style={styles.validationText}>Values must be between -10 and 10</Text>
+                </View>
+              </View>
+
+              <View style={styles.settingRow}>
+                <Text style={styles.settingLabel}>Start Date:</Text>
+                <DateTimePicker
+                  value={new Date(editedHabit.start_date)}
+                  mode="date"
+                  display="default"
+                  onChange={(event, date) => date && handleChange('start_date', date)}
+                />
+              </View>
+
+              <View style={styles.settingGroup}>
+                <View style={styles.settingRow}>
+                  <Text style={styles.settingLabel}>Notifications:</Text>
+                  <Switch
+                    value={editedHabit.notificationFrequency !== 'off'}
+                    onValueChange={(value) => {
+                      handleChange('notificationFrequency', value ? 'daily' : 'off');
+                    }}
+                  />
+                </View>
+
+                {editedHabit.notificationFrequency !== 'off' && (
+                  <>
+                    <View style={styles.settingRow}>
+                      <Text style={styles.settingLabel}>Frequency:</Text>
+                      <TouchableOpacity
+                        style={styles.frequencyButton}
+                        onPress={() => {
+                          const current = editedHabit.notificationFrequency;
+                          const next: 'daily' | 'weekly' | 'custom' =
+                            current === 'daily'
+                              ? 'weekly'
+                              : current === 'weekly'
+                                ? 'custom'
+                                : 'daily';
+                          handleChange('notificationFrequency', next);
+                        }}
+                      >
+                        <Text style={styles.frequencyButtonText}>
+                          {editedHabit.notificationFrequency || 'daily'}
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
+
+                    {editedHabit.notificationFrequency === 'custom' && (
+                      <View style={styles.settingRow}>
+                        <Text style={styles.settingLabel}>Days:</Text>
+                        <TouchableOpacity
+                          style={styles.daysButton}
+                          onPress={() => setShowDaysPicker(!showDaysPicker)}
+                        >
+                          <Text style={styles.daysButtonText}>
+                            {editedHabit.notificationDays && editedHabit.notificationDays.length > 0
+                              ? editedHabit.notificationDays
+                                  .map((d) => d.substring(0, 3))
+                                  .join(', ')
+                              : 'Select days'}
+                          </Text>
+                        </TouchableOpacity>
+                      </View>
+                    )}
+
+                    {showDaysPicker && (
+                      <View style={styles.daysPicker}>
+                        {DAYS_OF_WEEK.map((day) => (
+                          <TouchableOpacity
+                            key={day}
+                            style={[
+                              styles.dayOption,
+                              (editedHabit.notificationDays || []).includes(day) &&
+                                styles.selectedDayOption,
+                            ]}
+                            onPress={() => handleToggleDay(day)}
+                          >
+                            <Text style={styles.dayOptionText}>{day.substring(0, 3)}</Text>
+                          </TouchableOpacity>
+                        ))}
+                      </View>
+                    )}
+
+                    <View style={styles.settingRow}>
+                      <Text style={styles.settingLabel}>Time:</Text>
+                      <View style={styles.timeInputContainer}>
+                        <TouchableOpacity
+                          style={styles.timeButton}
+                          onPress={() => setShowTimePicker(true)}
+                        >
+                          <Text style={styles.timeButtonText}>{notificationTime}</Text>
+                        </TouchableOpacity>
+
+                        <TouchableOpacity
+                          style={styles.addTimeButton}
+                          onPress={handleAddNotificationTime}
+                        >
+                          <Text style={styles.addTimeButtonText}>+</Text>
+                        </TouchableOpacity>
+                      </View>
+                    </View>
+
+                    {(Platform.OS === 'ios' || Platform.OS === 'android') &&
+                      showTimePicker &&
+                      renderTimePicker()}
+
+                    {(editedHabit.notificationTimes || []).length > 0 && (
+                      <View style={styles.timesList}>
+                        {(editedHabit.notificationTimes || []).map((time, index) => (
+                          <View key={index} style={styles.timeItem}>
+                            <Text style={styles.timeText}>{time}</Text>
+                            <TouchableOpacity
+                              style={styles.removeTimeButton}
+                              onPress={() => handleRemoveNotificationTime(time)}
+                            >
+                              <Text style={styles.removeTimeButtonText}>×</Text>
+                            </TouchableOpacity>
+                          </View>
+                        ))}
+                      </View>
+                    )}
+                  </>
+                )}
+
+                <View style={styles.settingRow}>
+                  <Text style={styles.settingLabel}>Milestone Notifications:</Text>
+                  <Switch
+                    value={editedHabit.milestoneNotifications || false}
+                    onValueChange={(value) => handleChange('milestoneNotifications', value)}
+                  />
+                </View>
+              </View>
+
+              <View style={styles.buttonGroup}>
+                <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
+                  <Text style={styles.saveButtonText}>Save Changes</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.deleteButton} onPress={handleDelete}>
+                  <Text style={styles.deleteButtonText}>Delete Habit</Text>
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+      {showEmojiSelector && (
+        <Modal transparent animationType="slide" visible>
+          <View style={styles.modalOverlay}>
+            <View style={styles.emojiPickerModal}>
+              <View style={styles.emojiPickerHeader}>
+                <Text style={styles.emojiPickerTitle}>Select Icon</Text>
+                <TouchableOpacity
+                  style={styles.closeEmojiPicker}
+                  onPress={() => setShowEmojiSelector(false)}
+                >
+                  <Text style={styles.closeEmojiPickerText}>×</Text>
+                </TouchableOpacity>
+              </View>
+              <View style={{ height: 250 }}>
                 <EmojiSelector
                   onEmojiSelected={(emoji) => {
                     handleChange('icon', emoji);
@@ -168,205 +380,13 @@ export const HabitSettingsModal = ({
                   }}
                   showSearchBar
                   columns={8}
-                  placeholder="Search emoji..."
-                />
-              </View>
-            )}
-
-            <View style={styles.settingRow}>
-              <Text style={styles.settingLabel}>Stage:</Text>
-              <Text style={styles.settingValue}>{editedHabit.stage}</Text>
-            </View>
-
-            <TouchableOpacity
-              style={styles.reorderButton}
-              onPress={() => onOpenReorderModal(allHabits)}
-            >
-              <Text style={styles.reorderButtonText}>Reorder Habits</Text>
-            </TouchableOpacity>
-
-            <View style={styles.settingRow}>
-              <Text style={styles.settingLabel}>Energy Rating:</Text>
-            </View>
-
-            <View style={styles.energyContainer}>
-              <View style={styles.energyHeader}>
-                <Text style={styles.energyHeaderText}>Cost</Text>
-                <Text style={styles.energyHeaderText}>Return</Text>
-                <Text style={styles.energyHeaderText}>Net</Text>
-              </View>
-
-              <View style={styles.energyRow}>
-                <TextInput
-                  style={styles.energyInput}
-                  value={editedHabit.energy_cost.toString()}
-                  onChangeText={(text) => {
-                    const value = parseInt(text) || 0;
-                    if (value >= -10 && value <= 10) {
-                      handleChange('energy_cost', value);
-                    }
-                  }}
-                  keyboardType="numeric"
-                />
-                <TextInput
-                  style={styles.energyInput}
-                  value={editedHabit.energy_return.toString()}
-                  onChangeText={(text) => {
-                    const value = parseInt(text) || 0;
-                    if (value >= -10 && value <= 10) {
-                      handleChange('energy_return', value);
-                    }
-                  }}
-                  keyboardType="numeric"
-                />
-                <Text style={styles.netEnergyValue}>{netEnergy}</Text>
-              </View>
-
-              <View style={styles.validationNote}>
-                <Text style={styles.validationText}>Values must be between -10 and 10</Text>
-              </View>
-            </View>
-
-            <View style={styles.settingRow}>
-              <Text style={styles.settingLabel}>Start Date:</Text>
-              <DateTimePicker
-                value={new Date(editedHabit.start_date)}
-                mode="date"
-                display="default"
-                onChange={(event, date) => date && handleChange('start_date', date)}
-              />
-            </View>
-
-            <View style={styles.settingGroup}>
-              <View style={styles.settingRow}>
-                <Text style={styles.settingLabel}>Notifications:</Text>
-                <Switch
-                  value={editedHabit.notificationFrequency !== 'off'}
-                  onValueChange={(value) => {
-                    handleChange('notificationFrequency', value ? 'daily' : 'off');
-                  }}
-                />
-              </View>
-
-              {editedHabit.notificationFrequency !== 'off' && (
-                <>
-                  <View style={styles.settingRow}>
-                    <Text style={styles.settingLabel}>Frequency:</Text>
-                    <TouchableOpacity
-                      style={styles.frequencyButton}
-                      onPress={() => {
-                        const current = editedHabit.notificationFrequency;
-                        const next: 'daily' | 'weekly' | 'custom' =
-                          current === 'daily'
-                            ? 'weekly'
-                            : current === 'weekly'
-                              ? 'custom'
-                              : 'daily';
-                        handleChange('notificationFrequency', next);
-                      }}
-                    >
-                      <Text style={styles.frequencyButtonText}>
-                        {editedHabit.notificationFrequency || 'daily'}
-                      </Text>
-                    </TouchableOpacity>
-                  </View>
-
-                  {editedHabit.notificationFrequency === 'custom' && (
-                    <View style={styles.settingRow}>
-                      <Text style={styles.settingLabel}>Days:</Text>
-                      <TouchableOpacity
-                        style={styles.daysButton}
-                        onPress={() => setShowDaysPicker(!showDaysPicker)}
-                      >
-                        <Text style={styles.daysButtonText}>
-                          {editedHabit.notificationDays && editedHabit.notificationDays.length > 0
-                            ? editedHabit.notificationDays.map((d) => d.substring(0, 3)).join(', ')
-                            : 'Select days'}
-                        </Text>
-                      </TouchableOpacity>
-                    </View>
-                  )}
-
-                  {showDaysPicker && (
-                    <View style={styles.daysPicker}>
-                      {DAYS_OF_WEEK.map((day) => (
-                        <TouchableOpacity
-                          key={day}
-                          style={[
-                            styles.dayOption,
-                            (editedHabit.notificationDays || []).includes(day) &&
-                              styles.selectedDayOption,
-                          ]}
-                          onPress={() => handleToggleDay(day)}
-                        >
-                          <Text style={styles.dayOptionText}>{day.substring(0, 3)}</Text>
-                        </TouchableOpacity>
-                      ))}
-                    </View>
-                  )}
-
-                  <View style={styles.settingRow}>
-                    <Text style={styles.settingLabel}>Time:</Text>
-                    <View style={styles.timeInputContainer}>
-                      <TouchableOpacity
-                        style={styles.timeButton}
-                        onPress={() => setShowTimePicker(true)}
-                      >
-                        <Text style={styles.timeButtonText}>{notificationTime}</Text>
-                      </TouchableOpacity>
-
-                      <TouchableOpacity
-                        style={styles.addTimeButton}
-                        onPress={handleAddNotificationTime}
-                      >
-                        <Text style={styles.addTimeButtonText}>+</Text>
-                      </TouchableOpacity>
-                    </View>
-                  </View>
-
-                  {(Platform.OS === 'ios' || Platform.OS === 'android') &&
-                    showTimePicker &&
-                    renderTimePicker()}
-
-                  {(editedHabit.notificationTimes || []).length > 0 && (
-                    <View style={styles.timesList}>
-                      {(editedHabit.notificationTimes || []).map((time, index) => (
-                        <View key={index} style={styles.timeItem}>
-                          <Text style={styles.timeText}>{time}</Text>
-                          <TouchableOpacity
-                            style={styles.removeTimeButton}
-                            onPress={() => handleRemoveNotificationTime(time)}
-                          >
-                            <Text style={styles.removeTimeButtonText}>×</Text>
-                          </TouchableOpacity>
-                        </View>
-                      ))}
-                    </View>
-                  )}
-                </>
-              )}
-
-              <View style={styles.settingRow}>
-                <Text style={styles.settingLabel}>Milestone Notifications:</Text>
-                <Switch
-                  value={editedHabit.milestoneNotifications || false}
-                  onValueChange={(value) => handleChange('milestoneNotifications', value)}
                 />
               </View>
             </View>
-
-            <View style={styles.buttonGroup}>
-              <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
-                <Text style={styles.saveButtonText}>Save Changes</Text>
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.deleteButton} onPress={handleDelete}>
-                <Text style={styles.deleteButtonText}>Delete Habit</Text>
-              </TouchableOpacity>
-            </View>
-          </ScrollView>
-        </View>
-      </View>
-    </Modal>
+          </View>
+        </Modal>
+      )}
+    </>
   );
 };
 

--- a/app/features/Habits/components/HabitSettingsModal.tsx
+++ b/app/features/Habits/components/HabitSettingsModal.tsx
@@ -380,6 +380,7 @@ export const HabitSettingsModal = ({
                   }}
                   showSearchBar
                   columns={8}
+                  {...({ emojiSize: 28 } as unknown as { emojiSize: number })}
                 />
               </View>
             </View>

--- a/app/features/Habits/components/OnboardingModal.tsx
+++ b/app/features/Habits/components/OnboardingModal.tsx
@@ -1,3 +1,4 @@
+import DateTimePicker from '@react-native-community/datetimepicker';
 import React, { useState } from 'react';
 import {
   View,
@@ -11,15 +12,19 @@ import {
 } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import EmojiSelector from 'react-native-emoji-selector';
-import DateTimePickerModal from 'react-native-modal-datetime-picker';
 
 import styles from '../Habits.styles';
 import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
 import { DEFAULT_ICONS } from '../HabitsScreen';
 import { getStaggeredStartDate, getStageByIndex } from '../OnboardingUtils';
 
-export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingModalProps) => {
-  const [step, setStep] = useState(1);
+export const OnboardingModal = ({
+  visible,
+  onClose,
+  onSaveHabits,
+  initialStep = 1,
+}: OnboardingModalProps) => {
+  const [step, setStep] = useState(initialStep);
   const [habits, setHabits] = useState<OnboardingHabit[]>([]);
   const [newHabitName, setNewHabitName] = useState('');
   const [startDate, setStartDate] = useState(new Date());
@@ -233,7 +238,11 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
 
       <View style={styles.startDateContainer}>
         <Text style={styles.startDateLabel}>First habit starts on:</Text>
-        <TouchableOpacity style={styles.startDateButton} onPress={() => setDatePickerVisible(true)}>
+        <TouchableOpacity
+          testID="start-date-button"
+          style={styles.startDateButton}
+          onPress={() => setDatePickerVisible(true)}
+        >
           <Text style={styles.startDateButtonText}>
             {startDate.toLocaleDateString('en-US', {
               month: 'short',
@@ -243,23 +252,26 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
           </Text>
         </TouchableOpacity>
 
-        <DateTimePickerModal
-          isVisible={isDatePickerVisible}
-          mode="date"
-          onConfirm={(selectedDate) => {
-            setDatePickerVisible(false);
-            if (selectedDate) {
-              setStartDate(selectedDate);
-              setHabits((prev) =>
-                prev.map((habit, index) => ({
-                  ...habit,
-                  start_date: getStaggeredStartDate(selectedDate, index),
-                })),
-              );
-            }
-          }}
-          onCancel={() => setDatePickerVisible(false)}
-        />
+        {isDatePickerVisible && (
+          <DateTimePicker
+            testID="start-date-picker"
+            value={startDate}
+            mode="date"
+            display="default"
+            onChange={(event, selectedDate) => {
+              setDatePickerVisible(false);
+              if (selectedDate) {
+                setStartDate(selectedDate);
+                setHabits((prev) =>
+                  prev.map((habit, index) => ({
+                    ...habit,
+                    start_date: getStaggeredStartDate(selectedDate, index),
+                  })),
+                );
+              }
+            }}
+          />
+        )}
       </View>
 
       <View style={styles.habitsList}>
@@ -413,6 +425,7 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
                   onEmojiSelected={(emoji) => updateHabitIcon(selectedHabitIndex, emoji)}
                   showSearchBar
                   columns={8}
+                  {...({ emojiSize: 28 } as unknown as { emojiSize: number })}
                 />
               </View>
             </View>


### PR DESCRIPTION
## Summary
- allow tapping habit icons to open emoji picker
- gate energy scaffolding net scores until cost & return entered and stagger start dates 21/42 days
- add utility tests for energy calculations and scheduling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acd43923ac8322972511b959c824b1