### PR TITLE
chore: adopt adepthood-linters (tranche 1/5: skills, agents, scripts)

### DIFF
--- a/.claude/agents/chief-architect.md
+++ b/.claude/agents/chief-architect.md
@@ -1,0 +1,72 @@
+---
+name: chief-architect
+description: "Strategic orchestrator for system-wide decisions. Select for research paper selection, repository-wide architectural patterns, cross-section coordination, and technology stack decisions."
+level: 0
+phase: Plan
+tools: Read,Grep,Glob,Task
+model: opus
+delegates_to: [foundation-orchestrator, shared-library-orchestrator, tooling-orchestrator, papers-orchestrator, cicd-orchestrator, agentic-workflows-orchestrator]
+receives_from: []
+---
+# Chief Architect
+
+## Identity
+
+Level 0 meta-orchestrator responsible for strategic decisions across the entire adepthood-linters repository
+ecosystem. Set system-wide architectural patterns, select linting rules and quality checks, and coordinate all 6 section
+orchestrators.
+
+## Scope
+
+- **Owns**: Strategic vision, linting strategy, system architecture, coding standards, quality gates
+- **Does NOT own**: Implementation details, subsection decisions, individual component code
+
+## Workflow
+
+1. **Strategic Analysis** - Review requirements, analyze feasibility, create high-level strategy
+2. **Architecture Definition** - Define system boundaries, cross-section interfaces, dependency graph
+3. **Delegation** - Break down strategy into section tasks, assign to orchestrators
+4. **Oversight** - Monitor progress, resolve cross-section conflicts, ensure consistency
+5. **Documentation** - Create and maintain Architectural Decision Records (ADRs)
+
+## Skills
+
+| Skill | When to Invoke |
+|-------|----------------|
+| `agent-run-orchestrator` | Delegating to section orchestrators |
+| `agent-validate-config` | Creating/modifying agent configurations |
+| `agent-test-delegation` | Testing delegation patterns before deployment |
+| `agent-coverage-check` | Verifying complete workflow coverage |
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle and scope control.
+
+**Chief Architect Specific**:
+
+- Do NOT micromanage implementation details
+- Do NOT make decisions outside repository scope
+- Do NOT override section decisions without clear rationale
+- Focus on "what" and "why", delegate "how" to orchestrators
+
+## Example: Linting Rule Selection and Architecture Definition
+
+**Scenario**: Selecting pylint integration as first linter implementation
+
+**Actions**:
+
+1. Analyze linter requirements and feasibility
+2. Define required components (rule parser, code analyzer, report generator)
+3. Create ADR documenting architecture decisions
+4. Delegate linter configuration to Quality Control Orchestrator
+5. Monitor progress and resolve cross-section conflicts
+
+**Outcome**: Clear architectural vision with all sections aligned
+
+---
+
+**References**: [common-constraints](../shared/common-constraints.md),
+[documentation-rules](../shared/documentation-rules.md),
+[error-handling](../shared/error-handling.md)
+
+---

--- a/.claude/agents/dependency-checker.md
+++ b/.claude/agents/dependency-checker.md
@@ -1,0 +1,107 @@
+---
+name: dependency-review-specialist
+description: "Reviews dependency management, version pinning, environment reproducibility, and license compatibility. Select for requirements.txt, pixi.toml, and dependency conflict resolution."
+level: 3
+phase: Cleanup
+tools: Read,Grep,Glob
+model: sonnet
+delegates_to: []
+receives_from: [code-review-orchestrator]
+---
+# Dependency Review Specialist
+
+## Identity
+
+Level 3 specialist responsible for reviewing dependency management practices, version constraints,
+environment reproducibility, and license compatibility. Focuses exclusively on external dependencies
+and their management.
+
+## Scope
+
+**What I review:**
+
+- Version pinning strategies and semantic versioning
+- Dependency version compatibility
+- Transitive dependency conflicts
+- Environment reproducibility (lock files)
+- License compatibility
+- Platform-specific dependency handling
+- Development vs. production dependency separation
+
+**What I do NOT review:**
+
+- Code architecture (→ Architecture Specialist)
+- Security vulnerabilities (→ Security Specialist)
+- Test dependencies (→ Test Specialist)
+- Performance of dependencies (→ Performance Specialist)
+- Documentation (→ Documentation Specialist)
+
+## Workflow
+
+## Skills
+
+## Constraints
+
+## Output Location
+
+**CRITICAL**: All review feedback MUST be posted directly to the GitHub pull request using
+`gh pr review` or the GitHub MCP. **NEVER** write reviews to local files or `notes/review/`.
+
+## Review Checklist
+
+- [ ] Version pinning strategies are appropriate (not too strict or loose)
+- [ ] No transitive dependency conflicts
+- [ ] Version compatibility across all dependencies verified
+- [ ] Lock files present and up to date (e.g., poetry.lock, Pipfile.lock, requirements.txt with hashes)
+- [ ] Platform-specific dependencies handled correctly
+- [ ] Development vs. production dependencies properly separated
+- [ ] License compatibility checked and documented
+- [ ] No duplicate dependencies
+- [ ] Semantic versioning followed
+- [ ] CI/CD environment matches development environment
+
+## Feedback Format
+
+```markdown
+[EMOJI] [SEVERITY]: [Issue summary] - Fix all N occurrences
+
+Locations:
+- requirements.txt:42: [brief description]
+
+Fix: [2-3 line solution]
+
+See: [link to version compatibility doc]
+```
+
+Severity: 🔴 CRITICAL (must fix), 🟠 MAJOR (should fix), 🟡 MINOR (nice to have), 🔵 INFO (informational)
+
+## Example Review
+
+**Issue**: Overly loose version specification causing inconsistent environments
+
+**Feedback**:
+🟠 MAJOR: Loose version constraint - pylint requirement allows incompatible versions
+
+**Solution**: Pin to compatible range with tested version
+
+```txt
+# requirements.txt
+pylint>=2.15.0,<3.0.0  # Tested with 2.17.x
+astroid>=2.12.0,<3.0.0  # Compatible with pylint constraint
+black>=23.0.0,<24.0.0  # Code formatter for linting standards
+```
+
+## Coordinates With
+
+- [Code Review Orchestrator](./code-review-orchestrator.md) - Receives review assignments
+- [Security Review Specialist](./security-review-specialist.md) - Checks for known vulnerabilities
+
+## Escalates To
+
+- [Code Review Orchestrator](./code-review-orchestrator.md) - Issues outside dependency scope
+
+---
+
+*Dependency Review Specialist ensures reproducible environments, proper version management, and license compatibility.*
+
+---

--- a/.claude/agents/documentation.md
+++ b/.claude/agents/documentation.md
@@ -1,0 +1,82 @@
+---
+name: documentation-specialist
+description: "Level 3 Component Specialist. Select for component documentation. Creates READMEs, API docs, usage examples, and tutorials."
+level: 3
+phase: Package,Cleanup
+tools: Read,Write,Edit,Grep,Glob,Task
+model: sonnet
+delegates_to: [documentation-engineer, junior-documentation-engineer]
+receives_from: [architecture-design, implementation-specialist]
+---
+# Documentation Specialist
+
+## Identity
+
+Level 3 Component Specialist responsible for creating comprehensive documentation for components.
+Primary responsibility: document APIs, create usage examples, write tutorials. Position: receives
+component specs and implementations from designers/implementers, delegates documentation tasks to
+documentation engineers.
+
+## Scope
+
+**What I own**:
+
+- Linter plugin README files and overview documentation
+- Configuration API reference documentation and specifications
+- Usage examples and integration tutorials
+- Code-level documentation strategy
+- Migration guides (for configuration changes)
+
+**What I do NOT own**:
+
+- Implementing documentation yourself - delegate to engineers
+- Writing or modifying code
+- Configuration design decisions - escalate to design agents
+
+## Workflow
+
+1. Receive linter plugin spec and implemented code from designers/implementers
+2. Analyze linter functionality and configuration APIs
+3. Create documentation structure and outline
+4. Write comprehensive configuration reference
+5. Create clear usage examples and integration tutorials
+6. Define code documentation strategy (docstrings, comments)
+7. Delegate detailed documentation writing to Documentation Engineers
+8. Review all documentation for accuracy and clarity
+9. Ensure documentation is published and linked
+
+## Skills
+
+| Skill | When to Invoke |
+|-------|---|
+| doc-issue-readme | Creating issue-specific README structure |
+| doc-validate-markdown | Validating markdown format before publishing |
+| doc-generate-adr | Documenting architectural decisions |
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle.
+
+See [documentation-rules.md](../shared/documentation-rules.md) for documentation location requirements.
+
+**Agent-specific constraints**:
+
+- Do NOT implement documentation yourself - delegate to engineers
+- Do NOT write or modify code
+- All documentation must be accurate and complete
+- Configuration documentation must match implementation exactly
+- Do NOT duplicate docs - link to shared references instead
+
+## Example
+
+**Component**: Python linter plugin for code quality checks
+
+**Documentation**: Overview and features, installation/setup guide, quick start examples, complete configuration
+reference (with types and validation rules), advanced usage patterns, performance characteristics,
+migration guide.
+
+---
+
+**References**: [shared/common-constraints](../shared/common-constraints.md),
+[shared/documentation-rules](../shared/documentation-rules.md),
+[shared/pr-workflow](../shared/pr-workflow.md)

--- a/.claude/agents/performance.md
+++ b/.claude/agents/performance.md
@@ -1,0 +1,81 @@
+---
+name: performance-specialist
+description: "Level 3 Component Specialist. Select for performance-critical components. Defines requirements, designs benchmarks, profiles code, identifies optimizations."
+level: 3
+phase: Plan,Implementation,Cleanup
+tools: Read,Write,Edit,Grep,Glob,Task
+model: sonnet
+delegates_to: [performance-engineer]
+receives_from: [architecture-design, implementation-specialist]
+---
+# Performance Specialist
+
+## Identity
+
+Level 3 Component Specialist responsible for ensuring component performance meets requirements.
+Primary responsibility: define performance baselines, design benchmarks, profile code, identify optimizations.
+Position: works with Implementation Specialist to optimize components.
+
+## Scope
+
+**What I own**:
+
+- Component performance requirements and baselines
+- Benchmark design and specification
+- Performance profiling and analysis strategy
+- Optimization opportunity identification
+- Performance regression prevention
+
+**What I do NOT own**:
+
+- Implementing optimizations yourself - delegate to engineers
+- Architectural decisions
+- Individual engineer task execution
+
+## Workflow
+
+1. Receive component spec with performance requirements
+2. Define clear performance baselines and metrics
+3. Design benchmark suite for all performance-critical operations
+4. Profile reference implementation to identify bottlenecks
+5. Identify optimization opportunities (algorithmic improvements, caching, lazy evaluation)
+6. Delegate optimization tasks to Performance Engineers
+7. Validate improvements meet requirements
+8. Prevent performance regressions
+
+## Skills
+
+| Skill | When to Invoke |
+|-------|---|
+| python-performance-optimize | Defining Python optimization strategies |
+| quality-complexity-check | Identifying performance bottlenecks |
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle.
+
+See [python-best-practices.md](../shared/python-best-practices.md) for Python performance patterns and profiling guidelines.
+
+**Agent-specific constraints**:
+
+- Do NOT implement optimizations yourself - delegate to engineers
+- Do NOT optimize without profiling first
+- Never sacrifice correctness for performance
+- All performance claims must be validated with benchmarks
+- Always consider algorithmic complexity before micro-optimizations
+- Use appropriate profiling tools (cProfile, line_profiler, memory_profiler)
+
+## Example
+
+**Component**: Large codebase linting with multiple rule checks (required: <5s for 10,000 files)
+
+**Plan**: Design benchmarks for various codebase sizes and rule combinations, profile naive implementation, identify bottlenecks
+in rule evaluation and file I/O patterns. Delegate optimization (parallel processing, AST caching, incremental analysis) to Performance Engineer.
+Validate final version meets throughput requirement without missing lint violations.
+
+---
+
+**References**: [common-constraints](../shared/common-constraints.md),
+[python-best-practices](../shared/python-best-practices.md), [documentation-rules](../shared/documentation-rules.md)
+
+---

