### PR TITLE
feat: add practice session API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,13 @@
+"""Main FastAPI application instance."""
+
 from fastapi import FastAPI
 
+from .practice import router as practice_router
+
 app = FastAPI()
+
+# Register feature routers
+app.include_router(practice_router)
 
 
 @app.get("/")

--- a/backend/app/practice.py
+++ b/backend/app/practice.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from itertools import count
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+
+class PracticeSession(BaseModel):
+    """Represents one timed practice session performed by a user."""
+
+    id: int
+    user_id: int
+    practice_id: int
+    stage_number: int
+    duration_minutes: float
+    timestamp: datetime
+    reflection: str | None = None
+
+
+class PracticeSessionCreate(BaseModel):
+    """Payload for creating a new practice session."""
+
+    user_id: int
+    practice_id: int
+    stage_number: int
+    duration_minutes: float
+    reflection: str | None = None
+
+
+router = APIRouter(prefix="/practice_sessions", tags=["practice"])
+_sessions: list[PracticeSession] = []
+_id_counter = count(1)
+
+
+@router.post("/", response_model=PracticeSession)
+def create_session(payload: PracticeSessionCreate) -> PracticeSession:
+    """Store a practice session in memory and return it."""
+    session = PracticeSession(
+        id=next(_id_counter),
+        timestamp=datetime.utcnow(),
+        **payload.dict(),
+    )
+    _sessions.append(session)
+    return session
+
+
+@router.get("/{user_id}/week_count")
+def week_count(user_id: int) -> dict[str, int]:
+    """Return the number of sessions a user has completed this week."""
+    now = datetime.utcnow()
+    start_of_week = now - timedelta(days=now.weekday())
+    count = sum(1 for s in _sessions if s.user_id == user_id and s.timestamp >= start_of_week)
+    return {"count": count}

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timedelta
+from itertools import count
+
+import pytest  # type: ignore[import-not-found]
+from fastapi.testclient import TestClient
+
+import app.practice as practice_module
+from app.main import app
+
+client = TestClient(app)
+OK = 200
+
+
+@pytest.fixture(autouse=True)
+def clear_sessions() -> None:
+    """Ensure each test starts with a clean in-memory store."""
+    practice_module._sessions.clear()  # noqa: SLF001
+    practice_module._id_counter = count(1)  # noqa: SLF001
+
+
+def test_create_session() -> None:
+    payload = {
+        "user_id": 1,
+        "practice_id": 2,
+        "stage_number": 1,
+        "duration_minutes": 5,
+        "reflection": "felt calm",
+    }
+    response = client.post("/practice_sessions/", json=payload)
+    assert response.status_code == OK
+    data = response.json()
+    assert data["reflection"] == "felt calm"
+    assert data["id"] == 1
+
+
+def test_week_count_ignores_old_sessions() -> None:
+    old = practice_module.PracticeSession(
+        id=99,
+        user_id=1,
+        practice_id=1,
+        stage_number=1,
+        duration_minutes=5,
+        timestamp=datetime.utcnow() - timedelta(days=8),
+    )
+    practice_module._sessions.append(old)  # noqa: SLF001
+    response = client.get("/practice_sessions/1/week_count")
+    assert response.status_code == OK
+    assert response.json()["count"] == 0


### PR DESCRIPTION
## Summary
- add in-memory PracticeSession API with weekly counts
- cover practice endpoints with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acf6ac0da08322b27934ca8d7d36d2