### PR TITLE
feat(full-stack): add habit stats API and wire StatsModal to real data

### DIFF
--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import date as date_type
+
 from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -9,10 +11,12 @@ from sqlmodel import select
 
 from database import get_session
 from errors import not_found
+from models.goal import Goal
 from models.habit import Habit
 from routers.auth import get_current_user
 from schemas.habit import Habit as HabitSchema
 from schemas.habit import HabitCreate, HabitWithGoals
+from schemas.habit_stats import HabitStats
 
 router = APIRouter(prefix="/habits", tags=["habits"])
 
@@ -96,3 +100,98 @@ async def delete_habit(
     await session.delete(habit)
     await session.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+_DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+
+@router.get("/{habit_id}/stats", response_model=HabitStats)
+async def get_habit_stats(
+    habit_id: int,
+    current_user: int = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> HabitStats:
+    """Return aggregated statistics for a habit's goal completions."""
+    statement = (
+        select(Habit)
+        .where(Habit.id == habit_id)
+        .options(selectinload(Habit.goals).selectinload(Goal.completions))  # type: ignore[arg-type]
+    )
+    result = await session.execute(statement)
+    habit = result.scalars().first()
+    if habit is None or habit.user_id != current_user:
+        raise not_found("habit")
+
+    # Gather all completions for this user across all goals
+    completions = [c for goal in habit.goals for c in goal.completions if c.user_id == current_user]
+
+    if not completions:
+        return HabitStats(
+            day_labels=list(_DAY_LABELS),
+            values=[0.0] * 7,
+            completions_by_day=[0] * 7,
+            longest_streak=0,
+            current_streak=0,
+            total_completions=0,
+            completion_rate=0.0,
+            completion_dates=[],
+        )
+
+    # Aggregate units per day-of-week and track unique calendar dates
+    units_by_day = [0.0] * 7
+    presence_by_day = [0] * 7
+    days_with_completions: set[str] = set()
+
+    for c in completions:
+        day_idx = c.timestamp.weekday()
+        # Convert Monday=0 to Sunday=0 format (JS getDay() convention)
+        js_day_idx = (day_idx + 1) % 7
+        units_by_day[js_day_idx] += c.completed_units
+        presence_by_day[js_day_idx] = 1
+        days_with_completions.add(c.timestamp.strftime("%Y-%m-%d"))
+
+    # Sort unique dates for streak and rate calculations
+    sorted_dates = sorted(days_with_completions)
+
+    # Longest streak: max consecutive calendar days with completions
+    longest_streak = 0
+    current_run = 0
+    prev_date: date_type | None = None
+    for date_str in sorted_dates:
+        d = date_type.fromisoformat(date_str)
+        if prev_date is not None and (d - prev_date).days == 1:
+            current_run += 1
+        else:
+            current_run = 1
+        longest_streak = max(longest_streak, current_run)
+        prev_date = d
+
+    # Current streak: consecutive days ending at the most recent date
+    current_streak = 0
+    for i in range(len(sorted_dates) - 1, -1, -1):
+        d = date_type.fromisoformat(sorted_dates[i])
+        if i == len(sorted_dates) - 1:
+            current_streak = 1
+        else:
+            next_d = date_type.fromisoformat(sorted_dates[i + 1])
+            if (next_d - d).days == 1:
+                current_streak += 1
+            else:
+                break
+
+    # Completion rate: days-with-completions / span-of-days (inclusive)
+    first_date = date_type.fromisoformat(sorted_dates[0])
+    last_date = date_type.fromisoformat(sorted_dates[-1])
+    span_days = (last_date - first_date).days + 1
+    completion_rate = len(days_with_completions) / span_days if span_days > 0 else 0.0
+
+    return HabitStats(
+        day_labels=list(_DAY_LABELS),
+        values=units_by_day,
+        completions_by_day=presence_by_day,
+        longest_streak=longest_streak,
+        current_streak=current_streak,
+        total_completions=len(completions),
+        completion_rate=completion_rate,
+        completion_dates=sorted_dates,
+    )

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -10,6 +10,7 @@ from schemas.energy import (
 from schemas.energy import Habit as EnergyHabit
 from schemas.goal import Goal
 from schemas.habit import Habit, HabitWithGoals
+from schemas.habit_stats import HabitStats
 from schemas.milestone import Milestone
 from schemas.practice import PracticeSessionCreate, PracticeSessionResponse
 
@@ -23,6 +24,7 @@ __all__ = [
     "EnergyPlanResponse",
     "Goal",
     "Habit",
+    "HabitStats",
     "HabitWithGoals",
     "Milestone",
     "PracticeSessionCreate",

--- a/backend/src/schemas/habit_stats.py
+++ b/backend/src/schemas/habit_stats.py
@@ -1,0 +1,23 @@
+"""Habit statistics response schema."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class HabitStats(BaseModel):
+    """Aggregated statistics for a single habit.
+
+    Computed from the habit's goal completions. The shape matches
+    the frontend ``HabitStatsData`` interface so the client can
+    consume the response directly.
+    """
+
+    day_labels: list[str]
+    values: list[float]
+    completions_by_day: list[int]
+    longest_streak: int
+    current_streak: int
+    total_completions: int
+    completion_rate: float
+    completion_dates: list[str]

--- a/backend/tests/test_habit_stats_api.py
+++ b/backend/tests/test_habit_stats_api.py
@@ -1,0 +1,355 @@
+"""Tests for GET /habits/{id}/stats endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+
+# Named constants for test assertions (avoids magic-number lint warnings)
+DAYS_IN_WEEK = 7
+EXPECTED_MONDAY_UNITS = 3.0  # 2.0 + 1.0 from two completions
+EXPECTED_WEDNESDAY_UNITS = 3.0
+EXPECTED_COMPLETIONS_3_ENTRIES = 3
+EXPECTED_LONGEST_STREAK_3 = 3
+EXPECTED_COMPLETIONS_5_ENTRIES = 5
+EXPECTED_CURRENT_STREAK_2 = 2
+COMPLETION_RATE_TOLERANCE = 0.01
+EXPECTED_ALICE_UNITS = 5.0
+
+
+def sample_payload(**overrides: object) -> dict[str, object]:
+    """Return a valid habit creation payload."""
+    payload: dict[str, object] = {
+        "name": "Drink Water",
+        "icon": "💧",
+        "start_date": "2024-01-01",
+        "energy_cost": 1,
+        "energy_return": 2,
+        "stage": "aptitude",
+        "notification_times": ["08:00"],
+        "notification_frequency": "daily",
+        "notification_days": ["mon"],
+        "milestone_notifications": True,
+        "sort_order": 1,
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
+    """Create a user and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_habit_with_goal(
+    client: AsyncClient,
+    session: AsyncSession,
+    headers: dict[str, str],
+) -> tuple[int, int]:
+    """Create a habit and a goal, returning (habit_id, goal_id)."""
+    resp = await client.post("/habits/", json=sample_payload(), headers=headers)
+    habit_id: int = resp.json()["id"]
+    goal = Goal(
+        habit_id=habit_id,
+        title="Drink 8 glasses",
+        tier="clear",
+        target=8,
+        target_unit="glasses",
+        frequency=1,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    assert goal.id is not None
+    return habit_id, goal.id
+
+
+# ── Authentication ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stats_unauthenticated_returns_401(async_client: AsyncClient) -> None:
+    resp = await async_client.get("/habits/1/stats")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_stats_nonexistent_habit_returns_404(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    resp = await async_client.get("/habits/9999/stats", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_stats_other_users_habit_returns_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    alice_headers = await _signup(async_client, "alice")
+    bob_headers = await _signup(async_client, "bob")
+    habit_id, _ = await _create_habit_with_goal(async_client, db_session, alice_headers)
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+# ── Empty stats ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stats_no_completions(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    """A habit with no completions returns zeroed stats."""
+    headers = await _signup(async_client)
+    habit_id, _ = await _create_habit_with_goal(async_client, db_session, headers)
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["total_completions"] == 0
+    assert data["longest_streak"] == 0
+    assert data["current_streak"] == 0
+    assert data["completion_rate"] == 0.0
+    assert data["completion_dates"] == []
+    assert len(data["day_labels"]) == DAYS_IN_WEEK
+    assert all(v == 0 for v in data["values"])
+    assert all(v == 0 for v in data["completions_by_day"])
+
+
+# ── Stats with completions ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stats_aggregates_completions_by_day_of_week(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Units should be summed per day-of-week across all goals."""
+    headers = await _signup(async_client)
+    habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
+
+    # Get user_id from the habit
+    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
+    user_id = resp.json()["user_id"]
+
+    # Monday 2024-01-01 — two completions
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=user_id,
+            timestamp=datetime(2024, 1, 1, 8, 0, tzinfo=UTC),
+            completed_units=2.0,
+        )
+    )
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=user_id,
+            timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+            completed_units=1.0,
+        )
+    )
+    # Wednesday 2024-01-03
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=user_id,
+            timestamp=datetime(2024, 1, 3, 10, 0, tzinfo=UTC),
+            completed_units=3.0,
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["total_completions"] == EXPECTED_COMPLETIONS_3_ENTRIES
+    # Monday=index 1, Wednesday=index 3
+    assert data["values"][1] == EXPECTED_MONDAY_UNITS  # 2+1
+    assert data["values"][3] == EXPECTED_WEDNESDAY_UNITS
+    # completions_by_day: 1 if any completion that weekday, else 0
+    assert data["completions_by_day"][1] == 1
+    assert data["completions_by_day"][2] == 0
+    assert data["completions_by_day"][3] == 1
+
+
+@pytest.mark.asyncio
+async def test_stats_longest_streak(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    """Longest streak is the max consecutive calendar days with completions."""
+    headers = await _signup(async_client)
+    habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
+    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
+    user_id = resp.json()["user_id"]
+
+    # 3 consecutive days, then a gap, then 2 consecutive
+    base = datetime(2024, 1, 1, 8, 0, tzinfo=UTC)
+    for day_offset in [0, 1, 2, 4, 5]:
+        db_session.add(
+            GoalCompletion(
+                goal_id=goal_id,
+                user_id=user_id,
+                timestamp=base + timedelta(days=day_offset),
+                completed_units=1.0,
+            )
+        )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=headers)
+    data = resp.json()
+    assert data["longest_streak"] == EXPECTED_LONGEST_STREAK_3
+    assert data["total_completions"] == EXPECTED_COMPLETIONS_5_ENTRIES
+
+
+@pytest.mark.asyncio
+async def test_stats_current_streak(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    """Current streak counts consecutive days ending at the most recent completion."""
+    headers = await _signup(async_client)
+    habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
+    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
+    user_id = resp.json()["user_id"]
+
+    # Gap, then 2 consecutive days at the end
+    base = datetime(2024, 1, 1, 8, 0, tzinfo=UTC)
+    for day_offset in [0, 3, 4]:
+        db_session.add(
+            GoalCompletion(
+                goal_id=goal_id,
+                user_id=user_id,
+                timestamp=base + timedelta(days=day_offset),
+                completed_units=1.0,
+            )
+        )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=headers)
+    data = resp.json()
+    assert data["current_streak"] == EXPECTED_CURRENT_STREAK_2
+
+
+@pytest.mark.asyncio
+async def test_stats_completion_rate(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    """Completion rate = days-with-completions / span-days."""
+    headers = await _signup(async_client)
+    habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
+    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
+    user_id = resp.json()["user_id"]
+
+    # Jan 1 and Jan 3 — span is 3 days, completed on 2
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=user_id,
+            timestamp=datetime(2024, 1, 1, 8, 0, tzinfo=UTC),
+            completed_units=1.0,
+        )
+    )
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=user_id,
+            timestamp=datetime(2024, 1, 3, 8, 0, tzinfo=UTC),
+            completed_units=1.0,
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=headers)
+    data = resp.json()
+    assert abs(data["completion_rate"] - 2 / 3) < COMPLETION_RATE_TOLERANCE
+
+
+@pytest.mark.asyncio
+async def test_stats_completion_dates(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    """completion_dates lists unique ISO date strings for calendar marking."""
+    headers = await _signup(async_client)
+    habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
+    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
+    user_id = resp.json()["user_id"]
+
+    # Two completions on same day + one on another day
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=user_id,
+            timestamp=datetime(2024, 1, 1, 8, 0, tzinfo=UTC),
+            completed_units=2.0,
+        )
+    )
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=user_id,
+            timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+            completed_units=1.0,
+        )
+    )
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=user_id,
+            timestamp=datetime(2024, 1, 3, 10, 0, tzinfo=UTC),
+            completed_units=3.0,
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=headers)
+    data = resp.json()
+    dates = sorted(data["completion_dates"])
+    assert dates == ["2024-01-01", "2024-01-03"]
+
+
+@pytest.mark.asyncio
+async def test_stats_only_counts_current_users_completions(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Stats should not include completions from other users."""
+    alice_headers = await _signup(async_client, "alice")
+    bob_headers = await _signup(async_client, "bob")
+
+    # Alice creates a habit+goal
+    habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, alice_headers)
+    resp = await async_client.get(f"/habits/{habit_id}", headers=alice_headers)
+    alice_user_id = resp.json()["user_id"]
+
+    # Bob's user_id (from a different habit)
+    bob_resp = await async_client.post("/habits/", json=sample_payload(), headers=bob_headers)
+    bob_user_id = bob_resp.json()["user_id"]
+
+    # Alice's completion
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=alice_user_id,
+            timestamp=datetime(2024, 1, 1, 8, 0, tzinfo=UTC),
+            completed_units=5.0,
+        )
+    )
+    # Bob's completion on Alice's goal (should not count)
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal_id,
+            user_id=bob_user_id,
+            timestamp=datetime(2024, 1, 2, 8, 0, tzinfo=UTC),
+            completed_units=10.0,
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=alice_headers)
+    data = resp.json()
+    assert data["total_completions"] == 1
+    assert sum(data["values"]) == EXPECTED_ALICE_UNITS

--- a/frontend/src/api/__tests__/habits-api.test.ts
+++ b/frontend/src/api/__tests__/habits-api.test.ts
@@ -79,6 +79,28 @@ describe('habits API client', () => {
     expect(url).toBe('http://test/habits/1');
     expect(init.method).toBe('DELETE');
   });
+
+  test('habits.getStats sends GET to /habits/{id}/stats', async () => {
+    const stats = {
+      day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      values: [0, 3, 0, 3, 0, 0, 0],
+      completions_by_day: [0, 1, 0, 1, 0, 0, 0],
+      longest_streak: 3,
+      current_streak: 2,
+      total_completions: 5,
+      completion_rate: 0.67,
+      completion_dates: ['2024-01-01', '2024-01-03'],
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(stats));
+
+    const result = await habits.getStats(42, 'test-token');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/habits/42/stats');
+    expect(init.method).toBeUndefined(); // GET is default
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer test-token' });
+    expect(result).toEqual(stats);
+  });
 });
 
 describe('goalCompletions API client', () => {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -141,6 +141,17 @@ export interface ApiHabitWithGoals extends ApiHabit {
   goals: ApiGoal[];
 }
 
+export interface ApiHabitStats {
+  day_labels: string[];
+  values: number[];
+  completions_by_day: number[];
+  longest_streak: number;
+  current_streak: number;
+  total_completions: number;
+  completion_rate: number;
+  completion_dates: string[];
+}
+
 /** @deprecated Use ApiHabit instead — this only includes the OpenAPI subset. */
 export type Habit = components['schemas']['Habit'];
 
@@ -209,6 +220,9 @@ export const habits = {
   },
   delete(habitId: number, token?: string): Promise<void> {
     return request<void>(`/habits/${habitId}`, { method: 'DELETE', token });
+  },
+  getStats(habitId: number, token?: string): Promise<ApiHabitStats> {
+    return request<ApiHabitStats>(`/habits/${habitId}/stats`, { token });
   },
 };
 

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
+import type { ApiHabitStats } from '../../api';
 import { colors, STAGE_COLORS, STAGE_ORDER } from '../../design/tokens';
 
 import type { Goal, Habit, Completion, HabitStatsData } from './Habits.types';
@@ -276,8 +277,10 @@ export const generateStatsForHabit = (habit: Habit): HabitStatsData => {
     completionsByDay: new Array(7).fill(0) as number[],
     dayLabels,
     longestStreak: 0,
+    currentStreak: habit.streak,
     totalCompletions: 0,
     completionRate: 0,
+    completionDates: [],
   };
 
   const completions = habit.completions;
@@ -326,16 +329,53 @@ export const generateStatsForHabit = (habit: Habit): HabitStatsData => {
   const spanDays = Math.round((lastDay.getTime() - firstDay.getTime()) / MS_PER_DAY) + 1;
   const completionRate = spanDays > 0 ? daysWithCompletions.size / spanDays : 0;
 
+  // Current streak: consecutive days ending at the most recent date
+  let endStreak = 0;
+  for (let i = sortedDays.length - 1; i >= 0; i--) {
+    const day = sortedDays[i]!;
+    if (i === sortedDays.length - 1) {
+      endStreak = 1;
+    } else {
+      const nextDay = sortedDays[i + 1]!;
+      const diff = (nextDay.getTime() - day.getTime()) / MS_PER_DAY;
+      if (diff === 1) {
+        endStreak += 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  // Collect unique ISO date strings for calendar marking
+  const completionDates = sortedDays.map((d) => d.toISOString().split('T')[0] ?? '');
+
   return {
     dates: dayLabels,
     values: unitsByDay,
     completionsByDay: presenceByDay,
     dayLabels,
     longestStreak,
+    currentStreak: endStreak,
     totalCompletions: completions.length,
     completionRate,
+    completionDates,
   };
 };
+
+/**
+ * Convert an API habit stats response (snake_case) to local HabitStatsData (camelCase).
+ */
+export const toLocalHabitStats = (api: ApiHabitStats): HabitStatsData => ({
+  dates: api.day_labels,
+  values: api.values,
+  completionsByDay: api.completions_by_day,
+  dayLabels: api.day_labels,
+  longestStreak: api.longest_streak,
+  currentStreak: api.current_streak,
+  totalCompletions: api.total_completions,
+  completionRate: api.completion_rate,
+  completionDates: api.completion_dates,
+});
 
 /**
  * Calculate days without completions between the first and last completion.

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -73,8 +73,10 @@ export interface HabitStatsData {
   completionsByDay: number[];
   dayLabels: string[];
   longestStreak: number;
+  currentStreak: number;
   totalCompletions: number;
   completionRate: number;
+  completionDates: string[];
 }
 
 export interface OnboardingHabit {

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -1,11 +1,13 @@
 // HabitsScreen.tsx
 
 import { BarChart2, Check, MoreHorizontal, Pencil, Zap } from 'lucide-react';
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, FlatList, Text, TouchableOpacity, View, Modal } from 'react-native';
 import EmojiSelector from 'react-native-emoji-selector';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { habits as habitsApi } from '../../api';
+import { useAuth } from '../../context/AuthContext';
 import { spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 
@@ -16,9 +18,9 @@ import OnboardingModal from './components/OnboardingModal';
 import ReorderHabitsModal from './components/ReorderHabitsModal';
 import StatsModal from './components/StatsModal';
 import styles from './Habits.styles';
-import type { Habit } from './Habits.types';
+import type { Habit, HabitStatsData } from './Habits.types';
 import HabitTile from './HabitTile';
-import { generateStatsForHabit, calculateMissedDays } from './HabitUtils';
+import { generateStatsForHabit, toLocalHabitStats, calculateMissedDays } from './HabitUtils';
 import { useHabits } from './hooks/useHabits';
 import { useModalCoordinator } from './hooks/useModalCoordinator';
 
@@ -28,8 +30,29 @@ export { calculateNetEnergy } from './HabitUtils';
 const HabitsScreen = () => {
   const { habits, loading, error, selectedHabit, setSelectedHabit, mode, setMode, actions, ui } =
     useHabits();
+  const { token } = useAuth();
+  const [habitStats, setHabitStats] = useState<HabitStatsData | null>(null);
 
   const modals = useModalCoordinator();
+
+  const fetchStats = useCallback(
+    (habit: Habit) => {
+      if (habit.id == null) return;
+      habitsApi
+        .getStats(habit.id, token ?? undefined)
+        .then((apiStats) => setHabitStats(toLocalHabitStats(apiStats)))
+        .catch(() => setHabitStats(generateStatsForHabit(habit)));
+    },
+    [token],
+  );
+
+  useEffect(() => {
+    if (modals.stats && selectedHabit) {
+      fetchStats(selectedHabit);
+    } else {
+      setHabitStats(null);
+    }
+  }, [modals.stats, selectedHabit, fetchStats]);
   const { columns, gridGutter, scale, isLG, isXL } = useResponsive();
   const screenPadding = spacing(isLG || isXL ? 2 : 1, scale);
 
@@ -211,7 +234,7 @@ const HabitsScreen = () => {
       <StatsModal
         visible={modals.stats}
         habit={selectedHabit}
-        stats={selectedHabit ? generateStatsForHabit(selectedHabit) : null}
+        stats={habitStats}
         onClose={() => modals.close('stats')}
       />
       <HabitSettingsModal

--- a/frontend/src/features/Habits/__tests__/HabitStats.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitStats.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 /* global describe, test, expect */
 import type { Habit, Goal } from '../Habits.types';
-import { generateStatsForHabit, calculateMissedDays } from '../HabitUtils';
+import { generateStatsForHabit, toLocalHabitStats, calculateMissedDays } from '../HabitUtils';
 
 describe('generateStatsForHabit', () => {
   const goals: Goal[] = [
@@ -124,6 +124,60 @@ describe('generateStatsForHabit', () => {
     expect(stats.completionsByDay[1]).toBe(1); // Monday
     expect(stats.completionsByDay[2]).toBe(0); // Tuesday
     expect(stats.completionsByDay[3]).toBe(1); // Wednesday
+  });
+
+  test('includes currentStreak counting from the most recent date backwards', () => {
+    const habit: Habit = {
+      ...baseHabit,
+      completions: [
+        { id: 'c-1', timestamp: new Date('2024-01-01T08:00:00'), completed_units: 1 },
+        // gap on Jan 2
+        { id: 'c-2', timestamp: new Date('2024-01-03T08:00:00'), completed_units: 1 },
+        { id: 'c-3', timestamp: new Date('2024-01-04T08:00:00'), completed_units: 1 },
+      ],
+    };
+    const stats = generateStatsForHabit(habit);
+    expect(stats.currentStreak).toBe(2); // Jan 3-4
+  });
+
+  test('includes completionDates as ISO date strings', () => {
+    const habit: Habit = {
+      ...baseHabit,
+      completions: [
+        { id: 'c-1', timestamp: new Date('2024-01-01T08:00:00'), completed_units: 1 },
+        { id: 'c-2', timestamp: new Date('2024-01-01T12:00:00'), completed_units: 1 },
+        { id: 'c-3', timestamp: new Date('2024-01-03T08:00:00'), completed_units: 1 },
+      ],
+    };
+    const stats = generateStatsForHabit(habit);
+    expect(stats.completionDates).toContain('2024-01-01');
+    expect(stats.completionDates).toContain('2024-01-03');
+    expect(stats.completionDates).toHaveLength(2);
+  });
+});
+
+describe('toLocalHabitStats', () => {
+  test('converts snake_case API response to camelCase HabitStatsData', () => {
+    const api = {
+      day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      values: [0, 3, 0, 3, 0, 0, 0],
+      completions_by_day: [0, 1, 0, 1, 0, 0, 0],
+      longest_streak: 3,
+      current_streak: 2,
+      total_completions: 5,
+      completion_rate: 0.67,
+      completion_dates: ['2024-01-01', '2024-01-03'],
+    };
+    const local = toLocalHabitStats(api);
+    expect(local.dayLabels).toEqual(api.day_labels);
+    expect(local.dates).toEqual(api.day_labels);
+    expect(local.values).toEqual(api.values);
+    expect(local.completionsByDay).toEqual(api.completions_by_day);
+    expect(local.longestStreak).toBe(3);
+    expect(local.currentStreak).toBe(2);
+    expect(local.totalCompletions).toBe(5);
+    expect(local.completionRate).toBe(0.67);
+    expect(local.completionDates).toEqual(['2024-01-01', '2024-01-03']);
   });
 });
 

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -14,8 +14,22 @@ jest.mock('../../../api', () => ({
     create: jest.fn() as any,
     update: jest.fn() as any,
     delete: jest.fn() as any,
+    getStats: (jest.fn() as any).mockResolvedValue({
+      day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      values: [0, 0, 0, 0, 0, 0, 0],
+      completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+      longest_streak: 0,
+      current_streak: 0,
+      total_completions: 0,
+      completion_rate: 0,
+      completion_dates: [],
+    }),
   },
   goalCompletions: { create: jest.fn() as any },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
 }));
 
 jest.mock('expo-notifications', () => ({

--- a/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
@@ -12,10 +12,24 @@ jest.mock('../../../api', () => ({
     create: (jest.fn() as any).mockResolvedValue({}),
     update: jest.fn(),
     delete: jest.fn(),
+    getStats: (jest.fn() as any).mockResolvedValue({
+      day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      values: [0, 0, 0, 0, 0, 0, 0],
+      completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+      longest_streak: 0,
+      current_streak: 0,
+      total_completions: 0,
+      completion_rate: 0,
+      completion_dates: [],
+    }),
   },
   goalCompletions: { create: jest.fn() },
 }));
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
 
 const mockOnboardingModal = jest.fn();
 jest.mock('../components/OnboardingModal', () =>

--- a/frontend/src/features/Habits/components/StatsModal.tsx
+++ b/frontend/src/features/Habits/components/StatsModal.tsx
@@ -44,16 +44,12 @@ export const StatsModal = ({ visible, habit, stats, onClose }: StatsModalProps) 
 
   const getMarkedDates = () => {
     const marked: Record<string, { selected: boolean; selectedColor: string }> = {};
-    if (!habit.completions) return marked;
-    habit.completions.forEach((completion) => {
-      const dateStr = new Date(completion.timestamp).toISOString().split('T')[0] ?? '';
-      if (dateStr) {
-        marked[dateStr] = {
-          selected: true,
-          selectedColor: STAGE_COLORS[habit.stage] || '#50cebb',
-        };
-      }
-    });
+    for (const dateStr of stats.completionDates) {
+      marked[dateStr] = {
+        selected: true,
+        selectedColor: STAGE_COLORS[habit.stage] || '#50cebb',
+      };
+    }
     return marked;
   };
 
@@ -107,7 +103,7 @@ export const StatsModal = ({ visible, habit, stats, onClose }: StatsModalProps) 
                   </View>
                   <View style={styles.statsRow}>
                     <Text style={styles.statLabel}>Current Streak:</Text>
-                    <Text style={styles.statValue}>{habit.streak} days</Text>
+                    <Text style={styles.statValue}>{stats.currentStreak} days</Text>
                   </View>
                   <View style={styles.statsRow}>
                     <Text style={styles.statLabel}>Completion Rate:</Text>


### PR DESCRIPTION
## Summary

- **Backend**: Add `GET /habits/{id}/stats` endpoint that aggregates goal completions into day-of-week distributions, longest/current streak calculations, completion rates, and calendar date lists
- **Backend**: Add `HabitStats` Pydantic response schema (`schemas/habit_stats.py`)
- **Frontend**: Add `habits.getStats()` API client method and `ApiHabitStats` type
- **Frontend**: Wire `StatsModal` to fetch stats from the API (with client-side fallback on error), replacing the previous local-only `generateStatsForHabit` approach
- **Frontend**: Calendar view now uses `completionDates` from API instead of reading `habit.completions` directly; current streak now comes from stats response

Closes #88

## Files changed (13)

| File | Change |
|------|--------|
| `backend/src/schemas/habit_stats.py` | New — HabitStats Pydantic schema |
| `backend/src/schemas/__init__.py` | Export HabitStats |
| `backend/src/routers/habits.py` | Add `GET /{id}/stats` endpoint |
| `backend/tests/test_habit_stats_api.py` | New — 10 integration tests |
| `frontend/src/api/index.ts` | Add `ApiHabitStats` type + `getStats` method |
| `frontend/src/features/Habits/Habits.types.ts` | Add `currentStreak`, `completionDates` to `HabitStatsData` |
| `frontend/src/features/Habits/HabitUtils.ts` | Add `toLocalHabitStats` converter; update `generateStatsForHabit` |
| `frontend/src/features/Habits/HabitsScreen.tsx` | Fetch stats from API with fallback |
| `frontend/src/features/Habits/components/StatsModal.tsx` | Use `completionDates` for calendar, `currentStreak` from stats |
| `frontend/src/api/__tests__/habits-api.test.ts` | Add `getStats` API test |
| `frontend/src/features/Habits/__tests__/HabitStats.test.ts` | Add `toLocalHabitStats` + new field tests |
| `frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx` | Mock `useAuth` + `getStats` |
| `frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx` | Mock `useAuth` + `getStats` |

## Test plan

- [x] All 22 pre-commit hooks pass green (black, ruff, mypy, isort, bandit, pip-audit, detect-secrets, eslint, prettier, tsc, jest, pytest with 90% coverage)
- [x] 10 new backend integration tests: auth (401, 404, user isolation), empty stats, day-of-week aggregation, longest streak, current streak, completion rate, completion dates, cross-user isolation
- [x] 4 new frontend tests: `getStats` API call, `toLocalHabitStats` converter, `currentStreak` field, `completionDates` field
- [x] 393 frontend tests pass (0 failures)
- [x] All existing backend tests pass with no regressions

https://claude.ai/code/session_01BXy3re2Ty5Z4AaM9YpP6Uv