### PR TITLE
chore(backend): audit legacy completed_stages gaps

### DIFF
--- a/backend/migrations/versions/c0d1e2f3a4b5_audit_completed_stages_gaps.py
+++ b/backend/migrations/versions/c0d1e2f3a4b5_audit_completed_stages_gaps.py
@@ -39,14 +39,14 @@ def _coerce_completed(raw: object) -> list[int]:
     """Normalize the driver representation of ``completed_stages`` to ``list[int]``."""
     if raw is None:
         return []
-    if isinstance(raw, list):
-        return [int(x) for x in raw]
-    # Postgres ARRAY(Integer) round-trips as a list already; this branch is a
-    # defensive fallback for drivers that expose a tuple or similar sequence.
-    try:
-        return [int(x) for x in raw]  # type: ignore[call-overload]
-    except TypeError:
-        return []
+    # Postgres ARRAY(Integer) round-trips as a list already; the tuple branch
+    # is a defensive fallback for drivers that return a non-list sequence.
+    if isinstance(raw, (list, tuple)):
+        try:
+            return [int(x) for x in raw]
+        except (TypeError, ValueError):
+            return []
+    return []
 
 
 def upgrade() -> None:

--- a/backend/migrations/versions/c0d1e2f3a4b5_audit_completed_stages_gaps.py
+++ b/backend/migrations/versions/c0d1e2f3a4b5_audit_completed_stages_gaps.py
@@ -1,0 +1,88 @@
+"""audit legacy completed_stages gaps
+
+Revision ID: c0d1e2f3a4b5
+Revises: b9c0d1e2f3a4
+Create Date: 2026-04-20 00:00:00.000000
+
+One-shot *read-only* data audit that logs every ``stageprogress`` row whose
+``completed_stages`` set is not exactly ``{1..current_stage-1}``.  Rows like
+``completed_stages=[1, 3]`` with ``current_stage=4`` (stage 2 missing) can
+slip through if the chain-validation invariant (next commit) is ever relaxed
+by an admin tool, data import, or a bug.
+
+The migration deliberately does **not** auto-repair: silently mutating user
+progression would hide the defect and could forfeit completion credit the
+user is actually owed.  Instead, operators use the new
+``GET /admin/stage-progress/gaps`` endpoint to inspect the flagged rows and
+``POST /admin/stage-progress/{user_id}/repair`` to rewrite a single row
+explicitly.  This migration makes those admin calls safe to run against a
+legacy database by surfacing every candidate in the alembic log.
+"""
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c0d1e2f3a4b5"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "b9c0d1e2f3a4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_logger = logging.getLogger("alembic.runtime.migration")
+
+
+def _coerce_completed(raw: object) -> list[int]:
+    """Normalize the driver representation of ``completed_stages`` to ``list[int]``."""
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [int(x) for x in raw]
+    # Postgres ARRAY(Integer) round-trips as a list already; this branch is a
+    # defensive fallback for drivers that expose a tuple or similar sequence.
+    try:
+        return [int(x) for x in raw]  # type: ignore[call-overload]
+    except TypeError:
+        return []
+
+
+def upgrade() -> None:
+    """Scan ``stageprogress`` rows and log every non-contiguous row."""
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT user_id, current_stage, completed_stages FROM stageprogress")
+    ).fetchall()
+
+    flagged = 0
+    for row in rows:
+        current_stage = int(row.current_stage)
+        completed = set(_coerce_completed(row.completed_stages))
+        expected = set(range(1, current_stage))
+        if completed == expected:
+            continue
+        flagged += 1
+        _logger.warning(
+            "stage_progress_gap: user_id=%s current_stage=%s completed=%s "
+            "missing=%s extra=%s",
+            row.user_id,
+            current_stage,
+            sorted(completed),
+            sorted(expected - completed),
+            sorted(completed - expected),
+        )
+
+    if flagged:
+        _logger.warning(
+            "stage_progress_audit: %d row(s) flagged. Repair via "
+            "POST /admin/stage-progress/{user_id}/repair.",
+            flagged,
+        )
+    else:
+        _logger.info("stage_progress_audit: no rows flagged")
+
+
+def downgrade() -> None:
+    """Read-only audit; nothing to revert."""

