### PR TITLE
fix(backend): store datetimes as TIMESTAMP WITH TIME ZONE

### DIFF
--- a/backend/migrations/versions/78b1620cafde_convert_datetime_columns_to_timestamptz.py
+++ b/backend/migrations/versions/78b1620cafde_convert_datetime_columns_to_timestamptz.py
@@ -1,0 +1,64 @@
+"""convert datetime columns to timestamptz
+
+Revision ID: 78b1620cafde
+Revises: 145d340640ce
+Create Date: 2026-04-13 22:30:00.000000
+
+Converts every ``TIMESTAMP WITHOUT TIME ZONE`` column to
+``TIMESTAMP WITH TIME ZONE`` so the application's timezone-aware UTC
+datetimes can be bound by asyncpg.  Existing naive values are reinterpreted
+as UTC via the ``USING ... AT TIME ZONE 'UTC'`` clause — safe because the
+application has always written ``datetime.now(UTC)``.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "78b1620cafde"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "145d340640ce"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (table, column) pairs that should be converted.  Order doesn't matter.
+_DATETIME_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("loginattempt", "created_at"),
+    ("user", "monthly_reset_date"),
+    ("user", "created_at"),
+    ("promptresponse", "timestamp"),
+    ("stageprogress", "stage_started_at"),
+    ("contentcompletion", "completed_at"),
+    ("goalcompletion", "timestamp"),
+    ("practicesession", "timestamp"),
+    ("journalentry", "timestamp"),
+    ("llmusagelog", "timestamp"),
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    for table, column in _DATETIME_COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.DateTime(timezone=True),
+            existing_type=sa.DateTime(timezone=False),
+            existing_nullable=False,
+            postgresql_using=f'"{column}" AT TIME ZONE \'UTC\'',
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    for table, column in _DATETIME_COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.DateTime(timezone=False),
+            existing_type=sa.DateTime(timezone=True),
+            existing_nullable=False,
+            postgresql_using=f'("{column}" AT TIME ZONE \'UTC\')',
+        )

--- a/backend/src/models/content_completion.py
+++ b/backend/src/models/content_completion.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, SQLModel
 
 
@@ -11,4 +12,7 @@ class ContentCompletion(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     user_id: int = Field(foreign_key="user.id", index=True)
     content_id: int = Field(foreign_key="stagecontent.id", index=True)
-    completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    completed_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/src/models/goal_completion.py
+++ b/backend/src/models/goal_completion.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
@@ -21,7 +22,10 @@ class GoalCompletion(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     goal_id: int = Field(foreign_key="goal.id")
     user_id: int = Field(foreign_key="user.id")
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
     completed_units: float
     via_timer: bool = False
     goal: "Goal" = Relationship(back_populates="completions")

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -2,6 +2,7 @@ import enum
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
@@ -28,7 +29,10 @@ class JournalEntry(SQLModel, table=True):
     """
 
     id: int | None = Field(default=None, primary_key=True)
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
     message: str = Field(max_length=10_000)
     sender: str = Field(max_length=10)  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id")

--- a/backend/src/models/llm_usage_log.py
+++ b/backend/src/models/llm_usage_log.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, SQLModel
 
 
@@ -29,7 +30,7 @@ class LLMUsageLog(SQLModel, table=True):
     user_id: int = Field(foreign_key="user.id", index=True)
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        index=True,
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
     )
     provider: str = Field(max_length=32, index=True)
     model: str = Field(max_length=128, index=True)

--- a/backend/src/models/login_attempt.py
+++ b/backend/src/models/login_attempt.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, SQLModel
 
 
@@ -17,4 +18,7 @@ class LoginAttempt(SQLModel, table=True):
     email: str = Field(index=True)
     ip_address: str = Field(default="")
     success: bool = Field(default=False)
-    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/src/models/practice_session.py
+++ b/backend/src/models/practice_session.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, SQLModel
 
 
@@ -14,5 +15,8 @@ class PracticeSession(SQLModel, table=True):
     user_id: int = Field(foreign_key="user.id")
     user_practice_id: int = Field(foreign_key="userpractice.id")
     duration_minutes: float
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
     reflection: str | None = Field(default=None, max_length=5_000)

--- a/backend/src/models/prompt_response.py
+++ b/backend/src/models/prompt_response.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
@@ -17,6 +18,9 @@ class PromptResponse(SQLModel, table=True):
     week_number: int
     question: str = Field(max_length=1_000)
     response: str = Field(max_length=10_000)
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
     user_id: int = Field(foreign_key="user.id")
     user: "User" = Relationship(back_populates="responses")

--- a/backend/src/models/stage_progress.py
+++ b/backend/src/models/stage_progress.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, Integer
+from sqlalchemy import Column, DateTime, Integer
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -21,6 +21,9 @@ class StageProgress(SQLModel, table=True):
         default_factory=list,
         sa_column=Column(ARRAY(Integer), nullable=False),
     )
-    stage_started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    stage_started_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
     user_id: int = Field(foreign_key="user.id", unique=True)
     user: "User" = Relationship(back_populates="stage_progress")

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Optional
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, Relationship, SQLModel
 
 from services.usage import compute_next_reset
@@ -34,10 +35,16 @@ class User(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     offering_balance: int = Field(default=0)
     monthly_messages_used: int = Field(default=0)
-    monthly_reset_date: datetime = Field(default_factory=_default_reset_date)
+    monthly_reset_date: datetime = Field(
+        default_factory=_default_reset_date,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
     email: str = Field(unique=True, index=True, max_length=254)
     password_hash: str = Field(default="")
-    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
     habits: list["Habit"] = Relationship(back_populates="user")
     journals: list["JournalEntry"] = Relationship(back_populates="user")
     responses: list["PromptResponse"] = Relationship(back_populates="user")


### PR DESCRIPTION
The application creates timezone-aware UTC datetimes via ``datetime.now(UTC)``
but every ``DateTime`` column was declared without ``timezone=True``, so
Alembic generated ``TIMESTAMP WITHOUT TIME ZONE``. When asyncpg tried to bind
an aware datetime to a naive column it raised
``TypeError: can't subtract offset-naive and offset-aware datetimes``,
which surfaced in production as 500s on /auth/login and /auth/signup.

Switch every datetime column to ``DateTime(timezone=True)`` via ``sa_column``
and add an Alembic migration that ALTERs the existing columns in place,
reinterpreting the stored naive values as UTC.