### PR TITLE
fix(backend): ensure migrations/ dir reaches Railway build context

### DIFF
--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,0 +1,7 @@
+Alembic migrations live here.
+
+This directory is intentionally tracked in git before Alembic is
+configured so that the Docker build context reliably includes it.
+Once `alembic init migrations` is run, this placeholder can be removed.
+
+See DEPLOYMENT.md ("Database Migrations") for setup instructions.


### PR DESCRIPTION
Railway's BuildKit was stripping backend/migrations/ from the build
context because the directory only contained a hidden .gitkeep file,
causing the Dockerfile's `COPY migrations/ migrations/` to fail with
"/migrations": not found.

Add a non-hidden README placeholder so the directory is reliably
uploaded as part of the Docker build context until Alembic is
initialized.

https://claude.ai/code/session_015SE1ZDSU4YDVQ3DPtwv4fW