### PR TITLE
refactor(frontend): introduce authStatus state machine in AuthContext

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,3 +34,6 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+# test coverage
+coverage/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { AuthProvider, useAuth } from './context/AuthContext';
 import { NetworkStatusProvider } from './context/NetworkStatusContext';
 import { colors, SPACING } from './design/tokens';
 import LoginScreen from './features/Auth/LoginScreen';
+import { ReauthSheet } from './features/Auth/ReauthSheet';
 import SignupScreen from './features/Auth/SignupScreen';
 import type { RootTabParamList } from './navigation/BottomTabs';
 import type { RootStackParamList } from './navigation/RootStack';
@@ -76,21 +77,24 @@ function AuthNavigator() {
 }
 
 /**
- * BUG-FRONTEND-INFRA-002 / 003 / 022 — keying the subtree on the auth state
- * forces a full remount on login/logout, which clears:
+ * BUG-NAV-001 / BUG-NAV-002: gate on the explicit ``authStatus`` state
+ * machine — never on raw ``token``. A transient 401 now transitions to
+ * ``'reauth-required'`` instead of nulling the token, so RootStack stays
+ * mounted and the ``ReauthSheet`` overlay asks the user to re-authenticate
+ * in place. The ``'loading'`` branch is a one-shot cold-start splash; the
+ * state machine guarantees we never rewind into it mid-session, so the
+ * navigator cannot collapse to a spinner on StrictMode double-invoke or
+ * hot reload.
  *
- *   - Tab navigator state (selected tab, scroll offsets, pending navigation)
- *   - Route params carried over from a prior session (e.g. the Course screen
- *     still holding a stageNumber from the previous user)
- *   - Stale route state that ``CommonActions.reset`` would otherwise miss
- *
- * Two keys instead of one so the pre-login and post-login trees don't share
- * navigator identity.
+ * BUG-FRONTEND-INFRA-002 / 003 / 022 — keying the authed vs. anon subtrees
+ * on distinct keys forces a full remount on login/logout, which clears
+ * tab state, stale route params, and route state that ``CommonActions.reset``
+ * would otherwise miss.
  */
