### PR TITLE
refactor(backend): extract service layer from routers (phase 7-01)

### DIFF
--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -1,32 +1,24 @@
-"""BotMason AI chat router — metered AI conversations via a two-bucket wallet.
+"""BotMason AI chat router — thin HTTP adapter over the service layer.
 
 Every user gets ``BOTMASON_MONTHLY_CAP`` free messages per calendar month.
-Once the free allocation is spent, requests fall through to ``offering_balance``
-(purchased / gifted credits, no expiry).  When both are empty the router
-returns 402.  All wallet mutations are performed as atomic SQL statements —
-no TOCTOU read/check/write patterns — so concurrent requests can never
-overspend either bucket (see ``tests/test_botmason_api.py::test_concurrent_*``).
+Once the free allocation is spent, requests fall through to
+``offering_balance`` (purchased / gifted credits, no expiry).  Wallet
+mechanics, LLM orchestration, and SSE framing all live in the
+:mod:`services` package — this router only wires HTTP request / response
+shapes to those services.
 """
 
 from __future__ import annotations
 
-import json
-import os
-from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, Header, Request, status
 from fastapi.responses import StreamingResponse
-from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col, select
 
 from database import get_session
-from errors import bad_request, payment_required
-from models.journal_entry import JournalEntry
-from models.llm_usage_log import LLMUsageLog
-from models.user import User
+from errors import bad_request
 from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.botmason import (
@@ -37,18 +29,11 @@ from schemas.botmason import (
     ChatResponse,
     UsageResponse,
 )
-from services.botmason import (
-    CONVERSATION_HISTORY_LIMIT,
-    LLM_API_KEY_MAX_LENGTH,
-    LLMResponse,
-    generate_response,
-    generate_response_stream,
-    get_provider,
-    provider_requires_api_key,
-    validate_llm_api_key_format,
-)
-from services.llm_pricing import estimate_cost_usd
-from services.usage import compute_next_reset, get_monthly_cap
+from services import wallet as wallet_service
+from services.botmason import resolve_chat_api_key
+from services.chat_stream import PreflightedRequest, handle_chat_request, stream_bot_response
+from services.usage import get_monthly_cap
+from services.wallet import preflight_deduction, require_user_fresh, reset_monthly_usage_if_due
 
 router = APIRouter(tags=["botmason"])
 
@@ -58,130 +43,6 @@ router = APIRouter(tags=["botmason"])
 # logged. Kept as a module constant so tests and the CORS policy can reference
 # the same string without drift.
 LLM_API_KEY_HEADER = "X-LLM-API-Key"  # pragma: allowlist secret
-
-
-def _resolve_user_api_key(header_value: str | None) -> str | None:
-    """Return the sanitised user-supplied key, or raise 400 if malformed.
-
-    A missing header resolves to ``None`` so the caller can decide whether to
-    fall back to the server-side env var.
-    """
-    if header_value is None:
-        return None
-    key = header_value.strip()
-    if not key:
-        return None
-    if len(key) > LLM_API_KEY_MAX_LENGTH:
-        raise bad_request("invalid_llm_api_key_format")
-    provider = get_provider()
-    if not validate_llm_api_key_format(key, provider):
-        raise bad_request("invalid_llm_api_key_format")
-    return key
-
-
-def _resolve_api_key_for_chat(header_value: str | None) -> str | None:
-    """Choose the API key to forward for a ``/journal/chat`` request.
-
-    Precedence: validated user-supplied header → server ``LLM_API_KEY`` env →
-    none. Raises 402 ``llm_key_required`` when the active provider needs a key
-    but neither source has one. The returned key is used for a single call and
-    is never persisted.
-    """
-    user_key = _resolve_user_api_key(header_value)
-    if user_key is not None:
-        return user_key
-    if provider_requires_api_key() and not os.getenv("LLM_API_KEY"):
-        raise payment_required("llm_key_required")
-    return None
-
-
-async def _get_user(user_id: int, session: AsyncSession) -> User:
-    """Fetch user by ID or raise 400, always reading fresh from database."""
-    result = await session.execute(
-        select(User).where(User.id == user_id).execution_options(populate_existing=True)
-    )
-    user = result.scalars().first()
-    if user is None:
-        msg = "user_not_found"
-        raise bad_request(msg)
-    return user
-
-
-async def _reset_monthly_usage_if_due(
-    session: AsyncSession,
-    user_id: int,
-    now: datetime,
-) -> None:
-    """Atomically roll the monthly counter over when the reset date has passed.
-
-    The conditional WHERE clause makes this idempotent under concurrency: if
-    two requests race through the boundary, the second one's predicate no
-    longer matches (the first request has already advanced ``monthly_reset_date``
-    to next month) and the second UPDATE is a no-op.
-    """
-    next_reset = compute_next_reset(now)
-    await session.execute(
-        update(User)
-        .where(col(User.id) == user_id, col(User.monthly_reset_date) <= now)
-        .values(monthly_messages_used=0, monthly_reset_date=next_reset)
-    )
-
-
-async def _spend_one_message(
-    session: AsyncSession,
-    user_id: int,
-    monthly_cap: int,
-) -> tuple[int, int] | None:
-    """Consume exactly one BotMason message from whichever wallet has capacity.
-
-    Returns ``(monthly_messages_used, offering_balance)`` after the deduction,
-    or ``None`` when both wallets are empty (caller returns 402).  The free
-    monthly allocation is drained first; only once it is at the cap do we
-    touch the paid ``offering_balance``.  Each branch is a single atomic
-    UPDATE … WHERE … RETURNING so concurrent requests can never overspend.
-    """
-    monthly_result = await session.execute(
-        update(User)
-        .where(
-            col(User.id) == user_id,
-            col(User.monthly_messages_used) < monthly_cap,
-        )
-        .values(monthly_messages_used=col(User.monthly_messages_used) + 1)
-        .returning(col(User.monthly_messages_used), col(User.offering_balance))
-    )
-    monthly_row = monthly_result.first()
-    if monthly_row is not None:
-        return int(monthly_row[0]), int(monthly_row[1])
-
-    balance_result = await session.execute(
-        update(User)
-        .where(col(User.id) == user_id, col(User.offering_balance) > 0)
-        .values(offering_balance=col(User.offering_balance) - 1)
-        .returning(col(User.monthly_messages_used), col(User.offering_balance))
-    )
-    balance_row = balance_result.first()
-    if balance_row is not None:
-        return int(balance_row[0]), int(balance_row[1])
-
-    return None
-
-
-async def _load_conversation_history(session: AsyncSession, user_id: int) -> list[dict[str, str]]:
-    """Return the last ``CONVERSATION_HISTORY_LIMIT`` messages in chronological order.
-
-    Centralising the query keeps the streaming and non-streaming endpoints in
-    sync: if the context window grows later, both inherit the new behaviour
-    without drift.
-    """
-    history_query = (
-        select(JournalEntry)
-        .where(JournalEntry.user_id == user_id)
-        .order_by(col(JournalEntry.id).desc())
-        .limit(CONVERSATION_HISTORY_LIMIT)
-    )
-    result = await session.execute(history_query)
-    entries = list(reversed(result.scalars().all()))
-    return [{"sender": entry.sender, "message": entry.message} for entry in entries]
 
 
 @router.post(
@@ -197,102 +58,9 @@ async def chat_with_botmason(
     session: AsyncSession = Depends(get_session),  # noqa: B008
     x_llm_api_key: str | None = Header(default=None, alias=LLM_API_KEY_HEADER),
 ) -> ChatResponse:
-    """Send a message to BotMason and receive an AI response.
-
-    1. Resolve the LLM API key (user-supplied header > server env var)
-    2. Lazily roll over the monthly counter if the reset date has passed
-    3. Atomically spend one message from the free monthly bucket or, once that
-       bucket is full, from ``offering_balance`` (prevents TOCTOU races)
-    4. Store user's message as JournalEntry(sender='user')
-    5. Load recent conversation history
-    6. Call BotMason AI service
-    7. Store bot's response as JournalEntry(sender='bot')
-    8. Return bot's response + remaining wallet state
-
-    The ``X-LLM-API-Key`` header is validated for format and forwarded to the
-    provider for this single request. It is never logged, never written to
-    the database, and never echoed back in the response.
-    """
-    # Resolve the key BEFORE deducting balance so a malformed key (400) or a
-    # missing key on a provider that needs one (402) never costs the user a
-    # message. Fails fast without touching the DB.
-    api_key = _resolve_api_key_for_chat(x_llm_api_key)
-
-    now = datetime.now(UTC)
-    monthly_cap = get_monthly_cap()
-
-    # Roll over the monthly counter before metering so a first-of-the-month
-    # request gets a freshly zeroed bucket.  The WHERE clause makes this a
-    # no-op when the reset date is still in the future.
-    await _reset_monthly_usage_if_due(session, current_user, now)
-
-    spent = await _spend_one_message(session, current_user, monthly_cap)
-    if spent is None:
-        # Neither bucket had capacity.  Distinguish "user vanished mid-request"
-        # (extremely unlikely, but would otherwise surface as a misleading 402)
-        # from the real payment-required case.
-        await _get_user(current_user, session)  # raises bad_request if missing
-        raise payment_required("insufficient_offerings")
-    monthly_used, new_balance = spent
-    remaining_messages = max(monthly_cap - monthly_used, 0)
-
-    # Store user's message
-    user_entry = JournalEntry(sender="user", user_id=current_user, message=payload.message)
-    session.add(user_entry)
-    await session.flush()
-
-    conversation_history = await _load_conversation_history(session, current_user)
-
-    # Generate AI response. ``api_key`` is passed by value for a single call
-    # and is discarded when this function returns.
-    llm_response = await generate_response(
-        payload.message,
-        conversation_history,
-        api_key=api_key,
-    )
-
-    # Store bot's response
-    bot_entry = JournalEntry(sender="bot", user_id=current_user, message=llm_response.text)
-    session.add(bot_entry)
-    # Flush so ``bot_entry.id`` is available as the FK for the usage log row.
-    # Both rows commit together below, so a rollback at commit-time still
-    # leaves the log consistent with the journal.
-    await session.flush()
-
-    _record_llm_usage(session, current_user, bot_entry.id, llm_response)
-
-    await session.commit()
-    await session.refresh(bot_entry)
-
-    # Look up the freshly-advanced reset date so the client can surface an
-    # accurate "resets in N days" countdown without a second round-trip.
-    user_after = await _get_user(current_user, session)
-
-    return ChatResponse(
-        response=llm_response.text,
-        remaining_balance=new_balance,
-        remaining_messages=remaining_messages,
-        monthly_reset_date=user_after.monthly_reset_date,
-        bot_entry_id=bot_entry.id,
-    )
-
-
-# Server-Sent Events framing. Keeping the helper here (not in a shared module)
-# because SSE is only used by this router and the shape is tightly coupled to
-# the ChatResponse payload we send on completion.
-
-
-def _sse_event(event: str, data: dict[str, Any]) -> bytes:
-    """Encode a single named Server-Sent Event.
-
-    Each event follows the spec's ``event:``/``data:``/blank-line framing so
-    any standards-compliant client (EventSource or custom fetch reader) can
-    parse the stream without provider-specific shims. ``data`` is JSON-encoded
-    on a single line because multi-line ``data:`` fields would require extra
-    framing on both ends for no gain.
-    """
-    payload = json.dumps(data, separators=(",", ":"))
-    return f"event: {event}\ndata: {payload}\n\n".encode()
+    """Send a message to BotMason and receive an AI response."""
+    api_key = resolve_chat_api_key(x_llm_api_key)
+    return await handle_chat_request(session, current_user, payload.message, api_key)
 
 
 @router.post("/journal/chat/stream")
@@ -304,198 +72,28 @@ async def chat_with_botmason_stream(
     session: AsyncSession = Depends(get_session),  # noqa: B008
     x_llm_api_key: str | None = Header(default=None, alias=LLM_API_KEY_HEADER),
 ) -> StreamingResponse:
-    """Stream a BotMason response as Server-Sent Events (SSE).
+    """Stream a BotMason response as Server-Sent Events.
 
-    Emits three event types:
-
-    - ``event: chunk`` — ``{"text": "..."}`` for each incremental token(s)
-    - ``event: complete`` — the full :class:`ChatResponse` payload on success
-    - ``event: error`` — ``{"status": int, "detail": str}`` on provider failure
-
-    Pre-flight validation (auth, API key format, wallet capacity, rate limit)
-    still runs before the stream opens and raises real HTTP errors (400 / 401 /
-    402 / 429) so clients can distinguish "don't even try again" failures from
-    transient mid-stream ones. Once streaming has begun the HTTP status is
-    pinned to 200; any downstream failure is surfaced via an SSE ``error``
-    event followed by a clean close, and no partial state is committed.
+    Pre-flight validation (auth, key format, wallet, rate limit) raises real
+    HTTP errors *before* the stream opens so clients can distinguish
+    "don't retry" failures (400/401/402/429) from transient mid-stream ones.
+    Once streaming begins the status is pinned to 200 and any downstream
+    failure surfaces as an SSE ``error`` event followed by a clean rollback —
+    no partial state is committed.
     """
