### PR TITLE
feat(frontend): add victory color system to progress bars (phase-5-03)

### DIFF
--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -51,6 +51,9 @@ export const colors = {
 // Stage colors — maps stage name → hex color used across Habits and Map
 // ---------------------------------------------------------------------------
 
+/** Warm gold shown on progress bars when the user has met their clear goal. */
+export const VICTORY_COLOR = '#c9a44c';
+
 export const STAGE_COLORS: Record<string, string> = {
   Beige: '#d8cbb8',
   Purple: '#a093c6',

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, Easing, Text, TouchableOpacity, View, type DimensionValue } from 'react-native';
 
 import { STAGE_COLORS, spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
@@ -332,6 +332,62 @@ const LabelList = ({ markers, scale }: { markers: GoalMarkerEntry[]; scale: numb
   </>
 );
 
+const COLOR_TRANSITION_MS = 400;
+
+const useColorTransition = (color: string) => {
+  const fadeAnim = useRef(new Animated.Value(1)).current;
+  const prevColorRef = useRef(color);
+
+  useEffect(() => {
+    if (prevColorRef.current !== color) {
+      fadeAnim.setValue(0);
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: COLOR_TRANSITION_MS,
+        easing: Easing.linear,
+        useNativeDriver: false,
+      }).start(() => {
+        prevColorRef.current = color;
+      });
+    }
+  }, [color, fadeAnim]);
+
+  return { fadeAnim, prevColor: prevColorRef.current };
+};
+
+interface AnimatedFillProps {
+  width: DimensionValue;
+  color: string;
+  prevColor: string;
+  fadeAnim: Animated.Value;
+  borderRadius: number;
+}
+
+const AnimatedFill = ({ width, color, prevColor, fadeAnim, borderRadius }: AnimatedFillProps) => (
+  <>
+    <View
+      style={{
+        position: 'absolute',
+        height: '100%',
+        width,
+        backgroundColor: prevColor,
+        borderRadius,
+      }}
+    />
+    <Animated.View
+      testID="progress-fill"
+      style={{
+        position: 'absolute',
+        height: '100%',
+        width,
+        backgroundColor: color,
+        borderRadius,
+        opacity: fadeAnim,
+      }}
+    />
+  </>
+);
+
 const ProgressBar = ({
   habit,
   barHeight,
@@ -341,41 +397,45 @@ const ProgressBar = ({
   scale,
   tooltip,
   setTooltip,
-}: ProgressBarProps) => (
-  <View style={{ marginTop: spacing(1, scale) }}>
-    <View style={{ height: barHeight, position: 'relative' }}>
-      <View
-        style={{
-          height: '100%',
-          backgroundColor: '#eee',
-          borderRadius: barHeight / 2,
-          overflow: 'hidden',
-        }}
-      >
+}: ProgressBarProps) => {
+  const { fadeAnim, prevColor } = useColorTransition(progressBarColor);
+  const widthStyle: DimensionValue = `${progressPercentage}%`;
+  const borderR = barHeight / 2;
+
+  return (
+    <View style={{ marginTop: spacing(1, scale) }}>
+      <View style={{ height: barHeight, position: 'relative' }}>
         <View
-          testID="progress-fill"
           style={{
             height: '100%',
-            width: `${progressPercentage}%`,
-            backgroundColor: progressBarColor,
-            borderRadius: barHeight / 2,
+            backgroundColor: '#eee',
+            borderRadius: borderR,
+            overflow: 'hidden',
           }}
+        >
+          <AnimatedFill
+            width={widthStyle}
+            color={progressBarColor}
+            prevColor={prevColor}
+            fadeAnim={fadeAnim}
+            borderRadius={borderR}
+          />
+        </View>
+        <MarkerList
+          markers={markers}
+          habit={habit}
+          barHeight={barHeight}
+          scale={scale}
+          tooltip={tooltip}
+          setTooltip={setTooltip}
         />
       </View>
-      <MarkerList
-        markers={markers}
-        habit={habit}
-        barHeight={barHeight}
-        scale={scale}
-        tooltip={tooltip}
-        setTooltip={setTooltip}
-      />
+      <View style={{ position: 'relative', marginTop: spacing(0.5, scale) }}>
+        <LabelList markers={markers} scale={scale} />
+      </View>
     </View>
-    <View style={{ position: 'relative', marginTop: spacing(0.5, scale) }}>
-      <LabelList markers={markers} scale={scale} />
-    </View>
-  </View>
-);
+  );
+};
 
 const useHabitTileData = (habit: Habit) => {
   const lowGoal = habit.goals.find((g) => g.tier === 'low');

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import type { ApiHabitStats } from '../../api';
-import { colors, STAGE_COLORS, STAGE_ORDER } from '../../design/tokens';
+import { colors, STAGE_COLORS, STAGE_ORDER, VICTORY_COLOR } from '../../design/tokens';
 
 import type { Goal, Habit, Completion, HabitStatsData } from './Habits.types';
 
@@ -271,7 +271,24 @@ export const getProgressPercentage = (
 };
 
 export const getProgressBarColor = (habit: Habit): string => {
-  return STAGE_COLORS[habit.stage] ?? '#000';
+  const stageColor = STAGE_COLORS[habit.stage] ?? '#000';
+  const clearGoal = habit.goals.find((g) => g.tier === 'clear');
+
+  if (!clearGoal) return stageColor;
+
+  const progress = calculateHabitProgress(habit);
+
+  if (clearGoal.is_additive) {
+    return progress >= getGoalTarget(clearGoal) ? VICTORY_COLOR : stageColor;
+  }
+
+  // Subtractive: victory when staying at or under stretch target
+  const stretchGoal = habit.goals.find((g) => g.tier === 'stretch');
+  if (stretchGoal && progress <= getGoalTarget(stretchGoal)) {
+    return VICTORY_COLOR;
+  }
+
+  return stageColor;
 };
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest, describe, afterEach, it, expect } from '@jest/globals';
 
-import { STAGE_COLORS } from '../../../design/tokens';
+import { STAGE_COLORS, VICTORY_COLOR } from '../../../design/tokens';
 
 const renderer = require('react-test-renderer');
 
@@ -78,11 +78,14 @@ const assertTileLayout = (tile: any, height: number, expectedColumns: number): v
   expect(colorValues).toContain(style.borderColor);
 
   const fill = tile.findByProps({ testID: 'progress-fill' });
-  const fillStyle = Array.isArray(fill.props.style) ? fill.props.style[1] : fill.props.style;
+  const fillStyle = Array.isArray(fill.props.style)
+    ? Object.assign({}, ...fill.props.style)
+    : fill.props.style;
   const val = parseFloat(fillStyle.width);
   expect(val).toBeGreaterThanOrEqual(0);
   expect(val).toBeLessThanOrEqual(100);
-  expect(fillStyle.backgroundColor).toBe(style.borderColor);
+  const validBarColors = [...colorValues, VICTORY_COLOR];
+  expect(validBarColors).toContain(fillStyle.backgroundColor);
 };
 
 describe('HabitsScreen responsive layout', () => {

--- a/frontend/src/features/Habits/__tests__/HabitsScreen.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitsScreen.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { STAGE_COLORS } from '../../../design/tokens';
+import { STAGE_COLORS, VICTORY_COLOR } from '../../../design/tokens';
 import type { Habit, Goal } from '../Habits.types';
 import {
   calculateHabitProgress,
@@ -136,9 +136,43 @@ describe('habit progress utilities', () => {
     expect(percentage).toBeCloseTo(50);
   });
 
-  it('returns the stage color for progress bars', () => {
+  it('returns the stage color when goals are not met (additive)', () => {
     const habit: Habit = {
       id: 4,
+      stage: 'Blue',
+      name: 'Additive',
+      icon: '🔥',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: additiveGoals,
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 1 }],
+    };
+
+    expect(getProgressBarColor(habit)).toBe(STAGE_COLORS[habit.stage]);
+  });
+
+  it('returns victory color when clear goal is met (additive)', () => {
+    const habit: Habit = {
+      id: 5,
+      stage: 'Blue',
+      name: 'Additive',
+      icon: '🔥',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: additiveGoals,
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 2 }],
+    };
+
+    expect(getProgressBarColor(habit)).toBe(VICTORY_COLOR);
+  });
+
+  it('returns victory color when under stretch target (subtractive)', () => {
+    const habit: Habit = {
+      id: 6,
       stage: 'Blue',
       name: 'Subtractive',
       icon: '❄️',
@@ -147,6 +181,42 @@ describe('habit progress utilities', () => {
       energy_return: 0,
       start_date: new Date(),
       goals: subtractiveGoals,
+      completions: [],
+    };
+
+    // No completions = 0 progress, which is <= stretch target (0) → victory
+    expect(getProgressBarColor(habit)).toBe(VICTORY_COLOR);
+  });
+
+  it('returns stage color when stretch threshold is broken (subtractive)', () => {
+    const habit: Habit = {
+      id: 7,
+      stage: 'Blue',
+      name: 'Subtractive',
+      icon: '❄️',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: subtractiveGoals,
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 150 }],
+    };
+
+    // 150 > stretch target (0) → stage color
+    expect(getProgressBarColor(habit)).toBe(STAGE_COLORS[habit.stage]);
+  });
+
+  it('returns stage color for habit with no goals', () => {
+    const habit: Habit = {
+      id: 8,
+      stage: 'Green',
+      name: 'No Goals',
+      icon: '🌿',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: [],
       completions: [],
     };
 


### PR DESCRIPTION
## Summary

- Add `VICTORY_COLOR` (#c9a44c warm gold) to design tokens for goal-achieved state
- Refactor `getProgressBarColor()` to return victory color when clear goal is met (additive) or when staying under stretch target (subtractive)
- Add 400ms animated crossfade between stage color and victory color using `Animated.View` opacity transition
- Subtractive habits start in victory state (zero progress = winning)

## Acceptance Criteria

- [x] Progress bar is gold when clear goal met (additive)
- [x] Progress bar is gold when under stretch target (subtractive)
- [x] Progress bar is stage color when working toward goals
- [x] Color transitions are animated (400ms), not instant
- [x] Subtractive habits start with victory color
- [x] Subtractive habits revert to stage color when stretch threshold broken
- [x] Existing progress percentage calculations unchanged
- [x] All existing tests pass (413 total)

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/design/tokens.ts` | Add `VICTORY_COLOR` constant |
| `frontend/src/features/Habits/HabitUtils.ts` | Refactor `getProgressBarColor()` with goal-aware logic |
| `frontend/src/features/Habits/HabitTile.tsx` | Add `useColorTransition` hook and `AnimatedFill` component |
| `frontend/src/features/Habits/__tests__/HabitsScreen.test.ts` | Add 5 victory color tests |
| `frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx` | Update assertion for victory color support |

## Test Plan

- [x] All 24 pre-commit hooks pass green
- [x] 54/54 test suites pass, 413/413 tests pass
- [x] TypeScript strict mode passes
- [x] ESLint zero warnings
- [x] New tests cover: additive victory, subtractive victory, subtractive revert, no-goals fallback, stage color default

https://claude.ai/code/session_01JS1dCk5LvD1QuNsGpgbLfj