### PR TITLE
chore(backend): phase 3 infra sweep (23 bugs)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -46,3 +46,60 @@ jobs:
         run: |
           uv pip install --system pip-audit
           pip-audit -r backend/requirements.txt
+
+  migration-drift:
+    # BUG-INFRA-023: guard against models diverging from migrations.
+    # Runs ``alembic upgrade head`` + ``alembic check`` on a throwaway
+    # Postgres; fails if a developer added a model without generating
+    # the matching migration, or if the downgrade path is broken
+    # (BUG-INFRA-022 regression guard).
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: aptitude
+          POSTGRES_PASSWORD: aptitude  # pragma: allowlist secret
+          POSTGRES_DB: aptitude
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U aptitude"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      # asyncpg requires ``postgresql+asyncpg`` and the alembic env normalises
+      # either scheme, so any of the three forms would work here.
+      DATABASE_URL: postgresql+asyncpg://aptitude:aptitude@localhost:5432/aptitude  # pragma: allowlist secret
+      SECRET_KEY: ci-only-secret-do-not-use-in-prod  # pragma: allowlist secret
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+
+      - name: Install backend deps
+        run: |
+          uv pip install --system -r backend/requirements-lock.txt
+          uv pip install --system -r backend/requirements-dev.txt
+
+      - name: Upgrade, downgrade, re-upgrade (round-trip)
+        working-directory: backend
+        run: |
+          alembic upgrade head
+          alembic downgrade -1
+          alembic upgrade head
+
+      - name: Detect migration drift (models vs. migrations)
+        working-directory: backend
+        run: |
+          # ``alembic check`` exits non-zero if autogenerate would produce
+          # any operations — i.e. if a model was added/modified without a
+          # matching migration.
+          alembic check

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -48,22 +48,33 @@ def _replace_array_columns() -> None:
 
 @pytest_asyncio.fixture
 async def db_session() -> AsyncGenerator[AsyncSession, None]:
-    """Provide a clean async session with all tables created."""
+    """Provide a clean async session with all tables created.
+
+    BUG-INFRA-027: schema teardown lives in ``finally`` so tables are dropped
+    even when a test raises mid-flight.  Without this, a failing test can
+    leave residual rows that pollute the next test in the same engine.
+    """
     _replace_array_columns()
 
     async with test_engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
 
-    async with test_session_factory() as session:
-        yield session
-
-    async with test_engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.drop_all)
+    try:
+        async with test_session_factory() as session:
+            yield session
+    finally:
+        async with test_engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.drop_all)
 
 
 @pytest_asyncio.fixture
 async def async_client(db_session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
-    """HTTP client with database dependency overridden to use test DB."""
+    """HTTP client with database dependency overridden to use test DB.
+
+    BUG-INFRA-026: ``app.dependency_overrides`` is cleared in ``finally`` and
+    asserted empty at teardown so a failing test cannot leak its session
+    override into subsequent tests in the same process.
+    """
 
     async def _override_get_session() -> AsyncGenerator[AsyncSession, None]:
         yield db_session
@@ -71,10 +82,12 @@ async def async_client(db_session: AsyncSession) -> AsyncGenerator[AsyncClient, 
     app.dependency_overrides[get_session] = _override_get_session
 
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client
-
-    app.dependency_overrides.clear()
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+        assert not app.dependency_overrides, "dependency_overrides leaked between tests"
 
 
 @pytest.fixture(autouse=True)

--- a/backend/migrations/versions/78b1620cafde_convert_datetime_columns_to_timestamptz.py
+++ b/backend/migrations/versions/78b1620cafde_convert_datetime_columns_to_timestamptz.py
@@ -52,7 +52,13 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
+    """Downgrade schema.
+
+    BUG-INFRA-022: align the downgrade expression with the upgrade so
+    ``alembic downgrade -1`` succeeds.  ``column AT TIME ZONE 'UTC'`` on a
+    ``TIMESTAMP WITH TIME ZONE`` value yields a ``TIMESTAMP WITHOUT TIME ZONE``
+    in UTC, which is exactly the inverse of the upgrade conversion.
+    """
     for table, column in _DATETIME_COLUMNS:
         op.alter_column(
             table,
@@ -60,5 +66,5 @@ def downgrade() -> None:
             type_=sa.DateTime(timezone=False),
             existing_type=sa.DateTime(timezone=True),
             existing_nullable=False,
-            postgresql_using=f'("{column}" AT TIME ZONE \'UTC\')',
+            postgresql_using=f'"{column}" AT TIME ZONE \'UTC\'',
         )

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -35,6 +35,17 @@ async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_o
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
-    """FastAPI dependency that yields an async database session."""
+    """FastAPI dependency that yields an async database session.
+
+    BUG-INFRA-021: wrap the body in ``try/finally`` so a failed handler
+    rolls back its transaction *and* releases the connection.  The outer
+    ``async with`` already guarantees ``close()``, but adding the explicit
+    rollback prevents an in-flight ``BEGIN`` from being silently committed
+    by the connection pool when reused.
+    """
     async with async_session_factory() as session:
-        yield session
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,5 +1,6 @@
 """Main FastAPI application instance."""
 
+import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -14,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 from database import get_session
+from observability import CorrelationIdMiddleware, install_trace_id_logging
 from rate_limit import limiter
 from routers.admin import router as admin_router
 from routers.auth import router as auth_router
@@ -30,6 +32,8 @@ from routers.prompts import router as prompts_router
 from routers.stages import router as stages_router
 from routers.user_practices import router as user_practices_router
 
+logger = logging.getLogger(__name__)
+
 VALID_ENVIRONMENTS = {"development", "staging", "production"}
 
 DEV_ORIGINS = [
@@ -37,6 +41,12 @@ DEV_ORIGINS = [
     "http://localhost:8080",
     "http://127.0.0.1:3000",
 ]
+
+# CORS — only the methods the API actually serves are allowed.  Listing them
+# explicitly (BUG-INFRA-008) keeps the preflight surface tight; if a new
+# method is added (PATCH, etc.) the test suite will surface the omission.
+ALLOWED_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+ALLOWED_HEADERS = ["Authorization", "Content-Type", "X-LLM-API-Key", "X-Admin-API-Key"]
 
 
 def _validate_https_origins(origins: list[str]) -> None:
@@ -61,7 +71,9 @@ def _parse_prod_origins() -> list[str]:
         raise RuntimeError("PROD_DOMAIN must not be empty")
 
     _validate_https_origins(origins)
-    return origins
+    # BUG-INFRA-007: order-preserving dedup so duplicate entries in
+    # PROD_DOMAIN don't produce duplicate Access-Control-Allow-Origin lines.
+    return list(dict.fromkeys(origins))
 
 
 def get_cors_origins(env: str | None = None) -> list[str]:
@@ -79,9 +91,32 @@ def get_cors_origins(env: str | None = None) -> list[str]:
         )
 
     if env == "development":
+        # BUG-INFRA-006: warn loudly when PROD_DOMAIN is set in dev so
+        # developers notice misconfiguration before staging rollout.
+        if os.getenv("PROD_DOMAIN"):
+            logger.warning(
+                "PROD_DOMAIN is set but ENV=development — production origins ignored. "
+                "Set ENV=staging or ENV=production to honour PROD_DOMAIN."
+            )
         return list(DEV_ORIGINS)
 
     return _parse_prod_origins()
+
+
+def _assert_credentials_safe(origins: list[str]) -> None:
+    """Reject ``*`` in the CORS allow-list when credentials are enabled.
+
+    BUG-INFRA-005: ``Access-Control-Allow-Origin: *`` plus
+    ``Access-Control-Allow-Credentials: true`` is forbidden by the CORS
+    spec and silently ignored by browsers.  Failing closed at startup
+    surfaces the misconfiguration immediately instead of letting a
+    misbehaving prod env appear to be working.
+    """
+    if "*" in origins:
+        raise RuntimeError(
+            "CORS allow-list contains '*' but allow_credentials=True. "
+            "Browsers will reject the response — pick explicit origins instead."
+        )
 
 
 def _rate_limit_exceeded_handler(_request: Request, exc: RateLimitExceeded) -> JSONResponse:
@@ -94,18 +129,42 @@ def _rate_limit_exceeded_handler(_request: Request, exc: RateLimitExceeded) -> J
     )
 
 
+# Content-Security-Policy is conservative: only same-origin scripts/styles,
+# block plugins, and disallow framing.  The frontend is a React Native app
+# that talks JSON; if a future web build needs richer CSP it should be
+# expanded here rather than loosened ad-hoc per route.
+_CSP_DIRECTIVES = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self'; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "object-src 'none'; "
+    "base-uri 'self'; "
+    "frame-ancestors 'none'"
+)
+
+_PERMISSIONS_POLICY = "geolocation=(), microphone=(), camera=()"
+
+
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Add security headers to every response.
 
     - X-Content-Type-Options: nosniff — prevents MIME-type sniffing
     - X-Frame-Options: DENY — prevents clickjacking via iframes
     - Strict-Transport-Security — enforces HTTPS in production/staging
