### PR TITLE
fix(backend): prevent offering balance race condition (sec-17)

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -91,3 +91,33 @@ def disable_rate_limit() -> Generator[None, None, None]:
     limiter.enabled = False
     yield
     limiter.enabled = True
+
+
+@pytest_asyncio.fixture
+async def concurrent_async_client(tmp_path: Path) -> AsyncGenerator[AsyncClient, None]:
+    """HTTP client with per-request sessions for concurrency testing.
+
+    Uses a file-based SQLite database so each request gets its own connection,
+    enabling meaningful concurrency tests with ``asyncio.gather``.
+    """
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'concurrent.db'}"
+    concurrent_engine = create_async_engine(db_url, echo=False)
+    concurrent_factory = async_sessionmaker(
+        concurrent_engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    _replace_array_columns()
+    async with concurrent_engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    async def _per_request_session() -> AsyncGenerator[AsyncSession, None]:
+        async with concurrent_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _per_request_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+    app.dependency_overrides.clear()
+    await concurrent_engine.dispose()

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request, status
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -25,8 +26,11 @@ router = APIRouter(tags=["botmason"])
 
 
 async def _get_user(user_id: int, session: AsyncSession) -> User:
-    """Fetch user by ID or raise 404."""
-    user = await session.get(User, user_id)
+    """Fetch user by ID or raise 400, always reading fresh from database."""
+    result = await session.execute(
+        select(User).where(User.id == user_id).execution_options(populate_existing=True)
+    )
+    user = result.scalars().first()
     if user is None:
         msg = "user_not_found"
         raise bad_request(msg)
@@ -47,17 +51,25 @@ async def chat_with_botmason(
 ) -> ChatResponse:
     """Send a message to BotMason and receive an AI response.
 
-    1. Check offering_balance > 0
+    1. Atomically deduct 1 from offering_balance (prevents TOCTOU race)
     2. Store user's message as JournalEntry(sender='user')
     3. Load recent conversation history
     4. Call BotMason AI service
     5. Store bot's response as JournalEntry(sender='bot')
-    6. Deduct 1 from offering_balance
-    7. Return bot's response + remaining balance
+    6. Return bot's response + remaining balance
     """
-    user = await _get_user(current_user, session)
-
-    if user.offering_balance <= 0:
+    # Atomic balance deduction — single SQL statement, no TOCTOU race window.
+    # The WHERE clause guarantees the decrement only happens if balance > 0.
+    deduct_result = await session.execute(
+        update(User)
+        .where(col(User.id) == current_user, col(User.offering_balance) > 0)
+        .values(offering_balance=col(User.offering_balance) - 1)
+        .returning(col(User.offering_balance))
+    )
+    new_balance = deduct_result.scalar()
+    if new_balance is None:
+        # No rows matched — either user missing or balance already 0
+        await _get_user(current_user, session)  # raises bad_request if missing
         raise payment_required("insufficient_offerings")
 
     # Store user's message
@@ -86,17 +98,12 @@ async def chat_with_botmason(
     bot_entry = JournalEntry(sender="bot", user_id=current_user, message=bot_text)
     session.add(bot_entry)
 
-    # Deduct offering
-    user.offering_balance -= 1
-    session.add(user)
-
     await session.commit()
     await session.refresh(bot_entry)
-    await session.refresh(user)
 
     return ChatResponse(
         response=bot_text,
-        remaining_balance=user.offering_balance,
+        remaining_balance=new_balance,
         bot_entry_id=bot_entry.id,
     )
 
@@ -123,10 +130,18 @@ async def add_balance(
     if payload.amount <= 0:
         raise bad_request("amount_must_be_positive")
 
-    user = await _get_user(current_user, session)
-    user.offering_balance += payload.amount
-    session.add(user)
-    await session.commit()
-    await session.refresh(user)
+    # Atomic balance addition — single SQL statement, no lost-update window.
+    result = await session.execute(
+        update(User)
+        .where(col(User.id) == current_user)
+        .values(offering_balance=col(User.offering_balance) + payload.amount)
+        .returning(col(User.offering_balance))
+    )
+    new_balance = result.scalar()
+    if new_balance is None:
+        msg = "user_not_found"
+        raise bad_request(msg)
 
-    return BalanceAddResponse(balance=user.offering_balance, added=payload.amount)
+    await session.commit()
+
+    return BalanceAddResponse(balance=new_balance, added=payload.amount)

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import pathlib
 from http import HTTPStatus
 
@@ -390,3 +391,98 @@ async def test_stub_provider_works_without_api_key(
     monkeypatch.delenv("LLM_API_KEY", raising=False)
     result = await generate_response("Hello", [])
     assert "Hello" in result
+
+
+# ── Race condition prevention tests (sec-17) ──────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_chat_with_balance_one_allows_exactly_one(
+    concurrent_async_client: AsyncClient,
+) -> None:
+    """Concurrent chat requests with balance=1 must yield exactly 1 success (sec-17)."""
+    headers = await _signup(concurrent_async_client)
+    await _add_balance(concurrent_async_client, headers, amount=1)
+
+    # Fire 5 concurrent requests — only 1 should succeed
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post(
+                "/journal/chat", json={"message": f"msg-{i}"}, headers=headers
+            )
+            for i in range(5)
+        ]
+    )
+
+    status_codes = [r.status_code for r in responses]
+    successes = status_codes.count(HTTPStatus.CREATED)
+    failures = status_codes.count(HTTPStatus.PAYMENT_REQUIRED)
+
+    assert successes == 1, f"Expected exactly 1 success, got {successes}"
+    assert failures == 4, f"Expected 4 failures, got {failures}"  # noqa: PLR2004
+
+    # Balance must be exactly 0, never negative
+    balance_resp = await concurrent_async_client.get("/user/balance", headers=headers)
+    assert balance_resp.json()["balance"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_balance_never_negative_after_concurrent_chat(
+    concurrent_async_client: AsyncClient,
+) -> None:
+    """Balance must never go negative, even under concurrent load (sec-17)."""
+    headers = await _signup(concurrent_async_client)
+    await _add_balance(concurrent_async_client, headers, amount=3)
+
+    # Fire 10 concurrent requests with only 3 credits
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post(
+                "/journal/chat", json={"message": f"msg-{i}"}, headers=headers
+            )
+            for i in range(10)
+        ]
+    )
+
+    status_codes = [r.status_code for r in responses]
+    successes = status_codes.count(HTTPStatus.CREATED)
+    failures = status_codes.count(HTTPStatus.PAYMENT_REQUIRED)
+
+    assert successes == 3, f"Expected 3 successes, got {successes}"  # noqa: PLR2004
+    assert failures == 7, f"Expected 7 failures, got {failures}"  # noqa: PLR2004
+
+    # Balance must be exactly 0, never negative
+    balance_resp = await concurrent_async_client.get("/user/balance", headers=headers)
+    assert balance_resp.json()["balance"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_balance_additions_are_atomic(
+    concurrent_async_client: AsyncClient,
+) -> None:
+    """Concurrent balance additions must not lose updates (sec-17)."""
+    headers = await _signup(concurrent_async_client)
+
+    # Fire 5 concurrent add-balance requests, each adding 2
+    add_amount = 2
+    num_requests = 5
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post(
+                "/user/balance/add", json={"amount": add_amount}, headers=headers
+            )
+            for _ in range(num_requests)
+        ]
+    )
+
+    # All should succeed
+    for resp in responses:
+        assert resp.status_code == HTTPStatus.OK
+
+    # Final balance should be exactly 10 (5 * 2), no lost updates
+    expected_balance = add_amount * num_requests
+    balance_resp = await concurrent_async_client.get("/user/balance", headers=headers)
+    assert balance_resp.json()["balance"] == expected_balance


