### PR TITLE
feat: add compact energy sliders in onboarding

### DIFF
--- a/app/features/Habits/Habits.styles.ts
+++ b/app/features/Habits/Habits.styles.ts
@@ -1079,74 +1079,32 @@ export const styles = StyleSheet.create({
   },
 
   // ===== Energy Rating =====
-  energyRatingItem: {
+  energyTile: {
     backgroundColor: COLORS.background.primary,
-    padding: SPACING.lg,
+    padding: SPACING.sm,
     borderRadius: BORDER_RADIUS.md,
-    marginVertical: SPACING.sm,
-    ...SHADOWS.small,
-  },
-  energyRatingName: {
-    fontSize: 18,
-    fontWeight: '600',
-    marginBottom: SPACING.md,
-    color: COLORS.text.primary,
-  },
-  energyRatingDetails: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  energySliders: {
-    flex: 3,
-  },
-  energySliderLabel: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: COLORS.text.primary,
-    marginRight: SPACING.md,
-  },
-  sliderContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: SPACING.md,
-    marginTop: SPACING.xs,
     marginBottom: SPACING.sm,
-  },
-  sliderButton: {
-    width: 32,
-    height: 32,
-    borderRadius: BORDER_RADIUS.md,
-    backgroundColor: COLORS.background.accent,
-    justifyContent: 'center',
-    alignItems: 'center',
     ...SHADOWS.small,
   },
-  sliderButtonText: {
-    fontSize: 20,
-    fontWeight: 'bold',
+  energyTileName: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: SPACING.xs,
     color: COLORS.text.primary,
+  },
+  energySliderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  energySlider: {
+    flex: 1,
+    marginRight: SPACING.sm,
   },
   sliderValue: {
     fontSize: 16,
     fontWeight: '600',
-    minWidth: 24,
+    width: 24,
     textAlign: 'center',
-    color: COLORS.text.primary,
-  },
-  netEnergyContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: COLORS.background.accent,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md,
-    marginLeft: SPACING.md,
-  },
-  netEnergyLabel: {
-    fontSize: 14,
-    fontWeight: 'bold',
     color: COLORS.text.primary,
   },
 