--- a/.claude/agents/quality-reviewer.md
+++ b/.claude/agents/quality-reviewer.md
@@ -1,0 +1,127 @@
+---
+name: code-review-orchestrator
+description: "Level 2 orchestrator. Coordinates comprehensive code reviews across all dimensions by routing PR changes to appropriate specialist reviewers. Select when PR analysis and specialist coordination required."
+level: 2
+phase: Cleanup
+tools: Read,Grep,Glob,Task
+model: sonnet
+delegates_to: [algorithm-review-specialist, architecture-review-specialist, data-engineering-review-specialist, dependency-review-specialist, documentation-review-specialist, implementation-review-specialist, mojo-language-review-specialist, paper-review-specialist, performance-review-specialist, research-review-specialist, safety-review-specialist, security-review-specialist, test-review-specialist]
+receives_from: []
+---
+# Code Review Orchestrator
+
+## Identity
+
+Level 2 orchestrator responsible for coordinating comprehensive code reviews across the adepthood-linters project.
+Analyzes pull requests and routes different aspects to specialized reviewers, ensuring thorough coverage
+without overlap. Prevents redundant reviews while ensuring all critical dimensions are covered.
+
+## Scope
+
+**What I do:**
+
+- Analyze changed files and determine review scope
+- Route code changes to 11 specialist reviewers
+- Coordinate feedback from multiple specialists
+- Prevent overlapping reviews through clear routing
+- Consolidate specialist feedback into coherent review reports
+- Identify and escalate conflicts between specialist recommendations
+
+**What I do NOT do:**
+
+- Perform individual code reviews (specialists handle that)
+- Override specialist decisions
+- Create unilateral architectural decisions (escalate to Chief Architect)
+
+## Output Location
+
+**CRITICAL**: All review feedback MUST be posted directly to the GitHub pull request.
+
+```bash
+# Post review comments to PR
+gh pr review <pr-number> --comment --body "$(cat <<'EOF'
+## Code Review Summary
+
+[Review content here]
+EOF
+)"
+
+# Or use the GitHub MCP to create review comments
+# mcp__github__pull_request_review_write with method: "create"
+```
+
+**NEVER** write reviews to:
+
+- `notes/review/` directory (reserved for architectural specs only)
+- Local files
+- Issue comments (use PR review comments instead)
+
+## Workflow
+
+1. Receive PR notification
+2. Analyze all changed files (extensions, types, impact)
+3. Categorize changes by dimension (code quality, Python language, security, test coverage, etc.)
+4. Route each dimension to appropriate specialist (one specialist per dimension)
+5. Collect feedback from all specialists in parallel
+6. Identify conflicts or contradictions
+7. **Post consolidated review to GitHub PR** using `gh pr review` or GitHub MCP
+8. Escalate unresolved conflicts to Chief Architect
+
+## Routing Dimensions
+
+| Dimension | Specialist | What They Review |
+|-----------|-----------|------------------|
+| **Correctness** | Implementation | Logic, bugs, maintainability |
+| **Language** | Python Language | Python idioms, type hints, best practices |
+| **Security** | Security | Vulnerabilities, attack vectors |
+| **Safety** | Safety | Type safety, error handling, edge cases |
+| **Performance** | Performance | Algorithmic complexity, optimization |
+| **Testing** | Test | Test coverage, quality, assertions |
+| **Documentation** | Documentation | Clarity, completeness, comments |
+| **Linting Rules** | Linting | Rule implementation, AST patterns, correctness |
+| **Plugin Architecture** | Plugin | Plugin design, extensibility, compatibility |
+| **Architecture** | Architecture | System design, modularity |
+| **Dependencies** | Dependency | Version management, conflicts |
+
+**Rule**: Each file aspect is routed to exactly one specialist per dimension.
+
+## Review Feedback Protocol
+
+See [CLAUDE.md](../../CLAUDE.md#handling-pr-review-comments) for complete protocol.
+
+**For Specialists**: Batch similar issues into single comments, count occurrences, list file:line
+locations, provide actionable fixes.
+
+**For Engineers**: Reply to EACH comment with ✅ Brief description of fix.
+
+## Delegates To
+
+All 11 specialists:
+
+- [Architecture Review Specialist](./architecture-review-specialist.md)
+- [Dependency Review Specialist](./dependency-review-specialist.md)
+- [Documentation Review Specialist](./documentation-review-specialist.md)
+- [Implementation Review Specialist](./implementation-review-specialist.md)
+- [Linting Review Specialist](./linting-review-specialist.md)
+- [Performance Review Specialist](./performance-review-specialist.md)
+- [Plugin Review Specialist](./plugin-review-specialist.md)
+- [Python Language Review Specialist](./python-language-review-specialist.md)
+- [Safety Review Specialist](./safety-review-specialist.md)
+- [Security Review Specialist](./security-review-specialist.md)
+- [Test Review Specialist](./test-review-specialist.md)
+
+## Escalates To
+
+- [Chief Architect](./chief-architect.md) - When specialist recommendations conflict architecturally or
+  major architectural review needed
+
+## Coordinates With
+
+- [CI/CD Orchestrator](./cicd-orchestrator.md) - Integrate reviews into pipeline
+
+---
+
+*Code Review Orchestrator ensures comprehensive, non-overlapping reviews across all dimensions of
+code quality, security, performance, and correctness.*
+
+---

--- a/.claude/agents/refactorer.md
+++ b/.claude/agents/refactorer.md
@@ -1,0 +1,88 @@
+---
+name: implementation-specialist
+description: "Level 3 Component Specialist. Select for component implementation planning. Breaks components into functions/classes, plans implementation, coordinates engineers."
+level: 3
+phase: Plan,Implementation,Cleanup
+tools: Read,Write,Edit,Grep,Glob,Task
+model: sonnet
+delegates_to: [senior-implementation-engineer, implementation-engineer, junior-implementation-engineer]
+receives_from: [architecture-design, integration-design]
+---
+# Implementation Specialist
+
+## Identity
+
+Level 3 Component Specialist responsible for breaking down components into implementable functions and
+classes. Primary responsibility: create detailed implementation plans, coordinate implementation engineers,
+and ensure code quality. Position: receives component specs from Level 2 design agents, delegates
+implementation tasks to Level 4 engineers.
+
+## Scope
+
+**What I own**:
+
+- Complex component breakdown into functions/classes
+- Detailed implementation planning and task assignment
+- Code quality review and standards enforcement
+- Performance requirement validation
+- Coordination of TDD with Test Specialist
+
+**What I do NOT own**:
+
+- Implementing functions myself - delegate to engineers
+- Architectural decisions - escalate to design agents
+- Test implementation
+- Individual engineer task execution
+
+## Workflow
+
+1. Receive component spec from Architecture/Integration Design agents
+2. Analyze component complexity and requirements
+3. Break component into implementable functions and classes
+4. Design class structures, interfaces, and function signatures
+5. Create detailed implementation plan with task assignments
+6. Coordinate TDD approach with Test Specialist
+7. Delegate implementation tasks to appropriate engineers
+8. Monitor progress and review code quality
+9. Validate final implementation against specs
+
+## Skills
+
+| Skill | When to Invoke |
+|-------|---|
+| phase-implement | Coordinating implementation across engineers |
+| quality-run-linters | Code quality validation before PR |
+| python-format | Code formatting with black/isort |
+| quality-complexity-check | Identifying complex functions needing simplification |
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle and skip-level guidelines.
+
+See [python-guidelines.md](../shared/python-guidelines.md) for Python coding standards and best practices.
+
+**Agent-specific constraints**:
+
+- Do NOT implement functions yourself - delegate to engineers
+- Do NOT skip code quality review
+- Do NOT make architectural decisions - escalate
+- Always coordinate TDD with Test Specialist
+
+## Example
+
+**Component**: AST-based code complexity analyzer
+
+**Breakdown**:
+
+- Class ComplexityAnalyzer (configuration, analysis parameters)
+- Function parse_source_file (basic AST parsing, Junior Engineer)
+- Function calculate_cyclomatic_complexity (complexity metrics, Implementation Engineer)
+- Function generate_complexity_report (reporting with optimization, Senior Engineer)
+
+**Plan**: Define test cases for various code patterns, coordinate test writing, review each implementation for correctness and accuracy.
+
+---
+
+**References**: [shared/common-constraints](../shared/common-constraints.md),
+[shared/python-guidelines](../shared/python-guidelines.md),
+[shared/documentation-rules](../shared/documentation-rules.md)

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,0 +1,89 @@
+---
+name: security-specialist
+description: "Select for security implementation and testing. Implements security requirements, applies best practices, performs security testing, identifies and fixes vulnerabilities. Level 3 Component Specialist."
+level: 3
+phase: Implementation
+tools: Read,Write,Edit,Grep,Glob,Task
+model: sonnet
+delegates_to: [implementation-engineer, senior-implementation-engineer, test-engineer]
+receives_from: [security-design]
+---
+# Security Specialist
+
+## Identity
+
+Level 3 Component Specialist responsible for implementing security requirements and ensuring component
+security. Reviews code for vulnerabilities, applies security best practices, performs security testing,
+and coordinates security fixes with Implementation Engineers.
+
+## Scope
+
+- Security requirements implementation
+- Security best practices application
+- Security testing and vulnerability identification
+- Vulnerability remediation planning
+- Secure coding guidance
+
+## Workflow
+
+1. Receive security requirements from Security Design
+2. Review component implementation for vulnerabilities
+3. Identify and document security issues
+4. Create remediation plan
+5. Delegate fixes to Implementation Engineers
+6. Perform security testing
+7. Verify all security controls implemented
+8. Validate security measures effective
+
+## Skills
+
+| Skill | When to Invoke |
+|-------|---|
+| `quality-security-scan` | Scanning code for vulnerabilities |
+| `quality-run-linters` | Checking for security issues |
+| `python-static-analysis` | Analyzing code for security patterns |
+| `python-dependency-audit` | Checking dependencies for vulnerabilities |
+| `gh-create-pr-linked` | Security fixes complete |
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle and scope discipline.
+
+**Security-Specific Constraints:**
+
+- DO: Identify and document all vulnerabilities
+- DO: Create comprehensive security test plans
+- DO: Coordinate with Implementation Engineers on fixes
+- DO: Validate all security controls
+- DO NOT: Implement security fixes yourself (delegate)
+- DO NOT: Skip security testing
+- DO NOT: Approve code with known vulnerabilities
+
+**Escalation Triggers:** Escalate to Security Design when:
+
+- Critical vulnerabilities require architectural changes
+- Security requirements conflict with functionality
+- Fundamental security design needed
+
+## Example
+
+**Task:** Review linter plugin component for security vulnerabilities.
+
+**Actions:**
+
+1. Review implementation code for security issues
+2. Identify path validation gaps (directory traversal in config loading)
+3. Check file size handling (DoS prevention for large codebases)
+4. Verify input validation (malformed configuration files)
+5. Check error messages (no information leakage about system paths)
+6. Create remediation plan
+7. Delegate implementation to engineers
+8. Perform security testing
+
+**Deliverable:** Security vulnerability report with remediation plan and testing results.
+
+---
+
+**References**: [Common Constraints](../shared/common-constraints.md), [Documentation Rules](../shared/documentation-rules.md)
+
+---

--- a/.claude/agents/test-generator.md
+++ b/.claude/agents/test-generator.md
@@ -1,0 +1,84 @@
+---
+name: test-specialist
+description: "Level 3 Component Specialist. Select for test planning and TDD coordination. Creates comprehensive test plans, defines test cases, specifies coverage."
+level: 3
+phase: Plan,Test,Implementation
+tools: Read,Write,Edit,Grep,Glob,Task
+model: sonnet
+delegates_to: [test-engineer, junior-test-engineer]
+receives_from: [architecture-design, implementation-specialist]
+---
+# Linter Specialist
+
+## Identity
+
+Level 3 Component Specialist responsible for designing comprehensive linting strategies for code quality rules.
+Primary responsibility: create linting plans, define rule cases, coordinate rule definition with Implementation Specialist.
+Position: receives rule specs from design agents, delegates rule implementation to linter engineers.
+
+## Scope
+
+**What I own**:
+
+- Rule-level linting planning and strategy
+- Linting case definition (syntax checks, style enforcement, anti-patterns)
+- Coverage requirements (quality over quantity)
+- Rule prioritization and risk-based linting
+- Rule definition coordination with Implementation Specialist
+- CI/CD linting integration planning
+
+**What I do NOT own**:
+
+- Implementing linters yourself - delegate to engineers
+- Architectural decisions
+- Individual linter engineer task execution
+
+## Workflow
+
+1. Receive rule spec from Architecture Design Agent
+2. Design linting strategy covering critical code patterns
+3. Define linting cases (syntax, style, anti-patterns, edge cases)
+4. Specify test code approach and fixtures
+5. Prioritize rules (critical code quality first)
+6. Coordinate rule definition with Implementation Specialist
+7. Define CI/CD integration requirements
+8. Delegate linter implementation to Linter Engineers
+9. Review linting coverage and quality
+
+## Skills
+
+| Skill | When to Invoke |
+|-------|---|
+| phase-lint-rules | Coordinating rule definition workflow |
+| python-linter-runner | Executing linters and verifying coverage |
+| quality-coverage-report | Analyzing linting coverage |
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle.
+
+See [python-guidelines.md](../shared/python-guidelines.md) for Python-specific patterns in linting rules.
+
+**Agent-specific constraints**:
+
+- Do NOT implement linters yourself - delegate to engineers
+- DO focus on quality over quantity (avoid 100% coverage chase)
+- DO lint critical code patterns and error-prone constructs
+- DO coordinate rule definition with Implementation Specialist
+- All linters must run automatically in CI/CD
+
+## Example
+
+**Component**: Import statement validation rule
+
+**Linting Cases**: Basic import detection (basic functionality), relative vs absolute imports, circular import detection
+(edge cases), unused import identification, performance patterns (import optimization), integration with type checkers (integration).
+
+**Coverage**: Focus on correctness and critical patterns, not percentage. Each rule must add confidence.
+
+---
+
+**References**: [common-constraints](../shared/common-constraints.md),
+[python-guidelines](../shared/python-guidelines.md), [documentation-rules](../shared/documentation-rules.md)
+
+---

--- a/.claude/skills/architectural-decisions/SKILL.md
+++ b/.claude/skills/architectural-decisions/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: architectural-decisions
+description: >-
+  Guide explicit, factual trade-off analysis for architectural choices.
+  Use when choosing between libraries, patterns, technologies, databases,
+  or API designs. Presents 2-4 options with comparison matrices and
+  recommendations. Do NOT use for trivial choices, variable naming,
+  or code formatting decisions.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Architectural Decisions
+
+Never make architectural decisions unilaterally. Always present options with explicit, factual trade-off analysis.
+
+## Instructions
+
+### Step 1: Identify the Decision Point
+
+State clearly what needs to be decided:
+- **Decision Required**: Specific choice to be made
+- **Context**: Why this decision matters now
+- **Impact**: What will be affected
+
+### Step 2: Present Options (2-4 alternatives)
+
+For each option, provide:
+- **Name**: Clear, descriptive label
+- **Description**: What this approach entails
+- **Pros**: Factual advantages (measurable when possible)
+- **Cons**: Factual disadvantages (measurable when possible)
+- **Implementation Effort**: Low/Medium/High
+- **Maintenance Impact**: Long-term considerations
+
+### Step 3: Build a Comparison Matrix
+
+Compare options across key dimensions:
+- Performance characteristics
+- Development time
+- Maintenance burden
+- Scalability implications
+- Testing complexity
+- Learning curve
+- Community support
+
+### Step 4: Make a Recommendation
+
+If one option is clearly superior for the context:
+- State factual reasoning based on project constraints
+- Explain why alternatives are less suitable
+- Always let the user make the final decision
+
+### Factual vs Subjective Analysis
+
+**Use factual statements**: "PostgreSQL supports 15K writes/sec", "JWT tokens are ~200 bytes"
+
+**Avoid subjective statements**: "PostgreSQL is better", "JWT is more modern"
+
+## Examples
+
+See `references/examples.md` for three complete worked examples:
+- Database choice (PostgreSQL vs MongoDB vs SQLite)
+- Authentication strategy (JWT vs Session Cookies vs API Keys)
+- Error response format (RFC 7807 vs Simple Object vs Framework Default)
+
+### Example 1: Quick Decision Template
+
+```markdown
+## Architectural Decision: [Topic]
+
+**Context**: [Why we need to decide this now]
+**Impact**: [What parts of the system are affected]
+
+### Option 1: [Name]
+**Pros**: ...
+**Cons**: ...
+**Implementation**: [Low/Medium/High]
+
+### Option 2: [Name]
+**Pros**: ...
+**Cons**: ...
+**Implementation**: [Low/Medium/High]
+
+### Comparison Matrix
+| Criterion | Option 1 | Option 2 |
+|-----------|----------|----------|
+| Performance | ... | ... |
+| Dev Time | ... | ... |
+
+### Recommendation
+**Recommended**: Option X
+**Rationale**: [Factual reasoning]
+
+**Question for User**: Which option should we proceed with?
+```
+
+### Example 2: When NOT to Use This Skill
+
+- Variable naming choices -> just follow project conventions
+- Code formatting -> use the linter
+- Trivial choices with no trade-offs -> just pick one
+- Decisions already made -> follow existing patterns
+
+## Troubleshooting
+
+### Error: Analysis paralysis with too many options
+- Limit to 2-4 realistic options
+- Eliminate obviously unsuitable options early
+- Focus comparison on the 3-4 most important criteria for this project
+
+### Error: Recommendation feels subjective
+- Replace opinions with metrics: throughput, latency, LOC, dependency count
+- Reference benchmarks or documentation
+- State "when this matters" for each pro/con

--- a/.claude/skills/architectural-decisions/references/examples.md
+++ b/.claude/skills/architectural-decisions/references/examples.md
@@ -1,0 +1,207 @@
+# Architectural Decision Examples
+
+## Example 1: Database Choice
+
+```markdown
+## Architectural Decision: Database for User Data
+
+**Context**: Need to persist user data (users, sessions, preferences)
+**Impact**: Data layer, API response times, operational complexity
+
+### Option 1: PostgreSQL (Relational)
+
+**Pros**:
+- Strong consistency guarantees (ACID transactions)
+- Rich query capabilities (JOINs, aggregations, full-text search)
+- Mature ecosystem (SQLAlchemy, Django ORM)
+- Data integrity via foreign keys and constraints
+- Well-understood operational patterns
+
+**Cons**:
+- Vertical scaling limitations (~15K-20K writes/sec single server)
+- Schema migrations required for changes
+- More complex local development setup
+- Higher resource usage for simple key-value operations
+
+**Implementation**: Low (SQLAlchemy already common)
+**Maintenance**: Low (well-documented, stable)
+
+### Option 2: MongoDB (Document)
+
+**Pros**:
+- Flexible schema (easy to add fields without migrations)
+- Horizontal scaling built-in (~30K writes/sec per shard)
+- Good performance for document retrieval (~2-3x faster for document-centric patterns)
+- JSON-native (matches API data structures)
+
+**Cons**:
+- Eventual consistency by default
+- No foreign key constraints (integrity in application layer)
+- Less efficient for complex queries (no JOINs)
+- Larger disk footprint (data duplication from denormalization)
+
+**Implementation**: Medium (need new ODM, different patterns)
+**Maintenance**: Medium (requires MongoDB expertise)
+
+### Option 3: SQLite (Embedded)
+
+**Pros**:
+- Zero configuration (single file)
+- ACID compliant
+- Fast for read-heavy workloads
+
+**Cons**:
+- Single writer limitation
+- Not suitable for distributed systems
+- Migration path to production DB required
+
+**Implementation**: Low (stdlib support)
+
+### Comparison Matrix
+
+| Criterion | PostgreSQL | MongoDB | SQLite |
+|-----------|------------|---------|--------|
+| Write Throughput | ~15K/sec | ~30K/sec per shard | ~5K/sec |
+| Data Integrity | Excellent (FK, constraints) | App-layer only | Excellent |
+| Scalability | Vertical + read replicas | Horizontal (sharding) | None |
+| Operational Cost | ~$50/mo managed | ~$100/mo managed | Free |
+| Learning Curve | Low (SQL) | Medium (query API) | Low (SQL) |
+
+### Recommendation
+
+**Recommended**: PostgreSQL
+- Data integrity critical for user/session data
+- Rich queries needed for analytics
+- Write volume well within single-server capacity
+- Team has SQL expertise
+
+**Alternative**: SQLite for rapid prototyping if production deployment not planned.
+```
+
+---
+
+## Example 2: Authentication Strategy
+
+```markdown
+## Architectural Decision: User Authentication
+
+**Context**: Need to authenticate users for API endpoints
+**Impact**: Security model, session management, API design
+
+### Option 1: JWT (Stateless)
+
+**Pros**:
+- Stateless (no server-side session storage)
+- Scales horizontally (no shared session state)
+- Contains user claims (reduces DB lookups, ~50ms saved/request)
+- Works across domains (CORS-friendly)
+
+**Cons**:
+- Cannot invalidate tokens before expiry (logout delay)
+- Token size larger (~200 bytes vs 32 bytes session ID)
+- XSS risk if stored in localStorage
+- Requires client-side token management
+
+**Implementation**: Medium (PyJWT, token refresh logic)
+
+### Option 2: Session Cookies (Stateful)
+
+**Pros**:
+- Small cookie size (32 bytes)
+- Easy to invalidate (delete server-side session)
+- Secure defaults (httpOnly, secure, sameSite)
+- Simple implementation
+
+**Cons**:
+- Requires session storage (Redis ~$20/mo)
+- Sticky sessions or shared store for scaling
+- CSRF protection needed
+- Not ideal for mobile apps
+
+**Implementation**: Low (Flask-Session)
+
+### Option 3: API Keys (Static)
+
+**Pros**:
+- Simple to implement
+- Good for service-to-service auth
+
+**Cons**:
+- No expiration (security risk if leaked)
+- No user context
+- Not suitable for user-facing auth
+
+### Comparison Matrix
+
+| Criterion | JWT | Session Cookie | API Key |
+|-----------|-----|----------------|---------|
+| Security | Medium (XSS risk) | High (httpOnly) | Low (no expiry) |
+| Scalability | Excellent (stateless) | Good (needs Redis) | Excellent |
+| Logout | Hard (wait expiry) | Easy (delete session) | Hard |
+| Mobile Support | Excellent | Limited | Good |
+| Bandwidth | ~200 bytes/req | ~32 bytes/req | ~64 bytes/req |
+
+### Recommendation
+
+**Recommended**: Session Cookies
+- User-facing web app: httpOnly cookies eliminate XSS
+- Flask-Session: 10 LOC vs JWT's 50+ LOC
+- Immediate logout is expected behavior
+- Single server: stateless benefit unused
+
+**Alternative**: JWT if mobile app required or microservices planned.
+```
+
+---
+
+## Example 3: Error Response Format
+
+```markdown
+## Architectural Decision: Error Response Format
+
+**Context**: Need consistent error responses from API
+**Impact**: API contract, client error handling, debugging
+
+### Option 1: Problem Details (RFC 7807)
+
+**Pros**: Industry standard, machine-readable, extensible
+**Cons**: ~100 bytes overhead, requires implementation
+**Implementation**: Medium (50 LOC)
+
+Example:
+```json
+{
+  "type": "https://api.example.com/errors/validation",
+  "title": "Validation Failed",
+  "status": 400,
+  "detail": "Email field is required"
+}
+```
+
+### Option 2: Simple Error Object
+
+**Pros**: Minimal (~30 bytes), trivial to implement
+**Cons**: No standard, not extensible
+**Implementation**: Low (5 LOC)
+
+### Option 3: FastAPI Default
+
+**Pros**: Zero implementation, consistent with ecosystem
+**Cons**: Not customizable, format varies by error type
+**Implementation**: Zero
+
+### Comparison Matrix
+
+| Criterion | Problem Details | Simple Object | FastAPI Default |
+|-----------|----------------|---------------|-----------------|
+| Payload Size | ~100 bytes | ~30 bytes | ~20 bytes |
+| Implementation | 50 LOC | 5 LOC | 0 LOC |
+| Extensibility | Excellent | Poor | Limited |
+
+### Recommendation
+
+**Recommended**: FastAPI Default
+- Zero implementation cost
+- Sufficient for current needs
+- Can enhance later if building public API
+```

--- a/.claude/skills/backlog-grooming/SKILL.md
+++ b/.claude/skills/backlog-grooming/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: backlog-grooming
+description: >-
+  Systematic GitHub backlog maintenance: review merged PRs, close resolved
+  issues, identify gaps, and create missing issues. Use when asked to
+  groom the backlog, clean up the issue tracker, or review recent work.
+  Do NOT use for PR code review (use comprehensive-pr-review) or
+  issue-first development workflow and PR creation (use git-workflow).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Backlog Grooming
+
+Systematically review recent work, close resolved issues, identify gaps, and maintain a clean issue backlog.
+
+## Instructions
+
+### Step 1: Initialize Progress Tracking
+
+Create a dated progress file:
+```bash
+DATE=$(date +%Y-%m-%d)
+PROGRESS_FILE="plan/${DATE}_BACKLOG_GROOMING.md"
+```
+
+### Step 2: Fetch and Analyze Recent PRs
+
+```bash
+gh pr list --state merged --limit 15 --json number,title,mergedAt,body,url
+```
+
+For each PR, extract:
+- Issues referenced (closes #N, fixes #N, resolves #N)
+- Work done (features, fixes, refactors)
+- Gaps (work done without corresponding issues)
+
+### Step 3: Verify Issue Resolution
+
+For each issue referenced in PRs:
+```bash
+gh issue view 123 --json state,title,labels
+```
+
+Decision matrix:
+- **Fully resolved** -> Close with comment referencing PR
+- **Partially resolved** -> Update with progress comment
+- **Not resolved** -> Keep open, remove incorrect PR reference
+- **Spawned new work** -> Create follow-up issue, close original
+
+### Step 4: Close Resolved Issues
+
+```bash
+gh issue close 123 --comment "Resolved in PR #456. [Description of fix]. Changes: [list]. Closes via: [PR URL]"
+```
+
+### Step 5: Check for Duplicates Before Creating New Issues
+
+```bash
+gh issue list --search "keyword" --state all
+gh issue list --label "bug" --state open
+```
+
+### Step 6: Create Missing Issues
+
+For gaps identified (features, bugs fixed, follow-up work) that have no existing issue:
+```bash
+gh issue create --title "Issue title" --body "Description" --label "label1,label2"
+```
+
+### Step 7: Finalize Progress File
+
+Complete the summary with statistics: PRs analyzed, issues closed, issues created, issues updated, backlog health before/after.
+
+## Examples
+
+See `references/templates.md` for issue close/create templates and `references/example-session.md` for a complete grooming session walkthrough.
+
+### Example 1: Closing a Resolved Issue
+
+```bash
+gh issue close 123 --comment "Resolved in PR #456
+
+Added input validation for single-object payloads.
+
+Changes:
+- Added type check in process_input()
+- Added test for single-object case
+
+Thank you for reporting! Fix is merged and available."
+```
+
+### Example 2: Creating a Follow-Up Issue
+
+```bash
+gh issue create --title "perf: Optimize database queries in user search" \
+  --body "During PR #458, identified N+1 query in user search. Need to add eager loading." \
+  --label "enhancement,performance"
+```
+
+## Troubleshooting
+
+### Error: Too many PRs to review
+- Focus on most recent PRs first
+- Split into multiple sessions, document stopping point
+- Default to last 15 PRs unless specified otherwise
+
+### Error: Can't find issues referenced in PR
+- Check PR body AND individual commit messages
+- Look for variations: "close", "fix", "resolve" (with/without #)
+- If genuinely missing, create retrospective issue
+
+### Error: Found many duplicate issues
+- Consolidate into a canonical issue
+- Close duplicates with link to canonical
+- Consider improving issue labels/search to prevent future duplicates

--- a/.claude/skills/backlog-grooming/references/example-session.md
+++ b/.claude/skills/backlog-grooming/references/example-session.md
@@ -1,0 +1,58 @@
+# Example Grooming Session
+
+## Backlog Grooming Session: 2026-01-27
+
+### Parameters
+- PRs Reviewed: Last 15
+- Date Range: 2026-01-20 to 2026-01-27
+- Started: 10:00
+- Completed: 11:30
+
+### Phase 1: PR Analysis
+
+Analyzed PRs #450-465:
+- 12 PRs referenced issues
+- 3 PRs had no issue reference
+- 2 PRs partially resolved issues
+
+### Phase 2: Issue Resolution
+
+Closed 8 issues:
+- #120 via PR #450 (authentication bug)
+- #121 via PR #451 (export feature)
+- #122 via PR #452 (documentation update)
+- #123 via PR #453 (test coverage)
+- #124 via PR #455 (API validation)
+- #125 via PR #457 (performance fix)
+- #126 via PR #460 (dependency update)
+- #127 via PR #462 (config refactor)
+
+### Phase 3: Gap Identification
+
+Created 3 new issues:
+- #500 - Performance optimization follow-up (from PR #455 TODO)
+- #501 - Test coverage gap in auth module (from PR #450 review)
+- #502 - Documentation update for new API endpoints (from PR #458)
+
+### Phase 4: Cleanup
+
+Updated 2 issues:
+- #99 - Added progress comment from PR #458
+- #100 - Removed "blocked" label (blocker resolved in PR #460)
+
+### Summary
+
+**Statistics:**
+- PRs analyzed: 15
+- Issues closed: 8
+- Issues created: 3
+- Issues updated: 2
+- Duplicates avoided: 1
+- Time spent: 1.5 hours
+
+**Backlog Health:**
+- Before: 45 open issues
+- After: 40 open issues
+- Net change: -5 issues
+
+**Next grooming:** 2026-02-03

--- a/.claude/skills/backlog-grooming/references/templates.md
+++ b/.claude/skills/backlog-grooming/references/templates.md
@@ -1,0 +1,107 @@
+# Backlog Grooming Templates
+
+## Issue Close Comment Template
+
+```markdown
+Resolved in PR #XXX
+
+[1-2 sentence description of solution]
+
+Changes made:
+- [Change 1]
+- [Change 2]
+
+Thank you for [reporting/requesting] this! The fix will be available in [version/release].
+
+Closes via: [PR URL]
+```
+
+## Retrospective Issue Template
+
+For documenting work completed without a tracking issue:
+
+```markdown
+## Context
+
+This retrospective issue documents work completed in PR #XXX.
+
+## What Was Done
+
+[Description]
+
+## Why
+
+[Rationale]
+
+## Related
+
+- PR #XXX
+- Issue #XXX (if any)
+
+## Status
+
+Completed in PR #XXX
+Documented: YYYY-MM-DD
+```
+
+## Follow-up Issue Template
+
+For work identified during grooming that needs future attention:
+
+```markdown
+## Background
+
+During PR #XXX, we identified: [description]
+
+## Problem
+
+[What needs addressing]
+
+## Proposed Solution
+
+[If known]
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Priority
+
+[High/Medium/Low] - [Why]
+
+## Related
+
+- PR #XXX - Where this was identified
+- Issue #XXX - Original work (if any)
+```
+
+## Progress File Template
+
+```markdown
+# Backlog Grooming Session: YYYY-MM-DD
+
+## Parameters
+- **PRs Reviewed**: Last N PRs
+- **Date Range**: YYYY-MM-DD to YYYY-MM-DD
+
+## Phase 1: PR Analysis
+[PR-by-PR analysis]
+
+## Phase 2: Issue Resolution
+### Closed Issues
+- [x] #123 - Title -> Closed via PR #456
+
+## Phase 3: Gap Identification
+### New Issues Created
+- [ ] #789 - Title -> Created
+
+## Summary
+- PRs analyzed: N
+- Issues closed: N
+- Issues created: N
+- Issues updated: N
+
+## Next Grooming
+**Recommended**: YYYY-MM-DD
+```

--- a/.claude/skills/bug-squashing-methodology/SKILL.md
+++ b/.claude/skills/bug-squashing-methodology/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: bug-squashing-methodology
+description: >-
+  Structured 5-step bug fix process with root cause analysis and TDD.
+  Use when fixing bugs, debugging failures, or investigating defects.
+  Covers RCA documentation, reproduction, TDD fix cycle, and PR workflow.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Bug Squashing Methodology
+
+Systematic process for fixing bugs: Document, Understand, Fix, Verify. Never skip straight to coding.
+
+## Instructions
+
+### Step 1: Root Cause Analysis (RCA)
+
+Before writing any fix, understand what's actually broken. Create an RCA with:
+- **Problem Statement**: Exact error message, reproduction steps, which test/endpoint fails
+- **Root Cause**: Exact file, line, and logic causing the failure
+- **Analysis**: Why it happens — trace the data flow, check schema mismatches, verify mocks
+- **Impact**: What's broken, what depends on it, is it blocking other work?
+- **Contributing Factors**: Why wasn't it caught? Missing test? Schema drift?
+- **Fix Strategy**: Options with recommended approach
+
+### Step 2: Reproduce First
+
+```bash
+# Backend: run the specific failing test
+source .venv/bin/activate
+cd backend && pytest tests/test_file.py::test_name -x -v
+
+# Frontend: run the specific failing test
+cd frontend && npx jest __tests__/file.test.tsx -t "test name"
+```
+
+If the test doesn't exist yet, write one that reproduces the bug before fixing anything.
+
+**For 422/validation errors**: Always capture the response body:
+```python
+resp = await async_client.post("/endpoint", json=payload)
+if resp.status_code != expected:
+    print(f"Status: {resp.status_code}, Body: {resp.json()}")
+```
+
+**For mock-related failures**: Check that:
+- Fixtures override the right dependencies
+- Test DB session is properly injected
+- Rate limiter is reset between tests
+- Schema changes are reflected in test payloads
+
+### Step 3: TDD Fix Cycle
+
+1. **Red**: Write/update a test that reproduces the bug (confirm it fails)
+2. **Green**: Write the minimal fix (test passes)
+3. **Refactor**: Clean up while keeping tests green
+
+### Step 4: Quality Gates
+
+```bash
+# Backend
+source .venv/bin/activate
+cd backend && pytest --cov=. --cov-report=term-missing --cov-fail-under=90
+
+# Frontend
+cd frontend && npm test -- --watchAll=false
+
+# All hooks
+pre-commit run --all-files
+```
+
+### Step 5: Commit and PR
+
+Use conventional commit: `fix(component): brief description`
+
+Include in commit body:
+- What was broken and why (reference RCA)
+- What the fix does
+- Confirmation that both quality gates pass
+
+## Troubleshooting
+
+### Error: Can't reproduce locally
+- Check if test fixtures properly override dependencies (get_session, rate limiter)
+- Verify test database is SQLite in-memory (conftest.py)
+- Check for environment-dependent behavior (timezone, locale)
+
+### Error: Fix breaks other tests
+- Run full suite, not just the failing test
+- Check if other tests depended on buggy behavior
+- Look for shared mutable state between tests
+
+### Error: 422 from FastAPI endpoint in tests
+- Capture `resp.json()` to see Pydantic validation details
+- Compare test payload against the current Pydantic model
+- Check if schema fields were added/renamed/required since the test was written
+- Verify Content-Type header is correct (json= vs data=)

--- a/.claude/skills/ci-debugging/SKILL.md
+++ b/.claude/skills/ci-debugging/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: ci-debugging
+description: >-
+  Debug CI test failures on pull requests with structured protocol.
+  Use when CI fails on your PR, tests pass locally but fail in CI,
+  or you're tempted to say "pre-existing issue". Covers state comparison,
+  error reading, local reproduction, and common root causes.
+  Do NOT use for local-only test failures or feature development.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# CI Debugging
+
+If tests passed before and fail now, YOUR changes broke something. Debug properly.
+
+## Instructions
+
+### Step 1: Compare States (2 minutes)
+
+```bash
+# What did the last passing PR have?
+gh pr view <last-passing-pr> --json checks
+
+# What does my PR have?
+gh pr checks <my-pr>
+
+# What changed between them?
+git diff <last-passing-commit> HEAD
+```
+
+Ask: Did I modify config files? Add dependencies? Change imports or module structure?
+
+### Step 2: Read the Actual Error (5 minutes)
+
+```bash
+gh run view --job=<failing-job-id> --log | grep -A 50 "ERROR\|FAILED\|AssertionError"
+```
+
+Look for: path issues, configuration errors, dependency problems, file artifacts.
+
+### Step 3: Reproduce Locally (5 minutes)
+
+```bash
+pytest tests/ --strict-markers --strict-config -v
+pytest --cov=<package> --cov-report=term --cov-fail-under=90
+pytest <failing-test-file>::<failing-test> -vv
+```
+
+If it passes locally but fails in CI, check environment differences, test artifacts, coverage configuration, and absolute paths.
+
+### Step 4: Inspect Your Changes (10 minutes)
+
+```bash
+# Config changes
+git diff HEAD~1 pyproject.toml
+git diff HEAD~1 .github/workflows/
+
+# Test artifacts
+find . -name "*project*" -o -name "MagicMock" -o -name "tmp*"
+
+# Import validation
+python -c "from my_package import main; print('OK')"
+```
+
+### Step 5: Fix and Verify
+
+Make a targeted fix, verify locally, push, confirm CI passes.
+
+## Examples
+
+### Example 1: Coverage Failure
+
+**Symptom**: "Required test coverage of 90% not reached. Total coverage: 57.14%"
+
+**Root Cause**: Test-generated files being measured by coverage.
+
+**Debug**:
+```bash
+pytest --cov=. --cov-report=term | grep -v "my_package"
+# Shows: my_project/main.py  50.00%  ← shouldn't be measured
+```
+
+**Fix**: Add both glob patterns to coverage omit:
+```toml
+[tool.coverage.run]
+omit = [
+    "*/artifact/*",  # Nested paths
+    "artifact/*",    # Root paths
+]
+```
+
+### Example 2: Marker Error
+
+**Symptom**: "'e2e' not found in `markers` configuration option"
+
+**Root Cause**: Added `@pytest.mark.e2e` but didn't register marker.
+
+**Fix**:
+```toml
+[tool.pytest.ini_options]
+markers = [
+    "e2e: marks tests as end-to-end tests",
+]
+```
+
+### Example 3: Import Error After Module Rename
+
+**Symptom**: "ModuleNotFoundError: No module named 'old_name'"
+
+**Root Cause**: Renamed module but didn't update all imports.
+
+**Debug**:
+```bash
+git diff HEAD~1 --name-status | grep -E "^R"  # Find renames
+grep -r "old_name" src/ tests/                  # Find stale imports
+```
+
+## Troubleshooting
+
+### Error: "Passes locally, fails in CI"
+- Check for hardcoded paths or environment-specific assumptions
+- Ensure test cleanup removes all artifacts (tmp files, directories)
+- Verify coverage omit patterns work with both `*/pattern/*` and `pattern/*`
+- Check working directory differences between local and CI
+
+### Error: "Flaky test - sometimes passes, sometimes fails"
+- Look for test order dependencies (use `pytest-randomly`)
+- Check for shared state between tests (global variables, class-level state)
+- Look for timing-sensitive code (use mocked time)
+- Check for file system race conditions in parallel test runs
+
+### Error: Spending more than 30 minutes debugging
+- Re-read the actual error message carefully
+- Check if you modified any config files (pyproject.toml, .github/)
+- Compare your branch with the last green commit line by line
+- Ask: "What's different between the passing state and my state?"

--- a/.claude/skills/comprehensive-pr-review/SKILL.md
+++ b/.claude/skills/comprehensive-pr-review/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: comprehensive-pr-review
+description: >-
+  Structured 10-section PR review covering security, quality, testing,
+  and documentation. Use when reviewing pull requests, evaluating code
+  changes, or doing code review. Produces verdicts with specific references.
+  Do NOT use for backlog grooming or issue triage (use backlog-grooming)
+  or issue-first development workflow and PR creation (use git-workflow).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Comprehensive PR Review
+
+Structured code review evaluating PRs across security, quality, testing, documentation, and project compliance.
+
+## Instructions
+
+### Step 1: Summarize the PR
+Brief overview of what the PR does (2-3 sentences).
+
+### Step 2: Identify Strengths
+What is done well: good design decisions, well-written code, comprehensive tests, clear documentation, proper error handling.
+
+### Step 3: Security Review
+Flag security issues with severity:
+- **BLOCKING**: Must fix before merge (injection, auth bypass, secrets exposure)
+- **HIGH**: Should fix soon (missing input validation, weak crypto)
+- **LOW**: Nice to have (hardening, defense-in-depth)
+
+### Step 4: Identify Problems
+Critical issues blocking merge: bugs, incorrect logic, failing tests, missing required features.
+
+### Step 5: Evaluate Code Quality
+Non-blocking improvements: readability, naming, organization, complexity.
+
+### Step 6: Check Project Compliance
+Verify against project standards (adjust to project's CLAUDE.md):
+- Test coverage meets threshold
+- Docstring coverage meets threshold
+- Linting rules pass
+- Type checking passes
+- No forbidden patterns
+- Conventional commits used
+
+### Step 7: Assess Testing
+- Test coverage adequate?
+- Edge cases covered?
+- Integration tests included?
+
+### Step 8: Review Documentation
+- Docstrings complete?
+- README updated if needed?
+- Examples provided for new APIs?
+
+### Step 9: List Requests
+Medium-priority suggestions that would improve the PR.
+
+### Step 10: Deliver Verdict
+- **LGTM** - Ready to merge
+- **CHANGES_REQUESTED** - Must fix blocking issues
+- **COMMENTS** - Suggestions only, can merge as-is
+
+Include reasoning with specific file:line references.
+
+## Examples
+
+### Example 1: Approval with Suggestions
+
+```markdown
+## Summary
+Adds user search endpoint with partial name/email matching.
+
+## Strengths
+- Clean separation of concerns (router -> service -> repository)
+- Parameterized SQL queries prevent injection
+- Good test coverage (94%)
+
+## Security Concerns
+None identified.
+
+## Problems
+None blocking.
+
+## Code Quality
+- Consider extracting the search query builder into its own method
+- `search_users` could benefit from a `limit` parameter with default
+
+## Verdict: LGTM
+Well-structured PR with good test coverage. Suggestions are non-blocking.
+```
+
+### Example 2: Changes Requested
+
+```markdown
+## Summary
+Adds file upload endpoint for user avatars.
+
+## Security Concerns
+- BLOCKING: No file type validation - allows arbitrary file upload (src/api/upload.py:23)
+- HIGH: No file size limit - potential DoS vector (src/api/upload.py:15)
+
+## Problems
+- Missing error handling for disk full scenario (src/services/storage.py:45)
+- Test doesn't verify file content, only status code (tests/test_upload.py:30)
+
+## Verdict: CHANGES_REQUESTED
+Security concerns must be addressed before merge. Add file type whitelist
+and size limit validation.
+```
+
+## Troubleshooting
+
+### Error: PR is too large to review effectively
+- Ask the author to split into smaller PRs
+- Focus on the most critical files first (API surface, security-sensitive code)
+- Use `gh pr diff --name-only` to prioritize which files to review
+
+### Error: Unclear what the PR is supposed to do
+- Check for linked issues or a description
+- Ask the author to add context before reviewing
+- Review the test names - they often describe intended behavior

--- a/.claude/skills/concurrency/SKILL.md
+++ b/.claude/skills/concurrency/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: concurrency
+description: >-
+  Safe and efficient concurrent code patterns across languages.
+  Use when implementing async operations, parallel processing,
+  thread pools, or managing shared state. Covers Python asyncio,
+  TypeScript Promises, Go goroutines, and Rust Tokio.
+  Do NOT use for general performance optimization without concurrency.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Concurrency
+
+Prefer immutability, minimize shared state, use structured concurrency, handle cancellation explicitly.
+
+## Instructions
+
+### Step 1: Choose the Right Concurrency Model
+
+- **I/O-bound** (network, file, database): Use async/await
+- **CPU-bound with I/O**: Use thread pools
+- **True parallelism (CPU-intensive)**: Use process pools or language-native parallelism
+
+### Step 2: Apply Language-Specific Patterns
+
+See `references/patterns-by-language.md` for detailed patterns.
+
+Key rules:
+- Always handle errors in concurrent tasks (never fire-and-forget)
+- Use context managers / structured concurrency for cleanup
+- Limit concurrency with semaphores (don't spawn unlimited tasks)
+- Use channels/queues for communication, not shared state
+
+### Step 3: Avoid Anti-Patterns
+
+- **Fire and forget**: Always await or handle task results
+- **Unhandled rejections**: Catch errors in every concurrent branch
+- **Race conditions**: Use locks for shared state, or eliminate shared state
+- **Blocking in async**: Never call blocking I/O in async code
+
+## Examples
+
+### Example 1: Python asyncio - Concurrent HTTP Fetches
+
+```python
+async def process_multiple_urls(urls: list[str]) -> list[dict]:
+    tasks = [fetch_data(url) for url in urls]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    valid_results = []
+    for result in results:
+        if isinstance(result, Exception):
+            logger.error(f"Failed to fetch: {result}")
+        else:
+            valid_results.append(result)
+    return valid_results
+```
+
+### Example 2: Go - Goroutines with WaitGroup
+
+```go
+func processItems(items []Item) []Result {
+    results := make([]Result, len(items))
+    var wg sync.WaitGroup
+    for i, item := range items {
+        wg.Add(1)
+        go func(index int, it Item) {
+            defer wg.Done()
+            results[index] = processItem(it)
+        }(i, item)
+    }
+    wg.Wait()
+    return results
+}
+```
+
+## Troubleshooting
+
+### Error: Tasks silently failing
+- Check if you're using `asyncio.gather(*tasks, return_exceptions=True)` and actually inspecting the results
+- In Go, ensure goroutine panics are recovered
+- In TypeScript, add `.catch()` to every Promise or use try/catch with await
+
+### Error: Deadlock or hang
+- Check for lock ordering issues (always acquire locks in the same order)
+- Look for await inside a lock that another task needs
+- Use timeouts on all blocking operations

--- a/.claude/skills/concurrency/references/patterns-by-language.md
+++ b/.claude/skills/concurrency/references/patterns-by-language.md
@@ -1,0 +1,164 @@
+# Concurrency Patterns by Language
+
+## Python
+
+### asyncio (I/O-bound)
+```python
+async def fetch_data(url: str) -> dict:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            return await response.json()
+
+async def process_multiple_urls(urls: list[str]) -> list[dict]:
+    tasks = [fetch_data(url) for url in urls]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    return [r for r in results if not isinstance(r, Exception)]
+```
+
+### ThreadPoolExecutor (CPU-bound with I/O)
+```python
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+def process_files_concurrently(file_paths: list[Path]) -> list[dict]:
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {executor.submit(process_file, p): p for p in file_paths}
+        results = []
+        for future in as_completed(futures):
+            try:
+                results.append(future.result())
+            except Exception as e:
+                logger.error(f"Failed {futures[future]}: {e}")
+        return results
+```
+
+### ProcessPoolExecutor (true parallelism)
+```python
+from concurrent.futures import ProcessPoolExecutor
+
+def parallel_processing(datasets: list[bytes]) -> list[int]:
+    with ProcessPoolExecutor() as executor:
+        return list(executor.map(cpu_intensive_task, datasets))
+```
+
+## TypeScript
+
+### Promise.all with error handling
+```typescript
+async function fetchMultipleResources(urls: string[]): Promise<Array<Resource | null>> {
+  return Promise.all(urls.map(async (url) => {
+    try {
+      const response = await fetch(url);
+      return await response.json();
+    } catch (error) {
+      console.error(`Failed to fetch ${url}:`, error);
+      return null;
+    }
+  }));
+}
+```
+
+### Worker threads (CPU-bound)
+```typescript
+import { Worker } from 'worker_threads';
+
+function runWorker(workerData: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker('./worker.js', { workerData });
+    worker.on('message', resolve);
+    worker.on('error', reject);
+    worker.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`Worker exit code ${code}`));
+    });
+  });
+}
+```
+
+## Go
+
+### Goroutines with sync.WaitGroup
+```go
+func processItems(items []Item) []Result {
+    results := make([]Result, len(items))
+    var wg sync.WaitGroup
+    for i, item := range items {
+        wg.Add(1)
+        go func(index int, it Item) {
+            defer wg.Done()
+            results[index] = processItem(it)
+        }(i, item)
+    }
+    wg.Wait()
+    return results
+}
+```
+
+### Context for cancellation
+```go
+func fetchWithTimeout(ctx context.Context, url string) (*Response, error) {
+    ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+    defer cancel()
+    req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+    if err != nil { return nil, err }
+    return http.DefaultClient.Do(req)
+}
+```
+
+## Rust
+
+### Tokio JoinSet
+```rust
+async fn process_items(items: Vec<Item>) -> Vec<Result<Output, Error>> {
+    let mut set = JoinSet::new();
+    for item in items {
+        set.spawn(async move { process_item(item).await });
+    }
+    let mut results = Vec::new();
+    while let Some(result) = set.join_next().await {
+        results.push(result.unwrap());
+    }
+    results
+}
+```
+
+### Channels
+```rust
+use tokio::sync::mpsc;
+
+async fn producer_consumer() {
+    let (tx, mut rx) = mpsc::channel(100);
+    tokio::spawn(async move {
+        for i in 0..10 { tx.send(i).await.unwrap(); }
+    });
+    while let Some(value) = rx.recv().await {
+        println!("Received: {}", value);
+    }
+}
+```
+
+## Resource Management
+
+```python
+# Always clean up with context managers
+async with aiohttp.ClientSession() as session:
+    async with session.get(url) as response:
+        return await response.json()
+
+# Or ensure cleanup in finally
+task = None
+try:
+    task = asyncio.create_task(operation())
+    await task
+finally:
+    if task and not task.done():
+        task.cancel()
+        try: await task
+        except asyncio.CancelledError: pass
+```
+
+## Performance Considerations
+
+1. Don't create too many concurrent tasks (use semaphores)
+2. Batch operations when possible
+3. Use connection pooling
+4. Consider backpressure mechanisms
+5. Profile before optimizing

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: documentation
+description: >-
+  Write clear, comprehensive documentation with language-specific patterns.
+  Use when writing docstrings, module docs, README files, API references,
+  or architecture decision records. Covers Python, TypeScript, Go, and Rust
+  documentation conventions. Do NOT use for code style (use vibe skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Documentation
+
+Create clear, comprehensive documentation that serves as a reliable reference for both humans and AI agents.
+
+## Instructions
+
+### Step 1: Follow the Principles
+
+1. Write for your future self (you will forget)
+2. Document the "why", not just the "what"
+3. Keep documentation close to code
+4. Use examples liberally
+5. Update docs when changing code
+6. Make documentation searchable and navigable
+
+### Step 2: Apply Language-Specific Patterns
+
+See `references/` for detailed patterns:
+- `references/python-patterns.md` - Google-style docstrings, module docs
+- `references/typescript-patterns.md` - TSDoc comments, README sections
+- `references/go-patterns.md` - Package and function documentation
+- `references/rust-patterns.md` - Doc comments with examples
+
+### Step 3: Verify Completeness
+
+Use the documentation checklist:
+- [ ] All public functions have docstrings
+- [ ] All public classes have class docstrings
+- [ ] Module has module-level docstring
+- [ ] All parameters documented
+- [ ] Return values documented
+- [ ] All exceptions documented
+- [ ] At least one example provided
+- [ ] Complex logic has inline comments
+- [ ] Error messages are clear and actionable
+
+## Examples
+
+### Example 1: Python Function Documentation
+
+```python
+def process_file(
+    input_path: Path,
+    output_path: Path,
+    *,
+    encoding: str = "utf-8",
+    validate: bool = True,
+) -> dict[str, int]:
+    """Process input file and write results to output file.
+
+    Args:
+        input_path: Path to input file. Must exist and be readable.
+        output_path: Path to output file. Parent directory must exist.
+        encoding: Character encoding for file I/O. Defaults to UTF-8.
+        validate: Whether to validate input before processing.
+
+    Returns:
+        Dictionary with 'lines_processed', 'tokens_found', 'errors_encountered'.
+
+    Raises:
+        FileNotFoundError: If input_path does not exist.
+        ValueError: If validate=True and input content is invalid.
+
+    Examples:
+        >>> result = process_file(Path("input.txt"), Path("output.txt"))
+        >>> print(f"Processed {result['lines_processed']} lines")
+    """
+```
+
+### Example 2: Anti-Pattern vs Good Documentation
+
+**Bad** - documents implementation:
+```python
+def fetch_user(user_id: str) -> User:
+    """First we check the cache using a dict lookup.
+    If not found, we make an HTTP GET request to /api/users/{id}.
+    Then we parse the JSON response using json.loads()."""
+```
+
+**Good** - documents interface:
+```python
+def fetch_user(user_id: str) -> User:
+    """Retrieve user by ID from API.
+
+    Fetches user data from the API, using cache when available.
+
+    Args:
+        user_id: Unique user identifier
+
+    Returns:
+        User object with profile data
+
+    Raises:
+        UserNotFoundError: If user doesn't exist
+
+    Note:
+        Results are cached for 5 minutes.
+    """
+```
+
+## Troubleshooting
+
+### Error: Documentation gets stale after code changes
+- Update docs in the same commit as code changes
+- Add docstring checks to CI (e.g., pydocstyle or ruff D rules for Python)
+- Review docstrings during PR review
+
+### Error: Documentation is too verbose
+- Focus on the "what" and "why", not the "how"
+- Use type hints to reduce parameter description length
+- Link to detailed examples instead of inlining them

--- a/.claude/skills/documentation/references/go-patterns.md
+++ b/.claude/skills/documentation/references/go-patterns.md
@@ -1,0 +1,75 @@
+# Go Documentation Patterns
+
+## Package Documentation
+
+```go
+// Package config provides configuration management for applications.
+//
+// This package supports loading configuration from JSON, YAML, and TOML files,
+// with environment-specific overrides and validation.
+//
+// Basic Usage
+//
+//	manager, err := config.NewManager("config.json")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	apiKey := manager.Get("api_key")
+//
+// Environment Overrides
+//
+//	export APP_API_KEY="override-key"  // pragma: allowlist secret
+//
+// See examples/ directory for complete usage examples.
+package config
+```
+
+## Function Documentation
+
+```go
+// LoadConfig loads configuration from the specified file path.
+//
+// Supports JSON, YAML, and TOML formats based on file extension.
+// Automatically applies environment variable overrides.
+//
+// Parameters:
+//   - path: Path to configuration file. Must exist and be readable.
+//
+// Returns:
+//   - *Config: Loaded configuration object
+//   - error: FileNotFoundError if file doesn't exist,
+//     ValidationError if content is invalid
+//
+// Example:
+//
+//	config, err := LoadConfig("config.json")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Println("API Key:", config.APIKey)
+func LoadConfig(path string) (*Config, error) {
+    // Implementation...
+}
+```
+
+## Struct Documentation
+
+```go
+// Manager manages application configuration with validation and hot-reloading.
+//
+// Thread Safety:
+// Manager is safe for concurrent reads. Reload operations acquire an
+// exclusive lock.
+//
+// Example:
+//
+//	manager, err := NewManager("config.json")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	apiKey := manager.Get("api_key")
+type Manager struct {
+    ConfigPath    string
+    CurrentConfig *Config
+}
+```

--- a/.claude/skills/documentation/references/python-patterns.md
+++ b/.claude/skills/documentation/references/python-patterns.md
@@ -1,0 +1,101 @@
+# Python Documentation Patterns
+
+## Google-Style Docstrings
+
+```python
+def process_file(
+    input_path: Path,
+    output_path: Path,
+    *,
+    encoding: str = "utf-8",
+    validate: bool = True,
+) -> dict[str, int]:
+    """Process input file and write results to output file.
+
+    Reads the input file, performs validation if enabled, processes
+    the content, and writes formatted results to the output file.
+
+    Args:
+        input_path: Path to input file. Must exist and be readable.
+        output_path: Path to output file. Parent directory must exist.
+        encoding: Character encoding for file I/O. Defaults to UTF-8.
+        validate: Whether to validate input before processing.
+            When True, raises ValueError for invalid input.
+            When False, attempts best-effort processing.
+
+    Returns:
+        Dictionary containing processing statistics:
+            - 'lines_processed': Number of lines processed
+            - 'tokens_found': Number of tokens extracted
+            - 'errors_encountered': Number of validation errors
+
+    Raises:
+        FileNotFoundError: If input_path does not exist.
+        PermissionError: If input_path is not readable or output_path
+            is not writable.
+        ValueError: If validate=True and input content is invalid.
+
+    Examples:
+        Basic usage:
+        >>> result = process_file(Path("input.txt"), Path("output.txt"))
+        >>> print(f"Processed {result['lines_processed']} lines")
+
+        Skip validation:
+        >>> result = process_file(
+        ...     Path("messy.txt"), Path("out.txt"), validate=False
+        ... )
+
+    Note:
+        Uses atomic writes. Output file is never in a partial state.
+
+    See Also:
+        process_file_streaming: Memory-efficient alternative for large files
+    """
+```
+
+## Class Docstrings
+
+```python
+class ConfigurationManager:
+    """Manage application configuration with validation and reloading.
+
+    Handles loading, validating, and hot-reloading of application
+    configuration from JSON or YAML files.
+
+    Attributes:
+        config_path: Path to primary configuration file.
+        current_config: Currently loaded configuration dictionary.
+
+    Examples:
+        >>> manager = ConfigurationManager("config.json")
+        >>> api_key = manager.get("api_key")
+        >>> timeout = manager.get("timeout", default=30)
+
+    Note:
+        Thread-safe for concurrent reads. Write operations (reload)
+        acquire an exclusive lock.
+    """
+```
+
+## Module-Level Docstrings
+
+```python
+"""Configuration management for the application.
+
+This module provides configuration loading, validation, and management
+utilities. Supports JSON, YAML, TOML formats and environment overrides.
+
+Key Components:
+    - ConfigurationManager: Primary configuration interface
+    - ConfigValidator: Schema validation for configurations
+
+Usage:
+    >>> from myapp.config import ConfigurationManager
+    >>> manager = ConfigurationManager("config.json")
+    >>> api_key = manager.get("api_key")
+
+Environment Variables:
+    APP_CONFIG_PATH: Override default configuration file path
+    APP_ENV: Environment name (dev, staging, production)
+"""
+```

--- a/.claude/skills/documentation/references/rust-patterns.md
+++ b/.claude/skills/documentation/references/rust-patterns.md
@@ -1,0 +1,80 @@
+# Rust Documentation Patterns
+
+## Function Doc Comments
+
+```rust
+/// Process input file and write results to output file.
+///
+/// Reads the input file, performs validation if enabled, processes the content,
+/// and writes formatted results to the output file.
+///
+/// # Arguments
+///
+/// * `input_path` - Path to input file. Must exist and be readable.
+/// * `output_path` - Path to output file. Parent directory must exist.
+/// * `validate` - Whether to validate input before processing.
+///
+/// # Returns
+///
+/// Returns `HashMap` containing processing statistics:
+/// - `lines_processed`: Number of lines processed
+/// - `tokens_found`: Number of tokens extracted
+///
+/// # Errors
+///
+/// Returns error if:
+/// - Input file doesn't exist (`io::ErrorKind::NotFound`)
+/// - Permission denied (`io::ErrorKind::PermissionDenied`)
+/// - Validation fails (when `validate=true`)
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+///
+/// let stats = process_file(
+///     Path::new("input.txt"),
+///     Path::new("output.txt"),
+///     true
+/// ).expect("Failed to process file");
+///
+/// println!("Processed {} lines", stats.get("lines_processed").unwrap());
+/// ```
+///
+/// # See Also
+///
+/// * [`process_file_streaming`] - Memory-efficient alternative
+pub fn process_file(
+    input_path: &Path,
+    output_path: &Path,
+    validate: bool,
+) -> Result<HashMap<String, usize>, Error> {
+    // Implementation...
+}
+```
+
+## Struct Doc Comments
+
+```rust
+/// Configuration manager for application settings.
+///
+/// Handles loading, validation, and hot-reloading from JSON/YAML files.
+///
+/// # Thread Safety
+///
+/// `ConfigManager` is safe for concurrent reads using `Arc` and `RwLock`.
+///
+/// # Examples
+///
+/// ```
+/// let manager = ConfigManager::new("config.json")?;
+/// let api_key = manager.get("api_key")?;
+/// ```
+pub struct ConfigManager {
+    /// Path to primary configuration file
+    pub config_path: PathBuf,
+
+    /// Currently loaded configuration (read-only access via getter)
+    current_config: Arc<RwLock<Config>>,
+}
+```

--- a/.claude/skills/documentation/references/typescript-patterns.md
+++ b/.claude/skills/documentation/references/typescript-patterns.md
@@ -1,0 +1,110 @@
+# TypeScript Documentation Patterns
+
+## TSDoc Comments
+
+```typescript
+/**
+ * Process user input and validate against schema.
+ *
+ * Performs comprehensive validation including type checking,
+ * format validation, and business rule enforcement.
+ *
+ * @param input - Raw user input data (may be any type)
+ * @param schema - JSON schema for validation
+ * @param options - Optional validation settings
+ * @returns Validated and typed user data
+ *
+ * @throws {ValidationError} When input fails validation
+ * @throws {SchemaError} When schema itself is invalid
+ *
+ * @example
+ * Basic validation:
+ * ```typescript
+ * const userData = processInput(
+ *   { email: 'user@example.com', age: 25 },
+ *   userSchema
+ * );
+ * ```
+ *
+ * @see {@link ValidationOptions} for available options
+ * @since 1.0.0
+ */
+export function processInput(
+  input: unknown,
+  schema: JSONSchema,
+  options?: ValidationOptions
+): UserData {
+  // Implementation...
+}
+```
+
+## Class Documentation
+
+```typescript
+/**
+ * Configuration manager for application settings.
+ *
+ * Handles loading, validation, and hot-reloading from JSON/YAML files.
+ * Supports environment-specific overrides and type-safe access.
+ *
+ * @example
+ * ```typescript
+ * const manager = new ConfigManager('config.json');
+ * const apiKey = manager.get('apiKey');
+ * ```
+ *
+ * @example
+ * With auto-reload:
+ * ```typescript
+ * const manager = new ConfigManager('config.json', {
+ *   autoReload: true,
+ *   onReload: (config) => console.log('Config reloaded')
+ * });
+ * ```
+ */
+export class ConfigManager {
+  /** Path to primary configuration file. */
+  public readonly configPath: string;
+
+  /**
+   * Create new configuration manager.
+   *
+   * @param configPath - Path to configuration file
+   * @param options - Optional configuration settings
+   * @throws {FileNotFoundError} If config file doesn't exist
+   */
+  constructor(configPath: string, options?: ConfigManagerOptions) {
+    // Implementation...
+  }
+}
+```
+
+## README Structure
+
+```markdown
+# Component Name
+
+## Overview
+Brief description.
+
+## Installation
+npm install @scope/component
+
+## Quick Start
+[Code example]
+
+## API Reference
+### `ClassName`
+#### Constructor
+#### Methods
+
+## Configuration
+### Environment Variables
+### Configuration File
+
+## Error Handling
+[Typed errors and how to handle them]
+
+## Examples
+See examples/ directory.
+```

--- a/.claude/skills/error-handling/SKILL.md
+++ b/.claude/skills/error-handling/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: error-handling
+description: >-
+  Implement robust error handling that fails fast with clear diagnostics.
+  Use when designing error strategies, writing exception handling,
+  creating custom error types, or implementing validation. Covers
+  Python, TypeScript, Go, and Rust patterns.
+  Do NOT use for security-specific input validation (use security skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Error Handling
+
+Fail fast with clear error messages. Use typed exceptions, include context, never silence errors.
+
+## Instructions
+
+### Step 1: Follow the Principles
+
+1. Fail fast with clear error messages
+2. Use typed exceptions/errors over generic ones
+3. Include context in error messages (what, where, why)
+4. Never silence errors without logging
+5. Validate inputs at boundaries
+6. Handle errors at the appropriate abstraction level
+
+### Step 2: Apply Language-Specific Patterns
+
+See `references/patterns-by-language.md` for detailed patterns in Python, TypeScript, Go, and Rust.
+
+Key patterns:
+- **Python**: Typed exceptions with context, context managers for cleanup, specific exception catching
+- **TypeScript**: Custom error classes, Result type pattern, Promise error handling
+- **Go**: Error wrapping with `fmt.Errorf` and `%w`, custom error types, immediate error checking
+- **Rust**: Custom error enums with `Display`, `?` operator for propagation, `map_err` for context
+
+### Step 3: Avoid Anti-Patterns
+
+- **Silent failures**: `except: pass` - always log or re-raise
+- **Generic catching**: `except Exception` - catch specific exceptions
+- **Bare except**: Catches KeyboardInterrupt and SystemExit
+- **No context**: `raise ValueError("Invalid")` - include what, where, why
+- **Error codes**: Return -1 on error - use exceptions/Result types
+
+## Examples
+
+See `references/examples.md` for complete worked examples.
+
+### Example 1: Python - Typed Exception with Context
+
+```python
+class ConfigurationError(Exception):
+    def __init__(self, field: str, value: str, reason: str) -> None:
+        self.field = field
+        self.value = value
+        super().__init__(f"Invalid {field}={value!r}: {reason}")
+
+# Usage
+raise ConfigurationError(
+    field="timeout",
+    value="abc",
+    reason="Must be a positive integer",
+)
+```
+
+### Example 2: TypeScript - Result Type Pattern
+
+```typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+function parseConfig(content: string): Result<Config> {
+  try {
+    const data = JSON.parse(content);
+    if (!isValidConfig(data)) {
+      return { ok: false, error: new Error('Invalid config structure') };
+    }
+    return { ok: true, value: data };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error : new Error('Unknown error') };
+  }
+}
+```
+
+## Troubleshooting
+
+### Error: Too many exception types making code complex
+- Create a base exception for your module, subclass for specific cases
+- Use 3-5 exception types per module, not one per function
+- Group by category: ValidationError, NotFoundError, PermissionError
+
+### Error: Error messages aren't helpful for debugging
+- Include the failing value: `f"Invalid email: {email!r}"`
+- Include the location: `f"in {path.absolute()}`
+- Include the expectation: `f"expected positive integer, got {value}"`

--- a/.claude/skills/error-handling/references/examples.md
+++ b/.claude/skills/error-handling/references/examples.md
@@ -1,0 +1,115 @@
+# Error Handling Examples
+
+## Example 1: API Client Error Handling (Python)
+
+```python
+class APIError(Exception):
+    def __init__(self, message: str, status_code: int | None = None, response_body: str | None = None) -> None:
+        self.status_code = status_code
+        self.response_body = response_body
+        super().__init__(message)
+
+class APIClient:
+    def fetch_user(self, user_id: str) -> dict:
+        if not user_id or not user_id.strip():
+            raise ValueError(f"Invalid user_id: {user_id!r} (must be non-empty)")
+
+        url = f"{self.base_url}/users/{user_id}"
+
+        try:
+            response = requests.get(url, timeout=10)
+        except requests.Timeout as e:
+            raise APIError(f"Request to {url} timed out after 10s") from e
+        except requests.ConnectionError as e:
+            raise APIError(f"Failed to connect to {url}: {e}") from e
+
+        if response.status_code == 404:
+            raise APIError(f"User not found: {user_id}", status_code=404, response_body=response.text)
+
+        if not response.ok:
+            raise APIError(f"API error for {url}: HTTP {response.status_code}", status_code=response.status_code)
+
+        try:
+            return response.json()
+        except ValueError as e:
+            raise APIError(f"Invalid JSON from {url}: {e}", status_code=response.status_code) from e
+```
+
+## Example 2: File Processing with Cleanup (Python)
+
+```python
+def process_file_safely(input_path: Path, output_path: Path, processor: Callable[[bytes], bytes]) -> None:
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file not found: {input_path.absolute()}")
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="process_"))
+    temp_output = temp_dir / "output"
+
+    try:
+        try:
+            input_data = input_path.read_bytes()
+        except PermissionError as e:
+            raise IOError(f"Cannot read {input_path}: permission denied") from e
+
+        try:
+            output_data = processor(input_data)
+        except Exception as e:
+            raise ProcessingError(f"Failed to process {input_path}: {e}") from e
+
+        temp_output.write_bytes(output_data)
+        shutil.move(str(temp_output), str(output_path))
+    finally:
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir, ignore_errors=True)
+```
+
+## Example 3: Validation with Error Collection (TypeScript)
+
+```typescript
+interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+function validateRegistration(data: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, errors: ['Expected object, got ' + typeof data] };
+  }
+
+  const { email, password, username } = data as Record<string, unknown>;
+
+  if (typeof email !== 'string' || !email.includes('@')) {
+    errors.push('Invalid email format');
+  }
+  if (typeof password !== 'string' || password.length < 8) {  // pragma: allowlist secret
+    errors.push('Password must be at least 8 characters');
+  }
+  if (typeof username !== 'string' || username.length < 3) {
+    errors.push('Username must be at least 3 characters');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+```
+
+## Error Logging Best Practices
+
+```python
+# Include structured context
+logger.error("Failed to process user data", extra={
+    "user_id": user_id,
+    "operation": "update_profile",
+    "error_type": type(e).__name__,
+})
+
+# Use appropriate levels
+# ERROR: Operation failed, needs attention
+# WARNING: Degraded operation
+# INFO: Normal operation events
+# DEBUG: Detailed diagnostics
+
+# Include stack traces for debugging
+logger.error("Critical error occurred", exc_info=True)
+```

--- a/.claude/skills/error-handling/references/patterns-by-language.md
+++ b/.claude/skills/error-handling/references/patterns-by-language.md
@@ -1,0 +1,175 @@
+# Error Handling Patterns by Language
+
+## Python
+
+### Typed Exceptions with Context
+```python
+class ConfigurationError(Exception):
+    def __init__(self, field: str, value: str, reason: str) -> None:
+        self.field = field
+        self.value = value
+        self.reason = reason
+        super().__init__(f"Invalid {field}={value!r}: {reason}")
+
+def load_config(path: Path) -> dict[str, str]:
+    if not path.exists():
+        raise FileNotFoundError(f"Config not found: {path.absolute()}")
+    content = path.read_text()
+    if not content.strip():
+        raise ValueError(f"Config file is empty: {path.absolute()}")
+    config = parse_config(content)
+    required = {"api_key", "base_url"}
+    missing = required - config.keys()
+    if missing:
+        raise ConfigurationError("required_fields", str(missing), "Missing required fields")
+    return config
+```
+
+### Context Managers for Resource Cleanup
+```python
+@contextmanager
+def atomic_write(path: Path) -> Iterator[Path]:
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        yield temp_path
+        temp_path.replace(path)
+    except Exception as e:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise IOError(f"Failed to write {path}: {e}") from e
+```
+
+### Specific Exception Catching
+```python
+try:
+    content = path.read_text()
+except FileNotFoundError:
+    raise FileNotFoundError(f"JSON file not found: {path.absolute()}")
+except PermissionError as e:
+    raise PermissionError(f"Cannot read {path.absolute()}: {e}") from e
+
+try:
+    data = json.loads(content)
+except json.JSONDecodeError as e:
+    raise ValueError(f"Invalid JSON in {path}: {e.msg} at line {e.lineno}") from e
+```
+
+## TypeScript
+
+### Custom Error Classes
+```typescript
+class ValidationError extends Error {
+  constructor(
+    public readonly field: string,
+    public readonly value: unknown,
+    message: string
+  ) {
+    super(`Validation failed for ${field}: ${message}`);
+    this.name = 'ValidationError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ValidationError);
+    }
+  }
+}
+```
+
+### Result Type Pattern
+```typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+function parseConfig(content: string): Result<Config> {
+  try {
+    const data = JSON.parse(content);
+    if (!isValidConfig(data)) {
+      return { ok: false, error: new Error('Invalid configuration') };
+    }
+    return { ok: true, value: data };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error : new Error('Unknown error') };
+  }
+}
+```
+
+### Promise Error Handling
+```typescript
+async function fetchUserData(userId: string): Promise<UserData> {
+  try {
+    const response = await fetch(`/api/users/${userId}`);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    return validateUserData(await response.json());
+  } catch (error) {
+    if (error instanceof ValidationError) throw error;
+    throw new Error(`Failed to fetch user ${userId}: ${error instanceof Error ? error.message : 'Unknown'}`);
+  }
+}
+```
+
+## Go
+
+### Error Wrapping with Context
+```go
+func LoadConfig(path string) (*Config, error) {
+    file, err := os.Open(path)
+    if err != nil {
+        return nil, fmt.Errorf("failed to open config %q: %w", path, err)
+    }
+    defer file.Close()
+
+    config, err := parseConfig(file)
+    if err != nil {
+        return nil, fmt.Errorf("failed to parse config from %q: %w", path, err)
+    }
+    return config, nil
+}
+```
+
+### Custom Error Types
+```go
+type ValidationError struct {
+    Field  string
+    Value  interface{}
+    Reason string
+}
+
+func (e *ValidationError) Error() string {
+    return fmt.Sprintf("validation failed for %s=%v: %s", e.Field, e.Value, e.Reason)
+}
+```
+
+## Rust
+
+### Custom Error Enums
+```rust
+#[derive(Debug)]
+pub enum ConfigError {
+    NotFound(String),
+    ParseError(String),
+    ValidationError { field: String, reason: String },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ConfigError::NotFound(path) => write!(f, "Config not found: {}", path),
+            ConfigError::ParseError(msg) => write!(f, "Parse failed: {}", msg),
+            ConfigError::ValidationError { field, reason } => write!(f, "Validation failed for {}: {}", field, reason),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+```
+
+### The ? Operator with Context
+```rust
+fn load_config(path: &str) -> Result<Config, String> {
+    let contents = read_file_contents(path)
+        .map_err(|e| format!("Failed to read config from {}: {}", path, e))?;
+    parse_config(&contents)
+        .map_err(|e| format!("Failed to parse config from {}: {}", path, e))
+}
+```

--- a/.claude/skills/file-naming-conventions/SKILL.md
+++ b/.claude/skills/file-naming-conventions/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: file-naming-conventions
+description: >-
+  ISO 8601 date-prefix file naming conventions for documents and plans.
+  Use when creating dated documents, plan files, analysis reports,
+  meeting notes, or any time-sensitive documentation.
+  Do NOT use for source code files, configs, or permanent reference docs.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# File Naming Conventions
+
+Always prefix dated documents with ISO 8601 format (YYYY-MM-DD) for natural chronological sorting.
+
+## Instructions
+
+### Step 1: Determine if the Document Needs a Date Prefix
+
+**Use date prefixes for**: analysis reports, status reports, plans, meeting notes, decision records, changelogs, progress updates, retrospectives, any time-sensitive documentation.
+
+**Skip date prefixes for**: permanent reference docs (README.md), configuration files, source code, test files, templates, general guides.
+
+### Step 2: Construct the Filename
+
+**Format**: `YYYY-MM-DD_DESCRIPTIVE_NAME.ext`
+
+- Date: 4-digit year, 2-digit month, 2-digit day, separated by hyphens
+- Separator: Single underscore between date and description
+- Name: ALL_CAPS for major documents, lowercase_with_underscores for supporting docs
+- Be descriptive but concise; use common abbreviations (CLI, API, DB)
+
+### Step 3: Handle Special Cases
+
+**Multiple documents same day**: Use descriptive disambiguation:
+```
+2026-01-26_MUTATION_ANALYSIS_CLI.md
+2026-01-26_MUTATION_ANALYSIS_CREDENTIALS.md
+```
+
+**Versioned documents**: `YYYY-MM-DD_DOCUMENT_NAME_vX.Y.md`
+
+**Living documents**: Either update the date prefix on major revisions, or skip the date prefix entirely.
+
+## Examples
+
+### Example 1: Plan File
+```
+2026-01-26_MUTANT_EXTERMINATION_PLAN_CLI.md
+2026-01-25_MUTATION_TESTING_STATUS.md
+2026-01-20_FEATURE_IMPLEMENTATION_STRATEGY.md
+```
+
+### Example 2: Analysis Reports
+```
+2026-01-26_mutation_analysis_cli.md
+2026-01-25_performance_analysis_database.md
+2026-01-20_security_audit_report.md
+```
+
+### Example 3: Quick Creation
+```bash
+# Bash alias
+alias newplan='touch "$(date +%Y-%m-%d)_PLAN_NAME.md"'
+
+# Python
+from datetime import date
+filename = f"{date.today().isoformat()}_MY_DOCUMENT.md"
+```
+
+## Troubleshooting
+
+### Error: Files don't sort chronologically
+- Verify the date comes FIRST in the filename, not at the end
+- Use `YYYY-MM-DD` format, never `MM-DD-YYYY` or `DD-MM-YYYY`
+- Use hyphens in dates, underscores between date and name
+
+### Error: Naming conflicts on the same day
+- Add a descriptive suffix to disambiguate
+- Or use sequential numbering: `2026-01-26_01_FIRST.md`, `2026-01-26_02_SECOND.md`

--- a/.claude/skills/frontend-aesthetics/SKILL.md
+++ b/.claude/skills/frontend-aesthetics/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: frontend-aesthetics
+description: >-
+  Produce polished, accessible frontend UI with design tokens, semantic
+  HTML, and Pico CSS. Use when creating HTML templates, adding CSS,
+  building user-facing pages, or working with Jinja2 templates.
+  Covers design tokens, typography, components, accessibility (WCAG 2.1 AA),
+  dark mode, and micro-interactions.
+  Do NOT use for backend API design or data modeling.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Frontend Aesthetics
+
+The difference between "works" and "wow" is 20 lines of CSS and semantic HTML choices.
+
+## Instructions
+
+### Step 1: Follow the Core Philosophy
+
+1. **Design with tokens, not magic numbers** - every value from a system
+2. **Semantic HTML is the foundation** - right element gets 80% of the way
+3. **Accessibility is not optional** - WCAG 2.1 AA minimum
+4. **Motion is meaning** - animate to communicate; respect `prefers-reduced-motion`
+5. **Dark mode is table stakes** - use CSS custom properties
+
+### Step 2: Use the Design Token System
+
+See `references/design-tokens.md` for the complete token system including colors, spacing, typography, shadows, and dark mode adaptation.
+
+Key rules:
+- Never use raw hex codes or pixel values in component styles
+- All colors from tokens or Pico defaults
+- All spacing uses `--space-*` tokens (8px rhythm)
+- Typography uses `clamp()` for fluid scaling
+
+### Step 3: Build with Component Patterns
+
+See `references/component-patterns.md` for cards, badges, forms, alerts, and layout patterns.
+
+### Step 4: Ensure Accessibility (Non-Negotiable)
+
+- **Color contrast**: 4.5:1 for body text, 3:1 for large text
+- **Focus management**: Visible `:focus-visible` ring on all interactive elements
+- **Motion safety**: `prefers-reduced-motion` rule in every template
+- **Semantic HTML**: `<nav>`, `<article>`, `<section>`, `role="alert"` for errors
+- **Touch targets**: Minimum 44px (2.75rem)
+
+### Step 5: Use the Pre-Ship Checklist
+
+- [ ] All colors from tokens or Pico defaults
+- [ ] All spacing uses `--space-*` tokens
+- [ ] Page has exactly one `<h1>`; heading levels don't skip
+- [ ] All interactive elements have `:focus-visible` states
+- [ ] `prefers-reduced-motion` is respected
+- [ ] `role="alert"` on error messages
+- [ ] No text wider than ~65ch
+- [ ] Touch targets >= 44px
+- [ ] Dark mode works (toggle `data-theme`)
+
+## Examples
+
+### Example 1: Jinja2 Card Grid with Conditional Badges
+
+```html
+<div class="card-grid">
+    {% for item in items %}
+    <article class="card {{ 'card-highlighted' if item.featured else '' }}">
+        <h3>{{ item.title }}</h3>
+        <p>{{ item.description }}</p>
+        {% if item.severity == 'high' %}
+            <span class="badge badge-danger">High</span>
+        {% elif item.severity == 'medium' %}
+            <span class="badge badge-warning">Medium</span>
+        {% endif %}
+    </article>
+    {% endfor %}
+</div>
+```
+
+### Example 2: Accessible Error Display
+
+```html
+{% if error %}
+<div class="alert alert-error" role="alert" aria-live="assertive">
+    <strong>Error:</strong> {{ error }}
+</div>
+{% endif %}
+```
+
+## Troubleshooting
+
+### Error: Colors look wrong in dark mode
+- Verify you're using CSS custom properties, not hardcoded colors
+- Check that dark mode tokens override light mode values
+- Test with both `prefers-color-scheme: dark` and `data-theme="dark"`
+
+### Error: Layout breaks on mobile
+- Use `min(72rem, 100% - var(--space-xl) * 2)` for containers
+- Use `100dvh` instead of `100vh` for full-height layouts
+- Use `minmax(min(250px, 100%), 1fr)` for grid columns

--- a/.claude/skills/frontend-aesthetics/references/component-patterns.md
+++ b/.claude/skills/frontend-aesthetics/references/component-patterns.md
@@ -1,0 +1,154 @@
+# Component Patterns
+
+## Cards
+
+```css
+.card {
+    background: var(--surface-1);
+    border: 1px solid var(--surface-3);
+    border-radius: var(--radius-md);
+    padding: var(--space-lg);
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow var(--duration-normal) var(--ease-out),
+                transform var(--duration-normal) var(--ease-out);
+}
+.card:hover {
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
+}
+@media (prefers-reduced-motion: reduce) {
+    .card:hover { transform: none; }
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(250px, 100%), 1fr));
+    gap: var(--space-lg);
+}
+```
+
+## Badges / Tags
+
+```css
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: var(--space-xs) var(--space-sm);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    line-height: 1;
+    border-radius: var(--radius-full);
+    white-space: nowrap;
+}
+.badge-danger  { background: hsl(0 72% 51% / 0.12);   color: hsl(0 72% 40%); }
+.badge-warning { background: hsl(38 92% 50% / 0.12);   color: hsl(38 70% 35%); }
+.badge-success { background: hsl(145 63% 42% / 0.12);  color: hsl(145 63% 30%); }
+.badge-info    { background: hsl(200 80% 50% / 0.12);  color: hsl(200 80% 35%); }
+```
+
+## Forms
+
+```css
+input, select, textarea {
+    border: 1.5px solid var(--surface-3);
+    border-radius: var(--radius-md);
+    padding: var(--space-sm) var(--space-md);
+    font-size: var(--text-base);
+    background: var(--surface-1);
+    color: var(--text-1);
+    transition: border-color var(--duration-fast) var(--ease-out),
+                box-shadow var(--duration-fast) var(--ease-out);
+    min-height: 2.75rem;  /* 44px touch target */
+}
+input:focus-visible, select:focus-visible, textarea:focus-visible {
+    outline: none;
+    border-color: var(--brand);
+    box-shadow: var(--shadow-glow);
+}
+button, [type="submit"] {
+    min-height: 2.75rem;
+    padding: var(--space-sm) var(--space-xl);
+    font-weight: 600;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+}
+```
+
+## Alerts
+
+```css
+.alert {
+    padding: var(--space-md) var(--space-lg);
+    border-radius: var(--radius-md);
+    border-left: 4px solid;
+}
+.alert-error   { background: hsl(0 72% 51% / 0.08); border-color: var(--color-danger); }
+.alert-success { background: hsl(145 63% 42% / 0.08); border-color: var(--color-success); }
+.alert-info    { background: hsl(200 80% 50% / 0.08); border-color: var(--color-info); }
+```
+
+## Layout
+
+```css
+body { min-height: 100dvh; display: flex; flex-direction: column; background: var(--surface-2); }
+main { flex: 1; }
+footer { margin-top: auto; }
+
+.container { width: min(72rem, 100% - var(--space-xl) * 2); margin-inline: auto; }
+```
+
+## Accessibility Essentials
+
+```css
+:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
+:focus:not(:focus-visible) { outline: none; }
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+.sr-only {
+    position: absolute; width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+```
+
+## Micro-Interactions
+
+```css
+/* Page entrance */
+main { animation: fadeUp var(--duration-normal) var(--ease-out); }
+@keyframes fadeUp { from { opacity: 0; transform: translateY(8px); } }
+
+/* Skeleton loading */
+.skeleton-line {
+    height: 1em;
+    border-radius: var(--radius-sm);
+    background: linear-gradient(90deg, var(--surface-3) 25%, var(--surface-2) 50%, var(--surface-3) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+}
+@keyframes shimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
+
+/* Staggered card entrance */
+.card-grid > :nth-child(1) { animation-delay: 0ms; }
+.card-grid > :nth-child(2) { animation-delay: 50ms; }
+.card-grid > :nth-child(3) { animation-delay: 100ms; }
+.card-grid > * { animation: fadeUp var(--duration-normal) var(--ease-out) backwards; }
+```
+
+## Semantic HTML Quick Reference
+
+| Need | Use | NOT |
+|------|-----|-----|
+| Navigation | `<nav>` | `<div class="nav">` |
+| Page section | `<section>` with heading | `<div>` |
+| Self-contained | `<article>` | `<div class="card">` |
+| Error alert | `<div role="alert">` | `<div class="error">` |
+| Loading | `aria-busy="true"` | No indication |
+| Icon button | `<button aria-label="Close">` | `<button>X</button>` |

--- a/.claude/skills/frontend-aesthetics/references/design-tokens.md
+++ b/.claude/skills/frontend-aesthetics/references/design-tokens.md
@@ -1,0 +1,108 @@
+# Design Token System
+
+## Color Tokens
+
+```css
+:root {
+    /* Brand */
+    --brand-hue: 220;
+    --brand: hsl(var(--brand-hue) 70% 50%);
+    --brand-light: hsl(var(--brand-hue) 70% 92%);
+    --brand-dark: hsl(var(--brand-hue) 70% 30%);
+
+    /* Semantic */
+    --color-success: hsl(145 63% 42%);
+    --color-warning: hsl(38 92% 50%);
+    --color-danger: hsl(0 72% 51%);
+    --color-info: hsl(200 80% 50%);
+
+    /* Surface & Text (light mode) */
+    --surface-1: hsl(0 0% 100%);
+    --surface-2: hsl(0 0% 97%);
+    --surface-3: hsl(0 0% 93%);
+    --text-1: hsl(0 0% 10%);
+    --text-2: hsl(0 0% 35%);
+    --text-muted: hsl(0 0% 55%);
+
+    /* Shadows */
+    --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.05);
+    --shadow-md: 0 4px 12px hsl(0 0% 0% / 0.08);
+    --shadow-lg: 0 12px 32px hsl(0 0% 0% / 0.12);
+    --shadow-glow: 0 0 0 3px hsl(var(--brand-hue) 70% 50% / 0.25);
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        --surface-1: hsl(220 15% 12%);
+        --surface-2: hsl(220 15% 16%);
+        --surface-3: hsl(220 15% 21%);
+        --text-1: hsl(0 0% 93%);
+        --text-2: hsl(0 0% 72%);
+        --text-muted: hsl(0 0% 50%);
+        --brand-light: hsl(var(--brand-hue) 50% 20%);
+        --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.2);
+        --shadow-md: 0 4px 12px hsl(0 0% 0% / 0.3);
+        --shadow-lg: 0 12px 32px hsl(0 0% 0% / 0.4);
+    }
+}
+```
+
+## Spacing Tokens (8px rhythm)
+
+```css
+:root {
+    --space-xs: 0.25rem;   /* 4px */
+    --space-sm: 0.5rem;    /* 8px */
+    --space-md: 1rem;      /* 16px */
+    --space-lg: 1.5rem;    /* 24px */
+    --space-xl: 2rem;      /* 32px */
+    --space-2xl: 3rem;     /* 48px */
+    --space-3xl: 4rem;     /* 64px */
+}
+```
+
+## Typography Tokens (major third scale: 1.25)
+
+```css
+:root {
+    --text-xs: clamp(0.7rem, 0.66rem + 0.2vw, 0.8rem);
+    --text-sm: clamp(0.8rem, 0.76rem + 0.2vw, 0.9rem);
+    --text-base: clamp(0.95rem, 0.91rem + 0.2vw, 1.05rem);
+    --text-lg: clamp(1.125rem, 1.05rem + 0.35vw, 1.3rem);
+    --text-xl: clamp(1.4rem, 1.3rem + 0.5vw, 1.65rem);
+    --text-2xl: clamp(1.75rem, 1.6rem + 0.75vw, 2.1rem);
+    --text-3xl: clamp(2.2rem, 2rem + 1vw, 2.8rem);
+}
+```
+
+## Radius and Transition Tokens
+
+```css
+:root {
+    --radius-sm: 0.375rem;
+    --radius-md: 0.625rem;
+    --radius-lg: 1rem;
+    --radius-full: 9999px;
+
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+    --duration-fast: 150ms;
+    --duration-normal: 250ms;
+}
+```
+
+## Typography Rules
+
+1. Maximum two font weights: 400 (regular) and 600 (semibold)
+2. Line height: 1.6 for body, 1.2 for headings
+3. Max width: 65ch for body text
+4. One `<h1>` per page, never skip heading levels
+5. Use `clamp()` tokens for fluid scaling
+
+```css
+body { font-size: var(--text-base); line-height: 1.6; color: var(--text-1); }
+h1, h2, h3 { line-height: 1.2; letter-spacing: -0.02em; }
+h1 { font-size: var(--text-3xl); }
+h2 { font-size: var(--text-2xl); }
+h3 { font-size: var(--text-xl); }
+```

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: git-workflow
+description: >-
+  Issue-first development workflow with template-file-based gh commands and
+  label hygiene. Use when creating issues, starting new work, making branches,
+  committing changes, or opening PRs. Covers the full issue-to-PR lifecycle
+  using file-based templates instead of inline strings. Do NOT use for
+  bug-specific debugging or RCA (use bug-squashing-methodology), PR code review
+  (use comprehensive-pr-review), or backlog cleanup and issue triage (use
+  backlog-grooming).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Git Workflow
+
+Issue-first development: every change starts with an issue, flows through a branch, and lands via a PR. Use template files for all gh commands instead of inline strings.
+
+## Instructions
+
+### Step 1: Check for Existing Issue
+
+Before any work, search for an existing issue:
+
+```bash
+gh issue list --search "keyword" --state open
+gh issue list --search "keyword" --state all
+```
+
+- If an issue exists, reference it and skip to Step 4.
+- If no issue exists, confirm with the user before creating one.
+
+### Step 2: Label Hygiene
+
+Before creating an issue, check existing labels:
+
+```bash
+gh label list
+```
+
+- Use an existing label if one fits.
+- Create a new label only if no similar one exists:
+  ```bash
+  gh label create "label-name" --description "What it covers" --color "hex"
+  ```
+
+### Step 3: Create Issue via Template File
+
+Write the issue body to a file, then pass it to `gh`:
+
+```bash
+mkdir -p plans/github-issues
+# Write body to plans/github-issues/ISSUE_NNN_slug.md
+gh issue create \
+  --title "type(scope): Brief description" \
+  --body-file plans/github-issues/ISSUE_NNN_slug.md \
+  --label "label1,label2"
+```
+
+Never inline long strings into `--body`. See `references/templates.md` for the issue body structure.
+
+After creation, note the issue number for branch naming and commit references.
+
+### Step 4: Branch from Issue
+
+Create a branch referencing the issue number:
+
+```bash
+git checkout -b type/short-description-NNN
+```
+
+Branch type prefixes:
+- `feat/` — new feature
+- `fix/` — bug fix
+- `chore/` — maintenance, deps, config
+- `docs/` — documentation only
+
+Example: `feat/add-user-search-42`, `fix/pagination-offset-87`
+
+### Step 5: Commit via Message File
+
+Write the commit message to a temp file, then commit with `-F`:
+
+```bash
+# Write message to plans/github-issues/COMMIT_NNN_slug.md
+git commit -F plans/github-issues/COMMIT_NNN_slug.md
+```
+
+Use conventional commit format in the message. See `references/templates.md` for the commit message structure.
+
+### Step 6: PR via Template File
+
+Write the PR body to a file, then create the PR:
+
+```bash
+# Write body to plans/github-issues/PR_NNN_slug.md
+gh pr create \
+  --title "type(scope): Brief description" \
+  --body-file plans/github-issues/PR_NNN_slug.md
+```
+
+The PR body must include `Closes #NNN` to auto-close the issue on merge. See `references/templates.md` for the PR body structure.
+
+### Step 7: Post-Merge Cleanup
+
+After the PR merges:
+
+```bash
+# Switch back to main and pull
+git checkout main && git pull
+
+# Delete the local branch
+git branch -d type/short-description-NNN
+
+# Verify the issue auto-closed
+gh issue view NNN --json state
+```
+
+## Examples
+
+### Example 1: Feature Development from Scratch
+
+User asks: "Add a /health endpoint to the API."
+
+**Search for existing issue:**
+```bash
+gh issue list --search "health endpoint" --state all
+# No results
+```
+
+**Confirm with user**, then check labels and create issue:
+```bash
+gh label list
+# "enhancement" exists, no need to create
+```
+
+Write `plans/github-issues/ISSUE_52_health-endpoint.md`:
+```markdown
+## Problem
+
+The API has no health check endpoint. Load balancers and monitoring tools
+need a lightweight endpoint to verify the service is running.
+
+## Proposed Solution
+
+Add a `GET /health` endpoint that returns `200 OK` with a JSON body
+containing service status and version.
+
+## Acceptance Criteria
+
+- [ ] `GET /health` returns 200 with `{"status": "ok", "version": "x.y.z"}`
+- [ ] Response time under 50ms (no DB calls)
+- [ ] Endpoint is unauthenticated
+```
+
+```bash
+gh issue create \
+  --title "feat(api): Add /health endpoint" \
+  --body-file plans/github-issues/ISSUE_52_health-endpoint.md \
+  --label "enhancement"
+# Created issue #52
+```
+
+**Branch and work:**
+```bash
+git checkout -b feat/add-health-endpoint-52
+# ... implement the feature ...
+```
+
+**Commit via file** — write `plans/github-issues/COMMIT_52_health-endpoint.md`:
+```
+feat(api): add /health endpoint
+
+Add lightweight health check endpoint for load balancer and monitoring
+integration. Returns service status and version without hitting the
+database.
+
+Refs #52
+```
+
+```bash
+git commit -F plans/github-issues/COMMIT_52_health-endpoint.md
+```
+
+**PR via file** — write `plans/github-issues/PR_52_health-endpoint.md`:
+```markdown
+## Summary
+
+Add a `GET /health` endpoint that returns service status and version
+for load balancer health checks.
+
+## Changes
+
+- Added `GET /health` route in `src/routes/health.ts`
+- Returns `{"status": "ok", "version": "1.2.0"}`
+- No authentication required, no database calls
+
+## Test Plan
+
+- [ ] `curl localhost:3000/health` returns 200
+- [ ] Response body matches expected schema
+- [ ] Response time under 50ms
+
+Closes #52
+```
+
+```bash
+gh pr create \
+  --title "feat(api): Add /health endpoint" \
+  --body-file plans/github-issues/PR_52_health-endpoint.md
+```
+
+### Example 2: Work Where Issue Already Exists
+
+User asks: "Fix the broken pagination on the users list."
+
+**Search for existing issue:**
+```bash
+gh issue list --search "pagination users" --state open
+# Found: #87 "bug: Users list pagination returns duplicates"
+```
+
+Issue #87 already exists — skip issue creation, go straight to branching:
+
+```bash
+git checkout -b fix/pagination-offset-87
+# ... fix the bug ...
+```
+
+**Commit via file** — write `plans/github-issues/COMMIT_87_pagination-fix.md`:
+```
+fix(users): correct pagination offset calculation
+
+Off-by-one error in offset: page * limit should be (page - 1) * limit
+since pages are 1-indexed.
+
+Fixes #87
+```
+
+```bash
+git commit -F plans/github-issues/COMMIT_87_pagination-fix.md
+```
+
+**PR via file** — write `plans/github-issues/PR_87_pagination-fix.md`:
+```markdown
+## Summary
+
+Fix off-by-one pagination bug causing duplicate items across pages.
+
+## Changes
+
+- Fixed offset calculation in `src/services/users.ts:45`
+- `offset = (page - 1) * limit` instead of `page * limit`
+
+## Test Plan
+
+- [ ] Page 1 and page 2 return no overlapping items
+- [ ] Last page returns correct number of items
+- [ ] Single-page result sets unaffected
+
+Closes #87
+```
+
+```bash
+gh pr create \
+  --title "fix(users): Correct pagination offset" \
+  --body-file plans/github-issues/PR_87_pagination-fix.md
+```
+
+## Troubleshooting
+
+### Error: No matching labels found
+
+If `gh label list` returns no relevant labels:
+1. Check if the repo uses a different labeling convention (e.g., `type:bug` vs `bug`).
+2. Create a new label only after confirming no similar one exists.
+3. Use descriptive names and colors consistent with existing labels.
+
+### Error: Issue already exists for this work
+
+If `gh issue list --search` finds a matching issue:
+1. Read the existing issue to confirm it covers the same scope.
+2. If it does, reference it directly — do not create a duplicate.
+3. If it's related but different, create a new issue and cross-reference.
+
+### Error: PR description file path issues
+
+If `gh pr create --body-file` fails:
+1. Verify the file exists: `ls plans/github-issues/PR_NNN_slug.md`
+2. Check for typos in the path — the directory may be `plan/` or `plans/`.
+3. Ensure the file is not empty (gh rejects empty body files).

--- a/.claude/skills/git-workflow/references/templates.md
+++ b/.claude/skills/git-workflow/references/templates.md
@@ -1,0 +1,92 @@
+# Git Workflow Templates
+
+## Issue Body Template
+
+Write to `plans/github-issues/ISSUE_NNN_slug.md`:
+
+```markdown
+## Problem
+
+[What is broken, missing, or needed. 2-3 sentences.]
+
+## Context
+
+[Why this matters. User impact, system impact, or business reason.]
+
+## Proposed Solution
+
+[How to fix or implement. Brief technical approach.]
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Labels
+
+[Suggested labels — verify against `gh label list` before applying.]
+```
+
+## PR Body Template
+
+Write to `plans/github-issues/PR_NNN_slug.md`:
+
+```markdown
+## Summary
+
+[1-3 sentences describing what this PR does and why.]
+
+## Changes
+
+- [Change 1 with file reference]
+- [Change 2 with file reference]
+- [Change 3 with file reference]
+
+## Test Plan
+
+- [ ] Test scenario 1
+- [ ] Test scenario 2
+- [ ] Test scenario 3
+
+Closes #NNN
+```
+
+## Commit Message Template
+
+Write to `plans/github-issues/COMMIT_NNN_slug.md`:
+
+```
+type(scope): brief description
+
+[Body: 1-3 sentences explaining WHY, not just WHAT. Include context
+that isn't obvious from the diff.]
+
+[Footer: issue reference]
+Refs #NNN
+```
+
+### Conventional Commit Types
+
+| Type       | When to Use                        |
+|------------|------------------------------------|
+| `feat`     | New feature                        |
+| `fix`      | Bug fix                            |
+| `chore`    | Maintenance, deps, config          |
+| `docs`     | Documentation only                 |
+| `refactor` | Code change that doesn't add/fix   |
+| `test`     | Adding or updating tests           |
+| `ci`       | CI/CD pipeline changes             |
+
+### Issue Reference Keywords
+
+Use in commit messages and PR bodies:
+
+| Keyword               | Effect on Merge              |
+|-----------------------|------------------------------|
+| `Closes #NNN`        | Auto-closes the issue        |
+| `Fixes #NNN`         | Auto-closes the issue        |
+| `Resolves #NNN`      | Auto-closes the issue        |
+| `Refs #NNN`          | Links without closing        |
+
+Use `Closes` in the PR body (auto-close on merge). Use `Refs` in commit messages (link without closing, since the PR handles closure).

--- a/.claude/skills/max-quality-no-shortcuts/SKILL.md
+++ b/.claude/skills/max-quality-no-shortcuts/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: max-quality-no-shortcuts
+description: >-
+  Anti-bypass philosophy for linter and type checker warnings. Activates
+  when you consider adding noqa, type-ignore, pylint-disable, or similar
+  bypasses. Fix the root cause instead. Covers complexity refactoring,
+  type fixes, and argument reduction patterns.
+  Do NOT use for general code quality guidance (use vibe or stay-green).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# MAX QUALITY: No Shortcuts
+
+When you're about to add a linter bypass: STOP. Fix the root cause instead.
+
+## Instructions
+
+### Step 1: Understand the Warning
+
+Read the error message carefully. Look up the rule if unfamiliar. Understand the underlying principle the tool is enforcing.
+
+### Step 2: Identify the Root Cause
+
+Ask:
+- Is my code too complex? -> Refactor into smaller functions
+- Is my type annotation wrong? -> Fix the type or implementation
+- Is my import unused? -> Remove it
+- Is my function too long? -> Extract helper functions
+- Are there too many arguments? -> Use a dataclass/config object
+
+### Step 3: Fix Properly
+
+See `references/fix-examples.md` for detailed before/after examples.
+
+| Bypass | Proper Fix |
+|--------|-----------|
+| `# noqa: C901` (complexity) | Refactor into smaller functions |
+| `# type: ignore` | Fix the type annotation or implementation |
+| `# pylint: disable=invalid-name` | Use proper naming conventions |
+| `# noqa: F401` (unused import) | Remove the import |
+| `# pylint: disable=too-many-arguments` | Use a config object or dataclass |
+| `# noqa: E501` (line too long) | Break into multiple lines |
+
+### Step 4: Handle Genuine Exceptions
+
+Bypasses are acceptable ONLY for:
+1. Third-party library bugs you can't fix
+2. Python version compatibility
+3. Benchmarked performance necessity
+4. Auto-generated code you don't control
+
+For these cases, you MUST include:
+```python
+# pylint: disable=no-member
+# Reason: boto3 dynamically creates methods via __getattr__
+# Reference: https://github.com/boto/boto3/issues/123
+# Alternative considered: Custom wrapper (unnecessary complexity)
+# Review: 2026-06-27
+```
+
+## Examples
+
+See `references/fix-examples.md` for complete refactoring examples.
+
+### Example 1: Complexity Too High
+
+```python
+# BAD: # noqa: C901
+def process_order(order, user, payment, shipping):
+    if order.status == "pending":
+        if user.is_verified:
+            if payment.is_valid:
+                # 30 more lines of nested ifs...
+
+# GOOD: Extract validation functions
+def process_order(order, user, payment, shipping) -> Result:
+    _validate_order_ready(order)
+    _validate_user_eligible(user)
+    _validate_payment(payment)
+    _validate_shipping(shipping)
+    return _fulfill_order(order, user, payment, shipping)
+```
+
+### Example 2: Type Error
+
+```python
+# BAD: return config.get(key)  # type: ignore[return-value]
+
+# GOOD: Fix the return type
+def get_config(key: str) -> str | None:
+    return config.get(key)
+
+# Or if the key must exist:
+def get_required_config(key: str) -> str:
+    value = config.get(key)
+    if value is None:
+        raise ConfigError(f"Required key not found: {key}")
+    return value
+```
+
+## Troubleshooting
+
+### Error: "I genuinely can't fix this without a bypass"
+- Is it a third-party library issue? Document it with a link to the issue tracker
+- Is it a Python version limitation? Document which versions are affected
+- Can you restructure the code to avoid the situation entirely?
+- If truly necessary, add full justification comment with review date
+
+### Error: "Fixing this properly will take too long"
+- 10 minutes fixing properly now saves 2 hours debugging later
+- The bypass will still be there when you come back
+- Each bypass makes the next one easier to justify

--- a/.claude/skills/max-quality-no-shortcuts/references/fix-examples.md
+++ b/.claude/skills/max-quality-no-shortcuts/references/fix-examples.md
@@ -1,0 +1,114 @@
+# Fix Examples: Root Cause vs Bypass
+
+## Example 1: Complexity Too High (C901)
+
+### Bypass (BAD)
+```python
+def process_order(order, user, payment, shipping):  # noqa: C901
+    if order.status == "pending":
+        if user.is_verified:
+            if payment.is_valid:
+                if shipping.is_available:
+                    # 30 more lines...
+```
+
+### Proper Fix (GOOD)
+```python
+def process_order(order: Order, user: User, payment: Payment, shipping: Shipping) -> Result:
+    """Process order through validation and fulfillment pipeline."""
+    _validate_order_ready(order)
+    _validate_user_eligible(user)
+    _validate_payment(payment)
+    _validate_shipping(shipping)
+    return _fulfill_order(order, user, payment, shipping)
+
+def _validate_order_ready(order: Order) -> None:
+    if order.status != "pending":
+        raise OrderError(f"Cannot process order with status: {order.status}")
+
+def _validate_user_eligible(user: User) -> None:
+    if not user.is_verified:
+        raise UserError("User must be verified to place orders")
+```
+
+**Result**: Each function has complexity <= 3. Clear, testable units.
+
+## Example 2: Type Errors
+
+### Bypass (BAD)
+```python
+def get_config(key: str) -> str:
+    config = load_config()
+    return config.get(key)  # type: ignore[return-value]
+```
+
+### Proper Fix (GOOD)
+```python
+def get_config(key: str) -> str | None:
+    """Get config value. Returns None if not found."""
+    return load_config().get(key)
+
+# Or for required keys:
+def get_required_config(key: str) -> str:
+    """Get required config value. Raises if not found."""
+    value = load_config().get(key)
+    if value is None:
+        raise ConfigError(f"Required config key not found: {key}")
+    return value
+```
+
+**Result**: Types accurately reflect reality. Explicit error handling.
+
+## Example 3: Too Many Arguments
+
+### Bypass (BAD)
+```python
+def create_user(  # pylint: disable=too-many-arguments
+    username: str, email: str, password: str,
+    first_name: str, last_name: str, phone: str,
+    address: str, city: str, country: str,
+) -> User:
+    pass
+```
+
+### Proper Fix (GOOD)
+```python
+@dataclass
+class UserRegistration:
+    """User registration data."""
+    username: str
+    email: str
+    password: str
+    first_name: str
+    last_name: str
+    phone: str
+    address: str
+    city: str
+    country: str
+
+def create_user(registration: UserRegistration) -> User:
+    """Create new user from registration data."""
+    _validate_registration(registration)
+    return User.from_registration(registration)
+```
+
+**Result**: Clean signature, grouped data, easy to extend.
+
+## The Rare Legitimate Bypass
+
+```python
+# pylint: disable=no-member
+# Reason: boto3 dynamically creates methods via __getattr__
+# Reference: https://github.com/boto/boto3/issues/123
+# Alternative considered: Custom wrapper (adds unnecessary complexity)
+# Reviewed: 2026-01-27
+# Review again: 2026-06-27 (when boto3 v2.0 releases)
+response = client.get_item(TableName="users", Key={"id": user_id})
+```
+
+Requirements for legitimate bypasses:
+- Explicit reason why bypass is necessary
+- Link to external issue/documentation
+- Alternatives considered
+- Review date for reconsideration
+- Targeted (specific line, not blanket disable)

--- a/.claude/skills/mutation-testing/SKILL.md
+++ b/.claude/skills/mutation-testing/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: mutation-testing
+description: >-
+  Write high-value tests that kill mutants through logic validation.
+  Use when writing tests that need to verify behavior, improving
+  mutation scores, or evaluating test quality. Covers boundary testing,
+  exact value assertions, error message validation, and state verification.
+  Do NOT use for general test writing (use testing skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Mutation Testing
+
+Mutation testing reveals whether your tests verify behavior or just achieve coverage. A test that doesn't kill mutants doesn't test.
+
+## Instructions
+
+### Step 1: Apply the Mutant-Killing Checklist
+
+For every test, ask:
+
+1. **Would this fail if I changed a constant by 1?** -> Test exact values
+2. **Would this fail if I changed an operator?** -> Test exact boundaries
+3. **Would this fail if I removed a check?** -> Test that validation happens
+4. **Would this fail if I changed an error message?** -> Validate message content
+
+### Step 2: Use High-Value Test Patterns
+
+- **Exact constants**: `assert MAX_RETRIES == 3` (not just `assert MAX_RETRIES > 0`)
+- **Boundary testing**: Test at, above, and below the boundary
+- **Complete error messages**: Match on message content, not just exception type
+- **State verification**: Assert before and after state changes
+- **Collection contents**: Test exact contents and order, not just size
+
+### Step 3: Write Testable Code
+
+- Use named constants for magic numbers
+- Write specific error messages
+- Make behavior testable (raise exceptions, don't just print)
+
+### Step 4: Run Mutation Tests
+
+```bash
+./scripts/mutation.sh --paths-to-mutate src/module.py
+./scripts/analyze_mutations.py
+# Target: >= 80% mutation score
+```
+
+## Examples
+
+See `references/practical-examples.md` for complete worked examples.
+
+### Example 1: Boundary Testing
+
+```python
+# BAD: Doesn't kill MAX_LENGTH = 100 -> 101
+assert len(name) <= MAX_PROJECT_NAME_LENGTH
+
+# GOOD: Kills the mutant
+assert MAX_PROJECT_NAME_LENGTH == 100
+assert is_valid("a" * 100) == True   # At max
+assert is_valid("a" * 101) == False  # Over max
+assert is_valid("a" * 99) == True    # Under max
+```
+
+### Example 2: Error Message Validation
+
+```python
+# BAD: Doesn't kill message mutations
+with pytest.raises(FileNotFoundError):
+    load_config(missing_file)
+
+# GOOD: Validates exact message
+with pytest.raises(FileNotFoundError) as exc:
+    load_config(missing_file)
+assert "Configuration file not found" in str(exc.value)
+assert str(missing_file) in str(exc.value)
+```
+
+## Troubleshooting
+
+### Error: Mutation score below 80%
+- Run `mutmut show <id>` to see surviving mutants
+- Focus on logic mutations (constants, operators, conditions) first
+- Add exact value assertions, not just truthiness checks
+- Test both branches of every condition
+
+### Error: Too many equivalent mutants
+- Some mutations produce equivalent behavior and can't be killed
+- Focus on mutations that actually change observable behavior
+- Use `mutmut show` to identify which are truly equivalent

--- a/.claude/skills/mutation-testing/references/practical-examples.md
+++ b/.claude/skills/mutation-testing/references/practical-examples.md
@@ -1,0 +1,110 @@
+# Mutation Testing Practical Examples
+
+## Example 1: Password Validation
+
+```python
+# Code
+MIN_PASSWORD_LENGTH = 8
+MAX_PASSWORD_LENGTH = 128
+
+def validate_password(password: str) -> None:
+    if len(password) < MIN_PASSWORD_LENGTH:
+        raise ValueError(f"Password too short. Minimum {MIN_PASSWORD_LENGTH} characters.")
+    if len(password) > MAX_PASSWORD_LENGTH:
+        raise ValueError(f"Password too long. Maximum {MAX_PASSWORD_LENGTH} characters.")
+
+# HIGH-VALUE Tests
+def test_password_min_length_exact():
+    """Kills: MIN_PASSWORD_LENGTH = 8 -> 7, 9"""
+    assert MIN_PASSWORD_LENGTH == 8
+    validate_password("a" * 8)  # Should pass
+    with pytest.raises(ValueError, match="Password too short"):
+        validate_password("a" * 7)  # Should fail
+
+def test_password_max_length_exact():
+    """Kills: MAX_PASSWORD_LENGTH = 128 -> 127, 129"""
+    assert MAX_PASSWORD_LENGTH == 128
+    validate_password("a" * 128)  # Should pass
+    with pytest.raises(ValueError, match="Password too long"):
+        validate_password("a" * 129)  # Should fail
+
+def test_password_error_messages_exact():
+    """Kills: error message string mutations"""
+    with pytest.raises(ValueError) as exc:
+        validate_password("short")
+    error = str(exc.value)
+    assert "Password too short" in error
+    assert "8 characters" in error
+```
+
+## Example 2: State Machine
+
+```python
+# Code
+class OrderStateMachine:
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+
+    def __init__(self):
+        self.state = self.PENDING
+
+    def start_processing(self):
+        if self.state != self.PENDING:
+            raise ValueError(f"Cannot process order in state: {self.state}")
+        self.state = self.PROCESSING
+
+    def complete(self):
+        if self.state != self.PROCESSING:
+            raise ValueError(f"Cannot complete order in state: {self.state}")
+        self.state = self.COMPLETED
+
+# HIGH-VALUE Tests
+def test_state_constants_exact():
+    """Kills: state string mutations"""
+    assert OrderStateMachine.PENDING == "pending"
+    assert OrderStateMachine.PROCESSING == "processing"
+    assert OrderStateMachine.COMPLETED == "completed"
+
+def test_initial_state_exact():
+    """Kills: wrong initial state"""
+    order = OrderStateMachine()
+    assert order.state == OrderStateMachine.PENDING
+    assert order.state != OrderStateMachine.PROCESSING
+
+def test_state_transition_exact():
+    """Kills: missing state updates, wrong transitions"""
+    order = OrderStateMachine()
+    order.start_processing()
+    assert order.state == OrderStateMachine.PROCESSING
+    assert order.state != OrderStateMachine.PENDING
+    order.complete()
+    assert order.state == OrderStateMachine.COMPLETED
+
+def test_invalid_transitions_blocked():
+    """Kills: missing validation checks"""
+    order = OrderStateMachine()
+    with pytest.raises(ValueError, match="Cannot complete order in state: pending"):
+        order.complete()
+    assert order.state == OrderStateMachine.PENDING  # State unchanged
+```
+
+## Common Mutation Categories
+
+| Mutation Type | How to Kill It |
+|---------------|----------------|
+| Constant Mutations | Test exact value with equality assertions |
+| Operator Mutations | Test boundary cases and edge values |
+| Boolean Mutations | Test both True and False branches explicitly |
+| String Mutations | Test exact string contents with equality |
+| Collection Mutations | Test exact size, order, and contents |
+| None Mutations | Test both None and not-None cases |
+| Return Mutations | Test exact return values, not just type |
+
+## Red Flags (Tests That Don't Kill Mutants)
+
+- `assert result` - truthy test misses specific values
+- `assert function() is not None` - doesn't test what the value IS
+- `assert len(result) > 0` - doesn't test exact size or contents
+- `assert "error" in output` - weak string matching
+- Tests with no assertions - coverage without verification

--- a/.claude/skills/prompt-engineering/SKILL.md
+++ b/.claude/skills/prompt-engineering/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: prompt-engineering
+description: >-
+  Transform vague requests into effective 6-component prompts.
+  Use when crafting prompts for AI agents, writing plan files,
+  delegating tasks, or when Claude's responses miss the mark.
+  Covers role, goal, context, format, examples, and constraints.
+  Do NOT use for direct code implementation or testing.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Prompt Engineering
+
+Transform vague requests into effective, actionable prompts using the 6-component framework.
+
+## Instructions
+
+### Step 1: Identify Missing Components
+
+Check the prompt against the 6-component checklist:
+1. **Role or Persona** - Who the AI should be
+2. **Goal / Task Statement** - Exactly what you want done
+3. **Context or References** - Key data the model needs
+4. **Format or Output Requirements** - How you want the answer
+5. **Examples or Demonstrations** - Show, don't just tell
+6. **Constraints / Additional Instructions** - Boundaries that improve quality
+
+Missing 3+ items? Rewrite the prompt.
+
+### Step 2: Rewrite with All Components
+
+Transform the vague request into a structured prompt with all 6 components present. Be concise but complete.
+
+### Step 3: Apply to Plan Files
+
+All files in `plan/` should follow this structure:
+```markdown
+## Role
+You are a [specific role with relevant expertise].
+
+## Goal
+[Specific, measurable task with clear success criteria]
+
+## Context
+- Current state, problem, constraints, file references
+
+## Output Format
+[Specify structure: numbered steps, code blocks, etc.]
+
+## Examples
+[Concrete examples of what you want]
+
+## Requirements
+- [Specific constraints]
+```
+
+## Examples
+
+### Example 1: Code Review Request
+
+**Ineffective**: "Review this code."
+
+**Effective**:
+```
+Role: Senior Python engineer focused on code quality.
+
+Task: Review the FastAPI endpoint in src/api/users.py for:
+- Security vulnerabilities
+- Performance issues
+- Code style violations
+
+Context: User registration endpoint handling ~1000 requests/day.
+
+Format: Numbered list with issue description, severity
+(Critical/Medium/Low), line number, and recommended fix.
+
+Example:
+1. SQL Injection Risk (Critical)
+   Line 45: Direct string interpolation in query
+   Fix: Use parameterized queries
+
+Constraints:
+- Only flag issues with confidence > 80%
+- Skip minor style issues if functionality is correct
+```
+
+### Example 2: Bug Fix Plan
+
+**Ineffective**: "Help me fix the login bug."
+
+**Effective**:
+```
+Role: Backend debugging specialist with FastAPI expertise.
+
+Task: Create root cause analysis and fix plan for login failures.
+
+Context:
+- Error: "401 Unauthorized" on POST /auth/login
+- Happens intermittently (30% of requests)
+- Started after deploying commit abc123
+- JWT token validation in src/auth/jwt.py
+
+Format: Markdown with Root Cause, Reproduction Steps,
+Fix Strategy, and Testing Plan sections.
+
+Constraints:
+- Must include specific file:line references
+- Fix must maintain backward compatibility
+- Include regression test cases
+```
+
+## Troubleshooting
+
+### Error: AI responses are too vague or miss the mark
+- Add concrete examples showing exactly what good output looks like
+- Specify the output format explicitly (table, numbered list, code block)
+- Add constraints to narrow the scope
+
+### Error: Prompt is getting too long
+- Move reference data to separate files and point to them
+- Use "See Also" references instead of inlining everything
+- Focus on the 3 most important components for your use case

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: security
+description: >-
+  Security best practices for Adepthood's FastAPI + React Native stack.
+  Use when handling user input, API keys, JWT tokens, database queries,
+  CORS configuration, or preparing for production deployment.
+  Covers OWASP Top 10, secrets management, and deployment hardening.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Security
+
+Defense in depth, least privilege, fail securely, never trust user input.
+
+## Instructions
+
+### Principles
+
+1. Defense in depth — multiple layers of security
+2. Least privilege — minimal access required
+3. Fail securely — errors don't expose sensitive data
+4. Input validation at all boundaries
+5. Never trust user input
+6. Secure by default, not by configuration
+
+### Pre-Launch Security Checklist
+
+**Authentication & Authorization:**
+- [ ] JWT tokens expire (check TTL)
+- [ ] SECRET_KEY is cryptographically random (not `replace-me`)
+- [ ] Password hashing uses bcrypt with adequate rounds (≥12)
+- [ ] Account lockout after failed attempts
+- [ ] Rate limiting on auth endpoints
+- [ ] Timing-attack resistant error messages (generic "invalid credentials")
+
+**Input Validation:**
+- [ ] All user inputs validated via Pydantic models
+- [ ] No raw SQL (parameterized queries via SQLAlchemy)
+- [ ] Email format validated
+- [ ] Password minimum length enforced
+- [ ] Request body size limits
+
+**API Security:**
+- [ ] CORS restricted to specific origins (not `*`)
+- [ ] HTTPS enforced in production (HSTS header)
+- [ ] Security headers set (X-Content-Type-Options, X-Frame-Options)
+- [ ] No sensitive data in error responses
+- [ ] No debug endpoints in production
+
+**Secrets Management:**
+- [ ] No hardcoded secrets in source code
+- [ ] .env files in .gitignore
+- [ ] detect-secrets baseline up to date
+- [ ] API keys never logged or returned in responses
+- [ ] User API keys never stored in plaintext
+
+**Dependencies:**
+- [ ] `pip-audit` passes (no known vulnerabilities)
+- [ ] `npm audit` reviewed (no critical/high)
+- [ ] Docker base images are slim/minimal
+- [ ] Non-root user in Docker containers
+
+**Database:**
+- [ ] No raw SQL injection vectors
+- [ ] Sensitive fields not exposed in API responses
+- [ ] Database credentials via environment variables only
+
+### User API Key Handling
+
+When users provide their own LLM API keys:
+- Never store keys server-side (keep in client SecureStore/localStorage)
+- Pass via request header (`X-LLM-API-Key`), not in URL or body
+- Never log the key value
+- Never return the key in API responses
+- Validate key format before forwarding to LLM provider
+- Clear from memory after use
+
+## Examples
+
+### Safe Secret Handling
+```python
+# WRONG - logs the secret
+logger.info(f"Using API key: {api_key}")
+
+# CORRECT - never log secrets
+logger.info("LLM request initiated for user %s", user_id)
+```
+
+### Safe Error Response
+```python
+# WRONG - leaks internal details
+raise HTTPException(status_code=500, detail=str(exc))
+
+# CORRECT - generic error, log details server-side
+logger.exception("Database error in endpoint X")
+raise HTTPException(status_code=500, detail="internal_error")
+```
+
+## Troubleshooting
+
+### Error: detect-secrets flags false positives
+- Add to `.secrets.baseline` with `detect-secrets scan --baseline .secrets.baseline`
+- Use `# pragma: allowlist secret` for test fixtures only
+
+### Error: pip-audit finds vulnerability in transitive dependency
+- Check if it's exploitable in your usage
+- Pin a safe version or add to `.pip-audit-known-vulnerabilities`
+- Document the decision

--- a/.claude/skills/security/references/examples.md
+++ b/.claude/skills/security/references/examples.md
@@ -1,0 +1,124 @@
+# Security Examples
+
+## Example 1: Comprehensive Input Validator (Python)
+
+```python
+import re
+from pathlib import Path
+from typing import Optional
+
+class InputValidator:
+    """Validate user inputs for security."""
+
+    PROJECT_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9_-]+$')
+    EMAIL_PATTERN = re.compile(r'^[^@]+@[^@]+\.[^@]+$')
+    RESERVED_NAMES = {'con', 'prn', 'aux', 'nul', 'com1', 'com2', 'lpt1', 'lpt2'}
+
+    @staticmethod
+    def validate_project_name(name: str) -> str:
+        name = name.strip()
+        if not name:
+            raise ValueError("Project name cannot be empty")
+        if len(name) > 100:
+            raise ValueError(f"Project name too long: {len(name)} chars (max 100)")
+        if not InputValidator.PROJECT_NAME_PATTERN.match(name):
+            raise ValueError(f"Invalid project name: {name!r}")
+        if name[0] in ('-', '_'):
+            raise ValueError(f"Project name cannot start with {name[0]!r}")
+        if name.lower() in InputValidator.RESERVED_NAMES:
+            raise ValueError(f"Project name {name!r} is reserved")
+        return name
+
+    @staticmethod
+    def validate_email(email: str) -> str:
+        email = email.strip().lower()
+        if not email:
+            raise ValueError("Email cannot be empty")
+        if len(email) > 254:
+            raise ValueError("Email address too long")
+        if not InputValidator.EMAIL_PATTERN.match(email):
+            raise ValueError(f"Invalid email format: {email!r}")
+        if any(c in email for c in ['\n', '\r', '\0', ';']):
+            raise ValueError("Email contains invalid characters")
+        return email
+
+    @staticmethod
+    def validate_url(url: str, allowed_schemes: Optional[list[str]] = None) -> str:
+        if allowed_schemes is None:
+            allowed_schemes = ['https', 'git', 'ssh']
+        url = url.strip()
+        if not url:
+            raise ValueError("URL cannot be empty")
+        if not any(url.startswith(f"{scheme}://") for scheme in allowed_schemes):
+            raise ValueError(f"Invalid URL scheme. Allowed: {', '.join(allowed_schemes)}")
+        # Prevent SSRF
+        dangerous_hosts = ['localhost', '127.0.0.1', '0.0.0.0', '169.254', '10.', '172.16.', '192.168.']
+        if any(host in url.lower() for host in dangerous_hosts):
+            raise ValueError("URLs pointing to localhost or private IPs are not allowed")
+        return url
+```
+
+## Example 2: Secure File Manager (Python)
+
+```python
+class SecureFileManager:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir.resolve()
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _validate_path(self, file_path: str) -> Path:
+        target = (self.base_dir / file_path).resolve()
+        try:
+            target.relative_to(self.base_dir)
+        except ValueError:
+            raise ValueError(f"Path traversal detected: {file_path!r}") from None
+        return target
+
+    def write_file(self, file_path: str, content: str) -> None:
+        target = self._validate_path(file_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write using temporary file
+        temp_fd, temp_path = tempfile.mkstemp(dir=target.parent)
+        try:
+            with open(temp_fd, 'w', encoding='utf-8') as f:
+                f.write(content)
+            Path(temp_path).replace(target)
+        except Exception:
+            Path(temp_path).unlink(missing_ok=True)
+            raise
+
+    def read_file(self, file_path: str) -> str:
+        target = self._validate_path(file_path)
+        if not target.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        return target.read_text(encoding='utf-8')
+```
+
+## Example 3: Secure API Client (Python)
+
+```python
+class SecureAPIClient:
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self.base_url = base_url.rstrip('/')
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': 'MyApp/1.0',
+            'X-API-Key': api_key,
+        })
+
+    def request(self, method: str, path: str, data: dict | None = None, timeout: int = 30) -> dict:
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        response = self.session.request(
+            method=method,
+            url=url,
+            json=data if method in ('POST', 'PUT', 'PATCH') else None,
+            timeout=timeout,
+            verify=True,           # Verify SSL certificates
+            allow_redirects=False,  # Don't follow redirects (prevent SSRF)
+        )
+        response.raise_for_status()
+        content_type = response.headers.get('Content-Type', '')
+        if 'application/json' not in content_type:
+            raise ValueError(f"Unexpected content type: {content_type}")
+        return response.json()
+```

--- a/.claude/skills/security/references/patterns-by-language.md
+++ b/.claude/skills/security/references/patterns-by-language.md
@@ -1,0 +1,178 @@
+# Security Patterns by Language
+
+## Python
+
+### Input Validation
+```python
+import re
+
+def validate_project_name(name: str) -> None:
+    if not re.match(r'^[a-zA-Z0-9_-]+$', name):
+        raise ValueError(f"Invalid project name: {name!r}. Only letters, numbers, hyphens, underscores.")
+    if len(name) > 100:
+        raise ValueError(f"Project name too long: {len(name)} chars (max 100)")
+    if name.startswith(('-', '_')):
+        raise ValueError(f"Project name cannot start with {name[0]!r}")
+    reserved = {'con', 'prn', 'aux', 'nul', 'com1', 'lpt1'}
+    if name.lower() in reserved:
+        raise ValueError(f"Project name {name!r} is reserved")
+```
+
+### Path Traversal Prevention
+```python
+def safe_path_join(base_dir: Path, user_path: str) -> Path:
+    base_dir = base_dir.resolve()
+    target = (base_dir / user_path).resolve()
+    try:
+        target.relative_to(base_dir)
+    except ValueError:
+        raise ValueError(f"Path traversal detected: {user_path!r}") from None
+    return target
+```
+
+### Subprocess Safety
+```python
+def run_git_command(args: list[str], cwd: Path) -> str:
+    dangerous_chars = {';', '|', '&', '$', '`', '\n', '\r'}
+    for arg in args:
+        if any(char in arg for char in dangerous_chars):
+            raise ValueError(f"Argument contains dangerous characters: {arg!r}")
+    # NEVER use shell=True
+    result = subprocess.run(['git'] + args, cwd=cwd, capture_output=True, text=True, check=True)
+    return result.stdout
+```
+
+### SQL Injection Prevention
+```python
+# WRONG - SQL injection
+query = f"SELECT * FROM users WHERE email = '{email}'"
+cursor.execute(query)
+
+# CORRECT - parameterized query
+query = "SELECT * FROM users WHERE email = ?"
+cursor.execute(query, (email,))
+```
+
+### API Key Management
+```python
+import keyring
+
+def get_api_key(key_name: str) -> str:
+    api_key = keyring.get_password("my_app", key_name)
+    if not api_key:
+        raise ValueError(f"API key '{key_name}' not found in OS keyring.")
+    return api_key
+
+# WRONG: API_KEY = "sk-ant-1234567890"  # pragma: allowlist secret
+# WRONG: api_key = os.environ.get("API_KEY")
+# CORRECT: api_key = get_api_key("claude_api_key")
+```
+
+## TypeScript
+
+### Input Validation
+```typescript
+export class InputValidator {
+  static validateEmail(email: string): string {
+    email = email.trim().toLowerCase();
+    if (!validator.isEmail(email)) throw new Error(`Invalid email: ${email}`);
+    if (email.length > 254) throw new Error('Email too long');
+    return email;
+  }
+
+  static sanitizeHtml(html: string): string {
+    return validator.escape(html);
+  }
+}
+```
+
+### XSS Prevention
+```typescript
+function renderUserContent(content: string): string {
+  return content
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+// React/JSX escapes by default - {content} is safe
+// dangerouslySetInnerHTML should be avoided
+```
+
+### CSRF Protection
+```typescript
+import crypto from 'crypto';
+
+function generateCsrfToken(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+function validateCsrfToken(token: string, sessionToken: string): boolean {
+  return crypto.timingSafeEqual(Buffer.from(token), Buffer.from(sessionToken));
+}
+```
+
+## Go
+
+### Input Validation
+```go
+var projectNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+func ValidateProjectName(name string) error {
+    name = strings.TrimSpace(name)
+    if name == "" { return errors.New("project name cannot be empty") }
+    if len(name) > 100 { return errors.New("project name too long (max 100)") }
+    if !projectNameRegex.MatchString(name) { return errors.New("invalid characters in project name") }
+    return nil
+}
+```
+
+### Path Traversal Prevention
+```go
+func SafePathJoin(baseDir, userPath string) (string, error) {
+    baseDir = filepath.Clean(baseDir)
+    target := filepath.Join(baseDir, filepath.Clean(userPath))
+    if !strings.HasPrefix(target, baseDir+string(filepath.Separator)) {
+        return "", errors.New("path traversal detected")
+    }
+    return target, nil
+}
+```
+
+### Command Injection Prevention
+```go
+// exec.Command does NOT use shell - safe by default
+cmd := exec.CommandContext(ctx, "git", args...)
+cmd.Dir = dir
+output, err := cmd.CombinedOutput()
+```
+
+## Rust
+
+### Input Validation
+```rust
+lazy_static! {
+    static ref PROJECT_NAME_REGEX: Regex = Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
+}
+
+pub fn validate_project_name(name: &str) -> Result<String, Box<dyn Error>> {
+    let name = name.trim();
+    if name.is_empty() { return Err("Project name cannot be empty".into()); }
+    if name.len() > 100 { return Err("Project name too long".into()); }
+    if !PROJECT_NAME_REGEX.is_match(name) { return Err("Invalid characters".into()); }
+    Ok(name.to_string())
+}
+```
+
+### Path Traversal Prevention
+```rust
+pub fn safe_path_join(base_dir: &Path, user_path: &str) -> Result<PathBuf, io::Error> {
+    let base_dir = base_dir.canonicalize()?;
+    let target = base_dir.join(user_path).canonicalize()?;
+    if !target.starts_with(&base_dir) {
+        return Err(io::Error::new(io::ErrorKind::PermissionDenied, "Path traversal detected"));
+    }
+    Ok(target)
+}
+```

--- a/.claude/skills/skill-craft/SKILL.md
+++ b/.claude/skills/skill-craft/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: skill-craft
+description: >-
+  Build and validate Claude Code skills to production quality. Use when
+  creating new skills, modifying existing SKILL.md files, writing skill
+  descriptions, structuring skill directories, or reviewing skill quality.
+  Ensures progressive disclosure, trigger optimization, and composability.
+  Do NOT use for general documentation or code quality guidance.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Skill Craft
+
+Meta-skill for creating world-class Claude Code skills. Every skill this produces must pass the same quality bar it enforces — including itself.
+
+## Instructions
+
+### Step 1: Define Use Cases Before Writing
+
+Identify 2-3 concrete use cases before any code or markdown. For each:
+- What does the user want to accomplish?
+- What trigger phrases would they use?
+- What should the skill NOT handle? (prevents overtriggering)
+
+### Step 2: Structure the Directory
+
+```
+skill-name/
+├── SKILL.md          # Required — core instructions
+├── references/       # Optional — detailed docs loaded on demand
+├── scripts/          # Optional — executable validation/tooling
+└── assets/           # Optional — templates, icons, fonts
+```
+
+Rules:
+- Folder name: kebab-case, no spaces, no capitals, no underscores
+- File: exactly `SKILL.md` (case-sensitive, not `skill.md` or `SKILL.MD`)
+- No `README.md` inside the skill folder
+
+### Step 3: Write the YAML Frontmatter
+
+The frontmatter is the most important part — it determines when Claude loads the skill.
+
+```yaml
+---
+name: skill-name-in-kebab-case
+description: >-
+  [What it does]. Use when [specific trigger phrases the user would say].
+  [Key capabilities]. Do NOT use for [exclusions with cross-references].
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+```
+
+**Frontmatter rules:**
+- `name`: kebab-case, must match folder name
+- `description`: under 1024 characters, MUST include:
+  - What the skill does (1 sentence)
+  - When to use it with specific trigger phrases
+  - What NOT to use it for (with cross-references to correct skill)
+- No XML angle brackets (`<` or `>`) anywhere in frontmatter
+- No "claude" or "anthropic" in the name (reserved)
+
+### Step 4: Write the Body with Progressive Disclosure
+
+SKILL.md body structure:
+
+```markdown
+# Skill Name
+
+[1-2 sentence overview of the skill's purpose]
+
+## Instructions
+### Step 1: [First action]
+### Step 2: [Second action]
+
+## Examples
+### Example 1: [Common scenario]
+### Example 2: [Edge case or alternative]
+
+## Troubleshooting
+### Error: [Common problem]
+```
+
+**Progressive disclosure levels:**
+1. **Frontmatter** (always loaded): Just enough for Claude to know WHEN to use it
+2. **SKILL.md body** (loaded when relevant): Full instructions and guidance
+3. **references/** (loaded on demand): Detailed docs, language-specific patterns, worked examples
+
+Keep SKILL.md under 5,000 words. Move verbose content to `references/`.
+
+### Step 5: Optimize the Description for Triggering
+
+The description field controls whether the skill activates. Test mentally:
+
+- **Too vague**: "Helps with projects" — won't trigger on anything specific
+- **Missing triggers**: "Creates sophisticated multi-page documentation systems" — no user phrases
+- **Too technical**: "Implements the entity model with hierarchical relationships" — no user language
+
+**Good pattern**: `[Verb phrase]. Use when [user says X, Y, or Z]. [Capabilities]. Do NOT use for [exclusions].`
+
+### Step 6: Ensure Composability
+
+Skills load simultaneously. Your skill must:
+- Work alongside others without assuming it's the only capability
+- Have bilateral exclusions with related skills (if skill A excludes B's domain, B should exclude A's)
+- Use cross-references in "Do NOT use for" clauses (e.g., "use security skill" not just "use another skill")
+
+### Step 7: Validate Before Shipping
+
+Run the checklist in `references/quality-checklist.md`. Every item must pass.
+
+Quick self-test: Ask "When would you use the [skill-name] skill?" — if the answer is vague, the description needs work.
+
+## Examples
+
+### Example 1: Creating a New Skill from a Simple Prompt
+
+User says: "Create a skill for database migration best practices"
+
+1. Define use cases: schema changes, data migration, rollback procedures
+2. Define triggers: "migrate database", "schema change", "add column", "data migration"
+3. Define exclusions: "Do NOT use for general SQL queries (use appropriate language docs)"
+4. Create `database-migrations/SKILL.md` with frontmatter, instructions, examples, troubleshooting
+5. If content exceeds ~200 lines, extract language-specific patterns to `references/`
+6. Validate against checklist
+
+### Example 2: Reviewing an Existing Skill
+
+User says: "Review this skill for quality"
+
+1. Check frontmatter: name kebab-case, description has WHAT + WHEN + DO NOT, under 1024 chars, no XML
+2. Check body: has Instructions, Examples (2+), Troubleshooting sections
+3. Check progressive disclosure: SKILL.md focused, verbose content in references/
+4. Check composability: exclusions are bilateral with related skills
+5. Check triggering: description includes phrases users would actually say
+6. Report issues with specific fixes
+
+### Example 3: Fixing an Overtriggering Skill
+
+Symptom: Skill loads for unrelated queries.
+
+1. Add negative triggers: "Do NOT use for [unrelated domain]"
+2. Make description more specific: "Processes PDF legal documents for contract review" not "Processes documents"
+3. Clarify scope: "Use specifically for online payment workflows, not for general financial queries"
+4. Test with unrelated queries to confirm it no longer triggers
+
+## Troubleshooting
+
+### Error: Skill doesn't trigger when it should
+- Description is too generic — add specific trigger phrases users would say
+- Missing keywords — include technical terms relevant to the domain
+- Debug: Ask Claude "When would you use the [skill-name] skill?" and adjust based on what's missing
+
+### Error: Skill triggers too often
+- Description is too broad — add "Do NOT use for" exclusions
+- Clarify scope with specific domains, file types, or contexts
+- Add negative triggers referencing the correct alternative skill
+
+### Error: Instructions not followed
+- Instructions too verbose — keep SKILL.md focused, move detail to references/
+- Critical instructions buried — put them at the top, use `## Important` headers
+- Ambiguous language — replace "validate things properly" with specific checklists
+
+### Error: Skill content too large / slow responses
+- Move detailed reference material to `references/` files
+- Keep SKILL.md under 5,000 words
+- Link to references instead of inlining content

--- a/.claude/skills/skill-craft/references/patterns.md
+++ b/.claude/skills/skill-craft/references/patterns.md
@@ -1,0 +1,151 @@
+# Skill Design Patterns
+
+Patterns that consistently produce effective skills, derived from Anthropic's guide and production experience.
+
+## Pattern 1: Sequential Workflow Orchestration
+
+**Use when**: Users need multi-step processes in a specific order.
+
+```markdown
+## Workflow: [Task Name]
+
+### Step 1: [Action]
+[What to do, what tool to call, what parameters]
+
+### Step 2: [Action]
+[Dependencies on Step 1 output]
+
+### Step 3: [Validation]
+[How to verify the workflow succeeded]
+```
+
+Key techniques:
+- Explicit step ordering with dependencies between steps
+- Validation at each stage
+- Rollback instructions for failures
+
+## Pattern 2: Iterative Refinement
+
+**Use when**: Output quality improves with iteration.
+
+```markdown
+### Initial Draft
+1. Generate first version
+2. Save to temporary location
+
+### Quality Check
+1. Run validation (script or checklist)
+2. Identify issues
+
+### Refinement Loop
+1. Address each issue
+2. Regenerate affected sections
+3. Re-validate
+4. Repeat until quality threshold met
+
+### Finalization
+1. Apply final formatting
+2. Generate summary
+```
+
+Key techniques:
+- Explicit quality criteria (what "done" looks like)
+- Validation scripts where possible (deterministic > language instructions)
+- Clear stopping conditions
+
+## Pattern 3: Context-Aware Selection
+
+**Use when**: Same goal, different approach depending on context.
+
+```markdown
+### Decision Tree
+1. Assess context: [what to check]
+2. Determine approach:
+   - If [condition A]: [approach A]
+   - If [condition B]: [approach B]
+   - Default: [safe fallback]
+
+### Execute
+Based on decision, follow the appropriate path.
+
+### Explain
+Tell the user why that approach was chosen.
+```
+
+Key techniques:
+- Clear decision criteria
+- Fallback options
+- Transparency about choices
+
+## Pattern 4: Domain-Specific Intelligence
+
+**Use when**: The skill adds specialized knowledge beyond tool access.
+
+```markdown
+### Before Action (Domain Check)
+1. Gather context
+2. Apply domain rules:
+   - [Rule 1]
+   - [Rule 2]
+3. Document decision
+
+### Execute
+IF checks passed: proceed
+ELSE: flag for review, explain why
+
+### Audit Trail
+- Log all decisions
+- Record reasoning
+```
+
+Key techniques:
+- Domain expertise embedded in logic
+- Validation before action
+- Comprehensive documentation of decisions
+
+## Description Field Patterns
+
+### Good Descriptions (with analysis)
+
+```yaml
+# Pattern: [Verb phrase] + [Trigger phrases] + [Capabilities] + [Exclusions]
+description: >-
+  Analyzes Figma design files and generates developer handoff documentation.
+  Use when user uploads .fig files, asks for "design specs", "component
+  documentation", or "design-to-code handoff".
+  Do NOT use for general design discussion (use design-review skill).
+```
+
+Why this works:
+- Starts with what it does (analyzes Figma files)
+- Includes 4 specific trigger phrases
+- Mentions file types (.fig)
+- Has exclusions with cross-reference
+
+### Bad Descriptions (with fixes)
+
+| Bad | Problem | Fix |
+|-----|---------|-----|
+| "Helps with projects" | Too vague, no triggers | "Manages project setup including repository creation, CI configuration, and team onboarding. Use when..." |
+| "Creates sophisticated multi-page documentation systems" | No trigger phrases | Add: "Use when user asks to 'generate docs', 'write API reference', or 'create a README'" |
+| "Implements the entity model with hierarchical relationships" | Too technical, no user language | Rewrite from user perspective: "Sets up database models for hierarchical data..." |
+
+## Anti-Patterns to Avoid
+
+### 1. The Kitchen Sink Skill
+Trying to do everything. Split into focused skills with clear boundaries.
+
+### 2. The Invisible Skill
+Vague description that never triggers. Include specific phrases users say.
+
+### 3. The Greedy Skill
+Overly broad triggers that fire on unrelated queries. Add "Do NOT use for" exclusions.
+
+### 4. The Monolith
+Everything in SKILL.md with no progressive disclosure. Move reference content to `references/`.
+
+### 5. The Island
+No exclusions or cross-references. Every skill should acknowledge its neighbors.
+
+### 6. The One-Way Door
+Exclusions only go in one direction. If skill A says "don't use for B's domain", skill B should say "don't use for A's domain".

--- a/.claude/skills/skill-craft/references/quality-checklist.md
+++ b/.claude/skills/skill-craft/references/quality-checklist.md
@@ -1,0 +1,77 @@
+# Skill Quality Checklist
+
+Every item must pass before a skill ships. This checklist is derived from Anthropic's Complete Guide to Building Skills for Claude and validated against production skills.
+
+## Structure
+
+- [ ] Folder named in kebab-case (no spaces, capitals, or underscores)
+- [ ] `SKILL.md` file exists with exact spelling (case-sensitive)
+- [ ] No `README.md` inside the skill folder
+- [ ] `references/` used for verbose content (if SKILL.md > ~200 lines)
+- [ ] `scripts/` used for executable validation (if applicable)
+
+## YAML Frontmatter
+
+- [ ] `---` delimiters present (opening and closing)
+- [ ] `name` field: kebab-case, matches folder name
+- [ ] `name` does not contain "claude" or "anthropic" (reserved)
+- [ ] `description` field present and under 1024 characters
+- [ ] `description` includes WHAT the skill does
+- [ ] `description` includes WHEN to use it (with specific trigger phrases)
+- [ ] `description` includes "Do NOT use for" exclusions with cross-references
+- [ ] No XML angle brackets (`<` or `>`) anywhere in frontmatter
+- [ ] `metadata.author` present
+- [ ] `metadata.version` present (semver format)
+
+## Body Structure
+
+- [ ] Starts with `# Skill Name` heading
+- [ ] 1-2 sentence overview immediately after heading
+- [ ] `## Instructions` section with numbered steps
+- [ ] `## Examples` section with at least 2 examples
+- [ ] `## Troubleshooting` section with at least 1 error case
+- [ ] Instructions are specific and actionable (not "validate things properly")
+- [ ] References to bundled files use explicit paths (`references/filename.md`)
+
+## Progressive Disclosure
+
+- [ ] Frontmatter is minimal: just WHAT, WHEN, and DO NOT
+- [ ] SKILL.md body contains full instructions but stays under 5,000 words
+- [ ] Verbose content (language-specific patterns, worked examples, templates) lives in `references/`
+- [ ] SKILL.md links to reference files where appropriate
+
+## Triggering Quality
+
+- [ ] Description includes phrases users would actually say
+- [ ] Description is NOT too vague (e.g., "Helps with projects")
+- [ ] Description is NOT missing trigger conditions
+- [ ] Description is NOT overly technical without user-facing language
+- [ ] Negative triggers present for related skill domains
+- [ ] Mental test: "When would you use the [skill-name] skill?" produces a clear, specific answer
+
+## Composability
+
+- [ ] Works alongside other skills without assuming exclusivity
+- [ ] Exclusions are bilateral (if A excludes B's domain, B excludes A's)
+- [ ] Cross-references name the specific alternative skill
+- [ ] No overlapping trigger phrases with existing skills (or properly disambiguated)
+
+## Content Quality
+
+- [ ] Instructions use imperative voice ("Do X" not "You should do X")
+- [ ] Examples cover both common scenarios and edge cases
+- [ ] Troubleshooting addresses real failure modes, not hypothetical ones
+- [ ] No over-engineering or unnecessary complexity
+- [ ] Error handling guidance included where applicable
+
+## Meta-Recursive Validity
+
+This checklist applies to itself. The skill-craft skill:
+- [x] Is in kebab-case folder (`skill-craft/`)
+- [x] Has `SKILL.md` with valid frontmatter
+- [x] Description includes WHAT + WHEN + DO NOT
+- [x] Description under 1024 characters
+- [x] Has Instructions, Examples (3), Troubleshooting sections
+- [x] Uses `references/` for this checklist
+- [x] Has bilateral exclusions with related skills
+- [x] No XML angle brackets in frontmatter

--- a/.claude/skills/stay-green/SKILL.md
+++ b/.claude/skills/stay-green/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: stay-green
+description: >-
+  2-gate TDD development workflow: Gate 1 is Red-Green-Refactor testing,
+  Gate 2 is pre-commit quality checks. Use when implementing features,
+  fixing bugs, or doing any development work. Ensures code is never
+  committed without passing tests and quality checks.
+  Do NOT use for bug-specific debugging (use bug-squashing-methodology).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Stay Green
+
+Write tests first, then code. Never declare work finished until all checks pass.
+
+## Instructions
+
+### Gate 1: TDD (Red-Green-Refactor)
+
+1. **Red** - Write a failing test describing the behavior you want
+   ```bash
+   ./scripts/test.sh --all  # Should fail
+   ```
+
+2. **Green** - Write just enough code to make the test pass
+   ```bash
+   ./scripts/test.sh --all  # Should pass
+   ```
+
+3. **Refactor** - Clean up while keeping tests green
+   ```bash
+   ./scripts/test.sh --all  # Should still pass
+   ```
+
+Repeat for each small piece of functionality. Write tests incrementally, not all at once.
+
+### Gate 2: Pre-Commit Quality Checks
+
+```bash
+pre-commit run --all-files
+```
+
+When checks fail: read errors, fix issues, run again. Repeat until all green.
+
+Quality checks include: formatting (Black + isort), linting (Ruff), type checking (MyPy), complexity (<=10 per function), security (Bandit), tests with coverage (>=90%), file hygiene.
+
+### Work is DONE when:
+1. All tests pass (Gate 1 complete)
+2. All pre-commit checks pass (Gate 2 complete)
+
+No exceptions.
+
+## Examples
+
+### Example 1: Adding a New Function
+
+```python
+# Gate 1 - Red: Write failing test
+def test_calculate_cost_from_impressions():
+    result = calculate_cost(impressions=1000, cpm=5.0)
+    assert result == 5.0
+
+# Gate 1 - Green: Make it pass
+def calculate_cost(impressions: int, cpm: float) -> float:
+    return impressions * (cpm / 1000)
+
+# Gate 1 - Refactor: (already clean, move on)
+# Gate 2: pre-commit run --all-files -> All passed!
+```
+
+### Example 2: Fixing a Formatting Failure
+
+```bash
+# Gate 2 fails on formatting
+$ pre-commit run --all-files
+black....Failed
+
+# Auto-fix and re-run
+$ ./scripts/format.sh --fix
+$ pre-commit run --all-files
+# All passed!
+```
+
+## Troubleshooting
+
+### Error: Coverage below 90%
+```bash
+./scripts/test.sh --all --coverage  # See what's not covered
+# Add tests for uncovered lines, then re-run pre-commit
+```
+
+### Error: Complexity above 10
+```bash
+./scripts/complexity.sh  # Find complex functions
+# Extract helper functions, simplify branching
+# Then verify: ./scripts/complexity.sh && pre-commit run --all-files
+```
+
+### Error: Type errors from MyPy
+```bash
+./scripts/typecheck.sh  # See specific errors
+# Add/fix type annotations
+# Then verify: ./scripts/typecheck.sh && pre-commit run --all-files
+```

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: testing
+description: >-
+  Write comprehensive, maintainable tests following TDD and AAA pattern.
+  Use when writing unit tests, integration tests, setting up fixtures,
+  mocking dependencies, or improving test coverage. Covers Python (pytest)
+  and TypeScript (Jest/React Native Testing Library).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Testing
+
+Test behavior, not implementation. One assertion concept per test. Follow AAA (Arrange-Act-Assert).
+
+## Instructions
+
+### Principles
+
+1. Test behavior, not implementation
+2. One assertion concept per test
+3. Follow AAA pattern (Arrange-Act-Assert)
+4. Write tests first (TDD) when possible
+5. Keep tests fast and isolated
+6. Make tests readable and self-documenting
+
+### Backend (pytest + async)
+
+```python
+@pytest.mark.asyncio
+async def test_endpoint_returns_expected(async_client: AsyncClient) -> None:
+    # Arrange
+    payload = {"email": "test@example.com", "password": "securepass123"}  # pragma: allowlist secret
+
+    # Act
+    response = await async_client.post("/auth/signup", json=payload)
+
+    # Assert
+    assert response.status_code == 200
+    assert "token" in response.json()
+```
+
+**Key fixtures** (from conftest.py):
+- `db_session` — clean SQLite in-memory session, tables created/dropped per test
+- `async_client` — httpx AsyncClient with test DB injected
+- `disable_rate_limit` — turns off rate limiting for tests needing many requests
+- `_reset_rate_limiter` (autouse) — clears rate limiter between tests
+
+**Common pitfalls:**
+- Schema changes not reflected in test payloads → 422 errors
+- Forgetting to use `disable_rate_limit` fixture → 429 errors
+- Test ordering dependency from shared DB state → use `db_session` fixture
+
+### Frontend (Jest + React Native Testing Library)
+
+```typescript
+import { render, fireEvent } from "@testing-library/react-native";
+
+it("does the thing", () => {
+  // Arrange
+  const { getByText } = render(<Component />);
+
+  // Act
+  fireEvent.press(getByText("Button"));
+
+  // Assert
+  expect(getByText("Result")).toBeTruthy();
+});
+```
+
+**Common pitfalls:**
+- Timezone-sensitive tests — use `jest.useFakeTimers().setSystemTime(new Date('2025-06-15T12:00:00'))` (noon UTC, not midnight)
+- Missing mocks for native modules (expo-secure-store, expo-notifications)
+- Async state updates — wrap in `act()`
+
+### Coverage
+
+- Backend: 90% minimum (enforced by pytest-cov)
+- Run: `cd backend && pytest --cov=. --cov-report=term-missing --cov-fail-under=90`
+- Frontend: `cd frontend && npm test -- --watchAll=false`
+
+## Troubleshooting
+
+### Error: Tests are slow
+- Backend tests use SQLite in-memory — should be fast
+- If hanging, check for event loop issues or missing async/await
+- Frontend: check for unresolved promises or missing timer mocks
+
+### Error: Tests are flaky
+- Look for shared state between tests (rate limiter, DB)
+- Check for test order dependencies
+- Mock time-dependent code with fake timers
+- Avoid real network calls — mock API responses

--- a/.claude/skills/testing/references/examples.md
+++ b/.claude/skills/testing/references/examples.md
@@ -1,0 +1,83 @@
+# Testing Examples
+
+## Example 1: Comprehensive Python Test Suite
+
+```python
+class TestConfigurationManager:
+    @pytest.fixture
+    def manager(self) -> ConfigurationManager:
+        return ConfigurationManager()
+
+    @pytest.fixture
+    def valid_config_file(self, tmp_path: Path) -> Path:
+        config = tmp_path / "config.json"
+        config.write_text('{"api_key": "abc123", "timeout": 30}')  # pragma: allowlist secret
+        return config
+
+    def test_load_valid_config_returns_config_object(self, manager, valid_config_file):
+        result = manager.load(valid_config_file)
+        assert isinstance(result, Config)
+        assert result.api_key == "abc123"  # pragma: allowlist secret
+        assert result.timeout == 30
+
+    def test_load_missing_file_raises_file_not_found(self, manager, tmp_path):
+        with pytest.raises(FileNotFoundError) as exc:
+            manager.load(tmp_path / "nonexistent.json")
+        assert "not found" in str(exc.value).lower()
+
+    @pytest.mark.parametrize("content,error_pattern", [
+        pytest.param("", "empty", id="empty_file"),
+        pytest.param("{invalid}", "invalid JSON", id="malformed_json"),
+        pytest.param("[]", "must be object", id="array_not_object"),
+        pytest.param('{"timeout": 30}', "missing required.*api_key", id="missing_field"),
+    ])
+    def test_load_invalid_content_raises_validation_error(self, manager, tmp_path, content, error_pattern):
+        config_file = tmp_path / "invalid.json"
+        config_file.write_text(content)
+        with pytest.raises(ValidationError, match=error_pattern):
+            manager.load(config_file)
+
+    def test_reload_updates_configuration(self, manager, valid_config_file):
+        manager.load(valid_config_file)
+        valid_config_file.write_text('{"api_key": "xyz789", "timeout": 60}')  # pragma: allowlist secret
+        manager.reload()
+        assert manager.current_config.api_key == "xyz789"  # pragma: allowlist secret
+        assert manager.current_config.timeout == 60
+```
+
+## Example 2: Integration Test
+
+```python
+@pytest.mark.integration
+class TestProjectGenerator:
+    @pytest.fixture
+    def output_dir(self) -> Iterator[Path]:
+        temp_dir = Path(tempfile.mkdtemp())
+        yield temp_dir
+        shutil.rmtree(temp_dir)
+
+    def test_generate_creates_complete_project(self, output_dir):
+        generator = ProjectGenerator(project_name="test-project", language="python")
+        result = generator.generate(output_dir)
+        assert result.success
+        assert (output_dir / "src").is_dir()
+        assert (output_dir / "tests").is_dir()
+        assert (output_dir / "README.md").is_file()
+        readme = (output_dir / "README.md").read_text()
+        assert "test-project" in readme
+```
+
+## Example 3: Property-Based Test (Python)
+
+```python
+from hypothesis import given, strategies as st
+
+@given(project_name=st.text(
+    min_size=1, max_size=50,
+    alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd")),
+))
+def test_validate_accepts_valid_names(project_name: str) -> None:
+    result = validate_project_name(project_name)
+    assert result.is_valid
+    assert not result.errors
+```

--- a/.claude/skills/testing/references/patterns-by-language.md
+++ b/.claude/skills/testing/references/patterns-by-language.md
@@ -1,0 +1,175 @@
+# Testing Patterns by Language
+
+## Python (pytest)
+
+### Fixtures
+```python
+@pytest.fixture
+def sample_config() -> dict[str, str]:
+    return {"api_key": "test_key_123", "base_url": "https://api.example.com", "timeout": "30"}  # pragma: allowlist secret
+
+@pytest.fixture
+def config_file(tmp_path: Path, sample_config: dict) -> Path:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(sample_config))
+    return config_path
+
+@pytest.fixture
+def mock_api_client(mocker) -> Iterator[Mock]:
+    client = mocker.Mock(spec=APIClient)
+    client.fetch.return_value = {"status": "success"}
+    yield client
+    assert client.fetch.called
+```
+
+### Async Testing
+```python
+@pytest.mark.asyncio
+async def test_async_fetch_returns_data() -> None:
+    client = AsyncAPIClient(base_url="https://api.test.com")
+    result = await client.fetch_user("user123")
+    assert result["id"] == "user123"
+
+@pytest.fixture
+async def async_client() -> AsyncGenerator[AsyncAPIClient, None]:
+    client = AsyncAPIClient()
+    await client.connect()
+    yield client
+    await client.disconnect()
+```
+
+### Mocking
+```python
+def test_service_calls_api_correctly(mocker) -> None:
+    mock_requests = mocker.patch("requests.get")
+    mock_response = Mock()
+    mock_response.json.return_value = {"data": "test"}
+    mock_response.status_code = 200
+    mock_requests.return_value = mock_response
+
+    service = ExternalService()
+    result = service.fetch_data("endpoint")
+
+    mock_requests.assert_called_once_with(
+        "https://api.example.com/endpoint", timeout=10,
+        headers={"Authorization": "Bearer token"},
+    )
+    assert result == {"data": "test"}
+```
+
+## TypeScript (Jest)
+
+### Unit Tests
+```typescript
+describe('ConfigLoader', () => {
+  let loader: ConfigLoader;
+  beforeEach(() => { loader = new ConfigLoader(); });
+
+  it('should load valid configuration', async () => {
+    jest.spyOn(fs.promises, 'readFile').mockResolvedValue(JSON.stringify({ apiKey: 'test' }));  // pragma: allowlist secret
+    const result = await loader.load('/tmp/config.json');
+    expect(result).toEqual({ apiKey: 'test' });  // pragma: allowlist secret
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['{invalid', 'invalid JSON'],
+  ])('should reject invalid content: %s', async (content, errorMsg) => {
+    jest.spyOn(fs.promises, 'readFile').mockResolvedValue(content);
+    await expect(loader.load('/tmp/config.json')).rejects.toThrow(errorMsg);
+  });
+});
+```
+
+### React Component Testing
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react';
+
+describe('UserProfile', () => {
+  it('should display user information', () => {
+    render(<UserProfile user={{ name: 'John', email: 'john@test.com' }} />);
+    expect(screen.getByText('John')).toBeInTheDocument();
+  });
+
+  it('should call onEdit when clicked', () => {
+    const mockOnEdit = jest.fn();
+    render(<UserProfile user={{ name: 'John' }} onEdit={mockOnEdit} />);
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    expect(mockOnEdit).toHaveBeenCalled();
+  });
+});
+```
+
+## Go
+
+### Table-Driven Tests
+```go
+func TestValidateConfig(t *testing.T) {
+    tests := []struct {
+        name    string
+        config  Config
+        wantErr bool
+    }{
+        {"valid", Config{APIKey: "key", Timeout: 30}, false},  // pragma: allowlist secret
+        {"missing key", Config{Timeout: 30}, true},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            err := ValidateConfig(tt.config)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+            }
+        })
+    }
+}
+```
+
+### Mock Interfaces
+```go
+type mockAPIClient struct {
+    fetchFunc func(string) (interface{}, error)
+}
+
+func (m *mockAPIClient) Fetch(url string) (interface{}, error) {
+    if m.fetchFunc != nil { return m.fetchFunc(url) }
+    return nil, nil
+}
+```
+
+## Rust
+
+### Unit Tests
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_config() {
+        let json = r#"{"api_key": "test123", "timeout": 30}"#;  // pragma: allowlist secret
+        let result = parse_config(json);
+        assert!(result.is_ok());
+        let config = result.unwrap();
+        assert_eq!(config.api_key, "test123");
+    }
+
+    #[test]
+    fn test_parse_invalid_json_returns_error() {
+        let result = parse_config("{invalid}");
+        assert!(result.is_err());
+    }
+}
+```
+
+### Property-Based Testing (proptest)
+```rust
+proptest! {
+    #[test]
+    fn test_roundtrip(api_key in "[a-zA-Z0-9]{10,50}", timeout in 1u32..3600u32) {
+        let original = Config { api_key, timeout };
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: Config = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(original.api_key, parsed.api_key);
+    }
+}
+```

--- a/.claude/skills/tracer-code/SKILL.md
+++ b/.claude/skills/tracer-code/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: tracer-code
+description: >-
+  Tracer code development methodology for building working systems
+  incrementally. Use when starting complex projects, working under
+  time constraints, doing interview coding sessions, or when you need
+  a demoable application at every stage. Wire the skeleton first,
+  then replace stubs with real logic one at a time.
+  Do NOT use for small bug fixes or single-function tasks.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Tracer Code Development
+
+Wire the entire system end-to-end with stubs, then iteratively replace them with real implementations - always maintaining a working, demoable application.
+
+## Instructions
+
+### Phase 1: Wire the Skeleton (10-15% of time budget)
+
+1. **Define the API surface** - All endpoints with request/response models
+2. **Stub every endpoint** - Return mock/hardcoded data matching response models
+3. **Connect all layers** - Router -> Service -> Model, even if one-liners
+4. **Verify it runs** - Hit every endpoint, confirm valid responses
+5. **Write smoke tests** - One test per endpoint proving it returns 200
+
+```python
+# Stubbed endpoint example
+@router.post("/billing/calculate", response_model=BillingResponse)
+async def calculate_billing(request: BillingRequest) -> BillingResponse:
+    # TODO: implement real calculation
+    return BillingResponse(cost=0.0, currency="USD")
+```
+
+**Gate check**: All tests pass. You now have a demoable skeleton.
+
+### Phase 2: Prioritize and Iterate (75-80% of time budget)
+
+Replace stubs with real implementations one at a time, in priority order:
+
+1. Rank features by demo impact
+2. For each feature: write failing test -> implement -> verify -> commit
+3. Never break the skeleton - if stuck, keep the stub and move on
+4. Reassess priority after each feature
+
+**Priority heuristic**:
+- **P0**: Core business logic (the thing they asked you to build)
+- **P1**: Input validation and meaningful error responses
+- **P2**: Edge cases and secondary features
+- **P3**: Nice-to-haves (logging, metrics, advanced error handling)
+
+### Phase 3: Polish (5-10% of time budget)
+
+- Add edge case tests for implemented features
+- Improve error messages
+- Clean up remaining TODOs in implemented code
+- Do NOT start new features - polish what works
+
+### Decision Framework
+
+At any point, ask: "If the clock ran out right now, would I have something to demo?"
+- **Yes** -> Keep going, pick next highest-impact feature
+- **No** -> Stop. Get back to green. Stub it out and move on.
+
+## Examples
+
+### Example 1: Building a Billing API
+
+**Phase 1** (skeleton):
+```python
+class BillingService:
+    def calculate(self, impressions: int, cpm: float) -> float:
+        return 0.0  # TODO: implement
+```
+
+**Phase 2** (real logic):
+```python
+class BillingService:
+    def calculate(self, impressions: int, cpm: float) -> float:
+        return impressions * (cpm / 1000)
+```
+
+### Example 2: Interview Time Management
+
+1. **Minutes 0-10**: Wire skeleton (all endpoints return stubs)
+2. **Demo to interviewer**: "All endpoints respond with correct shapes"
+3. **Minutes 10-50**: Implement P0 features with TDD
+4. **Minutes 50-60**: Polish, add edge case tests
+
+## Troubleshooting
+
+### Error: Feature is harder than expected and breaking the skeleton
+- Revert the change immediately
+- Keep the stub for that feature
+- Move to the next priority item
+- Come back to it if time remains
+
+### Error: Spending too long on one feature
+- Check the clock. If you've spent >25% of remaining time on one feature, stub it
+- A working skeleton with 3 real features beats a broken app with 1 perfect feature

--- a/.claude/skills/vibe/SKILL.md
+++ b/.claude/skills/vibe/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: vibe
+description: >-
+  Code style, naming conventions, and structural patterns for consistent
+  codebases. Use when writing new code, reviewing style choices, or
+  establishing project conventions. Covers Python, TypeScript, Go, and
+  Rust idioms. Do NOT use for documentation content (use documentation
+  skill) or architectural decisions.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Vibe
+
+Consistent code style: consistency over cleverness, readability over brevity, explicitness over implicitness.
+
+## Instructions
+
+### Step 1: Follow Language Idioms
+
+**Python**: PEP 8/257, type hints, dataclasses/Pydantic, pathlib, async/await for I/O.
+
+**TypeScript**: Strict mode, interfaces over types for objects, const assertions, `unknown` over `any`.
+
+**Go**: Effective Go, gofmt/goimports, composition over inheritance, small interfaces, context.Context.
+
+**Rust**: API guidelines, clippy, owned types at boundaries, Result<T,E>, leverage type system.
+
+### Step 2: Apply Naming Conventions
+
+| Element | Python | TypeScript | Go | Rust |
+|---------|--------|------------|-----|------|
+| Functions | `snake_case` | `camelCase` | `CamelCase`/`camelCase` | `snake_case` |
+| Classes/Types | `PascalCase` | `PascalCase` | `PascalCase` | `PascalCase` |
+| Constants | `SCREAMING_SNAKE` | `SCREAMING_SNAKE` | `CamelCase` | `SCREAMING_SNAKE` |
+
+### Step 3: Avoid Anti-Patterns
+
+- No clever code over clear code
+- No abbreviations (unless universally understood)
+- No deep nesting (> 3 levels)
+- No long functions (> 50 lines)
+- No mixed abstraction levels
+- No magic numbers without constants
+- No global state or god objects
+
+## Examples
+
+### Example 1: Good Python Style
+
+```python
+from pathlib import Path
+from typing import Protocol
+
+class FileReader(Protocol):
+    """Protocol for reading file contents."""
+    def read_text(self) -> str: ...
+
+def process_config_file(config_path: Path) -> dict[str, str]:
+    """Process configuration file and return parsed settings.
+
+    Args:
+        config_path: Path to configuration file
+
+    Returns:
+        Dictionary of configuration key-value pairs
+
+    Raises:
+        FileNotFoundError: If configuration file doesn't exist
+    """
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+    return parse_config(config_path.read_text())
+```
+
+### Example 2: Good TypeScript Style
+
+```typescript
+interface UserSettings {
+  readonly userId: string;
+  readonly preferences: ReadonlyArray<string>;
+  readonly theme: 'light' | 'dark';
+}
+
+function processUserSettings(settings: UserSettings): void {
+  const { userId, preferences, theme } = settings;
+
+  if (preferences.length === 0) {
+    throw new Error('User must have at least one preference');
+  }
+
+  applyTheme(theme);
+  savePreferences(userId, preferences);
+}
+```
+
+## Troubleshooting
+
+### Error: Inconsistent style across the codebase
+- Run the language's formatter (Black, Prettier, gofmt, rustfmt)
+- Check for an existing style configuration in the project
+- Follow existing patterns in the codebase over personal preference
+
+### Error: Function is getting too long
+- Extract logical blocks into well-named helper functions
+- Each function should do one thing at one abstraction level
+- If you need comments to separate sections, those sections should be functions

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,58 @@
+# scripts/
+
+Quality-gate shell scripts ported from
+[`adepthood-linters`](https://github.com/Geoffe-Ga/adepthood-linters). The
+original scripts assume a flat repo; these have been adapted for the
+`backend/` + `frontend/` monorepo layout.
+
+## Layout
+
+```
+scripts/
+├── backend/           # Python quality gates — runs against backend/
+│   ├── check-all.sh   # Run lint + format + typecheck + security + complexity + tests
+│   ├── fix-all.sh     # Auto-fix linting and formatting
+│   ├── lint.sh        # ruff
+│   ├── format.sh      # black + isort
+│   ├── typecheck.sh   # mypy
+│   ├── test.sh        # pytest (--unit / --integration / --e2e / --all)
+│   ├── coverage.sh    # pytest with coverage (≥90%)
+│   ├── security.sh    # bandit + pip-audit
+│   ├── complexity.sh  # radon + xenon
+│   ├── mutation.sh    # mutmut (≥80% mutation score)
+│   ├── analyze_mutations.py  # detailed mutmut cache analysis
+│   └── pr-status.sh   # gh CLI workflow monitor for PRs
+├── frontend/          # TypeScript quality gates — runs against frontend/
+│   ├── check-all.sh
+│   ├── fix-all.sh
+│   ├── lint.sh        # eslint
+│   ├── format.sh      # prettier
+│   ├── typecheck.sh   # tsc --noEmit
+│   ├── test.sh        # jest
+│   └── pr-status.sh
+├── dev-setup.sh       # Pre-existing: idempotent dev env bootstrap
+└── pre-deploy-check.sh # Pre-existing: deployment readiness check
+```
+
+## Adaptations from source
+
+- `PROJECT_ROOT` in each script is resolved to `backend/` or `frontend/`
+  (not the repo root) so invocations like `ruff check .` operate on the
+  correct subtree.
+- The Python package name `adepthood_linters` has been replaced with
+  `src` (Adepthood's actual backend package).
+- Frontend and backend pairs are intentionally duplicated rather than
+  unified so each subsection remains independently runnable and can
+  evolve separately.
+
+## Usage
+
+```bash
+source .venv/bin/activate                  # Python scripts need the venv
+scripts/backend/check-all.sh --verbose     # Run every backend gate
+scripts/backend/fix-all.sh                 # Auto-fix what can be fixed
+scripts/frontend/check-all.sh              # Run every frontend gate
+```
+
+New tools that aren't yet installed (`mutmut`, `interrogate`, `xenon`) will
+be added in the next tranche of the integration.

--- a/scripts/backend/analyze_mutations.py
+++ b/scripts/backend/analyze_mutations.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Analyze mutmut cache database for mutation testing insights.
+
+This script provides detailed analysis of mutation testing results including:
+- Overall mutation score and statistics
+- Files with the most surviving mutants
+- Sample of specific surviving mutants for debugging
+
+Usage:
+    ./scripts/analyze_mutations.py
+    python scripts/analyze_mutations.py --top 10
+"""
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+# Quality thresholds
+MINIMUM_MUTATION_SCORE = 80
+
+
+def analyze_cache(
+    cache_path: Path, top_files: int = 20, filter_file: str | None = None
+) -> None:
+    """Analyze mutmut cache and print detailed statistics.
+
+    Args:
+        cache_path: Path to .mutmut-cache file.
+        top_files: Number of top files to show (default: 20).
+        filter_file: Optional filename to filter results (e.g., "cli.py").
+    """
+    if not cache_path.exists():
+        print(f"Error: Cache file not found: {cache_path}", file=sys.stderr)
+        print("Run mutation tests first: ./scripts/mutation.sh", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(cache_path)
+    cursor = conn.cursor()
+
+    # Build file filter condition
+    file_filter_sql = ""
+    file_filter_params: tuple[str, ...] = ()
+    if filter_file:
+        # Match any path ending with the specified file
+        file_filter_sql = """
+            AND sf.filename LIKE ?
+        """
+        file_filter_params = (f"%{filter_file}",)
+        print(f"=== Mutmut Cache Analysis (filtered: {filter_file}) ===\n")
+    else:
+        print("=== Mutmut Cache Analysis ===\n")
+
+    # Get total mutants (with optional filter)
+    query = f"""
+        SELECT COUNT(*)
+        FROM Mutant m, Line l, SourceFile sf
+        WHERE m.line = l.id
+          AND l.sourcefile = sf.id
+          {file_filter_sql}
+    """
+    cursor.execute(query, file_filter_params)
+    total = cursor.fetchone()[0]
+    print(f"Total mutants: {total}")
+    print()
+
+    # Get status counts (with optional filter)
+    query = f"""
+        SELECT m.status, COUNT(*)
+        FROM Mutant m, Line l, SourceFile sf
+        WHERE m.line = l.id
+          AND l.sourcefile = sf.id
+          {file_filter_sql}
+        GROUP BY m.status
+    """
+    cursor.execute(query, file_filter_params)
+    status_counts = dict(cursor.fetchall())
+    killed = status_counts.get("ok_killed", 0)
+    survived = status_counts.get("bad_survived", 0)
+    suspicious = status_counts.get("ok_suspicious", 0)
+    timeout = status_counts.get("bad_timeout", 0)
+    untested = status_counts.get("untested", 0)
+
+    print("Status counts:")
+    for status, count in sorted(status_counts.items()):
+        print(f"  {status}: {count}")
+    print()
+
+    # Calculate score
+    if total > 0:
+        tested_total = total - untested
+        if tested_total > 0:
+            score = (killed / tested_total) * 100
+            print(f"Mutation Score: {score:.1f}%")
+            print(f"Required: {MINIMUM_MUTATION_SCORE}%")
+            print()
+            print("Breakdown:")
+            killed_pct = killed / tested_total * 100
+            survived_pct = survived / tested_total * 100
+            suspicious_pct = suspicious / tested_total * 100
+            timeout_pct = timeout / tested_total * 100
+            print(f"  Killed: {killed} ({killed_pct:.1f}% of tested)")
+            print(f"  Survived: {survived} ({survived_pct:.1f}% of tested)")
+            print(f"  Suspicious: {suspicious} ({suspicious_pct:.1f}%)")
+            print(f"  Timeout: {timeout} ({timeout_pct:.1f}%)")
+            print(f"  Untested: {untested}")
+            print()
+
+            if score < MINIMUM_MUTATION_SCORE:
+                gap = int((MINIMUM_MUTATION_SCORE / 100 * tested_total) - killed)
+                msg = f"⚠️  Need to kill {gap} more mutants"
+                msg += f" to reach {MINIMUM_MUTATION_SCORE}%"
+                print(msg)
+                print()
+
+    # Show files with most survived mutants (with optional filter)
+    if survived > 0:
+        print(f"=== Files with Most Survived Mutants (Top {top_files}) ===")
+        query = f"""
+            SELECT sf.filename, COUNT(*) as count
+            FROM Mutant m, Line l, SourceFile sf
+            WHERE m.line = l.id
+              AND l.sourcefile = sf.id
+              AND m.status = "bad_survived"
+              {file_filter_sql}
+            GROUP BY sf.filename
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cursor.execute(query, (*file_filter_params, top_files))
+        for filename, count in cursor.fetchall():
+            percentage = (count / survived) * 100
+            print(f"  {count:3d} ({percentage:5.1f}%): {filename}")
+        print()
+
+        # Show sample of survived mutants (with optional filter)
+        print("Sample of survived mutants (first 10):")
+        query = f"""
+            SELECT m.id, sf.filename, l.line_number
+            FROM Mutant m, Line l, SourceFile sf
+            WHERE m.line = l.id
+              AND l.sourcefile = sf.id
+              AND m.status = "bad_survived"
+              {file_filter_sql}
+            ORDER BY sf.filename, l.line_number
+            LIMIT 10
+        """
+        cursor.execute(query, file_filter_params)
+        for mutant_id, filename, line_number in cursor.fetchall():
+            print(f"  Mutant {mutant_id}: {filename}:{line_number}")
+        print()
+        print("To view a specific mutant: mutmut show <id>")
+        print("To generate HTML report: mutmut html")
+
+    conn.close()
+
+
+def main() -> None:
+    """Parse arguments and run cache analysis."""
+    parser = argparse.ArgumentParser(
+        description="Analyze mutation testing results from .mutmut-cache",
+        epilog="Examples:\n"
+        "  %(prog)s                  # Analyze all files\n"
+        "  %(prog)s cli.py           # Analyze only cli.py\n"
+        "  %(prog)s --cache .cache   # Use custom cache file\n",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "filename",
+        nargs="?",
+        help="Optional filename to filter results (e.g., 'cli.py')",
+    )
+    parser.add_argument(
+        "--cache",
+        type=Path,
+        default=Path(".mutmut-cache"),
+        help="Path to mutmut cache file (default: .mutmut-cache)",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=20,
+        help="Number of top files to show (default: 20)",
+    )
+
+    args = parser.parse_args()
+    analyze_cache(args.cache, args.top, args.filename)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backend/check-all.sh
+++ b/scripts/backend/check-all.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# scripts/check-all.sh - Run all quality checks
+# Usage: ./scripts/check-all.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run all quality checks in sequence.
+
+Runs:
+  1. Linting (Ruff)
+  2. Formatting (Black + isort)
+  3. Type checking (MyPy)
+  4. Security checks (Bandit + Safety)
+  5. Complexity analysis (Radon)
+  6. Unit tests
+  7. Coverage report
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           One or more checks failed
+    2           Error running checks
+
+EXAMPLES:
+    $(basename "$0")          # Run all checks
+    $(basename "$0") --verbose # Show detailed output
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+VERBOSE_FLAG=""
+if $VERBOSE; then
+    VERBOSE_FLAG="--verbose"
+fi
+
+echo "=== Running All Quality Checks ==="
+echo ""
+
+FAILED_CHECKS=()
+PASSED_CHECKS=()
+
+# Helper function to run a check
+run_check() {
+    local check_name=$1
+    local script=$2
+    shift 2
+    local args=("$@")
+
+    echo "Running: $check_name"
+    if "$SCRIPT_DIR/$script" "${args[@]+"${args[@]}"}" $VERBOSE_FLAG; then
+        PASSED_CHECKS+=("$check_name")
+        echo "✓ $check_name passed"
+    else
+        FAILED_CHECKS+=("$check_name")
+        echo "✗ $check_name failed" >&2
+    fi
+    echo ""
+}
+
+# Run all checks
+run_check "Linting" "lint.sh" --check
+run_check "Formatting" "format.sh" --check
+run_check "Type checking" "typecheck.sh"
+run_check "Security checks" "security.sh"
+run_check "Complexity analysis" "complexity.sh"
+run_check "Unit tests" "test.sh" --unit
+run_check "Coverage report" "coverage.sh"
+
+echo "=== Quality Checks Summary ==="
+echo "Passed: ${#PASSED_CHECKS[@]}"
+echo "Failed: ${#FAILED_CHECKS[@]}"
+
+if [ ${#FAILED_CHECKS[@]} -gt 0 ]; then
+    echo ""
+    echo "Failed checks:"
+    for check in "${FAILED_CHECKS[@]}"; do
+        echo "  ✗ $check"
+    done
+    exit 1
+else
+    echo ""
+    echo "✓ All quality checks passed!"
+    exit 0
+fi

--- a/scripts/backend/complexity.sh
+++ b/scripts/backend/complexity.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# scripts/complexity.sh - Code complexity analysis
+# Usage: ./scripts/complexity.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Analyze code complexity using Radon and Xenon.
+
+Metrics:
+  - Cyclomatic complexity (should be <= 10)
+  - Maintainability index (should be >= 20)
+  - Cognitive complexity
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Complexity acceptable
+    1           Complexity exceeds thresholds
+    2           Error during analysis
+
+EXAMPLES:
+    $(basename "$0")          # Analyze complexity
+    $(basename "$0") --verbose # Show detailed output
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Code Complexity Analysis ==="
+
+# Check Cyclomatic Complexity with Radon
+if command -v radon &> /dev/null; then
+    echo ""
+    echo "Cyclomatic Complexity (should be <= 10):"
+    radon cc -a src/ || true
+
+    echo ""
+    echo "Maintainability Index (should be >= 20):"
+    radon mi -a src/ || true
+else
+    echo "Warning: radon not installed, skipping cyclomatic complexity check" >&2
+fi
+
+# Check complexity with Xenon
+if command -v xenon &> /dev/null; then
+    if $VERBOSE; then
+        echo "Running Xenon complexity check..."
+    fi
+    xenon --max-absolute B --max-modules B --max-average B src/ ||         { echo "✗ Complexity exceeds thresholds" >&2; exit 1; }
+else
+    if $VERBOSE; then
+        echo "Note: xenon not installed for strict complexity checks"
+    fi
+fi
+
+echo "✓ Complexity analysis completed"
+exit 0

--- a/scripts/backend/coverage.sh
+++ b/scripts/backend/coverage.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# scripts/coverage.sh - Run tests with coverage report
+# Usage: ./scripts/coverage.sh [--html] [--xml] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+HTML_REPORT=false
+XML_REPORT=false
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --html)
+            HTML_REPORT=true
+            shift
+            ;;
+        --xml)
+            XML_REPORT=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run tests with coverage report.
+
+OPTIONS:
+    --html      Generate HTML coverage report
+    --xml       Generate XML coverage report (for CI)
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Coverage threshold met
+    1           Coverage below threshold
+    2           Error running coverage
+
+EXAMPLES:
+    $(basename "$0")          # Run coverage with terminal report
+    $(basename "$0") --html   # Generate HTML report
+    $(basename "$0") --xml    # Generate XML report for CI
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Coverage Report ==="
+
+# Build pytest arguments
+PYTEST_ARGS=(
+    -v
+    --cov=src
+    --cov-branch
+    --cov-report=term-missing
+    --cov-fail-under=90
+)
+
+# Add HTML report if requested
+if $HTML_REPORT; then
+    PYTEST_ARGS+=(--cov-report=html)
+    echo "HTML report will be generated in htmlcov/"
+fi
+
+# Add XML report if requested
+if $XML_REPORT; then
+    PYTEST_ARGS+=(--cov-report=xml)
+    echo "XML report will be generated as coverage.xml"
+fi
+
+# Run tests with coverage
+pytest "${PYTEST_ARGS[@]}" tests/ || {
+    echo "✗ Coverage below threshold" >&2
+    exit 1
+}
+
+echo "✓ Coverage threshold met"
+
+exit 0

--- a/scripts/backend/fix-all.sh
+++ b/scripts/backend/fix-all.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# scripts/fix-all.sh - Auto-fix all issues
+# Usage: ./scripts/fix-all.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Auto-fix all auto-fixable issues in sequence.
+
+Fixes:
+  1. Linting issues (Ruff)
+  2. Formatting (Black + isort)
+
+Note: Some issues may require manual intervention.
+Check the output and review changes before committing.
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Fixes applied successfully
+    1           Some fixes failed
+    2           Error during fixes
+
+EXAMPLES:
+    $(basename "$0")          # Apply all auto-fixes
+    $(basename "$0") --verbose # Show detailed output
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+VERBOSE_FLAG=""
+if $VERBOSE; then
+    VERBOSE_FLAG="--verbose"
+fi
+
+echo "=== Auto-fixing Issues ==="
+echo ""
+
+FAILED_FIXES=()
+
+# Helper function to run a fix
+run_fix() {
+    local fix_name=$1
+    local script=$2
+    shift 2
+    local args=("$@")
+
+    echo "Running: $fix_name"
+    if "$SCRIPT_DIR/$script" --fix "${args[@]}" $VERBOSE_FLAG; then
+        echo "✓ $fix_name completed"
+    else
+        FAILED_FIXES+=("$fix_name")
+        echo "✗ $fix_name failed" >&2
+    fi
+    echo ""
+}
+
+# Run all fixes
+run_fix "Linting" "lint.sh"
+run_fix "Formatting" "format.sh"
+
+echo "=== Auto-fix Summary ==="
+if [ ${#FAILED_FIXES[@]} -gt 0 ]; then
+    echo "Failed fixes: ${#FAILED_FIXES[@]}"
+    echo ""
+    for fix in "${FAILED_FIXES[@]}"; do
+        echo "  ✗ $fix"
+    done
+    exit 1
+else
+    echo "✓ All auto-fixes completed successfully!"
+    echo ""
+    echo "Review the changes with: git diff"
+    echo "Stage changes with: git add ."
+    exit 0
+fi

--- a/scripts/backend/format.sh
+++ b/scripts/backend/format.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# scripts/format.sh - Format code with Black and isort
+# Usage: ./scripts/format.sh [--fix] [--check] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+FIX=false
+CHECK=false
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --fix)
+            FIX=true
+            shift
+            ;;
+        --check)
+            CHECK=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Format code using Black and isort.
+
+OPTIONS:
+    --fix       Apply formatting changes (default)
+    --check     Check only, fail if changes needed
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Code is properly formatted
+    1           Formatting issues found
+    2           Error running checks
+
+EXAMPLES:
+    $(basename "$0") --fix         # Apply formatting
+    $(basename "$0") --check       # Check only
+    $(basename "$0") --verbose     # Show detailed output
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Formatting (Black + isort) ==="
+
+# Determine mode
+if $CHECK; then
+    MODE="--check"
+else
+    MODE=""
+fi
+
+# Run isort
+if $VERBOSE; then
+    echo "Running isort..."
+fi
+isort $MODE . || { echo "✗ isort failed" >&2; exit 1; }
+
+# Run Black
+if $VERBOSE; then
+    echo "Running Black..."
+fi
+black $MODE . || { echo "✗ Black failed" >&2; exit 1; }
+
+if [ -n "$MODE" ]; then
+    echo "✓ Code formatting check passed"
+else
+    echo "✓ Code formatted successfully"
+fi
+exit 0

--- a/scripts/backend/lint.sh
+++ b/scripts/backend/lint.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# scripts/lint.sh - Run linting checks with Ruff
+# Usage: ./scripts/lint.sh [--fix] [--check] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+FIX=false
+CHECK=false
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --fix)
+            FIX=true
+            shift
+            ;;
+        --check)
+            CHECK=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run linting checks on the project using Ruff.
+
+OPTIONS:
+    --fix       Auto-fix linting issues where possible
+    --check     Check only, fail if issues found (default mode)
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           Linting issues found
+    2           Error running checks
+
+EXAMPLES:
+    $(basename "$0")              # Run checks in check mode
+    $(basename "$0") --fix         # Auto-fix issues
+    $(basename "$0") --verbose     # Show detailed output
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Linting (Ruff) ==="
+
+if $FIX; then
+    if $VERBOSE; then
+        echo "Fixing linting issues..."
+    fi
+    ruff check . --fix
+    EXIT_CODE=$?
+else
+    if $VERBOSE; then
+        echo "Checking for linting issues..."
+    fi
+    ruff check .
+    EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "✓ Linting checks passed"
+    exit 0
+else
+    echo "✗ Linting checks failed" >&2
+    exit 1
+fi

--- a/scripts/backend/mutation.sh
+++ b/scripts/backend/mutation.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# scripts/mutation.sh - Run mutation tests with score validation
+# Usage: ./scripts/mutation.sh [--min-score SCORE] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+MIN_SCORE=80  # MAXIMUM QUALITY: 80% mutation score minimum
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --min-score)
+            MIN_SCORE="$2"
+            shift 2
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run mutation tests and validate minimum score threshold.
+
+Mutation testing introduces small changes (mutations) to your code
+to verify that your test suite catches them. A high mutation score
+indicates effective tests.
+
+OPTIONS:
+    --min-score SCORE   Minimum mutation score (default: 80)
+    --verbose           Show detailed output
+    --help              Display this help message
+
+EXIT CODES:
+    0                   Mutation score meets or exceeds minimum
+    1                   Mutation score below minimum threshold
+    2                   Error running mutation tests
+
+QUALITY STANDARDS:
+    MAXIMUM QUALITY:    80% minimum mutation score
+    Good:               70-79%
+    Acceptable:         60-69%
+    Poor:               <60%
+
+EXAMPLES:
+    $(basename "$0")                    # Run with 80% minimum
+    $(basename "$0") --min-score 70     # Run with 70% minimum
+    $(basename "$0") --verbose          # Show detailed output
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+if $VERBOSE; then
+    set -x
+fi
+
+# Check if mutmut is installed
+if ! command -v mutmut &> /dev/null; then
+    echo "Error: mutmut is not installed" >&2
+    echo "Install with: pip install mutmut" >&2
+    exit 2
+fi
+
+echo "=== Running Mutation Tests ==="
+echo "Minimum required score: ${MIN_SCORE}%"
+echo ""
+
+# Run mutation tests (allow failure, we'll check score)
+echo "Running mutmut (this may take several minutes)..."
+if mutmut run 2>&1; then
+    echo "✓ Mutmut run completed"
+else
+    # mutmut returns non-zero if there are surviving mutants, which is expected
+    echo "Info: Mutmut run completed (some mutants may have survived)"
+fi
+
+echo ""
+echo "=== Mutation Test Results ==="
+
+# Get results as JSON
+if ! mutmut junitxml > /dev/null 2>&1; then
+    echo "Warning: Could not generate JUnit XML (may be empty results)" >&2
+fi
+
+# Parse mutmut results
+RESULTS=$(mutmut results)
+echo "$RESULTS"
+echo ""
+
+# Extract counts from results
+KILLED=$(echo "$RESULTS" | grep -o 'Killed: [0-9]*' | \
+    grep -o '[0-9]*$' || echo "0")
+SURVIVED=$(echo "$RESULTS" | grep -o 'Survived: [0-9]*' | \
+    grep -o '[0-9]*$' || echo "0")
+SUSPICIOUS=$(echo "$RESULTS" | grep -o 'Suspicious: [0-9]*' | \
+    grep -o '[0-9]*$' || echo "0")
+TIMEOUT=$(echo "$RESULTS" | grep -o 'Timeout: [0-9]*' | \
+    grep -o '[0-9]*$' || echo "0")
+
+# Calculate total and score
+TOTAL=$((KILLED + SURVIVED + SUSPICIOUS + TIMEOUT))
+
+if [ "$TOTAL" -eq 0 ]; then
+    echo "Warning: No mutants were generated" >&2
+    echo "This might indicate:"
+    echo "  - No code to mutate in src/"
+    echo "  - Configuration issue with mutmut"
+    echo ""
+    echo "Skipping mutation score validation"
+    exit 0
+fi
+
+# Calculate mutation score (killed / total * 100)
+SCORE=$(awk "BEGIN {printf \"%.1f\", ($KILLED / $TOTAL) * 100}")
+
+echo "=== Mutation Score ==="
+echo "Killed:      $KILLED"
+echo "Survived:    $SURVIVED"
+echo "Suspicious:  $SUSPICIOUS"
+echo "Timeout:     $TIMEOUT"
+echo "Total:       $TOTAL"
+echo ""
+echo "Mutation Score: ${SCORE}%"
+echo "Required:       ${MIN_SCORE}%"
+echo ""
+
+# Compare score to threshold
+if awk "BEGIN {exit !($SCORE >= $MIN_SCORE)}"; then
+    echo "✓ Mutation score meets minimum threshold"
+    echo ""
+
+    if [ "$SURVIVED" -gt 0 ]; then
+        echo "Note: $SURVIVED mutants survived. To view them:"
+        echo "  mutmut show <id>"
+        echo "  mutmut html  # Generate HTML report"
+    fi
+
+    exit 0
+else
+    echo "✗ Mutation score below minimum threshold" >&2
+    echo "" >&2
+    echo "Your test suite killed ${SCORE}% of mutants" >&2
+    echo "Minimum required: ${MIN_SCORE}%" >&2
+    echo "" >&2
+    echo "To improve mutation score:" >&2
+    echo "  1. View surviving mutants: mutmut show <id>" >&2
+    echo "  2. Add tests to catch these mutations" >&2
+    echo "  3. Generate HTML report: mutmut html" >&2
+    echo "" >&2
+
+    if [ "$SURVIVED" -gt 0 ]; then
+        echo "Surviving mutants:" >&2
+        mutmut show 1 2>&1 | head -20 || true
+    fi
+
+    exit 1
+fi

--- a/scripts/backend/pr-status.sh
+++ b/scripts/backend/pr-status.sh
@@ -1,0 +1,474 @@
+#!/usr/bin/env bash
+# scripts/pr-status.sh - GitHub Actions workflow monitor for PRs
+# Usage: ./scripts/pr-status.sh <subcommand> [OPTIONS]
+
+set -euo pipefail
+
+VERSION="1.0.0"
+VERBOSE=false
+
+# Auto-detect repo
+get_repo() {
+    gh repo view --json nameWithOwner --jq '.nameWithOwner'
+}
+
+# Print usage
+usage() {
+    cat << EOF
+Usage: $(basename "$0") <subcommand> [OPTIONS]
+
+GitHub Actions workflow monitor for PRs (src).
+
+SUBCOMMANDS:
+    list [--branch NAME] [--limit N]    List recent CI workflow runs
+    view ID [ID...]                      View workflow run conclusions
+    watch ID [ID...]                     Watch runs until complete
+    checks PR_NUMBER                     Show PR check status
+    status PR_NUMBER [--workflow FILE]   Full PR verdict (CI + Claude review)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --version   Show version and exit
+    --help      Display this help message
+
+STATUS OPTIONS:
+    --workflow FILE   CI workflow filename (default: ci.yml)
+
+EXIT CODES:
+    0           Success / ready to merge
+    1           Failure / not ready to merge
+    2           Usage error
+
+EXAMPLES:
+    $(basename "$0") list                    # List recent CI runs
+    $(basename "$0") list --branch feat/foo  # Filter by branch
+    $(basename "$0") view 12345              # View run #12345
+    $(basename "$0") watch 12345 12346       # Watch two runs
+    $(basename "$0") checks 74               # Show PR #74 checks
+    $(basename "$0") status 74               # Full PR #74 verdict
+EOF
+}
+
+# === list subcommand ===
+cmd_list() {
+    local branch=""
+    local limit=10
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --branch)
+                branch="$2"
+                shift 2
+                ;;
+            --limit)
+                if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+                    echo "Error: --limit requires a numeric value, got '$2'" >&2
+                    exit 2
+                fi
+                limit="$2"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown option for list: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    local repo
+    repo="$(get_repo)"
+
+    echo "=== Recent CI Workflow Runs ==="
+    echo ""
+
+    local args=(run list --repo "$repo" --limit "$limit")
+    if [[ -n "$branch" ]]; then
+        args+=(--branch "$branch")
+    fi
+    args+=(--json "databaseId,headBranch,workflowName,status,conclusion,createdAt")
+    local jqexpr='.[] | [(.databaseId|tostring),'
+    jqexpr+=' .headBranch, .workflowName, .status,'
+    jqexpr+=' (.conclusion // "—"), .createdAt] | @tsv'
+    args+=(--jq "$jqexpr")
+
+    if $VERBOSE; then
+        echo "Running: gh ${args[*]}"
+    fi
+
+    local fmt="%-12s %-30s %-20s %-12s %-18s %s\n"
+    printf "$fmt" "ID" "BRANCH" "WORKFLOW" \
+        "STATUS" "CONCLUSION" "CREATED"
+    printf "$fmt" "----" "------" "--------" \
+        "------" "----------" "-------"
+
+    gh "${args[@]}" | while IFS=$'\t' \
+        read -r id branch_name workflow status conclusion created; do
+        printf "$fmt" "$id" "$branch_name" \
+            "$workflow" "$status" "$conclusion" "$created"
+    done
+}
+
+# === view subcommand ===
+cmd_view() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: view requires at least one run ID" >&2
+        exit 2
+    fi
+
+    local repo
+    repo="$(get_repo)"
+    local any_failed=false
+
+    for run_id in "$@"; do
+        echo "=== Run #${run_id} ==="
+        echo ""
+
+        local run_json
+        local fields="status,conclusion,workflowName"
+        fields+=",headBranch,jobs"
+        run_json="$(gh run view "$run_id" \
+            --repo "$repo" --json "$fields")"
+
+        if $VERBOSE; then
+            echo "Fetched run data for #${run_id}"
+        fi
+
+        local status conclusion workflow branch
+        local jq_tsv='[.workflowName, .headBranch,'
+        jq_tsv+=' .status, (.conclusion // "—")] | @tsv'
+        read -r workflow branch status conclusion < <(
+            echo "$run_json" | jq -r "$jq_tsv"
+        )
+
+        echo "Workflow:   $workflow"
+        echo "Branch:     $branch"
+        echo "Status:     $status"
+        echo "Conclusion: $conclusion"
+        echo ""
+
+        echo "Jobs:"
+        local jq_jobs='.jobs[] | "  '
+        jq_jobs+='\(if .conclusion == "success" then "✓"'
+        jq_jobs+=' elif .conclusion == "failure" then "✗"'
+        jq_jobs+=' elif .conclusion == "skipped" then "—"'
+        jq_jobs+=' else "●" end)'
+        jq_jobs+=' \(.name): \(.conclusion // .status)"'
+        echo "$run_json" | jq -r "$jq_jobs"
+        echo ""
+
+        if [[ "$conclusion" == "failure" ]]; then
+            any_failed=true
+        fi
+    done
+
+    if $any_failed; then
+        exit 1
+    fi
+}
+
+# === watch subcommand ===
+cmd_watch() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: watch requires at least one run ID" >&2
+        exit 2
+    fi
+
+    local repo
+    repo="$(get_repo)"
+    local any_failed=false
+
+    for run_id in "$@"; do
+        echo "=== Watching Run #${run_id} ==="
+        echo ""
+
+        if $VERBOSE; then
+            echo "Watching run #${run_id} in repo $repo"
+        fi
+
+        if ! gh run watch "$run_id" --repo "$repo" --exit-status; then
+            any_failed=true
+            echo "✗ Run #${run_id} failed" >&2
+        else
+            echo "✓ Run #${run_id} passed"
+        fi
+        echo ""
+    done
+
+    if $any_failed; then
+        exit 1
+    fi
+}
+
+# === checks subcommand ===
+cmd_checks() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: checks requires a PR number" >&2
+        exit 2
+    fi
+
+    local pr_number="$1"
+    local repo
+    repo="$(get_repo)"
+
+    echo "=== PR #${pr_number} Checks ==="
+    echo ""
+
+    if $VERBOSE; then
+        echo "Fetching checks for PR #${pr_number} in repo $repo"
+    fi
+
+    gh pr checks "$pr_number" --repo "$repo"
+}
+
+# === status subcommand ===
+cmd_status() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: status requires a PR number" >&2
+        exit 2
+    fi
+
+    local pr_number="$1"
+    shift
+    local workflow="ci.yml"
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --workflow)
+                workflow="$2"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown option for status: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    local repo
+    repo="$(get_repo)"
+
+    # Get PR info
+    local pr_json
+    pr_json="$(gh pr view "$pr_number" \
+        --repo "$repo" \
+        --json "title,headRefName,comments")"
+
+    local pr_title pr_branch
+    pr_title="$(echo "$pr_json" | jq -r '.title')"
+    pr_branch="$(echo "$pr_json" | jq -r '.headRefName')"
+
+    echo "=== PR #${pr_number}: ${pr_title} ==="
+    echo ""
+
+    # --- CI Status ---
+    local ci_status="UNKNOWN"
+    local ci_detail=""
+    local ci_pass=false
+
+    local run_json
+    if $VERBOSE; then
+        echo "Looking for workflow: $workflow on branch: $pr_branch"
+    fi
+
+    run_json="$(gh run list --repo "$repo" \
+        --branch "$pr_branch" \
+        --workflow "$workflow" --limit 1 \
+        --json "databaseId,conclusion,status" \
+        2>/dev/null || echo "[]")"
+
+    local run_count
+    run_count="$(echo "$run_json" | jq 'length')"
+
+    if [[ "$run_count" -eq 0 ]]; then
+        ci_status="NO RUNS"
+        ci_detail="No CI runs found for branch $pr_branch"
+        echo "Warning: No runs found for workflow" \
+            "'$workflow' on branch '$pr_branch'." >&2
+        echo "  Check workflow filename or" \
+            "use --workflow <file> to specify." >&2
+    else
+        local run_id run_conclusion run_status
+        run_id="$(echo "$run_json" | jq -r '.[0].databaseId')"
+        run_conclusion="$(echo "$run_json" | jq -r '.[0].conclusion // ""')"
+        run_status="$(echo "$run_json" | jq -r '.[0].status')"
+
+        if [[ "$run_status" != "completed" ]]; then
+            ci_status="IN PROGRESS"
+            ci_detail="Run #${run_id} is ${run_status}"
+        else
+            local jobs_json
+            jobs_json="$(gh run view "$run_id" --repo "$repo" --json jobs)"
+
+            local total_jobs passed_jobs failed_jobs
+            total_jobs="$(echo "$jobs_json" | jq '.jobs | length')"
+            passed_jobs="$(echo "$jobs_json" | \
+                jq '[.jobs[] | select(.conclusion == "success")] | length')"
+            failed_jobs="$(echo "$jobs_json" | \
+                jq '[.jobs[] | select(.conclusion == "failure")] | length')"
+
+            if [[ "$run_conclusion" == "success" ]]; then
+                ci_status="PASS"
+                ci_detail="${passed_jobs}/${total_jobs} jobs green"
+                ci_pass=true
+            else
+                ci_status="FAIL"
+                ci_detail="${passed_jobs}/${total_jobs} jobs green,"
+                ci_detail="${ci_detail} ${failed_jobs} failed"
+
+                # Show failed jobs
+                local failed_names
+                failed_names="$(echo "$jobs_json" | \
+                    jq -r '.jobs[] | select(.conclusion == "failure") | .name')"
+                if [[ -n "$failed_names" ]]; then
+                    ci_detail="${ci_detail}"$'\n'"Failed jobs:"
+                    while IFS= read -r name; do
+                        ci_detail="${ci_detail}"$'\n'"  ✗ ${name}"
+                    done <<< "$failed_names"
+                fi
+            fi
+        fi
+    fi
+
+    # --- Claude Review Status ---
+    local review_status="NO REVIEW"
+    local review_issues=""
+    local review_pass=false
+
+    # Scan comments for Claude review verdicts (latest wins)
+    local comments_count
+    comments_count="$(echo "$pr_json" | jq '.comments | length')"
+
+    if [[ "$comments_count" -gt 0 ]]; then
+        # Search from latest comment backwards for a verdict
+        local i
+        for ((i = comments_count - 1; i >= 0; i--)); do
+            local body
+            body="$(echo "$pr_json" | jq -r ".comments[$i].body")"
+
+            # Check for verdict patterns
+            if echo "$body" | grep -qE '✅\s*LGTM|Verdict:.*LGTM'; then
+                review_status="LGTM"
+                review_pass=true
+                break
+            elif echo "$body" | \
+                grep -qE '🔄\s*CHANGES_REQUESTED|Verdict:.*CHANGES_REQUESTED'; then
+                review_status="CHANGES_REQUESTED"
+
+                # Extract problems section
+                review_issues="$(echo "$body" | \
+                    sed -n '/^## Problems/,/^## [^P]/p' | sed '$d')"
+                if [[ -z "$review_issues" ]]; then
+                    # Try alternate format: lines starting with 🔴
+                    review_issues="$(echo "$body" | grep '🔴' || true)"
+                fi
+                break
+            elif echo "$body" | grep -qE '💬\s*COMMENTS|Verdict:.*COMMENTS'; then
+                review_status="COMMENTS"
+                review_pass=true
+                break
+            fi
+        done
+    fi
+
+    # --- Output ---
+    if $ci_pass; then
+        echo "CI Status:     ✓ ${ci_status}  (${ci_detail})"
+    else
+        echo "CI Status:     ✗ ${ci_status}  (${ci_detail})"
+    fi
+
+    if $review_pass; then
+        echo "Claude Review: ✓ ${review_status}"
+    else
+        echo "Claude Review: ✗ ${review_status}"
+    fi
+
+    if [[ -n "$review_issues" ]]; then
+        echo ""
+        echo "Review Issues:"
+        echo "$review_issues" | while IFS= read -r line; do
+            # Indent if not already indented
+            if [[ "$line" == "  "* ]]; then
+                echo "$line"
+            else
+                echo "  $line"
+            fi
+        done
+    fi
+
+    echo ""
+
+    # --- Verdict ---
+    if $ci_pass && $review_pass; then
+        echo "Verdict: READY TO MERGE"
+        exit 0
+    else
+        echo "Verdict: NOT READY TO MERGE"
+        exit 1
+    fi
+}
+
+# === Main argument parsing ===
+
+# Handle no arguments
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 2
+fi
+
+# Extract global flags first, collect remaining args
+REMAINING_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --version)
+            echo "$(basename "$0") version $VERSION"
+            exit 0
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            REMAINING_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Restore positional args
+set -- "${REMAINING_ARGS[@]+"${REMAINING_ARGS[@]}"}"
+
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 2
+fi
+
+SUBCOMMAND="$1"
+shift
+
+case "$SUBCOMMAND" in
+    list)
+        cmd_list "$@"
+        ;;
+    view)
+        cmd_view "$@"
+        ;;
+    watch)
+        cmd_watch "$@"
+        ;;
+    checks)
+        cmd_checks "$@"
+        ;;
+    status)
+        cmd_status "$@"
+        ;;
+    *)
+        echo "Error: Unknown subcommand: $SUBCOMMAND" >&2
+        echo "Run '$(basename "$0") --help' for usage." >&2
+        exit 2
+        ;;
+esac

