### PR TITLE
refactor(frontend): unify state management with normalized stores (phase-7-03)

### DIFF
--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -16,10 +16,12 @@ export const useHabitActions = (
 ): HabitsActions => {
   const logUnit = useCallback(
     (habitId: number, amount: number) => {
-      const updated = habitManager.logUnit(habitId, amount, showToast);
-      if (updated && ui.selectedHabit?.id === habitId) ui.setSelectedHabit(updated);
+      // `selectedHabit` is derived from the store via `useHabitUI`, so the
+      // updated habit propagates automatically after `habitManager.logUnit`
+      // writes to the store — no manual re-selection needed.
+      habitManager.logUnit(habitId, amount, showToast);
     },
-    [showToast, ui],
+    [showToast],
   );
 
   const iconPress = useCallback((index: number) => ui.setEmojiHabitIndex(index), [ui]);

--- a/frontend/src/features/Habits/hooks/useHabitUI.ts
+++ b/frontend/src/features/Habits/hooks/useHabitUI.ts
@@ -1,12 +1,15 @@
 import { useCallback, useState } from 'react';
 
+import { selectHabitById, useHabitStore } from '../../../store/useHabitStore';
 import type { Habit, HabitScreenMode } from '../Habits.types';
 
 /** Toast dismissal delay for the archive-CTA acknowledgement message. */
 const ARCHIVE_MESSAGE_DURATION_MS = 3000;
 
 export interface HabitUIState {
+  /** Currently selected habit, derived from the store by ID. */
   selectedHabit: Habit | null;
+  /** Pass the full habit or null; only the ID is stored in local state. */
   setSelectedHabit: (_habit: Habit | null) => void;
   mode: HabitScreenMode;
   setMode: (_mode: HabitScreenMode) => void;
@@ -18,16 +21,24 @@ export interface HabitUIState {
 }
 
 /**
- * Local UI state for the Habits screen — selection, current mode, emoji
- * picker target, and the energy-scaffolding CTA lifecycle. Everything here
- * is component-local; no global store involvement.
+ * Transient UI state for the Habits screen — the selected-habit ID, current
+ * mode, emoji picker target, and the energy-scaffolding CTA lifecycle.
+ *
+ * Domain data (the actual habit objects) lives in the Zustand store. We store
+ * only `selectedHabitId` here; the habit is resolved via a selector so that
+ * updates to the store propagate automatically — no stale closures.
  */
 export const useHabitUI = (): HabitUIState => {
-  const [selectedHabit, setSelectedHabit] = useState<Habit | null>(null);
+  const [selectedHabitId, setSelectedHabitId] = useState<number | null>(null);
+  const selectedHabit = useHabitStore(selectHabitById(selectedHabitId)) ?? null;
   const [mode, setMode] = useState<HabitScreenMode>('normal');
   const [emojiHabitIndex, setEmojiHabitIndex] = useState<number | null>(null);
   const [showEnergyCTA, setShowEnergyCTA] = useState(true);
   const [showArchiveMessage, setShowArchiveMessage] = useState(false);
+
+  const setSelectedHabit = useCallback((habit: Habit | null) => {
+    setSelectedHabitId(habit?.id ?? null);
+  }, []);
 
   const archiveEnergyCTA = useCallback(() => {
     setShowEnergyCTA(false);

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -18,9 +18,16 @@ import type { HabitHistoryItem, PracticeHistoryItem, StageHistoryResponse } from
 import { stages as stagesApi } from '../../api';
 import { MAP_BACKGROUND_URI } from '../../constants/images';
 import { useAppNavigation } from '../../navigation/hooks';
-import { useStageStore } from '../../store/useStageStore';
+import {
+  selectCurrentStage,
+  selectStages,
+  selectStagesError,
+  selectStagesLoading,
+  useStageStore,
+} from '../../store/useStageStore';
 
 import styles from './Map.styles';
+import { stageService } from './services/stageService';
 import type { StageData } from './stageData';
 
 const FULL_PROGRESS = 1;
@@ -428,14 +435,17 @@ const MapBackground = ({
 
 const MapScreen = (): React.JSX.Element => {
   const navigation = useAppNavigation();
-  const { stages, loading, error, fetchStages, currentStage } = useStageStore();
+  const stages = useStageStore(selectStages);
+  const loading = useStageStore(selectStagesLoading);
+  const error = useStageStore(selectStagesError);
+  const currentStage = useStageStore(selectCurrentStage);
   const [activeStage, setActiveStage] = useState<StageData | null>(null);
 
   useEffect(() => {
     if (stages.length === 0 && !loading) {
-      void fetchStages();
+      void stageService.loadStages();
     }
-  }, [stages.length, loading, fetchStages]);
+  }, [stages.length, loading]);
 
   const handleNavigate = useCallback(
     (screen: 'Practice' | 'Course' | 'Journal', stage: StageData) => {

--- a/frontend/src/features/Map/__tests__/MapHistory.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapHistory.test.tsx
@@ -69,18 +69,37 @@ function mockMakeStage(stageNumber: number, overrides: Partial<{ isUnlocked: boo
 
 const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
 
-const mockFetchStages = jest.fn();
+const mockLoadStages = jest.fn();
+jest.mock('../services/stageService', () => ({
+  stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+}));
+
+const buildMockStageState = () => ({
+  stages: mockStages,
+  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
+  stageOrder: mockStages.map((s) => s.stageNumber),
+  currentStage: 1,
+  loading: false,
+  error: null,
+  setStages: jest.fn(),
+  setCurrentStage: jest.fn(),
+  setLoading: jest.fn(),
+  setError: jest.fn(),
+  updateStageProgress: jest.fn(),
+});
+
 jest.mock('../../../store/useStageStore', () => ({
   useStageStore: jest.fn((selector) => {
-    const mockState = {
-      stages: mockStages,
-      currentStage: 1,
-      loading: false,
-      error: null,
-      fetchStages: mockFetchStages,
-    };
+    const mockState = buildMockStageState();
     return selector ? selector(mockState) : mockState;
   }),
+  selectStages: (s: { stages: unknown }) => s.stages,
+  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
+  selectStagesLoading: (s: { loading: unknown }) => s.loading,
+  selectStagesError: (s: { error: unknown }) => s.error,
+  selectStageByNumber:
+    (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>
+      n == null ? undefined : s.stagesByNumber[n],
 }));
 
 import MapScreen from '../MapScreen';
@@ -115,7 +134,7 @@ const EMPTY_HISTORY: StageHistoryData = {
 describe('MapScreen — Stage History', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
-    mockFetchStages.mockClear();
+    mockLoadStages.mockClear();
     mockHistoryFn.mockReset();
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -43,18 +43,37 @@ function mockMakeStage(stageNumber: number) {
 
 const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
 
-const mockFetchStages = jest.fn();
+const mockLoadStages = jest.fn();
+jest.mock('../services/stageService', () => ({
+  stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+}));
+
+const buildMockStageState = () => ({
+  stages: mockStages,
+  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
+  stageOrder: mockStages.map((s) => s.stageNumber),
+  currentStage: 1,
+  loading: false,
+  error: null,
+  setStages: jest.fn(),
+  setCurrentStage: jest.fn(),
+  setLoading: jest.fn(),
+  setError: jest.fn(),
+  updateStageProgress: jest.fn(),
+});
+
 jest.mock('../../../store/useStageStore', () => ({
   useStageStore: jest.fn((selector) => {
-    const mockState = {
-      stages: mockStages,
-      currentStage: 1,
-      loading: false,
-      error: null,
-      fetchStages: mockFetchStages,
-    };
+    const mockState = buildMockStageState();
     return selector ? selector(mockState) : mockState;
   }),
+  selectStages: (s: { stages: unknown }) => s.stages,
+  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
+  selectStagesLoading: (s: { loading: unknown }) => s.loading,
+  selectStagesError: (s: { error: unknown }) => s.error,
+  selectStageByNumber:
+    (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>
+      n == null ? undefined : s.stagesByNumber[n],
 }));
 
 import MapScreen from '../MapScreen';
@@ -62,7 +81,7 @@ import MapScreen from '../MapScreen';
 describe('MapScreen', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
-    mockFetchStages.mockClear();
+    mockLoadStages.mockClear();
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { act } from '@testing-library/react-native';
+
+import type { Stage } from '../../../../api';
+
+const mockList = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<Stage[]>>;
+jest.mock('../../../../api', () => ({
+  stages: { list: (...args: [string?]) => mockList(...args) },
+}));
+
+/** Build a fake API Stage response. */
+function makeApiStage(stageNumber: number, overrides: Partial<Stage> = {}): Stage {
+  return {
+    id: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    stage_number: stageNumber,
+    overview_url: '',
+    category: 'Test',
+    aspect: 'Aspect',
+    spiral_dynamics_color: 'Beige',
+    growing_up_stage: 'Growing',
+    divine_gender_polarity: 'Polarity',
+    relationship_to_free_will: 'Free Will',
+    free_will_description: 'Desc',
+    is_unlocked: stageNumber <= 2,
+    progress: stageNumber === 1 ? 0.5 : 0,
+    ...overrides,
+  };
+}
+
+describe('stageService', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockList.mockReset();
+    const { useStageStore } = require('../../../../store/useStageStore');
+    act(() => {
+      useStageStore.getState().setStages([]);
+      useStageStore.getState().setCurrentStage(1);
+      useStageStore.getState().setLoading(false);
+      useStageStore.getState().setError(null);
+    });
+  });
+
+  it('loadStages writes sorted-descending StageData into the store', async () => {
+    mockList.mockResolvedValueOnce([makeApiStage(1), makeApiStage(2), makeApiStage(3)]);
+
+    const { stageService } = require('../stageService');
+    const { useStageStore } = require('../../../../store/useStageStore');
+
+    await act(async () => {
+      await stageService.loadStages();
+    });
+
+    const state = useStageStore.getState();
+    expect(state.stages).toHaveLength(3);
+    expect(state.stages.map((s: { stageNumber: number }) => s.stageNumber)).toEqual([3, 2, 1]);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it('loadStages sets currentStage to first unlocked, in-progress stage', async () => {
+    mockList.mockResolvedValueOnce([
+      makeApiStage(1, { is_unlocked: true, progress: 1 }), // completed
+      makeApiStage(2, { is_unlocked: true, progress: 0.3 }), // in progress
+      makeApiStage(3, { is_unlocked: false, progress: 0 }),
+    ]);
+
+    const { stageService } = require('../stageService');
+    const { useStageStore } = require('../../../../store/useStageStore');
+
+    await act(async () => {
+      await stageService.loadStages();
+    });
+
+    expect(useStageStore.getState().currentStage).toBe(2);
+  });
+
+  it('loadStages records an error message on API failure', async () => {
+    mockList.mockRejectedValueOnce(new Error('Network error'));
+
+    const { stageService } = require('../stageService');
+    const { useStageStore } = require('../../../../store/useStageStore');
+
+    await act(async () => {
+      await stageService.loadStages();
+    });
+
+    const state = useStageStore.getState();
+    expect(state.error).toBe('Network error');
+    expect(state.loading).toBe(false);
+    expect(state.stages).toHaveLength(0);
+  });
+
+  it('loadStages maps StageData metadata fields correctly', async () => {
+    mockList.mockResolvedValueOnce([
+      makeApiStage(1, {
+        category: 'Survival',
+        aspect: 'Active Yes-And-Ness',
+        growing_up_stage: 'Archaic',
+        divine_gender_polarity: 'Masculine',
+        relationship_to_free_will: 'Deterministic',
+        free_will_description: 'Pure instinct',
+      }),
+    ]);
+
+    const { stageService } = require('../stageService');
+    const { useStageStore } = require('../../../../store/useStageStore');
+
+    await act(async () => {
+      await stageService.loadStages();
+    });
+
+    const stage = useStageStore.getState().stages[0]!;
+    expect(stage.category).toBe('Survival');
+    expect(stage.aspect).toBe('Active Yes-And-Ness');
+    expect(stage.growingUpStage).toBe('Archaic');
+    expect(stage.divineGenderPolarity).toBe('Masculine');
+    expect(stage.relationshipToFreeWill).toBe('Deterministic');
+    expect(stage.freeWillDescription).toBe('Pure instinct');
+  });
+
+  it('loadStages forwards the optional token to the API client', async () => {
+    mockList.mockResolvedValueOnce([]);
+    const { stageService } = require('../stageService');
+
+    await act(async () => {
+      await stageService.loadStages('abc-token');
+    });
+
+    expect(mockList).toHaveBeenCalledWith('abc-token');
+  });
+});

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -1,0 +1,72 @@
+/**
+ * Stage service — orchestrates API calls for stages and writes the result into
+ * `useStageStore`. This keeps API access out of the Zustand store, which is a
+ * pure state container.
+ *
+ * Consumers should call `stageService.loadStages()` from hooks / effects and
+ * read state via `useStageStore` selectors.
+ */
+
+import { stages as stagesApi } from '../../../api';
+import type { Stage } from '../../../api';
+import { STAGE_COLORS, STAGE_ORDER } from '../../../design/tokens';
+import { useStageStore } from '../../../store/useStageStore';
+import { HOTSPOTS, STAGE_COUNT } from '../stageData';
+import type { StageData } from '../stageData';
+
+/** Convert a backend Stage response into a frontend StageData with layout. */
+export const toStageData = (apiStage: Stage): StageData => {
+  const index = STAGE_COUNT - apiStage.stage_number; // stage 10 → index 0
+  const colorName = STAGE_ORDER[apiStage.stage_number - 1] ?? 'Beige';
+  return {
+    id: apiStage.id,
+    title: apiStage.title,
+    subtitle: apiStage.subtitle,
+    stageNumber: apiStage.stage_number,
+    progress: apiStage.progress,
+    color: STAGE_COLORS[colorName] ?? '#888',
+    isUnlocked: apiStage.is_unlocked,
+    category: apiStage.category,
+    aspect: apiStage.aspect,
+    spiralDynamicsColor: apiStage.spiral_dynamics_color,
+    growingUpStage: apiStage.growing_up_stage,
+    divineGenderPolarity: apiStage.divine_gender_polarity,
+    relationshipToFreeWill: apiStage.relationship_to_free_will,
+    freeWillDescription: apiStage.free_will_description,
+    overviewUrl: apiStage.overview_url,
+    hotspots: [...(HOTSPOTS[index] ?? [])],
+  };
+};
+
+/** First unlocked, still-in-progress stage; falls back to the last stage or 1. */
+const pickCurrentStage = (apiStages: Stage[]): number =>
+  apiStages.find((s) => s.is_unlocked && s.progress < 1)?.stage_number ??
+  apiStages.at(-1)?.stage_number ??
+  1;
+
+export const stageService = {
+  /**
+   * Fetch the stage list, map to StageData, and write it into the store. On
+   * failure, leaves existing state in place and records an error message.
+   */
+  loadStages: async (token?: string): Promise<void> => {
+    const store = useStageStore.getState();
+    store.setLoading(true);
+    store.setError(null);
+    try {
+      const apiStages = await stagesApi.list(token);
+      // Sort descending by stage_number (10 at top, 1 at bottom) to match
+      // the background artwork.
+      const sorted = [...apiStages].sort((a, b) => b.stage_number - a.stage_number);
+      useStageStore.getState().setStages(sorted.map(toStageData));
+      useStageStore.getState().setCurrentStage(pickCurrentStage(sorted));
+      useStageStore.getState().setLoading(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load stages';
+      useStageStore.getState().setError(message);
+      useStageStore.getState().setLoading(false);
+    }
+  },
+};
+
+export type StageService = typeof stageService;

--- a/frontend/src/store/__tests__/useHabitStore.test.ts
+++ b/frontend/src/store/__tests__/useHabitStore.test.ts
@@ -38,9 +38,14 @@ const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
 
 describe('useHabitStore', () => {
   beforeEach(() => {
-    // Reset store state between tests
+    // Reset store state between tests via the normalizing `setHabits` action
+    // so `habitsById` and `habitOrder` stay consistent with `habits`.
     const { useHabitStore } = require('../useHabitStore');
-    useHabitStore.setState({ habits: [], loading: false, error: null });
+    act(() => {
+      useHabitStore.getState().setHabits([]);
+      useHabitStore.getState().setLoading(false);
+      useHabitStore.getState().setError(null);
+    });
     jest.clearAllMocks();
   });
 
@@ -49,8 +54,36 @@ describe('useHabitStore', () => {
     const state = useHabitStore.getState();
 
     expect(state.habits).toEqual([]);
+    expect(state.habitsById).toEqual({});
+    expect(state.habitOrder).toEqual([]);
     expect(state.loading).toBe(false);
     expect(state.error).toBeNull();
+  });
+
+  it('setHabits normalizes into habitsById and habitOrder', () => {
+    const { useHabitStore } = require('../useHabitStore');
+    const h1 = makeHabit({ id: 1, name: 'First' });
+    const h2 = makeHabit({ id: 2, name: 'Second' });
+
+    act(() => useHabitStore.getState().setHabits([h1, h2]));
+
+    const state = useHabitStore.getState();
+    expect(state.habitsById[1]).toEqual(h1);
+    expect(state.habitsById[2]).toEqual(h2);
+    expect(state.habitOrder).toEqual([1, 2]);
+    expect(state.habits).toEqual([h1, h2]);
+  });
+
+  it('selectHabitById returns a habit by id or undefined', () => {
+    const { useHabitStore, selectHabitById } = require('../useHabitStore');
+    const habit = makeHabit({ id: 42 });
+    act(() => useHabitStore.getState().setHabits([habit]));
+
+    const state = useHabitStore.getState();
+    expect(selectHabitById(42)(state)).toEqual(habit);
+    expect(selectHabitById(99)(state)).toBeUndefined();
+    expect(selectHabitById(null)(state)).toBeUndefined();
+    expect(selectHabitById(undefined)(state)).toBeUndefined();
   });
 
   it('setHabits updates habits array', () => {

--- a/frontend/src/store/__tests__/useStageStore.test.ts
+++ b/frontend/src/store/__tests__/useStageStore.test.ts
@@ -1,75 +1,61 @@
-import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { describe, expect, it, beforeEach } from '@jest/globals';
 import { act } from '@testing-library/react-native';
 
-import type { Stage } from '../../api';
 import type { StageData } from '../../features/Map/stageData';
 
-// Mock the API module
-const mockList = jest.fn() as jest.MockedFunction<() => Promise<Stage[]>>;
-jest.mock('../../api', () => ({
-  stages: { list: () => mockList() },
-}));
-
-/** Build a fake API Stage response. */
-function makeApiStage(stageNumber: number, overrides: Partial<Stage> = {}): Stage {
-  return {
-    id: stageNumber,
-    title: `Stage ${stageNumber}`,
-    subtitle: `Subtitle ${stageNumber}`,
-    stage_number: stageNumber,
-    overview_url: '',
-    category: 'Test',
-    aspect: 'Aspect',
-    spiral_dynamics_color: 'Beige',
-    growing_up_stage: 'Growing',
-    divine_gender_polarity: 'Polarity',
-    relationship_to_free_will: 'Free Will',
-    free_will_description: 'Desc',
-    is_unlocked: stageNumber <= 2,
-    progress: stageNumber === 1 ? 0.5 : 0,
-    ...overrides,
-  };
-}
+const makeStage = (stageNumber: number, overrides: Partial<StageData> = {}): StageData => ({
+  id: stageNumber,
+  title: `Stage ${stageNumber}`,
+  subtitle: `Subtitle ${stageNumber}`,
+  stageNumber,
+  progress: 0,
+  color: '#aaa',
+  isUnlocked: true,
+  category: '',
+  aspect: '',
+  spiralDynamicsColor: '',
+  growingUpStage: '',
+  divineGenderPolarity: '',
+  relationshipToFreeWill: '',
+  freeWillDescription: '',
+  overviewUrl: '',
+  hotspots: [],
+  ...overrides,
+});
 
 describe('useStageStore', () => {
   beforeEach(() => {
-    jest.resetModules();
-    mockList.mockReset();
+    const { useStageStore } = require('../useStageStore');
+    act(() => {
+      useStageStore.getState().setStages([]);
+      useStageStore.getState().setCurrentStage(1);
+      useStageStore.getState().setLoading(false);
+      useStageStore.getState().setError(null);
+    });
   });
 
-  it('starts with empty stages and loading false', () => {
+  it('starts with empty stages, no loading, no error', () => {
     const { useStageStore } = require('../useStageStore');
     const state = useStageStore.getState();
     expect(state.stages).toHaveLength(0);
+    expect(state.stagesByNumber).toEqual({});
+    expect(state.stageOrder).toEqual([]);
     expect(state.loading).toBe(false);
     expect(state.error).toBeNull();
   });
 
-  it('setStages replaces the stages array', () => {
+  it('setStages normalizes into stagesByNumber and stageOrder', () => {
     const { useStageStore } = require('../useStageStore');
-    const newStages: StageData[] = [
-      {
-        id: 1,
-        title: 'Custom Stage',
-        subtitle: 'Test',
-        stageNumber: 1,
-        progress: 0.75,
-        color: '#fff',
-        isUnlocked: true,
-        category: '',
-        aspect: '',
-        spiralDynamicsColor: '',
-        growingUpStage: '',
-        divineGenderPolarity: '',
-        relationshipToFreeWill: '',
-        freeWillDescription: '',
-        overviewUrl: '',
-        hotspots: [],
-      },
-    ];
+    const s1 = makeStage(1);
+    const s2 = makeStage(2);
 
-    act(() => useStageStore.getState().setStages(newStages));
-    expect(useStageStore.getState().stages).toEqual(newStages);
+    act(() => useStageStore.getState().setStages([s2, s1]));
+
+    const state = useStageStore.getState();
+    expect(state.stageOrder).toEqual([2, 1]);
+    expect(state.stagesByNumber[1]).toEqual(s1);
+    expect(state.stagesByNumber[2]).toEqual(s2);
+    expect(state.stages).toEqual([s2, s1]);
   });
 
   it('setCurrentStage updates the current stage number', () => {
@@ -78,140 +64,49 @@ describe('useStageStore', () => {
     expect(useStageStore.getState().currentStage).toBe(5);
   });
 
-  it('updateStageProgress updates a specific stage progress', () => {
+  it('setLoading / setError update flags without touching stages', () => {
     const { useStageStore } = require('../useStageStore');
-    // Seed with one stage
-    act(() =>
-      useStageStore.getState().setStages([
-        {
-          id: 1,
-          title: 'S1',
-          subtitle: '',
-          stageNumber: 1,
-          progress: 0,
-          color: '#fff',
-          isUnlocked: true,
-          category: '',
-          aspect: '',
-          spiralDynamicsColor: '',
-          growingUpStage: '',
-          divineGenderPolarity: '',
-          relationshipToFreeWill: '',
-          freeWillDescription: '',
-          overviewUrl: '',
-          hotspots: [],
-        },
-      ]),
-    );
-
-    act(() => useStageStore.getState().updateStageProgress(1, 0.8));
-    const stage1 = useStageStore.getState().stages.find((s: StageData) => s.stageNumber === 1);
-    expect(stage1!.progress).toBe(0.8);
+    act(() => useStageStore.getState().setStages([makeStage(1)]));
+    act(() => {
+      useStageStore.getState().setLoading(true);
+      useStageStore.getState().setError('boom');
+    });
+    const state = useStageStore.getState();
+    expect(state.loading).toBe(true);
+    expect(state.error).toBe('boom');
+    expect(state.stages).toHaveLength(1);
   });
 
-  it('updateStageProgress does nothing for unknown stage', () => {
+  it('updateStageProgress updates a specific stage progress', () => {
     const { useStageStore } = require('../useStageStore');
-    act(() =>
-      useStageStore.getState().setStages([
-        {
-          id: 1,
-          title: 'S1',
-          subtitle: '',
-          stageNumber: 1,
-          progress: 0.5,
-          color: '#fff',
-          isUnlocked: true,
-          category: '',
-          aspect: '',
-          spiralDynamicsColor: '',
-          growingUpStage: '',
-          divineGenderPolarity: '',
-          relationshipToFreeWill: '',
-          freeWillDescription: '',
-          overviewUrl: '',
-          hotspots: [],
-        },
-      ]),
-    );
+    act(() => useStageStore.getState().setStages([makeStage(1, { progress: 0 })]));
+
+    act(() => useStageStore.getState().updateStageProgress(1, 0.8));
+
+    const state = useStageStore.getState();
+    expect(state.stagesByNumber[1]!.progress).toBe(0.8);
+    expect(state.stages[0]!.progress).toBe(0.8);
+  });
+
+  it('updateStageProgress is a no-op for an unknown stage', () => {
+    const { useStageStore } = require('../useStageStore');
+    act(() => useStageStore.getState().setStages([makeStage(1, { progress: 0.5 })]));
+
     const before = useStageStore.getState().stages.map((s: StageData) => s.progress);
     act(() => useStageStore.getState().updateStageProgress(99, 1.0));
     const after = useStageStore.getState().stages.map((s: StageData) => s.progress);
+
     expect(after).toEqual(before);
   });
 
-  it('fetchStages loads from API, sorts descending, and maps to StageData', async () => {
-    const apiStages = [makeApiStage(1), makeApiStage(2), makeApiStage(3)];
-    mockList.mockResolvedValueOnce(apiStages);
-
-    const { useStageStore } = require('../useStageStore');
-    await act(async () => {
-      await useStageStore.getState().fetchStages();
-    });
-
+  it('selectStageByNumber returns a stage or undefined', () => {
+    const { useStageStore, selectStageByNumber } = require('../useStageStore');
+    act(() => useStageStore.getState().setStages([makeStage(3)]));
     const state = useStageStore.getState();
-    expect(state.stages).toHaveLength(3);
-    // Should be sorted descending by stageNumber
-    expect(state.stages[0].stageNumber).toBe(3);
-    expect(state.stages[1].stageNumber).toBe(2);
-    expect(state.stages[2].stageNumber).toBe(1);
-    expect(state.loading).toBe(false);
-    expect(state.error).toBeNull();
-  });
 
-  it('fetchStages sets currentStage to first unlocked incomplete stage', async () => {
-    const apiStages = [
-      makeApiStage(1, { is_unlocked: true, progress: 1 }), // completed
-      makeApiStage(2, { is_unlocked: true, progress: 0.3 }), // in progress
-      makeApiStage(3, { is_unlocked: false, progress: 0 }),
-    ];
-    mockList.mockResolvedValueOnce(apiStages);
-
-    const { useStageStore } = require('../useStageStore');
-    await act(async () => {
-      await useStageStore.getState().fetchStages();
-    });
-
-    expect(useStageStore.getState().currentStage).toBe(2);
-  });
-
-  it('fetchStages sets error on API failure', async () => {
-    mockList.mockRejectedValueOnce(new Error('Network error'));
-
-    const { useStageStore } = require('../useStageStore');
-    await act(async () => {
-      await useStageStore.getState().fetchStages();
-    });
-
-    const state = useStageStore.getState();
-    expect(state.error).toBe('Network error');
-    expect(state.loading).toBe(false);
-    expect(state.stages).toHaveLength(0);
-  });
-
-  it('fetchStages maps metadata fields correctly', async () => {
-    const apiStages = [
-      makeApiStage(1, {
-        category: 'Survival',
-        aspect: 'Active Yes-And-Ness',
-        growing_up_stage: 'Archaic',
-        divine_gender_polarity: 'Masculine',
-        relationship_to_free_will: 'Deterministic',
-        free_will_description: 'Pure instinct',
-      }),
-    ];
-    mockList.mockResolvedValueOnce(apiStages);
-
-    const { useStageStore } = require('../useStageStore');
-    await act(async () => {
-      await useStageStore.getState().fetchStages();
-    });
-
-    const stage = useStageStore.getState().stages[0];
-    expect(stage.category).toBe('Survival');
-    expect(stage.aspect).toBe('Active Yes-And-Ness');
-    expect(stage.growingUpStage).toBe('Archaic');
-    expect(stage.divineGenderPolarity).toBe('Masculine');
-    expect(stage.relationshipToFreeWill).toBe('Deterministic');
-    expect(stage.freeWillDescription).toBe('Pure instinct');
+    expect(selectStageByNumber(3)(state)!.stageNumber).toBe(3);
+    expect(selectStageByNumber(99)(state)).toBeUndefined();
+    expect(selectStageByNumber(null)(state)).toBeUndefined();
+    expect(selectStageByNumber(undefined)(state)).toBeUndefined();
   });
 });

--- a/frontend/src/store/useHabitStore.ts
+++ b/frontend/src/store/useHabitStore.ts
@@ -2,7 +2,22 @@ import { create } from 'zustand';
 
 import type { Habit } from '../features/Habits/Habits.types';
 
+/**
+ * Habit store — a dumb state container. No API calls live here; those belong
+ * in `features/Habits/services/habitManager.ts`.
+ *
+ * Canonical shape is `habitsById` + `habitOrder` for O(1) lookups; the `habits`
+ * array is a derived cache maintained by the mutation actions so consumers can
+ * iterate without rebuilding it on every render. Use the `selectHabitById`
+ * selector for single-item subscriptions to avoid re-renders on unrelated
+ * mutations.
+ */
 export interface HabitStoreState {
+  /** ID-keyed map — the canonical source of truth for per-habit lookups. */
+  habitsById: Record<number, Habit>;
+  /** Insertion order, preserved across mutations. */
+  habitOrder: number[];
+  /** Derived array view of habits in `habitOrder`. Kept in sync by actions. */
   habits: Habit[];
   loading: boolean;
   error: string | null;
@@ -14,20 +29,68 @@ export interface HabitStoreState {
   removeHabit: (_habitId: number) => void;
 }
 
+interface NormalizedHabits {
+  habitsById: Record<number, Habit>;
+  habitOrder: number[];
+  habits: Habit[];
+}
+
+const normalizeHabits = (habits: Habit[]): NormalizedHabits => {
+  const habitsById: Record<number, Habit> = {};
+  const habitOrder: number[] = [];
+  for (const habit of habits) {
+    habitsById[habit.id] = habit;
+    habitOrder.push(habit.id);
+  }
+  return { habitsById, habitOrder, habits: [...habits] };
+};
+
+const rebuildHabitsList = (habitsById: Record<number, Habit>, habitOrder: number[]): Habit[] =>
+  habitOrder.map((id) => habitsById[id]!).filter((h): h is Habit => h !== undefined);
+
 export const useHabitStore = create<HabitStoreState>((set) => ({
+  habitsById: {},
+  habitOrder: [],
   habits: [],
   loading: false,
   error: null,
 
-  setHabits: (habits) => set({ habits }),
+  setHabits: (habits) => set(normalizeHabits(habits)),
   setLoading: (loading) => set({ loading }),
   setError: (error) => set({ error }),
   updateHabit: (updatedHabit) =>
-    set((state) => ({
-      habits: state.habits.map((h) => (h.id === updatedHabit.id ? updatedHabit : h)),
-    })),
+    set((state) => {
+      if (!(updatedHabit.id in state.habitsById)) return state;
+      const habitsById = { ...state.habitsById, [updatedHabit.id]: updatedHabit };
+      return { habitsById, habits: rebuildHabitsList(habitsById, state.habitOrder) };
+    }),
   removeHabit: (habitId) =>
-    set((state) => ({
-      habits: state.habits.filter((h) => h.id !== habitId),
-    })),
+    set((state) => {
+      if (!(habitId in state.habitsById)) return state;
+      const habitsById = { ...state.habitsById };
+      delete habitsById[habitId];
+      const habitOrder = state.habitOrder.filter((id) => id !== habitId);
+      return { habitsById, habitOrder, habits: rebuildHabitsList(habitsById, habitOrder) };
+    }),
 }));
+
+// ---------------------------------------------------------------------------
+// Selectors — narrow state subscriptions. Zustand compares the *value*
+// returned by a selector with `Object.is`, so components re-render only when
+// their specific slice changes. Prefer these over destructuring the whole
+// store (which re-renders on every unrelated mutation).
+// ---------------------------------------------------------------------------
+
+export const selectHabits = (state: HabitStoreState): Habit[] => state.habits;
+export const selectHabitsLoading = (state: HabitStoreState): boolean => state.loading;
+export const selectHabitsError = (state: HabitStoreState): string | null => state.error;
+
+/**
+ * Factory for a "single habit by ID" selector. The habit lookup is O(1) via
+ * the canonical `habitsById` map, and Zustand will only trigger a re-render
+ * when that specific habit's reference changes.
+ */
+export const selectHabitById =
+  (id: number | null | undefined) =>
+  (state: HabitStoreState): Habit | undefined =>
+    id == null ? undefined : state.habitsById[id];

--- a/frontend/src/store/useStageStore.ts
+++ b/frontend/src/store/useStageStore.ts
@@ -1,36 +1,23 @@
 import { create } from 'zustand';
 
-import { stages as stagesApi } from '../api';
-import type { Stage } from '../api';
-import { STAGE_COLORS, STAGE_ORDER } from '../design/tokens';
-import { HOTSPOTS, STAGE_COUNT } from '../features/Map/stageData';
 import type { StageData } from '../features/Map/stageData';
 
-/** Convert a backend Stage response into a frontend StageData with hotspot layout. */
-function toStageData(apiStage: Stage): StageData {
-  const index = STAGE_COUNT - apiStage.stage_number; // stage 10 = index 0
-  const colorName = STAGE_ORDER[apiStage.stage_number - 1] ?? 'Beige';
-  return {
-    id: apiStage.id,
-    title: apiStage.title,
-    subtitle: apiStage.subtitle,
-    stageNumber: apiStage.stage_number,
-    progress: apiStage.progress,
-    color: STAGE_COLORS[colorName] ?? '#888',
-    isUnlocked: apiStage.is_unlocked,
-    category: apiStage.category,
-    aspect: apiStage.aspect,
-    spiralDynamicsColor: apiStage.spiral_dynamics_color,
-    growingUpStage: apiStage.growing_up_stage,
-    divineGenderPolarity: apiStage.divine_gender_polarity,
-    relationshipToFreeWill: apiStage.relationship_to_free_will,
-    freeWillDescription: apiStage.free_will_description,
-    overviewUrl: apiStage.overview_url,
-    hotspots: [...(HOTSPOTS[index] ?? [])],
-  };
-}
-
+/**
+ * Stage store — a dumb state container. API calls live in
+ * `features/Map/services/stageService.ts`; this module only holds and mutates
+ * state.
+ *
+ * Canonical shape is `stagesByNumber` (keyed by `stageNumber`) plus
+ * `stageOrder` for O(1) lookups while preserving the artwork-aligned ordering
+ * (stage 10 → stage 1 = descending). The `stages` array is a derived cache
+ * kept in sync by the mutation actions.
+ */
 export interface StageStoreState {
+  /** `stageNumber` → StageData map. O(1) lookup for selectors. */
+  stagesByNumber: Record<number, StageData>;
+  /** Stage numbers in display order (descending: 10 first, 1 last). */
+  stageOrder: number[];
+  /** Derived array view. Kept in sync by actions. */
   stages: StageData[];
   currentStage: number;
   loading: boolean;
@@ -38,37 +25,69 @@ export interface StageStoreState {
 
   setStages: (_stages: StageData[]) => void;
   setCurrentStage: (_stageNumber: number) => void;
+  setLoading: (_loading: boolean) => void;
+  setError: (_error: string | null) => void;
   updateStageProgress: (_stageNumber: number, _progress: number) => void;
-  fetchStages: (_token?: string) => Promise<void>;
 }
 
+interface NormalizedStages {
+  stagesByNumber: Record<number, StageData>;
+  stageOrder: number[];
+  stages: StageData[];
+}
+
+const normalizeStages = (stages: StageData[]): NormalizedStages => {
+  const stagesByNumber: Record<number, StageData> = {};
+  const stageOrder: number[] = [];
+  for (const stage of stages) {
+    stagesByNumber[stage.stageNumber] = stage;
+    stageOrder.push(stage.stageNumber);
+  }
+  return { stagesByNumber, stageOrder, stages: [...stages] };
+};
+
+const rebuildStageList = (
+  stagesByNumber: Record<number, StageData>,
+  stageOrder: number[],
+): StageData[] =>
+  stageOrder.map((num) => stagesByNumber[num]!).filter((s): s is StageData => s !== undefined);
+
 export const useStageStore = create<StageStoreState>((set) => ({
+  stagesByNumber: {},
+  stageOrder: [],
   stages: [],
   currentStage: 1,
   loading: false,
   error: null,
 
-  setStages: (stages) => set({ stages }),
+  setStages: (stages) => set(normalizeStages(stages)),
   setCurrentStage: (currentStage) => set({ currentStage }),
+  setLoading: (loading) => set({ loading }),
+  setError: (error) => set({ error }),
   updateStageProgress: (stageNumber, progress) =>
-    set((state) => ({
-      stages: state.stages.map((s) => (s.stageNumber === stageNumber ? { ...s, progress } : s)),
-    })),
-  fetchStages: async (token?: string) => {
-    set({ loading: true, error: null });
-    try {
-      const apiStages = await stagesApi.list(token);
-      // Sort descending by stage_number (10 at top, 1 at bottom) to match artwork
-      const sorted = [...apiStages].sort((a, b) => b.stage_number - a.stage_number);
-      const mapped = sorted.map(toStageData);
-      const current =
-        sorted.find((s) => s.is_unlocked && s.progress < 1)?.stage_number ??
-        sorted.at(-1)?.stage_number ??
-        1;
-      set({ stages: mapped, currentStage: current, loading: false });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load stages';
-      set({ loading: false, error: message });
-    }
-  },
+    set((state) => {
+      const existing = state.stagesByNumber[stageNumber];
+      if (!existing) return state;
+      const stagesByNumber = {
+        ...state.stagesByNumber,
+        [stageNumber]: { ...existing, progress },
+      };
+      return { stagesByNumber, stages: rebuildStageList(stagesByNumber, state.stageOrder) };
+    }),
 }));
+
+// ---------------------------------------------------------------------------
+// Selectors — narrow state subscriptions. Zustand compares the *value*
+// returned with `Object.is`, so components re-render only when their slice
+// changes. Prefer these over destructuring the whole store.
+// ---------------------------------------------------------------------------
+
+export const selectStages = (state: StageStoreState): StageData[] => state.stages;
+export const selectCurrentStage = (state: StageStoreState): number => state.currentStage;
+export const selectStagesLoading = (state: StageStoreState): boolean => state.loading;
+export const selectStagesError = (state: StageStoreState): string | null => state.error;
+
+export const selectStageByNumber =
+  (stageNumber: number | null | undefined) =>
+  (state: StageStoreState): StageData | undefined =>
+    stageNumber == null ? undefined : state.stagesByNumber[stageNumber];


### PR DESCRIPTION
## Summary

Implements **phase-7-03: Unify Frontend State Management** from the Phase 7
architecture-cleanup epic. Establishes clear boundaries between transient UI
state (React `useState`), domain data (Zustand), and auth/settings (React
Context) — and removes the re-render-triggering anti-patterns called out in
the architecture review.

## What changed

- **API calls out of Zustand stores.** `useStageStore.fetchStages()` is gone.
  The API call now lives in `frontend/src/features/Map/services/stageService.ts`
  and writes into the store via its setters. The store is a pure state
  container again.
- **Normalized store shape.** Both `useHabitStore` and `useStageStore` use
  `Record<id, T>` + `order: number[]` for canonical state, with an `items[]`
  array derived and maintained alongside by the mutation actions. Habit lookup
  by ID is now O(1).
- **Narrow selectors.** Exported `selectHabits`, `selectHabitsLoading`,
  `selectHabitsError`, `selectHabitById`, and the equivalents for stages.
  Components subscribe only to the slice they need so unrelated mutations
  don't trigger re-renders.
- **Selected-habit as ID, not object.** `useHabitUI` now stores
  `selectedHabitId: number | null` and resolves the habit via
  `selectHabitById`. This removes the stale-closure issue where
  `useHabitActions.logUnit` had to manually re-sync `ui.setSelectedHabit(updated)`
  after every mutation.
- **MapScreen uses the service + selectors.** `fetchStages` call site switches
  to `stageService.loadStages()`.
- **Tests.** Store tests cover the new normalized shape and the selector
  factories; fetch-side tests moved into a new `stageService` suite; MapScreen
  test mocks updated accordingly.

## Acceptance criteria (from `phase-7-03-unify-state-management.md`)

- [x] Zustand stores have no API calls (pure state + selectors)
- [x] Each store uses `Record<id, T>` alongside an order-preserving array view
- [x] Memoized selectors prevent unnecessary re-renders
- [x] No domain data in local `useState` for the Habits feature (only
      `selectedHabitId` — a transient UI selection)
- [x] All existing tests pass (614/614)

## Test plan

- [x] `npm test` — 73 suites, 614 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint -- --max-warnings=0` — clean
- [x] `pre-commit run --all-files` — all hooks green
- [x] `pre-commit run --hook-stage pre-push --all-files` — backend tests +
      coverage + complexity gates all green

https://claude.ai/code/session_01XoNbVnRJJtmgQfJfJLArsS