### PR TITLE
feat: add web app deployment setup for Railway

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,181 +1,506 @@
-# Deployment Guide
+# Deploying Adepthood on Railway (Web App)
 
-Adepthood uses **Railway** for the backend API and **Expo EAS** for the
-React Native mobile app. This guide covers both.
+This guide walks you through deploying Adepthood as a **web application** on
+[Railway](https://railway.com). You will end up with two Railway services (API
++ frontend) and a managed PostgreSQL database, all inside one Railway project.
+
+> **Mobile deployment** (Expo EAS for iOS/Android) is covered in a
+> [separate section](#mobile-deployment-expo-eas) at the end of this doc.
+
+---
 
 ## Architecture
 
 ```
-┌─────────────────┐     ┌──────────────────┐
-│  React Native    │────▶│  Railway Backend  │
-│  (Expo/EAS)      │     │  (FastAPI)        │
-│  iOS + Android   │     │  Port: $PORT      │
-└─────────────────┘     └────────┬─────────┘
-                                  │
-                                  ▼
-                         ┌──────────────────┐
-                         │ Railway PostgreSQL │
-                         │ (auto-provisioned) │
-                         └──────────────────┘
+                 ┌──────────────────────────────────────────────┐
+                 │            Railway Project                    │
+                 │                                              │
+ Browser ──────▶│  Frontend Service          Backend Service    │
+                 │  (nginx, static files)     (FastAPI, Docker) │
+                 │  https://app.adepthood.com  https://api.adepthood.com
+                 │        │                       │             │
+                 │        │   fetch /api/*         │             │
+                 │        └──────────────────────▶│             │
+                 │                                 │             │
+                 │                          ┌──────▼──────┐     │
+                 │                          │  PostgreSQL  │     │
+                 │                          │  (managed)   │     │
+                 │                          └─────────────┘     │
+                 └──────────────────────────────────────────────┘
+```
+
+**Frontend service** — Expo web build (`npx expo export --platform web`)
+served by nginx. Produces a static `dist/` folder with HTML/JS/CSS.
+
+**Backend service** — FastAPI running on Uvicorn inside Docker. Handles all
+API requests, JWT auth, and database access.
+
+**PostgreSQL** — Railway's managed PostgreSQL add-on. Connection string is
+auto-injected as `DATABASE_URL`.
+
+---
+
+## Prerequisites
+
+- A [Railway](https://railway.com) account (Hobby plan recommended — $5/mo,
+  includes enough resources for a production web app)
+- Railway CLI installed (optional but helpful):
+  ```bash
+  npm i -g @railway/cli
+  railway login
+  ```
+- Your repo pushed to GitHub (Railway deploys from GitHub)
+
+---
+
+## Step 1: Create the Railway Project
+
+1. Go to [railway.com/new](https://railway.com/new)
+2. Click **"Empty Project"**
+3. Name it `adepthood` (or whatever you prefer)
+
+You'll add three things to this project: a PostgreSQL database, the backend
+service, and the frontend service.
+
+---
+
+## Step 2: Add PostgreSQL
+
+1. Inside your Railway project, click **"+ New"** → **"Database"** → **"PostgreSQL"**
+2. That's it. Railway provisions the database and makes `DATABASE_URL`
+   available to any service you link.
+
+**Important:** Keep the PostgreSQL service in the same project. Railway
+automatically injects `DATABASE_URL` as an environment variable into linked
+services — you never need to copy/paste connection strings.
+
+### Connecting locally (optional)
+
+To inspect the production database:
+```bash
+# Via Railway CLI
+railway connect postgres
+
+# Or copy the connection string from the Railway dashboard:
+# PostgreSQL service → Variables → DATABASE_URL
 ```
 
 ---
 
-## Backend Deployment (Railway)
+## Step 3: Deploy the Backend
 
-### Prerequisites
+### 3a. How it works
 
-- A [Railway](https://railway.com) account (free tier works for initial setup)
-- Railway CLI installed (`npm i -g @railway/cli`) or use the web dashboard
+The backend deploys via the existing `backend/Dockerfile` and `railway.toml`:
 
-### 1. Create a Railway Project
+- **`railway.toml`** tells Railway to use the Dockerfile at
+  `backend/Dockerfile` and to health-check `/health`
+- **`backend/Dockerfile`** is a multi-stage build: installs Python
+  dependencies, copies source code, runs migrations (if Alembic is configured),
+  and starts Uvicorn
+- **On every deploy**, the container runs
+  `alembic upgrade head` (if `alembic.ini` exists) then starts the server
 
-```bash
-railway login
-railway init
-```
+### 3b. Create the backend service
 
-Or create a project via the Railway web dashboard.
+1. In your Railway project, click **"+ New"** → **"GitHub Repo"**
+2. Select your `adepthood` repository
+3. Railway detects `railway.toml` and uses it automatically
+4. The service name will default to your repo name — rename it to
+   **`backend`** for clarity
 
-### 2. Add PostgreSQL
+> **Root directory:** Since `railway.toml` already points to
+> `backend/Dockerfile`, you do **not** need to set a custom root directory.
+> Railway reads `railway.toml` from the repo root.
 
-- In the Railway dashboard: click **New** > **Database** > **PostgreSQL**
-- Railway automatically sets `DATABASE_URL` for linked services
+### 3c. Link PostgreSQL to the backend
 
-### 3. Set Environment Variables
+1. Click on the **backend** service → **Variables**
+2. Click **"+ Add Variable"** → **"Add Reference"** → select the PostgreSQL
+   service
+3. This injects `DATABASE_URL` (among others) into the backend automatically
 
-In the Railway dashboard, configure:
+### 3d. Set environment variables
 
-| Variable | Value | Notes |
-|----------|-------|-------|
-| `ENV` | `production` | Required |
-| `PROD_DOMAIN` | `https://your-domain.com` | Comma-separated HTTPS URLs for CORS |
-| `SECRET_KEY` | *(generate below)* | JWT signing key |
-| `BOTMASON_PROVIDER` | `stub` or `openai` or `anthropic` | AI chat backend |
-| `LLM_API_KEY` | *(your key)* | Only if using openai/anthropic |
+In the backend service's **Variables** tab, add:
 
-Generate a secure `SECRET_KEY`:
+| Variable | Value | Required? |
+|----------|-------|-----------|
+| `ENV` | `production` | Yes |
+| `SECRET_KEY` | *(see below)* | Yes |
+| `PROD_DOMAIN` | `https://your-frontend-domain.com` | Yes |
+| `BOTMASON_PROVIDER` | `stub` | Yes (use `stub` to start) |
+| `LLM_API_KEY` | *(your API key)* | Only if provider is `openai` or `anthropic` |
+| `LLM_MODEL` | *(model name)* | No (sensible defaults built in) |
+| `WEB_CONCURRENCY` | `2` | No (default: 2) |
 
+**Generate a SECRET_KEY:**
 ```bash
 python -c "import secrets; print(secrets.token_urlsafe(32))"
 ```
+Copy the output and paste it as the `SECRET_KEY` value. This is used to sign
+JWT tokens — keep it secret, keep it safe.
 
-> `DATABASE_URL`, `PORT`, and `RAILWAY_*` variables are auto-injected by
-> Railway. Do not set them manually.
+**About PROD_DOMAIN:**
+This controls CORS (which origins can call your API). Set it to the URL where
+your frontend will live. Comma-separated if you have multiple:
+```
+https://app.adepthood.com,https://www.adepthood.com
+```
+All entries **must** use `https://`. The backend will refuse to start if they
+don't — this is intentional.
 
-### 4. Deploy
+> You can come back and update `PROD_DOMAIN` after you deploy the frontend and
+> know its URL. The backend will need a redeploy to pick up the change.
 
-Connect your GitHub repo to Railway. It auto-detects `railway.toml` and uses
-the Dockerfile at `backend/Dockerfile`.
+**Variables you should NOT set manually:**
+- `DATABASE_URL` — auto-injected by Railway from the linked PostgreSQL
+- `PORT` — auto-injected by Railway
+- `RAILWAY_*` — auto-injected by Railway
 
-Or deploy via CLI:
+### 3e. Deploy and verify
 
+Railway auto-deploys when you push to `main`. To trigger a manual deploy:
+- Railway dashboard: backend service → **"Deploy"** button
+- Or CLI: `railway up`
+
+**Verify the deploy:**
 ```bash
-railway up
+curl https://your-backend.up.railway.app/health
+# Expected: {"status":"healthy","database":"connected"}
 ```
 
-### 5. Verify
-
-```bash
-curl https://your-app.up.railway.app/health
-# Expected: {"status": "healthy", "database": "connected"}
-```
-
-### 6. Custom Domain (Optional)
-
-In Railway dashboard: **Settings** > **Domains** > add your domain and
-configure DNS.
+If you get `{"detail":"Database unavailable"}` (503), the PostgreSQL service
+isn't linked — go back to step 3c.
 
 ---
 
-## Frontend Deployment (Expo EAS)
+## Step 4: Deploy the Frontend (Web)
 
-The frontend is a React Native Expo app. It does **not** deploy to Railway.
+The frontend is an Expo/React Native app that compiles to a static website
+via `npx expo export --platform web`. The static files are served by nginx
+in a Docker container.
+
+The following files are already in the repo:
+
+- **`frontend/Dockerfile`** — Multi-stage build: installs npm deps, runs the
+  Expo web export, copies the resulting `dist/` into an nginx image
+- **`frontend/nginx.conf`** — SPA routing (all routes fall back to
+  `index.html`), gzip compression, aggressive caching for fingerprinted assets
+- **`frontend/metro.config.js`** — Enables Node package exports resolution
+  (required for `react-native-web` to resolve `styleq` subpath imports)
+- **`frontend/.dockerignore`** — Excludes `node_modules`, tests, etc. from
+  the Docker build context
+
+You can test the web build locally:
+```bash
+cd frontend
+npm run web:build    # outputs to dist/
+```
+
+### 4a. Create the frontend service on Railway
+
+1. In your Railway project, click **"+ New"** → **"GitHub Repo"**
+2. Select the same `adepthood` repository
+3. Rename the service to **`frontend`**
+4. Go to the **Settings** tab for this service:
+   - **Build Command:** Leave blank (Dockerfile handles it)
+   - **Dockerfile Path:** `frontend/Dockerfile`
+   - **Watch Paths:** `frontend/**`
+
+### 4b. Set frontend environment variables
+
+In the frontend service's **Variables** tab, add:
+
+| Variable | Value | Notes |
+|----------|-------|-------|
+| `EXPO_PUBLIC_API_BASE_URL` | `https://your-backend.up.railway.app` | The backend service URL |
+| `PORT` | `80` | nginx listens on 80 |
+
+> **Important:** `EXPO_PUBLIC_API_BASE_URL` is baked into the JavaScript
+> bundle at **build time** (not runtime). If you change the backend URL, you
+> must **redeploy** the frontend for it to take effect.
+
+### 4c. Deploy and verify
+
+Push to `main` or trigger a manual deploy. Once Railway shows the deploy as
+healthy, visit the frontend URL in your browser. You should see the app.
+
+---
+
+## Step 5: Connect the Services (CORS)
+
+Now that both services are deployed, you need to tell the backend to accept
+requests from the frontend's URL.
+
+1. Copy the frontend service's public URL from Railway (e.g.,
+   `https://adepthood-frontend.up.railway.app`)
+2. Go to the backend service → **Variables**
+3. Set `PROD_DOMAIN` to the frontend URL:
+   ```
+   https://adepthood-frontend.up.railway.app
+   ```
+4. The backend will redeploy automatically and start accepting requests from
+   the frontend
+
+**If you add a custom domain later**, update `PROD_DOMAIN` to include it:
+```
+https://app.adepthood.com,https://adepthood-frontend.up.railway.app
+```
+
+---
+
+## Step 6: Custom Domains (Optional)
+
+For each service in the Railway dashboard:
+
+1. Go to **Settings** → **Networking** → **Custom Domain**
+2. Add your domain (e.g., `api.adepthood.com` for the backend,
+   `app.adepthood.com` for the frontend)
+3. Railway shows you the DNS records to add (usually a CNAME)
+4. Add the DNS records in your domain registrar
+5. Railway auto-provisions HTTPS via Let's Encrypt
+
+**Remember to update `PROD_DOMAIN`** on the backend to include any custom
+domains you add for the frontend.
+
+---
+
+## Database Migrations (Alembic)
+
+### Current status
+
+Alembic is **not yet configured**. The `migrations/` directory exists but is
+empty. The Dockerfile is already set up to run `alembic upgrade head` on
+deploy — once you create `alembic.ini`, migrations will run automatically.
+
+### Initial setup
+
+```bash
+source .venv/bin/activate
+cd backend
+
+# Initialize Alembic
+pip install alembic   # Already in requirements.txt
+alembic init migrations
+
+# Edit alembic.ini: set sqlalchemy.url to empty string (we'll use env.py)
+# Edit migrations/env.py: import your models and configure the async engine
+```
+
+In `migrations/env.py`, you'll want to:
+1. Import your SQLModel metadata (`from models import *`)
+2. Read `DATABASE_URL` from the environment
+3. Use the async engine for migrations
+
+### Creating migrations
+
+```bash
+cd backend
+source ../.venv/bin/activate
+alembic revision --autogenerate -m "initial schema"
+```
+
+### Running migrations manually against Railway
+
+```bash
+railway run alembic upgrade head
+```
+
+### On deploy
+
+The Dockerfile CMD checks for `alembic.ini`:
+```bash
+if [ -f alembic.ini ]; then python -m alembic upgrade head; fi
+```
+Once you commit `alembic.ini` and your migration files, they run automatically
+on every deploy.
+
+### Before Alembic is set up
+
+Without Alembic, tables are **not** auto-created in production. You have two
+options:
+1. Set up Alembic (recommended)
+2. Add a startup event in `main.py` that calls
+   `SQLModel.metadata.create_all()` — quick and dirty, not recommended for
+   production
+
+---
+
+## Environment Variables Reference
+
+### Backend
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ENV` | Yes | `development` | `development`, `staging`, or `production` |
+| `SECRET_KEY` | Yes | `replace-me` | JWT signing key. Generate with `python -c "import secrets; print(secrets.token_urlsafe(32))"` |
+| `PROD_DOMAIN` | In prod/staging | — | Comma-separated HTTPS origins for CORS (e.g., `https://app.adepthood.com`) |
+| `BOTMASON_PROVIDER` | No | `stub` | AI backend: `stub`, `openai`, or `anthropic` |
+| `LLM_API_KEY` | If not stub | — | API key for the chosen LLM provider |
+| `LLM_MODEL` | No | Provider default | `gpt-4o-mini` (OpenAI) or `claude-sonnet-4-20250514` (Anthropic) |
+| `WEB_CONCURRENCY` | No | `2` | Number of Uvicorn worker processes |
+| `BOTMASON_SYSTEM_PROMPT` | No | Built-in | Path to prompt file or inline text |
+
+**Auto-injected by Railway (do not set manually):**
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL connection string (from linked database) |
+| `PORT` | Port the container should listen on |
+| `RAILWAY_ENVIRONMENT` | Railway environment name |
+| `RAILWAY_PUBLIC_DOMAIN` | Public domain assigned by Railway |
+
+### Frontend
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `EXPO_PUBLIC_API_BASE_URL` | Yes | Full URL of the backend API (e.g., `https://api.adepthood.com`). Baked in at build time. |
+
+---
+
+## Web Compatibility Notes
+
+The frontend is built with React Native + Expo, which compiles to web via
+`react-native-web`. A few things to be aware of:
+
+### Token storage
+`expo-secure-store` falls back to **localStorage** on web. This is fine for
+a web app — tokens are stored in the browser. On native (iOS/Android), it
+uses the platform's secure keychain.
+
+### Push notifications
+`expo-notifications` and `react-native-push-notification` do **not** work on
+web. If you need web push notifications later, you'll need to add a web-specific
+implementation using the Web Push API. For now, notification features will
+simply be unavailable in the web version.
+
+### Navigation
+React Navigation works on web out of the box. URLs map to screens
+automatically. Deep links work as expected.
+
+### Gestures and animations
+`react-native-gesture-handler` and `react-native-reanimated` have web support.
+Drag-and-drop (`react-native-draggable-flatlist`) may behave differently on
+web — test these interactions.
+
+---
+
+## Monitoring and Operations
+
+### Health check
+
+Railway pings `GET /health` every 30 seconds. A healthy response:
+```json
+{"status": "healthy", "database": "connected"}
+```
+
+A 503 means the database is unreachable.
+
+### Logs
+
+```bash
+# Via CLI
+railway logs
+
+# Or: Railway dashboard → Service → Deployments → click a deploy → Logs
+```
+
+### Database access
+
+```bash
+railway connect postgres   # Opens a psql shell
+```
+
+### Restarting a service
+
+Railway dashboard → Service → **"Restart"** button. Or push a new commit.
+
+---
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Backend deploy fails immediately | Missing `SECRET_KEY` or invalid `ENV` | Check logs. The app fails fast on bad config — set all required env vars |
+| `503` on `/health` | Database not connected | Verify PostgreSQL is linked (step 3c). Check `DATABASE_URL` is in the service's variables |
+| CORS errors in browser console | `PROD_DOMAIN` doesn't match frontend URL | Set `PROD_DOMAIN` to the exact frontend URL (with `https://`). Redeploy backend |
+| Frontend shows blank page | `EXPO_PUBLIC_API_BASE_URL` not set or wrong | Check the variable is set on the frontend service. Redeploy (it's baked at build time) |
+| Frontend routes return 404 | nginx not configured for SPA | Make sure `nginx.conf` has the `try_files` fallback to `index.html` |
+| `alembic upgrade head` fails on deploy | Migration files missing or DB schema mismatch | Run `railway logs` to see the error. You may need to create an initial migration |
+| Slow cold starts | Free tier or single worker | Upgrade Railway plan and/or increase `WEB_CONCURRENCY` |
+| Rate limit errors (429) | Too many requests from one IP | Rate limits reset on container restart. In-memory by design — not persistent across deploys |
+
+---
+
+## Pre-deploy Checklist
+
+Run the automated checks before deploying:
+
+```bash
+./scripts/pre-deploy-check.sh
+```
+
+This runs:
+1. Backend tests (90% coverage minimum)
+2. Frontend tests
+3. All pre-commit hooks
+4. Docker image build
+
+**Manual checklist:**
+- [ ] `SECRET_KEY` is a cryptographically random string (not `replace-me`)
+- [ ] `ENV=production` on the backend
+- [ ] `PROD_DOMAIN` matches your frontend URL(s) exactly, with `https://`
+- [ ] `EXPO_PUBLIC_API_BASE_URL` on the frontend matches your backend URL
+- [ ] PostgreSQL is linked to the backend service
+- [ ] Health check returns `{"status":"healthy","database":"connected"}`
+- [ ] Alembic migrations are up to date (if configured)
+- [ ] `BOTMASON_PROVIDER` is set (`stub` is fine to start)
+
+---
+
+## Cost Estimate (Railway)
+
+Railway's Hobby plan ($5/month) includes:
+- 8 GB RAM, 8 vCPU shared across services
+- 100 GB outbound bandwidth
+- PostgreSQL included
+
+For a low-traffic web app, this is more than sufficient. You only pay for
+actual resource usage beyond the $5 credit.
+
+---
+
+## Mobile Deployment (Expo EAS)
+
+Once the web app is running, you can also ship native iOS/Android builds via
+Expo Application Services (EAS). The same backend serves both web and mobile.
 
 ### Prerequisites
 
 - An [Expo](https://expo.dev) account
-- EAS CLI: `npm install -g eas-cli`
+- EAS CLI: `npm install -g eas-cli && eas login`
 
-### 1. Log In
-
-```bash
-eas login
-```
-
-### 2. Configure API URL
-
-Set the production API URL as an EAS secret:
+### Set the API URL
 
 ```bash
 eas secret:create --name EXPO_PUBLIC_API_BASE_URL \
-  --value https://your-app.up.railway.app
+  --value https://your-backend.up.railway.app
 ```
 
-The frontend reads this via `process.env.EXPO_PUBLIC_API_BASE_URL` in
-`frontend/src/config.ts`.
-
-### 3. Build for Production
+### Build
 
 ```bash
 cd frontend
 eas build --platform all --profile production
 ```
 
-### 4. Submit to App Stores
+### Submit to app stores
 
 ```bash
 eas submit --platform all
 ```
 
----
-
-## Database Migrations
-
-Migrations run automatically on each deploy via the Dockerfile `CMD`. When
-Alembic is configured (`alembic.ini` exists), the container runs
-`alembic upgrade head` before starting the server.
-
-To run migrations manually against the Railway database:
-
-```bash
-railway run alembic upgrade head
-```
-
-To create a new migration locally:
-
-```bash
-cd backend
-source ../.venv/bin/activate
-alembic revision --autogenerate -m "description of change"
-```
-
----
-
-## Monitoring
-
-- **Health check:** Railway pings `/health` every 30 seconds
-- **Logs:** `railway logs` or Railway dashboard > Deployments > Logs
-- **Database:** `railway connect postgres` for direct psql access
-
-## Troubleshooting
-
-| Problem | Solution |
-|---------|----------|
-| Deploy fails on migrations | Check `DATABASE_URL` is set; run `railway logs` |
-| 503 on `/health` | Database not connected — verify PostgreSQL plugin is linked |
-| CORS errors | Verify `PROD_DOMAIN` matches your frontend URL exactly (must use HTTPS) |
-| Slow cold starts | Increase `WEB_CONCURRENCY` or upgrade Railway plan |
-
----
-
-## Pre-deploy Checklist
-
-Run the automated check script before deploying:
-
-```bash
-./scripts/pre-deploy-check.sh
-```
-
-This runs backend tests (90% coverage minimum), frontend tests, all pre-commit
-hooks, and builds the Docker image locally.
+The mobile app connects to the same Railway backend. CORS is not relevant for
+native apps (only browsers enforce CORS), but the backend's rate limiting and
+JWT auth apply to all clients equally.

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.expo
+__tests__
+*.test.ts
+*.test.tsx
+.env
+.env.*
+*.md
+.git
+.github
+coverage

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,26 @@
+# ---- Build stage ----
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+# Install dependencies first (layer caching)
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy source and build for web
+COPY . .
+
+# EXPO_PUBLIC_API_BASE_URL is baked into the JS bundle at build time.
+# Set it via Railway env vars — it's passed through as a Docker build arg.
+ARG EXPO_PUBLIC_API_BASE_URL
+ENV EXPO_PUBLIC_API_BASE_URL=$EXPO_PUBLIC_API_BASE_URL
+
+RUN npx expo export --platform web
+
+# ---- Serve stage ----
+FROM nginx:1.27-alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/frontend/__tests__/DatePicker.test.tsx
+++ b/frontend/__tests__/DatePicker.test.tsx
@@ -55,7 +55,7 @@ describe('date utilities', () => {
 
 describe('DatePicker component', () => {
   beforeAll(() => {
-    jest.useFakeTimers().setSystemTime(new Date('2025-06-15'));
+    jest.useFakeTimers().setSystemTime(new Date('2025-06-15T12:00:00'));
   });
   afterAll(() => {
     jest.useRealTimers();

--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -21,6 +21,7 @@ module.exports = tseslint.config(
       'android/',
       'ios/',
       'babel.config.js',
+      'metro.config.js',
     ],
   },
 

--- a/frontend/metro.config.js
+++ b/frontend/metro.config.js
@@ -1,0 +1,11 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+// Enable Node package exports resolution so Metro can resolve subpath imports
+// like "styleq/transform-localize-style" used by react-native-web.
+config.resolver.unstable_enablePackageExports = true;
+
+module.exports = config;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,28 @@
+server {
+    listen       80;
+    server_name  _;
+    root         /usr/share/nginx/html;
+    index        index.html;
+
+    # SPA fallback: serve index.html for all routes that don't match a file
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets aggressively (fingerprinted by Expo build)
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Don't cache index.html so new deploys take effect immediately
+    location = /index.html {
+        expires -1;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    # Gzip text-based assets
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml;
+    gzip_min_length 256;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "react-native-screens": "~4.4.0",
         "react-native-svg": "15.8.0",
         "react-native-web": "~0.19.13",
+        "styleq": "0.1.3",
         "uuid": "^13.0.0",
         "zustand": "^5.0.12"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "react-native-screens": "~4.4.0",
     "react-native-svg": "15.8.0",
     "react-native-web": "~0.19.13",
+    "styleq": "0.1.3",
     "uuid": "^13.0.0",
     "zustand": "^5.0.12"
   },
@@ -70,6 +71,7 @@
     "lint": "eslint . --max-warnings=0",
     "start": "expo start",
     "web": "expo start --web",
+    "web:build": "expo export --platform web",
     "test": "jest --passWithNoTests",
     "complexity": "eslint . --format json | node -e \"const r=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));const msgs=r.flatMap(f=>f.messages.filter(m=>['complexity','sonarjs/cognitive-complexity'].includes(m.ruleId)).map(m=>({file:f.filePath,line:m.line,rule:m.ruleId,msg:m.message})));console.table(msgs);console.log('Total complexity warnings:',msgs.length)\""
   },


### PR DESCRIPTION
## Summary
- Revamp DEPLOYMENT.md from a sparse backend-only guide into a comprehensive web-first deployment walkthrough (6 steps, env var reference, troubleshooting, pre-deploy checklist, cost estimate)
- Add frontend Docker infrastructure: `Dockerfile` (Node build + nginx serve), `nginx.conf` (SPA routing, gzip, cache headers), `.dockerignore`
- Add `metro.config.js` enabling package exports resolution (fixes `react-native-web` + `styleq` subpath import for web builds)
- Add `styleq` as direct dependency and `web:build` script to `package.json`
- Fix pre-existing timezone-sensitive `DatePicker.test.tsx` failure (use noon UTC instead of midnight)
- Add `metro.config.js` to ESLint ignores (CommonJS file not in TS project)

## Test plan
- [x] `npx expo export --platform web` produces valid `dist/` with `index.html` and JS bundle (5.3MB)
- [x] All pre-commit hooks pass (eslint, prettier, typecheck, jest, commitlint)
- [x] DatePicker test passes regardless of local timezone
- [ ] Deploy backend service on Railway and verify `/health` endpoint
- [ ] Deploy frontend service on Railway and verify web app loads in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)