+    - Content-Security-Policy — restricts loadable assets (BUG-INFRA-001)
+    - Referrer-Policy: strict-origin-when-cross-origin (BUG-INFRA-002)
+    - Permissions-Policy: deny camera/mic/geo by default (BUG-INFRA-003)
     """
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Content-Security-Policy"] = _CSP_DIRECTIVES
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Permissions-Policy"] = _PERMISSIONS_POLICY
 
         env = os.getenv("ENV", "development")
         if env in ("production", "staging"):
@@ -120,6 +179,10 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     """Startup/shutdown lifecycle for the application."""
     import models  # noqa: F401, PLC0415
 
+    # Install the trace-id log filter once per process so every log line
+    # carries the request's correlation ID (BUG-INFRA-025).
+    install_trace_id_logging()
+
     yield
 
 
@@ -128,6 +191,11 @@ app = FastAPI(lifespan=lifespan)
 # Attach the rate limiter to the app so slowapi can find it
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
+
+# Correlation-ID middleware sits at the outermost edge so every other
+# middleware (security headers, CORS, slowapi) and every route handler sees
+# the trace ID through ``contextvars`` (BUG-INFRA-025).
+app.add_middleware(CorrelationIdMiddleware)
 
 # Security headers on all responses
 app.add_middleware(SecurityHeadersMiddleware)
@@ -138,13 +206,14 @@ app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(SlowAPIMiddleware)
 
 origins = get_cors_origins()
+_assert_credentials_safe(origins)
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE"],
-    allow_headers=["Authorization", "Content-Type", "X-LLM-API-Key", "X-Admin-API-Key"],
+    allow_methods=ALLOWED_METHODS,
+    allow_headers=ALLOWED_HEADERS,
 )
 
 # Register feature routers
@@ -164,12 +233,6 @@ app.include_router(goal_groups_router)
 app.include_router(stages_router)
 
 
-@app.get("/")
-def read_root() -> dict[str, str]:
-    """Basic root endpoint."""
-    return {"status": "ok"}
-
-
 @app.get("/health")
 async def health_check(
     session: AsyncSession = Depends(get_session),  # noqa: B008
@@ -179,9 +242,15 @@ async def health_check(
     Returns a 200 with ``{"status": "healthy", "database": "connected"}`` when
     the database is reachable.  Railway pings this endpoint to determine
     service health; a 503 signals an unhealthy container.
+
+    BUG-INFRA-021: session lifecycle is owned by ``Depends(get_session)`` —
+    we don't open or close the session here, so a failed ``SELECT 1`` cannot
+    leak a connection.  The dependency's ``async with`` (in ``database.py``)
+    guarantees ``close()`` runs even when the handler raises.
     """
     try:
         await session.execute(text("SELECT 1"))
     except Exception as exc:
+        logger.exception("health_check_failed")
         raise HTTPException(status_code=503, detail="Database unavailable") from exc
     return {"status": "healthy", "database": "connected"}

--- a/backend/src/observability.py
+++ b/backend/src/observability.py
@@ -1,0 +1,112 @@
+"""Cross-cutting observability primitives — correlation IDs and log filters.
+
+BUG-INFRA-024 / BUG-INFRA-025: every request gets a trace ID (read from the
+``X-Request-ID`` header or minted as a UUID4) that:
+
+* propagates through ``contextvars`` so any code in the call chain can read
+  it without explicit threading,
+* is automatically injected into log records via :class:`TraceIdLogFilter`
+  so structured-logging consumers can stitch entries together, and
+* is echoed back to the client in the ``X-Request-ID`` response header so
+  client logs can be matched against server logs by support staff.
+
+The module is intentionally framework-agnostic except for the middleware
+adapter; the core mechanics (contextvar + log filter) work in background
+tasks and Celery / RQ workers without modification.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+# Header used by upstream load balancers / browser clients to propagate a
+# trace identifier.  We honour whatever value the caller supplied as long as
+# it looks reasonable; otherwise we mint a new UUID4 so every log line in
+# every request has a non-empty trace_id.
+TRACE_ID_HEADER = "X-Request-ID"
+
+# Maximum length we'll accept for a caller-supplied trace ID.  256 chars is
+# well above the 36-char UUID and any reasonable correlation token while
+# capping memory usage if a client sends pathological input.
+_MAX_TRACE_ID_LENGTH = 256
+
+# Sentinel returned by ``get_trace_id`` when no request is in flight.  Using
+# a distinct constant (rather than ``""``) means dashboards can filter out
+# "no-trace" entries explicitly when needed.
+NO_TRACE = "-"
+
+trace_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("trace_id", default=NO_TRACE)
+
+
+def get_trace_id() -> str:
+    """Return the current request's trace ID, or :data:`NO_TRACE` if none is set."""
+    return trace_id_var.get()
+
+
+def _normalise_trace_id(raw: str | None) -> str:
+    """Sanitise an inbound ``X-Request-ID`` value and fall back to a UUID4.
+
+    Strips surrounding whitespace and rejects values that are empty or
+    longer than :data:`_MAX_TRACE_ID_LENGTH`.  We don't try to enforce a
+    specific format (UUID, ULID, etc.) because callers in different
+    environments use different conventions.
+    """
+    if raw is None:
+        return uuid.uuid4().hex
+    candidate = raw.strip()
+    if not candidate or len(candidate) > _MAX_TRACE_ID_LENGTH:
+        return uuid.uuid4().hex
+    return candidate
+
+
+class TraceIdLogFilter(logging.Filter):
+    """Inject the current request's trace ID into every log record.
+
+    Adding the filter at the root logger means every handler picks up the
+    ``trace_id`` attribute without having to be reconfigured individually.
+    Use ``%(trace_id)s`` in the formatter to emit the value, or read it
+    directly from a structured-log handler.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.trace_id = get_trace_id()
+        return True
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Set ``trace_id_var`` for the duration of each request and echo it back.
+
+    The middleware reads :data:`TRACE_ID_HEADER` from the inbound request
+    (minting a fresh UUID4 when absent), pushes it into the contextvar so
+    downstream handlers and log records can see it, and writes the value
+    onto the response so clients can correlate their own logs with ours.
+    """
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        trace_id = _normalise_trace_id(request.headers.get(TRACE_ID_HEADER))
+        token = trace_id_var.set(trace_id)
+        try:
+            response = await call_next(request)
+        finally:
+            trace_id_var.reset(token)
+        response.headers[TRACE_ID_HEADER] = trace_id
+        return response
+
+
+def install_trace_id_logging() -> None:
+    """Attach :class:`TraceIdLogFilter` to the root logger (idempotent).
+
+    Safe to call from app startup and from tests; calling it more than
+    once is a no-op because we check for an existing instance before
+    appending.  This means importing :mod:`main` repeatedly during a test
+    run doesn't accumulate filters.
+    """
+    root = logging.getLogger()
+    if not any(isinstance(f, TraceIdLogFilter) for f in root.filters):
+        root.addFilter(TraceIdLogFilter())

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -10,6 +10,7 @@ shapes to those services.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
 
@@ -36,6 +37,8 @@ from services.botmason import resolve_chat_api_key
 from services.chat_stream import PreflightedRequest, handle_chat_request, stream_bot_response
 from services.usage import get_monthly_cap
 from services.wallet import preflight_deduction, require_user_fresh, reset_monthly_usage_if_due
+
+logger = logging.getLogger(__name__)
 
 
 def _per_user_key(request: StarletteRequest) -> str:
