### PR TITLE
feat: add habit stats endpoint

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI
 
 from routers.energy import router as energy_router
+from routers.habits import router as habits_router
 from routers.practice import router as practice_router
 
 app = FastAPI()
@@ -10,6 +11,7 @@ app = FastAPI()
 # Register feature routers
 app.include_router(practice_router)
 app.include_router(energy_router)
+app.include_router(habits_router)
 
 
 @app.get("/")

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from schemas.habit_stats import GoalStats, HabitStats
+
+router = APIRouter(prefix="/habits", tags=["habits"])
+
+# In-memory stores for tests; populated directly in tests.
+_habits: dict[int, Habit] = {}
+_goals: dict[int, Goal] = {}
+_goal_completions: list[GoalCompletion] = []
+
+
+@router.get("/{habit_id}/stats", response_model=HabitStats)
+def habit_stats(habit_id: int) -> HabitStats:
+    """Return aggregated completion statistics for a habit."""
+
+    habit = _habits.get(habit_id)
+    if habit is None:
+        raise HTTPException(status_code=404, detail="Habit not found")
+
+    goals = [g for g in _goals.values() if g.habit_id == habit_id]
+    goal_stats: list[GoalStats] = []
+    for goal in goals:
+        comps = [c for c in _goal_completions if c.goal_id == goal.id]
+        total_units = sum(c.completed_units for c in comps)
+        goal_stats.append(
+            GoalStats(
+                goal_id=goal.id,
+                total_units=total_units,
+                completion_count=len(comps),
+            )
+        )
+
+    return HabitStats(habit_id=habit_id, goals=goal_stats)

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -9,6 +9,7 @@ from schemas.energy import (
     Habit,
 )
 from schemas.goal import Goal
+from schemas.habit_stats import GoalStats, HabitStats
 from schemas.milestone import Milestone
 
 __all__ = [
@@ -19,6 +20,8 @@ __all__ = [
     "EnergyPlanRequest",
     "EnergyPlanResponse",
     "Goal",
+    "GoalStats",
     "Habit",
+    "HabitStats",
     "Milestone",
 ]

--- a/backend/src/schemas/habit_stats.py
+++ b/backend/src/schemas/habit_stats.py
@@ -1,0 +1,20 @@
+"""Habit statistics schemas."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class GoalStats(BaseModel):
+    """Aggregated completion data for a single goal."""
+
+    goal_id: int
+    total_units: float
+    completion_count: int
+
+
+class HabitStats(BaseModel):
+    """Aggregated statistics for a habit across its goals."""
+
+    habit_id: int
+    goals: list[GoalStats]

--- a/backend/tests/test_habit_stats_api.py
+++ b/backend/tests/test_habit_stats_api.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+# mypy: ignore-errors
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, cast
+
+import pytest  # type: ignore[import-not-found]
+from fastapi.testclient import TestClient
+
+from main import app
+from routers import habits as habits_module
+
+client = TestClient(app)
+OK = 200
+
+
+@pytest.fixture(autouse=True)
+def clear_store() -> None:
+    """Ensure the in-memory habit store is reset between tests."""
+    habits_module._habits.clear()  # noqa: SLF001
+    habits_module._goals.clear()  # noqa: SLF001
+    habits_module._goal_completions.clear()  # noqa: SLF001
+
+
+def _setup_sample_data() -> None:
+    @dataclass
+    class Habit:
+        id: int
+        name: str
+        icon: str
+        start_date: date
+        energy_cost: int
+        energy_return: int
+        user_id: int
+
+    @dataclass
+    class Goal:
+        id: int
+        habit_id: int
+        title: str
+        tier: str
+        target: float
+        target_unit: str
+        frequency: float
+        frequency_unit: str
+        is_additive: bool = True
+
+    @dataclass
+    class GoalCompletion:
+        id: int
+        goal_id: int
+        user_id: int
+        completed_units: float
+
+    habit = Habit(
+        id=1,
+        name="Water",
+        icon="💧",
+        start_date=date.today(),
+        energy_cost=0,
+        energy_return=0,
+        user_id=1,
+    )
+    habits_module._habits[habit.id] = habit  # type: ignore[assignment]  # noqa: SLF001
+
+    g1 = Goal(
+        id=1,
+        habit_id=habit.id,
+        title="Low",
+        tier="low",
+        target=1,
+        target_unit="cup",
+        frequency=1,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    g2 = Goal(
+        id=2,
+        habit_id=habit.id,
+        title="Stretch",
+        tier="stretch",
+        target=2,
+        target_unit="cup",
+        frequency=1,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    habits_module._goals[g1.id] = g1  # type: ignore[assignment]  # noqa: SLF001
+    habits_module._goals[g2.id] = g2  # type: ignore[assignment]  # noqa: SLF001
+
+    habits_module._goal_completions.extend(  # noqa: SLF001
+        [
+            cast(Any, GoalCompletion(id=1, goal_id=g1.id, user_id=1, completed_units=3)),
+            cast(Any, GoalCompletion(id=2, goal_id=g1.id, user_id=1, completed_units=4)),
+        ]
+    )
+
+
+def test_habit_stats_aggregates_goal_completions() -> None:
+    _setup_sample_data()
+    res = client.get("/habits/1/stats")
+    assert res.status_code == OK
+    data = res.json()
+    assert data["habit_id"] == 1
+    goals = sorted(data["goals"], key=lambda g: g["goal_id"])
+    assert goals == [
+        {"goal_id": 1, "total_units": 7.0, "completion_count": 2},
+        {"goal_id": 2, "total_units": 0.0, "completion_count": 0},
+    ]


### PR DESCRIPTION
## Summary
- add habit statistics endpoint aggregating goal completions
- expose habit stats schema models
- test habit stats aggregation

## Testing
- `pre-commit run --files backend/tests/test_habit_stats_api.py backend/src/main.py backend/src/routers/habits.py backend/src/schemas/habit_stats.py backend/src/schemas/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf48e7528083229487c97d1629e9a5