### PR TITLE
fix(backend): add remaining input length constraints (sec-15)

### DIFF
--- a/backend/src/models/goal.py
+++ b/backend/src/models/goal.py
@@ -30,7 +30,7 @@ class Goal(SQLModel, table=True):
     habit_id: int = Field(foreign_key="habit.id")
     title: str = Field(max_length=255)
     description: str | None = Field(default=None, max_length=2_000)
-    tier: str  # "low", "clear", "stretch"
+    tier: str = Field(max_length=50)  # "low", "clear", "stretch"
     target: float
     target_unit: str = Field(max_length=50)  # "minutes", "reps", etc.
     frequency: float  # e.g. 2.0 = 2x per frequency_unit
@@ -41,7 +41,7 @@ class Goal(SQLModel, table=True):
     )
     track_with_timer: bool = False
     timer_duration_minutes: int | None = None
-    origin: str | None = None
+    origin: str | None = Field(default=None, max_length=255)
     goal_group_id: int | None = Field(default=None, foreign_key="goalgroup.id")
     goal_group: Optional["GoalGroup"] = Relationship(back_populates="goals")
     is_additive: bool = True

--- a/backend/src/models/goal_group.py
+++ b/backend/src/models/goal_group.py
@@ -10,10 +10,10 @@ class GoalGroup(SQLModel, table=True):
     """Logical grouping for related goals."""
 
     id: int | None = Field(default=None, primary_key=True)
-    name: str
-    icon: str | None = None
-    description: str | None = None
+    name: str = Field(max_length=255)
+    icon: str | None = Field(default=None, max_length=100)
+    description: str | None = Field(default=None, max_length=2_000)
     user_id: int | None = Field(default=None, foreign_key="user.id")
     shared_template: bool = False
-    source: str | None = None
+    source: str | None = Field(default=None, max_length=255)
     goals: list["Goal"] = Relationship(back_populates="goal_group")

--- a/backend/src/models/habit.py
+++ b/backend/src/models/habit.py
@@ -15,8 +15,8 @@ class Habit(SQLModel, table=True):
     """Tracks a user's habit and related goals."""
 
     id: int | None = Field(default=None, primary_key=True)
-    name: str
-    icon: str
+    name: str = Field(max_length=255)
+    icon: str = Field(max_length=100)
     start_date: date
     energy_cost: int
     energy_return: int
@@ -24,13 +24,13 @@ class Habit(SQLModel, table=True):
     notification_times: list[str] | None = Field(
         default=None, sa_column=Column(PG_ARRAY(String), nullable=True)
     )
-    notification_frequency: str | None = None
+    notification_frequency: str | None = Field(default=None, max_length=20)
     notification_days: list[str] | None = Field(
         default=None, sa_column=Column(PG_ARRAY(String), nullable=True)
     )
     milestone_notifications: bool = Field(default=False)
     sort_order: int | None = None
