### PR TITLE
feat: add map screen with bottom tab navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,9 @@ secrets.json
 *.swp
 *.swo
 
+# Development-only assets
+app/local-assets/
+
 # ======================================
 # Keep these tracked
 # ======================================

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,18 +1,21 @@
 // app/App.tsx
 
+import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
 import { StatusBar, StyleSheet } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
-import HabitsScreen from './features/Habits/HabitsScreen';
+import BottomTabs from './navigation/BottomTabs';
 
 export default function App(): React.JSX.Element {
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={styles.safeArea}>
-        <StatusBar barStyle="dark-content" />
-        <HabitsScreen />
-      </SafeAreaView>
+      <NavigationContainer>
+        <SafeAreaView style={styles.safeArea}>
+          <StatusBar barStyle="dark-content" />
+          <BottomTabs />
+        </SafeAreaView>
+      </NavigationContainer>
     </SafeAreaProvider>
   );
 }

--- a/app/constants/images.ts
+++ b/app/constants/images.ts
@@ -1,0 +1,2 @@
+export const MAP_BACKGROUND_URI =
+  process.env.EXPO_PUBLIC_MAP_BACKGROUND_URI || 'https://placehold.co/600x800/png';

--- a/app/features/Course/CourseScreen.tsx
+++ b/app/features/Course/CourseScreen.tsx
@@ -1,0 +1,29 @@
+// app/features/Course/CourseScreen.tsx
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+/**
+ * Placeholder course screen.
+ * The full version will present the APTITUDE curriculum content.
+ */
+const CourseScreen = (): React.JSX.Element => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Course Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});
+
+export default CourseScreen;

--- a/app/features/Journal/JournalScreen.tsx
+++ b/app/features/Journal/JournalScreen.tsx
@@ -1,0 +1,29 @@
+// app/features/Journal/JournalScreen.tsx
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+/**
+ * Placeholder journal screen.
+ * Users will log reflections here in future iterations.
+ */
+const JournalScreen = (): React.JSX.Element => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Journal Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});
+
+export default JournalScreen;

--- a/app/features/Map/Map.styles.ts
+++ b/app/features/Map/Map.styles.ts
@@ -1,0 +1,74 @@
+// app/features/Map/Map.styles.ts
+
+import { StyleSheet } from 'react-native';
+
+import { radius, spacing } from '../../Sources/design/DesignSystem';
+
+/**
+ * Styles for the Map screen hotspot layout and modal.
+ */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  background: {
+    flex: 1,
+    resizeMode: 'cover',
+  },
+  hotspot: {
+    position: 'absolute',
+    padding: spacing(1),
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    width: '80%',
+    backgroundColor: '#fff',
+    padding: spacing(2),
+    borderRadius: radius.md,
+  },
+  modalTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: spacing(0.5),
+  },
+  modalSubtitle: {
+    fontSize: 14,
+    marginBottom: spacing(1),
+  },
+  progressBar: {
+    height: 8,
+    backgroundColor: '#eee',
+    borderRadius: radius.sm,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    backgroundColor: '#7c3aed',
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: spacing(2),
+  },
+  actionButton: {
+    backgroundColor: '#ede9fe',
+    paddingVertical: spacing(1),
+    paddingHorizontal: spacing(2),
+    borderRadius: radius.sm,
+  },
+  actionText: {
+    fontSize: 14,
+    color: '#1e1e1e',
+  },
+});
+
+export default styles;

--- a/app/features/Map/Map.styles.ts
+++ b/app/features/Map/Map.styles.ts
@@ -29,6 +29,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     padding: spacing(2),
     borderRadius: radius.md,
