### PR TITLE
feat: user-provided LLM API keys for BotMason (BYOK, #185)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -143,7 +143,7 @@ app.add_middleware(
     allow_origins=origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE"],
-    allow_headers=["Authorization", "Content-Type"],
+    allow_headers=["Authorization", "Content-Type", "X-LLM-API-Key"],
 )
 
 # Register feature routers

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Request, status
+import os
+
+from fastapi import APIRouter, Depends, Header, Request, status
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -20,9 +22,58 @@ from schemas.botmason import (
     ChatRequest,
     ChatResponse,
 )
-from services.botmason import CONVERSATION_HISTORY_LIMIT, generate_response
+from services.botmason import (
+    CONVERSATION_HISTORY_LIMIT,
+    LLM_API_KEY_MAX_LENGTH,
+    generate_response,
+    get_provider,
+    provider_requires_api_key,
+    validate_llm_api_key_format,
+)
 
 router = APIRouter(tags=["botmason"])
+
+
+# Custom header used by clients to carry a user-provided LLM API key (BYOK).
+# The value is consumed for a single LLM call and must never be stored or
+# logged. Kept as a module constant so tests and the CORS policy can reference
+# the same string without drift.
+LLM_API_KEY_HEADER = "X-LLM-API-Key"  # pragma: allowlist secret
+
+
+def _resolve_user_api_key(header_value: str | None) -> str | None:
+    """Return the sanitised user-supplied key, or raise 400 if malformed.
+
+    A missing header resolves to ``None`` so the caller can decide whether to
+    fall back to the server-side env var.
+    """
+    if header_value is None:
+        return None
+    key = header_value.strip()
+    if not key:
+        return None
+    if len(key) > LLM_API_KEY_MAX_LENGTH:
+        raise bad_request("invalid_llm_api_key_format")
+    provider = get_provider()
+    if not validate_llm_api_key_format(key, provider):
+        raise bad_request("invalid_llm_api_key_format")
+    return key
+
+
+def _resolve_api_key_for_chat(header_value: str | None) -> str | None:
+    """Choose the API key to forward for a ``/journal/chat`` request.
+
+    Precedence: validated user-supplied header → server ``LLM_API_KEY`` env →
+    none. Raises 402 ``llm_key_required`` when the active provider needs a key
+    but neither source has one. The returned key is used for a single call and
+    is never persisted.
+    """
+    user_key = _resolve_user_api_key(header_value)
+    if user_key is not None:
+        return user_key
+    if provider_requires_api_key() and not os.getenv("LLM_API_KEY"):
+        raise payment_required("llm_key_required")
+    return None
 
 
 async def _get_user(user_id: int, session: AsyncSession) -> User:
@@ -48,16 +99,27 @@ async def chat_with_botmason(
     payload: ChatRequest,
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
+    x_llm_api_key: str | None = Header(default=None, alias=LLM_API_KEY_HEADER),
 ) -> ChatResponse:
     """Send a message to BotMason and receive an AI response.
 
-    1. Atomically deduct 1 from offering_balance (prevents TOCTOU race)
-    2. Store user's message as JournalEntry(sender='user')
-    3. Load recent conversation history
-    4. Call BotMason AI service
-    5. Store bot's response as JournalEntry(sender='bot')
-    6. Return bot's response + remaining balance
+    1. Resolve the LLM API key (user-supplied header > server env var)
+    2. Atomically deduct 1 from offering_balance (prevents TOCTOU race)
+    3. Store user's message as JournalEntry(sender='user')
+    4. Load recent conversation history
+    5. Call BotMason AI service
+    6. Store bot's response as JournalEntry(sender='bot')
+    7. Return bot's response + remaining balance
+
+    The ``X-LLM-API-Key`` header is validated for format and forwarded to the
+    provider for this single request. It is never logged, never written to
+    the database, and never echoed back in the response.
     """
