### PR TITLE
fix(backend): add global and per-endpoint rate limits (sec-11)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -8,6 +8,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -82,11 +83,13 @@ def get_cors_origins(env: str | None = None) -> list[str]:
     return _parse_prod_origins()
 
 
-def _rate_limit_exceeded_handler(_request: Request, _exc: RateLimitExceeded) -> JSONResponse:
-    """Return a JSON 429 response when the rate limit is exceeded."""
+def _rate_limit_exceeded_handler(_request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    """Return a JSON 429 response with Retry-After header when rate limit is exceeded."""
+    retry_after = getattr(exc, "retry_after", 60)
     return JSONResponse(
         status_code=429,
         content={"detail": "rate_limit_exceeded"},
+        headers={"Retry-After": str(retry_after)},
     )
 
 
@@ -127,6 +130,11 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # ty
 
 # Security headers on all responses
 app.add_middleware(SecurityHeadersMiddleware)
+
+# Apply default rate limits to all endpoints (including undecorated ones).
+# Must be added after SecurityHeaders and before CORS so that:
+#   CORS (outermost) → SlowAPI → SecurityHeaders → route handler
+app.add_middleware(SlowAPIMiddleware)
 
 origins = get_cors_origins()
 

--- a/backend/src/rate_limit.py
+++ b/backend/src/rate_limit.py
@@ -3,6 +3,11 @@
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+# Default rate limit applied to all endpoints that don't declare their own.
+# Auth endpoints override this with stricter per-route limits (3/min signup,
+# 5/min login). The global default protects against scraping and general abuse.
+DEFAULT_RATE_LIMIT = "60/minute"
+
 # Rate limiter keyed by client IP address. Shared across routers so all
 # endpoints use a single limiter with consistent state.
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=get_remote_address, default_limits=[DEFAULT_RATE_LIMIT])

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -10,6 +10,7 @@ from database import get_session
 from errors import bad_request, payment_required
 from models.journal_entry import JournalEntry
 from models.user import User
+from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.botmason import (
     BalanceAddRequest,
@@ -37,7 +38,9 @@ async def _get_user(user_id: int, session: AsyncSession) -> User:
     response_model=ChatResponse,
     status_code=status.HTTP_201_CREATED,
 )
