### PR TITLE
fix(frontend): enforce HTTPS for API base URL in production builds

### DIFF
--- a/frontend/src/__tests__/config.test.ts
+++ b/frontend/src/__tests__/config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { API_BASE_URL, validateApiBaseUrl } from '../config';
+
+const HTTPS_URL = 'https://api.example.com';
+const HTTP_URL = 'http://api.example.com';
+const DEV_DEFAULT = 'http://localhost:8000';
+const ERROR_PREFIX = 'EXPO_PUBLIC_API_BASE_URL must be set to an HTTPS URL in production builds';
+
+describe('config', () => {
+  describe('validateApiBaseUrl in development mode', () => {
+    it('allows HTTP URLs', () => {
+      expect(validateApiBaseUrl(DEV_DEFAULT, true)).toBe(DEV_DEFAULT);
+    });
+
+    it('allows HTTPS URLs', () => {
+      expect(validateApiBaseUrl(HTTPS_URL, true)).toBe(HTTPS_URL);
+    });
+
+    it('allows empty URLs without throwing', () => {
+      expect(validateApiBaseUrl('', true)).toBe('');
+    });
+  });
+
+  describe('validateApiBaseUrl in production mode', () => {
+    it('accepts HTTPS URLs', () => {
+      expect(validateApiBaseUrl(HTTPS_URL, false)).toBe(HTTPS_URL);
+    });
+
+    it('throws for HTTP URLs', () => {
+      expect(() => validateApiBaseUrl(HTTP_URL, false)).toThrow(ERROR_PREFIX);
+    });
+
+    it('throws for empty URLs', () => {
+      expect(() => validateApiBaseUrl('', false)).toThrow(ERROR_PREFIX);
+    });
+
+    it('includes the received URL in the error message', () => {
+      expect(() => validateApiBaseUrl(HTTP_URL, false)).toThrow(`Received: "${HTTP_URL}"`);
+    });
+
+    it('shows "(empty)" for missing URLs in the error message', () => {
+      expect(() => validateApiBaseUrl('', false)).toThrow('Received: "(empty)"');
+    });
+  });
+
+  describe('API_BASE_URL module export', () => {
+    it('defaults to http://localhost:8000 in development mode', () => {
+      expect(API_BASE_URL).toBe(DEV_DEFAULT);
+    });
+  });
+});

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,1 +1,15 @@
-export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+const DEV_DEFAULT_URL = 'http://localhost:8000';
+
+export function validateApiBaseUrl(url: string, isDev: boolean): string {
+  if (!isDev && !url.startsWith('https://')) {
+    throw new Error(
+      'EXPO_PUBLIC_API_BASE_URL must be set to an HTTPS URL in production builds. ' +
+        `Received: "${url || '(empty)'}"`,
+    );
+  }
+  return url;
+}
+
+const rawUrl = process.env.EXPO_PUBLIC_API_BASE_URL || (__DEV__ ? DEV_DEFAULT_URL : '');
+
+export const API_BASE_URL = validateApiBaseUrl(rawUrl, __DEV__);


### PR DESCRIPTION
## Summary

- **sec-08**: The API config (`frontend/src/config.ts`) defaulted to `http://localhost:8000` regardless of build mode, risking cleartext transmission of JWTs and credentials if `EXPO_PUBLIC_API_BASE_URL` was missing in production
- Adds a `validateApiBaseUrl` function that throws at startup if a production build has a non-HTTPS (or missing) API URL, while preserving the HTTP localhost default for development
- Adds 9 tests covering dev/prod mode validation, error message content, and module export integration

## Changes

| File | What changed |
|------|-------------|
| `frontend/src/config.ts` | Added `validateApiBaseUrl()` with HTTPS enforcement; split dev/prod defaults |
| `frontend/src/__tests__/config.test.ts` | New — 9 tests for validation logic and module export |

## Acceptance Criteria

- [x] Production builds refuse to start with HTTP or missing API base URL
- [x] Development builds continue to use `http://localhost:8000`
- [x] Error message clearly identifies the misconfiguration

## Test plan

- [x] All 9 new config tests pass
- [x] All 471 existing frontend tests pass (no regressions)
- [x] All 24 pre-commit hooks pass green (`pre-commit run --all-files`)
- [x] ESLint, Prettier, TypeScript strict — zero warnings
- [x] Backend coverage remains above 90%

https://claude.ai/code/session_01DofT1dTdgZkaznKGYEyHFi