### PR TITLE
Derive habit net energy from cost and return

### DIFF
--- a/app/src/api/types.ts
+++ b/app/src/api/types.ts
@@ -94,7 +94,8 @@ export interface components {
     Habit: {
       id: number;
       name: string;
-      energy: number;
+      energy_cost: number;
+      energy_return: number;
     };
     PracticeSession: {
       id: number;

--- a/backend/app/domain/energy.py
+++ b/backend/app/domain/energy.py
@@ -7,11 +7,17 @@ from datetime import date, timedelta
 
 @dataclass(frozen=True)
 class Habit:
-    """A habit with an associated energy value."""
+    """A habit with associated energy cost and return."""
 
     id: int
     name: str
-    energy: int
+    energy_cost: int
+    energy_return: int
+
+    @property
+    def net_energy(self) -> int:
+        """Net energy gained from performing the habit."""
+        return self.energy_return - self.energy_cost
 
 
 @dataclass(frozen=True)
@@ -44,6 +50,6 @@ def generate_plan(habits: Sequence[Habit], start_date: date) -> tuple[EnergyPlan
     for offset in range(21):
         habit = habits[offset % len(habits)]
         items.append(EnergyPlanItem(habit_id=habit.id, date=start_date + timedelta(days=offset)))
-        net_energy += habit.energy
+        net_energy += habit.net_energy
     plan = EnergyPlan(items=items, net_energy=net_energy)
     return plan, "generated_21_day_plan"

--- a/backend/app/schemas/energy.py
+++ b/backend/app/schemas/energy.py
@@ -10,7 +10,8 @@ from pydantic import BaseModel
 class Habit(BaseModel):
     id: int
     name: str
-    energy: int
+    energy_cost: int
+    energy_return: int
 
 
 class EnergyPlanItem(BaseModel):

--- a/backend/tests/domain/test_energy.py
+++ b/backend/tests/domain/test_energy.py
@@ -4,12 +4,16 @@ from app.domain.energy import EnergyPlanItem, Habit, generate_plan
 
 
 def test_generate_plan_creates_21_day_schedule() -> None:
-    habits = [Habit(id=1, name="Run", energy=3), Habit(id=2, name="Sleep", energy=-1)]
+    habits = [
+        Habit(id=1, name="Run", energy_cost=2, energy_return=5),
+        Habit(id=2, name="Sleep", energy_cost=1, energy_return=0),
+    ]
     start = date(2024, 1, 1)
 
     plan, reason = generate_plan(habits, start)
 
     assert reason == "generated_21_day_plan"
     assert len(plan.items) == 21  # noqa: PLR2004
-    assert plan.net_energy == 3 * 11 + (-1) * 10
+    expected_net = habits[0].net_energy * 11 + habits[1].net_energy * 10
+    assert plan.net_energy == expected_net
     assert plan.items[0] == EnergyPlanItem(habit_id=1, date=start)

--- a/backend/tests/test_energy_api.py
+++ b/backend/tests/test_energy_api.py
@@ -10,8 +10,8 @@ client = TestClient(app)
 def sample_payload() -> dict[str, Any]:
     return {
         "habits": [
-            {"id": 1, "name": "Run", "energy": 3},
-            {"id": 2, "name": "Sleep", "energy": -1},
+            {"id": 1, "name": "Run", "energy_cost": 2, "energy_return": 5},
+            {"id": 2, "name": "Sleep", "energy_cost": 1, "energy_return": 0},
         ],
         "start_date": "2024-01-01",
     }
@@ -23,6 +23,8 @@ def test_energy_plan_endpoint_returns_plan() -> None:
     data = res.json()
     assert data["reason_code"] == "generated_21_day_plan"
     assert len(data["plan"]["items"]) == 21  # noqa: PLR2004
+    expected_net = (5 - 2) * 11 + (0 - 1) * 10
+    assert data["plan"]["net_energy"] == expected_net
 
 
 def test_energy_plan_endpoint_idempotency() -> None:


### PR DESCRIPTION
## Summary
- represent habits with `energy_cost` and `energy_return`
- compute `net_energy` during plan generation
- adjust tests and frontend API types for new habit shape

## Testing
- `pre-commit run --files backend/app/domain/energy.py backend/app/schemas/energy.py backend/tests/domain/test_energy.py backend/tests/test_energy_api.py app/src/api/types.ts`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8b01c37ec83228b99c61428d7373c