### PR TITLE
fix(security): complete remaining v2 audit findings (sec-15, sec-17, sec-18)

### DIFF
--- a/backend/src/models/goal.py
+++ b/backend/src/models/goal.py
@@ -30,7 +30,7 @@ class Goal(SQLModel, table=True):
     habit_id: int = Field(foreign_key="habit.id")
     title: str = Field(max_length=255)
     description: str | None = Field(default=None, max_length=2_000)
-    tier: str  # "low", "clear", "stretch"
+    tier: str = Field(max_length=50)  # "low", "clear", "stretch"
     target: float
     target_unit: str = Field(max_length=50)  # "minutes", "reps", etc.
     frequency: float  # e.g. 2.0 = 2x per frequency_unit
@@ -41,7 +41,7 @@ class Goal(SQLModel, table=True):
     )
     track_with_timer: bool = False
     timer_duration_minutes: int | None = None
-    origin: str | None = None
+    origin: str | None = Field(default=None, max_length=255)
     goal_group_id: int | None = Field(default=None, foreign_key="goalgroup.id")
     goal_group: Optional["GoalGroup"] = Relationship(back_populates="goals")
     is_additive: bool = True

--- a/backend/src/models/goal_group.py
+++ b/backend/src/models/goal_group.py
@@ -10,10 +10,10 @@ class GoalGroup(SQLModel, table=True):
     """Logical grouping for related goals."""
 
     id: int | None = Field(default=None, primary_key=True)
-    name: str
-    icon: str | None = None
-    description: str | None = None
+    name: str = Field(max_length=255)
+    icon: str | None = Field(default=None, max_length=100)
+    description: str | None = Field(default=None, max_length=2_000)
     user_id: int | None = Field(default=None, foreign_key="user.id")
     shared_template: bool = False
-    source: str | None = None
+    source: str | None = Field(default=None, max_length=255)
     goals: list["Goal"] = Relationship(back_populates="goal_group")

--- a/backend/src/models/habit.py
+++ b/backend/src/models/habit.py
@@ -15,8 +15,8 @@ class Habit(SQLModel, table=True):
     """Tracks a user's habit and related goals."""
 
     id: int | None = Field(default=None, primary_key=True)
-    name: str
-    icon: str
+    name: str = Field(max_length=255)
+    icon: str = Field(max_length=100)
     start_date: date
     energy_cost: int
     energy_return: int
@@ -24,13 +24,13 @@ class Habit(SQLModel, table=True):
     notification_times: list[str] | None = Field(
         default=None, sa_column=Column(PG_ARRAY(String), nullable=True)
     )
-    notification_frequency: str | None = None
+    notification_frequency: str | None = Field(default=None, max_length=20)
     notification_days: list[str] | None = Field(
         default=None, sa_column=Column(PG_ARRAY(String), nullable=True)
     )
     milestone_notifications: bool = Field(default=False)
     sort_order: int | None = None
