### PR TITLE
fix(infra): add per-service railway.toml for frontend and backend

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+watchPatterns = ["backend/**"]
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3

--- a/frontend/railway.toml
+++ b/frontend/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+watchPatterns = ["frontend/**"]
+
+[deploy]
+healthcheckPath = "/"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
The repo-root railway.toml hard-codes dockerfilePath to
backend/Dockerfile, so the Railway frontend service (with
rootDirectory=frontend/) was falling back to it and trying to build the
backend image against the frontend build context — failing on
`COPY migrations/ migrations/`.

Add frontend/railway.toml and backend/railway.toml so each service
picks up its own Dockerfile and healthcheck config from its own root.

https://claude.ai/code/session_01SoawV96KgBxsgvdr2mUNrD