### PR TITLE
fix(backend): unblock Railway deploy migrations + scrub email PII from logs

### DIFF
--- a/backend/migrations/versions/d4e5f6a7b8c9_goal_completion_unique_per_day_and_index.py
+++ b/backend/migrations/versions/d4e5f6a7b8c9_goal_completion_unique_per_day_and_index.py
@@ -9,6 +9,13 @@ to prevent duplicate completions for the same goal on the same day.
 
 BUG-HABITS-002: Adds a compound index on (goal_id, user_id, timestamp) to
 speed up streak computation queries.
+
+``timestamp`` is stored as ``TIMESTAMPTZ``; the naive ``timestamp::date`` cast
+is only STABLE because it depends on the session timezone, and Postgres
+refuses to index non-IMMUTABLE expressions. Pinning the conversion to UTC
+with ``AT TIME ZONE 'UTC'`` yields a ``TIMESTAMP WITHOUT TIME ZONE`` whose
+``::date`` cast is IMMUTABLE. The app always writes ``datetime.now(UTC)``,
+so "one completion per UTC calendar day" matches the intended semantics.
 """
 
 from typing import Sequence, Union
@@ -29,7 +36,8 @@ def upgrade() -> None:
     """Add unique-per-day constraint and compound performance index."""
     op.execute(
         f'CREATE UNIQUE INDEX "{_UNIQUE_PER_DAY_INDEX}" '
-        "ON goalcompletion (goal_id, user_id, (timestamp::date))"
+        "ON goalcompletion "
+        "(goal_id, user_id, ((timestamp AT TIME ZONE 'UTC')::date))"
     )
     op.execute(
         f'CREATE INDEX "{_COMPOUND_INDEX}" '

--- a/backend/migrations/versions/e8376b41c6a1_unique_lower_email_index.py
+++ b/backend/migrations/versions/e8376b41c6a1_unique_lower_email_index.py
@@ -29,17 +29,19 @@ depends_on: Union[str, Sequence[str], None] = None
 
 _UNIQUE_LOWER_EMAIL_INDEX = "ix_user_lower_email_unique"
 
-# CTE that pairs each duplicate user row with the keeper (lowest id per email).
+# CTE that pairs each duplicate user row with the keeper (lowest id per
+# lower(email) group). Duplicates can only differ by case because ``user.email``
+# already has a case-sensitive unique constraint.
 _DUPES_CTE = """
     WITH dupes AS (
         SELECT u.id AS dupe_id, keeper.keeper_id
         FROM "user" u
         JOIN (
-            SELECT email, min(id) AS keeper_id
+            SELECT lower(email) AS lower_email, min(id) AS keeper_id
             FROM "user"
-            GROUP BY email
+            GROUP BY lower(email)
             HAVING count(*) > 1
-        ) keeper ON keeper.email = u.email AND u.id != keeper.keeper_id
+        ) keeper ON keeper.lower_email = lower(u.email) AND u.id != keeper.keeper_id
     )
 """
 
@@ -59,11 +61,14 @@ _CHILD_TABLES: list[tuple[str, str]] = [
 
 
 def upgrade() -> None:
-    """Deduplicate case-variant emails, then add a unique index on lower(email)."""
-    # 1. Normalize every email to lowercase.
-    op.execute('UPDATE "user" SET email = lower(email)')
+    """Deduplicate case-variant emails, then add a unique index on lower(email).
 
