### PR TITLE
feat(frontend): show locked habits as greyed-out tiles (phase-5-01)

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -421,11 +421,85 @@ const useHabitTileData = (habit: Habit) => {
   return { progressPercentage, progressBarColor, hasCompletedGoal, markers };
 };
 
-export const HabitTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: HabitTileProps) => {
+const LOCKED_BACKGROUND = '#e8e8e8';
+const LOCKED_OPACITY = 0.4;
+const MS_PER_DAY = 86_400_000;
+
+const calculateDaysUntilUnlock = (startDate: Date): number => {
+  const now = new Date();
+  const start = new Date(startDate);
+  return Math.max(0, Math.ceil((start.getTime() - now.getTime()) / MS_PER_DAY));
+};
+
+const getUnlockLabel = (habit: Habit): string => {
+  const days = calculateDaysUntilUnlock(habit.start_date);
+  if (days > 0) return `Unlocks in ${days} day${days === 1 ? '' : 's'}`;
+  return `Stage ${habit.stage} · Locked`;
+};
+
+interface LockedTileProps {
+  habit: Habit;
+  stageColor: string;
+  scale: number;
+  gridGutter: number;
+  tileMinHeight: number;
+}
+
+const LockedTile = ({ habit, stageColor, scale, gridGutter, tileMinHeight }: LockedTileProps) => (
+  <View
+    testID="habit-tile"
+    accessibilityLabel={`${habit.name} locked`}
+    style={{
+      flex: 1,
+      borderWidth: 1,
+      borderColor: stageColor,
+      padding: spacing(1, scale),
+      margin: gridGutter / 2,
+      minHeight: tileMinHeight,
+      borderRadius: spacing(1, scale),
+      backgroundColor: LOCKED_BACKGROUND,
+      opacity: LOCKED_OPACITY,
+    }}
+  >
+    <View testID="habit-header" style={{ flexDirection: 'row', alignItems: 'center' }}>
+      <Text style={{ fontSize: spacing(2, scale), marginRight: spacing(1, scale) }}>🔒</Text>
+      <Text
+        style={{
+          flex: 1,
+          fontSize: spacing(2, scale),
+          fontWeight: '700',
+          textTransform: 'uppercase',
+          color: '#999',
+        }}
+      >
+        {habit.name}
+      </Text>
+    </View>
+    <Text
+      testID="unlock-label"
+      style={{
+        fontSize: spacing(1.5, scale),
+        color: '#999',
+        marginTop: spacing(0.5, scale),
+        fontStyle: 'italic',
+      }}
+    >
+      {getUnlockLabel(habit)}
+    </Text>
+  </View>
+);
+
+interface UnlockedTileProps {
+  habit: Habit;
+  onOpenGoals?: () => void;
+  onLongPress?: () => void;
+  onIconPress?: () => void;
+}
+
+const UnlockedTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: UnlockedTileProps) => {
   const { scale, gridGutter, tileMinHeight, iconInline } = useTileLayout();
   const stageColor = STAGE_COLORS[habit.stage] ?? '#000';
   const [tooltip, setTooltip] = useState<TierType | null>(null);
-
   const { progressPercentage, progressBarColor, hasCompletedGoal, markers } =
     useHabitTileData(habit);
 
@@ -471,6 +545,38 @@ export const HabitTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: Habi
         setTooltip={setTooltip}
       />
     </TouchableOpacity>
+  );
+};
+
+export const HabitTile = ({
+  habit,
+  locked,
+  onOpenGoals,
+  onLongPress,
+  onIconPress,
+}: HabitTileProps) => {
+  const { scale, gridGutter, tileMinHeight } = useTileLayout();
+  const stageColor = STAGE_COLORS[habit.stage] ?? '#000';
+
+  if (locked) {
+    return (
+      <LockedTile
+        habit={habit}
+        stageColor={stageColor}
+        scale={scale}
+        gridGutter={gridGutter}
+        tileMinHeight={tileMinHeight}
+      />
+    );
+  }
+
+  return (
+    <UnlockedTile
+      habit={habit}
+      onOpenGoals={onOpenGoals}
+      onLongPress={onLongPress}
+      onIconPress={onIconPress}
+    />
   );
 };
 

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -114,8 +114,9 @@ export interface EditableGoalProps {
 
 export interface HabitTileProps {
   habit: Habit;
-  onOpenGoals: () => void;
-  onLongPress: () => void;
+  locked?: boolean;
+  onOpenGoals?: () => void;
+  onLongPress?: () => void;
   onIconPress?: () => void;
 }
 

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -275,7 +275,7 @@ const HabitList = ({ habits, columns, gridGutter, renderItem }: HabitListProps) 
   <FlatList
     key={`cols-${columns}`}
     testID="habits-list"
-    data={habits.filter((h) => h.revealed)}
+    data={habits}
     keyExtractor={(item) => item.id?.toString() ?? item.name}
     renderItem={renderItem}
     numColumns={columns}
@@ -319,23 +319,39 @@ const useHabitTileRenderer = (
   actions: ReturnType<typeof useHabits>['actions'],
   setSelectedHabit: (_h: Habit) => void,
 ) => {
-  const renderHabitTile = ({ item, index }: { item: Habit; index: number }) => (
-    <HabitTile
-      habit={item}
-      onOpenGoals={() => {
-        setSelectedHabit(item);
-        openModalForMode(mode, modals, actions, item.id!);
-      }}
-      onLongPress={() => {
-        setSelectedHabit(item);
-        modals.open('settings');
-      }}
-      onIconPress={() => {
-        actions.iconPress(index);
-        modals.open('emojiPicker');
-      }}
-    />
-  );
+  const renderHabitTile = ({ item, index }: { item: Habit; index: number }) => {
+    const isLocked = item.revealed === false;
+    return (
+      <HabitTile
+        habit={item}
+        locked={isLocked}
+        onOpenGoals={
+          isLocked
+            ? undefined
+            : () => {
+                setSelectedHabit(item);
+                openModalForMode(mode, modals, actions, item.id!);
+              }
+        }
+        onLongPress={
+          isLocked
+            ? undefined
+            : () => {
+                setSelectedHabit(item);
+                modals.open('settings');
+              }
+        }
+        onIconPress={
+          isLocked
+            ? undefined
+            : () => {
+                actions.iconPress(index);
+                modals.open('emojiPicker');
+              }
+        }
+      />
+    );
+  };
   return renderHabitTile;
 };
 

--- a/frontend/src/features/Habits/__tests__/HabitTileLocked.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileLocked.test.tsx
@@ -1,0 +1,200 @@
+/* eslint-env jest */
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import React from 'react';
+import { View } from 'react-native';
+import renderer from 'react-test-renderer';
+
+import type { Habit } from '../Habits.types';
+import { HabitTile } from '../HabitTile';
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 1,
+  stage: 'Purple',
+  name: 'Locked Habit',
+  icon: '🔮',
+  streak: 0,
+  energy_cost: 5,
+  energy_return: 7,
+  start_date: new Date(Date.now() + 7 * 86_400_000), // 7 days from now
+  goals: [
+    {
+      title: 'Low',
+      tier: 'low',
+      target: 1,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+    {
+      title: 'Clear',
+      tier: 'clear',
+      target: 2,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+    {
+      title: 'Stretch',
+      tier: 'stretch',
+      target: 3,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+  ],
+  completions: [],
+  revealed: false,
+  ...overrides,
+});
+
+describe('HabitTile locked state', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-06T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders a non-interactive locked tile with lock icon', () => {
+    const habit = makeHabit({ start_date: new Date('2026-04-13T00:00:00Z') });
+
+    const component = renderer.create(
+      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
+    );
+
+    const tile = component.root.findByProps({ testID: 'habit-tile' });
+
+    // Should be a View (non-interactive), not TouchableOpacity
+    expect(tile.type).toBe(View);
+
+    // Should have reduced opacity
+    expect(tile.props.style.opacity).toBe(0.4);
+
+    // Should have greyed-out background
+    expect(tile.props.style.backgroundColor).toBe('#e8e8e8');
+  });
+
+  it('shows lock icon instead of streak data', () => {
+    const habit = makeHabit();
+
+    const component = renderer.create(
+      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
+    );
+
+    const { Text } = require('react-native');
+    const texts = component.root.findAllByType(Text);
+    const textContents = texts.map((t: { props: { children: string } }) => t.props.children);
+
+    // Should contain lock icon
+    expect(textContents).toContain('🔒');
+
+    // Should contain habit name
+    expect(textContents).toContain('Locked Habit');
+
+    // Should NOT contain streak text
+    const hasStreakText = textContents.some(
+      (t: string) => typeof t === 'string' && t.includes('DAYS'),
+    );
+    expect(hasStreakText).toBe(false);
+  });
+
+  it('shows "Unlocks in X days" countdown for future start dates', () => {
+    const habit = makeHabit({ start_date: new Date('2026-04-13T00:00:00Z') });
+
+    const component = renderer.create(
+      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
+    );
+
+    const unlockLabel = component.root.findByProps({ testID: 'unlock-label' });
+    expect(unlockLabel.props.children).toBe('Unlocks in 7 days');
+  });
+
+  it('shows singular "day" for 1 day remaining', () => {
+    const habit = makeHabit({ start_date: new Date('2026-04-07T12:00:00Z') });
+
+    const component = renderer.create(
+      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
+    );
+
+    const unlockLabel = component.root.findByProps({ testID: 'unlock-label' });
+    expect(unlockLabel.props.children).toBe('Unlocks in 1 day');
+  });
+
+  it('shows "Stage X · Locked" when start date has passed', () => {
+    const habit = makeHabit({
+      stage: 'Purple',
+      start_date: new Date('2026-04-01T00:00:00Z'),
+    });
+
+    const component = renderer.create(
+      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
+    );
+
+    const unlockLabel = component.root.findByProps({ testID: 'unlock-label' });
+    expect(unlockLabel.props.children).toBe('Stage Purple · Locked');
+  });
+
+  it('does not render progress bar for locked tiles', () => {
+    const habit = makeHabit();
+
+    const component = renderer.create(
+      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
+    );
+
+    const progressFills = component.root.findAllByProps({ testID: 'progress-fill' });
+    expect(progressFills).toHaveLength(0);
+  });
+
+  it('renders normally when not locked', () => {
+    const habit = makeHabit({ revealed: true });
+
+    const onOpenGoals = jest.fn();
+    const onLongPress = jest.fn();
+
+    const component = renderer.create(
+      <HabitTile habit={habit} onOpenGoals={onOpenGoals} onLongPress={onLongPress} />,
+    );
+
+    const tile = component.root.findByProps({ testID: 'habit-tile' });
+
+    // Should have normal background
+    expect(tile.props.style.backgroundColor).toBe('#f8f8f8');
+
+    // Should have progress bar
+    const progressFills = component.root.findAllByProps({ testID: 'progress-fill' });
+    expect(progressFills.length).toBeGreaterThanOrEqual(1);
+
+    // Should be interactive
+    renderer.act(() => {
+      tile.props.onPress();
+    });
+    expect(onOpenGoals).toHaveBeenCalled();
+  });
+
+  it('has accessible label for locked tiles', () => {
+    const habit = makeHabit({ name: 'Sangha' });
+
+    const component = renderer.create(
+      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
+    );
+
+    const tile = component.root.findByProps({ testID: 'habit-tile' });
+    expect(tile.props.accessibilityLabel).toBe('Sangha locked');
+  });
+
+  it('uses the stage color for tile border even when locked', () => {
+    const habit = makeHabit({ stage: 'Purple' });
+
+    const component = renderer.create(
+      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
+    );
+
+    const tile = component.root.findByProps({ testID: 'habit-tile' });
+    expect(tile.props.style.borderColor).toBe('#a093c6');
+  });
+});


