### PR TITLE
fix(backend): add email format validation to auth endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -160,5 +164,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-05T17:57:00Z"
+  "generated_at": "2026-04-11T07:24:51Z"
 }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ cachetools
 fastapi
 uvicorn
 pydantic
+email-validator
 sqlalchemy
 sqlmodel
 asyncpg

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -19,7 +19,7 @@ class User(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     offering_balance: int = Field(default=0)
-    email: str = Field(unique=True, index=True)
+    email: str = Field(unique=True, index=True, max_length=254)
     password_hash: str = Field(default="")
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     habits: list["Habit"] = Relationship(back_populates="user")

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime, timedelta
 import bcrypt
 import jwt
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -48,7 +48,7 @@ def _get_secret_key() -> str:
 
 
 class AuthRequest(BaseModel):
-    email: str
+    email: EmailStr
     password: str
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -44,6 +44,60 @@ async def _fail_login(
     )
 
 
+# ── Email validation ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_email",
+    [
+        "not-an-email",
+        "missing-at-sign.com",
+        "@no-local-part.com",
+        "spaces in@email.com",
+        "",
+        "   ",
+    ],
+    ids=[
+        "plain-string",
+        "no-at-sign",
+        "no-local-part",
+        "spaces-in-local",
+        "empty-string",
+        "whitespace-only",
+    ],
+)
+async def test_signup_rejects_malformed_email(
+    async_client: AsyncClient,
+    bad_email: str,
+) -> None:
+    resp = await async_client.post(
+        SIGNUP_URL,
+        json={"email": bad_email, "password": "securepassword123"},  # pragma: allowlist secret
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_email",
+    [
+        "not-an-email",
+        "",
+    ],
+    ids=["plain-string", "empty-string"],
+)
+async def test_login_rejects_malformed_email(
+    async_client: AsyncClient,
+    bad_email: str,
+) -> None:
+    resp = await async_client.post(
+        LOGIN_URL,
+        json={"email": bad_email, "password": "securepassword123"},  # pragma: allowlist secret
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
 # ── Signup ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- **Use Pydantic `EmailStr`** on `AuthRequest.email` so signup and login reject malformed emails with HTTP 422 (RFC 5321 format validation + case normalization)
- **Add `max_length=254`** to `User.email` model field (RFC 5321 maximum)
- **Add `email-validator`** to `backend/requirements.txt` (backing library for `EmailStr`)

Closes sec-02

## Changes

| File | Change |
|------|--------|
| `backend/src/routers/auth.py` | `email: str` → `email: EmailStr` |
| `backend/src/models/user.py` | `Field(unique=True, index=True)` → `Field(unique=True, index=True, max_length=254)` |
| `backend/requirements.txt` | Added `email-validator` |
| `backend/tests/test_auth.py` | 8 new parametrized tests (6 signup + 2 login) covering: plain strings, missing @, missing local part, spaces, empty strings, whitespace-only |
| `.secrets.baseline` | Regenerated (added standard baseline filter) |

## Acceptance Criteria

- [x] Signup and login reject malformed emails with 422
- [x] User.email column has a max_length constraint (254, per RFC 5321)
- [x] `email-validator` added to requirements

## Test plan

- [x] All 30 auth tests pass (8 new + 22 existing, zero regressions)
- [x] All 24 pre-commit hooks pass green (including mypy, bandit, detect-secrets, backend coverage)
- [x] Valid emails (e.g. `alice@example.com`) still work for signup/login
- [x] Malformed emails return HTTP 422 with Pydantic validation error detail

https://claude.ai/code/session_01WV1ZNGPyQqkeSS8ykZ6Ru9