-    # Pre-flight mirrors ``chat_with_botmason`` exactly so the two endpoints
-    # enforce identical auth / wallet / rate-limit semantics — clients can
-    # fall back between them without divergent error handling.
-    api_key = _resolve_api_key_for_chat(x_llm_api_key)
-
-    now = datetime.now(UTC)
-    monthly_cap = get_monthly_cap()
-
-    await _reset_monthly_usage_if_due(session, current_user, now)
-
-    spent = await _spend_one_message(session, current_user, monthly_cap)
-    if spent is None:
-        await _get_user(current_user, session)
-        raise payment_required("insufficient_offerings")
-    monthly_used, new_balance = spent
-    remaining_messages = max(monthly_cap - monthly_used, 0)
-
-    user_entry = JournalEntry(sender="user", user_id=current_user, message=payload.message)
-    session.add(user_entry)
-    await session.flush()
-
-    conversation_history = await _load_conversation_history(session, current_user)
-
-    async def event_stream() -> AsyncIterator[bytes]:
-        """Drive the provider stream and finalise persistence on the last yield.
-
-        Wallet deduction and the user-side JournalEntry are already staged on
-        the session by the pre-flight block. Committing happens here, only
-        after the final LLMResponse is in hand — so a provider failure rolls
-        back the pre-flight work and the user is not charged for an empty
-        stream.
-        """
-        try:
-            final_response = await _forward_provider_stream(
-                payload.message, conversation_history, api_key
-            )
-        except Exception as exc:
-            await session.rollback()
-            yield _sse_event("error", {"status": 502, "detail": "llm_provider_error"})
-            # Re-log nothing further; the rollback discards the wallet deduction
-            # and the user entry so the user can retry without being charged.
-            del exc
-            return
-
-        for chunk in final_response.chunks:
-            yield chunk
-        yield await _finalise_stream_commit(
-            session=session,
-            current_user=current_user,
-            final_response=final_response.response,
-            new_balance=new_balance,
-            remaining_messages=remaining_messages,
-        )
-
+    api_key = resolve_chat_api_key(x_llm_api_key)
+    spent = await preflight_deduction(session, current_user)
+    context = PreflightedRequest(
+        message=payload.message,
+        api_key=api_key,
+        spent=spent,
+        remaining_messages=max(get_monthly_cap() - spent.monthly_used, 0),
+    )
     # ``X-Accel-Buffering: no`` disables proxy buffering so nginx / Railway
