### PR TITLE
feat(full-stack): migrate journal tags from booleans to enum (phase-5-05)

### DIFF
--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -1,3 +1,4 @@
+import enum
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -5,6 +6,19 @@ from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
     from .user import User
+
+
+class JournalTag(str, enum.Enum):
+    """Extensible tag for journal entries.
+
+    Stored as a plain string column so new values can be added without
+    a database migration — the Python enum validates at the application layer.
+    """
+
+    FREEFORM = "freeform"
+    STAGE_REFLECTION = "stage_reflection"
+    PRACTICE_NOTE = "practice_note"
+    HABIT_NOTE = "habit_note"
 
 
 class JournalEntry(SQLModel, table=True):
@@ -18,9 +32,7 @@ class JournalEntry(SQLModel, table=True):
     message: str
     sender: str  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id")
-    is_stage_reflection: bool = False
-    is_practice_note: bool = False
-    is_habit_note: bool = False
+    tag: str = JournalTag.FREEFORM
     practice_session_id: int | None = Field(default=None, foreign_key="practicesession.id")
     user_practice_id: int | None = Field(default=None, foreign_key="userpractice.id")
     user: "User" = Relationship(back_populates="journals")

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -10,8 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
-from errors import bad_request, not_found
-from models.journal_entry import JournalEntry
+from errors import not_found
+from models.journal_entry import JournalEntry, JournalTag
 from routers.auth import get_current_user
 from schemas.journal import (
     JournalBotMessageCreate,
@@ -22,21 +22,13 @@ from schemas.journal import (
 
 router = APIRouter(prefix="/journal", tags=["journal"])
 
-_VALID_TAGS = {"stage_reflection", "practice_note", "habit_note"}
-
-_TAG_TO_FIELD = {
-    "stage_reflection": JournalEntry.is_stage_reflection,
-    "practice_note": JournalEntry.is_practice_note,
-    "habit_note": JournalEntry.is_habit_note,
-}
-
 
 @dataclass
 class _ListFilters:
     """Query parameters for listing journal entries."""
 
     search: str | None = Query(default=None)
-    tag: str | None = Query(default=None)
+    tag: JournalTag | None = None
     practice_session_id: int | None = Query(default=None)
     limit: int = Query(default=50, ge=1, le=200)
     offset: int = Query(default=0, ge=0)
@@ -62,7 +54,7 @@ def _build_filter_conditions(filters: _ListFilters) -> list[ColumnElement[bool]]
     if filters.search is not None:
         conditions.append(col(JournalEntry.message).ilike(f"%{filters.search}%"))
     if filters.tag is not None:
-        conditions.append(col(_TAG_TO_FIELD[filters.tag]).is_(True))
+        conditions.append(col(JournalEntry.tag) == filters.tag.value)
     if filters.practice_session_id is not None:
         conditions.append(col(JournalEntry.practice_session_id) == filters.practice_session_id)
     return conditions
@@ -75,9 +67,6 @@ async def list_journal_entries(
     filters: _ListFilters = Depends(),  # noqa: B008
 ) -> JournalListResponse:
     """List journal entries for the current user with optional filtering."""
-    if filters.tag is not None and filters.tag not in _VALID_TAGS:
-        raise bad_request("invalid_tag")
-
     conditions = _build_filter_conditions(filters)
     query = select(JournalEntry).where(JournalEntry.user_id == current_user, *conditions)
 

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -13,7 +13,7 @@ from sqlmodel import col, select
 from database import get_session
 from domain.weekly_prompts import TOTAL_WEEKS, get_prompt_for_week
 from errors import bad_request, not_found
-from models.journal_entry import JournalEntry
+from models.journal_entry import JournalEntry, JournalTag
 from models.prompt_response import PromptResponse
 from models.stage_progress import StageProgress
 from models.user import User
@@ -190,7 +190,7 @@ async def submit_prompt_response(
         message=payload.response,
         sender="user",
         user_id=current_user,
-        is_stage_reflection=True,
+        tag=JournalTag.STAGE_REFLECTION,
     )
     session.add(journal_entry)
 

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+from models.journal_entry import JournalTag
+
 
 class JournalMessageCreate(BaseModel):
     """Payload for creating a user journal message.
@@ -15,9 +17,7 @@ class JournalMessageCreate(BaseModel):
     """
 
     message: str
-    is_stage_reflection: bool = False
-    is_practice_note: bool = False
-    is_habit_note: bool = False
+    tag: JournalTag = JournalTag.FREEFORM
     practice_session_id: int | None = None
     user_practice_id: int | None = None
 
@@ -27,9 +27,7 @@ class JournalBotMessageCreate(BaseModel):
 
     message: str
     user_id: int
-    is_stage_reflection: bool = False
-    is_practice_note: bool = False
-    is_habit_note: bool = False
+    tag: JournalTag = JournalTag.FREEFORM
     practice_session_id: int | None = None
     user_practice_id: int | None = None
 
@@ -42,9 +40,7 @@ class JournalMessageResponse(BaseModel):
     sender: str
     user_id: int
     timestamp: datetime
-    is_stage_reflection: bool
-    is_practice_note: bool
-    is_habit_note: bool
+    tag: str
     practice_session_id: int | None
     user_practice_id: int | None
 

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -57,22 +57,55 @@ async def test_create_journal_entry(async_client: AsyncClient) -> None:
     assert data["sender"] == "user"
     assert data["id"] is not None
     assert data["timestamp"] is not None
-    assert data["is_stage_reflection"] is False
+    assert data["tag"] == "freeform"
 
 
 @pytest.mark.asyncio
-async def test_create_journal_entry_with_tags(async_client: AsyncClient) -> None:
+async def test_create_journal_entry_with_tag(async_client: AsyncClient) -> None:
     headers = await _signup(async_client)
     resp = await async_client.post(
         "/journal/",
-        json=_message_payload(is_stage_reflection=True, is_habit_note=True),
+        json=_message_payload(tag="stage_reflection"),
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.CREATED
     data = resp.json()
-    assert data["is_stage_reflection"] is True
-    assert data["is_habit_note"] is True
-    assert data["is_practice_note"] is False
+    assert data["tag"] == "stage_reflection"
+
+
+@pytest.mark.asyncio
+async def test_create_journal_entry_with_practice_note_tag(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/journal/",
+        json=_message_payload(tag="practice_note"),
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["tag"] == "practice_note"
+
+
+@pytest.mark.asyncio
+async def test_create_journal_entry_with_habit_note_tag(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/journal/",
+        json=_message_payload(tag="habit_note"),
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["tag"] == "habit_note"
+
+
+@pytest.mark.asyncio
+async def test_create_journal_entry_invalid_tag_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/journal/",
+        json=_message_payload(tag="nonexistent"),
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
@@ -223,7 +256,7 @@ async def test_filter_by_tag_stage_reflection(async_client: AsyncClient) -> None
     headers = await _signup(async_client)
     await async_client.post(
         "/journal/",
-        json=_message_payload(message="Reflection on stage 2", is_stage_reflection=True),
+        json=_message_payload(message="Reflection on stage 2", tag="stage_reflection"),
         headers=headers,
     )
     await async_client.post(
@@ -233,7 +266,7 @@ async def test_filter_by_tag_stage_reflection(async_client: AsyncClient) -> None
     resp = await async_client.get("/journal/?tag=stage_reflection", headers=headers)
     data = resp.json()
     assert data["total"] == 1
-    assert data["items"][0]["is_stage_reflection"] is True
+    assert data["items"][0]["tag"] == "stage_reflection"
 
 
 @pytest.mark.asyncio
@@ -241,7 +274,7 @@ async def test_filter_by_tag_practice_note(async_client: AsyncClient) -> None:
     headers = await _signup(async_client)
     await async_client.post(
         "/journal/",
-        json=_message_payload(message="Practice went great", is_practice_note=True),
+        json=_message_payload(message="Practice went great", tag="practice_note"),
         headers=headers,
     )
     await async_client.post(
@@ -251,7 +284,7 @@ async def test_filter_by_tag_practice_note(async_client: AsyncClient) -> None:
     resp = await async_client.get("/journal/?tag=practice_note", headers=headers)
     data = resp.json()
     assert data["total"] == 1
-    assert data["items"][0]["is_practice_note"] is True
+    assert data["items"][0]["tag"] == "practice_note"
 
 
 @pytest.mark.asyncio
@@ -259,7 +292,7 @@ async def test_filter_by_tag_habit_note(async_client: AsyncClient) -> None:
     headers = await _signup(async_client)
     await async_client.post(
         "/journal/",
-        json=_message_payload(message="Habit streak broken", is_habit_note=True),
+        json=_message_payload(message="Habit streak broken", tag="habit_note"),
         headers=headers,
     )
 
@@ -269,10 +302,28 @@ async def test_filter_by_tag_habit_note(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_filter_by_invalid_tag_returns_400(async_client: AsyncClient) -> None:
+async def test_filter_by_tag_freeform(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    await async_client.post(
+        "/journal/", json=_message_payload(message="Freeform entry"), headers=headers
+    )
+    await async_client.post(
+        "/journal/",
+        json=_message_payload(message="Tagged entry", tag="habit_note"),
+        headers=headers,
+    )
+
+    resp = await async_client.get("/journal/?tag=freeform", headers=headers)
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["tag"] == "freeform"
+
+
+@pytest.mark.asyncio
+async def test_filter_by_invalid_tag_returns_422(async_client: AsyncClient) -> None:
     headers = await _signup(async_client)
     resp = await async_client.get("/journal/?tag=nonexistent", headers=headers)
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 # ── Practice session filtering ───────────────────────────────────────────

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -156,7 +156,7 @@ async def test_submit_response_invalid_week_returns_404(async_client: AsyncClien
 
 @pytest.mark.asyncio
 async def test_submit_response_creates_journal_entry(async_client: AsyncClient) -> None:
-    """Submitting a prompt response also creates a journal entry with is_stage_reflection."""
+    """Submitting a prompt response also creates a journal entry with stage_reflection tag."""
     headers = await _signup(async_client)
     await async_client.post(
         "/prompts/1/respond",
@@ -171,7 +171,7 @@ async def test_submit_response_creates_journal_entry(async_client: AsyncClient) 
     assert journal_data["total"] == 1
     entry = journal_data["items"][0]
     assert entry["message"] == "I reflected on grounding."
-    assert entry["is_stage_reflection"] is True
+    assert entry["tag"] == "stage_reflection"
     assert entry["sender"] == "user"
 
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -304,11 +304,11 @@ export const goalGroups = {
 };
 
 // Journal types and client
+export type JournalTag = 'freeform' | 'stage_reflection' | 'practice_note' | 'habit_note';
+
 export interface JournalMessageCreate {
   message: string;
-  is_stage_reflection?: boolean;
-  is_practice_note?: boolean;
-  is_habit_note?: boolean;
+  tag?: JournalTag;
   practice_session_id?: number | null;
   user_practice_id?: number | null;
 }
@@ -319,9 +319,7 @@ export interface JournalMessage {
   sender: 'user' | 'bot';
   user_id: number;
   timestamp: string;
-  is_stage_reflection: boolean;
-  is_practice_note: boolean;
-  is_habit_note: boolean;
+  tag: JournalTag;
   practice_session_id: number | null;
   user_practice_id: number | null;
 }

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -210,7 +210,7 @@ function useCourseViewer(selectedStage: number) {
   const handleReflect = useCallback(() => {
     if (!viewingItem) return;
     navigation.navigate('Journal', {
-      stageReflection: true,
+      tag: 'stage_reflection',
       stageNumber: selectedStage,
       contentTitle: viewingItem.title,
     });

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -294,7 +294,7 @@ describe('CourseScreen', () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith('Journal', {
-      stageReflection: true,
+      tag: 'stage_reflection',
       stageNumber: 2,
       contentTitle: 'Welcome Essay',
     });

--- a/frontend/src/features/Journal/ChatInput.tsx
+++ b/frontend/src/features/Journal/ChatInput.tsx
@@ -1,49 +1,44 @@
 import React, { useCallback, useState } from 'react';
 import { Text, TextInput, TouchableOpacity, View } from 'react-native';
 
+import type { JournalTag } from '../../api';
+
 import styles from './Journal.styles';
 
-export interface MessageTags {
-  is_stage_reflection: boolean;
-  is_practice_note: boolean;
-  is_habit_note: boolean;
-}
-
-const DEFAULT_TAGS: MessageTags = {
-  is_stage_reflection: false,
-  is_practice_note: false,
-  is_habit_note: false,
-};
-
-const TAG_OPTIONS: Array<{ key: keyof MessageTags; label: string }> = [
-  { key: 'is_stage_reflection', label: 'Reflection' },
-  { key: 'is_practice_note', label: 'Practice' },
-  { key: 'is_habit_note', label: 'Habit' },
+const TAG_OPTIONS: Array<{ value: JournalTag; label: string }> = [
+  { value: 'stage_reflection', label: 'Reflection' },
+  { value: 'practice_note', label: 'Practice' },
+  { value: 'habit_note', label: 'Habit' },
 ];
 
 interface ChatInputProps {
-  onSend: (_text: string, _tags?: MessageTags) => void;
+  onSend: (_text: string, _tag?: JournalTag) => void;
   disabled?: boolean;
-  initialTags?: MessageTags;
+  initialTag?: JournalTag;
 }
 
 interface TagPickerProps {
-  tags: MessageTags;
-  onToggleTag: (_key: keyof MessageTags) => void;
+  activeTag: JournalTag | undefined;
+  onSelectTag: (_tag: JournalTag | undefined) => void;
 }
 
-const TagPicker = ({ tags, onToggleTag }: TagPickerProps): React.JSX.Element => (
+const TagPicker = ({ activeTag, onSelectTag }: TagPickerProps): React.JSX.Element => (
   <View style={styles.tagPickerContainer} testID="tag-picker">
-    {TAG_OPTIONS.map(({ key, label }) => (
-      <TouchableOpacity
-        key={key}
-        testID={`tag-option-${key}`}
-        style={[styles.tagPickerOption, tags[key] && styles.tagPickerOptionActive]}
-        onPress={() => onToggleTag(key)}
-      >
-        <Text style={[styles.tagPickerText, tags[key] && styles.tagPickerTextActive]}>{label}</Text>
-      </TouchableOpacity>
-    ))}
+    {TAG_OPTIONS.map(({ value, label }) => {
+      const isActive = activeTag === value;
+      return (
+        <TouchableOpacity
+          key={value}
+          testID={`tag-option-${value}`}
+          style={[styles.tagPickerOption, isActive && styles.tagPickerOptionActive]}
+          onPress={() => onSelectTag(isActive ? undefined : value)}
+        >
+          <Text style={[styles.tagPickerText, isActive && styles.tagPickerTextActive]}>
+            {label}
+          </Text>
+        </TouchableOpacity>
+      );
+    })}
   </View>
 );
 
@@ -53,7 +48,7 @@ interface InputRowProps {
   disabled: boolean;
   canSend: boolean;
   onSend: () => void;
-  hasActiveTags: boolean;
+  hasActiveTag: boolean;
   onToggleTagPicker: () => void;
 }
 
@@ -63,7 +58,7 @@ const InputRow = ({
   disabled,
   canSend,
   onSend,
-  hasActiveTags,
+  hasActiveTag,
   onToggleTagPicker,
 }: InputRowProps): React.JSX.Element => (
   <View style={styles.inputContainer}>
@@ -79,7 +74,7 @@ const InputRow = ({
     />
     <TouchableOpacity
       testID="tag-toggle"
-      style={[styles.tagToggleButton, hasActiveTags && styles.tagToggleButtonActive]}
+      style={[styles.tagToggleButton, hasActiveTag && styles.tagToggleButtonActive]}
       onPress={onToggleTagPicker}
       accessibilityLabel="Toggle tag picker"
     >
@@ -97,29 +92,19 @@ const InputRow = ({
   </View>
 );
 
-const ChatInput = ({
-  onSend,
-  disabled = false,
-  initialTags,
-}: ChatInputProps): React.JSX.Element => {
+const ChatInput = ({ onSend, disabled = false, initialTag }: ChatInputProps): React.JSX.Element => {
   const [text, setText] = useState('');
-  const [tags, setTags] = useState<MessageTags>(initialTags ?? DEFAULT_TAGS);
+  const [selectedTag, setSelectedTag] = useState<JournalTag | undefined>(initialTag);
   const [showTagPicker, setShowTagPicker] = useState(false);
-
-  const hasActiveTags = tags.is_stage_reflection || tags.is_practice_note || tags.is_habit_note;
 
   const handleSend = useCallback(() => {
     const trimmed = text.trim();
     if (trimmed.length === 0) return;
-    onSend(trimmed, hasActiveTags ? tags : undefined);
+    onSend(trimmed, selectedTag);
     setText('');
-    setTags(DEFAULT_TAGS);
+    setSelectedTag(initialTag);
     setShowTagPicker(false);
-  }, [text, onSend, tags, hasActiveTags]);
-
-  const toggleTag = useCallback((key: keyof MessageTags) => {
-    setTags((prev) => ({ ...prev, [key]: !prev[key] }));
-  }, []);
+  }, [text, onSend, selectedTag, initialTag]);
 
   const toggleTagPicker = useCallback(() => {
     setShowTagPicker((prev) => !prev);
@@ -129,14 +114,14 @@ const ChatInput = ({
 
   return (
     <View>
-      {showTagPicker && <TagPicker tags={tags} onToggleTag={toggleTag} />}
+      {showTagPicker && <TagPicker activeTag={selectedTag} onSelectTag={setSelectedTag} />}
       <InputRow
         text={text}
         onChangeText={setText}
         disabled={disabled}
         canSend={canSend}
         onSend={handleSend}
-        hasActiveTags={hasActiveTags}
+        hasActiveTag={selectedTag !== undefined}
         onToggleTagPicker={toggleTagPicker}
       />
     </View>

--- a/frontend/src/features/Journal/JournalScreen.tsx
+++ b/frontend/src/features/Journal/JournalScreen.tsx
@@ -7,16 +7,17 @@ import {
   journal as journalApi,
   prompts as promptsApi,
   type JournalMessage,
+  type JournalTag,
   type PromptDetail,
   ApiError,
 } from '../../api';
 import { useAppRoute } from '../../navigation/hooks';
 
-import ChatInput, { type MessageTags } from './ChatInput';
+import ChatInput from './ChatInput';
 import styles from './Journal.styles';
 import MessageBubble from './MessageBubble';
 import SearchBar from './SearchBar';
-import TagFilter, { type JournalTag } from './TagFilter';
+import TagFilter from './TagFilter';
 import WeeklyPromptBanner from './WeeklyPromptBanner';
 
 const PAGE_SIZE = 50;
@@ -230,11 +231,11 @@ function useFreeformSend(
   removeOptimistic: (_id: number) => void,
 ) {
   return useCallback(
-    async (text: string, mergedTags: MessageTags, optimisticId: number) => {
+    async (text: string, tag: JournalTag, optimisticId: number) => {
       try {
         const created = await journalApi.create({
           message: text,
-          ...mergedTags,
+          tag,
           practice_session_id: practiceSessionId,
           user_practice_id: userPracticeId,
         });
@@ -254,12 +255,12 @@ function useBotSend(
   loadMessages: (_offset?: number) => Promise<void>,
   setOfferingBalance: (_b: number) => void,
   removeOptimistic: (_id: number) => void,
-  sendFreeform: (_text: string, _tags: MessageTags, _id: number) => Promise<void>,
+  sendFreeform: (_text: string, _tag: JournalTag, _id: number) => Promise<void>,
 ) {
   const [awaitingBot, setAwaitingBot] = useState(false);
 
   const sendWithBot = useCallback(
-    async (text: string, mergedTags: MessageTags, optimisticId: number) => {
+    async (text: string, tag: JournalTag, optimisticId: number) => {
       try {
         setAwaitingBot(true);
         const chatResult = await botmasonApi.chat({ message: text });
@@ -268,7 +269,7 @@ function useBotSend(
       } catch (err) {
         if (err instanceof ApiError && err.status === 402) {
           setOfferingBalance(0);
-          await sendFreeform(text, mergedTags, optimisticId);
+          await sendFreeform(text, tag, optimisticId);
         } else {
           console.error('BotMason chat failed:', err);
           removeOptimistic(optimisticId);
@@ -285,21 +286,16 @@ function useBotSend(
 
 // --- Pure helpers ---
 
-function buildMergedTags(
-  tags: MessageTags | undefined,
-  isCourseReflection: boolean,
-  isPracticeReflection: boolean,
-): MessageTags {
-  return {
-    is_stage_reflection: isCourseReflection || (tags?.is_stage_reflection ?? false),
-    is_practice_note: isPracticeReflection || (tags?.is_practice_note ?? false),
-    is_habit_note: tags?.is_habit_note ?? false,
-  };
+function resolveTag(
+  userTag: JournalTag | undefined,
+  contextTag: JournalTag | undefined,
+): JournalTag {
+  return contextTag ?? userTag ?? 'freeform';
 }
 
 function buildOptimisticMessage(
   text: string,
-  mergedTags: MessageTags,
+  tag: JournalTag,
   practiceSessionId: number | null,
   userPracticeId: number | null,
 ): JournalMessage {
@@ -309,9 +305,7 @@ function buildOptimisticMessage(
     sender: 'user',
     user_id: 0,
     timestamp: new Date().toISOString(),
-    is_stage_reflection: mergedTags.is_stage_reflection,
-    is_practice_note: mergedTags.is_practice_note,
-    is_habit_note: mergedTags.is_habit_note,
+    tag,
     practice_session_id: practiceSessionId,
     user_practice_id: userPracticeId,
   };
@@ -417,6 +411,7 @@ interface JournalRouteParams {
   isCourseReflection: boolean;
   stageNumber: number | null;
   contentTitle: string | null;
+  contextTag: JournalTag | undefined;
 }
 
 type JournalParams = NonNullable<ReturnType<typeof useAppRoute<'Journal'>>['params']>;
@@ -430,21 +425,27 @@ const DEFAULT_ROUTE_PARAMS: JournalRouteParams = {
   isCourseReflection: false,
   stageNumber: null,
   contentTitle: null,
+  contextTag: undefined,
 };
 
 function extractFromParams(p: JournalParams): JournalRouteParams {
   const practiceSessionId = p.practiceSessionId ?? null;
   const contentTitle = p.contentTitle ?? null;
+  const tag = p.tag;
+
+  const isCourseReflection = tag === 'stage_reflection' && contentTitle !== null;
+  const isPracticeReflection = practiceSessionId !== null;
 
   return {
     practiceSessionId,
     userPracticeId: p.userPracticeId ?? null,
     practiceName: p.practiceName ?? null,
     practiceDuration: p.practiceDuration ?? null,
-    isPracticeReflection: practiceSessionId !== null,
-    isCourseReflection: (p.stageReflection ?? false) && contentTitle !== null,
+    isPracticeReflection,
+    isCourseReflection,
     stageNumber: p.stageNumber ?? null,
     contentTitle,
+    contextTag: tag,
   };
 }
 
@@ -504,27 +505,22 @@ function useJournalSend(
   rp: JournalRouteParams,
   offeringBalance: number | null,
   prependMessage: (_msg: JournalMessage) => void,
-  sendWithBot: (_text: string, _tags: MessageTags, _id: number) => Promise<void>,
-  sendFreeform: (_text: string, _tags: MessageTags, _id: number) => Promise<void>,
+  sendWithBot: (_text: string, _tag: JournalTag, _id: number) => Promise<void>,
+  sendFreeform: (_text: string, _tag: JournalTag, _id: number) => Promise<void>,
 ) {
   const [sending, setSending] = useState(false);
 
   const handleSend = useCallback(
-    async (text: string, tags?: MessageTags) => {
+    async (text: string, userTag?: JournalTag) => {
       setSending(true);
-      const mergedTags = buildMergedTags(tags, rp.isCourseReflection, rp.isPracticeReflection);
-      const optimistic = buildOptimisticMessage(
-        text,
-        mergedTags,
-        rp.practiceSessionId,
-        rp.userPracticeId,
-      );
+      const tag = resolveTag(userTag, rp.contextTag);
+      const optimistic = buildOptimisticMessage(text, tag, rp.practiceSessionId, rp.userPracticeId);
       prependMessage(optimistic);
       const hasBalance = offeringBalance !== null && offeringBalance > 0;
       if (hasBalance) {
-        await sendWithBot(text, mergedTags, optimistic.id);
+        await sendWithBot(text, tag, optimistic.id);
       } else {
-        await sendFreeform(text, mergedTags, optimistic.id);
+        await sendFreeform(text, tag, optimistic.id);
       }
       setSending(false);
     },
@@ -590,26 +586,6 @@ const TypingIndicator = ({ visible }: { visible: boolean }): React.JSX.Element |
   );
 };
 
-const PRACTICE_INITIAL_TAGS: MessageTags = {
-  is_stage_reflection: false,
-  is_practice_note: true,
-  is_habit_note: false,
-};
-
-const COURSE_INITIAL_TAGS: MessageTags = {
-  is_stage_reflection: true,
-  is_practice_note: false,
-  is_habit_note: false,
-};
-
-// --- Helper: resolve initial tags ---
-
-function resolveInitialTags(rp: JournalRouteParams): MessageTags | undefined {
-  if (rp.isCourseReflection) return COURSE_INITIAL_TAGS;
-  if (rp.isPracticeReflection) return PRACTICE_INITIAL_TAGS;
-  return undefined;
-}
-
 // --- Main component ---
 
 const JournalScreen = (): React.JSX.Element => {
@@ -650,7 +626,7 @@ const JournalScreen = (): React.JSX.Element => {
         onLoadMore={j.loader.handleLoadMore}
       />
       <TypingIndicator visible={j.awaitingBot} />
-      <ChatInput onSend={j.handleSend} disabled={j.sending} initialTags={resolveInitialTags(rp)} />
+      <ChatInput onSend={j.handleSend} disabled={j.sending} initialTag={rp.contextTag} />
     </SafeAreaView>
   );
 };

--- a/frontend/src/features/Journal/MessageBubble.tsx
+++ b/frontend/src/features/Journal/MessageBubble.tsx
@@ -11,14 +11,6 @@ const TAG_LABELS: Record<string, string> = {
   habit_note: 'Habit',
 };
 
-function getTags(message: JournalMessage): string[] {
-  const tags: string[] = [];
-  if (message.is_stage_reflection) tags.push('stage_reflection');
-  if (message.is_practice_note) tags.push('practice_note');
-  if (message.is_habit_note) tags.push('habit_note');
-  return tags;
-}
-
 function formatTimestamp(iso: string): string {
   const date = new Date(iso);
   return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
@@ -30,7 +22,7 @@ interface MessageBubbleProps {
 
 const MessageBubble = ({ message }: MessageBubbleProps): React.JSX.Element => {
   const isUser = message.sender === 'user';
-  const tags = getTags(message);
+  const tagLabel = TAG_LABELS[message.tag];
 
   return (
     <View style={[styles.bubbleRow, isUser ? styles.bubbleRowUser : styles.bubbleRowBot]}>
@@ -43,18 +35,18 @@ const MessageBubble = ({ message }: MessageBubbleProps): React.JSX.Element => {
         <Text style={[styles.bubbleText, isUser ? styles.bubbleTextUser : styles.bubbleTextBot]}>
           {message.message}
         </Text>
-        {(tags.length > 0 || message.practice_session_id !== null) && (
+        {(tagLabel !== undefined || message.practice_session_id !== null) && (
           <View style={styles.tagRow}>
             {message.practice_session_id !== null && (
               <View style={styles.tag} testID="practice-session-badge">
                 <Text style={styles.tagText}>Practice Session</Text>
               </View>
             )}
-            {tags.map((tag) => (
-              <View key={tag} style={styles.tag}>
-                <Text style={styles.tagText}>{TAG_LABELS[tag]}</Text>
+            {tagLabel !== undefined && (
+              <View style={styles.tag}>
+                <Text style={styles.tagText}>{tagLabel}</Text>
               </View>
-            ))}
+            )}
           </View>
         )}
         <Text style={[styles.timestamp, isUser ? styles.timestampUser : styles.timestampBot]}>

--- a/frontend/src/features/Journal/TagFilter.tsx
+++ b/frontend/src/features/Journal/TagFilter.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 
-import styles from './Journal.styles';
+import type { JournalTag } from '../../api';
 
-export type JournalTag = 'stage_reflection' | 'practice_note' | 'habit_note';
+import styles from './Journal.styles';
 
 interface TagChip {
   label: string;
@@ -12,6 +12,7 @@ interface TagChip {
 
 const TAG_CHIPS: TagChip[] = [
   { label: 'All', value: null },
+  { label: 'Freeform', value: 'freeform' },
   { label: 'Reflections', value: 'stage_reflection' },
   { label: 'Practice Notes', value: 'practice_note' },
   { label: 'Habit Notes', value: 'habit_note' },

--- a/frontend/src/features/Journal/__tests__/ChatInput.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ChatInput.test.tsx
@@ -18,7 +18,7 @@ describe('ChatInput', () => {
     expect(getByTestId('send-button')).toBeTruthy();
   });
 
-  it('calls onSend with trimmed text and clears input', () => {
+  it('calls onSend with trimmed text and no tag when none selected', () => {
     const { getByTestId } = render(<ChatInput onSend={onSend} />);
     const input = getByTestId('chat-input');
     const sendBtn = getByTestId('send-button');
@@ -70,34 +70,44 @@ describe('ChatInput', () => {
     fireEvent.press(getByTestId('tag-toggle'));
 
     expect(getByTestId('tag-picker')).toBeTruthy();
-    expect(getByTestId('tag-option-is_stage_reflection')).toBeTruthy();
-    expect(getByTestId('tag-option-is_practice_note')).toBeTruthy();
-    expect(getByTestId('tag-option-is_habit_note')).toBeTruthy();
+    expect(getByTestId('tag-option-stage_reflection')).toBeTruthy();
+    expect(getByTestId('tag-option-practice_note')).toBeTruthy();
+    expect(getByTestId('tag-option-habit_note')).toBeTruthy();
   });
 
-  it('sends tags with message when tags are selected', () => {
+  it('sends tag with message when a tag is selected', () => {
     const { getByTestId } = render(<ChatInput onSend={onSend} />);
 
     // Open tag picker and select a tag
     fireEvent.press(getByTestId('tag-toggle'));
-    fireEvent.press(getByTestId('tag-option-is_stage_reflection'));
+    fireEvent.press(getByTestId('tag-option-stage_reflection'));
 
     // Type and send
     fireEvent.changeText(getByTestId('chat-input'), 'Tagged message');
     fireEvent.press(getByTestId('send-button'));
 
-    expect(onSend).toHaveBeenCalledWith('Tagged message', {
-      is_stage_reflection: true,
-      is_practice_note: false,
-      is_habit_note: false,
-    });
+    expect(onSend).toHaveBeenCalledWith('Tagged message', 'stage_reflection');
   });
 
-  it('resets tags after sending', () => {
+  it('deselects tag when same tag is pressed again', () => {
+    const { getByTestId } = render(<ChatInput onSend={onSend} />);
+
+    fireEvent.press(getByTestId('tag-toggle'));
+    fireEvent.press(getByTestId('tag-option-stage_reflection'));
+    // Press again to deselect
+    fireEvent.press(getByTestId('tag-option-stage_reflection'));
+
+    fireEvent.changeText(getByTestId('chat-input'), 'No tag');
+    fireEvent.press(getByTestId('send-button'));
+
+    expect(onSend).toHaveBeenCalledWith('No tag', undefined);
+  });
+
+  it('resets tag after sending', () => {
     const { getByTestId, queryByTestId } = render(<ChatInput onSend={onSend} />);
 
     fireEvent.press(getByTestId('tag-toggle'));
-    fireEvent.press(getByTestId('tag-option-is_habit_note'));
+    fireEvent.press(getByTestId('tag-option-habit_note'));
     fireEvent.changeText(getByTestId('chat-input'), 'Test');
     fireEvent.press(getByTestId('send-button'));
 
@@ -105,22 +115,12 @@ describe('ChatInput', () => {
     expect(queryByTestId('tag-picker')).toBeNull();
   });
 
-  it('uses initialTags when provided', () => {
-    const initialTags = {
-      is_stage_reflection: false,
-      is_practice_note: true,
-      is_habit_note: false,
-    };
-
-    const { getByTestId } = render(<ChatInput onSend={onSend} initialTags={initialTags} />);
+  it('uses initialTag when provided', () => {
+    const { getByTestId } = render(<ChatInput onSend={onSend} initialTag="practice_note" />);
 
     fireEvent.changeText(getByTestId('chat-input'), 'Practice reflection');
     fireEvent.press(getByTestId('send-button'));
 
-    expect(onSend).toHaveBeenCalledWith('Practice reflection', {
-      is_stage_reflection: false,
-      is_practice_note: true,
-      is_habit_note: false,
-    });
+    expect(onSend).toHaveBeenCalledWith('Practice reflection', 'practice_note');
   });
 });

--- a/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
@@ -11,9 +11,7 @@ const sampleMessages: JournalMessage[] = [
     sender: 'bot',
     user_id: 1,
     timestamp: '2026-01-15T10:31:00Z',
-    is_stage_reflection: false,
-    is_practice_note: false,
-    is_habit_note: false,
+    tag: 'freeform',
     practice_session_id: null,
     user_practice_id: null,
   },
@@ -23,9 +21,7 @@ const sampleMessages: JournalMessage[] = [
     sender: 'user',
     user_id: 1,
     timestamp: '2026-01-15T10:30:00Z',
-    is_stage_reflection: true,
-    is_practice_note: false,
-    is_habit_note: false,
+    tag: 'stage_reflection',
     practice_session_id: null,
     user_practice_id: null,
   },
@@ -46,16 +42,14 @@ const mockJournalList = (jest.fn() as any).mockResolvedValue({
 });
 
 const mockJournalCreate = (jest.fn() as any).mockImplementation(
-  (payload: { message: string; is_stage_reflection?: boolean }) =>
+  (payload: { message: string; tag?: string }) =>
     Promise.resolve({
       id: 99,
       message: payload.message,
       sender: 'user',
       user_id: 1,
       timestamp: new Date().toISOString(),
-      is_stage_reflection: payload.is_stage_reflection ?? false,
-      is_practice_note: false,
-      is_habit_note: false,
+      tag: payload.tag ?? 'freeform',
       practice_session_id: null,
       user_practice_id: null,
     }),
@@ -228,16 +222,14 @@ describe('JournalScreen', () => {
 
     expect(mockJournalCreate).toHaveBeenCalledWith({
       message: 'Freeform thought',
-      is_stage_reflection: false,
-      is_practice_note: false,
-      is_habit_note: false,
+      tag: 'freeform',
       practice_session_id: null,
       user_practice_id: null,
     });
     expect(mockBotmasonChat).not.toHaveBeenCalled();
   });
 
-  it('sends a message with tags when tags are selected', async () => {
+  it('sends a message with tag when a tag is selected', async () => {
     mockBotmasonGetBalance.mockResolvedValue({ balance: 0 });
     const { getByTestId, getByText } = renderJournal();
 
@@ -251,7 +243,7 @@ describe('JournalScreen', () => {
     });
 
     await act(async () => {
-      fireEvent.press(getByTestId('tag-option-is_stage_reflection'));
+      fireEvent.press(getByTestId('tag-option-stage_reflection'));
     });
 
     const input = getByTestId('chat-input');
@@ -265,9 +257,7 @@ describe('JournalScreen', () => {
 
     expect(mockJournalCreate).toHaveBeenCalledWith({
       message: 'Tagged message',
-      is_stage_reflection: true,
-      is_practice_note: false,
-      is_habit_note: false,
+      tag: 'stage_reflection',
       practice_session_id: null,
       user_practice_id: null,
     });
@@ -405,6 +395,7 @@ describe('JournalScreen', () => {
 
   it('shows practice reflection header when practiceSessionId is passed', async () => {
     const { getByTestId, getByText } = renderJournal({
+      tag: 'practice_note',
       practiceSessionId: 42,
       userPracticeId: 10,
       practiceName: 'Breath Awareness',
@@ -426,9 +417,9 @@ describe('JournalScreen', () => {
     });
   });
 
-  it('shows course reflection header when stageReflection params are passed', async () => {
+  it('shows course reflection header when tag is stage_reflection with content', async () => {
     const { getByTestId, getByText } = renderJournal({
-      stageReflection: true,
+      tag: 'stage_reflection',
       stageNumber: 3,
       contentTitle: 'The Hero Journey',
     });
@@ -440,7 +431,7 @@ describe('JournalScreen', () => {
     });
   });
 
-  it('does not show course reflection header without stageReflection param', async () => {
+  it('does not show course reflection header without tag param', async () => {
     const { queryByTestId } = renderJournal();
 
     await waitFor(() => {
@@ -448,11 +439,11 @@ describe('JournalScreen', () => {
     });
   });
 
-  it('sends journal entry with is_stage_reflection when in course reflection mode', async () => {
+  it('sends journal entry with stage_reflection tag when in course reflection mode', async () => {
     mockBotmasonGetBalance.mockResolvedValue({ balance: 0 });
 
     const { getByTestId, getByText } = renderJournal({
-      stageReflection: true,
+      tag: 'stage_reflection',
       stageNumber: 3,
       contentTitle: 'The Hero Journey',
     });
@@ -473,7 +464,7 @@ describe('JournalScreen', () => {
     expect(mockJournalCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'This essay changed my perspective',
-        is_stage_reflection: true,
+        tag: 'stage_reflection',
       }),
     );
   });
@@ -482,6 +473,7 @@ describe('JournalScreen', () => {
     mockBotmasonGetBalance.mockResolvedValue({ balance: 0 });
 
     const { getByTestId, getByText } = renderJournal({
+      tag: 'practice_note',
       practiceSessionId: 42,
       userPracticeId: 10,
       practiceName: 'Breath Awareness',
@@ -504,7 +496,7 @@ describe('JournalScreen', () => {
     expect(mockJournalCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Great session',
-        is_practice_note: true,
+        tag: 'practice_note',
         practice_session_id: 42,
         user_practice_id: 10,
       }),

--- a/frontend/src/features/Journal/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/features/Journal/__tests__/MessageBubble.test.tsx
@@ -16,9 +16,7 @@ const makeMessage = (overrides: Partial<JournalMessage> = {}): JournalMessage =>
   sender: 'user',
   user_id: 1,
   timestamp: '2026-01-15T10:30:00Z',
-  is_stage_reflection: false,
-  is_practice_note: false,
-  is_habit_note: false,
+  tag: 'freeform',
   practice_session_id: null,
   user_practice_id: null,
   ...overrides,
@@ -52,18 +50,25 @@ describe('MessageBubble', () => {
     expect(avatarText).toBeUndefined();
   });
 
-  it('displays tag badges when tags are set', () => {
-    const msg = makeMessage({ is_stage_reflection: true, is_practice_note: true });
+  it('displays tag badge when tag is set', () => {
+    const msg = makeMessage({ tag: 'stage_reflection' });
     const tree = renderer.create(<MessageBubble message={msg} />);
     const root = tree.root;
     const texts = root.findAllByType('Text') as TextInstance[];
     const reflectionTag = texts.find((t) => t.props.children === 'Reflection');
-    const practiceTag = texts.find((t) => t.props.children === 'Practice');
     expect(reflectionTag).toBeTruthy();
+  });
+
+  it('displays practice tag badge', () => {
+    const msg = makeMessage({ tag: 'practice_note' });
+    const tree = renderer.create(<MessageBubble message={msg} />);
+    const root = tree.root;
+    const texts = root.findAllByType('Text') as TextInstance[];
+    const practiceTag = texts.find((t) => t.props.children === 'Practice');
     expect(practiceTag).toBeTruthy();
   });
 
-  it('does not display tags when none are set', () => {
+  it('does not display tag badge for freeform entries', () => {
     const tree = renderer.create(<MessageBubble message={makeMessage()} />);
     const root = tree.root;
     const texts = root.findAllByType('Text') as TextInstance[];

--- a/frontend/src/features/Journal/__tests__/TagFilter.test.tsx
+++ b/frontend/src/features/Journal/__tests__/TagFilter.test.tsx
@@ -15,6 +15,7 @@ describe('TagFilter', () => {
   it('renders all filter chips', () => {
     const { getByText } = render(<TagFilter activeTag={null} onSelectTag={onSelectTag} />);
     expect(getByText('All')).toBeTruthy();
+    expect(getByText('Freeform')).toBeTruthy();
     expect(getByText('Reflections')).toBeTruthy();
     expect(getByText('Practice Notes')).toBeTruthy();
     expect(getByText('Habit Notes')).toBeTruthy();
@@ -24,6 +25,12 @@ describe('TagFilter', () => {
     const { getByText } = render(<TagFilter activeTag={null} onSelectTag={onSelectTag} />);
     fireEvent.press(getByText('Reflections'));
     expect(onSelectTag).toHaveBeenCalledWith('stage_reflection');
+  });
+
+  it('calls onSelectTag with freeform when Freeform chip is pressed', () => {
+    const { getByText } = render(<TagFilter activeTag={null} onSelectTag={onSelectTag} />);
+    fireEvent.press(getByText('Freeform'));
+    expect(onSelectTag).toHaveBeenCalledWith('freeform');
   });
 
   it('calls onSelectTag with null when All is pressed', () => {

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -291,7 +291,7 @@ const MapScreen = (): React.JSX.Element => {
     (screen: 'Practice' | 'Course' | 'Journal', stage: StageData) => {
       setActiveStage(null);
       if (screen === 'Journal') {
-        navigation.navigate('Journal', { stageReflection: true, stageNumber: stage.stageNumber });
+        navigation.navigate('Journal', { tag: 'stage_reflection', stageNumber: stage.stageNumber });
       } else {
         navigation.navigate(screen, { stageNumber: stage.stageNumber });
       }

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -121,7 +121,7 @@ describe('MapScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('Course', { stageNumber: 1 });
   });
 
-  it('navigates to Journal with stageReflection when Journal is tapped', () => {
+  it('navigates to Journal with stage_reflection tag when Journal is tapped', () => {
     const tree = create(<MapScreen />);
     act(() => {
       tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
@@ -130,7 +130,7 @@ describe('MapScreen', () => {
       tree.root.findByProps({ testID: 'journal-link' }).props.onPress();
     });
     expect(mockNavigate).toHaveBeenCalledWith('Journal', {
-      stageReflection: true,
+      tag: 'stage_reflection',
       stageNumber: 1,
     });
   });

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -364,6 +364,7 @@ function usePracticeView(
   const handleWriteReflection = useCallback(() => {
     if (!savedSession || !selectedPractice) return;
     navigation.navigate('Journal', {
+      tag: 'practice_note',
       practiceSessionId: savedSession.id,
       userPracticeId: savedSession.user_practice_id,
       practiceName: selectedPractice.name,

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -367,6 +367,7 @@ describe('PracticeScreen', () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith('Journal', {
+      tag: 'practice_note',
       practiceSessionId: 100,
       userPracticeId: 10,
       practiceName: 'Breath Awareness',

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -4,6 +4,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity } from 'react-native';
 
+import type { JournalTag } from '../api';
 import CourseScreen from '../features/Course/CourseScreen';
 import HabitsScreen from '../features/Habits/HabitsScreen';
 import JournalScreen from '../features/Journal/JournalScreen';
@@ -18,7 +19,7 @@ export type RootTabParamList = {
   Course: { stageNumber?: number } | undefined;
   Journal:
     | {
-        stageReflection?: boolean;
+        tag?: JournalTag;
         stageNumber?: number;
         contentTitle?: string;
         practiceSessionId?: number;


### PR DESCRIPTION
## Summary

- Replace three boolean tag columns (`is_stage_reflection`, `is_practice_note`, `is_habit_note`) with a single `tag` string column backed by a `JournalTag` StrEnum, making the tagging system extensible without database migrations
- Simplify backend router tag filtering from boolean field lookups to direct string comparison, with FastAPI enum validation returning 422 for invalid tags
- Update all frontend components (ChatInput radio-style picker, TagFilter with Freeform chip, MessageBubble, JournalScreen) and deep-link navigation params (Course, Practice, Map) to use the new single-tag model

## Test plan

- [x] All 25 backend journal API tests pass (create with each tag, filter by each tag including freeform, invalid tag returns 422, pagination, search, user isolation)
- [x] Prompts API test updated and passing (journal entry created with `tag: "stage_reflection"`)
- [x] All frontend tests pass (ChatInput single-tag selection/deselection/reset, TagFilter with freeform chip, JournalScreen tag filtering and context-aware sending, MessageBubble tag badge rendering, CourseScreen/MapScreen/PracticeScreen deep-link params)
- [x] All 23 pre-commit hooks pass green (ruff, mypy, black, eslint, tsc, jest, pytest with 90%+ coverage on touched files, bandit, detect-secrets)

https://claude.ai/code/session_013zQVQuGtMquKQxFA224nsy