### PR TITLE
feat: add cross-platform date picker

### DIFF
--- a/app/__tests__/DatePicker.test.tsx
+++ b/app/__tests__/DatePicker.test.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable import/order */
+import { describe, expect, test, jest, beforeAll, afterAll } from '@jest/globals';
+
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+import DatePicker, { parseDateInput, isDateWithinRange } from '../components/DatePicker';
+
+jest.mock('react-native-modal-datetime-picker', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('date utilities', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-01-01'));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test('parseDateInput handles various formats', () => {
+    expect(parseDateInput('9/1/25')?.toISOString().slice(0, 10)).toBe('2025-09-01');
+    expect(parseDateInput('Sep 1')?.toISOString().slice(0, 10)).toBe('2025-09-01');
+    expect(parseDateInput('invalid')).toBeNull();
+  });
+
+  test('isDateWithinRange validates correctly', () => {
+    const min = new Date('2025-01-01');
+    const max = new Date('2025-12-31');
+    expect(isDateWithinRange(new Date('2025-06-01'), min, max)).toBe(true);
+    expect(isDateWithinRange(new Date('2024-12-31'), min, max)).toBe(false);
+  });
+});
+
+describe('DatePicker component', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-06-15'));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test('allows typing and validates range', () => {
+    const handleChange = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let tree: any;
+    act(() => {
+      tree = renderer.create(
+        <DatePicker
+          value="2025-09-01"
+          onChange={handleChange}
+          minDate="2025-01-01"
+          maxDate="2025-12-31"
+        />,
+      );
+    });
+    const input = tree!.root.findByProps({ accessibilityLabel: 'Date' });
+    act(() => {
+      input.props.onChangeText('2024-12-31');
+    });
+    const error = tree!.root.findByProps({ accessibilityRole: 'alert' });
+    expect(error.props.children).toBe('Date must be between 2025-01-01 and 2025-12-31');
+    act(() => {
+      input.props.onChangeText('2025-10-10');
+    });
+    expect(handleChange).toHaveBeenLastCalledWith('2025-10-10');
+  });
+
+  test('quick action sets today', () => {
+    const handleChange = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let tree: any;
+    act(() => {
+      tree = renderer.create(<DatePicker value="2025-09-01" onChange={handleChange} />);
+    });
+    const btn = tree!.root.findByProps({ accessibilityLabel: 'Select today' });
+    act(() => {
+      btn.props.onPress();
+    });
+    expect(handleChange).toHaveBeenLastCalledWith('2025-06-15');
+  });
+});

--- a/app/__tests__/DatePicker.test.tsx
+++ b/app/__tests__/DatePicker.test.tsx
@@ -4,7 +4,12 @@ import { describe, expect, test, jest, beforeAll, afterAll } from '@jest/globals
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 
-import DatePicker, { parseDateInput, isDateWithinRange } from '../components/DatePicker';
+import DatePicker, {
+  parseDateInput,
+  isDateWithinRange,
+  parseISODate,
+  toISODate,
+} from '../components/DatePicker';
 
 jest.mock('react-native-modal-datetime-picker', () => ({
   __esModule: true,
@@ -60,7 +65,7 @@ describe('DatePicker component', () => {
       input.props.onChangeText('2024-12-31');
     });
     const error = tree!.root.findByProps({ accessibilityRole: 'alert' });
-    expect(error.props.children).toBe('Date must be between 2025-01-01 and 2025-12-31');
+    expect(error.props.children).toBe('between 2025-01-01 and 2025-12-31');
     act(() => {
       input.props.onChangeText('2025-10-10');
     });
@@ -79,5 +84,23 @@ describe('DatePicker component', () => {
       btn.props.onPress();
     });
     expect(handleChange).toHaveBeenLastCalledWith('2025-06-15');
+  });
+});
+
+describe('ISO helpers', () => {
+  const originalTZ = process.env.TZ;
+  beforeAll(() => {
+    process.env.TZ = 'America/Los_Angeles';
+  });
+  afterAll(() => {
+    process.env.TZ = originalTZ;
+  });
+
+  test('parseISODate preserves local day', () => {
+    const d = parseISODate('2025-09-10');
+    expect(d.getFullYear()).toBe(2025);
+    expect(d.getMonth()).toBe(8);
+    expect(d.getDate()).toBe(10);
+    expect(toISODate(d)).toBe('2025-09-10');
   });
 });