--- a/scripts/backend/security.sh
+++ b/scripts/backend/security.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/security.sh - Run security checks with Bandit and Safety
+# Usage: ./scripts/security.sh [--full] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+FULL=false
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --full)
+            FULL=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run security checks using Bandit and Safety.
+
+OPTIONS:
+    --full      Run comprehensive security scan
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           No security issues found
+    1           Security issues found
+    2           Error running checks
+
+EXAMPLES:
+    $(basename "$0")             # Run basic security checks
+    $(basename "$0") --full      # Run comprehensive scan
+    $(basename "$0") --verbose   # Show detailed output
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Security Checks (Bandit) ==="
+
+# Run Bandit
+if $VERBOSE; then
+    echo "Running Bandit security scanner..."
+fi
+bandit -r src/ || { echo "✗ Bandit found issues" >&2; exit 1; }
+
+echo "=== Security Checks (pip-audit) ==="
+
+# Run pip-audit for dependency vulnerability scanning
+if $VERBOSE; then
+    echo "Running pip-audit dependency checker..."
+fi
+pip-audit || { echo "✗ pip-audit found issues" >&2; exit 1; }
+
+if $FULL; then
+    echo "=== Comprehensive Security Scan ==="
+
+    # Check for hardcoded secrets
+    if command -v detect-secrets &> /dev/null; then
+        if $VERBOSE; then
+            echo "Running detect-secrets scan..."
+        fi
+        detect-secrets scan . || true
+    fi
+fi
+
+echo "✓ Security checks passed"
+exit 0

