### PR TITLE
docs: add Phase 6 Gumroad-gated access epic and sub-issues

### DIFF
--- a/prompts/github-issues/phase-6-01-gumroad-api-and-webhooks.md
+++ b/prompts/github-issues/phase-6-01-gumroad-api-and-webhooks.md
@@ -1,0 +1,142 @@
+# phase-6-01: Gumroad API client, webhook scaffolding, HMAC verification
+
+**Labels:** `phase-6`, `backend`, `monetization`, `priority-high`
+**Epic:** Phase 6 — Gumroad-gated access and monetization
+**Depends on:** phase-1-03
+**Estimated LoC:** ~300–400 (including tests)
+
+## Problem
+
+Adepthood has no integration with Gumroad, so it cannot:
+
+- Verify a buyer's license key before granting course access
+- Receive notifications when a sale, refund, cancellation, or
+  subscription event happens
+- Store a durable record of Gumroad sales for idempotency and audit
+
+This issue builds the shared infrastructure every other Phase 6 issue
+depends on: a typed HTTP client for Gumroad's API, a webhook endpoint
+that authenticates and deduplicates incoming events, and a raw sale
+record used by downstream grant/credit logic.
+
+**This issue intentionally does not change signup, does not grant
+course access, and does not touch BotMason.** Those are follow-up issues
+that build on the foundation laid here.
+
+## Background — what Gumroad offers
+
+- **License API** — `POST https://api.gumroad.com/v2/licenses/verify`
+  with `product_id`, `license_key`, and optional `increment_uses_count`.
+  Returns the sale record when valid, 404 when not. This is how we turn
+  a user-supplied key into a verified sale at signup time.
+- **Resource Subscriptions (webhooks)** — called "ping" in the docs. We
+  subscribe (via `POST /v2/resource_subscriptions`) to `sale`, `refund`,
+  `dispute`, `cancellation`, and `subscription_ended` events. Each
+  event POSTs a form-encoded payload to our endpoint.
+- **HMAC signing** — Gumroad supports a shared-secret model where each
+  ping includes a signature header. We validate every incoming event
+  before trusting any of its fields.
+
+All three require a seller-scoped API token, generated from the Gumroad
+seller settings page.
+
+## Scope
+
+### 1. Configuration and secrets
+
+- Add env vars, all read at startup, fail-fast if missing in production:
+  - `GUMROAD_API_TOKEN` — seller API token, used for license verification
+  - `GUMROAD_WEBHOOK_SECRET` — shared secret for HMAC verification
+  - `GUMROAD_APTITUDE_PRODUCT_IDS` — comma-separated allowlist of APTITUDE
+    SKU IDs (one-time, monthly, any variants). Used to reject licenses
+    from unrelated products.
+  - `GUMROAD_TOKEN_PACK_PRODUCT_IDS` — comma-separated allowlist of
+    token-pack SKU IDs, used by phase-6-05.
+- Document in `backend/.env.example` and `README.md`.
+
+### 2. Typed HTTP client (`backend/src/integrations/gumroad.py`)
+
+- Use `httpx.AsyncClient` (already a transitive dep via FastAPI tests).
+- Implement `verify_license(product_id: str, license_key: str) -> GumroadSale | None`
+  that returns a typed `GumroadSale` Pydantic model on success and
+  `None` on Gumroad's 404.
+- Implement a structured logger call on every outbound request with
+  latency and status, following the `reason_code` pattern in
+  `routers/energy.py`.
+- 5-second timeout; retry once on connection error (not on 4xx/5xx).
+- Never log the license key or API token.
+
+### 3. Webhook router (`backend/src/routers/gumroad.py`)
+
+- Mount at `/webhooks/gumroad` (not `/auth/*` — these are
+  service-to-service, not user-facing).
+- `POST /webhooks/gumroad/ping` — single endpoint, event type is in
+  the payload's `resource_name` field (`sale`, `refund`, ...).
+- Verify the HMAC signature header using
+  `hmac.compare_digest(expected, provided)`. Reject with 401 on
+  mismatch. Log the rejection with `reason_code=invalid_signature`.
+- Deduplicate by `sale_id` using a unique constraint on
+  `GumroadSale.gumroad_sale_id` — if a duplicate arrives, return 200
+  without reprocessing (idempotent replay).
+- For this issue, the endpoint only **persists** the sale record;
+  grant/credit logic is a downstream issue's responsibility. Emit a
+  typed internal event (e.g., a dispatched pytest hook or a simple
+  "unhandled resource type" log) for any `resource_name` we don't
+  recognize yet, so `phase-6-02` and `phase-6-05` can wire in their
+  handlers without modifying this scaffolding.
+
+### 4. Raw sale model (`backend/src/models/gumroad_sale.py`)
+
+- Fields: `id`, `gumroad_sale_id` (unique, indexed), `product_id`,
+  `email`, `resource_name`, `is_recurring_charge`, `refunded`,
+  `raw_payload` (JSON column), `created_at`.
+- Alembic migration adds the table and unique index.
+
+### 5. Tests
+
+- Unit: `verify_license` mocks httpx and asserts request shape, parses
+  success and 404 into the expected types, redacts secrets from logs.
+- Unit: HMAC verification rejects tampered payloads and accepts valid
+  ones (constant-time comparison; no early-exit on first byte).
+- Integration: `POST /webhooks/gumroad/ping` with a valid signature
+  persists exactly one `GumroadSale` row; replaying the same payload
+  does not create a second row.
+- Integration: invalid signature returns 401 and writes nothing.
+
+## Acceptance criteria
+
+- `backend/src/integrations/gumroad.py::verify_license` returns the
+  correct typed result for valid, invalid, and unknown-product keys.
+- `POST /webhooks/gumroad/ping` requires a valid HMAC signature and is
+  idempotent on replay.
+- Every Gumroad event we receive is persisted as a `GumroadSale` row
+  regardless of whether downstream handlers exist yet.
+- Tests pass and coverage for the new files is ≥ 90%.
+- `pip-audit` clean; no new high-severity deps.
+- `pre-commit run --all-files` green.
+
+## Files to create / modify
+
+| File | Action |
+|------|--------|
+| `backend/src/integrations/__init__.py` | Create |
+| `backend/src/integrations/gumroad.py` | Create (API client) |
+| `backend/src/routers/gumroad.py` | Create (webhook endpoint) |
+| `backend/src/models/gumroad_sale.py` | Create |
+| `backend/src/main.py` | Modify (mount router, validate env at startup) |
+| `backend/alembic/versions/xxxx_gumroad_sale.py` | Create |
+| `backend/.env.example` | Modify (add 4 vars) |
+| `backend/tests/integrations/test_gumroad_client.py` | Create |
+| `backend/tests/routers/test_gumroad_webhook.py` | Create |
+| `README.md` | Modify (brief setup note with link to Gumroad docs) |
+
+## Notes for implementer
+
+- Store the raw webhook payload verbatim in `raw_payload`. Gumroad
+  occasionally adds fields and we don't want to silently drop them.
+- Do not hit the real Gumroad API in any test. All tests use mocked
+  `httpx` transports.
+- Treat the webhook secret as a credential: never log it, include in
+  `detect-secrets` baseline if necessary.
+- Follow the `reason_code` structured-logging pattern already
+  established in `routers/energy.py` for every rejection path.

