### PR TITLE
fix(backend): drop placeholder migrations/ COPY from Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,10 +24,12 @@ RUN apt-get update && \
 COPY --from=builder /install /usr/local
 COPY src/ src/
 
-# Copy Alembic config and migrations.
-# The glob (alembic.ini*) is a no-op when the file is absent.
+# Copy Alembic config (optional — glob is a no-op when the file is absent).
+# Once `alembic init migrations` is run and alembic.ini is committed,
+# add `COPY migrations/ migrations/` below so `alembic upgrade head`
+# can find the revision scripts. Until then, the CMD guards on the
+# presence of alembic.ini and skips migrations entirely.
 COPY alembic.ini* ./
-COPY migrations/ migrations/
 
 # Create non-root user
 RUN useradd --create-home appuser

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,7 +1,13 @@
 Alembic migrations live here.
 
-This directory is intentionally tracked in git before Alembic is
-configured so that the Docker build context reliably includes it.
-Once `alembic init migrations` is run, this placeholder can be removed.
+This directory is a placeholder until Alembic is initialized with
+`alembic init migrations`. While it is empty, the Dockerfile does
+NOT copy it into the image — Railway's BuildKit intermittently
+fails to resolve near-empty directories in the build context,
+which caused repeated deploy failures.
+
+Once Alembic is configured and real revision scripts land here,
+re-add `COPY migrations/ migrations/` to backend/Dockerfile
+alongside the existing `COPY alembic.ini* ./` line.
 
 See DEPLOYMENT.md ("Database Migrations") for setup instructions.


### PR DESCRIPTION
Railway's BuildKit has repeatedly failed to resolve the near-empty
backend/migrations/ directory in the build context, producing:

    ERROR: failed to build: ... "/migrations": not found

The earlier workaround (adding a non-hidden README to keep BuildKit
from stripping the directory, commit 2f36360) did not resolve the
failure on subsequent deploys.

Since Alembic isn't initialized yet — there's no alembic.ini and the
CMD already guards migrations with `if [ -f alembic.ini ]` — the
image doesn't need migrations/ at runtime. Drop the COPY line so
the build succeeds, and document in the migrations README when the
COPY should be re-added (once `alembic init migrations` has produced
real revision scripts).

https://claude.ai/code/session_0184FT59HxnWMX7gPH1LcRi5