--- a/scripts/backend/test.sh
+++ b/scripts/backend/test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# scripts/test.sh - Run tests with Pytest
+# Usage: ./scripts/test.sh [--unit|--integration|--e2e|--all] [--coverage]
+#                          [--mutation] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+TEST_TYPE="unit"
+COVERAGE=false
+MUTATION=false
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --unit)
+            TEST_TYPE="unit"
+            shift
+            ;;
+        --integration)
+            TEST_TYPE="integration"
+            shift
+            ;;
+        --e2e)
+            TEST_TYPE="e2e"
+            shift
+            ;;
+        --all)
+            TEST_TYPE="all"
+            shift
+            ;;
+        --coverage)
+            COVERAGE=true
+            shift
+            ;;
+        --mutation)
+            MUTATION=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run tests using Pytest.
+
+OPTIONS:
+    --unit          Run unit tests only (default)
+    --integration   Run integration tests only
+    --e2e           Run end-to-end tests only
+    --all           Run all test types
+    --coverage      Generate coverage report
+    --mutation      Run mutation tests
+    --verbose       Show detailed output
+    --help          Display this help message
+
+EXIT CODES:
+    0               All tests passed
+    1               Test failures
+    2               Error running tests
+
+EXAMPLES:
+    $(basename "$0")                     # Run unit tests
+    $(basename "$0") --all               # Run all tests
+    $(basename "$0") --unit --coverage   # Unit tests with coverage
+    $(basename "$0") --mutation          # Run mutation tests
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+if $VERBOSE; then
+    set -x
+fi
+
+# Build pytest arguments
+PYTEST_ARGS=(-v)
+
+case "$TEST_TYPE" in
+    unit)
+        echo "=== Running Unit Tests ==="
+        PYTEST_ARGS+=(-m "not integration and not e2e")
+        ;;
+    integration)
+        echo "=== Running Integration Tests ==="
+        PYTEST_ARGS+=(-m "integration")
+        ;;
+    e2e)
+        echo "=== Running End-to-End Tests ==="
+        PYTEST_ARGS+=(-m "e2e")
+        ;;
+    all)
+        echo "=== Running All Tests ==="
+        ;;
+esac
+
+# Add coverage if requested
+if $COVERAGE; then
+    echo "Coverage enabled"
+    PYTEST_ARGS+=(
+        --cov=src
+        --cov-branch
+        --cov-report=term-missing
+        --cov-report=html
+        --cov-report=xml
+        --cov-fail-under=90
+    )
+fi
+
+# Run tests
+if $VERBOSE; then
+    echo "Running pytest with args: ${PYTEST_ARGS[*]}"
+fi
+
+pytest "${PYTEST_ARGS[@]}" tests/ || { echo "✗ Tests failed" >&2; exit 1; }
+
+echo "✓ Tests passed"
+
+# Run mutation tests if requested
+if $MUTATION; then
+    echo "=== Running Mutation Tests ==="
+    if command -v mutmut &> /dev/null; then
+        mutmut run || { echo "✗ Mutation tests failed" >&2; exit 1; }
+        echo "✓ Mutation tests passed"
+    else
+        echo "Warning: mutmut not installed, skipping mutation tests" >&2
+    fi
+fi
+
+exit 0