--- a/prompts/github-issues/phase-6-02-course-entitlement-and-signup-gating.md
+++ b/prompts/github-issues/phase-6-02-course-entitlement-and-signup-gating.md
@@ -1,0 +1,170 @@
+# phase-6-02: Course entitlement model and signup gating via license redemption
+
+**Labels:** `phase-6`, `backend`, `monetization`, `priority-high`
+**Epic:** Phase 6 — Gumroad-gated access and monetization
+**Depends on:** phase-6-01
+**Estimated LoC:** ~400–500 (including tests)
+
+## Problem
+
+Once phase-6-01 is in place, the backend can verify Gumroad licenses and
+receive sale webhooks, but nothing gates access on them. Any email +
+password combination still produces a usable account.
+
+This issue introduces the **course entitlement** — a per-user, binary
+"may access paid course content" flag — and modifies signup so that an
+account can only be created alongside a verified Gumroad license. It
+also wires the webhook handler from phase-6-01 to grant entitlement
+when a sale event arrives for a pre-registered email.
+
+Refund and cancellation revocation are out of scope for this issue and
+are covered in phase-6-05.
+
+## Design decisions
+
+- **Entitlement, not role**: We use a dedicated `Entitlement` table
+  rather than a boolean column on `User`, because we anticipate more
+  kinds of entitlements (BotMason tokens in phase-6-04, future
+  cohort-gated content, etc.), and because entitlements have their own
+  lifecycle (granted, revoked, source sale, timestamps) that doesn't
+  belong on the user record.
+- **Email as the join key**: Gumroad's identity is the buyer's email.
+  At signup we require the user to use the same email they used on
+  Gumroad; the license verification proves they hold the key for a sale
+  issued to that email.
+- **License key required for the primary signup flow**: Per the epic,
+  every user must have a Gumroad sale. The signup request therefore
+  requires `license_key` in addition to `email` and `password`.
+- **Verify-then-create**: The signup transaction verifies the license
+  first. Only on verification success does it create the `User` and
+  `Entitlement` rows. A failed verification returns a generic
+  `invalid_license` error without revealing whether the key format, the
+  key value, or the product ID was the mismatch — same account-
+  enumeration caution that already guards login.
+- **Webhook-first paths also work**: If a Gumroad sale webhook arrives
+  for an email that already has a `User` but no `Entitlement`, the
+  webhook handler creates the entitlement. This covers the case where
+  someone buys a new SKU (e.g. a monthly subscription) after signing
+  up.
+
+## Scope
+
+### 1. Entitlement model (`backend/src/models/entitlement.py`)
+
+- Fields: `id`, `user_id` (FK, indexed), `kind` (enum:
+  `course_access` for now; `botmason_tokens` lands in phase-6-04),
+  `product_id` (nullable; links to the Gumroad SKU when applicable),
+  `source_sale_id` (FK to `GumroadSale`, nullable for manual grants),
+  `granted_at`, `revoked_at` (nullable), `metadata` (JSON column for
+  future extensibility without migrations).
+- Unique partial index on `(user_id, kind)` where `revoked_at IS NULL`,
+  so a user has at most one active entitlement of each kind.
+- Alembic migration adds the table and index.
+
+### 2. Domain logic (`backend/src/domain/entitlements.py`)
+
+- `grant_course_access(session, user, sale)` — idempotent: if an active
+  `course_access` entitlement already exists for the user, update
+  `source_sale_id` in place rather than creating a duplicate. Returns
+  the entitlement.
+- `has_course_access(session, user_id) -> bool` — reads the active
+  entitlement, used by the signup gate and by any route that later
+  wants to paywall content.
+- `revoke_course_access(session, user_id, reason)` — sets
+  `revoked_at=now()`; a helper for phase-6-05 (refund handling) and
+  phase-6-06 (admin revocation).
+- Structured logging on every grant/revoke with
+  `reason_code` (e.g. `signup_redemption`, `webhook_sale`, `refund`,
+  `admin_override`).
+
+### 3. Modified signup flow (`backend/src/routers/auth.py`)
+
+- `AuthRequest` gains an optional `license_key` field. Make it optional
+  in the schema to preserve login's payload, but required in the
+  signup handler's validation.
+- Before creating the user:
+  1. Call `gumroad.verify_license(product_id=<each APTITUDE id>,
+     license_key=payload.license_key)` against the allowlist from
+     `GUMROAD_APTITUDE_PRODUCT_IDS` until one matches. Stop on first
+     match.
+  2. On no match → `raise bad_request("invalid_license")` with the
+     same generic message used for the other account-enumeration
+     defenses (200 ms dummy-hash delay kept).
+  3. On match → assert the license's email matches
+     `payload.email` (case-insensitive). If not, return
+     `invalid_license` (don't expose that the key is valid for a
+     different account).
+  4. Find or create the `User` row. If found with no active
+     entitlement (webhook-preregistered), continue; if found with
+     an active entitlement, return the same `invalid_license` to
+     avoid account enumeration while logging
+     `reason_code=duplicate_signup` server-side.
+  5. Create the `Entitlement` with `source_sale_id` pointing at the
+     `GumroadSale` row we can look up by `gumroad_sale_id`.
+  6. Issue the JWT and return.
+- The rate limit stays at `3/minute` on signup. Add a second-layer
+  limit of `10/hour` per IP on invalid-license attempts specifically,
+  to blunt brute-forcing of license keys. Hooks into the existing
+  `slowapi` limiter.
+
+### 4. Webhook handler for sale events
+
+- Extend `backend/src/routers/gumroad.py` (from phase-6-01): when the
+  stored `GumroadSale.resource_name == "sale"`, dispatch to a handler
+  that looks up an existing `User` by email.
+  - If the user exists: call `grant_course_access` (idempotent).
+  - If no user exists yet: do nothing beyond persisting the
+    `GumroadSale` row. The next signup attempt with that email +
+    license key will find it.
+
+### 5. Tests
+
+- Unit: `grant_course_access` is idempotent, revoking then re-granting
+  works, uniqueness is preserved.
+- Integration: signup with no `license_key` → 400.
+- Integration: signup with invalid `license_key` → 400, no user row
+  created, no entitlement created.
+- Integration: signup with a valid key for a non-APTITUDE product → 400
+  (license matches but product not on allowlist).
+- Integration: signup with a valid key but mismatched email → 400 with
+  same `invalid_license` message; server logs `email_mismatch`.
+- Integration: signup with a valid key, matched product, matched email
+  → 201, user row, entitlement row, JWT returned.
+- Integration: duplicate signup (same email, same key) returns
+  `invalid_license` without leaking that the account exists.
+- Integration: sale webhook arrives before signup → only
+  `GumroadSale` row; subsequent signup succeeds and links to it.
+
+## Acceptance criteria
+
+- Signup without a valid APTITUDE Gumroad license is impossible.
+- The $0 free-tier SKU works identically to paid SKUs, as long as its
+  product ID is on `GUMROAD_APTITUDE_PRODUCT_IDS`.
+- Webhook-arriving-first and signup-arriving-first both produce the
+  same end state (user + entitlement + link to sale).
+- No account-enumeration leak from any rejection path.
+- Coverage ≥ 90% on new files; existing auth tests still pass.
+
+## Files to create / modify
+
+| File | Action |
+|------|--------|
+| `backend/src/models/entitlement.py` | Create |
+| `backend/src/domain/entitlements.py` | Create |
+| `backend/src/routers/auth.py` | Modify (license gate) |
+| `backend/src/routers/gumroad.py` | Modify (sale-event dispatch) |
+| `backend/alembic/versions/xxxx_entitlement.py` | Create |
+| `backend/tests/routers/test_auth_signup_license.py` | Create |
+| `backend/tests/routers/test_gumroad_sale_dispatch.py` | Create |
+| `backend/tests/domain/test_entitlements.py` | Create |
+| `frontend/src/api/types.ts` | Regenerate (OpenAPI) |
+
+## Notes for implementer
+
+- The "always verify against every APTITUDE product ID" loop is
+  acceptable because the allowlist is small (single digits). If it
+  grows large, switch to reading the sale by ID once we get it back.
+- Do not expose Gumroad's verify-response fields in our API response.
+  Only the JWT leaves the backend.
+- Preserve the timing-attack defense: all failure paths should still
+  do the dummy bcrypt hash that the current signup does.

