### PR TITLE
docs(prompts): add comprehensive bug-remediation audit reports

### DIFF
--- a/prompts/2026-04-14-bug-remediation/00-INDEX.md
+++ b/prompts/2026-04-14-bug-remediation/00-INDEX.md
@@ -1,0 +1,67 @@
+# Adepthood — "Pay the Debts" Bug Remediation Initiative
+
+**Kicked off:** 2026-04-14
+**Branch:** `claude/code-review-bug-analysis-BvOHp`
+**Scope:** Comprehensive self-review of the Adepthood codebase across every feature surface.
+
+## Why this exists
+
+The user tried to sign up. Hit ~5 bugs. Never made it through the door. That was enough signal to stop shipping features and take stock. This initiative is the audit, broken into per-component bug reports written like a senior QA engineer's findings — each bug has a severity, file:line reference, symptom, root cause with code excerpt, and a concrete fix.
+
+Total findings across all reports: **146 bugs** (20 Critical, 34 High, 69 Medium, 23 Low).
+
+## Reports
+
+| File | Component | Bugs | Crit | High |
+|---|---|---:|---:|---:|
+| [`01-auth-and-signup-bugs.md`](./01-auth-and-signup-bugs.md) | Auth, signup, login, JWT, lockout | 14 | 2 | 2 |
+| [`02-habits-bugs.md`](./02-habits-bugs.md) | Habits, goals, streaks, milestones | 20 | 0 | 6 |
+| [`03-practice-sessions-bugs.md`](./03-practice-sessions-bugs.md) | Practices, timers, sessions | 17 | 2 | 4 |
+| [`04-journal-botmason-bugs.md`](./04-journal-botmason-bugs.md) | Journal entries, BotMason LLM, weekly prompts | 18 | 4 | 6 |
+| [`05-course-stages-goals-bugs.md`](./05-course-stages-goals-bugs.md) | Course content, stage progression, goals | 25 | 5 | 6 |
+| [`06-backend-infrastructure-bugs.md`](./06-backend-infrastructure-bugs.md) | FastAPI app, DB, CORS, migrations, obs | 27 | 3 | 9 |
+| [`07-frontend-infrastructure-bugs.md`](./07-frontend-infrastructure-bugs.md) | API client, nav, state, storage, a11y | 25 | 2 | 1 |
+
+(Counts approximate — classifications occasionally blur; severity is a prioritization hint, not a contract.)
+
+## Top suspects for "the 5 bugs during signup"
+
+From the auth report:
+
+1. **BUG-AUTH-003** — email lookups are case-sensitive (`Alice@Example.com` ≠ `alice@example.com`).
+2. **BUG-AUTH-010** — whitespace not stripped from the email field.
+3. **BUG-AUTH-004** — no client-side email validation; the user sees a generic 422 instead of a field error.
+4. **BUG-AUTH-002** — `AuthResponse.user_id` optional in TS but required on the server (may crash the post-login screen).
+5. **BUG-AUTH-001 / 005** — `saveToken` / `clearToken` not awaited; a quick kill/restart after signup logs you back out.
+
+Fix those five first; you'll walk through the door.
+
+## How to use these reports
+
+- Each file stands alone and can be handed to a single engineer or to `/continue-epic`.
+- Each bug has a stable ID (`BUG-AUTH-003`, `BUG-HABITS-017`, …) — reference it in commit messages, PR titles, and the issue tracker.
+- Severity is Critical/High/Medium/Low; reports group the Critical/High near the top plus a suggested remediation order at the bottom.
+- The "Suggested remediation order" section of each report minimizes rework (e.g., "land the unique-per-day constraint + the race fix together; they're the same change").
+
+## Cross-cutting themes
+
+Patterns that recur across reports, worth solving once rather than N times:
+
+1. **Async hygiene** — many fire-and-forget writes, missing `await`s, misplaced `await`s. An RN/FastAPI lint pass catches the bulk.
+2. **No runtime validation at API boundaries** — Zod on the client, stricter Pydantic on the server, and regenerated shared types.
+3. **Authorization is per-handler** rather than per-resource — locked-stage content, other users' histories, and the `bot-response` endpoint all leak because the stage/user check is a snowflake each time. Consider a `require_access_to_stage` dep.
+4. **Timezone handling is inconsistent** — pick UTC-everywhere for storage and aggregation, render user-local at the edge.
+5. **Pagination missing on every list endpoint** — add a single `PaginationParams` dep and fix them all in one PR.
+6. **Observability is thin** — no correlation IDs, most endpoints don't log, LLM stream errors are swallowed. This blocks diagnostic work on everything else.
+7. **Idempotency is ad hoc** — goal completions, prompt responses, practice sessions all have their own race/duplicate stories. A `(user, resource, day)` uniqueness pattern and `Idempotency-Key` header support covers most of them.
+
+## Recommended next steps
+
+1. **Ship fixes for the 5 top suspects above** on a dedicated PR so you can sign up and log in.
+2. **Triage this index into GitHub issues** — one issue per report, with the bug IDs as task-list checkboxes. That makes it easy to run `/continue-epic`.
+3. **Pick two reports per sprint**, starting with infra (06/07) so the fixes for feature reports land on stable ground.
+4. **Add regression tests alongside every fix.** No bug gets fixed without a test that fails before the fix.
+
+## Maintenance note
+
+These reports are point-in-time (2026-04-14). If a bug is fixed, strike it through or delete it from the file and note the fixing commit. When adding new findings, append them with a fresh ID rather than renumbering.

--- a/prompts/2026-04-14-bug-remediation/01-auth-and-signup-bugs.md
+++ b/prompts/2026-04-14-bug-remediation/01-auth-and-signup-bugs.md
@@ -1,0 +1,174 @@
+# Authentication & Signup — Bug Remediation Report
+
+**Component:** Signup, Login, Token refresh, Account lockout, JWT handling
+**Date:** 2026-04-14
+**Auditor:** Claude Code (self-review)
+**Branch:** `claude/code-review-bug-analysis-BvOHp`
+
+## Executive Summary
+
+This is the component that is currently blocking you from even reaching the app. The audit found **14 bugs**, and the most likely suspects for the five you hit on the way in are:
+
+1. **Email case sensitivity** — signing up with `Alice@Example.com` then attempting to log in with `alice@example.com` fails with `invalid_credentials`.
+2. **Whitespace not stripped from email** — a trailing space from a paste/auto-fill produces 422 and a generic error toast.
+3. **No client-side email validation** — a malformed address sends a raw 422 to the user without a useful message.
+4. **`user_id` optional in frontend type but required in backend schema** — any code path assuming it exists can break the post-login navigation.
+5. **Unawaited `saveToken` in the 401/refresh callback** — the first login can succeed, state updates, but the token isn't actually persisted by the time you close the app — next launch dumps you back at the login screen.
+
+Plus: account-lockout attempts aren't recorded, silent refresh failures are swallowed, `X-Forwarded-For` is trusted blindly, and there are multiple accessibility / empty-field gaps.
+
+---
+
+## Table of Contents
+
+| # | Severity | Title |
+|---|---|---|
+| BUG-AUTH-001 | Critical | Token save not awaited in 401 refresh callback |
+| BUG-AUTH-002 | Critical | `AuthResponse.user_id` optional in TS, required in backend |
+| BUG-AUTH-003 | High | Email lookups are case-sensitive |
+| BUG-AUTH-005 | High | `clearToken` not awaited in `onUnauthorized` callback |
+| BUG-AUTH-004 | Medium | No client-side email format validation |
+| BUG-AUTH-006 | Medium | Account-lockout path doesn't record the attempt |
+| BUG-AUTH-007 | Medium | Silent token-refresh failure not logged |
+| BUG-AUTH-009 | Medium | No empty-field check before auth requests |
+| BUG-AUTH-010 | Medium | Whitespace not stripped from email input |
+| BUG-AUTH-008 | Low | Missing a11y labels / testIDs on auth inputs |
+| BUG-AUTH-011 | Low | Proactive-refresh timer continues after signature rotation |
+| BUG-AUTH-012 | Low | `X-Forwarded-For` trusted without proxy allow-list |
+| BUG-AUTH-013 | Low | No password-strength feedback |
+| BUG-AUTH-014 | Low | Login error persists across navigation |
+
+---
+
+### BUG-AUTH-001: Token save not awaited in 401 refresh callback
+**Severity:** Critical
+**Component:** `frontend/src/context/AuthContext.tsx:75`, `frontend/src/api/index.ts:135`
+**Symptom:** After a mid-session token refresh, `saveToken` is fire-and-forget. If the app is closed or crashes before the async write completes, the new token never reaches secure storage and the user is logged out on next launch.
+**Root cause:**
+```ts
+// AuthContext.tsx:75
+setOnTokenRefreshed((t: string) => { saveToken(t); setToken(t); });
+// api/index.ts:135
+onTokenRefreshedCallback?.(data.token);
+```
+Callback signature is sync; callers don't await.
+**Fix:** Make the callback async-aware — wrap `saveToken` + `setToken` in one async function, await it on the call site, and add a `.catch` that logs and triggers logout.
+
+---
+
+### BUG-AUTH-002: `AuthResponse.user_id` optional in TS, required on the server
+**Severity:** Critical
+**Component:** `frontend/src/api/index.ts:907-909` vs `backend/src/routers/auth.py:56-58`
+**Symptom:** TS declares `user_id?: number` while the backend guarantees it. Every downstream consumer either loses type safety or has to check for undefined that can't actually occur.
+**Fix:** Remove the `?`. Regenerate/realign types from a single source (OpenAPI schema or shared package).
+
+---
+
+### BUG-AUTH-003: Email lookups are case-sensitive
+**Severity:** High
+**Component:** `backend/src/routers/auth.py:168, 215`; `backend/src/models/user.py`
+**Symptom:** Sign up as `Alice@Example.com`, log in as `alice@example.com` → 401.
+**Fix:**
+- Normalize at input: `email = payload.email.strip().lower()` in both signup and login.
+- Store the normalized form.
+- Add a migration for a unique index on `lower(email)` to prevent duplicates slipping through.
+- Also normalize in `_is_account_locked` and `_record_attempt`.
+
+---
+
+### BUG-AUTH-005: `clearToken` not awaited in `onUnauthorized`
+**Severity:** High
+**Component:** `frontend/src/context/AuthContext.tsx:71, 137`
+**Symptom:** `setToken(null)` runs immediately while the storage delete is in-flight. An app crash in that window leaves a stale token in secure storage, which is rehydrated on next launch.
+**Fix:** `await clearToken()` before `setToken(null)`, or chain as a promise with a logged-out sentinel in storage as a defensive marker.
+
+---
+
+### BUG-AUTH-004: No client-side email format validation
+**Severity:** Medium
+**Component:** `frontend/src/features/Auth/SignupScreen.tsx:89-111`, `LoginScreen.tsx:21-34`
+**Symptom:** `"notanemail"` sends a 422 that the user sees as a generic "That didn't go through."
+**Fix:** Add `isValidEmail` regex (RFC-simple) and gate submission. Show "Please enter a valid email address."
+
+---
+
+### BUG-AUTH-006: Lockout path doesn't record the attempt
+**Severity:** Medium
+**Component:** `backend/src/routers/auth.py:202-213`
+**Symptom:** While an account is locked, subsequent attempts log to the application logger but aren't inserted into `LoginAttempt`. Forensic trail is incomplete.
+**Fix:** Call `await _record_attempt(..., success=False)` before raising the 401.
+
+---
+
+### BUG-AUTH-007: Silent token-refresh failure not logged
+**Severity:** Medium
+**Component:** `frontend/src/context/AuthContext.tsx:25-32`
+**Symptom:** `silentRefresh` swallows errors with an empty arrow. Users have no signal; operators can't debug.
+**Fix:** `console.warn` + report to analytics. On `ApiError` 401, immediately trigger `onUnauthorized` rather than waiting for the next 401.
+
+---
+
+### BUG-AUTH-009: No empty-field check before auth requests
+**Severity:** Medium
+**Component:** `SignupScreen.tsx`, `LoginScreen.tsx`
+**Symptom:** Submit with blank email / blank password → backend 422 → generic UI error.
+**Fix:** Field-level validation with specific messages ("Email is required", "Password is required") before calling the API.
+
+---
+
+### BUG-AUTH-010: Whitespace not stripped from email input
+**Severity:** Medium
+**Component:** `SignupScreen.tsx:103`, `LoginScreen.tsx:25`, `backend/src/routers/auth.py`
+**Symptom:** A leading or trailing space from paste/autofill → 422.
+**Fix:** `email.trim()` on the client; `.strip().lower()` on the server. Tighten `EmailStr` with Pydantic validator if desired.
+
+---
+
+### BUG-AUTH-008: Missing a11y labels / testIDs on auth inputs
+**Severity:** Low
+**Component:** `SignupScreen.tsx:34-55`, `LoginScreen.tsx:39-52`
+**Symptom:** Screen readers announce "text input"; Detox/E2E has no stable hooks.
+**Fix:** Add `accessibilityLabel`, `accessibilityHint`, and `testID` (`signup-email-input`, etc.).
+
+---
+
+### BUG-AUTH-011: Proactive-refresh timer after signature rotation
+**Severity:** Low
+**Component:** `frontend/src/context/AuthContext.tsx:40-61`
+**Symptom:** If `SECRET_KEY` rotates, the scheduled refresh fires with a now-invalid token; refresh fails silently (see AUTH-007).
+**Fix:** On refresh failure with 401, dispatch the unauthorized callback immediately instead of waiting for the next request.
+
+---
+
+### BUG-AUTH-012: `X-Forwarded-For` trusted without proxy allow-list
+**Severity:** Low
+**Component:** `backend/src/routers/auth.py:97-106`
+**Symptom:** If the service is ever exposed without a TLS-terminating proxy, an attacker can spoof the client IP and either bypass rate limits or frame a victim for lockout.
+**Fix:** Only honor `X-Forwarded-For` when `request.client.host` is in a `TRUSTED_PROXIES` list from env. Document the deployment contract in `DEPLOYMENT.md`.
+
+---
+
+### BUG-AUTH-013: No password-strength feedback
+**Severity:** Low
+**Component:** `SignupScreen.tsx`
+**Symptom:** `password123` is accepted silently.
+**Fix:** Add a small strength meter (length + classes of chars) in the UI. Consider enforcing a minimum entropy on the server; don't rely solely on the frontend.
+
+---
+
+### BUG-AUTH-014: Login error persists across navigation
+**Severity:** Low
+**Component:** `LoginScreen.tsx:18` and lifecycle
+**Symptom:** Error banner from a previous attempt remains visible after navigating away and back.
+**Fix:** `useFocusEffect(() => setError(null), [])`.
+
+---
+
+## Suggested remediation order
+
+1. **001 + 005** (async token lifecycle) — land together with tests that kill the app between `setToken` and `saveToken`.
+2. **003 + 010** (email normalization) — migration + backend + frontend trim.
+3. **002** (schema contract) — regenerate types, fix call sites.
+4. **004 + 009 + 014** (UX cleanup on auth screens).
+5. **006 + 007 + 012** (observability + abuse hardening).
+6. **008, 011, 013**.