### PR DESCRIPTION
## Summary

- Remove the `revealed` filter from `HabitsScreen` so all 10 habit tiles are always visible
- Add `LockedTile` component: greyed-out background (`#e8e8e8`), opacity 0.4, lock icon (🔒), no progress bar, non-interactive (`View` instead of `TouchableOpacity`)
- Show "Unlocks in X days" countdown based on `start_date`, or "Stage X · Locked" if the start date has passed
- Add 9 new tests covering locked tile rendering, interactivity, countdown logic, accessibility labels, and stage color borders

## Acceptance Criteria

- [x] All 10 habit tiles always visible on HabitsScreen
- [x] Unlocked habits look and behave exactly as before
- [x] Locked habits visually distinct: greyed out, no progress bar, lock icon
- [x] Locked tiles are not interactive (no modal on tap/long-press)
- [x] "Unlocks in X days" countdown accurate based on `start_date`
- [x] Grid layout remains responsive (2 columns on wide, 1 on narrow)
- [x] No regressions — all 117 Habits tests pass (18 suites)

## Test plan

- [x] 9 new tests in `HabitTileLocked.test.tsx` cover all locked state behaviors
- [x] All 18 existing Habits test suites pass with zero failures
- [x] All 24 pre-commit hooks pass green
- [x] TypeScript strict mode passes with no errors

https://claude.ai/code/session_01NqDvHvAnkyh1H3h4am5CVN