--- a/prompts/github-issues/phase-6-03-frontend-onboarding-flow.md
+++ b/prompts/github-issues/phase-6-03-frontend-onboarding-flow.md
@@ -1,0 +1,153 @@
+# phase-6-03: Frontend onboarding flow — redirect to Gumroad and redeem license
+
+**Labels:** `phase-6`, `frontend`, `monetization`, `priority-high`
+**Epic:** Phase 6 — Gumroad-gated access and monetization
+**Depends on:** phase-6-02
+**Estimated LoC:** ~300–400 (including tests)
+
+## Problem
+
+After phase-6-02, the backend requires a `license_key` to create an
+account. The frontend signup form currently only collects email and
+password, so signup will fail for every new user once the gate is
+turned on.
+
+This issue builds the user-facing onboarding flow: a welcome screen
+explaining the Gumroad-first model, a deep link to the Gumroad product
+page, and a license-key redemption step in the signup form. The copy
+frames the free tier as "pay what feels right, starting at zero" so
+users understand that they're not being upsold.
+
+## UX shape
+
+```
+[Welcome screen] ── "Get Adepthood"
+      │                    │
+      ▼                    ▼
+[Open Gumroad]      [I already have a key]
+      │                    │
+      └────────┬───────────┘
+               ▼
+       [Signup form]
+       ─ Email
+       ─ Password
+       ─ Gumroad license key   ← required
+       ─ "Where's my key?" helper link
+               │
+               ▼
+         [Create account]
+```
+
+- The welcome screen is the default landing for unauthenticated users.
+- "Open Gumroad" uses `Linking.openURL` with the Gumroad product URL
+  (configurable via `EXPO_PUBLIC_GUMROAD_PRODUCT_URL`). After purchase,
+  the user returns to the app manually; we do not attempt OAuth-style
+  return callbacks.
+- The help link opens a short `WebView` / external link to the Gumroad
+  page that explains where license keys live in a user's Gumroad
+  library.
+- The form's error display must handle the backend's `invalid_license`
+  error specifically, surfacing it as "We couldn't verify that key —
+  double-check it matches the email and product." rather than the
+  generic "Request failed".
+
+## Scope
+
+### 1. Config (`frontend/src/config.ts`)
+
+- Add `GUMROAD_PRODUCT_URL` and `GUMROAD_HELP_URL`, read from
+  `EXPO_PUBLIC_*` env vars with sensible defaults for local dev.
+- Document both in `frontend/README.md`.
+
+### 2. Welcome screen
+   (`frontend/src/features/Auth/screens/WelcomeScreen.tsx`)
+
+- New screen, added as the first screen in the unauthenticated stack.
+- Two primary CTAs: "Get Adepthood on Gumroad" (opens URL) and "I have
+  a license key" (navigates to signup).
+- Short copy explaining the gift-economy framing. Copy lives in the
+  component for now (no i18n yet in the codebase).
+
+### 3. Signup screen update
+   (`frontend/src/features/Auth/screens/SignupScreen.tsx`)
+
+- Add a `licenseKey` field to the form state.
+- Client-side validation: required, trimmed, minimum length of 8
+  (defensive — real format validation happens server-side).
+- Submit `{ email, password, license_key }` to `authApi.signup`.
+- Add an inline "Where's my key?" link that opens `GUMROAD_HELP_URL`.
+- Map backend error details:
+  - `invalid_license` → surfaced inline on the license field.
+  - `password_too_short` → inline on password field.
+  - Other errors → the existing generic error banner.
+
+### 4. API types and client (`frontend/src/api/index.ts`)
+
+- Extend `AuthRequest` with optional `license_key?: string`.
+- Leave the login endpoint unaffected (the backend makes license_key
+  optional, required-at-handler for signup).
+
+### 5. AuthContext
+   (`frontend/src/context/AuthContext.tsx`)
+
+- `signup(email, password, licenseKey)` — adds a third argument.
+- Pass through to `authApi.signup({ email, password, license_key:
+  licenseKey })`.
+
+### 6. Better error extraction (`frontend/src/api/index.ts`)
+
+Small quality-of-life fix that belongs with this work: the current
+`extractErrorDetail` (lines 98–108) only handles string `detail`
+fields. FastAPI's 422 validation errors come back as an array. Extend
+to:
+- If `detail` is a string, return it.
+- If `detail` is an array of `{ loc, msg, type }`, join the `msg`
+  values or return the first one. This lets the signup screen show a
+  real message when the body shape is wrong.
+
+### 7. Tests
+
+- Unit: signup form rejects empty license key without a network call.
+- Unit: signup form submits `license_key` in the payload.
+- Unit: `invalid_license` error from the API is rendered inline on the
+  license field, not in the generic banner.
+- Unit: Welcome screen's "Get Adepthood" CTA calls
+  `Linking.openURL(GUMROAD_PRODUCT_URL)`.
+- Snapshot: welcome screen layout stable.
+
+## Acceptance criteria
+
+- Fresh install → welcome screen is the first thing the user sees.
+- "Get Adepthood" opens Gumroad in the external browser.
+- Signup fails client-side without a license key and shows a helpful
+  error.
+- Signup succeeds end-to-end when a valid key is entered (manual test
+  against a local backend with a seeded Gumroad sale).
+- Backend validation errors are surfaced on the correct fields.
+- ESLint, TypeScript, Jest all green.
+
+## Files to create / modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Auth/screens/WelcomeScreen.tsx` | Create |
+| `frontend/src/features/Auth/screens/SignupScreen.tsx` | Modify |
+| `frontend/src/navigation/AuthStack.tsx` | Modify (add WelcomeScreen) |
+| `frontend/src/context/AuthContext.tsx` | Modify (licenseKey arg) |
+| `frontend/src/api/index.ts` | Modify (AuthRequest, error extraction) |
+| `frontend/src/config.ts` | Modify (2 new URL config entries) |
+| `frontend/src/features/Auth/__tests__/SignupScreen.test.tsx` | Modify |
+| `frontend/src/features/Auth/__tests__/WelcomeScreen.test.tsx` | Create |
+| `frontend/src/context/__tests__/AuthContext.test.tsx` | Modify |
+| `frontend/__tests__/api.test.ts` | Modify |
+| `frontend/README.md` | Modify |
+
+## Notes for implementer
+
+- `Linking.openURL` returns a promise — await it and log (not throw)
+  if it rejects, since on simulator/emulator it can fail silently.
+- Do not log the license key anywhere, even on error. Treat it as a
+  credential.
+- Keep the welcome screen copy short — this is an onboarding speed
+  bump, not a landing page. Link-out to the Gumroad product page
+  for the real marketing copy.

