### PR TITLE
feat: expand goal schema to match data model

### DIFF
--- a/backend/app/domain/goals.py
+++ b/backend/app/domain/goals.py
@@ -3,23 +3,24 @@
 from __future__ import annotations
 
 
-def compute_progress(current: float, target: float, mode: str = "additive") -> tuple[float, str]:
+def compute_progress(
+    current: float, target: float, *, is_additive: bool = True
+) -> tuple[float, str]:
     """Compute progress toward ``target``.
 
-    ``mode`` can be ``additive`` or ``subtractive``.
+    ``is_additive`` mirrors the ``Goal.is_additive`` model field. When ``True``
+    progress increases toward the target; when ``False`` progress reflects how
+    much remains before exceeding the target.
     Returns a tuple of ``progress`` (0-1) and ``reason_code``.
     """
 
     if target <= 0:
         raise ValueError("target must be positive")
-    if mode not in {"additive", "subtractive"}:
-        raise ValueError("mode must be 'additive' or 'subtractive'")
 
-    if mode == "additive":
+    if is_additive:
         progress = max(0.0, min(current / target, 1.0))
         return progress, "additive_progress"
 
-    # subtractive
     remaining = max(target - current, 0)
     progress = max(0.0, min(remaining / target, 1.0))
     return progress, "subtractive_progress"

--- a/backend/app/schemas/goal.py
+++ b/backend/app/schemas/goal.py
@@ -6,6 +6,19 @@ from pydantic import BaseModel
 
 
 class Goal(BaseModel):
+    """Public representation of a :class:`models.data_model.Goal`.
+
+    This schema mirrors the SQLModel definition so API consumers can rely on a
+    stable contract. Only fields exposed over the wire are included.
+    """
+
     id: int
+    habit_id: int
+    title: str
+    description: str | None = None
+    tier: str
     target: float
-    mode: str = "additive"
+    target_unit: str
+    frequency: float
+    frequency_unit: str
+    is_additive: bool = True

--- a/backend/tests/domain/test_goals.py
+++ b/backend/tests/domain/test_goals.py
@@ -2,12 +2,12 @@ from app.domain.goals import compute_progress
 
 
 def test_additive_progress() -> None:
-    progress, code = compute_progress(5, 10, mode="additive")
+    progress, code = compute_progress(5, 10, is_additive=True)
     assert code == "additive_progress"
     assert progress == 0.5  # noqa: PLR2004
 
 
 def test_subtractive_progress() -> None:
-    progress, code = compute_progress(3, 10, mode="subtractive")
+    progress, code = compute_progress(3, 10, is_additive=False)
     assert code == "subtractive_progress"
     assert progress == 0.7  # noqa: PLR2004

--- a/backend/tests/schemas/test_goal_schema.py
+++ b/backend/tests/schemas/test_goal_schema.py
@@ -1,0 +1,30 @@
+from app.models.data_model import Goal as GoalModel
+from app.schemas.goal import Goal as GoalSchema
+
+
+def test_goal_schema_fields_match_model() -> None:
+    """Schema exposes a subset of the model fields."""
+
+    schema_fields = set(GoalSchema.model_fields.keys())
+    model_fields = set(GoalModel.model_fields.keys())
+    assert schema_fields.issubset(model_fields)
+
+
+def test_goal_schema_round_trip() -> None:
+    """Ensure schema serializes and deserializes database-like records."""
+
+    record = {
+        "id": 1,
+        "habit_id": 2,
+        "title": "Drink Water",
+        "description": None,
+        "tier": "clear",
+        "target": 8.0,
+        "target_unit": "cups",
+        "frequency": 1.0,
+        "frequency_unit": "per_day",
+        "is_additive": True,
+    }
+
+    schema_goal = GoalSchema.model_validate(record)
+    assert schema_goal.model_dump() == record


### PR DESCRIPTION
## Summary
- expand Goal schema with title, tier, frequency details, and is_additive flag
- adjust goal progress logic to use is_additive instead of string mode
- add tests covering updated schema and progress computation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8b01d4f908322bfc228e44ffd8d91