### PR TITLE
fix(backend): add global and per-endpoint rate limits (sec-16)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -8,6 +8,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -121,8 +122,11 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
 
 app = FastAPI(lifespan=lifespan)
 
-# Attach the rate limiter to the app so slowapi can find it
+# Attach the rate limiter to the app so slowapi can find it.
+# SlowAPIMiddleware enforces default_limits on all endpoints — endpoints with
+# explicit @limiter.limit() decorators use their own stricter limits instead.
 app.state.limiter = limiter
+app.add_middleware(SlowAPIMiddleware)
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
 # Security headers on all responses

--- a/backend/src/rate_limit.py
+++ b/backend/src/rate_limit.py
@@ -3,6 +3,11 @@
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+# Default rate limit applied to all endpoints that don't declare their own.
+# Auth endpoints override this with stricter per-route limits (3/min signup,
+# 5/min login). The global default protects against scraping and general abuse.
+DEFAULT_RATE_LIMIT = "60/minute"
+
 # Rate limiter keyed by client IP address. Shared across routers so all
 # endpoints use a single limiter with consistent state.
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=get_remote_address, default_limits=[DEFAULT_RATE_LIMIT])

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -10,6 +10,7 @@ from database import get_session
 from errors import bad_request, payment_required
 from models.journal_entry import JournalEntry
 from models.user import User
+from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.botmason import (
     BalanceAddRequest,
@@ -37,7 +38,9 @@ async def _get_user(user_id: int, session: AsyncSession) -> User:
     response_model=ChatResponse,
     status_code=status.HTTP_201_CREATED,
 )
+@limiter.limit("10/minute")
 async def chat_with_botmason(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     payload: ChatRequest,
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
@@ -109,7 +112,9 @@ async def get_balance(
 
 
 @router.post("/user/balance/add", response_model=BalanceAddResponse)
+@limiter.limit("5/minute")
 async def add_balance(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     payload: BalanceAddRequest,
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008

--- a/backend/src/routers/practices.py
+++ b/backend/src/routers/practices.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from database import get_session
 from errors import not_found
 from models.practice import Practice
+from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.practice import PracticeCreate, PracticeResponse
 
@@ -46,7 +47,9 @@ async def get_practice(
 
 
 @router.post("/", response_model=PracticeResponse, status_code=status.HTTP_201_CREATED)
+@limiter.limit("5/minute")
 async def submit_practice(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     payload: PracticeCreate,
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -1,0 +1,150 @@
+"""Tests for data endpoint rate limiting (sec-16).
+
+Verifies that:
+- The global default rate limit (60/minute) applies to endpoints without explicit limits
+- Expensive operations have stricter per-endpoint limits
+- 429 responses are returned with the correct JSON body
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+# Number of requests matching each rate limit — used to fire exactly at the boundary.
+GLOBAL_DEFAULT_LIMIT = 60
+CHAT_LIMIT = 10
+BALANCE_ADD_LIMIT = 5
+PRACTICE_SUBMIT_LIMIT = 5
+
+
+async def _signup(client: AsyncClient, username: str = "limiter") -> dict[str, str]:
+    """Create a user and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Per-endpoint limits ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chat_rate_limit_returns_429(async_client: AsyncClient) -> None:
+    """POST /journal/chat returns 429 after exceeding 10 requests/minute."""
+    headers = await _signup(async_client)
+
+    # Make 10 requests (the limit). They'll return 402 (no balance) but still
+    # count against the rate limiter — the decorator runs before the handler.
+    for _ in range(CHAT_LIMIT):
+        await async_client.post("/journal/chat", json={"message": "hello"}, headers=headers)
+
+    # The 11th request should be rate-limited
+    resp = await async_client.post("/journal/chat", json={"message": "hello"}, headers=headers)
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_add_balance_rate_limit_returns_429(async_client: AsyncClient) -> None:
+    """POST /user/balance/add returns 429 after exceeding 5 requests/minute."""
+    headers = await _signup(async_client)
+
+    for _ in range(BALANCE_ADD_LIMIT):
+        await async_client.post("/user/balance/add", json={"amount": 1}, headers=headers)
+
+    resp = await async_client.post("/user/balance/add", json={"amount": 1}, headers=headers)
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_practice_submit_rate_limit_returns_429(
+    async_client: AsyncClient,
+) -> None:
+    """POST /practices/ returns 429 after exceeding 5 requests/minute."""
+    headers = await _signup(async_client)
+
+    practice_payload = {
+        "stage_number": 1,
+        "name": "Test Practice",
+        "description": "A test practice",
+        "instructions": "Do the thing",
+        "default_duration_minutes": 10,
+    }
+
+    for _ in range(PRACTICE_SUBMIT_LIMIT):
+        await async_client.post("/practices/", json=practice_payload, headers=headers)
+
+    resp = await async_client.post("/practices/", json=practice_payload, headers=headers)
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+
+
+# ── Global default limit ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_global_default_rate_limit_returns_429(
+    async_client: AsyncClient,
+) -> None:
+    """GET /user/balance (no explicit limit) returns 429 after 60 requests/minute."""
+    headers = await _signup(async_client)
+
+    for _ in range(GLOBAL_DEFAULT_LIMIT):
+        await async_client.get("/user/balance", headers=headers)
+
+    resp = await async_client.get("/user/balance", headers=headers)
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+
+
+# ── Auth limits unchanged ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auth_limits_still_enforced(async_client: AsyncClient) -> None:
+    """Auth endpoints retain their explicit limits (not overridden by global default).
+
+    Signup is 3/minute — verify the 4th request is rate-limited.
+    """
+    for i in range(3):
+        await async_client.post(
+            "/auth/signup",
+            json={
+                "email": f"ratelimit{i}@example.com",
+                "password": "secret12345",  # pragma: allowlist secret
+            },
+        )
+
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "ratelimit99@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+
+
+# ── Below-limit requests succeed ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_requests_within_limit_succeed(async_client: AsyncClient) -> None:
+    """Requests within the per-endpoint limit return normal responses (not 429)."""
+    headers = await _signup(async_client)
+
+    # 4 add-balance requests (limit is 5) — all should succeed
+    for _ in range(BALANCE_ADD_LIMIT - 1):
+        resp = await async_client.post("/user/balance/add", json={"amount": 1}, headers=headers)
+        assert resp.status_code == HTTPStatus.OK


### PR DESCRIPTION
## Closing — already delivered

All sec-16 acceptance criteria are already met on `main` via previously merged PRs (sec-11 and related security work):

- `default_limits=["60/minute"]` on the Limiter (`backend/src/rate_limit.py`)
- `SlowAPIMiddleware` enforcing global defaults (`backend/src/main.py`)
- `@limiter.limit("10/minute")` on `POST /journal/chat` (`backend/src/routers/botmason.py`)
- `@limiter.limit("5/minute")` on `POST /user/balance/add` (`backend/src/routers/botmason.py`)
- `@limiter.limit("5/minute")` on `POST /practices/` (`backend/src/routers/practices.py`)
- `@limiter.limit("30/minute")` on `GET /journal/` (`backend/src/routers/journal.py`) — bonus beyond sec-16 scope
- 224-line test suite in `backend/tests/test_rate_limits.py` covering all rate limit behaviors
- Auth endpoints unchanged (3/min signup, 5/min login)
- Retry-After header included in 429 responses

No diff remains after rebasing onto latest main. Closing as already complete.

https://claude.ai/code/session_012oHVd87mzsdEQdBFPEQHy9