-function RootNavigator() {
-  const { token, isLoading } = useAuth();
+export function RootNavigator(): React.JSX.Element {
+  const { authStatus } = useAuth();
 
-  if (isLoading) {
+  if (authStatus === 'loading') {
     return (
       <View style={styles.loading} testID="auth-loading">
         <ActivityIndicator size="large" />
@@ -98,13 +102,21 @@ function RootNavigator() {
     );
   }
 
-  return token ? (
+  if (authStatus === 'anonymous') {
+    return (
+      <FeatureErrorBoundary name="Auth">
+        <AuthNavigator key="anon" />
+      </FeatureErrorBoundary>
+    );
+  }
+
+  // ``'authenticated'`` or ``'reauth-required'`` — RootStack stays mounted
+  // in both cases; the overlay only appears when we need the user to sign
+  // back in.
+  return (
     <FeatureErrorBoundary name="App">
       <RootStack key="auth" />
-    </FeatureErrorBoundary>
-  ) : (
-    <FeatureErrorBoundary name="Auth">
-      <AuthNavigator key="anon" />
+      {authStatus === 'reauth-required' ? <ReauthSheet /> : null}
     </FeatureErrorBoundary>
   );
 }

--- a/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
+++ b/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
@@ -1,0 +1,165 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+/**
+ * BUG-NAV-001 / BUG-NAV-002: the root navigator used to gate on the raw
+ * ``token`` field, so any transient 401 that nulled the token also
+ * unmounted BottomTabs and landed the user on Signup. With the explicit
+ * ``authStatus`` state machine, a 401 transitions to ``'reauth-required'``
+ * — RootStack stays mounted and the re-auth sheet appears as an overlay.
+ *
+ * These tests exercise the navigator gate directly rather than going
+ * through the full React Navigation tree so they stay focused on the
+ * state-machine → navigator contract.
+ */
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    NavigationContainer: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useNavigation: () => ({ navigate: jest.fn(), getParent: () => undefined }),
+    useRoute: () => ({ params: undefined }),
+    useFocusEffect: (fn: () => void) => fn(),
+  };
+});
+
+jest.mock('@/navigation/RootStack', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const RootStackMock = () => React.createElement(Text, { testID: 'root-stack' }, 'RootStack');
+  return { __esModule: true, default: RootStackMock };
+});
+
+jest.mock('@/features/Auth/LoginScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const LoginMock = () => React.createElement(Text, { testID: 'login-screen' }, 'Login');
+  return { __esModule: true, default: LoginMock };
+});
+
+jest.mock('@/features/Auth/SignupScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const SignupMock = () => React.createElement(Text, { testID: 'signup-screen' }, 'Signup');
+  return { __esModule: true, default: SignupMock };
+});
+
+jest.mock('@react-navigation/native-stack', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    createNativeStackNavigator: () => ({
+      // A bare-bones stand-in: ``Navigator`` renders the first child's
+      // component, which is enough for the "is AuthNavigator mounted?" test.
+      Navigator: ({ children }: { children: React.ReactNode }) => {
+        const first = React.Children.toArray(children)[0] as React.ReactElement<{
+          component: React.ComponentType;
+        }>;
+        if (!first) return null;
+        const Component = first.props.component;
+        return React.createElement(Component);
+      },
+      Screen: () => null,
+    }),
+  };
+});
+
+jest.mock('@/components/FeatureErrorBoundary', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const Boundary = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(View, null, children);
+  return { __esModule: true, FeatureErrorBoundary: Boundary };
+});
+
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import { RootNavigator } from '@/App';
+import * as AuthContextModule from '@/context/AuthContext';
+import type { AuthStatus } from '@/context/AuthContext';
+
+type MockAuth = {
+  token: string | null;
+  authStatus: AuthStatus;
+  isLoading: boolean;
+  login: jest.Mock;
+  signup: jest.Mock;
+  logout: jest.Mock;
+  onUnauthorized: jest.Mock;
+  dismissReauth: jest.Mock;
+};
+
+function buildAuth(overrides: Partial<MockAuth> = {}): MockAuth {
+  return {
+    token: null,
+    authStatus: 'anonymous',
+    isLoading: false,
+    login: jest.fn(() => Promise.resolve()),
+    signup: jest.fn(() => Promise.resolve()),
+    logout: jest.fn(() => Promise.resolve()),
+    onUnauthorized: jest.fn(),
+    dismissReauth: jest.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+function mockAuthStatus(status: AuthStatus, token: string | null = null) {
+  jest.spyOn(AuthContextModule, 'useAuth').mockReturnValue(
+    buildAuth({
+      authStatus: status,
+      token,
+      isLoading: status === 'loading',
+    }),
+  );
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('RootNavigator gated on authStatus (BUG-NAV-001 / BUG-NAV-002)', () => {
+  it("mounts the BootSplash only while authStatus is 'loading'", () => {
+    mockAuthStatus('loading');
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    expect(getByTestId('auth-loading')).toBeTruthy();
+    expect(queryByTestId('root-stack')).toBeNull();
+  });
+
+  it("mounts the AuthNavigator when authStatus is 'anonymous'", () => {
+    mockAuthStatus('anonymous');
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    expect(getByTestId('login-screen')).toBeTruthy();
+    expect(queryByTestId('root-stack')).toBeNull();
+    expect(queryByTestId('reauth-sheet')).toBeNull();
+  });
+
+  it("mounts RootStack (no overlay) when authStatus is 'authenticated'", () => {
+    mockAuthStatus('authenticated', 'jwt');
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    expect(getByTestId('root-stack')).toBeTruthy();
+    expect(queryByTestId('reauth-sheet')).toBeNull();
+    expect(queryByTestId('login-screen')).toBeNull();
+  });
+
+  it("mounts RootStack *and* the re-auth sheet when authStatus is 'reauth-required'", () => {
+    mockAuthStatus('reauth-required');
+    const { getByTestId } = render(<RootNavigator />);
+    // Critical: RootStack stays mounted — do NOT boot the user to Signup.
+    expect(getByTestId('root-stack')).toBeTruthy();
+    // Overlay surfaces the re-auth prompt without tearing down tabs.
+    expect(getByTestId('reauth-sheet')).toBeTruthy();
+  });
+
+  it('keeps RootStack mounted across an authenticated → reauth-required transition', () => {
+    mockAuthStatus('authenticated', 'jwt');
+    const { getByTestId, rerender } = render(<RootNavigator />);
+    expect(getByTestId('root-stack')).toBeTruthy();
+
+    mockAuthStatus('reauth-required');
+    rerender(<RootNavigator />);
+    // RootStack must still be there — we never unmount it for a 401.
+    expect(getByTestId('root-stack')).toBeTruthy();
+    expect(getByTestId('reauth-sheet')).toBeTruthy();
+  });
+});

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -11,13 +11,40 @@ import {
 
 type LoginOrSignup = (_emailOrUsername: string, _pw: string) => Promise<void>;
 
+/**
+ * BUG-NAV-001 / BUG-NAV-002: the navigator used to gate on the raw ``token``
+ * field, so any transient 401 that nulled the token also unmounted the
+ * authenticated tree and booted the user to Signup. The explicit state
+ * machine below lets the navigator distinguish "logged out" from "prompt
+ * the user to re-authenticate without tearing down their navigation state".
+ *
+ * Transitions:
+ *
+ *   loading ───▶ authenticated (valid stored token)
+ *   loading ───▶ anonymous     (no / expired / corrupt stored token)
+ *   anonymous ─▶ authenticated (login / signup success)
+ *   authenticated ─▶ reauth-required (401 → onUnauthorized)
+ *   authenticated ─▶ anonymous (explicit logout)
+ *   reauth-required ─▶ authenticated (re-auth sheet succeeded → login/signup)
+ *   reauth-required ─▶ anonymous (user dismissed the sheet)
+ *
+ * ``loading`` is a one-shot cold-start state. Once bootstrap settles we
+ * never rewind to ``loading`` — a mid-session storage read must not
+ * collapse the navigator to a spinner (BUG-NAV-002).
+ */
+export type AuthStatus = 'loading' | 'authenticated' | 'reauth-required' | 'anonymous';
+
 interface AuthContextValue {
   token: string | null;
+  authStatus: AuthStatus;
+  /** Mirrors ``authStatus === 'loading'``. Kept for backwards compatibility. */
   isLoading: boolean;
   login: LoginOrSignup;
   signup: LoginOrSignup;
   logout: () => Promise<void>;
   onUnauthorized: () => void;
+  /** User dismissed the re-auth sheet: treat as an explicit logout. */
+  dismissReauth: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -60,20 +87,26 @@ function useProactiveRefresh(
   }, [token, tokenRef, applyNewToken]);
 }
 
+interface AuthMutators {
+  setToken: React.Dispatch<React.SetStateAction<string | null>>;
+  setAuthStatus: React.Dispatch<React.SetStateAction<AuthStatus>>;
+}
+
 /**
- * BUG-AUTH-005: the storage write must complete before we drop the token
- * from state; otherwise a crash between the two leaves a stale token in
- * secure storage that hydrates on next launch.
+ * BUG-AUTH-005 / BUG-NAV-001: the storage write must complete before we drop
+ * the token from state; otherwise a crash between the two leaves a stale
+ * token in secure storage that hydrates on next launch. When the API layer
+ * reports 401 we transition to ``'reauth-required'`` (so the navigator keeps
+ * Tabs mounted), not ``'anonymous'``.
  */
-async function clearTokenThenReset(
-  setToken: React.Dispatch<React.SetStateAction<string | null>>,
-): Promise<void> {
+async function clearTokenForReauth(mutators: AuthMutators): Promise<void> {
   try {
     await clearToken();
   } catch (err: unknown) {
     console.warn('clearToken failed in onUnauthorized', err);
   }
-  setToken(null);
+  mutators.setToken(null);
+  mutators.setAuthStatus((prev) => (prev === 'loading' ? 'anonymous' : 'reauth-required'));
 }
 
 /**
@@ -87,7 +120,7 @@ async function clearTokenThenReset(
  */
 async function saveTokenThenApply(
   newToken: string,
-  setToken: React.Dispatch<React.SetStateAction<string | null>>,
+  mutators: AuthMutators,
   tokenRef: React.MutableRefObject<string | null>,
 ): Promise<void> {
   if (tokenRef.current === null) {
@@ -101,13 +134,14 @@ async function saveTokenThenApply(
     return;
   }
   if (tokenRef.current === null) return;
-  setToken(newToken);
+  mutators.setToken(newToken);
+  mutators.setAuthStatus('authenticated');
 }
 
 /** Register API-layer callbacks that bridge token state to the HTTP client. */
 function useApiCallbacks(
   tokenRef: React.MutableRefObject<string | null>,
-  setToken: React.Dispatch<React.SetStateAction<string | null>>,
+  mutators: AuthMutators,
 ): void {
   // BUG-FRONTEND-INFRA-013: hold the getter in a ref that outlives the effect
   // so a mid-request logout (which clears ``tokenRef.current``) can't lose
@@ -118,80 +152,133 @@ function useApiCallbacks(
   useEffect(() => {
     setTokenGetter(stableGetter);
     setOnUnauthorized(() => {
-      void clearTokenThenReset(setToken);
+      void clearTokenForReauth(mutators);
     });
     setOnTokenRefreshed((t: string) => {
-      void saveTokenThenApply(t, setToken, tokenRef);
+      void saveTokenThenApply(t, mutators, tokenRef);
     });
     return () => {
       setTokenGetter(null);
       setOnUnauthorized(null);
       setOnTokenRefreshed(null);
     };
-  }, [stableGetter, setToken, tokenRef]);
+  }, [stableGetter, mutators, tokenRef]);
 }
 
-/** Load token from storage on mount, discarding expired tokens. */
-function useLoadStoredToken(
-  setToken: React.Dispatch<React.SetStateAction<string | null>>,
-  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
-): void {
+/**
+ * Load token from storage on mount, discarding expired tokens. Terminates
+ * in either ``'authenticated'`` or ``'anonymous'`` — ``'loading'`` is a
+ * one-shot state, so later effects must not rewind it (BUG-NAV-002).
+ */
+function useLoadStoredToken(mutators: AuthMutators): void {
   useEffect(() => {
     loadToken()
-      .then((stored) => {
+      .then(async (stored) => {
         if (stored && !isTokenExpired(stored)) {
-          setToken(stored);
-        } else if (stored) {
-          clearToken();
+          mutators.setToken(stored);
+          mutators.setAuthStatus('authenticated');
+          return;
         }
+        if (stored) {
+          try {
+            await clearToken();
+          } catch (err: unknown) {
+            console.warn('clearToken failed discarding expired stored token', err);
+          }
+        }
+        mutators.setAuthStatus('anonymous');
       })
-      .finally(() => setIsLoading(false));
-  }, [setToken, setIsLoading]);
+      .catch((err: unknown) => {
+        console.warn('loadToken failed on bootstrap', err);
+        mutators.setAuthStatus('anonymous');
+      });
+  }, [mutators]);
 }
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [token, setToken] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+interface AuthActions {
+  login: LoginOrSignup;
+  signup: LoginOrSignup;
+  logout: () => Promise<void>;
+  onUnauthorized: () => void;
+  dismissReauth: () => Promise<void>;
+}
 
-  const tokenRef = React.useRef<string | null>(null);
-  tokenRef.current = token;
+function useAuthActions(mutators: AuthMutators): AuthActions {
+  const { setToken, setAuthStatus } = mutators;
 
-  const applyNewToken = useCallback(async (newToken: string) => {
-    await saveToken(newToken);
-    setToken(newToken);
-  }, []);
+  const login = useCallback<LoginOrSignup>(
+    async (email, password) => {
+      const response = await authApi.login({ email, password });
+      await saveToken(response.token);
+      setToken(response.token);
+      setAuthStatus('authenticated');
+    },
+    [setToken, setAuthStatus],
+  );
 
-  useApiCallbacks(tokenRef, setToken);
-  useProactiveRefresh(token, tokenRef, applyNewToken);
-  useLoadStoredToken(setToken, setIsLoading);
-
-  const login = useCallback(async (email: string, password: string) => {
-    const response = await authApi.login({ email, password });
-    await saveToken(response.token);
-    setToken(response.token);
-  }, []);
-
-  const signup = useCallback(async (email: string, password: string) => {
-    const response = await authApi.signup({ email, password });
-    await saveToken(response.token);
-    setToken(response.token);
-  }, []);
+  const signup = useCallback<LoginOrSignup>(
+    async (email, password) => {
+      const response = await authApi.signup({ email, password });
+      await saveToken(response.token);
+      setToken(response.token);
+      setAuthStatus('authenticated');
+    },
+    [setToken, setAuthStatus],
+  );
 
   const logout = useCallback(async () => {
     await clearToken();
     setToken(null);
-  }, []);
+    setAuthStatus('anonymous');
+  }, [setToken, setAuthStatus]);
 
   // BUG-AUTH-005: mirror the persistence-first ordering used by the API-layer
   // onUnauthorized hook so callers of the context-exposed helper get the same
-  // crash-safety guarantee.
+  // crash-safety guarantee. Routes to ``'reauth-required'`` so RootStack
+  // stays mounted (BUG-NAV-001).
   const onUnauthorized = useCallback(() => {
-    void clearTokenThenReset(setToken);
+    void clearTokenForReauth(mutators);
+  }, [mutators]);
+
+  const dismissReauth = useCallback(async () => {
+    try {
+      await clearToken();
+    } catch (err: unknown) {
+      console.warn('clearToken failed in dismissReauth', err);
+    }
+    setToken(null);
+    setAuthStatus('anonymous');
+  }, [setToken, setAuthStatus]);
+
+  return { login, signup, logout, onUnauthorized, dismissReauth };
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [authStatus, setAuthStatus] = useState<AuthStatus>('loading');
+
+  const tokenRef = React.useRef<string | null>(null);
+  tokenRef.current = token;
+
+  // Stable handle so effects depending on the mutators don't thrash.
+  const mutators = useMemo<AuthMutators>(() => ({ setToken, setAuthStatus }), []);
+
+  const applyNewToken = useCallback(async (newToken: string) => {
+    await saveToken(newToken);
+    setToken(newToken);
+    setAuthStatus('authenticated');
   }, []);
 
+  useApiCallbacks(tokenRef, mutators);
+  useProactiveRefresh(token, tokenRef, applyNewToken);
+  useLoadStoredToken(mutators);
+
+  const actions = useAuthActions(mutators);
+  const isLoading = authStatus === 'loading';
+
   const value = useMemo(
-    () => ({ token, isLoading, login, signup, logout, onUnauthorized }),
-    [token, isLoading, login, signup, logout, onUnauthorized],
+    () => ({ token, authStatus, isLoading, ...actions }),
+    [token, authStatus, isLoading, actions],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -2,6 +2,9 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 
 import { auth as authApi, setOnTokenRefreshed, setOnUnauthorized, setTokenGetter } from '@/api';
 import { clearToken, loadToken, saveToken } from '@/storage/authStorage';
+import { clearHabits, clearPendingCheckIns } from '@/storage/habitStorage';
+import { clearLlmApiKey } from '@/storage/llmKeyStorage';
+import { resetAllStores } from '@/store/registry';
 import {
   decodeJwtPayload,
   isTokenExpired,
@@ -90,6 +93,30 @@ function useProactiveRefresh(
 interface AuthMutators {
   setToken: React.Dispatch<React.SetStateAction<string | null>>;
   setAuthStatus: React.Dispatch<React.SetStateAction<AuthStatus>>;
+}
+
+/**
+ * BUG-FE-STATE-001: every logout path (explicit ``logout`` and the re-auth
+ * sheet's "sign out instead" button) must wipe the in-memory Zustand stores
+ * AND the AsyncStorage persistence keys so the next user on the device
+ * doesn't inherit the previous user's habits, stage progress, or BYOK key.
+ * The storage clears are wrapped in try/catch so one failing key doesn't
+ * leave the rest of the wipe half-done.
+ */
+async function wipeUserState(): Promise<void> {
+  resetAllStores();
+  const clears: Array<[string, Promise<void>]> = [
+    ['habits', clearHabits()],
+    ['pending check-ins', clearPendingCheckIns()],
+    ['LLM API key', clearLlmApiKey()],
+  ];
+  for (const [label, promise] of clears) {
+    try {
+      await promise;
+    } catch (err: unknown) {
+      console.warn(`[auth] failed to clear ${label} on logout`, err);
+    }
+  }
 }
 
 /**
@@ -228,6 +255,7 @@ function useAuthActions(mutators: AuthMutators): AuthActions {
 
   const logout = useCallback(async () => {
     await clearToken();
+    await wipeUserState();
     setToken(null);
     setAuthStatus('anonymous');
   }, [setToken, setAuthStatus]);
@@ -246,6 +274,7 @@ function useAuthActions(mutators: AuthMutators): AuthActions {
     } catch (err: unknown) {
       console.warn('clearToken failed in dismissReauth', err);
     }
+    await wipeUserState();
     setToken(null);
     setAuthStatus('anonymous');
   }, [setToken, setAuthStatus]);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -4,6 +4,7 @@ import { auth as authApi, setOnTokenRefreshed, setOnUnauthorized, setTokenGetter
 import { clearToken, loadToken, saveToken } from '@/storage/authStorage';
 import { clearHabits, clearPendingCheckIns } from '@/storage/habitStorage';
 import { clearLlmApiKey } from '@/storage/llmKeyStorage';
+import { clearAllNotificationData } from '@/storage/notificationStorage';
 import { resetAllStores } from '@/store/registry';
 import {
   decodeJwtPayload,
@@ -109,14 +110,18 @@ async function wipeUserState(): Promise<void> {
     ['habits', clearHabits()],
     ['pending check-ins', clearPendingCheckIns()],
     ['LLM API key', clearLlmApiKey()],
+    ['notification data', clearAllNotificationData()],
   ];
-  for (const [label, promise] of clears) {
-    try {
-      await promise;
-    } catch (err: unknown) {
-      console.warn(`[auth] failed to clear ${label} on logout`, err);
+  // Run the clears concurrently — they target independent AsyncStorage keys —
+  // but surface every failure via ``allSettled`` so one dead key doesn't
+  // silently strand the others.
+  const results = await Promise.allSettled(clears.map(([, promise]) => promise));
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      const label = clears[index]?.[0] ?? 'unknown';
+      console.warn(`[auth] failed to clear ${label} on logout`, result.reason);
     }
-  }
+  });
 }
 
 /**
@@ -254,7 +259,14 @@ function useAuthActions(mutators: AuthMutators): AuthActions {
   );
 
   const logout = useCallback(async () => {
-    await clearToken();
+    // BUG-FE-STATE-001 review follow-up: if SecureStore rejects we must still
+    // null the in-memory token and wipe the stores — otherwise a flaky
+    // device keychain leaves the app indefinitely authenticated.
+    try {
+      await clearToken();
+    } catch (err: unknown) {
+      console.warn('clearToken failed in logout', err);
+    }
     await wipeUserState();
     setToken(null);
     setAuthStatus('anonymous');
@@ -279,7 +291,12 @@ function useAuthActions(mutators: AuthMutators): AuthActions {
     setAuthStatus('anonymous');
   }, [setToken, setAuthStatus]);
 
-  return { login, signup, logout, onUnauthorized, dismissReauth };
+  // Memoize the bundle so the context value's ``useMemo`` actually short-
+  // circuits on renders where none of the identity-stable callbacks changed.
+  return useMemo(
+    () => ({ login, signup, logout, onUnauthorized, dismissReauth }),
+    [login, signup, logout, onUnauthorized, dismissReauth],
+  );
 }
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -176,6 +176,28 @@ describe('AuthContext', () => {
       expect(mockClearToken).toHaveBeenCalled();
       expect(result.current.token).toBeNull();
     });
+
+    // BUG-FE-STATE-001 review follow-up: if ``clearToken`` rejects (SecureStore
+    // unavailable, device locked, etc.) logout must still null the in-memory
+    // token and transition to ``anonymous`` — otherwise a flaky SecureStore
+    // leaves the app indefinitely authenticated with a user who asked to
+    // sign out.
+    it('still transitions to anonymous when clearToken rejects', async () => {
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      mockClearToken.mockRejectedValueOnce(new Error('SecureStore unavailable'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.token).toBe('existing-jwt'));
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(result.current.token).toBeNull();
+      expect(result.current.authStatus).toBe('anonymous');
+      warnSpy.mockRestore();
+    });
   });
 
   describe('onUnauthorized', () => {

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -194,6 +194,115 @@ describe('AuthContext', () => {
     });
   });
 
+  // BUG-NAV-001 / BUG-NAV-002: the navigator must discriminate between
+  // "transient 401, ask to re-auth" and "user is anonymous" — otherwise
+  // any 401 during a tab switch unmounts BottomTabs and boots the user
+  // to Signup. The machine also guards against re-entering ``'loading'``
+  // mid-session: once bootstrap settles we never rewind.
+  describe('authStatus state machine (BUG-NAV-001 / BUG-NAV-002)', () => {
+    it("starts in 'loading' before the stored-token read resolves", () => {
+      mockLoadToken.mockReturnValue(new Promise(() => {}));
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      expect(result.current.authStatus).toBe('loading');
+    });
+
+    it("resolves to 'anonymous' when no token is stored", async () => {
+      mockLoadToken.mockResolvedValue(null);
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+    });
+
+    it("resolves to 'authenticated' when a valid token is stored", async () => {
+      mockLoadToken.mockResolvedValue('valid-jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('authenticated'));
+    });
+
+    it("resolves to 'anonymous' when the stored token is expired", async () => {
+      mockLoadToken.mockResolvedValue('expired-jwt');
+      mockIsTokenExpired.mockReturnValue(true);
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+    });
+
+    it("transitions to 'authenticated' after successful login", async () => {
+      mockAuth.login.mockResolvedValue({ token: 'new-jwt', user_id: 1 });
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+
+      await act(async () => {
+        await result.current.login('user@test.com', 'password123');
+      });
+      expect(result.current.authStatus).toBe('authenticated');
+    });
+
+    it("transitions to 'reauth-required' on onUnauthorized (NOT 'anonymous')", async () => {
+      mockLoadToken.mockResolvedValue('stored-jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('authenticated'));
+
+      await act(async () => {
+        result.current.onUnauthorized();
+      });
+      await waitFor(() => expect(result.current.authStatus).toBe('reauth-required'));
+      // Explicitly not 'anonymous' — that would unmount RootStack.
+      expect(result.current.authStatus).not.toBe('anonymous');
+    });
+
+    it("transitions to 'anonymous' on explicit logout", async () => {
+      mockLoadToken.mockResolvedValue('stored-jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('authenticated'));
+
+      await act(async () => {
+        await result.current.logout();
+      });
+      expect(result.current.authStatus).toBe('anonymous');
+    });
+
+    it("does not re-enter 'loading' after bootstrap completes", async () => {
+      mockLoadToken.mockResolvedValue(null);
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+
+      mockAuth.login.mockResolvedValue({ token: 'new-jwt', user_id: 1 });
+      await act(async () => {
+        await result.current.login('user@test.com', 'p'); // pragma: allowlist secret
+      });
+      expect(result.current.authStatus).toBe('authenticated');
+
+      await act(async () => {
+        result.current.onUnauthorized();
+      });
+      // Still not 'loading' — we never rewind the one-shot bootstrap flag.
+      await waitFor(() => expect(result.current.authStatus).toBe('reauth-required'));
+      expect(result.current.authStatus).not.toBe('loading');
+    });
+
+    it("dismissReauth transitions from 'reauth-required' to 'anonymous'", async () => {
+      mockLoadToken.mockResolvedValue('stored-jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('authenticated'));
+
+      await act(async () => {
+        result.current.onUnauthorized();
+      });
+      await waitFor(() => expect(result.current.authStatus).toBe('reauth-required'));
+
+      await act(async () => {
+        await result.current.dismissReauth();
+      });
+      expect(result.current.authStatus).toBe('anonymous');
+    });
+
+    it("isLoading mirrors authStatus === 'loading' for backwards compatibility", () => {
+      mockLoadToken.mockReturnValue(new Promise(() => {}));
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.authStatus).toBe('loading');
+    });
+  });
+
   describe('token expiration on startup', () => {
     it('discards an expired stored token', async () => {
       mockLoadToken.mockResolvedValue('expired-jwt');

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -518,4 +518,59 @@ describe('AuthContext', () => {
       expect(result.current.token).toBe('second-jwt');
     });
   });
+
+  // BUG-FE-STATE-001: every logout path — explicit logout and the re-auth
+  // sheet's "sign out instead" button — must wipe the in-memory stores AND
+  // the AsyncStorage keys that act as persistent caches so the next user on
+  // the device doesn't inherit the previous user's data.
+  describe('logout clears all user state (BUG-FE-STATE-001)', () => {
+    it('calls resetAllStores from the registry on explicit logout', async () => {
+      const { resetAllStores } = require('@/store/registry');
+      const resetSpy = jest.spyOn(require('@/store/registry'), 'resetAllStores');
+      mockLoadToken.mockResolvedValue('jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('jwt'));
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(resetSpy).toHaveBeenCalledTimes(1);
+      expect(typeof resetAllStores).toBe('function');
+      resetSpy.mockRestore();
+    });
+
+    it('calls resetAllStores when the user dismisses the re-auth sheet', async () => {
+      const resetSpy = jest.spyOn(require('@/store/registry'), 'resetAllStores');
+      mockLoadToken.mockResolvedValue('jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('jwt'));
+
+      await act(async () => {
+        await result.current.dismissReauth();
+      });
+
+      expect(resetSpy).toHaveBeenCalledTimes(1);
+      expect(result.current.authStatus).toBe('anonymous');
+      resetSpy.mockRestore();
+    });
+
+    it('does NOT reset stores on a 401-triggered reauth-required transition', async () => {
+      // A 401 is a hint that the session went stale, not that the user is
+      // done with the app. Keep their in-memory habits/stages around so the
+      // ReauthSheet feels like a single-modal interruption, not a logout.
+      const resetSpy = jest.spyOn(require('@/store/registry'), 'resetAllStores');
+      mockLoadToken.mockResolvedValue('jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('jwt'));
+
+      await act(async () => {
+        result.current.onUnauthorized();
+      });
+
+      await waitFor(() => expect(result.current.authStatus).toBe('reauth-required'));
+      expect(resetSpy).not.toHaveBeenCalled();
+      resetSpy.mockRestore();
+    });
+  });
 });

--- a/frontend/src/features/Auth/ReauthSheet.tsx
+++ b/frontend/src/features/Auth/ReauthSheet.tsx
@@ -56,7 +56,9 @@ function ReauthActions({
       <TouchableOpacity
         accessibilityLabel="Sign out"
         accessibilityRole="button"
+        accessibilityState={{ disabled: submitting }}
         onPress={onDismiss}
+        disabled={submitting}
         testID="reauth-dismiss"
       >
         <Text style={styles.secondaryLink}>Sign out instead</Text>

--- a/frontend/src/features/Auth/ReauthSheet.tsx
+++ b/frontend/src/features/Auth/ReauthSheet.tsx
@@ -1,0 +1,204 @@
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { formatApiError } from '@/api/errorMessages';
+import { useAuth } from '@/context/AuthContext';
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+const REAUTH_FALLBACK =
+  "We couldn't sign you back in. Check your connection, then try again in a moment.";
+
+interface ReauthFormProps {
+  email: string;
+  password: string;
+  error: string | null;
+  submitting: boolean;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onSubmit: () => void;
+  onDismiss: () => void;
+}
+
+function ReauthActions({
+  submitting,
+  onSubmit,
+  onDismiss,
+}: {
+  submitting: boolean;
+  onSubmit: () => void;
+  onDismiss: () => void;
+}): React.JSX.Element {
+  return (
+    <>
+      <TouchableOpacity
+        accessibilityLabel="Sign back in"
+        accessibilityRole="button"
+        accessibilityState={{ disabled: submitting, busy: submitting }}
+        style={styles.primaryButton}
+        onPress={onSubmit}
+        disabled={submitting}
+        testID="reauth-submit"
+      >
+        {submitting ? (
+          <ActivityIndicator color={colors.text.light} />
+        ) : (
+          <Text style={styles.primaryButtonText}>Sign in</Text>
+        )}
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityLabel="Sign out"
+        accessibilityRole="button"
+        onPress={onDismiss}
+        testID="reauth-dismiss"
+      >
+        <Text style={styles.secondaryLink}>Sign out instead</Text>
+      </TouchableOpacity>
+    </>
+  );
+}
+
+function ReauthForm(props: ReauthFormProps): React.JSX.Element {
+  const { email, password, error, submitting } = props;
+  const { onEmailChange, onPasswordChange, onSubmit, onDismiss } = props;
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Sign back in</Text>
+      <Text style={styles.subtitle}>
+        Your session expired. Enter your credentials to keep going where you left off.
+      </Text>
+      <TextInput
+        accessibilityLabel="Email"
+        style={styles.input}
+        placeholder="Email"
+        value={email}
+        onChangeText={onEmailChange}
+        autoCapitalize="none"
+        keyboardType="email-address"
+        testID="reauth-email"
+      />
+      <TextInput
+        accessibilityLabel="Password"
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={onPasswordChange}
+        secureTextEntry
+        testID="reauth-password"
+      />
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <ReauthActions submitting={submitting} onSubmit={onSubmit} onDismiss={onDismiss} />
+    </View>
+  );
+}
+
+/**
+ * BUG-NAV-001: the re-auth sheet is an overlay — it sits *on top of*
+ * RootStack so a 401-induced ``'reauth-required'`` transition never
+ * unmounts BottomTabs. The user re-authenticates in place and lands
+ * back on the tab they were on.
+ */
+export function ReauthSheet(): React.JSX.Element {
+  const { login, dismissReauth } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    setError(null);
+    setSubmitting(true);
+    try {
+      await login(email.trim(), password);
+    } catch (err: unknown) {
+      setError(formatApiError(err, { fallback: REAUTH_FALLBACK }));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [login, email, password]);
+
+  const handleDismiss = useCallback(() => {
+    void dismissReauth();
+  }, [dismissReauth]);
+
+  return (
+    <Modal
+      transparent
+      animationType="fade"
+      visible
+      onRequestClose={handleDismiss}
+      testID="reauth-sheet"
+    >
+      <View style={styles.backdrop}>
+        <ReauthForm
+          email={email}
+          password={password}
+          error={error}
+          submitting={submitting}
+          onEmailChange={setEmail}
+          onPasswordChange={setPassword}
+          onSubmit={handleSubmit}
+          onDismiss={handleDismiss}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'center',
+    padding: SPACING.xl,
+  },
+  card: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.xl,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text.primary,
+    marginBottom: SPACING.sm,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    marginBottom: SPACING.lg,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md,
+    marginBottom: SPACING.md,
+    fontSize: 16,
+  },
+  error: {
+    color: colors.danger,
+    marginBottom: SPACING.md,
+    textAlign: 'center',
+  },
+  primaryButton: {
+    backgroundColor: colors.primary,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md + 2,
+    alignItems: 'center',
+    marginBottom: SPACING.md,
+  },
+  primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
+  secondaryLink: {
+    textAlign: 'center',
+    color: colors.text.secondary,
+    paddingVertical: SPACING.sm,
+  },
+});

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -3,8 +3,16 @@
 import { render } from '@testing-library/react-native';
 import React from 'react';
 
-// Control mock state per test
-let mockAuthState = { token: null as string | null, isLoading: false };
+type AuthStatus = 'loading' | 'authenticated' | 'reauth-required' | 'anonymous';
+
+// Control mock state per test. ``token`` + ``isLoading`` are kept so
+// legacy callers that still read them keep working; the navigator
+// itself now gates on ``authStatus`` (BUG-NAV-001 / BUG-NAV-002).
+let mockAuthState: { token: string | null; authStatus: AuthStatus; isLoading: boolean } = {
+  token: null,
+  authStatus: 'anonymous',
+  isLoading: false,
+};
 
 jest.mock('@/context/AuthContext', () => ({
   AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -14,6 +22,7 @@ jest.mock('@/context/AuthContext', () => ({
     signup: jest.fn(),
     logout: jest.fn(),
     onUnauthorized: jest.fn(),
+    dismissReauth: jest.fn(),
   }),
 }));
 
@@ -45,6 +54,10 @@ jest.mock('@/features/Auth/SignupScreen', () => {
   const { Text } = require('react-native');
   return () => <Text>SignupScreen</Text>;
 });
+jest.mock('@/features/Auth/ReauthSheet', () => {
+  const { Text } = require('react-native');
+  return { ReauthSheet: () => <Text>ReauthSheet</Text> };
+});
 jest.mock('@/navigation/BottomTabs', () => {
   const { Text } = require('react-native');
   return () => <Text>BottomTabs</Text>;
@@ -53,42 +66,52 @@ jest.mock('@/navigation/BottomTabs', () => {
 import App from '@/App';
 
 beforeEach(() => {
-  mockAuthState = { token: null, isLoading: false };
+  mockAuthState = { token: null, authStatus: 'anonymous', isLoading: false };
 });
 
 describe('App auth flow', () => {
-  it('shows auth screens when user is not authenticated', () => {
-    mockAuthState = { token: null, isLoading: false };
+  it('shows auth screens when user is anonymous', () => {
+    mockAuthState = { token: null, authStatus: 'anonymous', isLoading: false };
     const { getByText } = render(<App />);
 
     expect(getByText('LoginScreen')).toBeTruthy();
   });
 
-  it('shows loading indicator while checking auth', () => {
-    mockAuthState = { token: null, isLoading: true };
+  it('shows loading indicator while authStatus is loading', () => {
+    mockAuthState = { token: null, authStatus: 'loading', isLoading: true };
     const { getByTestId } = render(<App />);
 
     expect(getByTestId('auth-loading')).toBeTruthy();
   });
 
   it('shows main app when user is authenticated', () => {
-    mockAuthState = { token: 'valid-jwt', isLoading: false };
+    mockAuthState = { token: 'valid-jwt', authStatus: 'authenticated', isLoading: false };
     const { getByText } = render(<App />);
 
     expect(getByText('BottomTabs')).toBeTruthy();
   });
 
   it('does not show auth screens when authenticated', () => {
-    mockAuthState = { token: 'valid-jwt', isLoading: false };
+    mockAuthState = { token: 'valid-jwt', authStatus: 'authenticated', isLoading: false };
     const { queryByText } = render(<App />);
 
     expect(queryByText('LoginScreen')).toBeNull();
   });
 
-  it('does not show main app when not authenticated', () => {
-    mockAuthState = { token: null, isLoading: false };
+  it('does not show main app when anonymous', () => {
+    mockAuthState = { token: null, authStatus: 'anonymous', isLoading: false };
     const { queryByText } = render(<App />);
 
     expect(queryByText('BottomTabs')).toBeNull();
+  });
+
+  // BUG-NAV-001: a 401 must not unmount the tabs. When authStatus is
+  // 'reauth-required' we show BottomTabs *and* the ReauthSheet overlay.
+  it('keeps BottomTabs mounted and shows ReauthSheet when reauth-required', () => {
+    mockAuthState = { token: null, authStatus: 'reauth-required', isLoading: false };
+    const { getByText } = render(<App />);
+
+    expect(getByText('BottomTabs')).toBeTruthy();
+    expect(getByText('ReauthSheet')).toBeTruthy();
   });
 });

--- a/frontend/src/features/Auth/__tests__/ReauthSheet.test.tsx
+++ b/frontend/src/features/Auth/__tests__/ReauthSheet.test.tsx
@@ -1,0 +1,118 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+/**
+ * BUG-NAV-001 follow-up — the ReauthSheet is the user-facing surface of the
+ * ``'reauth-required'`` state. These tests pin down its form wiring, error
+ * rendering, submit lifecycle, and the dismiss-during-submit race that
+ * @claude[bot] flagged on #245.
+ */
+const mockLogin = jest.fn<Promise<void>, [string, string]>();
+const mockDismissReauth = jest.fn<Promise<void>, []>();
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({
+    token: null,
+    authStatus: 'reauth-required',
+    isLoading: false,
+    login: mockLogin,
+    signup: jest.fn(),
+    logout: jest.fn(),
+    onUnauthorized: jest.fn(),
+    dismissReauth: mockDismissReauth,
+  }),
+}));
+
+jest.mock('@/api/errorMessages', () => ({
+  formatApiError: (_err: unknown, { fallback }: { fallback: string }) =>
+    (_err as { message?: string })?.message ?? fallback,
+}));
+
+import { ReauthSheet } from '@/features/Auth/ReauthSheet';
+
+beforeEach(() => {
+  mockLogin.mockReset();
+  mockDismissReauth.mockReset();
+  mockLogin.mockResolvedValue(undefined);
+  mockDismissReauth.mockResolvedValue(undefined);
+});
+
+describe('ReauthSheet', () => {
+  it('renders email + password fields and both action buttons', () => {
+    const { getByTestId } = render(<ReauthSheet />);
+    expect(getByTestId('reauth-email')).toBeTruthy();
+    expect(getByTestId('reauth-password')).toBeTruthy();
+    expect(getByTestId('reauth-submit')).toBeTruthy();
+    expect(getByTestId('reauth-dismiss')).toBeTruthy();
+  });
+
+  it('calls login(email.trim(), password) when submit is pressed', async () => {
+    const { getByTestId } = render(<ReauthSheet />);
+    fireEvent.changeText(getByTestId('reauth-email'), '  user@example.com  ');
+    fireEvent.changeText(getByTestId('reauth-password'), 'secret'); // pragma: allowlist secret
+    fireEvent.press(getByTestId('reauth-submit'));
+
+    await waitFor(
+      () => expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'secret'), // pragma: allowlist secret
+    );
+  });
+
+  it('displays the formatted error when login rejects', async () => {
+    mockLogin.mockRejectedValueOnce(new Error('Invalid credentials'));
+    const { getByTestId, findByText } = render(<ReauthSheet />);
+    fireEvent.changeText(getByTestId('reauth-email'), 'a@b.co');
+    fireEvent.changeText(getByTestId('reauth-password'), 'pw'); // pragma: allowlist secret
+    fireEvent.press(getByTestId('reauth-submit'));
+
+    expect(await findByText('Invalid credentials')).toBeTruthy();
+  });
+
+  it('calls dismissReauth when "Sign out instead" is pressed', () => {
+    const { getByTestId } = render(<ReauthSheet />);
+    fireEvent.press(getByTestId('reauth-dismiss'));
+    expect(mockDismissReauth).toHaveBeenCalledTimes(1);
+  });
+
+  // BUG-NAV-001 review follow-up: if dismiss fires while a login is in flight,
+  // the login completion races the dismiss and can silently log the user back
+  // in after they chose to sign out. Disable the dismiss button while
+  // submitting so the race is impossible by construction.
+  it('disables the dismiss button while a login is in flight', () => {
+    const resolveLoginRef: { current: (() => void) | null } = { current: null };
+    mockLogin.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoginRef.current = () => resolve();
+        }),
+    );
+
+    const { getByTestId } = render(<ReauthSheet />);
+    fireEvent.changeText(getByTestId('reauth-email'), 'a@b.co');
+    fireEvent.changeText(getByTestId('reauth-password'), 'pw'); // pragma: allowlist secret
+    fireEvent.press(getByTestId('reauth-submit'));
+
+    const dismiss = getByTestId('reauth-dismiss');
+    expect(dismiss.props.accessibilityState?.disabled).toBe(true);
+
+    // Tapping the disabled dismiss must be a no-op so the mid-flight login
+    // cannot be silently superseded by a logout.
+    fireEvent.press(dismiss);
+    expect(mockDismissReauth).not.toHaveBeenCalled();
+
+    resolveLoginRef.current?.();
+  });
+
+  it('re-enables the dismiss button once the login promise settles', async () => {
+    mockLogin.mockRejectedValueOnce(new Error('nope'));
+    const { getByTestId } = render(<ReauthSheet />);
+    fireEvent.changeText(getByTestId('reauth-email'), 'a@b.co');
+    fireEvent.changeText(getByTestId('reauth-password'), 'pw'); // pragma: allowlist secret
+    fireEvent.press(getByTestId('reauth-submit'));
+
+    await waitFor(() =>
+      expect(getByTestId('reauth-dismiss').props.accessibilityState?.disabled).toBe(false),
+    );
+  });
+});

--- a/frontend/src/storage/__tests__/notificationStorage.test.ts
+++ b/frontend/src/storage/__tests__/notificationStorage.test.ts
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
 import {
+  clearAllNotificationData,
   saveNotificationIds,
   loadNotificationIds,
   clearNotificationIds,
@@ -152,6 +153,36 @@ describe('notificationStorage', () => {
         'adepthood_push_token',
         'ExponentPushToken[abc]',
       );
+    });
+  });
+
+  // BUG-FE-STATE-001: logout must wipe every per-user persistence key so the
+  // next user on the device does not inherit the previous user's scheduled
+  // notifications or tracked habit IDs.
+  describe('clearAllNotificationData', () => {
+    test('removes every per-habit notification key and the tracking list', async () => {
+      mockAsyncStorage.getItem.mockImplementation(async (key: string) => {
+        if (key === '@adepthood/notification_habit_ids') return JSON.stringify([1, 2]);
+        return null;
+      });
+
+      await clearAllNotificationData();
+
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/notifications/1');
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/notifications/2');
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/notification_habit_ids');
+    });
+
+    test('is a no-op when no habits are tracked', async () => {
+      mockAsyncStorage.getItem.mockReset();
+      mockAsyncStorage.getItem.mockResolvedValue(null);
+      mockAsyncStorage.removeItem.mockClear();
+
+      await clearAllNotificationData();
+
+      // Only the tracking-list key itself is removed (defensively).
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledTimes(1);
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/notification_habit_ids');
     });
   });
 

--- a/frontend/src/storage/notificationStorage.ts
+++ b/frontend/src/storage/notificationStorage.ts
@@ -50,6 +50,20 @@ export async function clearNotificationIds(habitId: number): Promise<void> {
   await untrackHabitId(habitId);
 }
 
+/**
+ * BUG-FE-STATE-001 — remove every per-user notification key on logout so
+ * the next user on the device does not inherit scheduled notifications or
+ * the tracking list that points at them. The push-token key is intentionally
+ * NOT cleared: it is a device credential, not a user credential.
+ */
+export async function clearAllNotificationData(): Promise<void> {
+  const habitIds = await loadTrackedHabitIds();
+  for (const habitId of habitIds) {
+    await AsyncStorage.removeItem(keyFor(habitId));
+  }
+  await AsyncStorage.removeItem(ALL_HABIT_IDS_KEY);
+}
+
 export async function loadAllNotificationMappings(): Promise<Record<number, string[]>> {
   const habitIds = await loadTrackedHabitIds();
   const mappings: Record<number, string[]> = {};

--- a/frontend/src/store/__tests__/registry.test.ts
+++ b/frontend/src/store/__tests__/registry.test.ts
@@ -1,0 +1,71 @@
+/**
+ * BUG-FE-STATE-001: logout must wipe every in-memory store and every
+ * persistence key so the next user on the device does not inherit the old
+ * user's habits, stage progress, journal drafts, etc. The registry is the
+ * single place every store publishes its reset callback — ``resetAllStores``
+ * walks the registry so ``AuthContext.logout`` never has to know which
+ * stores exist.
+ */
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+
+import { __resetRegistryForTests, registerStoreReset, resetAllStores } from '../registry';
+
+describe('store reset registry (BUG-FE-STATE-001)', () => {
+  beforeEach(() => {
+    __resetRegistryForTests();
+  });
+
+  it('invokes every registered reset callback when resetAllStores is called', () => {
+    const resetA = jest.fn();
+    const resetB = jest.fn();
+    registerStoreReset(resetA);
+    registerStoreReset(resetB);
+
+    resetAllStores();
+
+    expect(resetA).toHaveBeenCalledTimes(1);
+    expect(resetB).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent — calling resetAllStores twice invokes each callback twice', () => {
+    const reset = jest.fn();
+    registerStoreReset(reset);
+
+    resetAllStores();
+    resetAllStores();
+
+    expect(reset).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues resetting remaining stores even if one reset throws', () => {
+    const boom = jest.fn(() => {
+      throw new Error('store A exploded');
+    });
+    const resetB = jest.fn();
+    registerStoreReset(boom);
+    registerStoreReset(resetB);
+
+    // A thrown reset must not prevent the rest from running — a user-visible
+    // logout that silently keeps a store of a previous user's data would
+    // reintroduce BUG-FE-STATE-001.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      resetAllStores();
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(boom).toHaveBeenCalledTimes(1);
+    expect(resetB).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates — registering the same callback twice only runs it once', () => {
+    const reset = jest.fn();
+    registerStoreReset(reset);
+    registerStoreReset(reset);
+
+    resetAllStores();
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/store/__tests__/registry.test.ts
+++ b/frontend/src/store/__tests__/registry.test.ts
@@ -68,4 +68,17 @@ describe('store reset registry (BUG-FE-STATE-001)', () => {
 
     expect(reset).toHaveBeenCalledTimes(1);
   });
+
+  // Review follow-up: the test-only escape hatch is dangerous if it ever fires
+  // in production — it would erase every store's reset callback. Guard it so
+  // a stray import can't nuke the registry at runtime.
+  it('__resetRegistryForTests throws when called outside NODE_ENV=test', () => {
+    const originalEnv = process.env.NODE_ENV;
+    (process.env as { NODE_ENV?: string }).NODE_ENV = 'production';
+    try {
+      expect(() => __resetRegistryForTests()).toThrow(/NODE_ENV=test/);
+    } finally {
+      (process.env as { NODE_ENV?: string }).NODE_ENV = originalEnv;
+    }
+  });
 });

--- a/frontend/src/store/__tests__/useHabitStore.test.ts
+++ b/frontend/src/store/__tests__/useHabitStore.test.ts
@@ -170,4 +170,37 @@ describe('useHabitStore', () => {
     const stateFromSecondCall = useHabitStore.getState();
     expect(stateFromSecondCall.habits).toEqual([habit]);
   });
+
+  // BUG-FE-STATE-001: the global store must fully wipe on logout so the next
+  // user on the device doesn't inherit the previous user's habits.
+  it('reset() restores the initial empty state', () => {
+    const { useHabitStore } = require('../useHabitStore');
+    act(() => {
+      useHabitStore.getState().setHabits([makeHabit({ id: 1 }), makeHabit({ id: 2 })]);
+      useHabitStore.getState().setLoading(true);
+      useHabitStore.getState().setError('boom');
+    });
+
+    act(() => useHabitStore.getState().reset());
+
+    const state = useHabitStore.getState();
+    expect(state.habits).toEqual([]);
+    expect(state.habitsById).toEqual({});
+    expect(state.habitOrder).toEqual([]);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it('registers its reset with the shared store registry', () => {
+    // The registry lets AuthContext.logout fire a single call that clears
+    // every store without needing to know this module exists.
+    const { useHabitStore } = require('../useHabitStore');
+    const { resetAllStores } = require('../registry');
+
+    act(() => useHabitStore.getState().setHabits([makeHabit({ id: 7 })]));
+    expect(useHabitStore.getState().habits).toHaveLength(1);
+
+    act(() => resetAllStores());
+    expect(useHabitStore.getState().habits).toEqual([]);
+  });
 });

--- a/frontend/src/store/__tests__/useStageStore.test.ts
+++ b/frontend/src/store/__tests__/useStageStore.test.ts
@@ -109,4 +109,33 @@ describe('useStageStore', () => {
     expect(selectStageByNumber(null)(state)).toBeUndefined();
     expect(selectStageByNumber(undefined)(state)).toBeUndefined();
   });
+
+  // BUG-FE-STATE-001
+  it('reset() restores the initial empty state', () => {
+    const { useStageStore } = require('../useStageStore');
+    act(() => {
+      useStageStore.getState().setStages([makeStage(1), makeStage(2)]);
+      useStageStore.getState().setCurrentStage(5);
+      useStageStore.getState().setLoading(true);
+      useStageStore.getState().setError('boom');
+    });
+
+    act(() => useStageStore.getState().reset());
+
+    const state = useStageStore.getState();
+    expect(state.stages).toEqual([]);
+    expect(state.stagesByNumber).toEqual({});
+    expect(state.stageOrder).toEqual([]);
+    expect(state.currentStage).toBe(1);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it('reset runs when resetAllStores is called', () => {
+    const { useStageStore } = require('../useStageStore');
+    const { resetAllStores } = require('../registry');
+    act(() => useStageStore.getState().setStages([makeStage(7)]));
+    act(() => resetAllStores());
+    expect(useStageStore.getState().stages).toEqual([]);
+  });
 });

--- a/frontend/src/store/__tests__/useUserStore.test.ts
+++ b/frontend/src/store/__tests__/useUserStore.test.ts
@@ -38,4 +38,27 @@ describe('useUserStore', () => {
 
     expect(useUserStore.getState().preferences.notificationsEnabled).toBe(false);
   });
+
+  // BUG-FE-STATE-001
+  it('reset() restores the initial preferences', () => {
+    const { useUserStore } = require('../useUserStore');
+    act(() =>
+      useUserStore.getState().updatePreferences({ theme: 'dark', notificationsEnabled: false }),
+    );
+
+    act(() => useUserStore.getState().reset());
+
+    expect(useUserStore.getState().preferences).toEqual({
+      theme: 'light',
+      notificationsEnabled: true,
+    });
+  });
+
+  it('reset runs when resetAllStores is called', () => {
+    const { useUserStore } = require('../useUserStore');
+    const { resetAllStores } = require('../registry');
+    act(() => useUserStore.getState().updatePreferences({ theme: 'dark' }));
+    act(() => resetAllStores());
+    expect(useUserStore.getState().preferences.theme).toBe('light');
+  });
 });

--- a/frontend/src/store/registry.ts
+++ b/frontend/src/store/registry.ts
@@ -1,0 +1,44 @@
+/**
+ * BUG-FE-STATE-001: logout must wipe every in-memory store so the next user
+ * on the device does not inherit the old user's habits, stage progress,
+ * journal drafts, etc. The registry is the seam that lets ``AuthContext``
+ * reset every store without having to know which stores exist — each store
+ * publishes its own ``reset`` callback on module load.
+ */
+
+type StoreReset = () => void;
+
+const registered = new Set<StoreReset>();
+
+/**
+ * Register a store's ``reset`` action. Safe to call at module scope; the
+ * registry deduplicates so hot-reload re-registrations do not fire the same
+ * reset multiple times.
+ */
+export function registerStoreReset(reset: StoreReset): void {
+  registered.add(reset);
+}
+
+/**
+ * Invoke every registered reset. A thrown reset must not stop the rest — a
+ * silently-skipped store would leave a previous user's data in memory, the
+ * exact failure mode BUG-FE-STATE-001 describes. Errors are logged so they
+ * still surface in development.
+ */
+export function resetAllStores(): void {
+  for (const reset of registered) {
+    try {
+      reset();
+    } catch (err: unknown) {
+      console.warn('[store/registry] reset callback threw', err);
+    }
+  }
+}
+
+/**
+ * Test-only escape hatch: clears the registry so each test starts from a
+ * clean slate. Production code must never call this.
+ */
+export function __resetRegistryForTests(): void {
+  registered.clear();
+}

--- a/frontend/src/store/registry.ts
+++ b/frontend/src/store/registry.ts
@@ -37,8 +37,13 @@ export function resetAllStores(): void {
 
 /**
  * Test-only escape hatch: clears the registry so each test starts from a
- * clean slate. Production code must never call this.
+ * clean slate. Production code must never call this — calling it outside
+ * ``NODE_ENV === 'test'`` throws so a stray import can't silently erase the
+ * reset callbacks at runtime.
  */
 export function __resetRegistryForTests(): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('__resetRegistryForTests is only callable in NODE_ENV=test');
+  }
   registered.clear();
 }

--- a/frontend/src/store/useHabitStore.ts
+++ b/frontend/src/store/useHabitStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 
 import type { Habit } from '../features/Habits/Habits.types';
 
+import { registerStoreReset } from './registry';
+
 /**
  * Habit store — a dumb state container. No API calls live here; those belong
  * in `features/Habits/services/habitManager.ts`.
@@ -27,7 +29,17 @@ export interface HabitStoreState {
   setError: (_error: string | null) => void;
   updateHabit: (_habit: Habit) => void;
   removeHabit: (_habitId: number) => void;
+  /** BUG-FE-STATE-001: wipe every field back to its initial value on logout. */
+  reset: () => void;
 }
+
+const INITIAL_STATE = {
+  habitsById: {} as Record<number, Habit>,
+  habitOrder: [] as number[],
+  habits: [] as Habit[],
+  loading: false,
+  error: null as string | null,
+};
 
 interface NormalizedHabits {
   habitsById: Record<number, Habit>;
@@ -49,11 +61,7 @@ const rebuildHabitsList = (habitsById: Record<number, Habit>, habitOrder: number
   habitOrder.map((id) => habitsById[id]!).filter((h): h is Habit => h !== undefined);
 
 export const useHabitStore = create<HabitStoreState>((set) => ({
-  habitsById: {},
-  habitOrder: [],
-  habits: [],
-  loading: false,
-  error: null,
+  ...INITIAL_STATE,
 
   setHabits: (habits) => set(normalizeHabits(habits)),
   setLoading: (loading) => set({ loading }),
@@ -72,7 +80,14 @@ export const useHabitStore = create<HabitStoreState>((set) => ({
       const habitOrder = state.habitOrder.filter((id) => id !== habitId);
       return { habitsById, habitOrder, habits: rebuildHabitsList(habitsById, habitOrder) };
     }),
+  reset: () => set({ ...INITIAL_STATE }),
 }));
+
+// BUG-FE-STATE-001: publish our reset to the shared registry so a single
+// ``resetAllStores()`` call in AuthContext.logout clears every store.
+registerStoreReset(() => {
+  useHabitStore.getState().reset();
+});
 
 // ---------------------------------------------------------------------------
 // Selectors — narrow state subscriptions. Zustand compares the *value*

--- a/frontend/src/store/useStageStore.ts
+++ b/frontend/src/store/useStageStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 
 import type { StageData } from '../features/Map/stageData';
 
+import { registerStoreReset } from './registry';
+
 /**
  * Stage store — a dumb state container. API calls live in
  * `features/Map/services/stageService.ts`; this module only holds and mutates
@@ -28,7 +30,18 @@ export interface StageStoreState {
   setLoading: (_loading: boolean) => void;
   setError: (_error: string | null) => void;
   updateStageProgress: (_stageNumber: number, _progress: number) => void;
+  /** BUG-FE-STATE-001: wipe every field back to its initial value on logout. */
+  reset: () => void;
 }
+
+const INITIAL_STATE = {
+  stagesByNumber: {} as Record<number, StageData>,
+  stageOrder: [] as number[],
+  stages: [] as StageData[],
+  currentStage: 1,
+  loading: false,
+  error: null as string | null,
+};
 
 interface NormalizedStages {
   stagesByNumber: Record<number, StageData>;
@@ -53,12 +66,7 @@ const rebuildStageList = (
   stageOrder.map((num) => stagesByNumber[num]!).filter((s): s is StageData => s !== undefined);
 
 export const useStageStore = create<StageStoreState>((set) => ({
-  stagesByNumber: {},
-  stageOrder: [],
-  stages: [],
-  currentStage: 1,
-  loading: false,
-  error: null,
+  ...INITIAL_STATE,
 
   setStages: (stages) => set(normalizeStages(stages)),
   setCurrentStage: (currentStage) => set({ currentStage }),
@@ -74,7 +82,13 @@ export const useStageStore = create<StageStoreState>((set) => ({
       };
       return { stagesByNumber, stages: rebuildStageList(stagesByNumber, state.stageOrder) };
     }),
+  reset: () => set({ ...INITIAL_STATE }),
 }));
+
+// BUG-FE-STATE-001
+registerStoreReset(() => {
+  useStageStore.getState().reset();
+});
 
 // ---------------------------------------------------------------------------
 // Selectors — narrow state subscriptions. Zustand compares the *value*

--- a/frontend/src/store/useUserStore.ts
+++ b/frontend/src/store/useUserStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 
+import { registerStoreReset } from './registry';
+
 export interface UserPreferences {
   theme: 'light' | 'dark';
   notificationsEnabled: boolean;
@@ -9,16 +11,26 @@ export interface UserStoreState {
   preferences: UserPreferences;
 
   updatePreferences: (_prefs: Partial<UserPreferences>) => void;
+  /** BUG-FE-STATE-001: wipe every field back to its initial value on logout. */
+  reset: () => void;
 }
 
+const INITIAL_PREFERENCES: UserPreferences = {
+  theme: 'light',
+  notificationsEnabled: true,
+};
+
 export const useUserStore = create<UserStoreState>((set) => ({
-  preferences: {
-    theme: 'light',
-    notificationsEnabled: true,
-  },
+  preferences: { ...INITIAL_PREFERENCES },
 
   updatePreferences: (prefs) =>
     set((state) => ({
       preferences: { ...state.preferences, ...prefs },
     })),
+  reset: () => set({ preferences: { ...INITIAL_PREFERENCES } }),
 }));
+
+// BUG-FE-STATE-001
+registerStoreReset(() => {
+  useUserStore.getState().reset();
+});

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -24,7 +24,7 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 
 | # | Prompt | Wave | Branch / PR | Status |
 |--:|--------|:----:|-------------|:------:|
-| 01 | unblock-auth-nav-flash            | 1 | | [ ] |
+| 01 | unblock-auth-nav-flash            | 1 | `claude/bug-fix-01-unblock-auth-nav-flash` / [#245](https://github.com/Geoffe-Ga/adepthood/pull/245) | [x] |
 | 02 | close-credit-minting-chain        | 2 | | [ ] |
 | 03 | close-stage-skip-chain            | 2 | | [ ] |
 | 04 | centralize-sanitize-user-text     | 3 | | [ ] |


### PR DESCRIPTION
## Summary

Stops the app from booting signed-in users back to the Signup screen on transient 401s. The root navigator used to gate on the raw `token` field — any blip that nulled the token instantly unmounted BottomTabs. This PR lands an explicit auth state machine, keeps RootStack mounted across a 401, and wipes user state on real logout.

Three atomic commits:

1. **`refactor(frontend): introduce authStatus state machine in AuthContext`** — adds `AuthStatus = 'loading' | 'authenticated' | 'reauth-required' | 'anonymous'`. `loading` is one-shot (never rewound mid-session). The 401 hook transitions to `'reauth-required'` instead of nulling the token; explicit logout still goes to `'anonymous'`.
2. **`fix(frontend): gate RootNavigator on authStatus, add re-auth overlay`** — swaps the `token ? Tabs : Auth` conditional for an explicit branch on `authStatus`. New `ReauthSheet` modal sits on top of RootStack so re-auth happens in place; BottomTabs never unmount for a 401.
3. **`fix(frontend): reset all stores on logout + harden 401 path`** — introduces a store-reset registry. Every Zustand store (`useHabitStore`, `useStageStore`, `useUserStore`) publishes a `reset` callback at module load. `logout` / `dismissReauth` call `resetAllStores()` and clear the AsyncStorage / SecureStore keys that cache habits, pending check-ins, and the BYOK LLM key. The 401 path deliberately does **not** reset stores — a transient network blip shouldn't cost the user their in-memory data.

## Bugs

- **Closes BUG-NAV-001** — 401 no longer unmounts BottomTabs.
- **Closes BUG-NAV-002** — navigator never rewinds into the `'loading'` spinner after bootstrap.
- **Closes BUG-FE-STATE-001** — logout wipes every in-memory store + persistence key.
- Touches BUG-NAV-011, BUG-FE-AUTH-003.

## Test plan

- [x] `pre-commit run --all-files` — all hooks green (eslint, prettier, typecheck, tests, mypy, bandit, ...)
- [x] 675 Jest tests pass, coverage preserved
- [x] New tests: 10 authStatus state-machine tests, 5 navigator-gate tests, 4 registry tests, 6 per-store reset tests, 3 logout-wipes-state tests
- [x] AppAuthFlow integration test confirms BottomTabs stay mounted on `reauth-required`
- [ ] Manual: confirm a dev-tools-forced 401 shows the ReauthSheet without unmounting the active tab
- [ ] Manual: confirm explicit logout → login as a different user shows no previous-user habits

https://claude.ai/code/session_01Wqwi8pxvzC6F5m3GhjhoRB