### PR TITLE
chore(ci): streamline pre-commit and CI (phase-7-10)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -36,10 +36,11 @@ jobs:
         run: |
           pre-commit run --hook-stage pre-commit --files $(git ls-files 'backend')
 
-      - name: Run tests
+      - name: Run pre-push hooks (complexity + maintainability + tests)
+        # xenon/radon/backend-tests-coverage moved to pre-push locally to keep
+        # `git commit` fast. CI still runs them so nothing escapes review.
         run: |
-          uv pip install --system pytest pytest-cov
-          pytest -q
+          pre-commit run --hook-stage pre-push --files $(git ls-files 'backend')
 
       - name: Security (pip-audit)
         run: |

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version-file: "frontend/.nvmrc"
           cache: "npm"
-          cache-dependency-path: "frontend/package.json"
+          cache-dependency-path: "frontend/package-lock.json"
 
       - name: Install dependencies
         working-directory: frontend

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,9 @@ repos:
           ^frontend/package-lock\.json$
 
   # Python format / lint / type-check
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-        files: ^backend/
-        args: ["--config=backend/pyproject.toml"]
-
+  # ruff-format is the single source of truth for Python formatting;
+  # ruff --fix handles lint auto-fixes. Black was removed to eliminate
+  # redundant/conflicting formatters.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.9
     hooks:
@@ -68,27 +64,29 @@ repos:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
 
-  # Frontend (React Native) checks using local hooks (requires Node in the environment)
+  # Frontend (React Native) checks using local hooks (requires Node in the environment).
+  # `bash -c` is used (not `bash -lc`) so hooks do not depend on interactive shell
+  # profiles (.bashrc/.bash_profile), which keeps CI environments reproducible.
   - repo: local
     hooks:
       - id: frontend-eslint
         name: frontend eslint
         language: system
-        entry: bash -lc 'cd frontend && npm run lint'
+        entry: bash -c 'cd frontend && npm run lint'
         pass_filenames: false
         files: ^frontend/
         exclude: ^frontend/(?:node_modules|dist|build|coverage)/
 
       - id: frontend-prettier
         name: frontend prettier (write)
-        entry: bash -lc 'cd frontend && npx prettier --write .'
+        entry: bash -c 'cd frontend && npx prettier --write .'
         language: system
         files: ^frontend/.*\.(js|jsx|ts|tsx|json|css|md|ya?ml)$
         exclude: ^frontend/(?:node_modules|dist|build|coverage)/|^frontend/(?:tsconfig\.json|package-lock\.json)$
 
       - id: frontend-typecheck
         name: frontend typecheck
-        entry: bash -lc 'cd frontend && npx tsc -p tsconfig.json --noEmit'
+        entry: bash -c 'cd frontend && npx tsc -p tsconfig.json --noEmit'
         language: system
         pass_filenames: false
         files: ^frontend/.*\.(ts|tsx)$
@@ -96,19 +94,21 @@ repos:
 
       - id: frontend-tests
         name: frontend tests
-        entry: bash -lc 'cd frontend && npx jest --passWithNoTests'
+        entry: bash -c 'cd frontend && npx jest --passWithNoTests'
         language: system
         pass_filenames: false
         files: ^frontend/
         exclude: ^frontend/(?:node_modules|dist|build|coverage)/
 
+      # Expensive hooks run on pre-push only. This keeps `git commit` under
+      # ~10s while still gating pushes on the full quality suite.
       - id: xenon-complexity
         name: xenon complexity check
         entry: bash -c '[ -f .venv/bin/activate ] && source .venv/bin/activate; cd backend && xenon src/ --max-absolute A --max-modules A --max-average A'
         language: system
         pass_filenames: false
         files: ^backend/.*\.py$
-        stages: [pre-commit]
+        stages: [pre-push]
 
       - id: radon-maintainability
         name: radon maintainability index
@@ -116,7 +116,7 @@ repos:
         language: system
         pass_filenames: false
         files: ^backend/.*\.py$
-        stages: [pre-commit]
+        stages: [pre-push]
 
       - id: backend-tests-coverage
         name: backend tests (coverage required)
@@ -124,12 +124,12 @@ repos:
         entry: bash -c '[ -f .venv/bin/activate ] && source .venv/bin/activate; cd backend && pytest --cov=. --cov-report=term-missing --cov-fail-under=90'
         pass_filenames: false
         files: ^backend/
-        stages: [pre-commit, pre-push]
+        stages: [pre-push]
 
       - id: commitlint
         name: commitlint (conventional commits)
         language: system
-        entry: bash -lc 'npx commitlint --cwd frontend --extends @commitlint/config-conventional --edit "$1"'
+        entry: bash -c 'cd frontend && npx commitlint --extends @commitlint/config-conventional --edit "$1"'
         stages: [commit-msg]
         # IMPORTANT: commit-msg hooks receive the commit message path as $1
         # so do NOT set pass_filenames: false here.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,10 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 
-[tool.black]
-line-length = 100
-target-version = ["py312"]
-
 [tool.isort]
 profile = "black"
 line_length = 100

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,6 +1,5 @@
 uvicorn
 bandit
-black
 isort
 mypy
 pre-commit


### PR DESCRIPTION
## Summary

Phase 7-10 — streamline pre-commit and CI. Pure configuration cleanup; no production code touched.

- **Drop Black**, rely on `ruff-format` as the sole Python formatter. Removes the redundant formatter that could (and occasionally did) fight with `ruff-format`. Also removes `[tool.black]` from `backend/pyproject.toml` and `black` from `backend/requirements-dev.txt`.
- **Move expensive hooks to `pre-push`** (`xenon-complexity`, `radon-maintainability`, `backend-tests-coverage`) so `git commit` stays fast (formatting + lint only). The backend CI job now runs `pre-commit run --hook-stage pre-push` so nothing slips through review.
- **Fix the frontend CI npm cache key** to depend on `frontend/package-lock.json` (was `package.json`), so cache hits actually occur across runs.
- **Replace `bash -lc` with `bash -c`** in all frontend/local hooks so they no longer depend on interactive shell profiles (`.bashrc` / `.bash_profile`) that may not exist in CI.
- **Rewrite the commitlint entry**: `cd frontend && npx commitlint …` instead of `--cwd frontend`. `--cwd` was being applied to the commitlint tool itself rather than to resolving the workspace, and `bash -lc` is gone for the same reasons as above.

## Test plan

- [x] `pre-commit run --all-files` — green (pre-commit stage: 20 hooks pass, expensive hooks correctly deferred).
- [x] `pre-commit run --all-files --hook-stage pre-push` — green (all 23 hooks pass, including xenon, radon, and backend-tests-coverage at ≥90% coverage).
- [x] `commitlint` verified with both a valid `feat(ci): …` message (exit 0) and a malformed message (exit 1, correct error output).
- [x] Clean commit through the updated `commit-msg` hook.
- [x] Push through the updated `pre-push` hook (full quality suite runs).
- [ ] Verify backend-ci.yml passes in CI (xenon + radon + coverage all enforced via `--hook-stage pre-push`).
- [ ] Verify frontend-ci.yml caches hit on subsequent runs.

## Acceptance criteria (from `prompts/github-issues/phase-7-10-streamline-ci.md`)

- [x] Pre-commit runs formatting + linting only (expensive hooks deferred)
- [x] Pre-push runs full test suite + complexity checks
- [x] No conflicting formatters (Black removed)
- [x] CI cache key uses `package-lock.json`
- [x] commitlint validates commit messages correctly
- [x] Hooks work in both local and CI environments

https://claude.ai/code/session_01DukD31USu243SWVAXojzVe