### PR TITLE
feat(full-stack): add Map stage history (phase-5-04)

### DIFF
--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -7,9 +7,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from models.course_stage import CourseStage
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.practice import Practice
 from models.practice_session import PracticeSession
 from models.stage_progress import StageProgress
 from models.user_practice import UserPractice
+from schemas.stage import HabitHistoryItem, PracticeHistoryItem
 
 # Stage N+1 unlocks when stage N is in completed_stages or is the current stage
 _STAGE_1 = 1
@@ -76,3 +81,92 @@ async def stage_exists(session: AsyncSession, stage_number: int) -> bool:
         select(CourseStage).where(CourseStage.stage_number == stage_number)
     )
     return result.scalars().first() is not None
+
+
+async def get_stage_practice_history(
+    session: AsyncSession,
+    user_id: int,
+    stage_number: int,
+) -> list[PracticeHistoryItem]:
+    """Aggregate practice session history for a user in a specific stage."""
+    # Get all user-practices for this stage, joined with Practice for names
+    result = await session.execute(
+        select(
+            Practice.name,
+            func.count(col(PracticeSession.id)).label("sessions_completed"),
+            func.coalesce(func.sum(PracticeSession.duration_minutes), 0).label("total_minutes"),
+            func.max(PracticeSession.timestamp).label("last_session"),
+        )
+        .select_from(PracticeSession)
+        .join(UserPractice, col(PracticeSession.user_practice_id) == col(UserPractice.id))
+        .join(Practice, col(UserPractice.practice_id) == col(Practice.id))
+        .where(
+            PracticeSession.user_id == user_id,
+            UserPractice.stage_number == stage_number,
+        )
+        .group_by(Practice.name)
+    )
+    rows = result.all()
+    return [
+        PracticeHistoryItem(
+            name=row.name,
+            sessions_completed=row.sessions_completed,
+            total_minutes=float(row.total_minutes),
+            last_session=row.last_session,
+        )
+        for row in rows
+    ]
+
+
+async def get_stage_habit_history(
+    session: AsyncSession,
+    user_id: int,
+    stage_number: int,
+) -> list[HabitHistoryItem]:
+    """Aggregate habit and goal history for a user in a specific stage.
+
+    Habits are matched by their ``stage`` field against the stage_number
+    (converted to string).
+    """
+    stage_str = str(stage_number)
+    result = await session.execute(
+        select(Habit).where(Habit.user_id == user_id, Habit.stage == stage_str)
+    )
+    habits = result.scalars().all()
+
+    items: list[HabitHistoryItem] = []
+    for habit in habits:
+        # Count total goal completions for this habit's goals
+        completion_count_result = await session.execute(
+            select(func.count())
+            .select_from(GoalCompletion)
+            .join(Goal, col(GoalCompletion.goal_id) == col(Goal.id))
+            .where(GoalCompletion.user_id == user_id, Goal.habit_id == habit.id)
+        )
+        total_completions = completion_count_result.scalar() or 0
+
+        # Determine which goal tiers are achieved (have at least one completion)
+        goals_result = await session.execute(select(Goal).where(Goal.habit_id == habit.id))
+        goals = goals_result.scalars().all()
+
+        goals_achieved: dict[str, bool] = {}
+        for goal in goals:
+            gc_result = await session.execute(
+                select(func.count())
+                .select_from(GoalCompletion)
+                .where(GoalCompletion.goal_id == goal.id, GoalCompletion.user_id == user_id)
+            )
+            count = gc_result.scalar() or 0
+            goals_achieved[goal.tier] = count > 0
+
+        items.append(
+            HabitHistoryItem(
+                name=habit.name,
+                icon=habit.icon,
+                goals_achieved=goals_achieved,
+                best_streak=habit.streak,
+                total_completions=total_completions,
+            )
+        )
+
+    return items

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -11,6 +11,8 @@ from sqlmodel import col, select
 from database import get_session
 from domain.stage_progress import (
     compute_stage_progress,
+    get_stage_habit_history,
+    get_stage_practice_history,
     get_user_progress,
     is_stage_unlocked,
     stage_exists,
@@ -20,6 +22,7 @@ from models.course_stage import CourseStage
 from models.stage_progress import StageProgress
 from routers.auth import get_current_user
 from schemas.stage import (
+    StageHistoryResponse,
     StageProgressRecord,
     StageProgressResponse,
     StageProgressUpdate,
@@ -105,6 +108,26 @@ async def get_stage_progress(
 
     data = await compute_stage_progress(session, current_user, stage_number)
     return StageProgressResponse(**data)
+
+
+@router.get("/{stage_number}/history", response_model=StageHistoryResponse)
+async def get_stage_history(
+    stage_number: int,
+    current_user: int = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> StageHistoryResponse:
+    """Aggregated practice and habit history for a stage."""
+    if not await stage_exists(session, stage_number):
+        raise not_found("stage")
+
+    practices = await get_stage_practice_history(session, current_user, stage_number)
+    habits = await get_stage_habit_history(session, current_user, stage_number)
+
+    return StageHistoryResponse(
+        stage_number=stage_number,
+        practices=practices,
+        habits=habits,
+    )
 
 
 @router.put("/progress", response_model=StageProgressRecord)

--- a/backend/src/schemas/stage.py
+++ b/backend/src/schemas/stage.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
@@ -46,3 +48,30 @@ class StageProgressRecord(BaseModel):
     user_id: int
     current_stage: int
     completed_stages: list[int]
+
+
+class PracticeHistoryItem(BaseModel):
+    """A practice's aggregated history within a stage."""
+
+    name: str
+    sessions_completed: int
+    total_minutes: float
+    last_session: datetime | None
+
+
+class HabitHistoryItem(BaseModel):
+    """A habit's aggregated history within a stage."""
+
+    name: str
+    icon: str
+    goals_achieved: dict[str, bool]
+    best_streak: int
+    total_completions: int
+
+
+class StageHistoryResponse(BaseModel):
+    """Aggregated history of practices and habits for a stage."""
+
+    stage_number: int
+    practices: list[PracticeHistoryItem]
+    habits: list[HabitHistoryItem]

--- a/backend/tests/test_stages_history.py
+++ b/backend/tests/test_stages_history.py
@@ -1,0 +1,316 @@
+"""Tests for GET /stages/{stage_number}/history endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.course_stage import CourseStage
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.practice import Practice
+from models.practice_session import PracticeSession
+from models.user_practice import UserPractice
+
+
+def _stage_data(stage_number: int = 1) -> dict[str, object]:
+    """Valid CourseStage fields for DB insertion."""
+    return {
+        "title": f"Stage {stage_number}",
+        "subtitle": f"Subtitle {stage_number}",
+        "stage_number": stage_number,
+        "overview_url": f"https://example.com/stage-{stage_number}",
+        "category": "test",
+        "aspect": "test-aspect",
+        "spiral_dynamics_color": "beige",
+        "growing_up_stage": "archaic",
+        "divine_gender_polarity": "masculine",
+        "relationship_to_free_will": "active",
+        "free_will_description": "Test description",
+    }
+
+
+async def _signup(
+    client: AsyncClient,
+    username: str = "histuser",
+) -> tuple[dict[str, str], int]:
+    """Create a user and return (auth headers, user_id)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+async def _seed_stage(db_session: AsyncSession, stage_number: int = 1) -> CourseStage:
+    """Insert a single test stage."""
+    stage = CourseStage(**_stage_data(stage_number))
+    db_session.add(stage)
+    await db_session.commit()
+    await db_session.refresh(stage)
+    return stage
+
+
+# ── Authentication ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_history_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.get("/stages/1/history")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+# ── Not found ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_history_stage_not_found(async_client: AsyncClient) -> None:
+    headers, _uid = await _signup(async_client)
+    resp = await async_client.get("/stages/99/history", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+# ── Empty history ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_history_empty_for_stage_with_no_activity(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Stage with no practices or habits returns empty lists."""
+    headers, _uid = await _signup(async_client)
+    await _seed_stage(db_session, stage_number=1)
+
+    resp = await async_client.get("/stages/1/history", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["stage_number"] == 1
+    assert data["practices"] == []
+    assert data["habits"] == []
+
+
+# ── Practice history aggregation ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_history_returns_practice_aggregation(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Practices show session count, total minutes, and last session."""
+    headers, user_id = await _signup(async_client)
+    await _seed_stage(db_session, stage_number=1)
+
+    practice = Practice(
+        stage_number=1,
+        name="Breath of Fire",
+        description="Rapid breath",
+        instructions="Inhale-exhale quickly",
+        default_duration_minutes=15,
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+
+    user_practice = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=1,
+        start_date=date(2026, 1, 1),
+    )
+    db_session.add(user_practice)
+    await db_session.commit()
+    await db_session.refresh(user_practice)
+
+    session_count = 3
+    duration = 15.0
+    for i in range(session_count):
+        ps = PracticeSession(
+            user_id=user_id,
+            user_practice_id=user_practice.id,
+            duration_minutes=duration,
+            timestamp=datetime(2026, 3, 10 + i, 10, 0, tzinfo=UTC),
+        )
+        db_session.add(ps)
+    await db_session.commit()
+
+    resp = await async_client.get("/stages/1/history", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+
+    assert len(data["practices"]) == 1
+    p = data["practices"][0]
+    assert p["name"] == "Breath of Fire"
+    assert p["sessions_completed"] == session_count
+    assert p["total_minutes"] == duration * session_count
+    assert p["last_session"] is not None
+
+
+# ── Habit history aggregation ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_history_returns_habit_aggregation(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Habits show goals_achieved tiers, best_streak, and total completions."""
+    headers, user_id = await _signup(async_client)
+    await _seed_stage(db_session, stage_number=1)
+
+    best_streak = 14
+    habit = Habit(
+        name="Morning Exercise",
+        icon="🏃",
+        start_date=date(2026, 1, 1),
+        energy_cost=2,
+        energy_return=3,
+        user_id=user_id,
+        stage="1",
+        streak=best_streak,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+
+    # Create goals at three tiers
+    low_goal = Goal(
+        habit_id=habit.id,
+        title="Low",
+        tier="low",
+        target=10,
+        target_unit="reps",
+        frequency=1,
+        frequency_unit="per_day",
+    )
+    clear_goal = Goal(
+        habit_id=habit.id,
+        title="Clear",
+        tier="clear",
+        target=20,
+        target_unit="reps",
+        frequency=1,
+        frequency_unit="per_day",
+    )
+    stretch_goal = Goal(
+        habit_id=habit.id,
+        title="Stretch",
+        tier="stretch",
+        target=30,
+        target_unit="reps",
+        frequency=1,
+        frequency_unit="per_day",
+    )
+    db_session.add_all([low_goal, clear_goal, stretch_goal])
+    await db_session.commit()
+    for g in [low_goal, clear_goal, stretch_goal]:
+        await db_session.refresh(g)
+
+    # Add completions for low and clear, but not stretch
+    completion_count = 5
+    for goal in [low_goal, clear_goal]:
+        for _ in range(completion_count):
+            gc = GoalCompletion(
+                goal_id=goal.id,
+                user_id=user_id,
+                completed_units=10,
+            )
+            db_session.add(gc)
+    await db_session.commit()
+
+    resp = await async_client.get("/stages/1/history", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+
+    assert len(data["habits"]) == 1
+    h = data["habits"][0]
+    assert h["name"] == "Morning Exercise"
+    assert h["icon"] == "🏃"
+    assert h["best_streak"] == best_streak
+    assert h["total_completions"] == completion_count * 2  # low + clear
+    assert h["goals_achieved"]["low"] is True
+    assert h["goals_achieved"]["clear"] is True
+    assert h["goals_achieved"]["stretch"] is False
+
+
+# ── User isolation ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_history_only_returns_requesting_users_data(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """User A's history should not include user B's practices or habits."""
+    alice_headers, alice_id = await _signup(async_client, "alice_hist")
+    bob_headers, bob_id = await _signup(async_client, "bob_hist")
+    await _seed_stage(db_session, stage_number=1)
+
+    # Create practice data for Alice only
+    practice = Practice(
+        stage_number=1,
+        name="Meditation",
+        description="Sit",
+        instructions="Breathe",
+        default_duration_minutes=10,
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+
+    alice_up = UserPractice(
+        user_id=alice_id,
+        practice_id=practice.id,
+        stage_number=1,
+        start_date=date(2026, 1, 1),
+    )
+    db_session.add(alice_up)
+    await db_session.commit()
+    await db_session.refresh(alice_up)
+
+    ps = PracticeSession(
+        user_id=alice_id,
+        user_practice_id=alice_up.id,
+        duration_minutes=10.0,
+    )
+    db_session.add(ps)
+    await db_session.commit()
+
+    # Create a habit for Alice only
+    habit = Habit(
+        name="Alice Habit",
+        icon="🌸",
+        start_date=date(2026, 1, 1),
+        energy_cost=1,
+        energy_return=1,
+        user_id=alice_id,
+        stage="1",
+        streak=5,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+
+    # Bob should see empty history
+    resp = await async_client.get("/stages/1/history", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["practices"] == []
+    assert data["habits"] == []
+
+    # Alice should see her data
+    resp = await async_client.get("/stages/1/history", headers=alice_headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert len(data["practices"]) == 1
+    assert len(data["habits"]) == 1

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -465,6 +465,27 @@ export interface StageProgressDetail {
   overall_progress: number;
 }
 
+export interface PracticeHistoryItem {
+  name: string;
+  sessions_completed: number;
+  total_minutes: number;
+  last_session: string | null;
+}
+
+export interface HabitHistoryItem {
+  name: string;
+  icon: string;
+  goals_achieved: Record<string, boolean>;
+  best_streak: number;
+  total_completions: number;
+}
+
+export interface StageHistoryResponse {
+  stage_number: number;
+  practices: PracticeHistoryItem[];
+  habits: HabitHistoryItem[];
+}
+
 export const stages = {
   list(token?: string): Promise<Stage[]> {
     return request<Stage[]>('/stages', { token });
@@ -474,6 +495,9 @@ export const stages = {
   },
   progress(stageNumber: number, token?: string): Promise<StageProgressDetail> {
     return request<StageProgressDetail>(`/stages/${stageNumber}/progress`, { token });
+  },
+  history(stageNumber: number, token?: string): Promise<StageHistoryResponse> {
+    return request<StageHistoryResponse>(`/stages/${stageNumber}/history`, { token });
   },
 };
 

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -209,6 +209,79 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 
+  // History section
+  historySection: {
+    marginTop: spacing(1),
+  },
+  historyHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: spacing(1),
+  },
+  historyTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.text.light,
+  },
+  historyToggle: {
+    fontSize: 12,
+    color: colors.mystical.transparentLight,
+  },
+  historyLoading: {
+    paddingVertical: spacing(1.5),
+    alignItems: 'center',
+  },
+  historyEmpty: {
+    fontSize: 12,
+    color: colors.mystical.transparentLight,
+    fontStyle: 'italic',
+    paddingVertical: spacing(1),
+    textAlign: 'center',
+  },
+  historySubheading: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.mystical.transparentLight,
+    marginTop: spacing(1),
+    marginBottom: spacing(0.5),
+  },
+  historyItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing(0.5),
+  },
+  historyItemIcon: {
+    fontSize: 16,
+    marginRight: spacing(0.75),
+  },
+  historyItemName: {
+    fontSize: 12,
+    color: colors.text.light,
+    flex: 1,
+  },
+  historyItemDetail: {
+    fontSize: 11,
+    color: colors.mystical.transparentLight,
+  },
+  goalBadges: {
+    flexDirection: 'row',
+    gap: 4,
+    marginLeft: spacing(0.5),
+  },
+  goalBadge: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  goalBadgeText: {
+    fontSize: 8,
+    fontWeight: '700',
+    color: colors.text.light,
+  },
+
   // Completed stage checkmark
   completedBadge: {
     position: 'absolute',

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -14,6 +14,8 @@ import {
   useWindowDimensions,
 } from 'react-native';
 
+import type { HabitHistoryItem, PracticeHistoryItem, StageHistoryResponse } from '../../api';
+import { stages as stagesApi } from '../../api';
 import { MAP_BACKGROUND_URI } from '../../constants/images';
 import { useAppNavigation } from '../../navigation/hooks';
 import { useStageStore } from '../../store/useStageStore';
@@ -178,6 +180,153 @@ const ActionLinks = ({ stage, onNavigate }: ActionLinksProps): React.JSX.Element
   </View>
 );
 
+const GOAL_TIER_COLORS: Record<string, string> = {
+  low: '#CD7F32',
+  clear: '#C0C0C0',
+  stretch: '#FFD700',
+};
+
+const GOAL_TIER_LABELS: Record<string, string> = {
+  low: 'L',
+  clear: 'C',
+  stretch: 'S',
+};
+
+const MINUTES_PER_HOUR = 60;
+
+const formatMinutes = (minutes: number): string => {
+  if (minutes >= MINUTES_PER_HOUR) {
+    const hours = Math.round(minutes / MINUTES_PER_HOUR);
+    return `${hours} hr${hours !== 1 ? 's' : ''}`;
+  }
+  return `${Math.round(minutes)} min`;
+};
+
+const PracticeHistoryRow = ({ item }: { item: PracticeHistoryItem }): React.JSX.Element => (
+  <View style={styles.historyItem} testID="practice-history-item">
+    <Text style={styles.historyItemIcon}>🧘</Text>
+    <Text style={styles.historyItemName}>{item.name}</Text>
+    <Text style={styles.historyItemDetail}>
+      {item.sessions_completed} sessions, {formatMinutes(item.total_minutes)}
+    </Text>
+  </View>
+);
+
+const HabitHistoryRow = ({ item }: { item: HabitHistoryItem }): React.JSX.Element => (
+  <View style={styles.historyItem} testID="habit-history-item">
+    <Text style={styles.historyItemIcon}>{item.icon}</Text>
+    <Text style={styles.historyItemName}>
+      {item.name} · {item.best_streak}d streak
+    </Text>
+    <View style={styles.goalBadges}>
+      {Object.entries(item.goals_achieved).map(([tier, achieved]) => (
+        <View
+          key={tier}
+          style={[
+            styles.goalBadge,
+            {
+              backgroundColor: achieved
+                ? GOAL_TIER_COLORS[tier] ?? '#888'
+                : 'rgba(255,255,255,0.15)',
+            },
+          ]}
+          testID={`goal-badge-${tier}`}
+        >
+          <Text style={styles.goalBadgeText}>{GOAL_TIER_LABELS[tier] ?? tier[0]}</Text>
+        </View>
+      ))}
+    </View>
+  </View>
+);
+
+const HistoryContent = ({ history }: { history: StageHistoryResponse }): React.JSX.Element => (
+  <View testID="history-content">
+    {history.practices.length > 0 && (
+      <>
+        <Text style={styles.historySubheading}>Practices</Text>
+        {history.practices.map((p) => (
+          <PracticeHistoryRow key={p.name} item={p} />
+        ))}
+      </>
+    )}
+    {history.habits.length > 0 && (
+      <>
+        <Text style={styles.historySubheading}>Habits</Text>
+        {history.habits.map((h) => (
+          <HabitHistoryRow key={h.name} item={h} />
+        ))}
+      </>
+    )}
+  </View>
+);
+
+const HistoryBody = ({
+  loading,
+  history,
+}: {
+  loading: boolean;
+  history: StageHistoryResponse | null;
+}): React.JSX.Element | null => {
+  const hasContent =
+    history !== null && (history.practices.length > 0 || history.habits.length > 0);
+
+  if (loading) {
+    return (
+      <View style={styles.historyLoading} testID="history-loading">
+        <ActivityIndicator size="small" color="#fff" />
+      </View>
+    );
+  }
+  if (!hasContent) {
+    return (
+      <Text style={styles.historyEmpty} testID="history-empty">
+        Begin this stage to start tracking your journey
+      </Text>
+    );
+  }
+  return history !== null ? <HistoryContent history={history} /> : null;
+};
+
+interface StageHistorySectionProps {
+  stageNumber: number;
+  isUnlocked: boolean;
+}
+
+const StageHistorySection = ({
+  stageNumber,
+  isUnlocked,
+}: StageHistorySectionProps): React.JSX.Element | null => {
+  const [expanded, setExpanded] = useState(false);
+  const [history, setHistory] = useState<StageHistoryResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!expanded || !isUnlocked || history !== null) return;
+    setLoading(true);
+    stagesApi
+      .history(stageNumber)
+      .then(setHistory)
+      .catch(() => setHistory(null))
+      .finally(() => setLoading(false));
+  }, [expanded, stageNumber, isUnlocked, history]);
+
+  if (!isUnlocked) return null;
+
+  return (
+    <View style={styles.historySection} testID="history-section">
+      <TouchableOpacity
+        style={styles.historyHeader}
+        onPress={() => setExpanded((prev) => !prev)}
+        testID="history-toggle"
+      >
+        <Text style={styles.historyTitle}>Your Journey</Text>
+        <Text style={styles.historyToggle}>{expanded ? '▲' : '▼'}</Text>
+      </TouchableOpacity>
+      {expanded && <HistoryBody loading={loading} history={history} />}
+    </View>
+  );
+};
+
 interface ModalBodyProps {
   stage: StageData;
   onClose: () => void;
@@ -196,6 +345,7 @@ const ModalBody = ({ stage, onClose, onNavigate }: ModalBodyProps): React.JSX.El
     <Text style={styles.modalSubtitle}>{stage.subtitle}</Text>
     <StageProgressSection stage={stage} />
     <StageMetadataSection stage={stage} />
+    <StageHistorySection stageNumber={stage.stageNumber} isUnlocked={stage.isUnlocked} />
     <View style={styles.separator} />
     <ActionLinks stage={stage} onNavigate={onNavigate} />
   </ScrollView>

--- a/frontend/src/features/Map/__tests__/MapHistory.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapHistory.test.tsx
@@ -1,0 +1,229 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+import React from 'react';
+import { Image } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+// Mock navigation
+const mockNavigate = jest.fn();
+jest.mock('../../../navigation/hooks', () => ({
+  useAppNavigation: () => ({ navigate: mockNavigate }),
+}));
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: () => 0,
+}));
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+/** Inline type to avoid import/order conflict with type-only parent imports. */
+interface StageHistoryData {
+  stage_number: number;
+  practices: Array<{
+    name: string;
+    sessions_completed: number;
+    total_minutes: number;
+    last_session: string | null;
+  }>;
+  habits: Array<{
+    name: string;
+    icon: string;
+    goals_achieved: Record<string, boolean>;
+    best_streak: number;
+    total_completions: number;
+  }>;
+}
+
+// Mock API — must be declared before use in jest.mock factory
+const mockHistoryFn = jest.fn<Promise<StageHistoryData>, [number, string?]>();
+
+jest.mock('../../../api', () => ({
+  stages: {
+    history: (...args: [number, string?]) => mockHistoryFn(...args),
+  },
+}));
+
+function mockMakeStage(stageNumber: number, overrides: Partial<{ isUnlocked: boolean }> = {}) {
+  return {
+    id: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    stageNumber,
+    progress: 0,
+    color: '#aaa',
+    isUnlocked: overrides.isUnlocked ?? stageNumber <= 2,
+    category: 'Test',
+    aspect: 'Aspect',
+    spiralDynamicsColor: 'Beige',
+    growingUpStage: 'Growing',
+    divineGenderPolarity: 'Polarity',
+    relationshipToFreeWill: 'Free Will',
+    freeWillDescription: 'Description',
+    overviewUrl: '',
+    hotspots: [
+      { top: (10 - stageNumber) * 8 + 4, left: 4, width: 32, height: 6 },
+      { top: (10 - stageNumber) * 8 + 4, left: 34, width: 40, height: 6 },
+    ],
+  };
+}
+
+const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+
+const mockFetchStages = jest.fn();
+jest.mock('../../../store/useStageStore', () => ({
+  useStageStore: jest.fn((selector) => {
+    const mockState = {
+      stages: mockStages,
+      currentStage: 1,
+      loading: false,
+      error: null,
+      fetchStages: mockFetchStages,
+    };
+    return selector ? selector(mockState) : mockState;
+  }),
+}));
+
+import MapScreen from '../MapScreen';
+
+const HISTORY_WITH_DATA: StageHistoryData = {
+  stage_number: 1,
+  practices: [
+    {
+      name: 'Breath of Fire',
+      sessions_completed: 12,
+      total_minutes: 180,
+      last_session: '2026-03-15T10:30:00Z',
+    },
+  ],
+  habits: [
+    {
+      name: 'Morning Exercise',
+      icon: '🏃',
+      goals_achieved: { low: true, clear: true, stretch: false },
+      best_streak: 14,
+      total_completions: 45,
+    },
+  ],
+};
+
+const EMPTY_HISTORY: StageHistoryData = {
+  stage_number: 1,
+  practices: [],
+  habits: [],
+};
+
+describe('MapScreen — Stage History', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockFetchStages.mockClear();
+    mockHistoryFn.mockReset();
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('shows history section for unlocked stages', () => {
+    const tree = create(<MapScreen />);
+    // Open modal for stage 1 (unlocked)
+    act(() => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    const section = tree.root.findByProps({ testID: 'history-section' });
+    expect(section).toBeTruthy();
+  });
+
+  it('does not show history section for locked stages', () => {
+    const tree = create(<MapScreen />);
+    // Open modal for stage 3 (locked in our test data)
+    act(() => {
+      tree.root.findByProps({ testID: 'stage-hotspot-3-0' }).props.onPress();
+    });
+    const sections = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) => node.props.testID === 'history-section',
+    );
+    expect(sections.length).toBe(0);
+  });
+
+  it('shows empty state message for stages with no activity', async () => {
+    mockHistoryFn.mockResolvedValueOnce(EMPTY_HISTORY);
+    const tree = create(<MapScreen />);
+
+    // Open modal and expand history
+    await act(async () => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    await act(async () => {
+      tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
+    });
+
+    const empty = tree.root.findByProps({ testID: 'history-empty' });
+    expect(empty).toBeTruthy();
+    expect(empty.props.children).toContain('Begin this stage');
+  });
+
+  it('renders practice and habit history items when expanded', async () => {
+    mockHistoryFn.mockResolvedValueOnce(HISTORY_WITH_DATA);
+    const tree = create(<MapScreen />);
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    await act(async () => {
+      tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
+    });
+
+    const content = tree.root.findByProps({ testID: 'history-content' });
+    expect(content).toBeTruthy();
+
+    // Practice items — findAll may return duplicates from deep traversal
+    const practiceItems = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) => node.props.testID === 'practice-history-item',
+    );
+    expect(practiceItems.length).toBeGreaterThanOrEqual(1);
+
+    // Habit items
+    const habitItems = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) => node.props.testID === 'habit-history-item',
+    );
+    expect(habitItems.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders goal tier badges for habits', async () => {
+    mockHistoryFn.mockResolvedValueOnce(HISTORY_WITH_DATA);
+    const tree = create(<MapScreen />);
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    await act(async () => {
+      tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
+    });
+
+    // Should have 3 goal badges (low, clear, stretch)
+    const badges = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) =>
+        typeof node.props.testID === 'string' && node.props.testID.startsWith('goal-badge-'),
+    );
+    // Deep traversal may find duplicates; at minimum 3 unique tiers
+    expect(badges.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('lazy loads history data only when expanded', async () => {
+    mockHistoryFn.mockResolvedValueOnce(HISTORY_WITH_DATA);
+    const tree = create(<MapScreen />);
+
+    // Open modal — history API should NOT be called yet
+    await act(async () => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    expect(mockHistoryFn).not.toHaveBeenCalled();
+
+    // Expand history — NOW it should fetch
+    await act(async () => {
+      tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
+    });
+    expect(mockHistoryFn).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `GET /stages/{stage_number}/history` backend endpoint that aggregates practice sessions (count, total minutes, last session) and habit goal achievements (tier badges, best streak, total completions) per stage, auth-gated and user-isolated
- Add "Your Journey" collapsible section to the Map stage detail modal with lazy-loaded history data, goal tier badges (bronze/silver/gold), and empty state for unstarted stages
- Hidden for locked stages, fetched only when the user expands the section (not on Map mount)

## Changes

| File | Change |
|------|--------|
| `backend/src/schemas/stage.py` | Add `PracticeHistoryItem`, `HabitHistoryItem`, `StageHistoryResponse` schemas |
| `backend/src/domain/stage_progress.py` | Add `get_stage_practice_history()` and `get_stage_habit_history()` aggregation functions |
| `backend/src/routers/stages.py` | Add `GET /stages/{stage_number}/history` endpoint |
| `backend/tests/test_stages_history.py` | **New** — 6 tests (auth, 404, empty, practice aggregation, habit aggregation, user isolation) |
| `frontend/src/api/index.ts` | Add `stages.history()` client + TypeScript types |
| `frontend/src/features/Map/MapScreen.tsx` | Add `StageHistorySection`, `HistoryBody`, `HistoryContent`, `PracticeHistoryRow`, `HabitHistoryRow` components |
| `frontend/src/features/Map/Map.styles.ts` | Add history section styles |
| `frontend/src/features/Map/__tests__/MapHistory.test.tsx` | **New** — 6 tests (unlocked/locked visibility, empty state, content rendering, goal badges, lazy loading) |

## Acceptance Criteria

- [x] Map stage detail modal includes a "Your Journey" section
- [x] Past practices show session count and total time
- [x] Past habits show icon, name, best streak, and goal tier achievements
- [x] Data is loaded lazily when the modal opens (not on Map mount)
- [x] Empty state is shown for stages with no activity
- [x] Locked stages do not show a history section
- [x] Backend endpoint is auth-gated and returns only the requesting user's data

## Test Plan

- [x] 6 backend tests pass (auth, 404, empty history, practice aggregation, habit + goal tier aggregation, user isolation)
- [x] 6 frontend tests pass (unlocked visibility, locked hidden, empty state, content rendering, goal badges, lazy load verification)
- [x] All 20 existing Map tests still pass (no regressions)
- [x] Full backend suite: 286 passed, 93.14% coverage
- [x] All 23 pre-commit hooks pass green

https://claude.ai/code/session_01APV6cDR98kzC4k9YJpGrE9