+    position: 'relative',
   },
   modalTitle: {
     fontSize: 16,
@@ -63,6 +64,16 @@ const styles = StyleSheet.create({
   actionText: {
     fontSize: 14,
     color: '#1e1e1e',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: spacing(1),
+    right: spacing(1),
+    padding: spacing(0.5),
+  },
+  closeText: {
+    fontSize: 16,
+    fontWeight: '600',
   },
 });
 

--- a/app/features/Map/Map.styles.ts
+++ b/app/features/Map/Map.styles.ts
@@ -10,18 +10,13 @@ import { radius, spacing } from '../../Sources/design/DesignSystem';
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  background: {
-    flex: 1,
-    resizeMode: 'cover',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   hotspot: {
     position: 'absolute',
-    padding: spacing(1),
-  },
-  label: {
-    fontSize: 14,
-    fontWeight: '600',
+    // Transparent but still receives touch events
+    backgroundColor: 'rgba(255,255,255,0.01)',
   },
   modalOverlay: {
     flex: 1,

--- a/app/features/Map/MapScreen.tsx
+++ b/app/features/Map/MapScreen.tsx
@@ -1,0 +1,91 @@
+// app/features/Map/MapScreen.tsx
+
+import { useNavigation } from '@react-navigation/native';
+import React, { useState } from 'react';
+import { ImageBackground, Modal, Text, TouchableOpacity, View } from 'react-native';
+
+import { MAP_BACKGROUND_URI } from '../../constants/images';
+
+import styles from './Map.styles';
+import { STAGES } from './stageData';
+import type { StageData } from './stageData';
+
+/**
+ * Displays the ten APTITUDE stages over a background image.
+ * Tapping a stage reveals a modal with quick links to Practice and Course.
+ */
+const MapScreen = (): React.JSX.Element => {
+  const navigation = useNavigation();
+  const [activeStage, setActiveStage] = useState<StageData | null>(null);
+
+  return (
+    <View style={styles.container}>
+      <ImageBackground
+        source={{ uri: MAP_BACKGROUND_URI }}
+        style={styles.background}
+        testID="map-background"
+      >
+        {STAGES.map((stage) => (
+          <TouchableOpacity
+            key={stage.id}
+            testID={`stage-hotspot-${stage.stageNumber}`}
+            style={[
+              styles.hotspot,
+              { top: `${stage.position.top}%`, left: `${stage.position.left}%` },
+            ]}
+            onPress={() => setActiveStage(stage)}
+          >
+            <Text style={[styles.label, { color: stage.color }]}>{stage.title}</Text>
+          </TouchableOpacity>
+        ))}
+      </ImageBackground>
+
+      <Modal
+        visible={!!activeStage}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setActiveStage(null)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent} testID="stage-modal">
+            {activeStage && (
+              <>
+                <Text style={styles.modalTitle}>{activeStage.title}</Text>
+                <Text style={styles.modalSubtitle}>{activeStage.subtitle}</Text>
+                <View style={styles.progressBar}>
+                  <View
+                    style={[styles.progressFill, { width: `${activeStage.progress * 100}%` }]}
+                  />
+                </View>
+                <View style={styles.actions}>
+                  <TouchableOpacity
+                    testID="practice-link"
+                    style={styles.actionButton}
+                    onPress={() => {
+                      setActiveStage(null);
+                      navigation.navigate('Practice' as never);
+                    }}
+                  >
+                    <Text style={styles.actionText}>Practice</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    testID="course-link"
+                    style={styles.actionButton}
+                    onPress={() => {
+                      setActiveStage(null);
+                      navigation.navigate('Course' as never);
+                    }}
+                  >
+                    <Text style={styles.actionText}>Course</Text>
+                  </TouchableOpacity>
+                </View>
+              </>
+            )}
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+};
+
+export default MapScreen;

--- a/app/features/Map/MapScreen.tsx
+++ b/app/features/Map/MapScreen.tsx
@@ -7,6 +7,7 @@ import {
   Image,
   ImageBackground,
   Modal,
+  Pressable,
   Text,
   TouchableOpacity,
   View,
@@ -76,10 +77,21 @@ const MapScreen = (): React.JSX.Element => {
         animationType="fade"
         onRequestClose={() => setActiveStage(null)}
       >
-        <View style={styles.modalOverlay}>
-          <View style={styles.modalContent} testID="stage-modal">
+        <Pressable
+          style={styles.modalOverlay}
+          onPress={() => setActiveStage(null)}
+          testID="modal-overlay"
+        >
+          <Pressable style={styles.modalContent} onPress={() => {}} testID="stage-modal">
             {activeStage && (
               <>
+                <TouchableOpacity
+                  testID="close-modal"
+                  style={styles.closeButton}
+                  onPress={() => setActiveStage(null)}
+                >
+                  <Text style={styles.closeText}>×</Text>
+                </TouchableOpacity>
                 <Text style={styles.modalTitle}>{activeStage.title}</Text>
                 <Text style={styles.modalSubtitle}>{activeStage.subtitle}</Text>
                 <View style={styles.progressBar}>
@@ -111,8 +123,8 @@ const MapScreen = (): React.JSX.Element => {
                 </View>
               </>
             )}
-          </View>
-        </View>
+          </Pressable>
+        </Pressable>
       </Modal>
     </View>
   );

--- a/app/features/Map/__tests__/MapScreen.test.tsx
+++ b/app/features/Map/__tests__/MapScreen.test.tsx
@@ -36,7 +36,7 @@ describe('MapScreen', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       stages.map((s: any) => s.props.testID as string),
     );
-    expect(unique.size).toBe(20);
+    expect(unique.size).toBe(21);
   });
 
   it('shows modal with stage details when a hotspot is tapped', () => {

--- a/app/features/Map/__tests__/MapScreen.test.tsx
+++ b/app/features/Map/__tests__/MapScreen.test.tsx
@@ -2,6 +2,7 @@
 /* global describe, it, expect, beforeEach, jest */
 /* eslint-disable import/order */
 import React from 'react';
+import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import MapScreen from '../MapScreen';
@@ -11,13 +12,20 @@ const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: () => 0,
+}));
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 
 describe('MapScreen', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 
-  it('renders ten stage hotspots', () => {
+  it('renders text and arrow hotspots for each stage', () => {
     const tree = create(<MapScreen />);
     const stages = tree.root.findAll(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -28,13 +36,13 @@ describe('MapScreen', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       stages.map((s: any) => s.props.testID as string),
     );
-    expect(unique.size).toBe(10);
+    expect(unique.size).toBe(20);
   });
 
   it('shows modal with stage details when a hotspot is tapped', () => {
     const tree = create(<MapScreen />);
     act(() => {
-      tree.root.findByProps({ testID: 'stage-hotspot-1' }).props.onPress();
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
     });
     const modal = tree.root.findByProps({ testID: 'stage-modal' });
     expect(modal).toBeTruthy();
@@ -43,7 +51,7 @@ describe('MapScreen', () => {
   it('navigates to Practice when Practice is tapped inside modal', () => {
     const tree = create(<MapScreen />);
     act(() => {
-      tree.root.findByProps({ testID: 'stage-hotspot-1' }).props.onPress();
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
     });
     act(() => {
       tree.root.findByProps({ testID: 'practice-link' }).props.onPress();

--- a/app/features/Map/__tests__/MapScreen.test.tsx
+++ b/app/features/Map/__tests__/MapScreen.test.tsx
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+/* eslint-disable import/order */
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import MapScreen from '../MapScreen';
+
+// Mock navigation so we can observe tab linking behaviour.
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+describe('MapScreen', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders ten stage hotspots', () => {
+    const tree = create(<MapScreen />);
+    const stages = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) =>
+        typeof node.props.testID === 'string' && node.props.testID.startsWith('stage-hotspot'),
+    );
+    const unique = new Set(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      stages.map((s: any) => s.props.testID as string),
+    );
+    expect(unique.size).toBe(10);
+  });
+
+  it('shows modal with stage details when a hotspot is tapped', () => {
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1' }).props.onPress();
+    });
+    const modal = tree.root.findByProps({ testID: 'stage-modal' });
+    expect(modal).toBeTruthy();
+  });
+
+  it('navigates to Practice when Practice is tapped inside modal', () => {
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1' }).props.onPress();
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'practice-link' }).props.onPress();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('Practice');
+  });
+});

--- a/app/features/Map/__tests__/MapScreen.test.tsx
+++ b/app/features/Map/__tests__/MapScreen.test.tsx
@@ -58,4 +58,26 @@ describe('MapScreen', () => {
     });
     expect(mockNavigate).toHaveBeenCalledWith('Practice');
   });
+
+  it('closes modal when X is pressed', () => {
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'close-modal' }).props.onPress();
+    });
+    expect(() => tree.root.findByProps({ testID: 'stage-modal' })).toThrow();
+  });
+
+  it('closes modal when tapping outside content', () => {
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'modal-overlay' }).props.onPress();
+    });
+    expect(() => tree.root.findByProps({ testID: 'stage-modal' })).toThrow();
+  });
 });

