### PR TITLE
fix(frontend): validate URL schemes before Linking.openURL

### DIFF
--- a/frontend/src/features/Course/ContentViewer.tsx
+++ b/frontend/src/features/Course/ContentViewer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { ActivityIndicator, Linking, Text, TouchableOpacity, View } from 'react-native';
 
 import { course as courseApi, type ContentItem } from '../../api';
+import { isValidUrl } from '../../utils/url';
 
 import styles from './Course.styles';
 
@@ -102,7 +103,7 @@ const ContentViewer = ({
   }, [isRead, marking, item.id, onMarkRead]);
 
   const handleOpenUrl = useCallback(async () => {
-    if (!item.url) return;
+    if (!item.url || !isValidUrl(item.url)) return;
     try {
       await Linking.openURL(item.url);
     } catch (err) {

--- a/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
+++ b/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
@@ -162,4 +162,40 @@ describe('ContentViewer', () => {
     );
     expect(queryByTestId('reflect-button')).toBeNull();
   });
+
+  it('does not open javascript: URLs', () => {
+    const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as any);
+    const item = makeItem({ url: 'javascript:alert(1)' });
+    const { getByTestId } = render(
+      <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
+    );
+
+    fireEvent.press(getByTestId('open-url-button'));
+    expect(openURLSpy).not.toHaveBeenCalled();
+    openURLSpy.mockRestore();
+  });
+
+  it('does not open tel: URLs', () => {
+    const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as any);
+    const item = makeItem({ url: 'tel:+1234567890' });
+    const { getByTestId } = render(
+      <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
+    );
+
+    fireEvent.press(getByTestId('open-url-button'));
+    expect(openURLSpy).not.toHaveBeenCalled();
+    openURLSpy.mockRestore();
+  });
+
+  it('does not open file: URLs', () => {
+    const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as any);
+    const item = makeItem({ url: 'file:///etc/passwd' });
+    const { getByTestId } = render(
+      <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
+    );
+
+    fireEvent.press(getByTestId('open-url-button'));
+    expect(openURLSpy).not.toHaveBeenCalled();
+    openURLSpy.mockRestore();
+  });
 });

--- a/frontend/src/utils/__tests__/url.test.ts
+++ b/frontend/src/utils/__tests__/url.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { isValidUrl } from '../url';
+
+describe('isValidUrl', () => {
+  it('accepts https URLs', () => {
+    expect(isValidUrl('https://example.com')).toBe(true);
+    expect(isValidUrl('https://example.com/path?q=1#hash')).toBe(true);
+  });
+
+  it('accepts http URLs', () => {
+    expect(isValidUrl('http://example.com')).toBe(true);
+    expect(isValidUrl('http://localhost:3000')).toBe(true);
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(isValidUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects tel: URLs', () => {
+    expect(isValidUrl('tel:+1234567890')).toBe(false);
+  });
+
+  it('rejects sms: URLs', () => {
+    expect(isValidUrl('sms:+1234567890')).toBe(false);
+  });
+
+  it('rejects file: URLs', () => {
+    expect(isValidUrl('file:///etc/passwd')).toBe(false);
+  });
+
+  it('rejects intent: URLs', () => {
+    expect(isValidUrl('intent://scan/#Intent;scheme=zxing;end')).toBe(false);
+  });
+
+  it('rejects data: URLs', () => {
+    expect(isValidUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('rejects empty strings', () => {
+    expect(isValidUrl('')).toBe(false);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(isValidUrl('not-a-url')).toBe(false);
+    expect(isValidUrl('://missing-scheme')).toBe(false);
+  });
+});

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -1,0 +1,10 @@
+const ALLOWED_SCHEMES = ['https:', 'http:'];
+
+export function isValidUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return ALLOWED_SCHEMES.includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `isValidUrl` utility that allowlists only `http:` and `https:` URL schemes, rejecting dangerous schemes (`javascript:`, `tel:`, `file:`, `intent:`, `data:`, etc.)
- Apply URL validation in `ContentViewer.tsx` before calling `Linking.openURL` as a defense-in-depth measure against compromised API responses
- Add 10 unit tests for the URL validator and 3 integration tests for scheme rejection in ContentViewer

Closes sec-10 (Unvalidated URLs before Linking.openURL — OWASP A03:2021 Injection).

## Test plan

- [x] `https://` and `http://` URLs are opened normally (existing test + new unit tests)
- [x] `javascript:`, `tel:`, `file:` URLs are silently rejected — `Linking.openURL` is never called
- [x] `sms:`, `intent:`, `data:` URLs rejected at the utility level
- [x] Empty strings and malformed URLs rejected
- [x] All 24 pre-commit hooks pass green
- [x] No regressions in existing ContentViewer tests

https://claude.ai/code/session_01FZFQQqjj7i1Uygc4Ld5E1q