### PR TITLE
fix(infra): remove unnecessary PYSEC-0000 pip-audit exemption

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,8 +60,7 @@ repos:
       - id: pip-audit
         name: pip-audit (backend dependencies)
         files: ^backend/
-        args: ["-r", "backend/requirements.txt", "--ignore-vuln", "PYSEC-0000"]
-        # If you use Poetry/uv instead of requirements.txt, adjust accordingly.
+        args: ["-r", "backend/requirements.txt"]
 
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0


### PR DESCRIPTION
## Summary

- **Removes** the undocumented `--ignore-vuln PYSEC-0000` flag from the pip-audit pre-commit hook
- **PYSEC-0000** is a placeholder/test ID in the PyPI Advisory Database — not a real vulnerability
- **Aligns** pre-commit config with CI (`backend-ci.yml`) which already runs pip-audit without any ignore flags

## Investigation

Ran `pip-audit -r backend/requirements.txt` without the ignore flag — result: **"No known vulnerabilities found"**. The exemption was unnecessary and created a confusing inconsistency between local pre-commit checks and CI.

## Acceptance Criteria (sec-13)

- [x] The exemption is either documented with justification or removed
- [x] Pre-commit and CI pip-audit configurations are consistent
- [x] No real vulnerabilities are being silently suppressed

## Test plan

- [x] `pip-audit -r backend/requirements.txt` passes clean (no ignore flag needed)
- [x] `pre-commit run --all-files` — all 24 hooks pass green
- [x] CI `backend-ci.yml` pip-audit step already matches this config

https://claude.ai/code/session_01BumuT3PVCaj63noh4oyQkr