### PR TITLE
feat: add habit schema and CRUD API

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,12 +3,14 @@
 from fastapi import FastAPI
 
 from routers.energy import router as energy_router
+from routers.habits import router as habits_router
 from routers.practice import router as practice_router
 
 app = FastAPI()
 
 # Register feature routers
 app.include_router(practice_router)
+app.include_router(habits_router)
 app.include_router(energy_router)
 
 

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -1,0 +1,58 @@
+"""Habit CRUD API endpoints."""
+
+from __future__ import annotations
+
+from itertools import count
+
+from fastapi import APIRouter, HTTPException
+
+from schemas.habit import Habit, HabitCreate
+
+router = APIRouter(prefix="/habits", tags=["habits"])
+
+_habits: list[Habit] = []
+_id_counter = count(1)
+
+
+@router.post("/", response_model=Habit)
+def create_habit(payload: HabitCreate) -> Habit:
+    """Create a habit and store it in memory."""
+    habit = Habit(id=next(_id_counter), **payload.model_dump())
+    _habits.append(habit)
+    return habit
+
+
+@router.get("/", response_model=list[Habit])
+def list_habits() -> list[Habit]:
+    """Return all habits sorted by their sort order."""
+    return sorted(_habits, key=lambda h: (h.sort_order if h.sort_order is not None else h.id))
+
+
+@router.get("/{habit_id}", response_model=Habit)
+def get_habit(habit_id: int) -> Habit:
+    """Return a single habit by id."""
+    for habit in _habits:
+        if habit.id == habit_id:
+            return habit
+    raise HTTPException(status_code=404, detail="Habit not found")
+
+
+@router.put("/{habit_id}", response_model=Habit)
+def update_habit(habit_id: int, payload: HabitCreate) -> Habit:
+    """Replace an existing habit."""
+    for index, habit in enumerate(_habits):
+        if habit.id == habit_id:
+            updated = Habit(id=habit_id, **payload.model_dump())
+            _habits[index] = updated
+            return updated
+    raise HTTPException(status_code=404, detail="Habit not found")
+
+
+@router.delete("/{habit_id}")
+def delete_habit(habit_id: int) -> None:
+    """Delete a habit from the in-memory store."""
+    for index, habit in enumerate(_habits):
+        if habit.id == habit_id:
+            del _habits[index]
+            return None
+    raise HTTPException(status_code=404, detail="Habit not found")

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -6,14 +6,16 @@ from schemas.energy import (
     EnergyPlanItem,
     EnergyPlanRequest,
     EnergyPlanResponse,
-    Habit,
 )
+from schemas.energy import Habit as EnergyHabit
 from schemas.goal import Goal
+from schemas.habit import Habit
 from schemas.milestone import Milestone
 
 __all__ = [
     "CheckInRequest",
     "CheckInResult",
+    "EnergyHabit",
     "EnergyPlan",
     "EnergyPlanItem",
     "EnergyPlanRequest",

--- a/backend/src/schemas/habit.py
+++ b/backend/src/schemas/habit.py
@@ -1,0 +1,44 @@
+"""Habit related schemas."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class Habit(BaseModel):
+    """Public representation of a :class:`models.habit.Habit`.
+
+    Mirrors the SQLModel definition so API consumers can rely on a stable
+    contract. Includes notification fields and client-controlled sort order.
+    """
+
+    id: int
+    user_id: int
+    name: str
+    icon: str
+    start_date: date
+    energy_cost: int
+    energy_return: int
+    notification_times: list[str] | None = None
+    notification_frequency: str | None = None
+    notification_days: list[str] | None = None
+    milestone_notifications: bool = False
+    sort_order: int | None = None
+
+
+class HabitCreate(BaseModel):
+    """Payload for creating/updating a habit."""
+
+    user_id: int
+    name: str
+    icon: str
+    start_date: date
+    energy_cost: int
+    energy_return: int
+    notification_times: list[str] | None = None
+    notification_frequency: str | None = None
+    notification_days: list[str] | None = None
+    milestone_notifications: bool = False
+    sort_order: int | None = None

--- a/backend/tests/test_habits_api.py
+++ b/backend/tests/test_habits_api.py
@@ -1,0 +1,68 @@
+from itertools import count
+
+import pytest  # type: ignore[import-not-found]
+from fastapi.testclient import TestClient
+
+from main import app
+from routers import habits as habits_module
+
+client = TestClient(app)
+OK = 200
+NOT_FOUND = 404
+
+
+def sample_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "user_id": 1,
+        "name": "Drink Water",
+        "icon": "💧",
+        "start_date": "2024-01-01",
+        "energy_cost": 1,
+        "energy_return": 2,
+        "notification_times": ["08:00"],
+        "notification_frequency": "daily",
+        "notification_days": ["mon"],
+        "milestone_notifications": True,
+        "sort_order": 1,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture(autouse=True)
+def clear_store() -> None:
+    habits_module._habits.clear()  # noqa: SLF001
+    habits_module._id_counter = count(1)  # noqa: SLF001
+
+
+def test_create_habit() -> None:
+    response = client.post("/habits/", json=sample_payload())
+    assert response.status_code == OK
+    data = response.json()
+    assert data["id"] == 1
+    assert data["notification_times"] == ["08:00"]
+
+
+def test_list_habits_sorted() -> None:
+    client.post("/habits/", json=sample_payload(name="Two", sort_order=2))
+    client.post("/habits/", json=sample_payload(name="One", sort_order=1))
+    response = client.get("/habits/")
+    assert response.status_code == OK
+    names = [h["name"] for h in response.json()]
+    assert names == ["One", "Two"]
+
+
+def test_get_update_delete_habit() -> None:
+    client.post("/habits/", json=sample_payload())
+    # Get
+    response = client.get("/habits/1")
+    assert response.status_code == OK
+    # Update
+    response = client.put("/habits/1", json=sample_payload(name="Updated"))
+    assert response.status_code == OK
+    assert response.json()["name"] == "Updated"
+    # Delete
+    delete_resp = client.delete("/habits/1")
+    assert delete_resp.status_code == OK
+    missing = client.get("/habits/1")
+    assert missing.status_code == NOT_FOUND


### PR DESCRIPTION
## Summary
- add Habit schema with notification and sort fields
- implement in-memory habit CRUD router and register in app
- cover habit endpoints with tests

## Testing
- `pre-commit run --all-files`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf4897ef948322b8cba281f5f60d40