### PR TITLE
fix(backend): unify JWT error responses (sec-04)

### DIFF
--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -228,18 +228,23 @@ async def login(
 
 
 def get_current_user(authorization: str | None = Header(default=None)) -> int:
+    """Extract and validate the JWT from the Authorization header.
+
+    All rejection scenarios return an identical 401 with detail="unauthorized"
+    to prevent attackers from distinguishing token states (OWASP A07:2021,
+    sec-04). The specific reason is logged server-side for debugging.
+    """
     if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing_token")
+        logger.info("token_rejected", extra={"reason": "missing_or_malformed_header"})
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
     token = authorization.split(" ", 1)[1]
     try:
         payload = jwt.decode(token, _get_secret_key(), algorithms=[_JWT_ALGORITHM])
-    except jwt.ExpiredSignatureError as exc:
+    except jwt.PyJWTError as exc:
+        reason = "expired" if isinstance(exc, jwt.ExpiredSignatureError) else "invalid"
+        logger.info("token_rejected", extra={"reason": reason})
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="expired_token"
-        ) from exc
-    except jwt.InvalidTokenError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_token"
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
         ) from exc
     user_id = int(payload["sub"])
     return user_id

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -247,20 +247,22 @@ async def test_valid_token_accesses_protected_endpoint(async_client: AsyncClient
 
 
 @pytest.mark.asyncio
-async def test_missing_token_returns_401(async_client: AsyncClient) -> None:
+async def test_missing_token_returns_401_unauthorized(async_client: AsyncClient) -> None:
     resp = await async_client.get("/habits/")
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
+    assert resp.json()["detail"] == "unauthorized"
 
 
 @pytest.mark.asyncio
-async def test_invalid_token_returns_401(async_client: AsyncClient) -> None:
+async def test_invalid_token_returns_401_unauthorized(async_client: AsyncClient) -> None:
     headers = {"Authorization": "Bearer badtoken"}  # pragma: allowlist secret
     resp = await async_client.get("/habits/", headers=headers)
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
+    assert resp.json()["detail"] == "unauthorized"
 
 
 @pytest.mark.asyncio
-async def test_expired_token_returns_401(async_client: AsyncClient) -> None:
+async def test_expired_token_returns_401_unauthorized(async_client: AsyncClient) -> None:
     data = await _signup(async_client)
     user_id = data["user_id"]
     # Create an already-expired JWT
@@ -273,6 +275,41 @@ async def test_expired_token_returns_401(async_client: AsyncClient) -> None:
     headers = {"Authorization": f"Bearer {expired_token}"}
     resp = await async_client.get("/habits/", headers=headers)
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
+    assert resp.json()["detail"] == "unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_all_token_errors_return_identical_response(async_client: AsyncClient) -> None:
+    """All token rejection scenarios must return the same detail to prevent
+    information leakage about token state (sec-04)."""
+    data = await _signup(async_client)
+    user_id = data["user_id"]
+
+    # Missing token
+    missing_resp = await async_client.get("/habits/")
+
+    # Invalid token
+    invalid_resp = await async_client.get(
+        "/habits/",
+        headers={"Authorization": "Bearer badtoken"},  # pragma: allowlist secret
+    )
+
+    # Expired token
+    expired_payload = {"sub": str(user_id), "exp": 0, "iat": 0}
+    expired_token = jwt.encode(expired_payload, SECRET_KEY, algorithm="HS256")
+    expired_resp = await async_client.get(
+        "/habits/", headers={"Authorization": f"Bearer {expired_token}"}
+    )
+
+    # Malformed Authorization header (no "Bearer " prefix)
+    no_prefix_resp = await async_client.get(
+        "/habits/", headers={"Authorization": "NotBearer sometoken"}
+    )
+
+    # All must return identical status + detail
+    for resp in (missing_resp, invalid_resp, expired_resp, no_prefix_resp):
+        assert resp.status_code == HTTPStatus.UNAUTHORIZED
+        assert resp.json()["detail"] == "unauthorized"
 
 
 # ── Full flow ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Unify all token rejection responses** in `get_current_user` to return an identical `401 Unauthorized` with `detail="unauthorized"`, replacing three distinct error codes (`missing_token`, `expired_token`, `invalid_token`) that leaked token state to attackers (OWASP A07:2021)
- **Add server-side logging** (`logger.info("token_rejected", extra={"reason": ...})`) so ops can still diagnose auth issues without exposing details to clients
- **Add comprehensive tests** verifying all four rejection paths (missing, invalid, expired, malformed header) return identical responses

## Security Impact

Previously, an attacker could:
1. Distinguish expired from invalid tokens — confirming account existence
2. Time token expiration precisely via response transitions
3. Fingerprint the JWT library error hierarchy

Now all rejection scenarios are indistinguishable from the client's perspective.

## Files Changed

| File | Change |
|------|--------|
| `backend/src/routers/auth.py` | Unified `get_current_user` error details + added server-side logging |
| `backend/tests/test_auth.py` | Updated 3 existing tests + added `test_all_token_errors_return_identical_response` |

## Test plan

- [x] All 33 auth tests pass
- [x] All 24 pre-commit hooks pass green (including 90%+ backend coverage)
- [x] Frontend `onUnauthorized` handler verified unaffected (checks `status === 401`, not detail)
- [x] Existing tests for login, signup, lockout, rate limiting all still pass

https://claude.ai/code/session_015X9A69Fqaw1Gq6mFp4yPC7