### PR TITLE
fix(backend): prevent path traversal in BotMason system prompt loading

### DIFF
--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -24,21 +24,50 @@ _DEFAULT_SYSTEM_PROMPT = (
 # Maximum number of recent messages to include as conversation context.
 CONVERSATION_HISTORY_LIMIT = 20
 
+# Only allow prompt files from this directory to prevent path traversal.
+_ALLOWED_PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+# Maximum prompt file size in bytes (50 KB).
+_MAX_PROMPT_FILE_SIZE = 50 * 1024
+
 
 def get_system_prompt() -> str:
     """Load the BotMason system prompt from config.
 
     Checks ``BOTMASON_SYSTEM_PROMPT`` env var first. If it points to a file
-    that exists, the file contents are returned. Otherwise the env var value
-    is used as inline text. Falls back to the built-in default prompt.
+    that exists **within the allowed prompts directory**, the file contents
+    are returned. Otherwise the env var value is used as inline text. Falls
+    back to the built-in default prompt.
+
+    Raises:
+        RuntimeError: If the file path resolves outside the allowed directory
+            or exceeds the maximum file size.
     """
     prompt_config = os.getenv("BOTMASON_SYSTEM_PROMPT", "")
-    if prompt_config:
-        prompt_path = Path(prompt_config)
-        if prompt_path.is_file():
-            return prompt_path.read_text().strip()
-        return prompt_config
-    return _DEFAULT_SYSTEM_PROMPT
+    if not prompt_config:
+        return _DEFAULT_SYSTEM_PROMPT
+
+    prompt_path = Path(prompt_config).resolve()
+    if prompt_path.is_file():
+        # Prevent path traversal — must be within the allowed directory
+        try:
+            prompt_path.relative_to(_ALLOWED_PROMPT_DIR.resolve())
+        except ValueError:
+            msg = f"BOTMASON_SYSTEM_PROMPT path must be within {_ALLOWED_PROMPT_DIR}"
+            raise RuntimeError(msg) from None
+
+        file_size = prompt_path.stat().st_size
+        if file_size > _MAX_PROMPT_FILE_SIZE:
+            msg = (
+                f"BOTMASON_SYSTEM_PROMPT file exceeds maximum size "
+                f"({file_size} > {_MAX_PROMPT_FILE_SIZE} bytes)"
+            )
+            raise RuntimeError(msg)
+
+        return prompt_path.read_text().strip()
+
+    # Treat as inline text
+    return prompt_config
 
 
 def _build_messages(

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 
+import services.botmason as botmason_mod
 from services.botmason import generate_response, get_system_prompt
 
 
@@ -229,8 +230,105 @@ async def test_system_prompt_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_system_prompt_from_file(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
-    prompt_file = pathlib.Path(str(tmp_path)) / "prompt.txt"
+    """Valid prompt file inside the allowed directory is loaded."""
+    allowed_dir = pathlib.Path(str(tmp_path)) / "prompts"
+    allowed_dir.mkdir()
+    prompt_file = allowed_dir / "prompt.txt"
     prompt_file.write_text("File-based system prompt")
+
+    monkeypatch.setattr(botmason_mod, "_ALLOWED_PROMPT_DIR", allowed_dir)
     monkeypatch.setenv("BOTMASON_SYSTEM_PROMPT", str(prompt_file))
     prompt = get_system_prompt()
     assert prompt == "File-based system prompt"
+
+
+# ── Path traversal security tests ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_rejects_path_outside_allowed_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: object,
+) -> None:
+    """File path outside the allowed directory raises RuntimeError."""
+    allowed_dir = pathlib.Path(str(tmp_path)) / "prompts"
+    allowed_dir.mkdir()
+
+    # Create a file outside the allowed dir
+    outside_file = pathlib.Path(str(tmp_path)) / "evil.txt"
+    outside_file.write_text("stolen secrets")
+
+    monkeypatch.setattr(botmason_mod, "_ALLOWED_PROMPT_DIR", allowed_dir)
+    monkeypatch.setenv("BOTMASON_SYSTEM_PROMPT", str(outside_file))
+    with pytest.raises(RuntimeError, match="must be within"):
+        get_system_prompt()
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_rejects_path_traversal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: object,
+) -> None:
+    """Relative traversal paths (../../etc/passwd) are rejected."""
+    allowed_dir = pathlib.Path(str(tmp_path)) / "prompts"
+    allowed_dir.mkdir()
+
+    # Create a file via path traversal that resolves outside allowed dir
+    outside_file = pathlib.Path(str(tmp_path)) / "secret.txt"
+    outside_file.write_text("password data")
+    traversal_path = str(allowed_dir / ".." / "secret.txt")
+
+    monkeypatch.setattr(botmason_mod, "_ALLOWED_PROMPT_DIR", allowed_dir)
+    monkeypatch.setenv("BOTMASON_SYSTEM_PROMPT", traversal_path)
+    with pytest.raises(RuntimeError, match="must be within"):
+        get_system_prompt()
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_rejects_etc_passwd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: object,
+) -> None:
+    """Absolute paths to sensitive system files are rejected."""
+    allowed_dir = pathlib.Path(str(tmp_path)) / "prompts"
+    allowed_dir.mkdir()
+
+    monkeypatch.setattr(botmason_mod, "_ALLOWED_PROMPT_DIR", allowed_dir)
+    monkeypatch.setenv("BOTMASON_SYSTEM_PROMPT", "/etc/passwd")
+    with pytest.raises(RuntimeError, match="must be within"):
+        get_system_prompt()
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_rejects_oversized_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: object,
+) -> None:
+    """Prompt files larger than the max size limit are rejected."""
+    allowed_dir = pathlib.Path(str(tmp_path)) / "prompts"
+    allowed_dir.mkdir()
+    large_file = allowed_dir / "huge.txt"
+    # Write a file just over the 50KB limit
+    large_file.write_text("x" * (50 * 1024 + 1))
+
+    monkeypatch.setattr(botmason_mod, "_ALLOWED_PROMPT_DIR", allowed_dir)
+    monkeypatch.setenv("BOTMASON_SYSTEM_PROMPT", str(large_file))
+    with pytest.raises(RuntimeError, match="exceeds maximum"):
+        get_system_prompt()
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_allows_file_at_size_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: object,
+) -> None:
+    """Prompt file exactly at the max size limit is accepted."""
+    allowed_dir = pathlib.Path(str(tmp_path)) / "prompts"
+    allowed_dir.mkdir()
+    max_file = allowed_dir / "max.txt"
+    max_file.write_text("x" * (50 * 1024))
+
+    monkeypatch.setattr(botmason_mod, "_ALLOWED_PROMPT_DIR", allowed_dir)
+    monkeypatch.setenv("BOTMASON_SYSTEM_PROMPT", str(max_file))
+    prompt = get_system_prompt()
+    assert len(prompt) == 50 * 1024


