### PR TITLE
fix(ci): pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -16,15 +16,15 @@ jobs:
   backend-quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
 
       - name: Install backend deps
         run: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0  # v1.0.93
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0  # v1.0.93
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version-file: "frontend/.nvmrc"
           cache: "npm"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,17 @@ Agents working on this project must abide by the following operating principles:
 
     - Checking network requests for accurate backend interaction
 
-6. **Respect the Archetypal Wavelength**
+6. **Pin GitHub Actions to Commit SHAs**
+
+  - All `uses:` references in `.github/workflows/` must use full 40-character commit SHAs, not mutable version tags.
+
+  - Include a version comment after the SHA for readability (e.g., `actions/checkout@<sha>  # v4.3.1`).
+
+  - Dependabot is configured (`.github/dependabot.yml`) to propose weekly updates for pinned actions.
+
+  - Never reference an action by tag alone (`@v4`, `@v1`) — tags can be force-pushed, enabling supply chain attacks.
+
+7. **Respect the Archetypal Wavelength**
 
   - Restoration leads to Rising.
 


### PR DESCRIPTION
## Summary\n\n- **Pin all 9 GitHub Actions references** across 4 workflow files from mutable version tags (`@v4`, `@v5`, `@v3`, `@v1`) to full 40-character commit SHAs, preventing supply chain attacks via tag force-push\n- **Add Dependabot config** (`.github/dependabot.yml`) for weekly automated action update proposals so pinned SHAs stay current\n- **Document the SHA pinning practice** in AGENTS.md as a required operating principle for all contributors\n\n### Actions pinned\n\n| Action | SHA | Tag |\n|--------|-----|-----|\n| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |\n| `actions/setup-python` | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |\n| `astral-sh/setup-uv` | `caf0cab7a618c569241d31dcd442f54681755d39` | v3.2.4 |\n| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |\n| `anthropics/claude-code-action` | `b47fd721da662d48c5680e154ad16a73ed74d2e0` | v1.0.93 |\n\nResolves: sec-12 (OWASP A08:2021 — Software and Data Integrity Failures)\n\n## Test plan\n\n- [x] All 24 pre-commit hooks pass green on `--all-files`\n- [x] SHAs verified via `git ls-remote` against upstream repositories\n- [x] Each SHA is exactly 40 hex characters\n- [x] Version comments match the resolved tag for each SHA\n- [x] Dependabot config uses correct `github-actions` ecosystem and weekly schedule\n- [x] No functional workflow changes — only action references updated\n\nhttps://claude.ai/code/session_01LtVn91g8id4ewnSJHZ7GTF"