-    # 2. Reassign child records from duplicate users to the keeper.
+    Order matters: the existing ``ix_user_email`` unique constraint would reject
+    ``UPDATE ... SET email = lower(email)`` whenever two case-variant rows
+    would collide (e.g. ``Geoff@…`` → ``geoff@…``). Merge the duplicates first,
+    *then* lowercase, *then* create the new index.
+    """
+    # 1. Reassign child records from duplicate users to the keeper.
     for table, col in _CHILD_TABLES:
         op.execute(
             f"{_DUPES_CTE}"
@@ -71,7 +76,7 @@ def upgrade() -> None:
             f'FROM dupes WHERE "{table}".{col} = dupes.dupe_id'
         )
 
-    # 3. stageprogress has a UNIQUE(user_id) constraint — special handling.
+    # 2. stageprogress has a UNIQUE(user_id) constraint — special handling.
     #    Delete the duplicate's row when the keeper already has one.
     op.execute(
         f"{_DUPES_CTE}"
@@ -88,11 +93,16 @@ def upgrade() -> None:
         "FROM dupes WHERE stageprogress.user_id = dupes.dupe_id"
     )
 
-    # 4. Delete duplicate user rows (all children have been moved).
+    # 3. Delete duplicate user rows (all children have been moved).
     op.execute(
         'DELETE FROM "user" '
-        "WHERE id NOT IN (SELECT min(id) FROM \"user\" GROUP BY email)"
+        'WHERE id NOT IN (SELECT min(id) FROM "user" GROUP BY lower(email))'
     )
+
+    # 4. Normalize every remaining email to lowercase. Safe now: deduplication
+    #    guarantees no two rows share a lower(email) value, so the existing
+    #    case-sensitive unique constraint cannot be violated.
+    op.execute('UPDATE "user" SET email = lower(email) WHERE email != lower(email)')
 
     # 5. Create the case-insensitive unique index.
     op.execute(

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import secrets
@@ -46,6 +47,23 @@ def _get_secret_key() -> str:
         msg = "SECRET_KEY environment variable must be set to a secure value"
         raise RuntimeError(msg)
     return SECRET_KEY
+
+
+# Length of the email log fingerprint. Twelve hex chars (48 bits) is ample to
+# distinguish accounts in a single tenant's log stream while remaining short
+# enough to read at a glance, and it is not reversible to the original email.
+_EMAIL_LOG_FINGERPRINT_LEN = 12
+
+
+def _email_log_fingerprint(email: str) -> str:
+    """Stable, non-reversible identifier safe for logs — never log raw emails.
+
+    Returned value is deterministic for a given normalized email, so operators
+    can still correlate events across log lines (e.g. repeated failed logins)
+    without exposing PII to log aggregation.
+    """
+    digest = hashlib.sha256(email.strip().lower().encode("utf-8")).hexdigest()
+    return digest[:_EMAIL_LOG_FINGERPRINT_LEN]
 
 
 class AuthRequest(BaseModel):
@@ -138,7 +156,7 @@ async def _record_attempt(
     logger.info(
         "auth_attempt",
         extra={
-            "email": email,
+            "email_fingerprint": _email_log_fingerprint(email),
             "ip_address": ip_address,
             "success": success,
             "timestamp": datetime.now(UTC).isoformat(),
@@ -216,7 +234,7 @@ async def login(
         logger.info(
             "auth_attempt_blocked",
             extra={
-                "email": payload.email,
+                "email_fingerprint": _email_log_fingerprint(payload.email),
                 "ip_address": ip_address,
                 "reason": "account_locked",
                 "timestamp": datetime.now(UTC).isoformat(),


### PR DESCRIPTION
## Summary

Production deploy on Railway has been failing in a loop. This PR unblocks two consecutive Alembic migrations and scrubs raw emails from auth logs.

### 1. `f3d8373` — dedupe case-variant emails before lowercasing

Migration `e8376b41c6a1_unique_lower_email_index` ran `UPDATE "user" SET email = lower(email)` *before* deduplication. The pre-existing `ix_user_email` unique index then rejected the UPDATE the moment it tried to collapse a case-variant pair (e.g. `Geoff@creekmasons.com` → `geoff@creekmasons.com` collided with the already-present lowercased row). The dedup logic that was supposed to handle this never ran, and even if it had, its CTE was grouping by `email` instead of `lower(email)` so it couldn't have found the duplicates.

Reorder: merge duplicates (keyed on `lower(email)`) → reassign child FKs → delete duplicate rows → lowercase the survivors → create the new unique index. All in one transaction.

### 2. `b3fa8ab` — pin goalcompletion day index to UTC for IMMUTABLE cast

Once the email migration unblocked, Railway hit:

```
asyncpg.exceptions.InvalidObjectDefinitionError:
  functions in index expression must be marked IMMUTABLE
[SQL: CREATE UNIQUE INDEX ... ON goalcompletion (goal_id, user_id, (timestamp::date))]
```

`goalcompletion.timestamp` is `TIMESTAMPTZ`, so `timestamp::date` is STABLE (depends on session `TimeZone`). Postgres won't index that. Anchor the cast to UTC: `((timestamp AT TIME ZONE 'UTC')::date)` — IMMUTABLE and indexable. The app always writes `datetime.now(UTC)`, so "one completion per UTC calendar day" matches existing semantics with no behavior change.

### 3. `6dc363f` — replace raw email with hashed fingerprint in auth logs

The Postgres `DETAIL: Key (email)=(geoff@…)` line in the failed deploy logs revealed that we were also emitting raw emails from our own auth logger on every login attempt and lockout event. Swap `email` for `email_fingerprint` (first 12 hex chars of SHA-256 over the normalized email) in the two `logger.info` `extra` dicts in `routers/auth.py`. Operators can still correlate "same account, repeated failures" but the value isn't reversible to the address. `LoginAttempt` rows still persist the raw email in the DB (needed for the exact-match lockout query) — that's intentionally out of scope.

## Test plan

- [x] `pytest` — 503 passed (full backend suite)
- [x] `pre-commit run` — all hooks green on every changed file
- [x] Verified migration `d4e5f6a7b8c9` had never applied anywhere (tests use SQLite + `metadata.create_all`, not Alembic), so in-place edit is safe
- [x] Verified no app SQL uses `::date` on `goalcompletion.timestamp`, so changing the indexed expression doesn't break a query plan
- [ ] Redeploy on Railway and watch migrations advance past `e8376b41c6a1`, `d4e5f6a7b8c9`, and through to head
- [ ] After deploy, confirm `ix_user_email` is gone, `ix_user_lower_email_unique` exists, and a duplicate-case signup is rejected at the DB level

https://claude.ai/code/session_01UMUK66NZCwJi8FPRYDVhnp