@@ -160,4 +163,8 @@ async def add_balance(
         raise bad_request("user_not_found")
 
     await session.commit()
+    logger.info(
+        "balance_added",
+        extra={"user_id": current_user, "added": payload.amount, "new_balance": new_balance},
+    )
     return BalanceAddResponse(balance=new_balance, added=payload.amount)

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -14,11 +16,14 @@ from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 from routers.auth import get_current_user
+from schemas import Page, PaginationParams, build_page
 from schemas.course import (
     ContentCompletionResponse,
     ContentItemResponse,
     CourseProgressResponse,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/course", tags=["course"])
 
@@ -94,13 +99,24 @@ async def _check_stage_unlocked(session: AsyncSession, user_id: int, stage_numbe
         raise forbidden("stage_locked")
 
 
-@router.get("/stages/{stage_number}/content", response_model=list[ContentItemResponse])
+@router.get("/stages/{stage_number}/content", response_model=None)
 async def list_stage_content(
     stage_number: int,
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
-) -> list[ContentItemResponse]:
-    """List content for a stage with drip-feed gating applied."""
+    pagination: PaginationParams = Depends(),  # noqa: B008
+) -> Page[ContentItemResponse] | list[ContentItemResponse]:
+    """List content for a stage with drip-feed gating applied.
+
+    BUG-INFRA-018: returns ``Page[ContentItemResponse]`` when
+    ``?paginate=true`` is set; otherwise the legacy bare list is returned
+    for one release while the frontend migrates to the envelope.
+
+    Pagination is applied **after** drip-feed filtering so the envelope's
+    ``total`` reflects the items the user can actually see — not the raw
+    count in the database.  Stage content lists are small (tens of items
+    per stage) so paginating in Python after fetching is fine.
+    """
     stage = await _get_stage_by_number(session, stage_number)
 
     result = await session.execute(
@@ -116,7 +132,12 @@ async def list_stage_content(
 
     raw = _items_to_raw_dicts(items)
     filtered = filter_content_for_user(raw, days_elapsed=max(days, -1), read_content_ids=read_ids)
-    return [ContentItemResponse(**f) for f in filtered]
+    responses = [ContentItemResponse(**f) for f in filtered]
+
+    if pagination.paginate:
+        sliced = responses[pagination.offset : pagination.offset + pagination.limit]
+        return build_page(sliced, len(responses), pagination)
+    return responses
 
 
 @router.get("/content/{content_id}", response_model=ContentItemResponse)
@@ -203,6 +224,7 @@ async def mark_content_read(
     session.add(completion)
     await session.commit()
     await session.refresh(completion)
+    logger.info("content_marked_read", extra={"user_id": current_user, "content_id": content_id})
     return ContentCompletionResponse(
         id=completion.id,
         user_id=completion.user_id,

--- a/backend/src/routers/energy.py
+++ b/backend/src/routers/energy.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
+
 from fastapi import APIRouter, Header
 
 from schemas import EnergyPlanRequest, EnergyPlanResponse
 from services.energy import get_or_generate_plan
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/v1/energy", tags=["energy"])
 
 
 @router.post("/plan", response_model=EnergyPlanResponse)
-def create_plan(
+async def create_plan(
     payload: EnergyPlanRequest, x_idempotency_key: str | None = Header(default=None)
 ) -> EnergyPlanResponse:
-    """Create an energy plan from submitted habits."""
-    return get_or_generate_plan(payload, x_idempotency_key)
+    """Create an energy plan from submitted habits.
+
+    BUG-INFRA-009: ``generate_plan`` (called via :func:`get_or_generate_plan`)
+    performs CPU-bound scheduling work.  Running it inline on the event loop
+    would block every other request for the duration of the computation, so
+    we offload to the default executor via :func:`asyncio.to_thread`.  The
+    cache lookup itself is cheap and could run inline, but keeping the entire
+    call off-loop keeps the contract simple — every request returns control
+    to the loop while the worker thread runs.
+    """
+    response = await asyncio.to_thread(get_or_generate_plan, payload, x_idempotency_key)
+    logger.info("energy_plan_created", extra={"reason_code": response.reason_code})
+    return response

--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,6 +16,8 @@ from models.habit import Habit
 from routers.auth import get_current_user
 from schemas import CheckInResult
 from services.streaks import check_milestones, compute_consecutive_streak, update_streak
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/goal_completions", tags=["goals"])
 
@@ -64,6 +68,16 @@ async def create_goal_completion(
         )
     )
     await session.commit()
+
+    logger.info(
+        "goal_completion_recorded",
+        extra={
+            "user_id": current_user,
+            "goal_id": payload.goal_id,
+            "did_complete": payload.did_complete,
+            "streak": new_streak,
+        },
+    )
 
     return CheckInResult(
         streak=new_streak,

--- a/backend/src/routers/goal_groups.py
+++ b/backend/src/routers/goal_groups.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
@@ -11,7 +13,11 @@ from errors import not_found
 from load_options import GOAL_GROUP_WITH_GOALS
 from models.goal_group import GoalGroup
 from routers.auth import get_current_user
+from schemas import Page, PaginationParams, build_page
 from schemas.goal_group import GoalGroupCreate, GoalGroupResponse
+from schemas.pagination import paginate_query
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/goal-groups", tags=["goal-groups"])
 
@@ -53,22 +59,31 @@ async def ensure_seed_templates(session: AsyncSession) -> None:
     await session.commit()
 
 
-@router.get("/", response_model=list[GoalGroupResponse])
+@router.get("/", response_model=None)
 async def list_goal_groups(
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
-) -> list[GoalGroup]:
-    """Return user's goal groups and all shared templates."""
+    pagination: PaginationParams = Depends(),  # noqa: B008
+) -> Page[GoalGroupResponse] | list[GoalGroupResponse]:
+    """Return user's goal groups and all shared templates.
+
+    BUG-INFRA-015: returns ``Page[GoalGroupResponse]`` when ``?paginate=true``
+    is set; otherwise the legacy bare list is returned for one release while
+    the frontend migrates to the envelope.
+    """
     await ensure_seed_templates(session)
-    statement = (
+    query = (
         select(GoalGroup)
         .where(
             (GoalGroup.user_id == current_user) | (GoalGroup.shared_template == True)  # noqa: E712
         )
         .options(GOAL_GROUP_WITH_GOALS)
     )
-    result = await session.execute(statement)
-    return list(result.scalars().all())
+    items, total = await paginate_query(session, query, pagination)
+    serialized = [GoalGroupResponse.model_validate(g, from_attributes=True) for g in items]
+    if pagination.paginate:
+        return build_page(serialized, total, pagination)
+    return serialized
 
 
 @router.get("/{group_id}", response_model=GoalGroupResponse)
@@ -104,7 +119,11 @@ async def create_goal_group(
     # Re-fetch with eager-loaded goals to avoid lazy-load greenlet errors
     statement = select(GoalGroup).where(GoalGroup.id == group.id).options(GOAL_GROUP_WITH_GOALS)
     result = await session.execute(statement)
-    return result.scalars().one()
+    refreshed = result.scalars().one()
+    logger.info(
+        "goal_group_created", extra={"user_id": current_user, "goal_group_id": refreshed.id}
+    )
+    return refreshed
 
 
 @router.put("/{group_id}", response_model=GoalGroupResponse)
@@ -122,10 +141,16 @@ async def update_goal_group(
         setattr(group, key, value)
     session.add(group)
     await session.commit()
-    # Re-fetch with eager-loaded goals to avoid lazy-load greenlet errors
+    # Re-fetch with eager-loaded goals to avoid lazy-load greenlet errors.
+    # BUG-INFRA-020: use ``.first()`` + None check rather than ``.one()`` so a
+    # concurrent delete doesn't surface as ``NoResultFound`` instead of a 404.
     statement = select(GoalGroup).where(GoalGroup.id == group_id).options(GOAL_GROUP_WITH_GOALS)
     result = await session.execute(statement)
-    return result.scalars().one()
+    refreshed = result.scalars().first()
+    if refreshed is None:
+        raise not_found("goal_group")
+    logger.info("goal_group_updated", extra={"user_id": current_user, "goal_group_id": group_id})
+    return refreshed
 
 
 @router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -146,4 +171,5 @@ async def delete_goal_group(
         session.add(goal)
     await session.delete(group)
     await session.commit()
+    logger.info("goal_group_deleted", extra={"user_id": current_user, "goal_group_id": group_id})
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/routers/goal_groups.py
+++ b/backend/src/routers/goal_groups.py
@@ -126,6 +126,20 @@ async def create_goal_group(
     return refreshed
 
 
+async def _refetch_goal_group_with_goals(session: AsyncSession, group_id: int) -> GoalGroup:
+    """Re-fetch a goal group with eager-loaded goals or raise 404.
+
+    BUG-INFRA-020: uses ``.first()`` + None check rather than ``.one()`` so a
+    concurrent delete surfaces as a 404 rather than ``NoResultFound``.
+    """
+    statement = select(GoalGroup).where(GoalGroup.id == group_id).options(GOAL_GROUP_WITH_GOALS)
+    result = await session.execute(statement)
+    refreshed = result.scalars().first()
+    if refreshed is None:
+        raise not_found("goal_group")
+    return refreshed
+
+
 @router.put("/{group_id}", response_model=GoalGroupResponse)
 async def update_goal_group(
     group_id: int,
@@ -141,14 +155,7 @@ async def update_goal_group(
         setattr(group, key, value)
     session.add(group)
     await session.commit()
-    # Re-fetch with eager-loaded goals to avoid lazy-load greenlet errors.
-    # BUG-INFRA-020: use ``.first()`` + None check rather than ``.one()`` so a
-    # concurrent delete doesn't surface as ``NoResultFound`` instead of a 404.
-    statement = select(GoalGroup).where(GoalGroup.id == group_id).options(GOAL_GROUP_WITH_GOALS)
-    result = await session.execute(statement)
-    refreshed = result.scalars().first()
-    if refreshed is None:
-        raise not_found("goal_group")
+    refreshed = await _refetch_goal_group_with_goals(session, group_id)
     logger.info("goal_group_updated", extra={"user_id": current_user, "goal_group_id": group_id})
     return refreshed
 

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
@@ -12,9 +14,13 @@ from errors import not_found
 from load_options import HABIT_WITH_GOALS, HABIT_WITH_GOALS_AND_COMPLETIONS
 from models.habit import Habit
 from routers.auth import get_current_user
+from schemas import Page, PaginationParams, build_page
 from schemas.habit import Habit as HabitSchema
 from schemas.habit import HabitCreate, HabitWithGoals
 from schemas.habit_stats import HabitStats
+from schemas.pagination import paginate_query
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/habits", tags=["habits"])
 
@@ -30,23 +36,33 @@ async def create_habit(
     session.add(habit)
     await session.commit()
     await session.refresh(habit)
+    logger.info("habit_created", extra={"user_id": current_user, "habit_id": habit.id})
     return habit
 
 
-@router.get("/", response_model=list[HabitWithGoals])
+@router.get("/", response_model=None)
 async def list_habits(
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
-) -> list[Habit]:
-    """Return all habits for the authenticated user, sorted by sort_order."""
-    statement = (
+    pagination: PaginationParams = Depends(),  # noqa: B008
+) -> Page[HabitWithGoals] | list[HabitWithGoals]:
+    """Return all habits for the authenticated user, sorted by sort_order.
+
+    BUG-INFRA-013: returns ``Page[HabitWithGoals]`` when ``?paginate=true``
+    is set; otherwise the legacy bare list is returned for one release while
+    the frontend migrates to the envelope.
+    """
+    query = (
         select(Habit)
         .where(Habit.user_id == current_user)
         .options(HABIT_WITH_GOALS)
         .order_by(Habit.sort_order.asc())  # type: ignore[union-attr]
     )
-    result = await session.execute(statement)
-    return list(result.scalars().all())
+    items, total = await paginate_query(session, query, pagination)
+    serialized = [HabitWithGoals.model_validate(h, from_attributes=True) for h in items]
+    if pagination.paginate:
+        return build_page(serialized, total, pagination)
+    return serialized
 
 
 @router.get("/{habit_id}", response_model=HabitWithGoals)
@@ -80,6 +96,7 @@ async def update_habit(
     session.add(habit)
     await session.commit()
     await session.refresh(habit)
+    logger.info("habit_updated", extra={"user_id": current_user, "habit_id": habit.id})
     return habit
 
 
@@ -95,6 +112,7 @@ async def delete_habit(
         raise not_found("habit")
     await session.delete(habit)
     await session.commit()
+    logger.info("habit_deleted", extra={"user_id": current_user, "habit_id": habit_id})
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from fastapi import APIRouter, Depends, Query, Request, Response, status
@@ -20,6 +21,8 @@ from schemas.journal import (
     JournalMessageCreate,
     JournalMessageResponse,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/journal", tags=["journal"])
 
@@ -46,6 +49,7 @@ async def create_journal_entry(
     session.add(entry)
     await session.commit()
     await session.refresh(entry)
+    logger.info("journal_entry_created", extra={"user_id": current_user, "entry_id": entry.id})
     return entry
 
 
@@ -124,6 +128,7 @@ async def delete_journal_entry(
         raise not_found("journal_entry")
     await session.delete(entry)
     await session.commit()
+    logger.info("journal_entry_deleted", extra={"user_id": current_user, "entry_id": entry_id})
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -146,4 +151,7 @@ async def create_bot_response(
     session.add(entry)
     await session.commit()
     await session.refresh(entry)
+    logger.info(
+        "journal_bot_response_created", extra={"user_id": current_user, "entry_id": entry.id}
+    )
     return entry

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends
@@ -13,7 +14,11 @@ from errors import forbidden, not_found
 from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
+from schemas import Page, PaginationParams, build_page
+from schemas.pagination import paginate_query
 from schemas.practice import PracticeSessionCreate, PracticeSessionResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/practice-sessions", tags=["practice-sessions"])
 
@@ -43,23 +48,39 @@ async def create_session(
     session.add(practice_session)
     await session.commit()
     await session.refresh(practice_session)
+    logger.info(
+        "practice_session_logged",
+        extra={
+            "user_id": current_user,
+            "user_practice_id": payload.user_practice_id,
+            "duration_minutes": payload.duration_minutes,
+        },
+    )
     return practice_session
 
 
-@router.get("/", response_model=list[PracticeSessionResponse])
+@router.get("/", response_model=None)
 async def list_sessions(
     user_practice_id: int,
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
-) -> list[PracticeSession]:
-    """List sessions for a specific user-practice."""
-    result = await session.execute(
-        select(PracticeSession).where(
-            PracticeSession.user_practice_id == user_practice_id,
-            PracticeSession.user_id == current_user,
-        )
+    pagination: PaginationParams = Depends(),  # noqa: B008
+) -> Page[PracticeSessionResponse] | list[PracticeSessionResponse]:
+    """List sessions for a specific user-practice.
+
+    BUG-INFRA-014: returns ``Page[PracticeSessionResponse]`` when
+    ``?paginate=true`` is set; otherwise the legacy bare list is returned
+    for one release while the frontend migrates to the envelope.
+    """
+    query = select(PracticeSession).where(
+        PracticeSession.user_practice_id == user_practice_id,
+        PracticeSession.user_id == current_user,
     )
-    return list(result.scalars().all())
+    items, total = await paginate_query(session, query, pagination)
+    serialized = [PracticeSessionResponse.model_validate(s, from_attributes=True) for s in items]
+    if pagination.paginate:
+        return build_page(serialized, total, pagination)
+    return serialized
 
 
 @router.get("/week-count")

--- a/backend/src/routers/practices.py
+++ b/backend/src/routers/practices.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
@@ -11,25 +13,37 @@ from errors import not_found
 from models.practice import Practice
 from rate_limit import limiter
 from routers.auth import get_current_user
+from schemas import Page, PaginationParams, build_page
+from schemas.pagination import paginate_query
 from schemas.practice import PracticeCreate, PracticeResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/practices", tags=["practices"])
 
 
-@router.get("/", response_model=list[PracticeResponse])
+@router.get("/", response_model=None)
 async def list_practices(
     stage_number: int,
     _current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
-) -> list[Practice]:
-    """List approved practices for a given stage."""
-    result = await session.execute(
-        select(Practice).where(
-            Practice.stage_number == stage_number,
-            Practice.approved == True,  # noqa: E712
-        )
+    pagination: PaginationParams = Depends(),  # noqa: B008
+) -> Page[PracticeResponse] | list[PracticeResponse]:
+    """List approved practices for a given stage.
+
+    BUG-INFRA-012: returns ``Page[PracticeResponse]`` when ``?paginate=true``
+    is set; otherwise the legacy bare list is returned for one release while
+    the frontend migrates to the envelope.
+    """
+    query = select(Practice).where(
+        Practice.stage_number == stage_number,
+        Practice.approved == True,  # noqa: E712
     )
-    return list(result.scalars().all())
+    items, total = await paginate_query(session, query, pagination)
+    serialized = [PracticeResponse.model_validate(p, from_attributes=True) for p in items]
+    if pagination.paginate:
+        return build_page(serialized, total, pagination)
+    return serialized
 
 
 @router.get("/{practice_id}", response_model=PracticeResponse)
@@ -63,4 +77,8 @@ async def submit_practice(
     session.add(practice)
     await session.commit()
     await session.refresh(practice)
+    logger.info(
+        "practice_submitted",
+        extra={"user_id": current_user, "practice_id": practice.id},
+    )
     return practice

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from fastapi import APIRouter, Depends, Query, status
@@ -17,6 +18,8 @@ from models.journal_entry import JournalEntry, JournalTag
 from models.prompt_response import PromptResponse
 from routers.auth import get_current_user
 from schemas.prompt import PromptDetail, PromptListResponse, PromptSubmit
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/prompts", tags=["prompts"])
 
@@ -189,6 +192,11 @@ async def submit_prompt_response(
         raise conflict("already_responded") from None
 
     await session.refresh(prompt_response)
+
+    logger.info(
+        "prompt_response_submitted",
+        extra={"user_id": current_user, "week_number": week_number},
+    )
 
     return PromptDetail(
         week_number=prompt_response.week_number,

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends
@@ -22,6 +23,8 @@ from errors import bad_request, forbidden, not_found
 from models.course_stage import CourseStage
 from models.stage_progress import StageProgress
 from routers.auth import get_current_user
+from schemas import Page, PaginationParams, build_page
+from schemas.pagination import paginate_query
 from schemas.stage import (
     StageHistoryResponse,
     StageProgressRecord,
@@ -30,14 +33,47 @@ from schemas.stage import (
     StageResponse,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/stages", tags=["stages"])
 
 
-@router.get("", response_model=list[StageResponse])
+async def _build_stage_response(
+    stage: CourseStage,
+    session: AsyncSession,
+    user_id: int,
+    progress: StageProgress | None,
+) -> StageResponse:
+    """Assemble a :class:`StageResponse` with the current user's progress overlay."""
+    unlocked = is_stage_unlocked(stage.stage_number, progress)
+    stage_progress = 0.0
+    if unlocked:
+        data = await compute_stage_progress(session, user_id, stage.stage_number)
+        stage_progress = data["overall_progress"]
+    return StageResponse(
+        id=stage.id,
+        title=stage.title,
+        subtitle=stage.subtitle,
+        stage_number=stage.stage_number,
+        overview_url=stage.overview_url,
+        category=stage.category,
+        aspect=stage.aspect,
+        spiral_dynamics_color=stage.spiral_dynamics_color,
+        growing_up_stage=stage.growing_up_stage,
+        divine_gender_polarity=stage.divine_gender_polarity,
+        relationship_to_free_will=stage.relationship_to_free_will,
+        free_will_description=stage.free_will_description,
+        is_unlocked=unlocked,
+        progress=float(stage_progress),
+    )
+
+
+@router.get("", response_model=None)
 async def list_stages(
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
-) -> list[StageResponse]:
+    pagination: PaginationParams = Depends(),  # noqa: B008
+) -> Page[StageResponse] | list[StageResponse]:
     """List all stages with per-user progress overlay.
 
     Each stage's ``progress`` field is populated from
@@ -45,38 +81,19 @@ async def list_stages(
     without a follow-up call. This accepts an N+M round-trip (one query
     per metric per stage) since N=10 stages is small and caching would
     add complexity disproportionate to the benefit.
+
+    BUG-INFRA-016: returns ``Page[StageResponse]`` when ``?paginate=true``
+    is set; otherwise the legacy bare list is returned for one release while
+    the frontend migrates to the envelope.
     """
-    result = await session.execute(
-        select(CourseStage).order_by(col(CourseStage.stage_number).asc())
-    )
-    stages = result.scalars().all()
+    query = select(CourseStage).order_by(col(CourseStage.stage_number).asc())
+    stages, total = await paginate_query(session, query, pagination)
     progress = await get_user_progress(session, current_user)
 
-    responses: list[StageResponse] = []
-    for s in stages:
-        unlocked = is_stage_unlocked(s.stage_number, progress)
-        stage_progress = 0.0
-        if unlocked:
-            data = await compute_stage_progress(session, current_user, s.stage_number)
-            stage_progress = data["overall_progress"]
-        responses.append(
-            StageResponse(
-                id=s.id,
-                title=s.title,
-                subtitle=s.subtitle,
-                stage_number=s.stage_number,
-                overview_url=s.overview_url,
-                category=s.category,
-                aspect=s.aspect,
-                spiral_dynamics_color=s.spiral_dynamics_color,
-                growing_up_stage=s.growing_up_stage,
-                divine_gender_polarity=s.divine_gender_polarity,
-                relationship_to_free_will=s.relationship_to_free_will,
-                free_will_description=s.free_will_description,
-                is_unlocked=unlocked,
-                progress=float(stage_progress),
-            )
-        )
+    responses = [await _build_stage_response(s, session, current_user, progress) for s in stages]
+
+    if pagination.paginate:
+        return build_page(responses, total, pagination)
     return responses
 
 
@@ -183,6 +200,10 @@ async def update_progress(
         session.add(existing)
         await session.commit()
         await session.refresh(existing)
+        logger.info(
+            "stage_advanced",
+            extra={"user_id": current_user, "current_stage": existing.current_stage},
+        )
         return StageProgressRecord(
             id=existing.id,
             user_id=existing.user_id,
@@ -201,6 +222,7 @@ async def update_progress(
     session.add(progress)
     await session.commit()
     await session.refresh(progress)
+    logger.info("stage_progress_started", extra={"user_id": current_user})
     return StageProgressRecord(
         id=progress.id,
         user_id=progress.user_id,

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
 
@@ -15,11 +16,15 @@ from models.practice import Practice
 from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
+from schemas import Page, PaginationParams, build_page
+from schemas.pagination import paginate_query
 from schemas.practice import (
     UserPracticeCreate,
     UserPracticeDetail,
     UserPracticeResponse,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/user-practices", tags=["user-practices"])
 
@@ -48,17 +53,35 @@ async def create_user_practice(
     session.add(user_practice)
     await session.commit()
     await session.refresh(user_practice)
+    logger.info(
+        "user_practice_created",
+        extra={
+            "user_id": current_user,
+            "practice_id": payload.practice_id,
+            "stage_number": payload.stage_number,
+        },
+    )
     return user_practice
 
 
-@router.get("/", response_model=list[UserPracticeResponse])
+@router.get("/", response_model=None)
 async def list_user_practices(
     current_user: int = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),  # noqa: B008
-) -> list[UserPractice]:
-    """List the authenticated user's practice selections."""
-    result = await session.execute(select(UserPractice).where(UserPractice.user_id == current_user))
-    return list(result.scalars().all())
+    pagination: PaginationParams = Depends(),  # noqa: B008
+) -> Page[UserPracticeResponse] | list[UserPracticeResponse]:
+    """List the authenticated user's practice selections.
+
+    BUG-INFRA-017: returns ``Page[UserPracticeResponse]`` when
+    ``?paginate=true`` is set; otherwise the legacy bare list is returned
+    for one release while the frontend migrates to the envelope.
+    """
+    query = select(UserPractice).where(UserPractice.user_id == current_user)
+    items, total = await paginate_query(session, query, pagination)
+    serialized = [UserPracticeResponse.model_validate(u, from_attributes=True) for u in items]
+    if pagination.paginate:
+        return build_page(serialized, total, pagination)
+    return serialized
 
 
 @router.get("/{user_practice_id}", response_model=UserPracticeDetail)

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -12,9 +12,18 @@ from schemas.goal import Goal
 from schemas.habit import Habit, HabitWithGoals
 from schemas.habit_stats import HabitStats
 from schemas.milestone import Milestone
+from schemas.pagination import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    Page,
+    PaginationParams,
+    build_page,
+)
 from schemas.practice import PracticeSessionCreate, PracticeSessionResponse
 
 __all__ = [
+    "DEFAULT_PAGE_SIZE",
+    "MAX_PAGE_SIZE",
     "CheckInRequest",
     "CheckInResult",
     "EnergyHabit",
@@ -27,6 +36,9 @@ __all__ = [
     "HabitStats",
     "HabitWithGoals",
     "Milestone",
+    "Page",
+    "PaginationParams",
     "PracticeSessionCreate",
     "PracticeSessionResponse",
+    "build_page",
 ]

--- a/backend/src/schemas/pagination.py
+++ b/backend/src/schemas/pagination.py
@@ -1,0 +1,102 @@
+"""Shared pagination primitives for list endpoints.
+
+Defines the ``Page[T]`` response envelope and the ``PaginationParams``
+dependency so every paginated list endpoint serialises the same shape and
+shares a single source of validation for ``limit`` / ``offset``.
+
+The envelope is opt-in via ``?paginate=true`` so this can ship before the
+frontend consumes it (BUG-INFRA-012-018).  When the frontend has migrated,
+the bare-list code path is dropped and the envelope becomes the only shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from fastapi import Query
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Select
+
+T = TypeVar("T")
+
+# Hard upper bounds on per-page results.  ``MAX_PAGE_SIZE`` matches the audit
+# recommendation; ``DEFAULT_PAGE_SIZE`` is what callers get when they omit
+# ``limit`` entirely.
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
+
+
+class Page(BaseModel, Generic[T]):  # noqa: UP046
+    """Generic pagination envelope returned when ``?paginate=true`` is set.
+
+    Fields mirror what the frontend needs to render a paged list without a
+    second round-trip: the items themselves, the absolute total for "page X
+    of Y" displays, and the request parameters echoed back so retries can
+    reproduce the page exactly.
+    """
+
+    items: list[T]
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+@dataclass
+class PaginationParams:
+    """Standard ``limit`` / ``offset`` / ``paginate`` query parameters.
+
+    ``paginate`` defaults to ``False`` so existing clients receive the bare
+    list shape they were built against.  New clients (and the frontend, once
+    migrated) opt in by sending ``?paginate=true``; the response then becomes
+    a :class:`Page` envelope.
+    """
+
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE)
+    offset: int = Query(default=0, ge=0)
+    paginate: bool = Query(
+        default=False,
+        description=(
+            "When true, return a Page envelope ({items, total, limit, offset, "
+            "has_more}) instead of a bare list.  Default is bare list for "
+            "backwards compatibility; will become the default in a future "
+            "release."
+        ),
+    )
+
+
+def build_page(items: list[T], total: int, params: PaginationParams) -> Page[T]:  # noqa: UP047
+    """Construct a :class:`Page` envelope from sliced items + count + params."""
+    return Page[T](
+        items=items,
+        total=total,
+        limit=params.limit,
+        offset=params.offset,
+        has_more=(params.offset + params.limit) < total,
+    )
+
+
+async def paginate_query(
+    session: AsyncSession,
+    query: Select[Any],
+    params: PaginationParams,
+) -> tuple[list[Any], int]:
+    """Apply ``offset`` / ``limit`` to ``query`` and return ``(items, total)``.
+
+    Performs two database round-trips: a ``SELECT COUNT(*)`` over the
+    pre-pagination query (to populate ``Page.total`` for "page X of Y"
+    displays) and the actual paged ``SELECT``.  Eager-loaded relationships
+    declared on ``query`` via ``selectinload`` continue to work because they
+    issue separate ``IN`` queries that aren't affected by the outer
+    ``OFFSET`` / ``LIMIT``.
+    """
+    count_query = select(func.count()).select_from(query.order_by(None).subquery())
+    total = (await session.execute(count_query)).scalar() or 0
+
+    paged_query = query.offset(params.offset).limit(params.limit)
+    result = await session.execute(paged_query)
+    items = list(result.scalars().all())
+    return items, int(total)

--- a/backend/src/services/chat_stream.py
+++ b/backend/src/services/chat_stream.py
@@ -174,20 +174,31 @@ async def stream_bot_response(
     # Load history before staging anything so the user's new text is only
     # sent via the ``user_message`` parameter, not duplicated from DB.
     history = await load_recent_conversation(session, user_id)
+
+    # BUG-INFRA-011: split the rollback path from the commit path with
+    # ``try/except/else/finally`` so ``finalise_stream_commit`` only runs on
+    # the success branch.  Rollback is wrapped in its own ``try`` because
+    # rolling back an already-rolled-back session must not raise — the
+    # caller is already mid-error and shouldn't see a secondary failure.
+    aborted = False
     try:
         collected = await collect_provider_stream(context.message, history, context.api_key)
     except Exception:
+        aborted = True
         # BUG-JOURNAL-009: log exception context so ops can debug production outages.
         logger.exception("Stream provider error for user_id=%s", user_id)
-        # Roll back the wallet deduction so the user isn't charged for a
-        # failed request.  No user message was staged so there's nothing
-        # to orphan (BUG-JOURNAL-015).
-        await session.rollback()
+        try:
+            await session.rollback()
+        except Exception:  # pragma: no cover - defensive; rollback is idempotent
+            logger.exception("Stream rollback failed for user_id=%s", user_id)
         yield sse_event("error", {"status": 502, "detail": "llm_provider_error"})
         return
 
-    # Persist both messages together only after the stream completed
-    # successfully (BUG-JOURNAL-015).
+    if aborted:  # pragma: no cover - unreachable; ``return`` above guards this
+        return
+
+    # Happy path: persist both messages together only after the stream
+    # completed successfully (BUG-JOURNAL-015).
     await persist_user_message(session, user_id, context.message)
 
     for chunk in collected.chunks:

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,10 +1,11 @@
+import logging
 from http import HTTPStatus
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from main import DEV_ORIGINS, app, get_cors_origins
+from main import DEV_ORIGINS, _assert_credentials_safe, app, get_cors_origins
 
 client = TestClient(app)
 
@@ -90,25 +91,112 @@ def test_production_with_blank_entries_raises() -> None:
         get_cors_origins("production")
 
 
+@patch.dict(
+    "os.environ",
+    {"PROD_DOMAIN": "https://app.adepthood.com, https://app.adepthood.com"},
+)
+def test_production_dedupes_origins() -> None:
+    """BUG-INFRA-007: duplicate PROD_DOMAIN entries collapse to a single origin."""
+    origins = get_cors_origins("production")
+    assert origins == ["https://app.adepthood.com"]
+
+
+@patch.dict("os.environ", {"PROD_DOMAIN": "https://app.adepthood.com"})
+def test_dev_env_warns_when_prod_domain_set(caplog: pytest.LogCaptureFixture) -> None:
+    """BUG-INFRA-006: dev env logs a warning when PROD_DOMAIN is configured."""
+    with caplog.at_level(logging.WARNING, logger="main"):
+        origins = get_cors_origins("development")
+    assert origins == DEV_ORIGINS
+    assert any("PROD_DOMAIN" in rec.message for rec in caplog.records)
+
+
+def test_credentials_with_wildcard_origin_raises() -> None:
+    """BUG-INFRA-005: ``*`` plus credentials must fail closed at startup."""
+    with pytest.raises(RuntimeError, match="allow_credentials"):
+        _assert_credentials_safe(["*"])
+
+
+def test_credentials_safe_with_explicit_origins() -> None:
+    """``_assert_credentials_safe`` returns silently for explicit origins."""
+    _assert_credentials_safe(["https://app.adepthood.com"])  # no exception
+
+
+# --- Security headers ------------------------------------------------------
+
+
+def test_security_headers_present_on_every_response() -> None:
+    """BUG-INFRA-001/002/003: CSP, Referrer-Policy, and Permissions-Policy
+    must be on every response (not just authenticated ones)."""
+    response = client.get("/auth/login")  # public path; CORS-friendly
+    assert "Content-Security-Policy" in response.headers
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert "Permissions-Policy" in response.headers
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+
+
+def test_csp_blocks_inline_scripts_by_default() -> None:
+    """CSP should not include unsafe-inline so XSS attempts are mitigated."""
+    response = client.get("/auth/login")
+    csp = response.headers["Content-Security-Policy"]
+    assert "unsafe-inline" not in csp
+    assert "default-src 'self'" in csp
+    assert "frame-ancestors 'none'" in csp
+
+
+# --- Correlation ID --------------------------------------------------------
+
+
+def test_response_includes_correlation_id() -> None:
+    """BUG-INFRA-025: every response carries an ``X-Request-ID`` header."""
+    response = client.get("/auth/login")
+    assert "X-Request-ID" in response.headers
+    assert response.headers["X-Request-ID"]
+
+
+def test_correlation_id_echoed_when_supplied() -> None:
+    """Inbound ``X-Request-ID`` is echoed back so clients can correlate logs."""
+    response = client.get("/auth/login", headers={"X-Request-ID": "abc-123-xyz"})
+    assert response.headers["X-Request-ID"] == "abc-123-xyz"
+
+
+def test_correlation_id_minted_when_missing_or_empty() -> None:
+    """Empty / whitespace ``X-Request-ID`` triggers a fresh UUID4."""
+    response = client.get("/auth/login", headers={"X-Request-ID": "   "})
+    minted = response.headers["X-Request-ID"]
+    min_uuid_hex_length = 16  # UUIDs are 32 hex chars; sanity bound
+    assert minted
+    assert minted != "   "
+    assert len(minted) >= min_uuid_hex_length
+
+
 # --- Integration tests (middleware behavior) ---
 
 
 def test_options_request_allowed() -> None:
-    """Preflight OPTIONS request should succeed for allowed origin/method."""
+    """Preflight OPTIONS request should succeed for allowed origin/method.
+
+    We hit ``/auth/login`` (a real public endpoint) because ``/`` is now
+    intentionally unmapped (BUG-INFRA-004); CORS preflight is handled by
+    middleware so the route's auth requirements don't matter.
+    """
     headers = {
         "Origin": ALLOWED_ORIGIN,
-        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Method": "POST",
     }
-    response = client.options("/", headers=headers)
+    response = client.options("/auth/login", headers=headers)
     assert response.status_code == HTTPStatus.OK
     assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
 
 
 def test_cross_origin_get_allowed() -> None:
-    """GET requests from an allowed origin include CORS headers."""
+    """GET requests from an allowed origin include CORS headers.
+
+    Uses ``/auth/login`` rather than ``/`` (BUG-INFRA-004 removed root).
+    The 405 status is fine — CORS headers are emitted regardless.
+    """
     headers = {"Origin": ALLOWED_ORIGIN}
-    response = client.get("/", headers=headers)
-    assert response.status_code == HTTPStatus.OK
+    response = client.get("/auth/login", headers=headers)
     assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
 
 
@@ -136,8 +224,7 @@ def test_cross_origin_post_with_credentials() -> None:
 def test_forbidden_origin_no_cors_headers() -> None:
     """Requests from disallowed origins should not receive CORS headers."""
     headers = {"Origin": FORBIDDEN_ORIGIN}
-    response = client.get("/", headers=headers)
-    assert response.status_code == HTTPStatus.OK
+    response = client.get("/auth/login", headers=headers)
     assert "access-control-allow-origin" not in response.headers
 
 
@@ -147,5 +234,5 @@ def test_preflight_disallowed_method() -> None:
         "Origin": ALLOWED_ORIGIN,
         "Access-Control-Request-Method": "PATCH",
     }
-    response = client.options("/", headers=headers)
+    response = client.options("/auth/login", headers=headers)
     assert response.status_code == HTTPStatus.BAD_REQUEST

--- a/backend/tests/test_energy_api.py
+++ b/backend/tests/test_energy_api.py
@@ -1,8 +1,12 @@
+import asyncio
+import time
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 from cachetools import TTLCache
 from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 
 from main import app
 from services import energy
@@ -72,3 +76,43 @@ def test_idempotency_miss_after_cache_clear() -> None:
         # Both should succeed (recomputed, not from cache)
         assert res1.status_code == 200  # noqa: PLR2004
         assert res2.status_code == 200  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_create_plan_does_not_block_event_loop() -> None:
+    """BUG-INFRA-009: slow plan generation must not starve concurrent requests.
+
+    We replace ``get_or_generate_plan`` with a sync sleep that would block
+    the event loop for 300ms if executed inline.  With ``asyncio.to_thread``
+    the main loop is free during the sleep, so two concurrent requests
+    complete in ~300ms total — not ~600ms serialised.
+    """
+    sleep_seconds = 0.3
+
+    def _slow_plan(payload: Any, _key: Any) -> Any:  # noqa: ANN401
+        # ``time.sleep`` (not ``asyncio.sleep``) — this is the sync CPU-ish
+        # stand-in.  If the endpoint runs inline on the loop, this stalls
+        # every other coroutine for ``sleep_seconds``.
+        time.sleep(sleep_seconds)
+        return energy.build_energy_response(payload)
+
+    with patch.object(energy, "get_or_generate_plan", _slow_plan):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            start = time.perf_counter()
+            results = await asyncio.gather(
+                ac.post("/v1/energy/plan", json=sample_payload()),
+                ac.post("/v1/energy/plan", json=sample_payload()),
+            )
+            elapsed = time.perf_counter() - start
+
+    for res in results:
+        assert res.status_code == 200  # noqa: PLR2004
+
+    # If the endpoint were synchronous on the loop, elapsed would be
+    # >= 2 * sleep_seconds.  Offloading via ``asyncio.to_thread`` brings it
+    # close to a single sleep duration — allow generous headroom so CI
+    # noise doesn't flake the assertion.
+    assert elapsed < sleep_seconds * 1.8, (
+        f"expected concurrent energy requests to overlap; took {elapsed:.3f}s"
+    )

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -5,8 +5,12 @@ from main import app
 client = TestClient(app)
 
 
-def test_read_root() -> None:
+def test_root_returns_404() -> None:
+    """BUG-INFRA-004: ``GET /`` is intentionally not exposed.
+
+    The Railway healthcheck uses ``/health``; ``/`` returning 404 means an
+    unauthenticated probe can't fingerprint the service from the root path.
+    """
     response = client.get("/")
-    ok_status = 200
-    assert response.status_code == ok_status
-    assert response.json() == {"status": "ok"}
+    not_found_status = 404
+    assert response.status_code == not_found_status

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,58 @@
+"""Static sanity checks on the alembic migration scripts.
+
+BUG-INFRA-022: earlier the downgrade for the timestamptz migration used a
+subtly-different ``USING`` expression from the upgrade, which failed on
+Postgres.  The real round-trip check runs against a Postgres container in
+CI (see ``.github/workflows/backend-ci.yml``).  These tests catch the
+cheap-to-detect regressions at unit-test speed so drift is surfaced before
+CI wakes up.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+MIGRATIONS_DIR = Path(__file__).parent.parent / "migrations" / "versions"
+
+TIMESTAMPTZ_MIGRATION = MIGRATIONS_DIR / "78b1620cafde_convert_datetime_columns_to_timestamptz.py"
+
+
+def test_timestamptz_migration_exists() -> None:
+    """Regression guard: the migration file must stay where Alembic finds it."""
+    assert TIMESTAMPTZ_MIGRATION.is_file()
+
+
+def test_upgrade_and_downgrade_use_same_using_expression() -> None:
+    """BUG-INFRA-022: the upgrade and downgrade ``USING`` expressions must
+    be structurally identical so ``alembic downgrade -1`` round-trips.
+
+    Specifically, both should produce ``"col" AT TIME ZONE 'UTC'`` — the
+    conversion is symmetric (timestamp ↔ timestamptz in UTC), so the
+    expression should be the same for both directions.
+    """
+    text = TIMESTAMPTZ_MIGRATION.read_text()
+    upgrade_section = text.split("def upgrade")[1].split("def downgrade")[0]
+    downgrade_section = text.split("def downgrade")[1]
+
+    # The exact f-string literal used in both directions.
+    expected_literal = "f'\"{column}\" AT TIME ZONE \\'UTC\\''"
+    assert expected_literal in upgrade_section, "upgrade uses a different USING clause"
+    assert expected_literal in downgrade_section, (
+        "downgrade uses a different USING clause — BUG-INFRA-022 regressed"
+    )
+
+
+@pytest.mark.parametrize("direction", ["upgrade", "downgrade"])
+def test_both_directions_exist(direction: str) -> None:
+    """Every migration must define both ``upgrade`` and ``downgrade``.
+
+    Without this any new migration could ship without a rollback path,
+    re-introducing the same class of bug BUG-INFRA-022 caught.
+    """
+    for path in MIGRATIONS_DIR.glob("*.py"):
+        if path.name.startswith("_"):
+            continue
+        text = path.read_text()
+        assert f"def {direction}" in text, f"{path.name} missing {direction}()"

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,97 @@
+"""Tests for the correlation-ID middleware and trace-id log filter.
+
+BUG-INFRA-025: every request must have a trace ID that:
+
+* propagates through ``contextvars`` for the duration of the request,
+* is injected into log records via :class:`TraceIdLogFilter`, and
+* is echoed back on the response as ``X-Request-ID``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi.testclient import TestClient
+
+from main import app
+from observability import (
+    NO_TRACE,
+    TRACE_ID_HEADER,
+    TraceIdLogFilter,
+    get_trace_id,
+    install_trace_id_logging,
+    trace_id_var,
+)
+
+client = TestClient(app)
+
+
+def test_get_trace_id_outside_request_returns_sentinel() -> None:
+    """Outside the middleware the contextvar yields :data:`NO_TRACE`."""
+    assert get_trace_id() == NO_TRACE
+
+
+def test_trace_id_contextvar_holds_value_inside_block() -> None:
+    """``trace_id_var.set`` is visible to :func:`get_trace_id` in scope."""
+    token = trace_id_var.set("req-42")
+    try:
+        assert get_trace_id() == "req-42"
+    finally:
+        trace_id_var.reset(token)
+    assert get_trace_id() == NO_TRACE
+
+
+def test_log_filter_injects_trace_id() -> None:
+    """The filter attaches ``trace_id`` to log records."""
+    record = logging.LogRecord(
+        name="t",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    token = trace_id_var.set("trace-xyz")
+    try:
+        TraceIdLogFilter().filter(record)
+    finally:
+        trace_id_var.reset(token)
+    assert record.trace_id == "trace-xyz"  # type: ignore[attr-defined]
+
+
+def test_install_trace_id_logging_is_idempotent() -> None:
+    """Calling :func:`install_trace_id_logging` twice adds only one filter."""
+    install_trace_id_logging()
+    install_trace_id_logging()
+    root = logging.getLogger()
+    trace_filters = [f for f in root.filters if isinstance(f, TraceIdLogFilter)]
+    assert len(trace_filters) == 1
+
+
+def test_caller_provided_id_is_echoed() -> None:
+    """An inbound ``X-Request-ID`` is copied verbatim onto the response."""
+    response = client.get(
+        "/auth/login",
+        headers={TRACE_ID_HEADER: "caller-supplied-trace"},
+    )
+    assert response.headers[TRACE_ID_HEADER] == "caller-supplied-trace"
+
+
+def test_missing_id_is_minted() -> None:
+    """A response without an inbound ``X-Request-ID`` still has one set."""
+    response = client.get("/auth/login")
+    minted = response.headers[TRACE_ID_HEADER]
+    assert minted
+    assert minted != NO_TRACE
+
+
+_SANITY_MAX_TRACE_ID = 100
+
+
+def test_pathologically_long_id_is_rejected_and_replaced() -> None:
+    """Values longer than the cap are silently replaced by a fresh UUID."""
+    long_id = "x" * 10_000
+    response = client.get("/auth/login", headers={TRACE_ID_HEADER: long_id})
+    assert response.headers[TRACE_ID_HEADER] != long_id
+    assert len(response.headers[TRACE_ID_HEADER]) < _SANITY_MAX_TRACE_ID

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -1,0 +1,153 @@
+"""Tests for the shared pagination envelope and ``PaginationParams``.
+
+BUG-INFRA-012..018: every list endpoint in the audit should switch between
+the bare-list shape (default) and the :class:`Page` envelope when the client
+sends ``?paginate=true``.  These tests exercise one representative endpoint
+(``/practices/``) to prove the toggle works; per-endpoint tests live
+alongside each feature's API tests.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.practice import Practice
+from schemas import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page, PaginationParams, build_page
+
+_SEED_COUNT_SMALL = 3
+_SEED_COUNT_LARGE = 5
+_SLICE_LIMIT = 2
+_SLICE_OFFSET = 1
+_ROUND_TRIP_COUNT = 2
+
+
+async def _signup(client: AsyncClient) -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": "pager@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _seed(db_session: AsyncSession, count: int) -> None:
+    for i in range(count):
+        db_session.add(
+            Practice(
+                stage_number=1,
+                name=f"Practice {i:02d}",
+                description="",
+                instructions="",
+                default_duration_minutes=10,
+                approved=True,
+            )
+        )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_bare_list_is_the_default(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Without ``?paginate=true`` the response is a plain JSON array."""
+    headers = await _signup(async_client)
+    await _seed(db_session, count=_SEED_COUNT_SMALL)
+
+    resp = await async_client.get("/practices/", params={"stage_number": 1}, headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) == _SEED_COUNT_SMALL
+
+
+@pytest.mark.asyncio
+async def test_envelope_returned_when_paginate_true(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``?paginate=true`` switches the response to the :class:`Page` envelope."""
+    headers = await _signup(async_client)
+    await _seed(db_session, count=_SEED_COUNT_SMALL)
+
+    resp = await async_client.get(
+        "/practices/",
+        params={"stage_number": 1, "paginate": "true"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["total"] == _SEED_COUNT_SMALL
+    assert body["limit"] == DEFAULT_PAGE_SIZE
+    assert body["offset"] == 0
+    assert body["has_more"] is False
+    assert len(body["items"]) == _SEED_COUNT_SMALL
+
+
+@pytest.mark.asyncio
+async def test_envelope_respects_limit_and_offset(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``limit`` / ``offset`` produce the expected slice of a larger result."""
+    headers = await _signup(async_client)
+    await _seed(db_session, count=_SEED_COUNT_LARGE)
+
+    resp = await async_client.get(
+        "/practices/",
+        params={
+            "stage_number": 1,
+            "paginate": "true",
+            "limit": _SLICE_LIMIT,
+            "offset": _SLICE_OFFSET,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["total"] == _SEED_COUNT_LARGE
+    assert body["limit"] == _SLICE_LIMIT
+    assert body["offset"] == _SLICE_OFFSET
+    assert body["has_more"] is True
+    assert len(body["items"]) == _SLICE_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_envelope_rejects_out_of_range_limit(async_client: AsyncClient) -> None:
+    """``limit`` above :data:`MAX_PAGE_SIZE` is a 422 validation error."""
+    headers = await _signup(async_client)
+    resp = await async_client.get(
+        "/practices/",
+        params={"stage_number": 1, "paginate": "true", "limit": MAX_PAGE_SIZE + 1},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+def test_build_page_has_more_boundary() -> None:
+    """``has_more`` flips exactly at ``offset + limit == total``."""
+    params = PaginationParams(limit=10, offset=0, paginate=True)
+    page = build_page(items=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], total=10, params=params)
+    assert page.has_more is False
+
+    params = PaginationParams(limit=10, offset=0, paginate=True)
+    page = build_page(items=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], total=11, params=params)
+    assert page.has_more is True
+
+
+def test_page_schema_round_trip() -> None:
+    """:class:`Page` round-trips through JSON with parametrised item type."""
+    page: Page[dict[str, int]] = Page(
+        items=[{"a": 1}, {"a": 2}],
+        total=2,
+        limit=50,
+        offset=0,
+        has_more=False,
+    )
+    restored = Page[dict[str, int]].model_validate_json(page.model_dump_json())
+    assert restored.items == page.items
+    assert restored.total == _ROUND_TRIP_COUNT


### PR DESCRIPTION
Cross-cutting backend infrastructure fixes from [`prompts/2026-04-14-bug-remediation/06-backend-infrastructure-bugs.md`](./prompts/2026-04-14-bug-remediation/06-backend-infrastructure-bugs.md).

## Bugs fixed (23 of 27 in scope)

### Critical
- **BUG-INFRA-009** — `/v1/energy/plan` was `def` on an async stack; flipped to `async def` and offloaded the CPU-bound `generate_plan` via `asyncio.to_thread`. Includes a concurrency sentinel test that fails if two simultaneous requests serialise on the event loop.
- **BUG-INFRA-022** — downgrade in `78b1620cafde_convert_datetime_columns_to_timestamptz.py` used a different `USING` expression from the upgrade; aligned and guarded with (a) a unit test over the file text and (b) a CI round-trip job against a Postgres container.

### High — pagination sweep
- **BUG-INFRA-012..018** — `Page[T]` envelope defined once in `backend/src/schemas/pagination.py`, consumed by the seven list endpoints via a shared `PaginationParams` dependency:
  - `/practices/`, `/habits/`, `/practice-sessions/`, `/goal-groups/`, `/stages`, `/user-practices/`, `/course/stages/{n}/content`

  Envelope is **opt-in** via `?paginate=true`; bare list remains the default for one release while the frontend migrates. See follow-up issue #221.

### High — security headers + root endpoint
- **BUG-INFRA-001/002/003** — CSP (no `unsafe-inline`), `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: geolocation=(), microphone=(), camera=()`.
- **BUG-INFRA-004** — removed unauthenticated `GET /`. Railway healthcheck already uses `/health`.

### Medium — CORS, observability, hygiene
- **BUG-INFRA-005** — fail-closed startup when `*` origin meets `allow_credentials=True`.
- **BUG-INFRA-006** — warn when `ENV=development` and `PROD_DOMAIN` is set.
- **BUG-INFRA-007** — order-preserving dedup of `PROD_DOMAIN` origins.
- **BUG-INFRA-008** — explicit `allow_methods` list.
- **BUG-INFRA-011** — split stream rollback from commit with `try/except/else`; rollback wrapped so a double-rollback can't mask the original error.
- **BUG-INFRA-020** — `.first()` + None check replaces `.one()` in `goal_groups.update_goal_group`.
- **BUG-INFRA-021** — `get_session` wraps its yield in `try/finally` with explicit rollback; `/health` relies on the dependency for cleanup.
- **BUG-INFRA-023** — new CI job runs `alembic upgrade head → downgrade -1 → upgrade head → alembic check` against a Postgres 16 service container. Guards the next regression of -022 and any model-drift-without-migration.
- **BUG-INFRA-024** — `logger = logging.getLogger(__name__)` per router plus one structured log line on every mutating endpoint (`habit_created`, `practice_session_logged`, `goal_completion_recorded`, …). Full structlog can come later; this is the factory + coverage.
- **BUG-INFRA-025** — `CorrelationIdMiddleware` reads `X-Request-ID` (or mints a UUID4), stores it in a `contextvars.ContextVar`, injects it into every log record via `TraceIdLogFilter`, and echoes it back on the response.
- **BUG-INFRA-026/027** — `db_session` and `async_client` fixtures use `try/finally` teardown; `async_client` asserts `app.dependency_overrides` is empty at exit so a failing test can't leak state between runs.

### False positives
- **BUG-INFRA-010 / 019** — audit claimed `await session.delete(...)` raises `TypeError` because "`AsyncSession.delete` returns `None`". Not true since SQLAlchemy 2.0.21: `delete` is a coroutine (`inspect.iscoroutinefunction(AsyncSession.delete) == True` on our 2.0.49). All three call sites (`habits.py`, `goal_groups.py`, `journal.py`) are correct as-is. Documented but not changed.

## Pagination envelope decision

- **Shape:** `{ items, total, limit, offset, has_more }` (see `schemas/pagination.py:Page`).
- **Toggle:** `?paginate=true` query param. Default is bare list for one release. **Frontend must migrate before we can drop bare-list support** → issue #221.
- **Why opt-in and not a header:** a query param survives client-side caches and is trivially visible in browser-network tabs, which matters for the frontend team's rollout.

## Breaking-ish

- `GET /` → 404. If anything was depending on that endpoint (status pages, smoke probes), switch to `/health`.
- List endpoints gain `limit`, `offset`, `paginate` query params. Existing callers that don't send them keep the old bare-list shape, so this is **not** a hard break — but a caller that sends an out-of-range `limit` (> 200) now gets a 422 instead of being silently capped.

## Coverage

- 92.94% (threshold 90%).
- New tests:
  - `tests/test_pagination.py` — envelope vs. bare-list toggle, `build_page` boundary, round-trip.
  - `tests/test_observability.py` — trace-id contextvar, log filter, middleware echo, idempotent filter install.
  - `tests/test_migrations.py` — upgrade/downgrade `USING` expression parity.
  - `tests/test_cors.py` — security headers, CORS hardening, correlation-ID echo.
  - `tests/test_energy_api.py::test_create_plan_does_not_block_event_loop` — concurrency sentinel for -009.

## Files touched

- `backend/src/main.py` — middleware order, security headers, CORS hardening, root removal, health cleanup.
- `backend/src/database.py` — try/finally rollback.
- `backend/src/observability.py` *(new)* — correlation ID primitives.
- `backend/src/schemas/pagination.py` *(new)* — `Page[T]`, `PaginationParams`, `paginate_query`, `build_page`.
- `backend/src/schemas/__init__.py` — re-export.
- `backend/src/routers/*.py` — three cross-cutting edits per the agent brief: pagination, logger, removed superfluous `.one()`.
- `backend/src/routers/energy.py` — full conversion to `async def` + `asyncio.to_thread`.
- `backend/src/services/chat_stream.py` — stream rollback hardening (-011).
- `backend/migrations/versions/78b1620cafde_*.py` — downgrade fix (-022).
- `backend/conftest.py` — fixture hygiene (-026/-027).
- `.github/workflows/backend-ci.yml` — migration-drift job (-023).

## Follow-ups

- Issue #221: frontend consumes the `Page[T]` envelope.
- Once #221 lands, a follow-up PR should flip `paginate=true` to the default and remove the bare-list branch.

## Out of scope (for the separate deploy-failure conversation)

`e8376b41c6a1_unique_lower_email_index.py`'s `UPDATE "user" SET email = lower(email)` hitting `UniqueViolationError` on the production DB is **not** fixed here; that's the domain of #220's follow-up. Phase 3 only touches the timestamptz downgrade.
