### PR TITLE
feat: scrollable onboarding reorder with stage colors

### DIFF
--- a/app/features/Habits/Habits.styles.ts
+++ b/app/features/Habits/Habits.styles.ts
@@ -957,6 +957,7 @@ export const styles = StyleSheet.create({
     borderRadius: BORDER_RADIUS.xl,
     padding: SPACING.xl,
     height: '90%',
+    overflow: 'hidden',
     ...SHADOWS.large,
   },
   modalClose: {
@@ -1055,6 +1056,15 @@ export const styles = StyleSheet.create({
   habitDragInfo: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  dragHandle: {
+    width: 20,
+    alignItems: 'center',
+    marginRight: SPACING.md,
+  },
+  dragHandleText: {
+    fontSize: 20,
+    color: COLORS.text.secondary,
   },
   habitListItemDate: {
     fontSize: 14,

--- a/app/features/Habits/Habits.types.ts
+++ b/app/features/Habits/Habits.types.ts
@@ -61,6 +61,7 @@ export interface HabitStatsData {
 }
 
 export interface OnboardingHabit {
+  id: string;
   name: string;
   icon: string;
   energy_cost: number;

--- a/app/features/Habits/components/OnboardingModal.tsx
+++ b/app/features/Habits/components/OnboardingModal.tsx
@@ -15,12 +15,15 @@ import {
 } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import EmojiSelector from 'react-native-emoji-selector';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated from 'react-native-reanimated';
 
 import DatePicker, { parseISODate, toISODate } from '../../../components/DatePicker';
+import { STAGE_COLORS } from '../../../constants/stageColors';
 import styles, { COLORS } from '../Habits.styles';
 import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
 import { DEFAULT_ICONS } from '../HabitsScreen';
-import { calculateHabitStartDate } from '../HabitUtils';
+import { STAGE_ORDER, calculateHabitStartDate } from '../HabitUtils';
 
 interface SmoothSliderProps extends SliderProps {
   animateTransitions?: boolean;
@@ -66,6 +69,7 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
     const habitsWithDates = sortedHabits.map((habit, index) => ({
       ...habit,
       start_date: calculateHabitStartDate(startDate, index),
+      stage: STAGE_ORDER[index] ?? 'Clear Light',
     }));
 
     setHabits(habitsWithDates);
@@ -99,6 +103,7 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
     const randomIcon = DEFAULT_ICONS[Math.floor(Math.random() * DEFAULT_ICONS.length)] ?? '⭐';
 
     const newHabit: OnboardingHabit = {
+      id: Date.now().toString(),
       name: newHabitName.trim(),
       icon: randomIcon,
       energy_cost: 5,
@@ -225,6 +230,7 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
     const updatedHabits = data.map((habit, index) => ({
       ...habit,
       start_date: calculateHabitStartDate(startDate, index),
+      stage: STAGE_ORDER[index] ?? 'Clear Light',
     }));
     setHabits(updatedHabits);
   };
@@ -244,47 +250,75 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
 
   const renderReorderStep = () => (
     <View style={styles.onboardingStep}>
-      <Text style={styles.onboardingTitle}>Reorder Your Habits</Text>
-      <Text style={styles.onboardingSubtitle}>
-        Habits are ordered by energy efficiency. You can drag to reorder if needed.
-      </Text>
+      <DraggableFlatList
+        testID="reorder-list"
+        data={habits}
+        keyExtractor={(item) => item.id}
+        activationDistance={8}
+        contentContainerStyle={styles.habitsListContent}
+        ListHeaderComponent={
+          <>
+            <Text style={styles.onboardingTitle}>Reorder Your Habits</Text>
+            <Text style={styles.onboardingSubtitle}>
+              Habits are ordered by energy efficiency. You can drag to reorder if needed.
+            </Text>
+            <View style={styles.startDateContainer}>
+              <Text style={styles.startDateLabel}>First habit starts on:</Text>
+              <DatePicker
+                value={toISODate(startDate)}
+                minDate={toISODate(new Date())}
+                mode="scaffoldingStart"
+                onChange={(iso) => {
+                  const selectedDate = parseISODate(iso);
+                  setStartDate(selectedDate);
+                  setHabits((prev) =>
+                    prev.map((habit, index) => ({
+                      ...habit,
+                      start_date: calculateHabitStartDate(selectedDate, index),
+                    })),
+                  );
+                }}
+              />
+            </View>
+          </>
+        }
+        ListFooterComponent={
+          <TouchableOpacity
+            testID="finish-setup"
+            style={styles.onboardingContinueButton}
+            onPress={handleFinish}
+          >
+            <Text style={styles.onboardingContinueButtonText}>Done</Text>
+          </TouchableOpacity>
+        }
+        renderItem={({ item, drag, isActive, getIndex }) => {
+          const index = getIndex() ?? 0;
+          const stage = (STAGE_ORDER[index] ??
+            STAGE_ORDER[STAGE_ORDER.length - 1]) as keyof typeof STAGE_COLORS;
+          const color = STAGE_COLORS[stage] || '#ccc';
 
-      <View style={styles.startDateContainer}>
-        <Text style={styles.startDateLabel}>First habit starts on:</Text>
-        <DatePicker
-          value={toISODate(startDate)}
-          minDate={toISODate(new Date())}
-          mode="scaffoldingStart"
-          onChange={(iso) => {
-            const selectedDate = parseISODate(iso);
-            setStartDate(selectedDate);
-            setHabits((prev) =>
-              prev.map((habit, index) => ({
-                ...habit,
-                start_date: calculateHabitStartDate(selectedDate, index),
-              })),
-            );
-          }}
-        />
-      </View>
+          const longPress = Gesture.LongPress()
+            .minDuration(150)
+            .onStart(() => drag());
+          const mouseGrab = Gesture.Pan()
+            .activateAfterLongPress(0)
+            .onBegin(() => drag());
+          const startDrag = Gesture.Race(longPress, mouseGrab);
 
-      <View style={styles.habitsList}>
-        <DraggableFlatList
-          style={{ flex: 1 }}
-          data={habits}
-          keyExtractor={(_, index) => index.toString()}
-          contentContainerStyle={styles.habitsListContent}
-          renderItem={({ item, drag, isActive }) => {
-            const index = habits.findIndex((h) => h === item);
-
-            return (
-              <TouchableOpacity
-                onLongPress={drag}
-                onPressIn={Platform.OS === 'web' ? drag : undefined}
-                delayLongPress={150}
-                style={[styles.habitListItem, isActive && { backgroundColor: '#eaeaea' }]}
+          return (
+            <GestureDetector gesture={startDrag}>
+              <Animated.View
+                testID={`reorder-item-${item.id}`}
+                style={[
+                  styles.habitListItem,
+                  isActive && { backgroundColor: '#eaeaea' },
+                  { borderLeftColor: color, borderLeftWidth: 4 },
+                ]}
               >
                 <View style={styles.habitDragInfo}>
+                  <View accessibilityLabel={`Reorder ${item.name}`} style={styles.dragHandle}>
+                    <Text style={styles.dragHandleText}>≡</Text>
+                  </View>
                   <Text style={styles.habitListItemDate}>
                     {new Date(item.start_date).toLocaleDateString('en-US', {
                       month: 'short',
@@ -297,26 +331,26 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
                   <TouchableOpacity
                     style={styles.iconEditButton}
                     onPress={() => {
-                      setSelectedHabitIndex(index);
+                      const currentIndex = getIndex() ?? 0;
+                      setSelectedHabitIndex(currentIndex);
                       setShowEmojiPicker(true);
                     }}
                   >
                     <Text style={styles.iconEditButtonText}>📝</Text>
                   </TouchableOpacity>
                 </View>
-
                 <View style={styles.habitEnergyInfo}>
                   <Text style={styles.habitEnergyText}>
                     Cost: {item.energy_cost} | Return: {item.energy_return} | Net:{' '}
                     {item.energy_return - item.energy_cost}
                   </Text>
                 </View>
-              </TouchableOpacity>
-            );
-          }}
-          onDragEnd={handleDragEnd}
-        />
-      </View>
+              </Animated.View>
+            </GestureDetector>
+          );
+        }}
+        onDragEnd={handleDragEnd}
+      />
 
       {showEmojiPicker && selectedHabitIndex !== null && (
         <View style={styles.emojiPickerModal}>
@@ -341,14 +375,6 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
           />
         </View>
       )}
-
-      <TouchableOpacity
-        testID="finish-setup"
-        style={styles.onboardingContinueButton}
-        onPress={handleFinish}
-      >
-        <Text style={styles.onboardingContinueButtonText}>Finish Setup</Text>
-      </TouchableOpacity>
     </View>
   );
 
@@ -453,7 +479,7 @@ export const OnboardingModal = ({ visible, onClose, onSaveHabits }: OnboardingMo
             style={StyleSheet.absoluteFill}
             testID="onboarding-overlay"
           />
-          <View style={styles.onboardingModalContent}>
+          <View style={styles.onboardingModalContent} testID="onboarding-modal-content">
             <TouchableOpacity
               testID="onboarding-close"
               style={styles.modalClose}

--- a/app/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
@@ -9,6 +9,19 @@ jest.mock('../../HabitsScreen', () => ({ DEFAULT_ICONS: ['⭐'] }));
 jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
 jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
 jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: React.ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ activateAfterLongPress: () => ({ onBegin: () => ({}) }) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
 
 describe('OnboardingModal Step 1 interactions', () => {
   it('Enter adds habit, clears input, refocuses input', () => {

--- a/app/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
@@ -11,6 +11,19 @@ jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
 jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
 jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
 jest.mock('@react-native-community/slider', () => 'Slider');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: React.ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ activateAfterLongPress: () => ({ onBegin: () => ({}) }) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
 
 describe('OnboardingModal cost step', () => {
   const setupToCostStep = () => {

--- a/app/features/Habits/components/__tests__/OnboardingModal.step4.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.step4.test.tsx
@@ -1,0 +1,113 @@
+/* eslint-env jest */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, fireEvent } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+
+import { STAGE_COLORS } from '../../../../constants/stageColors';
+import { STAGE_ORDER } from '../../HabitUtils';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../HabitsScreen', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ activateAfterLongPress: () => ({ onBegin: () => ({}) }) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+jest.mock('react-native-draggable-flatlist', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return ({
+    data,
+    renderItem,
+    onDragEnd,
+    testID,
+    contentContainerStyle,
+    ListHeaderComponent,
+    ListFooterComponent,
+  }: any) => (
+    <View testID={testID} onDragEnd={onDragEnd} data={data} style={contentContainerStyle}>
+      {ListHeaderComponent}
+      {data.map((item: any, index: number) =>
+        React.cloneElement(
+          renderItem({ item, index, drag: jest.fn(), isActive: false, getIndex: () => index }),
+          { key: item.id },
+        ),
+      )}
+      {ListFooterComponent}
+    </View>
+  );
+});
+
+describe('OnboardingModal reorder step', () => {
+  const setupToReorder = () => {
+    const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />);
+    const input = result.getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, 'Habit A');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    fireEvent.changeText(input, 'Habit B');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    const advance = () => {
+      fireEvent.press(result.getByTestId('continue-button'));
+      const warn = result.queryByTestId('count-warning-continue');
+      if (warn) fireEvent.press(warn);
+    };
+    advance();
+    advance();
+    advance();
+    return result;
+  };
+
+  const getBorderColor = (elem: any) => {
+    const styles = Array.isArray(elem.props.style) ? elem.props.style : [elem.props.style];
+    const found = styles.find((s: any) => s && s.borderLeftColor);
+    return found?.borderLeftColor as string | undefined;
+  };
+
+  it('maps stage colors by index and updates after reorder', () => {
+    const { getByTestId } = setupToReorder();
+    const list = getByTestId('reorder-list');
+    const data = list.props.data;
+    const firstId = data[0].id;
+    const secondId = data[1].id;
+
+    expect(getBorderColor(getByTestId(`reorder-item-${firstId}`))).toBe(
+      STAGE_COLORS[STAGE_ORDER[0] as keyof typeof STAGE_COLORS],
+    );
+    expect(getBorderColor(getByTestId(`reorder-item-${secondId}`))).toBe(
+      STAGE_COLORS[STAGE_ORDER[1] as keyof typeof STAGE_COLORS],
+    );
+
+    const newOrder = [data[1], data[0]];
+    const { act } = require('react-test-renderer');
+    act(() => {
+      list.props.onDragEnd({ data: newOrder });
+    });
+
+    expect(getBorderColor(getByTestId(`reorder-item-${secondId}`))).toBe(
+      STAGE_COLORS[STAGE_ORDER[0] as keyof typeof STAGE_COLORS],
+    );
+    expect(getBorderColor(getByTestId(`reorder-item-${firstId}`))).toBe(
+      STAGE_COLORS[STAGE_ORDER[1] as keyof typeof STAGE_COLORS],
+    );
+  });
+
+  it('modal content constrains height', () => {
+    const { getByTestId } = setupToReorder();
+    const modal = getByTestId('onboarding-modal-content');
+    const styles = Array.isArray(modal.props.style) ? modal.props.style : [modal.props.style];
+    const found = styles.find((s: any) => s && s.height);
+    expect(found?.height).toBe('90%');
+  });
+});


### PR DESCRIPTION
## Summary
- make onboarding reorder list scrollable with left color bands reflecting stage order
- support drag-to-reorder across platforms and keep stages in sync
- add tests for stage color mapping and modal layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1c0dea208322a80f6f73b793ea8e