### PR TITLE
feat(frontend): replace milestone alerts with toast notifications

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { ActivityIndicator, StatusBar, StyleSheet, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
+import { ToastProvider } from './components/ToastProvider';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import LoginScreen from './features/Auth/LoginScreen';
 import SignupScreen from './features/Auth/SignupScreen';
@@ -61,12 +62,14 @@ export default function App(): React.JSX.Element {
   return (
     <SafeAreaProvider>
       <AuthProvider>
-        <NavigationContainer linking={linking}>
-          <SafeAreaView style={styles.safeArea}>
-            <StatusBar barStyle="dark-content" />
-            <RootNavigator />
-          </SafeAreaView>
-        </NavigationContainer>
+        <ToastProvider>
+          <NavigationContainer linking={linking}>
+            <SafeAreaView style={styles.safeArea}>
+              <StatusBar barStyle="dark-content" />
+              <RootNavigator />
+            </SafeAreaView>
+          </NavigationContainer>
+        </ToastProvider>
       </AuthProvider>
     </SafeAreaProvider>
   );

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, View } from 'react-native';
+
+import { colors, radius, shadows, SPACING } from '../design/tokens';
+
+export interface ToastConfig {
+  message: string;
+  icon?: string;
+  color?: string;
+  duration?: number;
+}
+
+interface ToastProps extends ToastConfig {
+  onDismiss: () => void;
+}
+
+const DEFAULT_DURATION_MS = 3000;
+const ANIMATION_DURATION_MS = 300;
+const SLIDE_DISTANCE = -80;
+
+const buildAnimation = (
+  opacity: Animated.Value,
+  translateY: Animated.Value,
+  toOpacity: number,
+  toTranslateY: number,
+) =>
+  Animated.parallel([
+    Animated.timing(opacity, {
+      toValue: toOpacity,
+      duration: ANIMATION_DURATION_MS,
+      useNativeDriver: true,
+    }),
+    Animated.timing(translateY, {
+      toValue: toTranslateY,
+      duration: ANIMATION_DURATION_MS,
+      useNativeDriver: true,
+    }),
+  ]);
+
+const scheduleExit = (
+  fadeOut: Animated.CompositeAnimation,
+  onDismiss: () => void,
+  delayMs: number,
+): ReturnType<typeof setTimeout> => setTimeout(() => fadeOut.start(onDismiss), delayMs);
+
+function useToastAnimation(duration: number | undefined, onDismiss: () => void) {
+  const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(SLIDE_DISTANCE)).current;
+
+  useEffect(() => {
+    const fadeIn = buildAnimation(opacity, translateY, 1, 0);
+    const fadeOut = buildAnimation(opacity, translateY, 0, SLIDE_DISTANCE);
+    let timeout: ReturnType<typeof setTimeout>;
+
+    fadeIn.start(() => {
+      timeout = scheduleExit(fadeOut, onDismiss, duration ?? DEFAULT_DURATION_MS);
+    });
+
+    return () => clearTimeout(timeout);
+  }, [opacity, translateY, duration, onDismiss]);
+
+  return { opacity, translateY };
+}
+
+export default function Toast({ message, icon, color, duration, onDismiss }: ToastProps) {
+  const { opacity, translateY } = useToastAnimation(duration, onDismiss);
+  const borderColor = color ?? colors.tier.default;
+
+  return (
+    <Animated.View
+      testID="toast-container"
+      style={[
+        styles.container,
+        { opacity, transform: [{ translateY }], borderLeftColor: borderColor },
+      ]}
+    >
+      {icon ? (
+        <Text style={styles.icon} testID="toast-icon">
+          {icon}
+        </Text>
+      ) : null}
+      <View style={styles.content}>
+        <Text style={styles.message} testID="toast-message">
+          {message}
+        </Text>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: SPACING.lg,
+    marginTop: SPACING.sm,
+    paddingVertical: SPACING.md,
+    paddingHorizontal: SPACING.lg,
+    backgroundColor: colors.background.card,
+    borderRadius: radius.md,
+    borderLeftWidth: 4,
+    ...shadows.medium,
+  },
+  icon: {
+    fontSize: 24,
+    marginRight: SPACING.md,
+  },
+  content: {
+    flex: 1,
+  },
+  message: {
+    color: colors.text.primary,
+    fontSize: 14,
+    fontWeight: '500',
+  },
+});

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -1,0 +1,74 @@
+import React, { createContext, useCallback, useContext, useRef, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import Toast, { type ToastConfig } from './Toast';
+
+interface ToastContextValue {
+  showToast: (config: ToastConfig) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const TOAST_GAP_MS = 400;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [currentToast, setCurrentToast] = useState<ToastConfig | null>(null);
+  const queueRef = useRef<ToastConfig[]>([]);
+  const isShowingRef = useRef(false);
+
+  const showNext = useCallback(() => {
+    const next = queueRef.current.shift();
+    if (next) {
+      isShowingRef.current = true;
+      setCurrentToast(next);
+    } else {
+      isShowingRef.current = false;
+      setCurrentToast(null);
+    }
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    setCurrentToast(null);
+    setTimeout(showNext, TOAST_GAP_MS);
+  }, [showNext]);
+
+  const showToast = useCallback(
+    (config: ToastConfig) => {
+      queueRef.current.push(config);
+      if (!isShowingRef.current) {
+        showNext();
+      }
+    },
+    [showNext],
+  );
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <View style={styles.overlay} pointerEvents="none" testID="toast-overlay">
+        {currentToast ? <Toast {...currentToast} onDismiss={handleDismiss} /> : null}
+      </View>
+    </ToastContext.Provider>
+  );
+}
+
+const NOOP_CONTEXT: ToastContextValue = {
+  showToast: () => {
+    // no-op: ToastProvider not mounted
+  },
+};
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  return context ?? NOOP_CONTEXT;
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    top: 60,
+    left: 0,
+    right: 0,
+    zIndex: 9999,
+  },
+});