--- a/scripts/backend/typecheck.sh
+++ b/scripts/backend/typecheck.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/typecheck.sh - Run type checking with MyPy
+# Usage: ./scripts/typecheck.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run type checking on the project using MyPy.
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All type checks passed
+    1           Type errors found
+    2           Error running type checker
+
+EXAMPLES:
+    $(basename "$0")          # Run type checking
+    $(basename "$0") --verbose # Show detailed output
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Type Checking (MyPy) ==="
+
+if command -v mypy &> /dev/null; then
+    mypy src/ || {
+        echo "✗ Type checking failed" >&2
+        exit 1
+    }
+    echo "✓ Type checking passed"
+else
+    echo "Warning: mypy not installed, skipping type checking" >&2
+    echo "Install with: pip install mypy" >&2
+    exit 0
+fi
+
+exit 0

--- a/scripts/frontend/check-all.sh
+++ b/scripts/frontend/check-all.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# scripts/check-all.sh - Run all quality checks
+# Usage: ./scripts/check-all.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../frontend" && pwd)"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run all quality checks in sequence.
+
+Runs:
+  1. Linting (ESLint)
+  2. Formatting (Prettier)
+  3. Type checking (TypeScript)
+  4. Tests (Jest)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           One or more checks failed
+    2           Error running checks
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+VERBOSE_FLAG=""
+if $VERBOSE; then
+    VERBOSE_FLAG="--verbose"
+fi
+
+echo "=== Running All Quality Checks ==="
+echo ""
+
+FAILED_CHECKS=()
+PASSED_CHECKS=()
+
+run_check() {
+    local check_name=$1
+    local script=$2
+    shift 2
+    local args=("$@")
+
+    echo "Running: $check_name"
+    if "$SCRIPT_DIR/$script" "${args[@]+"${args[@]}"}" $VERBOSE_FLAG; then
+        PASSED_CHECKS+=("$check_name")
+        echo "✓ $check_name passed"
+    else
+        FAILED_CHECKS+=("$check_name")
+        echo "✗ $check_name failed" >&2
+    fi
+    echo ""
+}
+
+run_check "Linting" "lint.sh" --check
+run_check "Formatting" "format.sh" --check
+run_check "Type checking" "typecheck.sh"
+run_check "Tests" "test.sh"
+
+echo "=== Quality Checks Summary ==="
+echo "Passed: ${#PASSED_CHECKS[@]}"
+echo "Failed: ${#FAILED_CHECKS[@]}"
+
+if [ ${#FAILED_CHECKS[@]} -gt 0 ]; then
+    echo ""
+    for check in "${FAILED_CHECKS[@]}"; do
+        echo "  ✗ $check"
+    done
+    exit 1
+else
+    echo ""
+    echo "✓ All quality checks passed!"
+    exit 0
+fi

--- a/scripts/frontend/fix-all.sh
+++ b/scripts/frontend/fix-all.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# scripts/fix-all.sh - Auto-fix all issues
+# Usage: ./scripts/fix-all.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../frontend" && pwd)"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Auto-fix all auto-fixable issues in sequence.
+
+Fixes:
+  1. Linting issues (ESLint)
+  2. Formatting (Prettier)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Fixes applied successfully
+    1           Some fixes failed
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+VERBOSE_FLAG=""
+if $VERBOSE; then
+    VERBOSE_FLAG="--verbose"
+fi
+
+echo "=== Auto-fixing Issues ==="
+echo ""
+
+FAILED_FIXES=()
+
+run_fix() {
+    local fix_name=$1
+    local script=$2
+    shift 2
+
+    echo "Running: $fix_name"
+    if "$SCRIPT_DIR/$script" --fix $VERBOSE_FLAG; then
+        echo "✓ $fix_name completed"
+    else
+        FAILED_FIXES+=("$fix_name")
+        echo "✗ $fix_name failed" >&2
+    fi
+    echo ""
+}
+
+run_fix "Linting" "lint.sh"
+run_fix "Formatting" "format.sh"
+
+echo "=== Auto-fix Summary ==="
+if [ ${#FAILED_FIXES[@]} -gt 0 ]; then
+    echo "Failed fixes: ${#FAILED_FIXES[@]}"
+    exit 1
+else
+    echo "✓ All auto-fixes completed successfully!"
+    exit 0
+fi

--- a/scripts/frontend/format.sh
+++ b/scripts/frontend/format.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scripts/format.sh - Format code with Prettier
+# Usage: ./scripts/format.sh [--fix] [--check] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../frontend" && pwd)"
+
+FIX=false
+CHECK=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --fix)
+            FIX=true
+            shift
+            ;;
+        --check)
+            CHECK=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Format code using Prettier.
+
+OPTIONS:
+    --fix       Apply formatting changes (default)
+    --check     Check only, fail if changes needed
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Code is properly formatted
+    1           Formatting issues found
+    2           Error running checks
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Formatting (Prettier) ==="
+
+if $CHECK; then
+    if $VERBOSE; then
+        echo "Checking formatting..."
+    fi
+    npx prettier --check "src/**/*.{ts,tsx}" "tests/**/*.{ts,tsx}" "*.{js,json}" || { echo "✗ Formatting check failed" >&2; exit 1; }
+    echo "✓ Code formatting check passed"
+else
+    if $VERBOSE; then
+        echo "Formatting code..."
+    fi
+    npx prettier --write "src/**/*.{ts,tsx}" "tests/**/*.{ts,tsx}" "*.{js,json}" || { echo "✗ Formatting failed" >&2; exit 1; }
+    echo "✓ Code formatted successfully"
+fi
+exit 0

--- a/scripts/frontend/lint.sh
+++ b/scripts/frontend/lint.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scripts/lint.sh - Run linting checks with ESLint
+# Usage: ./scripts/lint.sh [--fix] [--check] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../frontend" && pwd)"
+
+FIX=false
+CHECK=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --fix)
+            FIX=true
+            shift
+            ;;
+        --check)
+            CHECK=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run linting checks using ESLint.
+
+OPTIONS:
+    --fix       Auto-fix linting issues where possible
+    --check     Check only, fail if issues found
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           Linting issues found
+    2           Error running checks
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Linting (ESLint) ==="
+
+if $FIX; then
+    if $VERBOSE; then
+        echo "Fixing linting issues..."
+    fi
+    npx eslint . --fix || { echo "✗ ESLint fix failed" >&2; exit 1; }
+else
+    if $VERBOSE; then
+        echo "Checking for linting issues..."
+    fi
+    npx eslint . || { echo "✗ ESLint check failed" >&2; exit 1; }
+fi
+
+echo "✓ Linting checks passed"
+exit 0