+    # Resolve the key BEFORE deducting balance so a malformed key (400) or a
+    # missing key on a provider that needs one (402) never costs the user an
+    # offering. Fails fast without touching the DB.
+    api_key = _resolve_api_key_for_chat(x_llm_api_key)
+
     # Atomic balance deduction — single SQL statement, no TOCTOU race window.
     # The WHERE clause guarantees the decrement only happens if balance > 0.
     deduct_result = await session.execute(
@@ -91,8 +153,13 @@ async def chat_with_botmason(
         {"sender": entry.sender, "message": entry.message} for entry in history_entries
     ]
 
-    # Generate AI response
-    bot_text = await generate_response(payload.message, conversation_history)
+    # Generate AI response. ``api_key`` is passed by value for a single call
+    # and is discarded when this function returns.
+    bot_text = await generate_response(
+        payload.message,
+        conversation_history,
+        api_key=api_key,
+    )
 
     # Store bot's response
     bot_entry = JournalEntry(sender="bot", user_id=current_user, message=bot_text)

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -30,6 +30,69 @@ _ALLOWED_PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
 # Maximum prompt file size in bytes (50 KB).
 _MAX_PROMPT_FILE_SIZE = 50 * 1024
 
+# Maximum allowed length for a user-supplied LLM API key. Real keys from
+# OpenAI/Anthropic are ~200 chars; this cap prevents header-size DoS.
+LLM_API_KEY_MAX_LENGTH = 256
+
+# Provider-specific key prefixes. Anthropic keys share the ``sk-`` prefix with
+# OpenAI, so their check is the more specific ``sk-ant-``.
+_OPENAI_KEY_PREFIX = "sk-"
+_ANTHROPIC_KEY_PREFIX = "sk-ant-"
+
+
+def get_provider() -> str:
+    """Return the currently configured LLM provider identifier."""
+    return os.getenv("BOTMASON_PROVIDER", "stub")
+
+
+def provider_requires_api_key(provider: str | None = None) -> bool:
+    """Return True when the selected provider needs an API key to function."""
+    return (provider or get_provider()) in {"openai", "anthropic"}
+
+
+# Prefix rules per provider — a dict keeps ``validate_llm_api_key_format``
+# branch-free so xenon's complexity budget stays at rank A.
+_PROVIDER_KEY_RULES: dict[str, tuple[str, tuple[str, ...]]] = {
+    # provider -> (required_prefix, disallowed_more_specific_prefixes)
+    # OpenAI keys start with ``sk-``; Anthropic keys also do, so disallow the
+    # more specific ``sk-ant-`` prefix to prevent provider cross-wiring.
+    "openai": (_OPENAI_KEY_PREFIX, (_ANTHROPIC_KEY_PREFIX,)),
+    "anthropic": (_ANTHROPIC_KEY_PREFIX, ()),
+}
+
+
+def _has_valid_length(api_key: str) -> bool:
+    """Return True when the key is non-empty and within the header-size cap."""
+    return bool(api_key) and len(api_key) <= LLM_API_KEY_MAX_LENGTH
+
+
+def _matches_provider_rule(api_key: str, rule: tuple[str, tuple[str, ...]] | None) -> bool:
+    """Return True when the key satisfies a (prefix, disallowed-prefixes) rule.
+
+    ``rule`` is ``None`` for unknown or stub providers, which are considered
+    passing — the real provider call happens later.
+    """
+    if rule is None:
+        return True
+    required_prefix, disallowed_prefixes = rule
+    if not api_key.startswith(required_prefix):
+        return False
+    return not any(api_key.startswith(bad) for bad in disallowed_prefixes)
+
+
+def validate_llm_api_key_format(api_key: str, provider: str) -> bool:
+    """Return True when ``api_key`` matches the expected format for ``provider``.
+
+    The check is intentionally prefix-based — real key validation happens when
+    the provider rejects the request. The purpose here is to stop obviously
+    malformed values from leaving our server (and to keep Anthropic keys from
+    being routed through the OpenAI client by mistake). Unknown providers
+    (including ``"stub"``) skip the check entirely.
+    """
+    if not _has_valid_length(api_key):
+        return False
+    return _matches_provider_rule(api_key, _PROVIDER_KEY_RULES.get(provider))
+
 
 def get_system_prompt() -> str:
     """Load the BotMason system prompt from config.
@@ -92,6 +155,7 @@ async def generate_response(
     user_message: str,
     conversation_history: list[dict[str, str]],
     system_prompt: str | None = None,
+    api_key: str | None = None,
 ) -> str:
     """Generate a BotMason response using the configured LLM provider.
 
@@ -101,16 +165,18 @@ async def generate_response(
     - ``"openai"`` — calls the OpenAI chat completions API
     - ``"anthropic"`` — calls the Anthropic messages API
 
-    External providers require the ``LLM_API_KEY`` env var to be set and
-    the corresponding SDK to be installed.
+    External providers require an API key. Callers may pass ``api_key``
+    directly (e.g. sourced from a user-supplied header) to override the
+    server-side ``LLM_API_KEY`` env var. When ``api_key`` is ``None`` the
+    env var is used; the key is never persisted or logged by this layer.
     """
     resolved_prompt = system_prompt or get_system_prompt()
-    provider = os.getenv("BOTMASON_PROVIDER", "stub")
+    provider = get_provider()
 
     if provider == "openai":
-        return await _call_openai(user_message, conversation_history, resolved_prompt)
+        return await _call_openai(user_message, conversation_history, resolved_prompt, api_key)
     if provider == "anthropic":
-        return await _call_anthropic(user_message, conversation_history, resolved_prompt)
+        return await _call_anthropic(user_message, conversation_history, resolved_prompt, api_key)
     # Default: stub provider for development and testing
     return _stub_response(user_message)
 
@@ -136,7 +202,7 @@ def _import_optional(module_name: str, provider_label: str) -> ModuleType:
 
 
 def _get_llm_api_key() -> str:
-    """Return the LLM API key, raising if unset or empty.
+    """Return the server-side LLM API key, raising if unset or empty.
 
     Follows the same fail-fast pattern as ``_get_secret_key`` in auth.py.
     """
@@ -147,16 +213,29 @@ def _get_llm_api_key() -> str:
     return api_key
 
 
+def _resolve_api_key(override: str | None) -> str:
+    """Return the API key to use for a provider call.
+
+    Prefers the caller-supplied ``override`` (e.g. user-owned BYOK key from a
+    request header) and falls back to the server-side ``LLM_API_KEY`` env var.
+    The key is returned by value — callers must not log or persist it.
+    """
+    if override:
+        return override
+    return _get_llm_api_key()
+
+
 async def _call_openai(
     user_message: str,
     conversation_history: list[dict[str, str]],
     system_prompt: str,
+    api_key: str | None = None,
 ) -> str:
     """Call the OpenAI chat completions API."""
-    api_key = _get_llm_api_key()
+    key = _resolve_api_key(api_key)
     openai_mod = _import_optional("openai", "OpenAI")
 
-    client = openai_mod.AsyncOpenAI(api_key=api_key)
+    client = openai_mod.AsyncOpenAI(api_key=key)
     messages = _build_messages(user_message, conversation_history, system_prompt)
     completion = await client.chat.completions.create(
         model=os.getenv("LLM_MODEL", "gpt-4o-mini"),
@@ -169,12 +248,13 @@ async def _call_anthropic(
     user_message: str,
     conversation_history: list[dict[str, str]],
     system_prompt: str,
+    api_key: str | None = None,
 ) -> str:
     """Call the Anthropic messages API."""
-    api_key = _get_llm_api_key()
+    key = _resolve_api_key(api_key)
     anthropic_mod = _import_optional("anthropic", "Anthropic")
 
-    client = anthropic_mod.AsyncAnthropic(api_key=api_key)
+    client = anthropic_mod.AsyncAnthropic(api_key=key)
     # Anthropic uses a separate system parameter, not a system message in the list.
     messages_for_api: list[dict[str, str]] = []
     for entry in conversation_history:

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -3,14 +3,22 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import pathlib
 from http import HTTPStatus
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
 
 import services.botmason as botmason_mod
-from services.botmason import generate_response, get_system_prompt
+from routers.botmason import LLM_API_KEY_HEADER
+from services.botmason import (
+    LLM_API_KEY_MAX_LENGTH,
+    generate_response,
+    get_system_prompt,
+    validate_llm_api_key_format,
+)
 
 
 async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
@@ -486,3 +494,320 @@ async def test_concurrent_balance_additions_are_atomic(
     expected_balance = add_amount * num_requests
     balance_resp = await concurrent_async_client.get("/user/balance", headers=headers)
     assert balance_resp.json()["balance"] == expected_balance
+
+
+# ── BYOK (user-supplied LLM API key) ───────────────────────────────────
+# Covers issue #185 — users bring their own API key via ``X-LLM-API-Key``.
+# The key must be validated, forwarded to the provider for a single request,
+# and never logged, stored, or echoed back.
+
+
+_VALID_OPENAI_KEY = "sk-abcdef1234567890abcdef1234567890"  # pragma: allowlist secret
+_VALID_ANTHROPIC_KEY = "sk-ant-api03-" + "x" * 64  # pragma: allowlist secret
+
+
+def _forwarded_key(mock_call: AsyncMock) -> object:
+    """Return the ``api_key`` argument forwarded to a provider call mock.
+
+    ``_call_openai`` / ``_call_anthropic`` accept the key as the 4th positional
+    argument or as the ``api_key`` keyword — this helper hides that detail and
+    narrows the mypy types around ``await_args`` being optional.
+    """
+    call = mock_call.await_args
+    assert call is not None, "expected provider mock to have been awaited"
+    args, kwargs = call
+    if "api_key" in kwargs:
+        return kwargs["api_key"]
+    if len(args) >= 4:  # noqa: PLR2004 - positional index for api_key
+        return args[3]
+    return None
+
+
+def test_validate_format_accepts_openai_key() -> None:
+    assert validate_llm_api_key_format(_VALID_OPENAI_KEY, "openai") is True
+
+
+def test_validate_format_accepts_anthropic_key() -> None:
+    assert validate_llm_api_key_format(_VALID_ANTHROPIC_KEY, "anthropic") is True
+
+
+def test_validate_format_rejects_cross_provider_keys() -> None:
+    # An Anthropic key sent to the OpenAI provider is a misconfiguration, not
+    # a valid OpenAI key — the ``sk-ant-`` prefix must be rejected there.
+    assert validate_llm_api_key_format(_VALID_ANTHROPIC_KEY, "openai") is False
+    # An OpenAI key lacks the ``sk-ant-`` prefix the Anthropic SDK expects.
+    assert validate_llm_api_key_format(_VALID_OPENAI_KEY, "anthropic") is False
+
+
+def test_validate_format_rejects_missing_prefix() -> None:
+    assert validate_llm_api_key_format("not-a-real-key", "openai") is False
+    assert validate_llm_api_key_format("not-a-real-key", "anthropic") is False
+
+
+def test_validate_format_rejects_empty_or_oversized_key() -> None:
+    assert validate_llm_api_key_format("", "openai") is False
+    oversized = "sk-" + "x" * LLM_API_KEY_MAX_LENGTH
+    assert validate_llm_api_key_format(oversized, "openai") is False
+
+
+def test_validate_format_skips_check_for_stub_provider() -> None:
+    # Stub provider accepts anything — it never makes a real call.
+    assert validate_llm_api_key_format("anything", "stub") is True
+
+
+@pytest.mark.asyncio
+async def test_chat_returns_402_when_provider_needs_key_and_none_available(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With provider=openai and no env/header key, chat responds 402."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+
+    resp = await async_client.post(
+        "/journal/chat",
+        json={"message": "Hello"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.PAYMENT_REQUIRED
+    assert resp.json()["detail"] == "llm_key_required"
+
+    # Balance must not have been decremented — the key check happens first.
+    balance_resp = await async_client.get("/user/balance", headers=headers)
+    assert balance_resp.json()["balance"] == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_falls_back_to_env_key_when_header_absent(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no header but LLM_API_KEY set, the env key is used for the call."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+
+    mock_call = AsyncMock(return_value="env-fallback-response")
+    with patch.object(botmason_mod, "_call_openai", mock_call):
+        resp = await async_client.post(
+            "/journal/chat",
+            json={"message": "Hello"},
+            headers=headers,
+        )
+
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["response"] == "env-fallback-response"
+    # The key forwarded to the provider should be ``None`` — the service layer
+    # resolves env-var fallback internally so the router never touches the env.
+    assert _forwarded_key(mock_call) is None
+
+
+@pytest.mark.asyncio
+async def test_chat_uses_user_supplied_key_from_header(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid ``X-LLM-API-Key`` header is forwarded to the provider."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+    headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
+
+    mock_call = AsyncMock(return_value="byok-response")
+    with patch.object(botmason_mod, "_call_openai", mock_call):
+        resp = await async_client.post(
+            "/journal/chat",
+            json={"message": "Hello"},
+            headers=headers,
+        )
+
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["response"] == "byok-response"
+    assert _forwarded_key(mock_call) == _VALID_OPENAI_KEY
+
+
+@pytest.mark.asyncio
+async def test_chat_header_key_overrides_env_key(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both header and env are set, the header key wins (BYOK priority)."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", "sk-server-fallback-key")
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+    headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
+
+    mock_call = AsyncMock(return_value="byok-response")
+    with patch.object(botmason_mod, "_call_openai", mock_call):
+        await async_client.post(
+            "/journal/chat",
+            json={"message": "Hello"},
+            headers=headers,
+        )
+
+    assert _forwarded_key(mock_call) == _VALID_OPENAI_KEY
+
+
+@pytest.mark.asyncio
+async def test_chat_rejects_malformed_header_key_with_400(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed ``X-LLM-API-Key`` yields 400 without spending balance."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+    headers[LLM_API_KEY_HEADER] = "not-a-real-key"  # pragma: allowlist secret
+
+    resp = await async_client.post(
+        "/journal/chat",
+        json={"message": "Hello"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "invalid_llm_api_key_format"
+
+    # Balance must not have been decremented.
+    balance_resp = await async_client.get("/user/balance", headers=headers)
+    assert balance_resp.json()["balance"] == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_rejects_oversized_header_key_with_400(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+    headers[LLM_API_KEY_HEADER] = "sk-" + "x" * LLM_API_KEY_MAX_LENGTH  # pragma: allowlist secret
+
+    resp = await async_client.post(
+        "/journal/chat",
+        json={"message": "Hello"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_chat_ignores_empty_header_and_uses_env(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty header value behaves like a missing header (env fallback)."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+    headers[LLM_API_KEY_HEADER] = "   "
+
+    mock_call = AsyncMock(return_value="env-response")
+    with patch.object(botmason_mod, "_call_openai", mock_call):
+        resp = await async_client.post(
+            "/journal/chat",
+            json={"message": "Hello"},
+            headers=headers,
+        )
+
+    assert resp.status_code == HTTPStatus.CREATED
+    assert _forwarded_key(mock_call) is None
+
+
+@pytest.mark.asyncio
+async def test_chat_does_not_log_header_key_value(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The raw key value must never appear in log output."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+    headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
+
+    mock_call = AsyncMock(return_value="ok")
+    with caplog.at_level(logging.DEBUG), patch.object(botmason_mod, "_call_openai", mock_call):
+        await async_client.post(
+            "/journal/chat",
+            json={"message": "Hello"},
+            headers=headers,
+        )
+
+    for record in caplog.records:
+        assert _VALID_OPENAI_KEY not in record.getMessage()
+
+
+@pytest.mark.asyncio
+async def test_chat_response_body_does_not_echo_key(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+    headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
+
+    mock_call = AsyncMock(return_value="a response")
+    with patch.object(botmason_mod, "_call_openai", mock_call):
+        resp = await async_client.post(
+            "/journal/chat",
+            json={"message": "Hello"},
+            headers=headers,
+        )
+
+    assert _VALID_OPENAI_KEY not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_stub_provider_ignores_header_key(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stub provider never needs a key and must not 402 when one is absent."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    headers = await _signup(async_client)
+    await _add_balance(async_client, headers, amount=1)
+
+    resp = await async_client.post(
+        "/journal/chat",
+        json={"message": "Hello"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+
+@pytest.mark.asyncio
+async def test_generate_response_uses_override_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``generate_response(api_key=...)`` forwards the override to the provider."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    mock_call = AsyncMock(return_value="overridden")
+    with patch.object(botmason_mod, "_call_openai", mock_call):
+        result = await generate_response("hi", [], api_key=_VALID_OPENAI_KEY)
+
+    assert result == "overridden"
+    assert _forwarded_key(mock_call) == _VALID_OPENAI_KEY

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,11 +8,12 @@ import { ActivityIndicator, StatusBar, StyleSheet, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 import { ToastProvider } from './components/ToastProvider';
+import { ApiKeyProvider } from './context/ApiKeyContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import LoginScreen from './features/Auth/LoginScreen';
 import SignupScreen from './features/Auth/SignupScreen';
 import type { RootTabParamList } from './navigation/BottomTabs';
-import BottomTabs from './navigation/BottomTabs';
+import RootStack from './navigation/RootStack';
 
 type AuthStackParamList = {
   Login: undefined;
@@ -55,21 +56,23 @@ function RootNavigator() {
     );
   }
 
-  return token ? <BottomTabs /> : <AuthNavigator />;
+  return token ? <RootStack /> : <AuthNavigator />;
 }
 
 export default function App(): React.JSX.Element {
   return (
     <SafeAreaProvider>
       <AuthProvider>
-        <ToastProvider>
-          <NavigationContainer linking={linking}>
-            <SafeAreaView style={styles.safeArea}>
-              <StatusBar barStyle="dark-content" />
-              <RootNavigator />
-            </SafeAreaView>
-          </NavigationContainer>
-        </ToastProvider>
+        <ApiKeyProvider>
+          <ToastProvider>
+            <NavigationContainer linking={linking}>
+              <SafeAreaView style={styles.safeArea}>
+                <StatusBar barStyle="dark-content" />
+                <RootNavigator />
+              </SafeAreaView>
+            </NavigationContainer>
+          </ToastProvider>
+        </ApiKeyProvider>
       </AuthProvider>
     </SafeAreaProvider>
   );

--- a/frontend/src/api/__tests__/botmason-byok.test.ts
+++ b/frontend/src/api/__tests__/botmason-byok.test.ts
@@ -1,0 +1,89 @@
+/* eslint-env jest */
+/* global describe, test, expect, afterEach, beforeEach, jest */
+import { botmason, setLlmApiKeyGetter, LLM_API_KEY_HEADER } from '../index';
+
+// Mock global fetch
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 201) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  // Clear any getter registered by a test so state does not bleed across cases.
+  setLlmApiKeyGetter(null);
+});
+
+function chatPayload() {
+  return {
+    response: 'hi back',
+    remaining_balance: 1,
+    bot_entry_id: 42,
+  };
+}
+
+describe('botmason.chat BYOK header', () => {
+  test('omits X-LLM-API-Key header when no getter is registered', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(chatPayload()));
+
+    await botmason.chat({ message: 'hi' }, 'jwt');
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers).not.toHaveProperty(LLM_API_KEY_HEADER);
+  });
+
+  test('omits header when the getter returns null', async () => {
+    setLlmApiKeyGetter(() => null);
+    mockFetch.mockReturnValueOnce(jsonResponse(chatPayload()));
+
+    await botmason.chat({ message: 'hi' }, 'jwt');
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers).not.toHaveProperty(LLM_API_KEY_HEADER);
+  });
+
+  test('omits header when the getter returns an empty string', async () => {
+    setLlmApiKeyGetter(() => '');
+    mockFetch.mockReturnValueOnce(jsonResponse(chatPayload()));
+
+    await botmason.chat({ message: 'hi' }, 'jwt');
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers).not.toHaveProperty(LLM_API_KEY_HEADER);
+  });
+
+  test('attaches header with the getter-supplied key', async () => {
+    setLlmApiKeyGetter(() => 'sk-user-supplied');
+    mockFetch.mockReturnValueOnce(jsonResponse(chatPayload()));
+
+    await botmason.chat({ message: 'hi' }, 'jwt');
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers[LLM_API_KEY_HEADER]).toBe('sk-user-supplied');
+  });
+
+  test('re-polls the getter on each call so rotations take effect immediately', async () => {
+    let key: string | null = 'sk-first';
+    setLlmApiKeyGetter(() => key);
+
+    mockFetch.mockReturnValueOnce(jsonResponse(chatPayload()));
+    await botmason.chat({ message: 'hi' }, 'jwt');
+    expect(mockFetch.mock.calls[0][1].headers[LLM_API_KEY_HEADER]).toBe('sk-first');
+
+    key = 'sk-second';
+    mockFetch.mockReturnValueOnce(jsonResponse(chatPayload()));
+    await botmason.chat({ message: 'hi again' }, 'jwt');
+    expect(mockFetch.mock.calls[1][1].headers[LLM_API_KEY_HEADER]).toBe('sk-second');
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -24,6 +24,10 @@ export class ApiError extends Error {
 let tokenGetter: (() => string | null) | null = null;
 let onUnauthorizedCallback: (() => void) | null = null;
 let onTokenRefreshedCallback: ((token: string) => void) | null = null;
+let llmApiKeyGetter: (() => string | null) | null = null;
+
+/** Header used to forward a user-provided LLM API key (BYOK, issue #185). */
+export const LLM_API_KEY_HEADER = 'X-LLM-API-Key'; // pragma: allowlist secret
 
 export function setTokenGetter(getter: (() => string | null) | null) {
   tokenGetter = getter;
@@ -35,6 +39,16 @@ export function setOnUnauthorized(callback: (() => void) | null) {
 
 export function setOnTokenRefreshed(callback: ((token: string) => void) | null) {
   onTokenRefreshedCallback = callback;
+}
+
+/**
+ * Register a getter for the user-owned LLM API key. When registered and
+ * non-null, the key is attached to BotMason chat requests via the
+ * ``X-LLM-API-Key`` header. The getter is polled per-request so rotations
+ * take effect without reconfiguring the HTTP client.
+ */
+export function setLlmApiKeyGetter(getter: (() => string | null) | null) {
+  llmApiKeyGetter = getter;
 }
 
 interface RequestOptions {
@@ -465,10 +479,16 @@ export interface BalanceResponse {
 
 export const botmason = {
   chat(payload: ChatRequest, token?: string): Promise<ChatResponse> {
+    // The user-owned key (if any) is fetched from the getter at call time
+    // so rotations made in Settings apply immediately. A missing or empty
+    // key means "fall back to the server-side env var" on the backend.
+    const apiKey = llmApiKeyGetter?.() ?? null;
+    const headers = apiKey ? { [LLM_API_KEY_HEADER]: apiKey } : undefined;
     return request<ChatResponse>('/journal/chat', {
       method: 'POST',
       body: payload,
       token,
+      headers,
     });
   },
   getBalance(token?: string): Promise<BalanceResponse> {
@@ -757,4 +777,6 @@ export default {
   setTokenGetter,
   setOnUnauthorized,
   setOnTokenRefreshed,
+  setLlmApiKeyGetter,
+  LLM_API_KEY_HEADER,
 };

--- a/frontend/src/context/ApiKeyContext.tsx
+++ b/frontend/src/context/ApiKeyContext.tsx
@@ -1,0 +1,84 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { setLlmApiKeyGetter } from '@/api';
+import { clearLlmApiKey, loadLlmApiKey, saveLlmApiKey } from '@/storage/llmKeyStorage';
+
+/**
+ * React context managing the user-owned BYOK LLM API key (issue #185).
+ *
+ * The key is loaded from SecureStore on mount, exposed read-only via
+ * {@link useApiKey}, and registered with the HTTP client so that BotMason
+ * chat requests automatically carry the ``X-LLM-API-Key`` header when a key
+ * is present.
+ *
+ * The key is **never** uploaded to the server database and **never** returned
+ * in any API response — it lives only on the device.
+ */
+
+interface ApiKeyContextValue {
+  /** Current user-owned key, or null if none is stored. */
+  apiKey: string | null;
+  /** True until the initial load from SecureStore completes. */
+  isLoading: boolean;
+  /** Persist a new key to SecureStore and update context state. */
+  saveApiKey: (_key: string) => Promise<void>;
+  /** Remove the stored key (SecureStore + context state). */
+  clearApiKey: () => Promise<void>;
+}
+
+const ApiKeyContext = createContext<ApiKeyContextValue | null>(null);
+
+export function ApiKeyProvider({ children }: { children: React.ReactNode }) {
+  const [apiKey, setApiKey] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Mirror the state into a ref so the getter we register with the API layer
+  // always reads the latest value without needing to re-register on every
+  // change.
+  const apiKeyRef = useRef<string | null>(null);
+  apiKeyRef.current = apiKey;
+
+  useEffect(() => {
+    setLlmApiKeyGetter(() => apiKeyRef.current);
+    return () => setLlmApiKeyGetter(null);
+  }, []);
+
+  useEffect(() => {
+    loadLlmApiKey()
+      .then((stored) => setApiKey(stored))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const saveApiKey = useCallback(async (key: string) => {
+    await saveLlmApiKey(key);
+    setApiKey(key);
+  }, []);
+
+  const clearApiKey = useCallback(async () => {
+    await clearLlmApiKey();
+    setApiKey(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({ apiKey, isLoading, saveApiKey, clearApiKey }),
+    [apiKey, isLoading, saveApiKey, clearApiKey],
+  );
+
+  return <ApiKeyContext.Provider value={value}>{children}</ApiKeyContext.Provider>;
+}
+
+export function useApiKey(): ApiKeyContextValue {
+  const ctx = useContext(ApiKeyContext);
+  if (!ctx) {
+    throw new Error('useApiKey must be used within an ApiKeyProvider');
+  }
+  return ctx;
+}

--- a/frontend/src/context/__tests__/ApiKeyContext.test.tsx
+++ b/frontend/src/context/__tests__/ApiKeyContext.test.tsx
@@ -1,0 +1,125 @@
+/* eslint-env jest */
+/* global describe, test, expect, jest, beforeEach */
+import { act, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import * as apiModule from '@/api';
+import { ApiKeyProvider, useApiKey } from '@/context/ApiKeyContext';
+import * as llmKeyStorage from '@/storage/llmKeyStorage';
+
+jest.mock('@/api', () => ({
+  setLlmApiKeyGetter: jest.fn(),
+}));
+
+jest.mock('@/storage/llmKeyStorage', () => ({
+  loadLlmApiKey: jest.fn(() => Promise.resolve(null)),
+  saveLlmApiKey: jest.fn(() => Promise.resolve()),
+  clearLlmApiKey: jest.fn(() => Promise.resolve()),
+}));
+
+const mockApi = apiModule as jest.Mocked<typeof apiModule>;
+const mockStorage = llmKeyStorage as jest.Mocked<typeof llmKeyStorage>;
+
+function TestConsumer({
+  onValue,
+}: {
+  onValue: (_v: ReturnType<typeof useApiKey>) => void;
+}): React.JSX.Element {
+  const ctx = useApiKey();
+  onValue(ctx);
+  return <Text>{ctx.apiKey ?? '(none)'}</Text>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStorage.loadLlmApiKey.mockResolvedValue(null);
+});
+
+describe('ApiKeyProvider', () => {
+  test('loads the stored key from SecureStore on mount', async () => {
+    mockStorage.loadLlmApiKey.mockResolvedValueOnce('sk-stored');
+    const captured: Array<ReturnType<typeof useApiKey>> = [];
+
+    const view = render(
+      <ApiKeyProvider>
+        <TestConsumer onValue={(v) => captured.push(v)} />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(view.getByText('sk-stored')).toBeTruthy());
+    const last = captured[captured.length - 1];
+    expect(last).toBeDefined();
+    expect(last!.isLoading).toBe(false);
+  });
+
+  test('registers an API-layer getter that returns the current key', async () => {
+    mockStorage.loadLlmApiKey.mockResolvedValueOnce('sk-alpha');
+
+    render(
+      <ApiKeyProvider>
+        <TestConsumer onValue={() => undefined} />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(mockApi.setLlmApiKeyGetter).toHaveBeenCalled());
+    const firstCall = mockApi.setLlmApiKeyGetter.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const registered = firstCall![0];
+    expect(registered).not.toBeNull();
+    await waitFor(() => expect(registered?.()).toBe('sk-alpha'));
+  });
+
+  test('saveApiKey persists and updates state', async () => {
+    let ctx: ReturnType<typeof useApiKey> | null = null;
+    render(
+      <ApiKeyProvider>
+        <TestConsumer
+          onValue={(v) => {
+            ctx = v;
+          }}
+        />
+      </ApiKeyProvider>,
+    );
+    await waitFor(() => expect(ctx?.isLoading).toBe(false));
+
+    await act(async () => {
+      await ctx!.saveApiKey('sk-new');
+    });
+
+    expect(mockStorage.saveLlmApiKey).toHaveBeenCalledWith('sk-new');
+    expect(ctx!.apiKey).toBe('sk-new');
+  });
+
+  test('clearApiKey deletes the stored key and resets state', async () => {
+    mockStorage.loadLlmApiKey.mockResolvedValueOnce('sk-existing');
+    let ctx: ReturnType<typeof useApiKey> | null = null;
+    render(
+      <ApiKeyProvider>
+        <TestConsumer
+          onValue={(v) => {
+            ctx = v;
+          }}
+        />
+      </ApiKeyProvider>,
+    );
+    await waitFor(() => expect(ctx?.apiKey).toBe('sk-existing'));
+
+    await act(async () => {
+      await ctx!.clearApiKey();
+    });
+
+    expect(mockStorage.clearLlmApiKey).toHaveBeenCalled();
+    expect(ctx!.apiKey).toBeNull();
+  });
+
+  test('useApiKey throws when used outside a provider', () => {
+    const suppress = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const NakedConsumer = (): React.JSX.Element => {
+      useApiKey();
+      return <Text>never</Text>;
+    };
+    expect(() => render(<NakedConsumer />)).toThrow(/ApiKeyProvider/);
+    suppress.mockRestore();
+  });
+});

--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -1,0 +1,409 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { useApiKey } from '@/context/ApiKeyContext';
+
+/**
+ * BYOK ("Bring Your Own Key") settings for BotMason chat.
+ *
+ * Lets a user paste an OpenAI or Anthropic API key that is stored **only on
+ * their device** via SecureStore and is attached per-request to
+ * ``/journal/chat`` via the ``X-LLM-API-Key`` header (issue #185). The key is
+ * never uploaded to the backend database and is masked by default — reveal
+ * toggles only show the value locally in this screen.
+ */
+
+const OPENAI_PREFIX = 'sk-';
+const ANTHROPIC_PREFIX = 'sk-ant-';
+const MAX_KEY_LENGTH = 256;
+const MIN_KEY_LENGTH = 10;
+const PLACEHOLDER_KEY = 'sk-... or sk-ant-...';
+const MASK_VISIBLE_CHARS = 4;
+
+interface KeyValidationError {
+  code: 'empty' | 'too_short' | 'too_long' | 'bad_prefix';
+  message: string;
+}
+
+export function validateUserApiKey(raw: string): KeyValidationError | null {
+  const key = raw.trim();
+  if (!key) {
+    return { code: 'empty', message: 'Paste an API key before saving.' };
+  }
+  if (key.length < MIN_KEY_LENGTH) {
+    return { code: 'too_short', message: 'This key is shorter than any real API key.' };
+  }
+  if (key.length > MAX_KEY_LENGTH) {
+    return { code: 'too_long', message: 'This key is longer than any real API key.' };
+  }
+  if (!key.startsWith(OPENAI_PREFIX) && !key.startsWith(ANTHROPIC_PREFIX)) {
+    return {
+      code: 'bad_prefix',
+      message: `API keys start with "${OPENAI_PREFIX}" (OpenAI) or "${ANTHROPIC_PREFIX}" (Anthropic).`,
+    };
+  }
+  return null;
+}
+
+function maskKey(key: string): string {
+  if (key.length <= MASK_VISIBLE_CHARS * 2) return '••••••••';
+  return `${key.slice(0, MASK_VISIBLE_CHARS)}••••${key.slice(-MASK_VISIBLE_CHARS)}`;
+}
+
+interface Props {
+  navigation?: { goBack?: () => void };
+}
+
+interface StoredKeyCardProps {
+  apiKey: string;
+  disabled: boolean;
+  onRequestRemove: () => void;
+}
+
+const StoredKeyCard = ({
+  apiKey,
+  disabled,
+  onRequestRemove,
+}: StoredKeyCardProps): React.JSX.Element => (
+  <View style={styles.storedCard} testID="stored-key-card">
+    <Text style={styles.storedLabel}>Stored on this device</Text>
+    <Text style={styles.storedValue}>{maskKey(apiKey)}</Text>
+    <TouchableOpacity
+      onPress={onRequestRemove}
+      style={[styles.button, styles.destructiveButton]}
+      disabled={disabled}
+      testID="remove-key-button"
+    >
+      <Text style={styles.destructiveButtonText}>Remove key</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+interface KeyInputRowProps {
+  draft: string;
+  reveal: boolean;
+  onChangeText: (_v: string) => void;
+  onToggleReveal: () => void;
+}
+
+const KeyInputRow = ({
+  draft,
+  reveal,
+  onChangeText,
+  onToggleReveal,
+}: KeyInputRowProps): React.JSX.Element => (
+  <View style={styles.inputRow}>
+    <TextInput
+      style={styles.input}
+      placeholder={PLACEHOLDER_KEY}
+      value={draft}
+      onChangeText={onChangeText}
+      autoCapitalize="none"
+      autoCorrect={false}
+      secureTextEntry={!reveal}
+      testID="api-key-input"
+    />
+    <TouchableOpacity
+      onPress={onToggleReveal}
+      style={styles.revealButton}
+      testID="reveal-toggle"
+      accessibilityLabel={reveal ? 'Hide API key' : 'Show API key'}
+    >
+      <Text style={styles.revealButtonText}>{reveal ? 'Hide' : 'Show'}</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+function useRemoveConfirmation(performClear: () => Promise<void>): () => void {
+  return useCallback(() => {
+    Alert.alert(
+      'Remove API key?',
+      'BotMason will fall back to the shared server key (if configured). You can add your own key again at any time.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Remove', style: 'destructive', onPress: () => void performClear() },
+      ],
+    );
+  }, [performClear]);
+}
+
+interface FeedbackBannerProps {
+  error: string | null;
+  status: string | null;
+}
+
+const FeedbackBanner = ({ error, status }: FeedbackBannerProps): React.JSX.Element | null => {
+  if (error) {
+    return (
+      <Text style={styles.error} testID="api-key-error">
+        {error}
+      </Text>
+    );
+  }
+  if (status) {
+    return (
+      <Text style={styles.success} testID="api-key-status">
+        {status}
+      </Text>
+    );
+  }
+  return null;
+};
+
+interface ScreenBodyProps {
+  apiKey: string | null;
+  draft: string;
+  reveal: boolean;
+  submitting: boolean;
+  error: string | null;
+  status: string | null;
+  onChangeDraft: (_v: string) => void;
+  onToggleReveal: () => void;
+  onRequestRemove: () => void;
+  onSave: () => void;
+  onBack?: () => void;
+}
+
+const ScreenBody = ({
+  apiKey,
+  draft,
+  reveal,
+  submitting,
+  error,
+  status,
+  onChangeDraft,
+  onToggleReveal,
+  onRequestRemove,
+  onSave,
+  onBack,
+}: ScreenBodyProps): React.JSX.Element => (
+  <>
+    <Text style={styles.title}>BotMason API Key</Text>
+    <Text style={styles.body}>
+      Bring your own OpenAI or Anthropic API key. It is stored only on this device and sent with
+      every BotMason request via the X-LLM-API-Key header. We never upload it to our servers.
+    </Text>
+
+    {apiKey ? (
+      <StoredKeyCard apiKey={apiKey} disabled={submitting} onRequestRemove={onRequestRemove} />
+    ) : (
+      <Text style={styles.hint} testID="no-key-hint">
+        No key saved yet. BotMason will use the shared server key if one is configured.
+      </Text>
+    )}
+
+    <Text style={styles.inputLabel}>{apiKey ? 'Replace key' : 'Add your key'}</Text>
+    <KeyInputRow
+      draft={draft}
+      reveal={reveal}
+      onChangeText={onChangeDraft}
+      onToggleReveal={onToggleReveal}
+    />
+
+    <FeedbackBanner error={error} status={status} />
+
+    <TouchableOpacity
+      onPress={onSave}
+      style={[styles.button, styles.primaryButton]}
+      disabled={submitting}
+      testID="save-key-button"
+    >
+      <Text style={styles.primaryButtonText}>{submitting ? 'Saving…' : 'Save key'}</Text>
+    </TouchableOpacity>
+
+    {onBack && (
+      <TouchableOpacity onPress={onBack} style={styles.linkRow}>
+        <Text style={styles.link}>Back</Text>
+      </TouchableOpacity>
+    )}
+  </>
+);
+
+interface ApiKeyScreenState {
+  draft: string;
+  reveal: boolean;
+  submitting: boolean;
+  error: string | null;
+  status: string | null;
+  setDraft: React.Dispatch<React.SetStateAction<string>>;
+  setReveal: React.Dispatch<React.SetStateAction<boolean>>;
+  setSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
+  setError: React.Dispatch<React.SetStateAction<string | null>>;
+  setStatus: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+function useApiKeyScreenState(): ApiKeyScreenState {
+  const [draft, setDraft] = useState('');
+  const [reveal, setReveal] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  return {
+    draft,
+    reveal,
+    submitting,
+    error,
+    status,
+    setDraft,
+    setReveal,
+    setSubmitting,
+    setError,
+    setStatus,
+  };
+}
+
+function useSaveKeyHandler(
+  state: ApiKeyScreenState,
+  saveApiKey: (_k: string) => Promise<void>,
+): () => Promise<void> {
+  const { draft, setDraft, setReveal, setSubmitting, setError, setStatus } = state;
+  return useCallback(async () => {
+    setStatus(null);
+    const problem = validateUserApiKey(draft);
+    if (problem) {
+      setError(problem.message);
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await saveApiKey(draft.trim());
+      setDraft('');
+      setReveal(false);
+      setStatus('API key saved on this device.');
+    } catch (err) {
+      setError((err as Error).message ?? 'Could not save the API key.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [draft, saveApiKey, setDraft, setReveal, setSubmitting, setError, setStatus]);
+}
+
+function useClearKeyHandler(
+  state: ApiKeyScreenState,
+  clearApiKey: () => Promise<void>,
+): () => Promise<void> {
+  const { setStatus, setError, setSubmitting } = state;
+  return useCallback(async () => {
+    setStatus(null);
+    setSubmitting(true);
+    try {
+      await clearApiKey();
+      setStatus('API key removed from this device.');
+    } catch (err) {
+      setError((err as Error).message ?? 'Could not remove the API key.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [clearApiKey, setStatus, setError, setSubmitting]);
+}
+
+export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.JSX.Element {
+  const { apiKey, isLoading, saveApiKey, clearApiKey } = useApiKey();
+  const state = useApiKeyScreenState();
+  const handleSave = useSaveKeyHandler(state, saveApiKey);
+  const performClear = useClearKeyHandler(state, clearApiKey);
+  const handleRequestRemove = useRemoveConfirmation(performClear);
+
+  const onChangeDraft = useCallback(
+    (value: string) => {
+      state.setDraft(value);
+      state.setError(null);
+    },
+    [state],
+  );
+  const toggleReveal = useCallback(() => state.setReveal((prev) => !prev), [state]);
+  const onBack = useMemo(
+    () => (navigation?.goBack ? () => navigation.goBack?.() : undefined),
+    [navigation],
+  );
+
+  if (isLoading) {
+    return (
+      <View style={styles.loadingContainer} testID="api-key-loading">
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <ScreenBody
+        apiKey={apiKey}
+        draft={state.draft}
+        reveal={state.reveal}
+        submitting={state.submitting}
+        error={state.error}
+        status={state.status}
+        onChangeDraft={onChangeDraft}
+        onToggleReveal={toggleReveal}
+        onRequestRemove={handleRequestRemove}
+        onSave={handleSave}
+        onBack={onBack}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 24, backgroundColor: '#fff', flexGrow: 1 },
+  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 22, fontWeight: '700', marginBottom: 12 },
+  body: { fontSize: 14, color: '#444', marginBottom: 20, lineHeight: 20 },
+  storedCard: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 24,
+    backgroundColor: '#fafafa',
+  },
+  storedLabel: { fontSize: 12, color: '#666', textTransform: 'uppercase', letterSpacing: 0.5 },
+  storedValue: {
+    fontSize: 18,
+    fontFamily: 'Menlo',
+    marginTop: 8,
+    marginBottom: 16,
+    color: '#222',
+  },
+  hint: { fontSize: 14, color: '#666', marginBottom: 24, fontStyle: 'italic' },
+  inputLabel: { fontSize: 14, fontWeight: '600', marginBottom: 8, color: '#222' },
+  inputRow: { flexDirection: 'row', alignItems: 'stretch', marginBottom: 12 },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+  },
+  revealButton: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderLeftWidth: 0,
+    borderTopRightRadius: 8,
+    borderBottomRightRadius: 8,
+    paddingHorizontal: 12,
+    justifyContent: 'center',
+    backgroundColor: '#f3f3f3',
+  },
+  revealButtonText: { fontSize: 14, color: '#333', fontWeight: '600' },
+  error: { color: '#d32f2f', marginBottom: 12 },
+  success: { color: '#2e7d32', marginBottom: 12 },
+  button: { borderRadius: 8, padding: 14, alignItems: 'center' },
+  primaryButton: { backgroundColor: '#4a90d9', marginTop: 4 },
+  primaryButtonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  destructiveButton: { backgroundColor: '#f8e0e0', borderWidth: 1, borderColor: '#e58a8a' },
+  destructiveButtonText: { color: '#b12828', fontWeight: '600' },
+  linkRow: { marginTop: 24, alignItems: 'center' },
+  link: { color: '#4a90d9', fontWeight: '600' },
+});

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -1,0 +1,139 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { Alert } from 'react-native';
+
+import ApiKeySettingsScreen, { validateUserApiKey } from '../ApiKeySettingsScreen';
+
+import { useApiKey } from '@/context/ApiKeyContext';
+
+jest.mock('@/context/ApiKeyContext', () => ({
+  useApiKey: jest.fn(),
+}));
+
+const mockUseApiKey = useApiKey as jest.MockedFunction<typeof useApiKey>;
+
+const VALID_KEY = 'sk-user-owned-example-key-0123456789';
+
+function setApiKeyState(partial: Partial<ReturnType<typeof useApiKey>>) {
+  const base = {
+    apiKey: null,
+    isLoading: false,
+    saveApiKey: jest.fn(() => Promise.resolve()),
+    clearApiKey: jest.fn(() => Promise.resolve()),
+  };
+  const value = { ...base, ...partial } as ReturnType<typeof useApiKey>;
+  mockUseApiKey.mockReturnValue(value);
+  return value;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('validateUserApiKey', () => {
+  test('accepts a well-formed OpenAI key', () => {
+    expect(validateUserApiKey(VALID_KEY)).toBeNull();
+  });
+
+  test('accepts a well-formed Anthropic key', () => {
+    expect(validateUserApiKey(`sk-ant-${'x'.repeat(60)}`)).toBeNull();
+  });
+
+  test('rejects an empty or whitespace-only input', () => {
+    expect(validateUserApiKey('')?.code).toBe('empty');
+    expect(validateUserApiKey('   ')?.code).toBe('empty');
+  });
+
+  test('rejects a key without the expected prefix', () => {
+    expect(validateUserApiKey('definitely-not-real-enough')?.code).toBe('bad_prefix');
+  });
+
+  test('rejects a key that is too short', () => {
+    expect(validateUserApiKey('sk-a')?.code).toBe('too_short');
+  });
+
+  test('rejects a key that is too long', () => {
+    expect(validateUserApiKey(`sk-${'x'.repeat(300)}`)?.code).toBe('too_long');
+  });
+});
+
+describe('ApiKeySettingsScreen', () => {
+  test('shows the loading indicator while the stored key is being read', () => {
+    setApiKeyState({ isLoading: true });
+    const { getByTestId, queryByTestId } = render(<ApiKeySettingsScreen />);
+    expect(getByTestId('api-key-loading')).toBeTruthy();
+    expect(queryByTestId('save-key-button')).toBeNull();
+  });
+
+  test('shows a hint when no key is saved yet', () => {
+    setApiKeyState({});
+    const { getByTestId } = render(<ApiKeySettingsScreen />);
+    expect(getByTestId('no-key-hint')).toBeTruthy();
+  });
+
+  test('shows a masked summary of the stored key', () => {
+    setApiKeyState({ apiKey: VALID_KEY });
+    const { getByText, queryByText } = render(<ApiKeySettingsScreen />);
+    // The raw key must not appear — only a mask with the first and last
+    // few characters plus bullet fill.
+    expect(queryByText(VALID_KEY)).toBeNull();
+    expect(getByText(/^sk-u/)).toBeTruthy();
+    expect(getByText(/••••/)).toBeTruthy();
+  });
+
+  test('rejects a malformed key and does not persist it', async () => {
+    const state = setApiKeyState({});
+    const { getByTestId, findByTestId } = render(<ApiKeySettingsScreen />);
+
+    fireEvent.changeText(getByTestId('api-key-input'), 'not-a-real-key');
+    fireEvent.press(getByTestId('save-key-button'));
+
+    const error = await findByTestId('api-key-error');
+    expect(error).toBeTruthy();
+    expect(state.saveApiKey).not.toHaveBeenCalled();
+  });
+
+  test('persists a well-formed key and clears the input', async () => {
+    const state = setApiKeyState({});
+    const { getByTestId, findByTestId } = render(<ApiKeySettingsScreen />);
+
+    fireEvent.changeText(getByTestId('api-key-input'), VALID_KEY);
+    await act(async () => {
+      fireEvent.press(getByTestId('save-key-button'));
+    });
+
+    await waitFor(() => expect(state.saveApiKey).toHaveBeenCalledWith(VALID_KEY));
+    const status = await findByTestId('api-key-status');
+    expect(status).toBeTruthy();
+    // Input should have been cleared after save.
+    expect(getByTestId('api-key-input').props.value).toBe('');
+  });
+
+  test('the reveal toggle flips secureTextEntry', () => {
+    setApiKeyState({});
+    const { getByTestId } = render(<ApiKeySettingsScreen />);
+    const input = getByTestId('api-key-input');
+    expect(input.props.secureTextEntry).toBe(true);
+    fireEvent.press(getByTestId('reveal-toggle'));
+    expect(input.props.secureTextEntry).toBe(false);
+  });
+
+  test('remove button asks for confirmation before clearing', async () => {
+    const state = setApiKeyState({ apiKey: VALID_KEY });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+      // Simulate the user tapping the destructive "Remove" button.
+      const destructive = buttons?.find((b) => b.style === 'destructive');
+      destructive?.onPress?.();
+    });
+
+    const { getByTestId } = render(<ApiKeySettingsScreen />);
+    await act(async () => {
+      fireEvent.press(getByTestId('remove-key-button'));
+    });
+
+    await waitFor(() => expect(state.clearApiKey).toHaveBeenCalled());
+    alertSpy.mockRestore();
+  });
+});

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -1,8 +1,10 @@
 // frontend/navigation/BottomTabs.tsx
 
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { JournalTag } from '../api';
 import CourseScreen from '../features/Course/CourseScreen';
@@ -10,6 +12,8 @@ import HabitsScreen from '../features/Habits/HabitsScreen';
 import JournalScreen from '../features/Journal/JournalScreen';
 import MapScreen from '../features/Map/MapScreen';
 import PracticeScreen from '../features/Practice/PracticeScreen';
+
+import type { RootStackParamList } from './RootStack';
 
 import { useAuth } from '@/context/AuthContext';
 
@@ -39,15 +43,30 @@ const Tab = createBottomTabNavigator<RootTabParamList>();
  */
 const BottomTabs = (): React.JSX.Element => {
   const { logout } = useAuth();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  const openSettings = React.useCallback(() => {
+    navigation.navigate('ApiKeySettings');
+  }, [navigation]);
 
   return (
     <Tab.Navigator
       initialRouteName="Habits"
       screenOptions={{
         headerRight: () => (
-          <TouchableOpacity onPress={logout} style={styles.logoutButton}>
-            <Text style={styles.logoutText}>Logout</Text>
-          </TouchableOpacity>
+          <View style={styles.headerRight}>
+            <TouchableOpacity
+              onPress={openSettings}
+              style={styles.headerButton}
+              accessibilityLabel="Open settings"
+              testID="open-settings-button"
+            >
+              <Text style={styles.headerButtonText}>⚙︎</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={logout} style={styles.headerButton}>
+              <Text style={styles.headerButtonText}>Logout</Text>
+            </TouchableOpacity>
+          </View>
         ),
       }}
     >
@@ -61,8 +80,9 @@ const BottomTabs = (): React.JSX.Element => {
 };
 
 const styles = StyleSheet.create({
-  logoutButton: { marginRight: 12 },
-  logoutText: { color: '#4a90d9', fontSize: 14, fontWeight: '600' },
+  headerRight: { flexDirection: 'row', alignItems: 'center', marginRight: 8 },
+  headerButton: { paddingHorizontal: 8, paddingVertical: 4 },
+  headerButtonText: { color: '#4a90d9', fontSize: 14, fontWeight: '600' },
 });
 
 export default BottomTabs;

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -1,0 +1,31 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import React from 'react';
+
+import ApiKeySettingsScreen from '../features/Settings/ApiKeySettingsScreen';
+
+import BottomTabs from './BottomTabs';
+
+/**
+ * Root stack for the authenticated app. Hosts the bottom-tabs shell plus
+ * modal-style screens (e.g. BYOK API key settings) that should not live
+ * inside any single tab.
+ */
+export type RootStackParamList = {
+  Tabs: undefined;
+  ApiKeySettings: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const RootStack = (): React.JSX.Element => (
+  <Stack.Navigator>
+    <Stack.Screen name="Tabs" component={BottomTabs} options={{ headerShown: false }} />
+    <Stack.Screen
+      name="ApiKeySettings"
+      component={ApiKeySettingsScreen}
+      options={{ title: 'API Key' }}
+    />
+  </Stack.Navigator>
+);
+
+export default RootStack;

--- a/frontend/src/storage/__tests__/llmKeyStorage.test.ts
+++ b/frontend/src/storage/__tests__/llmKeyStorage.test.ts
@@ -1,0 +1,52 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import * as SecureStore from 'expo-secure-store';
+
+import { clearLlmApiKey, loadLlmApiKey, saveLlmApiKey } from '../llmKeyStorage';
+
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('llmKeyStorage', () => {
+  describe('saveLlmApiKey', () => {
+    test('stores key in SecureStore under adepthood namespace', async () => {
+      await saveLlmApiKey('sk-user-owned-key');
+
+      expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+        '@adepthood/llm_api_key',
+        'sk-user-owned-key',
+      );
+    });
+  });
+
+  describe('loadLlmApiKey', () => {
+    test('returns null when no key stored', async () => {
+      mockSecureStore.getItemAsync.mockResolvedValueOnce(null);
+
+      await expect(loadLlmApiKey()).resolves.toBeNull();
+    });
+
+    test('returns stored key when present', async () => {
+      mockSecureStore.getItemAsync.mockResolvedValueOnce('sk-user-owned-key');
+
+      await expect(loadLlmApiKey()).resolves.toBe('sk-user-owned-key');
+    });
+  });
+
+  describe('clearLlmApiKey', () => {
+    test('removes key from SecureStore', async () => {
+      await clearLlmApiKey();
+
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('@adepthood/llm_api_key');
+    });
+  });
+});

--- a/frontend/src/storage/llmKeyStorage.ts
+++ b/frontend/src/storage/llmKeyStorage.ts
@@ -1,0 +1,23 @@
+import * as SecureStore from 'expo-secure-store';
+
+/**
+ * Storage layer for the user's BYOK (Bring Your Own Key) LLM API key.
+ *
+ * The key is stored **only** on the device via `expo-secure-store` — it is
+ * never uploaded to our backend database. This eliminates server-side breach
+ * liability for user-owned keys and is the storage contract guaranteed by
+ * issue #185.
+ */
+const LLM_API_KEY_STORAGE_KEY = '@adepthood/llm_api_key';
+
+export async function saveLlmApiKey(apiKey: string): Promise<void> {
+  await SecureStore.setItemAsync(LLM_API_KEY_STORAGE_KEY, apiKey);
+}
+
+export async function loadLlmApiKey(): Promise<string | null> {
+  return SecureStore.getItemAsync(LLM_API_KEY_STORAGE_KEY);
+}
+
+export async function clearLlmApiKey(): Promise<void> {
+  await SecureStore.deleteItemAsync(LLM_API_KEY_STORAGE_KEY);
+}


### PR DESCRIPTION
Closes #185.

## Summary

Lets users bring their own OpenAI or Anthropic API key instead of relying on the operator-subsidised `LLM_API_KEY`. The key lives only on the device (SecureStore), ships per-request via the `X-LLM-API-Key` header, is validated and forwarded to the provider for a single call, and is never stored, logged, or echoed back by the server.

### Backend (`acf8006`)
- `services/botmason`: `generate_response` accepts an optional `api_key` override; provider-specific prefix rules (`sk-` for OpenAI, `sk-ant-` for Anthropic) gate the forwarded key so a misrouted key can't reach the wrong SDK.
- `routers/botmason`: reads `X-LLM-API-Key`, validates format (400 on bad prefix/oversized), falls back to the server env var, or returns **402 `llm_key_required`** when the active provider needs a key and neither source has one. Key resolution runs **before** balance deduction so malformed/missing-key requests never cost an offering.
- `main`: `X-LLM-API-Key` added to the CORS allow-headers list.

### Frontend (`959e266`)
- `storage/llmKeyStorage`: SecureStore save/load/clear, mirroring the auth-token pattern from sec-10.
- `api/index`: `setLlmApiKeyGetter` registers a getter polled at call time so rotations take effect immediately; `botmason.chat` attaches the header when a non-empty key is available.
- `context/ApiKeyContext`: loads the stored key on mount, exposes `saveApiKey` / `clearApiKey`, and wires the getter.
- `features/Settings/ApiKeySettingsScreen`: masked display, reveal toggle, client-side format validation, and confirm-before-remove.
- `navigation/RootStack`: new stack above the tabs so the settings screen has a home; the gear button on the tab header opens it.
- `App`: wraps the authenticated tree in `ApiKeyProvider`.

### Security contract enforced by tests
- Key never written to the DB (no schema or model field touched).
- Key never logged — `caplog` scan explicitly asserts absence.
- Key never returned — response body asserted clean.
- Key cleared from memory after the LLM call (parameter scope + `ApiKeyProvider` unmount).
- Rate limit unchanged (`10/minute` per IP applies regardless of key source).

### Test coverage
- **Backend**: 17 new cases covering format validation, header precedence over env, 402 on no key, 400 on malformed/oversized keys, env fallback, stub provider bypass, balance-preservation on failure, and negative assertions for logging/response echo. Overall coverage 93.38%.
- **Frontend**: 27 new cases across storage round-trip, API header injection (incl. empty/null/rotation), context lifecycle, and the settings screen UI (validation, mask format, reveal toggle, remove-confirmation flow).

Pre-commit on this branch is green across all 24 hooks (black, ruff, mypy, isort, bandit, pip-audit, detect-secrets, eslint, prettier, tsc, jest, xenon, radon, backend-tests-coverage).

## Test plan

- [ ] CI green (pre-commit + backend pytest + frontend jest)
- [ ] Manual: with `BOTMASON_PROVIDER=openai` and no `LLM_API_KEY`, hitting `/journal/chat` without a header yields 402 `llm_key_required`; with a valid `sk-...` header, the call proceeds.
- [ ] Manual: in the mobile app, open Settings → API Key, save a key, send a BotMason message, verify the server sees the header; remove key, verify fallback/shared-key behaviour.

https://claude.ai/code/session_01ABDyZM4qPND3NERhGNtVDS