-    # forward bytes as soon as they are written. Without it the SSE stream
-    # stalls until the connection closes.
-    headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
-    return StreamingResponse(event_stream(), media_type="text/event-stream", headers=headers)
-
-
-class _CollectedStream:
-    """Buffered view over a completed provider stream.
-
-    The provider iterator must be drained inside a ``try`` so we can convert
-    any mid-stream exception into a single SSE ``error`` event. That forces
-    us to buffer the chunks and only yield them once the stream finished
-    cleanly. The SSE-side latency is still proportional to the provider's
-    first-token latency in the happy path because the buffer is consumed
-    immediately after it fills.
-    """
-
-    __slots__ = ("chunks", "response")
-
-    def __init__(self, chunks: list[bytes], response: LLMResponse) -> None:
-        self.chunks = chunks
-        self.response = response
-
-
-async def _forward_provider_stream(
-    user_message: str,
-    conversation_history: list[dict[str, str]],
-    api_key: str | None,
-) -> _CollectedStream:
-    """Pull every chunk from the provider and return them as SSE-framed bytes.
-
-    Runs inside the router's try/except so any provider failure (timeout,
-    network error, SDK exception) is translated to a single SSE ``error``
-    event by the caller. Returning only after the stream closes keeps the
-    commit / rollback decision centralised.
-    """
-    final_response: LLMResponse | None = None
-    framed_chunks: list[bytes] = []
-    async for chunk_text, final in generate_response_stream(
-        user_message, conversation_history, api_key=api_key
-    ):
-        if chunk_text:
-            framed_chunks.append(_sse_event("chunk", {"text": chunk_text}))
-        if final is not None:
-            final_response = final
-    if final_response is None:  # pragma: no cover - defensive; stub/providers always yield final
-        msg = "provider stream ended without final response"
-        raise RuntimeError(msg)
-    return _CollectedStream(framed_chunks, final_response)
-
-
-async def _finalise_stream_commit(
-    *,
-    session: AsyncSession,
-    current_user: int,
-    final_response: LLMResponse,
-    new_balance: int,
-    remaining_messages: int,
-) -> bytes:
-    """Persist the bot entry + usage log and encode the terminal SSE event.
-
-    Split out so the main streaming generator stays linear and so this commit
-    path is easy to unit-test in isolation.
-    """
-    bot_entry = JournalEntry(sender="bot", user_id=current_user, message=final_response.text)
-    session.add(bot_entry)
-    await session.flush()
-
-    _record_llm_usage(session, current_user, bot_entry.id, final_response)
-
-    await session.commit()
-    await session.refresh(bot_entry)
-
-    user_after = await _get_user(current_user, session)
-
-    return _sse_event(
-        "complete",
-        {
-            "response": final_response.text,
-            "remaining_balance": new_balance,
-            "remaining_messages": remaining_messages,
-            "monthly_reset_date": user_after.monthly_reset_date.isoformat(),
-            "bot_entry_id": bot_entry.id,
-        },
-    )
-
-
-def _record_llm_usage(
-    session: AsyncSession,
-    user_id: int,
-    journal_entry_id: int | None,
-    llm_response: LLMResponse,
-) -> None:
-    """Append an :class:`LLMUsageLog` row for a single chat call.
-
-    The log row is staged on the caller's session so it commits in the same
-    transaction as the bot's :class:`JournalEntry`.  ``journal_entry_id`` is
-    typed ``int | None`` because SQLModel exposes the primary key that way
-    until flush; the caller is responsible for flushing before invoking this
-    helper and we assert the invariant here to fail loudly rather than write
-    a row with a NULL FK.
-    """
-    if journal_entry_id is None:  # pragma: no cover - defensive; caller flushes first
-        msg = "journal_entry_id must be set before logging LLM usage"
-        raise RuntimeError(msg)
-
-    session.add(
-        LLMUsageLog(
-            user_id=user_id,
-            provider=llm_response.provider,
-            model=llm_response.model,
-            prompt_tokens=llm_response.prompt_tokens,
-            completion_tokens=llm_response.completion_tokens,
-            total_tokens=llm_response.total_tokens,
-            estimated_cost_usd=estimate_cost_usd(
-                llm_response.model,
-                llm_response.prompt_tokens,
-                llm_response.completion_tokens,
-            ),
-            journal_entry_id=journal_entry_id,
-        )
-    )
+    # forward bytes as soon as they are written.
+    headers: dict[str, Any] = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+    stream = stream_bot_response(session, current_user, context)
+    return StreamingResponse(stream, media_type="text/event-stream", headers=headers)
 
 
 @router.get("/user/balance", response_model=BalanceResponse)
@@ -504,7 +102,7 @@ async def get_balance(
     session: AsyncSession = Depends(get_session),  # noqa: B008
 ) -> BalanceResponse:
     """Return the current offering balance for the authenticated user."""
-    user = await _get_user(current_user, session)
+    user = await require_user_fresh(session, current_user)
     return BalanceResponse(balance=user.offering_balance)
 
 
@@ -513,23 +111,16 @@ async def get_usage(
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
 ) -> UsageResponse:
-    """Return the authenticated user's BotMason usage for the current month.
-
-    Rolls the monthly counter over in-place when the stored reset date has
-    passed so the caller never sees stale values — a user who opens the app
-    on the first of the month gets a freshly zeroed usage card without
-    waiting for their next chat request.
-    """
-    now = datetime.now(UTC)
-    await _reset_monthly_usage_if_due(session, current_user, now)
+    """Return the authenticated user's BotMason usage for the current month."""
+    # Roll the monthly counter over in-place so callers never see stale values.
+    await reset_monthly_usage_if_due(session, current_user, datetime.now(UTC))
     await session.commit()
 
-    user = await _get_user(current_user, session)
+    user = await require_user_fresh(session, current_user)
     cap = get_monthly_cap()