### PR DESCRIPTION
## Summary

- Replace TOCTOU-vulnerable read-check-write pattern in `chat_with_botmason` and `add_balance` with atomic `UPDATE...WHERE...RETURNING` SQL statements, eliminating the race window that allowed concurrent requests to bypass the `offering_balance` guard
- Add `concurrent_async_client` fixture backed by file-based SQLite for meaningful concurrency testing with per-request session isolation
- Add 3 concurrency tests validating: only 1 of N concurrent chats succeeds with balance=1, balance never goes negative, and concurrent balance additions never lose updates

## Problem

The BotMason chat endpoint had a Time-Of-Check-to-Time-Of-Use (TOCTOU) race condition (OWASP A04:2021). Between reading `offering_balance` and decrementing it, an attacker could fire multiple concurrent requests — all passing the `> 0` check before any committed the decrement. With 1 credit, an attacker could make unlimited LLM API calls. The same pattern existed in `POST /user/balance/add`.

## Solution

Single atomic SQL statement per operation — no race window:

```sql
-- Deduction: check and decrement in one statement
UPDATE user SET offering_balance = offering_balance - 1
WHERE id = :id AND offering_balance > 0
RETURNING offering_balance;

-- Addition: no lost-update window
UPDATE user SET offering_balance = offering_balance + :amount
WHERE id = :id
RETURNING offering_balance;
```

## Test plan

- [x] `test_concurrent_chat_with_balance_one_allows_exactly_one` — 5 concurrent requests with balance=1 → exactly 1 success, 4 failures
- [x] `test_balance_never_negative_after_concurrent_chat` — 10 concurrent requests with balance=3 → exactly 3 successes, balance=0
- [x] `test_concurrent_balance_additions_are_atomic` — 5 concurrent add requests → final balance equals sum of all additions
- [x] All 344 existing tests pass (no regressions)
- [x] All 24 pre-commit hooks pass green
- [x] Backend coverage: 93.25% (above 90% threshold)

https://claude.ai/code/session_01GNK7tNdSHm8cm8SExypV5e