--- a/scripts/frontend/pr-status.sh
+++ b/scripts/frontend/pr-status.sh
@@ -1,0 +1,474 @@
+#!/usr/bin/env bash
+# scripts/pr-status.sh - GitHub Actions workflow monitor for PRs
+# Usage: ./scripts/pr-status.sh <subcommand> [OPTIONS]
+
+set -euo pipefail
+
+VERSION="1.0.0"
+VERBOSE=false
+
+# Auto-detect repo
+get_repo() {
+    gh repo view --json nameWithOwner --jq '.nameWithOwner'
+}
+
+# Print usage
+usage() {
+    cat << EOF
+Usage: $(basename "$0") <subcommand> [OPTIONS]
+
+GitHub Actions workflow monitor for PRs (adepthood_linters).
+
+SUBCOMMANDS:
+    list [--branch NAME] [--limit N]    List recent CI workflow runs
+    view ID [ID...]                      View workflow run conclusions
+    watch ID [ID...]                     Watch runs until complete
+    checks PR_NUMBER                     Show PR check status
+    status PR_NUMBER [--workflow FILE]   Full PR verdict (CI + Claude review)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --version   Show version and exit
+    --help      Display this help message
+
+STATUS OPTIONS:
+    --workflow FILE   CI workflow filename (default: ci.yml)
+
+EXIT CODES:
+    0           Success / ready to merge
+    1           Failure / not ready to merge
+    2           Usage error
+
+EXAMPLES:
+    $(basename "$0") list                    # List recent CI runs
+    $(basename "$0") list --branch feat/foo  # Filter by branch
+    $(basename "$0") view 12345              # View run #12345
+    $(basename "$0") watch 12345 12346       # Watch two runs
+    $(basename "$0") checks 74               # Show PR #74 checks
+    $(basename "$0") status 74               # Full PR #74 verdict
+EOF
+}
+
+# === list subcommand ===
+cmd_list() {
+    local branch=""
+    local limit=10
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --branch)
+                branch="$2"
+                shift 2
+                ;;
+            --limit)
+                if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+                    echo "Error: --limit requires a numeric value, got '$2'" >&2
+                    exit 2
+                fi
+                limit="$2"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown option for list: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    local repo
+    repo="$(get_repo)"
+
+    echo "=== Recent CI Workflow Runs ==="
+    echo ""
+
+    local args=(run list --repo "$repo" --limit "$limit")
+    if [[ -n "$branch" ]]; then
+        args+=(--branch "$branch")
+    fi
+    args+=(--json "databaseId,headBranch,workflowName,status,conclusion,createdAt")
+    local jqexpr='.[] | [(.databaseId|tostring),'
+    jqexpr+=' .headBranch, .workflowName, .status,'
+    jqexpr+=' (.conclusion // "—"), .createdAt] | @tsv'
+    args+=(--jq "$jqexpr")
+
+    if $VERBOSE; then
+        echo "Running: gh ${args[*]}"
+    fi
+
+    local fmt="%-12s %-30s %-20s %-12s %-18s %s\n"
+    printf "$fmt" "ID" "BRANCH" "WORKFLOW" \
+        "STATUS" "CONCLUSION" "CREATED"
+    printf "$fmt" "----" "------" "--------" \
+        "------" "----------" "-------"
+
+    gh "${args[@]}" | while IFS=$'\t' \
+        read -r id branch_name workflow status conclusion created; do
+        printf "$fmt" "$id" "$branch_name" \
+            "$workflow" "$status" "$conclusion" "$created"
+    done
+}
+
+# === view subcommand ===
+cmd_view() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: view requires at least one run ID" >&2
+        exit 2
+    fi
+
+    local repo
+    repo="$(get_repo)"
+    local any_failed=false
+
+    for run_id in "$@"; do
+        echo "=== Run #${run_id} ==="
+        echo ""
+
+        local run_json
+        local fields="status,conclusion,workflowName"
+        fields+=",headBranch,jobs"
+        run_json="$(gh run view "$run_id" \
+            --repo "$repo" --json "$fields")"
+
+        if $VERBOSE; then
+            echo "Fetched run data for #${run_id}"
+        fi
+
+        local status conclusion workflow branch
+        local jq_tsv='[.workflowName, .headBranch,'
+        jq_tsv+=' .status, (.conclusion // "—")] | @tsv'
+        read -r workflow branch status conclusion < <(
+            echo "$run_json" | jq -r "$jq_tsv"
+        )
+
+        echo "Workflow:   $workflow"
+        echo "Branch:     $branch"
+        echo "Status:     $status"
+        echo "Conclusion: $conclusion"
+        echo ""
+
+        echo "Jobs:"
+        local jq_jobs='.jobs[] | "  '
+        jq_jobs+='\(if .conclusion == "success" then "✓"'
+        jq_jobs+=' elif .conclusion == "failure" then "✗"'
+        jq_jobs+=' elif .conclusion == "skipped" then "—"'
+        jq_jobs+=' else "●" end)'
+        jq_jobs+=' \(.name): \(.conclusion // .status)"'
+        echo "$run_json" | jq -r "$jq_jobs"
+        echo ""
+
+        if [[ "$conclusion" == "failure" ]]; then
+            any_failed=true
+        fi
+    done
+
+    if $any_failed; then
+        exit 1
+    fi
+}
+
+# === watch subcommand ===
+cmd_watch() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: watch requires at least one run ID" >&2
+        exit 2
+    fi
+
+    local repo
+    repo="$(get_repo)"
+    local any_failed=false
+
+    for run_id in "$@"; do
+        echo "=== Watching Run #${run_id} ==="
+        echo ""
+
+        if $VERBOSE; then
+            echo "Watching run #${run_id} in repo $repo"
+        fi
+
+        if ! gh run watch "$run_id" --repo "$repo" --exit-status; then
+            any_failed=true
+            echo "✗ Run #${run_id} failed" >&2
+        else
+            echo "✓ Run #${run_id} passed"
+        fi
+        echo ""
+    done
+
+    if $any_failed; then
+        exit 1
+    fi
+}
+
+# === checks subcommand ===
+cmd_checks() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: checks requires a PR number" >&2
+        exit 2
+    fi
+
+    local pr_number="$1"
+    local repo
+    repo="$(get_repo)"
+
+    echo "=== PR #${pr_number} Checks ==="
+    echo ""
+
+    if $VERBOSE; then
+        echo "Fetching checks for PR #${pr_number} in repo $repo"
+    fi
+
+    gh pr checks "$pr_number" --repo "$repo"
+}
+
+# === status subcommand ===
+cmd_status() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: status requires a PR number" >&2
+        exit 2
+    fi
+
+    local pr_number="$1"
+    shift
+    local workflow="ci.yml"
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --workflow)
+                workflow="$2"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown option for status: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    local repo
+    repo="$(get_repo)"
+
+    # Get PR info
+    local pr_json
+    pr_json="$(gh pr view "$pr_number" \
+        --repo "$repo" \
+        --json "title,headRefName,comments")"
+
+    local pr_title pr_branch
+    pr_title="$(echo "$pr_json" | jq -r '.title')"
+    pr_branch="$(echo "$pr_json" | jq -r '.headRefName')"
+
+    echo "=== PR #${pr_number}: ${pr_title} ==="
+    echo ""
+
+    # --- CI Status ---
+    local ci_status="UNKNOWN"
+    local ci_detail=""
+    local ci_pass=false
+
+    local run_json
+    if $VERBOSE; then
+        echo "Looking for workflow: $workflow on branch: $pr_branch"
+    fi
+
+    run_json="$(gh run list --repo "$repo" \
+        --branch "$pr_branch" \
+        --workflow "$workflow" --limit 1 \
+        --json "databaseId,conclusion,status" \
+        2>/dev/null || echo "[]")"
+
+    local run_count
+    run_count="$(echo "$run_json" | jq 'length')"
+
+    if [[ "$run_count" -eq 0 ]]; then
+        ci_status="NO RUNS"
+        ci_detail="No CI runs found for branch $pr_branch"
+        echo "Warning: No runs found for workflow" \
+            "'$workflow' on branch '$pr_branch'." >&2
+        echo "  Check workflow filename or" \
+            "use --workflow <file> to specify." >&2
+    else
+        local run_id run_conclusion run_status
+        run_id="$(echo "$run_json" | jq -r '.[0].databaseId')"
+        run_conclusion="$(echo "$run_json" | jq -r '.[0].conclusion // ""')"
+        run_status="$(echo "$run_json" | jq -r '.[0].status')"
+
+        if [[ "$run_status" != "completed" ]]; then
+            ci_status="IN PROGRESS"
+            ci_detail="Run #${run_id} is ${run_status}"
+        else
+            local jobs_json
+            jobs_json="$(gh run view "$run_id" --repo "$repo" --json jobs)"
+
+            local total_jobs passed_jobs failed_jobs
+            total_jobs="$(echo "$jobs_json" | jq '.jobs | length')"
+            passed_jobs="$(echo "$jobs_json" | \
+                jq '[.jobs[] | select(.conclusion == "success")] | length')"
+            failed_jobs="$(echo "$jobs_json" | \
+                jq '[.jobs[] | select(.conclusion == "failure")] | length')"
+
+            if [[ "$run_conclusion" == "success" ]]; then
+                ci_status="PASS"
+                ci_detail="${passed_jobs}/${total_jobs} jobs green"
+                ci_pass=true
+            else
+                ci_status="FAIL"
+                ci_detail="${passed_jobs}/${total_jobs} jobs green,"
+                ci_detail="${ci_detail} ${failed_jobs} failed"
+
+                # Show failed jobs
+                local failed_names
+                failed_names="$(echo "$jobs_json" | \
+                    jq -r '.jobs[] | select(.conclusion == "failure") | .name')"
+                if [[ -n "$failed_names" ]]; then
+                    ci_detail="${ci_detail}"$'\n'"Failed jobs:"
+                    while IFS= read -r name; do
+                        ci_detail="${ci_detail}"$'\n'"  ✗ ${name}"
+                    done <<< "$failed_names"
+                fi
+            fi
+        fi
+    fi
+
+    # --- Claude Review Status ---
+    local review_status="NO REVIEW"
+    local review_issues=""
+    local review_pass=false
+
+    # Scan comments for Claude review verdicts (latest wins)
+    local comments_count
+    comments_count="$(echo "$pr_json" | jq '.comments | length')"
+
+    if [[ "$comments_count" -gt 0 ]]; then
+        # Search from latest comment backwards for a verdict
+        local i
+        for ((i = comments_count - 1; i >= 0; i--)); do
+            local body
+            body="$(echo "$pr_json" | jq -r ".comments[$i].body")"
+
+            # Check for verdict patterns
+            if echo "$body" | grep -qE '✅\s*LGTM|Verdict:.*LGTM'; then
+                review_status="LGTM"
+                review_pass=true
+                break
+            elif echo "$body" | \
+                grep -qE '🔄\s*CHANGES_REQUESTED|Verdict:.*CHANGES_REQUESTED'; then
+                review_status="CHANGES_REQUESTED"
+
+                # Extract problems section
+                review_issues="$(echo "$body" | \
+                    sed -n '/^## Problems/,/^## [^P]/p' | sed '$d')"
+                if [[ -z "$review_issues" ]]; then
+                    # Try alternate format: lines starting with 🔴
+                    review_issues="$(echo "$body" | grep '🔴' || true)"
+                fi
+                break
+            elif echo "$body" | grep -qE '💬\s*COMMENTS|Verdict:.*COMMENTS'; then
+                review_status="COMMENTS"
+                review_pass=true
+                break
+            fi
+        done
+    fi
+
+    # --- Output ---
+    if $ci_pass; then
+        echo "CI Status:     ✓ ${ci_status}  (${ci_detail})"
+    else
+        echo "CI Status:     ✗ ${ci_status}  (${ci_detail})"
+    fi
+
+    if $review_pass; then
+        echo "Claude Review: ✓ ${review_status}"
+    else
+        echo "Claude Review: ✗ ${review_status}"
+    fi
+
+    if [[ -n "$review_issues" ]]; then
+        echo ""
+        echo "Review Issues:"
+        echo "$review_issues" | while IFS= read -r line; do
+            # Indent if not already indented
+            if [[ "$line" == "  "* ]]; then
+                echo "$line"
+            else
+                echo "  $line"
+            fi
+        done
+    fi
+
+    echo ""
+
+    # --- Verdict ---
+    if $ci_pass && $review_pass; then
+        echo "Verdict: READY TO MERGE"
+        exit 0
+    else
+        echo "Verdict: NOT READY TO MERGE"
+        exit 1
+    fi
+}
+
+# === Main argument parsing ===
+
+# Handle no arguments
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 2
+fi
+
+# Extract global flags first, collect remaining args
+REMAINING_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --version)
+            echo "$(basename "$0") version $VERSION"
+            exit 0
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            REMAINING_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Restore positional args
+set -- "${REMAINING_ARGS[@]+"${REMAINING_ARGS[@]}"}"
+
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 2
+fi
+
+SUBCOMMAND="$1"
+shift
+
+case "$SUBCOMMAND" in
+    list)
+        cmd_list "$@"
+        ;;
+    view)
+        cmd_view "$@"
+        ;;
+    watch)
+        cmd_watch "$@"
+        ;;
+    checks)
+        cmd_checks "$@"
+        ;;
+    status)
+        cmd_status "$@"
+        ;;
+    *)
+        echo "Error: Unknown subcommand: $SUBCOMMAND" >&2
+        echo "Run '$(basename "$0") --help' for usage." >&2
+        exit 2
+        ;;
+esac

