### PR TITLE
fix(frontend): strip trailing slash from API base URL

### DIFF
--- a/frontend/src/__tests__/config.test.ts
+++ b/frontend/src/__tests__/config.test.ts
@@ -20,11 +20,23 @@ describe('config', () => {
     it('allows empty URLs without throwing', () => {
       expect(validateApiBaseUrl('', true)).toBe('');
     });
+
+    it('strips a single trailing slash', () => {
+      expect(validateApiBaseUrl(`${HTTPS_URL}/`, true)).toBe(HTTPS_URL);
+    });
+
+    it('strips multiple trailing slashes', () => {
+      expect(validateApiBaseUrl(`${HTTPS_URL}///`, true)).toBe(HTTPS_URL);
+    });
   });
 
   describe('validateApiBaseUrl in production mode', () => {
     it('accepts HTTPS URLs', () => {
       expect(validateApiBaseUrl(HTTPS_URL, false)).toBe(HTTPS_URL);
+    });
+
+    it('strips a trailing slash on HTTPS URLs', () => {
+      expect(validateApiBaseUrl(`${HTTPS_URL}/`, false)).toBe(HTTPS_URL);
     });
 
     it('throws for HTTP URLs', () => {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -7,7 +7,9 @@ export function validateApiBaseUrl(url: string, isDev: boolean): string {
         `Received: "${url || '(empty)'}"`,
     );
   }
-  return url;
+  // Strip trailing slashes so `${API_BASE_URL}${path}` — where paths always
+  // start with "/" — can't produce "//auth/signup" (which FastAPI 404s).
+  return url.replace(/\/+$/, '');
 }
 
 const rawUrl = process.env.EXPO_PUBLIC_API_BASE_URL || (__DEV__ ? DEV_DEFAULT_URL : '');


### PR DESCRIPTION
## Summary
- Signup (and every other API call) 404s whenever `EXPO_PUBLIC_API_BASE_URL` is deployed with a trailing slash, because `${API_BASE_URL}${path}` produces `//auth/signup`. CORS preflight still returns 200 (Starlette's `CORSMiddleware` short-circuits OPTIONS without consulting the router), but the POST hits the router and 404s — the asymmetry users see in the logs.
- Fix normalizes trailing slashes in `validateApiBaseUrl` (`frontend/src/config.ts`) so the single source of truth is defensive. Covers signup, token refresh (`api/index.ts:129`), and the journal streaming endpoint (`api/index.ts:592`) in one shot.
- Added three test cases to `frontend/src/__tests__/config.test.ts` (single slash in dev, multiple slashes in dev, trailing slash on HTTPS in prod). Confirmed red before the fix, green after.

## Test plan
- [x] `npx jest src/__tests__/config.test.ts` — 13 passed
- [x] `npm test -- --watchAll=false` — 570 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `pre-commit run --files frontend/src/config.ts frontend/src/__tests__/config.test.ts` — clean
- [ ] Manual: deploy and verify `POST /auth/signup` returns 201 on a Railway env with a trailing-slash `EXPO_PUBLIC_API_BASE_URL`

## Follow-up
Recommend also removing the stray `/` from the Railway `EXPO_PUBLIC_API_BASE_URL` value so the bundle doesn't need to compensate — the fix makes the frontend tolerant, but clean config is better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)