### PR TITLE
fix(auth): accept user_id=0 sentinel in authResponseSchema

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -222,6 +222,11 @@ async def test_signup_duplicate_email_returns_same_shape(async_client: AsyncClie
     assert "token" in second_data
     assert "user_id" in second_data
     assert isinstance(second_data["user_id"], int)
+    # The duplicate response uses ``user_id=0`` as a sentinel. The frontend
+    # ``authResponseSchema`` accepts non-negative integers so this sentinel
+    # does not trip Zod validation and surface the generic "server changed"
+    # error instead of completing the signup flow. Keep these in lock-step.
+    assert second_data["user_id"] == 0
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/__tests__/retryAndValidation.test.ts
+++ b/frontend/src/api/__tests__/retryAndValidation.test.ts
@@ -79,6 +79,31 @@ describe('BUG-024: Zod validation at the API boundary', () => {
     ).rejects.toBeInstanceOf(ApiValidationError);
   });
 
+  test('auth.signup accepts user_id=0 (duplicate-email sentinel, BUG-AUTH-002)', async () => {
+    // The backend returns ``user_id: 0`` together with a dummy JWT when the
+    // email is already registered, so the response is indistinguishable in
+    // shape from a fresh signup and account enumeration is blocked. The
+    // frontend must accept this sentinel, not reject it as a validation
+    // failure.
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: 'dummy', user_id: 0 }));
+    const result = await auth.signup({
+      email: 'u@test.com',
+      password: 'securepass123', // pragma: allowlist secret
+    });
+    expect(result.user_id).toBe(0);
+    expect(result.token).toBe('dummy');
+  });
+
+  test('auth.signup still rejects negative user_id', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: 'x', user_id: -1 }));
+    await expect(
+      auth.signup({
+        email: 'u@test.com',
+        password: 'securepass123', // pragma: allowlist secret
+      }),
+    ).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
   test('habits.list accepts a schema-valid list and returns it unchanged', async () => {
     mockFetch.mockReturnValueOnce(jsonResponse([validHabit()]));
     const result = await habits.list();

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -54,7 +54,11 @@ export type Page<T> = {
 
 export const authResponseSchema = z.object({
   token: z.string().min(1),
-  user_id: z.number().int().positive(),
+  // ``user_id`` is ``0`` in the anti-enumeration signup response (BUG-AUTH-002):
+  // when a caller signs up with an already-registered email the backend returns
+  // a dummy token and ``user_id=0`` so the wire shape is indistinguishable from
+  // a fresh signup. Real signups return a positive autoincrement id.
+  user_id: z.number().int().nonnegative(),
 });
 
 export type AuthResponseT = z.infer<typeof authResponseSchema>;


### PR DESCRIPTION
When a signup attempt hits an already-registered email, the backend
returns a dummy JWT and user_id=0 so the response is shape-identical to
a real signup and no account enumeration is possible (BUG-AUTH-002).

The frontend Zod schema was tightened to user_id: z.number().int().positive()
during the infra sweep (PR #225, BUG-FRONTEND-INFRA-024), and
z.number().positive() rejects 0. The response therefore failed
validation, ApiValidationError was raised, and the user saw the generic
"Something changed on the server and we couldn't read the response"
message on the signup screen instead of completing the flow.

The fix relaxes the constraint to .nonnegative() with a comment pointing
at the sentinel contract, adds a frontend test that covers the accepted
user_id=0 case (and still rejects negatives), and tightens the backend
indistinguishability test to lock the sentinel value in place so both
sides stay in sync.

Backend suite: 92.41% coverage, all tests green.
Frontend suite: 644/644 passing.
pre-commit run --all-files: all hooks pass.

https://claude.ai/code/session_01LFoXY7mEosJciHgYDP1p5V