### PR TITLE
feat: add map screen with bottom tab navigation

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,18 +1,21 @@
 // app/App.tsx
 
+import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
 import { StatusBar, StyleSheet } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
-import HabitsScreen from './features/Habits/HabitsScreen';
+import BottomTabs from './navigation/BottomTabs';
 
 export default function App(): React.JSX.Element {
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={styles.safeArea}>
-        <StatusBar barStyle="dark-content" />
-        <HabitsScreen />
-      </SafeAreaView>
+      <NavigationContainer>
+        <SafeAreaView style={styles.safeArea}>
+          <StatusBar barStyle="dark-content" />
+          <BottomTabs />
+        </SafeAreaView>
+      </NavigationContainer>
     </SafeAreaProvider>
   );
 }

--- a/app/features/Course/CourseScreen.tsx
+++ b/app/features/Course/CourseScreen.tsx
@@ -1,0 +1,29 @@
+// app/features/Course/CourseScreen.tsx
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+/**
+ * Placeholder course screen.
+ * The full version will present the APTITUDE curriculum content.
+ */
+const CourseScreen = (): React.JSX.Element => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Course Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});
+
+export default CourseScreen;

--- a/app/features/Journal/JournalScreen.tsx
+++ b/app/features/Journal/JournalScreen.tsx
@@ -1,0 +1,29 @@
+// app/features/Journal/JournalScreen.tsx
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+/**
+ * Placeholder journal screen.
+ * Users will log reflections here in future iterations.
+ */
+const JournalScreen = (): React.JSX.Element => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Journal Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});
+
+export default JournalScreen;

--- a/app/features/Map/Map.styles.ts
+++ b/app/features/Map/Map.styles.ts
@@ -1,0 +1,64 @@
+// app/features/Map/Map.styles.ts
+
+import { StyleSheet } from 'react-native';
+
+import { radius, spacing } from '../../Sources/design/DesignSystem';
+
+/**
+ * Styles for the Map screen and its stage cards.
+ */
+const styles = StyleSheet.create({
+  container: {
+    padding: spacing(2),
+    backgroundColor: '#fdfcf8',
+  },
+  card: {
+    backgroundColor: '#fff',
+    marginBottom: spacing(2),
+    padding: spacing(2),
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: '#eee',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: spacing(0.5),
+  },
+  subtitle: {
+    fontSize: 14,
+    marginBottom: spacing(1),
+  },
+  progressBar: {
+    height: 8,
+    backgroundColor: '#eee',
+    borderRadius: radius.sm,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    backgroundColor: '#7c3aed',
+  },
+  meta: {
+    marginTop: spacing(1),
+    fontSize: 12,
+    color: '#555',
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: spacing(1),
+  },
+  actionButton: {
+    backgroundColor: '#ede9fe',
+    paddingVertical: spacing(1),
+    paddingHorizontal: spacing(2),
+    borderRadius: radius.sm,
+  },
+  actionText: {
+    fontSize: 14,
+    color: '#1e1e1e',
+  },
+});
+
+export default styles;

--- a/app/features/Map/MapScreen.tsx
+++ b/app/features/Map/MapScreen.tsx
@@ -1,0 +1,56 @@
+// app/features/Map/MapScreen.tsx
+
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+
+import styles from './Map.styles';
+import { STAGES } from './stageData';
+
+/**
+ * Displays the ten APTITUDE stages as a simple ladder.
+ * Each card links out to the relevant course and practice areas.
+ */
+const MapScreen = (): React.JSX.Element => {
+  const navigation = useNavigation();
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {STAGES.map((stage) => (
+        <View key={stage.id} testID={`stage-card-${stage.stageNumber}`} style={styles.card}>
+          <Text style={styles.title}>
+            {stage.stageNumber}. {stage.title}
+          </Text>
+          <Text style={styles.subtitle}>{stage.subtitle}</Text>
+
+          <View style={styles.progressBar}>
+            <View style={[styles.progressFill, { width: `${stage.progress * 100}%` }]} />
+          </View>
+
+          <Text style={styles.meta}>
+            {stage.practices.length} practices • {stage.goals.length} goals
+          </Text>
+
+          <View style={styles.actions}>
+            <TouchableOpacity
+              testID={`practice-button-${stage.stageNumber}`}
+              style={styles.actionButton}
+              onPress={() => navigation.navigate('Practice' as never)}
+            >
+              <Text style={styles.actionText}>Practice</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              testID={`course-button-${stage.stageNumber}`}
+              style={styles.actionButton}
+              onPress={() => navigation.navigate('Course' as never)}
+            >
+              <Text style={styles.actionText}>Course</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      ))}
+    </ScrollView>
+  );
+};
+
+export default MapScreen;

