### PR TITLE
fix(auth): route auth token storage through AsyncStorage on web

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -33,12 +33,18 @@ jobs:
           uv pip install --system pre-commit
 
       - name: Run pre-commit (Python hooks only)
+        # ``no-commit-to-branch`` exists to block *local* commits to main;
+        # in CI the push is already on main, so the hook is a false positive.
+        env:
+          SKIP: no-commit-to-branch
         run: |
           pre-commit run --hook-stage pre-commit --files $(git ls-files 'backend')
 
       - name: Run pre-push hooks (complexity + maintainability + tests)
         # xenon/radon/backend-tests-coverage moved to pre-push locally to keep
         # `git commit` fast. CI still runs them so nothing escapes review.
+        env:
+          SKIP: no-commit-to-branch
         run: |
           pre-commit run --hook-stage pre-push --files $(git ls-files 'backend')
 

--- a/frontend/src/storage/__tests__/authStorage.test.ts
+++ b/frontend/src/storage/__tests__/authStorage.test.ts
@@ -1,8 +1,19 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
-import { saveToken, loadToken, clearToken } from '../authStorage';
+import type * as AuthStorageModule from '../authStorage';
+
+const platformRef = { value: 'ios' as 'ios' | 'android' | 'web' };
+
+jest.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return platformRef.value;
+    },
+  },
+}));
 
 jest.mock('expo-secure-store', () => ({
   setItemAsync: jest.fn(() => Promise.resolve()),
@@ -10,44 +21,86 @@ jest.mock('expo-secure-store', () => ({
   deleteItemAsync: jest.fn(() => Promise.resolve()),
 }));
 
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
 const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+function loadAuthStorage(): typeof AuthStorageModule {
+  let mod: typeof AuthStorageModule | undefined;
+  jest.isolateModules(() => {
+    mod = require('../authStorage') as typeof AuthStorageModule;
+  });
+  if (!mod) throw new Error('failed to load authStorage');
+  return mod;
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('authStorage', () => {
-  describe('saveToken', () => {
-    test('stores token in SecureStore', async () => {
-      await saveToken('my-jwt-token');
-
-      expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
-        'adepthood_auth_token',
-        'my-jwt-token',
-      );
-    });
+describe('authStorage (native)', () => {
+  beforeEach(() => {
+    platformRef.value = 'ios';
   });
 
-  describe('loadToken', () => {
-    test('returns null when no token stored', async () => {
-      mockSecureStore.getItemAsync.mockResolvedValueOnce(null);
-
-      const result = await loadToken();
-      expect(result).toBeNull();
-    });
-
-    test('returns stored token', async () => {
-      mockSecureStore.getItemAsync.mockResolvedValueOnce('my-jwt-token');
-
-      const result = await loadToken();
-      expect(result).toBe('my-jwt-token');
-    });
+  test('saveToken routes to SecureStore on native', async () => {
+    const { saveToken } = loadAuthStorage();
+    await saveToken('my-jwt-token');
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      'adepthood_auth_token',
+      'my-jwt-token',
+    );
+    expect(mockAsyncStorage.setItem).not.toHaveBeenCalled();
   });
 
-  describe('clearToken', () => {
-    test('removes token from SecureStore', async () => {
-      await clearToken();
-      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('adepthood_auth_token');
-    });
+  test('loadToken reads from SecureStore on native', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce('my-jwt-token');
+    const { loadToken } = loadAuthStorage();
+    await expect(loadToken()).resolves.toBe('my-jwt-token');
+    expect(mockAsyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  test('clearToken removes from SecureStore on native', async () => {
+    const { clearToken } = loadAuthStorage();
+    await clearToken();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('adepthood_auth_token');
+    expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('authStorage (web)', () => {
+  // ``expo-secure-store`` v55 ships no web implementation (its web bundle is
+  // literally ``export default {}``), so the native branch would throw
+  // ``TypeError`` and every auth call in the Expo Web build would fall back
+  // to the generic ``SIGNUP_FALLBACK`` copy. These cases pin the
+  // AsyncStorage fallback in place.
+  beforeEach(() => {
+    platformRef.value = 'web';
+  });
+
+  test('saveToken routes to AsyncStorage on web', async () => {
+    const { saveToken } = loadAuthStorage();
+    await saveToken('my-jwt-token');
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith('adepthood_auth_token', 'my-jwt-token');
+    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalled();
+  });
+
+  test('loadToken reads from AsyncStorage on web', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce('my-jwt-token');
+    const { loadToken } = loadAuthStorage();
+    await expect(loadToken()).resolves.toBe('my-jwt-token');
+    expect(mockSecureStore.getItemAsync).not.toHaveBeenCalled();
+  });
+
+  test('clearToken removes from AsyncStorage on web', async () => {
+    const { clearToken } = loadAuthStorage();
+    await clearToken();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('adepthood_auth_token');
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/storage/authStorage.ts
+++ b/frontend/src/storage/authStorage.ts
@@ -1,17 +1,36 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
 
 // expo-secure-store only allows alphanumerics plus `.`, `-`, `_` in keys,
 // so we cannot use the `@adepthood/...` namespace prefix here.
 const TOKEN_KEY = 'adepthood_auth_token';
 
+// ``expo-secure-store`` v55 has no web implementation — its web module is
+// literally ``export default {}``, so calling ``SecureStore.setItemAsync``
+// throws ``TypeError: … is not a function`` and every auth attempt in the
+// Expo Web build fails with the generic signup fallback copy. On web we
+// fall back to ``AsyncStorage`` (which resolves to ``localStorage``) so
+// the flow works end-to-end. Native keeps using Keychain/Keystore.
+const isWeb = Platform.OS === 'web';
+
 export async function saveToken(token: string): Promise<void> {
+  if (isWeb) {
+    await AsyncStorage.setItem(TOKEN_KEY, token);
+    return;
+  }
   await SecureStore.setItemAsync(TOKEN_KEY, token);
 }
 
 export async function loadToken(): Promise<string | null> {
+  if (isWeb) return AsyncStorage.getItem(TOKEN_KEY);
   return SecureStore.getItemAsync(TOKEN_KEY);
 }
 
 export async function clearToken(): Promise<void> {
+  if (isWeb) {
+    await AsyncStorage.removeItem(TOKEN_KEY);
+    return;
+  }
   await SecureStore.deleteItemAsync(TOKEN_KEY);
 }


### PR DESCRIPTION
``expo-secure-store`` v55 has no web implementation — its web bundle is
literally ``export default {}`` (see
``node_modules/expo-secure-store/build/ExpoSecureStore.web.js:1``), so
``SecureStore.setItemAsync`` on web calls an undefined method and
throws ``TypeError: … is not a function``.

In the signup flow this lands after a 200 from ``POST /auth/signup``.
The HTTP response is valid, but ``saveToken`` in ``AuthContext`` throws
while writing the JWT to storage. The thrown ``TypeError`` has no
``status``/``detail`` and is not an ``ApiError``/``ApiTimeoutError``/
``ApiValidationError``, so ``formatApiError`` falls all the way through
to ``SIGNUP_FALLBACK`` — the "We couldn't create your account. Check
your connection…" message users see on app.aptitude.guru even when the
request succeeded. Login has the same code path and is equally broken.

Fix: detect ``Platform.OS === 'web'`` in ``authStorage.ts`` and route
reads/writes through ``@react-native-async-storage/async-storage``
(which resolves to ``localStorage`` on web). Native keeps using
Keychain/Keystore so the security properties are preserved there.
Adds six tests pinning both the native and web routing.

Also fix the ``no-commit-to-branch`` false positive that failed Backend
CI on the #226 merge: the hook exists to block *local* commits to
main, but in CI on a push to main the hook fires correctly and fails
the job. Add ``SKIP: no-commit-to-branch`` to both ``pre-commit`` and
``pre-push`` steps in ``backend-ci.yml``. The hook still protects
local commits.

Frontend suite: 646/646 passing.
pre-commit run --all-files (with local SKIP): all hooks pass.

https://claude.ai/code/session_01LFoXY7mEosJciHgYDP1p5V