--- a/app/components/DatePicker.tsx
+++ b/app/components/DatePicker.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useState } from 'react';
+import type { ComponentType } from 'react';
+import { Platform, Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+let DateTimePickerModal: ComponentType<Record<string, unknown>> = () => null;
+if (Platform.OS !== 'web') {
+  try {
+    DateTimePickerModal = require('react-native-modal-datetime-picker').default;
+  } catch {
+    DateTimePickerModal = () => null;
+  }
+}
+
+export interface DatePickerProps {
+  value: string;
+  onChange: (value: string) => void; // eslint-disable-line no-unused-vars
+  minDate?: string;
+  maxDate?: string;
+  disabledDate?: (date: Date) => boolean; // eslint-disable-line no-unused-vars
+  locale?: string;
+  mode?: 'scaffoldingStart' | 'courseStart';
+  stageColor?: string;
+}
+
+export const toISODate = (date: Date): string => date.toISOString().slice(0, 10);
+
+export const formatDisplayDate = (date: Date, locale = 'en-US'): string =>
+  date.toLocaleDateString(locale, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+export const parseDateInput = (input: string): Date | null => {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // MM/DD/YY or MM/DD/YYYY
+  const mdy = trimmed.match(/^([0-9]{1,2})\/([0-9]{1,2})(?:\/([0-9]{2,4}))?$/);
+  if (mdy) {
+    let year = mdy[3] ? Number.parseInt(mdy[3], 10) : new Date().getFullYear();
+    if (year < 100) year += 2000;
+    const month = Number.parseInt(mdy[1]!, 10) - 1;
+    const day = Number.parseInt(mdy[2]!, 10);
+    const date = new Date(year, month, day);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  // Month name and day, e.g., Sep 1
+  const monthDay = trimmed.match(/^([a-zA-Z]+)\s+(\d{1,2})$/);
+  if (monthDay) {
+    const md = Date.parse(`${monthDay[1]} ${monthDay[2]} ${new Date().getFullYear()}`);
+    if (!Number.isNaN(md)) {
+      return new Date(md);
+    }
+  }
+
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+export const isDateWithinRange = (date: Date, min?: Date, max?: Date): boolean => {
+  if (min && date < min) return false;
+  if (max && date > max) return false;
+  return true;
+};
+
+const DatePicker: React.FC<DatePickerProps> = ({
+  value,
+  onChange,
+  minDate,
+  maxDate,
+  disabledDate,
+  locale = 'en-US',
+}) => {
+  const [textValue, setTextValue] = useState(
+    value ? formatDisplayDate(new Date(value), locale) : '',
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [pickerVisible, setPickerVisible] = useState(false);
+
+  useEffect(() => {
+    if (value) {
+      setTextValue(formatDisplayDate(new Date(value), locale));
+    }
+  }, [value, locale]);
+
+  const commitDate = (date: Date) => {
+    if (minDate || maxDate || disabledDate) {
+      const min = minDate ? new Date(minDate) : undefined;
+      const max = maxDate ? new Date(maxDate) : undefined;
+      if (!isDateWithinRange(date, min, max)) {
+        setError(`Date must be between ${minDate ?? '-∞'} and ${maxDate ?? '∞'}`);
+        return;
+      }
+      if (disabledDate && disabledDate(date)) {
+        setError('This date is unavailable');
+        return;
+      }
+    }
+    setError(null);
+    onChange(toISODate(date));
+  };
+
+  const handleChangeText = (t: string) => {
+    setTextValue(t);
+    const parsed = parseDateInput(t);
+    if (!parsed) {
+      setError('Enter a date like 2025-09-01');
+      return;
+    }
+    commitDate(parsed);
+  };
+
+  const quickToday = () => commitDate(new Date());
+  const quickNextMonday = () => {
+    const d = new Date();
+    const add = (8 - d.getDay()) % 7 || 7;
+    d.setDate(d.getDate() + add);
+    commitDate(d);
+  };
+  const quickFirstNextMonth = () => {
+    const d = new Date();
+    d.setMonth(d.getMonth() + 1, 1);
+    commitDate(d);
+  };
+
+  return (
+    <View>
+      {Platform.OS === 'web' ? (
+        <input
+          aria-label="Date"
+          type="date"
+          value={value}
+          min={minDate}
+          max={maxDate}
+          onChange={(e) => commitDate(new Date(e.target.value))}
+        />
+      ) : (
+        <TextInput
+          accessibilityLabel="Date"
+          placeholder="Select date"
+          value={textValue}
+          onChangeText={handleChangeText}
+          onFocus={() => setPickerVisible(true)}
+        />
+      )}
+      {error && <Text accessibilityRole="alert">{error}</Text>}
+      {Platform.OS !== 'web' && (
+        <DateTimePickerModal
+          isVisible={pickerVisible}
+          mode="date"
+          date={value ? new Date(value) : new Date()}
+          minimumDate={minDate ? new Date(minDate) : undefined}
+          maximumDate={maxDate ? new Date(maxDate) : undefined}
+          onConfirm={(date: Date) => {
+            setPickerVisible(false);
+            commitDate(date);
+          }}
+          onCancel={() => setPickerVisible(false)}
+        />
+      )}
+      <View style={{ flexDirection: 'row', marginTop: 8 }}>
+        <TouchableOpacity onPress={quickToday} accessibilityLabel="Select today">
+          <Text>Today</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={quickNextMonday}
+          style={{ marginLeft: 12 }}
+          accessibilityLabel="Select next Monday"
+        >
+          <Text>Next Monday</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={quickFirstNextMonth}
+          style={{ marginLeft: 12 }}
+          accessibilityLabel="Select first of next month"
+        >
+          <Text>First of Next Month</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default DatePicker;

--- a/app/features/Habits/components/OnboardingModal.tsx
+++ b/app/features/Habits/components/OnboardingModal.tsx
@@ -1,4 +1,3 @@
-import DateTimePicker from '@react-native-community/datetimepicker';
 import React, { useState } from 'react';
 import {
   FlatList,
@@ -13,6 +12,7 @@ import {
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import EmojiSelector from 'react-native-emoji-selector';
 
+import DatePicker from '../../../components/DatePicker';
 import styles from '../Habits.styles';
 import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
 import { DEFAULT_ICONS } from '../HabitsScreen';
@@ -23,7 +23,6 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
   const [habits, setHabits] = useState<OnboardingHabit[]>([]);
   const [newHabitName, setNewHabitName] = useState('');
   const [startDate, setStartDate] = useState(new Date());
-  const [showDatePicker, setShowDatePicker] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [selectedHabitIndex, setSelectedHabitIndex] = useState<number | null>(null);
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
@@ -219,61 +218,21 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
 
       <View style={styles.startDateContainer}>
         <Text style={styles.startDateLabel}>First habit starts on:</Text>
-        <TouchableOpacity
-          testID="start-date-button"
-          style={styles.startDateButton}
-          onPress={() => {
-            if (Platform.OS === 'web') {
-              const input = window.prompt(
-                'Select start date (YYYY-MM-DD)',
-                startDate.toISOString().slice(0, 10),
-              );
-              if (input) {
-                const selectedDate = new Date(input);
-                setStartDate(selectedDate);
-                setHabits((prev) =>
-                  prev.map((habit, index) => ({
-                    ...habit,
-                    start_date: calculateHabitStartDate(selectedDate, index),
-                  })),
-                );
-              }
-            } else {
-              setShowDatePicker(true);
-            }
+        <DatePicker
+          value={startDate.toISOString().slice(0, 10)}
+          minDate={new Date().toISOString().slice(0, 10)}
+          mode="scaffoldingStart"
+          onChange={(iso) => {
+            const selectedDate = new Date(iso);
+            setStartDate(selectedDate);
+            setHabits((prev) =>
+              prev.map((habit, index) => ({
+                ...habit,
+                start_date: calculateHabitStartDate(selectedDate, index),
+              })),
+            );
           }}
-        >
-          <Text style={styles.startDateButtonText}>
-            {startDate.toLocaleDateString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-            })}
-          </Text>
-        </TouchableOpacity>
-
-        {showDatePicker && Platform.OS !== 'web' && (
-          <Modal transparent testID="date-picker-modal">
-            <DateTimePicker
-              value={startDate}
-              mode="date"
-              display="default"
-              onChange={(event, selectedDate) => {
-                setShowDatePicker(Platform.OS === 'ios');
-                if (selectedDate) {
-                  setStartDate(selectedDate);
-                  // Update all start dates
-                  setHabits((prev) =>
-                    prev.map((habit, index) => ({
-                      ...habit,
-                      start_date: calculateHabitStartDate(selectedDate, index),
-                    })),
-                  );
-                }
-              }}
-            />
-          </Modal>
-        )}
+        />
       </View>
 
       <View style={styles.habitsList}>

--- a/app/features/Habits/components/OnboardingModal.tsx
+++ b/app/features/Habits/components/OnboardingModal.tsx
@@ -12,7 +12,7 @@ import {
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import EmojiSelector from 'react-native-emoji-selector';
 
-import DatePicker from '../../../components/DatePicker';
+import DatePicker, { parseISODate, toISODate } from '../../../components/DatePicker';
 import styles from '../Habits.styles';
 import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
 import { DEFAULT_ICONS } from '../HabitsScreen';
@@ -219,11 +219,11 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
       <View style={styles.startDateContainer}>
         <Text style={styles.startDateLabel}>First habit starts on:</Text>
         <DatePicker
-          value={startDate.toISOString().slice(0, 10)}
-          minDate={new Date().toISOString().slice(0, 10)}
+          value={toISODate(startDate)}
+          minDate={toISODate(new Date())}
           mode="scaffoldingStart"
           onChange={(iso) => {
-            const selectedDate = new Date(iso);
+            const selectedDate = parseISODate(iso);
             setStartDate(selectedDate);
             setHabits((prev) =>
               prev.map((habit, index) => ({

--- a/app/features/Habits/components/__tests__/OnboardingModal.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.test.tsx
@@ -98,11 +98,10 @@ describe('OnboardingModal close behaviour', () => {
     pressContinue(); // to return step
     pressContinue(); // to reorder step
 
-    const startBtn = root.findByProps({ testID: 'start-date-button' });
+    const dateInput = root.findByProps({ accessibilityLabel: 'Date' });
     renderer.act(() => {
-      startBtn.props.onPress();
+      dateInput.props.onChangeText('2025-09-10');
     });
-    expect(root.findByProps({ testID: 'date-picker-modal' })).toBeTruthy();
 
     const finish = root.findByProps({ testID: 'finish-setup' });
     renderer.act(() => {

--- a/app/features/Habits/components/__tests__/OnboardingModal.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.test.tsx
@@ -109,4 +109,64 @@ describe('OnboardingModal close behaviour', () => {
     });
     expect(onSave).toHaveBeenCalled();
   });
+
+  it('uses selected start date for first habit', () => {
+    const originalTZ = process.env.TZ;
+    process.env.TZ = 'America/Los_Angeles';
+    // eslint-disable-next-line no-unused-vars
+    const onSave = jest.fn<(_: { start_date: Date }[]) => void>();
+    const tree = renderer.create(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={onSave} />,
+    );
+    const root = tree.root;
+
+    const input = root.findByType(TextInput);
+    renderer.act(() => {
+      input.props.onChangeText('Test');
+    });
+    // add habit via plus button
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const plus = root.findAllByType(Text).find((t: any) => t.props.children === '+');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let plusParent: any = plus.parent;
+    while (plusParent && plusParent.type !== TouchableOpacity) {
+      plusParent = plusParent.parent;
+    }
+    renderer.act(() => {
+      plusParent.props.onPress();
+    });
+
+    const pressContinue = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const text = root.findAllByType(Text).find((t: any) => t.props.children === 'Continue');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let parent: any = text.parent;
+      while (parent && parent.type !== TouchableOpacity) {
+        parent = parent.parent;
+      }
+      renderer.act(() => {
+        parent.props.onPress();
+      });
+    };
+    pressContinue();
+    pressContinue();
+    pressContinue();
+
+    const dateInput = root.findByProps({ accessibilityLabel: 'Date' });
+    renderer.act(() => {
+      dateInput.props.onChangeText('2025-09-10');
+    });
+
+    const finish = root.findByProps({ testID: 'finish-setup' });
+    renderer.act(() => {
+      finish.props.onPress();
+    });
+
+    const saved = onSave.mock.calls[0]?.[0]?.[0];
+    expect(saved).toBeDefined();
+    expect(saved!.start_date.getFullYear()).toBe(2025);
+    expect(saved!.start_date.getMonth()).toBe(8);
+    expect(saved!.start_date.getDate()).toBe(10);
+    process.env.TZ = originalTZ;
+  });
 });


### PR DESCRIPTION
## Summary
- add adaptive DatePicker component with native and web implementations
- wire date picker into Energy Scaffolding onboarding flow
- cover date parsing and range validation with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b75e113d008322a5438d56c47411b7