+@limiter.limit("10/minute")
 async def chat_with_botmason(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     payload: ChatRequest,
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
@@ -109,7 +112,9 @@ async def get_balance(
 
 
 @router.post("/user/balance/add", response_model=BalanceAddResponse)
+@limiter.limit("5/minute")
 async def add_balance(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     payload: BalanceAddRequest,
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from fastapi import APIRouter, Depends, Query, Response, status
+from fastapi import APIRouter, Depends, Query, Request, Response, status
 from sqlalchemy import ColumnElement, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -12,6 +12,7 @@ from sqlmodel import col, select
 from database import get_session
 from errors import not_found
 from models.journal_entry import JournalEntry, JournalTag
+from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.journal import (
     JournalBotMessageCreate,
@@ -61,7 +62,9 @@ def _build_filter_conditions(filters: _ListFilters) -> list[ColumnElement[bool]]
 
 
 @router.get("/", response_model=JournalListResponse)
+@limiter.limit("30/minute")
 async def list_journal_entries(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
     filters: _ListFilters = Depends(),  # noqa: B008

--- a/backend/src/routers/practices.py
+++ b/backend/src/routers/practices.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from database import get_session
 from errors import not_found
 from models.practice import Practice
+from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.practice import PracticeCreate, PracticeResponse
 
@@ -46,7 +47,9 @@ async def get_practice(
 
 
 @router.post("/", response_model=PracticeResponse, status_code=status.HTTP_201_CREATED)
+@limiter.limit("5/minute")
 async def submit_practice(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     payload: PracticeCreate,
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -1,0 +1,224 @@
+"""Tests for global and per-endpoint rate limiting (sec-11).
+
+Verifies that:
+- All endpoints have a global default rate limit (60/minute)
+- Expensive endpoints have stricter per-endpoint limits
+- 429 responses include a Retry-After header
+- Existing auth rate limits remain unchanged
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+from rate_limit import DEFAULT_RATE_LIMIT
+
+
+async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
+    """Create a user and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _add_balance(client: AsyncClient, headers: dict[str, str], amount: int = 50) -> None:
+    """Add offering credits to the authenticated user."""
+    resp = await client.post("/user/balance/add", json={"amount": amount}, headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+
+# ── Configuration ────────────────────────────────────────────────────────
+
+
+def test_default_rate_limit_constant() -> None:
+    """The DEFAULT_RATE_LIMIT constant is set to 60 requests per minute."""
+    assert DEFAULT_RATE_LIMIT == "60/minute"
+
+
+# ── Retry-After header ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_response_includes_retry_after(async_client: AsyncClient) -> None:
+    """429 responses include a Retry-After header."""
+    # Use signup endpoint (3/minute) to trigger rate limit quickly
+    for i in range(3):
+        await async_client.post(
+            "/auth/signup",
+            json={
+                "email": f"ratelimit{i}@example.com",
+                "password": "secret12345",  # pragma: allowlist secret
+            },
+        )
+
+    # 4th request exceeds the limit
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "ratelimit99@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+    assert "retry-after" in resp.headers
+
+
+# ── Per-endpoint: POST /journal/chat (10/minute) ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chat_rate_limit_returns_429(async_client: AsyncClient) -> None:
+    """POST /journal/chat returns 429 after exceeding 10 requests/minute."""
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=20)
+
+    # Make 10 requests (the limit)
+    for _ in range(10):
+        await async_client.post(
+            "/journal/chat",
+            json={"message": "Hello BotMason"},
+            headers=headers,
+        )
+
+    # 11th request should be rate-limited
+    resp = await async_client.post(
+        "/journal/chat",
+        json={"message": "One too many"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+    assert "retry-after" in resp.headers
+
+
+# ── Per-endpoint: POST /user/balance/add (5/minute) ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_add_balance_rate_limit_returns_429(async_client: AsyncClient) -> None:
+    """POST /user/balance/add returns 429 after exceeding 5 requests/minute."""
+    headers = await _signup(async_client)
+
+    # Make 5 requests (the limit)
+    for _ in range(5):
+        await async_client.post(
+            "/user/balance/add",
+            json={"amount": 1},
+            headers=headers,
+        )
+
+    # 6th request should be rate-limited
+    resp = await async_client.post(
+        "/user/balance/add",
+        json={"amount": 1},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+    assert "retry-after" in resp.headers
+
+
+# ── Per-endpoint: POST /practices/ (5/minute) ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_submit_practice_rate_limit_returns_429(async_client: AsyncClient) -> None:
+    """POST /practices/ returns 429 after exceeding 5 requests/minute."""
+    headers = await _signup(async_client)
+
+    practice_payload = {
+        "stage_number": 1,
+        "name": "Test Practice",
+        "description": "Test desc",
+        "instructions": "Test instructions",
+        "default_duration_minutes": 10,
+    }
+
+    # Make 5 requests (the limit)
+    for _ in range(5):
+        await async_client.post("/practices/", json=practice_payload, headers=headers)
+
+    # 6th request should be rate-limited
+    resp = await async_client.post("/practices/", json=practice_payload, headers=headers)
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+    assert "retry-after" in resp.headers
+
+
+# ── Per-endpoint: GET /journal/ (30/minute) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_journal_list_rate_limit_returns_429(async_client: AsyncClient) -> None:
+    """GET /journal/ returns 429 after exceeding 30 requests/minute."""
+    headers = await _signup(async_client)
+
+    # Make 30 requests (the limit)
+    for _ in range(30):
+        await async_client.get("/journal/", headers=headers)
+
+    # 31st request should be rate-limited
+    resp = await async_client.get("/journal/", headers=headers)
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+    assert "retry-after" in resp.headers
+
+
+# ── Auth rate limits unchanged ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auth_signup_limit_unchanged_at_3_per_minute(async_client: AsyncClient) -> None:
+    """Auth signup rate limit remains at 3/minute (not overridden by default)."""
+    for i in range(3):
+        await async_client.post(
+            "/auth/signup",
+            json={
+                "email": f"auth{i}@example.com",
+                "password": "secret12345",  # pragma: allowlist secret
+            },
+        )
+
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "auth99@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+
+
+@pytest.mark.asyncio
+async def test_auth_login_limit_unchanged_at_5_per_minute(async_client: AsyncClient) -> None:
+    """Auth login rate limit remains at 5/minute (not overridden by default)."""
+    await _signup(async_client)
+
+    for _ in range(5):
+        await async_client.post(
+            "/auth/login",
+            json={
+                "email": "alice@example.com",
+                "password": "secret12345",  # pragma: allowlist secret
+            },
+        )
+
+    resp = await async_client.post(
+        "/auth/login",
+        json={
+            "email": "alice@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS


### PR DESCRIPTION
## Summary

- Add global default rate limit of **60 requests/minute** to all endpoints via `SlowAPIMiddleware` and `default_limits` on the `Limiter`
- Add stricter per-endpoint limits on expensive operations:
  - `POST /journal/chat`: **10/min** (LLM API cost)
  - `POST /user/balance/add`: **5/min** (financial operation)
  - `POST /practices/`: **5/min** (content creation spam)
  - `GET /journal/`: **30/min** (data enumeration)
- 429 responses now include a `Retry-After` header
- Existing auth rate limits unchanged (3/min signup, 5/min login)

## Security Context

**OWASP:** A04:2021 — Insecure Design
**Severity:** MEDIUM

Previously, only auth endpoints had rate limits. An authenticated attacker could exhaust LLM credits by spamming `/journal/chat`, enumerate data via rapid pagination, or flood POST endpoints with spam content.

## Files Changed

| File | Change |
|------|--------|
| `backend/src/rate_limit.py` | Add `DEFAULT_RATE_LIMIT` constant and `default_limits` to Limiter |
| `backend/src/main.py` | Add `SlowAPIMiddleware`, update 429 handler with `Retry-After` header |
| `backend/src/routers/botmason.py` | Add 10/min limit on chat, 5/min on balance/add |
| `backend/src/routers/journal.py` | Add 30/min limit on journal list |
| `backend/src/routers/practices.py` | Add 5/min limit on practice submission |
| `backend/tests/test_rate_limits.py` | 8 new tests covering all acceptance criteria |

## Test Plan

- [x] Global default rate limit constant verified (`DEFAULT_RATE_LIMIT == "60/minute"`)
- [x] 429 responses include `Retry-After` header
- [x] `POST /journal/chat` returns 429 after 10 requests/minute
- [x] `POST /user/balance/add` returns 429 after 5 requests/minute
- [x] `POST /practices/` returns 429 after 5 requests/minute
- [x] `GET /journal/` returns 429 after 30 requests/minute
- [x] Auth signup limit unchanged at 3/minute
- [x] Auth login limit unchanged at 5/minute
- [x] All 313 backend tests pass, 93.17% coverage (above 90% threshold)
- [x] All pre-commit hooks pass green

https://claude.ai/code/session_018yqJ4G9UXT5EnYPvuUMnq9