--- a/app/features/Map/__tests__/stageData.test.ts
+++ b/app/features/Map/__tests__/stageData.test.ts
@@ -7,4 +7,31 @@ describe('stageData', () => {
     expect(STAGES[0]!.stageNumber).toBe(10);
     expect(STAGES[STAGES.length - 1]!.stageNumber).toBe(1);
   });
+
+  it('has non-overlapping vertical hotspot ranges', () => {
+    for (let i = 0; i < STAGES.length - 1; i++) {
+      const current = STAGES[i]!;
+      const next = STAGES[i + 1]!;
+      const currentBottom = Math.max(...current.hotspots.map((h) => h.top + h.height));
+      const nextTop = Math.min(...next.hotspots.map((h) => h.top));
+      expect(currentBottom).toBeLessThanOrEqual(nextTop);
+    }
+  });
+
+  it('positions arrow hotspots on alternating sides of the spiral', () => {
+    STAGES.forEach((stage) => {
+      const arrowSpots = stage.hotspots.slice(1);
+      if (stage.stageNumber === 9) {
+        expect(arrowSpots).toHaveLength(2);
+      } else {
+        expect(arrowSpots).toHaveLength(1);
+        const arrow = arrowSpots[0]!;
+        if (stage.stageNumber % 2 === 0) {
+          expect(arrow.left).toBeLessThan(40);
+        } else {
+          expect(arrow.left).toBeGreaterThan(40);
+        }
+      }
+    });
+  });
 });