--- a/scripts/frontend/test.sh
+++ b/scripts/frontend/test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scripts/test.sh - Run tests with Jest
+# Usage: ./scripts/test.sh [--coverage] [--watch] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../frontend" && pwd)"
+
+COVERAGE=false
+WATCH=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --coverage)
+            COVERAGE=true
+            shift
+            ;;
+        --watch)
+            WATCH=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run tests using Jest.
+
+OPTIONS:
+    --coverage  Generate coverage report
+    --watch     Watch mode (rerun on file changes)
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All tests passed
+    1           Test failures
+    2           Error running tests
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Running Tests (Jest) ==="
+
+JEST_ARGS=()
+
+if $COVERAGE; then
+    JEST_ARGS+=(--coverage)
+fi
+
+if $WATCH; then
+    JEST_ARGS+=(--watch)
+fi
+
+npx jest ${JEST_ARGS[@]+"${JEST_ARGS[@]}"} || { echo "✗ Tests failed" >&2; exit 1; }
+
+echo "✓ Tests passed"
+exit 0

--- a/scripts/frontend/typecheck.sh
+++ b/scripts/frontend/typecheck.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# scripts/typecheck.sh - Run type checking with TypeScript compiler
+# Usage: ./scripts/typecheck.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../frontend" && pwd)"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run type checking using the TypeScript compiler.
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All type checks passed
+    1           Type errors found
+    2           Error running type checker
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Type Checking (TypeScript) ==="
+
+npx tsc --noEmit || { echo "✗ Type checking failed" >&2; exit 1; }
+
+echo "✓ Type checking passed"
+exit 0