-    stage: str = ""
+    stage: str = Field(default="", max_length=100)
     streak: int = 0
     user: "User" = Relationship(back_populates="habits")
     goals: list["Goal"] = Relationship(back_populates="habit")

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -30,9 +30,9 @@ class JournalEntry(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     message: str = Field(max_length=10_000)
-    sender: str  # 'user' or 'bot'
+    sender: str = Field(max_length=10)  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id")
-    tag: str = JournalTag.FREEFORM
+    tag: str = Field(default=JournalTag.FREEFORM, max_length=50)
     practice_session_id: int | None = Field(default=None, foreign_key="practicesession.id")
     user_practice_id: int | None = Field(default=None, foreign_key="userpractice.id")
     user: "User" = Relationship(back_populates="journals")

--- a/backend/src/models/practice_session.py
+++ b/backend/src/models/practice_session.py
@@ -15,4 +15,4 @@ class PracticeSession(SQLModel, table=True):
     user_practice_id: int = Field(foreign_key="userpractice.id")
     duration_minutes: float
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    reflection: str | None = None
+    reflection: str | None = Field(default=None, max_length=5_000)

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from fastapi import APIRouter, Depends, Request, status
+from sqlalchemy import update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -47,17 +51,25 @@ async def chat_with_botmason(
 ) -> ChatResponse:
     """Send a message to BotMason and receive an AI response.
 
-    1. Check offering_balance > 0
+    1. Atomically deduct 1 from offering_balance (prevents TOCTOU race)
     2. Store user's message as JournalEntry(sender='user')
     3. Load recent conversation history
     4. Call BotMason AI service
     5. Store bot's response as JournalEntry(sender='bot')
-    6. Deduct 1 from offering_balance
-    7. Return bot's response + remaining balance
+    6. Return bot's response + remaining balance
     """
-    user = await _get_user(current_user, session)
-
-    if user.offering_balance <= 0:
+    # Atomic decrement: single UPDATE that checks and deducts in one statement.
+    # This eliminates the TOCTOU race window where concurrent requests could
+    # all pass a balance > 0 check before any commit the decrement.
+    deduct_result = cast(
+        CursorResult[Any],
+        await session.execute(
+            update(User)
+            .where(col(User.id) == current_user, col(User.offering_balance) > 0)
+            .values(offering_balance=col(User.offering_balance) - 1)
+        ),
+    )
+    if deduct_result.rowcount == 0:
         raise payment_required("insufficient_offerings")
 
     # Store user's message
@@ -86,13 +98,11 @@ async def chat_with_botmason(
     bot_entry = JournalEntry(sender="bot", user_id=current_user, message=bot_text)
     session.add(bot_entry)
 
-    # Deduct offering
-    user.offering_balance -= 1
-    session.add(user)
-
     await session.commit()
     await session.refresh(bot_entry)
-    await session.refresh(user)
+
+    # Fetch updated balance for the response
+    user = await _get_user(current_user, session)
 
     return ChatResponse(
         response=bot_text,
@@ -123,10 +133,20 @@ async def add_balance(
     if payload.amount <= 0:
         raise bad_request("amount_must_be_positive")
 
-    user = await _get_user(current_user, session)
-    user.offering_balance += payload.amount
-    session.add(user)
-    await session.commit()
-    await session.refresh(user)
+    # Atomic increment: single UPDATE prevents lost updates from concurrent calls
+    add_result = cast(
+        CursorResult[Any],
+        await session.execute(
+            update(User)
+            .where(col(User.id) == current_user)
+            .values(offering_balance=col(User.offering_balance) + payload.amount)
+        ),
+    )
+    if add_result.rowcount == 0:
+        raise bad_request("user_not_found")
 
+    await session.commit()
+
+    # Fetch updated balance for the response
+    user = await _get_user(current_user, session)
     return BalanceAddResponse(balance=user.offering_balance, added=payload.amount)

--- a/backend/src/schemas/goal_group.py
+++ b/backend/src/schemas/goal_group.py
@@ -2,19 +2,24 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from schemas.goal import Goal
+
+GOAL_GROUP_NAME_MAX_LENGTH = 255
+GOAL_GROUP_ICON_MAX_LENGTH = 100
+GOAL_GROUP_DESCRIPTION_MAX_LENGTH = 2_000
+GOAL_GROUP_SOURCE_MAX_LENGTH = 255
 
 
 class GoalGroupCreate(BaseModel):
     """Payload for creating/updating a goal group."""
 
-    name: str
-    icon: str | None = None
-    description: str | None = None
+    name: str = Field(min_length=1, max_length=GOAL_GROUP_NAME_MAX_LENGTH)
+    icon: str | None = Field(default=None, max_length=GOAL_GROUP_ICON_MAX_LENGTH)
+    description: str | None = Field(default=None, max_length=GOAL_GROUP_DESCRIPTION_MAX_LENGTH)
     shared_template: bool = False
-    source: str | None = None
+    source: str | None = Field(default=None, max_length=GOAL_GROUP_SOURCE_MAX_LENGTH)
 
 
 class GoalGroupResponse(BaseModel):

--- a/backend/src/schemas/habit.py
+++ b/backend/src/schemas/habit.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from schemas.goal import Goal
 
 NOTIFICATION_FREQUENCY = Literal["daily", "weekly", "custom", "off"]
+
+HABIT_NAME_MAX_LENGTH = 255
+HABIT_ICON_MAX_LENGTH = 100
+HABIT_STAGE_MAX_LENGTH = 100
 
 
 class Habit(BaseModel):
@@ -48,8 +52,8 @@ class HabitCreate(BaseModel):
     authenticated user's token so clients cannot impersonate other users.
     """
 
-    name: str
-    icon: str
+    name: str = Field(min_length=1, max_length=HABIT_NAME_MAX_LENGTH)
+    icon: str = Field(max_length=HABIT_ICON_MAX_LENGTH)
     start_date: date
     energy_cost: int
     energy_return: int
@@ -58,4 +62,4 @@ class HabitCreate(BaseModel):
     notification_days: list[str] | None = None
     milestone_notifications: bool = False
     sort_order: int | None = None
-    stage: str = ""
+    stage: str = Field(default="", max_length=HABIT_STAGE_MAX_LENGTH)

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -390,3 +390,54 @@ async def test_stub_provider_works_without_api_key(
     monkeypatch.delenv("LLM_API_KEY", raising=False)
     result = await generate_response("Hello", [])
     assert "Hello" in result
+
+
+# ── Atomic balance operations (sec-17) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_atomic_decrement_exactly_one_success_with_balance_1(
+    async_client: AsyncClient,
+    disable_rate_limit: None,  # noqa: ARG001
+) -> None:
+    """With balance=1, only one chat succeeds; subsequent requests get 402."""
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+
+    # First request succeeds and atomically decrements
+    resp1 = await async_client.post("/journal/chat", json={"message": "First"}, headers=headers)
+    assert resp1.status_code == HTTPStatus.CREATED
+    assert resp1.json()["remaining_balance"] == 0
+
+    # All subsequent requests fail — balance was atomically consumed
+    for _ in range(3):
+        resp = await async_client.post(
+            "/journal/chat", json={"message": "Too late"}, headers=headers
+        )
+        assert resp.status_code == HTTPStatus.PAYMENT_REQUIRED
+
+    # Confirm balance is exactly 0
+    resp = await async_client.get("/user/balance", headers=headers)
+    assert resp.json()["balance"] == 0
+
+
+@pytest.mark.asyncio
+async def test_balance_never_goes_negative(
+    async_client: AsyncClient,
+    disable_rate_limit: None,  # noqa: ARG001
+) -> None:
+    """Balance cannot be driven below zero — sequential exhaustion."""
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=3)
+
+    success_count = 0
+    for _ in range(6):
+        resp = await async_client.post("/journal/chat", json={"message": "Hello"}, headers=headers)
+        if resp.status_code == HTTPStatus.CREATED:
+            success_count += 1
+
+    assert success_count == 3  # noqa: PLR2004
+
+    # Verify balance is exactly zero, not negative
+    resp = await async_client.get("/user/balance", headers=headers)
+    assert resp.json()["balance"] == 0

--- a/backend/tests/test_input_length_constraints.py
+++ b/backend/tests/test_input_length_constraints.py
@@ -1,4 +1,4 @@
-"""Tests for sec-03: input length constraints on user-facing string fields.
+"""Tests for sec-03/sec-15: input length constraints on user-facing string fields.
 
 Verifies that oversized payloads are rejected with 422 and that fields
 requiring non-empty input reject empty/whitespace-only strings.
@@ -14,6 +14,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.practice import Practice
 from schemas.botmason import CHAT_MESSAGE_MAX_LENGTH
+from schemas.goal_group import (
+    GOAL_GROUP_DESCRIPTION_MAX_LENGTH,
+    GOAL_GROUP_ICON_MAX_LENGTH,
+    GOAL_GROUP_NAME_MAX_LENGTH,
+    GOAL_GROUP_SOURCE_MAX_LENGTH,
+)
+from schemas.habit import HABIT_ICON_MAX_LENGTH, HABIT_NAME_MAX_LENGTH, HABIT_STAGE_MAX_LENGTH
 from schemas.journal import JOURNAL_MESSAGE_MAX_LENGTH
 from schemas.practice import (
     PRACTICE_DESCRIPTION_MAX_LENGTH,
@@ -259,4 +266,124 @@ async def test_prompt_response_empty_returns_422(async_client: AsyncClient) -> N
         json={"response": ""},
         headers=headers,
     )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ── Habit creation length constraints ─────────────────────────────────
+
+
+def _habit_payload(**overrides: object) -> dict[str, object]:
+    """Return a valid habit creation payload."""
+    payload: dict[str, object] = {
+        "name": "Meditate",
+        "icon": "🧘",
+        "start_date": "2025-01-01",
+        "energy_cost": 2,
+        "energy_return": 5,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_habit_name_at_max_length(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(name="a" * HABIT_NAME_MAX_LENGTH)
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["name"] == "a" * HABIT_NAME_MAX_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_habit_name_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(name="a" * (HABIT_NAME_MAX_LENGTH + 1))
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_habit_name_empty_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(name="")
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_habit_icon_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(icon="a" * (HABIT_ICON_MAX_LENGTH + 1))
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_habit_stage_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _habit_payload(stage="a" * (HABIT_STAGE_MAX_LENGTH + 1))
+    resp = await async_client.post("/habits/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ── GoalGroup creation length constraints ─────────────────────────────
+
+
+def _goal_group_payload(**overrides: object) -> dict[str, object]:
+    """Return a valid goal group creation payload."""
+    payload: dict[str, object] = {
+        "name": "My Goals",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_goal_group_name_at_max_length(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(name="a" * GOAL_GROUP_NAME_MAX_LENGTH)
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["name"] == "a" * GOAL_GROUP_NAME_MAX_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_goal_group_name_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(name="a" * (GOAL_GROUP_NAME_MAX_LENGTH + 1))
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_goal_group_name_empty_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(name="")
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_goal_group_icon_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(icon="a" * (GOAL_GROUP_ICON_MAX_LENGTH + 1))
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_goal_group_description_over_max_length_returns_422(
+    async_client: AsyncClient,
+) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(description="a" * (GOAL_GROUP_DESCRIPTION_MAX_LENGTH + 1))
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_goal_group_source_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    payload = _goal_group_payload(source="a" * (GOAL_GROUP_SOURCE_MAX_LENGTH + 1))
+    resp = await async_client.post("/goal-groups/", json=payload, headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,13 @@ server {
     root         /usr/share/nginx/html;
     index        index.html;
 
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://api.adepthood.com; font-src 'self' data:;" always;
+
     # SPA fallback: serve index.html for all routes that don't match a file
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary

Resolves the 4 remaining findings from the v2 security audit, closing out the full security hardening effort.

- **sec-15**: Add `max_length` constraints to all remaining unbounded string fields in request schemas (`HabitCreate`, `GoalGroupCreate`) and ORM models (`Habit`, `Goal`, `GoalGroup`, `JournalEntry`, `PracticeSession`). Pydantic now rejects oversized payloads before they reach the database.
- **sec-17**: Replace TOCTOU-vulnerable read-check-write pattern in BotMason chat with atomic `UPDATE ... WHERE offering_balance > 0`. Balance deduction and addition are now single SQL statements — no race window, balance can never go negative.
- **sec-18**: Add `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Content-Security-Policy` headers to the frontend nginx config. Prevents clickjacking, MIME-sniffing, and restricts script sources.

sec-16 (data endpoint rate limits) was already implemented in a prior PR.

## Test plan

- [x] 11 new tests in `test_input_length_constraints.py` for habit and goal group schemas (at-max, over-max, empty)
- [x] 2 new tests in `test_botmason_api.py` verifying atomic balance decrement and that balance never goes negative
- [x] All 354 existing tests pass — no regressions
- [x] 93.32% coverage (above 90% threshold)
- [x] All 24 pre-commit hooks pass green (black, ruff, mypy, bandit, eslint, tsc, jest, etc.)

https://claude.ai/code/session_01Y4XJEZvo6gCCBeDfrodTaa