### PR TITLE
feat(backend): LLM usage tracking and cost metering (#187)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -15,6 +15,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 
 from database import get_session
 from rate_limit import limiter
+from routers.admin import router as admin_router
 from routers.auth import router as auth_router
 from routers.botmason import router as botmason_router
 from routers.course import router as course_router
@@ -143,10 +144,11 @@ app.add_middleware(
     allow_origins=origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE"],
-    allow_headers=["Authorization", "Content-Type", "X-LLM-API-Key"],
+    allow_headers=["Authorization", "Content-Type", "X-LLM-API-Key", "X-Admin-API-Key"],
 )
 
 # Register feature routers
+app.include_router(admin_router)
 app.include_router(auth_router)
 app.include_router(botmason_router)
 app.include_router(course_router)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -7,6 +7,7 @@ from .goal_completion import GoalCompletion
 from .goal_group import GoalGroup
 from .habit import Habit
 from .journal_entry import JournalEntry
+from .llm_usage_log import LLMUsageLog
 from .login_attempt import LoginAttempt
 from .practice import Practice
 from .practice_session import PracticeSession
@@ -24,6 +25,7 @@ __all__ = [
     "GoalGroup",
     "Habit",
     "JournalEntry",
+    "LLMUsageLog",
     "LoginAttempt",
     "Practice",
     "PracticeSession",

--- a/backend/src/models/llm_usage_log.py
+++ b/backend/src/models/llm_usage_log.py
@@ -1,0 +1,40 @@
+"""Per-request LLM cost + token accounting.
+
+One row per successful ``/journal/chat`` call.  The table is append-only —
+never updated, never deleted by the application code — so it doubles as an
+audit log for cost investigations.  Aggregates (total spend, per-user, per-
+model breakdowns) are computed on read by the admin stats endpoint.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlmodel import Field, SQLModel
+
+
+class LLMUsageLog(SQLModel, table=True):
+    """Token counts + estimated USD cost for a single LLM call.
+
+    ``estimated_cost_usd`` is derived from ``prompt_tokens`` /
+    ``completion_tokens`` via the pricing table in
+    :mod:`services.llm_pricing`.  It is stored on the row so historical rows
+    survive unchanged when the pricing table is updated for future requests.
+
+    ``journal_entry_id`` points at the bot's reply (``sender='bot'``) so a
+    single JOIN reconstructs the conversational context of any logged call.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        index=True,
+    )
+    provider: str = Field(max_length=32, index=True)
+    model: str = Field(max_length=128, index=True)
+    prompt_tokens: int = Field(default=0, ge=0)
+    completion_tokens: int = Field(default=0, ge=0)
+    total_tokens: int = Field(default=0, ge=0)
+    estimated_cost_usd: float = Field(default=0.0, ge=0.0)
+    journal_entry_id: int = Field(foreign_key="journalentry.id", index=True)

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -1,0 +1,133 @@
+"""Admin-only endpoints — gated by ``ADMIN_API_KEY`` shared-secret header.
+
+The admin surface is intentionally minimal: enough to observe LLM cost and
+token consumption without introducing a whole role-based-access-control layer
+up front.  Once the app grows an admin user role, swap the header gate for a
+user-role check and the endpoints here can stay unchanged.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+
+from fastapi import APIRouter, Depends, Header
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from database import get_session
+from errors import forbidden
+from models.llm_usage_log import LLMUsageLog
+from schemas.admin import (
+    ModelUsageBreakdown,
+    UsageStatsResponse,
+    UserUsageBreakdown,
+)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+# Header used by the admin to authenticate.  The value is compared to the
+# ``ADMIN_API_KEY`` env var using a constant-time comparison so attackers
+# cannot recover the key via timing side-channels.
+ADMIN_API_KEY_HEADER = "X-Admin-API-Key"  # pragma: allowlist secret
+
+
+def _require_admin(
+    x_admin_api_key: str | None = Header(default=None, alias=ADMIN_API_KEY_HEADER),
+) -> None:
+    """FastAPI dependency: reject requests without a valid admin key.
+
+    ``ADMIN_API_KEY`` must be set to a non-empty value for the endpoint to be
+    reachable at all.  An unset env var fails closed — we never treat "no
+    password configured" as "anyone may enter".
+    """
+    expected = os.getenv("ADMIN_API_KEY", "")
+    if not expected:
+        raise forbidden("admin_api_disabled")
+    if not x_admin_api_key or not hmac.compare_digest(x_admin_api_key, expected):
+        raise forbidden("admin_auth_required")
+
+
+@router.get("/usage-stats", response_model=UsageStatsResponse)
+async def get_usage_stats(
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+    _: None = Depends(_require_admin),
+) -> UsageStatsResponse:
+    """Return aggregate LLM usage stats across all users.
+
+    Three views are returned in a single response so a dashboard can render
+    total spend, top users by cost, and model-mix breakdown without making
+    three round trips:
+
+    * ``total_*`` — all-time totals
+    * ``per_user`` — one row per user who has consumed any tokens
+    * ``per_model`` — one row per distinct ``(provider, model)`` pair
+    """
+    totals_row = (
+        await session.execute(
+            select(
+                func.count(col(LLMUsageLog.id)),
+                func.coalesce(func.sum(col(LLMUsageLog.prompt_tokens)), 0),
+                func.coalesce(func.sum(col(LLMUsageLog.completion_tokens)), 0),
+                func.coalesce(func.sum(col(LLMUsageLog.total_tokens)), 0),
+                func.coalesce(func.sum(col(LLMUsageLog.estimated_cost_usd)), 0.0),
+            )
+        )
+    ).one()
+    total_calls, total_prompt, total_completion, total_tokens, total_cost = totals_row
+
+    per_user_rows = (
+        await session.execute(
+            select(
+                col(LLMUsageLog.user_id),
+                func.count(col(LLMUsageLog.id)),
+                func.coalesce(func.sum(col(LLMUsageLog.total_tokens)), 0),
+                func.coalesce(func.sum(col(LLMUsageLog.estimated_cost_usd)), 0.0),
+            )
+            .group_by(col(LLMUsageLog.user_id))
+            .order_by(func.sum(col(LLMUsageLog.estimated_cost_usd)).desc())
+        )
+    ).all()
+
+    per_model_rows = (
+        await session.execute(
+            select(
+                col(LLMUsageLog.provider),
+                col(LLMUsageLog.model),
+                func.count(col(LLMUsageLog.id)),
+                func.coalesce(func.sum(col(LLMUsageLog.total_tokens)), 0),
+                func.coalesce(func.sum(col(LLMUsageLog.estimated_cost_usd)), 0.0),
+            )
+            .group_by(col(LLMUsageLog.provider), col(LLMUsageLog.model))
+            .order_by(func.sum(col(LLMUsageLog.estimated_cost_usd)).desc())
+        )
+    ).all()
+
+    return UsageStatsResponse(
+        total_calls=int(total_calls),
+        total_prompt_tokens=int(total_prompt),
+        total_completion_tokens=int(total_completion),
+        total_tokens=int(total_tokens),
+        total_estimated_cost_usd=float(total_cost),
+        per_user=[
+            UserUsageBreakdown(
+                user_id=int(user_id),
+                call_count=int(calls),
+                total_tokens=int(tokens),
+                estimated_cost_usd=float(cost),
+            )
+            for user_id, calls, tokens, cost in per_user_rows
+        ],
+        per_model=[
+            ModelUsageBreakdown(
+                provider=str(provider),
+                model=str(model),
+                call_count=int(calls),
+                total_tokens=int(tokens),
+                estimated_cost_usd=float(cost),
+            )
+            for provider, model, calls, tokens, cost in per_model_rows
+        ],
+    )

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -21,6 +21,7 @@ from sqlmodel import col, select
 from database import get_session
 from errors import bad_request, payment_required
 from models.journal_entry import JournalEntry
+from models.llm_usage_log import LLMUsageLog
 from models.user import User
 from rate_limit import limiter
 from routers.auth import get_current_user
@@ -35,11 +36,13 @@ from schemas.botmason import (
 from services.botmason import (
     CONVERSATION_HISTORY_LIMIT,
     LLM_API_KEY_MAX_LENGTH,
+    LLMResponse,
     generate_response,
     get_provider,
     provider_requires_api_key,
     validate_llm_api_key_format,
 )
+from services.llm_pricing import estimate_cost_usd
 from services.usage import compute_next_reset, get_monthly_cap
 
 router = APIRouter(tags=["botmason"])
@@ -231,15 +234,21 @@ async def chat_with_botmason(
 
     # Generate AI response. ``api_key`` is passed by value for a single call
     # and is discarded when this function returns.
-    bot_text = await generate_response(
+    llm_response = await generate_response(
         payload.message,
         conversation_history,
         api_key=api_key,
     )
 
     # Store bot's response
-    bot_entry = JournalEntry(sender="bot", user_id=current_user, message=bot_text)
+    bot_entry = JournalEntry(sender="bot", user_id=current_user, message=llm_response.text)
     session.add(bot_entry)
+    # Flush so ``bot_entry.id`` is available as the FK for the usage log row.
+    # Both rows commit together below, so a rollback at commit-time still
+    # leaves the log consistent with the journal.
+    await session.flush()
+
+    _record_llm_usage(session, current_user, bot_entry.id, llm_response)
 
     await session.commit()
     await session.refresh(bot_entry)
@@ -249,11 +258,48 @@ async def chat_with_botmason(
     user_after = await _get_user(current_user, session)
 
     return ChatResponse(
-        response=bot_text,
+        response=llm_response.text,
         remaining_balance=new_balance,
         remaining_messages=remaining_messages,
         monthly_reset_date=user_after.monthly_reset_date,
         bot_entry_id=bot_entry.id,
+    )
+
+
+def _record_llm_usage(
+    session: AsyncSession,
+    user_id: int,
+    journal_entry_id: int | None,
+    llm_response: LLMResponse,
+) -> None:
+    """Append an :class:`LLMUsageLog` row for a single chat call.
+
+    The log row is staged on the caller's session so it commits in the same
+    transaction as the bot's :class:`JournalEntry`.  ``journal_entry_id`` is
+    typed ``int | None`` because SQLModel exposes the primary key that way
+    until flush; the caller is responsible for flushing before invoking this
+    helper and we assert the invariant here to fail loudly rather than write
+    a row with a NULL FK.
+    """
+    if journal_entry_id is None:  # pragma: no cover - defensive; caller flushes first
+        msg = "journal_entry_id must be set before logging LLM usage"
+        raise RuntimeError(msg)
+
+    session.add(
+        LLMUsageLog(
+            user_id=user_id,
+            provider=llm_response.provider,
+            model=llm_response.model,
+            prompt_tokens=llm_response.prompt_tokens,
+            completion_tokens=llm_response.completion_tokens,
+            total_tokens=llm_response.total_tokens,
+            estimated_cost_usd=estimate_cost_usd(
+                llm_response.model,
+                llm_response.prompt_tokens,
+                llm_response.completion_tokens,
+            ),
+            journal_entry_id=journal_entry_id,
+        )
     )
 
 

--- a/backend/src/schemas/admin.py
+++ b/backend/src/schemas/admin.py
@@ -1,0 +1,40 @@
+"""Admin-dashboard response schemas for LLM usage stats."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class UserUsageBreakdown(BaseModel):
+    """Per-user LLM usage aggregate."""
+
+    user_id: int
+    call_count: int
+    total_tokens: int
+    estimated_cost_usd: float
+
+
+class ModelUsageBreakdown(BaseModel):
+    """Per-model LLM usage aggregate.  Grouped by ``(provider, model)``."""
+
+    provider: str
+    model: str
+    call_count: int
+    total_tokens: int
+    estimated_cost_usd: float
+
+
+class UsageStatsResponse(BaseModel):
+    """Aggregate LLM usage stats for the admin dashboard.
+
+    Totals are precomputed so the client never has to sum the breakdown lists
+    to render the headline number.
+    """
+
+    total_calls: int
+    total_prompt_tokens: int
+    total_completion_tokens: int
+    total_tokens: int
+    total_estimated_cost_usd: float
+    per_user: list[UserUsageBreakdown]
+    per_model: list[ModelUsageBreakdown]

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 
@@ -38,6 +39,32 @@ LLM_API_KEY_MAX_LENGTH = 256
 # OpenAI, so their check is the more specific ``sk-ant-``.
 _OPENAI_KEY_PREFIX = "sk-"
 _ANTHROPIC_KEY_PREFIX = "sk-ant-"
+
+# Identifier the stub provider reports as its "model" in usage logs.  Kept as a
+# module constant so callers can branch on it without magic strings.
+STUB_MODEL_NAME = "stub"
+
+
+@dataclass(frozen=True, slots=True)
+class LLMResponse:
+    """Response from an LLM provider plus the token counts needed for metering.
+
+    ``text`` is the bot's reply that becomes a :class:`JournalEntry`; every
+    other field is metadata for the usage log.  The stub provider reports
+    zero tokens and the sentinel model :data:`STUB_MODEL_NAME` so downstream
+    accounting can treat it as a free no-op.
+    """
+
+    text: str
+    provider: str
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+
+    @property
+    def total_tokens(self) -> int:
+        """Sum of prompt and completion tokens — always derived, never stored."""
+        return self.prompt_tokens + self.completion_tokens
 
 
 def get_provider() -> str:
@@ -156,7 +183,7 @@ async def generate_response(
     conversation_history: list[dict[str, str]],
     system_prompt: str | None = None,
     api_key: str | None = None,
-) -> str:
+) -> LLMResponse:
     """Generate a BotMason response using the configured LLM provider.
 
     Currently supports the ``BOTMASON_PROVIDER`` env var with values:
@@ -169,6 +196,9 @@ async def generate_response(
     directly (e.g. sourced from a user-supplied header) to override the
     server-side ``LLM_API_KEY`` env var. When ``api_key`` is ``None`` the
     env var is used; the key is never persisted or logged by this layer.
+
+    Returns an :class:`LLMResponse` carrying both the generated text and the
+    token counts needed to log usage downstream.
     """
     resolved_prompt = system_prompt or get_system_prompt()
     provider = get_provider()
