### PR TITLE
fix(frontend): migrate push token storage to SecureStore

### DIFF
--- a/frontend/src/storage/__tests__/notificationStorage.test.ts
+++ b/frontend/src/storage/__tests__/notificationStorage.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, jest } from '@jest/globals';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 
 import {
   saveNotificationIds,
@@ -16,7 +17,13 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(() => Promise.resolve()),
 }));
 
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+}));
+
 const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -139,9 +146,9 @@ describe('notificationStorage', () => {
   });
 
   describe('savePushToken', () => {
-    test('stores the push token', async () => {
+    test('stores the push token in SecureStore', async () => {
       await savePushToken('ExponentPushToken[abc]');
-      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+      expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
         '@adepthood/push_token',
         'ExponentPushToken[abc]',
       );
@@ -154,14 +161,14 @@ describe('notificationStorage', () => {
       expect(result).toBeNull();
     });
 
-    test('returns stored token', async () => {
-      mockAsyncStorage.getItem.mockResolvedValueOnce('ExponentPushToken[abc]');
+    test('returns stored token from SecureStore', async () => {
+      mockSecureStore.getItemAsync.mockResolvedValueOnce('ExponentPushToken[abc]');
       const result = await loadPushToken();
       expect(result).toBe('ExponentPushToken[abc]');
     });
 
     test('returns null on storage error', async () => {
-      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('storage error'));
+      mockSecureStore.getItemAsync.mockRejectedValueOnce(new Error('storage error'));
       const result = await loadPushToken();
       expect(result).toBeNull();
     });

--- a/frontend/src/storage/notificationStorage.ts
+++ b/frontend/src/storage/notificationStorage.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 
 const KEY_PREFIX = '@adepthood/notifications';
 const PUSH_TOKEN_KEY = '@adepthood/push_token';
@@ -41,12 +42,12 @@ export async function loadAllNotificationMappings(): Promise<Record<number, stri
 }
 
 export async function savePushToken(token: string): Promise<void> {
-  await AsyncStorage.setItem(PUSH_TOKEN_KEY, token);
+  await SecureStore.setItemAsync(PUSH_TOKEN_KEY, token);
 }
 
 export async function loadPushToken(): Promise<string | null> {
   try {
-    return await AsyncStorage.getItem(PUSH_TOKEN_KEY);
+    return await SecureStore.getItemAsync(PUSH_TOKEN_KEY);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- **Migrates push notification token storage** from plaintext `AsyncStorage` to encrypted `expo-secure-store`, closing a HIGH-severity OWASP A02:2021 (Cryptographic Failures) finding
- **Keeps non-sensitive notification ID mappings** in `AsyncStorage` (scheduling data, not credentials)
- **Updates tests** to mock `SecureStore` for push token operations while preserving `AsyncStorage` mocks for notification IDs

## Context

The push token was stored via `AsyncStorage.setItem()`, which writes plaintext to the device filesystem. On rooted Android or jailbroken iOS devices, any app could read this token and send unsolicited push notifications to the user. The codebase already correctly uses `expo-secure-store` for JWT tokens in `authStorage.ts` — this PR extends that pattern to push tokens.

## Changes

| File | What changed |
|------|-------------|
| `frontend/src/storage/notificationStorage.ts` | `savePushToken` → `SecureStore.setItemAsync`, `loadPushToken` → `SecureStore.getItemAsync` |
| `frontend/src/storage/__tests__/notificationStorage.test.ts` | Added `SecureStore` mock, updated 3 push token tests to assert against `mockSecureStore` |

## Test plan

- [x] All 15 notification storage tests pass
- [x] All 24 pre-commit hooks pass green (`pre-commit run --all-files`)
- [x] No changes to public API — `savePushToken`/`loadPushToken` signatures unchanged
- [x] `useHabitNotifications.ts` imports unaffected (same module, same exports)

Closes sec-07

https://claude.ai/code/session_01KBTEo87K1b78nL4XHAP9YH