-    remaining = max(cap - user.monthly_messages_used, 0)
     return UsageResponse(
         monthly_messages_used=user.monthly_messages_used,
-        monthly_messages_remaining=remaining,
+        monthly_messages_remaining=max(cap - user.monthly_messages_used, 0),
         monthly_cap=cap,
         monthly_reset_date=user.monthly_reset_date,
         offering_balance=user.offering_balance,
@@ -548,18 +139,9 @@ async def add_balance(
     if payload.amount <= 0:
         raise bad_request("amount_must_be_positive")
 
-    # Atomic balance addition — single SQL statement, no lost-update window.
-    result = await session.execute(
-        update(User)
-        .where(col(User.id) == current_user)
-        .values(offering_balance=col(User.offering_balance) + payload.amount)
-        .returning(col(User.offering_balance))
-    )
-    new_balance = result.scalar()
+    new_balance = await wallet_service.add_balance(session, current_user, payload.amount)
     if new_balance is None:
-        msg = "user_not_found"
-        raise bad_request(msg)
+        raise bad_request("user_not_found")
 
     await session.commit()
-
     return BalanceAddResponse(balance=new_balance, added=payload.amount)

--- a/backend/src/routers/energy.py
+++ b/backend/src/routers/energy.py
@@ -1,42 +1,13 @@
-"""Energy plan API endpoints."""
+"""Energy plan API endpoints — thin HTTP adapter over :mod:`services.energy`."""
 
 from __future__ import annotations
 
-import logging
-from dataclasses import asdict
-
-from cachetools import TTLCache
 from fastapi import APIRouter, Header
 
-from domain.energy import Habit as DomainHabit
-from domain.energy import generate_plan
-from errors import bad_request
-from schemas import EnergyPlan, EnergyPlanRequest, EnergyPlanResponse
+from schemas import EnergyPlanRequest, EnergyPlanResponse
+from services.energy import get_or_generate_plan
 
 router = APIRouter(prefix="/v1/energy", tags=["energy"])
-
-# Idempotency cache prevents duplicate plan generation within the same session.
-# - maxsize=1000: supports ~1000 concurrent users before eviction (LRU).
-# - ttl=3600 (1 hour): matches _TOKEN_TTL in auth.py so cached plans expire
-#   alongside the JWT that initiated them.
-_CACHE_MAX_ENTRIES = 1000
-_CACHE_TTL_SECONDS = 3600
-_idempotency_cache: TTLCache[str, EnergyPlanResponse] = TTLCache(
-    maxsize=_CACHE_MAX_ENTRIES, ttl=_CACHE_TTL_SECONDS
-)
-
-
-def _build_energy_response(payload: EnergyPlanRequest) -> EnergyPlanResponse:
-    """Generate an energy plan from the request payload."""
-    habits = [DomainHabit(**h.model_dump()) for h in payload.habits]
-    try:
-        plan, reason = generate_plan(habits, payload.start_date)
-    except ValueError as exc:
-        raise bad_request(str(exc).replace(" ", "_")) from exc
-    plan_model = EnergyPlan.model_validate(asdict(plan))
-    response = EnergyPlanResponse(plan=plan_model, reason_code=reason)
-    logging.info("energy_plan", extra={"reason_code": reason})
-    return response
 
 
 @router.post("/plan", response_model=EnergyPlanResponse)
@@ -44,12 +15,4 @@ def create_plan(
     payload: EnergyPlanRequest, x_idempotency_key: str | None = Header(default=None)
 ) -> EnergyPlanResponse:
     """Create an energy plan from submitted habits."""
-    if x_idempotency_key and x_idempotency_key in _idempotency_cache:
-        return _idempotency_cache[x_idempotency_key]
-
-    response = _build_energy_response(payload)
-
-    if x_idempotency_key:
-        _idempotency_cache[x_idempotency_key] = response
-
-    return response
+    return get_or_generate_plan(payload, x_idempotency_key)

--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -5,20 +5,20 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col, select
 
 from database import get_session
-from domain.milestones import achieved_milestones
-from domain.streaks import update_streak
 from errors import forbidden, not_found
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from routers.auth import get_current_user
-from schemas import CheckInResult, Milestone
+from schemas import CheckInResult
+from services.streaks import check_milestones, compute_consecutive_streak, update_streak
 
 router = APIRouter(prefix="/goal_completions", tags=["goals"])
 
+# Streak milestones surfaced on check-in responses.  Kept as a module constant
+# so both the router and future background jobs share the same thresholds.
 _DEFAULT_THRESHOLDS = [1, 3, 7, 14, 30]
 
 
@@ -27,22 +27,6 @@ class GoalCompletionRequest(BaseModel):
 
     goal_id: int
     did_complete: bool = True
-
-
-async def _count_consecutive_streak(session: AsyncSession, goal_id: int, user_id: int) -> int:
-    """Count consecutive completed check-ins for a goal, newest first."""
-    rows = await session.execute(
-        select(GoalCompletion.completed_units)
-        .where(GoalCompletion.goal_id == goal_id, GoalCompletion.user_id == user_id)
-        .order_by(col(GoalCompletion.timestamp).desc())
-    )
-    streak = 0
-    for (units,) in rows:
-        if units > 0:
-            streak += 1
-        else:
-            break
-    return streak
 
 
 async def _get_owned_goal(session: AsyncSession, goal_id: int, user_id: int) -> Goal:
@@ -70,7 +54,7 @@ async def create_goal_completion(
     goal = await _get_owned_goal(session, payload.goal_id, current_user)
 
     assert goal.id is not None
-    current_streak = await _count_consecutive_streak(session, goal.id, current_user)
+    current_streak = await compute_consecutive_streak(session, goal.id, current_user)
     new_streak, reason = update_streak(current_streak, payload.did_complete)
 
     completed_units = goal.target if payload.did_complete else 0
@@ -81,9 +65,8 @@ async def create_goal_completion(
     )
     await session.commit()
 
-    reached, _ = achieved_milestones(new_streak, _DEFAULT_THRESHOLDS)
     return CheckInResult(
         streak=new_streak,
-        milestones=[Milestone(threshold=t) for t in reached],
+        milestones=check_milestones(new_streak, _DEFAULT_THRESHOLDS),
         reason_code=reason,
     )

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 
+from errors import bad_request, payment_required
+
 # Default system prompt used when no external prompt file is configured.
 _DEFAULT_SYSTEM_PROMPT = (
     "You are BotMason, a Liminal Trickster Mystic guide for the APTITUDE "
@@ -106,6 +108,39 @@ def _matches_provider_rule(api_key: str, rule: tuple[str, tuple[str, ...]] | Non
     if not api_key.startswith(required_prefix):
         return False
     return not any(api_key.startswith(bad) for bad in disallowed_prefixes)
+
+
+def _validated_header_key(header_value: str | None) -> str | None:
+    """Strip, validate, and return the user-supplied BYOK key or ``None``.
+
+    Returns ``None`` when the header is absent or empty (so the caller can
+    fall back to the env var).  Raises 400 when the value is present but
+    fails length or format checks for the active provider.
+    """
+    if header_value is None:
+        return None
+    key = header_value.strip()
+    if not key:
+        return None
+    if len(key) > LLM_API_KEY_MAX_LENGTH or not validate_llm_api_key_format(key, get_provider()):
+        raise bad_request("invalid_llm_api_key_format")
+    return key
+
+
+def resolve_chat_api_key(header_value: str | None) -> str | None:
+    """Return the validated LLM API key to forward, or raise the right HTTP error.
+
+    Precedence: user-supplied header (BYOK) → server ``LLM_API_KEY`` env →
+    none.  Raises 400 for a malformed header, 402 ``llm_key_required`` when
+    the active provider needs a key but neither source has one.  The key is
+    used for a single call and is never persisted, logged, or echoed back.
+    """
+    user_key = _validated_header_key(header_value)
+    if user_key is not None:
+        return user_key
+    if provider_requires_api_key() and not os.getenv("LLM_API_KEY"):
+        raise payment_required("llm_key_required")
+    return None
 
 
 def validate_llm_api_key_format(api_key: str, provider: str) -> bool:

--- a/backend/src/services/chat_stream.py
+++ b/backend/src/services/chat_stream.py
@@ -1,0 +1,211 @@
+"""Server-Sent Events orchestration for the BotMason streaming endpoint.
+
+The router owns HTTP framing and response construction; this service owns the
+mechanics of draining the LLM provider stream, buffering chunks, and shaping
+the ``chunk``/``complete``/``error`` SSE events.  Keeping the two concerns
+separate means the router stays well under 150 lines of pure HTTP handling
+and the stream machinery can be unit-tested without spinning up a
+``TestClient``.
+
+The module imports :mod:`services.botmason` (not individual names) so tests
+can ``patch.object(services.botmason, "generate_response_stream", ...)``
+and this module will see the patched reference at call time.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from schemas.botmason import ChatResponse
+from services import botmason as _botmason
+from services.botmason import LLMResponse, generate_response
+from services.journal import (
+    load_recent_conversation,
+    persist_bot_reply,
+    persist_user_message,
+)
+from services.usage import get_monthly_cap
+from services.wallet import SpendResult, get_user_fresh, preflight_deduction, require_user_fresh
+
+
+@dataclass(frozen=True)
+class CollectedStream:
+    """Buffered view over a completed provider stream.
+
+    The provider iterator must be drained inside a ``try`` so we can convert
+    any mid-stream exception into a single SSE ``error`` event.  That forces
+    us to buffer the chunks and only yield them once the stream finished
+    cleanly.  Latency in the happy path is still bounded by the provider's
+    first-token latency because the buffer is consumed immediately after
+    the stream closes.
+    """
+
+    chunks: list[bytes]
+    response: LLMResponse
+
+
+def sse_event(event: str, data: dict[str, Any]) -> bytes:
+    """Encode a single named Server-Sent Event.
+
+    Each event follows the spec's ``event:``/``data:``/blank-line framing so
+    any standards-compliant client (EventSource or custom ``fetch`` reader)
+    can parse the stream without provider-specific shims.  ``data`` is
+    JSON-encoded on a single line because multi-line ``data:`` fields would
+    require extra framing on both ends for no gain.
+    """
+    payload = json.dumps(data, separators=(",", ":"))
+    return f"event: {event}\ndata: {payload}\n\n".encode()
+
+
+async def collect_provider_stream(
+    user_message: str,
+    conversation_history: list[dict[str, str]],
+    api_key: str | None,
+) -> CollectedStream:
+    """Drain the provider stream, returning SSE-framed chunks plus the final response.
+
+    Runs inside the caller's ``try``/``except`` so any provider failure
+    (timeout, network error, SDK exception) can be translated to a single
+    SSE ``error`` event.  Returning only after the stream closes keeps the
+    commit / rollback decision centralised.
+    """
+    final_response: LLMResponse | None = None
+    framed_chunks: list[bytes] = []
+    async for chunk_text, final in _botmason.generate_response_stream(
+        user_message, conversation_history, api_key=api_key
+    ):
+        if chunk_text:
+            framed_chunks.append(sse_event("chunk", {"text": chunk_text}))
+        if final is not None:
+            final_response = final
+    if final_response is None:  # pragma: no cover - defensive; providers always yield final
+        msg = "provider stream ended without final response"
+        raise RuntimeError(msg)
+    return CollectedStream(chunks=framed_chunks, response=final_response)
+
+
+async def handle_chat_request(
+    session: AsyncSession,
+    user_id: int,
+    message: str,
+    api_key: str | None,
+) -> ChatResponse:
+    """Execute a full non-streaming BotMason exchange and return the response.
+
+    Encapsulates the wallet deduction, journal writes, LLM call, and commit
+    so the router layer stays a thin dispatch.  Any exception raised here
+    (e.g. ``402 insufficient_offerings`` from :func:`preflight_deduction`)
+    surfaces to FastAPI's normal error path.
+    """
+    spent = await preflight_deduction(session, user_id)
+    remaining_messages = max(get_monthly_cap() - spent.monthly_used, 0)
+
+    await persist_user_message(session, user_id, message)
+    history = await load_recent_conversation(session, user_id)
+
+    llm_response = await generate_response(message, history, api_key=api_key)
+
+    bot_entry = await persist_bot_reply(session, user_id, llm_response)
+    await session.commit()
+    await session.refresh(bot_entry)
+
+    user_after = await require_user_fresh(session, user_id)
+    return ChatResponse(
+        response=llm_response.text,
+        remaining_balance=spent.offering_balance,
+        remaining_messages=remaining_messages,
+        monthly_reset_date=user_after.monthly_reset_date,
+        bot_entry_id=bot_entry.id,
+    )
+
+
+@dataclass(frozen=True)
+class PreflightedRequest:
+    """Pre-flight context for a streaming chat — wallet and message in one bundle.
+
+    The router does the pre-flight wallet deduction synchronously (so HTTP
+    errors fire before the SSE stream opens) and hands the result to
+    :func:`stream_bot_response` inside this DTO.  Keeping the three
+    wallet-state fields together makes the generator's signature small and
+    lets future fields (e.g. a correlation ID) ride along without touching
+    every caller.
+    """
+
+    message: str
+    api_key: str | None
+    spent: SpendResult
+    remaining_messages: int
+
+
+async def stream_bot_response(
+    session: AsyncSession,
+    user_id: int,
+    context: PreflightedRequest,
+) -> AsyncIterator[bytes]:
+    """Yield SSE events for a streaming BotMason exchange.
+
+    Pre-flight (auth, wallet deduction, key resolution) is the caller's
+    responsibility so HTTP errors fire *before* the stream opens.  Once
+    invoked, this generator persists the user's message (so conversation
+    history includes it), drains the provider, commits on success, or rolls
+    back and emits a single ``error`` event on provider failure.
+    """
+    await persist_user_message(session, user_id, context.message)
+    history = await load_recent_conversation(session, user_id)
+    try:
+        collected = await collect_provider_stream(context.message, history, context.api_key)
+    except Exception:
+        await session.rollback()
+        yield sse_event("error", {"status": 502, "detail": "llm_provider_error"})
+        return
+
+    for chunk in collected.chunks:
+        yield chunk
+    yield await finalise_stream_commit(
+        session=session,
+        current_user=user_id,
+        final_response=collected.response,
+        new_balance=context.spent.offering_balance,
+        remaining_messages=context.remaining_messages,
+    )
+
+
+async def finalise_stream_commit(
+    *,
+    session: AsyncSession,
+    current_user: int,
+    final_response: LLMResponse,
+    new_balance: int,
+    remaining_messages: int,
+) -> bytes:
+    """Persist the bot entry + usage log and encode the terminal SSE event.
+
+    Split out so the main streaming generator stays linear and so this commit
+    path is easy to unit-test in isolation.  The user row is re-read after
+    commit to surface the freshly-advanced ``monthly_reset_date`` without a
+    second round-trip from the client.
+    """
+    bot_entry = await persist_bot_reply(session, current_user, final_response)
+    await session.commit()
+    await session.refresh(bot_entry)
+
+    user_after = await get_user_fresh(session, current_user)
+    if user_after is None:  # pragma: no cover - defensive; user authenticated moments ago
+        msg = "user_not_found"
+        raise RuntimeError(msg)
+
+    return sse_event(
+        "complete",
+        {
+            "response": final_response.text,
+            "remaining_balance": new_balance,
+            "remaining_messages": remaining_messages,
+            "monthly_reset_date": user_after.monthly_reset_date.isoformat(),
+            "bot_entry_id": bot_entry.id,
+        },
+    )

--- a/backend/src/services/energy.py
+++ b/backend/src/services/energy.py
@@ -1,0 +1,74 @@
+"""Energy-plan generation service with idempotency caching.
+
+The router layer is a thin HTTP adapter: it accepts a request, hands the
+payload to :func:`get_or_generate_plan`, and returns the response.  The
+idempotency cache lives here (not in the router) so background regeneration
+jobs, admin tools, and tests can share the same de-duplication semantics
+without reaching into route handlers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+
+from cachetools import TTLCache
+from fastapi import HTTPException, status
+
+from domain.energy import Habit as DomainHabit
+from domain.energy import generate_plan
+from schemas import EnergyPlan, EnergyPlanRequest, EnergyPlanResponse
+
+# Idempotency cache prevents duplicate plan generation within the same session.
+# - ``CACHE_MAX_ENTRIES = 1000`` supports ~1000 concurrent users before LRU
+#   eviction starts.
+# - ``CACHE_TTL_SECONDS = 3600`` (1 hour) matches ``_TOKEN_TTL`` in ``auth.py``
+#   so cached plans expire alongside the JWT that initiated them.
+CACHE_MAX_ENTRIES = 1000
+CACHE_TTL_SECONDS = 3600
+
+idempotency_cache: TTLCache[str, EnergyPlanResponse] = TTLCache(
+    maxsize=CACHE_MAX_ENTRIES, ttl=CACHE_TTL_SECONDS
+)
+
+
+def build_energy_response(payload: EnergyPlanRequest) -> EnergyPlanResponse:
+    """Generate an energy plan from the request payload.
+
+    ``domain.energy.generate_plan`` raises ``ValueError`` for empty habit
+    lists; we translate that to a 400 so the HTTP surface is stable.  The
+    reason code is logged for audit — it never changes the response body.
+    """
+    habits = [DomainHabit(**h.model_dump()) for h in payload.habits]
+    try:
+        plan, reason = generate_plan(habits, payload.start_date)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc).replace(" ", "_"),
+        ) from exc
+    plan_model = EnergyPlan.model_validate(asdict(plan))
+    response = EnergyPlanResponse(plan=plan_model, reason_code=reason)
+    logging.info("energy_plan", extra={"reason_code": reason})
+    return response
+
+
+def get_or_generate_plan(
+    payload: EnergyPlanRequest, idempotency_key: str | None
+) -> EnergyPlanResponse:
+    """Return a cached plan for ``idempotency_key`` or compute and cache a new one.
+
+    Callers that do not pass a key always get a freshly-generated plan and
+    nothing is cached.  When a key is supplied the cached response is used
+    verbatim — including the ``reason_code`` — so clients retrying a failed
+    request never see a different outcome for the same request ID.
+    """
+    if idempotency_key and idempotency_key in idempotency_cache:
+        return idempotency_cache[idempotency_key]
+
+    response = build_energy_response(payload)
+
+    if idempotency_key:
+        idempotency_cache[idempotency_key] = response
+
+    return response

--- a/backend/src/services/journal.py
+++ b/backend/src/services/journal.py
@@ -1,0 +1,98 @@
+"""Journal persistence helpers shared by the BotMason chat endpoints.
+
+Routers stay thin by delegating DB writes and query shape to this module.
+The service assumes the caller owns the :class:`AsyncSession` lifecycle — it
+stages rows on the session (``session.add`` / ``session.flush``) but leaves
+commit/rollback to the route handler so wallet mutations and journal rows
+land atomically together.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.journal_entry import JournalEntry
+from models.llm_usage_log import LLMUsageLog
+from services.botmason import CONVERSATION_HISTORY_LIMIT, LLMResponse
+from services.llm_pricing import estimate_cost_usd
+
+
+async def load_recent_conversation(
+    session: AsyncSession,
+    user_id: int,
+) -> list[dict[str, str]]:
+    """Return the last ``CONVERSATION_HISTORY_LIMIT`` messages chronologically.
+
+    Centralising the query keeps the streaming and non-streaming endpoints in
+    sync: if the context window grows later, both inherit the new behaviour
+    without drift.  Each entry is returned as a plain dict so provider
+    adapters do not need to know about ORM types.
+    """
+    history_query = (
+        select(JournalEntry)
+        .where(JournalEntry.user_id == user_id)
+        .order_by(col(JournalEntry.id).desc())
+        .limit(CONVERSATION_HISTORY_LIMIT)
+    )
+    result = await session.execute(history_query)
+    entries = list(reversed(result.scalars().all()))
+    return [{"sender": entry.sender, "message": entry.message} for entry in entries]
+
+
+async def persist_user_message(
+    session: AsyncSession,
+    user_id: int,
+    message: str,
+) -> JournalEntry:
+    """Stage and flush the user's chat message as a :class:`JournalEntry`.
+
+    The flush assigns a primary key so subsequent operations (loading history,
+    forming the bot's FK) can reference it without guessing.  The commit is
+    still the caller's responsibility so a provider failure can roll back the
+    whole interaction.
+    """
+    entry = JournalEntry(sender="user", user_id=user_id, message=message)
+    session.add(entry)
+    await session.flush()
+    return entry
+
+
+async def persist_bot_reply(
+    session: AsyncSession,
+    user_id: int,
+    response: LLMResponse,
+) -> JournalEntry:
+    """Stage the bot's :class:`JournalEntry` and its :class:`LLMUsageLog` row.
+
+    ``LLMUsageLog`` carries a foreign key to the bot's journal entry so each
+    usage row can be traced back to the exact response it billed.  We flush
+    after adding the entry to lock in the FK value, then add the usage log
+    against the same session.  The caller owns the final ``commit()``; both
+    rows land in the same transaction.
+    """
+    entry = JournalEntry(sender="bot", user_id=user_id, message=response.text)
+    session.add(entry)
+    await session.flush()
+
+    if entry.id is None:  # pragma: no cover - defensive; flush assigns the PK
+        msg = "journal_entry_id must be set before logging LLM usage"
+        raise RuntimeError(msg)
+
+    session.add(
+        LLMUsageLog(
+            user_id=user_id,
+            provider=response.provider,
+            model=response.model,
+            prompt_tokens=response.prompt_tokens,
+            completion_tokens=response.completion_tokens,
+            total_tokens=response.total_tokens,
+            estimated_cost_usd=estimate_cost_usd(
+                response.model,
+                response.prompt_tokens,
+                response.completion_tokens,
+            ),
+            journal_entry_id=entry.id,
+        )
+    )
+    return entry

--- a/backend/src/services/streaks.py
+++ b/backend/src/services/streaks.py
@@ -1,0 +1,63 @@
+"""Streak and milestone services — DB-aware wrappers over pure domain logic.
+
+Routers call these helpers instead of computing streaks inline so the same
+logic can be reused from background jobs, admin tools, and tests without
+needing HTTP fixtures.  Pure functions stay in :mod:`domain.streaks` and
+:mod:`domain.milestones` so they remain trivially unit-testable; this module
+only adds the DB-query layer that composes them into a request-ready
+result.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.milestones import achieved_milestones
+from domain.streaks import update_streak
+from models.goal_completion import GoalCompletion
+from schemas.milestone import Milestone
+
+__all__ = [
+    "check_milestones",
+    "compute_consecutive_streak",
+    "update_streak",
+]
+
+
+async def compute_consecutive_streak(
+    session: AsyncSession,
+    goal_id: int,
+    user_id: int,
+) -> int:
+    """Count consecutive completed check-ins for a goal, newest first.
+
+    Scans :class:`GoalCompletion` rows for the goal in reverse-chronological
+    order and counts rows where ``completed_units > 0`` until it hits a miss
+    (or the end of history).  Returns ``0`` when the most recent check-in
+    was a miss or when no history exists.
+    """
+    rows = await session.execute(
+        select(GoalCompletion.completed_units)
+        .where(GoalCompletion.goal_id == goal_id, GoalCompletion.user_id == user_id)
+        .order_by(col(GoalCompletion.timestamp).desc())
+    )
+    streak = 0
+    for (units,) in rows:
+        if units > 0:
+            streak += 1
+        else:
+            break
+    return streak
+
+
+def check_milestones(streak: int, thresholds: list[int]) -> list[Milestone]:
+    """Return the :class:`Milestone` objects reached by ``streak``.
+
+    Wraps :func:`domain.milestones.achieved_milestones` so callers that want
+    response-ready DTOs do not have to map the raw ``list[int]`` themselves.
+    The underlying domain function stays pure and is still used directly by
+    tests that only care about thresholds.
+    """
+    reached, _reason = achieved_milestones(streak, thresholds)
+    return [Milestone(threshold=t) for t in reached]

--- a/backend/src/services/wallet.py
+++ b/backend/src/services/wallet.py
@@ -1,0 +1,169 @@
+"""User-wallet mutations for BotMason metering.
+
+The BotMason wallet has two buckets:
+
+- ``monthly_messages_used`` / ``monthly_reset_date`` — a free allocation that
+  rolls over at the start of every calendar month.
+- ``offering_balance`` — paid / gifted credits with no expiry.
+
+Every mutation in this module is expressed as a single atomic SQL statement
+(``UPDATE … WHERE … RETURNING``) so concurrent requests can never overspend
+either bucket.  The router layer is responsible for translating ``None``
+returns into HTTP errors; the service only reports capacity outcomes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from errors import bad_request, payment_required
+from models.user import User
+from services.usage import compute_next_reset, get_monthly_cap
+
+
+@dataclass(frozen=True)
+class SpendResult:
+    """Outcome of a successful wallet deduction.
+
+    ``monthly_used`` is the post-update value of ``monthly_messages_used``
+    (useful for computing ``remaining_messages``); ``offering_balance`` is the
+    post-update paid-credit balance.  Both fields are stable references to the
+    row as seen by the spending transaction — concurrent spenders observe
+    their own totals, never someone else's mid-flight value.
+    """
+
+    monthly_used: int
+    offering_balance: int
+
+
+async def get_user_fresh(session: AsyncSession, user_id: int) -> User | None:
+    """Return the user row, always reading fresh from the database.
+
+    ``populate_existing=True`` forces SQLAlchemy to refresh any cached instance
+    on the session so callers that need post-commit values (e.g. the updated
+    ``monthly_reset_date`` after a rollover) always see the latest row.
+    Returns ``None`` when the user does not exist so callers can decide how
+    to shape the HTTP response.
+    """
+    result = await session.execute(
+        select(User).where(User.id == user_id).execution_options(populate_existing=True)
+    )
+    return result.scalars().first()
+
+
+async def reset_monthly_usage_if_due(
+    session: AsyncSession,
+    user_id: int,
+    now: datetime,
+) -> None:
+    """Atomically roll the monthly counter over when the reset date has passed.
+
+    The conditional WHERE clause makes this idempotent under concurrency: if
+    two requests race through the boundary, the second one's predicate no
+    longer matches (the first request has already advanced
+    ``monthly_reset_date`` to next month) and the second UPDATE is a no-op.
+    """
+    next_reset = compute_next_reset(now)
+    await session.execute(
+        update(User)
+        .where(col(User.id) == user_id, col(User.monthly_reset_date) <= now)
+        .values(monthly_messages_used=0, monthly_reset_date=next_reset)
+    )
+
+
+async def spend_one_message(
+    session: AsyncSession,
+    user_id: int,
+    monthly_cap: int,
+) -> SpendResult | None:
+    """Consume exactly one BotMason message from whichever wallet has capacity.
+
+    Returns a :class:`SpendResult` after the deduction, or ``None`` when both
+    wallets are empty (caller should return 402).  The free monthly allocation
+    is drained first; only once it is at the cap do we touch the paid
+    ``offering_balance``.  Each branch is a single atomic
+    ``UPDATE … WHERE … RETURNING`` so concurrent requests can never overspend.
+    """
+    monthly_result = await session.execute(
+        update(User)
+        .where(
+            col(User.id) == user_id,
+            col(User.monthly_messages_used) < monthly_cap,
+        )
+        .values(monthly_messages_used=col(User.monthly_messages_used) + 1)
+        .returning(col(User.monthly_messages_used), col(User.offering_balance))
+    )
+    monthly_row = monthly_result.first()
+    if monthly_row is not None:
+        return SpendResult(monthly_used=int(monthly_row[0]), offering_balance=int(monthly_row[1]))
+
+    balance_result = await session.execute(
+        update(User)
+        .where(col(User.id) == user_id, col(User.offering_balance) > 0)
+        .values(offering_balance=col(User.offering_balance) - 1)
+        .returning(col(User.monthly_messages_used), col(User.offering_balance))
+    )
+    balance_row = balance_result.first()
+    if balance_row is not None:
+        return SpendResult(monthly_used=int(balance_row[0]), offering_balance=int(balance_row[1]))
+
+    return None
+
+
+async def require_user_fresh(session: AsyncSession, user_id: int) -> User:
+    """Return the user row or raise ``400 user_not_found``.
+
+    Convenience wrapper over :func:`get_user_fresh` for HTTP endpoints that
+    treat a missing user row as a 400 (the authenticated identity should
+    always resolve to a real row — a ``None`` here means the account was
+    deleted mid-request).
+    """
+    user = await get_user_fresh(session, user_id)
+    if user is None:
+        raise bad_request("user_not_found")
+    return user
+
+
+async def preflight_deduction(session: AsyncSession, user_id: int) -> SpendResult:
+    """Roll over the monthly counter and deduct one BotMason message.
+
+    Shared pre-flight for the streaming and non-streaming chat endpoints.
+    Raises ``400 user_not_found`` if the authenticated user disappeared
+    between auth and spend and ``402 insufficient_offerings`` when neither
+    wallet has capacity.  Returns the post-deduction :class:`SpendResult`
+    otherwise.
+    """
+    await reset_monthly_usage_if_due(session, user_id, datetime.now(UTC))
+
+    spent = await spend_one_message(session, user_id, get_monthly_cap())
+    if spent is not None:
+        return spent
+
+    if await get_user_fresh(session, user_id) is None:
+        raise bad_request("user_not_found")
+    raise payment_required("insufficient_offerings")
+
+
+async def add_balance(session: AsyncSession, user_id: int, amount: int) -> int | None:
+    """Add ``amount`` credits to ``offering_balance`` and return the new total.
+
+    The caller is expected to validate ``amount > 0`` so the service can stay
+    focused on the DB mutation.  Returns ``None`` when the user does not exist
+    so the caller can surface a 400.  Performs the addition in a single atomic
+    SQL statement — no lost-update window between read and write.
+    """
+    result = await session.execute(
+        update(User)
+        .where(col(User.id) == user_id)
+        .values(offering_balance=col(User.offering_balance) + amount)
+        .returning(col(User.offering_balance))
+    )
+    new_balance = result.scalar()
+    if new_balance is None:
+        return None
+    return int(new_balance)

--- a/backend/tests/services/test_energy.py
+++ b/backend/tests/services/test_energy.py
@@ -1,0 +1,73 @@
+"""Unit tests for :mod:`services.energy` — idempotency cache + response building."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from cachetools import TTLCache
+from fastapi import HTTPException
+
+from schemas import EnergyPlanRequest
+from services.energy import (
+    CACHE_MAX_ENTRIES,
+    CACHE_TTL_SECONDS,
+    build_energy_response,
+    get_or_generate_plan,
+    idempotency_cache,
+)
+
+
+def _payload() -> EnergyPlanRequest:
+    """Return a minimal energy-plan request suitable for service-level tests."""
+    return EnergyPlanRequest.model_validate(
+        {
+            "habits": [{"id": 1, "name": "Run", "energy_cost": 1, "energy_return": 3}],
+            "start_date": "2025-06-01",
+        }
+    )
+
+
+def test_idempotency_cache_is_ttl_bounded() -> None:
+    """The module-level cache should be a TTLCache with the documented limits."""
+    assert isinstance(idempotency_cache, TTLCache)
+    assert idempotency_cache.maxsize == CACHE_MAX_ENTRIES
+    assert idempotency_cache.ttl == CACHE_TTL_SECONDS
+
+
+def test_build_energy_response_returns_21_day_plan() -> None:
+    response = build_energy_response(_payload())
+    assert response.reason_code == "generated_21_day_plan"
+    assert len(response.plan.items) == 21  # noqa: PLR2004
+
+
+def test_build_energy_response_raises_400_on_empty_habits() -> None:
+    payload = EnergyPlanRequest.model_validate({"habits": [], "start_date": "2025-06-01"})
+    with pytest.raises(HTTPException) as excinfo:
+        build_energy_response(payload)
+    assert excinfo.value.status_code == HTTPStatus.BAD_REQUEST
+    assert excinfo.value.detail == "habits_must_not_be_empty"
+
+
+def test_get_or_generate_plan_without_key_skips_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No idempotency key means no cache write — subsequent calls recompute."""
+    fresh_cache: TTLCache[str, object] = TTLCache(maxsize=100, ttl=60)
+    monkeypatch.setattr("services.energy.idempotency_cache", fresh_cache)
+
+    get_or_generate_plan(_payload(), idempotency_key=None)
+    assert len(fresh_cache) == 0
+
+
+def test_get_or_generate_plan_returns_cached_response_for_same_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fresh_cache: TTLCache[str, object] = TTLCache(maxsize=100, ttl=60)
+    monkeypatch.setattr("services.energy.idempotency_cache", fresh_cache)
+
+    first = get_or_generate_plan(_payload(), idempotency_key="k")
+    second = get_or_generate_plan(_payload(), idempotency_key="k")
+
+    # Identity check would be too strict against our response model;
+    # equality is enough to prove the second call reused the cached entry.
+    assert first == second
+    assert len(fresh_cache) == 1

--- a/backend/tests/services/test_streaks.py
+++ b/backend/tests/services/test_streaks.py
@@ -1,0 +1,123 @@
+"""Unit tests for :mod:`services.streaks` — DB-aware streak + milestone helpers."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.user import User
+from schemas.milestone import Milestone
+from services.streaks import check_milestones, compute_consecutive_streak, update_streak
+
+
+async def _make_goal(session: AsyncSession, user_id: int) -> Goal:
+    """Create a habit + goal owned by ``user_id`` and return the persisted goal."""
+    habit = Habit(
+        name="Meditate",
+        icon="meditate",
+        start_date=date.today(),
+        stage="1",
+        streak=0,
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    assert habit.id is not None
+
+    goal = Goal(
+        habit_id=habit.id,
+        title="Sit ten minutes",
+        tier="clear",
+        target=1.0,
+        target_unit="minutes",
+        frequency=1.0,
+        frequency_unit="per_day",
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    return goal
+
+
+async def _make_user(session: AsyncSession) -> User:
+    user = User(email="streaks@example.com")
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+def test_check_milestones_returns_milestone_objects_for_reached_thresholds() -> None:
+    """Only thresholds at or below the streak value come back as Milestones."""
+    assert check_milestones(7, [1, 3, 7, 14]) == [
+        Milestone(threshold=1),
+        Milestone(threshold=3),
+        Milestone(threshold=7),
+    ]
+
+
+def test_check_milestones_returns_empty_when_none_reached() -> None:
+    assert check_milestones(0, [1, 3, 7]) == []
+
+
+def test_update_streak_is_re_exported_from_service() -> None:
+    """``update_streak`` should stay importable from the service layer too."""
+    assert update_streak(2, did_check_in=True) == (3, "streak_incremented")
+    assert update_streak(99, did_check_in=False) == (0, "streak_reset")
+
+
+@pytest.mark.asyncio
+async def test_compute_consecutive_streak_counts_trailing_completions(
+    db_session: AsyncSession,
+) -> None:
+    """Completed check-ins in a row — newest first — contribute to the streak."""
+    user = await _make_user(db_session)
+    assert user.id is not None
+    goal = await _make_goal(db_session, user.id)
+    assert goal.id is not None
+
+    for _ in range(3):
+        db_session.add(
+            GoalCompletion(goal_id=goal.id, user_id=user.id, completed_units=goal.target)
+        )
+    await db_session.commit()
+
+    assert await compute_consecutive_streak(db_session, goal.id, user.id) == 3  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_compute_consecutive_streak_resets_on_most_recent_miss(
+    db_session: AsyncSession,
+) -> None:
+    """A single miss after any completions zeros the reported streak."""
+    user = await _make_user(db_session)
+    assert user.id is not None
+    goal = await _make_goal(db_session, user.id)
+    assert goal.id is not None
+
+    db_session.add(GoalCompletion(goal_id=goal.id, user_id=user.id, completed_units=goal.target))
+    await db_session.commit()
+    db_session.add(GoalCompletion(goal_id=goal.id, user_id=user.id, completed_units=0))
+    await db_session.commit()
+
+    assert await compute_consecutive_streak(db_session, goal.id, user.id) == 0
+
+
+@pytest.mark.asyncio
+async def test_compute_consecutive_streak_returns_zero_for_new_goal(
+    db_session: AsyncSession,
+) -> None:
+    user = await _make_user(db_session)
+    assert user.id is not None
+    goal = await _make_goal(db_session, user.id)
+    assert goal.id is not None
+
+    assert await compute_consecutive_streak(db_session, goal.id, user.id) == 0

--- a/backend/tests/services/test_wallet.py
+++ b/backend/tests/services/test_wallet.py
@@ -1,0 +1,207 @@
+"""Unit tests for :mod:`services.wallet` — pure DB-level wallet mutations.
+
+These tests exercise the service layer directly against the shared
+``db_session`` fixture, without spinning up an HTTP client.  That keeps each
+scenario tight and proves the wallet primitives can be reused from
+background jobs or admin tooling that does not touch FastAPI.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models.user import User
+from services.wallet import (
+    SpendResult,
+    add_balance,
+    get_user_fresh,
+    preflight_deduction,
+    require_user_fresh,
+    reset_monthly_usage_if_due,
+    spend_one_message,
+)
+
+_MONTHLY_CAP = 5
+# Initial monthly usage used by the no-op rollover scenario.  Any non-zero
+# value works; the assertion only checks that the counter survives untouched.
+_SEEDED_MONTHLY_USED = 4
+
+
+async def _make_user(
+    session: AsyncSession,
+    *,
+    email: str = "alice@example.com",
+    monthly_used: int = 0,
+    offering_balance: int = 0,
+    reset_in_days: int = 30,
+) -> User:
+    """Create and persist a minimal :class:`User` for wallet tests.
+
+    The caller's ``session`` runs against SQLite which returns timezone-naive
+    datetimes; we therefore write naive values at creation time so the row and
+    any subsequent ``UPDATE … WHERE monthly_reset_date <= :now`` comparison
+    stay comparable.  Expunging the in-memory instance afterwards forces the
+    service-under-test to re-read the row through ``get_user_fresh``.
+    """
+    now_naive = datetime.now(UTC).replace(tzinfo=None)
+    user = User(
+        email=email,
+        monthly_messages_used=monthly_used,
+        offering_balance=offering_balance,
+        monthly_reset_date=now_naive + timedelta(days=reset_in_days),
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    session.expunge(user)
+    return user
+
+
+@pytest.mark.asyncio
+async def test_get_user_fresh_returns_user_when_exists(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    assert user.id is not None
+    fetched = await get_user_fresh(db_session, user.id)
+    assert fetched is not None
+    assert fetched.email == user.email
+
+
+@pytest.mark.asyncio
+async def test_get_user_fresh_returns_none_when_missing(db_session: AsyncSession) -> None:
+    assert await get_user_fresh(db_session, user_id=999) is None
+
+
+@pytest.mark.asyncio
+async def test_require_user_fresh_raises_400_when_missing(db_session: AsyncSession) -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        await require_user_fresh(db_session, user_id=999)
+    assert excinfo.value.status_code == HTTPStatus.BAD_REQUEST
+    assert excinfo.value.detail == "user_not_found"
+
+
+@pytest.mark.asyncio
+async def test_reset_monthly_usage_rolls_over_when_due(db_session: AsyncSession) -> None:
+    """An expired reset date triggers the zero-and-advance update."""
+    user = await _make_user(db_session, monthly_used=3, reset_in_days=-1)
+    assert user.id is not None
+
+    now_naive = datetime.now(UTC).replace(tzinfo=None)
+    await reset_monthly_usage_if_due(db_session, user.id, now_naive)
+    await db_session.commit()
+
+    refreshed = await get_user_fresh(db_session, user.id)
+    assert refreshed is not None
+    assert refreshed.monthly_messages_used == 0
+    # Reset date must advance into the future so subsequent rollovers are no-ops.
+    assert refreshed.monthly_reset_date > now_naive
+
+
+@pytest.mark.asyncio
+async def test_reset_monthly_usage_is_noop_when_not_due(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session, monthly_used=_SEEDED_MONTHLY_USED, reset_in_days=30)
+    assert user.id is not None
+    before = user.monthly_reset_date
+
+    await reset_monthly_usage_if_due(db_session, user.id, datetime.now(UTC).replace(tzinfo=None))
+    await db_session.commit()
+
+    refreshed = await get_user_fresh(db_session, user.id)
+    assert refreshed is not None
+    assert refreshed.monthly_messages_used == _SEEDED_MONTHLY_USED  # untouched
+    assert refreshed.monthly_reset_date == before
+
+
+@pytest.mark.asyncio
+async def test_spend_one_message_drains_monthly_first(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session, monthly_used=0, offering_balance=10)
+    assert user.id is not None
+
+    result = await spend_one_message(db_session, user.id, _MONTHLY_CAP)
+    await db_session.commit()
+
+    assert result == SpendResult(monthly_used=1, offering_balance=10)
+
+
+@pytest.mark.asyncio
+async def test_spend_one_message_falls_through_to_offerings(db_session: AsyncSession) -> None:
+    """When the monthly bucket is full, the next spend hits ``offering_balance``."""
+    user = await _make_user(db_session, monthly_used=_MONTHLY_CAP, offering_balance=3)
+    assert user.id is not None
+
+    result = await spend_one_message(db_session, user.id, _MONTHLY_CAP)
+    await db_session.commit()
+
+    assert result == SpendResult(monthly_used=_MONTHLY_CAP, offering_balance=2)
+
+
+@pytest.mark.asyncio
+async def test_spend_one_message_returns_none_when_both_empty(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session, monthly_used=_MONTHLY_CAP, offering_balance=0)
+    assert user.id is not None
+
+    assert await spend_one_message(db_session, user.id, _MONTHLY_CAP) is None
+
+
+@pytest.mark.asyncio
+async def test_preflight_deduction_returns_spend_result(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session, monthly_used=0)
+    assert user.id is not None
+
+    result = await preflight_deduction(db_session, user.id)
+    await db_session.commit()
+
+    assert isinstance(result, SpendResult)
+    assert result.monthly_used == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_deduction_raises_402_when_empty(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With both wallets empty and ``BOTMASON_MONTHLY_CAP=0``, preflight must 402."""
+    user = await _make_user(db_session, monthly_used=0, offering_balance=0)
+    assert user.id is not None
+
+    monkeypatch.setenv("BOTMASON_MONTHLY_CAP", "0")
+    with pytest.raises(HTTPException) as excinfo:
+        await preflight_deduction(db_session, user.id)
+
+    assert excinfo.value.status_code == HTTPStatus.PAYMENT_REQUIRED
+    assert excinfo.value.detail == "insufficient_offerings"
+
+
+@pytest.mark.asyncio
+async def test_preflight_deduction_raises_400_when_user_missing(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A spend miss for a non-existent user must surface ``user_not_found``."""
+    monkeypatch.setenv("BOTMASON_MONTHLY_CAP", "0")
+    with pytest.raises(HTTPException) as excinfo:
+        await preflight_deduction(db_session, user_id=999)
+
+    assert excinfo.value.status_code == HTTPStatus.BAD_REQUEST
+    assert excinfo.value.detail == "user_not_found"
+
+
+@pytest.mark.asyncio
+async def test_add_balance_increments_and_returns_total(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session, offering_balance=5)
+    assert user.id is not None
+
+    new_total = await add_balance(db_session, user.id, 7)
+    await db_session.commit()
+
+    assert new_total == 12  # noqa: PLR2004
+    rows = (await db_session.execute(select(User).where(User.id == user.id))).scalars().all()
+    assert rows[0].offering_balance == 12  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_add_balance_returns_none_when_user_missing(db_session: AsyncSession) -> None:
+    assert await add_balance(db_session, user_id=999, amount=5) is None

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -15,7 +15,6 @@ from httpx import AsyncClient
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import routers.botmason as botmason_router_mod
 import services.botmason as botmason_mod
 from models.user import User
 from routers.botmason import LLM_API_KEY_HEADER
@@ -1243,7 +1242,7 @@ async def test_stream_provider_error_emits_error_event_and_rolls_back(
         msg = "upstream_boom"
         raise RuntimeError(msg)
 
-    with patch.object(botmason_router_mod, "generate_response_stream", _boom):
+    with patch.object(botmason_mod, "generate_response_stream", _boom):
         resp = await async_client.post(
             "/journal/chat/stream", json={"message": "Hi"}, headers=headers
         )
@@ -1289,7 +1288,7 @@ async def test_stream_falls_back_to_env_key_when_header_absent(
         _fake_stream.captured_key = api_key  # type: ignore[attr-defined]
         yield "world", final
 
-    with patch.object(botmason_router_mod, "generate_response_stream", _fake_stream):
+    with patch.object(botmason_mod, "generate_response_stream", _fake_stream):
         resp = await async_client.post(
             "/journal/chat/stream", json={"message": "Hi"}, headers=headers
         )

--- a/backend/tests/test_energy_api.py
+++ b/backend/tests/test_energy_api.py
@@ -5,8 +5,8 @@ from cachetools import TTLCache
 from fastapi.testclient import TestClient
 
 from main import app
-from routers import energy
-from routers.energy import _idempotency_cache
+from services import energy
+from services.energy import idempotency_cache
 
 client = TestClient(app)
 
@@ -40,9 +40,9 @@ def test_energy_plan_endpoint_idempotency() -> None:
 
 def test_idempotency_cache_is_ttl_bounded() -> None:
     """The idempotency cache should be a TTLCache with bounded size."""
-    assert isinstance(_idempotency_cache, TTLCache)
-    assert _idempotency_cache.maxsize == 1000  # noqa: PLR2004
-    assert _idempotency_cache.ttl == 3600  # noqa: PLR2004
+    assert isinstance(idempotency_cache, TTLCache)
+    assert idempotency_cache.maxsize == 1000  # noqa: PLR2004
+    assert idempotency_cache.ttl == 3600  # noqa: PLR2004
 
 
 def test_idempotency_cache_evicts_when_full() -> None:
@@ -64,10 +64,10 @@ def test_empty_habits_returns_400() -> None:
 
 def test_idempotency_miss_after_cache_clear() -> None:
     """After clearing the cache, duplicate keys should recompute."""
-    with patch.object(energy, "_idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
+    with patch.object(energy, "idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
         headers = {"X-Idempotency-Key": "unique-clear-test"}
         res1 = client.post("/v1/energy/plan", json=sample_payload(), headers=headers)
-        energy._idempotency_cache.clear()  # noqa: SLF001
+        energy.idempotency_cache.clear()
         res2 = client.post("/v1/energy/plan", json=sample_payload(), headers=headers)
         # Both should succeed (recomputed, not from cache)
         assert res1.status_code == 200  # noqa: PLR2004

--- a/backend/tests/test_energy_integration.py
+++ b/backend/tests/test_energy_integration.py
@@ -15,7 +15,7 @@ import pytest
 from cachetools import TTLCache
 from httpx import AsyncClient
 
-from routers import energy
+from services import energy as energy_service
 
 
 def _habits_payload(count: int = 3) -> list[dict[str, Any]]:
@@ -96,7 +96,7 @@ async def test_different_idempotency_keys_produce_independent_results(
     async_client: AsyncClient,
 ) -> None:
     """Different idempotency keys are cached independently."""
-    with patch.object(energy, "_idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
+    with patch.object(energy_service, "idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
         payload_a = _plan_request([{"id": 1, "name": "A", "energy_cost": 1, "energy_return": 2}])
         payload_b = _plan_request([{"id": 2, "name": "B", "energy_cost": 5, "energy_return": 1}])
 


### PR DESCRIPTION
## Summary
Extract business logic out of router files into a dedicated `services/` layer (phase 7-01) so wallet metering, streak computation, energy-plan caching, and SSE streaming can be reused from background jobs and unit-tested without HTTP fixtures.

- New `services/wallet.py`, `services/journal.py`, `services/streaks.py`, `services/energy.py`, `services/chat_stream.py`; `resolve_chat_api_key` moved into `services/botmason.py`.
- Routers become thin HTTP adapters:
  - `routers/botmason.py`: 565 → 147 lines
  - `routers/energy.py`: 55 → 18 lines
  - `routers/goal_completions.py`: 89 → 72 lines
- 24 new direct-service unit tests in `tests/services/` alongside the existing router-level tests.

## Acceptance criteria
- [x] Each touched router file is <150 lines (HTTP handling only).
- [x] Business logic callable without HTTP context.
- [x] Existing tests pass without behavior changes (4 patches retargeted from old private module names to the new service locations — no behavioral assertions changed).
- [x] New unit tests cover extracted services without HTTP fixtures.

## Test plan
- [x] `pre-commit run --all-files` — all 24 hooks green
- [x] `pytest` — 456 passed, 94.69% coverage (above the 90% gate)
- [x] New `tests/services/` directory: 24 tests covering wallet mutations, streak/milestone helpers, and energy idempotency
- [x] Streaming + non-streaming BotMason chat verified end-to-end via the existing `test_botmason_api.py` suite (rollback on provider error, monthly cap rollover, BYOK precedence)

https://claude.ai/code/session_01SeL9tUYuRNyF4cf4b4eZeK