--- a/prompts/github-issues/phase-6-04-botmason-token-wallet.md
+++ b/prompts/github-issues/phase-6-04-botmason-token-wallet.md
@@ -1,0 +1,206 @@
+# phase-6-04: BotMason token wallet — model, debit on chat, BYOK bypass
+
+**Labels:** `phase-6`, `backend`, `botmason`, `monetization`, `priority-high`
+**Epic:** Phase 6 — Gumroad-gated access and monetization
+**Depends on:** phase-6-01, phase-3-07 (BotMason AI)
+**Estimated LoC:** ~400–500 (including tests)
+
+## Problem
+
+BotMason calls an LLM on every journal reflection. Right now the cost
+of those tokens is absorbed by the server — fine during demo, not
+sustainable as the user base grows. Two monetization options already
+exist in the codebase:
+
+1. **BYOK** (issue #185) — the user provides their own LLM API key via
+   the `X-LLM-API-Key` header, and we pass it through without paying
+   for tokens.
+2. **Usage-based credits** — we sell BotMason token packs on Gumroad
+   and maintain a per-user token balance that debits as the user
+   chats.
+
+This issue introduces option 2 as the default for users who haven't
+supplied BYOK. A user with both a non-empty token balance and no BYOK
+header has tokens debited. A user with BYOK bypasses the balance
+entirely. A user with neither gets an `insufficient_tokens` error and
+a prompt to either buy a pack or add their own key.
+
+Crediting the balance from Gumroad webhooks is covered in phase-6-05.
+This issue is about the **model, the debit path, and the BYOK
+interaction** — it lands with a manual admin crediting helper so the
+balance can be exercised end-to-end before phase-6-05 automates it.
+
+## Design decisions
+
+- **Ledger, not just a counter**: Every debit and credit writes a
+  `TokenLedgerEntry` row. The balance is the sum of ledger entries.
+  This makes audits trivial, supports refunds without losing history,
+  and prevents race-condition "double-debit" bugs that a mutable
+  balance column would invite.
+- **Transactional debit**: The debit happens inside the same SQL
+  transaction as the BotMason request's other writes (journal entry,
+  response persistence). If the LLM call fails after the debit,
+  rollback refunds the tokens automatically. If the call succeeds but
+  we fail to persist, we also roll back — the user is not charged for
+  a response they didn't receive.
+- **Fixed-cost estimate at debit time**: We debit a conservative
+  upper-bound estimate (e.g., `max_tokens` from the request + a
+  prompt-size factor) before calling the LLM. After the response, we
+  refund the difference between estimate and actual usage. This avoids
+  the "user's balance is $0 but the in-flight request still charges
+  them into the negative" trap.
+- **BYOK fully bypasses the wallet**: Not "charge them anyway and hope
+  they don't notice". If `X-LLM-API-Key` is present and non-empty, no
+  ledger entry is written at all.
+- **Starter grant**: On first entitlement grant (phase-6-02), the user
+  receives a configurable starter balance so they can try BotMason
+  before committing to a pack. The starter amount is an env var
+  (`BOTMASON_STARTER_TOKENS`) so it can be tuned without a deploy.
+
+## Scope
+
+### 1. Model (`backend/src/models/token_ledger.py`)
+
+- `TokenLedgerEntry`:
+  - `id`, `user_id` (FK, indexed), `delta` (signed int, positive =
+    credit, negative = debit),
+  - `kind` enum: `starter_grant`, `purchase`, `debit`, `refund`,
+    `admin_adjustment`,
+  - `source_sale_id` (FK to `GumroadSale`, nullable),
+  - `request_id` (nullable string, populated on debit/refund for
+    matching a debit to its refund),
+  - `reason_code` (string, mirrors our structured-logging convention),
+  - `created_at`.
+- Partial indexes on `(user_id, created_at DESC)` for fast balance
+  reads.
+- Alembic migration.
+
+### 2. Domain logic (`backend/src/domain/token_wallet.py`)
+
+- `get_balance(session, user_id) -> int` — sums the `delta` column,
+  0 for users with no entries.
+- `credit(session, user_id, amount, kind, **meta) -> TokenLedgerEntry`
+  — positive only; rejects non-positive amounts loudly.
+- `debit(session, user_id, amount, request_id, reason_code) -> TokenLedgerEntry`
+  — negative; raises `InsufficientTokens` if the balance would drop
+  below zero. The check-then-insert is wrapped in a transaction using
+  `SELECT ... FOR UPDATE` on the user row (or a dedicated
+  `TokenBalance` row — see the race-condition note below) so
+  concurrent debits cannot both pass the check.
+- `refund_unused(session, request_id, actual_tokens) -> TokenLedgerEntry | None`
+  — finds the original debit by `request_id`, writes a positive
+  entry for `(estimated - actual)`. No-op if `actual >= estimated`.
+
+### 3. Race-condition handling
+
+Two concurrent BotMason requests for the same user must not both
+read the same pre-debit balance and both succeed when the user can
+only afford one.
+
+Options:
+- (a) `SELECT ... FOR UPDATE` on a dedicated `TokenBalance` summary
+  row, updated alongside every ledger write.
+- (b) Serializable transaction isolation for the debit path.
+- (c) Advisory locks (`pg_advisory_xact_lock(user_id)`).
+
+Pick (a) — it's the simplest to reason about and plays nicely with
+the existing SQLModel + async session. The `TokenBalance` row is a
+denormalization of the ledger's sum; a DB constraint ensures it can
+never go negative.
+
+### 4. BotMason chat integration
+
+Touching `backend/src/routers/botmason.py` (or wherever the chat
+endpoint lives — check phase-3-07):
+
+- Before calling the LLM:
+  - If request has valid `X-LLM-API-Key`: skip wallet entirely. Log
+    `reason_code=byok_bypass`.
+  - Else: compute estimated token cost (use an existing tokenizer if
+    one is available via `tiktoken`; otherwise a simple heuristic like
+    `ceil(len(prompt)/4) + max_tokens`). Call `debit(...)`. If it
+    raises `InsufficientTokens`, return 402 Payment Required with
+    `detail="insufficient_tokens"`.
+- After the LLM returns:
+  - Read `response.usage.total_tokens` (Anthropic / OpenAI).
+  - Call `refund_unused(request_id, actual)`.
+- On LLM or persistence error: the surrounding transaction rolls back,
+  automatically undoing the debit. Do not catch-and-swallow.
+
+### 5. Starter grant wired to phase-6-02
+
+- In `backend/src/domain/entitlements.py::grant_course_access`, after
+  a successful first-time grant, call `credit(..., amount=starter,
+  kind="starter_grant")`. Idempotency: do not re-grant on repeat
+  webhook deliveries (phase-6-02's grant is already idempotent; the
+  starter credit should key off a `starter_grant` ledger entry
+  existing for that user).
+
+### 6. Balance endpoint
+
+- `GET /users/me/tokens` — returns the current balance for the
+  authenticated user. Used by the frontend to decide whether to show
+  the BYOK prompt or the "buy more tokens" CTA. Rate-limited per
+  existing conventions.
+
+### 7. Tests
+
+- Unit: `credit`, `debit`, `refund_unused` behave correctly in
+  isolation. `InsufficientTokens` raised when expected.
+- Unit: `get_balance` returns zero for users with no ledger entries.
+- Integration: two concurrent debits that together exceed the balance
+  — exactly one succeeds, one raises `InsufficientTokens`. Run with
+  real Postgres (`pytest-postgresql`) to exercise the
+  `SELECT ... FOR UPDATE`.
+- Integration: chat endpoint with BYOK header writes no ledger
+  entries.
+- Integration: chat endpoint without BYOK with sufficient balance
+  debits the estimate, then refunds the difference after the LLM
+  responds.
+- Integration: chat endpoint without BYOK with zero balance returns
+  402.
+- Integration: LLM call fails after debit → rollback → balance
+  unchanged.
+- Integration: starter grant is written on first entitlement grant
+  and not re-written on a duplicate webhook.
+
+## Acceptance criteria
+
+- A new user with a fresh course entitlement has
+  `BOTMASON_STARTER_TOKENS` in their wallet.
+- A chat with no BYOK header debits their balance; running it while
+  at zero returns 402.
+- A chat with BYOK header never touches the wallet.
+- Under concurrent load, double-spend is impossible.
+- LLM errors after debit do not leave the user short.
+- `GET /users/me/tokens` returns the current balance.
+- Coverage ≥ 90% on the new files.
+
+## Files to create / modify
+
+| File | Action |
+|------|--------|
+| `backend/src/models/token_ledger.py` | Create (ledger + balance rows) |
+| `backend/src/domain/token_wallet.py` | Create |
+| `backend/src/routers/users.py` | Modify (add `/me/tokens`) |
+| `backend/src/routers/botmason.py` | Modify (wallet debit/refund) |
+| `backend/src/domain/entitlements.py` | Modify (starter grant) |
+| `backend/src/errors.py` | Modify (`InsufficientTokens`, 402) |
+| `backend/alembic/versions/xxxx_token_ledger.py` | Create |
+| `backend/tests/domain/test_token_wallet.py` | Create |
+| `backend/tests/routers/test_botmason_wallet.py` | Create |
+| `backend/.env.example` | Modify (`BOTMASON_STARTER_TOKENS`) |
+
+## Notes for implementer
+
+- If BotMason's chat handler isn't yet structured around a
+  transaction, restructure it in this issue. The transactional
+  invariant is the whole point of the ledger design.
+- Pick the token estimator carefully: underestimating invites
+  negative balances; gross overestimation frustrates users. Document
+  the chosen heuristic.
+- The 402 status code is the right fit (Payment Required, rarely
+  used, unambiguous semantics). Don't reuse 401 or 403.
+- Do not expose ledger entries directly via an API yet — the balance
+  is enough for frontend needs. A history endpoint can land when the
+  user actually asks for one.