--- a/prompts/2026-04-14-bug-remediation/02-habits-bugs.md
+++ b/prompts/2026-04-14-bug-remediation/02-habits-bugs.md
@@ -1,0 +1,208 @@
+# Habits — Bug Remediation Report
+
+**Component:** Habits, Goals (per-habit), Check-ins, Streaks, Milestones, Energy
+**Date:** 2026-04-14
+**Auditor:** Claude Code (self-review)
+**Branch:** `claude/code-review-bug-analysis-BvOHp`
+
+## Executive Summary
+
+The Habits surface is the daily-driver of the program and shows the most tech debt. There are **20 bugs** covering timezone correctness, concurrency, cascade integrity, and optimistic-UI recovery. The ones that corrupt data on the happy path:
+
+- **`Habit.streak` is never recomputed on `GET /habits`** — it's returned as 0 regardless of completions. UI shows stale or zero streaks on every app open.
+- **Backend streak counts rows, not unique days** — two check-ins in the same day bump the streak by 2.
+- **No `(goal_id, user_id, date)` uniqueness** — a retry after a server timeout double-records.
+- **Day-of-week aggregation uses local time on the client and UTC on the server** — bars land on the wrong day around midnight.
+- **Delete-habit doesn't cascade to goals/completions** — orphans linger and can bleed into new habits.
+- **Check-in is not serialized** — two taps race and both report streak=N instead of N+1.
+
+---
+
+## Table of Contents
+
+| # | Severity | Title |
+|---|---|---|
+| BUG-HABITS-001 | High | Day-of-week index mismatch between backend UTC and frontend local |
+| BUG-HABITS-002 | High | Missing compound index on `goal_completion(goal_id, user_id, timestamp)` |
+| BUG-HABITS-003 | High | Concurrent check-ins race on streak computation |
+| BUG-HABITS-004 | High | Habit delete doesn't cascade — orphan goals/completions |
+| BUG-HABITS-016 | High | Subtractive goal tier resolution semantics unclear |
+| BUG-HABITS-017 | High | `GET /habits` returns stale `streak` (never recomputed) |
+| BUG-HABITS-005 | Medium | Frontend `new Date(raw.start_date)` parses ISO as local |
+| BUG-HABITS-006 | Medium | Off-by-one in completion-date collection |
+| BUG-HABITS-007 | Medium | Failed check-in rolls back with no retry queue |
+| BUG-HABITS-008 | Medium | Milestone toast can double-fire on retry |
+| BUG-HABITS-009 | Medium | Completion-rate precision loss from `Math.round` |
+| BUG-HABITS-010 | Medium | `energy_cost` / `energy_return` accept negative values |
+| BUG-HABITS-011 | Medium | Streak counts rows, not unique days |
+| BUG-HABITS-013 | Medium | `persistHabits` is fire-and-forget; crash loses the check-in |
+| BUG-HABITS-015 | Medium | No unique constraint per (goal, user, day) |
+| BUG-HABITS-020 | Medium | `CheckInResult` lacks updated habit/goals |
+| BUG-HABITS-012 | Low | Goal target change doesn't renormalize progress |
+| BUG-HABITS-014 | Low | "Unlock early" is client-only — no server authorization |
+| BUG-HABITS-018 | Low | Energy plan includes dates before `habit.start_date` |
+| BUG-HABITS-019 | Low | `per_month` normalization uses hardcoded 30 days |
+
+---
+
+### BUG-HABITS-001: Day-of-week mismatch (UTC vs local)
+**Severity:** High
+**Component:** `backend/src/domain/habit_stats.py:38`, `frontend/src/features/Habits/HabitUtils.ts:316`
+**Symptom:** Stats bars shift by one day around midnight for users in non-UTC timezones.
+**Fix:** Pick one reference — UTC is cleanest for storage; the display can render "user-local" if the client normalizes via `.toISOString()` consistently. Covered with a parameterized test across ±14h TZ offsets.
+
+---
+
+### BUG-HABITS-002: Missing compound index
+**Severity:** High
+**Component:** `backend/src/models/goal_completion.py:11-25`
+**Symptom:** Streak computation is an ORDER-BY-without-index scan; latency grows linearly with completion count.
+**Fix:** `Index("ix_goal_completion_goal_user_timestamp", "goal_id", "user_id", "timestamp")`. Add migration.
+
+---
+
+### BUG-HABITS-003: Concurrent check-ins race
+**Severity:** High
+**Component:** `backend/src/routers/goal_completions.py:47-72`, `backend/src/services/streaks.py`
+**Symptom:** Two quick taps both compute streak from the same pre-insert state and return the same value; second response shows unchanged streak.
+**Fix:** Use `.with_for_update()` on the lookup or enforce at DB level with the unique-per-day constraint (BUG-HABITS-015). Re-read the streak after commit.
+
+---
+
+### BUG-HABITS-004: Delete cascade missing
+**Severity:** High
+**Component:** `backend/src/models/goal.py:29-30`, `backend/src/models/habit.py`, `backend/src/routers/habits.py:89-101`
+**Symptom:** Deleting a habit leaves its goals and completions in place.
+**Fix:** Declare `ondelete="CASCADE"` on `Goal.habit_id` (and transitively on `GoalCompletion.goal_id`). Add explicit deletes in the handler until the migration lands. Consider a soft-delete column if restoration is desired.
+
+---
+
+### BUG-HABITS-016: Subtractive goal tier resolution semantics
+**Severity:** High
+**Component:** `frontend/src/features/Habits/HabitUtils.ts:165-185, 245-255`
+**Symptom:** Tightly coupled to BUG-GOAL-002 in the Goals report. The comparisons are numerically right but the naming assumes additive semantics; downstream UI can mis-render.
+**Fix:** Align with the fix for BUG-GOAL-002 in `05-course-stages-goals-bugs.md`. Rename locals to `isUnderLimit`, `severity`, etc., and add a snapshot test.
+
+---
+
+### BUG-HABITS-017: `GET /habits` returns stale `streak`
+**Severity:** High
+**Component:** `backend/src/routers/habits.py:37-50`; `frontend/src/features/Habits/services/habitManager.ts:75-93`
+**Symptom:** UI shows streak 0 after restart even when the user has logged for weeks.
+**Fix:** Compute streak per habit server-side on `GET /habits` (eager-loaded) — or split: `/habits` is static, `/habits/stats` has computed values, and the client merges. The current `streak: 0` hardcoded on the client side is the actual source of the stale value; that's a one-line frontend fix once the backend exposes a truth.
+
+---
+
+### BUG-HABITS-005: Frontend parses ISO strings as local
+**Severity:** Medium
+**Component:** `frontend/src/storage/habitStorage.ts:14-19`, `HabitUtils.ts:319`
+**Symptom:** `toDateString()` / `getDay()` operate in local TZ.
+**Fix:** Compute the bucket with `toISOString().slice(0,10)` (UTC) everywhere, or a shared helper `dayKey(date)` used by both aggregation and comparisons.
+
+---
+
+### BUG-HABITS-006: Off-by-one in completion-date collection
+**Severity:** Medium
+**Component:** `frontend/src/features/Habits/HabitUtils.ts:364-365`
+**Symptom:** `?? ''` fallback inserts empty strings that skew downstream stats.
+**Fix:** Filter `isNaN(d.getTime())` first; drop the `?? ''`.
+
+---
+
+### BUG-HABITS-007: Optimistic check-in failure has no retry queue
+**Severity:** Medium
+**Component:** `frontend/src/features/Habits/services/habitManager.ts:393-420`
+**Symptom:** Airplane-mode tap → optimistic update → server call fails → revert → user's intent is lost.
+**Fix:** Store pending check-ins in AsyncStorage, replay on reconnect. Surface a "pending" badge.
+
+---
+
+### BUG-HABITS-008: Milestone toast can double-fire
+**Severity:** Medium
+**Component:** `backend/src/routers/goal_completions.py:70`, `frontend/.../habitManager.ts:238-245`
+**Symptom:** A retried success returns the same milestone list; client fires the toast twice.
+**Fix:** Backend returns only *newly crossed* thresholds (`old_streak < t <= new_streak`). Client keeps a `shownMilestones` set keyed by habit id.
+
+---
+
+### BUG-HABITS-009: Completion-rate precision
+**Severity:** Medium
+**Component:** `frontend/src/features/Habits/HabitUtils.ts:342-348`
+**Symptom:** Rare rate > 100% or rounding glitches when timestamps straddle DST.
+**Fix:** Use `Math.floor` on UTC-midnight-normalized day diffs.
+
+---
+
+### BUG-HABITS-010: Energy accepts negatives
+**Severity:** Medium
+**Component:** `backend/src/schemas/habit.py:58-59`
+**Fix:** `Field(ge=0, le=1000)` on `energy_cost` and `energy_return`.
+
+---
+
+### BUG-HABITS-011: Streak counts rows, not days
+**Severity:** Medium
+**Component:** `backend/src/services/streaks.py:28-51`
+**Fix:** Query `DISTINCT DATE(timestamp)` descending; collapse to day-level streak. Same once BUG-HABITS-015 (unique per day) lands.
+
+---
+
+### BUG-HABITS-013: Fire-and-forget persist
+**Severity:** Medium
+**Component:** `frontend/.../habitManager.ts:402`, `storage/habitStorage.ts:22-24`
+**Fix:** `await persistHabits(...)` before returning the updated habit. If the caller can't await (event handlers), wrap in a queue that drains on app state changes.
+
+---
+
+### BUG-HABITS-015: No uniqueness per day
+**Severity:** Medium
+**Component:** `backend/src/models/goal_completion.py`
+**Fix:** Migration adding `UNIQUE(goal_id, user_id, DATE(timestamp))`; handle the `IntegrityError` as "already logged today".
+
+---
+
+### BUG-HABITS-020: `CheckInResult` missing updated habit
+**Severity:** Medium
+**Component:** `backend/src/schemas/checkin.py:12-20`, `backend/src/routers/goal_completions.py`
+**Symptom:** Client has to re-fetch `/habits` to see new tier/milestone state.
+**Fix:** Embed the updated `HabitWithGoals` in the response.
+
+---
+
+### BUG-HABITS-012: Target change doesn't renormalize
+**Severity:** Low
+**Component:** `frontend/.../habitManager.ts:95-102`
+**Fix:** Either document that increasing target preserves absolute units (and the progress bar regresses proportionally), or offer the user a choice on edit.
+
+---
+
+### BUG-HABITS-014: Client-only "unlock early"
+**Severity:** Low
+**Component:** `frontend/.../habitManager.ts:457-461`
+**Fix:** Move to `POST /habits/{id}/unlock` with server-side eligibility check (stage progress, prior habits, etc.).
+
+---
+
+### BUG-HABITS-018: Energy plan includes dates before start
+**Severity:** Low
+**Component:** `backend/src/domain/energy.py:45-62`
+**Fix:** Skip offsets where `habit.start_date > current_date`.
+
+---
+
+### BUG-HABITS-019: `per_month` hardcodes 30 days
+**Severity:** Low
+**Component:** `frontend/.../HabitUtils.ts:120-132`
+**Fix:** Use 30.437 (365.25/12) or compute dynamically per calendar month.
+
+---
+
+## Suggested remediation order
+
+1. **017** (stale streak) + **002** (index) + **011** (streak from days) — land the backend compute together; write a regression test per bug.
+2. **015** (unique per day) + **003** (race) — these are the same fix fundamentally; once (goal, user, day) is unique, the race is resolved at the DB layer.
+3. **004** (cascade) — migration with explicit deletes.
+4. **001, 005, 006** (timezone/date correctness) — all small, all testable.
+5. **007, 013** (offline resilience) — coordinated client change.
+6. **008, 010, 020** (API polish).
+7. Remaining LOWs.

