### PR TITLE
fix(frontend): add nginx security headers (sec-18)

### DIFF
--- a/frontend/__tests__/nginx-security-headers.test.ts
+++ b/frontend/__tests__/nginx-security-headers.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from '@jest/globals';
+
+const NGINX_CONF_PATH = resolve(__dirname, '..', 'nginx.conf');
+const nginxConf = readFileSync(NGINX_CONF_PATH, 'utf-8');
+
+/**
+ * Required security headers that must appear in the nginx config.
+ * Each entry maps a header name to a substring that must appear in its value.
+ */
+const REQUIRED_HEADERS: Array<[string, string]> = [
+  ['X-Content-Type-Options', 'nosniff'],
+  ['X-Frame-Options', 'DENY'],
+  ['Referrer-Policy', 'strict-origin-when-cross-origin'],
+  ['Permissions-Policy', 'camera=()'],
+];
+
+describe('nginx.conf security headers', () => {
+  it.each(REQUIRED_HEADERS)('includes %s header with value containing "%s"', (header, value) => {
+    const pattern = new RegExp(
+      `add_header\\s+${header}\\s+"[^"]*${value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"]*"\\s+always`,
+    );
+    expect(nginxConf).toMatch(pattern);
+  });
+
+  it('includes Content-Security-Policy-Report-Only header', () => {
+    expect(nginxConf).toMatch(
+      /add_header\s+Content-Security-Policy-Report-Only\s+"[^"]+"\s+always/,
+    );
+  });
+
+  it('CSP report-only header includes default-src directive', () => {
+    const cspMatch = nginxConf.match(
+      /add_header\s+Content-Security-Policy-Report-Only\s+"([^"]+)"/,
+    );
+    expect(cspMatch).not.toBeNull();
+    expect(cspMatch![1]).toContain("default-src 'self'");
+  });
+
+  it('CSP report-only header includes script-src directive', () => {
+    const cspMatch = nginxConf.match(
+      /add_header\s+Content-Security-Policy-Report-Only\s+"([^"]+)"/,
+    );
+    expect(cspMatch).not.toBeNull();
+    expect(cspMatch![1]).toContain("script-src 'self'");
+  });
+
+  it('CSP report-only header includes frame-ancestors none', () => {
+    const cspMatch = nginxConf.match(
+      /add_header\s+Content-Security-Policy-Report-Only\s+"([^"]+)"/,
+    );
+    expect(cspMatch).not.toBeNull();
+    expect(cspMatch![1]).toContain("frame-ancestors 'none'");
+  });
+
+  describe('location blocks with add_header inherit security headers', () => {
+    // nginx does not inherit server-level add_header directives into location
+    // blocks that define their own add_header. Verify each such block repeats
+    // the security headers.
+    const locationBlocks = [...nginxConf.matchAll(/location\s+[^{]+\{([^}]+)\}/g)];
+    const blocksWithAddHeader = locationBlocks.filter(
+      (m): m is RegExpExecArray & { 1: string } =>
+        m[1] !== undefined && /add_header\s+Cache-Control/.test(m[1]),
+    );
+
+    it('finds location blocks that use add_header', () => {
+      expect(blocksWithAddHeader.length).toBeGreaterThan(0);
+    });
+
+    it.each(['X-Content-Type-Options', 'X-Frame-Options', 'Referrer-Policy', 'Permissions-Policy'])(
+      'every location block with Cache-Control also includes %s',
+      (header) => {
+        for (const [, body] of blocksWithAddHeader) {
+          expect(body).toMatch(new RegExp(`add_header\\s+${header}\\s+`));
+        }
+      },
+    );
+  });
+});

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,13 @@ server {
     root         /usr/share/nginx/html;
     index        index.html;
 
+    # Security headers — mitigate clickjacking, MIME-sniffing, and info leakage
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self'; connect-src 'self' https:; frame-ancestors 'none'" always;
+
     # SPA fallback: serve index.html for all routes that don't match a file
     location / {
         try_files $uri $uri/ /index.html;
@@ -13,12 +20,21 @@ server {
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     }
 
     # Don't cache index.html so new deploys take effect immediately
     location = /index.html {
         expires -1;
         add_header Cache-Control "no-store, no-cache, must-revalidate";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self'; connect-src 'self' https:; frame-ancestors 'none'" always;
     }
 
     # Gzip text-based assets


### PR DESCRIPTION
## Summary

- Add X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, and Content-Security-Policy-Report-Only headers to `frontend/nginx.conf`
- Repeat security headers in location blocks that define their own `add_header` (nginx does not inherit server-level `add_header` into such blocks)
- Add a 13-test suite validating all required headers are present, CSP directives are correct, and the nginx inheritance edge case is covered

## Details

**Problem:** The frontend Dockerfile serves the Expo web build via nginx, but the nginx config had no security headers. The backend's `SecurityHeadersMiddleware` only covers API responses — the HTML page itself was missing protections against clickjacking, MIME-sniffing, and info leakage.

**Headers added:**
| Header | Value | Purpose |
|--------|-------|---------|
| X-Content-Type-Options | nosniff | Prevent MIME-type sniffing |
| X-Frame-Options | DENY | Prevent clickjacking via iframes |
| Referrer-Policy | strict-origin-when-cross-origin | Limit referrer leakage |
| Permissions-Policy | camera=(), microphone=(), geolocation=() | Disable unused browser features |
| Content-Security-Policy-Report-Only | default-src 'self'; script-src 'self'; ... | CSP in report-only mode for safe rollout |

**nginx `add_header` inheritance:** nginx does not inherit server-level `add_header` directives into location blocks that define their own. Both the static assets and index.html location blocks already had `Cache-Control` headers, so security headers are explicitly repeated there. The test suite validates this.

## Test plan

- [x] 13 new tests in `frontend/__tests__/nginx-security-headers.test.ts` — all passing
- [x] All 24 pre-commit hooks pass green (`pre-commit run --all-files`)
- [x] No regressions in existing test suites (frontend + backend)
- [x] Acceptance criteria from sec-18 issue all met

https://claude.ai/code/session_01DZP2DHbheaXsL4FqzJdkSw