### PR DESCRIPTION
## Summary

- **Restrict `get_system_prompt()` file reads** to a dedicated `backend/src/prompts/` directory, preventing path traversal attacks via the `BOTMASON_SYSTEM_PROMPT` environment variable
- **Add a 50KB file size limit** to prevent memory exhaustion from oversized prompt files
- **Add 5 new security tests** covering: paths outside allowed directory, relative traversal (`../`), absolute system paths (`/etc/passwd`), oversized files, and boundary-exact file size acceptance

Closes sec-05 (OWASP A01:2021 — Broken Access Control / Path Traversal).

## What changed

| File | Change |
|------|--------|
| `backend/src/services/botmason.py` | Added `_ALLOWED_PROMPT_DIR` and `_MAX_PROMPT_FILE_SIZE` constants; rewrote `get_system_prompt()` to validate file paths with `Path.relative_to()` and check file size before reading |
| `backend/tests/test_botmason_api.py` | Added 5 new path traversal / file size tests; updated existing file-based prompt test to work within the allowed directory constraint |
| `backend/src/prompts/.gitkeep` | Created the allowed prompts directory |

## Test plan

- [x] `test_system_prompt_rejects_path_outside_allowed_dir` — file outside allowed dir raises `RuntimeError`
- [x] `test_system_prompt_rejects_path_traversal` — relative `../` traversal raises `RuntimeError`
- [x] `test_system_prompt_rejects_etc_passwd` — absolute path to `/etc/passwd` raises `RuntimeError`
- [x] `test_system_prompt_rejects_oversized_file` — file over 50KB raises `RuntimeError`
- [x] `test_system_prompt_allows_file_at_size_limit` — file exactly at 50KB is accepted
- [x] `test_system_prompt_from_file` — valid file within allowed dir loads correctly
- [x] All 24 pre-commit hooks pass green (`pre-commit run --all-files`)
- [x] All existing tests pass with no regressions

https://claude.ai/code/session_01LGazaEwoUqwhbiA3kCJmZG