@@ -1311,6 +1269,34 @@ export const styles = StyleSheet.create({
     color: COLORS.text.light,
     fontSize: 16,
     fontWeight: 'bold',
+  },
+  onboardingFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    borderTopWidth: 1,
+    borderColor: '#eee',
+    backgroundColor: COLORS.background.card,
+  },
+  onboardingBackButton: {
+    flex: 1,
+    marginRight: SPACING.sm,
+    paddingVertical: SPACING.md,
+    paddingHorizontal: SPACING.lg,
+    borderRadius: BORDER_RADIUS.xs,
+    alignItems: 'center',
+    backgroundColor: COLORS.background.accent,
+  },
+  onboardingBackButtonText: {
+    color: COLORS.text.primary,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  footerContinue: {
+    flex: 1,
+    marginLeft: SPACING.sm,
   },
   disabledButton: {
     opacity: 0.5,

--- a/app/features/Habits/Habits.styles.ts
+++ b/app/features/Habits/Habits.styles.ts
@@ -1,10 +1,10 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, type ViewStyle } from 'react-native';
 
 //------------------
 // Theme Configuration (easier to maintain and change)
 //------------------
 
-const COLORS = {
+export const COLORS = {
   // Primary palette
   primary: '#1a1910',
   secondary: '#413d2f',
@@ -1096,10 +1096,22 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  energySlider: {
+  energySliderContainer: {
     flex: 1,
     marginRight: SPACING.sm,
+    backgroundColor: COLORS.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingHorizontal: SPACING.sm,
+    justifyContent: 'center',
+    ...SHADOWS.small,
   },
+  energySlider: {
+    width: '100%',
+    height: SPACING.lg,
+  },
+  energySliderWeb: {
+    cursor: 'ew-resize',
+  } as unknown as ViewStyle,
   sliderValue: {
     fontSize: 16,
     fontWeight: '600',

--- a/app/features/Habits/components/OnboardingModal.tsx
+++ b/app/features/Habits/components/OnboardingModal.tsx
@@ -1,6 +1,6 @@
-import React, { useRef, useState } from 'react';
+import Slider from '@react-native-community/slider';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  FlatList,
   Modal,
   Platform,
   SafeAreaView,
@@ -33,6 +33,52 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
   const inputRef = useRef<TextInput>(null);
   const [error, setError] = useState('');
   const [showCountWarning, setShowCountWarning] = useState(false);
+  const scrollRef = useRef<ScrollView>(null);
+
+  useEffect(() => {
+    if (step === 2 || step === 3) {
+      scrollRef.current?.scrollTo({ y: 0, animated: false });
+    }
+  }, [step]);
+
+  const prepareHabitsForReorder = useCallback(() => {
+    const sortedHabits = [...habits].sort((a, b) => {
+      const netEnergyA = a.energy_return - a.energy_cost;
+      const netEnergyB = b.energy_return - b.energy_cost;
+
+      if (netEnergyA !== netEnergyB) {
+        return netEnergyB - netEnergyA; // Highest net energy first
+      } else if (a.energy_cost !== b.energy_cost) {
+        return a.energy_cost - b.energy_cost; // Lowest cost as tiebreaker
+      } else {
+        return b.energy_return - a.energy_return; // Highest return as second tiebreaker
+      }
+    });
+
+    const habitsWithDates = sortedHabits.map((habit, index) => ({
+      ...habit,
+      start_date: calculateHabitStartDate(startDate, index),
+    }));
+
+    setHabits(habitsWithDates);
+    setStep(4);
+  }, [habits, startDate]);
+
+  useEffect(() => {
+    if (Platform.OS === 'web' && (step === 2 || step === 3)) {
+      const handler = (e: KeyboardEvent) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+          if (step === 2) {
+            setStep(3);
+          } else if (step === 3) {
+            prepareHabitsForReorder();
+          }
+        }
+      };
+      document.addEventListener('keydown', handler);
+      return () => document.removeEventListener('keydown', handler);
+    }
+  }, [step, prepareHabitsForReorder]);
 
   // Step 1: Add habits
   const handleAddHabit = () => {
@@ -88,10 +134,12 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
 
   // Update energy values for a habit in onboarding
   const updateHabitEnergy = (index: number, type: 'cost' | 'return', value: number) => {
-    if (value < -10 || value > 10) return; // Validate range
+    if (value < 0 || value > 10) return;
 
     setHabits((prev) =>
-      prev.map((habit, i) => (i === index ? { ...habit, [`energy_${type}`]: value } : habit)),
+      prev.map((habit, i) =>
+        i === index ? { ...habit, [`energy_${type}`]: Math.round(value) } : habit,
+      ),
     );
   };
 
@@ -101,134 +149,60 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
     setSelectedHabitIndex(null);
   };
 
-  // Sort habits by net energy for step 3
-  const prepareHabitsForReorder = () => {
-    const sortedHabits = [...habits].sort((a, b) => {
-      const netEnergyA = a.energy_return - a.energy_cost;
-      const netEnergyB = b.energy_return - b.energy_cost;
+  // Step 2 & 3: Energy entry
+  const renderEnergyStep = (type: 'cost' | 'return') => {
+    const title = type === 'cost' ? 'Energy Cost' : 'Energy Return';
+    const subtitle =
+      type === 'cost'
+        ? '0 = effortless, easy as breathing. 10 = effort so big you might dread it.'
+        : '0 = almost no change to your overall vibe. 10 = lights you up and feels deeply rewarding.';
+    const onBack = () => setStep(type === 'cost' ? 1 : 2);
+    const onContinue = type === 'cost' ? () => setStep(3) : prepareHabitsForReorder;
 
-      if (netEnergyA !== netEnergyB) {
-        return netEnergyB - netEnergyA; // Highest net energy first
-      } else if (a.energy_cost !== b.energy_cost) {
-        return a.energy_cost - b.energy_cost; // Lowest cost as tiebreaker
-      } else {
-        return b.energy_return - a.energy_return; // Highest return as second tiebreaker
-      }
-    });
-
-    // Update start dates based on the sorted order
-    const habitsWithDates = sortedHabits.map((habit, index) => ({
-      ...habit,
-      start_date: calculateHabitStartDate(startDate, index),
-    }));
-
-    setHabits(habitsWithDates);
-    setStep(4);
+    return (
+      <SafeAreaView style={styles.onboardingStep}>
+        <ScrollView ref={scrollRef}>
+          <Text style={styles.onboardingTitle}>{title}</Text>
+          <Text style={styles.onboardingSubtitle}>{subtitle}</Text>
+          {habits.map((habit, index) => {
+            const value = type === 'cost' ? habit.energy_cost : habit.energy_return;
+            return (
+              <View key={index} style={styles.energyTile} testID={`energy-tile-${index}`}>
+                <Text style={styles.energyTileName}>
+                  {habit.icon} {habit.name}
+                </Text>
+                <View style={styles.energySliderRow}>
+                  <Slider
+                    testID={`${type}-slider`}
+                    minimumValue={0}
+                    maximumValue={10}
+                    step={1}
+                    value={value}
+                    onValueChange={(v) => updateHabitEnergy(index, type, v)}
+                    style={styles.energySlider}
+                  />
+                  <Text style={styles.sliderValue}>{value}</Text>
+                </View>
+              </View>
+            );
+          })}
+        </ScrollView>
+        <View style={styles.onboardingFooter}>
+          <TouchableOpacity style={styles.onboardingBackButton} onPress={onBack}>
+            <Text style={styles.onboardingBackButtonText}>Back</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            testID="continue-button"
+            style={[styles.onboardingContinueButton, styles.footerContinue]}
+            onPress={onContinue}
+            disabled={habits.length === 0}
+          >
+            <Text style={styles.onboardingContinueButtonText}>Continue</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
   };
-
-  // Step 2: Cost entry
-  const renderCostStep = () => (
-    <View style={styles.onboardingStep}>
-      <Text style={styles.onboardingTitle}>Energy Cost</Text>
-      <Text style={styles.onboardingSubtitle}>Rate each habit from -10 to 10 for energy cost</Text>
-      <FlatList
-        data={habits}
-        keyExtractor={(_, index) => index.toString()}
-        renderItem={({ item, index }) => (
-          <View style={styles.energyRatingItem}>
-            <Text style={styles.energyRatingName}>
-              {item.icon} {item.name}
-            </Text>
-            <View style={styles.energyRatingDetails}>
-              <View style={styles.energySliders}>
-                <Text style={styles.energySliderLabel}>Cost:</Text>
-                <View style={styles.sliderContainer}>
-                  <TouchableOpacity
-                    style={styles.sliderButton}
-                    onPress={() =>
-                      updateHabitEnergy(index, 'cost', Math.max(-10, item.energy_cost - 1))
-                    }
-                  >
-                    <Text style={styles.sliderButtonText}>-</Text>
-                  </TouchableOpacity>
-                  <Text style={styles.sliderValue}>{item.energy_cost}</Text>
-                  <TouchableOpacity
-                    style={styles.sliderButton}
-                    onPress={() =>
-                      updateHabitEnergy(index, 'cost', Math.min(10, item.energy_cost + 1))
-                    }
-                  >
-                    <Text style={styles.sliderButtonText}>+</Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
-            </View>
-          </View>
-        )}
-      />
-      <TouchableOpacity
-        testID="continue-button"
-        style={styles.onboardingContinueButton}
-        onPress={() => setStep(3)}
-        disabled={habits.length === 0}
-      >
-        <Text style={styles.onboardingContinueButtonText}>Continue</Text>
-      </TouchableOpacity>
-    </View>
-  );
-
-  // Step 3: Return entry
-  const renderReturnStep = () => (
-    <View style={styles.onboardingStep}>
-      <Text style={styles.onboardingTitle}>Energy Return</Text>
-      <Text style={styles.onboardingSubtitle}>
-        Rate each habit from -10 to 10 for energy return
-      </Text>
-      <FlatList
-        data={habits}
-        keyExtractor={(_, index) => index.toString()}
-        renderItem={({ item, index }) => (
-          <View style={styles.energyRatingItem}>
-            <Text style={styles.energyRatingName}>
-              {item.icon} {item.name}
-            </Text>
-            <View style={styles.energyRatingDetails}>
-              <View style={styles.energySliders}>
-                <Text style={styles.energySliderLabel}>Return:</Text>
-                <View style={styles.sliderContainer}>
-                  <TouchableOpacity
-                    style={styles.sliderButton}
-                    onPress={() =>
-                      updateHabitEnergy(index, 'return', Math.max(-10, item.energy_return - 1))
-                    }
-                  >
-                    <Text style={styles.sliderButtonText}>-</Text>
-                  </TouchableOpacity>
-                  <Text style={styles.sliderValue}>{item.energy_return}</Text>
-                  <TouchableOpacity
-                    style={styles.sliderButton}
-                    onPress={() =>
-                      updateHabitEnergy(index, 'return', Math.min(10, item.energy_return + 1))
-                    }
-                  >
-                    <Text style={styles.sliderButtonText}>+</Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
-            </View>
-          </View>
-        )}
-      />
-      <TouchableOpacity
-        testID="continue-button"
-        style={styles.onboardingContinueButton}
-        onPress={prepareHabitsForReorder}
-        disabled={habits.length === 0}
-      >
-        <Text style={styles.onboardingContinueButtonText}>Continue</Text>
-      </TouchableOpacity>
-    </View>
-  );
 
   // Step 3: Reorder habits using drag & drop
   const handleDragEnd = ({ data }: { data: OnboardingHabit[] }) => {
@@ -438,9 +412,9 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
           </SafeAreaView>
         );
       case 2:
-        return renderCostStep();
+        return renderEnergyStep('cost');
       case 3:
-        return renderReturnStep();
+        return renderEnergyStep('return');
       case 4:
         return renderReorderStep();
       default:

--- a/app/features/Habits/components/OnboardingModal.tsx
+++ b/app/features/Habits/components/OnboardingModal.tsx
@@ -1,4 +1,4 @@
-import Slider from '@react-native-community/slider';
+import Slider, { type SliderProps } from '@react-native-community/slider';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Modal,
@@ -17,10 +17,18 @@ import DraggableFlatList from 'react-native-draggable-flatlist';
 import EmojiSelector from 'react-native-emoji-selector';
 
 import DatePicker, { parseISODate, toISODate } from '../../../components/DatePicker';
-import styles from '../Habits.styles';
+import styles, { COLORS } from '../Habits.styles';
 import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
 import { DEFAULT_ICONS } from '../HabitsScreen';
 import { calculateHabitStartDate } from '../HabitUtils';
+
+interface SmoothSliderProps extends SliderProps {
+  animateTransitions?: boolean;
+  animationType?: 'timing' | 'spring';
+  animationConfig?: Record<string, unknown>;
+}
+
+const SmoothSlider = Slider as React.ComponentType<SmoothSliderProps>;
 
 export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingModalProps) => {
   const [step, setStep] = useState(1);
@@ -172,15 +180,23 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
                   {habit.icon} {habit.name}
                 </Text>
                 <View style={styles.energySliderRow}>
-                  <Slider
-                    testID={`${type}-slider`}
-                    minimumValue={0}
-                    maximumValue={10}
-                    step={1}
-                    value={value}
-                    onValueChange={(v) => updateHabitEnergy(index, type, v)}
-                    style={styles.energySlider}
-                  />
+                  <View style={styles.energySliderContainer}>
+                    <SmoothSlider
+                      testID={`${type}-slider`}
+                      minimumValue={0}
+                      maximumValue={10}
+                      step={1}
+                      value={value}
+                      onValueChange={(v) => updateHabitEnergy(index, type, v)}
+                      animateTransitions
+                      animationType="timing"
+                      animationConfig={{ duration: 150 }}
+                      minimumTrackTintColor={COLORS.secondary}
+                      maximumTrackTintColor={COLORS.mystical.glowLight}
+                      thumbTintColor={COLORS.secondary}
+                      style={[styles.energySlider, Platform.OS === 'web' && styles.energySliderWeb]}
+                    />
+                  </View>
                   <Text style={styles.sliderValue}>{value}</Text>
                 </View>
               </View>

--- a/app/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../HabitsScreen', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('@react-native-community/slider', () => 'Slider');
+
+describe('OnboardingModal cost step', () => {
+  const setupToCostStep = () => {
+    const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />);
+    const input = result.getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, 'Habit');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    fireEvent.press(result.getByTestId('continue-button'));
+    fireEvent.press(result.getByTestId('count-warning-continue'));
+    return result;
+  };
+
+  it('defaults cost sliders to 5', () => {
+    const { getAllByTestId } = setupToCostStep();
+    const sliders = getAllByTestId('cost-slider');
+    sliders.forEach((slider) => {
+      expect(slider.props.value).toBe(5);
+    });
+  });
+
+  it('renders compact habit tiles', () => {
+    const { getByTestId } = setupToCostStep();
+    const tile = getByTestId('energy-tile-0');
+    expect(tile.props.style).toMatchSnapshot();
+  });
+});

--- a/app/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
@@ -2,6 +2,8 @@ import { describe, expect, it, jest } from '@jest/globals';
 import { render, fireEvent } from '@testing-library/react-native';
 import React from 'react';
 
+import { COLORS } from '../../Habits.styles';
+
 const OnboardingModal = require('../OnboardingModal').default;
 
 jest.mock('../../HabitsScreen', () => ({ DEFAULT_ICONS: ['⭐'] }));
@@ -33,5 +35,13 @@ describe('OnboardingModal cost step', () => {
     const { getByTestId } = setupToCostStep();
     const tile = getByTestId('energy-tile-0');
     expect(tile.props.style).toMatchSnapshot();
+  });
+
+  it('applies mystical slider styling', () => {
+    const { getAllByTestId } = setupToCostStep();
+    const slider = getAllByTestId('cost-slider')[0];
+    expect(slider.props.animateTransitions).toBe(true);
+    expect(slider.props.minimumTrackTintColor).toBe(COLORS.secondary);
+    expect(slider.props.thumbTintColor).toBe(COLORS.secondary);
   });
 });

--- a/app/features/Habits/components/__tests__/__snapshots__/OnboardingModal.step2.test.tsx.snap
+++ b/app/features/Habits/components/__tests__/__snapshots__/OnboardingModal.step2.test.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OnboardingModal cost step renders compact habit tiles 1`] = `
+{
+  "backgroundColor": "#f8f8f8",
+  "borderRadius": 8,
+  "elevation": 2,
+  "marginBottom": 8,
+  "padding": 8,
+  "shadowColor": "#000000",
+  "shadowOffset": {
+    "height": 1,
+    "width": 0,
+  },
+  "shadowOpacity": 0.1,
+  "shadowRadius": 2,
+}
+`;


### PR DESCRIPTION
## Summary
- render energy cost and return screens with compact slider tiles
- add sticky footer with back and continue buttons
- test onboarding energy cost defaults and compact tile snapshot

## Testing
- `npm test -- features/Habits/components/__tests__/OnboardingModal.step2.test.tsx -- -u`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b345b7b883229f8a5d79472a74fe