### PR TITLE
fix: secure CORS configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
       - id: backend-tests-coverage
         name: backend tests (coverage required)
         language: system
-        entry: bash -lc 'cd backend && pytest'
+        entry: bash -c 'cd backend && pytest --cov=. --cov-report=term-missing --cov-fail-under=90'
         pass_filenames: false
         files: ^backend/
         stages: [pre-commit, pre-push]

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -21,8 +21,7 @@ if os.getenv("ENV", "development") == "development":
     ]
 else:
     origins = [
-        "https://yourdomain.com",
-        "https://www.yourdomain.com",
+        os.getenv("PROD_DOMAIN", "")
     ]
 
 app.add_middleware(

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,11 +1,37 @@
 """Main FastAPI application instance."""
 
+import os
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from routers.energy import router as energy_router
 from routers.practice import router as practice_router
 
 app = FastAPI()
+
+# Configure allowed CORS origins based on environment to avoid wildcard usage
+# with credentials enabled which is disallowed by browsers. Default to a
+# development setup with local origins.
+if os.getenv("ENV", "development") == "development":
+    origins = [
+        "http://localhost:3000",
+        "http://localhost:8080",
+        "http://127.0.0.1:3000",
+    ]
+else:
+    origins = [
+        "https://yourdomain.com",
+        "https://www.yourdomain.com",
+    ]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE"],
+    allow_headers=["Authorization", "Content-Type"],
+)
 
 # Register feature routers
 app.include_router(practice_router)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -21,7 +21,7 @@ if os.getenv("ENV", "development") == "development":
     ]
 else:
     origins = [
-        os.getenv("PROD_DOMAIN", "")
+        os.getenv("PROD_DOMAIN", ""),
     ]
 
 app.add_middleware(

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,68 @@
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+ALLOWED_ORIGIN = "http://localhost:3000"
+FORBIDDEN_ORIGIN = "http://malicious.com"
+
+
+def test_options_request_allowed() -> None:
+    """Preflight OPTIONS request should succeed for allowed origin/method."""
+    headers = {
+        "Origin": ALLOWED_ORIGIN,
+        "Access-Control-Request-Method": "GET",
+    }
+    response = client.options("/", headers=headers)
+    assert response.status_code == HTTPStatus.OK
+    assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+
+
+def test_cross_origin_get_allowed() -> None:
+    """GET requests from an allowed origin include CORS headers."""
+    headers = {"Origin": ALLOWED_ORIGIN}
+    response = client.get("/", headers=headers)
+    assert response.status_code == HTTPStatus.OK
+    assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+
+
+def test_cross_origin_post_with_credentials() -> None:
+    """POST requests with credentials are permitted for allowed origins."""
+    headers = {"Origin": ALLOWED_ORIGIN}
+    payload = {
+        "user_id": 1,
+        "practice_id": 1,
+        "stage_number": 1,
+        "duration_minutes": 10,
+    }
+    cookies = {"session": "abc"}
+    response = client.post(
+        "/practice_sessions/",
+        json=payload,
+        headers=headers,
+        cookies=cookies,
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+    assert response.headers.get("access-control-allow-credentials") == "true"
+
+
+def test_forbidden_origin_no_cors_headers() -> None:
+    """Requests from disallowed origins should not receive CORS headers."""
+    headers = {"Origin": FORBIDDEN_ORIGIN}
+    response = client.get("/", headers=headers)
+    assert response.status_code == HTTPStatus.OK
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_preflight_disallowed_method() -> None:
+    """Preflight request for a disallowed method should return 400."""
+    headers = {
+        "Origin": ALLOWED_ORIGIN,
+        "Access-Control-Request-Method": "PATCH",
+    }
+    response = client.options("/", headers=headers)
+    assert response.status_code == HTTPStatus.BAD_REQUEST


### PR DESCRIPTION
## Summary
- restrict CORS origins by environment and limit allowed methods and headers
- expand CORS tests for cross-origin, credentials, and forbidden scenarios
- enforce backend test coverage in pre-commit hook without sourcing virtualenv

## Testing
- `pre-commit run --all-files`
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf498adfdc8322922248a82dfb4b18