### PR TITLE
feat: improve onboarding habit entry

### DIFF
--- a/app/features/Habits/Habits.styles.ts
+++ b/app/features/Habits/Habits.styles.ts
@@ -1222,6 +1222,46 @@ export const styles = StyleSheet.create({
     lineHeight: 16,
   },
 
+  habitChipContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    paddingBottom: SPACING.lg,
+  },
+  habitChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: COLORS.background.primary,
+    borderRadius: BORDER_RADIUS.lg,
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    margin: SPACING.xs,
+    ...SHADOWS.small,
+  },
+  habitChipText: {
+    fontSize: 14,
+    color: COLORS.text.primary,
+  },
+  removeHabitChip: {
+    marginLeft: SPACING.xs,
+  },
+  removeHabitChipText: {
+    fontSize: 16,
+    color: COLORS.danger,
+  },
+  habitError: {
+    color: COLORS.danger,
+    textAlign: 'center',
+  },
+  bottomContainer: {
+    marginTop: 'auto',
+    alignItems: 'center',
+  },
+  habitCount: {
+    textAlign: 'center',
+    color: COLORS.text.secondary,
+    marginBottom: SPACING.md,
+  },
+
   // ===== Emoji Picker =====
   emojiPickerModal: {
     position: 'absolute',

--- a/app/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+import { TextInput } from 'react-native';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../HabitsScreen', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+
+describe('OnboardingModal Step 1 interactions', () => {
+  it('Enter adds habit, clears input, refocuses input', () => {
+    const focusSpy = jest.spyOn(TextInput.prototype, 'focus');
+    const { getByPlaceholderText, getByText } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, 'Drink water');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    getByText('⭐ Drink water');
+    expect(input.props.value).toBe('');
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it('Cmd+Enter triggers next step when habit exists', () => {
+    const { getByPlaceholderText, getByText } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, 'Read');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter', metaKey: true } });
+    getByText('Energy Cost');
+  });
+
+  it('adding more than 10 habits shows error and keeps count', () => {
+    const { getByPlaceholderText, getByTestId, getByText } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    for (let i = 0; i < 10; i++) {
+      fireEvent.changeText(input, `H${i}`);
+      fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    }
+    expect(getByTestId('habit-count')).toHaveTextContent('10 / 10');
+    fireEvent.changeText(input, 'H10');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    getByText('You can only add up to 10 habits.');
+    expect(getByTestId('habit-count')).toHaveTextContent('10 / 10');
+  });
+
+  it('Continue with fewer than 10 habits shows warning then advances', () => {
+    const { getByPlaceholderText, getByTestId, getByText } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    for (let i = 0; i < 3; i++) {
+      fireEvent.changeText(input, `H${i}`);
+      fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    }
+    fireEvent.press(getByTestId('continue-button'));
+    getByText("You've entered 3 of 10. Continue anyway?");
+    fireEvent.press(getByTestId('count-warning-continue'));
+    getByText('Energy Cost');
+  });
+});

--- a/app/features/Habits/components/__tests__/OnboardingModal.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.test.tsx
@@ -81,18 +81,16 @@ describe('OnboardingModal close behaviour', () => {
     });
 
     const pressContinue = () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const text = root.findAllByType(Text).find((t: any) => t.props.children === 'Continue');
-      if (!text) throw new Error('Continue button not found');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let parent: any = text.parent;
-      while (parent && parent.type !== TouchableOpacity) {
-        parent = parent.parent;
-      }
-      if (!parent) throw new Error('Continue button not found');
+      const button = root.findByProps({ testID: 'continue-button' });
       renderer.act(() => {
-        parent.props.onPress();
+        button.props.onPress();
       });
+      const modalContinue = root.findAllByProps({ testID: 'count-warning-continue' });
+      if (modalContinue.length > 0) {
+        renderer.act(() => {
+          modalContinue[0].props.onPress();
+        });
+      }
     };
     pressContinue(); // to cost step
     pressContinue(); // to return step
@@ -137,16 +135,16 @@ describe('OnboardingModal close behaviour', () => {
     });
 
     const pressContinue = () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const text = root.findAllByType(Text).find((t: any) => t.props.children === 'Continue');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let parent: any = text.parent;
-      while (parent && parent.type !== TouchableOpacity) {
-        parent = parent.parent;
-      }
+      const button = root.findByProps({ testID: 'continue-button' });
       renderer.act(() => {
-        parent.props.onPress();
+        button.props.onPress();
       });
+      const modalContinue = root.findAllByProps({ testID: 'count-warning-continue' });
+      if (modalContinue.length > 0) {
+        renderer.act(() => {
+          modalContinue[0].props.onPress();
+        });
+      }
     };
     pressContinue();
     pressContinue();

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -43,6 +43,7 @@
         "@commitlint/config-conventional": "19.2.2",
         "@eslint/js": "^9.33.0",
         "@testing-library/jest-native": "5.4.3",
+        "@testing-library/react-native": "13.3.3",
         "@types/jest": "29.5.11",
         "@types/react": "~18.3.12",
         "eslint": "^9.33.0",
@@ -4226,6 +4227,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -4283,6 +4294,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -5378,6 +5399,140 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.3.tgz",
+      "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.0.5",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.0.5",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-diff": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
+      "integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-matcher-utils": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
+      "integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",

--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,7 @@
     "@commitlint/config-conventional": "19.2.2",
     "@eslint/js": "^9.33.0",
     "@testing-library/jest-native": "5.4.3",
+    "@testing-library/react-native": "13.3.3",
     "@types/jest": "29.5.11",
     "@types/react": "~18.3.12",
     "eslint": "^9.33.0",


### PR DESCRIPTION
## Summary
- redesign onboarding habit entry with bottom-aligned continue and habit count
- add keyboard shortcuts, limit checks, and warning modal for partial lists
- cover onboarding habit interactions with RTL tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a9b53d94832285301cb0d836990e