### PR TITLE
Add goal and goal group CRUD API with tests

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,15 +1,30 @@
 """Main FastAPI application instance."""
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from routers.energy import router as energy_router
+from routers.goals import router as goals_router
 from routers.practice import router as practice_router
 
+# Origin allowed to make cross-origin requests with credentials.
+ALLOWED_ORIGIN = "https://example.com"
+
 app = FastAPI()
+
+# Enable cross-origin requests with credentials for the allowed origin.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[ALLOWED_ORIGIN],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Register feature routers
 app.include_router(practice_router)
 app.include_router(energy_router)
+app.include_router(goals_router)
 
 
 @app.get("/")

--- a/backend/src/routers/goals.py
+++ b/backend/src/routers/goals.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from itertools import count
+from threading import Lock
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, field_validator
+
+from schemas import Goal, GoalGroup
+
+router = APIRouter()
+_goals_router = APIRouter(prefix="/v1/goals", tags=["goals"])
+_habits_router = APIRouter(prefix="/v1/habits", tags=["goals"])
+
+# In-memory storage
+_goals: dict[int, Goal] = {}
+_goal_id_counter = count(1)
+_goal_id_lock = Lock()
+
+_goal_groups: dict[int, GoalGroup] = {}
+_group_id_counter = count(1)
+_group_id_lock = Lock()
+
+
+class GoalCreate(BaseModel):
+    habit_id: int
+    title: str
+    description: str | None = None
+    tier: str
+    target: float
+    target_unit: str
+    frequency: float
+    frequency_unit: str
+    is_additive: bool = True
+
+    @field_validator("target", "frequency")
+    @classmethod
+    def positive(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("must be positive")
+        return v
+
+    @field_validator("habit_id")
+    @classmethod
+    def habit_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("habit_id must be positive")
+        return v
+
+
+class GoalUpdate(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    tier: str | None = None
+    target: float | None = None
+    target_unit: str | None = None
+    frequency: float | None = None
+    frequency_unit: str | None = None
+    is_additive: bool | None = None
+
+    @field_validator("target", "frequency")
+    @classmethod
+    def positive(cls, v: float | None) -> float | None:
+        if v is not None and v <= 0:
+            raise ValueError("must be positive")
+        return v
+
+
+class GoalGroupCreate(BaseModel):
+    name: str
+    icon: str | None = None
+    description: str | None = None
+    user_id: int | None = None
+    shared_template: bool = False
+    source: str | None = None
+
+
+class GoalGroupUpdate(BaseModel):
+    name: str | None = None
+    icon: str | None = None
+    description: str | None = None
+    user_id: int | None = None
+    shared_template: bool | None = None
+    source: str | None = None
+
+
+@_goals_router.post("/", response_model=Goal, status_code=201)
+def create_goal(payload: GoalCreate) -> Goal:
+    with _goal_id_lock:
+        goal_id = next(_goal_id_counter)
+    goal = Goal(id=goal_id, **payload.model_dump())
+    _goals[goal_id] = goal
+    return goal
+
+
+@_goals_router.get("/{goal_id}", response_model=Goal)
+def get_goal(goal_id: int) -> Goal:
+    goal = _goals.get(goal_id)
+    if not goal:
+        raise HTTPException(status_code=404, detail=f"Goal {goal_id} not found")
+    return goal
+
+
+@_goals_router.put("/{goal_id}", response_model=Goal)
+def update_goal(goal_id: int, payload: GoalUpdate) -> Goal:
+    goal = _goals.get(goal_id)
+    if not goal:
+        raise HTTPException(status_code=404, detail=f"Goal {goal_id} not found")
+    update_data = payload.model_dump(exclude_unset=True)
+    updated = goal.model_copy(update=update_data)
+    _goals[goal_id] = updated
+    return updated
+
+
+@_goals_router.delete("/{goal_id}")
+def delete_goal(goal_id: int) -> dict[str, bool]:
+    if goal_id in _goals:
+        del _goals[goal_id]
+        return {"ok": True}
+    raise HTTPException(status_code=404, detail=f"Goal {goal_id} not found")
+
+
+@_goals_router.post("/groups", response_model=GoalGroup, status_code=201)
+def create_goal_group(payload: GoalGroupCreate) -> GoalGroup:
+    with _group_id_lock:
+        group_id = next(_group_id_counter)
+    group = GoalGroup(id=group_id, **payload.model_dump())
+    _goal_groups[group_id] = group
+    return group
+
+
+@_goals_router.get("/groups/{group_id}", response_model=GoalGroup)
+def get_goal_group(group_id: int) -> GoalGroup:
+    group = _goal_groups.get(group_id)
+    if not group:
+        raise HTTPException(status_code=404, detail=f"Goal group {group_id} not found")
+    return group
+
+
+@_goals_router.put("/groups/{group_id}", response_model=GoalGroup)
+def update_goal_group(group_id: int, payload: GoalGroupUpdate) -> GoalGroup:
+    group = _goal_groups.get(group_id)
+    if not group:
+        raise HTTPException(status_code=404, detail=f"Goal group {group_id} not found")
+    update_data = payload.model_dump(exclude_unset=True)
+    updated = group.model_copy(update=update_data)
+    _goal_groups[group_id] = updated
+    return updated
+
+
+@_goals_router.delete("/groups/{group_id}")
+def delete_goal_group(group_id: int) -> dict[str, bool]:
+    if group_id in _goal_groups:
+        del _goal_groups[group_id]
+        return {"ok": True}
+    raise HTTPException(status_code=404, detail=f"Goal group {group_id} not found")
+
+
+@_habits_router.get("/{habit_id}/goals", response_model=list[Goal])
+def list_goals_for_habit(habit_id: int) -> list[Goal]:
+    return [g for g in _goals.values() if g.habit_id == habit_id]
+
+
+router.include_router(_goals_router)
+router.include_router(_habits_router)

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -9,6 +9,8 @@ from schemas.energy import (
     Habit,
 )
 from schemas.goal import Goal
+from schemas.goal_completion import GoalCompletion
+from schemas.goal_group import GoalGroup
 from schemas.milestone import Milestone
 
 __all__ = [
@@ -19,6 +21,8 @@ __all__ = [
     "EnergyPlanRequest",
     "EnergyPlanResponse",
     "Goal",
+    "GoalCompletion",
+    "GoalGroup",
     "Habit",
     "Milestone",
 ]

--- a/backend/src/schemas/goal_completion.py
+++ b/backend/src/schemas/goal_completion.py
@@ -1,0 +1,18 @@
+"""Goal completion schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class GoalCompletion(BaseModel):
+    """Public representation of a :class:`models.goal_completion.GoalCompletion`."""
+
+    id: int
+    goal_id: int
+    user_id: int
+    timestamp: datetime
+    completed_units: float
+    via_timer: bool = False

--- a/backend/src/schemas/goal_group.py
+++ b/backend/src/schemas/goal_group.py
@@ -1,0 +1,17 @@
+"""Goal group related schemas."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class GoalGroup(BaseModel):
+    """Public representation of a :class:`models.goal_group.GoalGroup`."""
+
+    id: int
+    name: str
+    icon: str | None = None
+    description: str | None = None
+    user_id: int | None = None
+    shared_template: bool = False
+    source: str | None = None

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,28 @@
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+
+from main import ALLOWED_ORIGIN, app
+
+client = TestClient(app)
+
+
+def test_cross_origin_post_with_credentials() -> None:
+    """POST requests with credentials are permitted for allowed origins."""
+    headers = {"Origin": ALLOWED_ORIGIN}
+    payload = {
+        "user_id": 1,
+        "practice_id": 1,
+        "stage_number": 1,
+        "duration_minutes": 10,
+    }
+    cookies = {"session": "abc"}
+    response = client.post(
+        "/practice_sessions/",
+        json=payload,
+        headers=headers,
+        cookies=cookies,
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+    assert response.headers.get("access-control-allow-credentials") == "true"

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -1,0 +1,120 @@
+from itertools import count
+from typing import Any, cast
+
+import pytest  # type: ignore[import-not-found]
+from fastapi.testclient import TestClient
+
+from main import app
+from routers import goals as goals_module
+
+client = TestClient(app)
+OK = 200
+CREATED = 201
+NOT_FOUND = 404
+
+
+@pytest.fixture(autouse=True)
+def clear_state() -> None:
+    """Ensure each test starts with a clean in-memory store."""
+    goals_module._goals.clear()  # noqa: SLF001
+    goals_module._goal_groups.clear()  # noqa: SLF001
+    goals_module._goal_id_counter = count(1)  # noqa: SLF001
+    goals_module._group_id_counter = count(1)  # noqa: SLF001
+
+
+def create_sample_goal(habit_id: int = 1) -> dict[str, Any]:
+    payload = {
+        "habit_id": habit_id,
+        "title": "Read",
+        "description": "Read pages",
+        "tier": "low",
+        "target": 10,
+        "target_unit": "pages",
+        "frequency": 1,
+        "frequency_unit": "per_day",
+        "is_additive": True,
+    }
+    response = client.post("/v1/goals/", json=payload)
+    assert response.status_code == CREATED
+    return cast(dict[str, Any], response.json())
+
+
+def create_sample_group() -> dict[str, Any]:
+    payload = {
+        "name": "Reading",
+        "icon": "book",
+        "description": "Reading goals",
+        "user_id": 1,
+    }
+    response = client.post("/v1/goals/groups", json=payload)
+    assert response.status_code == CREATED
+    return cast(dict[str, Any], response.json())
+
+
+def test_create_goal() -> None:
+    data = create_sample_goal()
+    assert data["title"] == "Read"
+    assert data["id"] == 1
+
+
+def test_get_goal() -> None:
+    created = create_sample_goal()
+    response = client.get(f"/v1/goals/{created['id']}")
+    assert response.status_code == OK
+    assert response.json()["id"] == created["id"]
+
+
+def test_update_goal() -> None:
+    created = create_sample_goal()
+    payload = {"title": "Read more"}
+    response = client.put(f"/v1/goals/{created['id']}", json=payload)
+    assert response.status_code == OK
+    assert response.json()["title"] == "Read more"
+
+
+def test_delete_goal() -> None:
+    created = create_sample_goal()
+    response = client.delete(f"/v1/goals/{created['id']}")
+    assert response.status_code == OK
+    # ensure it's gone
+    response = client.get(f"/v1/goals/{created['id']}")
+    assert response.status_code == NOT_FOUND
+
+
+def test_create_goal_group() -> None:
+    data = create_sample_group()
+    assert data["name"] == "Reading"
+    assert data["id"] == 1
+
+
+def test_get_goal_group() -> None:
+    created = create_sample_group()
+    response = client.get(f"/v1/goals/groups/{created['id']}")
+    assert response.status_code == OK
+    assert response.json()["id"] == created["id"]
+
+
+def test_update_goal_group() -> None:
+    created = create_sample_group()
+    payload = {"description": "Updated"}
+    response = client.put(f"/v1/goals/groups/{created['id']}", json=payload)
+    assert response.status_code == OK
+    assert response.json()["description"] == "Updated"
+
+
+def test_delete_goal_group() -> None:
+    created = create_sample_group()
+    response = client.delete(f"/v1/goals/groups/{created['id']}")
+    assert response.status_code == OK
+    response = client.get(f"/v1/goals/groups/{created['id']}")
+    assert response.status_code == NOT_FOUND
+
+
+def test_list_goals_by_habit() -> None:
+    create_sample_goal(habit_id=1)
+    create_sample_goal(habit_id=2)
+    response = client.get("/v1/habits/1/goals")
+    assert response.status_code == OK
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["habit_id"] == 1


### PR DESCRIPTION
## Summary
- add GoalGroup and GoalCompletion schemas
- implement in-memory CRUD router for goals and goal groups
- expose habit-specific goals endpoint with tests
- version goal routes under /v1 with thread-safe IDs and validation
- allow credentialed cross-origin requests via CORS middleware and test

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf48ce71a88322a696dacfc7433c47