### PR TITLE
fix: update gesture handler mocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
       - id: backend-tests-coverage
         name: backend tests (coverage required)
         language: system
-        entry: bash -lc 'cd backend && pytest'
+        entry: bash -lc 'source .venv/bin/activate && cd backend && pytest'
         pass_filenames: false
         files: ^backend/
         stages: [pre-commit, pre-push]

--- a/app/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
@@ -13,7 +13,7 @@ jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: ({ children }: { children: React.ReactNode }) => children,
   Gesture: {
     LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
-    Pan: () => ({ activateAfterLongPress: () => ({ onBegin: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
     Race: () => ({}),
   },
 }));

--- a/app/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
@@ -15,7 +15,7 @@ jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: ({ children }: { children: React.ReactNode }) => children,
   Gesture: {
     LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
-    Pan: () => ({ activateAfterLongPress: () => ({ onBegin: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
     Race: () => ({}),
   },
 }));

--- a/app/features/Habits/components/__tests__/OnboardingModal.test.tsx
+++ b/app/features/Habits/components/__tests__/OnboardingModal.test.tsx
@@ -46,7 +46,7 @@ jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: ({ children }: { children: React.ReactNode }) => children,
   Gesture: {
     LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
-    Pan: () => ({ activateAfterLongPress: () => ({ onBegin: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
     Race: () => ({}),
   },
 }));


### PR DESCRIPTION
## Summary
- activate repo virtualenv before running backend tests in pre-commit
- simplify gesture handler mocks to use Pan.onBegin directly

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68baf8b4fbc88322b6219f49da1b4f4a