--- a/backend/src/domain/constants.py
+++ b/backend/src/domain/constants.py
@@ -1,0 +1,14 @@
+"""Shared domain constants with no further domain imports.
+
+Split from :mod:`domain.stage_progress` so Pydantic schemas can pull the
+curriculum length without triggering a ``schemas <-> domain`` import cycle.
+"""
+
+from __future__ import annotations
+
+# Declared length of the APTITUDE curriculum.  Router-level stage mutations
+# clamp their inputs to this range and callers use it to detect the
+# "everything is done" boundary.  Re-exported as ``TOTAL_STAGES`` from
+# :mod:`domain.stage_progress` and aliased as ``MAX_STAGE_NUMBER`` by the
+# Pydantic schemas.
+TOTAL_STAGES = 36

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from domain.constants import TOTAL_STAGES
-from errors import conflict
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.goal import Goal
@@ -27,6 +26,7 @@ _STAGE_1 = 1
 
 __all__ = [
     "TOTAL_STAGES",
+    "AllStagesCompletedError",
     "compute_stage_progress",
     "get_stage_habit_history",
     "get_stage_practice_history",
@@ -36,6 +36,16 @@ __all__ = [
     "next_stage_for",
     "stage_exists",
 ]
+
+
+class AllStagesCompletedError(Exception):
+    """Raised by :func:`next_stage_for` when every stage is already completed.
+
+    Keeping this as a plain domain exception — not ``HTTPException`` — lets
+    non-HTTP callers (admin tooling, async tasks, tests) use the helper
+    without pulling in FastAPI's transport layer.  Router code is responsible
+    for catching this and mapping it to the appropriate HTTP response.
+    """
 
 
 async def get_user_progress(session: AsyncSession, user_id: int) -> StageProgress | None:
@@ -86,15 +96,15 @@ def next_stage_for(progress: StageProgress | None) -> int:
     legacy rows like ``completed_stages=[1, 3]``: ``max+1`` would advance
     past stage 2 silently; ``min(missing)`` returns 2 and keeps the chain-
     validation invariant aligned with unlock-checking on dirty data.  Raises
-    a 409 conflict when every stage is already completed so the caller
-    cannot blindly advance past the curriculum.
+    :class:`AllStagesCompletedError` when every stage is already completed
+    so the caller cannot blindly advance past the curriculum.
     """
     if progress is None:
         return _STAGE_1
     completed = set(progress.completed_stages or [])
     missing = set(range(1, TOTAL_STAGES + 1)) - completed
     if not missing:
-        raise conflict("all_stages_completed")
+        raise AllStagesCompletedError
     return min(missing)
 
 

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -8,6 +8,8 @@ from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from domain.constants import TOTAL_STAGES
+from errors import conflict
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.goal import Goal
@@ -23,11 +25,17 @@ from schemas.stage import HabitHistoryItem, PracticeHistoryItem
 # Stage 1 is always unlocked regardless of progress state.
 _STAGE_1 = 1
 
-# Declared length of the APTITUDE curriculum.  Router-level stage mutations
-# clamp their inputs to this range and callers use it to detect the
-# "everything is done" boundary.  Duplicated by ``schemas.practice.
-# MAX_STAGE_NUMBER`` for Pydantic validation — keep the two in sync.
-TOTAL_STAGES = 36
+__all__ = [
+    "TOTAL_STAGES",
+    "compute_stage_progress",
+    "get_stage_habit_history",
+    "get_stage_practice_history",
+    "get_user_progress",
+    "get_user_progress_for_update",
+    "is_stage_unlocked",
+    "next_stage_for",
+    "stage_exists",
+]
 
 
 async def get_user_progress(session: AsyncSession, user_id: int) -> StageProgress | None:
@@ -59,7 +67,7 @@ def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool
     ``[35]``) expose every intermediate stage it never actually completed.
     The chain check closes that gap without depending on the separate
     ``current_stage`` signal, which can drift out of sync with
-    ``completed_stages`` independently (BUG-STAGE-002).
+    ``completed_stages`` independently.
     """
     if stage_number == _STAGE_1:
         return True
@@ -86,8 +94,6 @@ def next_stage_for(progress: StageProgress | None) -> int:
     completed = set(progress.completed_stages or [])
     missing = set(range(1, TOTAL_STAGES + 1)) - completed
     if not missing:
-        from errors import conflict  # noqa: PLC0415 — local import avoids layer cycle
-
         raise conflict("all_stages_completed")
     return min(missing)
 

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -23,6 +23,12 @@ from schemas.stage import HabitHistoryItem, PracticeHistoryItem
 # Stage 1 is always unlocked regardless of progress state.
 _STAGE_1 = 1
 
+# Declared length of the APTITUDE curriculum.  Router-level stage mutations
+# clamp their inputs to this range and callers use it to detect the
+# "everything is done" boundary.  Duplicated by ``schemas.practice.
+# MAX_STAGE_NUMBER`` for Pydantic validation — keep the two in sync.
+TOTAL_STAGES = 36
+
 
 async def get_user_progress(session: AsyncSession, user_id: int) -> StageProgress | None:
     """Fetch the StageProgress record for a user, or None."""
@@ -46,16 +52,44 @@ async def get_user_progress_for_update(session: AsyncSession, user_id: int) -> S
 def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool:
     """Determine if a stage is unlocked for the user.
 
-    Stage 1 is always unlocked.  For stage N > 1, the stage is unlocked
-    when ``stage_number - 1`` appears in ``progress.completed_stages``.
-    This single rule covers both stages at-or-below the current stage
-    and stages beyond it.
+    Stage 1 is always unlocked.  For stage N > 1, **every** prior stage must
+    be in ``completed_stages`` — not just the immediate predecessor.  The
+    single-predecessor shortcut (``(N-1) in completed_stages``) lets any
+    admin tool, data import, or legacy row with a hole in the chain (e.g.
+    ``[35]``) expose every intermediate stage it never actually completed.
+    The chain check closes that gap without depending on the separate
+    ``current_stage`` signal, which can drift out of sync with
+    ``completed_stages`` independently (BUG-STAGE-002).
     """
     if stage_number == _STAGE_1:
         return True
     if progress is None:
         return False
-    return (stage_number - 1) in (progress.completed_stages or [])
+    required = set(range(1, stage_number))
+    return required.issubset(set(progress.completed_stages or []))
+
+
+def next_stage_for(progress: StageProgress | None) -> int:
+    """Return the first unfinished stage for ``progress``.
+
+    Fresh users (``progress is None``) start at stage 1.  Otherwise we take
+    ``min({1..TOTAL_STAGES} - completed_stages)`` — the first *hole* in the
+    completion set, not ``max(completed) + 1``.  The distinction matters for
+    legacy rows like ``completed_stages=[1, 3]``: ``max+1`` would advance
+    past stage 2 silently; ``min(missing)`` returns 2 and keeps the chain-
+    validation invariant aligned with unlock-checking on dirty data.  Raises
+    a 409 conflict when every stage is already completed so the caller
+    cannot blindly advance past the curriculum.
+    """
+    if progress is None:
+        return _STAGE_1
+    completed = set(progress.completed_stages or [])
+    missing = set(range(1, TOTAL_STAGES + 1)) - completed
+    if not missing:
+        from errors import conflict  # noqa: PLC0415 — local import avoids layer cycle
+
+        raise conflict("all_stages_completed")
+    return min(missing)
 
 
 async def _compute_habits_progress(session: AsyncSession, user_id: int, stage_number: int) -> float:

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -23,6 +23,7 @@ from schemas.admin import (
     ModelUsageBreakdown,
     StageProgressGap,
     StageProgressGapsResponse,
+    StageProgressRepairResult,
     UsageStatsResponse,
     UserUsageBreakdown,
 )
@@ -153,18 +154,18 @@ async def list_stage_progress_gaps(
     return StageProgressGapsResponse(rows=gaps, total=len(gaps))
 
 
-@router.post("/stage-progress/{user_id}/repair", response_model=StageProgressGap)
+@router.post("/stage-progress/{user_id}/repair", response_model=StageProgressRepairResult)
 async def repair_stage_progress(
     user_id: int,
     session: Annotated[AsyncSession, Depends(get_session)],
     _admin: Annotated[User, Depends(require_admin)],
-) -> StageProgressGap:
+) -> StageProgressRepairResult:
     """Rewrite one user's ``completed_stages`` to ``{1..current_stage-1}``.
 
     Explicit admin action: running this is a decision to forfeit whatever
     intermediate-stage credit the gap encoded in favour of the canonical
-    chain-validation invariant.  Returns the old/new delta so the caller has
-    a record of what changed.
+    chain-validation invariant.  Returns the delta so the caller has a
+    record of what changed.
     """
     result = await session.execute(
         select(StageProgress).where(col(StageProgress.user_id) == user_id)
@@ -176,14 +177,13 @@ async def repair_stage_progress(
     before = set(progress.completed_stages or [])
     expected = set(range(1, progress.current_stage))
     progress.completed_stages = sorted(expected)
-    session.add(progress)
     await session.commit()
     await session.refresh(progress)
 
-    return StageProgressGap(
+    return StageProgressRepairResult(
         user_id=user_id,
         current_stage=progress.current_stage,
         completed_stages=sorted(expected),
-        missing_stages=sorted(expected - before),
-        extra_stages=sorted(before - expected),
+        stages_added=sorted(expected - before),
+        stages_removed=sorted(before - expected),
     )

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -6,6 +6,7 @@ identity is a first-class per-user flag rather than a shared header secret.
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
@@ -27,6 +28,8 @@ from schemas.admin import (
     UsageStatsResponse,
     UserUsageBreakdown,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -158,7 +161,7 @@ async def list_stage_progress_gaps(
 async def repair_stage_progress(
     user_id: int,
     session: Annotated[AsyncSession, Depends(get_session)],
-    _admin: Annotated[User, Depends(require_admin)],
+    admin: Annotated[User, Depends(require_admin)],
 ) -> StageProgressRepairResult:
     """Rewrite one user's ``completed_stages`` to ``{1..current_stage-1}``.
 
@@ -166,6 +169,11 @@ async def repair_stage_progress(
     intermediate-stage credit the gap encoded in favour of the canonical
     chain-validation invariant.  Returns the delta so the caller has a
     record of what changed.
+
+    Emits a structured ``stage_progress_repaired`` log entry with the
+    admin, target, and delta so the action is traceable — repair mutates
+    user progression irreversibly, so leaving no audit trail would let a
+    mistaken or malicious write vanish silently.
     """
     result = await session.execute(
         select(StageProgress).where(col(StageProgress.user_id) == user_id)
@@ -176,14 +184,27 @@ async def repair_stage_progress(
 
     before = set(progress.completed_stages or [])
     expected = set(range(1, progress.current_stage))
+    stages_added = sorted(expected - before)
+    stages_removed = sorted(before - expected)
     progress.completed_stages = sorted(expected)
     await session.commit()
     await session.refresh(progress)
+
+    logger.warning(
+        "stage_progress_repaired",
+        extra={
+            "admin_id": admin.id,
+            "user_id": user_id,
+            "current_stage": progress.current_stage,
+            "stages_added": stages_added,
+            "stages_removed": stages_removed,
+        },
+    )
 
     return StageProgressRepairResult(
         user_id=user_id,
         current_stage=progress.current_stage,
         completed_stages=sorted(expected),
-        stages_added=sorted(expected - before),
-        stages_removed=sorted(before - expected),
+        stages_added=stages_added,
+        stages_removed=stages_removed,
     )

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -15,10 +15,14 @@ from sqlmodel import col
 
 from database import get_session
 from dependencies.auth import require_admin
+from errors import not_found
 from models.llm_usage_log import LLMUsageLog
+from models.stage_progress import StageProgress
 from models.user import User
 from schemas.admin import (
     ModelUsageBreakdown,
+    StageProgressGap,
+    StageProgressGapsResponse,
     UsageStatsResponse,
     UserUsageBreakdown,
 )
@@ -106,4 +110,80 @@ async def get_usage_stats(
             )
             for provider, model, calls, tokens, cost in per_model_rows
         ],
+    )
+
+
+def _detect_gap(progress: StageProgress) -> StageProgressGap | None:
+    """Return a :class:`StageProgressGap` when ``completed_stages`` is non-contiguous.
+
+    The invariant every stage mutation must preserve is
+    ``set(completed_stages) == {1..current_stage-1}``.  Anything else — a
+    missing entry in the middle, an over-credited future stage, a duplicate
+    value that rounds the same way when set-reduced — is a gap the chain
+    validation in :func:`domain.stage_progress.is_stage_unlocked` must be
+    blind to.  Returning ``None`` for contiguous rows keeps the listing
+    endpoint's loop trivial.
+    """
+    completed = set(progress.completed_stages or [])
+    expected = set(range(1, progress.current_stage))
+    if completed == expected:
+        return None
+    return StageProgressGap(
+        user_id=progress.user_id,
+        current_stage=progress.current_stage,
+        completed_stages=sorted(completed),
+        missing_stages=sorted(expected - completed),
+        extra_stages=sorted(completed - expected),
+    )
+
+
+@router.get("/stage-progress/gaps", response_model=StageProgressGapsResponse)
+async def list_stage_progress_gaps(
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin: Annotated[User, Depends(require_admin)],
+) -> StageProgressGapsResponse:
+    """Return every ``stageprogress`` row whose completed set is non-contiguous.
+
+    Read-only: mirrors the audit migration's logging so operators can inspect
+    flagged rows on a live database without trawling alembic logs.  Pair with
+    :func:`repair_stage_progress` to rewrite a single row explicitly.
+    """
+    result = await session.execute(select(StageProgress))
+    gaps = [gap for row in result.scalars().all() if (gap := _detect_gap(row)) is not None]
+    return StageProgressGapsResponse(rows=gaps, total=len(gaps))
+
+
+@router.post("/stage-progress/{user_id}/repair", response_model=StageProgressGap)
+async def repair_stage_progress(
+    user_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    _admin: Annotated[User, Depends(require_admin)],
+) -> StageProgressGap:
+    """Rewrite one user's ``completed_stages`` to ``{1..current_stage-1}``.
+
+    Explicit admin action: running this is a decision to forfeit whatever
+    intermediate-stage credit the gap encoded in favour of the canonical
+    chain-validation invariant.  Returns the old/new delta so the caller has
+    a record of what changed.
+    """
+    result = await session.execute(
+        select(StageProgress).where(col(StageProgress.user_id) == user_id)
+    )
+    progress = result.scalars().first()
+    if progress is None:
+        raise not_found("stage_progress")
+
+    before = set(progress.completed_stages or [])
+    expected = set(range(1, progress.current_stage))
+    progress.completed_stages = sorted(expected)
+    session.add(progress)
+    await session.commit()
+    await session.refresh(progress)
+
+    return StageProgressGap(
+        user_id=user_id,
+        current_stage=progress.current_stage,
+        completed_stages=sorted(expected),
+        missing_stages=sorted(expected - before),
+        extra_stages=sorted(before - expected),
     )

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -117,8 +117,19 @@ async def list_stage_content(
     ``total`` reflects the items the user can actually see — not the raw
     count in the database.  Stage content lists are small (tens of items
     per stage) so paginating in Python after fetching is fine.
+
+    BUG-COURSE-001: the sibling endpoints (``get_content_item``,
+    ``mark_content_read``) gate on :func:`_check_stage_unlocked`; this
+    listing used to skip it and leak titles + release_days for future
+    stages while only nulling ``url``.  Aligning the unlock gate here
+    closes the last read path for locked-stage metadata.
     """
+    # 404-then-403: missing stages return not_found regardless of caller so a
+    # nonexistent stage_number can't be distinguished from a locked one by
+    # response code (callers for this endpoint don't see a content_id oracle,
+    # so the existence of stages 1..36 is already public knowledge).
     stage = await _get_stage_by_number(session, stage_number)
+    await _check_stage_unlocked(session, current_user, stage_number)
 
     result = await session.execute(
         select(StageContent)

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -118,11 +118,11 @@ async def list_stage_content(
     count in the database.  Stage content lists are small (tens of items
     per stage) so paginating in Python after fetching is fine.
 
-    BUG-COURSE-001: the sibling endpoints (``get_content_item``,
-    ``mark_content_read``) gate on :func:`_check_stage_unlocked`; this
-    listing used to skip it and leak titles + release_days for future
-    stages while only nulling ``url``.  Aligning the unlock gate here
-    closes the last read path for locked-stage metadata.
+    The sibling endpoints (``get_content_item``, ``mark_content_read``)
+    gate on :func:`_check_stage_unlocked`; this listing used to skip it
+    and leak titles + release_days for future stages while only nulling
+    ``url``.  Aligning the unlock gate here closes the last read path
+    for locked-stage metadata.
     """
     # 404-then-403: missing stages return not_found regardless of caller so a
     # nonexistent stage_number can't be distinguished from a locked one by

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -28,14 +28,14 @@ router = APIRouter(prefix="/prompts", tags=["prompts"])
 async def _get_user_week(session: AsyncSession, user_id: int) -> int:
     """Derive the user's current week from the count of completed prompts.
 
-    BUG-PROMPT-001: switching from ``max(week_number) + 1`` to
-    ``count(responses) + 1`` closes the skip-ahead vector where a single
-    POST to ``/prompts/36/respond`` would set ``max = 36`` and advance the
-    user past every intermediate week.  Because the submit endpoint now
-    rejects any ``week_number > user_week`` (see :func:`_check_week_unlocked`),
+    Switching from ``max(week_number) + 1`` to ``count(responses) + 1``
+    closes the skip-ahead vector where a single POST to
+    ``/prompts/36/respond`` would set ``max = 36`` and advance the user
+    past every intermediate week.  Because the submit endpoint now rejects
+    any ``week_number > user_week`` (see :func:`_check_week_unlocked`),
     the count only ever equals the number of contiguously completed weeks,
     so ``count + 1`` is the first unfinished week.  The result is clamped
-    to ``[1, TOTAL_WEEKS]`` (BUG-JOURNAL-014).
+    to ``[1, TOTAL_WEEKS]``.
     """
     result = await session.execute(
         select(func.count()).select_from(PromptResponse).where(PromptResponse.user_id == user_id)
@@ -47,11 +47,11 @@ async def _get_user_week(session: AsyncSession, user_id: int) -> int:
 async def _check_week_unlocked(session: AsyncSession, user_id: int, week_number: int) -> None:
     """Raise 403 when ``week_number`` is past the user's current week.
 
-    BUG-PROMPT-001/-002: both :func:`get_prompt_by_week` and
-    :func:`submit_prompt_response` must gate on this to prevent enumeration
-    of the full 36-week curriculum and one-request skip-ahead of the
-    weekly pacing.  Factored into a shared helper so the two endpoints
-    cannot drift out of sync.
+    Both :func:`get_prompt_by_week` and :func:`submit_prompt_response`
+    must gate on this to prevent enumeration of the full 36-week
+    curriculum and one-request skip-ahead of the weekly pacing.
+    Factored into a shared helper so the two endpoints cannot drift out
+    of sync.
     """
     user_week = await _get_user_week(session, user_id)
     if week_number > user_week:
@@ -139,9 +139,9 @@ async def get_prompt_by_week(
 ) -> PromptDetail:
     """Get a specific week's prompt and the user's response (if any).
 
-    BUG-PROMPT-002: gated on the user's current week.  Without this check
-    a fresh (week-1) user could enumerate ``/prompts/1`` … ``/prompts/36``
-    and lift every future question.  404 precedes 403 so unknown weeks
+    Gated on the user's current week.  Without this check a fresh
+    (week-1) user could enumerate ``/prompts/1`` … ``/prompts/36`` and
+    lift every future question.  404 precedes 403 so unknown weeks
     (outside 1..``TOTAL_WEEKS``) don't get re-interpreted as "locked".
     """
     question = get_prompt_for_week(week_number)
@@ -179,10 +179,10 @@ async def submit_prompt_response(
 ) -> PromptDetail:
     """Submit a response to a weekly prompt. Prevents duplicate responses.
 
-    BUG-PROMPT-001: refuses ``week_number > user_week`` so a single POST
-    cannot leapfrog the weekly pacing by driving ``max(week_number)`` up
-    in one request.  Paired with the ``count + 1``-based ``_get_user_week``
-    this makes the server-derived week a monotone function of *contiguous*
+    Refuses ``week_number > user_week`` so a single POST cannot leapfrog
+    the weekly pacing by driving ``max(week_number)`` up in one request.
+    Paired with the ``count + 1``-based ``_get_user_week`` this makes
+    the server-derived week a monotone function of *contiguous*
     completion, not the highest value the client has ever submitted.
     """
     question = get_prompt_for_week(week_number)

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -14,7 +14,7 @@ from sqlmodel import col, select
 
 from database import get_session
 from domain.weekly_prompts import TOTAL_WEEKS, get_prompt_for_week
-from errors import bad_request, conflict, not_found
+from errors import bad_request, conflict, forbidden, not_found
 from models.journal_entry import JournalEntry, JournalTag
 from models.prompt_response import PromptResponse
 from routers.auth import get_current_user
@@ -26,19 +26,36 @@ router = APIRouter(prefix="/prompts", tags=["prompts"])
 
 
 async def _get_user_week(session: AsyncSession, user_id: int) -> int:
-    """Derive the user's current week from their last completed prompt.
+    """Derive the user's current week from the count of completed prompts.
 
-    Returns ``max(PromptResponse.week_number) + 1`` so users advance only
-    by completing prompts, not by waiting.  Falls back to week 1 when no
-    responses exist yet.  The result is clamped to [1, TOTAL_WEEKS]
-    (BUG-JOURNAL-014).
+    BUG-PROMPT-001: switching from ``max(week_number) + 1`` to
+    ``count(responses) + 1`` closes the skip-ahead vector where a single
+    POST to ``/prompts/36/respond`` would set ``max = 36`` and advance the
+    user past every intermediate week.  Because the submit endpoint now
+    rejects any ``week_number > user_week`` (see :func:`_check_week_unlocked`),
+    the count only ever equals the number of contiguously completed weeks,
+    so ``count + 1`` is the first unfinished week.  The result is clamped
+    to ``[1, TOTAL_WEEKS]`` (BUG-JOURNAL-014).
     """
     result = await session.execute(
-        select(func.max(PromptResponse.week_number)).where(PromptResponse.user_id == user_id)
+        select(func.count()).select_from(PromptResponse).where(PromptResponse.user_id == user_id)
     )
-    max_week = result.scalar()
-    week = int(max_week) + 1 if max_week is not None else 1
-    return int(max(1, min(week, TOTAL_WEEKS)))
+    completed = int(result.scalar() or 0)
+    return int(max(1, min(completed + 1, TOTAL_WEEKS)))
+
+
+async def _check_week_unlocked(session: AsyncSession, user_id: int, week_number: int) -> None:
+    """Raise 403 when ``week_number`` is past the user's current week.
+
+    BUG-PROMPT-001/-002: both :func:`get_prompt_by_week` and
+    :func:`submit_prompt_response` must gate on this to prevent enumeration
+    of the full 36-week curriculum and one-request skip-ahead of the
+    weekly pacing.  Factored into a shared helper so the two endpoints
+    cannot drift out of sync.
+    """
+    user_week = await _get_user_week(session, user_id)
+    if week_number > user_week:
+        raise forbidden("week_locked")
 
 
 @router.get("/current", response_model=PromptDetail)
@@ -120,10 +137,17 @@ async def get_prompt_by_week(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> PromptDetail:
-    """Get a specific week's prompt and the user's response (if any)."""
+    """Get a specific week's prompt and the user's response (if any).
+
+    BUG-PROMPT-002: gated on the user's current week.  Without this check
+    a fresh (week-1) user could enumerate ``/prompts/1`` … ``/prompts/36``
+    and lift every future question.  404 precedes 403 so unknown weeks
+    (outside 1..``TOTAL_WEEKS``) don't get re-interpreted as "locked".
+    """
     question = get_prompt_for_week(week_number)
     if question is None:
         raise not_found("prompt")
+    await _check_week_unlocked(session, current_user, week_number)
 
     result = await session.execute(
         select(PromptResponse).where(
@@ -153,10 +177,18 @@ async def submit_prompt_response(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> PromptDetail:
-    """Submit a response to a weekly prompt. Prevents duplicate responses."""
+    """Submit a response to a weekly prompt. Prevents duplicate responses.
+
+    BUG-PROMPT-001: refuses ``week_number > user_week`` so a single POST
+    cannot leapfrog the weekly pacing by driving ``max(week_number)`` up
+    in one request.  Paired with the ``count + 1``-based ``_get_user_week``
+    this makes the server-derived week a monotone function of *contiguous*
+    completion, not the highest value the client has ever submitted.
+    """
     question = get_prompt_for_week(week_number)
     if question is None:
         raise not_found("prompt")
+    await _check_week_unlocked(session, current_user, week_number)
 
     # Prevent duplicate responses
     result = await session.execute(

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -18,6 +18,7 @@ from domain.stage_progress import (
     get_user_progress,
     get_user_progress_for_update,
     is_stage_unlocked,
+    next_stage_for,
     stage_exists,
 )
 from errors import bad_request, forbidden, not_found
@@ -176,57 +177,74 @@ async def update_progress(
 ) -> StageProgressRecord:
     """Advance the user to the next stage.
 
-    Semantics:
-    - **Create** (first ever progress): ``current_stage`` must be 1.
-    - **Update**: ``current_stage`` must equal ``existing.current_stage + 1``
-      (single-step forward only — no stage-skipping).
-    - ``completed_stages`` is always ``range(1, current_stage)`` — i.e. every
-      stage before the current one is marked complete.
+    BUG-SCHEMA-006: the request body is treated as an **assertion** of what
+    the client expects the new ``current_stage`` to be, not an authoritative
+    write.  The new state is derived server-side:
+
+    - **Create** (no prior row): ``current_stage`` is forced to 1; the
+      payload must assert 1 or it's rejected as ``must_start_at_stage_one``.
+    - **Update**: the server marks ``existing.current_stage`` complete, then
+      recomputes the new ``current_stage`` via :func:`next_stage_for` over
+      the updated completion set.  The payload's ``current_stage`` must
+      equal that derived value — otherwise the request is a skip/rewind/
+      stale-client scenario and returns ``stage_advance_mismatch``.
+
+    The ``completed_stages`` list is never read from the payload (the schema's
+    ``extra='forbid'`` would 422 such a field anyway), so the client cannot
+    mint credit for stages it hasn't actually completed.
 
     A ``SELECT … FOR UPDATE`` row-lock prevents two concurrent advance
     requests from both reading the same ``current_stage`` and passing the
-    forward-only check (TOCTOU race).
+    derivation check (TOCTOU race).
     """
     # Row lock prevents concurrent advances from both reading the same state
     existing = await get_user_progress_for_update(session, current_user)
 
-    if existing is not None:
-        expected_next = existing.current_stage + 1
-        if payload.current_stage != expected_next:
-            raise bad_request("must_advance_one_stage")
-        completed = list(range(1, payload.current_stage))
-        existing.current_stage = payload.current_stage
-        existing.completed_stages = completed
-        existing.stage_started_at = datetime.now(UTC)
-        session.add(existing)
+    if existing is None:
+        if payload.current_stage != 1:
+            raise bad_request("must_start_at_stage_one")
+        progress = StageProgress(
+            user_id=current_user,
+            current_stage=1,
+            completed_stages=[],
+        )
+        session.add(progress)
         await session.commit()
-        await session.refresh(existing)
-        logger.info(
-            "stage_advanced",
-            extra={"user_id": current_user, "current_stage": existing.current_stage},
-        )
+        await session.refresh(progress)
+        logger.info("stage_progress_started", extra={"user_id": current_user})
         return StageProgressRecord(
-            id=existing.id,
-            user_id=existing.user_id,
-            current_stage=existing.current_stage,
-            completed_stages=existing.completed_stages,
+            id=progress.id,
+            user_id=progress.user_id,
+            current_stage=progress.current_stage,
+            completed_stages=progress.completed_stages,
         )
 
-    if payload.current_stage != 1:
-        raise bad_request("must_start_at_stage_one")
-
-    progress = StageProgress(
-        user_id=current_user,
-        current_stage=1,
-        completed_stages=[],
+    # Simulate marking existing.current_stage complete on a detached copy so
+    # we can derive the expected next stage without mutating the tracked ORM
+    # row until the assertion passes.
+    candidate_completed = sorted(set(existing.completed_stages or []) | {existing.current_stage})
+    candidate = StageProgress(
+        user_id=existing.user_id,
+        current_stage=existing.current_stage,
+        completed_stages=candidate_completed,
     )
-    session.add(progress)
+    derived_next = next_stage_for(candidate)
+    if payload.current_stage != derived_next:
+        raise bad_request("stage_advance_mismatch")
+
+    existing.completed_stages = candidate_completed
+    existing.current_stage = derived_next
+    existing.stage_started_at = datetime.now(UTC)
+    session.add(existing)
     await session.commit()
-    await session.refresh(progress)
-    logger.info("stage_progress_started", extra={"user_id": current_user})
+    await session.refresh(existing)
+    logger.info(
+        "stage_advanced",
+        extra={"user_id": current_user, "current_stage": existing.current_stage},
+    )
     return StageProgressRecord(
-        id=progress.id,
-        user_id=progress.user_id,
-        current_stage=progress.current_stage,
-        completed_stages=progress.completed_stages,
+        id=existing.id,
+        user_id=existing.user_id,
+        current_stage=existing.current_stage,
+        completed_stages=existing.completed_stages,
     )

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -12,6 +12,7 @@ from sqlmodel import col, select
 
 from database import get_session
 from domain.stage_progress import (
+    AllStagesCompletedError,
     compute_stage_progress,
     get_stage_habit_history,
     get_stage_practice_history,
@@ -21,7 +22,7 @@ from domain.stage_progress import (
     next_stage_for,
     stage_exists,
 )
-from errors import bad_request, forbidden, not_found
+from errors import bad_request, conflict, forbidden, not_found
 from models.course_stage import CourseStage
 from models.stage_progress import StageProgress
 from routers.auth import get_current_user
@@ -228,7 +229,10 @@ async def update_progress(
         current_stage=existing.current_stage,
         completed_stages=candidate_completed,
     )
-    derived_next = next_stage_for(candidate)
+    try:
+        derived_next = next_stage_for(candidate)
+    except AllStagesCompletedError as exc:
+        raise conflict("all_stages_completed") from exc
     if payload.current_stage != derived_next:
         raise bad_request("stage_advance_mismatch")
 

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -177,9 +177,9 @@ async def update_progress(
 ) -> StageProgressRecord:
     """Advance the user to the next stage.
 
-    BUG-SCHEMA-006: the request body is treated as an **assertion** of what
-    the client expects the new ``current_stage`` to be, not an authoritative
-    write.  The new state is derived server-side:
+    The request body is treated as an **assertion** of what the client
+    expects the new ``current_stage`` to be, not an authoritative write.
+    The new state is derived server-side:
 
     - **Create** (no prior row): ``current_stage`` is forced to 1; the
       payload must assert 1 or it's rejected as ``must_start_at_stage_one``.

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -170,6 +170,74 @@ async def get_stage_history(
     )
 
 
+async def _create_initial_progress(
+    session: AsyncSession,
+    user_id: int,
+    payload: StageProgressUpdate,
+) -> StageProgressRecord:
+    """Handle the no-prior-row case: must assert stage 1, then create."""
+    if payload.current_stage != 1:
+        raise bad_request("must_start_at_stage_one")
+    progress = StageProgress(user_id=user_id, current_stage=1, completed_stages=[])
+    session.add(progress)
+    await session.commit()
+    await session.refresh(progress)
+    logger.info("stage_progress_started", extra={"user_id": user_id})
+    return StageProgressRecord(
+        id=progress.id,
+        user_id=progress.user_id,
+        current_stage=progress.current_stage,
+        completed_stages=progress.completed_stages,
+    )
+
+
+def _derive_next_stage(existing: StageProgress) -> tuple[int, list[int]]:
+    """Derive the server-expected next stage from ``existing``'s completion set.
+
+    Simulates marking ``existing.current_stage`` complete on a detached copy so
+    we can run :func:`next_stage_for` without mutating the tracked ORM row.
+    """
+    candidate_completed = sorted(set(existing.completed_stages or []) | {existing.current_stage})
+    candidate = StageProgress(
+        user_id=existing.user_id,
+        current_stage=existing.current_stage,
+        completed_stages=candidate_completed,
+    )
+    try:
+        derived_next = next_stage_for(candidate)
+    except AllStagesCompletedError as exc:
+        raise conflict("all_stages_completed") from exc
+    return derived_next, candidate_completed
+
+
+async def _advance_existing_progress(
+    session: AsyncSession,
+    existing: StageProgress,
+    payload: StageProgressUpdate,
+) -> StageProgressRecord:
+    """Validate the payload against the server-derived next stage, then commit."""
+    derived_next, candidate_completed = _derive_next_stage(existing)
+    if payload.current_stage != derived_next:
+        raise bad_request("stage_advance_mismatch")
+
+    existing.completed_stages = candidate_completed
+    existing.current_stage = derived_next
+    existing.stage_started_at = datetime.now(UTC)
+    session.add(existing)
+    await session.commit()
+    await session.refresh(existing)
+    logger.info(
+        "stage_advanced",
+        extra={"user_id": existing.user_id, "current_stage": existing.current_stage},
+    )
+    return StageProgressRecord(
+        id=existing.id,
+        user_id=existing.user_id,
+        current_stage=existing.current_stage,
+        completed_stages=existing.completed_stages,
+    )
+
+
 @router.put("/progress", response_model=StageProgressRecord)
 async def update_progress(
     payload: StageProgressUpdate,
@@ -198,57 +266,7 @@ async def update_progress(
     requests from both reading the same ``current_stage`` and passing the
     derivation check (TOCTOU race).
     """
-    # Row lock prevents concurrent advances from both reading the same state
     existing = await get_user_progress_for_update(session, current_user)
-
     if existing is None:
-        if payload.current_stage != 1:
-            raise bad_request("must_start_at_stage_one")
-        progress = StageProgress(
-            user_id=current_user,
-            current_stage=1,
-            completed_stages=[],
-        )
-        session.add(progress)
-        await session.commit()
-        await session.refresh(progress)
-        logger.info("stage_progress_started", extra={"user_id": current_user})
-        return StageProgressRecord(
-            id=progress.id,
-            user_id=progress.user_id,
-            current_stage=progress.current_stage,
-            completed_stages=progress.completed_stages,
-        )
-
-    # Simulate marking existing.current_stage complete on a detached copy so
-    # we can derive the expected next stage without mutating the tracked ORM
-    # row until the assertion passes.
-    candidate_completed = sorted(set(existing.completed_stages or []) | {existing.current_stage})
-    candidate = StageProgress(
-        user_id=existing.user_id,
-        current_stage=existing.current_stage,
-        completed_stages=candidate_completed,
-    )
-    try:
-        derived_next = next_stage_for(candidate)
-    except AllStagesCompletedError as exc:
-        raise conflict("all_stages_completed") from exc
-    if payload.current_stage != derived_next:
-        raise bad_request("stage_advance_mismatch")
-
-    existing.completed_stages = candidate_completed
-    existing.current_stage = derived_next
-    existing.stage_started_at = datetime.now(UTC)
-    session.add(existing)
-    await session.commit()
-    await session.refresh(existing)
-    logger.info(
-        "stage_advanced",
-        extra={"user_id": current_user, "current_stage": existing.current_stage},
-    )
-    return StageProgressRecord(
-        id=existing.id,
-        user_id=existing.user_id,
-        current_stage=existing.current_stage,
-        completed_stages=existing.completed_stages,
-    )
+        return await _create_initial_progress(session, current_user, payload)
+    return await _advance_existing_progress(session, existing, payload)

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -30,6 +30,51 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/user-practices", tags=["user-practices"])
 
 
+async def _resolve_practice(session: AsyncSession, practice_id: int) -> Practice:
+    """Fetch and validate the catalog practice (exists + approved)."""
+    result = await session.execute(select(Practice).where(Practice.id == practice_id))
+    practice = result.scalars().first()
+    if practice is None:
+        raise not_found("practice")
+    if not practice.approved:
+        raise bad_request("practice_not_approved")
+    return practice
+
+
+async def _check_stage_eligibility(
+    session: AsyncSession,
+    current_user: int,
+    practice: Practice,
+    payload_stage_number: int,
+) -> None:
+    """BUG-PRACTICE-004: gate on catalog-stage agreement + chain-unlock.
+
+    Kept separate from :func:`_resolve_practice` so the 400/403 split stays
+    explicit: mismatched stage is a client-side input error, locked stage is
+    an authorization failure against server-owned progression.
+    """
+    if practice.stage_number != payload_stage_number:
+        raise bad_request("stage_number_mismatch")
+    progress = await get_user_progress(session, current_user)
+    if not is_stage_unlocked(payload_stage_number, progress):
+        raise forbidden("stage_locked")
+
+
+async def _check_no_active_practice(
+    session: AsyncSession, current_user: int, stage_number: int
+) -> None:
+    """BUG-PRACTICE-011: at most one open UserPractice row per (user, stage)."""
+    existing = await session.execute(
+        select(UserPractice.id).where(
+            UserPractice.user_id == current_user,
+            UserPractice.stage_number == stage_number,
+            UserPractice.end_date.is_(None),  # type: ignore[union-attr]
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise bad_request("active_practice_exists_for_stage")
+
+
 @router.post("/", response_model=UserPracticeResponse, status_code=status.HTTP_201_CREATED)
 async def create_user_practice(
     payload: UserPracticeCreate,
@@ -37,38 +82,9 @@ async def create_user_practice(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> UserPractice:
     """Select a practice for a stage, creating a UserPractice record."""
-    # Verify practice exists and is approved
-    result = await session.execute(select(Practice).where(Practice.id == payload.practice_id))
-    practice = result.scalars().first()
-    if practice is None:
-        raise not_found("practice")
-    if not practice.approved:
-        raise bad_request("practice_not_approved")
-
-    # BUG-PRACTICE-004: the practice's catalog stage and the payload's stage
-    # must agree — otherwise the client can claim any practice against any
-    # stage (e.g. a stage-36 practice enrolled under stage-1).
-    if practice.stage_number != payload.stage_number:
-        raise bad_request("stage_number_mismatch")
-
-    # BUG-PRACTICE-004 (progression gate): a client cannot enrol in a
-    # practice for a stage they have not unlocked.  Uses the same chain-
-    # validated predicate as the course/history endpoints so the three
-    # surfaces share a single unlock truth.
-    progress = await get_user_progress(session, current_user)
-    if not is_stage_unlocked(payload.stage_number, progress):
-        raise forbidden("stage_locked")
-
-    # BUG-PRACTICE-011: prevent multiple active practices for the same stage
-    existing = await session.execute(
-        select(UserPractice.id).where(
-            UserPractice.user_id == current_user,
-            UserPractice.stage_number == payload.stage_number,
-            UserPractice.end_date.is_(None),  # type: ignore[union-attr]
-        )
-    )
-    if existing.scalar_one_or_none() is not None:
-        raise bad_request("active_practice_exists_for_stage")
+    practice = await _resolve_practice(session, payload.practice_id)
+    await _check_stage_eligibility(session, current_user, practice, payload.stage_number)
+    await _check_no_active_practice(session, current_user, payload.stage_number)
 
     user_practice = UserPractice(
         user_id=current_user,

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from domain.stage_progress import get_user_progress, is_stage_unlocked
 from errors import bad_request, forbidden, not_found
 from models.practice import Practice
 from models.practice_session import PracticeSession
@@ -43,6 +44,20 @@ async def create_user_practice(
         raise not_found("practice")
     if not practice.approved:
         raise bad_request("practice_not_approved")
+
+    # BUG-PRACTICE-004: the practice's catalog stage and the payload's stage
+    # must agree — otherwise the client can claim any practice against any
+    # stage (e.g. a stage-36 practice enrolled under stage-1).
+    if practice.stage_number != payload.stage_number:
+        raise bad_request("stage_number_mismatch")
+
+    # BUG-PRACTICE-004 (progression gate): a client cannot enrol in a
+    # practice for a stage they have not unlocked.  Uses the same chain-
+    # validated predicate as the course/history endpoints so the three
+    # surfaces share a single unlock truth.
+    progress = await get_user_progress(session, current_user)
+    if not is_stage_unlocked(payload.stage_number, progress):
+        raise forbidden("stage_locked")
 
     # BUG-PRACTICE-011: prevent multiple active practices for the same stage
     existing = await session.execute(

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -47,7 +47,7 @@ async def _check_stage_eligibility(
     practice: Practice,
     payload_stage_number: int,
 ) -> None:
-    """BUG-PRACTICE-004: gate on catalog-stage agreement + chain-unlock.
+    """Gate on catalog-stage agreement + chain-unlock.
 
     Kept separate from :func:`_resolve_practice` so the 400/403 split stays
     explicit: mismatched stage is a client-side input error, locked stage is
@@ -63,7 +63,7 @@ async def _check_stage_eligibility(
 async def _check_no_active_practice(
     session: AsyncSession, current_user: int, stage_number: int
 ) -> None:
-    """BUG-PRACTICE-011: at most one open UserPractice row per (user, stage)."""
+    """Enforce at most one open UserPractice row per (user, stage)."""
     existing = await session.execute(
         select(UserPractice.id).where(
             UserPractice.user_id == current_user,

--- a/backend/src/schemas/admin.py
+++ b/backend/src/schemas/admin.py
@@ -38,3 +38,26 @@ class UsageStatsResponse(BaseModel):
     total_estimated_cost_usd: float
     per_user: list[UserUsageBreakdown]
     per_model: list[ModelUsageBreakdown]
+
+
+class StageProgressGap(BaseModel):
+    """A ``stageprogress`` row whose completed set is non-contiguous from 1.
+
+    ``missing_stages`` and ``extra_stages`` are the symmetric-difference halves
+    so an operator can tell at a glance whether a row is under-credited (gaps
+    in the middle) or over-credited (a completed_stages value past the current
+    stage).
+    """
+
+    user_id: int
+    current_stage: int
+    completed_stages: list[int]
+    missing_stages: list[int]
+    extra_stages: list[int]
+
+
+class StageProgressGapsResponse(BaseModel):
+    """Report of every ``stageprogress`` row with a non-contiguous set."""
+
+    rows: list[StageProgressGap]
+    total: int

--- a/backend/src/schemas/admin.py
+++ b/backend/src/schemas/admin.py
@@ -61,3 +61,21 @@ class StageProgressGapsResponse(BaseModel):
 
     rows: list[StageProgressGap]
     total: int
+
+
+class StageProgressRepairResult(BaseModel):
+    """Outcome of a single repair of a ``stageprogress`` row.
+
+    ``completed_stages`` holds the canonical post-repair set.  The delta
+    fields describe what the repair *did* — ``stages_added`` are values
+    the invariant required but were missing, ``stages_removed`` are
+    over-credited values the invariant forbade.  Separating this shape
+    from :class:`StageProgressGap` keeps the pre-repair and post-repair
+    semantics distinct for clients that render both.
+    """
+
+    user_id: int
+    current_stage: int
+    completed_stages: list[int]
+    stages_added: list[int]
+    stages_removed: list[int]

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -6,12 +6,13 @@ from datetime import UTC, date, datetime
 
 from pydantic import BaseModel, Field, field_validator
 
+from domain.constants import TOTAL_STAGES as MAX_STAGE_NUMBER
+
 PRACTICE_NAME_MAX_LENGTH = 255
 PRACTICE_DESCRIPTION_MAX_LENGTH = 2_000
 PRACTICE_INSTRUCTIONS_MAX_LENGTH = 10_000
 PRACTICE_REFLECTION_MAX_LENGTH = 5_000
 
-MAX_STAGE_NUMBER = 36
 MAX_DURATION_MINUTES = 24 * 60
 
 # -- Practice ---------------------------------------------------------------

--- a/backend/src/schemas/stage.py
+++ b/backend/src/schemas/stage.py
@@ -6,11 +6,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
-# Declared length of the APTITUDE curriculum.  Duplicated by
-# ``domain.stage_progress.TOTAL_STAGES`` and ``schemas.practice.MAX_STAGE_NUMBER``
-# — keep all three in sync.  Pydantic needs a schema-local constant so the
-# field constraint below is independent of the domain import graph.
-MAX_STAGE_NUMBER = 36
+from domain.constants import TOTAL_STAGES as MAX_STAGE_NUMBER
 
 
 class StageResponse(BaseModel):
@@ -44,8 +40,8 @@ class StageProgressResponse(BaseModel):
 class StageProgressUpdate(BaseModel):
     """Payload asserting the client's expected ``current_stage`` after advance.
 
-    BUG-SCHEMA-006: the router ignores this value as a write; it is only used
-    as a server-vs-client sanity assertion.  ``extra='forbid'`` blocks the
+    The router ignores this value as a write; it is only used as a
+    server-vs-client sanity assertion.  ``extra='forbid'`` blocks the
     adjacent injection vector where a client attempts to set
     ``completed_stages`` directly in the same PUT body, which the server
     derives from its own state.

--- a/backend/src/schemas/stage.py
+++ b/backend/src/schemas/stage.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
+
+# Declared length of the APTITUDE curriculum.  Duplicated by
+# ``domain.stage_progress.TOTAL_STAGES`` and ``schemas.practice.MAX_STAGE_NUMBER``
+# — keep all three in sync.  Pydantic needs a schema-local constant so the
+# field constraint below is independent of the domain import graph.
+MAX_STAGE_NUMBER = 36
 
 
 class StageResponse(BaseModel):
@@ -36,9 +42,18 @@ class StageProgressResponse(BaseModel):
 
 
 class StageProgressUpdate(BaseModel):
-    """Payload for updating current stage."""
+    """Payload asserting the client's expected ``current_stage`` after advance.
 
-    current_stage: int
+    BUG-SCHEMA-006: the router ignores this value as a write; it is only used
+    as a server-vs-client sanity assertion.  ``extra='forbid'`` blocks the
+    adjacent injection vector where a client attempts to set
+    ``completed_stages`` directly in the same PUT body, which the server
+    derives from its own state.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    current_stage: int = Field(ge=1, le=MAX_STAGE_NUMBER)
 
 
 class StageProgressRecord(BaseModel):

--- a/backend/tests/domain/test_next_stage_for.py
+++ b/backend/tests/domain/test_next_stage_for.py
@@ -1,4 +1,4 @@
-"""Tests for ``next_stage_for`` (BUG-STAGE-001 helper).
+"""Tests for ``next_stage_for``.
 
 ``next_stage_for`` returns the first *hole* in ``completed_stages`` — i.e.
 ``min({1..TOTAL_STAGES} - completed_stages)`` — not ``max(completed) + 1``.
@@ -9,9 +9,12 @@ The distinction matters for legacy rows with gaps (e.g. ``[1, 3]`` where
 from __future__ import annotations
 
 import pytest
-from fastapi import HTTPException, status
 
-from domain.stage_progress import TOTAL_STAGES, next_stage_for
+from domain.stage_progress import (
+    TOTAL_STAGES,
+    AllStagesCompletedError,
+    next_stage_for,
+)
 from models.stage_progress import StageProgress
 
 
@@ -50,13 +53,16 @@ def test_mid_chain_gap_returns_earliest_hole() -> None:
     assert next_stage_for(_progress([1, 2, 4, 5])) == 3
 
 
-def test_all_stages_completed_raises_409() -> None:
-    """Every stage completed → HTTP 409 ``all_stages_completed``."""
+def test_all_stages_completed_raises_domain_error() -> None:
+    """Every stage completed → :class:`AllStagesCompletedError` (not HTTP).
+
+    Router code is responsible for translating this to a 409; keeping the
+    domain exception plain lets non-HTTP callers use ``next_stage_for``
+    without importing FastAPI.
+    """
     everything = list(range(1, TOTAL_STAGES + 1))
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(AllStagesCompletedError):
         next_stage_for(_progress(everything))
-    assert exc_info.value.status_code == status.HTTP_409_CONFLICT
-    assert exc_info.value.detail == "all_stages_completed"
 
 
 def test_last_stage_missing_returns_total_stages() -> None:

--- a/backend/tests/domain/test_next_stage_for.py
+++ b/backend/tests/domain/test_next_stage_for.py
@@ -1,0 +1,65 @@
+"""Tests for ``next_stage_for`` (BUG-STAGE-001 helper).
+
+``next_stage_for`` returns the first *hole* in ``completed_stages`` — i.e.
+``min({1..TOTAL_STAGES} - completed_stages)`` — not ``max(completed) + 1``.
+The distinction matters for legacy rows with gaps (e.g. ``[1, 3]`` where
+``max+1`` would incorrectly advance past stage 2).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException, status
+
+from domain.stage_progress import TOTAL_STAGES, next_stage_for
+from models.stage_progress import StageProgress
+
+
+def _progress(completed: list[int]) -> StageProgress:
+    """Build a StageProgress with the given completed_stages."""
+    return StageProgress(id=1, user_id=1, current_stage=1, completed_stages=completed)
+
+
+def test_no_progress_returns_stage_1() -> None:
+    """Fresh users (no progress row) start at stage 1."""
+    assert next_stage_for(None) == 1
+
+
+def test_empty_completed_returns_stage_1() -> None:
+    """Progress row with empty completed_stages also starts at stage 1."""
+    assert next_stage_for(_progress([])) == 1
+
+
+def test_sequential_completions_return_next() -> None:
+    """``[1, 2, 3]`` → 4 (the first unfinished stage)."""
+    assert next_stage_for(_progress([1, 2, 3])) == 4
+
+
+def test_gap_returns_min_missing_not_max_plus_one() -> None:
+    """``[1, 3]`` → 2, not 4 — legacy-gap robustness (BUG-STAGE-001)."""
+    assert next_stage_for(_progress([1, 3])) == 2
+
+
+def test_single_completion_returns_next() -> None:
+    """``[1]`` → 2."""
+    assert next_stage_for(_progress([1])) == 2
+
+
+def test_mid_chain_gap_returns_earliest_hole() -> None:
+    """``[1, 2, 4, 5]`` → 3, the earliest hole."""
+    assert next_stage_for(_progress([1, 2, 4, 5])) == 3
+
+
+def test_all_stages_completed_raises_409() -> None:
+    """Every stage completed → HTTP 409 ``all_stages_completed``."""
+    everything = list(range(1, TOTAL_STAGES + 1))
+    with pytest.raises(HTTPException) as exc_info:
+        next_stage_for(_progress(everything))
+    assert exc_info.value.status_code == status.HTTP_409_CONFLICT
+    assert exc_info.value.detail == "all_stages_completed"
+
+
+def test_last_stage_missing_returns_total_stages() -> None:
+    """Only the final stage missing → returns ``TOTAL_STAGES``."""
+    all_but_last = list(range(1, TOTAL_STAGES))
+    assert next_stage_for(_progress(all_but_last)) == TOTAL_STAGES

--- a/backend/tests/domain/test_stage_unlock.py
+++ b/backend/tests/domain/test_stage_unlock.py
@@ -32,6 +32,18 @@ _CASES: list[tuple[str, int, StageProgress | None, bool]] = [
     # Edge: current_stage jumped ahead (DB mutation) without completing predecessors
     ("stage 5 locked despite current=5 if 4 not completed", 5, _progress(5, [1, 2, 3]), False),
     ("stage 5 unlocked when current=5 and 4 completed", 5, _progress(5, [1, 2, 3, 4]), True),
+    # BUG-STAGE-001: chain-validation — the immediate predecessor alone is not
+    # enough.  ``completed_stages=[4]`` used to unlock stage 5 under the old
+    # single-step check; the chain check requires every stage in {1..4}.
+    ("BUG-STAGE-001 stage 5 locked when only 4 completed", 5, _progress(5, [4]), False),
+    ("BUG-STAGE-001 stage 5 locked with mid-chain gap", 5, _progress(5, [1, 2, 4]), False),
+    ("BUG-STAGE-001 stage 36 locked when only 35 completed", 36, _progress(36, [35]), False),
+    (
+        "BUG-STAGE-001 stage 5 unlocked only when {1,2,3,4} all completed",
+        5,
+        _progress(5, [1, 2, 3, 4]),
+        True,
+    ),
 ]
 
 

--- a/backend/tests/test_admin_stage_progress.py
+++ b/backend/tests/test_admin_stage_progress.py
@@ -20,7 +20,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col
+from sqlmodel import col, select
 
 from models.stage_progress import StageProgress
 from models.user import User
@@ -176,12 +176,11 @@ async def test_repair_rewrites_completed_stages_to_canonical_set(
     assert resp.status_code == HTTPStatus.OK
     body = resp.json()
     assert body["completed_stages"] == [1, 2, 3]
-    assert body["missing_stages"] == [2]  # now present after repair
-    assert body["extra_stages"] == []
+    assert body["stages_added"] == [2]
+    assert body["stages_removed"] == []
 
     # Verify the row was actually written.
     await db_session.commit()  # release any snapshot
-    await db_session.refresh(await _refetch(db_session, user_id))
     row = await _refetch(db_session, user_id)
     assert sorted(row.completed_stages) == [1, 2, 3]
 
@@ -198,8 +197,6 @@ async def test_repair_returns_404_for_unknown_user(
 
 async def _refetch(session: AsyncSession, user_id: int) -> StageProgress:
     """Load the user's :class:`StageProgress` row fresh from the DB."""
-    from sqlmodel import select  # noqa: PLC0415 — narrow local import keeps helpers tight.
-
     result = await session.execute(select(StageProgress).where(StageProgress.user_id == user_id))
     row = result.scalars().first()
     assert row is not None

--- a/backend/tests/test_admin_stage_progress.py
+++ b/backend/tests/test_admin_stage_progress.py
@@ -1,0 +1,206 @@
+"""Tests for the admin ``/stage-progress`` inspect + repair endpoints.
+
+Covers:
+
+- the auth gate (anonymous / non-admin / admin) to prove the helper inherits
+  the same per-user admin boundary as the rest of the admin surface;
+- the listing endpoint's gap detector (empty, contiguous, missing-middle,
+  over-credited, and both-at-once);
+- the explicit repair endpoint rewriting ``completed_stages`` to the canonical
+  ``{1..current_stage-1}`` set;
+- the repair endpoint's 404 on unknown users so the caller cannot blindly
+  loop over every integer id hoping to create a row.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from models.stage_progress import StageProgress
+from models.user import User
+
+
+async def _signup(
+    client: AsyncClient, email: str = "user@example.com", password: str = "secret12345"
+) -> tuple[int, dict[str, str]]:
+    """Create a user and return ``(user_id, auth headers)``."""
+    resp = await client.post("/auth/signup", json={"email": email, "password": password})
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    return int(body["user_id"]), {"Authorization": f"Bearer {body['token']}"}
+
+
+async def _promote(db_session: AsyncSession, email: str) -> None:
+    """Flip ``is_admin`` for a user by email."""
+    await db_session.execute(update(User).where(col(User.email) == email).values(is_admin=True))
+    await db_session.commit()
+
+
+async def _signup_admin(
+    client: AsyncClient, db_session: AsyncSession, email: str = "admin@example.com"
+) -> tuple[int, dict[str, str]]:
+    """Sign up + promote a user; return ``(user_id, auth headers)``."""
+    user_id, headers = await _signup(client, email=email)
+    await _promote(db_session, email)
+    return user_id, headers
+
+
+async def _seed_progress(
+    db_session: AsyncSession,
+    *,
+    user_id: int,
+    current_stage: int,
+    completed_stages: list[int],
+) -> None:
+    """Insert a :class:`StageProgress` row with a specific completed set."""
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=current_stage,
+            completed_stages=completed_stages,
+        )
+    )
+    await db_session.commit()
+
+
+# ── Auth gate ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gaps_rejects_anonymous(async_client: AsyncClient) -> None:
+    resp = await async_client.get("/admin/stage-progress/gaps")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_gaps_rejects_non_admin(async_client: AsyncClient) -> None:
+    _uid, headers = await _signup(async_client, email="plain@example.com")
+    resp = await async_client.get("/admin/stage-progress/gaps", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "admin_required"
+
+
+@pytest.mark.asyncio
+async def test_repair_rejects_non_admin(async_client: AsyncClient) -> None:
+    target_id, _ = await _signup(async_client, email="victim@example.com")
+    _uid, headers = await _signup(async_client, email="plain@example.com")
+    resp = await async_client.post(f"/admin/stage-progress/{target_id}/repair", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "admin_required"
+
+
+# ── Listing ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gaps_empty_when_no_progress_rows(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.get("/admin/stage-progress/gaps", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body == {"rows": [], "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_gaps_ignores_contiguous_rows(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``completed_stages == {1..current_stage-1}`` must not be flagged."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    user_id, _ = await _signup(async_client, email="good@example.com")
+    await _seed_progress(db_session, user_id=user_id, current_stage=3, completed_stages=[1, 2])
+
+    resp = await async_client.get("/admin/stage-progress/gaps", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json() == {"rows": [], "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_gaps_flags_missing_middle(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Stage-2 missing from ``[1, 3]`` at ``current_stage=4`` must be flagged."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    user_id, _ = await _signup(async_client, email="gappy@example.com")
+    await _seed_progress(db_session, user_id=user_id, current_stage=4, completed_stages=[1, 3])
+
+    resp = await async_client.get("/admin/stage-progress/gaps", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["rows"][0] == {
+        "user_id": user_id,
+        "current_stage": 4,
+        "completed_stages": [1, 3],
+        "missing_stages": [2],
+        "extra_stages": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_gaps_flags_over_credited_future_stages(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``completed_stages=[1, 2, 5]`` at ``current_stage=3`` has 5 as an 'extra'."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    user_id, _ = await _signup(async_client, email="over@example.com")
+    await _seed_progress(db_session, user_id=user_id, current_stage=3, completed_stages=[1, 2, 5])
+
+    resp = await async_client.get("/admin/stage-progress/gaps", headers=headers)
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["rows"][0]["missing_stages"] == []
+    assert body["rows"][0]["extra_stages"] == [5]
+
+
+# ── Repair ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_repair_rewrites_completed_stages_to_canonical_set(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    user_id, _ = await _signup(async_client, email="fix@example.com")
+    await _seed_progress(db_session, user_id=user_id, current_stage=4, completed_stages=[1, 3])
+
+    resp = await async_client.post(f"/admin/stage-progress/{user_id}/repair", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["completed_stages"] == [1, 2, 3]
+    assert body["missing_stages"] == [2]  # now present after repair
+    assert body["extra_stages"] == []
+
+    # Verify the row was actually written.
+    await db_session.commit()  # release any snapshot
+    await db_session.refresh(await _refetch(db_session, user_id))
+    row = await _refetch(db_session, user_id)
+    assert sorted(row.completed_stages) == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_repair_returns_404_for_unknown_user(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.post("/admin/stage-progress/99999/repair", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "stage_progress_not_found"
+
+
+async def _refetch(session: AsyncSession, user_id: int) -> StageProgress:
+    """Load the user's :class:`StageProgress` row fresh from the DB."""
+    from sqlmodel import select  # noqa: PLC0415 — narrow local import keeps helpers tight.
+
+    result = await session.execute(select(StageProgress).where(StageProgress.user_id == user_id))
+    row = result.scalars().first()
+    assert row is not None
+    return row

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -154,6 +154,27 @@ async def test_list_content_stage_not_found(
 
 
 @pytest.mark.asyncio
+async def test_list_content_rejects_locked_stage(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-COURSE-001: listing content for a locked stage must 403.
+
+    The sibling single-item endpoints gate on ``_check_stage_unlocked``;
+    until this fix ``list_stage_content`` leaked every item's title and
+    release_day (only the URL was nulled) so a never-enrolled user could
+    enumerate the full 36-stage drip schedule.
+    """
+    headers, _ = await _signup(async_client, "locked")
+    # Seed content for stage 2 without giving the user any progress.
+    await _seed_stage_with_content(db_session, stage_number=2)
+
+    resp = await async_client.get("/course/stages/2/content", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "stage_locked"
+
+
+@pytest.mark.asyncio
 async def test_list_content_no_progress_record(
     async_client: AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -87,7 +87,16 @@ async def test_get_current_prompt_advances_after_submit(
 
 @pytest.mark.asyncio
 async def test_get_prompt_by_week(async_client: AsyncClient) -> None:
+    """A user who has reached week 5 can fetch it (BUG-PROMPT-002 allow case)."""
     headers = await _signup(async_client)
+    # Advance to week 5 by responding to weeks 1..4.
+    for week in range(1, 5):
+        resp_w = await async_client.post(
+            f"/prompts/{week}/respond",
+            json={"response": f"Week {week} answer"},
+            headers=headers,
+        )
+        assert resp_w.status_code == HTTPStatus.CREATED
     resp = await async_client.get("/prompts/5", headers=headers)
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
@@ -157,6 +166,75 @@ async def test_submit_response_invalid_week_returns_404(async_client: AsyncClien
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+# ── BUG-PROMPT-001 / BUG-PROMPT-002: weekly unlock gate ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_future_week_is_forbidden(async_client: AsyncClient) -> None:
+    """BUG-PROMPT-002: GET /prompts/{week} must 403 for weeks past user_week.
+
+    Without the gate a week-1 user could enumerate /prompts/1..36 and lift
+    every future question.  The curriculum is supposed to unlock one week
+    at a time as responses are submitted.
+    """
+    headers = await _signup(async_client)
+    resp = await async_client.get("/prompts/36", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "week_locked"
+
+
+@pytest.mark.asyncio
+async def test_submit_future_week_is_forbidden(async_client: AsyncClient) -> None:
+    """BUG-PROMPT-001: POST to a future week must 403 before writing.
+
+    Under the old max(week)+1 derivation, one POST to /prompts/36/respond
+    would set the user's current_week to 36 on the next read, voiding the
+    entire 36-week pacing in a single request.
+    """
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/prompts/36/respond",
+        json={"response": "skip-ahead attempt"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "week_locked"
+
+
+@pytest.mark.asyncio
+async def test_current_week_derives_from_response_count_not_max(
+    async_client: AsyncClient,
+) -> None:
+    """BUG-PROMPT-001: user_week is ``count + 1``, never ``max + 1``.
+
+    The skip-ahead POST from ``test_submit_future_week_is_forbidden`` would,
+    under the old derivation, have left this user at week 37→clamped-to-36.
+    With count-based derivation a blocked future submit doesn't count, so
+    the user remains at week 1 — the intended behaviour.
+    """
+    headers = await _signup(async_client)
+    # Submit a response for week 1 successfully.
+    resp1 = await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "Ground."},
+        headers=headers,
+    )
+    assert resp1.status_code == HTTPStatus.CREATED
+
+    # Attempt a future week — must fail and NOT be persisted.
+    resp_skip = await async_client.post(
+        "/prompts/10/respond",
+        json={"response": "sneaky"},
+        headers=headers,
+    )
+    assert resp_skip.status_code == HTTPStatus.FORBIDDEN
+
+    # Current should be week 2 (count=1, next=2), not week 11.
+    resp_current = await async_client.get("/prompts/current", headers=headers)
+    assert resp_current.status_code == HTTPStatus.OK
+    assert resp_current.json()["week_number"] == 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -506,8 +506,10 @@ async def test_advance_returns_409_when_all_stages_completed(
     writes nonsense state.
     """
     headers, user_id = await _signup(async_client, "finished")
-    all_done = list(range(1, 37))
-    progress = StageProgress(user_id=user_id, current_stage=36, completed_stages=all_done)
+    # Canonical "current_stage == N implies completed_stages == {1..N-1}" shape.
+    # The router simulates marking current_stage=36 complete on a candidate,
+    # so candidate_completed becomes {1..36}; next_stage_for has no hole and 409s.
+    progress = StageProgress(user_id=user_id, current_stage=36, completed_stages=list(range(1, 36)))
     db_session.add(progress)
     await db_session.commit()
 

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -511,7 +511,13 @@ async def test_stage_unlocked_requires_predecessor_completed(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """BUG-STAGE-002: stage N <= current but N-1 NOT in completed_stages → locked."""
+    """BUG-STAGE-001/002: every prior stage must be in ``completed_stages``.
+
+    Seeding ``completed_stages=[2]`` with ``current_stage=3`` leaves stage 1
+    uncredited.  Under the chain-validation rule, stage 2 requires ``{1}`` and
+    stage 3 requires ``{1, 2}``; both fail when stage 1 is missing, so only
+    stage 1 (the always-unlocked root) stays open.
+    """
     headers, user_id = await _signup(async_client)
     await _seed_stages(db_session, count=3)
     # current_stage=3 but completed_stages is missing stage 1.
@@ -524,10 +530,10 @@ async def test_stage_unlocked_requires_predecessor_completed(
     data = resp.json()
     # Stage 1: always unlocked
     assert data[0]["is_unlocked"] is True
-    # Stage 2: current_stage=3 > 2, but predecessor (1) NOT in completed → locked
+    # Stage 2: chain requires {1} ⊆ completed; {2} fails → locked
     assert data[1]["is_unlocked"] is False
-    # Stage 3: current_stage=3, predecessor (2) IS in completed → unlocked
-    assert data[2]["is_unlocked"] is True
+    # Stage 3: chain requires {1, 2} ⊆ completed; {2} fails → locked (BUG-STAGE-001)
+    assert data[2]["is_unlocked"] is False
 
 
 # ── User isolation ──────────────────────────────────────────────────────

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -416,6 +416,84 @@ async def test_update_progress_cannot_stay_same(
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
+# ── BUG-SCHEMA-006: server derives stage, rejects client-supplied shortcuts ──
+
+
+@pytest.mark.asyncio
+async def test_update_progress_rejects_out_of_range_low(async_client: AsyncClient) -> None:
+    """BUG-SCHEMA-006: ``current_stage`` below 1 fails Pydantic validation (422)."""
+    headers, _ = await _signup(async_client, "schemalow")
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 0},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_update_progress_rejects_out_of_range_high(async_client: AsyncClient) -> None:
+    """BUG-SCHEMA-006: ``current_stage`` above the curriculum length fails at 422."""
+    headers, _ = await _signup(async_client, "schemahigh")
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 37},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_update_progress_rejects_completed_stages_injection(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-SCHEMA-006: payload may not smuggle ``completed_stages``.
+
+    Without ``extra='forbid'`` a client could PUT ``{"current_stage": 2,
+    "completed_stages": [1,2,3,4,5]}`` and silently pre-credit themselves.
+    The schema now rejects any unknown field at 422 before the handler runs.
+    """
+    headers, user_id = await _signup(async_client, "inject")
+    progress = StageProgress(user_id=user_id, current_stage=1, completed_stages=[])
+    db_session.add(progress)
+    await db_session.commit()
+
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 2, "completed_stages": [1, 2, 3, 4, 5]},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_update_progress_ignores_client_on_dirty_data(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-SCHEMA-006: client cannot skip past a legacy gap.
+
+    A pre-existing row with ``completed_stages=[1, 2, 4]`` and
+    ``current_stage=5`` encodes a missing stage-3 credit.  The server's
+    derived expectation after "completing" stage 5 is the first hole = 3,
+    not 6.  The client asserting 6 gets ``stage_advance_mismatch`` so the
+    gap must be repaired via the admin helper before advancement resumes.
+    """
+    headers, user_id = await _signup(async_client, "dirty")
+    progress = StageProgress(user_id=user_id, current_stage=5, completed_stages=[1, 2, 4])
+    db_session.add(progress)
+    await db_session.commit()
+
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 6},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "stage_advance_mismatch"
+
+
 # ── BUG-STAGE-005: TOCTOU race on PUT /stages/progress ─────────────────
 
 

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -494,6 +494,32 @@ async def test_update_progress_ignores_client_on_dirty_data(
     assert resp.json()["detail"] == "stage_advance_mismatch"
 
 
+@pytest.mark.asyncio
+async def test_advance_returns_409_when_all_stages_completed(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Advancing past the final stage must 409 instead of re-issuing 36.
+
+    When the user already has ``completed_stages`` covering the full
+    curriculum, ``next_stage_for`` has no hole to fill and
+    ``raise conflict('all_stages_completed')`` stops the request before it
+    writes nonsense state.
+    """
+    headers, user_id = await _signup(async_client, "finished")
+    all_done = list(range(1, 37))
+    progress = StageProgress(user_id=user_id, current_stage=36, completed_stages=all_done)
+    db_session.add(progress)
+    await db_session.commit()
+
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 36},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CONFLICT
+    assert resp.json()["detail"] == "all_stages_completed"
+
+
 # ── BUG-STAGE-005: TOCTOU race on PUT /stages/progress ─────────────────
 
 

--- a/backend/tests/test_user_practices_api.py
+++ b/backend/tests/test_user_practices_api.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.practice import Practice
+from models.stage_progress import StageProgress
 
 _EXPECTED_SELECTION_COUNT = 2
 _SESSION_DURATION = 10.0
@@ -114,14 +115,65 @@ async def test_select_nonexistent_practice_rejected(
     assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
+# -- BUG-PRACTICE-004: stage_number / practice stage consistency ------------
+
+
+@pytest.mark.asyncio
+async def test_select_practice_rejects_stage_mismatch(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """BUG-PRACTICE-004: payload.stage_number must equal practice.stage_number.
+
+    Practice is catalogued for stage 2; client tries to enrol under stage 1.
+    The server rejects the mismatch with 400 rather than silently letting a
+    stage-2 practice count as stage-1 progress.
+    """
+    headers, _ = await _signup(async_client, "mismatch")
+    practice = await _seed_practice(db_session, name="Stage2Practice", stage_number=2)
+
+    resp = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 1},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "stage_number_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_select_practice_rejects_locked_stage(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """BUG-PRACTICE-004: user cannot enrol in a practice for a locked stage.
+
+    Fresh user has no progress → stage 2 is locked.  Submitting a stage-2
+    practice (catalog-consistent) must still 403 because the user has not
+    completed stage 1.  Without this gate the chain-unlock invariant could
+    be bypassed via the practice-enrolment surface.
+    """
+    headers, _ = await _signup(async_client, "lockedstage")
+    practice = await _seed_practice(db_session, name="Stage2Practice", stage_number=2)
+
+    resp = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 2},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "stage_locked"
+
+
 # -- List user-practices ----------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_list_user_practices(async_client: AsyncClient, db_session: AsyncSession) -> None:
-    headers, _ = await _signup(async_client)
+    headers, user_id = await _signup(async_client)
     p1 = await _seed_practice(db_session, name="P1", stage_number=1)
     p2 = await _seed_practice(db_session, name="P2", stage_number=2)
+    # Unlock stage 2 so the second enrolment clears the BUG-PRACTICE-004 gate.
+    db_session.add(StageProgress(user_id=user_id, current_stage=2, completed_stages=[1]))
+    await db_session.commit()
 
     await async_client.post(
         "/user-practices/",

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -36,10 +36,10 @@ function useStagesLoader() {
       try {
         const stagesList = await stagesApi.list();
         setAllStages(stagesList);
-        // BUG-FE-COURSE-001/-002: derive current stage from server-owned
-        // progression (completed_count + 1), not from "max unlocked" — the
-        // latter lifts the selector to stage N when only `is_unlocked` is
-        // ahead, visually rewarding any skip-ahead attempt.
+        // Derive current stage from server-owned progression
+        // (completed_count + 1), not from "max unlocked" — the latter lifts
+        // the selector to stage N when only `is_unlocked` is ahead,
+        // visually rewarding any skip-ahead attempt.
         if (routeStageNumber === null) {
           setSelectedStage(deriveCurrentStage(stagesList));
         }

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../api';
 import { STAGE_COLORS, colors } from '../../design/tokens';
 import { useAppNavigation, useAppRoute } from '../../navigation/hooks';
+import { deriveCurrentStage } from '../Map/services/stageService';
 
 import ContentCard from './ContentCard';
 import ContentViewer from './ContentViewer';
@@ -35,13 +36,12 @@ function useStagesLoader() {
       try {
         const stagesList = await stagesApi.list();
         setAllStages(stagesList);
+        // BUG-FE-COURSE-001/-002: derive current stage from server-owned
+        // progression (completed_count + 1), not from "max unlocked" — the
+        // latter lifts the selector to stage N when only `is_unlocked` is
+        // ahead, visually rewarding any skip-ahead attempt.
         if (routeStageNumber === null) {
-          const currentUnlocked = stagesList
-            .filter((s) => s.is_unlocked)
-            .sort((a, b) => b.stage_number - a.stage_number);
-          if (currentUnlocked.length > 0) {
-            setSelectedStage(currentUnlocked[0]!.stage_number);
-          }
+          setSelectedStage(deriveCurrentStage(stagesList));
         }
       } catch (err) {
         console.error('Failed to load stages:', err);

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -22,8 +22,11 @@ const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
   ...overrides,
 });
 
+// Stage 1 is completed → backend-truth mirror derives currentStage = 2.
+// Keeping stage 2 unlocked+in-progress makes the "default selection" test
+// match what a user who just finished stage 1 would see.
 const sampleStages: Stage[] = [
-  makeStage({ id: 1, stage_number: 1, is_unlocked: true, progress: 0.5 }),
+  makeStage({ id: 1, stage_number: 1, is_unlocked: true, progress: 1 }),
   makeStage({
     id: 2,
     stage_number: 2,
@@ -135,11 +138,15 @@ describe('CourseScreen', () => {
     });
   });
 
-  it('selects the highest unlocked stage by default', async () => {
+  it('selects completed_count + 1 as the default stage (backend-truth mirror)', async () => {
+    // BUG-FE-COURSE-001: stage 1 is complete, stage 2 is in progress →
+    // default selection is the first unfinished stage, not the highest
+    // unlocked one.  This mirrors backend `next_stage_for` so a client
+    // cannot skip ahead by exploiting drift between `is_unlocked` and
+    // `progress`.
     const { getByTestId } = render(<CourseScreen />);
 
     await waitFor(() => {
-      // Stage 2 is the highest unlocked stage
       expect(mockStageContent).toHaveBeenCalledWith(2);
       expect(mockStageProgress).toHaveBeenCalledWith(2);
       expect(getByTestId('stage-selector')).toBeTruthy();

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -59,7 +59,11 @@ describe('stageService', () => {
     expect(state.error).toBeNull();
   });
 
-  it('loadStages sets currentStage to first unlocked, in-progress stage', async () => {
+  it('loadStages sets currentStage to completed_count + 1 (backend-truth mirror)', async () => {
+    // BUG-FE-MAP-001: one completed (progress==1) stage → current is 2.
+    // Matches the backend's `next_stage_for` under the chain-validation
+    // invariant; no longer leaks the "highest unlocked" value when
+    // `is_unlocked` runs ahead of actual completion.
     mockList.mockResolvedValueOnce([
       makeApiStage(1, { is_unlocked: true, progress: 1 }), // completed
       makeApiStage(2, { is_unlocked: true, progress: 0.3 }), // in progress
@@ -74,6 +78,27 @@ describe('stageService', () => {
     });
 
     expect(useStageStore.getState().currentStage).toBe(2);
+  });
+
+  it('loadStages ignores is_unlocked drift and derives from completion count', async () => {
+    // BUG-FE-MAP-001 regression: if the backend ever returned `is_unlocked`
+    // for stages beyond the user's completion (e.g. from cached data or a
+    // partially-applied migration) the old heuristic would jump currentStage
+    // to the highest unlocked row.  Now it stays at completed_count + 1.
+    mockList.mockResolvedValueOnce([
+      makeApiStage(1, { is_unlocked: true, progress: 0.4 }),
+      makeApiStage(2, { is_unlocked: true, progress: 0 }),
+      makeApiStage(3, { is_unlocked: true, progress: 0 }),
+    ]);
+
+    const { stageService } = require('../stageService');
+    const { useStageStore } = require('../../../../store/useStageStore');
+
+    await act(async () => {
+      await stageService.loadStages();
+    });
+
+    expect(useStageStore.getState().currentStage).toBe(1);
   });
 
   it('loadStages records an error message on API failure', async () => {

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -38,11 +38,28 @@ export const toStageData = (apiStage: Stage): StageData => {
   };
 };
 
-/** First unlocked, still-in-progress stage; falls back to the last stage or 1. */
-const pickCurrentStage = (apiStages: Stage[]): number =>
-  apiStages.find((s) => s.is_unlocked && s.progress < 1)?.stage_number ??
-  apiStages.at(-1)?.stage_number ??
-  1;
+const FULLY_COMPLETE = 1;
+
+/**
+ * Count-based current-stage derivation.
+ *
+ * Mirrors the backend's `next_stage_for(user)` under the chain-validation
+ * invariant: `current = completed + 1`.  A fresh user with nothing completed
+ * gets stage 1; each completed stage advances `current` by one, clamped to
+ * the catalog range.  This replaces the old "first unlocked, still-in-
+ * progress" heuristic (BUG-FE-MAP-001 / BUG-FE-COURSE-001 / BUG-FE-PRACTICE-
+ * 001) which silently drifted to `max(stage_number)` over unlocked rows when
+ * the backend's `is_unlocked` flag was ahead of completion.
+ */
+export const deriveCurrentStage = (apiStages: Stage[]): number => {
+  if (apiStages.length === 0) return 1;
+  const completed = apiStages.filter((s) => s.progress >= FULLY_COMPLETE).length;
+  const maxStage = apiStages.reduce(
+    (max, s) => (s.stage_number > max ? s.stage_number : max),
+    STAGE_COUNT,
+  );
+  return Math.min(Math.max(1, completed + 1), maxStage);
+};
 
 export const stageService = {
   /**
@@ -59,7 +76,7 @@ export const stageService = {
       // the background artwork.
       const sorted = [...apiStages].sort((a, b) => b.stage_number - a.stage_number);
       useStageStore.getState().setStages(sorted.map(toStageData));
-      useStageStore.getState().setCurrentStage(pickCurrentStage(sorted));
+      useStageStore.getState().setCurrentStage(deriveCurrentStage(apiStages));
       useStageStore.getState().setLoading(false);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load stages';

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -47,18 +47,14 @@ const FULLY_COMPLETE = 1;
  * invariant: `current = completed + 1`.  A fresh user with nothing completed
  * gets stage 1; each completed stage advances `current` by one, clamped to
  * the catalog range.  This replaces the old "first unlocked, still-in-
- * progress" heuristic (BUG-FE-MAP-001 / BUG-FE-COURSE-001 / BUG-FE-PRACTICE-
- * 001) which silently drifted to `max(stage_number)` over unlocked rows when
- * the backend's `is_unlocked` flag was ahead of completion.
+ * progress" heuristic which silently drifted to `max(stage_number)` over
+ * unlocked rows when the backend's `is_unlocked` flag was ahead of
+ * completion.
  */
 export const deriveCurrentStage = (apiStages: Stage[]): number => {
   if (apiStages.length === 0) return 1;
   const completed = apiStages.filter((s) => s.progress >= FULLY_COMPLETE).length;
-  const maxStage = apiStages.reduce(
-    (max, s) => (s.stage_number > max ? s.stage_number : max),
-    STAGE_COUNT,
-  );
-  return Math.min(Math.max(1, completed + 1), maxStage);
+  return Math.min(Math.max(1, completed + 1), STAGE_COUNT);
 };
 
 export const stageService = {

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -24,11 +24,11 @@ import type {
 import { practices, userPractices, practiceSessions } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { colors, SPACING, BORDER_RADIUS, shadows } from '@/design/tokens';
+import { stageService } from '@/features/Map/services/stageService';
 import { useAppNavigation, useAppRoute } from '@/navigation/hooks';
+import { selectCurrentStage, useStageStore } from '@/store/useStageStore';
 
 type ScreenView = 'selection' | 'timer' | 'summary' | 'reflection';
-
-const DEFAULT_STAGE_NUMBER = 1;
 
 // --- Hook: practice list state ---
 
@@ -497,7 +497,19 @@ function PracticeViewRouter({
 
 const PracticeScreen = (): React.JSX.Element => {
   const route = useAppRoute<'Practice'>();
-  const stageNumber = route.params?.stageNumber ?? DEFAULT_STAGE_NUMBER;
+  // BUG-FE-PRACTICE-001/-002: fall back to the backend-derived current stage
+  // rather than a hard-coded 1, so a deep-link with no route param doesn't
+  // enrol a stage-4 user in a stage-1 practice.
+  const storeCurrentStage = useStageStore(selectCurrentStage);
+  const storeStages = useStageStore((s) => s.stages);
+
+  useEffect(() => {
+    if (storeStages.length === 0) {
+      void stageService.loadStages();
+    }
+  }, [storeStages.length]);
+
+  const stageNumber = route.params?.stageNumber ?? storeCurrentStage;
   const loader = usePracticeLoader(stageNumber);
   const session = useSessionFlow(loader.activeUserPractice, loader.incrementWeekCount);
   const pv = usePracticeView(loader, session);

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -497,9 +497,9 @@ function PracticeViewRouter({
 
 const PracticeScreen = (): React.JSX.Element => {
   const route = useAppRoute<'Practice'>();
-  // BUG-FE-PRACTICE-001/-002: fall back to the backend-derived current stage
-  // rather than a hard-coded 1, so a deep-link with no route param doesn't
-  // enrol a stage-4 user in a stage-1 practice.
+  // Fall back to the backend-derived current stage rather than a hard-coded
+  // 1 so a deep-link with no route param doesn't enrol a stage-4 user in
+  // a stage-1 practice.
   const storeCurrentStage = useStageStore(selectCurrentStage);
   const storeStages = useStageStore((s) => s.stages);
 

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -26,7 +26,7 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 |--:|--------|:----:|-------------|:------:|
 | 01 | unblock-auth-nav-flash            | 1 | `claude/bug-fix-01-unblock-auth-nav-flash` / [#245](https://github.com/Geoffe-Ga/adepthood/pull/245) | [x] |
 | 02 | close-credit-minting-chain        | 2 | `claude/bug-fix-02-credit-minting-chain` / [#246](https://github.com/Geoffe-Ga/adepthood/pull/246) | [x] |
-| 03 | close-stage-skip-chain            | 2 | | [ ] |
+| 03 | close-stage-skip-chain            | 2 | `claude/bug-fix-03-stage-skip-chain` / [#247](https://github.com/Geoffe-Ga/adepthood/pull/247) | [x] |
 | 04 | centralize-sanitize-user-text     | 3 | | [ ] |
 | 05 | centralize-date-utils-tz          | 3 | | [ ] |
 | 06 | db-unique-constraints-toctou      | 3 | | [ ] |


### PR DESCRIPTION
## Summary

Closes the stage-skip chain (Prompt 03 of the 15-wave remediation plan). Six atomic backend+frontend commits make it impossible for a client to jump past uncompleted stages by exploiting any one of the collaborating bugs. A seventh commit refactors the validation helpers introduced in commit 4 back to xenon rank A.

Bug IDs closed (9): `BUG-SCHEMA-006`, `BUG-STAGE-001`, `BUG-COURSE-001`, `BUG-PRACTICE-004`, `BUG-PROMPT-001`, `BUG-PROMPT-002`, `BUG-FE-MAP-001/-002`, `BUG-FE-COURSE-001/-002`, `BUG-FE-PRACTICE-001/-002`.

Commits (in order):

1. `chore(backend): audit legacy completed_stages gaps` — read-only Alembic migration logging non-contiguous `completed_stages` rows, plus an admin inspect helper. Unblocks the chain-validation invariant without silently mutating user data.
2. `fix(backend): chain-validate stage unlock (BUG-STAGE-001)` — `is_stage_unlocked` now requires every predecessor in `[1..n-1]` to be in `completed_stages`. New `next_stage_for` uses `min(missing)` so it's robust on legacy gap data.
3. `fix(backend): server-derive stage progress (BUG-SCHEMA-006)` — `StageProgressUpdate.current_stage` is bounded by `Field(ge=1, le=36)` + `extra="forbid"`; server re-derives the real next stage and rejects payloads that disagree with `stage_advance_mismatch`.
4. `fix(backend): gate practices & course content on stage unlock` — `POST /user-practices` rejects `stage_number` that disagrees with the catalog practice stage, then 403s on locked stages. `GET /course/stages/{n}/content` 404s unknown stages, then 403s locked ones.
5. `fix(backend): gate weekly prompts on user_week (BUG-PROMPT-001/-002)` — `_get_user_week` derives from `count(responses) + 1` (not `max(week) + 1`); `GET /prompts/{week}` and `POST /prompts/{week}/respond` both 403 on `week > user_week`.
6. `fix(frontend): fetch current_stage from backend truth (BUG-FE-MAP/COURSE/PRACTICE-001/-002)` — Map/Course/Practice screens now read `current_stage = completed_count + 1` (mirroring `next_stage_for`) instead of "highest unlocked" / "first in-progress" / hard-coded 1.
7. `refactor(backend): extract create_user_practice validation helpers` — xenon rank A restored after commit 4.

## Test plan

- [x] `pre-commit run --all-files` green (full run, including xenon/radon/backend coverage/frontend tests).
- [x] 29 stage API tests, 18 weekly-prompts tests, 14 user-practices tests, 6 course API tests pass (chain-skip cases added for each router).
- [x] 8 `next_stage_for` unit tests (including gap data, full completion → 409, single-missing).
- [x] Frontend suite: 686/686 pass. New `stageService` regression test ignores `is_unlocked` drift.
- [x] TypeScript + ESLint clean.

https://claude.ai/code/session_011JvxjW4m5jw6u77eKrrYjz