### PR TITLE
fix(auth): ship the top-5 signup blockers (BUG-AUTH-001/002/003/005/010)

### DIFF
--- a/backend/migrations/versions/e8376b41c6a1_unique_lower_email_index.py
+++ b/backend/migrations/versions/e8376b41c6a1_unique_lower_email_index.py
@@ -1,0 +1,38 @@
+"""unique lower(email) index
+
+Revision ID: e8376b41c6a1
+Revises: 78b1620cafde
+Create Date: 2026-04-15 00:00:00.000000
+
+Guards against case-only duplicate signups (BUG-AUTH-003). The application
+now normalizes emails to ``strip().lower()`` at the request boundary, but a
+case-sensitive unique constraint would still permit pre-existing duplicates
+to coexist. A functional unique index on ``lower(email)`` makes the
+invariant a database-level guarantee, not just an application convention.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e8376b41c6a1"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "78b1620cafde"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_UNIQUE_LOWER_EMAIL_INDEX = "ix_user_lower_email_unique"
+
+
+def upgrade() -> None:
+    """Add a case-insensitive unique index on ``user.email``."""
+    op.execute(
+        f'CREATE UNIQUE INDEX "{_UNIQUE_LOWER_EMAIL_INDEX}" '
+        'ON "user" (lower(email))'
+    )
+
+
+def downgrade() -> None:
+    """Drop the case-insensitive unique index."""
+    op.execute(f'DROP INDEX IF EXISTS "{_UNIQUE_LOWER_EMAIL_INDEX}"')

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime, timedelta
 import bcrypt
 import jwt
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -51,6 +51,19 @@ def _get_secret_key() -> str:
 class AuthRequest(BaseModel):
     email: EmailStr
     password: str
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _normalize_email(cls, value: object) -> object:
+        """Strip whitespace and lowercase emails at the boundary.
+
+        Addresses BUG-AUTH-003 (case-sensitive lookups) and BUG-AUTH-010
+        (whitespace from paste/autofill). Applied before ``EmailStr``
+        validation so the normalized form is what gets stored and compared.
+        """
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
 
 
 class AuthResponse(BaseModel):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -99,6 +99,85 @@ async def test_login_rejects_malformed_email(
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
+# ── Email normalization (BUG-AUTH-003, BUG-AUTH-010) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_signup_normalizes_email_case_and_whitespace(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Email submitted with mixed case / surrounding whitespace is stored as
+    the trimmed, lowercased form so later lookups don't miss it."""
+    resp = await async_client.post(
+        SIGNUP_URL,
+        json={
+            "email": "  Alice@Example.COM ",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    result = await db_session.execute(select(User).where(User.email == "alice@example.com"))
+    user = result.scalars().first()
+    assert user is not None
+
+
+@pytest.mark.asyncio
+async def test_login_is_case_insensitive_after_signup(async_client: AsyncClient) -> None:
+    """Signing up as ``Alice@Example.com`` lets the user log in as
+    ``alice@example.com`` (BUG-AUTH-003)."""
+    await async_client.post(
+        SIGNUP_URL,
+        json={
+            "email": "Alice@Example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    resp = await async_client.post(
+        LOGIN_URL,
+        json={
+            "email": "alice@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_login_ignores_surrounding_whitespace(async_client: AsyncClient) -> None:
+    """Pasted / autofilled whitespace in the email field is stripped
+    server-side (BUG-AUTH-010)."""
+    await _signup(async_client, email="whitespace@example.com")
+    resp = await async_client.post(
+        LOGIN_URL,
+        json={
+            "email": "  whitespace@example.com\n",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_duplicate_signup_detected_with_different_case(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A second signup with a case-variant email must not create a second
+    user row (BUG-AUTH-003)."""
+    await _signup(async_client, email="caseonly@example.com")
+    await async_client.post(
+        SIGNUP_URL,
+        json={
+            "email": "CaseOnly@Example.com",
+            "password": "anotherpassword456",  # pragma: allowlist secret
+        },
+    )
+    result = await db_session.execute(select(User).where(User.email == "caseonly@example.com"))
+    users = result.scalars().all()
+    assert len(users) == 1
+
+
 # ── Signup ──────────────────────────────────────────────────────────────
 
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -905,7 +905,7 @@ export interface AuthRequest {
 }
 export interface AuthResponse {
   token: string;
-  user_id?: number;
+  user_id: number;
 }
 export const auth = {
   login(credentials: AuthRequest): Promise<AuthResponse> {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -60,6 +60,40 @@ function useProactiveRefresh(
   }, [token, tokenRef, applyNewToken]);
 }
 
+/**
+ * BUG-AUTH-005: the storage write must complete before we drop the token
+ * from state; otherwise a crash between the two leaves a stale token in
+ * secure storage that hydrates on next launch.
+ */
+async function clearTokenThenReset(
+  setToken: React.Dispatch<React.SetStateAction<string | null>>,
+): Promise<void> {
+  try {
+    await clearToken();
+  } catch (err: unknown) {
+    console.warn('clearToken failed in onUnauthorized', err);
+  }
+  setToken(null);
+}
+
+/**
+ * BUG-AUTH-001: a fire-and-forget saveToken loses the refreshed token if
+ * the app is killed between the refresh response and the secure-storage
+ * write. Await the persistence before surfacing the token to React state.
+ */
+async function saveTokenThenApply(
+  newToken: string,
+  setToken: React.Dispatch<React.SetStateAction<string | null>>,
+): Promise<void> {
+  try {
+    await saveToken(newToken);
+  } catch (err: unknown) {
+    console.warn('saveToken failed in onTokenRefreshed', err);
+    return;
+  }
+  setToken(newToken);
+}
+
 /** Register API-layer callbacks that bridge token state to the HTTP client. */
 function useApiCallbacks(
   tokenRef: React.MutableRefObject<string | null>,
@@ -68,12 +102,10 @@ function useApiCallbacks(
   useEffect(() => {
     setTokenGetter(() => tokenRef.current);
     setOnUnauthorized(() => {
-      clearToken();
-      setToken(null);
+      void clearTokenThenReset(setToken);
     });
     setOnTokenRefreshed((t: string) => {
-      saveToken(t);
-      setToken(t);
+      void saveTokenThenApply(t, setToken);
     });
     return () => {
       setOnUnauthorized(null);
@@ -133,9 +165,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setToken(null);
   }, []);
 
+  // BUG-AUTH-005: mirror the persistence-first ordering used by the API-layer
+  // onUnauthorized hook so callers of the context-exposed helper get the same
+  // crash-safety guarantee.
   const onUnauthorized = useCallback(() => {
-    clearToken();
-    setToken(null);
+    void clearTokenThenReset(setToken);
   }, []);
 
   const value = useMemo(

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -32,7 +32,7 @@ jest.mock('@/utils/token', () => ({
   REFRESH_BUFFER_SECONDS: 300,
 }));
 
-import { auth, setTokenGetter } from '@/api';
+import { auth, setOnTokenRefreshed, setOnUnauthorized, setTokenGetter } from '@/api';
 import { saveToken, loadToken, clearToken } from '@/storage/authStorage';
 import { isTokenExpired, shouldRefreshToken } from '@/utils/token';
 
@@ -41,6 +41,10 @@ const mockLoadToken = loadToken as jest.MockedFunction<typeof loadToken>;
 const mockSaveToken = saveToken as jest.MockedFunction<typeof saveToken>;
 const mockClearToken = clearToken as jest.MockedFunction<typeof clearToken>;
 const mockSetTokenGetter = setTokenGetter as jest.MockedFunction<typeof setTokenGetter>;
+const mockSetOnTokenRefreshed = setOnTokenRefreshed as jest.MockedFunction<
+  typeof setOnTokenRefreshed
+>;
+const mockSetOnUnauthorized = setOnUnauthorized as jest.MockedFunction<typeof setOnUnauthorized>;
 const mockIsTokenExpired = isTokenExpired as jest.MockedFunction<typeof isTokenExpired>;
 const mockShouldRefreshToken = shouldRefreshToken as jest.MockedFunction<typeof shouldRefreshToken>;
 
@@ -213,6 +217,73 @@ describe('AuthContext', () => {
 
       expect(result.current.token).toBe('valid-jwt');
       expect(mockClearToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('api-layer token callbacks (BUG-AUTH-001 / BUG-AUTH-005)', () => {
+    it('awaits saveToken before updating state when API refresh fires', async () => {
+      mockLoadToken.mockResolvedValue('old-jwt');
+      let resolveSave: (() => void) | null = null;
+      mockSaveToken.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve;
+          }),
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.token).toBe('old-jwt'));
+
+      // Grab the callback that the AuthProvider registered with the API layer.
+      const refreshed = mockSetOnTokenRefreshed.mock.calls.at(-1)?.[0];
+      expect(typeof refreshed).toBe('function');
+
+      await act(async () => {
+        refreshed?.('fresh-jwt');
+      });
+
+      // Save is in-flight — state must not have flipped yet.
+      expect(mockSaveToken).toHaveBeenCalledWith('fresh-jwt');
+      expect(result.current.token).toBe('old-jwt');
+
+      await act(async () => {
+        resolveSave?.();
+      });
+
+      await waitFor(() => expect(result.current.token).toBe('fresh-jwt'));
+    });
+
+    it('awaits clearToken before nulling state when API reports 401', async () => {
+      mockLoadToken.mockResolvedValue('stored-jwt');
+      let resolveClear: (() => void) | null = null;
+      mockClearToken.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveClear = resolve;
+          }),
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.token).toBe('stored-jwt'));
+
+      const unauthorized = mockSetOnUnauthorized.mock.calls.at(-1)?.[0];
+      expect(typeof unauthorized).toBe('function');
+
+      await act(async () => {
+        unauthorized?.();
+      });
+
+      // Clear is in-flight — state must not have flipped yet.
+      expect(mockClearToken).toHaveBeenCalled();
+      expect(result.current.token).toBe('stored-jwt');
+
+      await act(async () => {
+        resolveClear?.();
+      });
+
+      await waitFor(() => expect(result.current.token).toBeNull());
     });
   });
 

--- a/frontend/src/features/Auth/LoginScreen.tsx
+++ b/frontend/src/features/Auth/LoginScreen.tsx
@@ -22,7 +22,9 @@ export default function LoginScreen({ navigation }: Props) {
     setError(null);
     setSubmitting(true);
     try {
-      await login(email, password);
+      // BUG-AUTH-010: trim at submit so paste/autofill whitespace doesn't
+      // produce a confusing 422 from the backend.
+      await login(email.trim(), password);
     } catch (err: unknown) {
       // Backend ``detail`` strings (e.g. ``invalid_credentials``) are API
       // contract tokens, not user copy — route them through the shared

--- a/frontend/src/features/Auth/SignupScreen.tsx
+++ b/frontend/src/features/Auth/SignupScreen.tsx
@@ -100,7 +100,9 @@ export default function SignupScreen({ navigation }: Props) {
 
     setSubmitting(true);
     try {
-      await signup(email, password);
+      // BUG-AUTH-010: trim at submit so paste/autofill whitespace doesn't
+      // produce a confusing 422 from the backend.
+      await signup(email.trim(), password);
     } catch (err: unknown) {
       // Route backend ``detail`` codes (e.g. ``password_too_short``) through
       // the shared mapper rather than leaking snake_case to the user.

--- a/frontend/src/features/Auth/__tests__/LoginScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/LoginScreen.test.tsx
@@ -79,6 +79,19 @@ describe('LoginScreen', () => {
     expect(await findByText(/Check your connection/i)).toBeTruthy();
   });
 
+  it('trims whitespace from the email before submitting (BUG-AUTH-010)', async () => {
+    mockLogin.mockResolvedValue(undefined);
+    const { getByPlaceholderText, getByText } = render(<LoginScreen navigation={mockNavigation} />);
+
+    fireEvent.changeText(getByPlaceholderText('Email'), '  user@test.com\n');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
+    fireEvent.press(getByText('Log In'));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith('user@test.com', 'password123');
+    });
+  });
+
   it('has a link to navigate to signup', () => {
     const { getByText } = render(<LoginScreen navigation={mockNavigation} />);
 

--- a/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
@@ -107,6 +107,22 @@ describe('SignupScreen', () => {
     expect(await findByText(/Check your connection/i)).toBeTruthy();
   });
 
+  it('trims whitespace from the email before submitting (BUG-AUTH-010)', async () => {
+    mockSignup.mockResolvedValue(undefined);
+    const { getByPlaceholderText, getByText } = render(
+      <SignupScreen navigation={mockNavigation} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), '  new@test.com  ');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'password123');
+    fireEvent.press(getByText('Sign Up'));
+
+    await waitFor(() => {
+      expect(mockSignup).toHaveBeenCalledWith('new@test.com', 'password123');
+    });
+  });
+
   it('has a link to navigate to login', () => {
     const { getByText } = render(<SignupScreen navigation={mockNavigation} />);
 


### PR DESCRIPTION
Lands the five bugs that the user hit on the way through the front door,
per 2026-04-14 bug-remediation Top-5 triage:

- BUG-AUTH-003 + 010: normalize email at the request boundary (strip +
  lower) via a Pydantic pre-validator, and add a Postgres functional
  unique index on lower(email) so duplicates can't survive case variance
  at the DB layer.
- BUG-AUTH-002: tighten AuthResponse.user_id to required on the TS side
  so downstream consumers get the same guarantee the backend already
  makes.
- BUG-AUTH-001: await saveToken before flipping React state when the
  API-layer token-refresh callback fires, so a crash between refresh and
  persistence doesn't silently log the user out on next launch.
- BUG-AUTH-005: mirror the same persistence-first ordering for
  clearToken in both the API-layer onUnauthorized hook and the
  context-exposed helper.
- BUG-AUTH-010: trim the email field on submit in both SignupScreen and
  LoginScreen so paste/autofill whitespace doesn't produce a 422.

Regression tests cover case-insensitive login, whitespace-stripped
login, duplicate detection across case, the crash-safe save/clear
ordering, and the client-side trim.