### PR DESCRIPTION
## Summary
First of five logical groupings pulling tooling, skills, agents, and scripts from the sibling [`adepthood-linters`](https://github.com/Geoffe-Ga/adepthood-linters) repo. This PR is **purely additive** — no existing files are modified, no lint/type/test rules change, no new failures surfaced. Safe to ship independently.

## What's in this PR

### Tranche 1 — `.claude/skills/` expansion
Adds **17 new skills** with reference material. Target previously had 9 Adepthood-specific workflow skills (`continue-epic`, `preflight`, `status`, etc.); this imports general-purpose engineering skills from the source:

`architectural-decisions`, `backlog-grooming`, `ci-debugging`, `comprehensive-pr-review`, `concurrency`, `documentation`, `error-handling`, `file-naming-conventions`, `frontend-aesthetics`, `git-workflow`, `max-quality-no-shortcuts`, `mutation-testing`, `prompt-engineering`, `skill-craft`, `stay-green`, `tracer-code`, `vibe`

For the 3 overlapping skills (`testing`, `security`, `bug-squashing-methodology`) the Adepthood-customized `SKILL.md` is preserved and the source repo's `references/` subdirectories are added as additive reference packs.

### Tranche 2 — `.claude/agents/`
Adds **8 agents** to the previously-empty agents directory: `chief-architect`, `dependency-checker`, `documentation`, `performance`, `quality-reviewer`, `refactorer`, `security-auditor`, `test-generator`.

⚠️ **Imported as reference material, not working agents.** These files were authored for a multi-section repository with a Chief Architect → 6 Orchestrators → 11 Specialists hierarchy that doesn't exist in Adepthood. They reference `../shared/common-constraints.md` and sibling agents that are absent in both repos. Expect to prune `delegates_to` / `receives_from` frontmatter and adapt the linter-plugin-specific examples before actually invoking any of them — flagged in the individual commit.

### Tranche 3 — `scripts/backend/` and `scripts/frontend/`
Ports the full quality-gate script suite (20 scripts total). Adapted for the monorepo:

- `PROJECT_ROOT` resolves to `backend/` or `frontend/` (not repo root)
- Python package references `adepthood_linters` → `src` (Adepthood's actual package)

**Backend** (12): `check-all`, `fix-all`, `lint`, `format`, `typecheck`, `test`, `coverage`, `security`, `complexity`, `mutation`, `analyze_mutations.py`, `pr-status`

**Frontend** (7): `check-all`, `fix-all`, `lint`, `format`, `typecheck`, `test`, `pr-status`

Smoke-tested `lint.sh` and `typecheck.sh` in both subtrees. `mutation.sh` and `complexity.sh` depend on `mutmut` and `xenon`, which will be added to `requirements-dev.txt` in the next tranche.

Includes a `scripts/README.md` explaining the monorepo adaptation.

## What's NOT in this PR (coming next)

- Tranche 2/5 — Expanded pre-commit hooks + tighter `pyproject.toml`
- Tranche 3/5 — CI enhancements (matrix, docstring coverage, mutation job)
- Tranche 4/5 — `import-linter` architecture enforcement + CLAUDE.md merge
- Tranche 5/5 — Global green-up: fix every failure surfaced by the new gates

`scripts/backend/lint.sh` already reveals **48 pre-existing ruff issues** on `main` before any new rules are added — those will be addressed in Tranche 5/5.

## Test plan
- [x] Nothing removed; nothing existing modified
- [x] `scripts/backend/lint.sh --help` / `scripts/backend/typecheck.sh --help` etc. print usage
- [x] `scripts/frontend/typecheck.sh` — green on current codebase
- [x] `scripts/frontend/lint.sh` — green on current codebase
- [x] Pre-commit ran clean on all commits (end-of-file auto-fixes applied)
- [ ] CI workflows (no CI changes in this PR, but existing ones should still run clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)