### PR TITLE
fix(backend): dedupe case-variant emails before lowercasing

### DIFF
--- a/backend/migrations/versions/e8376b41c6a1_unique_lower_email_index.py
+++ b/backend/migrations/versions/e8376b41c6a1_unique_lower_email_index.py
@@ -29,17 +29,19 @@ depends_on: Union[str, Sequence[str], None] = None
 
 _UNIQUE_LOWER_EMAIL_INDEX = "ix_user_lower_email_unique"
 
-# CTE that pairs each duplicate user row with the keeper (lowest id per email).
+# CTE that pairs each duplicate user row with the keeper (lowest id per
+# lower(email) group). Duplicates can only differ by case because ``user.email``
+# already has a case-sensitive unique constraint.
 _DUPES_CTE = """
     WITH dupes AS (
         SELECT u.id AS dupe_id, keeper.keeper_id
         FROM "user" u
         JOIN (
-            SELECT email, min(id) AS keeper_id
+            SELECT lower(email) AS lower_email, min(id) AS keeper_id
             FROM "user"
-            GROUP BY email
+            GROUP BY lower(email)
             HAVING count(*) > 1
-        ) keeper ON keeper.email = u.email AND u.id != keeper.keeper_id
+        ) keeper ON keeper.lower_email = lower(u.email) AND u.id != keeper.keeper_id
     )
 """
 
@@ -59,11 +61,14 @@ _CHILD_TABLES: list[tuple[str, str]] = [
 
 
 def upgrade() -> None:
-    """Deduplicate case-variant emails, then add a unique index on lower(email)."""
-    # 1. Normalize every email to lowercase.
-    op.execute('UPDATE "user" SET email = lower(email)')
+    """Deduplicate case-variant emails, then add a unique index on lower(email).
 
-    # 2. Reassign child records from duplicate users to the keeper.
+    Order matters: the existing ``ix_user_email`` unique constraint would reject
+    ``UPDATE ... SET email = lower(email)`` whenever two case-variant rows
+    would collide (e.g. ``Geoff@…`` → ``geoff@…``). Merge the duplicates first,
+    *then* lowercase, *then* create the new index.
+    """
+    # 1. Reassign child records from duplicate users to the keeper.
     for table, col in _CHILD_TABLES:
         op.execute(
             f"{_DUPES_CTE}"
@@ -71,7 +76,7 @@ def upgrade() -> None:
             f'FROM dupes WHERE "{table}".{col} = dupes.dupe_id'
         )
 
-    # 3. stageprogress has a UNIQUE(user_id) constraint — special handling.
+    # 2. stageprogress has a UNIQUE(user_id) constraint — special handling.
     #    Delete the duplicate's row when the keeper already has one.
     op.execute(
         f"{_DUPES_CTE}"
@@ -88,11 +93,16 @@ def upgrade() -> None:
         "FROM dupes WHERE stageprogress.user_id = dupes.dupe_id"
     )
 
-    # 4. Delete duplicate user rows (all children have been moved).
+    # 3. Delete duplicate user rows (all children have been moved).
     op.execute(
         'DELETE FROM "user" '
-        "WHERE id NOT IN (SELECT min(id) FROM \"user\" GROUP BY email)"
+        'WHERE id NOT IN (SELECT min(id) FROM "user" GROUP BY lower(email))'
     )
+
+    # 4. Normalize every remaining email to lowercase. Safe now: deduplication
+    #    guarantees no two rows share a lower(email) value, so the existing
+    #    case-sensitive unique constraint cannot be violated.
+    op.execute('UPDATE "user" SET email = lower(email) WHERE email != lower(email)')
 
     # 5. Create the case-insensitive unique index.
     op.execute(

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import secrets
@@ -46,6 +47,23 @@ def _get_secret_key() -> str:
         msg = "SECRET_KEY environment variable must be set to a secure value"
         raise RuntimeError(msg)
     return SECRET_KEY
+
+
+# Length of the email log fingerprint. Twelve hex chars (48 bits) is ample to
+# distinguish accounts in a single tenant's log stream while remaining short
+# enough to read at a glance, and it is not reversible to the original email.
+_EMAIL_LOG_FINGERPRINT_LEN = 12
+
+
+def _email_log_fingerprint(email: str) -> str:
+    """Stable, non-reversible identifier safe for logs — never log raw emails.
+
+    Returned value is deterministic for a given normalized email, so operators
+    can still correlate events across log lines (e.g. repeated failed logins)
+    without exposing PII to log aggregation.
+    """
+    digest = hashlib.sha256(email.strip().lower().encode("utf-8")).hexdigest()
+    return digest[:_EMAIL_LOG_FINGERPRINT_LEN]
 
 
 class AuthRequest(BaseModel):
@@ -138,7 +156,7 @@ async def _record_attempt(
     logger.info(
         "auth_attempt",
         extra={
-            "email": email,
+            "email_fingerprint": _email_log_fingerprint(email),
             "ip_address": ip_address,
             "success": success,
             "timestamp": datetime.now(UTC).isoformat(),
@@ -216,7 +234,7 @@ async def login(
         logger.info(
             "auth_attempt_blocked",
             extra={
-                "email": payload.email,
+                "email_fingerprint": _email_log_fingerprint(payload.email),
                 "ip_address": ip_address,
                 "reason": "account_locked",
                 "timestamp": datetime.now(UTC).isoformat(),


### PR DESCRIPTION
The email-lowercase migration crashed on Railway because step 1 ran
`UPDATE "user" SET email = lower(email)` while `ix_user_email` (the
existing case-sensitive unique index) was still in place. When two rows
differed only by case (e.g. `Geoff@creekmasons.com` and
`geoff@creekmasons.com`), the UPDATE violated the unique constraint
before the deduplication logic ever executed. The `_DUPES_CTE` also
grouped by `email` instead of `lower(email)`, so it could not find
case-variant duplicates in the first place.

Reorder the migration to merge duplicates first (keyed on
`lower(email)`), lowercase the survivors, then create the new index.