### PR TITLE
fix(frontend): use SecureStore-compatible keys for auth/LLM/push tokens

### DIFF
--- a/frontend/src/storage/__tests__/authStorage.test.ts
+++ b/frontend/src/storage/__tests__/authStorage.test.ts
@@ -22,7 +22,7 @@ describe('authStorage', () => {
       await saveToken('my-jwt-token');
 
       expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
-        '@adepthood/auth_token',
+        'adepthood_auth_token',
         'my-jwt-token',
       );
     });
@@ -47,7 +47,7 @@ describe('authStorage', () => {
   describe('clearToken', () => {
     test('removes token from SecureStore', async () => {
       await clearToken();
-      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('@adepthood/auth_token');
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('adepthood_auth_token');
     });
   });
 });

--- a/frontend/src/storage/__tests__/llmKeyStorage.test.ts
+++ b/frontend/src/storage/__tests__/llmKeyStorage.test.ts
@@ -22,7 +22,7 @@ describe('llmKeyStorage', () => {
       await saveLlmApiKey('sk-user-owned-key');
 
       expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
-        '@adepthood/llm_api_key',
+        'adepthood_llm_api_key',
         'sk-user-owned-key',
       );
     });
@@ -46,7 +46,7 @@ describe('llmKeyStorage', () => {
     test('removes key from SecureStore', async () => {
       await clearLlmApiKey();
 
-      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('@adepthood/llm_api_key');
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('adepthood_llm_api_key');
     });
   });
 });

--- a/frontend/src/storage/__tests__/notificationStorage.test.ts
+++ b/frontend/src/storage/__tests__/notificationStorage.test.ts
@@ -149,7 +149,7 @@ describe('notificationStorage', () => {
     test('stores the push token in SecureStore', async () => {
       await savePushToken('ExponentPushToken[abc]');
       expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
-        '@adepthood/push_token',
+        'adepthood_push_token',
         'ExponentPushToken[abc]',
       );
     });

--- a/frontend/src/storage/authStorage.ts
+++ b/frontend/src/storage/authStorage.ts
@@ -1,6 +1,8 @@
 import * as SecureStore from 'expo-secure-store';
 
-const TOKEN_KEY = '@adepthood/auth_token';
+// expo-secure-store only allows alphanumerics plus `.`, `-`, `_` in keys,
+// so we cannot use the `@adepthood/...` namespace prefix here.
+const TOKEN_KEY = 'adepthood_auth_token';
 
 export async function saveToken(token: string): Promise<void> {
   await SecureStore.setItemAsync(TOKEN_KEY, token);

--- a/frontend/src/storage/llmKeyStorage.ts
+++ b/frontend/src/storage/llmKeyStorage.ts
@@ -8,7 +8,8 @@ import * as SecureStore from 'expo-secure-store';
  * liability for user-owned keys and is the storage contract guaranteed by
  * issue #185.
  */
-const LLM_API_KEY_STORAGE_KEY = '@adepthood/llm_api_key';
+// expo-secure-store only allows alphanumerics plus `.`, `-`, `_` in keys.
+const LLM_API_KEY_STORAGE_KEY = 'adepthood_llm_api_key'; // pragma: allowlist secret
 
 export async function saveLlmApiKey(apiKey: string): Promise<void> {
   await SecureStore.setItemAsync(LLM_API_KEY_STORAGE_KEY, apiKey);

--- a/frontend/src/storage/notificationStorage.ts
+++ b/frontend/src/storage/notificationStorage.ts
@@ -2,7 +2,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
 const KEY_PREFIX = '@adepthood/notifications';
-const PUSH_TOKEN_KEY = '@adepthood/push_token';
+// expo-secure-store only allows alphanumerics plus `.`, `-`, `_` in keys,
+// so this one cannot share the `@adepthood/...` prefix with AsyncStorage keys.
+const PUSH_TOKEN_KEY = 'adepthood_push_token';
 const ALL_HABIT_IDS_KEY = '@adepthood/notification_habit_ids';
 
 function keyFor(habitId: number): string {


### PR DESCRIPTION
expo-secure-store rejects keys containing characters outside
`[A-Za-z0-9._-]`. The `@adepthood/auth_token`, `@adepthood/llm_api_key`,
and `@adepthood/push_token` keys all contained `@` and `/`, so every
`SecureStore.setItemAsync` call on those keys threw:

  Invalid key provided to SecureStore. Keys must not be empty and
  contain only alphanumeric characters, ".", "-", and "_".

This manifested as a user-visible signup failure: the backend accepted
the credentials, but persisting the returned JWT to SecureStore crashed
before AuthContext could transition to the authenticated state.

Rename the three SecureStore keys to `adepthood_auth_token`,
`adepthood_llm_api_key`, and `adepthood_push_token`. AsyncStorage keys
(notification mappings) are untouched — AsyncStorage has no such
restriction.