--- a/app/features/Map/__tests__/MapScreen.test.tsx
+++ b/app/features/Map/__tests__/MapScreen.test.tsx
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+/* eslint-disable import/order */
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import MapScreen from '../MapScreen';
+
+// Mock navigation so we can observe tab linking behaviour.
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+describe('MapScreen', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders ten unique stage cards', () => {
+    const tree = create(<MapScreen />);
+    const stages = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) =>
+        typeof node.props.testID === 'string' && node.props.testID.startsWith('stage-card'),
+    );
+    const uniqueIds = new Set(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      stages.map((s: any) => s.props.testID as string),
+    );
+    expect(uniqueIds.size).toBe(10);
+  });
+
+  it('navigates to Practice when Practice is tapped', () => {
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'practice-button-1' }).props.onPress();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('Practice');
+  });
+});

--- a/app/features/Map/stageData.ts
+++ b/app/features/Map/stageData.ts
@@ -1,0 +1,29 @@
+// app/features/Map/stageData.ts
+
+/**
+ * Static placeholder data for the ten APTITUDE stages.
+ * In a full implementation these would be fetched from the backend `CourseStage` model.
+ */
+export interface StageData {
+  id: number;
+  title: string;
+  subtitle: string;
+  stageNumber: number;
+  progress: number; // 0–1 completion percentage
+  goals: string[];
+  practices: string[];
+}
+
+export const STAGES: StageData[] = Array.from({ length: 10 }, (_, index) => {
+  const stageNumber = index + 1;
+  return {
+    id: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    stageNumber,
+    // Simple demo progress – first stage partially complete, others locked
+    progress: stageNumber === 1 ? 0.5 : 0,
+    goals: [`Goal for stage ${stageNumber}`],
+    practices: [`Practice for stage ${stageNumber}`],
+  };
+});

--- a/app/features/Practice/PracticeScreen.tsx
+++ b/app/features/Practice/PracticeScreen.tsx
@@ -1,0 +1,29 @@
+// app/features/Practice/PracticeScreen.tsx
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+/**
+ * Placeholder practice screen.
+ * The real implementation will host guided exercises for each stage.
+ */
+const PracticeScreen = (): React.JSX.Element => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Practice Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});
+
+export default PracticeScreen;

--- a/app/navigation/BottomTabs.tsx
+++ b/app/navigation/BottomTabs.tsx
@@ -1,0 +1,38 @@
+// app/navigation/BottomTabs.tsx
+
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import React from 'react';
+
+import CourseScreen from '../features/Course/CourseScreen';
+import HabitsScreen from '../features/Habits/HabitsScreen';
+import JournalScreen from '../features/Journal/JournalScreen';
+import MapScreen from '../features/Map/MapScreen';
+import PracticeScreen from '../features/Practice/PracticeScreen';
+
+export type RootTabParamList = {
+  Habits: undefined;
+  Practice: undefined;
+  Course: undefined;
+  Journal: undefined;
+  Map: undefined;
+};
+
+const Tab = createBottomTabNavigator<RootTabParamList>();
+
+/**
+ * Application-wide bottom tab navigation.
+ * Each tab corresponds to a major feature area.
+ */
+const BottomTabs = (): React.JSX.Element => {
+  return (
+    <Tab.Navigator initialRouteName="Habits">
+      <Tab.Screen name="Habits" component={HabitsScreen} />
+      <Tab.Screen name="Practice" component={PracticeScreen} />
+      <Tab.Screen name="Course" component={CourseScreen} />
+      <Tab.Screen name="Journal" component={JournalScreen} />
+      <Tab.Screen name="Map" component={MapScreen} />
+    </Tab.Navigator>
+  );
+};
+
+export default BottomTabs;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,6 +15,7 @@
         "@react-native-community/push-notification-ios": "^1.11.0",
         "@react-native-community/slider": "4.5.5",
         "@react-native-picker/picker": "2.9.0",
+        "@react-navigation/bottom-tabs": "^7.4.6",
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/native-stack": "^7.3.10",
         "expo": "~52.0.43",
@@ -5200,6 +5201,23 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.4.6.tgz",
+      "integrity": "sha512-f4khxwcL70O5aKfZFbxyBo5RnzPFnBNSXmrrT7q9CRmvN4mHov9KFKGQ3H4xD5sLonsTBtyjvyvPfyEC4G7f+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.6.3",
+        "color": "^4.2.3"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.17",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@react-navigation/core": {

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
     "@react-native-community/push-notification-ios": "^1.11.0",
     "@react-native-community/slider": "4.5.5",
     "@react-native-picker/picker": "2.9.0",
+    "@react-navigation/bottom-tabs": "^7.4.6",
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/native-stack": "^7.3.10",
     "expo": "~52.0.43",


### PR DESCRIPTION
## Summary
- scaffold Map screen with 10 stage ladder and links to Course and Practice
- wire up bottom tab navigation across Habits, Practice, Course, Journal, and Map
- add test coverage for Map screen stage rendering and navigation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf7ff69388322ab0530aa390f44d1