-    stage: str = ""
+    stage: str = Field(default="", max_length=100)
     streak: int = 0
     user: "User" = Relationship(back_populates="habits")
     goals: list["Goal"] = Relationship(back_populates="habit")

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -30,9 +30,9 @@ class JournalEntry(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     message: str = Field(max_length=10_000)
-    sender: str  # 'user' or 'bot'
+    sender: str = Field(max_length=10)  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id")
-    tag: str = JournalTag.FREEFORM
+    tag: str = Field(default=JournalTag.FREEFORM, max_length=50)
     practice_session_id: int | None = Field(default=None, foreign_key="practicesession.id")
     user_practice_id: int | None = Field(default=None, foreign_key="userpractice.id")
     user: "User" = Relationship(back_populates="journals")

--- a/backend/src/models/practice_session.py
+++ b/backend/src/models/practice_session.py
@@ -15,4 +15,4 @@ class PracticeSession(SQLModel, table=True):
     user_practice_id: int = Field(foreign_key="userpractice.id")
     duration_minutes: float
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    reflection: str | None = None
+    reflection: str | None = Field(default=None, max_length=5_000)

--- a/backend/src/schemas/goal_group.py
+++ b/backend/src/schemas/goal_group.py
@@ -2,19 +2,24 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from schemas.goal import Goal
+
+GOAL_GROUP_NAME_MAX_LENGTH = 255
+GOAL_GROUP_ICON_MAX_LENGTH = 100
+GOAL_GROUP_DESCRIPTION_MAX_LENGTH = 2_000
+GOAL_GROUP_SOURCE_MAX_LENGTH = 255
 
 
 class GoalGroupCreate(BaseModel):
     """Payload for creating/updating a goal group."""
 
-    name: str
-    icon: str | None = None
-    description: str | None = None
+    name: str = Field(min_length=1, max_length=GOAL_GROUP_NAME_MAX_LENGTH)
+    icon: str | None = Field(default=None, max_length=GOAL_GROUP_ICON_MAX_LENGTH)
+    description: str | None = Field(default=None, max_length=GOAL_GROUP_DESCRIPTION_MAX_LENGTH)
     shared_template: bool = False
-    source: str | None = None
+    source: str | None = Field(default=None, max_length=GOAL_GROUP_SOURCE_MAX_LENGTH)
 
 
 class GoalGroupResponse(BaseModel):

--- a/backend/src/schemas/habit.py
+++ b/backend/src/schemas/habit.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from schemas.goal import Goal
 
 NOTIFICATION_FREQUENCY = Literal["daily", "weekly", "custom", "off"]
+
+HABIT_NAME_MAX_LENGTH = 255
+HABIT_ICON_MAX_LENGTH = 100
+HABIT_STAGE_MAX_LENGTH = 100
 
 
 class Habit(BaseModel):
@@ -48,8 +52,8 @@ class HabitCreate(BaseModel):
     authenticated user's token so clients cannot impersonate other users.
     """
 
-    name: str
-    icon: str
+    name: str = Field(min_length=1, max_length=HABIT_NAME_MAX_LENGTH)
+    icon: str = Field(max_length=HABIT_ICON_MAX_LENGTH)
     start_date: date
     energy_cost: int
     energy_return: int
@@ -58,4 +62,4 @@ class HabitCreate(BaseModel):
     notification_days: list[str] | None = None
     milestone_notifications: bool = False
     sort_order: int | None = None
-    stage: str = ""
+    stage: str = Field(default="", max_length=HABIT_STAGE_MAX_LENGTH)

--- a/backend/tests/test_input_length_constraints.py
+++ b/backend/tests/test_input_length_constraints.py
@@ -1,7 +1,9 @@
-"""Tests for sec-03: input length constraints on user-facing string fields.
+"""Tests for input length constraints on user-facing string fields.
 
 Verifies that oversized payloads are rejected with 422 and that fields
 requiring non-empty input reject empty/whitespace-only strings.
+
+Covers sec-03 (journal, chat, practice, prompt) and sec-15 (habit, goal_group).
 """
 
 from __future__ import annotations
@@ -14,6 +16,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.practice import Practice
 from schemas.botmason import CHAT_MESSAGE_MAX_LENGTH
+from schemas.goal_group import (
+    GOAL_GROUP_DESCRIPTION_MAX_LENGTH,
+    GOAL_GROUP_ICON_MAX_LENGTH,
+    GOAL_GROUP_NAME_MAX_LENGTH,
+    GOAL_GROUP_SOURCE_MAX_LENGTH,
+)
+from schemas.habit import (
+    HABIT_ICON_MAX_LENGTH,
+    HABIT_NAME_MAX_LENGTH,
+    HABIT_STAGE_MAX_LENGTH,
+)
 from schemas.journal import JOURNAL_MESSAGE_MAX_LENGTH
 from schemas.practice import (
     PRACTICE_DESCRIPTION_MAX_LENGTH,
@@ -259,4 +272,126 @@ async def test_prompt_response_empty_returns_422(async_client: AsyncClient) -> N
         json={"response": ""},
         headers=headers,
     )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ── Habit creation length constraints ─────────────────────────────────
+
+
+def _habit_payload(**overrides: object) -> dict[str, object]:
+    """Return a valid habit creation payload."""
+    payload: dict[str, object] = {
+        "name": "Morning Run",
+        "icon": "🏃",
+        "start_date": "2025-01-01",
+        "energy_cost": 3,
+        "energy_return": 5,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_habit_name_at_max_length(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(name="a" * HABIT_NAME_MAX_LENGTH)
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["name"] == "a" * HABIT_NAME_MAX_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_habit_name_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(name="a" * (HABIT_NAME_MAX_LENGTH + 1))
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_habit_name_empty_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(name="")
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_habit_icon_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(icon="a" * (HABIT_ICON_MAX_LENGTH + 1))
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_habit_stage_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(stage="a" * (HABIT_STAGE_MAX_LENGTH + 1))
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ── GoalGroup creation length constraints ─────────────────────────────
+
+
+def _goal_group_payload(**overrides: object) -> dict[str, object]:
+    """Return a valid goal group creation payload."""
+    payload: dict[str, object] = {
+        "name": "Meditation Goals",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_goal_group_name_at_max_length(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(name="a" * GOAL_GROUP_NAME_MAX_LENGTH)
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["name"] == "a" * GOAL_GROUP_NAME_MAX_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_goal_group_name_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(name="a" * (GOAL_GROUP_NAME_MAX_LENGTH + 1))
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_goal_group_name_empty_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(name="")
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_goal_group_icon_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(icon="a" * (GOAL_GROUP_ICON_MAX_LENGTH + 1))
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_goal_group_description_over_max_length_returns_422(
+    async_client: AsyncClient,
+) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(description="a" * (GOAL_GROUP_DESCRIPTION_MAX_LENGTH + 1))
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_goal_group_source_over_max_length_returns_422(
+    async_client: AsyncClient,
+) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(source="a" * (GOAL_GROUP_SOURCE_MAX_LENGTH + 1))
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## Summary

- Add `max_length` constraints to `HabitCreate` and `GoalGroupCreate` Pydantic request schemas so oversized payloads are rejected with 422 before reaching the database
- Add database-level `max_length` to all remaining unbounded string fields across 5 ORM models: `Habit`, `Goal`, `GoalGroup`, `JournalEntry`, `PracticeSession`
- Extend `test_input_length_constraints.py` with 11 new tests covering at-max acceptance, over-max rejection, and empty-name rejection for both habits and goal groups

### Fields constrained

| Model/Schema | Fields | Max Lengths |
|---|---|---|
| `HabitCreate` (schema) | name, icon, stage | 255, 100, 100 |
| `GoalGroupCreate` (schema) | name, icon, description, source | 255, 100, 2000, 255 |
| `Habit` (ORM) | name, icon, notification_frequency, stage | 255, 100, 20, 100 |
| `Goal` (ORM) | tier, origin | 50, 255 |
| `GoalGroup` (ORM) | name, icon, description, source | 255, 100, 2000, 255 |
| `JournalEntry` (ORM) | sender, tag | 10, 50 |
| `PracticeSession` (ORM) | reflection | 5000 |

## Test plan

- [x] 352 tests pass (0 failures)
- [x] Coverage at 93.41% (above 90% threshold)
- [x] All 24 pre-commit hooks pass green
- [x] Habit name at max length accepted, over max rejected with 422
- [x] Habit empty name rejected with 422
- [x] Habit icon and stage over max rejected with 422
- [x] GoalGroup name at max length accepted, over max rejected with 422
- [x] GoalGroup empty name rejected with 422
- [x] GoalGroup icon, description, source over max rejected with 422

Closes sec-15.

https://claude.ai/code/session_01EuFXJBfdL9k3LMNwEue7nE