### PR TITLE
fix(frontend): surface blank-screen root cause with visible error screens

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,10 +4,12 @@ import type { LinkingOptions } from '@react-navigation/native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { ActivityIndicator, StatusBar, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, ScrollView, StatusBar, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { ToastProvider } from './components/ToastProvider';
+import { CONFIG_ERROR } from './config';
 import { ApiKeyProvider } from './context/ApiKeyContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import LoginScreen from './features/Auth/LoginScreen';
@@ -59,22 +61,44 @@ function RootNavigator() {
   return token ? <RootStack /> : <AuthNavigator />;
 }
 
-export default function App(): React.JSX.Element {
+function ConfigErrorScreen({ message }: { message: string }): React.JSX.Element {
   return (
     <SafeAreaProvider>
-      <AuthProvider>
-        <ApiKeyProvider>
-          <ToastProvider>
-            <NavigationContainer linking={linking}>
-              <SafeAreaView style={styles.safeArea}>
-                <StatusBar barStyle="dark-content" />
-                <RootNavigator />
-              </SafeAreaView>
-            </NavigationContainer>
-          </ToastProvider>
-        </ApiKeyProvider>
-      </AuthProvider>
+      <SafeAreaView style={styles.safeArea}>
+        <ScrollView contentContainerStyle={styles.configError} testID="config-error">
+          <Text style={styles.configErrorHeading}>Configuration error</Text>
+          <Text style={styles.configErrorMessage}>{message}</Text>
+          <Text style={styles.configErrorHint}>
+            Set EXPO_PUBLIC_API_BASE_URL as a Railway service variable (and ensure it is passed
+            through as a Docker build arg) so it is baked into the web bundle at build time.
+          </Text>
+        </ScrollView>
+      </SafeAreaView>
     </SafeAreaProvider>
+  );
+}
+
+export default function App(): React.JSX.Element {
+  if (CONFIG_ERROR) {
+    return <ConfigErrorScreen message={CONFIG_ERROR} />;
+  }
+  return (
+    <ErrorBoundary>
+      <SafeAreaProvider>
+        <AuthProvider>
+          <ApiKeyProvider>
+            <ToastProvider>
+              <NavigationContainer linking={linking}>
+                <SafeAreaView style={styles.safeArea}>
+                  <StatusBar barStyle="dark-content" />
+                  <RootNavigator />
+                </SafeAreaView>
+              </NavigationContainer>
+            </ToastProvider>
+          </ApiKeyProvider>
+        </AuthProvider>
+      </SafeAreaProvider>
+    </ErrorBoundary>
   );
 }
 
@@ -87,5 +111,24 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  configError: {
+    padding: 24,
+    paddingTop: 48,
+  },
+  configErrorHeading: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#b00020',
+    marginBottom: 12,
+  },
+  configErrorMessage: {
+    fontSize: 16,
+    color: '#222',
+    marginBottom: 16,
+  },
+  configErrorHint: {
+    fontSize: 14,
+    color: '#555',
   },
 });

--- a/frontend/src/__tests__/config.test.ts
+++ b/frontend/src/__tests__/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { API_BASE_URL, validateApiBaseUrl } from '../config';
+import { API_BASE_URL, CONFIG_ERROR, validateApiBaseUrl } from '../config';
 
 const HTTPS_URL = 'https://api.example.com';
 const HTTP_URL = 'http://api.example.com';
@@ -47,6 +47,10 @@ describe('config', () => {
   describe('API_BASE_URL module export', () => {
     it('defaults to http://localhost:8000 in development mode', () => {
       expect(API_BASE_URL).toBe(DEV_DEFAULT);
+    });
+
+    it('does not record a CONFIG_ERROR in development mode', () => {
+      expect(CONFIG_ERROR).toBeNull();
     });
   });
 });

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Top-level boundary that renders a visible error screen instead of a blank
+ * page when a child throws during render. Essential for production web builds
+ * where devs debug from mobile browsers without readily-available dev tools.
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error('[ErrorBoundary]', error, info.componentStack);
+  }
+
+  render(): React.ReactNode {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+    return (
+      <View style={styles.container} testID="error-boundary">
+        <ScrollView contentContainerStyle={styles.content}>
+          <Text style={styles.heading}>Something went wrong</Text>
+          <Text style={styles.message}>{this.state.error.message}</Text>
+          {this.state.error.stack ? (
+            <Text style={styles.stack}>{this.state.error.stack}</Text>
+          ) : null}
+        </ScrollView>
+      </View>
+    );
+  }
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    padding: 24,
+    paddingTop: 48,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#b00020',
+    marginBottom: 12,
+  },
+  message: {
+    fontSize: 16,
+    color: '#222',
+    marginBottom: 16,
+  },
+  stack: {
+    fontSize: 12,
+    color: '#555',
+    fontFamily: 'monospace',
+  },
+});

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -12,4 +12,23 @@ export function validateApiBaseUrl(url: string, isDev: boolean): string {
 
 const rawUrl = process.env.EXPO_PUBLIC_API_BASE_URL || (__DEV__ ? DEV_DEFAULT_URL : '');
 
-export const API_BASE_URL = validateApiBaseUrl(rawUrl, __DEV__);
+/**
+ * Configuration error captured at module load, if any.
+ *
+ * We deliberately do NOT throw at top-level import: a top-level throw happens
+ * before React can mount, producing a silent blank screen in browsers where
+ * dev tools aren't readily available (e.g. iOS Safari). Instead, App.tsx reads
+ * this value and renders a visible error screen when set.
+ */
+export let CONFIG_ERROR: string | null = null;
+
+function resolveApiBaseUrl(): string {
+  try {
+    return validateApiBaseUrl(rawUrl, __DEV__);
+  } catch (err) {
+    CONFIG_ERROR = err instanceof Error ? err.message : String(err);
+    return rawUrl;
+  }
+}
+
+export const API_BASE_URL = resolveApiBaseUrl();


### PR DESCRIPTION
Top-level throws during bundle init (e.g. config.ts throwing when
EXPO_PUBLIC_API_BASE_URL is misconfigured in a production build) produce
a silent blank screen on deployed web builds — iOS Safari users cannot
easily reach dev tools, so root-causing the failure is impossible.

- Stop throwing at config.ts import; capture the error in CONFIG_ERROR
  and render a visible "Configuration error" screen in App.
- Wrap the app tree in an ErrorBoundary so any render-time crash shows
  an error screen with message + stack instead of a blank page.