### PR TITLE
feat: add goals and goal group CRUD APIs

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from routers.auth import router as auth_router
 from routers.energy import router as energy_router
 from routers.goal_completions import router as goal_completion_router
+from routers.goals import router as goals_router
 from routers.habits import router as habits_router
 from routers.practice import router as practice_router
 
@@ -41,6 +42,7 @@ app.include_router(practice_router)
 app.include_router(habits_router)
 app.include_router(energy_router)
 app.include_router(goal_completion_router)
+app.include_router(goals_router)
 
 
 @app.get("/")

--- a/backend/src/routers/goals.py
+++ b/backend/src/routers/goals.py
@@ -1,0 +1,114 @@
+"""Goal and goal group CRUD endpoints."""
+
+from __future__ import annotations
+
+from itertools import count
+
+from fastapi import APIRouter, HTTPException, Response, status
+from pydantic import BaseModel
+
+from schemas.goal import Goal
+from schemas.goal_group import GoalGroup, GoalGroupCreate
+
+router = APIRouter(prefix="/v1", tags=["goals"])
+
+_goals: dict[int, Goal] = {}
+_goal_groups: dict[int, GoalGroup] = {}
+_goal_id_counter = count(1)
+_group_id_counter = count(1)
+
+
+class GoalCreate(BaseModel):
+    """Payload for creating or updating a goal."""
+
+    habit_id: int
+    title: str
+    description: str | None = None
+    tier: str
+    target: float
+    target_unit: str
+    frequency: float
+    frequency_unit: str
+    is_additive: bool = True
+    goal_group_id: int | None = None
+
+
+@router.post("/goal-groups", response_model=GoalGroup, status_code=status.HTTP_201_CREATED)
+def create_goal_group(payload: GoalGroupCreate) -> GoalGroup:
+    group_id = next(_group_id_counter)
+    group = GoalGroup(id=group_id, **payload.model_dump())
+    _goal_groups[group_id] = group
+    return group
+
+
+@router.get("/goal-groups", response_model=list[GoalGroup])
+def list_goal_groups() -> list[GoalGroup]:
+    return list(_goal_groups.values())
+
+
+@router.get("/goal-groups/{group_id}", response_model=GoalGroup)
+def get_goal_group(group_id: int) -> GoalGroup:
+    group = _goal_groups.get(group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail=f"goal_group {group_id} not found")
+    return group
+
+
+@router.put("/goal-groups/{group_id}", response_model=GoalGroup)
+def update_goal_group(group_id: int, payload: GoalGroupCreate) -> GoalGroup:
+    if group_id not in _goal_groups:
+        raise HTTPException(status_code=404, detail=f"goal_group {group_id} not found")
+    group = GoalGroup(id=group_id, **payload.model_dump())
+    _goal_groups[group_id] = group
+    return group
+
+
+@router.delete("/goal-groups/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_goal_group(group_id: int) -> Response:
+    if group_id not in _goal_groups:
+        raise HTTPException(status_code=404, detail=f"goal_group {group_id} not found")
+    del _goal_groups[group_id]
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/goals", response_model=Goal, status_code=status.HTTP_201_CREATED)
+def create_goal(payload: GoalCreate) -> Goal:
+    goal_id = next(_goal_id_counter)
+    goal = Goal(id=goal_id, **payload.model_dump())
+    _goals[goal_id] = goal
+    return goal
+
+
+@router.get("/goals", response_model=list[Goal])
+def list_goals() -> list[Goal]:
+    return list(_goals.values())
+
+
+@router.get("/goals/{goal_id}", response_model=Goal)
+def get_goal(goal_id: int) -> Goal:
+    goal = _goals.get(goal_id)
+    if goal is None:
+        raise HTTPException(status_code=404, detail=f"goal {goal_id} not found")
+    return goal
+
+
+@router.put("/goals/{goal_id}", response_model=Goal)
+def update_goal(goal_id: int, payload: GoalCreate) -> Goal:
+    if goal_id not in _goals:
+        raise HTTPException(status_code=404, detail=f"goal {goal_id} not found")
+    goal = Goal(id=goal_id, **payload.model_dump())
+    _goals[goal_id] = goal
+    return goal
+
+
+@router.delete("/goals/{goal_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_goal(goal_id: int) -> Response:
+    if goal_id not in _goals:
+        raise HTTPException(status_code=404, detail=f"goal {goal_id} not found")
+    del _goals[goal_id]
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/habits/{habit_id}/goals", response_model=list[Goal])
+def list_goals_for_habit(habit_id: int) -> list[Goal]:
+    return [g for g in _goals.values() if g.habit_id == habit_id]

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -9,6 +9,8 @@ from schemas.energy import (
 )
 from schemas.energy import Habit as EnergyHabit
 from schemas.goal import Goal
+from schemas.goal_completion import GoalCompletion, GoalCompletionCreate
+from schemas.goal_group import GoalGroup, GoalGroupCreate
 from schemas.habit import Habit
 from schemas.milestone import Milestone
 
@@ -21,6 +23,10 @@ __all__ = [
     "EnergyPlanRequest",
     "EnergyPlanResponse",
     "Goal",
+    "GoalCompletion",
+    "GoalCompletionCreate",
+    "GoalGroup",
+    "GoalGroupCreate",
     "Habit",
     "Milestone",
 ]

--- a/backend/src/schemas/goal_completion.py
+++ b/backend/src/schemas/goal_completion.py
@@ -1,0 +1,28 @@
+"""Goal completion related schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class GoalCompletion(BaseModel):
+    """Public representation of a :class:`models.goal_completion.GoalCompletion`."""
+
+    id: int
+    goal_id: int
+    user_id: int
+    timestamp: datetime
+    completed_units: float
+    via_timer: bool = False
+
+
+class GoalCompletionCreate(BaseModel):
+    """Payload for recording a goal completion."""
+
+    goal_id: int
+    user_id: int
+    timestamp: datetime | None = None
+    completed_units: float
+    via_timer: bool = False

--- a/backend/src/schemas/goal_group.py
+++ b/backend/src/schemas/goal_group.py
@@ -1,0 +1,28 @@
+"""Goal group related schemas."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class GoalGroup(BaseModel):
+    """Public representation of a :class:`models.goal_group.GoalGroup`."""
+
+    id: int
+    name: str
+    icon: str | None = None
+    description: str | None = None
+    user_id: int | None = None
+    shared_template: bool = False
+    source: str | None = None
+
+
+class GoalGroupCreate(BaseModel):
+    """Payload for creating or updating a goal group."""
+
+    name: str
+    icon: str | None = None
+    description: str | None = None
+    user_id: int | None = None
+    shared_template: bool = False
+    source: str | None = None

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -32,8 +32,10 @@ def test_cross_origin_get_allowed() -> None:
 def test_cross_origin_post_with_credentials() -> None:
     """POST requests with credentials are permitted for allowed origins."""
     headers = {"Origin": ALLOWED_ORIGIN}
+    signup = client.post("/auth/signup", json={"username": "u", "password": "p"}).json()
+    headers["Authorization"] = f"Bearer {signup['token']}"
     payload = {
-        "user_id": 1,
+        "user_id": signup["user_id"],
         "practice_id": 1,
         "stage_number": 1,
         "duration_minutes": 10,

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -1,0 +1,71 @@
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_goal_group_crud() -> None:
+    payload = {"name": "Morning", "user_id": 1}
+    res = client.post("/v1/goal-groups", json=payload)
+    assert res.status_code == HTTPStatus.CREATED
+    group = res.json()
+    group_id = group["id"]
+
+    res = client.get("/v1/goal-groups")
+    assert res.status_code == HTTPStatus.OK
+    assert len(res.json()) == 1
+
+    res = client.get(f"/v1/goal-groups/{group_id}")
+    assert res.status_code == HTTPStatus.OK
+
+    update = {"name": "Evening", "user_id": 1}
+    res = client.put(f"/v1/goal-groups/{group_id}", json=update)
+    assert res.status_code == HTTPStatus.OK
+    assert res.json()["name"] == "Evening"
+
+    res = client.delete(f"/v1/goal-groups/{group_id}")
+    assert res.status_code == HTTPStatus.NO_CONTENT
+
+    res = client.get(f"/v1/goal-groups/{group_id}")
+    assert res.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_goal_crud_and_nested_listing() -> None:
+    payload = {
+        "habit_id": 1,
+        "title": "Drink Water",
+        "tier": "low",
+        "target": 8,
+        "target_unit": "cups",
+        "frequency": 1,
+        "frequency_unit": "per_day",
+    }
+    res = client.post("/v1/goals", json=payload)
+    assert res.status_code == HTTPStatus.CREATED
+    goal = res.json()
+    goal_id = goal["id"]
+
+    res = client.get("/v1/goals")
+    assert res.status_code == HTTPStatus.OK
+    assert len(res.json()) == 1
+
+    res = client.get(f"/v1/goals/{goal_id}")
+    assert res.status_code == HTTPStatus.OK
+
+    update = payload | {"title": "Drink More Water"}
+    res = client.put(f"/v1/goals/{goal_id}", json=update)
+    assert res.status_code == HTTPStatus.OK
+    assert res.json()["title"] == "Drink More Water"
+
+    res = client.get("/v1/habits/1/goals")
+    assert res.status_code == HTTPStatus.OK
+    assert len(res.json()) == 1
+
+    res = client.delete(f"/v1/goals/{goal_id}")
+    assert res.status_code == HTTPStatus.NO_CONTENT
+
+    res = client.get(f"/v1/goals/{goal_id}")
+    assert res.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
## Summary
- add Pydantic schemas for goal groups and goal completions
- implement in-memory CRUD API for goals and goal groups including nested habit listing
- secure CORS test using auth token

## Testing
- `pytest`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68c09d931b388322bcc1d9ff8900982b