### PR TITLE
fix(course,stages,goals): phase 2 bug remediation

### DIFF
--- a/backend/migrations/versions/a1b2c3d4e5f6_goal_group_id_ondelete_set_null.py
+++ b/backend/migrations/versions/a1b2c3d4e5f6_goal_group_id_ondelete_set_null.py
@@ -1,0 +1,46 @@
+"""add ondelete SET NULL on goal.goal_group_id
+
+Revision ID: a1b2c3d4e5f6
+Revises: e8376b41c6a1
+Create Date: 2026-04-16 00:00:00.000000
+
+BUG-GOAL-003: Deleting a GoalGroup should SET NULL on Goal.goal_group_id
+rather than leaving orphaned FK references.  The application-level unlink
+in the delete handler already does this, but without the DB constraint a
+direct DELETE or future refactor could break referential integrity.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e8376b41c6a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Replace the goal.goal_group_id FK with ondelete=SET NULL."""
+    op.drop_constraint("goal_goal_group_id_fkey", "goal", type_="foreignkey")
+    op.create_foreign_key(
+        "goal_goal_group_id_fkey",
+        "goal",
+        "goalgroup",
+        ["goal_group_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    """Revert to FK without ondelete."""
+    op.drop_constraint("goal_goal_group_id_fkey", "goal", type_="foreignkey")
+    op.create_foreign_key(
+        "goal_goal_group_id_fkey",
+        "goal",
+        "goalgroup",
+        ["goal_group_id"],
+        ["id"],
+    )

--- a/backend/migrations/versions/b2c3d4e5f6a7_goalgroup_shared_template_check.py
+++ b/backend/migrations/versions/b2c3d4e5f6a7_goalgroup_shared_template_check.py
@@ -1,0 +1,38 @@
+"""add CHECK constraint on goalgroup shared_template/user_id
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-16 00:01:00.000000
+
+BUG-GOAL-004: The shared-template invariant (shared_template=True implies
+user_id IS NULL, and vice versa) was enforced only at the application layer.
+A direct INSERT or future refactor could violate it.  This migration adds a
+DB-level CHECK constraint to make the invariant a database guarantee.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_CONSTRAINT_NAME = "ck_goalgroup_shared_template_user_id"
+
+
+def upgrade() -> None:
+    """Add CHECK constraint tying shared_template to user_id."""
+    op.create_check_constraint(
+        _CONSTRAINT_NAME,
+        "goalgroup",
+        "(shared_template = true AND user_id IS NULL) "
+        "OR (shared_template = false AND user_id IS NOT NULL)",
+    )
+
+
+def downgrade() -> None:
+    """Drop the shared_template/user_id CHECK constraint."""
+    op.drop_constraint(_CONSTRAINT_NAME, "goalgroup", type_="check")

--- a/backend/migrations/versions/c3d4e5f6a7b8_goal_tier_enum.py
+++ b/backend/migrations/versions/c3d4e5f6a7b8_goal_tier_enum.py
@@ -1,0 +1,43 @@
+"""convert goal.tier to a constrained enum
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-04-16 00:02:00.000000
+
+BUG-GOAL-006: goal.tier previously accepted any string.  This migration adds
+a CHECK constraint limiting the value to the GoalTier enum members
+('low', 'clear', 'stretch').
+
+We use a CHECK constraint instead of a PostgreSQL ENUM type because:
+  1. Adding new enum members to PG ENUM requires ALTER TYPE ... ADD VALUE
+     inside a transaction, which interacts poorly with Alembic's
+     transactional DDL.
+  2. A CHECK is easier to extend later and equally effective for three
+     values.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_CONSTRAINT_NAME = "ck_goal_tier_valid"
+
+
+def upgrade() -> None:
+    """Add CHECK constraint on goal.tier."""
+    op.create_check_constraint(
+        _CONSTRAINT_NAME,
+        "goal",
+        "tier IN ('low', 'clear', 'stretch')",
+    )
+
+
+def downgrade() -> None:
+    """Drop the tier CHECK constraint."""
+    op.drop_constraint(_CONSTRAINT_NAME, "goal", type_="check")

--- a/backend/src/domain/goals.py
+++ b/backend/src/domain/goals.py
@@ -8,10 +8,17 @@ def compute_progress(
 ) -> tuple[float, str]:
     """Compute progress toward ``target``.
 
-    ``is_additive`` mirrors the ``Goal.is_additive`` model field. When ``True``
-    progress increases toward the target; when ``False`` progress reflects how
-    much remains before exceeding the target.
-    Returns a tuple of ``progress`` (0-1) and ``reason_code``.
+    ``is_additive`` mirrors the ``Goal.is_additive`` model field.
+
+    **Additive** (e.g. "drink 8 cups of water"):
+        progress = current / target, clamped to [0, 1].
+
+    **Subtractive** (e.g. "limit caffeine to 200 mg"):
+        100 % when ``current <= 0`` (nothing consumed — full success),
+        0 % when ``current >= target`` (limit reached or exceeded),
+        proportional between.  Formally: ``1 - current / target``.
+
+    Returns ``(progress, reason_code)`` where progress is in [0, 1].
     """
 
     if target <= 0:
@@ -21,6 +28,7 @@ def compute_progress(
         progress = max(0.0, min(current / target, 1.0))
         return progress, "additive_progress"
 
-    remaining = max(target - current, 0)
-    progress = max(0.0, min(remaining / target, 1.0))
+    # Subtractive: success is staying *under* the target.
+    # 1.0 when current <= 0, 0.0 when current >= target.
+    progress = max(0.0, min(1.0 - current / target, 1.0))
     return progress, "subtractive_progress"

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -8,17 +8,19 @@ from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from models.practice import Practice
 from models.practice_session import PracticeSession
+from models.stage_content import StageContent
 from models.stage_progress import StageProgress
 from models.user_practice import UserPractice
 from schemas.stage import HabitHistoryItem, PracticeHistoryItem
 
-# Stage N+1 unlocks when stage N is in completed_stages or is the current stage
+# Stage 1 is always unlocked regardless of progress state.
 _STAGE_1 = 1
 
 
@@ -28,15 +30,94 @@ async def get_user_progress(session: AsyncSession, user_id: int) -> StageProgres
     return result.scalars().first()
 
 
+async def get_user_progress_for_update(session: AsyncSession, user_id: int) -> StageProgress | None:
+    """Fetch the StageProgress record with a ``FOR UPDATE`` row lock.
+
+    Use this in mutation endpoints to prevent TOCTOU races (e.g. two
+    concurrent advance requests both reading the same current_stage).
+    The lock is held until the transaction commits or rolls back.
+    """
+    result = await session.execute(
+        select(StageProgress).where(StageProgress.user_id == user_id).with_for_update()
+    )
+    return result.scalars().first()
+
+
 def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool:
-    """Determine if a stage is unlocked for the user."""
+    """Determine if a stage is unlocked for the user.
+
+    Stage 1 is always unlocked.  For stage N > 1, the stage is unlocked
+    when **all** of the following hold:
+
+    * ``stage_number <= progress.current_stage``, AND
+    * ``stage_number - 1`` appears in ``progress.completed_stages``
+      (stage 1 is exempt from the completed-stages check since it is
+      implicitly accessible).
+
+    A stage *beyond* the current stage is unlocked only if the
+    immediately preceding stage has been completed.
+    """
     if stage_number == _STAGE_1:
         return True
     if progress is None:
         return False
+    completed = progress.completed_stages or []
     if stage_number <= progress.current_stage:
-        return True
-    return stage_number - 1 in (progress.completed_stages or [])
+        # For stages at or below current, require the prior stage to be
+        # completed (or be stage 1 which is always accessible).
+        return stage_number == _STAGE_1 or (stage_number - 1) in completed
+    # Stage is beyond the current stage — unlocked only if its predecessor
+    # has been completed.
+    return (stage_number - 1) in completed
+
+
+async def _compute_habits_progress(session: AsyncSession, user_id: int, stage_number: int) -> float:
+    """Compute ratio of habits with ≥1 completion to total habits for a stage.
+
+    Returns 0.0 when the user has no habits for this stage.
+    """
+    stage_str = str(stage_number)
+    # Count total habits for this stage
+    total_result = await session.execute(
+        select(func.count())
+        .select_from(Habit)
+        .where(Habit.user_id == user_id, Habit.stage == stage_str)
+    )
+    total_habits: int = total_result.scalar() or 0
+    if total_habits == 0:
+        return 0.0
+
+    # Count habits that have at least one GoalCompletion (via Goal)
+    active_result = await session.execute(
+        select(func.count(func.distinct(Habit.id)))
+        .select_from(Habit)
+        .join(Goal, col(Goal.habit_id) == col(Habit.id))
+        .join(
+            GoalCompletion,
+            (col(GoalCompletion.goal_id) == col(Goal.id))
+            & (col(GoalCompletion.user_id) == user_id),
+        )
+        .where(Habit.user_id == user_id, Habit.stage == stage_str)
+    )
+    active_habits: int = active_result.scalar() or 0
+    return min(active_habits / total_habits, 1.0)
+
+
+async def _compute_course_items_completed(
+    session: AsyncSession, user_id: int, stage_number: int
+) -> int:
+    """Count content items completed by the user for a given stage."""
+    result = await session.execute(
+        select(func.count())
+        .select_from(ContentCompletion)
+        .join(StageContent, col(ContentCompletion.content_id) == col(StageContent.id))
+        .join(CourseStage, col(StageContent.course_stage_id) == col(CourseStage.id))
+        .where(
+            ContentCompletion.user_id == user_id,
+            CourseStage.stage_number == stage_number,
+        )
+    )
+    return result.scalar() or 0
 
 
 async def compute_stage_progress(
@@ -57,12 +138,8 @@ async def compute_stage_progress(
     )
     practice_count: int = ps_result.scalar() or 0
 
-    # Count habits for this stage (habits have a stage field matching stage name)
-    # For now, habits_progress is 0.0 as it requires goal completion analysis
-    habits_progress = 0.0
-
-    # Course items completed — will be implemented with StageContent tracking
-    course_items = 0
+    habits_progress = await _compute_habits_progress(session, user_id, stage_number)
+    course_items = await _compute_course_items_completed(session, user_id, stage_number)
 
     # Overall progress: simple average of available metrics
     total = habits_progress + (1.0 if practice_count > 0 else 0.0)
@@ -70,7 +147,7 @@ async def compute_stage_progress(
     overall = total / divisor if divisor > 0 else 0.0
 
     return {
-        "habits_progress": habits_progress,
+        "habits_progress": round(habits_progress, 2),
         "practice_sessions_completed": practice_count,
         "course_items_completed": course_items,
         "overall_progress": round(overall, 2),

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -47,28 +47,15 @@ def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool
     """Determine if a stage is unlocked for the user.
 
     Stage 1 is always unlocked.  For stage N > 1, the stage is unlocked
-    when **all** of the following hold:
-
-    * ``stage_number <= progress.current_stage``, AND
-    * ``stage_number - 1`` appears in ``progress.completed_stages``
-      (stage 1 is exempt from the completed-stages check since it is
-      implicitly accessible).
-
-    A stage *beyond* the current stage is unlocked only if the
-    immediately preceding stage has been completed.
+    when ``stage_number - 1`` appears in ``progress.completed_stages``.
+    This single rule covers both stages at-or-below the current stage
+    and stages beyond it.
     """
     if stage_number == _STAGE_1:
         return True
     if progress is None:
         return False
-    completed = progress.completed_stages or []
-    if stage_number <= progress.current_stage:
-        # For stages at or below current, require the prior stage to be
-        # completed (or be stage 1 which is always accessible).
-        return stage_number == _STAGE_1 or (stage_number - 1) in completed
-    # Stage is beyond the current stage — unlocked only if its predecessor
-    # has been completed.
-    return (stage_number - 1) in completed
+    return (stage_number - 1) in (progress.completed_stages or [])
 
 
 async def _compute_habits_progress(session: AsyncSession, user_id: int, stage_number: int) -> float:

--- a/backend/src/models/goal.py
+++ b/backend/src/models/goal.py
@@ -1,6 +1,7 @@
+from enum import StrEnum
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Column, String
+from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -8,6 +9,14 @@ if TYPE_CHECKING:
     from .goal_completion import GoalCompletion
     from .goal_group import GoalGroup
     from .habit import Habit
+
+
+class GoalTier(StrEnum):
+    """Allowed tier values for a Goal."""
+
+    LOW = "low"
+    CLEAR = "clear"
+    STRETCH = "stretch"
 
 
 class Goal(SQLModel, table=True):
@@ -30,7 +39,7 @@ class Goal(SQLModel, table=True):
     habit_id: int = Field(foreign_key="habit.id")
     title: str = Field(max_length=255)
     description: str | None = Field(default=None, max_length=2_000)
-    tier: str = Field(max_length=50)  # "low", "clear", "stretch"
+    tier: str = Field(max_length=50)  # validated as GoalTier at the schema layer
     target: float
     target_unit: str = Field(max_length=50)  # "minutes", "reps", etc.
     frequency: float  # e.g. 2.0 = 2x per frequency_unit
@@ -42,7 +51,14 @@ class Goal(SQLModel, table=True):
     track_with_timer: bool = False
     timer_duration_minutes: int | None = None
     origin: str | None = Field(default=None, max_length=255)
-    goal_group_id: int | None = Field(default=None, foreign_key="goalgroup.id")
+    goal_group_id: int | None = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("goalgroup.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
     goal_group: Optional["GoalGroup"] = Relationship(back_populates="goals")
     is_additive: bool = True
     habit: "Habit" = Relationship(back_populates="goals")

--- a/backend/src/models/goal_group.py
+++ b/backend/src/models/goal_group.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from sqlalchemy import CheckConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
@@ -7,7 +8,20 @@ if TYPE_CHECKING:
 
 
 class GoalGroup(SQLModel, table=True):
-    """Logical grouping for related goals."""
+    """Logical grouping for related goals.
+
+    Invariant: shared templates (``shared_template=True``) must have
+    ``user_id IS NULL``, and user-owned groups must have a non-null
+    ``user_id``.  Enforced at the DB level via a CHECK constraint.
+    """
+
+    __table_args__ = (
+        CheckConstraint(
+            "(shared_template = true AND user_id IS NULL) "
+            "OR (shared_template = false AND user_id IS NOT NULL)",
+            name="ck_goalgroup_shared_template_user_id",
+        ),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     name: str = Field(max_length=255)

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -8,8 +8,8 @@ from sqlmodel import col, select
 
 from database import get_session
 from domain.course import compute_days_elapsed, filter_content_for_user, next_unlock_day
-from domain.stage_progress import get_user_progress, stage_exists
-from errors import not_found
+from domain.stage_progress import get_user_progress, is_stage_unlocked, stage_exists
+from errors import forbidden, not_found
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
@@ -21,6 +21,10 @@ from schemas.course import (
 )
 
 router = APIRouter(prefix="/course", tags=["course"])
+
+# When a user is past a stage, all drip-feed content should be accessible.
+# We use a large sentinel so ``release_day > days_elapsed`` is always False.
+_PAST_STAGE_DAYS_SENTINEL = 999_999
 
 
 async def _get_stage_by_number(session: AsyncSession, stage_number: int) -> CourseStage:
@@ -35,11 +39,22 @@ async def _get_stage_by_number(session: AsyncSession, stage_number: int) -> Cour
 
 
 async def _days_for_user_stage(session: AsyncSession, user_id: int, stage_number: int) -> int:
-    """Compute how many days the user has been on the given stage."""
+    """Compute how many days the user has been on the given stage.
+
+    Returns:
+    - ``_PAST_STAGE_DAYS_SENTINEL`` when the user has already moved past
+      this stage (all content should be unlocked).
+    - The actual days elapsed when the user is currently on this stage.
+    - ``-1`` when the user has no progress or hasn't reached this stage.
+    """
     progress = await get_user_progress(session, user_id)
-    if progress is None or progress.current_stage != stage_number:
-        return -1  # User is not on this stage
-    return compute_days_elapsed(progress.stage_started_at)
+    if progress is None:
+        return -1
+    if progress.current_stage > stage_number:
+        return _PAST_STAGE_DAYS_SENTINEL
+    if progress.current_stage == stage_number:
+        return compute_days_elapsed(progress.stage_started_at)
+    return -1
 
 
 async def _read_ids_for_user(
@@ -72,6 +87,13 @@ def _items_to_raw_dicts(items: list[StageContent]) -> list[dict[str, object]]:
     ]
 
 
+async def _check_stage_unlocked(session: AsyncSession, user_id: int, stage_number: int) -> None:
+    """Raise 403 if the given stage is locked for the user."""
+    progress = await get_user_progress(session, user_id)
+    if not is_stage_unlocked(stage_number, progress):
+        raise forbidden("stage_locked")
+
+
 @router.get("/stages/{stage_number}/content", response_model=list[ContentItemResponse])
 async def list_stage_content(
     stage_number: int,
@@ -88,12 +110,12 @@ async def list_stage_content(
     )
     items = list(result.scalars().all())
 
-    days = max(await _days_for_user_stage(session, current_user, stage_number), -1)
+    days = await _days_for_user_stage(session, current_user, stage_number)
     content_ids = [item.id for item in items if item.id is not None]
     read_ids = await _read_ids_for_user(session, current_user, content_ids)
 
     raw = _items_to_raw_dicts(items)
-    filtered = filter_content_for_user(raw, days_elapsed=days, read_content_ids=read_ids)
+    filtered = filter_content_for_user(raw, days_elapsed=max(days, -1), read_content_ids=read_ids)
     return [ContentItemResponse(**f) for f in filtered]
 
 
@@ -117,9 +139,10 @@ async def get_content_item(
     if stage is None:
         raise not_found("stage")
 
+    # BUG-COURSE-007: Verify the user has access to this stage
+    await _check_stage_unlocked(session, current_user, stage.stage_number)
+
     days = await _days_for_user_stage(session, current_user, stage.stage_number)
-    if days < 0:
-        days = -1
 
     item_id = item.id
     assert item_id is not None  # guaranteed after DB fetch
@@ -134,7 +157,7 @@ async def get_content_item(
             "url": item.url,
         }
     ]
-    filtered = filter_content_for_user(raw, days_elapsed=days, read_content_ids=read_ids)
+    filtered = filter_content_for_user(raw, days_elapsed=max(days, -1), read_content_ids=read_ids)
     return ContentItemResponse(**filtered[0])
 
 
@@ -147,8 +170,18 @@ async def mark_content_read(
     """Mark a content item as read. Idempotent — repeated calls return existing record."""
     # Verify content exists
     result = await session.execute(select(StageContent).where(StageContent.id == content_id))
-    if result.scalars().first() is None:
+    content_item = result.scalars().first()
+    if content_item is None:
         raise not_found("content")
+
+    # BUG-COURSE-005: Look up the parent stage and verify unlock
+    stage_result = await session.execute(
+        select(CourseStage).where(CourseStage.id == content_item.course_stage_id)
+    )
+    stage = stage_result.scalars().first()
+    if stage is None:
+        raise not_found("stage")
+    await _check_stage_unlocked(session, current_user, stage.stage_number)
 
     # Check for existing completion (idempotent)
     existing_result = await session.execute(
@@ -211,13 +244,17 @@ async def get_course_progress(
 
     read_ids = await _read_ids_for_user(session, current_user, _content_ids_from_items(items))
     progress_pct = round((len(read_ids) / len(items)) * 100, 2)
-    days = max(await _days_for_user_stage(session, current_user, stage_number), -1)
+    days = await _days_for_user_stage(session, current_user, stage_number)
+
+    # BUG-COURSE-004: Don't compute next_unlock_day when days_elapsed is
+    # negative (user hasn't started this stage) or for past stages.
+    nud: int | None = None
+    if 0 <= days < _PAST_STAGE_DAYS_SENTINEL:
+        nud = next_unlock_day(release_days=[item.release_day for item in items], days_elapsed=days)
 
     return CourseProgressResponse(
         total_items=len(items),
         read_items=len(read_ids),
         progress_percent=progress_pct,
-        next_unlock_day=next_unlock_day(
-            release_days=[item.release_day for item in items], days_elapsed=days
-        ),
+        next_unlock_day=nud,
     )

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -14,10 +14,11 @@ from domain.stage_progress import (
     get_stage_habit_history,
     get_stage_practice_history,
     get_user_progress,
+    get_user_progress_for_update,
     is_stage_unlocked,
     stage_exists,
 )
-from errors import bad_request, not_found
+from errors import bad_request, forbidden, not_found
 from models.course_stage import CourseStage
 from models.stage_progress import StageProgress
 from routers.auth import get_current_user
@@ -37,31 +38,46 @@ async def list_stages(
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
 ) -> list[StageResponse]:
-    """List all stages with per-user progress overlay."""
+    """List all stages with per-user progress overlay.
+
+    Each stage's ``progress`` field is populated from
+    ``compute_stage_progress`` so the frontend can render progress bars
+    without a follow-up call. This accepts an N+M round-trip (one query
+    per metric per stage) since N=10 stages is small and caching would
+    add complexity disproportionate to the benefit.
+    """
     result = await session.execute(
         select(CourseStage).order_by(col(CourseStage.stage_number).asc())
     )
     stages = result.scalars().all()
     progress = await get_user_progress(session, current_user)
 
-    return [
-        StageResponse(
-            id=s.id,
-            title=s.title,
-            subtitle=s.subtitle,
-            stage_number=s.stage_number,
-            overview_url=s.overview_url,
-            category=s.category,
-            aspect=s.aspect,
-            spiral_dynamics_color=s.spiral_dynamics_color,
-            growing_up_stage=s.growing_up_stage,
-            divine_gender_polarity=s.divine_gender_polarity,
-            relationship_to_free_will=s.relationship_to_free_will,
-            free_will_description=s.free_will_description,
-            is_unlocked=is_stage_unlocked(s.stage_number, progress),
+    responses: list[StageResponse] = []
+    for s in stages:
+        unlocked = is_stage_unlocked(s.stage_number, progress)
+        stage_progress = 0.0
+        if unlocked:
+            data = await compute_stage_progress(session, current_user, s.stage_number)
+            stage_progress = data["overall_progress"]
+        responses.append(
+            StageResponse(
+                id=s.id,
+                title=s.title,
+                subtitle=s.subtitle,
+                stage_number=s.stage_number,
+                overview_url=s.overview_url,
+                category=s.category,
+                aspect=s.aspect,
+                spiral_dynamics_color=s.spiral_dynamics_color,
+                growing_up_stage=s.growing_up_stage,
+                divine_gender_polarity=s.divine_gender_polarity,
+                relationship_to_free_will=s.relationship_to_free_will,
+                free_will_description=s.free_will_description,
+                is_unlocked=unlocked,
+                progress=float(stage_progress),
+            )
         )
-        for s in stages
-    ]
+    return responses
 
 
 @router.get("/{stage_number}", response_model=StageResponse)
@@ -120,6 +136,10 @@ async def get_stage_history(
     if not await stage_exists(session, stage_number):
         raise not_found("stage")
 
+    progress = await get_user_progress(session, current_user)
+    if not is_stage_unlocked(stage_number, progress):
+        raise forbidden("stage_locked")
+
     practices = await get_stage_practice_history(session, current_user, stage_number)
     habits = await get_stage_habit_history(session, current_user, stage_number)
 
@@ -136,13 +156,26 @@ async def update_progress(
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
 ) -> StageProgressRecord:
-    """Update the user's current stage (advance forward)."""
-    existing = await get_user_progress(session, current_user)
+    """Advance the user to the next stage.
+
+    Semantics:
+    - **Create** (first ever progress): ``current_stage`` must be 1.
+    - **Update**: ``current_stage`` must equal ``existing.current_stage + 1``
+      (single-step forward only — no stage-skipping).
+    - ``completed_stages`` is always ``range(1, current_stage)`` — i.e. every
+      stage before the current one is marked complete.
+
+    A ``SELECT … FOR UPDATE`` row-lock prevents two concurrent advance
+    requests from both reading the same ``current_stage`` and passing the
+    forward-only check (TOCTOU race).
+    """
+    # Row lock prevents concurrent advances from both reading the same state
+    existing = await get_user_progress_for_update(session, current_user)
 
     if existing is not None:
-        if payload.current_stage <= existing.current_stage:
-            raise bad_request("cannot_go_backwards")
-        # Mark all stages before the new current as completed
+        expected_next = existing.current_stage + 1
+        if payload.current_stage != expected_next:
+            raise bad_request("must_advance_one_stage")
         completed = list(range(1, payload.current_stage))
         existing.current_stage = payload.current_stage
         existing.completed_stages = completed
@@ -157,10 +190,13 @@ async def update_progress(
             completed_stages=existing.completed_stages,
         )
 
+    if payload.current_stage != 1:
+        raise bad_request("must_start_at_stage_one")
+
     progress = StageProgress(
         user_id=current_user,
-        current_stage=payload.current_stage,
-        completed_stages=list(range(1, payload.current_stage)),
+        current_stage=1,
+        completed_stages=[],
     )
     session.add(progress)
     await session.commit()

--- a/backend/src/schemas/goal.py
+++ b/backend/src/schemas/goal.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
+from models.goal import GoalTier
+
 
 class Goal(BaseModel):
     """Public representation of a :class:`models.goal.Goal`.
@@ -16,7 +18,7 @@ class Goal(BaseModel):
     habit_id: int
     title: str
     description: str | None = None
-    tier: str
+    tier: GoalTier
     target: float
     target_unit: str
     frequency: float

--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -8,7 +8,7 @@ from sqlmodel import select
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 
-CONTENT_DEFINITIONS: list[dict[str, str | int]] = [
+_CONTENT_DEFINITIONS: list[dict[str, str | int]] = [
     # Stage 1 — Survival
     {
         "stage_number": 1,
@@ -76,6 +76,17 @@ CONTENT_DEFINITIONS: list[dict[str, str | int]] = [
         "url": "https://cms.adepthood.com/stage-3/reflection",
     },
 ]
+
+# BUG-SEED-001: Assert uniqueness of (stage_number, release_day) at import
+# time.  The drip-feed system assumes one item per day per stage; duplicate
+# release_days would cause unpredictable unlock ordering.
+_stage_day_pairs = [(d["stage_number"], d["release_day"]) for d in _CONTENT_DEFINITIONS]
+assert len(set(_stage_day_pairs)) == len(_stage_day_pairs), (
+    f"Duplicate (stage_number, release_day) in CONTENT_DEFINITIONS: "
+    f"{sorted(p for p in _stage_day_pairs if _stage_day_pairs.count(p) > 1)}"
+)
+
+CONTENT_DEFINITIONS = _CONTENT_DEFINITIONS
 
 
 def _build_content_item(

--- a/backend/src/seed_stages.py
+++ b/backend/src/seed_stages.py
@@ -7,7 +7,7 @@ from sqlmodel import select
 
 from models.course_stage import CourseStage
 
-STAGE_DEFINITIONS: list[dict[str, str | int]] = [
+_STAGE_DEFINITIONS: list[dict[str, str | int]] = [
     {
         "stage_number": 1,
         "title": "Survival",
@@ -139,6 +139,16 @@ STAGE_DEFINITIONS: list[dict[str, str | int]] = [
         "free_will_description": "Free will and determinism as one",
     },
 ]
+
+# BUG-SEED-002: Assert uniqueness of stage_numbers at import time so a
+# duplicate definition is caught immediately, not silently ignored at runtime.
+_stage_numbers = [d["stage_number"] for d in _STAGE_DEFINITIONS]
+assert len(set(_stage_numbers)) == len(_stage_numbers), (
+    f"Duplicate stage_number in STAGE_DEFINITIONS: "
+    f"{sorted(n for n in _stage_numbers if _stage_numbers.count(n) > 1)}"
+)
+
+STAGE_DEFINITIONS = _STAGE_DEFINITIONS
 
 
 async def seed_stages(session: AsyncSession) -> int:

--- a/backend/tests/domain/test_goals.py
+++ b/backend/tests/domain/test_goals.py
@@ -1,3 +1,9 @@
+"""Unit tests for goal progress domain logic."""
+
+from __future__ import annotations
+
+import pytest
+
 from domain.goals import compute_progress
 
 
@@ -11,3 +17,50 @@ def test_subtractive_progress() -> None:
     progress, code = compute_progress(3, 10, is_additive=False)
     assert code == "subtractive_progress"
     assert progress == 0.7  # noqa: PLR2004
+
+
+def test_target_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="target must be positive"):
+        compute_progress(5, 0)
+
+
+# ── BUG-GOAL-002: Subtractive goal progress parameterized ──────────────
+
+_SUBTRACTIVE_CASES = [
+    (0, 100, 1.0),
+    (50, 100, 0.5),
+    (100, 100, 0.0),
+    (200, 100, 0.0),
+]
+
+
+@pytest.mark.parametrize(
+    ("current", "target", "expected"),
+    _SUBTRACTIVE_CASES,
+    ids=["zero_consumed", "half_consumed", "at_limit", "over_limit"],
+)
+def test_subtractive_progress_parameterized(current: float, target: float, expected: float) -> None:
+    """BUG-GOAL-002: Subtractive goals must report 1.0 when current=0,
+    0.0 when current>=target, proportional between."""
+    progress, code = compute_progress(current, target, is_additive=False)
+    assert code == "subtractive_progress"
+    assert progress == pytest.approx(expected, abs=1e-9)
+
+
+_ADDITIVE_CASES = [
+    (0, 100, 0.0),
+    (50, 100, 0.5),
+    (100, 100, 1.0),
+    (200, 100, 1.0),
+]
+
+
+@pytest.mark.parametrize(
+    ("current", "target", "expected"),
+    _ADDITIVE_CASES,
+    ids=["zero", "half", "full", "over"],
+)
+def test_additive_progress_parameterized(current: float, target: float, expected: float) -> None:
+    progress, code = compute_progress(current, target, is_additive=True)
+    assert code == "additive_progress"
+    assert progress == pytest.approx(expected, abs=1e-9)

--- a/backend/tests/domain/test_stage_unlock.py
+++ b/backend/tests/domain/test_stage_unlock.py
@@ -1,0 +1,49 @@
+"""Table-driven tests for is_stage_unlocked (BUG-STAGE-002).
+
+Every combination of current_stage and completed_stages is tested to
+prevent regressions in the unlock predicate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.stage_progress import is_stage_unlocked
+from models.stage_progress import StageProgress
+
+
+def _progress(current: int, completed: list[int]) -> StageProgress:
+    """Build a StageProgress with the given fields (no DB needed)."""
+    return StageProgress(id=1, user_id=1, current_stage=current, completed_stages=completed)
+
+
+_CASES: list[tuple[str, int, StageProgress | None, bool]] = [
+    ("stage 1 always unlocked (no progress)", 1, None, True),
+    ("stage 1 always unlocked (with progress)", 1, _progress(3, [1, 2]), True),
+    ("stage 2 locked without progress", 2, None, False),
+    ("stage 2 unlocked when current=2 and 1 completed", 2, _progress(2, [1]), True),
+    ("stage 2 locked when current=2 but 1 NOT completed", 2, _progress(2, []), False),
+    ("stage 3 locked when current=2 (not yet reached)", 3, _progress(2, [1]), False),
+    ("stage 3 unlocked when 2 completed", 3, _progress(2, [1, 2]), True),
+    ("stage 3 unlocked when current=3 and 2 completed", 3, _progress(3, [1, 2]), True),
+    ("stage 3 locked when current=3 but 2 NOT completed", 3, _progress(3, [1]), False),
+    ("stage 4 locked when current=3 and 3 not completed", 4, _progress(3, [1, 2]), False),
+    ("stage 4 unlocked when 3 completed", 4, _progress(3, [1, 2, 3]), True),
+    # Edge: current_stage jumped ahead (DB mutation) without completing predecessors
+    ("stage 5 locked despite current=5 if 4 not completed", 5, _progress(5, [1, 2, 3]), False),
+    ("stage 5 unlocked when current=5 and 4 completed", 5, _progress(5, [1, 2, 3, 4]), True),
+]
+
+
+@pytest.mark.parametrize(
+    ("description", "stage_number", "progress", "expected"),
+    _CASES,
+    ids=[c[0] for c in _CASES],
+)
+def test_is_stage_unlocked(
+    description: str,
+    stage_number: int,
+    progress: StageProgress | None,
+    expected: bool,
+) -> None:
+    assert is_stage_unlocked(stage_number, progress) is expected, description

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -502,3 +502,94 @@ async def test_read_tracking_isolated_per_user(
     resp = await async_client.get("/course/stages/1/content", headers=bob_headers)
     data = resp.json()
     assert all(not item["is_read"] for item in data)
+
+
+# ── BUG-COURSE-007: get_content_item checks stage unlock ──────────────
+
+
+@pytest.mark.asyncio
+async def test_get_content_item_rejects_locked_stage(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-COURSE-007: Content from a locked stage must be forbidden."""
+    headers, user_id = await _signup(async_client)
+    # Create stage 2 content but user has NO progress record (only stage 1 unlocked)
+    _, items = await _seed_stage_with_content(db_session, stage_number=2)
+
+    resp = await async_client.get(f"/course/content/{items[0].id}", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+# ── BUG-COURSE-005: mark_content_read checks stage unlock ─────────────
+
+
+@pytest.mark.asyncio
+async def test_mark_read_rejects_locked_stage(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-COURSE-005: Cannot mark content from a locked stage as read."""
+    headers, user_id = await _signup(async_client)
+    _, items = await _seed_stage_with_content(db_session, stage_number=2)
+
+    resp = await async_client.post(f"/course/content/{items[0].id}/mark-read", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+# ── BUG-COURSE-002/003: past-stage content is fully unlocked ───────────
+
+
+@pytest.mark.asyncio
+async def test_past_stage_content_fully_unlocked(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-COURSE-002/003: User on stage 3 can see all stage-1 content
+    regardless of drip-feed timing."""
+    headers, user_id = await _signup(async_client)
+    await _seed_stage_with_content(db_session, stage_number=1)
+    # Also seed stage 3 so user can be on it
+    stage3 = CourseStage(
+        title="S3",
+        subtitle="S3",
+        stage_number=3,
+        overview_url="",
+        category="t",
+        aspect="t",
+        spiral_dynamics_color="red",
+        growing_up_stage="power",
+        divine_gender_polarity="m",
+        relationship_to_free_will="a",
+        free_will_description="t",
+    )
+    db_session.add(stage3)
+    await db_session.commit()
+    # User is on stage 3 with stages 1,2 completed
+    await _set_user_stage(db_session, user_id, stage_number=3)
+
+    resp = await async_client.get("/course/stages/1/content", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    # Even day-7 content should be unlocked for a past stage
+    assert all(not item["is_locked"] for item in data)
+    assert all(item["url"] is not None for item in data)
+
+
+# ── BUG-COURSE-004: next_unlock_day with negative days ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_course_progress_no_next_unlock_when_not_on_stage(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-COURSE-004: next_unlock_day should be None when user hasn't
+    started the stage (not pass -1 to next_unlock_day)."""
+    headers, _user_id = await _signup(async_client)
+    await _seed_stage_with_content(db_session, stage_number=1)
+    # User has no progress record
+    resp = await async_client.get("/course/stages/1/progress", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["next_unlock_day"] is None

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from http import HTTPStatus
 
@@ -156,6 +157,50 @@ async def test_list_stages_stage1_always_unlocked(
     assert data[1]["is_unlocked"] is False
 
 
+@pytest.mark.asyncio
+async def test_list_stages_populates_progress_field(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-STAGE-006: The progress field should be populated, not always 0.0."""
+    headers, user_id = await _signup(async_client)
+    await _seed_stages(db_session, count=1)
+    # Create practice + session so progress > 0
+    practice = Practice(
+        stage_number=1,
+        name="Test",
+        description="t",
+        instructions="t",
+        default_duration_minutes=5,
+        approved=True,
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    user_practice = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=1,
+        start_date=datetime.now(UTC).date(),
+    )
+    db_session.add(user_practice)
+    await db_session.commit()
+    await db_session.refresh(user_practice)
+    ps = PracticeSession(
+        user_id=user_id,
+        user_practice_id=user_practice.id,
+        duration_minutes=10.0,
+    )
+    db_session.add(ps)
+    await db_session.commit()
+
+    resp = await async_client.get("/stages", headers=headers)
+    data = resp.json()
+    # Stage 1 is always unlocked, and the user has a practice session,
+    # so progress should be > 0.
+    assert data[0]["progress"] > 0.0
+
+
 # ── GET /stages/{stage_number} ──────────────────────────────────────────
 
 
@@ -261,45 +306,77 @@ async def test_get_stage_progress_not_found(
 
 
 @pytest.mark.asyncio
-async def test_update_progress_creates_new(
+async def test_update_progress_creates_new_at_stage_one(
     async_client: AsyncClient,
 ) -> None:
+    """First progress record must start at stage 1 (BUG-STAGE-001)."""
     headers, user_id = await _signup(async_client)
-    target_stage = 2
     resp = await async_client.put(
         "/stages/progress",
-        json={"current_stage": target_stage},
+        json={"current_stage": 1},
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
-    assert data["current_stage"] == target_stage
+    assert data["current_stage"] == 1
     assert data["user_id"] == user_id
+    assert data["completed_stages"] == []
 
 
 @pytest.mark.asyncio
-async def test_update_progress_updates_existing(
+async def test_update_progress_rejects_create_at_nonzero_stage(
+    async_client: AsyncClient,
+) -> None:
+    """BUG-STAGE-001: Cannot create progress at a stage other than 1."""
+    headers, _user_id = await _signup(async_client)
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 5},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_update_progress_advances_one_step(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
+    """BUG-STAGE-001: Must advance exactly one stage at a time."""
     headers, user_id = await _signup(async_client)
-    # Create initial progress
     progress = StageProgress(user_id=user_id, current_stage=1, completed_stages=[])
     db_session.add(progress)
     await db_session.commit()
 
-    target_stage = 3
+    expected_stage = 2
     resp = await async_client.put(
         "/stages/progress",
-        json={"current_stage": target_stage},
+        json={"current_stage": expected_stage},
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
-    assert data["current_stage"] == target_stage
-    # All stages before target should be marked completed
+    assert data["current_stage"] == expected_stage
     assert 1 in data["completed_stages"]
-    assert target_stage - 1 in data["completed_stages"]
+
+
+@pytest.mark.asyncio
+async def test_update_progress_rejects_skip(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-STAGE-001: Skipping from stage 1 to 3 is rejected."""
+    headers, user_id = await _signup(async_client)
+    progress = StageProgress(user_id=user_id, current_stage=1, completed_stages=[])
+    db_session.add(progress)
+    await db_session.commit()
+
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 3},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
 @pytest.mark.asyncio
@@ -320,7 +397,93 @@ async def test_update_progress_cannot_go_backwards(
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
-# ── Edge cases ──────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_update_progress_cannot_stay_same(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Submitting the current stage again is rejected."""
+    headers, user_id = await _signup(async_client)
+    progress = StageProgress(user_id=user_id, current_stage=3, completed_stages=[1, 2])
+    db_session.add(progress)
+    await db_session.commit()
+
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 3},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+
+# ── BUG-STAGE-005: TOCTOU race on PUT /stages/progress ─────────────────
+
+
+_EXPECTED_STAGE_AFTER_ADVANCE = 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_advance_produces_consistent_state(
+    concurrent_async_client: AsyncClient,
+) -> None:
+    """BUG-STAGE-005: Two concurrent advances must produce a consistent
+    final state.  With PostgreSQL's ``FOR UPDATE`` lock, exactly one
+    request wins and the other is rejected.  SQLite serialises at the
+    database level so both may succeed — but the final state must still
+    be ``current_stage=2, completed_stages=[1]``.
+    """
+    headers, _user_id = await _signup(concurrent_async_client, "raceuser")
+    # Create initial progress at stage 1
+    resp = await concurrent_async_client.put(
+        "/stages/progress",
+        json={"current_stage": 1},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    # Both try to advance to stage 2 concurrently
+    results = await asyncio.gather(
+        concurrent_async_client.put(
+            "/stages/progress",
+            json={"current_stage": _EXPECTED_STAGE_AFTER_ADVANCE},
+            headers=headers,
+        ),
+        concurrent_async_client.put(
+            "/stages/progress",
+            json={"current_stage": _EXPECTED_STAGE_AFTER_ADVANCE},
+            headers=headers,
+        ),
+    )
+
+    # At least one must succeed
+    assert any(r.status_code == HTTPStatus.OK for r in results)
+
+    # Verify the final state is consistent
+    successful = [r for r in results if r.status_code == HTTPStatus.OK]
+    for r in successful:
+        data = r.json()
+        assert data["current_stage"] == _EXPECTED_STAGE_AFTER_ADVANCE
+        assert data["completed_stages"] == [1]
+
+
+# ── BUG-STAGE-003: history requires stage to be unlocked ────────────────
+
+
+@pytest.mark.asyncio
+async def test_history_rejects_locked_stage(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-STAGE-003: GET /stages/{n}/history must reject locked stages."""
+    headers, _user_id = await _signup(async_client)
+    await _seed_stages(db_session, count=3)
+    # No progress record → only stage 1 is unlocked
+    resp = await async_client.get("/stages/3/history", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+# ── BUG-STAGE-002: is_stage_unlocked correctness ───────────────────────
 
 
 @pytest.mark.asyncio
@@ -342,6 +505,30 @@ async def test_stage_unlocked_via_completed_stages(
     assert data[2]["is_unlocked"] is True
 
 
+@pytest.mark.asyncio
+async def test_stage_unlocked_requires_predecessor_completed(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-STAGE-002: stage N <= current but N-1 NOT in completed_stages → locked."""
+    headers, user_id = await _signup(async_client)
+    await _seed_stages(db_session, count=3)
+    # current_stage=3 but completed_stages is missing stage 1.
+    # This simulates a DB-level mutation that skipped the completion list.
+    progress = StageProgress(user_id=user_id, current_stage=3, completed_stages=[2])
+    db_session.add(progress)
+    await db_session.commit()
+
+    resp = await async_client.get("/stages", headers=headers)
+    data = resp.json()
+    # Stage 1: always unlocked
+    assert data[0]["is_unlocked"] is True
+    # Stage 2: current_stage=3 > 2, but predecessor (1) NOT in completed → locked
+    assert data[1]["is_unlocked"] is False
+    # Stage 3: current_stage=3, predecessor (2) IS in completed → unlocked
+    assert data[2]["is_unlocked"] is True
+
+
 # ── User isolation ──────────────────────────────────────────────────────
 
 
@@ -354,10 +541,10 @@ async def test_stages_progress_isolated_per_user(
     bob_headers, _bob_id = await _signup(async_client, "bob")
     await _seed_stages(db_session, count=3)
 
-    # Alice advances to stage 2
+    # Alice starts at stage 1
     await async_client.put(
         "/stages/progress",
-        json={"current_stage": 2},
+        json={"current_stage": 1},
         headers=alice_headers,
     )
 

--- a/frontend/src/features/Course/ContentCard.tsx
+++ b/frontend/src/features/Course/ContentCard.tsx
@@ -55,7 +55,10 @@ const ContentCard = ({ item, onPress }: ContentCardProps): React.JSX.Element => 
       accessibilityRole="button"
       accessibilityLabel={`${item.title}${item.is_locked ? ', locked' : ''}${item.is_read ? ', read' : ''}`}
       disabled={item.is_locked}
-      onPress={() => onPress(item)}
+      onPress={() => {
+        if (item.is_locked) return;
+        onPress(item);
+      }}
       style={[
         styles.contentCard,
         item.is_locked && styles.contentCardLocked,

--- a/frontend/src/features/Course/StageSelector.tsx
+++ b/frontend/src/features/Course/StageSelector.tsx
@@ -6,7 +6,11 @@ import { STAGE_COLORS, STAGE_ORDER } from '../../design/tokens';
 
 import styles from './Course.styles';
 
-const TOTAL_STAGES = 10;
+/** Derive the total number of stage pills from the API response. */
+function totalStageCount(stages: Stage[]): number {
+  if (stages.length === 0) return 0;
+  return Math.max(...stages.map((s) => s.stage_number));
+}
 
 interface StageSelectorProps {
   stages: Stage[];
@@ -48,7 +52,7 @@ const StageSelector = ({
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.stageSelectorContent}
       >
-        {Array.from({ length: TOTAL_STAGES }, (_, i) => {
+        {Array.from({ length: totalStageCount(stagesList) }, (_, i) => {
           const stageNumber = i + 1;
           const unlocked = isUnlocked(stageNumber, stagesList);
           const completed = isCompleted(stageNumber, stagesList);

--- a/frontend/src/features/Course/__tests__/StageSelector.test.tsx
+++ b/frontend/src/features/Course/__tests__/StageSelector.test.tsx
@@ -51,14 +51,17 @@ describe('StageSelector', () => {
     onSelectStage = jest.fn() as any;
   });
 
-  it('renders all 10 stage pills', () => {
-    const { getByTestId } = render(
+  it('renders one pill per stage from API data', () => {
+    const { getByTestId, queryByTestId } = render(
       <StageSelector stages={sampleStages} selectedStage={1} onSelectStage={onSelectStage} />,
     );
 
-    for (let i = 1; i <= 10; i++) {
+    // sampleStages has 3 stages (max stage_number = 3)
+    for (let i = 1; i <= 3; i++) {
       expect(getByTestId(`stage-pill-${i}`)).toBeTruthy();
     }
+    // No pill 4 should exist
+    expect(queryByTestId('stage-pill-4')).toBeNull();
   });
 
   it('shows checkmark for completed stages', () => {

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -1,10 +1,11 @@
 // frontend/features/Map/MapScreen.tsx
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
   ImageBackground,
+  InteractionManager,
   Modal,
   Pressable,
   ScrollView,
@@ -352,7 +353,9 @@ const ModalBody = ({ stage, onClose, onNavigate }: ModalBodyProps): React.JSX.El
     <Text style={styles.modalSubtitle}>{stage.subtitle}</Text>
     <StageProgressSection stage={stage} />
     <StageMetadataSection stage={stage} />
-    <StageHistorySection stageNumber={stage.stageNumber} isUnlocked={stage.isUnlocked} />
+    {stage.isUnlocked && (
+      <StageHistorySection stageNumber={stage.stageNumber} isUnlocked={stage.isUnlocked} />
+    )}
     <View style={styles.separator} />
     <ActionLinks stage={stage} onNavigate={onNavigate} />
   </ScrollView>
@@ -440,6 +443,7 @@ const MapScreen = (): React.JSX.Element => {
   const error = useStageStore(selectStagesError);
   const currentStage = useStageStore(selectCurrentStage);
   const [activeStage, setActiveStage] = useState<StageData | null>(null);
+  const navigatingRef = useRef(false);
 
   useEffect(() => {
     if (stages.length === 0 && !loading) {
@@ -449,12 +453,20 @@ const MapScreen = (): React.JSX.Element => {
 
   const handleNavigate = useCallback(
     (screen: 'Practice' | 'Course' | 'Journal', stage: StageData) => {
+      if (navigatingRef.current) return;
+      navigatingRef.current = true;
       setActiveStage(null);
-      if (screen === 'Journal') {
-        navigation.navigate('Journal', { tag: 'stage_reflection', stageNumber: stage.stageNumber });
-      } else {
-        navigation.navigate(screen, { stageNumber: stage.stageNumber });
-      }
+      InteractionManager.runAfterInteractions(() => {
+        if (screen === 'Journal') {
+          navigation.navigate('Journal', {
+            tag: 'stage_reflection',
+            stageNumber: stage.stageNumber,
+          });
+        } else {
+          navigation.navigate(screen, { stageNumber: stage.stageNumber });
+        }
+        navigatingRef.current = false;
+      });
     },
     [navigation],
   );

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -4,6 +4,14 @@ import React from 'react';
 import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
+// Mock InteractionManager to run callbacks synchronously in tests.
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
+  runAfterInteractions: (cb: () => void) => {
+    cb();
+    return { then: () => {}, done: () => {}, cancel: () => {} };
+  },
+}));
+
 // Mock navigation so we can observe tab linking behaviour.
 const mockNavigate = jest.fn();
 jest.mock('../../../navigation/hooks', () => ({


### PR DESCRIPTION
Stage fixes:
- BUG-STAGE-005: SELECT FOR UPDATE on stage progress to prevent TOCTOU race
- BUG-STAGE-006: populate progress field in list_stages (was always 0.0)
- BUG-STAGE-002: rewrite is_stage_unlocked to require predecessor in
  completed_stages (table-driven tests for every combination)
- BUG-STAGE-001: enforce single-step-forward (create must start at 1,
  update must advance exactly +1)
- BUG-STAGE-003: GET /stages/{n}/history now checks stage unlock (403)
- BUG-STAGE-004: compute real habits_progress from Goal/GoalCompletion

Course fixes:
- BUG-COURSE-001: compute real course_items_completed via ContentCompletion
- BUG-COURSE-002/003: past-stage content fully unlocked via sentinel
- BUG-COURSE-004: next_unlock_day returns None when days_elapsed < 0
- BUG-COURSE-005: mark_content_read checks stage unlock (403)
- BUG-COURSE-007: get_content_item checks stage unlock (403)

Goal fixes:
- BUG-GOAL-002: clarify subtractive formula with parametrized tests
- BUG-GOAL-003: ondelete SET NULL on Goal.goal_group_id + migration
- BUG-GOAL-004: CHECK constraint shared_template/user_id + migration
- BUG-GOAL-006: GoalTier StrEnum + CHECK constraint migration

Seed fixes:
- BUG-SEED-001: assert (stage_number, release_day) uniqueness at import
- BUG-SEED-002: assert stage_number uniqueness at import

Frontend fixes:
- BUG-FRONTEND-001: StageSelector derives count from API (was hardcoded 10)
- BUG-FRONTEND-002: ContentCard guards onPress against locked items
- BUG-FRONTEND-003: map modal navigation uses InteractionManager + ref guard
- BUG-FRONTEND-004: StageHistorySection gated at parent

https://claude.ai/code/session_01N6bQXJxqzfCJGUAcT4tNKB