### PR TITLE
feat: add OnboardingFlow tests, sonarjs config, and test refactoring

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -14,3 +14,4 @@ sqlmodel
 types-requests
 types-ujson
 types-orjson
+xenon>=0.9

--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -75,6 +75,15 @@ module.exports = tseslint.config(
       'unicorn/prevent-abbreviations': 'off',
       'unicorn/no-null': 'off',
 
+      // Complexity enforcement
+      complexity: ['error', { max: 15 }],
+      'max-depth': ['error', { max: 4 }],
+      'max-nested-callbacks': ['error', { max: 4 }],
+      'sonarjs/cognitive-complexity': ['error', 15],
+      'sonarjs/no-collapsible-if': 'error',
+      'sonarjs/prefer-single-boolean-return': 'error',
+      'sonarjs/no-redundant-jump': 'error',
+
       // TS hygiene
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-explicit-any': 'warn',

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -47,6 +47,30 @@ jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
 
 const widths = [320, 390, 600, 900, 1200];
 
+const colorValues = Object.values(STAGE_COLORS);
+
+const assertTileLayout = (tile: any, height: number, expectedColumns: number): void => {
+  const style = Array.isArray(tile.props.style)
+    ? tile.props.style.reduce((acc: any, s: any) => ({ ...acc, ...s }), {})
+    : tile.props.style;
+
+  const tileHeight = (style.minHeight ?? 0) + 2 * (style.padding ?? 0) + 2 * (style.margin ?? 0);
+
+  const maxTileHeight = (height * expectedColumns) / 10;
+  expect(tileHeight).toBeLessThanOrEqual(maxTileHeight);
+  if (expectedColumns === 2) {
+    expect(style.flex).toBe(1);
+  }
+  expect(colorValues).toContain(style.borderColor);
+
+  const fill = tile.findByProps({ testID: 'progress-fill' });
+  const fillStyle = Array.isArray(fill.props.style) ? fill.props.style[1] : fill.props.style;
+  const val = parseFloat(fillStyle.width);
+  expect(val).toBeGreaterThanOrEqual(0);
+  expect(val).toBeLessThanOrEqual(100);
+  expect(fillStyle.backgroundColor).toBe(style.borderColor);
+};
+
 describe('HabitsScreen responsive layout', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -70,30 +94,7 @@ describe('HabitsScreen responsive layout', () => {
       expect(list.props.horizontal).not.toBe(true);
 
       const tiles = tree.findAllByProps({ testID: 'habit-tile' });
-      const colorValues = Object.values(STAGE_COLORS);
-
-      tiles.forEach((t: any) => {
-        const style = Array.isArray(t.props.style)
-          ? t.props.style.reduce((acc: any, s: any) => ({ ...acc, ...s }), {})
-          : t.props.style;
-
-        const tileHeight =
-          (style.minHeight ?? 0) + 2 * (style.padding ?? 0) + 2 * (style.margin ?? 0);
-
-        const maxTileHeight = (height * expectedColumns) / 10;
-        expect(tileHeight).toBeLessThanOrEqual(maxTileHeight);
-        if (expectedColumns === 2) {
-          expect(style.flex).toBe(1);
-        }
-        expect(colorValues).toContain(style.borderColor);
-
-        const fill = t.findByProps({ testID: 'progress-fill' });
-        const fillStyle = Array.isArray(fill.props.style) ? fill.props.style[1] : fill.props.style;
-        const val = parseFloat(fillStyle.width);
-        expect(val).toBeGreaterThanOrEqual(0);
-        expect(val).toBeLessThanOrEqual(100);
-        expect(fillStyle.backgroundColor).toBe(style.borderColor);
-      });
+      tiles.forEach((t: any) => assertTileLayout(t, height, expectedColumns));
 
       const iconTopExpected = expectedColumns === 2 && w / expectedColumns >= 400;
       const iconTopNodes = tree.findAllByProps({ testID: 'habit-icon-top' });

--- a/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * Integration tests for the onboarding → habit creation pipeline.
+ *
+ * Verifies that onboarding habits integrate correctly with the
+ * useHabits hook actions and utility functions end-to-end.
+ */
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { renderHook, act } from '@testing-library/react-native';
+
+import type { Habit, Goal } from '../Habits.types';
+import { calculateHabitProgress, getGoalTier, getProgressPercentage } from '../HabitUtils';
+import { useHabits } from '../hooks/useHabits';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('../../../api', () => ({
+  habits: {
+    list: jest.fn(() => Promise.resolve([])),
+    create: jest.fn(() => Promise.resolve({})),
+    update: jest.fn(() => Promise.resolve({})),
+    delete: jest.fn(() => Promise.resolve({})),
+  },
+  goalCompletions: {
+    create: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+jest.mock('../../../storage/habitStorage', () => ({
+  saveHabits: jest.fn(() => Promise.resolve(undefined)),
+  loadHabits: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  getExpoPushTokenAsync: jest.fn(() => Promise.resolve({ data: 'token' })),
+  scheduleNotificationAsync: jest.fn(() => Promise.resolve('notif-id')),
+  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve(undefined)),
+  SchedulableTriggerInputTypes: { DAILY: 'daily', WEEKLY: 'weekly' },
+}));
+
+jest.mock('react-native', () => ({
+  Alert: { alert: jest.fn() },
+  Platform: { OS: 'ios' },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures — simulate what OnboardingModal produces
+// ---------------------------------------------------------------------------
+
+const makeOnboardedHabits = (): Habit[] => [
+  {
+    id: 1,
+    name: 'Meditate',
+    icon: '🧘',
+    energy_cost: 2,
+    energy_return: 4,
+    stage: 'Beige',
+    start_date: new Date('2025-01-01'),
+    streak: 0,
+    revealed: true,
+    completions: [],
+    goals: [
+      {
+        id: 1,
+        title: 'Low goal for Meditate',
+        tier: 'low',
+        target: 1,
+        target_unit: 'units',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 2,
+        title: 'Clear goal for Meditate',
+        tier: 'clear',
+        target: 2,
+        target_unit: 'units',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 3,
+        title: 'Stretch goal for Meditate',
+        tier: 'stretch',
+        target: 3,
+        target_unit: 'units',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: 'Exercise',
+    icon: '🏃',
+    energy_cost: 3,
+    energy_return: 5,
+    stage: 'Beige',
+    start_date: new Date('2025-01-01'),
+    streak: 0,
+    revealed: true,
+    completions: [],
+    goals: [
+      {
+        id: 4,
+        title: 'Low goal for Exercise',
+        tier: 'low',
+        target: 1,
+        target_unit: 'units',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 5,
+        title: 'Clear goal for Exercise',
+        tier: 'clear',
+        target: 2,
+        target_unit: 'units',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 6,
+        title: 'Stretch goal for Exercise',
+        tier: 'stretch',
+        target: 3,
+        target_unit: 'units',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Onboarding → Habit lifecycle flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { useHabitStore } = require('../../../store/useHabitStore');
+    useHabitStore.setState({ habits: [], loading: false, error: null });
+  });
+
+  it('onboarded habits start with zero progress at lowest tier', () => {
+    const { result } = renderHook(() => useHabits());
+    const habits = makeOnboardedHabits();
+
+    act(() => result.current.setHabitsForTesting(habits));
+
+    for (const habit of result.current.habits) {
+      expect(calculateHabitProgress(habit)).toBe(0);
+      const { currentGoal, completedAllGoals } = getGoalTier(habit);
+      // At zero progress, current goal is the "low" tier and nothing is completed
+      expect(currentGoal.tier).toBe('low');
+      expect(completedAllGoals).toBe(false);
+    }
+  });
+
+  it('logging units advances through goal tiers correctly', () => {
+    const { result } = renderHook(() => useHabits());
+
+    act(() => result.current.setHabitsForTesting(makeOnboardedHabits()));
+
+    // Log 1 unit — meets "low" tier (target=1)
+    act(() => result.current.actions.logUnit(1, 1));
+    let habit = result.current.habits.find((h: Habit) => h.id === 1)!;
+    let { currentGoal, nextGoal } = getGoalTier(habit);
+    expect(currentGoal?.tier).toBe('low');
+    expect(nextGoal?.tier).toBe('clear');
+
+    // Log 1 more unit — meets "clear" tier (target=2)
+    act(() => result.current.actions.logUnit(1, 1));
+    habit = result.current.habits.find((h: Habit) => h.id === 1)!;
+    ({ currentGoal, nextGoal } = getGoalTier(habit));
+    expect(currentGoal?.tier).toBe('clear');
+    expect(nextGoal?.tier).toBe('stretch');
+
+    // Log 1 more — meets "stretch" tier (target=3)
+    act(() => result.current.actions.logUnit(1, 1));
+    habit = result.current.habits.find((h: Habit) => h.id === 1)!;
+    ({ currentGoal } = getGoalTier(habit));
+    expect(currentGoal?.tier).toBe('stretch');
+  });
+
+  it('progress percentage scales between tier boundaries', () => {
+    const { result } = renderHook(() => useHabits());
+
+    act(() => result.current.setHabitsForTesting(makeOnboardedHabits()));
+
+    // Log 1.5 units — between low (1) and clear (2)
+    act(() => result.current.actions.logUnit(1, 1));
+    act(() => result.current.actions.logUnit(1, 0.5));
+
+    const habit = result.current.habits.find((h: Habit) => h.id === 1)!;
+    const { currentGoal, nextGoal } = getGoalTier(habit);
+    const pct = getProgressPercentage(habit, currentGoal, nextGoal);
+
+    expect(pct).toBeGreaterThan(0);
+    expect(pct).toBeLessThanOrEqual(100);
+  });
+
+  it('updating a goal on one habit does not affect the other', () => {
+    const { result } = renderHook(() => useHabits());
+
+    act(() => result.current.setHabitsForTesting(makeOnboardedHabits()));
+
+    // Raise Meditate's low goal target
+    const newLow: Goal = {
+      id: 1,
+      title: 'Low goal for Meditate',
+      tier: 'low',
+      target: 5,
+      target_unit: 'units',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    };
+
+    act(() => result.current.actions.updateGoal(1, newLow));
+
+    // Exercise's goals should be unchanged
+    const exercise = result.current.habits.find((h: Habit) => h.id === 2)!;
+    const exerciseLow = exercise.goals.find((g: Goal) => g.tier === 'low')!;
+    expect(exerciseLow.target).toBe(1);
+  });
+
+  it('delete removes a habit without affecting siblings', () => {
+    const { result } = renderHook(() => useHabits());
+
+    act(() => result.current.setHabitsForTesting(makeOnboardedHabits()));
+    expect(result.current.habits).toHaveLength(2);
+
+    act(() => result.current.actions.deleteHabit(1));
+    expect(result.current.habits).toHaveLength(1);
+    expect(result.current.habits[0]!.name).toBe('Exercise');
+  });
+});


### PR DESCRIPTION
## Summary

Additive changes on top of the phase-4-06 and phase-4-09 work already merged via #135 and #136:

- **OnboardingFlow integration tests** (`OnboardingFlow.test.tsx`): 5 tests covering zero progress at lowest tier, tier advancement through logging, progress percentage scaling, goal isolation between habits, and delete without affecting siblings.
- **eslint-plugin-sonarjs configuration**: Added `sonarjs/cognitive-complexity`, `sonarjs/no-collapsible-if`, `sonarjs/prefer-single-boolean-return`, `sonarjs/no-redundant-jump` rules to `eslint.config.cjs`.
- **HabitsResponsive test refactoring**: Extracted `assertTileLayout` helper to reduce `max-nested-callbacks` from 5 to 4.
- **Backend dev dependency**: Added `xenon` to `requirements-dev.txt`.

## Test plan

- [x] All 23 pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Frontend tests pass (`npx jest --passWithNoTests`)
- [x] ESLint zero warnings
- [x] TypeScript strict mode clean

https://claude.ai/code/session_01KbhDmLKXj1oE8LJrrZXg9K