### PR TITLE
Add goal API client and integrate with GoalModal

### DIFF
--- a/frontend/src/api/habits.ts
+++ b/frontend/src/api/habits.ts
@@ -1,0 +1,35 @@
+import type { Goal } from '../features/Habits/Habits.types';
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL ?? '';
+
+export async function updateGoal(habitId: number, goal: Goal): Promise<Goal> {
+  const res = await fetch(`${API_URL}/habits/${habitId}/goals/${goal.id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(goal),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to update goal: ${res.status}`);
+  }
+
+  return (await res.json()) as Goal;
+}
+
+export async function createGoal(habitId: number, goal: Goal): Promise<Goal> {
+  const res = await fetch(`${API_URL}/habits/${habitId}/goals`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(goal),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to create goal: ${res.status}`);
+  }
+
+  return (await res.json()) as Goal;
+}


### PR DESCRIPTION
## Summary
- add goal API helpers for creating and updating goals
- invoke goal API helpers from GoalModal when confirming changes
- test GoalModal calls updateGoal API

## Testing
- `cd frontend && npm test`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68bf48d5357c8322883f9ae286fd6e33