### PR TITLE
fix: use local timezone in date quick actions

### DIFF
--- a/app/components/DatePicker.tsx
+++ b/app/components/DatePicker.tsx
@@ -132,16 +132,16 @@ const DatePicker: React.FC<DatePickerProps> = ({
 
   const quickToday = () => {
     const now = new Date();
-    const utc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-    commitDate(utc);
+    const local = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    commitDate(local);
   };
   const quickNextMonday = () => {
     const now = new Date();
-    const utc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-    const dow = utc.getUTCDay(); // 0..6 (Sun..Sat) in UTC
-    const add = (8 - dow) % 7 || 7; // next Monday
-    utc.setUTCDate(utc.getUTCDate() + add); // add whole UTC days
-    commitDate(utc);
+    const local = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const dow = local.getDay();
+    const add = (8 - dow) % 7 || 7;
+    local.setDate(local.getDate() + add);
+    commitDate(local);
   };
   const quickFirstNextMonth = () => {
     const d = new Date();


### PR DESCRIPTION
## Summary
- normalize today and next Monday calculations to local time

## Testing
- `npm test __tests__/DatePicker.test.tsx`
- `pre-commit run --all-files` *(fails: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68bb0df563388322ae16d11178ed3e1c