--- a/prompts/github-issues/phase-6-05-token-credits-and-revocation.md
+++ b/prompts/github-issues/phase-6-05-token-credits-and-revocation.md
@@ -1,0 +1,174 @@
+# phase-6-05: Token-pack purchase crediting and refund/cancellation revocation
+
+**Labels:** `phase-6`, `backend`, `monetization`, `priority-high`
+**Epic:** Phase 6 — Gumroad-gated access and monetization
+**Depends on:** phase-6-02, phase-6-04
+**Estimated LoC:** ~300–400 (including tests)
+
+## Problem
+
+phase-6-01 stores raw Gumroad webhook events. phase-6-02 handles the
+`sale` event for the APTITUDE course. phase-6-04 adds the BotMason
+token wallet with a manual crediting helper.
+
+What's still missing:
+
+1. **Automated token-pack crediting.** When a user buys a BotMason
+   token pack on Gumroad, a webhook arrives and their balance should
+   go up by the pack's size — no manual admin action required.
+2. **Refund and cancellation handling.** When Gumroad sends a `refund`,
+   `dispute`, `cancellation`, or `subscription_ended` event, we need
+   to revoke course access and/or debit tokens (depending on what was
+   refunded).
+
+This issue closes the loop: the webhook endpoint fans out to dedicated
+handlers for each event type, each of which produces idempotent
+state changes.
+
+## Design decisions
+
+- **Product ID → entitlement type mapping.** The handler dispatches
+  based on the `product_id` of the sale: APTITUDE product IDs affect
+  course access; token-pack product IDs affect the wallet; anything
+  else is logged and ignored. The two allowlists
+  (`GUMROAD_APTITUDE_PRODUCT_IDS` and
+  `GUMROAD_TOKEN_PACK_PRODUCT_IDS`, introduced in phase-6-01) are the
+  sources of truth.
+- **Token-pack size encoded in a mapping**, not a Gumroad custom
+  field. Gumroad's product metadata is brittle and awkward to
+  validate. A `GUMROAD_TOKEN_PACK_SIZES` env var holds
+  `product_id:token_count` pairs — same pattern as Railway-friendly
+  config.
+- **Refund revokes, does not delete.** A refund writes
+  `Entitlement.revoked_at` and, for token packs, a negative ledger
+  entry of kind `refund`. History is preserved.
+- **Refund on token packs can go negative.** If the user has already
+  spent the tokens from a pack that later gets refunded, their balance
+  can drop below zero. That's the correct outcome for a chargeback:
+  they used tokens they didn't pay for. Future debits will fail with
+  `insufficient_tokens` until they credit the balance. This mirrors
+  how every other credit system handles chargebacks.
+- **Monthly subscription: conservative default.** Per the epic's open
+  question, we treat `subscription_ended` as an immediate access
+  revocation. If you want "keep access through the paid period"
+  later, that's a separate issue — simple to add given the ledger
+  model (a `paid_through` column on the entitlement).
+
+## Scope
+
+### 1. Event dispatch table (`backend/src/routers/gumroad.py`)
+
+Extend the webhook endpoint from phase-6-01 so `resource_name` routes
+to dedicated handlers:
+
+| `resource_name`         | Handler                          |
+|-------------------------|----------------------------------|
+| `sale`                  | `handle_sale`                    |
+| `refund`                | `handle_refund`                  |
+| `dispute`               | `handle_refund` (same behavior)  |
+| `cancellation`          | `handle_cancellation`            |
+| `subscription_ended`    | `handle_cancellation` (alias)    |
+
+Unknown types: log `reason_code=unhandled_event` and return 200 (so
+Gumroad doesn't keep retrying). Add a counter so we notice if a new
+event type becomes common.
+
+### 2. `handle_sale` (course access + token packs)
+
+Extends phase-6-02's handler:
+
+- If `product_id` in `APTITUDE_PRODUCT_IDS`: call
+  `grant_course_access` (existing, idempotent).
+- If `product_id` in `TOKEN_PACK_PRODUCT_IDS`: look up the token count
+  from `GUMROAD_TOKEN_PACK_SIZES`. Find the user by email. If found,
+  call `token_wallet.credit(...)` with `kind="purchase"` and
+  `source_sale_id=<the GumroadSale row>`. Idempotent: if a ledger
+  entry already exists with the same `source_sale_id` and
+  `kind="purchase"`, skip.
+- If user does not exist yet: persist the sale (already done in
+  phase-6-01) and stop. The credit happens when they sign up; the
+  entitlement handler looks up pre-existing unclaimed sales for the
+  email.
+- Neither allowlist: log and ignore.
+
+### 3. `handle_refund`
+
+- Look up the original sale by `gumroad_sale_id`.
+- If not found in our DB: log and ignore (the sale predates us, or
+  was never delivered).
+- If it was an APTITUDE sale:
+  - Check whether the user has any **other** active APTITUDE
+    entitlement (they might own both one-time and monthly).
+  - If not, call `revoke_course_access(user, reason="refund")`.
+- If it was a token-pack sale:
+  - Write a negative ledger entry for the original pack size with
+    `kind="refund"` and `source_sale_id` pointing at the refunded
+    sale. Allow negative balance per the design decision above.
+- Idempotency: if a matching `kind="refund"` ledger entry / revoked
+  entitlement already exists for that `source_sale_id`, skip.
+
+### 4. `handle_cancellation`
+
+Same as `handle_refund` for APTITUDE monthly subscriptions. Does not
+affect token packs (cancellations don't apply to one-time purchases).
+
+### 5. Expanded signup-time claim path
+
+Update phase-6-02's signup handler: after the license verification
+succeeds, also look up any **unclaimed token-pack sales** for the
+email (i.e., sales that exist in `GumroadSale` but have no
+corresponding positive ledger entry yet) and credit them at the same
+time as the starter grant. This covers the order-of-operations case
+where a user buys the course and a token pack before creating their
+Adepthood account.
+
+### 6. Tests
+
+- Integration: token-pack webhook for an existing user credits the
+  configured pack size once; replaying the same webhook does not
+  double-credit.
+- Integration: token-pack webhook for an unknown email persists the
+  sale only; subsequent signup credits the wallet.
+- Integration: refund on an APTITUDE sale revokes the entitlement.
+- Integration: refund on a user who owns both one-time and monthly
+  APTITUDE SKUs keeps access (other active entitlement covers them).
+- Integration: refund on a token-pack sale writes a negative ledger
+  entry, even if it drives the balance negative.
+- Integration: cancellation of a monthly subscription revokes access.
+- Integration: duplicate refund webhook is idempotent.
+- Integration: unknown product ID is logged and ignored.
+
+## Acceptance criteria
+
+- Token-pack purchases credit the buyer's wallet with no manual step.
+- Refunds and cancellations remove access within one webhook delivery.
+- Duplicate webhook deliveries never double-credit or double-revoke.
+- Users who buy before signing up are credited on first login.
+- Unknown event types and product IDs degrade gracefully (logged,
+  ignored, no 5xx).
+
+## Files to create / modify
+
+| File | Action |
+|------|--------|
+| `backend/src/routers/gumroad.py` | Modify (event dispatch, new handlers) |
+| `backend/src/domain/entitlements.py` | Modify (claim unclaimed sales at signup) |
+| `backend/src/domain/token_wallet.py` | Modify (refund helper) |
+| `backend/src/routers/auth.py` | Modify (call unclaimed-sale claim on signup) |
+| `backend/.env.example` | Modify (`GUMROAD_TOKEN_PACK_SIZES`) |
+| `backend/tests/routers/test_gumroad_refund.py` | Create |
+| `backend/tests/routers/test_gumroad_token_pack.py` | Create |
+| `backend/tests/routers/test_gumroad_cancellation.py` | Create |
+
+## Notes for implementer
+
+- The dispatcher table is the place to add new event types as Gumroad
+  expands — keep it a single source of truth.
+- Do not rely on Gumroad's `paid_through` or `subscription_duration`
+  fields. Treat every event as a discrete state change.
+- The "negative balance after refund" decision is opinionated. If
+  user-support feedback later says it feels punitive, we can relax
+  to "refund debits at most the remaining balance" — but that creates
+  an incentive to spend refundable tokens fast, which we don't want.
+- For the `dispute` event, consider whether an admin notification is
+  worth adding now. Probably not — phase-6-06 adds the admin surface.

--- a/prompts/github-issues/phase-6-06-admin-override-endpoints.md
+++ b/prompts/github-issues/phase-6-06-admin-override-endpoints.md
@@ -1,0 +1,171 @@
+# phase-6-06: Admin endpoints for manual grants, revocations, and balance adjustments
+
+**Labels:** `phase-6`, `backend`, `admin`, `monetization`, `priority-medium`
+**Epic:** Phase 6 — Gumroad-gated access and monetization
+**Depends on:** phase-6-02, phase-6-04, phase-6-05
+**Estimated LoC:** ~250–350 (including tests)
+
+## Problem
+
+Even with Gumroad as the system of record, manual override is required
+for at least four scenarios:
+
+1. **Gumroad is down** and a user needs access to present the course
+   at a conference tomorrow.
+2. **Comped access** — a friend, an early tester, or a beta cohort
+   member needs to bypass the purchase flow entirely.
+3. **Goodwill credits** — a support conversation ends in "here, have
+   another 5000 tokens on me", with no Gumroad sale behind it.
+4. **Corrective revocation** — a user is abusing the service and you
+   need to cut them off independent of Gumroad state.
+
+Without this endpoint, those scenarios require a SQL console. That's
+error-prone, unauditable, and leaves no paper trail.
+
+This issue adds a small admin surface that wraps the domain helpers
+introduced in phase-6-02 (entitlements), phase-6-04 (token wallet),
+and phase-6-05 (revocation). Every override is logged with an admin
+identity, a reason, and a timestamp.
+
+## Design decisions
+
+- **No new UI.** These are backend endpoints only. The operator uses
+  `curl` or a small admin web tool later. Putting this behind a UI
+  is explicitly out of scope for this issue.
+- **Simple token-based admin auth.** No new user roles — that's more
+  complexity than this product needs right now. A single
+  `ADMIN_API_TOKEN` env var gates the endpoints, sent as an
+  `X-Admin-Token` header. If we later need multi-admin or audit-per-
+  person, that's a separate (easy) refactor on top of this.
+- **Reason string is required.** Every override records a human-
+  readable justification in the ledger / entitlement `metadata`
+  column. No mysterious grants.
+- **Idempotency by operation key.** Every admin call takes an
+  optional `X-Idempotency-Key` header; we reject replays (same
+  key, different body) and silently succeed on exact replays. Same
+  pattern as `/v1/energy/plan`.
+
+## Scope
+
+### 1. Admin auth dependency (`backend/src/routers/admin.py`)
+
+- `require_admin(x_admin_token: str = Header(...))` — compares the
+  header against `ADMIN_API_TOKEN` using `hmac.compare_digest`.
+  Raises 401 on mismatch. Logs every rejected attempt with
+  `reason_code=admin_auth_failed` and the source IP.
+- Startup check in `main.py`: if `ADMIN_API_TOKEN` is unset in
+  production, fail fast.
+
+### 2. Endpoints
+
+All mounted at `/admin/` and protected by `require_admin`.
+
+#### `POST /admin/users/{user_id}/entitlements`
+Grant a manual entitlement.
+- Body: `{ "kind": "course_access", "reason": "string",
+  "expires_at": null | datetime }`
+- Writes an `Entitlement` row with `source_sale_id=NULL`,
+  `metadata={"admin_granted_by": <ip>, "reason": <reason>}`.
+- Returns the created entitlement.
+
+#### `DELETE /admin/users/{user_id}/entitlements/{entitlement_id}`
+Revoke a specific entitlement.
+- Body: `{ "reason": "string" }`
+- Sets `revoked_at` and stamps the reason into `metadata`.
+- 404 if the entitlement is already revoked or doesn't exist.
+
+#### `POST /admin/users/{user_id}/tokens`
+Adjust the token balance by an arbitrary delta.
+- Body: `{ "delta": int, "reason": "string" }`
+- `delta` may be negative; the balance may go negative. Writes a
+  `TokenLedgerEntry` with `kind="admin_adjustment"`,
+  `reason_code="admin:<first word of reason>"`.
+- Returns the new balance.
+
+#### `GET /admin/users/{user_id}/summary`
+Read-only debugging endpoint returning:
+- Email, created_at.
+- Active entitlements.
+- Current token balance.
+- Last 20 ledger entries (most recent first).
+- Last 10 Gumroad sales by this user's email.
+
+Useful when a user emails support with "why can't I chat with
+BotMason?" and you need to see the whole picture in one request.
+
+### 3. Structured logging
+
+Every admin mutation logs:
+- `actor="admin"`
+- `action` (e.g., `grant_entitlement`, `revoke_entitlement`,
+  `adjust_balance`)
+- `target_user_id`
+- `reason` (free-form)
+- `source_ip`
+
+These land in the same structured-log stream as user actions, which
+means they show up in whatever log aggregation lands in phase-4-10
+(Railway deployment) without extra wiring.
+
+### 4. Rate limiting and audit
+
+- Apply a `slowapi` limit of `30/minute` per IP on admin endpoints.
+  If we ever see an admin IP hitting this, something's wrong.
+- Persist every admin mutation to an `AdminAuditLog` table (new —
+  separate from the structured logs, for queryable history). Fields:
+  `id`, `action`, `target_user_id`, `payload` (JSON), `reason`,
+  `source_ip`, `idempotency_key`, `created_at`.
+
+### 5. Tests
+
+- Unit: `require_admin` rejects missing header, wrong token, correct
+  header.
+- Integration: `POST /admin/users/{id}/entitlements` creates the
+  entitlement and writes an audit log row.
+- Integration: same idempotency key twice returns the same result;
+  same key with a different body returns 409.
+- Integration: negative balance adjustment is allowed and logged.
+- Integration: `GET /admin/users/{id}/summary` returns the expected
+  shape with real user data.
+- Integration: endpoints return 401 without the admin header.
+- Unit: all admin mutations write a structured log with the expected
+  fields.
+
+## Acceptance criteria
+
+- Operator can grant/revoke course access without touching SQL.
+- Operator can adjust any user's BotMason token balance.
+- Operator can see a user's complete entitlement + wallet state in
+  one call.
+- Every mutation is audited in a queryable table and in structured
+  logs.
+- Missing/invalid admin token returns 401; valid token is required
+  on every admin endpoint.
+- Coverage ≥ 90% on the new files.
+
+## Files to create / modify
+
+| File | Action |
+|------|--------|
+| `backend/src/routers/admin.py` | Modify (large — new admin endpoints) |
+| `backend/src/models/admin_audit_log.py` | Create |
+| `backend/src/domain/admin.py` | Create (thin layer over entitlements + wallet) |
+| `backend/src/main.py` | Modify (admin token env check) |
+| `backend/alembic/versions/xxxx_admin_audit_log.py` | Create |
+| `backend/.env.example` | Modify (`ADMIN_API_TOKEN`) |
+| `backend/tests/routers/test_admin.py` | Create |
+| `README.md` | Modify (brief ops note: how to use the admin endpoints) |
+
+## Notes for implementer
+
+- There's already a `backend/src/routers/admin.py` from an earlier
+  issue — check its existing contents and augment rather than
+  replace. The auth dependency may already exist.
+- Do not expose ledger entries to non-admin users. The existing
+  `/users/me/tokens` endpoint (phase-6-04) returns only the balance,
+  not the history; that's intentional and stays.
+- Resist scope creep: this is not the place to build dashboards,
+  export CSVs, or add per-admin identities. Those are future issues.
+- Keep the admin token out of logs (same caution as the Gumroad
+  webhook secret). The `detect-secrets` hook should catch
+  accidental leaks but don't rely on it.

--- a/prompts/github-issues/phase-6-epic.md
+++ b/prompts/github-issues/phase-6-epic.md
@@ -1,0 +1,107 @@
+# EPIC: Phase 6 — Gumroad-gated access and monetization
+
+**Labels:** `epic`, `phase-6`, `priority-high`, `monetization`
+
+## Summary
+
+APTITUDE (the course Adepthood facilitates) is sold on Gumroad under a
+gift-economy model: the price is "pay what feels right", with free as the
+floor. Adepthood currently has its own email/password auth with no link to
+purchases. This epic makes Gumroad the system-of-record for access and
+introduces a usage-based entitlement for BotMason (so we are not
+subsidizing LLM tokens indefinitely).
+
+Two kinds of entitlement need to be modeled:
+
+1. **Course access** — binary. Granted by a verified Gumroad license for
+   an APTITUDE SKU (one-time or monthly subscription). Free-tier $0
+   licenses count; what matters is that a Gumroad sale exists.
+2. **BotMason tokens** — a per-user balance, debited as the user chats with
+   BotMason and credited by purchasing Gumroad token-pack SKUs. Must
+   coexist with the BYOK path from issue #185: users who supply their own
+   LLM API key via `X-LLM-API-Key` bypass the balance check.
+
+After this epic, signing up for Adepthood requires an existing Gumroad
+purchase. A user lands on the signup screen, is directed to Gumroad to
+"acquire" the course (free is fine), returns with a license key, and
+redeems it. Gumroad webhooks keep entitlements in sync for refunds,
+cancellations, and token-pack purchases.
+
+## Non-goals
+
+- Replacing our email/password auth with Gumroad as an OAuth identity
+  provider (Gumroad does not offer OAuth for end users). We continue to
+  own the JWT and password flow; Gumroad gates who is *allowed* to sign
+  up, not how they authenticate.
+- Stripe or any direct payment integration. Gumroad is the payment rail.
+- Migrating existing users. The app is still in demo, so we assume a
+  clean slate; if needed, a one-off backfill script can be written later.
+
+## Success criteria
+
+- A new user cannot create an Adepthood account without a valid Gumroad
+  license for an APTITUDE SKU.
+- The free-tier ($0) Gumroad variant grants the same course access as
+  the paid variants — price is not what gates access.
+- BotMason chat requests debit from a user-scoped token balance when BYOK
+  is not used; requests fail with a clear `insufficient_tokens` error
+  when the balance is zero and no BYOK key is supplied.
+- A refund or subscription cancellation on Gumroad revokes course access
+  within one webhook delivery window.
+- A Gumroad token-pack purchase credits the buyer's balance
+  idempotently (replaying the same webhook does not double-credit).
+- All Gumroad webhook traffic is HMAC-verified with a shared secret.
+- Manual override endpoints (admin-only) exist for comped access and
+  balance adjustments when Gumroad is unavailable.
+
+## Architecture at a glance
+
+```
+Gumroad (payment + identity gate)
+  │
+  ├─ Sale / subscription / refund webhooks ──▶ /webhooks/gumroad
+  │   (HMAC-verified, idempotent by sale_id)
+  │
+  └─ License verification API ◀────────────── /auth/redeem-license
+                                              (called during signup)
+
+Adepthood backend
+  ├─ models/
+  │    ├─ entitlement.py       # course access flag + metadata
+  │    ├─ token_wallet.py      # balance + ledger entries
+  │    └─ gumroad_sale.py      # raw sale record for idempotency + audit
+  ├─ routers/
+  │    ├─ gumroad.py           # webhook endpoint + license redemption
+  │    └─ auth.py              # signup now checks entitlement
+  └─ domain/
+       ├─ entitlements.py      # grant/revoke logic
+       └─ token_wallet.py      # debit/credit with ledger
+```
+
+## Sub-issues
+
+1. `phase-6-01` — Gumroad API client, webhook scaffolding, HMAC verification
+2. `phase-6-02` — Course entitlement model and signup gating via license redemption
+3. `phase-6-03` — Frontend onboarding flow: redirect to Gumroad and redeem license
+4. `phase-6-04` — BotMason token wallet (model, debit on chat, BYOK bypass)
+5. `phase-6-05` — Token-pack SKU crediting and refund/cancellation revocation
+6. `phase-6-06` — Admin endpoints for manual grants, revocations, and balance adjustments
+
+## Dependencies
+
+- Requires `phase-1-03` (auth router) — complete.
+- Touches `phase-3-07` (BotMason AI) for the token debit hook.
+- Interacts with issue #185 (BYOK) — BYOK requests must bypass the
+  token balance check, not debit zero.
+
+## Open questions to resolve before starting `phase-6-02`
+
+- What is the set of APTITUDE product IDs on Gumroad (one-time, monthly,
+  any pay-what-you-want tiers that have separate IDs)? These become a
+  configured allowlist in the backend.
+- Does the monthly subscription SKU emit `subscription_ended` webhooks
+  we want to treat as access revocation, or do we keep access through
+  the end of the paid period?
+- What is a sensible starting token grant on first redemption, if any?
+  (e.g., "every new account gets N tokens to try BotMason before
+  needing to buy a pack or supply BYOK".)

--- a/prompts/github-issues/phase-6-epic.md
+++ b/prompts/github-issues/phase-6-epic.md
@@ -80,12 +80,18 @@ Adepthood backend
 
 ## Sub-issues
 
-1. `phase-6-01` — Gumroad API client, webhook scaffolding, HMAC verification
-2. `phase-6-02` — Course entitlement model and signup gating via license redemption
-3. `phase-6-03` — Frontend onboarding flow: redirect to Gumroad and redeem license
-4. `phase-6-04` — BotMason token wallet (model, debit on chat, BYOK bypass)
-5. `phase-6-05` — Token-pack SKU crediting and refund/cancellation revocation
-6. `phase-6-06` — Admin endpoints for manual grants, revocations, and balance adjustments
+1. [`phase-6-01`](phase-6-01-gumroad-api-and-webhooks.md) —
+   Gumroad API client, webhook scaffolding, HMAC verification
+2. [`phase-6-02`](phase-6-02-course-entitlement-and-signup-gating.md) —
+   Course entitlement model and signup gating via license redemption
+3. [`phase-6-03`](phase-6-03-frontend-onboarding-flow.md) —
+   Frontend onboarding flow: redirect to Gumroad and redeem license
+4. [`phase-6-04`](phase-6-04-botmason-token-wallet.md) —
+   BotMason token wallet (model, debit on chat, BYOK bypass)
+5. [`phase-6-05`](phase-6-05-token-credits-and-revocation.md) —
+   Token-pack SKU crediting and refund/cancellation revocation
+6. [`phase-6-06`](phase-6-06-admin-override-endpoints.md) —
+   Admin endpoints for manual grants, revocations, and balance adjustments
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Drafts the Phase 6 epic and all six sub-issues for Gumroad-gated access
and monetization. Docs only — no code changes.

- `phase-6-epic.md` — epic spec: Gumroad is the identity gate for
  signup (including the free, pay-what-feels-right tier); BotMason
  usage is metered against a per-user token balance that coexists
  with BYOK from #185.
- `phase-6-01` — Gumroad API client, webhook scaffolding, HMAC
  verification.
- `phase-6-02` — Entitlement model + signup gated by verified license.
- `phase-6-03` — Frontend onboarding flow (welcome screen, Gumroad
  redirect, license redemption form).
- `phase-6-04` — BotMason token wallet (ledger-backed, race-safe,
  BYOK bypass, debit-then-refund pattern).
- `phase-6-05` — Token-pack crediting + refund/cancellation revocation
  via webhook dispatch table.
- `phase-6-06` — Admin endpoints for manual grants, revocations, and
  balance adjustments, with audit log.

Three open questions are flagged in the epic to resolve before
`phase-6-02` implementation begins (product IDs allowlist, subscription
revocation semantics, starter token grant size).

## Test plan

- [ ] Skim the epic — does the architecture match the intended
      gift-economy model?
- [ ] Review the design decisions called out in each sub-issue
      (entitlement-vs-boolean, ledger, race handling, refund
      semantics, admin auth).
- [ ] Flag any scope I should trim or split before implementation.

https://claude.ai/code/session_01FaqKRa5k2zJZtmxW7iNFii