--- a/prompts/2026-04-14-bug-remediation/03-practice-sessions-bugs.md
+++ b/prompts/2026-04-14-bug-remediation/03-practice-sessions-bugs.md
@@ -1,0 +1,232 @@
+# Practice Sessions — Bug Remediation Report
+
+**Component:** Practices, Practice Sessions, Practice Timer UI
+**Date:** 2026-04-14
+**Auditor:** Claude Code (self-review)
+**Branch:** `claude/code-review-bug-analysis-BvOHp`
+
+## Executive Summary
+
+The Practices feature contains 17 distinct bugs spanning timer drift / state management, session persistence, practice unlock bypass, missing validation, authorization gaps, schema mismatches, and UX issues. The highest-impact issues are:
+
+1. **Timer always logs full `durationMinutes`** instead of actual elapsed time, so every cancel/pause is silently recorded as a completed session.
+2. **Unapproved practices are retrievable** via `GET /practices/{id}`, bypassing the approval gate that `list_practices` enforces.
+3. **No stage-unlock check** when selecting a practice — users can pick practices from locked stages.
+4. **No min-value validation** on duration fields — negative and zero durations are accepted.
+5. **Users can hold multiple active practices for the same stage** because there's no uniqueness constraint on `(user_id, stage_number)`.
+
+These are not cosmetic — they corrupt the core data the program depends on (elapsed-time metrics, progression state) and invite inconsistent UX.
+
+---
+
+## Table of Contents
+
+| # | Severity | Title |
+|---|---|---|
+| BUG-PRACTICE-001 | Critical | Timer logs intended duration, not elapsed time |
+| BUG-PRACTICE-002 | Critical | Unapproved practices retrievable via GET `/practices/{id}` |
+| BUG-PRACTICE-003 | High | No min-value validation on duration fields |
+| BUG-PRACTICE-004 | High | `create_user_practice` skips stage-unlock check |
+| BUG-PRACTICE-005 | High | `stage_number` has no bounds validation |
+| BUG-PRACTICE-006 | High | Future timestamps silently accepted for sessions |
+| BUG-PRACTICE-007 | Medium | Pause/resume state not persisted across backgrounding |
+| BUG-PRACTICE-008 | Medium | Timer not cancelled when user navigates away |
+| BUG-PRACTICE-009 | Medium | `list_sessions` returns arbitrary order (no `order_by`) |
+| BUG-PRACTICE-010 | Medium | No loading state on "Start Practice" → duplicate UserPractice rows |
+| BUG-PRACTICE-011 | Medium | No uniqueness constraint on `(user_id, stage_number)` |
+| BUG-PRACTICE-012 | Medium | No runtime schema validation of practice API responses |
+| BUG-PRACTICE-013 | Medium | Locked-stage selector shows "empty" instead of "locked" |
+| BUG-PRACTICE-014 | Low | Audio playback failures silently swallowed |
+| BUG-PRACTICE-015 | Low | `default_duration_minutes` is `int` in model, `float` in sessions |
+| BUG-PRACTICE-016 | Low | Uses `== True` instead of `.is_(True)` |
+| BUG-PRACTICE-017 | Low | Missing accessibility labels on timer buttons |
+
+---
+
+### BUG-PRACTICE-001: Timer logs intended duration, not elapsed time
+**Severity:** Critical
+**Component:** `frontend/src/features/Practice/PracticeTimer.tsx:147`
+**Symptom:** Every session logs the full `durationMinutes`, regardless of how long the user actually practiced. Cancel at 30s of a 10min session → server records a 10-minute session.
+**Reproduction:**
+1. Start a 10-minute practice.
+2. Pause after 30 seconds, tap cancel.
+3. Inspect `/practice-sessions/` — row shows 10 minutes.
+**Root cause:** `onComplete` is handed the intended duration instead of the actual elapsed time:
+```tsx
+// PracticeTimer.tsx:147
+onComplete(durationMinutes);
+```
+**Fix:**
+```tsx
+const elapsedMinutes = (totalSeconds - remaining) / 60;
+onComplete(elapsedMinutes);
+```
+Also ensure the backend schema accepts fractional minutes (see BUG-PRACTICE-015).
+
+---
+
+### BUG-PRACTICE-002: Unapproved practices leak via GET `/practices/{id}`
+**Severity:** Critical
+**Component:** `backend/src/routers/practices.py:35-46`
+**Symptom:** Any authenticated user can fetch a practice pending approval — full instructions, metadata — by guessing or iterating IDs.
+**Reproduction:**
+1. Seed a practice with `approved=False`.
+2. `GET /practices/{id}` → returns 200 with full body.
+**Root cause:** `get_practice` filters by ID only; the approval predicate in `list_practices` is not applied:
+```python
+# routers/practices.py:42-45
+practice = result.scalars().first()
+if practice is None:
+    raise not_found("practice")
+return practice
+```
+**Fix:**
+```python
+if practice is None or not practice.approved:
+    raise not_found("practice")
+```
+Add an admin override if moderators must preview unapproved practices.
+
+---
+
+### BUG-PRACTICE-003: No minimum-value validation on duration
+**Severity:** High
+**Component:** `backend/src/schemas/practice.py:37`, `backend/src/schemas/practice.py:92`
+**Symptom:** API accepts `default_duration_minutes: -5` and session rows with `duration_minutes: 0` or negative.
+**Reproduction:** `POST /practices/` with `{"default_duration_minutes": -10}` → 201.
+**Root cause:**
+```python
+default_duration_minutes: int  # no constraint
+duration_minutes: float        # no constraint
+```
+**Fix:** `Field(gt=0)` on both (and `le=24*60` as a sanity upper bound).
+
+---
+
+### BUG-PRACTICE-004: User-practice creation skips stage-unlock check
+**Severity:** High
+**Component:** `backend/src/routers/user_practices.py:34-46`
+**Symptom:** A user on stage 1 can select a stage-3 practice by passing `stage_number: 3`. The endpoint only validates the practice's existence and approval.
+**Reproduction:** `POST /user-practices/ {practice_id: X, stage_number: 3}` for a user whose `StageProgress` shows stage 3 locked → 201.
+**Root cause:** No call to `is_stage_unlocked` before insert.
+**Fix:**
+```python
+user_progress = await get_user_progress(session, current_user)
+if not is_stage_unlocked(payload.stage_number, user_progress):
+    raise bad_request("stage_not_unlocked")
+```
+
+---
+
+### BUG-PRACTICE-005: `stage_number` unbounded
+**Severity:** High
+**Component:** `backend/src/schemas/practice.py:21, 25, 33, 37`
+**Symptom:** `stage_number=0` or negative values accepted everywhere stage_number is a field.
+**Fix:** `stage_number: int = Field(ge=1, le=36)` (36 = program length).
+
+---
+
+### BUG-PRACTICE-006: Future timestamps silently accepted
+**Severity:** High
+**Component:** `backend/src/models/practice_session.py:18-21`
+**Symptom:** Model uses `default_factory=datetime.now(UTC)` but has no validator preventing future timestamps if the field becomes user-supplied (and currently nothing in the schema forbids it being sent by a crafted client).
+**Fix:** Pydantic validator rejecting `v > datetime.now(UTC) + small_skew`.
+
+---
+
+### BUG-PRACTICE-007: Pause/resume state lost on app background
+**Severity:** Medium
+**Component:** `frontend/src/features/Practice/PracticeTimer.tsx:44-70`
+**Symptom:** iOS/Android suspend the RN thread when backgrounded; a paused timer's `remaining` is reset, and when the user foregrounds and completes, elapsed time is wrong. No AsyncStorage checkpointing.
+**Fix:** Persist `{started_at, paused_at, total_pause_ms}` to AsyncStorage on `AppState` change, reconcile on focus.
+
+---
+
+### BUG-PRACTICE-008: Timer not cancelled on navigate-away
+**Severity:** Medium
+**Component:** `frontend/src/features/Practice/PracticeScreen.tsx:414-422`
+**Symptom:** User navigates away mid-session → timer keeps running in memory, no session is recorded, and returning shows a stale timer state.
+**Fix:** `useFocusEffect` returning a cleanup that either saves or explicitly discards the active session.
+
+---
+
+### BUG-PRACTICE-009: `list_sessions` returns arbitrary order
+**Severity:** Medium
+**Component:** `backend/src/routers/practice_sessions.py:49-62`
+**Symptom:** Sessions come back in whatever order Postgres picks.
+**Fix:** Append `.order_by(col(PracticeSession.timestamp).desc())` and add pagination (`limit`/`offset`).
+
+---
+
+### BUG-PRACTICE-010: No loading state on "Start Practice"
+**Severity:** Medium
+**Component:** `frontend/src/features/Practice/PracticeScreen.tsx:166-173`
+**Symptom:** Slow network → user double-taps → duplicate `UserPractice` rows (see BUG-PRACTICE-011).
+**Fix:** Local `isSubmitting` flag, disable the button, show a spinner.
+
+---
+
+### BUG-PRACTICE-011: No uniqueness on `(user_id, stage_number)`
+**Severity:** Medium
+**Component:** `backend/src/models/user_practice.py`, `backend/src/routers/user_practices.py:27-51`
+**Symptom:** Two active practices can exist for the same stage, confusing every downstream aggregation.
+**Fix:** Partial unique index `(user_id, stage_number) WHERE end_date IS NULL` + pre-insert check returning 409.
+
+---
+
+### BUG-PRACTICE-012: No runtime validation of practice API responses
+**Severity:** Medium
+**Component:** `frontend/src/api/index.ts:871-872`
+**Symptom:** TS interfaces are compile-time only; a backend schema drift passes through and crashes deep in UI code.
+**Fix:** Zod schema + `.parse` at the API boundary.
+
+---
+
+### BUG-PRACTICE-013: Locked-stage selector shows "No practices available"
+**Severity:** Medium
+**Component:** `frontend/src/features/Practice/PracticeSelector.tsx:62-68`
+**Symptom:** Users can't tell whether a stage has no practices or is simply locked.
+**Fix:** Accept `isLocked` prop and render a distinct empty state.
+
+---
+
+### BUG-PRACTICE-014: Audio playback failures silently swallowed
+**Severity:** Low
+**Component:** `frontend/src/features/Practice/PracticeTimer.tsx:20-30`
+**Symptom:** Missing asset / permission denied → no bell, no indication. Users assume timer didn't start.
+**Fix:** `console.warn` + haptic fallback.
+
+---
+
+### BUG-PRACTICE-015: `int` vs `float` duration mismatch
+**Severity:** Low
+**Component:** `backend/src/models/practice.py:12` vs `backend/src/models/practice_session.py:17`
+**Symptom:** Practice template duration is `int` minutes but logged sessions are `float`. Arithmetic comparisons and reports cast inconsistently.
+**Fix:** Choose one (probably `float` to allow 7.5-min practices) and migrate.
+
+---
+
+### BUG-PRACTICE-016: `== True` instead of `.is_(True)`
+**Severity:** Low
+**Component:** `backend/src/routers/practices.py:28-29`
+**Symptom:** Linter-silenced stylistic issue; slightly worse query plans on nullable booleans.
+**Fix:** `Practice.approved.is_(True)`.
+
+---
+
+### BUG-PRACTICE-017: Missing accessibility labels on timer buttons
+**Severity:** Low
+**Component:** `frontend/src/features/Practice/PracticeScreen.tsx:452-467`
+**Symptom:** Screen reader users hear "Button" repeatedly.
+**Fix:** `accessibilityLabel`/`accessibilityRole="button"` on Pause/Resume/Cancel/Complete.
+
+---
+
+## Suggested remediation order
+
+1. 001, 002 (data-integrity / security) — same PR.
+2. 003, 004, 005 (validation hardening) — same PR; add regression tests.
+3. 011 + 010 (uniqueness + loading state) — must ship together or the uniqueness check surfaces as a UX bug.
+4. 009 (sort+paginate) — cheap and improves every list screen.
+5. 007 + 008 (timer lifecycle) — write a small state machine, cover with tests.
+6. Remaining (012–017).

