### PR TITLE
fix(frontend): send email field to auth endpoints

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -46,7 +46,7 @@ describe('API client request composition', () => {
   });
 
   it('logs in via POST /auth/login', async () => {
-    const creds = { username: 'u', password: 'p' }; // pragma: allowlist secret
+    const creds = { email: 'u@example.com', password: 'p' }; // pragma: allowlist secret
     await api.auth.login(creds);
     expect(fetch).toHaveBeenCalledWith(`${mockBaseUrl}/auth/login`, {
       method: 'POST',
@@ -56,7 +56,7 @@ describe('API client request composition', () => {
   });
 
   it('signs up via POST /auth/signup', async () => {
-    const creds = { username: 'u', password: 'p' }; // pragma: allowlist secret
+    const creds = { email: 'u@example.com', password: 'p' }; // pragma: allowlist secret
     await api.auth.signup(creds);
     expect(fetch).toHaveBeenCalledWith(`${mockBaseUrl}/auth/signup`, {
       method: 'POST',

--- a/frontend/src/api/__tests__/token-refresh.test.ts
+++ b/frontend/src/api/__tests__/token-refresh.test.ts
@@ -105,7 +105,7 @@ describe('retry-after-refresh on 401', () => {
   test('does not retry for auth endpoints (avoids infinite loops)', async () => {
     mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'invalid_credentials' }, 401));
 
-    const credentials = { username: 'test@test.com', password: 'wrong' }; // pragma: allowlist secret
+    const credentials = { email: 'test@test.com', password: 'wrong' }; // pragma: allowlist secret
     await expect(auth.login(credentials)).rejects.toThrow(ApiError);
 
     // Only the original call — no refresh attempt

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -734,7 +734,7 @@ export const practiceSessions = {
 
 // Auth types and client
 export interface AuthRequest {
-  username: string;
+  email: string;
   password: string;
 }
 export interface AuthResponse {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -117,13 +117,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useLoadStoredToken(setToken, setIsLoading);
 
   const login = useCallback(async (email: string, password: string) => {
-    const response = await authApi.login({ username: email, password });
+    const response = await authApi.login({ email, password });
     await saveToken(response.token);
     setToken(response.token);
   }, []);
 
   const signup = useCallback(async (email: string, password: string) => {
-    const response = await authApi.signup({ username: email, password });
+    const response = await authApi.signup({ email, password });
     await saveToken(response.token);
     setToken(response.token);
   }, []);

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -114,7 +114,7 @@ describe('AuthContext', () => {
       });
 
       expect(mockAuth.login).toHaveBeenCalledWith({
-        username: 'user@test.com',
+        email: 'user@test.com',
         password: 'password123', // pragma: allowlist secret
       });
       expect(mockSaveToken).toHaveBeenCalledWith('new-jwt');
@@ -150,7 +150,7 @@ describe('AuthContext', () => {
       });
 
       expect(mockAuth.signup).toHaveBeenCalledWith({
-        username: 'new@test.com',
+        email: 'new@test.com',
         password: 'password123', // pragma: allowlist secret
       });
       expect(mockSaveToken).toHaveBeenCalledWith('signup-jwt');

--- a/prompts/github-issues/phase-6-01-gumroad-api-and-webhooks.md
+++ b/prompts/github-issues/phase-6-01-gumroad-api-and-webhooks.md
@@ -1,0 +1,142 @@
+# phase-6-01: Gumroad API client, webhook scaffolding, HMAC verification
+
+**Labels:** `phase-6`, `backend`, `monetization`, `priority-high`
+**Epic:** Phase 6 — Gumroad-gated access and monetization
+**Depends on:** phase-1-03
+**Estimated LoC:** ~300–400 (including tests)
+
+## Problem
+
+Adepthood has no integration with Gumroad, so it cannot:
+
+- Verify a buyer's license key before granting course access
+- Receive notifications when a sale, refund, cancellation, or
+  subscription event happens
+- Store a durable record of Gumroad sales for idempotency and audit
+
+This issue builds the shared infrastructure every other Phase 6 issue
+depends on: a typed HTTP client for Gumroad's API, a webhook endpoint
+that authenticates and deduplicates incoming events, and a raw sale
+record used by downstream grant/credit logic.
+
+**This issue intentionally does not change signup, does not grant
+course access, and does not touch BotMason.** Those are follow-up issues
+that build on the foundation laid here.
+
+## Background — what Gumroad offers
+
+- **License API** — `POST https://api.gumroad.com/v2/licenses/verify`
+  with `product_id`, `license_key`, and optional `increment_uses_count`.
+  Returns the sale record when valid, 404 when not. This is how we turn
+  a user-supplied key into a verified sale at signup time.
+- **Resource Subscriptions (webhooks)** — called "ping" in the docs. We
+  subscribe (via `POST /v2/resource_subscriptions`) to `sale`, `refund`,
+  `dispute`, `cancellation`, and `subscription_ended` events. Each
+  event POSTs a form-encoded payload to our endpoint.
+- **HMAC signing** — Gumroad supports a shared-secret model where each
+  ping includes a signature header. We validate every incoming event
+  before trusting any of its fields.
+
+All three require a seller-scoped API token, generated from the Gumroad
+seller settings page.
+
+## Scope
+
+### 1. Configuration and secrets
+
+- Add env vars, all read at startup, fail-fast if missing in production:
+  - `GUMROAD_API_TOKEN` — seller API token, used for license verification
+  - `GUMROAD_WEBHOOK_SECRET` — shared secret for HMAC verification
+  - `GUMROAD_APTITUDE_PRODUCT_IDS` — comma-separated allowlist of APTITUDE
+    SKU IDs (one-time, monthly, any variants). Used to reject licenses
+    from unrelated products.
+  - `GUMROAD_TOKEN_PACK_PRODUCT_IDS` — comma-separated allowlist of
+    token-pack SKU IDs, used by phase-6-05.
+- Document in `backend/.env.example` and `README.md`.
+
+### 2. Typed HTTP client (`backend/src/integrations/gumroad.py`)
+
+- Use `httpx.AsyncClient` (already a transitive dep via FastAPI tests).
+- Implement `verify_license(product_id: str, license_key: str) -> GumroadSale | None`
+  that returns a typed `GumroadSale` Pydantic model on success and
+  `None` on Gumroad's 404.
+- Implement a structured logger call on every outbound request with
+  latency and status, following the `reason_code` pattern in
+  `routers/energy.py`.
+- 5-second timeout; retry once on connection error (not on 4xx/5xx).
+- Never log the license key or API token.
+
+### 3. Webhook router (`backend/src/routers/gumroad.py`)
+
+- Mount at `/webhooks/gumroad` (not `/auth/*` — these are
+  service-to-service, not user-facing).
+- `POST /webhooks/gumroad/ping` — single endpoint, event type is in
+  the payload's `resource_name` field (`sale`, `refund`, ...).
+- Verify the HMAC signature header using
+  `hmac.compare_digest(expected, provided)`. Reject with 401 on
+  mismatch. Log the rejection with `reason_code=invalid_signature`.
+- Deduplicate by `sale_id` using a unique constraint on
+  `GumroadSale.gumroad_sale_id` — if a duplicate arrives, return 200
+  without reprocessing (idempotent replay).
+- For this issue, the endpoint only **persists** the sale record;
+  grant/credit logic is a downstream issue's responsibility. Emit a
+  typed internal event (e.g., a dispatched pytest hook or a simple
+  "unhandled resource type" log) for any `resource_name` we don't
+  recognize yet, so `phase-6-02` and `phase-6-05` can wire in their
+  handlers without modifying this scaffolding.
+
+### 4. Raw sale model (`backend/src/models/gumroad_sale.py`)
+
+- Fields: `id`, `gumroad_sale_id` (unique, indexed), `product_id`,
+  `email`, `resource_name`, `is_recurring_charge`, `refunded`,
+  `raw_payload` (JSON column), `created_at`.
+- Alembic migration adds the table and unique index.
+
+### 5. Tests
+
+- Unit: `verify_license` mocks httpx and asserts request shape, parses
+  success and 404 into the expected types, redacts secrets from logs.
+- Unit: HMAC verification rejects tampered payloads and accepts valid
+  ones (constant-time comparison; no early-exit on first byte).
+- Integration: `POST /webhooks/gumroad/ping` with a valid signature
+  persists exactly one `GumroadSale` row; replaying the same payload
+  does not create a second row.
+- Integration: invalid signature returns 401 and writes nothing.
+
+## Acceptance criteria
+
+- `backend/src/integrations/gumroad.py::verify_license` returns the
+  correct typed result for valid, invalid, and unknown-product keys.
+- `POST /webhooks/gumroad/ping` requires a valid HMAC signature and is
+  idempotent on replay.
+- Every Gumroad event we receive is persisted as a `GumroadSale` row
+  regardless of whether downstream handlers exist yet.
+- Tests pass and coverage for the new files is ≥ 90%.
+- `pip-audit` clean; no new high-severity deps.
+- `pre-commit run --all-files` green.
+
+## Files to create / modify
+
+| File | Action |
+|------|--------|
+| `backend/src/integrations/__init__.py` | Create |
+| `backend/src/integrations/gumroad.py` | Create (API client) |
+| `backend/src/routers/gumroad.py` | Create (webhook endpoint) |
+| `backend/src/models/gumroad_sale.py` | Create |
+| `backend/src/main.py` | Modify (mount router, validate env at startup) |
+| `backend/alembic/versions/xxxx_gumroad_sale.py` | Create |
+| `backend/.env.example` | Modify (add 4 vars) |
+| `backend/tests/integrations/test_gumroad_client.py` | Create |
+| `backend/tests/routers/test_gumroad_webhook.py` | Create |
+| `README.md` | Modify (brief setup note with link to Gumroad docs) |
+
+## Notes for implementer
+
+- Store the raw webhook payload verbatim in `raw_payload`. Gumroad
+  occasionally adds fields and we don't want to silently drop them.
+- Do not hit the real Gumroad API in any test. All tests use mocked
+  `httpx` transports.
+- Treat the webhook secret as a credential: never log it, include in
+  `detect-secrets` baseline if necessary.
+- Follow the `reason_code` structured-logging pattern already
+  established in `routers/energy.py` for every rejection path.

--- a/prompts/github-issues/phase-6-epic.md
+++ b/prompts/github-issues/phase-6-epic.md
@@ -1,0 +1,107 @@
+# EPIC: Phase 6 — Gumroad-gated access and monetization
+
+**Labels:** `epic`, `phase-6`, `priority-high`, `monetization`
+
+## Summary
+
+APTITUDE (the course Adepthood facilitates) is sold on Gumroad under a
+gift-economy model: the price is "pay what feels right", with free as the
+floor. Adepthood currently has its own email/password auth with no link to
+purchases. This epic makes Gumroad the system-of-record for access and
+introduces a usage-based entitlement for BotMason (so we are not
+subsidizing LLM tokens indefinitely).
+
+Two kinds of entitlement need to be modeled:
+
+1. **Course access** — binary. Granted by a verified Gumroad license for
+   an APTITUDE SKU (one-time or monthly subscription). Free-tier $0
+   licenses count; what matters is that a Gumroad sale exists.
+2. **BotMason tokens** — a per-user balance, debited as the user chats with
+   BotMason and credited by purchasing Gumroad token-pack SKUs. Must
+   coexist with the BYOK path from issue #185: users who supply their own
+   LLM API key via `X-LLM-API-Key` bypass the balance check.
+
+After this epic, signing up for Adepthood requires an existing Gumroad
+purchase. A user lands on the signup screen, is directed to Gumroad to
+"acquire" the course (free is fine), returns with a license key, and
+redeems it. Gumroad webhooks keep entitlements in sync for refunds,
+cancellations, and token-pack purchases.
+
+## Non-goals
+
+- Replacing our email/password auth with Gumroad as an OAuth identity
+  provider (Gumroad does not offer OAuth for end users). We continue to
+  own the JWT and password flow; Gumroad gates who is *allowed* to sign
+  up, not how they authenticate.
+- Stripe or any direct payment integration. Gumroad is the payment rail.
+- Migrating existing users. The app is still in demo, so we assume a
+  clean slate; if needed, a one-off backfill script can be written later.
+
+## Success criteria
+
+- A new user cannot create an Adepthood account without a valid Gumroad
+  license for an APTITUDE SKU.
+- The free-tier ($0) Gumroad variant grants the same course access as
+  the paid variants — price is not what gates access.
+- BotMason chat requests debit from a user-scoped token balance when BYOK
+  is not used; requests fail with a clear `insufficient_tokens` error
+  when the balance is zero and no BYOK key is supplied.
+- A refund or subscription cancellation on Gumroad revokes course access
+  within one webhook delivery window.
+- A Gumroad token-pack purchase credits the buyer's balance
+  idempotently (replaying the same webhook does not double-credit).
+- All Gumroad webhook traffic is HMAC-verified with a shared secret.
+- Manual override endpoints (admin-only) exist for comped access and
+  balance adjustments when Gumroad is unavailable.
+
+## Architecture at a glance
+
+```
+Gumroad (payment + identity gate)
+  │
+  ├─ Sale / subscription / refund webhooks ──▶ /webhooks/gumroad
+  │   (HMAC-verified, idempotent by sale_id)
+  │
+  └─ License verification API ◀────────────── /auth/redeem-license
+                                              (called during signup)
+
+Adepthood backend
+  ├─ models/
+  │    ├─ entitlement.py       # course access flag + metadata
+  │    ├─ token_wallet.py      # balance + ledger entries
+  │    └─ gumroad_sale.py      # raw sale record for idempotency + audit
+  ├─ routers/
+  │    ├─ gumroad.py           # webhook endpoint + license redemption
+  │    └─ auth.py              # signup now checks entitlement
+  └─ domain/
+       ├─ entitlements.py      # grant/revoke logic
+       └─ token_wallet.py      # debit/credit with ledger
+```
+
+## Sub-issues
+
+1. `phase-6-01` — Gumroad API client, webhook scaffolding, HMAC verification
+2. `phase-6-02` — Course entitlement model and signup gating via license redemption
+3. `phase-6-03` — Frontend onboarding flow: redirect to Gumroad and redeem license
+4. `phase-6-04` — BotMason token wallet (model, debit on chat, BYOK bypass)
+5. `phase-6-05` — Token-pack SKU crediting and refund/cancellation revocation
+6. `phase-6-06` — Admin endpoints for manual grants, revocations, and balance adjustments
+
+## Dependencies
+
+- Requires `phase-1-03` (auth router) — complete.
+- Touches `phase-3-07` (BotMason AI) for the token debit hook.
+- Interacts with issue #185 (BYOK) — BYOK requests must bypass the
+  token balance check, not debit zero.
+
+## Open questions to resolve before starting `phase-6-02`
+
+- What is the set of APTITUDE product IDs on Gumroad (one-time, monthly,
+  any pay-what-you-want tiers that have separate IDs)? These become a
+  configured allowlist in the backend.
+- Does the monthly subscription SKU emit `subscription_ended` webhooks
+  we want to treat as access revocation, or do we keep access through
+  the end of the paid period?
+- What is a sensible starting token grant on first redemption, if any?
+  (e.g., "every new account gets N tokens to try BotMason before
+  needing to buy a pack or supply BYOK".)


### PR DESCRIPTION
The frontend's AuthRequest declared a `username` field, but the backend's
/auth/signup and /auth/login endpoints expect `email` (see
backend/src/routers/auth.py:51-53). The payload mismatch caused FastAPI to
reject every signup/login with a 422 validation error, surfacing to users
as a generic "Request failed" / not-found style message.

Rename the field on the frontend and update AuthContext call sites and
affected tests to match the backend contract.