--- a/frontend/src/components/__tests__/Toast.test.tsx
+++ b/frontend/src/components/__tests__/Toast.test.tsx
@@ -1,0 +1,182 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { render, act } from '@testing-library/react-native';
+import React from 'react';
+
+import Toast from '../Toast';
+import { ToastProvider, useToast } from '../ToastProvider';
+
+// Helper component that exposes showToast for testing
+function ToastTrigger({
+  onReady,
+}: {
+  onReady: (showToast: ReturnType<typeof useToast>['showToast']) => void;
+}) {
+  const { showToast } = useToast();
+  React.useEffect(() => {
+    onReady(showToast);
+  }, [onReady, showToast]);
+  return null;
+}
+
+describe('Toast component', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('renders message and icon', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(
+      <Toast message="Goal achieved!" icon="🎯" color="#807f66" onDismiss={onDismiss} />,
+    );
+
+    expect(getByTestId('toast-message').props.children).toBe('Goal achieved!');
+    expect(getByTestId('toast-icon').props.children).toBe('🎯');
+    expect(getByTestId('toast-container')).toBeTruthy();
+  });
+
+  it('renders without icon when not provided', () => {
+    const onDismiss = jest.fn();
+    const { queryByTestId, getByTestId } = render(
+      <Toast message="No icon toast" onDismiss={onDismiss} />,
+    );
+
+    expect(getByTestId('toast-message').props.children).toBe('No icon toast');
+    expect(queryByTestId('toast-icon')).toBeNull();
+  });
+
+  it('calls onDismiss after default duration', () => {
+    const onDismiss = jest.fn();
+    render(<Toast message="Auto dismiss" onDismiss={onDismiss} />);
+
+    // Animation in (300ms) + display (3000ms) + animation out (300ms)
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDismiss after custom duration', () => {
+    const onDismiss = jest.fn();
+    render(<Toast message="Custom" duration={5000} onDismiss={onDismiss} />);
+
+    // Animation in
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // Not dismissed before 5000ms
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // Dismissed after 5000ms + animation out
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ToastProvider', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('renders toast when showToast is called', () => {
+    let triggerToast: ReturnType<typeof useToast>['showToast'];
+
+    const { getByTestId } = render(
+      <ToastProvider>
+        <ToastTrigger onReady={(fn) => (triggerToast = fn)} />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      triggerToast({ message: 'Hello toast', icon: '🏅' });
+    });
+
+    expect(getByTestId('toast-message').props.children).toBe('Hello toast');
+    expect(getByTestId('toast-icon').props.children).toBe('🏅');
+  });
+
+  it('queues multiple toasts and shows them sequentially', () => {
+    let triggerToast: ReturnType<typeof useToast>['showToast'];
+
+    const { getByTestId, queryByTestId } = render(
+      <ToastProvider>
+        <ToastTrigger onReady={(fn) => (triggerToast = fn)} />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      triggerToast({ message: 'First toast' });
+      triggerToast({ message: 'Second toast' });
+    });
+
+    // First toast is visible
+    expect(getByTestId('toast-message').props.children).toBe('First toast');
+
+    // Dismiss first toast: animation in (300) + display (3000) + animation out (300) + gap (400)
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // After dismiss, gap before next
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    // Second toast should now be visible
+    const messageEl = queryByTestId('toast-message');
+    expect(messageEl).toBeTruthy();
+    expect(messageEl!.props.children).toBe('Second toast');
+  });
+
+  it('returns no-op showToast when used outside provider', () => {
+    let toastFn: ReturnType<typeof useToast>['showToast'] | null = null;
+
+    function StandaloneComponent() {
+      const { showToast } = useToast();
+      toastFn = showToast;
+      return null;
+    }
+
+    render(<StandaloneComponent />);
+    expect(toastFn).toBeDefined();
+    // Should not throw when called outside provider
+    expect(() => toastFn!({ message: 'test' })).not.toThrow();
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
@@ -48,6 +48,20 @@ jest.mock('../../../storage/habitStorage', () => ({
   loadHabits: jest.fn(() => Promise.resolve(null)),
 }));
 
+jest.mock('react-native', () => ({
+  Alert: { alert: jest.fn() },
+  Platform: { OS: 'ios' },
+  StyleSheet: { create: (s: Record<string, unknown>) => s },
+  Animated: {
+    Value: jest.fn(),
+    View: 'Animated.View',
+    timing: jest.fn(() => ({ start: jest.fn() })),
+    parallel: jest.fn(() => ({ start: jest.fn() })),
+  },
+  View: 'View',
+  Text: 'Text',
+}));
+
 jest.mock('expo-notifications', () => ({
   getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
   requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
@@ -56,11 +70,6 @@ jest.mock('expo-notifications', () => ({
   cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve(undefined)),
   getAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve([])),
   SchedulableTriggerInputTypes: { DAILY: 'daily', WEEKLY: 'weekly' },
-}));
-
-jest.mock('react-native', () => ({
-  Alert: { alert: jest.fn() },
-  Platform: { OS: 'ios' },
 }));
 
 const makeGoal = (tier: 'low' | 'clear' | 'stretch', target: number): Goal => ({

--- a/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
@@ -44,6 +44,15 @@ jest.mock('expo-notifications', () => ({
 jest.mock('react-native', () => ({
   Alert: { alert: jest.fn() },
   Platform: { OS: 'ios' },
+  StyleSheet: { create: (s: Record<string, unknown>) => s },
+  Animated: {
+    Value: jest.fn(),
+    View: 'Animated.View',
+    timing: jest.fn(() => ({ start: jest.fn() })),
+    parallel: jest.fn(() => ({ start: jest.fn() })),
+  },
+  View: 'View',
+  Text: 'Text',
 }));
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
@@ -1,7 +1,8 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import React from 'react';
-import { Alert } from 'react-native';
 import renderer from 'react-test-renderer';
+
+import { ToastProvider } from '../../../components/ToastProvider';
 
 const HabitsScreen = require('../HabitsScreen').default;
 
@@ -54,10 +55,25 @@ jest.mock('expo-notifications', () => ({
 }));
 
 describe('Onboarding completion', () => {
-  it('shows next steps alert after saving habits', async () => {
-    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    renderer.act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('shows next steps toast after saving habits', async () => {
+    let root: ReturnType<typeof renderer.create>;
     await renderer.act(async () => {
-      renderer.create(<HabitsScreen />);
+      root = renderer.create(
+        <ToastProvider>
+          <HabitsScreen />
+        </ToastProvider>,
+      );
     });
     const call = mockOnboardingModal.mock.calls[0];
     if (!call) throw new Error('OnboardingModal not rendered');
@@ -71,9 +87,12 @@ describe('Onboarding completion', () => {
       stage: 'Beige',
       start_date: new Date(),
     };
-    renderer.act(() => {
+    await renderer.act(async () => {
       props.onSaveHabits([sampleHabit]);
     });
-    expect(Alert.alert).toHaveBeenCalledWith('Next steps', 'Tap a habit tile to edit its goals.');
+    // Verify toast is rendered with the instructional message
+    const toastMessage = root!.root.findAllByProps({ testID: 'toast-message' });
+    expect(toastMessage.length).toBeGreaterThan(0);
+    expect(toastMessage[0].props.children).toBe('Tap a habit tile to edit its goals.');
   });
 });

--- a/frontend/src/features/Habits/__tests__/useHabits.test.ts
+++ b/frontend/src/features/Habits/__tests__/useHabits.test.ts
@@ -34,6 +34,15 @@ jest.mock('expo-notifications', () => ({
 jest.mock('react-native', () => ({
   Alert: { alert: jest.fn() },
   Platform: { OS: 'ios' },
+  StyleSheet: { create: (s: Record<string, unknown>) => s },
+  Animated: {
+    Value: jest.fn(),
+    View: 'Animated.View',
+    timing: jest.fn(() => ({ start: jest.fn() })),
+    parallel: jest.fn(() => ({ start: jest.fn() })),
+  },
+  View: 'View',
+  Text: 'Text',
 }));
 
 const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({

--- a/frontend/src/features/Habits/hooks/useHabits.ts
+++ b/frontend/src/features/Habits/hooks/useHabits.ts
@@ -4,6 +4,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { habits as habitsApi, goalCompletions as goalCompletionsApi } from '../../../api';
 import type { HabitCreatePayload } from '../../../api';
+import type { ToastConfig } from '../../../components/Toast';
+import { useToast } from '../../../components/ToastProvider';
+import { colors } from '../../../design/tokens';
 import {
   saveHabits as persistHabits,
   loadHabits as loadCachedHabits,
@@ -120,32 +123,46 @@ const normalizeGoalTiers = (goals: Goal[], updatedGoal: Goal): void => {
   else clampSubtractiveTargets(low, clear, stretch);
 };
 
-const checkMilestoneAlerts = (
+/** Milestone icon per goal tier. */
+const MILESTONE_ICONS: Record<string, string> = {
+  low: '\u{1F3C5}',
+  clear: '\u{1F3AF}',
+  stretch: '\u{1F31F}',
+};
+
+const buildMilestoneToast = (
   habitName: string,
   oldProgress: number,
   newProgress: number,
   currentGoal: Goal,
   nextGoal: Goal | null,
-): void => {
-  if (!currentGoal.is_additive) return;
+): ToastConfig | null => {
+  if (!currentGoal.is_additive) return null;
 
   const currentTarget = getGoalTarget(currentGoal);
   const justReached = oldProgress < currentTarget && newProgress >= currentTarget;
-  if (!justReached) return;
+  if (!justReached) return null;
 
   if (currentGoal.tier === 'low') {
-    Alert.alert(
-      'Goal Achieved!',
-      `You've reached your Low Goal for ${habitName}! Keep going for the Clear Goal.`,
-    );
+    return {
+      message: `Low Goal achieved for ${habitName}! Keep going for the Clear Goal.`,
+      icon: MILESTONE_ICONS.low,
+      color: colors.tier.low,
+    };
   } else if (currentGoal.tier === 'clear' && nextGoal) {
-    Alert.alert('Achieved! Keep going for the Stretch Goal!');
-  } else if (currentGoal.tier === 'stretch' && nextGoal) {
-    Alert.alert(
-      'Stretch Goal Achieved!',
-      `Amazing! You've reached your Stretch Goal for ${habitName}!`,
-    );
+    return {
+      message: 'Clear Goal achieved! Keep going for the Stretch Goal!',
+      icon: MILESTONE_ICONS.clear,
+      color: colors.tier.clear,
+    };
+  } else if (currentGoal.tier === 'stretch') {
+    return {
+      message: `Stretch Goal achieved for ${habitName}! Amazing!`,
+      icon: MILESTONE_ICONS.stretch,
+      color: colors.tier.stretch,
+    };
   }
+  return null;
 };
 
 const backfillHabit = (habit: Habit, days: Date[]): Habit => {
@@ -378,7 +395,9 @@ const useHabitMutations = () => {
   return { habits, storeSetHabits, updateGoal, updateHabit, deleteHabit, saveHabitOrder };
 };
 
-const useHabitCrud = () => {
+const INSTRUCTIONAL_TOAST_DURATION_MS = 5000;
+
+const useHabitCrud = (showToast: (_config: ToastConfig) => void) => {
   const mutations = useHabitMutations();
   const { habits, storeSetHabits } = mutations;
   const backfillMissedDays = useCallback(
@@ -397,19 +416,44 @@ const useHabitCrud = () => {
     async (newHabits: OnboardingHabit[]) => {
       const fullHabits = buildOnboardingHabits(newHabits);
       storeSetHabits(fullHabits);
-      Alert.alert('Next steps', 'Tap a habit tile to edit its goals.');
+      showToast({
+        message: 'Tap a habit tile to edit its goals.',
+        icon: '\u{1F449}',
+        duration: INSTRUCTIONAL_TOAST_DURATION_MS,
+      });
       await syncOnboardingHabits(fullHabits);
     },
-    [storeSetHabits],
+    [storeSetHabits, showToast],
   );
   return { ...mutations, backfillMissedDays, setNewStartDate, onboardingSave };
+};
+
+const logAndToast = (
+  habit: Habit,
+  habitId: number,
+  amount: number,
+  showToast: (_config: ToastConfig) => void,
+): Habit | null => {
+  if (habit.id !== habitId) return null;
+  const result = applyLogUnit(habit, amount);
+  const { currentGoal, nextGoal } = getGoalTier(result.updatedHabit);
+  const toast = buildMilestoneToast(
+    habit.name,
+    result.oldProgress,
+    result.newProgress,
+    currentGoal,
+    nextGoal,
+  );
+  if (toast) showToast(toast);
+  return result.updatedHabit;
 };
 
 const useHabitActions = (
   selectedHabit: Habit | null,
   setSelectedHabit: (_h: Habit | null) => void,
+  showToast: (_config: ToastConfig) => void,
 ) => {
-  const crud = useHabitCrud();
+  const crud = useHabitCrud(showToast);
   const { habits, storeSetHabits } = crud;
   const [emojiHabitIndex, setEmojiHabitIndex] = useState<number | null>(null);
 
@@ -418,12 +462,10 @@ const useHabitActions = (
       const previousHabits = habits;
       let updated: Habit | null = null;
       const newHabits = habits.map((h) => {
-        if (h.id !== habitId) return h;
-        const result = applyLogUnit(h, amount);
-        updated = result.updatedHabit;
-        const { currentGoal, nextGoal } = getGoalTier(result.updatedHabit);
-        checkMilestoneAlerts(h.name, result.oldProgress, result.newProgress, currentGoal, nextGoal);
-        return result.updatedHabit;
+        const result = logAndToast(h, habitId, amount, showToast);
+        if (!result) return h;
+        updated = result;
+        return result;
       });
       storeSetHabits(newHabits);
       if (selectedHabit?.id === habitId && updated) setSelectedHabit(updated);
@@ -434,7 +476,7 @@ const useHabitActions = (
         storeSetHabits,
       );
     },
-    [selectedHabit, habits, storeSetHabits, setSelectedHabit],
+    [selectedHabit, habits, storeSetHabits, setSelectedHabit, showToast],
   );
 
   const iconPress = useCallback((index: number) => {
@@ -471,11 +513,12 @@ export const useHabits = (): UseHabitsReturn => {
   const loading = useHabitStore((s) => s.loading);
   const error = useHabitStore((s) => s.error);
   const storeSetHabits = useHabitStore((s) => s.setHabits);
+  const { showToast } = useToast();
   const [selectedHabit, setSelectedHabit] = useState<Habit | null>(null);
   const [mode, setMode] = useState<HabitScreenMode>('normal');
 
   const loadHabits = useHabitLoader();
-  const actionsHook = useHabitActions(selectedHabit, setSelectedHabit);
+  const actionsHook = useHabitActions(selectedHabit, setSelectedHabit, showToast);
   const ui = useHabitUI();
 
   return {

--- a/frontend/src/store/__tests__/storeIntegration.test.ts
+++ b/frontend/src/store/__tests__/storeIntegration.test.ts
@@ -42,6 +42,15 @@ jest.mock('expo-notifications', () => ({
 jest.mock('react-native', () => ({
   Alert: { alert: jest.fn() },
   Platform: { OS: 'ios' },
+  StyleSheet: { create: (s: Record<string, unknown>) => s },
+  Animated: {
+    Value: jest.fn(),
+    View: 'Animated.View',
+    timing: jest.fn(() => ({ start: jest.fn() })),
+    parallel: jest.fn(() => ({ start: jest.fn() })),
+  },
+  View: 'View',
+  Text: 'Text',
 }));
 
 const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({


### PR DESCRIPTION
## Summary

- **Add toast notification system** (`Toast.tsx` + `ToastProvider.tsx`) with animated slide-in/fade-out, queue-based sequential display, and tier-specific icons/colors
- **Replace all milestone `Alert.alert()` calls** in `useHabits.ts` with non-blocking toasts: Low Goal (🏅 bronze), Clear Goal (🎯 target), Stretch Goal (🌟 star)
- **Replace onboarding "Next steps" alert** with a 5-second instructional toast
- **Fix stretch goal bug**: original code required `nextGoal` for stretch tier toast (which never exists), so stretch celebrations never fired

## Acceptance Criteria

- [x] Zero `Alert.alert()` calls remain for milestone/celebration events (3 error alerts remain — legitimate)
- [x] Toasts appear as non-blocking overlays with smooth animation (`pointerEvents="none"`)
- [x] Each goal tier has distinct icon and color from `colors.tier.*` tokens
- [x] Auto-dismiss: 3s default, 5s for instructional messages
- [x] Multiple rapid milestones queue and display sequentially (400ms gap)
- [x] No regressions — all 416 tests pass across 55 suites

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/components/Toast.tsx` | **New** — Animated toast component |
| `frontend/src/components/ToastProvider.tsx` | **New** — Context + queue + `useToast()` hook |
| `frontend/src/components/__tests__/Toast.test.tsx` | **New** — 7 tests (render, dismiss, duration, queue, fallback) |
| `frontend/src/App.tsx` | Wrap with `ToastProvider` |
| `frontend/src/features/Habits/hooks/useHabits.ts` | Replace `Alert.alert` → `showToast` for milestones |
| 4 test files | Extend `react-native` mock with `StyleSheet`/`Animated` for transitive Toast import |

## Test Plan

- [x] Toast renders message and icon correctly
- [x] Toast auto-dismisses after default (3s) and custom (5s) durations
- [x] Multiple toasts queue and display sequentially
- [x] `useToast()` returns no-op outside provider (graceful degradation)
- [x] Onboarding "next steps" shows as toast instead of alert
- [x] All 24 pre-commit hooks pass green
- [x] Full test suite: 55 suites, 416 tests, 0 failures

https://claude.ai/code/session_01M2ddwjkRJ4Ceh7HpZL7Znt