--- a/prompts/2026-04-14-bug-remediation/04-journal-botmason-bugs.md
+++ b/prompts/2026-04-14-bug-remediation/04-journal-botmason-bugs.md
@@ -1,0 +1,208 @@
+# Journal & BotMason (AI Companion) — Bug Remediation Report
+
+**Component:** Journal entries, BotMason chat, weekly prompts, LLM integration
+**Date:** 2026-04-14
+**Auditor:** Claude Code (self-review)
+**Branch:** `claude/code-review-bug-analysis-BvOHp`
+
+## Executive Summary
+
+The Journal + BotMason surface has **18 bugs** ranging from privacy/security leaks to LLM-integration reliability issues. Several are critical and reachable without privileged access:
+
+- **Cross-user journal injection.** `POST /journal/bot-response` accepts a `user_id` from the request body without validating it against the authenticated user. Any logged-in attacker can write bot messages into someone else's journal.
+- **`user_id` leaks in `JournalMessageResponse`.** Surrogate keys are exposed to the client, aiding enumeration.
+- **TOCTOU race on weekly prompt responses** — duplicate submissions can slip through the SELECT-then-INSERT gap.
+- **Hardcoded `max_tokens=1024`** with a 20-message history limit produces truncated responses in longer conversations.
+- **No request timeout / retry / backoff** on provider calls — a single blip burns the user's monthly quota.
+- **Orphaned user messages.** The user message is `flush()`ed before the LLM is invoked; on provider failure the rollback doesn't undo the flush in all configurations.
+
+---
+
+## Table of Contents
+
+| # | Severity | Title |
+|---|---|---|
+| BUG-JOURNAL-001 | Critical | Hardcoded `max_tokens=1024` regardless of conversation depth |
+| BUG-JOURNAL-002 | Critical | `/journal/bot-response` accepts arbitrary `user_id` (cross-user injection) |
+| BUG-JOURNAL-003 | Critical | TOCTOU race on `PromptResponse` duplicate check |
+| BUG-JOURNAL-004 | Critical | `user_id` leaks in `JournalMessageResponse` |
+| BUG-JOURNAL-005 | High | No timeout on LLM provider calls |
+| BUG-JOURNAL-006 | High | No retry / exponential backoff on transient provider failures |
+| BUG-JOURNAL-007 | High | Conversation history limit of 20 too low for the app's use case |
+| BUG-JOURNAL-008 | High | No per-user rate limit on chat (only global) |
+| BUG-JOURNAL-009 | High | Stream error path swallows exception context |
+| BUG-JOURNAL-010 | High | `X-LLM-API-Key` not in CORS allow-list |
+| BUG-JOURNAL-011 | Medium | Default Anthropic model ID hardcoded and may drift from current catalog |
+| BUG-JOURNAL-012 | Medium | No encryption at rest for journal entries |
+| BUG-JOURNAL-013 | Medium | LIKE search doesn't escape `%` / `_` |
+| BUG-JOURNAL-014 | Medium | Weekly prompt week derived from elapsed time, not completion |
+| BUG-JOURNAL-015 | Medium | User message flushed before LLM call → orphans on failure |
+| BUG-JOURNAL-016 | Medium | Streaming placeholder removed on abort, user message stays orphaned |
+| BUG-JOURNAL-017 | Medium | No prompt-injection guard on user input |
+| BUG-JOURNAL-018 | Low | Monthly-usage reset has a narrow concurrency window |
+
+---
+
+### BUG-JOURNAL-001: Hardcoded `max_tokens=1024`
+**Severity:** Critical
+**Component:** `backend/src/services/botmason.py:374` (non-streaming), `:569` (streaming)
+**Symptom:** Both the OpenAI and Anthropic calls fix `max_tokens=1024`. With a 20-message history plus a long user message, the model runs out of output budget and truncates mid-sentence.
+**Fix:** Scale dynamically. Target at least `max_tokens = clamp(1024, 4096, model_max - prompt_tokens - safety_margin)`. Budget using a tokenizer, not a string-length heuristic.
+
+---
+
+### BUG-JOURNAL-002: Cross-user journal injection via `bot-response`
+**Severity:** Critical
+**Component:** `backend/src/routers/journal.py:120-135`; schema `backend/src/schemas/journal.py:27-34`
+**Symptom:** The handler takes `user_id` directly from the payload; the authenticated user is bound to `_current_user` and ignored. Any logged-in user can write arbitrary bot messages into arbitrary journals.
+**Fix:** Remove `user_id` from `JournalBotMessageCreate`; source it from `Depends(get_current_user)` only. Or, better, make `POST /journal/bot-response` an internal-only endpoint protected by a service token — since bot messages flow through the chat endpoint anyway, this route might not need to exist at all.
+
+---
+
+### BUG-JOURNAL-003: Duplicate-response race on weekly prompts
+**Severity:** Critical
+**Component:** `backend/src/routers/prompts.py:169-177`
+**Symptom:** Double-submit between SELECT and INSERT can produce two `PromptResponse` rows for the same `(user_id, week_number)`.
+**Fix:**
+1. Add DB unique constraint `(user_id, week_number)` (migration).
+2. Handle `IntegrityError` in the handler and return 409 "already_responded".
+3. Optionally use `INSERT ... ON CONFLICT DO NOTHING RETURNING ...`.
+
+---
+
+### BUG-JOURNAL-004: `user_id` leaks in response schema
+**Severity:** Critical
+**Component:** `backend/src/schemas/journal.py:37-47`
+**Symptom:** Every journal entry response contains `user_id`. The client already knows its own ID. Exposing it aids enumeration and targeted attacks.
+**Fix:** Remove `user_id` from `JournalMessageResponse` and any other response schemas where it isn't strictly needed.
+
+---
+
+### BUG-JOURNAL-005: No timeout on provider calls
+**Severity:** High
+**Component:** `backend/src/services/botmason.py:336` (OpenAI), `:363` (Anthropic)
+**Symptom:** Default client timeouts are minutes-long; a wedged provider hangs requests and the frontend.
+**Fix:**
+```python
+client = AsyncAnthropic(api_key=key, timeout=30.0)
+client = AsyncOpenAI(api_key=key, http_client=httpx.AsyncClient(timeout=httpx.Timeout(30.0)))
+```
+Return 504 / SSE `error` promptly.
+
+---
+
+### BUG-JOURNAL-006: No retry / backoff
+**Severity:** High
+**Component:** `backend/src/services/botmason.py:217-247`, `:429-449`
+**Symptom:** Single transient 5xx or 429 fails the request permanently and consumes quota.
+**Fix:** Wrap provider calls in a retry helper with exponential backoff (`1s, 2s`, max 2 attempts) for `429 / 5xx / network`. Charge quota only on final success.
+
+---
+
+### BUG-JOURNAL-007: Conversation history limit of 20 is too low
+**Severity:** High
+**Component:** `backend/src/services/botmason.py:29`; consumer `backend/src/services/journal.py:25-40`
+**Symptom:** 20 total messages = ~10 exchanges. Deeper reflections drop out of context; the bot forgets.
+**Fix:** Bump to 50–100, combined with dynamic `max_tokens` (BUG-001). Consider a summarization step for older turns to keep prompts small while preserving memory.
+
+---
+
+### BUG-JOURNAL-008: No per-user rate limit on chat
+**Severity:** High
+**Component:** `backend/src/routers/botmason.py:53, 67`
+**Symptom:** Global limit (`10/minute`) is per-route, not per-user. One user can exhaust the budget for everyone.
+**Fix:** Use SlowAPI `key_func` that returns `str(current_user)` (or IP fallback for anonymous). Add a daily cap layered on top.
+
+---
+
+### BUG-JOURNAL-009: Stream error swallowed
+**Severity:** High
+**Component:** `backend/src/services/chat_stream.py:160-165`
+**Symptom:** `except Exception:` with no logging; ops can't debug production LLM outages.
+**Fix:** `logger.exception("Stream provider error", extra={"user_id": user_id})` before rollback and SSE error emit. Also consider emitting an opaque error code to the client and a correlation ID for support.
+
+---
+
+### BUG-JOURNAL-010: `X-LLM-API-Key` not in CORS allow-list
+**Severity:** High
+**Component:** `backend/src/routers/botmason.py:45`; CORS config in `backend/src/main.py`
+**Symptom:** BYOK header blocked by browsers on preflight; users silently fall back to the server key.
+**Fix:** Add `X-LLM-API-Key` (and any other custom headers) to CORSMiddleware `allow_headers`. Document in `DEPLOYMENT.md`.
+
+---
+
+### BUG-JOURNAL-011: Default Anthropic model string hardcoded
+**Severity:** Medium
+**Component:** `backend/src/services/botmason.py:371`, `backend/src/services/llm_pricing.py:38-39`
+**Symptom:** `claude-sonnet-4-20250514` may drift from Anthropic's current catalog / pricing.
+**Fix:** Centralize `MODEL_DEFAULTS` in a config module. Add a startup warning if `LLM_MODEL` is not in the pricing table. Prefer newer, tested stable snapshots. (Note: the latest 4.x Sonnet snapshot may be fine — the fix is the indirection, not the specific version.)
+
+---
+
+### BUG-JOURNAL-012: No encryption at rest for journal entries
+**Severity:** Medium
+**Component:** `backend/src/models/journal_entry.py`
+**Symptom:** Private reflections stored in plaintext. Database compromise exposes everything.
+**Fix:** Application-layer column encryption (Fernet or `pgp_sym_encrypt`). Rotate keys with a KMS. Document in `DEPLOYMENT.md` and the privacy policy.
+
+---
+
+### BUG-JOURNAL-013: LIKE wildcards not escaped
+**Severity:** Medium
+**Component:** `backend/src/routers/journal.py:56`
+**Symptom:** Searches for literal `%` or `_` produce false positives; no SQL injection (SQLAlchemy parameterizes), but UX is broken.
+**Fix:** Escape `%`, `_`, `\` and pass `escape="\\"` to `.ilike`. Longer-term: migrate to Postgres full-text search.
+
+---
+
+### BUG-JOURNAL-014: Weekly prompt week from elapsed time
+**Severity:** Medium
+**Component:** `backend/src/routers/prompts.py:28-49`
+**Symptom:** `int(elapsed / 7 days) + 1` auto-advances regardless of whether the user completed the earlier prompt. Users who miss a week lose access to that week's prompt forever.
+**Fix:** Derive current week from `max(PromptResponse.week_number) + 1`, not elapsed time. Optionally cap by `current_stage`.
+
+---
+
+### BUG-JOURNAL-015: User message flushed before LLM call
+**Severity:** Medium
+**Component:** `backend/src/services/journal.py:43-58`, `backend/src/services/chat_stream.py:158-161`
+**Symptom:** `flush()` persists the user's message; if the LLM call fails, the rollback only rolls back open work, but with autoflush/explicit flush semantics the write may still be visible. Orphaned user messages with no bot reply appear in history.
+**Fix:** Do not `flush()` before the LLM call. Either:
+- Persist both messages together after the LLM succeeds, OR
+- Keep the pre-flush but on failure append a bot "error" placeholder marked as such so the UI has a sibling row, OR
+- Use a savepoint: `async with session.begin_nested(): ...`.
+
+---
+
+### BUG-JOURNAL-016: Stream abort leaves user message stranded
+**Severity:** Medium
+**Component:** `backend/src/services/chat_stream.py`, `frontend/src/features/Journal/JournalScreen.tsx:519-540`
+**Symptom:** On SSE error/close without `complete`, the frontend removes the bot placeholder but the user message remains — the user sees their own question with no response or indication.
+**Fix:** Keep a "failed" bot placeholder with a retry affordance. Persist partial responses server-side when possible and reconcile on reload.
+
+---
+
+### BUG-JOURNAL-017: No prompt-injection guard
+**Severity:** Medium
+**Component:** `backend/src/services/botmason.py:199-214`
+**Symptom:** User messages are concatenated raw with the system prompt; well-known injection phrases pass through.
+**Fix:** Add a lightweight heuristic warning (log only, do not block) plus structured delimiters. Rely on the provider's instruction hierarchy — e.g., put user text inside an XML tag in the user message, and document in the system prompt that the assistant should only treat text inside `<user_input>` as user intent.
+
+---
+
+### BUG-JOURNAL-018: Monthly-usage reset concurrency window
+**Severity:** Low
+**Component:** `backend/src/services/wallet.py:59-76`
+**Symptom:** At the exact rollover boundary, two requests can both see `monthly_reset_date <= now`. The WHERE clause makes the UPDATE idempotent, so damage is limited, but subtly derived counters elsewhere could double-reset.
+**Fix:** Log the reset; add an assertion test for monthly rollover. Consider a Postgres advisory lock per user for the reset path.
+
+---
+
+## Suggested remediation order
+
+1. **002, 004** (privacy/security) — same PR, small surface.
+2. **003** (race + unique constraint) — migration + handler change.
+3. **001, 005, 006** (LLM reliability) — land together so quota-consuming retries are safe.
+4. **009, 010, 008** (observability + CORS + per-user limits).
+5. **015, 016** (orphan messages + stream UX) — coordinate backend + frontend.
+6. Remaining MEDIUM / LOW.

--- a/prompts/2026-04-14-bug-remediation/05-course-stages-goals-bugs.md
+++ b/prompts/2026-04-14-bug-remediation/05-course-stages-goals-bugs.md
@@ -1,0 +1,278 @@
+# Course, Stages & Goals — Bug Remediation Report
+
+**Component:** Course content, Stage progression/gating, Goals & Goal Groups
+**Date:** 2026-04-14
+**Auditor:** Claude Code (self-review)
+**Branch:** `claude/code-review-bug-analysis-BvOHp`
+
+## Executive Summary
+
+The Course / Stages / Goals subsystem — the heart of the 36-week program — has **25 bugs** spanning stage-gating logic, progress math, completion idempotency, authorization, and race conditions. Several are outright data-integrity failures:
+
+- **Stage progress is a lie.** The `progress` field on every stage row is never populated (always 0.0), `course_items_completed` is a hardcoded 0, and `habits_progress` is a hardcoded 0.0. The "overall progress" metric therefore is mathematically capped at 0.5 and usually returns 0.0. The user sees no movement no matter what they do.
+- **Stage unlock logic is too permissive** — the predicate `stage_number <= progress.current_stage` allows anyone to skip ahead by directly updating the DB or via race.
+- **PUT /stages/progress has a classic TOCTOU race** — two concurrent advances can both pass the "cannot go backwards" check.
+- **Locked-stage content leaks.** `GET /course/content/{id}`, `POST /course/content/{id}/mark-read`, and `GET /stages/{n}/history` all skip authorization.
+- **Subtractive goal progress is inverted.** A caffeine-limit goal rewards the wrong behavior.
+- **Goal completion is not idempotent.** Tapping "Complete" twice double-counts the streak.
+
+Most of the HIGH+ findings are reachable without any special access — they're in the default success path.
+
+---
+
+## Table of Contents
+
+| # | Severity | Title |
+|---|---|---|
+| BUG-STAGE-001 | Critical | `completed_stages` array semantics ambiguous; no single-step-forward guard |
+| BUG-STAGE-002 | Critical | `is_stage_unlocked` too permissive (`<=` instead of legitimate gating) |
+| BUG-STAGE-004 | Critical | `habits_progress` hardcoded to 0.0 |
+| BUG-STAGE-005 | Critical | TOCTOU race on `PUT /stages/progress` |
+| BUG-STAGE-006 | Critical | `StageResponse.progress` never populated |
+| BUG-STAGE-003 | High | `GET /stages/{n}/history` skips unlock check |
+| BUG-COURSE-001 | High | `course_items_completed` hardcoded to 0 |
+| BUG-COURSE-002 | High | `_days_for_user_stage` returns -1 for past stages, locks all content retroactively |
+| BUG-COURSE-003 | High | Drip-feed reapplied every time user revisits past stage |
+| BUG-COURSE-005 | High | `mark_content_read` skips stage-unlock check |
+| BUG-COURSE-007 | High | `get_content_item` skips stage-unlock check |
+| BUG-GOAL-002 | High | Subtractive goal progress inverted |
+| BUG-COURSE-004 | Medium | `next_unlock_day` passes invalid `days_elapsed=-1` |
+| BUG-COURSE-006 | Medium | Empty-progress response relies on implicit optional default |
+| BUG-SEED-001 | Medium | Content seed doesn't check `(stage, release_day)` uniqueness |
+| BUG-GOAL-001 | Medium | No validation on `completed_units` (negative/zero accepted) |
+| BUG-GOAL-003 | Medium | `delete_goal_group` orphans `GoalCompletion` rows |
+| BUG-GOAL-004 | Medium | `shared_template=True` not tied to `user_id IS NULL` |
+| BUG-GOAL-005 | Medium | Goal completion is not idempotent within a day |
+| BUG-GOAL-006 | Medium | `Goal.tier` accepts any string (no enum) |
+| BUG-FRONTEND-001 | Medium | `StageSelector` hardcodes `TOTAL_STAGES=10` |
+| BUG-FRONTEND-003 | Medium | Map modal close races with navigation |
+| BUG-SEED-002 | Low | `seed_stages` doesn't validate uniqueness of definitions |
+| BUG-FRONTEND-002 | Low | `ContentCard` relies solely on `disabled` for lock |
+| BUG-FRONTEND-004 | Low | `StageHistorySection` mounts then returns null |
+
+---
+
+### BUG-STAGE-001: `completed_stages` semantics / no single-step-forward guard
+**Severity:** Critical
+**Component:** `backend/src/routers/stages.py:146` (also line 163)
+**Symptom:** `completed_stages = range(1, payload.current_stage)` is applied on both create and update paths. There's no explicit contract for whether "completed_stages" means *all stages up to the current one* or *only finished ones*, and there's no guard that the user can only advance one stage at a time.
+**Reproduction:** `PUT /stages/progress {"current_stage": 10}` from fresh account → succeeds; user jumps 9 stages.
+**Root cause:**
+```python
+completed = list(range(1, payload.current_stage))  # stages.py:146
+# The `cannot_go_backwards` check only rejects <=, not skipping
+```
+**Fix:** Enforce `payload.current_stage == existing.current_stage + 1` (or accept an admin override). Freeze the semantics in a docstring.
+
+---
+
+### BUG-STAGE-002: `is_stage_unlocked` too permissive
+**Severity:** Critical
+**Component:** `backend/src/domain/stage_progress.py:30-40`
+**Symptom:** Predicate `stage_number <= progress.current_stage` returns True for *every* stage up to the current one, regardless of whether those stages were actually completed. Combined with BUG-STAGE-001, a DB-level mutation or race can advance `current_stage` without populating `completed_stages`, and every earlier stage becomes implicitly unlocked.
+**Fix:** Keep exactly one source of truth (completed_stages) and rewrite:
+```python
+if stage_number == 1:
+    return True
+if progress is None:
+    return False
+if stage_number <= progress.current_stage:
+    return stage_number - 1 in (progress.completed_stages or []) or stage_number == 1
+return False
+```
+
+---
+
+### BUG-STAGE-003: `/stages/{n}/history` skips unlock check
+**Severity:** High
+**Component:** `backend/src/routers/stages.py:113-130`
+**Symptom:** User on stage 1 can `GET /stages/10/history` and see everything they haven't earned.
+**Fix:** Add `is_stage_unlocked` check before aggregating.
+
+---
+
+### BUG-STAGE-004: `habits_progress` hardcoded to 0.0
+**Severity:** Critical
+**Component:** `backend/src/domain/stage_progress.py:60`
+**Symptom:** The overall progress metric is `(habits_progress + (1 if practice_count > 0 else 0)) / 2`. Because `habits_progress = 0.0` is a placeholder, overall progress is capped at 0.5 and is 0.0 for users with no practice sessions.
+**Fix:** Count `Habit` rows for the stage and the number with at least one `GoalCompletion`; compute the ratio. See the auditor's draft SQL in the internal notes (joining `Habit` → `Goal` → `GoalCompletion`).
+
+---
+
+### BUG-STAGE-005: TOCTOU race on `PUT /stages/progress`
+**Severity:** Critical
+**Component:** `backend/src/routers/stages.py:133-173`
+**Symptom:** Two concurrent advance requests both read the same `current_stage`, both pass the "cannot go backwards" check, both commit → non-deterministic final state.
+**Fix:** Lock the row with `SELECT ... FOR UPDATE` (SQLAlchemy `.with_for_update()`) at the start of the transaction. Commit/refresh afterward.
+
+---
+
+### BUG-STAGE-006: `StageResponse.progress` never populated
+**Severity:** Critical
+**Component:** `backend/src/routers/stages.py:48-64`
+**Symptom:** `list_stages` never sets `progress`, so every stage in the list carries the schema default (0.0). The frontend progress bar never moves.
+**Fix:** Compute stage progress per stage (batch-friendly) and populate. Alternatively, remove the field and have the client call `/stages/{n}/progress` when it needs it.
+
+---
+
+### BUG-COURSE-001: `course_items_completed` hardcoded to 0
+**Severity:** High
+**Component:** `backend/src/domain/stage_progress.py:63`
+**Symptom:** TODO left in place; `ContentCompletion` rows are never counted.
+**Fix:** Count `ContentCompletion` joined to `StageContent` joined to `CourseStage.stage_number`.
+
+---
+
+### BUG-COURSE-002: `_days_for_user_stage` returns -1 for non-current stages
+**Severity:** High
+**Component:** `backend/src/routers/course.py:37-42`, `backend/src/domain/course.py:31`
+**Symptom:** When the user revisits a *past* stage, `days_elapsed = -1`, and drip-feed logic `release_day > days_elapsed` evaluates true for every item — so previously-unlocked content becomes locked retroactively.
+**Fix:** Return a sentinel (e.g. a very large day count) when `progress.current_stage > stage_number`, so all content for past stages is unlocked.
+
+---
+
+### BUG-COURSE-003: Drip-feed replays for past stages
+**Severity:** High
+**Component:** `backend/src/routers/course.py:75-97`
+**Symptom:** No authorization check, and drip-feed is applied based on the *current* stage start date rather than the stage the user is viewing.
+**Fix:** Gate with `is_stage_unlocked`; for past stages, skip drip-feed entirely.
+
+---
+
+### BUG-COURSE-004: `next_unlock_day` invoked with -1
+**Severity:** Medium
+**Component:** `backend/src/routers/course.py:214-222`
+**Symptom:** When the user is not on the requested stage, `days = max(..., -1) = -1` is passed through, producing nonsensical `next_unlock_day` values.
+**Fix:** Short-circuit: `next_day = None if days < 0 else next_unlock_day(...)`.
+
+---
+
+### BUG-COURSE-005: `mark_content_read` skips stage check
+**Severity:** High
+**Component:** `backend/src/routers/course.py:141-178`
+**Symptom:** User can mark content from a locked stage as read by guessing the content ID.
+**Fix:** Look up the parent stage and call `is_stage_unlocked` before inserting the completion.
+
+---
+
+### BUG-COURSE-006: Empty progress response couples to schema default
+**Severity:** Medium
+**Component:** `backend/src/routers/course.py:181-185`
+**Symptom:** `_empty_progress()` passes `next_unlock_day=None`; schema change to required breaks this silently.
+**Fix:** Explicit `int | None` in the response schema, with test coverage.
+
+---
+
+### BUG-COURSE-007: `get_content_item` skips stage check
+**Severity:** High
+**Component:** `backend/src/routers/course.py:100-138`
+**Symptom:** Leaks the existence and metadata of content in locked stages.
+**Fix:** Same pattern as BUG-COURSE-005.
+
+---
+
+### BUG-SEED-001: Content seed lacks `(stage, release_day)` uniqueness
+**Severity:** Medium
+**Component:** `backend/src/seed_content.py:113-116`
+**Symptom:** Two items with the same release day in the same stage will both persist; drip-feed assumes one item per day.
+**Fix:** Track existing `(course_stage_id, release_day)` tuples; assert uniqueness in `STAGE_CONTENT_DEFINITIONS` at module import time.
+
+---
+
+### BUG-SEED-002: `seed_stages` doesn't assert uniqueness
+**Severity:** Low
+**Component:** `backend/src/seed_stages.py:144-161`
+**Symptom:** Duplicate `stage_number` in definitions → only one inserted, silently.
+**Fix:** Raise at import: `assert len({d['stage_number'] for d in STAGE_DEFINITIONS}) == len(STAGE_DEFINITIONS)`.
+
+---
+
+### BUG-GOAL-001: `completed_units` unvalidated
+**Severity:** Medium
+**Component:** `backend/src/routers/goal_completions.py:48-72`, `backend/src/models/goal_completion.py`
+**Symptom:** Model and API accept negative / zero / absurd values.
+**Fix:** `Field(gt=0)` and a ceiling (`le=goal.target * reasonable_factor`).
+
+---
+
+### BUG-GOAL-002: Subtractive goal progress inverted
+**Severity:** High
+**Component:** `backend/src/domain/goals.py:24-26`
+**Symptom:** Caffeine-style "stay under N" goals reward consumption. `progress = remaining / target` is the inverse of what success means.
+**Fix:** See the recommendation in the audit — 100% when `current <= 0`, 0% when `current >= target`, proportional between.
+
+---
+
+### BUG-GOAL-003: `delete_goal_group` orphans completions
+**Severity:** Medium
+**Component:** `backend/src/routers/goal_groups.py:137-157`
+**Symptom:** Cascade behavior inconsistent; no DB constraint.
+**Fix:** Add FK `ondelete="SET NULL"` on `Goal.goal_group_id`; explicitly commit the unlink before deleting.
+
+---
+
+### BUG-GOAL-004: `shared_template` not tied to `user_id IS NULL`
+**Severity:** Medium
+**Component:** `backend/src/routers/goal_groups.py:40-53`, `90-102`
+**Symptom:** The shared-template invariant is enforced in the create handler but not at the DB layer. A direct insert or a future refactor can break it.
+**Fix:** Add DB CHECK constraint: `(shared_template = true AND user_id IS NULL) OR (shared_template = false AND user_id IS NOT NULL)`.
+
+---
+
+### BUG-GOAL-005: Completion not idempotent
+**Severity:** Medium
+**Component:** `backend/src/routers/goal_completions.py:47-72`
+**Symptom:** Double-tap or retry → double streak.
+**Fix:** Check for an existing completion today; return the current streak instead of inserting. Add a partial unique index on `(goal_id, user_id, date(timestamp))`.
+
+---
+
+### BUG-GOAL-006: `Goal.tier` accepts any string
+**Severity:** Medium
+**Component:** `backend/src/models/goal.py:33`
+**Symptom:** `tier="banana"` accepted; frontend badge logic crashes / shows wrong color.
+**Fix:** `StrEnum("GoalTier", "low clear stretch")` or Pydantic `pattern="^(low|clear|stretch)$"`.
+
+---
+
+### BUG-FRONTEND-001: `StageSelector` hardcodes 10 stages
+**Severity:** Medium
+**Component:** `frontend/src/features/Course/StageSelector.tsx:51`
+**Symptom:** Fragile — always renders 10 pills even if API returns fewer. When the 36-week program is expanded, pills for stages 11+ won't appear.
+**Fix:** Derive count from API: `Math.max(...stages.map(s => s.stage_number))`.
+
+---
+
+### BUG-FRONTEND-002: `ContentCard` relies solely on `disabled`
+**Severity:** Low
+**Component:** `frontend/src/features/Course/ContentCard.tsx:52-63`
+**Symptom:** Long-press / accessibility activation can still fire `onPress`.
+**Fix:** Guard the handler: `if (item.is_locked) return;`.
+
+---
+
+### BUG-FRONTEND-003: Map modal close races with navigation
+**Severity:** Medium
+**Component:** `frontend/src/features/Map/MapScreen.tsx:440-448`
+**Symptom:** Rapid back-press after picking a destination leaves UI in inconsistent state.
+**Fix:** Chain navigation inside the state update via `InteractionManager.runAfterInteractions` or a ref guard.
+
+---
+
+### BUG-FRONTEND-004: `StageHistorySection` mounts then returns null
+**Severity:** Low
+**Component:** `frontend/src/features/Map/MapScreen.tsx:295-327`
+**Symptom:** Effect fires and loading state is set before the null-guard shortcuts the render.
+**Fix:** Gate mounting at the parent: `{isUnlocked && <StageHistorySection ... />}`.
+
+---
+
+## Suggested remediation order
+
+1. **STAGE-005** (race) + **STAGE-006** (progress never populated) — ship first; they're pure data-integrity and low-risk.
+2. **STAGE-002** + **STAGE-001** — lock down stage advancement semantics, add regression tests.
+3. **COURSE-005, COURSE-007, STAGE-003** — authorization hardening.
+4. **STAGE-004, COURSE-001** — implement real progress math; expect snapshot test churn.
+5. **COURSE-002, COURSE-003** — past-stage drip-feed fix.
+6. **GOAL-002, GOAL-005** — goal semantics and idempotency.
+7. Remaining MEDIUM / LOW in a cleanup PR.

--- a/prompts/2026-04-14-bug-remediation/06-backend-infrastructure-bugs.md
+++ b/prompts/2026-04-14-bug-remediation/06-backend-infrastructure-bugs.md
@@ -1,0 +1,192 @@
+# Backend Infrastructure & Cross-Cutting — Bug Remediation Report
+
+**Component:** FastAPI app setup, CORS, database/session, errors, rate limiting, migrations, admin, observability
+**Date:** 2026-04-14
+**Auditor:** Claude Code (self-review)
+**Branch:** `claude/code-review-bug-analysis-BvOHp`
+
+## Executive Summary
+
+27 infrastructure bugs. The ones that are production-hot:
+
+- **Energy plan endpoint is synchronous (`def`) but expected to run in an async stack** — a single slow call will block the entire event loop and stall every other request.
+- **`await session.delete(group)` in `goal_groups.py:155`** — `Session.delete` is not awaitable in SQLAlchemy async; this raises `TypeError: object NoneType can't be used in 'await' expression`. Deletion is broken.
+- **No pagination on seven list endpoints** — `/practices/`, `/habits/`, `/practice-sessions/`, `/goal-groups/`, `/stages/`, `/user-practices/`, `/course/stages/{n}/content`.
+- **Unauthenticated `GET /` leaks status** and returns 200 without auth.
+- **Security headers incomplete** — no CSP, no Referrer-Policy, no Permissions-Policy.
+- **Broken downgrade migration** for timestamptz columns.
+
+---
+
+## Table of Contents
+
+| # | Severity | Title |
+|---|---|---|
+| BUG-INFRA-009 | Critical | Energy endpoint is sync inside async stack |
+| BUG-INFRA-019 | Critical | `await session.delete(...)` raises TypeError in goal_groups |
+| BUG-INFRA-022 | Critical | Downgrade migration has broken SQL escaping |
+| BUG-INFRA-001 | High | No Content-Security-Policy header |
+| BUG-INFRA-004 | High | Unauthenticated root endpoint |
+| BUG-INFRA-010 | High | Misplaced `await` on `session.delete()` |
+| BUG-INFRA-012 | High | `/practices/` no pagination |
+| BUG-INFRA-013 | High | `/habits/` no pagination |
+| BUG-INFRA-014 | High | `/practice-sessions/` no pagination |
+| BUG-INFRA-015 | High | `/goal-groups/` no pagination |
+| BUG-INFRA-017 | High | `/user-practices/` no pagination |
+| BUG-INFRA-018 | High | `/course/stages/{n}/content` no pagination |
+| BUG-INFRA-002 | Medium | Missing Referrer-Policy header |
+| BUG-INFRA-003 | Medium | Missing Permissions-Policy header |
+| BUG-INFRA-005 | Medium | CORS `allow_credentials=True` with env-parsed origins |
+| BUG-INFRA-006 | Medium | Dev mode ignores `PROD_DOMAIN` silently |
+| BUG-INFRA-008 | Medium | Globally permissive HTTP methods in CORS |
+| BUG-INFRA-011 | Medium | Stream rollback path incomplete |
+| BUG-INFRA-016 | Medium | `/stages` no pagination |
+| BUG-INFRA-020 | Medium | Post-refresh `.one()` raises on race |
+| BUG-INFRA-021 | Medium | Health-check session leak on failure |
+| BUG-INFRA-023 | Medium | No CI guard that new models have migrations |
+| BUG-INFRA-024 | Medium | Most routers have no structured logging |
+| BUG-INFRA-025 | Medium | No correlation ID / request tracing |
+| BUG-INFRA-026 | Medium | Test client cookies don't mirror prod flags |
+| BUG-INFRA-027 | Medium | `db_session` fixture teardown not in `try/finally` |
+| BUG-INFRA-007 | Low | CORS origin list not deduplicated |
+
+---
+
+### BUG-INFRA-009: Energy endpoint sync in async stack
+**Severity:** Critical
+**Component:** `backend/src/routers/energy.py:14-18`
+**Symptom:** `def create_plan(...)` (not `async def`) is mounted on an `AsyncSession` app. FastAPI runs sync endpoints in a threadpool, but because `get_or_generate_plan` calls down into sync code that owns no session, any heavy work here serializes against the default threadpool limit.
+**Fix:** Convert to `async def`. If the plan generation is CPU-bound, offload with `asyncio.to_thread`.
+
+---
+
+### BUG-INFRA-019 / 010: `await session.delete(...)` misuse
+**Severity:** Critical
+**Component:** `backend/src/routers/goal_groups.py:155` (plus any callers using the same pattern)
+**Symptom:** `AsyncSession.delete` returns `None`; `await None` raises `TypeError`.
+**Fix:** Drop the `await` — `session.delete(group)` then `await session.commit()`. Audit the other routers for the same pattern with a grep.
+
+---
+
+### BUG-INFRA-022: Broken downgrade migration
+**Severity:** Critical
+**Component:** `backend/migrations/versions/78b1620cafde_convert_datetime_columns_to_timestamptz.py:63`
+**Symptom:** `postgresql_using` expression has malformed quote escaping; downgrade fails with a SQL syntax error.
+**Fix:** `postgresql_using=f'"{column}" AT TIME ZONE \'UTC\''` and add a test that runs `alembic upgrade head && alembic downgrade -1 && alembic upgrade head` in CI.
+
+---
+
+### BUG-INFRA-001 / 002 / 003: Missing security headers
+**Severity:** High / Medium / Medium
+**Component:** `backend/src/main.py:97-115` (SecurityHeadersMiddleware)
+**Fix:** Append `Content-Security-Policy`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: geolocation=(), microphone=(), camera=()`. Stake out CSP values that match the frontend's real needs — `script-src` should not include `unsafe-inline` unless Expo web requires it.
+
+---
+
+### BUG-INFRA-004: Unauthenticated `GET /`
+**Severity:** High
+**Component:** `backend/src/main.py:167-170`
+**Fix:** Remove it, or gate behind an admin dependency. If you want a public liveness probe, expose `/health` only.
+
+---
+
+### BUG-INFRA-012–018: Pagination gaps
+**Severity:** High (012–015, 017, 018), Medium (016 only because stages are few)
+**Component:**
+- `/practices/` — `routers/practices.py:19-32`
+- `/habits/` — `routers/habits.py:37-50`
+- `/practice-sessions/` — `routers/practice_sessions.py:49-62`
+- `/goal-groups/` — `routers/goal_groups.py:56-71`
+- `/stages` — `routers/stages.py:35-64`
+- `/user-practices/` — `routers/user_practices.py:54-61`
+- `/course/stages/{n}/content` — `routers/course.py:75-97`
+**Fix:** Add `limit` / `offset` (or cursor) with sensible maxima (e.g., `le=200`). Return `{items, total, limit, offset}` or `Link` headers. Add a shared `PaginationParams` dependency.
+
+---
+
+### BUG-INFRA-005: `allow_credentials=True` with env-parsed origins
+**Severity:** Medium
+**Component:** `backend/src/main.py:142-148`
+**Fix:** Hard-fail startup if `*` ever lands in the allow-list while `allow_credentials=True`. Also reject origins that don't parse as valid URLs.
+
+---
+
+### BUG-INFRA-006: Dev mode ignores `PROD_DOMAIN`
+**Severity:** Medium
+**Component:** `backend/src/main.py:67-84`
+**Fix:** Log a warning when `ENV=development` and `PROD_DOMAIN` is set so misconfiguration is obvious.
+
+---
+
+### BUG-INFRA-008: Globally permissive methods
+**Severity:** Medium
+**Component:** `backend/src/main.py:142-148`
+**Fix:** Explicitly list only methods the API uses. Drop `DELETE` unless exposed.
+
+---
+
+### BUG-INFRA-011: Stream rollback path incomplete
+**Severity:** Medium
+**Component:** `backend/src/services/chat_stream.py:145-176`
+**Fix:** Use `try/except/else/finally`; ensure `finalise_stream_commit` runs only on the success branch and `session.rollback` is idempotent on abort.
+
+---
+
+### BUG-INFRA-020: `.one()` after refresh races the record's existence
+**Severity:** Medium
+**Component:** `backend/src/routers/goal_groups.py:107-111` (pattern likely repeats)
+**Fix:** `.first()` with a None check and `not_found` fallback.
+
+---
+
+### BUG-INFRA-021: Health-check session leak
+**Severity:** Medium
+**Component:** `backend/src/main.py:173-187`
+**Fix:** Rely on the `Depends(get_session)` cleanup, but log the error and ensure that `get_session` itself has `try/finally` with explicit close/rollback.
+
+---
+
+### BUG-INFRA-023: No migration drift CI guard
+**Severity:** Medium
+**Component:** `backend/migrations/`, pre-commit config
+**Fix:** Add a CI step (or pre-commit hook) that runs `alembic check` or autogenerates a migration in a temp DB and fails if a diff exists.
+
+---
+
+### BUG-INFRA-024: No structured logging in routers
+**Severity:** Medium
+**Component:** `backend/src/routers/*.py`
+**Fix:** Centralize a `logger = structlog.get_logger(__name__)` (or std `logging` with a JSON formatter) and log one event per mutating endpoint: `habit_created`, `goal_completed`, etc. Include user_id but redact emails. Add a `logging.yaml` / dict-config loaded from env.
+
+---
+
+### BUG-INFRA-025: No correlation ID
+**Severity:** Medium
+**Component:** App-wide
+**Fix:** Middleware that reads `X-Request-ID` (or mints one), stores in `contextvars`, injects into log records and into the LLM provider calls so BotMason traces can be matched to user sessions. Echo back on the response.
+
+---
+
+### BUG-INFRA-026 / 027: Test fixture hygiene
+**Severity:** Medium
+**Component:** `backend/conftest.py:49-77`
+**Fix:** Wrap the `db_session` fixture body in `try/finally` so tables are dropped even on exception. Assert that `app.dependency_overrides` is empty at teardown.
+
+---
+
+### BUG-INFRA-007: CORS origin list not deduplicated
+**Severity:** Low
+**Component:** `backend/src/main.py:49-64`
+**Fix:** `list(dict.fromkeys(origins))` — order-preserving dedup.
+
+---
+
+## Suggested remediation order
+
+1. **010 / 019** and **022** (crashes) — same PR, trivial.
+2. **009** (sync-in-async) — same PR, include a load test.
+3. **012–018** (pagination) — big single PR with a shared dependency.
+4. **001–005** (security headers + CORS hardening).
+5. **024 / 025** (observability) — groundwork for anything else.
+6. **023, 027, 026** (CI + test hygiene).
+7. Remaining MEDIUM / LOW.

--- a/prompts/2026-04-14-bug-remediation/07-frontend-infrastructure-bugs.md
+++ b/prompts/2026-04-14-bug-remediation/07-frontend-infrastructure-bugs.md
@@ -1,0 +1,239 @@
+# Frontend Infrastructure & Cross-Cutting — Bug Remediation Report
+
+**Component:** API client, navigation, auth context, stores, AsyncStorage, design tokens, accessibility, error boundaries
+**Date:** 2026-04-14
+**Auditor:** Claude Code (self-review)
+**Branch:** `claude/code-review-bug-analysis-BvOHp`
+
+## Executive Summary
+
+25 frontend bugs covering the seams between API, navigation, state, and storage. The most consequential:
+
+- **No fetch timeout anywhere.** A wedged backend freezes screens forever.
+- **Logout doesn't reset navigation state.** Back button/deep link can return users to authenticated screens after logout; on re-login the tab navigator reuses the previous user's tab state.
+- **Retry only on 401.** Transient 5xx and 429 surface as hard errors even though a backoff would recover.
+- **Design-token drift.** ~15 files hardcode colors that should come from `design/tokens.ts`.
+- **No offline detection.** Users see timeouts instead of a banner.
+- **Unsafe casts at the API boundary** (`tier as ...`, `parseResponse<T>`) with no runtime validation.
+
+---
+
+## Table of Contents
+
+| # | Severity | Title |
+|---|---|---|
+| BUG-FRONTEND-INFRA-001 | Critical | Fetch calls have no timeout |
+| BUG-FRONTEND-INFRA-002 | Critical | Logout doesn't reset navigation stack |
+| BUG-FRONTEND-INFRA-003 | High | Tab navigator state persists across logout |
+| BUG-FRONTEND-INFRA-004 | Medium | `ToastProvider` context value not memoized |
+| BUG-FRONTEND-INFRA-005 | Medium | No offline detection |
+| BUG-FRONTEND-INFRA-006 | Medium | Hardcoded colors instead of design tokens |
+| BUG-FRONTEND-INFRA-007 | Medium | Retry logic covers only 401 |
+| BUG-FRONTEND-INFRA-008 | Medium | Deep links don't cover root stack (e.g., `ApiKeySettings`) |
+| BUG-FRONTEND-INFRA-009 | Medium | Missing `accessibilityLabel` on ~80% of touchables |
+| BUG-FRONTEND-INFRA-010 | Medium | Unsafe cast on `goal.tier` |
+| BUG-FRONTEND-INFRA-013 | Medium | Token getter can read stale ref during logout race |
+| BUG-FRONTEND-INFRA-015 | Medium | Journal `FlatList` missing `getItemLayout` |
+| BUG-FRONTEND-INFRA-016 | Medium | Login error message too generic for timeout |
+| BUG-FRONTEND-INFRA-017 | Medium | `ApiKeyContext` swallows SecureStore exceptions |
+| BUG-FRONTEND-INFRA-019 | Medium | Single top-level error boundary |
+| BUG-FRONTEND-INFRA-021 | Medium | StatusBar hardcoded light style |
+| BUG-FRONTEND-INFRA-022 | Medium | Course/Practice don't reset route params after logout |
+| BUG-FRONTEND-INFRA-023 | Medium | Route params inconsistent optional chaining |
+| BUG-FRONTEND-INFRA-024 | Medium | No runtime validation of API response shapes |
+| BUG-FRONTEND-INFRA-025 | Medium | Token contrast below WCAG AA in some combos |
+| BUG-FRONTEND-INFRA-011 | Low | Storage JSON parse errors silently return null |
+| BUG-FRONTEND-INFRA-012 | Low | Logout flow lacks end-to-end tests |
+| BUG-FRONTEND-INFRA-014 | Low | `keyExtractor` without explicit typing |
+| BUG-FRONTEND-INFRA-018 | Low | Config-error hint mentions Railway specifically |
+| BUG-FRONTEND-INFRA-020 | Low | No test for `REFRESH_BUFFER_SECONDS` integration |
+
+> IDs keep the agent's original numbers but are scoped with the `FRONTEND-INFRA-` prefix to avoid collision with the `BUG-FRONTEND-*` IDs used in the Course/Stages/Goals report.
+
+---
+
+### BUG-FRONTEND-INFRA-001: No fetch timeout
+**Severity:** Critical
+**Component:** `frontend/src/api/index.ts:142-143`
+**Symptom:** A stalled backend or DNS hiccup hangs the UI indefinitely.
+**Fix:** Wrap every `fetch` in an `AbortController` with a configurable timeout (default 30s). Bubble `AbortError` as a retryable `ApiError`. Respect BotMason streaming's own keepalive.
+
+---
+
+### BUG-FRONTEND-INFRA-002: Logout doesn't reset navigation
+**Severity:** Critical
+**Component:** `frontend/src/navigation/BottomTabs.tsx:66`, `App.tsx:50-62`
+**Symptom:** Deep-link or back button after logout can surface a cached authenticated screen.
+**Fix:** Key the root navigator by auth state (`<RootStack key="auth" />` vs `<AuthStack key="anon" />`) or dispatch a `CommonActions.reset` on logout.
+
+---
+
+### BUG-FRONTEND-INFRA-003: Tab state persists across logout
+**Severity:** High
+**Component:** `App.tsx:50-62`
+**Fix:** Same mount-key approach as 002. Covers scroll positions, pending screens, and tab selection.
+
+---
+
+### BUG-FRONTEND-INFRA-004: `ToastProvider` context not memoized
+**Severity:** Medium
+**Component:** `frontend/src/components/ToastProvider.tsx:46`
+**Fix:** Wrap provider value in `useMemo(() => ({ showToast }), [showToast])`.
+
+---
+
+### BUG-FRONTEND-INFRA-005: No offline detection
+**Severity:** Medium
+**Component:** App-wide
+**Fix:** Add `@react-native-community/netinfo`. Global banner on offline. Queue mutations (habits check-ins, journal sends) until reconnect.
+
+---
+
+### BUG-FRONTEND-INFRA-006: Design-token drift
+**Severity:** Medium
+**Component:** `features/Auth/LoginScreen.tsx:80,88`; `features/Auth/SignupScreen.tsx:147,155`; `features/Habits/HabitTile.tsx:66,136,161,505,622`; `features/Habits/components/GoalModal.tsx:52,66,76,657`; `features/Habits/components/OnboardingModal.tsx:191` (and more — grep for `#[0-9a-fA-F]{3,6}` in the styles).
+**Fix:** Replace hex strings with imports from `design/tokens.ts`. Add an ESLint rule banning hex literals in StyleSheets.
+
+---
+
+### BUG-FRONTEND-INFRA-007: Retry only on 401
+**Severity:** Medium
+**Component:** `frontend/src/api/index.ts:191-216`
+**Fix:** Add an `isTransient(err)` helper, retry with exponential backoff + jitter (max 2 attempts) for 408/429/500/502/503/504/network errors. Never retry non-idempotent methods unless the server sets `Idempotency-Key`.
+
+---
+
+### BUG-FRONTEND-INFRA-008: Deep-link config incomplete
+**Severity:** Medium
+**Component:** `frontend/src/App.tsx:26-37`
+**Fix:** Add the `ApiKeySettings` route (mapped to a path like `/api-key-settings`) and any other top-level stack screens to the linking config. <!-- pragma: allowlist secret -->
+
+---
+
+### BUG-FRONTEND-INFRA-009: Accessibility labels missing
+**Severity:** Medium
+**Component:** Across `features/*`
+**Fix:** Sweep every `TouchableOpacity`/`Pressable`/`Touchable*` and add `accessibilityLabel` + `accessibilityRole`. Add an ESLint a11y rule for React Native.
+
+---
+
+### BUG-FRONTEND-INFRA-010: Unsafe `tier` cast
+**Severity:** Medium
+**Component:** `frontend/src/api/index.ts:324`
+**Fix:** Narrow with a type guard + runtime default. Combine with BUG-GOAL-006 (server-side enum).
+
+---
+
+### BUG-FRONTEND-INFRA-013: Stale token-ref race
+**Severity:** Medium
+**Component:** `frontend/src/context/AuthContext.tsx:107-108`
+**Fix:** Register a stable callback getter `useCallback(() => tokenRef.current, [])`. Clear the getter on unmount.
+
+---
+
+### BUG-FRONTEND-INFRA-015: Missing `getItemLayout`
+**Severity:** Medium
+**Component:** `frontend/src/features/Journal/JournalScreen.tsx:668-700`
+**Fix:** If heights are variable, at least enable `removeClippedSubviews` and measure with `onLayout`. If heights are bounded, implement `getItemLayout` with a constant + bubble header height.
+
+---
+
+### BUG-FRONTEND-INFRA-016: Login error too generic for timeouts
+**Severity:** Medium
+**Component:** `frontend/src/features/Auth/LoginScreen.tsx:7-30`
+**Fix:** Branch on `err.name === 'AbortError'` or `isTransient(err)` and show a timeout-specific message.
+
+---
+
+### BUG-FRONTEND-INFRA-017: `ApiKeyContext` swallows SecureStore exceptions
+**Severity:** Medium
+**Component:** `frontend/src/context/ApiKeyContext.tsx:55`
+**Fix:** Add `loadError` state and surface a message. Fall back to in-memory key without persisting if SecureStore is broken.
+
+---
+
+### BUG-FRONTEND-INFRA-019: Single top-level error boundary
+**Severity:** Medium
+**Component:** `frontend/src/App.tsx:86`
+**Fix:** Wrap each tab/feature in its own boundary so a crash in Journal doesn't nuke Habits.
+
+---
+
+### BUG-FRONTEND-INFRA-021: Hardcoded StatusBar style
+**Severity:** Medium
+**Component:** `frontend/src/App.tsx:93`
+**Fix:** Read from user preferences / system theme. Ship now with the current `dark-content` default, make it reactive when dark mode lands.
+
+---
+
+### BUG-FRONTEND-INFRA-022: Course/Practice don't reset params on auth change
+**Severity:** Medium
+**Component:** `features/Course/CourseScreen.tsx`, `features/Practice/PracticeScreen.tsx`
+**Fix:** Reset via the nav-key remount in BUG-FRONTEND-INFRA-002/003, or add `useEffect(() => resetIfStale(), [isAuthenticated])`.
+
+---
+
+### BUG-FRONTEND-INFRA-023: Inconsistent optional chaining for route params
+**Severity:** Medium
+**Component:** `features/Course/CourseScreen.tsx:26,38` (and similar)
+**Fix:** Centralize through a `useRouteParams<T>()` helper that always returns a narrowed object with required fields defaulted.
+
+---
+
+### BUG-FRONTEND-INFRA-024: No runtime response validation
+**Severity:** Medium
+**Component:** `frontend/src/api/index.ts:117`
+**Fix:** Zod schemas per response type; parse before return. Start with auth + habits (highest-blast-radius mismatches).
+
+---
+
+### BUG-FRONTEND-INFRA-025: Contrast gaps
+**Severity:** Medium
+**Component:** `frontend/src/design/tokens.ts:26-31`
+**Fix:** Audit pairs against `background.primary`; introduce `textSecondaryAccessible` and migrate low-contrast uses.
+
+---
+
+### BUG-FRONTEND-INFRA-011: Silent storage parse errors
+**Severity:** Low
+**Component:** `frontend/src/storage/habitStorage.ts:32`, `storage/notificationStorage.ts:24,62`
+**Fix:** Log the error, clear the corrupt key, bubble a toast if user-visible.
+
+---
+
+### BUG-FRONTEND-INFRA-012: Logout flow lacks E2E test
+**Severity:** Low
+**Component:** `frontend/src/context/__tests__/AuthContext.test.tsx`
+**Fix:** Add tests for double-logout, logout during in-flight refresh, and logout→login cycles.
+
+---
+
+### BUG-FRONTEND-INFRA-014: `keyExtractor` untyped
+**Severity:** Low
+**Component:** `frontend/src/features/Journal/JournalScreen.tsx:678`
+**Fix:** Typed `useCallback` extractor.
+
+---
+
+### BUG-FRONTEND-INFRA-018: Railway-specific config hint
+**Severity:** Low
+**Component:** `frontend/src/App.tsx:72`
+**Fix:** Make it provider-agnostic; put Railway specifics in `DEPLOYMENT.md`.
+
+---
+
+### BUG-FRONTEND-INFRA-020: Missing integration test for refresh buffer
+**Severity:** Low
+**Component:** `frontend/src/utils/__tests__/token.test.ts`
+**Fix:** Add a test that advances fake timers past `exp - REFRESH_BUFFER_SECONDS` and asserts `silentRefresh` is invoked exactly once.
+
+---
+
+## Suggested remediation order
+
+1. **001, 002, 003** (network + nav lifecycle) — land together; this is the foundation everything else depends on.
+2. **024, 010** (runtime validation) — pair with the TS fix in BUG-AUTH-002.
+3. **007** (retry policy) + offline detection (**005**).
+4. **006, 009, 025** (design system + a11y sweep).
+5. **004, 013, 015, 017, 019, 021, 022, 023** (polish).
+6. **Low-severity backlog**.


### PR DESCRIPTION
Self-review of the Adepthood codebase, broken into seven per-component
QA bug reports plus an index. Captures 146 findings across auth, habits,
practice sessions, journal/BotMason, course/stages/goals, backend infra,
and frontend infra with severity, file:line references, reproductions,
root causes, and concrete fixes.

https://claude.ai/code/session_01B51QHygaWa4B3Kzhh66JMM