### PR TITLE
fix(backend): prevent account enumeration via signup endpoint

### DIFF
--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -167,6 +167,10 @@ async def signup(
         raise bad_request("password_too_short")
     result = await session.execute(select(User).where(User.email == payload.email))
     if result.scalars().first() is not None:
+        # Perform a dummy hash so the response time is indistinguishable from
+        # a real signup (bcrypt takes ~250 ms). Without this, an attacker could
+        # use timing to detect whether the email already exists.
+        _hash_password(payload.password)
         # Return an identical response shape to prevent account enumeration.
         # The dummy token is signed with a random key and will fail validation,
         # so it cannot be used to access the existing account.

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import secrets
 from datetime import UTC, datetime, timedelta
 
 import bcrypt
@@ -76,6 +77,21 @@ def _create_token(user_id: int) -> str:
         "iat": datetime.now(UTC),
     }
     return str(jwt.encode(payload, _get_secret_key(), algorithm=_JWT_ALGORITHM))
+
+
+def _create_dummy_token() -> str:
+    """Generate a structurally-valid JWT that will never decode with the real secret.
+
+    Used to return an indistinguishable response when a signup is attempted
+    with an already-registered email, preventing account enumeration.
+    """
+    nonce_key = secrets.token_hex(32)
+    payload = {
+        "sub": "0",
+        "exp": datetime.now(UTC) + _TOKEN_TTL,
+        "iat": datetime.now(UTC),
+    }
+    return str(jwt.encode(payload, nonce_key, algorithm=_JWT_ALGORITHM))
 
 
 def _get_client_ip(request: Request) -> str:
@@ -151,7 +167,10 @@ async def signup(
         raise bad_request("password_too_short")
     result = await session.execute(select(User).where(User.email == payload.email))
     if result.scalars().first() is not None:
-        raise bad_request("user_already_exists")
+        # Return an identical response shape to prevent account enumeration.
+        # The dummy token is signed with a random key and will fail validation,
+        # so it cannot be used to access the existing account.
+        return AuthResponse(token=_create_dummy_token(), user_id=0)
 
     user = User(
         email=payload.email,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from models.login_attempt import LoginAttempt
+from models.user import User
 from routers.auth import LOCKOUT_DURATION, MAX_FAILED_ATTEMPTS
 
 SIGNUP_URL = "/auth/signup"
@@ -64,17 +65,66 @@ async def test_signup_returns_token_and_user_id(async_client: AsyncClient) -> No
 
 
 @pytest.mark.asyncio
-async def test_signup_duplicate_email_returns_400(async_client: AsyncClient) -> None:
-    await _signup(async_client, email="dup@example.com")
-    resp = await async_client.post(
+async def test_signup_duplicate_email_returns_same_shape(async_client: AsyncClient) -> None:
+    """Signup with an existing email returns the same status and response shape
+    as a fresh signup — no information leakage about registered emails."""
+    first_resp = await async_client.post(
         SIGNUP_URL,
         json={
             "email": "dup@example.com",
             "password": "securepassword123",  # pragma: allowlist secret
         },
     )
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
-    assert resp.json()["detail"] == "user_already_exists"
+    second_resp = await async_client.post(
+        SIGNUP_URL,
+        json={
+            "email": "dup@example.com",
+            "password": "anotherpassword456",  # pragma: allowlist secret
+        },
+    )
+    assert second_resp.status_code == first_resp.status_code
+    first_data = first_resp.json()
+    second_data = second_resp.json()
+    assert set(first_data.keys()) == set(second_data.keys())
+    assert "token" in second_data
+    assert "user_id" in second_data
+    assert isinstance(second_data["user_id"], int)
+
+
+@pytest.mark.asyncio
+async def test_signup_duplicate_email_does_not_create_second_user(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A duplicate signup must not create a second user row."""
+    await _signup(async_client, email="nodupe@example.com")
+    await async_client.post(
+        SIGNUP_URL,
+        json={
+            "email": "nodupe@example.com",
+            "password": "anotherpassword456",  # pragma: allowlist secret
+        },
+    )
+    result = await db_session.execute(select(User).where(User.email == "nodupe@example.com"))
+    users = result.scalars().all()
+    assert len(users) == 1
+
+
+@pytest.mark.asyncio
+async def test_signup_duplicate_email_token_is_not_valid(async_client: AsyncClient) -> None:
+    """The token returned for a duplicate signup must not grant access."""
+    await _signup(async_client, email="invalid-tok@example.com")
+    resp = await async_client.post(
+        SIGNUP_URL,
+        json={
+            "email": "invalid-tok@example.com",
+            "password": "anotherpassword456",  # pragma: allowlist secret
+        },
+    )
+    fake_token = resp.json()["token"]
+    headers = {"Authorization": f"Bearer {fake_token}"}
+    protected_resp = await async_client.get("/habits/", headers=headers)
+    assert protected_resp.status_code == HTTPStatus.UNAUTHORIZED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Eliminate account enumeration via the signup endpoint (sec-01, OWASP A07:2021). Previously, signing up with an already-registered email returned `400 user_already_exists`, leaking whether the email was in use.
- Now returns an identical `200` response with the same `{token, user_id}` shape for both new and existing emails. The duplicate-email token is signed with a random nonce key and will never pass validation.
- Add a dummy bcrypt hash on the duplicate path to prevent timing-based enumeration (~250ms bcrypt makes response times indistinguishable).

## Test plan

- [x] `test_signup_duplicate_email_returns_same_shape` — verifies identical status code and response keys for new vs. duplicate signups
- [x] `test_signup_duplicate_email_does_not_create_second_user` — confirms no duplicate user row is created
- [x] `test_signup_duplicate_email_token_is_not_valid` — confirms the dummy token is rejected by protected endpoints
- [x] All 24 auth tests pass, 292 total backend tests pass at 93% coverage
- [x] All pre-commit hooks pass (black, ruff, mypy, isort, bandit, pip-audit, detect-secrets, commitlint)

https://claude.ai/code/session_01NusuyZmVJiDUw49iKyfrPB