@@ -181,11 +211,23 @@ async def generate_response(
     return _stub_response(user_message)
 
 
-def _stub_response(user_message: str) -> str:
-    """Return a deterministic response for development and testing."""
-    return (
+def _stub_response(user_message: str) -> LLMResponse:
+    """Return a deterministic response for development and testing.
+
+    Token counts are zero because no real model is invoked — this keeps the
+    usage log's cost total honest when stub traffic is mixed with production
+    calls during load tests.
+    """
+    text = (
         f'BotMason hears you. You said: "{user_message}" — '
         "Let the Archetypal Wavelength guide your reflection."
+    )
+    return LLMResponse(
+        text=text,
+        provider="stub",
+        model=STUB_MODEL_NAME,
+        prompt_tokens=0,
+        completion_tokens=0,
     )
 
 
@@ -225,23 +267,51 @@ def _resolve_api_key(override: str | None) -> str:
     return _get_llm_api_key()
 
 
+def extract_token_count(source: object, *attrs: str) -> int:
+    """Return the first non-``None`` attribute value coerced to a non-negative int.
+
+    Providers occasionally drop ``usage`` from streaming or error responses.
+    Treating a missing value as zero keeps the usage log append even when
+    upstream returns incomplete metadata — accepting "unknown" costs less
+    than losing the whole observability trail.
+    """
+    if source is None:
+        return 0
+    for attr in attrs:
+        value = getattr(source, attr, None)
+        if value is not None:
+            try:
+                return max(int(value), 0)
+            except (TypeError, ValueError):
+                continue
+    return 0
+
+
 async def _call_openai(
     user_message: str,
     conversation_history: list[dict[str, str]],
     system_prompt: str,
     api_key: str | None = None,
-) -> str:
+) -> LLMResponse:
     """Call the OpenAI chat completions API."""
     key = _resolve_api_key(api_key)
     openai_mod = _import_optional("openai", "OpenAI")
 
     client = openai_mod.AsyncOpenAI(api_key=key)
     messages = _build_messages(user_message, conversation_history, system_prompt)
+    model = os.getenv("LLM_MODEL", "gpt-4o-mini")
     completion = await client.chat.completions.create(
-        model=os.getenv("LLM_MODEL", "gpt-4o-mini"),
+        model=model,
         messages=messages,
     )
-    return str(completion.choices[0].message.content or "")
+    usage = getattr(completion, "usage", None)
+    return LLMResponse(
+        text=str(completion.choices[0].message.content or ""),
+        provider="openai",
+        model=model,
+        prompt_tokens=extract_token_count(usage, "prompt_tokens"),
+        completion_tokens=extract_token_count(usage, "completion_tokens"),
+    )
 
 
 async def _call_anthropic(
@@ -249,7 +319,7 @@ async def _call_anthropic(
     conversation_history: list[dict[str, str]],
     system_prompt: str,
     api_key: str | None = None,
-) -> str:
+) -> LLMResponse:
     """Call the Anthropic messages API."""
     key = _resolve_api_key(api_key)
     anthropic_mod = _import_optional("anthropic", "Anthropic")
@@ -262,11 +332,22 @@ async def _call_anthropic(
         messages_for_api.append({"role": role, "content": entry["message"]})
     messages_for_api.append({"role": "user", "content": user_message})
 
+    model = os.getenv("LLM_MODEL", "claude-sonnet-4-20250514")
     response = await client.messages.create(
-        model=os.getenv("LLM_MODEL", "claude-sonnet-4-20250514"),
+        model=model,
         max_tokens=1024,
         system=system_prompt,
         messages=messages_for_api,
     )
     block = response.content[0]
-    return str(block.text) if hasattr(block, "text") else str(block)
+    text = str(block.text) if hasattr(block, "text") else str(block)
+    usage = getattr(response, "usage", None)
+    return LLMResponse(
+        text=text,
+        provider="anthropic",
+        model=model,
+        # Anthropic exposes ``input_tokens`` / ``output_tokens`` where OpenAI
+        # uses ``prompt_tokens`` / ``completion_tokens``.
+        prompt_tokens=extract_token_count(usage, "input_tokens", "prompt_tokens"),
+        completion_tokens=extract_token_count(usage, "output_tokens", "completion_tokens"),
+    )

--- a/backend/src/services/llm_pricing.py
+++ b/backend/src/services/llm_pricing.py
@@ -1,0 +1,70 @@
+"""LLM cost estimation — token counts in, USD out.
+
+Pricing is expressed per one million tokens because that matches how every
+provider publishes their rate cards.  The table below is the single source of
+truth — updating a price is a one-line change and every caller picks it up on
+next request.
+
+Cost estimation is intentionally defensive: unknown models, zero token counts,
+and negative/garbage inputs all return ``0.0`` rather than raising.  The usage
+log's purpose is observability, and crashing on a surprise model name would be
+a regression from "no visibility" to "broken chat" — the opposite of the goal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# One million — the denominator for provider rate cards.
+_TOKENS_PER_MILLION = 1_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class ModelPricing:
+    """Per-million-token pricing for a single model."""
+
+    input_usd_per_million: float
+    output_usd_per_million: float
+
+
+# Public pricing table — update as providers adjust their rate cards.  Values
+# are the published list prices at the time of writing; see each provider's
+# pricing page for the canonical source.
+MODEL_PRICING: dict[str, ModelPricing] = {
+    # OpenAI — https://openai.com/api/pricing/
+    "gpt-4o-mini": ModelPricing(input_usd_per_million=0.15, output_usd_per_million=0.60),
+    "gpt-4o": ModelPricing(input_usd_per_million=2.50, output_usd_per_million=10.00),
+    # Anthropic — https://www.anthropic.com/pricing
+    "claude-sonnet-4-20250514": ModelPricing(
+        input_usd_per_million=3.00, output_usd_per_million=15.00
+    ),
+    "claude-3-5-sonnet-20241022": ModelPricing(
+        input_usd_per_million=3.00, output_usd_per_million=15.00
+    ),
+    "claude-3-5-haiku-20241022": ModelPricing(
+        input_usd_per_million=0.80, output_usd_per_million=4.00
+    ),
+}
+
+
+def get_model_pricing(model: str) -> ModelPricing | None:
+    """Return the :class:`ModelPricing` for ``model`` or ``None`` when unknown."""
+    return MODEL_PRICING.get(model)
+
+
+def estimate_cost_usd(model: str, prompt_tokens: int, completion_tokens: int) -> float:
+    """Estimate the USD cost of a single LLM call.
+
+    Returns ``0.0`` for unknown models or non-positive token counts so that
+    observability never breaks the chat path.  The caller is expected to log
+    the raw token counts alongside this estimate — cost is derived data, not
+    the source of truth.
+    """
+    pricing = MODEL_PRICING.get(model)
+    if pricing is None:
+        return 0.0
+    safe_prompt = max(prompt_tokens, 0)
+    safe_completion = max(completion_tokens, 0)
+    input_cost = safe_prompt / _TOKENS_PER_MILLION * pricing.input_usd_per_million
+    output_cost = safe_completion / _TOKENS_PER_MILLION * pricing.output_usd_per_million
+    return input_cost + output_cost

--- a/backend/tests/test_admin_usage_stats.py
+++ b/backend/tests/test_admin_usage_stats.py
@@ -1,0 +1,276 @@
+"""Tests for the admin usage stats endpoint.
+
+Covers the three layers the endpoint puts together: auth gate, SQL aggregates,
+and JSON response shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import JournalEntry
+from models.llm_usage_log import LLMUsageLog
+from models.user import User
+from routers.admin import ADMIN_API_KEY_HEADER
+
+_ADMIN_KEY = "super-secret-admin-key"  # pragma: allowlist secret
+
+
+@dataclass(frozen=True, slots=True)
+class _UsageLogSpec:
+    """Fixture knobs for seeded :class:`LLMUsageLog` rows.
+
+    Grouping the optional attributes on a dataclass keeps ``_seed_usage_log``
+    below ruff's argument-count limit without forcing every caller to pass a
+    fully populated record.
+    """
+
+    provider: str = "openai"
+    model: str = "gpt-4o-mini"
+    prompt_tokens: int = 100
+    completion_tokens: int = 50
+    estimated_cost_usd: float = 0.01
+
+
+async def _seed_user_and_journal_entry(
+    db_session: AsyncSession, email: str = "seed@example.com"
+) -> tuple[int, int]:
+    """Create a user + a single journal entry; return their ids."""
+    user = User(email=email, password_hash="x")
+    db_session.add(user)
+    await db_session.flush()
+    assert user.id is not None
+
+    journal = JournalEntry(
+        sender="bot", user_id=user.id, message="hello", timestamp=datetime.now(UTC)
+    )
+    db_session.add(journal)
+    await db_session.flush()
+    assert journal.id is not None
+    return user.id, journal.id
+
+
+async def _seed_usage_log(
+    db_session: AsyncSession,
+    *,
+    user_id: int,
+    journal_entry_id: int,
+    spec: _UsageLogSpec | None = None,
+) -> None:
+    """Append a single :class:`LLMUsageLog` row.  ``spec`` defaults to the OpenAI fixture."""
+    log = spec or _UsageLogSpec()
+    db_session.add(
+        LLMUsageLog(
+            user_id=user_id,
+            provider=log.provider,
+            model=log.model,
+            prompt_tokens=log.prompt_tokens,
+            completion_tokens=log.completion_tokens,
+            total_tokens=log.prompt_tokens + log.completion_tokens,
+            estimated_cost_usd=log.estimated_cost_usd,
+            journal_entry_id=journal_entry_id,
+        )
+    )
+    await db_session.flush()
+
+
+# ── Auth gate ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoint_rejects_without_key_configured(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``ADMIN_API_KEY`` is unset the endpoint is closed to everyone."""
+    monkeypatch.delenv("ADMIN_API_KEY", raising=False)
+    resp = await async_client.get("/admin/usage-stats")
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "admin_api_disabled"
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoint_rejects_without_header(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    resp = await async_client.get("/admin/usage-stats")
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "admin_auth_required"
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoint_rejects_wrong_key(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    resp = await async_client.get(
+        "/admin/usage-stats",
+        headers={ADMIN_API_KEY_HEADER: "wrong-key"},  # pragma: allowlist secret
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoint_accepts_correct_key(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    resp = await async_client.get(
+        "/admin/usage-stats",
+        headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY},
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+
+# ── Response shape with empty data ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoint_empty_totals(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY})
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["total_calls"] == 0
+    assert data["total_prompt_tokens"] == 0
+    assert data["total_completion_tokens"] == 0
+    assert data["total_tokens"] == 0
+    assert data["total_estimated_cost_usd"] == 0.0
+    assert data["per_user"] == []
+    assert data["per_model"] == []
+
+
+# ── Aggregates ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoint_sums_totals(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    user_id, journal_id = await _seed_user_and_journal_entry(db_session)
+    await _seed_usage_log(
+        db_session,
+        user_id=user_id,
+        journal_entry_id=journal_id,
+        spec=_UsageLogSpec(prompt_tokens=100, completion_tokens=50, estimated_cost_usd=0.01),
+    )
+    await _seed_usage_log(
+        db_session,
+        user_id=user_id,
+        journal_entry_id=journal_id,
+        spec=_UsageLogSpec(prompt_tokens=200, completion_tokens=25, estimated_cost_usd=0.02),
+    )
+    await db_session.commit()
+
+    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY})
+    data = resp.json()
+    assert data["total_calls"] == 2  # noqa: PLR2004
+    assert data["total_prompt_tokens"] == 300  # noqa: PLR2004
+    assert data["total_completion_tokens"] == 75  # noqa: PLR2004
+    assert data["total_tokens"] == 375  # noqa: PLR2004
+    assert data["total_estimated_cost_usd"] == pytest.approx(0.03)
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoint_per_user_breakdown_ordered_by_cost(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Users are returned highest-spend first so the dashboard top row is hottest."""
+    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    low_user_id, j1 = await _seed_user_and_journal_entry(db_session, "low@example.com")
+    high_user_id, j2 = await _seed_user_and_journal_entry(db_session, "high@example.com")
+    await _seed_usage_log(
+        db_session,
+        user_id=low_user_id,
+        journal_entry_id=j1,
+        spec=_UsageLogSpec(estimated_cost_usd=0.05),
+    )
+    await _seed_usage_log(
+        db_session,
+        user_id=high_user_id,
+        journal_entry_id=j2,
+        spec=_UsageLogSpec(estimated_cost_usd=1.50),
+    )
+    await db_session.commit()
+
+    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY})
+    data = resp.json()
+    assert len(data["per_user"]) == 2  # noqa: PLR2004
+    assert data["per_user"][0]["user_id"] == high_user_id
+    assert data["per_user"][0]["estimated_cost_usd"] == pytest.approx(1.50)
+    assert data["per_user"][1]["user_id"] == low_user_id
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoint_per_model_breakdown(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    user_id, journal_id = await _seed_user_and_journal_entry(db_session)
+    await _seed_usage_log(
+        db_session,
+        user_id=user_id,
+        journal_entry_id=journal_id,
+        spec=_UsageLogSpec(
+            provider="openai",
+            model="gpt-4o-mini",
+            prompt_tokens=100,
+            completion_tokens=50,
+            estimated_cost_usd=0.01,
+        ),
+    )
+    await _seed_usage_log(
+        db_session,
+        user_id=user_id,
+        journal_entry_id=journal_id,
+        spec=_UsageLogSpec(
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            prompt_tokens=200,
+            completion_tokens=100,
+            estimated_cost_usd=2.00,
+        ),
+    )
+    await db_session.commit()
+
+    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY})
+    data = resp.json()
+    assert len(data["per_model"]) == 2  # noqa: PLR2004
+    # Ordered by descending cost: claude (2.00) before gpt-4o-mini (0.01).
+    assert data["per_model"][0]["provider"] == "anthropic"
+    assert data["per_model"][0]["model"] == "claude-sonnet-4-20250514"
+    assert data["per_model"][0]["total_tokens"] == 300  # noqa: PLR2004
+    assert data["per_model"][1]["provider"] == "openai"
+    assert data["per_model"][1]["model"] == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoint_empty_key_is_rejected(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ``ADMIN_API_KEY=""`` env var must not open the endpoint to empty headers."""
+    monkeypatch.setenv("ADMIN_API_KEY", "")
+    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: ""})
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "admin_api_disabled"

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -19,6 +19,7 @@ from models.user import User
 from routers.botmason import LLM_API_KEY_HEADER
 from services.botmason import (
     LLM_API_KEY_MAX_LENGTH,
+    LLMResponse,
     generate_response,
     get_system_prompt,
     validate_llm_api_key_format,
@@ -28,6 +29,19 @@ from services.usage import (
     compute_next_reset,
     get_monthly_cap,
 )
+
+
+def _mock_openai_response(
+    text: str, *, prompt_tokens: int = 0, completion_tokens: int = 0
+) -> LLMResponse:
+    """Build an :class:`LLMResponse` shaped like an OpenAI call for provider mocks."""
+    return LLMResponse(
+        text=text,
+        provider="openai",
+        model="gpt-4o-mini",
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )
 
 
 async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
@@ -235,7 +249,11 @@ async def test_freeform_journal_works_at_zero_balance(async_client: AsyncClient)
 @pytest.mark.asyncio
 async def test_stub_response_contains_user_message() -> None:
     result = await generate_response("What is the Archetypal Wavelength?", [])
-    assert "What is the Archetypal Wavelength?" in result
+    assert "What is the Archetypal Wavelength?" in result.text
+    # Stub responses are token-free so the usage log never distorts real cost totals.
+    assert result.provider == "stub"
+    assert result.prompt_tokens == 0
+    assert result.completion_tokens == 0
 
 
 @pytest.mark.asyncio
@@ -413,7 +431,7 @@ async def test_stub_provider_works_without_api_key(
     monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
     monkeypatch.delenv("LLM_API_KEY", raising=False)
     result = await generate_response("Hello", [])
-    assert "Hello" in result
+    assert "Hello" in result.text
 
 
 # ── Race condition prevention tests (sec-17) ──────────────────────────
@@ -607,7 +625,7 @@ async def test_chat_falls_back_to_env_key_when_header_absent(
     headers = await _signup(async_client)
     await _add_balance(async_client, headers, amount=1)
 
-    mock_call = AsyncMock(return_value="env-fallback-response")
+    mock_call = AsyncMock(return_value=_mock_openai_response("env-fallback-response"))
     with patch.object(botmason_mod, "_call_openai", mock_call):
         resp = await async_client.post(
             "/journal/chat",
@@ -635,7 +653,7 @@ async def test_chat_uses_user_supplied_key_from_header(
     await _add_balance(async_client, headers, amount=1)
     headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
 
-    mock_call = AsyncMock(return_value="byok-response")
+    mock_call = AsyncMock(return_value=_mock_openai_response("byok-response"))
     with patch.object(botmason_mod, "_call_openai", mock_call):
         resp = await async_client.post(
             "/journal/chat",
@@ -661,7 +679,7 @@ async def test_chat_header_key_overrides_env_key(
     await _add_balance(async_client, headers, amount=1)
     headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
 
-    mock_call = AsyncMock(return_value="byok-response")
+    mock_call = AsyncMock(return_value=_mock_openai_response("byok-response"))
     with patch.object(botmason_mod, "_call_openai", mock_call):
         await async_client.post(
             "/journal/chat",
@@ -731,7 +749,7 @@ async def test_chat_ignores_empty_header_and_uses_env(
     await _add_balance(async_client, headers, amount=1)
     headers[LLM_API_KEY_HEADER] = "   "
 
-    mock_call = AsyncMock(return_value="env-response")
+    mock_call = AsyncMock(return_value=_mock_openai_response("env-response"))
     with patch.object(botmason_mod, "_call_openai", mock_call):
         resp = await async_client.post(
             "/journal/chat",
@@ -757,7 +775,7 @@ async def test_chat_does_not_log_header_key_value(
     await _add_balance(async_client, headers, amount=1)
     headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
 
-    mock_call = AsyncMock(return_value="ok")
+    mock_call = AsyncMock(return_value=_mock_openai_response("ok"))
     with caplog.at_level(logging.DEBUG), patch.object(botmason_mod, "_call_openai", mock_call):
         await async_client.post(
             "/journal/chat",
@@ -781,7 +799,7 @@ async def test_chat_response_body_does_not_echo_key(
     await _add_balance(async_client, headers, amount=1)
     headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
 
-    mock_call = AsyncMock(return_value="a response")
+    mock_call = AsyncMock(return_value=_mock_openai_response("a response"))
     with patch.object(botmason_mod, "_call_openai", mock_call):
         resp = await async_client.post(
             "/journal/chat",
@@ -820,11 +838,11 @@ async def test_generate_response_uses_override_key(
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.delenv("LLM_API_KEY", raising=False)
 
-    mock_call = AsyncMock(return_value="overridden")
+    mock_call = AsyncMock(return_value=_mock_openai_response("overridden"))
     with patch.object(botmason_mod, "_call_openai", mock_call):
         result = await generate_response("hi", [], api_key=_VALID_OPENAI_KEY)
 
-    assert result == "overridden"
+    assert result.text == "overridden"
     assert _forwarded_key(mock_call) == _VALID_OPENAI_KEY
 
 

--- a/backend/tests/test_llm_pricing.py
+++ b/backend/tests/test_llm_pricing.py
@@ -1,0 +1,80 @@
+"""Unit tests for LLM cost estimation."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.llm_pricing import (
+    MODEL_PRICING,
+    ModelPricing,
+    estimate_cost_usd,
+    get_model_pricing,
+)
+
+
+class TestEstimateCostUsd:
+    """Cost estimation converts token counts + model name into a USD figure."""
+
+    def test_known_openai_model(self) -> None:
+        # gpt-4o-mini: $0.15 / 1M input, $0.60 / 1M output
+        # 1,000,000 input + 1,000,000 output = $0.15 + $0.60 = $0.75
+        cost = estimate_cost_usd("gpt-4o-mini", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(0.75)
+
+    def test_known_anthropic_model(self) -> None:
+        # claude-sonnet-4-20250514: $3.00 / 1M input, $15.00 / 1M output
+        cost = estimate_cost_usd("claude-sonnet-4-20250514", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(18.0)
+
+    def test_partial_million_tokens_proportional(self) -> None:
+        # 1,500 input tokens at $0.15/1M = $0.000225
+        # 500 output tokens at $0.60/1M = $0.0003
+        # Total = $0.000525
+        cost = estimate_cost_usd("gpt-4o-mini", 1_500, 500)
+        assert cost == pytest.approx(0.000525)
+
+    def test_zero_tokens_zero_cost(self) -> None:
+        assert estimate_cost_usd("gpt-4o-mini", 0, 0) == 0.0
+
+    def test_unknown_model_returns_zero(self) -> None:
+        """Unknown models log $0 so tokens are still captured without guessing price."""
+        assert estimate_cost_usd("mystery-model-v99", 1_000, 500) == 0.0
+
+    def test_stub_model_returns_zero(self) -> None:
+        """The stub provider reports ``stub`` as its model and must cost nothing."""
+        assert estimate_cost_usd("stub", 0, 0) == 0.0
+
+    def test_negative_tokens_treated_as_zero(self) -> None:
+        """Defensive: never produce a negative cost even if upstream returns junk."""
+        assert estimate_cost_usd("gpt-4o-mini", -5, -5) == 0.0
+
+
+class TestGetModelPricing:
+    def test_returns_pricing_for_known_model(self) -> None:
+        pricing = get_model_pricing("gpt-4o-mini")
+        assert pricing is not None
+        assert pricing.input_usd_per_million > 0
+        assert pricing.output_usd_per_million > 0
+
+    def test_returns_none_for_unknown_model(self) -> None:
+        assert get_model_pricing("unknown-model") is None
+
+
+class TestModelPricingTable:
+    def test_table_contains_expected_providers(self) -> None:
+        """Sanity-check that the bundled pricing table covers both providers."""
+        openai_models = [m for m in MODEL_PRICING if m.startswith("gpt-")]
+        anthropic_models = [m for m in MODEL_PRICING if m.startswith("claude-")]
+        assert openai_models, "expected at least one OpenAI model in pricing table"
+        assert anthropic_models, "expected at least one Anthropic model in pricing table"
+
+    def test_all_prices_non_negative(self) -> None:
+        for model, pricing in MODEL_PRICING.items():
+            assert pricing.input_usd_per_million >= 0, f"{model} input cost is negative"
+            assert pricing.output_usd_per_million >= 0, f"{model} output cost is negative"
+
+    def test_model_pricing_is_frozen(self) -> None:
+        """``ModelPricing`` is a frozen dataclass so the table cannot be mutated."""
+        pricing = ModelPricing(input_usd_per_million=1.0, output_usd_per_million=2.0)
+        with pytest.raises(AttributeError):
+            pricing.input_usd_per_million = 99.0  # type: ignore[misc]

--- a/backend/tests/test_llm_usage_log.py
+++ b/backend/tests/test_llm_usage_log.py
@@ -1,0 +1,229 @@
+"""Tests for LLM usage logging — one row per chat call, cost estimated + persisted."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+import services.botmason as botmason_mod
+from models.llm_usage_log import LLMUsageLog
+from services.botmason import LLMResponse, extract_token_count
+
+# A realistic-looking OpenAI-style key that passes the format validator.
+_VALID_OPENAI_KEY = "sk-abcdef1234567890abcdef1234567890"  # pragma: allowlist secret
+
+# Fixed token counts used by OpenAI mock-call tests — extracted as named
+# constants so the USD-cost assertions stay readable.
+_OPENAI_PROMPT_TOKENS = 1_000
+_OPENAI_COMPLETION_TOKENS = 500
+_UNKNOWN_MODEL_PROMPT_TOKENS = 100
+_UNKNOWN_MODEL_COMPLETION_TOKENS = 50
+
+
+async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _fetch_all_logs(db_session: AsyncSession) -> list[LLMUsageLog]:
+    result = await db_session.execute(select(LLMUsageLog).order_by(col(LLMUsageLog.id)))
+    return list(result.scalars().all())
+
+
+# ── Stub provider: logs are created with zero tokens and zero cost ───────
+
+
+@pytest.mark.asyncio
+async def test_stub_chat_creates_log_with_zero_cost(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    headers = await _signup(async_client)
+
+    resp = await async_client.post("/journal/chat", json={"message": "hi there"}, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+
+    logs = await _fetch_all_logs(db_session)
+    assert len(logs) == 1
+    log = logs[0]
+    assert log.provider == "stub"
+    assert log.model == "stub"
+    assert log.prompt_tokens == 0
+    assert log.completion_tokens == 0
+    assert log.total_tokens == 0
+    assert log.estimated_cost_usd == 0.0
+    # FK points at the bot's journal entry, not the user's input.
+    assert log.journal_entry_id == resp.json()["bot_entry_id"]
+
+
+@pytest.mark.asyncio
+async def test_every_chat_appends_one_log(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    headers = await _signup(async_client)
+    for msg in ("a", "b", "c"):
+        r = await async_client.post("/journal/chat", json={"message": msg}, headers=headers)
+        assert r.status_code == HTTPStatus.CREATED
+
+    logs = await _fetch_all_logs(db_session)
+    assert len(logs) == 3  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_failed_chat_does_not_log(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 402 (cap reached, no balance) must not insert a usage-log row."""
+    monkeypatch.setenv("BOTMASON_MONTHLY_CAP", "0")
+    headers = await _signup(async_client)
+
+    resp = await async_client.post("/journal/chat", json={"message": "hi"}, headers=headers)
+    assert resp.status_code == HTTPStatus.PAYMENT_REQUIRED
+
+    logs = await _fetch_all_logs(db_session)
+    assert logs == []
+
+
+# ── OpenAI provider: tokens extracted and cost calculated ────────────────
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_logs_tokens_and_cost(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful OpenAI call logs prompt/completion tokens and estimated cost."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
+
+    headers = await _signup(async_client)
+    mock_call = AsyncMock(
+        return_value=LLMResponse(
+            text="response text",
+            provider="openai",
+            model="gpt-4o-mini",
+            prompt_tokens=_OPENAI_PROMPT_TOKENS,
+            completion_tokens=_OPENAI_COMPLETION_TOKENS,
+        )
+    )
+    with patch.object(botmason_mod, "_call_openai", mock_call):
+        resp = await async_client.post("/journal/chat", json={"message": "hello"}, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+
+    logs = await _fetch_all_logs(db_session)
+    assert len(logs) == 1
+    log = logs[0]
+    assert log.provider == "openai"
+    assert log.model == "gpt-4o-mini"
+    assert log.prompt_tokens == _OPENAI_PROMPT_TOKENS
+    assert log.completion_tokens == _OPENAI_COMPLETION_TOKENS
+    assert log.total_tokens == _OPENAI_PROMPT_TOKENS + _OPENAI_COMPLETION_TOKENS
+    # gpt-4o-mini: $0.15/1M input + $0.60/1M output.  1000 input + 500 output
+    # ⇒ 1000 * 0.15/1_000_000 + 500 * 0.60/1_000_000 = $0.00045.
+    assert log.estimated_cost_usd == pytest.approx(0.00045)
+
+
+@pytest.mark.asyncio
+async def test_log_survives_unknown_model_as_zero_cost(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown models log tokens but $0 cost — observability never breaks chat."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
+
+    headers = await _signup(async_client)
+    mock_call = AsyncMock(
+        return_value=LLMResponse(
+            text="ok",
+            provider="openai",
+            model="gpt-future-unreleased-model",
+            prompt_tokens=_UNKNOWN_MODEL_PROMPT_TOKENS,
+            completion_tokens=_UNKNOWN_MODEL_COMPLETION_TOKENS,
+        )
+    )
+    with patch.object(botmason_mod, "_call_openai", mock_call):
+        resp = await async_client.post("/journal/chat", json={"message": "?"}, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+
+    logs = await _fetch_all_logs(db_session)
+    assert len(logs) == 1
+    assert logs[0].model == "gpt-future-unreleased-model"
+    assert logs[0].prompt_tokens == _UNKNOWN_MODEL_PROMPT_TOKENS
+    assert logs[0].completion_tokens == _UNKNOWN_MODEL_COMPLETION_TOKENS
+    assert logs[0].estimated_cost_usd == 0.0
+
+
+# ── Unit tests for the extract_token_count helper ────────────────────────
+
+
+def test_extract_token_count_picks_first_present_attribute() -> None:
+    expected = 7
+
+    class Usage:
+        prompt_tokens = 42
+        input_tokens = expected
+
+    assert extract_token_count(Usage(), "input_tokens", "prompt_tokens") == expected
+
+
+def test_extract_token_count_falls_back_when_first_missing() -> None:
+    expected = 9
+
+    class Usage:
+        prompt_tokens = expected
+
+    assert extract_token_count(Usage(), "input_tokens", "prompt_tokens") == expected
+
+
+def test_extract_token_count_returns_zero_when_source_is_none() -> None:
+    assert extract_token_count(None, "prompt_tokens") == 0
+
+
+def test_extract_token_count_clamps_negatives_to_zero() -> None:
+    class Usage:
+        prompt_tokens = -3
+
+    assert extract_token_count(Usage(), "prompt_tokens") == 0
+
+
+def test_extract_token_count_ignores_non_numeric_values() -> None:
+    expected = 5
+
+    class Usage:
+        prompt_tokens = "not-a-number"
+        input_tokens = expected
+
+    assert extract_token_count(Usage(), "prompt_tokens", "input_tokens") == expected
+
+
+def test_llm_response_total_tokens_derived() -> None:
+    prompt = 100
+    completion = 25
+    response = LLMResponse(
+        text="hi",
+        provider="openai",
+        model="gpt-4o-mini",
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+    )
+    assert response.total_tokens == prompt + completion


### PR DESCRIPTION
Closes #187.

## Summary
- Log every `/journal/chat` call to a new `LLMUsageLog` table with provider, model, prompt/completion tokens, and estimated USD cost so BotMason spend is finally observable.
- Add `services.llm_pricing` with a per-model rate card for OpenAI and Anthropic. Unknown models log $0 cost so observability never breaks the chat path.
- Refactor the BotMason service to return a structured `LLMResponse` dataclass (text + provider + model + token counts). Token extraction is defensive against missing, non-numeric, and negative upstream metadata.
- New admin endpoint `GET /admin/usage-stats` returns total spend, per-user breakdown (top spenders first), and per-model breakdown in a single response. Gated by an `ADMIN_API_KEY` shared-secret header compared in constant time; an unset env var fails closed.

## Acceptance criteria (from #187)
- [x] LLMUsageLog table created
- [x] Token counts extracted from provider responses
- [x] Estimated cost calculated and logged per request
- [x] Usage stats queryable (for future admin dashboard)
- [x] Stub provider logs 0 tokens / $0.00 cost
- [x] No performance impact on chat response time (logging batched into the existing single commit)

## Test plan
- [x] `pre-commit run --all-files` green across all 24 hooks
- [x] 422/422 backend tests pass; coverage 93.30%
- [x] New tests cover pricing edge cases, stub/OpenAI logging, unknown-model cost fallback, failed chats don't log, admin auth gate (missing/wrong/empty key), and aggregate correctness (totals, per-user ordering, per-model grouping)

https://claude.ai/code/session_01TZAHLz1JmVhkg6dkVyKc8h