### PR TITLE
feat(backend): add User.is_admin column + require_admin dependency

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -123,7 +123,10 @@ async def concurrent_async_client(tmp_path: Path) -> AsyncGenerator[AsyncClient,
     """HTTP client with per-request sessions for concurrency testing.
 
     Uses a file-based SQLite database so each request gets its own connection,
-    enabling meaningful concurrency tests with ``asyncio.gather``.
+    enabling meaningful concurrency tests with ``asyncio.gather``.  Tests that
+    also need to seed state (e.g. flip ``User.is_admin``) should depend on
+    :func:`concurrent_session_factory` to open a session against the same
+    engine.
     """
     db_url = f"sqlite+aiosqlite:///{tmp_path / 'concurrent.db'}"
     concurrent_engine = create_async_engine(db_url, echo=False)
@@ -140,9 +143,28 @@ async def concurrent_async_client(tmp_path: Path) -> AsyncGenerator[AsyncClient,
             yield session
 
     app.dependency_overrides[get_session] = _per_request_session
+    app.state.concurrent_session_factory = concurrent_factory
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
 
     app.dependency_overrides.clear()
+    app.state.concurrent_session_factory = None
     await concurrent_engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def concurrent_session_factory(
+    concurrent_async_client: AsyncClient,  # noqa: ARG001 — side-effect: sets up the factory
+) -> async_sessionmaker[AsyncSession]:
+    """Session maker bound to the :func:`concurrent_async_client` engine.
+
+    Tests that need to seed rows in the concurrency fixture's DB (e.g. promote
+    a freshly-signed-up user to admin) should depend on this fixture and open
+    a short-lived session via ``async with factory() as session:``.
+    """
+    factory: async_sessionmaker[AsyncSession] | None = app.state.concurrent_session_factory
+    if factory is None:
+        msg = "concurrent_async_client must be requested before concurrent_session_factory"
+        raise RuntimeError(msg)
+    return factory

--- a/backend/migrations/versions/b9c0d1e2f3a4_add_user_is_admin.py
+++ b/backend/migrations/versions/b9c0d1e2f3a4_add_user_is_admin.py
@@ -4,9 +4,9 @@ Revision ID: b9c0d1e2f3a4
 Revises: a8b9c0d1e2f3
 Create Date: 2026-04-19 00:00:00.000000
 
-BUG-ADMIN-001 / BUG-MODEL-001: Promote admin identity from a shared env-var
-secret to a first-class per-user flag.  Every new user starts with
-``is_admin=False``; promote the initial operator with a one-line UPDATE.
+Promotes admin identity to a first-class per-user flag.  Every existing and
+new user starts with ``is_admin=False``; promote the initial operator with a
+one-line UPDATE.
 """
 
 from typing import Sequence, Union

--- a/backend/migrations/versions/b9c0d1e2f3a4_add_user_is_admin.py
+++ b/backend/migrations/versions/b9c0d1e2f3a4_add_user_is_admin.py
@@ -1,0 +1,39 @@
+"""add user.is_admin column
+
+Revision ID: b9c0d1e2f3a4
+Revises: a8b9c0d1e2f3
+Create Date: 2026-04-19 00:00:00.000000
+
+BUG-ADMIN-001 / BUG-MODEL-001: Promote admin identity from a shared env-var
+secret to a first-class per-user flag.  Every new user starts with
+``is_admin=False``; promote the initial operator with a one-line UPDATE.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b9c0d1e2f3a4"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "a8b9c0d1e2f3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add ``user.is_admin`` with ``server_default=false`` and ``NOT NULL``."""
+    op.add_column(
+        "user",
+        sa.Column(
+            "is_admin",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``user.is_admin`` column."""
+    op.drop_column("user", "is_admin")

--- a/backend/src/dependencies/__init__.py
+++ b/backend/src/dependencies/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-router FastAPI dependencies (auth gates, etc.)."""

--- a/backend/src/dependencies/auth.py
+++ b/backend/src/dependencies/auth.py
@@ -1,0 +1,51 @@
+"""Shared auth dependencies — resolve JWT user_id to full User models and gate admin routes.
+
+The JWT-decoding dependency (:func:`routers.auth.get_current_user`) returns an
+``int`` user-id so non-admin routes can avoid a database round-trip.  Admin
+gating requires the full :class:`User` row (to read ``is_admin``), so we layer
+a thin loader on top and expose :func:`require_admin` as the single source of
+truth for the admin boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from errors import forbidden
+from models.user import User
+from routers.auth import get_current_user
+
+
+async def get_current_user_model(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> User:
+    """Resolve the JWT user-id to the full :class:`User` row.
+
+    Raises 403 ``user_not_found`` when the decoded user-id has no matching
+    row — the JWT is authentic but refers to a deleted account, so the caller
+    has no authority to act on anyone's behalf.
+    """
+    user = await session.get(User, user_id)
+    if user is None:
+        raise forbidden("user_not_found")
+    return user
+
+
+async def require_admin(
+    current_user: Annotated[User, Depends(get_current_user_model)],
+) -> User:
+    """FastAPI dependency: allow only authenticated users with ``is_admin=True``.
+
+    Layered on top of :func:`get_current_user`, so an unauthenticated request
+    fails first with 401 (missing/expired/invalid JWT) and only authenticated
+    non-admins reach this check and receive 403.  Reuse this dependency for
+    every admin-only route — do not inline the ``is_admin`` check.
+    """
+    if not current_user.is_admin:
+        raise forbidden("admin_required")
+    return current_user

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -34,6 +34,7 @@ class User(SQLModel, table=True):
     """
 
     id: int | None = Field(default=None, primary_key=True)
+    is_admin: bool = Field(default=False, nullable=False)
     offering_balance: int = Field(default=0)
     monthly_messages_used: int = Field(default=0)
     monthly_reset_date: datetime = Field(

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -1,10 +1,7 @@
 """Admin-only endpoints — gated by the per-user ``User.is_admin`` flag.
 
-BUG-ADMIN-001: The previous implementation trusted a shared ``ADMIN_API_KEY``
-header, so any leak revoked the entire admin surface and nothing tied an
-action back to a specific operator.  Admin identity is now a first-class
-per-user flag (:attr:`User.is_admin`), so gate every admin route on
-:func:`dependencies.auth.require_admin` — never on an env-var header.
+Gate every admin route on :func:`dependencies.auth.require_admin` so admin
+identity is a first-class per-user flag rather than a shared header secret.
 """
 
 from __future__ import annotations

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -1,25 +1,25 @@
-"""Admin-only endpoints — gated by ``ADMIN_API_KEY`` shared-secret header.
+"""Admin-only endpoints — gated by the per-user ``User.is_admin`` flag.
 
-The admin surface is intentionally minimal: enough to observe LLM cost and
-token consumption without introducing a whole role-based-access-control layer
-up front.  Once the app grows an admin user role, swap the header gate for a
-user-role check and the endpoints here can stay unchanged.
+BUG-ADMIN-001: The previous implementation trusted a shared ``ADMIN_API_KEY``
+header, so any leak revoked the entire admin surface and nothing tied an
+action back to a specific operator.  Admin identity is now a first-class
+per-user flag (:attr:`User.is_admin`), so gate every admin route on
+:func:`dependencies.auth.require_admin` — never on an env-var header.
 """
 
 from __future__ import annotations
 
-import hmac
-import os
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header
+from fastapi import APIRouter, Depends
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
 from database import get_session
-from errors import forbidden
+from dependencies.auth import require_admin
 from models.llm_usage_log import LLMUsageLog
+from models.user import User
 from schemas.admin import (
     ModelUsageBreakdown,
     UsageStatsResponse,
@@ -29,32 +29,10 @@ from schemas.admin import (
 router = APIRouter(prefix="/admin", tags=["admin"])
 
 
-# Header used by the admin to authenticate.  The value is compared to the
-# ``ADMIN_API_KEY`` env var using a constant-time comparison so attackers
-# cannot recover the key via timing side-channels.
-ADMIN_API_KEY_HEADER = "X-Admin-API-Key"  # pragma: allowlist secret
-
-
-def _require_admin(
-    x_admin_api_key: str | None = Header(default=None, alias=ADMIN_API_KEY_HEADER),
-) -> None:
-    """FastAPI dependency: reject requests without a valid admin key.
-
-    ``ADMIN_API_KEY`` must be set to a non-empty value for the endpoint to be
-    reachable at all.  An unset env var fails closed — we never treat "no
-    password configured" as "anyone may enter".
-    """
-    expected = os.getenv("ADMIN_API_KEY", "")
-    if not expected:
-        raise forbidden("admin_api_disabled")
-    if not x_admin_api_key or not hmac.compare_digest(x_admin_api_key, expected):
-        raise forbidden("admin_auth_required")
-
-
 @router.get("/usage-stats", response_model=UsageStatsResponse)
 async def get_usage_stats(
     session: Annotated[AsyncSession, Depends(get_session)],
-    _: Annotated[None, Depends(_require_admin)],
+    _admin: Annotated[User, Depends(require_admin)],
 ) -> UsageStatsResponse:
     """Return aggregate LLM usage stats across all users.
 

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -166,8 +166,6 @@ async def add_balance(
     if admin.id is None:
         msg = "admin user missing id after authentication"
         raise RuntimeError(msg)
-    if payload.amount <= 0:
-        raise bad_request("amount_must_be_positive")
 
     new_balance = await wallet_service.add_balance(session, admin.id, payload.amount)
     if new_balance is None:

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -22,7 +22,7 @@ from starlette.requests import Request as StarletteRequest
 
 from database import get_session
 from dependencies.auth import require_admin
-from errors import bad_request
+from errors import forbidden
 from models.user import User
 from rate_limit import limiter
 from routers.auth import get_current_user
@@ -156,20 +156,14 @@ async def add_balance(
     admin: Annotated[User, Depends(require_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> BalanceAddResponse:
-    """Add credits to the calling admin's offering balance.
-
-    BUG-BM-010: Previously any authenticated user could mint credits into their
-    own wallet.  Gated on :func:`dependencies.auth.require_admin` so only
-    operator-accounts can grant credit; downstream work (Prompt 12) will thread
-    a target user-id and an append-only ledger through this endpoint.
-    """
-    if admin.id is None:
-        msg = "admin user missing id after authentication"
-        raise RuntimeError(msg)
-
+    """Add credits to the calling admin's offering balance."""
+    assert admin.id is not None  # noqa: S101 — persisted row always has an id
     new_balance = await wallet_service.add_balance(session, admin.id, payload.amount)
     if new_balance is None:
-        raise bad_request("user_not_found")
+        # TOCTOU: admin row existed when ``require_admin`` fetched it but was
+        # deleted before the wallet UPDATE landed.  Same failure mode as the
+        # admin-gate, so the same status keeps the client's retry logic simple.
+        raise forbidden("user_not_found")
 
     await session.commit()
     logger.info(

--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -21,7 +21,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request as StarletteRequest
 
 from database import get_session
+from dependencies.auth import require_admin
 from errors import bad_request
+from models.user import User
 from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.botmason import (
@@ -151,20 +153,29 @@ async def get_usage(
 async def add_balance(
     request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     payload: BalanceAddRequest,
-    current_user: Annotated[int, Depends(get_current_user)],
+    admin: Annotated[User, Depends(require_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> BalanceAddResponse:
-    """Add credits to the authenticated user's offering balance."""
+    """Add credits to the calling admin's offering balance.
+
+    BUG-BM-010: Previously any authenticated user could mint credits into their
+    own wallet.  Gated on :func:`dependencies.auth.require_admin` so only
+    operator-accounts can grant credit; downstream work (Prompt 12) will thread
+    a target user-id and an append-only ledger through this endpoint.
+    """
+    if admin.id is None:
+        msg = "admin user missing id after authentication"
+        raise RuntimeError(msg)
     if payload.amount <= 0:
         raise bad_request("amount_must_be_positive")
 
-    new_balance = await wallet_service.add_balance(session, current_user, payload.amount)
+    new_balance = await wallet_service.add_balance(session, admin.id, payload.amount)
     if new_balance is None:
         raise bad_request("user_not_found")
 
     await session.commit()
     logger.info(
         "balance_added",
-        extra={"user_id": current_user, "added": payload.amount, "new_balance": new_balance},
+        extra={"admin_id": admin.id, "added": payload.amount, "new_balance": new_balance},
     )
     return BalanceAddResponse(balance=new_balance, added=payload.amount)

--- a/backend/src/schemas/botmason.py
+++ b/backend/src/schemas/botmason.py
@@ -8,11 +8,8 @@ from pydantic import BaseModel, Field
 
 CHAT_MESSAGE_MAX_LENGTH = 5_000
 
-# BUG-SCHEMA-009 — bound credit grants so an admin (or a slip in validation)
-# cannot mint billion-credit wallets or zero-valued ledger noise.  A per-call
-# cap of one million credits is already far above any legitimate gift, and the
-# lower bound rejects both zero and negative amounts without the endpoint
-# needing a secondary `amount <= 0` guard.
+# Bound credit grants so a single call can neither zero-out the ledger nor
+# mint billion-credit wallets.  One million is far above any legitimate gift.
 BALANCE_ADD_MIN = 1
 BALANCE_ADD_MAX = 1_000_000
 

--- a/backend/src/schemas/botmason.py
+++ b/backend/src/schemas/botmason.py
@@ -8,6 +8,14 @@ from pydantic import BaseModel, Field
 
 CHAT_MESSAGE_MAX_LENGTH = 5_000
 
+# BUG-SCHEMA-009 — bound credit grants so an admin (or a slip in validation)
+# cannot mint billion-credit wallets or zero-valued ledger noise.  A per-call
+# cap of one million credits is already far above any legitimate gift, and the
+# lower bound rejects both zero and negative amounts without the endpoint
+# needing a secondary `amount <= 0` guard.
+BALANCE_ADD_MIN = 1
+BALANCE_ADD_MAX = 1_000_000
+
 
 class ChatRequest(BaseModel):
     """Payload for sending a message to BotMason."""
@@ -38,9 +46,14 @@ class BalanceResponse(BaseModel):
 
 
 class BalanceAddRequest(BaseModel):
-    """Request to add credits to a user's offering balance."""
+    """Request to add credits to a user's offering balance.
 
-    amount: int
+    ``amount`` is clamped to ``[BALANCE_ADD_MIN, BALANCE_ADD_MAX]`` so that
+    Pydantic rejects zero / negative / absurd grants with a 422 before any
+    wallet code runs — the router no longer needs to re-check the sign.
+    """
+
+    amount: int = Field(ge=BALANCE_ADD_MIN, le=BALANCE_ADD_MAX)
 
 
 class BalanceAddResponse(BaseModel):

--- a/backend/tests/test_admin_usage_stats.py
+++ b/backend/tests/test_admin_usage_stats.py
@@ -1,7 +1,7 @@
 """Tests for the admin usage stats endpoint.
 
-Covers the three layers the endpoint puts together: auth gate, SQL aggregates,
-and JSON response shape.
+Covers the three layers the endpoint puts together: the per-user admin gate
+(anonymous / non-admin / admin), SQL aggregates, and JSON response shape.
 """
 
 from __future__ import annotations
@@ -12,14 +12,13 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import delete, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 from models.journal_entry import JournalEntry
 from models.llm_usage_log import LLMUsageLog
 from models.user import User
-from routers.admin import ADMIN_API_KEY_HEADER
-
-_ADMIN_KEY = "super-secret-admin-key"  # pragma: allowlist secret
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,6 +35,28 @@ class _UsageLogSpec:
     prompt_tokens: int = 100
     completion_tokens: int = 50
     estimated_cost_usd: float = 0.01
+
+
+async def _signup(client: AsyncClient, email: str, password: str = "secret12345") -> dict[str, str]:
+    """Sign up a user and return Authorization headers bearing their JWT."""
+    resp = await client.post("/auth/signup", json={"email": email, "password": password})
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _promote_to_admin(db_session: AsyncSession, email: str) -> None:
+    """Flip ``is_admin`` for the user with the given email."""
+    await db_session.execute(update(User).where(col(User.email) == email).values(is_admin=True))
+    await db_session.commit()
+
+
+async def _signup_admin(
+    client: AsyncClient, db_session: AsyncSession, email: str = "admin@example.com"
+) -> dict[str, str]:
+    """Sign up a user, promote them to admin, and return their Authorization headers."""
+    headers = await _signup(client, email)
+    await _promote_to_admin(db_session, email)
+    return headers
 
 
 async def _seed_user_and_journal_entry(
@@ -84,51 +105,27 @@ async def _seed_usage_log(
 
 
 @pytest.mark.asyncio
-async def test_admin_endpoint_rejects_without_key_configured(
-    async_client: AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When ``ADMIN_API_KEY`` is unset the endpoint is closed to everyone."""
-    monkeypatch.delenv("ADMIN_API_KEY", raising=False)
+async def test_admin_endpoint_rejects_anonymous(async_client: AsyncClient) -> None:
+    """No Authorization header → 401, not 403 (distinguish auth from authz)."""
     resp = await async_client.get("/admin/usage-stats")
-    assert resp.status_code == HTTPStatus.FORBIDDEN
-    assert resp.json()["detail"] == "admin_api_disabled"
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
 
 
 @pytest.mark.asyncio
-async def test_admin_endpoint_rejects_without_header(
-    async_client: AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
-    resp = await async_client.get("/admin/usage-stats")
+async def test_admin_endpoint_rejects_non_admin(async_client: AsyncClient) -> None:
+    """Authenticated but ``is_admin=False`` → 403 ``admin_required``."""
+    headers = await _signup(async_client, "normal@example.com")
+    resp = await async_client.get("/admin/usage-stats", headers=headers)
     assert resp.status_code == HTTPStatus.FORBIDDEN
-    assert resp.json()["detail"] == "admin_auth_required"
+    assert resp.json()["detail"] == "admin_required"
 
 
 @pytest.mark.asyncio
-async def test_admin_endpoint_rejects_wrong_key(
-    async_client: AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
+async def test_admin_endpoint_accepts_admin(
+    async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
-    resp = await async_client.get(
-        "/admin/usage-stats",
-        headers={ADMIN_API_KEY_HEADER: "wrong-key"},  # pragma: allowlist secret
-    )
-    assert resp.status_code == HTTPStatus.FORBIDDEN
-
-
-@pytest.mark.asyncio
-async def test_admin_endpoint_accepts_correct_key(
-    async_client: AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
-    resp = await async_client.get(
-        "/admin/usage-stats",
-        headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY},
-    )
+    headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.get("/admin/usage-stats", headers=headers)
     assert resp.status_code == HTTPStatus.OK
 
 
@@ -137,11 +134,10 @@ async def test_admin_endpoint_accepts_correct_key(
 
 @pytest.mark.asyncio
 async def test_admin_endpoint_empty_totals(
-    async_client: AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
+    async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
-    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY})
+    headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.get("/admin/usage-stats", headers=headers)
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
     assert data["total_calls"] == 0
@@ -160,9 +156,8 @@ async def test_admin_endpoint_empty_totals(
 async def test_admin_endpoint_sums_totals(
     async_client: AsyncClient,
     db_session: AsyncSession,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    headers = await _signup_admin(async_client, db_session)
     user_id, journal_id = await _seed_user_and_journal_entry(db_session)
     await _seed_usage_log(
         db_session,
@@ -178,7 +173,7 @@ async def test_admin_endpoint_sums_totals(
     )
     await db_session.commit()
 
-    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY})
+    resp = await async_client.get("/admin/usage-stats", headers=headers)
     data = resp.json()
     assert data["total_calls"] == 2
     assert data["total_prompt_tokens"] == 300
@@ -191,10 +186,9 @@ async def test_admin_endpoint_sums_totals(
 async def test_admin_endpoint_per_user_breakdown_ordered_by_cost(
     async_client: AsyncClient,
     db_session: AsyncSession,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Users are returned highest-spend first so the dashboard top row is hottest."""
-    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    headers = await _signup_admin(async_client, db_session)
     low_user_id, j1 = await _seed_user_and_journal_entry(db_session, "low@example.com")
     high_user_id, j2 = await _seed_user_and_journal_entry(db_session, "high@example.com")
     await _seed_usage_log(
@@ -211,7 +205,7 @@ async def test_admin_endpoint_per_user_breakdown_ordered_by_cost(
     )
     await db_session.commit()
 
-    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY})
+    resp = await async_client.get("/admin/usage-stats", headers=headers)
     data = resp.json()
     assert len(data["per_user"]) == 2
     assert data["per_user"][0]["user_id"] == high_user_id
@@ -223,9 +217,8 @@ async def test_admin_endpoint_per_user_breakdown_ordered_by_cost(
 async def test_admin_endpoint_per_model_breakdown(
     async_client: AsyncClient,
     db_session: AsyncSession,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("ADMIN_API_KEY", _ADMIN_KEY)
+    headers = await _signup_admin(async_client, db_session)
     user_id, journal_id = await _seed_user_and_journal_entry(db_session)
     await _seed_usage_log(
         db_session,
@@ -253,7 +246,7 @@ async def test_admin_endpoint_per_model_breakdown(
     )
     await db_session.commit()
 
-    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: _ADMIN_KEY})
+    resp = await async_client.get("/admin/usage-stats", headers=headers)
     data = resp.json()
     assert len(data["per_model"]) == 2
     # Ordered by descending cost: claude (2.00) before gpt-4o-mini (0.01).
@@ -265,12 +258,20 @@ async def test_admin_endpoint_per_model_breakdown(
 
 
 @pytest.mark.asyncio
-async def test_admin_endpoint_empty_key_is_rejected(
+async def test_admin_endpoint_rejects_deleted_admin(
     async_client: AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
-    """An ``ADMIN_API_KEY=""`` env var must not open the endpoint to empty headers."""
-    monkeypatch.setenv("ADMIN_API_KEY", "")
-    resp = await async_client.get("/admin/usage-stats", headers={ADMIN_API_KEY_HEADER: ""})
+    """A valid JWT whose user has since been deleted is treated as unauthorized.
+
+    Regression for the privilege-boundary edge case: an admin whose row was
+    removed (or a stale token minted before an account purge) must not be
+    able to reach the admin surface.
+    """
+    headers = await _signup_admin(async_client, db_session)
+    await db_session.execute(delete(User).where(col(User.email) == "admin@example.com"))
+    await db_session.commit()
+
+    resp = await async_client.get("/admin/usage-stats", headers=headers)
     assert resp.status_code == HTTPStatus.FORBIDDEN
-    assert resp.json()["detail"] == "admin_api_disabled"
+    assert resp.json()["detail"] == "user_not_found"

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import update
+from sqlalchemy import delete, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import col
 
@@ -72,9 +72,9 @@ async def _signup_admin(
 ) -> dict[str, str]:
     """Sign up a user and promote them to admin — returns their auth headers.
 
-    Chat / balance tests use this because :http:post:`/user/balance/add` now
-    requires admin (BUG-BM-010 + BUG-ADMIN-001).  Tests that only exercise the
-    non-admin surface should keep using :func:`_signup`.
+    Chat / balance tests use this because :http:post:`/user/balance/add` is
+    admin-gated; tests that only exercise the non-admin surface should keep
+    using :func:`_signup`.
     """
     headers = await _signup(client, username)
     await _promote_admin(db_session, username)
@@ -84,10 +84,10 @@ async def _signup_admin(
 async def _add_balance(db_session: AsyncSession, amount: int = 10, username: str = "alice") -> None:
     """Seed offering credits for the signed-up user without going through HTTP.
 
-    BUG-BM-010 gated :http:post:`/user/balance/add` behind ``require_admin``,
-    so most tests only need the *effect* of a credit (enough balance to chat),
-    not the full admin flow.  Direct DB mutation keeps the fixture cheap while
-    the dedicated auth-boundary tests exercise the endpoint itself.
+    The balance-add endpoint is admin-gated, but most tests only need the
+    *effect* of a credit (enough balance to chat), not the full admin flow.
+    Direct DB mutation keeps the fixture cheap while the dedicated auth
+    boundary tests exercise the endpoint itself.
     """
     email = f"{username}@example.com"
     await db_session.execute(
@@ -158,11 +158,25 @@ async def test_add_balance_unauthenticated_returns_401(async_client: AsyncClient
 
 @pytest.mark.asyncio
 async def test_add_balance_non_admin_returns_403(async_client: AsyncClient) -> None:
-    """BUG-BM-010: a signed-in non-admin must not be able to mint credits."""
+    """A signed-in non-admin must not be able to mint credits."""
     headers = await _signup(async_client)
     resp = await async_client.post("/user/balance/add", json={"amount": 5}, headers=headers)
     assert resp.status_code == HTTPStatus.FORBIDDEN
     assert resp.json()["detail"] == "admin_required"
+
+
+@pytest.mark.asyncio
+async def test_add_balance_deleted_admin_returns_403(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A valid JWT whose admin row was deleted must not pass the auth gate."""
+    headers = await _signup_admin(async_client, db_session)
+    await db_session.execute(delete(User).where(col(User.email) == "alice@example.com"))
+    await db_session.commit()
+
+    resp = await async_client.post("/user/balance/add", json={"amount": 5}, headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "user_not_found"
 
 
 # ── Offering balance ───────────────────────────────────────────────────
@@ -202,7 +216,7 @@ async def test_add_balance_accumulates(async_client: AsyncClient, db_session: As
 async def test_add_balance_rejects_zero_amount(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """BUG-SCHEMA-009: ``amount=0`` fails Pydantic ``ge=1`` → 422, not 400."""
+    """``amount=0`` fails Pydantic ``ge=1`` → 422, not 400."""
     headers = await _signup_admin(async_client, db_session)
     resp = await async_client.post("/user/balance/add", json={"amount": 0}, headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
@@ -212,7 +226,7 @@ async def test_add_balance_rejects_zero_amount(
 async def test_add_balance_rejects_negative_amount(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """BUG-SCHEMA-009: negative amounts short-circuit at the schema."""
+    """Negative amounts short-circuit at the schema, never reaching the wallet."""
     headers = await _signup_admin(async_client, db_session)
     resp = await async_client.post("/user/balance/add", json={"amount": -5}, headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
@@ -222,7 +236,7 @@ async def test_add_balance_rejects_negative_amount(
 async def test_add_balance_rejects_amount_over_one_million(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """BUG-SCHEMA-009: ``amount > 1_000_000`` is rejected before wallet code runs."""
+    """``amount > 1_000_000`` is rejected before wallet code runs."""
     headers = await _signup_admin(async_client, db_session)
     resp = await async_client.post("/user/balance/add", json={"amount": 1_000_001}, headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -13,7 +13,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import update
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import col
 
 import services.botmason as botmason_mod
 from models.user import User
@@ -59,10 +60,79 @@ async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _add_balance(client: AsyncClient, headers: dict[str, str], amount: int = 10) -> None:
-    """Add offering credits to the authenticated user."""
-    resp = await client.post("/user/balance/add", json={"amount": amount}, headers=headers)
-    assert resp.status_code == HTTPStatus.OK
+async def _promote_admin(db_session: AsyncSession, username: str = "alice") -> None:
+    """Flip ``is_admin`` for the user created by :func:`_signup`."""
+    email = f"{username}@example.com"
+    await db_session.execute(update(User).where(col(User.email) == email).values(is_admin=True))
+    await db_session.commit()
+
+
+async def _signup_admin(
+    client: AsyncClient, db_session: AsyncSession, username: str = "alice"
+) -> dict[str, str]:
+    """Sign up a user and promote them to admin — returns their auth headers.
+
+    Chat / balance tests use this because :http:post:`/user/balance/add` now
+    requires admin (BUG-BM-010 + BUG-ADMIN-001).  Tests that only exercise the
+    non-admin surface should keep using :func:`_signup`.
+    """
+    headers = await _signup(client, username)
+    await _promote_admin(db_session, username)
+    return headers
+
+
+async def _add_balance(db_session: AsyncSession, amount: int = 10, username: str = "alice") -> None:
+    """Seed offering credits for the signed-up user without going through HTTP.
+
+    BUG-BM-010 gated :http:post:`/user/balance/add` behind ``require_admin``,
+    so most tests only need the *effect* of a credit (enough balance to chat),
+    not the full admin flow.  Direct DB mutation keeps the fixture cheap while
+    the dedicated auth-boundary tests exercise the endpoint itself.
+    """
+    email = f"{username}@example.com"
+    await db_session.execute(
+        update(User)
+        .where(col(User.email) == email)
+        .values(offering_balance=col(User.offering_balance) + amount)
+    )
+    await db_session.commit()
+
+
+async def _concurrent_promote_admin(
+    factory: async_sessionmaker[AsyncSession], username: str = "alice"
+) -> None:
+    """Promote a signed-up user via the concurrent-fixture engine."""
+    email = f"{username}@example.com"
+    async with factory() as session:
+        await session.execute(update(User).where(col(User.email) == email).values(is_admin=True))
+        await session.commit()
+
+
+async def _concurrent_signup_admin(
+    client: AsyncClient,
+    factory: async_sessionmaker[AsyncSession],
+    username: str = "alice",
+) -> dict[str, str]:
+    """Concurrent-fixture counterpart of :func:`_signup_admin`."""
+    headers = await _signup(client, username)
+    await _concurrent_promote_admin(factory, username)
+    return headers
+
+
+async def _concurrent_add_balance(
+    factory: async_sessionmaker[AsyncSession],
+    amount: int = 10,
+    username: str = "alice",
+) -> None:
+    """Concurrent-fixture counterpart of :func:`_add_balance`."""
+    email = f"{username}@example.com"
+    async with factory() as session:
+        await session.execute(
+            update(User)
+            .where(col(User.email) == email)
+            .values(offering_balance=col(User.offering_balance) + amount)
+        )
+        await session.commit()
 
 
 # ── Authentication ─────────────────────────────────────────────────────
@@ -86,6 +156,15 @@ async def test_add_balance_unauthenticated_returns_401(async_client: AsyncClient
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
 
 
+@pytest.mark.asyncio
+async def test_add_balance_non_admin_returns_403(async_client: AsyncClient) -> None:
+    """BUG-BM-010: a signed-in non-admin must not be able to mint credits."""
+    headers = await _signup(async_client)
+    resp = await async_client.post("/user/balance/add", json={"amount": 5}, headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "admin_required"
+
+
 # ── Offering balance ───────────────────────────────────────────────────
 
 
@@ -98,8 +177,8 @@ async def test_get_balance_default_zero(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_balance(async_client: AsyncClient) -> None:
-    headers = await _signup(async_client)
+async def test_add_balance(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    headers = await _signup_admin(async_client, db_session)
     resp = await async_client.post("/user/balance/add", json={"amount": 5}, headers=headers)
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
@@ -108,25 +187,31 @@ async def test_add_balance(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_balance_accumulates(async_client: AsyncClient) -> None:
-    headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=3)
-    await _add_balance(async_client, headers, amount=7)
+async def test_add_balance_accumulates(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    headers = await _signup_admin(async_client, db_session)
+    resp1 = await async_client.post("/user/balance/add", json={"amount": 3}, headers=headers)
+    assert resp1.status_code == HTTPStatus.OK
+    resp2 = await async_client.post("/user/balance/add", json={"amount": 7}, headers=headers)
+    assert resp2.status_code == HTTPStatus.OK
 
     resp = await async_client.get("/user/balance", headers=headers)
     assert resp.json()["balance"] == 10
 
 
 @pytest.mark.asyncio
-async def test_add_balance_rejects_zero_amount(async_client: AsyncClient) -> None:
-    headers = await _signup(async_client)
+async def test_add_balance_rejects_zero_amount(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _signup_admin(async_client, db_session)
     resp = await async_client.post("/user/balance/add", json={"amount": 0}, headers=headers)
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
 @pytest.mark.asyncio
-async def test_add_balance_rejects_negative_amount(async_client: AsyncClient) -> None:
-    headers = await _signup(async_client)
+async def test_add_balance_rejects_negative_amount(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _signup_admin(async_client, db_session)
     resp = await async_client.post("/user/balance/add", json={"amount": -5}, headers=headers)
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
@@ -147,9 +232,12 @@ async def test_chat_with_zero_balance_returns_402(async_client: AsyncClient) -> 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_monthly_cap")
-async def test_chat_success(async_client: AsyncClient) -> None:
+async def test_chat_success(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=5)
+    await _add_balance(db_session, amount=5)
 
     resp = await async_client.post(
         "/journal/chat", json={"message": "Hello BotMason"}, headers=headers
@@ -164,9 +252,12 @@ async def test_chat_success(async_client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_monthly_cap")
-async def test_chat_deducts_balance(async_client: AsyncClient) -> None:
+async def test_chat_deducts_balance(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=3)
+    await _add_balance(db_session, amount=3)
 
     await async_client.post("/journal/chat", json={"message": "First message"}, headers=headers)
     await async_client.post("/journal/chat", json={"message": "Second message"}, headers=headers)
@@ -177,9 +268,12 @@ async def test_chat_deducts_balance(async_client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_monthly_cap")
-async def test_chat_stores_user_and_bot_messages(async_client: AsyncClient) -> None:
+async def test_chat_stores_user_and_bot_messages(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
 
     await async_client.post(
         "/journal/chat", json={"message": "Tell me about meditation"}, headers=headers
@@ -199,9 +293,12 @@ async def test_chat_stores_user_and_bot_messages(async_client: AsyncClient) -> N
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_monthly_cap")
-async def test_chat_bot_response_in_journal_history(async_client: AsyncClient) -> None:
+async def test_chat_bot_response_in_journal_history(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
 
     chat_resp = await async_client.post(
         "/journal/chat", json={"message": "Guide me"}, headers=headers
@@ -216,9 +313,12 @@ async def test_chat_bot_response_in_journal_history(async_client: AsyncClient) -
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_monthly_cap")
-async def test_chat_exhausts_balance_then_402(async_client: AsyncClient) -> None:
+async def test_chat_exhausts_balance_then_402(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
 
     # First chat succeeds
     resp1 = await async_client.post("/journal/chat", json={"message": "First"}, headers=headers)
@@ -442,10 +542,11 @@ async def test_stub_provider_works_without_api_key(
 @pytest.mark.usefixtures("disable_rate_limit", "zero_monthly_cap")
 async def test_concurrent_chat_with_balance_one_allows_exactly_one(
     concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     """Concurrent chat requests with balance=1 must yield exactly 1 success (sec-17)."""
     headers = await _signup(concurrent_async_client)
-    await _add_balance(concurrent_async_client, headers, amount=1)
+    await _concurrent_add_balance(concurrent_session_factory, amount=1)
 
     # Fire 5 concurrent requests — only 1 should succeed
     responses = await asyncio.gather(
@@ -473,10 +574,11 @@ async def test_concurrent_chat_with_balance_one_allows_exactly_one(
 @pytest.mark.usefixtures("disable_rate_limit", "zero_monthly_cap")
 async def test_balance_never_negative_after_concurrent_chat(
     concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     """Balance must never go negative, even under concurrent load (sec-17)."""
     headers = await _signup(concurrent_async_client)
-    await _add_balance(concurrent_async_client, headers, amount=3)
+    await _concurrent_add_balance(concurrent_session_factory, amount=3)
 
     # Fire 10 concurrent requests with only 3 credits
     responses = await asyncio.gather(
@@ -504,9 +606,10 @@ async def test_balance_never_negative_after_concurrent_chat(
 @pytest.mark.usefixtures("disable_rate_limit")
 async def test_concurrent_balance_additions_are_atomic(
     concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     """Concurrent balance additions must not lose updates (sec-17)."""
-    headers = await _signup(concurrent_async_client)
+    headers = await _concurrent_signup_admin(concurrent_async_client, concurrent_session_factory)
 
     # Fire 5 concurrent add-balance requests, each adding 2
     add_amount = 2
@@ -593,13 +696,14 @@ def test_validate_format_skips_check_for_stub_provider() -> None:
 async def test_chat_returns_402_when_provider_needs_key_and_none_available(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """With provider=openai and no env/header key, chat responds 402."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.delenv("LLM_API_KEY", raising=False)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
 
     resp = await async_client.post(
         "/journal/chat",
@@ -618,13 +722,14 @@ async def test_chat_returns_402_when_provider_needs_key_and_none_available(
 async def test_chat_falls_back_to_env_key_when_header_absent(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """With no header but LLM_API_KEY set, the env key is used for the call."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
 
     mock_call = AsyncMock(return_value=_mock_openai_response("env-fallback-response"))
     with patch.object(botmason_mod, "_call_openai", mock_call):
@@ -645,13 +750,14 @@ async def test_chat_falls_back_to_env_key_when_header_absent(
 async def test_chat_uses_user_supplied_key_from_header(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """A valid ``X-LLM-API-Key`` header is forwarded to the provider."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.delenv("LLM_API_KEY", raising=False)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
 
     mock_call = AsyncMock(return_value=_mock_openai_response("byok-response"))
@@ -671,13 +777,14 @@ async def test_chat_uses_user_supplied_key_from_header(
 async def test_chat_header_key_overrides_env_key(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """When both header and env are set, the header key wins (BYOK priority)."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.setenv("LLM_API_KEY", "sk-server-fallback-key")
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
 
     mock_call = AsyncMock(return_value=_mock_openai_response("byok-response"))
@@ -695,13 +802,14 @@ async def test_chat_header_key_overrides_env_key(
 async def test_chat_rejects_malformed_header_key_with_400(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """A malformed ``X-LLM-API-Key`` yields 400 without spending balance."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     headers[LLM_API_KEY_HEADER] = "not-a-real-key"  # pragma: allowlist secret
 
     resp = await async_client.post(
@@ -721,12 +829,13 @@ async def test_chat_rejects_malformed_header_key_with_400(
 async def test_chat_rejects_oversized_header_key_with_400(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     headers[LLM_API_KEY_HEADER] = "sk-" + "x" * LLM_API_KEY_MAX_LENGTH  # pragma: allowlist secret
 
     resp = await async_client.post(
@@ -741,13 +850,14 @@ async def test_chat_rejects_oversized_header_key_with_400(
 async def test_chat_ignores_empty_header_and_uses_env(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """An empty header value behaves like a missing header (env fallback)."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     headers[LLM_API_KEY_HEADER] = "   "
 
     mock_call = AsyncMock(return_value=_mock_openai_response("env-response"))
@@ -767,13 +877,14 @@ async def test_chat_does_not_log_header_key_value(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    db_session: AsyncSession,
 ) -> None:
     """The raw key value must never appear in log output."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.delenv("LLM_API_KEY", raising=False)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
 
     mock_call = AsyncMock(return_value=_mock_openai_response("ok"))
@@ -792,12 +903,13 @@ async def test_chat_does_not_log_header_key_value(
 async def test_chat_response_body_does_not_echo_key(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.delenv("LLM_API_KEY", raising=False)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     headers[LLM_API_KEY_HEADER] = _VALID_OPENAI_KEY
 
     mock_call = AsyncMock(return_value=_mock_openai_response("a response"))
@@ -815,13 +927,14 @@ async def test_chat_response_body_does_not_echo_key(
 async def test_stub_provider_ignores_header_key(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """Stub provider never needs a key and must not 402 when one is absent."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
     monkeypatch.delenv("LLM_API_KEY", raising=False)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
 
     resp = await async_client.post(
         "/journal/chat",
@@ -885,11 +998,12 @@ async def test_usage_endpoint_unauthenticated_returns_401(async_client: AsyncCli
 async def test_chat_consumes_free_monthly_tier_first(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """With a positive cap, offering_balance is untouched until free tier is spent."""
     monkeypatch.setenv("BOTMASON_MONTHLY_CAP", "3")
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=10)
+    await _add_balance(db_session, amount=10)
 
     resp = await async_client.post("/journal/chat", json={"message": "first"}, headers=headers)
     assert resp.status_code == HTTPStatus.CREATED
@@ -903,11 +1017,12 @@ async def test_chat_consumes_free_monthly_tier_first(
 async def test_chat_falls_back_to_offering_balance_after_cap(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """Once the free tier is exhausted, subsequent chats draw from offering_balance."""
     monkeypatch.setenv("BOTMASON_MONTHLY_CAP", "1")
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=2)
+    await _add_balance(db_session, amount=2)
 
     # Spend the single free message.
     resp1 = await async_client.post("/journal/chat", json={"message": "a"}, headers=headers)
@@ -1051,11 +1166,12 @@ async def test_cap_honoured_under_concurrent_load(
 async def test_free_and_paid_wallets_combine_under_concurrent_load(
     concurrent_async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     """Free allocation + offering_balance determines total capacity, no more, no less."""
     monkeypatch.setenv("BOTMASON_MONTHLY_CAP", "2")
     headers = await _signup(concurrent_async_client)
-    await _add_balance(concurrent_async_client, headers, amount=3)
+    await _concurrent_add_balance(concurrent_session_factory, amount=3)
 
     responses = await asyncio.gather(
         *[
@@ -1166,10 +1282,13 @@ async def test_stream_with_zero_balance_returns_402(async_client: AsyncClient) -
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_monthly_cap")
-async def test_stream_emits_chunks_then_complete(async_client: AsyncClient) -> None:
+async def test_stream_emits_chunks_then_complete(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
     """Happy path: one or more ``chunk`` events followed by a single ``complete``."""
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=2)
+    await _add_balance(db_session, amount=2)
 
     resp = await async_client.post(
         "/journal/chat/stream", json={"message": "Guide me"}, headers=headers
@@ -1192,10 +1311,13 @@ async def test_stream_emits_chunks_then_complete(async_client: AsyncClient) -> N
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_monthly_cap")
-async def test_stream_persists_user_and_bot_messages(async_client: AsyncClient) -> None:
+async def test_stream_persists_user_and_bot_messages(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
     """After a successful stream both the user and bot entries are in the journal."""
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
 
     await async_client.post(
         "/journal/chat/stream", json={"message": "Tell me a secret"}, headers=headers
@@ -1211,10 +1333,13 @@ async def test_stream_persists_user_and_bot_messages(async_client: AsyncClient) 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_monthly_cap")
-async def test_stream_deducts_balance_once(async_client: AsyncClient) -> None:
+async def test_stream_deducts_balance_once(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
     """One stream costs exactly one wallet unit — same as the non-streaming path."""
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=3)
+    await _add_balance(db_session, amount=3)
 
     await async_client.post("/journal/chat/stream", json={"message": "Hello"}, headers=headers)
     balance = await async_client.get("/user/balance", headers=headers)
@@ -1225,10 +1350,11 @@ async def test_stream_deducts_balance_once(async_client: AsyncClient) -> None:
 @pytest.mark.usefixtures("zero_monthly_cap")
 async def test_stream_provider_error_emits_error_event_and_rolls_back(
     async_client: AsyncClient,
+    db_session: AsyncSession,
 ) -> None:
     """A mid-stream provider failure must not charge the user or persist a bot entry."""
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
 
     async def _boom(
         *_args: object, **_kwargs: object
@@ -1267,13 +1393,14 @@ async def test_stream_provider_error_emits_error_event_and_rolls_back(
 async def test_stream_falls_back_to_env_key_when_header_absent(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """Streaming endpoint honours the same BYOK precedence as the non-stream one."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
 
     async def _fake_stream(
         _user_message: str,
@@ -1303,13 +1430,14 @@ async def test_stream_falls_back_to_env_key_when_header_absent(
 async def test_stream_rejects_malformed_header_key_with_400(
     async_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
 ) -> None:
     """Malformed BYOK keys 400 *before* the stream opens (no SSE body)."""
     monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
     monkeypatch.setenv("LLM_API_KEY", _VALID_OPENAI_KEY)
 
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     headers[LLM_API_KEY_HEADER] = "not-a-real-key"  # pragma: allowlist secret
 
     resp = await async_client.post("/journal/chat/stream", json={"message": "Hi"}, headers=headers)

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -202,18 +202,51 @@ async def test_add_balance_accumulates(async_client: AsyncClient, db_session: As
 async def test_add_balance_rejects_zero_amount(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
+    """BUG-SCHEMA-009: ``amount=0`` fails Pydantic ``ge=1`` → 422, not 400."""
     headers = await _signup_admin(async_client, db_session)
     resp = await async_client.post("/user/balance/add", json={"amount": 0}, headers=headers)
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
 async def test_add_balance_rejects_negative_amount(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
+    """BUG-SCHEMA-009: negative amounts short-circuit at the schema."""
     headers = await _signup_admin(async_client, db_session)
     resp = await async_client.post("/user/balance/add", json={"amount": -5}, headers=headers)
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_add_balance_rejects_amount_over_one_million(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """BUG-SCHEMA-009: ``amount > 1_000_000`` is rejected before wallet code runs."""
+    headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.post("/user/balance/add", json={"amount": 1_000_001}, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_add_balance_accepts_upper_bound(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The upper bound (1_000_000) itself is valid — only *over* it is rejected."""
+    headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.post("/user/balance/add", json={"amount": 1_000_000}, headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["balance"] == 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_add_balance_rejects_non_integer_amount(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A floating-point amount (e.g. 1.5) is not a valid credit grant."""
+    headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.post("/user/balance/add", json={"amount": 1.5}, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 # ── Chat with BotMason ─────────────────────────────────────────────────

--- a/backend/tests/test_input_length_constraints.py
+++ b/backend/tests/test_input_length_constraints.py
@@ -57,9 +57,8 @@ async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str
 async def _add_balance(db_session: AsyncSession, amount: int = 10, username: str = "alice") -> None:
     """Seed offering credits via direct DB mutation.
 
-    BUG-BM-010 gated :http:post:`/user/balance/add` behind ``require_admin``,
-    so length-constraint tests bypass the endpoint and write the balance
-    column directly into the test database.
+    The balance-add endpoint is admin-gated, so length-constraint tests
+    bypass it and write the balance column directly into the test database.
     """
     email = f"{username}@example.com"
     await db_session.execute(

--- a/backend/tests/test_input_length_constraints.py
+++ b/backend/tests/test_input_length_constraints.py
@@ -12,9 +12,12 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 from models.practice import Practice
+from models.user import User
 from schemas.botmason import CHAT_MESSAGE_MAX_LENGTH
 from schemas.goal_group import (
     GOAL_GROUP_DESCRIPTION_MAX_LENGTH,
@@ -51,10 +54,20 @@ async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _add_balance(client: AsyncClient, headers: dict[str, str], amount: int = 10) -> None:
-    """Add offering credits to the authenticated user."""
-    resp = await client.post("/user/balance/add", json={"amount": amount}, headers=headers)
-    assert resp.status_code == HTTPStatus.OK
+async def _add_balance(db_session: AsyncSession, amount: int = 10, username: str = "alice") -> None:
+    """Seed offering credits via direct DB mutation.
+
+    BUG-BM-010 gated :http:post:`/user/balance/add` behind ``require_admin``,
+    so length-constraint tests bypass the endpoint and write the balance
+    column directly into the test database.
+    """
+    email = f"{username}@example.com"
+    await db_session.execute(
+        update(User)
+        .where(col(User.email) == email)
+        .values(offering_balance=col(User.offering_balance) + amount)
+    )
+    await db_session.commit()
 
 
 async def _seed_practice_and_select(
@@ -109,27 +122,33 @@ async def test_journal_message_over_max_length_returns_422(async_client: AsyncCl
 
 
 @pytest.mark.asyncio
-async def test_chat_message_at_max_length(async_client: AsyncClient) -> None:
+async def test_chat_message_at_max_length(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     message = "a" * CHAT_MESSAGE_MAX_LENGTH
     resp = await async_client.post("/journal/chat", json={"message": message}, headers=headers)
     assert resp.status_code == HTTPStatus.CREATED
 
 
 @pytest.mark.asyncio
-async def test_chat_message_over_max_length_returns_422(async_client: AsyncClient) -> None:
+async def test_chat_message_over_max_length_returns_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     message = "a" * (CHAT_MESSAGE_MAX_LENGTH + 1)
     resp = await async_client.post("/journal/chat", json={"message": message}, headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
-async def test_chat_empty_message_returns_422(async_client: AsyncClient) -> None:
+async def test_chat_empty_message_returns_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=1)
+    await _add_balance(db_session, amount=1)
     resp = await async_client.post("/journal/chat", json={"message": ""}, headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -13,7 +13,11 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
+from models.user import User
 from rate_limit import DEFAULT_RATE_LIMIT
 
 
@@ -31,10 +35,27 @@ async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _add_balance(client: AsyncClient, headers: dict[str, str], amount: int = 50) -> None:
-    """Add offering credits to the authenticated user."""
-    resp = await client.post("/user/balance/add", json={"amount": amount}, headers=headers)
-    assert resp.status_code == HTTPStatus.OK
+async def _promote_admin(db_session: AsyncSession, username: str = "alice") -> None:
+    """Flip ``is_admin`` for the signed-up user so they can hit admin routes."""
+    email = f"{username}@example.com"
+    await db_session.execute(update(User).where(col(User.email) == email).values(is_admin=True))
+    await db_session.commit()
+
+
+async def _add_balance(db_session: AsyncSession, amount: int = 50, username: str = "alice") -> None:
+    """Seed offering credits via direct DB mutation.
+
+    BUG-BM-010 gated :http:post:`/user/balance/add` behind ``require_admin``,
+    so rate-limit tests that just need a funded wallet sidestep the endpoint
+    and write the balance column straight into the test DB.
+    """
+    email = f"{username}@example.com"
+    await db_session.execute(
+        update(User)
+        .where(col(User.email) == email)
+        .values(offering_balance=col(User.offering_balance) + amount)
+    )
+    await db_session.commit()
 
 
 # ── Configuration ────────────────────────────────────────────────────────
@@ -78,10 +99,12 @@ async def test_rate_limit_response_includes_retry_after(async_client: AsyncClien
 
 
 @pytest.mark.asyncio
-async def test_chat_rate_limit_returns_429(async_client: AsyncClient) -> None:
+async def test_chat_rate_limit_returns_429(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
     """POST /journal/chat returns 429 after exceeding 10 requests/minute."""
     headers = await _signup(async_client)
-    await _add_balance(async_client, headers, amount=20)
+    await _add_balance(db_session, amount=20)
 
     # Make 10 requests (the limit)
     for _ in range(10):
@@ -106,9 +129,14 @@ async def test_chat_rate_limit_returns_429(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_balance_rate_limit_returns_429(async_client: AsyncClient) -> None:
+async def test_add_balance_rate_limit_returns_429(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
     """POST /user/balance/add returns 429 after exceeding 5 requests/minute."""
     headers = await _signup(async_client)
+    # BUG-BM-010: endpoint is now admin-only, so promote the signed-up user
+    # before hammering it to verify the rate-limit gate fires *after* authz.
+    await _promote_admin(db_session)
 
     # Make 5 requests (the limit)
     for _ in range(5):

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -45,9 +45,9 @@ async def _promote_admin(db_session: AsyncSession, username: str = "alice") -> N
 async def _add_balance(db_session: AsyncSession, amount: int = 50, username: str = "alice") -> None:
     """Seed offering credits via direct DB mutation.
 
-    BUG-BM-010 gated :http:post:`/user/balance/add` behind ``require_admin``,
-    so rate-limit tests that just need a funded wallet sidestep the endpoint
-    and write the balance column straight into the test DB.
+    The balance-add endpoint is admin-gated, so rate-limit tests that just
+    need a funded wallet sidestep the endpoint and write the balance column
+    straight into the test DB.
     """
     email = f"{username}@example.com"
     await db_session.execute(
@@ -134,8 +134,8 @@ async def test_add_balance_rate_limit_returns_429(
 ) -> None:
     """POST /user/balance/add returns 429 after exceeding 5 requests/minute."""
     headers = await _signup(async_client)
-    # BUG-BM-010: endpoint is now admin-only, so promote the signed-up user
-    # before hammering it to verify the rate-limit gate fires *after* authz.
+    # Endpoint is admin-only, so promote before hammering to verify the
+    # rate-limit gate fires *after* authz.
     await _promote_admin(db_session)
 
     # Make 5 requests (the limit)

--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -22,8 +22,8 @@ describe('USER_FACING_ERROR_MESSAGES', () => {
       'password_too_short',
       'unauthorized',
       // admin
-      'admin_api_disabled',
-      'admin_auth_required',
+      'admin_required',
+      'user_not_found',
       // resource not found
       'stage_not_found',
       'content_not_found',
@@ -34,7 +34,6 @@ describe('USER_FACING_ERROR_MESSAGES', () => {
       'goal_group_not_found',
       'prompt_not_found',
       'user_practice_not_found',
-      'user_not_found',
       // forbidden / ownership
       'forbidden',
       'not_owner',

--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -41,7 +41,6 @@ describe('USER_FACING_ERROR_MESSAGES', () => {
       'cannot_go_backwards',
       'already_responded',
       'practice_not_approved',
-      'amount_must_be_positive',
       'habits_must_not_be_empty',
       // wallet
       'payment_required',

--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -21,10 +21,10 @@ describe('USER_FACING_ERROR_MESSAGES', () => {
       'invalid_credentials',
       'password_too_short',
       'unauthorized',
-      // admin
+      // admin gate
       'admin_required',
-      'user_not_found',
       // resource not found
+      'user_not_found',
       'stage_not_found',
       'content_not_found',
       'practice_not_found',

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -39,10 +39,7 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   unauthorized: SESSION_EXPIRED,
 
   // --- Admin -----------------------------------------------------------
-  admin_api_disabled:
-    'Admin access is turned off on this server. Ask your administrator to enable it.',
-  admin_auth_required:
-    'Admin access requires a valid X-Admin-API-Key header. Check with your administrator.',
+  admin_required: 'Admin privileges are required for this action.',
 
   // --- Resource not found ----------------------------------------------
   stage_not_found: `We couldn't find that stage. ${PULL_TO_REFRESH}`,

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -66,7 +66,6 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   already_responded: "You've already answered this week's prompt. A new one unlocks each week.",
   practice_not_approved:
     "That practice isn't available for selection yet. Pick one of the approved options for this stage.",
-  amount_must_be_positive: 'Enter a number greater than zero.',
   habits_must_not_be_empty:
     'Add at least one habit before generating an energy plan. You can add habits from the Habits tab.',
 

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -25,7 +25,7 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 | # | Prompt | Wave | Branch / PR | Status |
 |--:|--------|:----:|-------------|:------:|
 | 01 | unblock-auth-nav-flash            | 1 | `claude/bug-fix-01-unblock-auth-nav-flash` / [#245](https://github.com/Geoffe-Ga/adepthood/pull/245) | [x] |
-| 02 | close-credit-minting-chain        | 2 | | [ ] |
+| 02 | close-credit-minting-chain        | 2 | `claude/bug-fix-02-credit-minting-chain` / [#246](https://github.com/Geoffe-Ga/adepthood/pull/246) | [x] |
 | 03 | close-stage-skip-chain            | 2 | | [ ] |
 | 04 | centralize-sanitize-user-text     | 3 | | [ ] |
 | 05 | centralize-date-utils-tz          | 3 | | [ ] |


### PR DESCRIPTION
## Summary

Closes the credit-minting chain documented in prompt 02 of the 2026-04-18
bug remediation plan.  Before this PR, any signed-in user could POST an
unbounded integer to `/user/balance/add` and mint credits into their own
wallet — an infinite-credit loophole compounded by a second admin-gate
(`/admin/usage-stats`) that relied on a shared env-var secret rather than
a per-user privilege bit.

Three atomic commits, each independently reversible:

1. **`feat(backend): add User.is_admin column + require_admin dependency`**
   - New `User.is_admin` column (NOT NULL, `server_default=false`) with
     a reversible Alembic migration (`b9c0d1e2f3a4_add_user_is_admin`).
   - New `dependencies.auth.require_admin` dependency that resolves the
     current user, 403s with `admin_required` when `is_admin=False`, and
     403s with `user_not_found` when the row has been deleted.
   - `/admin/usage-stats` now uses `Depends(require_admin)` — the old
     `X-Admin-API-Key` header + `ADMIN_API_KEY` env var are deleted.
   - Frontend `errorMessages` picks up `admin_required`; stale
     `admin_api_disabled` / `admin_auth_required` codes removed.
   - Regression tests: anonymous 401, non-admin 403 `admin_required`,
     admin 200, deleted-admin 403 `user_not_found` (BUG-ADMIN-001).

2. **`fix(backend): require admin on POST /user/balance/add`**
   - Endpoint swaps `get_current_user` for `require_admin`, so anonymous
     still 401s, any non-admin now 403s, and only admin accounts can
     grant credit (BUG-BM-010).
   - `_add_balance` helper refactored across `test_botmason_api.py`,
     `test_rate_limits.py`, and `test_input_length_constraints.py` to
     seed offering credit via direct DB mutation — those suites don't
     need the admin flow; they just need *having* a wallet.  Tests that
     specifically exercise the endpoint promote to admin via the new
     `_signup_admin` / `_concurrent_signup_admin` helpers.
   - Added `test_add_balance_non_admin_returns_403` as the authz
     boundary regression.

3. **`fix(backend): clamp BalanceAddRequest.amount to [1, 1_000_000]`**
   - `amount: int = Field(ge=1, le=1_000_000)` — Pydantic rejects zero,
     negative, over-cap, and non-integer values with 422 before any
     wallet code runs (BUG-SCHEMA-009).
   - Router drops the now-dead `amount_must_be_positive` raise; the
     frontend error-map entry + its test are deleted as dead code.
   - Regression tests cover both edges (0, -5, 1_000_001, 1.5) plus the
     inclusive upper bound (1_000_000 accepted).

## Test plan

- [x] `pre-commit run --all-files` — clean (28 hooks)
- [x] `pytest` — full backend suite passes
- [x] pre-push hooks — ruff / ruff-format / mypy / xenon / radon /
      coverage all green
- [x] Boundary tests explicitly cover anonymous, non-admin, admin,
      deleted-admin, and all four amount edges
- [x] Alembic migration reversible (`downgrade()` drops the column)

https://claude.ai/code/session_011JvxjW4m5jw6u77eKrrYjz