--- a/app/features/Map/__tests__/stageData.test.ts
+++ b/app/features/Map/__tests__/stageData.test.ts
@@ -1,0 +1,10 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { STAGES } from '../stageData';
+
+describe('stageData', () => {
+  it('orders stages from 10 at top to 1 at bottom', () => {
+    expect(STAGES[0]!.stageNumber).toBe(10);
+    expect(STAGES[STAGES.length - 1]!.stageNumber).toBe(1);
+  });
+});

--- a/app/features/Map/stageData.ts
+++ b/app/features/Map/stageData.ts
@@ -82,8 +82,11 @@ const HOTSPOTS: Hotspot[][] = [
   ],
 ] as const;
 
+// Stages are ordered from top (stage 10) to bottom (stage 1) to match the
+// background artwork where the spiral begins with 10 at the top and ends with
+// 1 at the bottom.
 export const STAGES: StageData[] = Array.from({ length: 10 }, (_, index) => {
-  const stageNumber = index + 1;
+  const stageNumber = 10 - index;
   return {
     id: stageNumber,
     title: `Stage ${stageNumber}`,
@@ -93,7 +96,7 @@ export const STAGES: StageData[] = Array.from({ length: 10 }, (_, index) => {
     progress: stageNumber === 1 ? 0.5 : 0,
     goals: [`Goal for stage ${stageNumber}`],
     practices: [`Practice for stage ${stageNumber}`],
-    color: COLORS[index]!,
+    color: COLORS[stageNumber - 1]!,
     hotspots: HOTSPOTS[index]!,
   };
 });

--- a/app/features/Map/stageData.ts
+++ b/app/features/Map/stageData.ts
@@ -4,6 +4,13 @@
  * Static placeholder data for the ten APTITUDE stages.
  * In a full implementation these would be fetched from the backend `CourseStage` model.
  */
+export interface Hotspot {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
 export interface StageData {
   id: number;
   title: string;
@@ -13,7 +20,7 @@ export interface StageData {
   goals: string[];
   practices: string[];
   color: string;
-  position: { top: number; left: number };
+  hotspots: Hotspot[]; // areas that respond to taps
 }
 
 const COLORS = [
@@ -29,17 +36,50 @@ const COLORS = [
   '#ea580c',
 ];
 
-const POSITIONS = [
-  { top: 8, left: 10 },
-  { top: 16, left: 60 },
-  { top: 24, left: 10 },
-  { top: 32, left: 60 },
-  { top: 40, left: 10 },
-  { top: 48, left: 60 },
-  { top: 56, left: 10 },
-  { top: 64, left: 60 },
-  { top: 72, left: 10 },
-  { top: 80, left: 60 },
+// Rough percentage-based hotspot layout matching the spiral image. Each stage has
+// two tappable regions: the colored text on the left and the arrow in the
+// middle. Adjust these values when the final background asset is available.
+const HOTSPOTS: Hotspot[][] = [
+  [
+    { top: 8, left: 4, width: 32, height: 8 },
+    { top: 8, left: 42, width: 32, height: 8 },
+  ],
+  [
+    { top: 16, left: 4, width: 32, height: 8 },
+    { top: 16, left: 42, width: 32, height: 8 },
+  ],
+  [
+    { top: 24, left: 4, width: 32, height: 8 },
+    { top: 24, left: 42, width: 32, height: 8 },
+  ],
+  [
+    { top: 32, left: 4, width: 32, height: 8 },
+    { top: 32, left: 42, width: 32, height: 8 },
+  ],
+  [
+    { top: 40, left: 4, width: 32, height: 8 },
+    { top: 40, left: 42, width: 32, height: 8 },
+  ],
+  [
+    { top: 48, left: 4, width: 32, height: 8 },
+    { top: 48, left: 42, width: 32, height: 8 },
+  ],
+  [
+    { top: 56, left: 4, width: 32, height: 8 },
+    { top: 56, left: 42, width: 32, height: 8 },
+  ],
+  [
+    { top: 64, left: 4, width: 32, height: 8 },
+    { top: 64, left: 42, width: 32, height: 8 },
+  ],
+  [
+    { top: 72, left: 4, width: 32, height: 8 },
+    { top: 72, left: 42, width: 32, height: 8 },
+  ],
+  [
+    { top: 80, left: 4, width: 32, height: 8 },
+    { top: 80, left: 42, width: 32, height: 8 },
+  ],
 ] as const;
 
 export const STAGES: StageData[] = Array.from({ length: 10 }, (_, index) => {
@@ -54,6 +94,6 @@ export const STAGES: StageData[] = Array.from({ length: 10 }, (_, index) => {
     goals: [`Goal for stage ${stageNumber}`],
     practices: [`Practice for stage ${stageNumber}`],
     color: COLORS[index]!,
-    position: POSITIONS[index]!,
+    hotspots: HOTSPOTS[index]!,
   };
 });

--- a/app/features/Map/stageData.ts
+++ b/app/features/Map/stageData.ts
@@ -1,0 +1,59 @@
+// app/features/Map/stageData.ts
+
+/**
+ * Static placeholder data for the ten APTITUDE stages.
+ * In a full implementation these would be fetched from the backend `CourseStage` model.
+ */
+export interface StageData {
+  id: number;
+  title: string;
+  subtitle: string;
+  stageNumber: number;
+  progress: number; // 0–1 completion percentage
+  goals: string[];
+  practices: string[];
+  color: string;
+  position: { top: number; left: number };
+}
+
+const COLORS = [
+  '#7f1d1d',
+  '#9f1239',
+  '#c026d3',
+  '#6d28d9',
+  '#1d4ed8',
+  '#0ea5e9',
+  '#059669',
+  '#65a30d',
+  '#ca8a04',
+  '#ea580c',
+];
+
+const POSITIONS = [
+  { top: 8, left: 10 },
+  { top: 16, left: 60 },
+  { top: 24, left: 10 },
+  { top: 32, left: 60 },
+  { top: 40, left: 10 },
+  { top: 48, left: 60 },
+  { top: 56, left: 10 },
+  { top: 64, left: 60 },
+  { top: 72, left: 10 },
+  { top: 80, left: 60 },
+] as const;
+
+export const STAGES: StageData[] = Array.from({ length: 10 }, (_, index) => {
+  const stageNumber = index + 1;
+  return {
+    id: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    stageNumber,
+    // Simple demo progress – first stage partially complete, others locked
+    progress: stageNumber === 1 ? 0.5 : 0,
+    goals: [`Goal for stage ${stageNumber}`],
+    practices: [`Practice for stage ${stageNumber}`],
+    color: COLORS[index]!,
+    position: POSITIONS[index]!,
+  };
+});

--- a/app/features/Map/stageData.ts
+++ b/app/features/Map/stageData.ts
@@ -36,49 +36,50 @@ const COLORS = [
   '#ea580c',
 ];
 
-// Rough percentage-based hotspot layout matching the spiral image. Each stage has
-// two tappable regions: the colored text on the left and the arrow in the
-// middle. Adjust these values when the final background asset is available.
+// Percentage-based hotspot layout matching the spiral image. Each stage has a
+// tappable region over the colored text on the left and another over its spiral
+// arrow. Arrows alternate sides as the spiral winds; stage 9 has two arrows.
 const HOTSPOTS: Hotspot[][] = [
   [
-    { top: 8, left: 4, width: 32, height: 8 },
-    { top: 8, left: 42, width: 32, height: 8 },
+    { top: 4, left: 4, width: 32, height: 6 },
+    { top: 4, left: 34, width: 40, height: 6 },
   ],
   [
-    { top: 16, left: 4, width: 32, height: 8 },
-    { top: 16, left: 42, width: 32, height: 8 },
+    { top: 12, left: 4, width: 32, height: 6 },
+    { top: 12, left: 34, width: 40, height: 6 },
+    { top: 12, left: 50, width: 40, height: 6 },
   ],
   [
-    { top: 24, left: 4, width: 32, height: 8 },
-    { top: 24, left: 42, width: 32, height: 8 },
+    { top: 20, left: 4, width: 32, height: 6 },
+    { top: 20, left: 34, width: 40, height: 6 },
   ],
   [
-    { top: 32, left: 4, width: 32, height: 8 },
-    { top: 32, left: 42, width: 32, height: 8 },
+    { top: 28, left: 4, width: 32, height: 6 },
+    { top: 28, left: 50, width: 40, height: 6 },
   ],
   [
-    { top: 40, left: 4, width: 32, height: 8 },
-    { top: 40, left: 42, width: 32, height: 8 },
+    { top: 36, left: 4, width: 32, height: 6 },
+    { top: 36, left: 34, width: 40, height: 6 },
   ],
   [
-    { top: 48, left: 4, width: 32, height: 8 },
-    { top: 48, left: 42, width: 32, height: 8 },
+    { top: 44, left: 4, width: 32, height: 6 },
+    { top: 44, left: 50, width: 40, height: 6 },
   ],
   [
-    { top: 56, left: 4, width: 32, height: 8 },
-    { top: 56, left: 42, width: 32, height: 8 },
+    { top: 52, left: 4, width: 32, height: 6 },
+    { top: 52, left: 34, width: 40, height: 6 },
   ],
   [
-    { top: 64, left: 4, width: 32, height: 8 },
-    { top: 64, left: 42, width: 32, height: 8 },
+    { top: 60, left: 4, width: 32, height: 6 },
+    { top: 60, left: 50, width: 40, height: 6 },
   ],
   [
-    { top: 72, left: 4, width: 32, height: 8 },
-    { top: 72, left: 42, width: 32, height: 8 },
+    { top: 68, left: 4, width: 32, height: 6 },
+    { top: 68, left: 34, width: 40, height: 6 },
   ],
   [
-    { top: 80, left: 4, width: 32, height: 8 },
-    { top: 80, left: 42, width: 32, height: 8 },
+    { top: 76, left: 4, width: 32, height: 6 },
+    { top: 76, left: 50, width: 40, height: 6 },
   ],
 ] as const;
 

--- a/app/features/Practice/PracticeScreen.tsx
+++ b/app/features/Practice/PracticeScreen.tsx
@@ -1,0 +1,29 @@
+// app/features/Practice/PracticeScreen.tsx
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+/**
+ * Placeholder practice screen.
+ * The real implementation will host guided exercises for each stage.
+ */
+const PracticeScreen = (): React.JSX.Element => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Practice Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});
+
+export default PracticeScreen;

--- a/app/navigation/BottomTabs.tsx
+++ b/app/navigation/BottomTabs.tsx
@@ -1,0 +1,38 @@
+// app/navigation/BottomTabs.tsx
+
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import React from 'react';
+
+import CourseScreen from '../features/Course/CourseScreen';
+import HabitsScreen from '../features/Habits/HabitsScreen';
+import JournalScreen from '../features/Journal/JournalScreen';
+import MapScreen from '../features/Map/MapScreen';
+import PracticeScreen from '../features/Practice/PracticeScreen';
+
+export type RootTabParamList = {
+  Habits: undefined;
+  Practice: undefined;
+  Course: undefined;
+  Journal: undefined;
+  Map: undefined;
+};
+
+const Tab = createBottomTabNavigator<RootTabParamList>();
+
+/**
+ * Application-wide bottom tab navigation.
+ * Each tab corresponds to a major feature area.
+ */
+const BottomTabs = (): React.JSX.Element => {
+  return (
+    <Tab.Navigator initialRouteName="Habits">
+      <Tab.Screen name="Habits" component={HabitsScreen} />
+      <Tab.Screen name="Practice" component={PracticeScreen} />
+      <Tab.Screen name="Course" component={CourseScreen} />
+      <Tab.Screen name="Journal" component={JournalScreen} />
+      <Tab.Screen name="Map" component={MapScreen} />
+    </Tab.Navigator>
+  );
+};
+
+export default BottomTabs;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,6 +15,7 @@
         "@react-native-community/push-notification-ios": "^1.11.0",
         "@react-native-community/slider": "4.5.5",
         "@react-native-picker/picker": "2.9.0",
+        "@react-navigation/bottom-tabs": "^7.4.6",
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/native-stack": "^7.3.10",
         "expo": "~52.0.43",
@@ -5200,6 +5201,23 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.4.6.tgz",
+      "integrity": "sha512-f4khxwcL70O5aKfZFbxyBo5RnzPFnBNSXmrrT7q9CRmvN4mHov9KFKGQ3H4xD5sLonsTBtyjvyvPfyEC4G7f+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.6.3",
+        "color": "^4.2.3"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.17",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@react-navigation/core": {

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
     "@react-native-community/push-notification-ios": "^1.11.0",
     "@react-native-community/slider": "4.5.5",
     "@react-native-picker/picker": "2.9.0",
+    "@react-navigation/bottom-tabs": "^7.4.6",
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/native-stack": "^7.3.10",
     "expo": "~52.0.43",


### PR DESCRIPTION
## Summary
- overlay map screen on background with clickable stage hotspots
- show stage details in modal with course and practice links
- load map background from configurable URI to avoid committing large assets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf7ff69388322ab0530aa390f44d1