### PR TITLE
fix(backend): validate LLM_API_KEY for non-stub providers (sec-06)

### DIFF
--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -135,15 +135,27 @@ def _import_optional(module_name: str, provider_label: str) -> ModuleType:
         raise RuntimeError(msg) from exc
 
 
+def _get_llm_api_key() -> str:
+    """Return the LLM API key, raising if unset or empty.
+
+    Follows the same fail-fast pattern as ``_get_secret_key`` in auth.py.
+    """
+    api_key = os.getenv("LLM_API_KEY", "")
+    if not api_key:
+        msg = "LLM_API_KEY environment variable must be set for non-stub providers"
+        raise RuntimeError(msg)
+    return api_key
+
+
 async def _call_openai(
     user_message: str,
     conversation_history: list[dict[str, str]],
     system_prompt: str,
 ) -> str:
     """Call the OpenAI chat completions API."""
+    api_key = _get_llm_api_key()
     openai_mod = _import_optional("openai", "OpenAI")
 
-    api_key = os.getenv("LLM_API_KEY", "")
     client = openai_mod.AsyncOpenAI(api_key=api_key)
     messages = _build_messages(user_message, conversation_history, system_prompt)
     completion = await client.chat.completions.create(
@@ -159,9 +171,9 @@ async def _call_anthropic(
     system_prompt: str,
 ) -> str:
     """Call the Anthropic messages API."""
+    api_key = _get_llm_api_key()
     anthropic_mod = _import_optional("anthropic", "Anthropic")
 
-    api_key = os.getenv("LLM_API_KEY", "")
     client = anthropic_mod.AsyncAnthropic(api_key=api_key)
     # Anthropic uses a separate system parameter, not a system message in the list.
     messages_for_api: list[dict[str, str]] = []

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -332,3 +332,61 @@ async def test_system_prompt_allows_file_at_size_limit(
     monkeypatch.setenv("BOTMASON_SYSTEM_PROMPT", str(max_file))
     prompt = get_system_prompt()
     assert len(prompt) == 50 * 1024
+
+
+# ── LLM API key validation tests ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_raises_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI provider raises RuntimeError when LLM_API_KEY is not set."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="LLM_API_KEY"):
+        await generate_response("Hello", [])
+
+
+@pytest.mark.asyncio
+async def test_anthropic_provider_raises_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic provider raises RuntimeError when LLM_API_KEY is not set."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "anthropic")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="LLM_API_KEY"):
+        await generate_response("Hello", [])
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_raises_with_empty_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI provider raises RuntimeError when LLM_API_KEY is empty string."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", "")
+    with pytest.raises(RuntimeError, match="LLM_API_KEY"):
+        await generate_response("Hello", [])
+
+
+@pytest.mark.asyncio
+async def test_anthropic_provider_raises_with_empty_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic provider raises RuntimeError when LLM_API_KEY is empty string."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "anthropic")
+    monkeypatch.setenv("LLM_API_KEY", "")
+    with pytest.raises(RuntimeError, match="LLM_API_KEY"):
+        await generate_response("Hello", [])
+
+
+@pytest.mark.asyncio
+async def test_stub_provider_works_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stub provider continues to work without LLM_API_KEY."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    result = await generate_response("Hello", [])
+    assert "Hello" in result


### PR DESCRIPTION
## Summary

- Add `_get_llm_api_key()` validation function that raises `RuntimeError` when `LLM_API_KEY` is unset or empty, following the same fail-fast pattern as `_get_secret_key()` in `auth.py`
- Wire the validation into both `_call_openai()` and `_call_anthropic()` **before** the SDK import, so misconfiguration surfaces immediately with a clear error message
- Stub provider continues to work without any API key configured

**Closes sec-06** — OWASP A07:2021 (Identification and Authentication Failures)

## Changes

| File | Change |
|------|--------|
| `backend/src/services/botmason.py` | Add `_get_llm_api_key()`, call it in both provider functions |
| `backend/tests/test_botmason_api.py` | 5 new tests: unset key (openai, anthropic), empty key (openai, anthropic), stub passthrough |

## Test plan

- [x] `test_openai_provider_raises_without_api_key` — unset `LLM_API_KEY` with openai provider raises `RuntimeError`
- [x] `test_anthropic_provider_raises_without_api_key` — same for anthropic provider
- [x] `test_openai_provider_raises_with_empty_api_key` — empty string `LLM_API_KEY` also rejected
- [x] `test_anthropic_provider_raises_with_empty_api_key` — same for anthropic
- [x] `test_stub_provider_works_without_api_key` — stub provider unaffected
- [x] All 310 backend tests pass, coverage 93.41% (above 90% threshold)
- [x] All 24 pre-commit hooks pass green

https://claude.ai/code/session_016y1cLRUVsAJzFDv7AHC59Y