### PR TITLE
refactor(frontend): rewrite user-facing error messages to be actionable

### DIFF
--- a/frontend/__tests__/DatePicker.test.tsx
+++ b/frontend/__tests__/DatePicker.test.tsx
@@ -80,7 +80,7 @@ describe('DatePicker component', () => {
       input.props.onChangeText('2024-12-31');
     });
     const error = tree!.root.findByProps({ accessibilityRole: 'alert' });
-    expect(error.props.children).toBe('between 2025-01-01 and 2025-12-31');
+    expect(error.props.children).toBe('Pick a date between 2025-01-01 and 2025-12-31.');
     act(() => {
       input.props.onChangeText('2025-10-10');
     });

--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -1,0 +1,173 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+
+import {
+  formatApiError,
+  GENERIC_FALLBACK,
+  mapDetailToMessage,
+  messageForCode,
+  USER_FACING_ERROR_MESSAGES,
+} from '../errorMessages';
+import { ApiError } from '../index';
+
+describe('USER_FACING_ERROR_MESSAGES', () => {
+  it('covers every backend error code the backend emits', () => {
+    // This set is the source of truth for what backend codes ship to clients.
+    // Keep it in sync with backend/src/errors.py and every router's
+    // HTTPException details. If the backend adds a new code, add its
+    // user-facing copy to ``errorMessages.ts`` and list it here.
+    const expectedCodes = [
+      // auth
+      'invalid_credentials',
+      'password_too_short',
+      'unauthorized',
+      // admin
+      'admin_api_disabled',
+      'admin_auth_required',
+      // resource not found
+      'stage_not_found',
+      'content_not_found',
+      'practice_not_found',
+      'habit_not_found',
+      'journal_entry_not_found',
+      'goal_not_found',
+      'goal_group_not_found',
+      'prompt_not_found',
+      'user_practice_not_found',
+      'user_not_found',
+      // forbidden / ownership
+      'forbidden',
+      'not_owner',
+      // validation / state
+      'cannot_go_backwards',
+      'already_responded',
+      'practice_not_approved',
+      'amount_must_be_positive',
+      'habits_must_not_be_empty',
+      // wallet
+      'payment_required',
+      'insufficient_offerings',
+      'llm_key_required',
+      'invalid_llm_api_key_format',
+      // streaming / rate limits / network
+      'rate_limit_exceeded',
+      'llm_provider_error',
+      'malformed_stream_frame',
+      'incomplete_stream',
+      'network_error',
+    ];
+    for (const code of expectedCodes) {
+      expect(USER_FACING_ERROR_MESSAGES[code]).toBeTruthy();
+    }
+  });
+
+  it('never exposes raw snake_case to users', () => {
+    for (const [code, message] of Object.entries(USER_FACING_ERROR_MESSAGES)) {
+      // The literal snake_case code must not appear verbatim in the copy
+      // (it would defeat the entire point of the mapping). The key
+      // ``'Database unavailable'`` is already a human string, so skip it.
+      if (code === 'Database unavailable') continue;
+      expect(message).not.toMatch(new RegExp(`\\b${code}\\b`));
+    }
+  });
+
+  it('gives messages that start with a capital letter', () => {
+    for (const message of Object.values(USER_FACING_ERROR_MESSAGES)) {
+      expect(message[0]).toMatch(/[A-Z"]/);
+    }
+  });
+
+  it('gives messages that end with punctuation (not a trailing period-less phrase)', () => {
+    for (const message of Object.values(USER_FACING_ERROR_MESSAGES)) {
+      expect(message).toMatch(/[.!?]$/);
+    }
+  });
+});
+
+describe('messageForCode', () => {
+  it('returns the mapped copy for a known code', () => {
+    expect(messageForCode('invalid_credentials')).toContain('email and password');
+  });
+
+  it('returns undefined for an unknown code', () => {
+    expect(messageForCode('totally_made_up')).toBeUndefined();
+  });
+
+  it('returns undefined for empty / null inputs', () => {
+    expect(messageForCode('')).toBeUndefined();
+    expect(messageForCode(null)).toBeUndefined();
+    expect(messageForCode(undefined)).toBeUndefined();
+  });
+});
+
+describe('mapDetailToMessage', () => {
+  it('maps known codes', () => {
+    expect(mapDetailToMessage('rate_limit_exceeded')).toMatch(/Slow down/);
+  });
+
+  it('falls back to the provider-trouble copy for unknown codes', () => {
+    expect(mapDetailToMessage('whatever_new_code')).toMatch(/having trouble/);
+  });
+});
+
+describe('formatApiError', () => {
+  it('translates an ApiError with a known detail code', () => {
+    const err = new ApiError(401, 'invalid_credentials');
+    expect(formatApiError(err)).toContain('email and password');
+  });
+
+  it('uses caller-supplied fallback over status default when the code is unknown', () => {
+    const err = new ApiError(400, 'some_new_unmapped_code');
+    expect(formatApiError(err, { fallback: 'Could not save practice.' })).toBe(
+      'Could not save practice.',
+    );
+  });
+
+  it('uses status override when provided', () => {
+    const err = new ApiError(404, 'some_unmapped_code');
+    expect(
+      formatApiError(err, { statusOverrides: { 404: 'Nothing here, pull to refresh.' } }),
+    ).toBe('Nothing here, pull to refresh.');
+  });
+
+  it('falls back to status-code copy when detail is unknown and no fallback set', () => {
+    const err = new ApiError(503, 'some_unmapped_code');
+    expect(formatApiError(err)).toMatch(/service is temporarily unavailable/i);
+  });
+
+  it('prefers a known code over a status override', () => {
+    // The contract: known codes are never overridden by status — users
+    // should see consistent copy regardless of which screen raised them.
+    const err = new ApiError(402, 'insufficient_offerings');
+    const result = formatApiError(err, {
+      statusOverrides: { 402: 'This should not be used.' },
+    });
+    expect(result).toMatch(/BotMason messages/);
+  });
+
+  it('returns GENERIC_FALLBACK for null/undefined inputs with no fallback', () => {
+    expect(formatApiError(null)).toBe(GENERIC_FALLBACK);
+    expect(formatApiError(undefined)).toBe(GENERIC_FALLBACK);
+  });
+
+  it('returns caller fallback when input is null/undefined', () => {
+    expect(formatApiError(null, { fallback: 'Sign in failed.' })).toBe('Sign in failed.');
+  });
+
+  it('ignores the generic ApiError synthetic message and uses the fallback instead', () => {
+    // ApiError.message is ``Request failed with status N: detail`` — that's
+    // debug text, never copy we want to show users.
+    const err = new ApiError(500, 'some_unmapped_code');
+    expect(formatApiError(err, { fallback: 'Could not save.' })).toBe('Could not save.');
+  });
+
+  it('accepts plain ``{ detail }`` objects (e.g. AuthContext rejections)', () => {
+    const plain = { detail: 'password_too_short' };
+    expect(formatApiError(plain)).toContain('at least 8 characters');
+  });
+
+  it('uses a readable ``.message`` when no detail, status, or fallback is given', () => {
+    const err = new Error('SecureStore is not available on this device.');
+    expect(formatApiError(err)).toBe('SecureStore is not available on this device.');
+  });
+});

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -1,0 +1,227 @@
+/**
+ * Centralised translation of backend error codes and network failures to
+ * **user-facing** messages.
+ *
+ * Philosophy: an error message is not a debug log. It's the last thing the
+ * user reads before deciding whether to self-serve, retry, or give up. Every
+ * message in this file should:
+ *
+ *  1. Name what happened in plain language (no snake_case, no jargon).
+ *  2. Tell the user exactly what they can do next.
+ *  3. Avoid shame ("oops", "sorry") — people just want to get unstuck.
+ *
+ * The backend returns stable snake_case ``detail`` strings (see
+ * ``backend/src/errors.py``) as an API contract. This module is the single
+ * place that turns those contract strings into copy that a real person can
+ * act on. If you add a new backend error code, add its translation here too.
+ */
+import { ApiError } from './index';
+
+// Shared copy fragments — duplicated strings trip sonarjs/no-duplicate-string
+// and, more importantly, drift when we eventually tweak the tone.
+const PULL_TO_REFRESH = 'Pull down to refresh and try again.';
+const CHECK_CONNECTION = 'Check your connection and try again.';
+const PROVIDER_TROUBLE =
+  "BotMason's AI provider is having trouble connecting. Give it a moment and tap retry.";
+const SESSION_EXPIRED = 'Your session has expired. Sign back in to continue.';
+const NO_ACCESS = "You don't have access to this.";
+
+/**
+ * Map of backend ``detail`` strings (see ``backend/src/errors.py`` and each
+ * router) to the copy we show the user. Keep keys in sync with the backend
+ * and grouped by domain for easy scanning.
+ */
+export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Object.freeze({
+  // --- Authentication --------------------------------------------------
+  invalid_credentials:
+    "That email and password don't match an account we have. Double-check both fields, or tap Sign Up if you're new.",
+  password_too_short: 'Pick a password that is at least 8 characters long.', // pragma: allowlist secret
+  unauthorized: SESSION_EXPIRED,
+
+  // --- Admin -----------------------------------------------------------
+  admin_api_disabled:
+    'Admin access is turned off on this server. Ask your administrator to enable it.',
+  admin_auth_required:
+    'Admin access requires a valid X-Admin-API-Key header. Check with your administrator.',
+
+  // --- Resource not found ----------------------------------------------
+  stage_not_found: `We couldn't find that stage. ${PULL_TO_REFRESH}`,
+  content_not_found: `We couldn't find that lesson. Try opening it again from the stage overview.`,
+  practice_not_found: `We couldn't find that practice. ${PULL_TO_REFRESH}`,
+  habit_not_found: `We couldn't find that habit — it may have been deleted. ${PULL_TO_REFRESH}`,
+  journal_entry_not_found:
+    "We couldn't find that journal entry. It may have been deleted from another device.",
+  goal_not_found: `We couldn't find that goal. ${PULL_TO_REFRESH}`,
+  goal_group_not_found: `We couldn't find that goal group. ${PULL_TO_REFRESH}`,
+  prompt_not_found:
+    "This week's prompt isn't ready yet. Check back in a few minutes, or pull down to refresh.",
+  user_practice_not_found:
+    "We couldn't find your practice selection. Pick a practice again to continue.",
+  user_not_found: "We couldn't find your account. Sign out and sign back in to reconnect.",
+
+  // --- Permission / ownership ------------------------------------------
+  forbidden: `${NO_ACCESS} If you think this is a mistake, sign out and back in.`,
+  not_owner: "That item belongs to another account, so you can't change it from here.",
+
+  // --- State / validation ----------------------------------------------
+  cannot_go_backwards:
+    "You can't move to an earlier stage — APTITUDE is designed to progress forward only.",
+  already_responded: "You've already answered this week's prompt. A new one unlocks each week.",
+  practice_not_approved:
+    "That practice isn't available for selection yet. Pick one of the approved options for this stage.",
+  amount_must_be_positive: 'Enter a number greater than zero.',
+  habits_must_not_be_empty:
+    'Add at least one habit before generating an energy plan. You can add habits from the Habits tab.',
+
+  // --- Wallet / BotMason quota -----------------------------------------
+  payment_required:
+    "You've reached this month's free allotment. Add your own API key in Settings, or wait until the next monthly reset.",
+  insufficient_offerings:
+    "You've used all your free BotMason messages for the month. Add your own API key in Settings, or wait until your next monthly reset.",
+  llm_key_required:
+    'BotMason needs a key to reply. Add your API key in Settings to start chatting.',
+  invalid_llm_api_key_format:
+    "That API key doesn't look right. Copy the full key from your OpenAI or Anthropic dashboard and paste it into Settings.",
+
+  // --- Streaming / rate limits / network -------------------------------
+  rate_limit_exceeded:
+    "You're sending messages faster than BotMason can keep up. Slow down to 10 messages per minute.",
+  llm_provider_error: PROVIDER_TROUBLE,
+  malformed_stream_frame: PROVIDER_TROUBLE,
+  incomplete_stream:
+    'The connection dropped before BotMason finished its reply. Tap retry to send the same message again.',
+  network_error: `You appear to be offline. ${CHECK_CONNECTION}`,
+
+  // --- Database / infra ------------------------------------------------
+  'Database unavailable':
+    "We can't reach the database right now. Give it a moment, then pull down to refresh.",
+});
+
+/**
+ * Fallback copy when the server returns an unrecognised ``detail`` string.
+ * Keyed by HTTP status so a generic 404 still feels different from a
+ * generic 500 — each code leads the user to a different remedy.
+ */
+const STATUS_FALLBACKS: Readonly<Record<number, string>> = Object.freeze({
+  400: "That didn't go through. Double-check what you entered and try again.",
+  401: SESSION_EXPIRED,
+  402: "You've reached this month's free allotment. Add your own API key in Settings, or wait until the next monthly reset.",
+  403: NO_ACCESS,
+  404: `We couldn't find what you were looking for. ${PULL_TO_REFRESH}`,
+  409: 'That conflicts with something we already have. Refresh and try again.',
+  422: "Some of what you entered doesn't look right. Review the highlighted fields and try again.",
+  429: "You're going a bit fast for us. Slow down and try again in a moment.",
+  500: 'Something went wrong on our end. Give it a moment and try again — if it keeps happening, let us know.',
+  502: PROVIDER_TROUBLE,
+  503: 'The service is temporarily unavailable. Give it a moment, then try again.',
+  504: 'The server took too long to respond. Check your connection, then try again.',
+});
+
+/** Last-resort copy when we have nothing else to go on (e.g. no status). */
+export const GENERIC_FALLBACK =
+  "Something didn't work as expected. Give it a moment and try again.";
+
+/**
+ * Translate a known backend error code, or return ``undefined`` if we don't
+ * recognise it. Lets callers fall back to their own context-aware copy
+ * ("Failed to save session") instead of the generic status-code fallback.
+ */
+export function messageForCode(code: string | null | undefined): string | undefined {
+  if (!code) return undefined;
+  return USER_FACING_ERROR_MESSAGES[code];
+}
+
+/**
+ * Options for ``formatApiError``. ``fallback`` is preferred over the
+ * status-code map when supplied — screens often know what the user was
+ * trying to do and can phrase the failure more concretely than a generic
+ * 500 message.
+ */
+export interface FormatErrorOptions {
+  /** Copy shown when the error code is unknown AND no status fallback fits. */
+  fallback?: string;
+  /**
+   * Per-status override. Useful when, e.g., a 404 on the practice screen
+   * should read "We couldn't find that practice — pull to refresh" rather
+   * than the default 404 copy.
+   */
+  statusOverrides?: Partial<Record<number, string>>;
+}
+
+type ErrorLike = {
+  detail?: unknown;
+  status?: unknown;
+  message?: unknown;
+};
+
+function extractDetail(err: ErrorLike): string | undefined {
+  return typeof err.detail === 'string' && err.detail.length > 0 ? err.detail : undefined;
+}
+
+function extractStatus(err: ErrorLike): number | undefined {
+  return typeof err.status === 'number' ? err.status : undefined;
+}
+
+function pickByStatus(status: number | undefined, options: FormatErrorOptions): string | undefined {
+  if (status === undefined) return undefined;
+  return options.statusOverrides?.[status];
+}
+
+function statusFallback(status: number | undefined): string | undefined {
+  if (status === undefined) return undefined;
+  return STATUS_FALLBACKS[status];
+}
+
+function readableMessage(errish: ErrorLike): string | undefined {
+  const message = typeof errish.message === 'string' ? errish.message : '';
+  if (!message) return undefined;
+  // The synthetic ``ApiError`` message ``Request failed with status N: detail``
+  // is debug text — never surface it to users.
+  if (message.startsWith('Request failed with status')) return undefined;
+  return message;
+}
+
+/**
+ * Universal ``unknown`` → user-facing-string converter. Handles:
+ *
+ *  - ``ApiError`` / any object with ``.detail`` and ``.status`` fields
+ *  - Plain ``Error`` instances (falls back to ``options.fallback``)
+ *  - Objects with only a ``.message`` property
+ *  - ``null`` / ``undefined`` / anything else
+ *
+ * Resolution order (most specific → least specific):
+ *   1. Known backend code       — consistent copy cross-screen
+ *   2. Caller status override   — explicit per-screen override for one status
+ *   3. Caller fallback          — screen-specific copy ("Couldn't save session…")
+ *   4. Generic status fallback  — per-HTTP-status default
+ *   5. Raw ``.message``         — if it reads like human prose
+ *   6. GENERIC_FALLBACK
+ */
+export function formatApiError(err: unknown, options: FormatErrorOptions = {}): string {
+  if (err == null) return options.fallback ?? GENERIC_FALLBACK;
+
+  const errish = err as ErrorLike;
+  const status = extractStatus(errish);
+
+  const resolved =
+    messageForCode(extractDetail(errish)) ??
+    pickByStatus(status, options) ??
+    options.fallback ??
+    statusFallback(status) ??
+    readableMessage(errish);
+
+  return resolved ?? GENERIC_FALLBACK;
+}
+
+/**
+ * Narrower helper for BotMason chat where callers already have a raw
+ * backend ``detail`` string (e.g. from an SSE ``error`` frame) and want
+ * the mapped user copy. Preserves the old ``JournalScreen`` API.
+ */
+export function mapDetailToMessage(detail: string): string {
+  return messageForCode(detail) ?? PROVIDER_TROUBLE;
+}
+
+// Re-export for use in contexts that can't import ``ApiError`` directly
+// without creating a circular import.
+export { ApiError };

--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -97,10 +97,10 @@ const validateDate = (
   const min = minDate ? parseISODate(minDate) : undefined;
   const max = maxDate ? parseISODate(maxDate) : undefined;
   if (!isDateWithinRange(date, min, max)) {
-    return `between ${minDate ?? ''} and ${maxDate ?? ''}`;
+    return `Pick a date between ${minDate ?? ''} and ${maxDate ?? ''}.`;
   }
   if (disabledDate?.(date)) {
-    return 'that day is blocked';
+    return "That day isn't available — choose another.";
   }
   return null;
 };
@@ -254,7 +254,7 @@ const makeHandleChangeText = (
     setTextValue(t);
     const parsed = parseDateInput(t);
     if (!parsed) {
-      setError('use YYYY-MM-DD');
+      setError('Use the format YYYY-MM-DD (for example, 2026-04-13).');
       return;
     }
     commitDate(parsed);

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -33,6 +33,10 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
       <View style={styles.container} testID="error-boundary">
         <ScrollView contentContainerStyle={styles.content}>
           <Text style={styles.heading}>Something went wrong</Text>
+          <Text style={styles.guidance}>
+            Try closing and reopening the app. If this keeps happening, copy the details below and
+            send them to support so we can fix it.
+          </Text>
           <Text style={styles.message}>{this.state.error.message}</Text>
           {this.state.error.stack ? (
             <Text style={styles.stack}>{this.state.error.stack}</Text>
@@ -56,6 +60,12 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: '#b00020',
     marginBottom: 12,
+  },
+  guidance: {
+    fontSize: 15,
+    color: '#333',
+    marginBottom: 16,
+    lineHeight: 22,
   },
   message: {
     fontSize: 16,

--- a/frontend/src/features/Auth/LoginScreen.tsx
+++ b/frontend/src/features/Auth/LoginScreen.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
+import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
+
+const LOGIN_FALLBACK =
+  "We couldn't sign you in. Check your connection, then try again in a moment.";
 
 interface Props {
   navigation: { navigate: (_screen: string) => void };
@@ -20,9 +24,10 @@ export default function LoginScreen({ navigation }: Props) {
     try {
       await login(email, password);
     } catch (err: unknown) {
-      const detail =
-        (err as { detail?: string }).detail ?? (err as Error).message ?? 'Login failed';
-      setError(detail);
+      // Backend ``detail`` strings (e.g. ``invalid_credentials``) are API
+      // contract tokens, not user copy — route them through the shared
+      // mapper so users see a plain-language explanation and a next step.
+      setError(formatApiError(err, { fallback: LOGIN_FALLBACK }));
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/features/Auth/SignupScreen.tsx
+++ b/frontend/src/features/Auth/SignupScreen.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
+import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
+
+const SIGNUP_FALLBACK =
+  "We couldn't create your account. Check your connection, then try again in a moment.";
+const MIN_PASSWORD_LENGTH = 8;
 
 interface Props {
   navigation: { navigate: (_screen: string) => void };
@@ -84,12 +89,12 @@ export default function SignupScreen({ navigation }: Props) {
   const handleSignup = async () => {
     setError(null);
 
-    if (password.length < 8) {
-      setError('Password must be at least 8 characters');
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Pick a password that is at least ${MIN_PASSWORD_LENGTH} characters long.`);
       return;
     }
     if (password !== confirmPassword) {
-      setError('Passwords do not match');
+      setError("Those passwords don't match. Re-type both fields to confirm.");
       return;
     }
 
@@ -97,9 +102,9 @@ export default function SignupScreen({ navigation }: Props) {
     try {
       await signup(email, password);
     } catch (err: unknown) {
-      const detail =
-        (err as { detail?: string }).detail ?? (err as Error).message ?? 'Signup failed';
-      setError(detail);
+      // Route backend ``detail`` codes (e.g. ``password_too_short``) through
+      // the shared mapper rather than leaking snake_case to the user.
+      setError(formatApiError(err, { fallback: SIGNUP_FALLBACK }));
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/features/Auth/__tests__/LoginScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/LoginScreen.test.tsx
@@ -49,9 +49,12 @@ describe('LoginScreen', () => {
     });
   });
 
-  it('shows error message on login failure', async () => {
-    mockLogin.mockRejectedValue({ detail: 'Invalid credentials' });
-    const { getByPlaceholderText, getByText, findByText } = render(
+  it('translates the backend invalid_credentials code to user-facing copy', async () => {
+    // The backend returns the stable code ``invalid_credentials`` (see
+    // backend/src/routers/auth.py). The screen must not leak snake_case to
+    // the user — it should display the mapped friendly message instead.
+    mockLogin.mockRejectedValue({ detail: 'invalid_credentials', status: 401 });
+    const { getByPlaceholderText, getByText, findByText, queryByText } = render(
       <LoginScreen navigation={mockNavigation} />,
     );
 
@@ -59,7 +62,21 @@ describe('LoginScreen', () => {
     fireEvent.changeText(getByPlaceholderText('Password'), 'wrong');
     fireEvent.press(getByText('Log In'));
 
-    expect(await findByText('Invalid credentials')).toBeTruthy();
+    expect(await findByText(/email and password/i)).toBeTruthy();
+    expect(queryByText('invalid_credentials')).toBeNull();
+  });
+
+  it('falls back to a connection-hint message when the error is unrecognised', async () => {
+    mockLogin.mockRejectedValue(new TypeError('Network request failed'));
+    const { getByPlaceholderText, getByText, findByText } = render(
+      <LoginScreen navigation={mockNavigation} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'user@test.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'whatever');
+    fireEvent.press(getByText('Log In'));
+
+    expect(await findByText(/Check your connection/i)).toBeTruthy();
   });
 
   it('has a link to navigate to signup', () => {

--- a/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
@@ -41,7 +41,7 @@ describe('SignupScreen', () => {
     fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'different');
     fireEvent.press(getByText('Sign Up'));
 
-    expect(await findByText('Passwords do not match')).toBeTruthy();
+    expect(await findByText(/passwords don't match/i)).toBeTruthy();
     expect(mockSignup).not.toHaveBeenCalled();
   });
 
@@ -55,7 +55,7 @@ describe('SignupScreen', () => {
     fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'short');
     fireEvent.press(getByText('Sign Up'));
 
-    expect(await findByText('Password must be at least 8 characters')).toBeTruthy();
+    expect(await findByText(/at least 8 characters/i)).toBeTruthy();
     expect(mockSignup).not.toHaveBeenCalled();
   });
 
@@ -75,9 +75,12 @@ describe('SignupScreen', () => {
     });
   });
 
-  it('shows error message on signup failure', async () => {
-    mockSignup.mockRejectedValue({ detail: 'Email already exists' });
-    const { getByPlaceholderText, getByText, findByText } = render(
+  it('translates backend password_too_short code to user-facing copy', async () => {
+    // If the user somehow bypasses the client-side length check (e.g. stale
+    // bundle), the backend still enforces it and returns the stable code
+    // ``password_too_short``. The screen must not leak snake_case to the UI.
+    mockSignup.mockRejectedValue({ detail: 'password_too_short', status: 400 });
+    const { getByPlaceholderText, getByText, findByText, queryByText } = render(
       <SignupScreen navigation={mockNavigation} />,
     );
 
@@ -86,7 +89,22 @@ describe('SignupScreen', () => {
     fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'password123');
     fireEvent.press(getByText('Sign Up'));
 
-    expect(await findByText('Email already exists')).toBeTruthy();
+    expect(await findByText(/at least 8 characters/i)).toBeTruthy();
+    expect(queryByText('password_too_short')).toBeNull();
+  });
+
+  it('falls back to a connection-hint message when the error is unrecognised', async () => {
+    mockSignup.mockRejectedValue(new TypeError('Network request failed'));
+    const { getByPlaceholderText, getByText, findByText } = render(
+      <SignupScreen navigation={mockNavigation} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'user@test.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'password123');
+    fireEvent.press(getByText('Sign Up'));
+
+    expect(await findByText(/Check your connection/i)).toBeTruthy();
   });
 
   it('has a link to navigate to login', () => {

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -68,7 +68,7 @@ const EnergySettings = ({ habit, netEnergy, onChange }: EnergySettingsProps) => 
       <Text style={styles.netEnergyValue}>{netEnergy}</Text>
     </View>
     <View style={styles.validationNote}>
-      <Text style={styles.validationText}>Values must be between -10 and 10</Text>
+      <Text style={styles.validationText}>Enter a whole number from -10 to 10.</Text>
     </View>
   </View>
 );

--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -739,7 +739,9 @@ const useHabitInput = (
   const handleAddHabit = () => {
     if (newHabitName.trim() === '') return;
     if (habits.length >= MAX_HABITS) {
-      setError('You can only add up to 10 habits.');
+      setError(
+        `You've hit the ${MAX_HABITS}-habit limit for onboarding. Remove one you don't need to add a different habit.`,
+      );
       return;
     }
     setHabits((prev) => [...prev, createNewHabit(newHabitName)]);

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
@@ -60,7 +60,7 @@ describe('OnboardingModal Step 1 interactions', () => {
     expect(getByTestId('habit-count')).toHaveTextContent('10 / 10');
     fireEvent.changeText(input, 'H10');
     fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
-    getByText('You can only add up to 10 habits.');
+    getByText(/hit the 10-habit limit/i);
     expect(getByTestId('habit-count')).toHaveTextContent('10 / 10');
   });
 

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -139,7 +139,10 @@ describe('habitManager', () => {
 
       await habitManager.loadHabits();
 
-      expect(useHabitStore.getState().error).toBe('Failed to load habits. Please try again.');
+      // Uses the shared error-message mapper in ``api/errorMessages`` —
+      // unknown errors fall back to an actionable, connection-focused hint
+      // rather than a generic "please try again" string.
+      expect(useHabitStore.getState().error).toMatch(/couldn't load your habits/i);
     });
   });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { habits as habitsApi, goalCompletions as goalCompletionsApi } from '../../../api';
 import type { HabitCreatePayload } from '../../../api';
+import { formatApiError } from '../../../api/errorMessages';
 import type { ToastConfig } from '../../../components/Toast';
 import { colors } from '../../../design/tokens';
 import {
@@ -289,7 +290,12 @@ const handleApiSuccess = (
 const handleApiError = (err: unknown, hasCachedData: boolean): void => {
   console.error('Failed to load habits:', err);
   if (!hasCachedData) {
-    setError('Failed to load habits. Please try again.');
+    setError(
+      formatApiError(err, {
+        fallback:
+          "We couldn't load your habits. Check your connection, then pull down to try again.",
+      }),
+    );
     setHabits(FALLBACK_HABITS);
   }
 };
@@ -304,10 +310,17 @@ const fetchFromApi = async (hasCachedData: boolean): Promise<void> => {
   }
 };
 
-const revertOnFailure = (prev: Habit[], message: string): (() => void) => {
-  return () => {
+/**
+ * On write failure, roll the optimistic state back and explain to the user
+ * what happened + what to do next. The fallback copy is intentionally
+ * specific to the operation (e.g. "couldn't save that check-in") rather
+ * than a generic "something went wrong" — users need to know whether to
+ * retry or just refresh.
+ */
+const revertOnFailure = (prev: Habit[], fallback: string): ((err: unknown) => void) => {
+  return (err: unknown) => {
     setHabits(prev);
-    Alert.alert('Error', message);
+    Alert.alert("Couldn't sync", formatApiError(err, { fallback }));
   };
 };
 
@@ -343,7 +356,12 @@ export const habitManager = {
     if (!updatedHabit.id) return;
     habitsApi
       .update(updatedHabit.id, toApiPayload(updatedHabit))
-      .catch(revertOnFailure(prev, 'Failed to update habit. Please try again.'));
+      .catch(
+        revertOnFailure(
+          prev,
+          "We couldn't save the changes to that habit. Your local copy was restored — check your connection and try again.",
+        ),
+      );
   },
 
   deleteHabit: (habitId: number): void => {
@@ -354,7 +372,12 @@ export const habitManager = {
     void cancelForHabit(habitId);
     habitsApi
       .delete(habitId)
-      .catch(revertOnFailure(prev, 'Failed to delete habit. Please try again.'));
+      .catch(
+        revertOnFailure(
+          prev,
+          "We couldn't delete that habit on the server. It's back in your list — check your connection and try again.",
+        ),
+      );
   },
 
   saveHabitOrder: (ordered: Habit[]): void => {
@@ -385,7 +408,12 @@ export const habitManager = {
       if (currentGoal.id) {
         goalCompletionsApi
           .create({ goal_id: currentGoal.id, did_complete: true })
-          .catch(revertOnFailure(prev, 'Failed to save progress. Please try again.'));
+          .catch(
+            revertOnFailure(
+              prev,
+              "We couldn't save that check-in to the server. Your progress was rolled back locally — check your connection and tap the habit again.",
+            ),
+          );
       }
     }
     return updated;

--- a/frontend/src/features/Journal/JournalScreen.tsx
+++ b/frontend/src/features/Journal/JournalScreen.tsx
@@ -12,6 +12,7 @@ import {
   ApiError,
   StreamingUnsupportedError,
 } from '../../api';
+import { mapDetailToMessage } from '../../api/errorMessages';
 import { useAppRoute } from '../../navigation/hooks';
 
 import ChatInput from './ChatInput';
@@ -23,29 +24,10 @@ import WeeklyPromptBanner from './WeeklyPromptBanner';
 
 const PAGE_SIZE = 50;
 
-// Generic fallback used when the server returns an unexpected detail string.
-// Kept as a module constant so multiple error keys can share the same copy
-// without duplicating the literal (sonarjs/no-duplicate-string).
-const GENERIC_PROVIDER_ERROR = 'BotMason is having trouble connecting. Try again in a moment.';
-
-// Maps the server's ``detail`` field to a human-readable, actionable message.
-// Centralising the mapping keeps the retry UI consistent regardless of which
-// layer (HTTP status, SSE error frame, network failure) surfaced the problem.
-const ERROR_MESSAGES: Record<string, string> = {
-  llm_key_required: 'Add your API key in Settings to chat with BotMason',
-  invalid_llm_api_key_format: 'Your API key is malformed — update it in Settings', // pragma: allowlist secret
-  insufficient_offerings:
-    "You've used your monthly messages. Add an API key or wait until next month.",
-  rate_limit_exceeded: 'Slow down — you can send 10 messages per minute',
-  llm_provider_error: GENERIC_PROVIDER_ERROR,
-  malformed_stream_frame: GENERIC_PROVIDER_ERROR,
-  incomplete_stream: 'The connection dropped before BotMason finished. Tap retry to try again.',
-  network_error: "You're offline. Tap retry once you reconnect.",
-};
-
-function mapErrorMessage(detail: string): string {
-  return ERROR_MESSAGES[detail] ?? GENERIC_PROVIDER_ERROR;
-}
+// Translating the server's ``detail`` field to user copy is the job of the
+// shared mapper in ``api/errorMessages``. We keep a thin alias here to
+// avoid churn in call sites that historically used ``mapErrorMessage``.
+const mapErrorMessage = mapDetailToMessage;
 
 // --- Sub-components ---
 

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -19,6 +19,7 @@ import type {
   UserPractice,
 } from '@/api';
 import { practices, userPractices, practiceSessions } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
 import { colors, SPACING, BORDER_RADIUS, shadows } from '@/design/tokens';
 import { useAppNavigation, useAppRoute } from '@/navigation/hooks';
 
@@ -74,8 +75,13 @@ function usePracticeSelect(
         setActiveUserPractice(newUp);
         const matching = availablePractices.find((p) => p.id === practiceId);
         if (matching) setSelectedPractice(matching);
-      } catch {
-        setError('Failed to select practice. Please try again.');
+      } catch (err) {
+        setError(
+          formatApiError(err, {
+            fallback:
+              "We couldn't save your practice selection. Check your connection and try again.",
+          }),
+        );
       }
     },
     [stageNumber, availablePractices, setActiveUserPractice, setSelectedPractice, setError],
@@ -109,8 +115,13 @@ function useLoadPracticeData(stageNumber: number, state: ReturnType<typeof usePr
         const match = practiceList.find((p: PracticeItem) => p.id === active.practice_id);
         if (match) setSelectedPractice(match);
       }
-    } catch {
-      setError('Failed to load practices. Please try again.');
+    } catch (err) {
+      setError(
+        formatApiError(err, {
+          fallback:
+            "We couldn't load your practices. Check your connection, then tap Retry to try again.",
+        }),
+      );
     } finally {
       setIsLoading(false);
     }
@@ -163,8 +174,13 @@ function useSessionFlow(activeUserPractice: UserPractice | null, incrementWeekCo
       const session = await practiceSessions.create(payload);
       incrementWeekCount();
       setSavedSession(session);
-    } catch {
-      setError('Failed to save session. Please try again.');
+    } catch (err) {
+      setError(
+        formatApiError(err, {
+          fallback:
+            "We couldn't save your practice session. Check your connection and try again — your timer minutes are still safe here.",
+        }),
+      );
     } finally {
       setIsSaving(false);
     }

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -141,7 +141,7 @@ describe('PracticeScreen', () => {
 
     await waitFor(() => {
       expect(getByTestId('practice-error')).toBeTruthy();
-      expect(getByText('Failed to load practices. Please try again.')).toBeTruthy();
+      expect(getByText(/couldn't load your practices/i)).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
Audit all error messages across the frontend and rewrite the opaque ones
so users can self-serve. The old state was a mix of (a) raw snake_case
codes from the backend leaking directly to Login/Signup screens, (b)
generic "Please try again" copy that told users nothing about what
happened or what to do, and (c) inline validation strings like
"use YYYY-MM-DD" that read more like a stack trace than a hint.

Introduces frontend/src/api/errorMessages.ts as the single source of
truth that translates every backend error code (see backend/src/errors.py
and each router's HTTPException details) to plain-language copy that
names what happened and what the user can do next. Exposes
``formatApiError`` for screens that want one-call translation with a
context-aware fallback, and ``mapDetailToMessage`` for call sites that
already have a raw detail string (e.g. BotMason SSE frames).

Rewires Auth, Practice, Habits, Journal, DatePicker, OnboardingModal,
HabitSettingsModal, and ErrorBoundary to use the new mapper or locally
improved copy. Updates tests to match the new messages and adds a
dedicated errorMessages test suite that pins every backend code to a
translation and verifies no snake_case ever leaks to the UI.