### PR TITLE
fix(idor): normalize 404→403 ordering + strip user_id from responses

### DIFF
--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -1,0 +1,158 @@
+"""Ownership-resolution dependencies — the canonical 404→403 split.
+
+Per the BUG-T7 remediation (prompt ``07-normalize-idor-ordering``), every
+``GET/PATCH/PUT/DELETE /resource/{id}`` route on a user-scoped resource MUST
+go through one of these dependencies.  They share the same two-step contract:
+
+1. Resolve the row by primary key.  Missing → 404 ``{resource}_not_found``.
+2. Authorize against ``current_user``.  Cross-user → 403 ``forbidden``.
+
+Splitting the two branches (rather than collapsing both to 404 like a few
+legacy routes did) keeps the audit trail honest -- a 403 on someone else's
+resource ID surfaces in security logs, and the policy is uniform across the
+API so a future endpoint cannot quietly drift back to "404-on-not-mine".
+
+We use one explicit dependency per resource (Option 2 from the prompt) rather
+than a generic factory.  Per-resource deps are explicit, type-stable, and
+require no ``inspect.Signature`` rewriting -- the prompt's ``max-quality-no-shortcuts``
+requirement steers us here.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from errors import forbidden, not_found
+from models.goal_group import GoalGroup
+from models.habit import Habit
+from models.journal_entry import JournalEntry
+from models.practice import Practice
+from models.practice_session import PracticeSession
+from models.user_practice import UserPractice
+from routers.auth import get_current_user
+
+
+async def require_owned_habit(
+    habit_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> Habit:
+    """Resolve ``habit_id`` and verify the caller owns it."""
+    habit = await session.get(Habit, habit_id)
+    if habit is None:
+        raise not_found("habit")
+    if habit.user_id != current_user:
+        raise forbidden("forbidden")
+    return habit
+
+
+async def require_owned_journal_entry(
+    entry_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> JournalEntry:
+    """Resolve ``entry_id`` and verify the caller owns it."""
+    entry = await session.get(JournalEntry, entry_id)
+    if entry is None:
+        raise not_found("journal_entry")
+    if entry.user_id != current_user:
+        raise forbidden("forbidden")
+    return entry
+
+
+async def require_owned_user_practice(
+    user_practice_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> UserPractice:
+    """Resolve ``user_practice_id`` and verify the caller owns it."""
+    user_practice = await session.get(UserPractice, user_practice_id)
+    if user_practice is None:
+        raise not_found("user_practice")
+    if user_practice.user_id != current_user:
+        raise forbidden("forbidden")
+    return user_practice
+
+
+async def require_owned_practice_session(
+    session_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PracticeSession:
+    """Resolve ``session_id`` and verify the caller owns it."""
+    practice_session = await session.get(PracticeSession, session_id)
+    if practice_session is None:
+        raise not_found("practice_session")
+    if practice_session.user_id != current_user:
+        raise forbidden("forbidden")
+    return practice_session
+
+
+async def require_visible_goal_group(
+    group_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> GoalGroup:
+    """Resolve ``group_id`` for read access — owner OR shared template.
+
+    Shared templates (``shared_template=True``, ``user_id IS NULL``) are
+    catalog content readable by every authenticated user.  Private groups
+    are readable only by their owner.  Mutation routes use
+    :func:`require_owned_goal_group`, which is strictly stricter.
+    """
+    group = await session.get(GoalGroup, group_id)
+    if group is None:
+        raise not_found("goal_group")
+    if group.shared_template:
+        return group
+    if group.user_id != current_user:
+        raise forbidden("forbidden")
+    return group
+
+
+async def require_owned_goal_group(
+    group_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> GoalGroup:
+    """Resolve ``group_id`` for write access — owner only.
+
+    Shared templates have no owner (``user_id IS NULL`` enforced by DB
+    CHECK constraint), so non-admin clients can never mutate them through
+    this surface.  Closes BUG-GOAL-006: any authenticated user used to be
+    able to edit/delete shared templates because the prior check
+    (``group.user_id is not None and group.user_id != current_user``)
+    short-circuited to "owner-equivalent" when ``user_id`` was NULL.
+    """
+    group = await session.get(GoalGroup, group_id)
+    if group is None:
+        raise not_found("goal_group")
+    if group.user_id != current_user:
+        raise forbidden("forbidden")
+    return group
+
+
+async def require_visible_practice(
+    practice_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> Practice:
+    """Resolve ``practice_id`` for read access — approved OR submitter.
+
+    Closes BUG-PRACTICE-001: ``GET /practices/{id}`` previously returned
+    pending submissions to anyone with the ID, leaking other users' draft
+    practices.  Now an unapproved practice is visible only to the user
+    who submitted it; everyone else gets 403.
+    """
+    practice = await session.get(Practice, practice_id)
+    if practice is None:
+        raise not_found("practice")
+    if practice.approved:
+        return practice
+    if practice.submitted_by_user_id != current_user:
+        raise forbidden("forbidden")
+    return practice

--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -31,7 +31,6 @@ from models.goal_group import GoalGroup
 from models.habit import Habit
 from models.journal_entry import JournalEntry
 from models.practice import Practice
-from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
 
@@ -76,20 +75,6 @@ async def require_owned_user_practice(
     if user_practice.user_id != current_user:
         raise forbidden("forbidden")
     return user_practice
-
-
-async def require_owned_practice_session(
-    session_id: int,
-    current_user: Annotated[int, Depends(get_current_user)],
-    session: Annotated[AsyncSession, Depends(get_session)],
-) -> PracticeSession:
-    """Resolve ``session_id`` and verify the caller owns it."""
-    practice_session = await session.get(PracticeSession, session_id)
-    if practice_session is None:
-        raise not_found("practice_session")
-    if practice_session.user_id != current_user:
-        raise forbidden("forbidden")
-    return practice_session
 
 
 async def require_visible_goal_group(

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -94,10 +94,27 @@ def _items_to_raw_dicts(items: list[StageContent]) -> list[dict[str, object]]:
 
 
 async def _check_stage_unlocked(session: AsyncSession, user_id: int, stage_number: int) -> None:
-    """Raise 403 if the given stage is locked for the user."""
+    """Raise 403 if the given stage is locked for the user.
+
+    Used by endpoints that take ``stage_number`` directly (1..36 are
+    public knowledge), so the 403 carries no enumeration risk.
+    """
     progress = await get_user_progress(session, user_id)
     if not is_stage_unlocked(stage_number, progress):
         raise forbidden("stage_locked")
+
+
+async def _is_stage_unlocked_for_user(
+    session: AsyncSession, user_id: int, stage_number: int
+) -> bool:
+    """Predicate form of :func:`_check_stage_unlocked`.
+
+    Used on ``content_id``-keyed endpoints (BUG-COURSE-004): callers mask
+    the locked branch as 404 to remove the existence oracle, rather than
+    raising a 403 the attacker could observe directly.
+    """
+    progress = await get_user_progress(session, user_id)
+    return is_stage_unlocked(stage_number, progress)
 
 
 @router.get("/stages/{stage_number}/content", response_model=None)
@@ -158,7 +175,15 @@ async def get_content_item(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ContentItemResponse:
-    """Get a single content item with lock/read status."""
+    """Get a single content item with lock/read status.
+
+    BUG-COURSE-004: collapses the "stage locked" 403 into a 404 so an
+    attacker enumerating ``content_id`` cannot distinguish "row exists
+    but locked for me" from "row does not exist".  Course content is a
+    shared catalog, not a user-owned resource, so the canonical 403
+    leak surface is content-row count + stage boundaries; masking the
+    locked branch as ``content_not_found`` removes the oracle.
+    """
     result = await session.execute(select(StageContent).where(StageContent.id == content_id))
     item = result.scalars().first()
     if item is None:
@@ -172,8 +197,10 @@ async def get_content_item(
     if stage is None:
         raise not_found("stage")
 
-    # BUG-COURSE-007: Verify the user has access to this stage
-    await _check_stage_unlocked(session, current_user, stage.stage_number)
+    # BUG-COURSE-004: mask locked-stage access as 404 so locked content
+    # is indistinguishable from nonexistent content over the wire.
+    if not await _is_stage_unlocked_for_user(session, current_user, stage.stage_number):
+        raise not_found("content")
 
     days = await _days_for_user_stage(session, current_user, stage.stage_number)
 
@@ -202,7 +229,14 @@ async def mark_content_read(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ContentCompletionResponse:
-    """Mark a content item as read. Idempotent — repeated calls return existing record."""
+    """Mark a content item as read. Idempotent — repeated calls return existing record.
+
+    BUG-COURSE-004: locked-stage access is reported as 404 (not 403) so
+    the same enumeration mask applied to ``GET /content/{id}`` also
+    holds here.  ``ContentCompletionResponse`` no longer echoes
+    ``user_id``: the row is created for ``current_user`` and the
+    surrogate key adds nothing for the client.
+    """
     # Verify content exists
     result = await session.execute(select(StageContent).where(StageContent.id == content_id))
     content_item = result.scalars().first()
@@ -216,7 +250,8 @@ async def mark_content_read(
     stage = stage_result.scalars().first()
     if stage is None:
         raise not_found("stage")
-    await _check_stage_unlocked(session, current_user, stage.stage_number)
+    if not await _is_stage_unlocked_for_user(session, current_user, stage.stage_number):
+        raise not_found("content")
 
     # Check for existing completion (idempotent)
     existing_result = await session.execute(
@@ -229,7 +264,6 @@ async def mark_content_read(
     if existing is not None:
         return ContentCompletionResponse(
             id=existing.id,
-            user_id=existing.user_id,
             content_id=existing.content_id,
             completed_at=existing.completed_at,
         )
@@ -241,7 +275,6 @@ async def mark_content_read(
     logger.info("content_marked_read", extra={"user_id": current_user, "content_id": content_id})
     return ContentCompletionResponse(
         id=completion.id,
-        user_id=completion.user_id,
         content_id=completion.content_id,
         completed_at=completion.completed_at,
     )

--- a/backend/src/routers/goal_groups.py
+++ b/backend/src/routers/goal_groups.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -168,13 +168,10 @@ async def update_goal_group(
     prior ``group.user_id is not None and ...`` short-circuit treated
     NULL ownership as caller-equivalent).
     """
-    # ``group.id`` is non-NULL on a row returned by the dep, but the
-    # SQLModel field type is ``int | None`` because of the primary-key
-    # default.  Pin it locally so the refetch helper sees a plain ``int``.
-    if group.id is None:
-        msg = "GoalGroup ID unexpectedly None after ownership dep returned row"
-        raise RuntimeError(msg)
-    group_id = group.id
+    # ``group.id`` is ``int | None`` on the SQLModel because of the
+    # primary-key default, but the ownership dep only ever returns a
+    # row freshly fetched from the DB, so the value is non-NULL here.
+    group_id = cast("int", group.id)
     for key, value in payload.model_dump().items():
         setattr(group, key, value)
     session.add(group)
@@ -195,13 +192,12 @@ async def delete_goal_group(
 
     Owner-only via ``require_owned_goal_group`` (BUG-GOAL-006).  We
     re-fetch with eager-loaded goals so the unlink step doesn't trigger
-    a lazy load on an async session.
+    a lazy load on an async session; existence has already been
+    verified by the dep, so ``.one()`` is correct here.
     """
     statement = select(GoalGroup).where(GoalGroup.id == group_id).options(GOAL_GROUP_WITH_GOALS)
     result = await session.execute(statement)
-    group = result.scalars().first()
-    if group is None:
-        raise not_found("goal_group")
+    group = result.scalars().one()
     # Unlink goals from the group before deleting
     for goal in group.goals:
         goal.goal_group_id = None

--- a/backend/src/routers/goal_groups.py
+++ b/backend/src/routers/goal_groups.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from database import get_session
+from dependencies.ownership import require_owned_goal_group, require_visible_goal_group
 from errors import not_found
 from load_options import GOAL_GROUP_WITH_GOALS
 from models.goal_group import GoalGroup
@@ -90,16 +91,19 @@ async def list_goal_groups(
 @router.get("/{group_id}", response_model=GoalGroupResponse)
 async def get_goal_group(
     group_id: int,
-    current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    _visible: Annotated[GoalGroup, Depends(require_visible_goal_group)],
 ) -> GoalGroup:
-    """Return a single goal group with its goals."""
+    """Return a single goal group with its goals.
+
+    Read access: owner OR shared template. ``require_visible_goal_group``
+    runs the canonical 404→403 split (404 for missing, 403 for another
+    user's private group); we then re-fetch with eager-loaded goals.
+    """
     statement = select(GoalGroup).where(GoalGroup.id == group_id).options(GOAL_GROUP_WITH_GOALS)
     result = await session.execute(statement)
     group = result.scalars().first()
     if group is None:
-        raise not_found("goal_group")
-    if group.user_id is not None and group.user_id != current_user:
         raise not_found("goal_group")
     return group
 
@@ -110,7 +114,14 @@ async def create_goal_group(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> GoalGroup:
-    """Create a new goal group for the authenticated user."""
+    """Create a new goal group for the authenticated user.
+
+    Ownership is sourced from ``current_user`` (BUG-GOAL-005); the
+    payload schema does not expose a ``user_id`` field, so a forged
+    body cannot plant a row under another account.  ``shared_template``
+    flips the row to a public template (``user_id IS NULL``) per the
+    DB CHECK constraint.
+    """
     group = GoalGroup(
         user_id=current_user if not payload.shared_template else None,
         **payload.model_dump(),
@@ -143,15 +154,27 @@ async def _refetch_goal_group_with_goals(session: AsyncSession, group_id: int) -
 
 @router.put("/{group_id}", response_model=GoalGroupResponse)
 async def update_goal_group(
-    group_id: int,
     payload: GoalGroupCreate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    group: Annotated[GoalGroup, Depends(require_owned_goal_group)],
 ) -> GoalGroup:
-    """Update an existing goal group."""
-    group = await session.get(GoalGroup, group_id)
-    if group is None or (group.user_id is not None and group.user_id != current_user):
-        raise not_found("goal_group")
+    """Update an existing goal group.
+
+    Mutation requires the strict owner-only check from
+    ``require_owned_goal_group``: shared templates have ``user_id IS NULL``
+    so they can never match ``current_user`` and always 403.  Closes
+    BUG-GOAL-006 (shared templates were editable by any user because the
+    prior ``group.user_id is not None and ...`` short-circuit treated
+    NULL ownership as caller-equivalent).
+    """
+    # ``group.id`` is non-NULL on a row returned by the dep, but the
+    # SQLModel field type is ``int | None`` because of the primary-key
+    # default.  Pin it locally so the refetch helper sees a plain ``int``.
+    if group.id is None:
+        msg = "GoalGroup ID unexpectedly None after ownership dep returned row"
+        raise RuntimeError(msg)
+    group_id = group.id
     for key, value in payload.model_dump().items():
         setattr(group, key, value)
     session.add(group)
@@ -166,12 +189,18 @@ async def delete_goal_group(
     group_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    _owned: Annotated[GoalGroup, Depends(require_owned_goal_group)],
 ) -> Response:
-    """Delete a goal group. Unlinks goals but does not delete them."""
+    """Delete a goal group. Unlinks goals but does not delete them.
+
+    Owner-only via ``require_owned_goal_group`` (BUG-GOAL-006).  We
+    re-fetch with eager-loaded goals so the unlink step doesn't trigger
+    a lazy load on an async session.
+    """
     statement = select(GoalGroup).where(GoalGroup.id == group_id).options(GOAL_GROUP_WITH_GOALS)
     result = await session.execute(statement)
     group = result.scalars().first()
-    if group is None or (group.user_id is not None and group.user_id != current_user):
+    if group is None:
         raise not_found("goal_group")
     # Unlink goals from the group before deleting
     for goal in group.goals:

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -10,8 +10,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from database import get_session
+from dependencies.ownership import require_owned_habit
 from domain.habit_stats import compute_habit_stats
-from errors import not_found
+from errors import forbidden, not_found
 from load_options import HABIT_WITH_GOALS_AND_COMPLETIONS
 from models.habit import Habit
 from routers.auth import get_current_user
@@ -89,12 +90,13 @@ async def get_habit(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> Habit:
-    """Return a single habit by id, scoped to the authenticated user."""
-    statement = select(Habit).where(Habit.id == habit_id).options(HABIT_WITH_GOALS_AND_COMPLETIONS)
-    result = await session.execute(statement)
-    habit = result.scalars().first()
-    if habit is None or habit.user_id != current_user:
-        raise not_found("habit")
+    """Return a single habit by id, scoped to the authenticated user.
+
+    Uses :func:`_get_habit_with_completions` for the eager-loaded fetch +
+    canonical 404→403 split rather than the bare ``require_owned_habit``
+    dep, since this endpoint needs goals + completions in the response.
+    """
+    habit = await _get_habit_with_completions(habit_id, current_user, session)
     user_tz = await get_user_timezone(session, current_user)
     _populate_streak(habit, current_user, user_tz)
     return habit
@@ -102,15 +104,16 @@ async def get_habit(
 
 @router.put("/{habit_id}", response_model=HabitSchema)
 async def update_habit(
-    habit_id: int,
     payload: HabitCreate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    habit: Annotated[Habit, Depends(require_owned_habit)],
 ) -> Habit:
-    """Replace an existing habit's fields."""
-    habit = await session.get(Habit, habit_id)
-    if habit is None or habit.user_id != current_user:
-        raise not_found("habit")
+    """Replace an existing habit's fields.
+
+    Ownership is verified by ``require_owned_habit`` (404 if missing,
+    403 if cross-user).
+    """
     for key, value in payload.model_dump().items():
         setattr(habit, key, value)
     session.add(habit)
@@ -122,14 +125,12 @@ async def update_habit(
 
 @router.delete("/{habit_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_habit(
-    habit_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    habit: Annotated[Habit, Depends(require_owned_habit)],
 ) -> Response:
     """Delete a habit. Returns 204 No Content on success."""
-    habit = await session.get(Habit, habit_id)
-    if habit is None or habit.user_id != current_user:
-        raise not_found("habit")
+    habit_id = habit.id
     await session.delete(habit)
     await session.commit()
     logger.info("habit_deleted", extra={"user_id": current_user, "habit_id": habit_id})
@@ -139,12 +140,14 @@ async def delete_habit(
 async def _get_habit_with_completions(
     habit_id: int, current_user: int, session: AsyncSession
 ) -> Habit:
-    """Load a habit with goals+completions, raising 404 if not owned."""
+    """Load a habit with goals+completions, with the canonical 404→403 split."""
     statement = select(Habit).where(Habit.id == habit_id).options(HABIT_WITH_GOALS_AND_COMPLETIONS)
     result = await session.execute(statement)
     habit = result.scalars().first()
-    if habit is None or habit.user_id != current_user:
+    if habit is None:
         raise not_found("habit")
+    if habit.user_id != current_user:
+        raise forbidden("forbidden")
     return habit
 
 

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -12,7 +12,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
-from errors import not_found, unprocessable
+from dependencies.ownership import require_owned_journal_entry
+from errors import unprocessable
 from models.journal_entry import JournalEntry, JournalTag
 from rate_limit import limiter
 from routers.auth import get_current_user
@@ -135,27 +136,24 @@ async def list_journal_entries(
 
 @router.get("/{entry_id}", response_model=JournalMessageResponse)
 async def get_journal_entry(
-    entry_id: int,
-    current_user: Annotated[int, Depends(get_current_user)],
-    session: Annotated[AsyncSession, Depends(get_session)],
+    entry: Annotated[JournalEntry, Depends(require_owned_journal_entry)],
 ) -> JournalEntry:
-    """Return a single journal entry by ID, scoped to the authenticated user."""
-    entry = await session.get(JournalEntry, entry_id)
-    if entry is None or entry.user_id != current_user:
-        raise not_found("journal_entry")
+    """Return a single journal entry by ID, scoped to the authenticated user.
+
+    Ownership is verified by ``require_owned_journal_entry``: 404 when the
+    row does not exist, 403 when it exists but belongs to another user.
+    """
     return entry
 
 
 @router.delete("/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_journal_entry(
-    entry_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    entry: Annotated[JournalEntry, Depends(require_owned_journal_entry)],
 ) -> Response:
     """Delete a journal entry. Returns 204 No Content on success."""
-    entry = await session.get(JournalEntry, entry_id)
-    if entry is None or entry.user_id != current_user:
-        raise not_found("journal_entry")
+    entry_id = entry.id
     await session.delete(entry)
     await session.commit()
     logger.info("journal_entry_deleted", extra={"user_id": current_user, "entry_id": entry_id})

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, func, select
 
 from database import get_session
+from dependencies.ownership import require_owned_user_practice
 from errors import forbidden, not_found
 from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
@@ -30,7 +31,14 @@ async def create_session(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> PracticeSession:
-    """Log a practice session against a user-practice selection."""
+    """Log a practice session against a user-practice selection.
+
+    Inline 404→403 split (rather than ``require_owned_user_practice``)
+    because the ``user_practice_id`` arrives in the body, not as a path
+    or query parameter — FastAPI's DI cannot extract body fields into
+    sub-dependencies.  The ordering and exception types match the shared
+    dep so the IDOR matrix test sees the same 403 for cross-user calls.
+    """
     result = await session.execute(
         select(UserPractice).where(UserPractice.id == payload.user_practice_id)
     )
@@ -38,7 +46,7 @@ async def create_session(
     if user_practice is None:
         raise not_found("user_practice")
     if user_practice.user_id != current_user:
-        raise forbidden()
+        raise forbidden("forbidden")
 
     duration_minutes = payload.duration_minutes
     practice_session = PracticeSession(
@@ -64,12 +72,17 @@ async def create_session(
 
 @router.get("/", response_model=None)
 async def list_sessions(
-    user_practice_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
     pagination: Annotated[PaginationParams, Depends()],
+    user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
 ) -> Page[PracticeSessionResponse] | list[PracticeSessionResponse]:
     """List sessions for a specific user-practice, newest first.
+
+    Cross-user calls used to return an empty list (the ``user_id`` filter
+    silently masked them); now ``require_owned_user_practice`` runs the
+    canonical 404→403 split before we hit the sessions table so the
+    auth-failure path is uniform with every other owned-resource route.
 
     BUG-INFRA-014: returns ``Page[PracticeSessionResponse]`` when
     ``?paginate=true`` is set; otherwise the legacy bare list is returned
@@ -78,7 +91,7 @@ async def list_sessions(
     query = (
         select(PracticeSession)
         .where(
-            PracticeSession.user_practice_id == user_practice_id,
+            PracticeSession.user_practice_id == user_practice.id,
             PracticeSession.user_id == current_user,
         )
         .order_by(col(PracticeSession.timestamp).desc())

--- a/backend/src/routers/practices.py
+++ b/backend/src/routers/practices.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
-from errors import not_found
+from dependencies.ownership import require_visible_practice
 from models.practice import Practice
 from rate_limit import limiter
 from routers.auth import get_current_user
@@ -49,15 +49,14 @@ async def list_practices(
 
 @router.get("/{practice_id}", response_model=PracticeResponse)
 async def get_practice(
-    practice_id: int,
-    _current_user: Annotated[int, Depends(get_current_user)],
-    session: Annotated[AsyncSession, Depends(get_session)],
+    practice: Annotated[Practice, Depends(require_visible_practice)],
 ) -> Practice:
-    """Get a single practice with full instructions."""
-    result = await session.execute(select(Practice).where(Practice.id == practice_id))
-    practice = result.scalars().first()
-    if practice is None or not practice.approved:
-        raise not_found("practice")
+    """Get a single practice with full instructions.
+
+    Visibility is approved-OR-submitter (BUG-PRACTICE-001): a draft is
+    only readable to the user who submitted it; everyone else gets 403.
+    Missing rows still 404.
+    """
     return practice
 
 

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from dependencies.ownership import require_owned_user_practice
 from domain.dates import today_in_tz
 from domain.stage_progress import get_user_progress, is_stage_unlocked
 from errors import bad_request, forbidden, not_found
@@ -135,28 +136,22 @@ async def list_user_practices(
 
 @router.get("/{user_practice_id}", response_model=UserPracticeDetail)
 async def get_user_practice(
-    user_practice_id: int,
-    current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
 ) -> dict[str, Any]:
-    """Get a single user-practice with its session history."""
-    result = await session.execute(select(UserPractice).where(UserPractice.id == user_practice_id))
-    user_practice = result.scalars().first()
-    if user_practice is None:
-        raise not_found("user_practice")
-    if user_practice.user_id != current_user:
-        raise forbidden()
+    """Get a single user-practice with its session history.
 
+    Ownership via ``require_owned_user_practice`` (404 → 403 split).
+    """
     sessions_result = await session.execute(
         select(PracticeSession)
-        .where(PracticeSession.user_practice_id == user_practice_id)
+        .where(PracticeSession.user_practice_id == user_practice.id)
         .order_by(col(PracticeSession.timestamp).desc())
     )
     sessions = list(sessions_result.scalars().all())
 
     return {
         "id": user_practice.id,
-        "user_id": user_practice.user_id,
         "practice_id": user_practice.practice_id,
         "stage_number": user_practice.stage_number,
         "start_date": user_practice.start_date,

--- a/backend/src/schemas/_base.py
+++ b/backend/src/schemas/_base.py
@@ -1,0 +1,24 @@
+"""Shared response-schema base classes.
+
+:class:`OwnedResourcePublic` is the base every user-scoped response DTO
+inherits from.  Its sole job is to lock in the no-``user_id`` invariant
+(per the BUG-T7 remediation): the client already knows its own identity
+(via the JWT it presented), and exposing surrogate ``user_id`` values aids
+enumeration-style attacks (BUG-HABIT-001, BUG-JOURNAL-004,
+BUG-SCHEMA-010, BUG-PRACTICE-001).
+
+The base is empty by design -- enforcement is by convention and by the
+``tests/security/test_idor.py`` matrix, which asserts no DTO body contains
+a ``user_id`` field.  Inheriting from this class is the documentation
+hook future contributors will see when adding a new owned-resource DTO.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class OwnedResourcePublic(BaseModel):
+    """Base for response schemas of user-scoped resources — never adds ``user_id``."""
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/src/schemas/course.py
+++ b/backend/src/schemas/course.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+from schemas._base import OwnedResourcePublic
+
 
 class ContentItemResponse(BaseModel):
     """A single course content item with drip-feed and read status."""
@@ -28,10 +30,14 @@ class CourseProgressResponse(BaseModel):
     next_unlock_day: int | None
 
 
-class ContentCompletionResponse(BaseModel):
-    """Response after marking content as read."""
+class ContentCompletionResponse(OwnedResourcePublic):
+    """Response after marking content as read.
+
+    ``user_id`` is intentionally excluded (BUG-T7): the completion is
+    always created for ``current_user``, so echoing it back is redundant
+    and aids enumeration.
+    """
 
     id: int
-    user_id: int
     content_id: int
     completed_at: datetime

--- a/backend/src/schemas/goal_group.py
+++ b/backend/src/schemas/goal_group.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from schemas._base import OwnedResourcePublic
 from schemas.goal import Goal
 
 GOAL_GROUP_NAME_MAX_LENGTH = 255
@@ -13,7 +14,13 @@ GOAL_GROUP_SOURCE_MAX_LENGTH = 255
 
 
 class GoalGroupCreate(BaseModel):
-    """Payload for creating/updating a goal group."""
+    """Payload for creating/updating a goal group.
+
+    ``user_id`` is intentionally absent — the server derives ownership from
+    ``current_user`` (BUG-GOAL-005), so a forged payload field is silently
+    ignored.  ``shared_template=True`` flips the row to a public template
+    with ``user_id IS NULL``; non-shared rows are owned by the caller.
+    """
 
     name: str = Field(min_length=1, max_length=GOAL_GROUP_NAME_MAX_LENGTH)
     icon: str | None = Field(default=None, max_length=GOAL_GROUP_ICON_MAX_LENGTH)
@@ -22,14 +29,20 @@ class GoalGroupCreate(BaseModel):
     source: str | None = Field(default=None, max_length=GOAL_GROUP_SOURCE_MAX_LENGTH)
 
 
-class GoalGroupResponse(BaseModel):
-    """Public representation of a goal group with its goals."""
+class GoalGroupResponse(OwnedResourcePublic):
+    """Public representation of a goal group with its goals.
+
+    ``user_id`` is intentionally excluded (BUG-T7 / BUG-GOAL-006): clients
+    distinguish their own private groups from public templates via the
+    ``shared_template`` flag rather than a surrogate user key.  The list
+    endpoint already filters to ``user_id == current_user OR shared_template``,
+    so any non-shared row in a response is by definition owned by the caller.
+    """
 
     id: int
     name: str
     icon: str | None = None
     description: str | None = None
-    user_id: int | None = None
     shared_template: bool = False
     source: str | None = None
-    goals: list[Goal] = []
+    goals: list[Goal] = Field(default_factory=list)

--- a/backend/src/schemas/habit.py
+++ b/backend/src/schemas/habit.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from schemas._base import OwnedResourcePublic
 from schemas.goal import Goal
 
 NOTIFICATION_FREQUENCY = Literal["daily", "weekly", "custom", "off"]
@@ -16,15 +17,18 @@ HABIT_ICON_MAX_LENGTH = 100
 HABIT_STAGE_MAX_LENGTH = 100
 
 
-class Habit(BaseModel):
+class Habit(OwnedResourcePublic):
     """Public representation of a :class:`models.habit.Habit`.
 
     Mirrors the SQLModel definition so API consumers can rely on a stable
     contract. Includes notification fields and client-controlled sort order.
+
+    ``user_id`` is intentionally excluded (BUG-HABIT-001 / BUG-SCHEMA-001):
+    the client already knows its own identity from the JWT, so emitting
+    surrogate user keys only aids enumeration.
     """
 
     id: int
-    user_id: int
     name: str
     icon: str
     start_date: date
@@ -42,7 +46,7 @@ class Habit(BaseModel):
 class HabitWithGoals(Habit):
     """Habit response that includes nested goals."""
 
-    goals: list[Goal] = []
+    goals: list[Goal] = Field(default_factory=list)
 
 
 class HabitCreate(BaseModel):

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -8,6 +8,7 @@ from typing import Self
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from domain.constants import TOTAL_STAGES as MAX_STAGE_NUMBER
+from schemas._base import OwnedResourcePublic
 
 PRACTICE_NAME_MAX_LENGTH = 255
 PRACTICE_DESCRIPTION_MAX_LENGTH = 2_000
@@ -52,8 +53,14 @@ def _session_window_violations(
 # -- Practice ---------------------------------------------------------------
 
 
-class PracticeResponse(BaseModel):
-    """Public representation of a practice."""
+class PracticeResponse(OwnedResourcePublic):
+    """Public representation of a practice.
+
+    ``submitted_by_user_id`` is intentionally excluded (BUG-PRACTICE-001 /
+    BUG-SCHEMA-010): exposing the submitter's user id on a catalog GET
+    leaks who proposed which draft and turns the practices endpoint into
+    a user-id enumeration oracle.
+    """
 
     id: int
     stage_number: int
@@ -61,7 +68,6 @@ class PracticeResponse(BaseModel):
     description: str
     instructions: str
     default_duration_minutes: float
-    submitted_by_user_id: int | None = None
     approved: bool
 
 
@@ -85,11 +91,16 @@ class UserPracticeCreate(BaseModel):
     stage_number: int = Field(ge=1, le=MAX_STAGE_NUMBER)
 
 
-class UserPracticeResponse(BaseModel):
-    """Public representation of a user-practice selection."""
+class UserPracticeResponse(OwnedResourcePublic):
+    """Public representation of a user-practice selection.
+
+    ``user_id`` is intentionally excluded (BUG-T7): the row is only ever
+    returned to its owner -- cross-user fetches raise 403 in the router
+    -- so echoing the surrogate key adds no information and aids
+    enumeration.
+    """
 
     id: int
-    user_id: int
     practice_id: int
     stage_number: int
     start_date: date
@@ -105,11 +116,14 @@ class PracticeSessionSummary(BaseModel):
     reflection: str | None = None
 
 
-class UserPracticeDetail(BaseModel):
-    """User-practice with session history."""
+class UserPracticeDetail(OwnedResourcePublic):
+    """User-practice with session history.
+
+    ``user_id`` is intentionally excluded (BUG-T7); see
+    :class:`UserPracticeResponse`.
+    """
 
     id: int
-    user_id: int
     practice_id: int
     stage_number: int
     start_date: date
@@ -152,11 +166,14 @@ class PracticeSessionCreate(BaseModel):
         return (self.ended_at - self.started_at).total_seconds() / 60
 
 
-class PracticeSessionResponse(BaseModel):
-    """Public representation of a practice session."""
+class PracticeSessionResponse(OwnedResourcePublic):
+    """Public representation of a practice session.
+
+    ``user_id`` is intentionally excluded (BUG-T7); the session is only
+    ever returned to its owner.
+    """
 
     id: int
-    user_id: int
     user_practice_id: int
     duration_minutes: float
     timestamp: datetime

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -1,0 +1,564 @@
+"""IDOR matrix — every owned-resource endpoint returns 403, not 404, for cross-user access.
+
+Each parametrised case exercises one HTTP method on one resource type:
+Alice creates the row, Bob calls the endpoint with Alice's id.  The
+endpoint MUST return 403 ``forbidden`` so the auth-failure path is
+distinguishable in audit logs and so a future change cannot silently
+collapse the cross-user branch back into 404.
+
+Per the BUG-T7 remediation (prompt ``07-normalize-idor-ordering``):
+
+- Genuinely missing rows still 404 (sibling tests in each
+  ``test_<resource>_api.py``).
+- Rows that exist but belong to another user 403, never 404.
+- Course content is a shared catalog rather than a per-user resource;
+  its enumeration oracle (BUG-COURSE-004) is closed by masking the
+  locked branch as 404 instead.  That mask is asserted in
+  ``test_course_api.py`` and revisited here so a regression on either
+  side surfaces in the security suite.
+
+Also asserts that no owned-resource response DTO echoes ``user_id``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.course_stage import CourseStage
+from models.practice import Practice
+from models.stage_content import StageContent
+from models.stage_progress import StageProgress
+
+# Severity: probe attempts use a sentinel id well above any seeded row so
+# the missing-row branch is the same code path as a malicious enumeration.
+_DEFINITELY_MISSING_ID = 999_999
+
+_HABIT_PAYLOAD: dict[str, object] = {
+    "name": "Drink Water",
+    "icon": "💧",
+    "start_date": "2024-01-01",
+    "energy_cost": 1,
+    "energy_return": 2,
+}
+
+_PRACTICE_DEFAULTS: dict[str, object] = {
+    "stage_number": 1,
+    "name": "Meditation",
+    "description": "Sit quietly",
+    "instructions": "Close your eyes and breathe",
+    "default_duration_minutes": 10,
+    "approved": True,
+}
+
+
+async def _signup(client: AsyncClient, username: str) -> tuple[dict[str, str], int]:
+    """Create a user and return (auth headers, user_id)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+async def _seed_practice(db_session: AsyncSession, **overrides: object) -> Practice:
+    """Insert a practice row directly through the ORM."""
+    fields = {**_PRACTICE_DEFAULTS, **overrides}
+    practice = Practice(**fields)
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    return practice
+
+
+async def _create_user_practice(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    headers: dict[str, str],
+    user_id: int,
+) -> int:
+    """Seed a practice the user owns (via UserPractice) and return its id."""
+    practice = await _seed_practice(db_session)
+    # Make sure the user is unlocked for stage 1 -- a fresh signup is.
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            stage_started_at=datetime.now(UTC),
+        )
+    )
+    await db_session.commit()
+    resp = await client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 1},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+async def _create_practice_session(
+    client: AsyncClient,
+    headers: dict[str, str],
+    user_practice_id: int,
+) -> int:
+    """Log a practice session against the given user-practice."""
+    resp = await client.post(
+        "/practice-sessions/",
+        json={"user_practice_id": user_practice_id, "duration_minutes": 5.0},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return int(resp.json()["id"])
+
+
+# ── Cross-user matrix: every endpoint must return 403 ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_idor_habit_get_returns_403(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, "alice_h_get")
+    bob_headers, _ = await _signup(async_client, "bob_h_get")
+
+    create = await async_client.post("/habits/", json=_HABIT_PAYLOAD, headers=alice_headers)
+    habit_id = create.json()["id"]
+
+    resp = await async_client.get(f"/habits/{habit_id}", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN, (
+        "404→403 ordering regression: cross-user GET /habits/{id} must 403, not 404"
+    )
+
+
+@pytest.mark.asyncio
+async def test_idor_habit_put_returns_403(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, "alice_h_put")
+    bob_headers, _ = await _signup(async_client, "bob_h_put")
+
+    create = await async_client.post("/habits/", json=_HABIT_PAYLOAD, headers=alice_headers)
+    habit_id = create.json()["id"]
+
+    resp = await async_client.put(
+        f"/habits/{habit_id}",
+        json={**_HABIT_PAYLOAD, "name": "Hijacked"},
+        headers=bob_headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_habit_delete_returns_403(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, "alice_h_del")
+    bob_headers, _ = await _signup(async_client, "bob_h_del")
+
+    create = await async_client.post("/habits/", json=_HABIT_PAYLOAD, headers=alice_headers)
+    habit_id = create.json()["id"]
+
+    resp = await async_client.delete(f"/habits/{habit_id}", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_habit_stats_returns_403(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, "alice_stats")
+    bob_headers, _ = await _signup(async_client, "bob_stats")
+
+    create = await async_client.post("/habits/", json=_HABIT_PAYLOAD, headers=alice_headers)
+    habit_id = create.json()["id"]
+
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_journal_entry_get_returns_403(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, "alice_j_get")
+    bob_headers, _ = await _signup(async_client, "bob_j_get")
+
+    create = await async_client.post(
+        "/journal/", json={"message": "private"}, headers=alice_headers
+    )
+    entry_id = create.json()["id"]
+
+    resp = await async_client.get(f"/journal/{entry_id}", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_journal_entry_delete_returns_403(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, "alice_j_del")
+    bob_headers, _ = await _signup(async_client, "bob_j_del")
+
+    create = await async_client.post(
+        "/journal/", json={"message": "private"}, headers=alice_headers
+    )
+    entry_id = create.json()["id"]
+
+    resp = await async_client.delete(f"/journal/{entry_id}", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_goal_group_get_returns_403(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, "alice_gg_get")
+    bob_headers, _ = await _signup(async_client, "bob_gg_get")
+
+    create = await async_client.post(
+        "/goal-groups/", json={"name": "Alice Private"}, headers=alice_headers
+    )
+    group_id = create.json()["id"]
+
+    resp = await async_client.get(f"/goal-groups/{group_id}", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_goal_group_put_returns_403(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, "alice_gg_put")
+    bob_headers, _ = await _signup(async_client, "bob_gg_put")
+
+    create = await async_client.post(
+        "/goal-groups/", json={"name": "Alice Private"}, headers=alice_headers
+    )
+    group_id = create.json()["id"]
+
+    resp = await async_client.put(
+        f"/goal-groups/{group_id}",
+        json={"name": "Hijacked"},
+        headers=bob_headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_goal_group_delete_returns_403(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, "alice_gg_del")
+    bob_headers, _ = await _signup(async_client, "bob_gg_del")
+
+    create = await async_client.post(
+        "/goal-groups/", json={"name": "Alice Private"}, headers=alice_headers
+    )
+    group_id = create.json()["id"]
+
+    resp = await async_client.delete(f"/goal-groups/{group_id}", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_shared_template_mutation_returns_403(async_client: AsyncClient) -> None:
+    """BUG-GOAL-006: shared templates have no owner -- mutation always 403.
+
+    Alice creates a shared template (``user_id IS NULL``).  Even the
+    creator cannot mutate it through the standard PUT/DELETE surface
+    because ``require_owned_goal_group`` checks ``group.user_id ==
+    current_user`` and ``None`` never equals an int.  An admin-only
+    moderation surface will land in a separate prompt; until then,
+    shared templates are read-only by design.
+    """
+    alice_headers, _ = await _signup(async_client, "alice_shared")
+
+    create = await async_client.post(
+        "/goal-groups/",
+        json={"name": "Community", "shared_template": True, "source": "community"},
+        headers=alice_headers,
+    )
+    assert create.status_code == HTTPStatus.CREATED
+    group_id = create.json()["id"]
+
+    put = await async_client.put(
+        f"/goal-groups/{group_id}",
+        json={"name": "Hijacked"},
+        headers=alice_headers,
+    )
+    assert put.status_code == HTTPStatus.FORBIDDEN
+
+    delete = await async_client.delete(f"/goal-groups/{group_id}", headers=alice_headers)
+    assert delete.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_shared_template_get_is_visible(async_client: AsyncClient) -> None:
+    """Shared templates are readable by every authenticated user."""
+    alice_headers, _ = await _signup(async_client, "alice_shared_get")
+    bob_headers, _ = await _signup(async_client, "bob_shared_get")
+
+    create = await async_client.post(
+        "/goal-groups/",
+        json={"name": "Community Yoga", "shared_template": True, "source": "community"},
+        headers=alice_headers,
+    )
+    group_id = create.json()["id"]
+
+    resp = await async_client.get(f"/goal-groups/{group_id}", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["name"] == "Community Yoga"
+
+
+@pytest.mark.asyncio
+async def test_idor_user_practice_get_returns_403(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    alice_headers, alice_id = await _signup(async_client, "alice_up_get")
+    bob_headers, _ = await _signup(async_client, "bob_up_get")
+
+    user_practice_id = await _create_user_practice(
+        async_client, db_session, alice_headers, alice_id
+    )
+
+    resp = await async_client.get(f"/user-practices/{user_practice_id}", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_practice_session_create_returns_403(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Cross-user POST /practice-sessions/ — body's user_practice_id is Alice's."""
+    alice_headers, alice_id = await _signup(async_client, "alice_ps_post")
+    bob_headers, _ = await _signup(async_client, "bob_ps_post")
+
+    user_practice_id = await _create_user_practice(
+        async_client, db_session, alice_headers, alice_id
+    )
+
+    resp = await async_client.post(
+        "/practice-sessions/",
+        json={"user_practice_id": user_practice_id, "duration_minutes": 5.0},
+        headers=bob_headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_practice_session_list_returns_403(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Cross-user GET /practice-sessions/?user_practice_id=... must 403."""
+    alice_headers, alice_id = await _signup(async_client, "alice_ps_list")
+    bob_headers, _ = await _signup(async_client, "bob_ps_list")
+
+    user_practice_id = await _create_user_practice(
+        async_client, db_session, alice_headers, alice_id
+    )
+    await _create_practice_session(async_client, alice_headers, user_practice_id)
+
+    resp = await async_client.get(
+        "/practice-sessions/",
+        params={"user_practice_id": user_practice_id},
+        headers=bob_headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_idor_practice_unapproved_returns_403(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """BUG-PRACTICE-001: Bob cannot read Alice's pending practice submission."""
+    alice_headers, alice_id = await _signup(async_client, "alice_p_pending")
+    bob_headers, _ = await _signup(async_client, "bob_p_pending")
+
+    practice = await _seed_practice(
+        db_session,
+        name="Alice Draft",
+        approved=False,
+        submitted_by_user_id=alice_id,
+    )
+
+    bob_resp = await async_client.get(f"/practices/{practice.id}", headers=bob_headers)
+    assert bob_resp.status_code == HTTPStatus.FORBIDDEN
+
+    # Alice (the submitter) can still read her own draft.
+    alice_resp = await async_client.get(f"/practices/{practice.id}", headers=alice_headers)
+    assert alice_resp.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_idor_practice_approved_visible_to_all(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Approved catalog practices stay readable to every authenticated user."""
+    _, _ = await _signup(async_client, "submitter_p_approved")
+    bob_headers, _ = await _signup(async_client, "reader_p_approved")
+
+    practice = await _seed_practice(db_session, name="Public", approved=True)
+
+    resp = await async_client.get(f"/practices/{practice.id}", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.OK
+
+
+# ── Genuinely-missing rows still 404 ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("method", "url"),
+    [
+        ("GET", f"/habits/{_DEFINITELY_MISSING_ID}"),
+        ("PUT", f"/habits/{_DEFINITELY_MISSING_ID}"),
+        ("DELETE", f"/habits/{_DEFINITELY_MISSING_ID}"),
+        ("GET", f"/habits/{_DEFINITELY_MISSING_ID}/stats"),
+        ("GET", f"/journal/{_DEFINITELY_MISSING_ID}"),
+        ("DELETE", f"/journal/{_DEFINITELY_MISSING_ID}"),
+        ("GET", f"/goal-groups/{_DEFINITELY_MISSING_ID}"),
+        ("PUT", f"/goal-groups/{_DEFINITELY_MISSING_ID}"),
+        ("DELETE", f"/goal-groups/{_DEFINITELY_MISSING_ID}"),
+        ("GET", f"/user-practices/{_DEFINITELY_MISSING_ID}"),
+        ("GET", f"/practices/{_DEFINITELY_MISSING_ID}"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_missing_row_returns_404(async_client: AsyncClient, method: str, url: str) -> None:
+    """Missing rows must still 404; the IDOR fix does not collapse them into 403."""
+    headers, _ = await _signup(async_client, f"missing_{method}_{abs(hash(url))}")
+    if method == "PUT":
+        resp = await async_client.put(
+            url,
+            json={**_HABIT_PAYLOAD, "name": "anything"},
+            headers=headers,
+        )
+    elif method == "DELETE":
+        resp = await async_client.delete(url, headers=headers)
+    else:
+        resp = await async_client.get(url, headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND, (
+        f"missing-row regression: {method} {url} must 404, got {resp.status_code}"
+    )
+
+
+# ── BUG-COURSE-004: locked course content masks as 404 ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_locked_content_indistinguishable_from_missing(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """BUG-COURSE-004: a stage-locked content row reads as 404, not 403.
+
+    Course content is shared catalog (no per-user ownership), so the
+    canonical 403-for-cross-user rule does not apply.  The leak surface
+    is content-row count — masking the locked branch as 404 closes the
+    enumeration oracle by making locked-but-existing indistinguishable
+    from never-existed.
+    """
+    headers, _ = await _signup(async_client, "locked_content_probe")
+
+    # Seed stage-2 content; the user has no progress so stage 2 is locked.
+    stage = CourseStage(
+        title="S2",
+        subtitle="x",
+        stage_number=2,
+        overview_url="https://example.com/s2",
+        category="x",
+        aspect="x",
+        spiral_dynamics_color="x",
+        growing_up_stage="x",
+        divine_gender_polarity="x",
+        relationship_to_free_will="active",
+        free_will_description="x",
+    )
+    db_session.add(stage)
+    await db_session.flush()
+    item = StageContent(
+        course_stage_id=stage.id,
+        title="locked",
+        content_type="essay",
+        release_day=0,
+        url="https://cms.example.com/locked",
+    )
+    db_session.add(item)
+    await db_session.commit()
+    await db_session.refresh(item)
+
+    locked_resp = await async_client.get(f"/course/content/{item.id}", headers=headers)
+    missing_resp = await async_client.get(
+        f"/course/content/{_DEFINITELY_MISSING_ID}", headers=headers
+    )
+
+    assert locked_resp.status_code == HTTPStatus.NOT_FOUND
+    assert missing_resp.status_code == HTTPStatus.NOT_FOUND
+    assert locked_resp.json()["detail"] == missing_resp.json()["detail"] == "content_not_found"
+
+    mark_locked = await async_client.post(f"/course/content/{item.id}/mark-read", headers=headers)
+    assert mark_locked.status_code == HTTPStatus.NOT_FOUND
+
+
+# ── No response DTO leaks user_id ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_user_id_in_owned_resource_responses(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """No owned-resource response body emits ``user_id`` (BUG-T7).
+
+    The auth response (``POST /auth/signup``) legitimately tells the
+    caller their own id, so it is excluded from this scan.
+    """
+    alice_headers, alice_id = await _signup(async_client, "user_id_scrub")
+
+    create_habit = await async_client.post("/habits/", json=_HABIT_PAYLOAD, headers=alice_headers)
+    habit_id = create_habit.json()["id"]
+
+    create_journal = await async_client.post(
+        "/journal/", json={"message": "scrub"}, headers=alice_headers
+    )
+    entry_id = create_journal.json()["id"]
+
+    create_group = await async_client.post(
+        "/goal-groups/", json={"name": "Scrub"}, headers=alice_headers
+    )
+    group_id = create_group.json()["id"]
+
+    user_practice_id = await _create_user_practice(
+        async_client, db_session, alice_headers, alice_id
+    )
+    session_id = await _create_practice_session(async_client, alice_headers, user_practice_id)
+
+    practice = await _seed_practice(db_session, name="Catalog Scrub")
+
+    probes: list[tuple[str, dict[str, object]]] = [
+        ("create_habit", create_habit.json()),
+        ("create_journal", create_journal.json()),
+        ("create_group", create_group.json()),
+        (
+            "get_habit",
+            (await async_client.get(f"/habits/{habit_id}", headers=alice_headers)).json(),
+        ),
+        (
+            "get_journal",
+            (await async_client.get(f"/journal/{entry_id}", headers=alice_headers)).json(),
+        ),
+        (
+            "get_group",
+            (await async_client.get(f"/goal-groups/{group_id}", headers=alice_headers)).json(),
+        ),
+        (
+            "get_user_practice",
+            (
+                await async_client.get(f"/user-practices/{user_practice_id}", headers=alice_headers)
+            ).json(),
+        ),
+        (
+            "get_practice",
+            (await async_client.get(f"/practices/{practice.id}", headers=alice_headers)).json(),
+        ),
+    ]
+
+    for label, body in probes:
+        assert "user_id" not in body, f"{label} response leaked user_id"
+        assert "submitted_by_user_id" not in body, f"{label} response leaked submitted_by_user_id"
+
+    # ``session_id`` is consumed by referencing the session POST response;
+    # the create-session response was already exercised in the existing
+    # ``test_practice_sessions.py`` suite, so we just keep the variable
+    # bound to satisfy the seeding flow.
+    _ = session_id

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -22,7 +22,7 @@ Also asserts that no owned-resource response DTO echoes ``user_id``.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
 import pytest
@@ -107,6 +107,22 @@ async def _create_user_practice(
     return int(resp.json()["id"])
 
 
+def _session_window_payload(user_practice_id: int) -> dict[str, object]:
+    """Build a fresh ``started_at``/``ended_at`` payload for a 5-minute session.
+
+    Mirrors :mod:`schemas.practice.PracticeSessionCreate` after the
+    BUG-PRACTICE-006 server-derived-duration migration -- the API rejects
+    legacy ``duration_minutes`` payloads with 422.
+    """
+    ended = datetime.now(UTC)
+    started = ended - timedelta(minutes=5)
+    return {
+        "user_practice_id": user_practice_id,
+        "started_at": started.isoformat(),
+        "ended_at": ended.isoformat(),
+    }
+
+
 async def _create_practice_session(
     client: AsyncClient,
     headers: dict[str, str],
@@ -115,7 +131,7 @@ async def _create_practice_session(
     """Log a practice session against the given user-practice."""
     resp = await client.post(
         "/practice-sessions/",
-        json={"user_practice_id": user_practice_id, "duration_minutes": 5.0},
+        json=_session_window_payload(user_practice_id),
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.OK
@@ -332,7 +348,7 @@ async def test_idor_practice_session_create_returns_403(
 
     resp = await async_client.post(
         "/practice-sessions/",
-        json={"user_practice_id": user_practice_id, "duration_minutes": 5.0},
+        json=_session_window_payload(user_practice_id),
         headers=bob_headers,
     )
     assert resp.status_code == HTTPStatus.FORBIDDEN
@@ -523,7 +539,7 @@ async def test_no_user_id_in_owned_resource_responses(
     )
     create_session = await async_client.post(
         "/practice-sessions/",
-        json={"user_practice_id": user_practice_id, "duration_minutes": 5.0},
+        json=_session_window_payload(user_practice_id),
         headers=alice_headers,
     )
     assert create_session.status_code == HTTPStatus.OK

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -521,7 +521,12 @@ async def test_no_user_id_in_owned_resource_responses(
     user_practice_id = await _create_user_practice(
         async_client, db_session, alice_headers, alice_id
     )
-    session_id = await _create_practice_session(async_client, alice_headers, user_practice_id)
+    create_session = await async_client.post(
+        "/practice-sessions/",
+        json={"user_practice_id": user_practice_id, "duration_minutes": 5.0},
+        headers=alice_headers,
+    )
+    assert create_session.status_code == HTTPStatus.OK
 
     practice = await _seed_practice(db_session, name="Catalog Scrub")
 
@@ -529,6 +534,7 @@ async def test_no_user_id_in_owned_resource_responses(
         ("create_habit", create_habit.json()),
         ("create_journal", create_journal.json()),
         ("create_group", create_group.json()),
+        ("create_practice_session", create_session.json()),
         (
             "get_habit",
             (await async_client.get(f"/habits/{habit_id}", headers=alice_headers)).json(),
@@ -556,9 +562,3 @@ async def test_no_user_id_in_owned_resource_responses(
     for label, body in probes:
         assert "user_id" not in body, f"{label} response leaked user_id"
         assert "submitted_by_user_id" not in body, f"{label} response leaked submitted_by_user_id"
-
-    # ``session_id`` is consumed by referencing the session POST response;
-    # the create-session response was already exercised in the existing
-    # ``test_practice_sessions.py`` suite, so we just keep the variable
-    # bound to satisfy the seeding flow.
-    _ = session_id

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -350,7 +350,8 @@ async def test_mark_content_read(
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
     assert data["content_id"] == items[0].id
-    assert data["user_id"] == user_id
+    # BUG-T7: ContentCompletionResponse no longer echoes user_id.
+    assert "user_id" not in data
     assert "completed_at" in data
 
 
@@ -533,13 +534,23 @@ async def test_get_content_item_rejects_locked_stage(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """BUG-COURSE-007: Content from a locked stage must be forbidden."""
+    """BUG-COURSE-007 / BUG-COURSE-004: locked-stage content reads as 404.
+
+    The locked branch is masked as ``content_not_found`` rather than
+    ``stage_locked`` (403) so an attacker enumerating ``content_id``
+    cannot distinguish "row exists but locked" from "row does not
+    exist".  Course content is shared catalog -- the prompt-07
+    canonical "403 for cross-user" rule does not apply here because
+    there is no per-user ownership; the leak surface is content-row
+    count, which the 404 mask removes.
+    """
     headers, _user_id = await _signup(async_client)
     # Create stage 2 content but user has NO progress record (only stage 1 unlocked)
     _, items = await _seed_stage_with_content(db_session, stage_number=2)
 
     resp = await async_client.get(f"/course/content/{items[0].id}", headers=headers)
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "content_not_found"
 
 
 # ── BUG-COURSE-005: mark_content_read checks stage unlock ─────────────
@@ -550,12 +561,17 @@ async def test_mark_read_rejects_locked_stage(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """BUG-COURSE-005: Cannot mark content from a locked stage as read."""
+    """BUG-COURSE-005 / BUG-COURSE-004: locked content marks read as 404.
+
+    See ``test_get_content_item_rejects_locked_stage`` for the rationale
+    behind the 404 mask.
+    """
     headers, _user_id = await _signup(async_client)
     _, items = await _seed_stage_with_content(db_session, stage_number=2)
 
     resp = await async_client.post(f"/course/content/{items[0].id}/mark-read", headers=headers)
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "content_not_found"
 
 
 # ── BUG-COURSE-002/003: past-stage content is fully unlocked ───────────

--- a/backend/tests/test_goal_groups_api.py
+++ b/backend/tests/test_goal_groups_api.py
@@ -114,7 +114,9 @@ async def test_create_goal_group(async_client: AsyncClient) -> None:
     assert data["icon"] == "💪"
     assert data["description"] == "Progressive strength targets"
     assert data["shared_template"] is False
-    assert data["user_id"] is not None
+    # BUG-T7: response no longer echoes user_id; the absence of
+    # ``shared_template`` is the client's "this is mine" signal.
+    assert "user_id" not in data
     assert data["goals"] == []
 
 
@@ -136,7 +138,9 @@ async def test_create_shared_template(async_client: AsyncClient) -> None:
     assert resp.status_code == HTTPStatus.CREATED
     data = resp.json()
     assert data["shared_template"] is True
-    assert data["user_id"] is None
+    # BUG-T7: shared templates are flagged via ``shared_template`` rather
+    # than a NULL ``user_id`` echo (which leaks ownership semantics).
+    assert "user_id" not in data
     assert data["source"] == "community"
 
 
@@ -172,10 +176,15 @@ async def test_get_goal_group_not_found(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_other_users_group_returns_404(
+async def test_get_other_users_group_returns_403(
     async_client: AsyncClient,
 ) -> None:
-    """A user cannot fetch another user's private group."""
+    """A user fetching another user's private group gets 403, not 404.
+
+    BUG-T7: the auth-failure path is now uniform across owned-resource
+    routes — 404 only for genuinely missing rows, 403 for cross-user
+    access.  This test must specifically fail if the ordering regresses.
+    """
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
 
@@ -187,7 +196,7 @@ async def test_get_other_users_group_returns_404(
     group_id = create_resp.json()["id"]
 
     resp = await async_client.get(f"/goal-groups/{group_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.asyncio
@@ -240,10 +249,10 @@ async def test_update_goal_group(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_other_users_group_returns_404(
+async def test_update_other_users_group_returns_403(
     async_client: AsyncClient,
 ) -> None:
-    """A user cannot update another user's group."""
+    """A user updating another user's group gets 403, not 404 (BUG-T7)."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
 
@@ -259,7 +268,7 @@ async def test_update_other_users_group_returns_404(
         json={"name": "Hijacked"},
         headers=bob_headers,
     )
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
 # ---------------------------------------------------------------------------
@@ -344,10 +353,10 @@ async def test_delete_unlinks_goals_but_keeps_them(
 
 
 @pytest.mark.asyncio
-async def test_delete_other_users_group_returns_404(
+async def test_delete_other_users_group_returns_403(
     async_client: AsyncClient,
 ) -> None:
-    """A user cannot delete another user's group."""
+    """A user deleting another user's group gets 403, not 404 (BUG-T7)."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
 
@@ -359,7 +368,7 @@ async def test_delete_other_users_group_returns_404(
     group_id = create_resp.json()["id"]
 
     resp = await async_client.delete(f"/goal-groups/{group_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_habit_stats_api.py
+++ b/backend/tests/test_habit_stats_api.py
@@ -336,14 +336,10 @@ async def test_stats_only_counts_current_users_completions(
 ) -> None:
     """Stats should not include completions from other users."""
     alice_headers, alice_user_id = await _signup_with_id(async_client, "alice")
-    bob_headers, bob_user_id = await _signup_with_id(async_client, "bob")
+    _, bob_user_id = await _signup_with_id(async_client, "bob")
 
     # Alice creates a habit+goal
     habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, alice_headers)
-    # ``bob_headers`` keeps Bob's auth context for any later request even
-    # though we no longer need to round-trip through ``POST /habits/`` to
-    # learn his user-id.
-    _ = bob_headers
 
     # Alice's completion
     db_session.add(

--- a/backend/tests/test_habit_stats_api.py
+++ b/backend/tests/test_habit_stats_api.py
@@ -57,6 +57,27 @@ async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str
     return {"Authorization": f"Bearer {token}"}
 
 
+async def _signup_with_id(
+    client: AsyncClient, username: str = "alice"
+) -> tuple[dict[str, str], int]:
+    """Create a user and return (auth headers, user_id).
+
+    BUG-T7: ``Habit`` responses no longer expose ``user_id``, so tests that
+    seed completions directly via the ORM source the id from ``/auth/signup``
+    (which legitimately returns it to the caller about themselves).
+    """
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
 async def _create_habit_with_goal(
     client: AsyncClient,
     session: AsyncSession,
@@ -99,14 +120,15 @@ async def test_stats_nonexistent_habit_returns_404(async_client: AsyncClient) ->
 
 
 @pytest.mark.asyncio
-async def test_stats_other_users_habit_returns_404(
+async def test_stats_other_users_habit_returns_403(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
+    """BUG-T7: cross-user stats fetch returns 403, not 404."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
     habit_id, _ = await _create_habit_with_goal(async_client, db_session, alice_headers)
     resp = await async_client.get(f"/habits/{habit_id}/stats", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
 # ── Empty stats ──────────────────────────────────────────────────────────
@@ -138,12 +160,8 @@ async def test_stats_aggregates_completions_by_day_of_week(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
     """Units should be summed per day-of-week across all goals."""
-    headers = await _signup(async_client)
+    headers, user_id = await _signup_with_id(async_client)
     habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
-
-    # Get user_id from the habit
-    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
-    user_id = resp.json()["user_id"]
 
     # Monday 2024-01-01 — two completions
     db_session.add(
@@ -189,10 +207,8 @@ async def test_stats_aggregates_completions_by_day_of_week(
 @pytest.mark.asyncio
 async def test_stats_longest_streak(async_client: AsyncClient, db_session: AsyncSession) -> None:
     """Longest streak is the max consecutive calendar days with completions."""
-    headers = await _signup(async_client)
+    headers, user_id = await _signup_with_id(async_client)
     habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
-    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
-    user_id = resp.json()["user_id"]
 
     # 3 consecutive days, then a gap, then 2 consecutive
     base = datetime(2024, 1, 1, 8, 0, tzinfo=UTC)
@@ -222,10 +238,8 @@ async def test_stats_current_streak(async_client: AsyncClient, db_session: Async
     ``streakFromCompletions`` rule) does not zero the chain because the
     fixture used dates from 2024.
     """
-    headers = await _signup(async_client)
+    headers, user_id = await _signup_with_id(async_client)
     habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
-    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
-    user_id = resp.json()["user_id"]
 
     # Older completion (gap), then yesterday + day-before-yesterday so the
     # recency gate sees a fresh chain ending within the one-day grace
@@ -250,10 +264,8 @@ async def test_stats_current_streak(async_client: AsyncClient, db_session: Async
 @pytest.mark.asyncio
 async def test_stats_completion_rate(async_client: AsyncClient, db_session: AsyncSession) -> None:
     """Completion rate = days-with-completions / span-days."""
-    headers = await _signup(async_client)
+    headers, user_id = await _signup_with_id(async_client)
     habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
-    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
-    user_id = resp.json()["user_id"]
 
     # Jan 1 and Jan 3 — span is 3 days, completed on 2
     db_session.add(
@@ -282,10 +294,8 @@ async def test_stats_completion_rate(async_client: AsyncClient, db_session: Asyn
 @pytest.mark.asyncio
 async def test_stats_completion_dates(async_client: AsyncClient, db_session: AsyncSession) -> None:
     """completion_dates lists unique ISO date strings for calendar marking."""
-    headers = await _signup(async_client)
+    headers, user_id = await _signup_with_id(async_client)
     habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
-    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
-    user_id = resp.json()["user_id"]
 
     # Two completions on same day + one on another day
     db_session.add(
@@ -325,17 +335,15 @@ async def test_stats_only_counts_current_users_completions(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
     """Stats should not include completions from other users."""
-    alice_headers = await _signup(async_client, "alice")
-    bob_headers = await _signup(async_client, "bob")
+    alice_headers, alice_user_id = await _signup_with_id(async_client, "alice")
+    bob_headers, bob_user_id = await _signup_with_id(async_client, "bob")
 
     # Alice creates a habit+goal
     habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, alice_headers)
-    resp = await async_client.get(f"/habits/{habit_id}", headers=alice_headers)
-    alice_user_id = resp.json()["user_id"]
-
-    # Bob's user_id (from a different habit)
-    bob_resp = await async_client.post("/habits/", json=sample_payload(), headers=bob_headers)
-    bob_user_id = bob_resp.json()["user_id"]
+    # ``bob_headers`` keeps Bob's auth context for any later request even
+    # though we no longer need to round-trip through ``POST /habits/`` to
+    # learn his user-id.
+    _ = bob_headers
 
     # Alice's completion
     db_session.add(
@@ -375,10 +383,8 @@ async def test_stats_current_streak_returns_zero_for_stale_chain(
     (``compute_habit_streak``) correctly returned 0 -- exactly the API
     contract divergence the recency gate was introduced to eliminate.
     """
-    headers = await _signup(async_client)
+    headers, user_id = await _signup_with_id(async_client)
     habit_id, goal_id = await _create_habit_with_goal(async_client, db_session, headers)
-    resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
-    user_id = resp.json()["user_id"]
 
     # Three consecutive days that ended five days ago -- chain is well
     # outside the one-day grace window, so the gate must fire.

--- a/backend/tests/test_habits_api.py
+++ b/backend/tests/test_habits_api.py
@@ -154,22 +154,24 @@ async def test_user_cannot_see_other_users_habits(async_client: AsyncClient) -> 
 
 @pytest.mark.asyncio
 async def test_user_cannot_get_other_users_habit(async_client: AsyncClient) -> None:
+    """BUG-T7: cross-user GET returns 403 (was 404).  See ``tests/security/test_idor.py``."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
     create_resp = await async_client.post("/habits/", json=sample_payload(), headers=alice_headers)
     habit_id = create_resp.json()["id"]
     resp = await async_client.get(f"/habits/{habit_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.asyncio
 async def test_user_cannot_delete_other_users_habit(async_client: AsyncClient) -> None:
+    """BUG-T7: cross-user DELETE returns 403 (was 404)."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
     create_resp = await async_client.post("/habits/", json=sample_payload(), headers=alice_headers)
     habit_id = create_resp.json()["id"]
     resp = await async_client.delete(f"/habits/{habit_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -43,6 +43,23 @@ async def _auth_headers(client: AsyncClient, email: str = "user@example.com") ->
     return {"Authorization": f"Bearer {token}"}
 
 
+async def _auth_headers_with_id(
+    client: AsyncClient, email: str = "user@example.com"
+) -> tuple[dict[str, str], int]:
+    """Sign up a user and return (auth headers, user_id).
+
+    Habit responses no longer echo ``user_id`` (BUG-T7), so flows that need
+    to seed completions directly source the id from the auth response —
+    which legitimately tells the caller their own id.
+    """
+    resp = await client.post(
+        SIGNUP_URL,
+        json={"email": email, "password": "securepassword123"},  # pragma: allowlist secret
+    )
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
 async def _create_habit(
     client: AsyncClient,
     headers: dict[str, str],
@@ -69,7 +86,7 @@ async def test_signup_create_habit_log_completion_check_streak(
     Signs up, creates a habit, adds a goal, logs completions, and
     verifies streak increments with milestone detection.
     """
-    headers = await _auth_headers(async_client)
+    headers, user_id = await _auth_headers_with_id(async_client)
 
     # Create a habit
     habit = await _create_habit(async_client, headers)
@@ -97,7 +114,7 @@ async def test_signup_create_habit_log_completion_check_streak(
         db_session.add(
             GoalCompletion(
                 goal_id=goal.id,
-                user_id=int(str(habit["user_id"])),
+                user_id=user_id,
                 completed_units=goal.target,
                 timestamp=now - timedelta(days=days_ago),
             )
@@ -254,9 +271,11 @@ async def test_user_isolation_habits(async_client: AsyncClient) -> None:
     assert resp.status_code == HTTPStatus.OK
     assert resp.json() == []
 
-    # Bob tries to access Alice's habit by ID — should get 404
+    # Bob tries to access Alice's habit by ID — must get 403, not 404
+    # (BUG-T7: cross-user access returns 403; 404 is reserved for genuinely
+    # missing rows so the auth-failure path is uniform).
     alice_habits = await async_client.get("/habits/", headers=headers_a)
     alice_habit_id = alice_habits.json()[0]["id"]
 
     resp = await async_client.get(f"/habits/{alice_habit_id}", headers=headers_b)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.FORBIDDEN

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -385,6 +385,7 @@ async def test_user_cannot_see_other_users_entries(async_client: AsyncClient) ->
 
 @pytest.mark.asyncio
 async def test_user_cannot_get_other_users_entry(async_client: AsyncClient) -> None:
+    """BUG-T7: cross-user GET returns 403 (was 404).  See ``tests/security/test_idor.py``."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
 
@@ -394,11 +395,12 @@ async def test_user_cannot_get_other_users_entry(async_client: AsyncClient) -> N
     entry_id = create_resp.json()["id"]
 
     resp = await async_client.get(f"/journal/{entry_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.asyncio
 async def test_user_cannot_delete_other_users_entry(async_client: AsyncClient) -> None:
+    """BUG-T7: cross-user DELETE returns 403 (was 404)."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
 
@@ -408,4 +410,4 @@ async def test_user_cannot_delete_other_users_entry(async_client: AsyncClient) -
     entry_id = create_resp.json()["id"]
 
     resp = await async_client.delete(f"/journal/{entry_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == HTTPStatus.FORBIDDEN

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -117,7 +117,7 @@ async def test_week_count_requires_auth(async_client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_create_session(async_client: AsyncClient, db_session: AsyncSession) -> None:
-    headers, user_id = await _signup(async_client)
+    headers, _user_id = await _signup(async_client)
     up_id = await _create_user_practice(async_client, db_session, headers)
 
     payload = _session_payload(up_id, reflection="felt calm")
@@ -128,7 +128,8 @@ async def test_create_session(async_client: AsyncClient, db_session: AsyncSessio
     assert data["user_practice_id"] == up_id
     assert data["duration_minutes"] == _DEFAULT_DURATION
     assert data["id"] is not None
-    assert data["user_id"] == user_id
+    # BUG-T7: response no longer echoes user_id (caller already knows from JWT).
+    assert "user_id" not in data
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_practices_api.py
+++ b/backend/tests/test_practices_api.py
@@ -158,7 +158,7 @@ async def test_get_practice_not_found(async_client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_submit_practice(async_client: AsyncClient) -> None:
-    headers, user_id = await _signup(async_client)
+    headers, _user_id = await _signup(async_client)
     payload = {
         "stage_number": 1,
         "name": "My Custom Practice",
@@ -170,7 +170,9 @@ async def test_submit_practice(async_client: AsyncClient) -> None:
     assert resp.status_code == HTTPStatus.CREATED
     data = resp.json()
     assert data["name"] == "My Custom Practice"
-    assert data["submitted_by_user_id"] == user_id
+    # BUG-PRACTICE-001 / BUG-SCHEMA-010: catalog responses must not leak the
+    # submitter's user id.  Server-side ownership lives on the row.
+    assert "submitted_by_user_id" not in data
     assert data["approved"] is False
 
 

--- a/backend/tests/test_user_practices_api.py
+++ b/backend/tests/test_user_practices_api.py
@@ -76,7 +76,7 @@ async def test_list_user_practices_requires_auth(async_client: AsyncClient) -> N
 
 @pytest.mark.asyncio
 async def test_select_practice(async_client: AsyncClient, db_session: AsyncSession) -> None:
-    headers, user_id = await _signup(async_client)
+    headers, _user_id = await _signup(async_client)
     practice = await _seed_practice(db_session)
 
     resp = await async_client.post(
@@ -86,7 +86,8 @@ async def test_select_practice(async_client: AsyncClient, db_session: AsyncSessi
     )
     assert resp.status_code == HTTPStatus.CREATED
     data = resp.json()
-    assert data["user_id"] == user_id
+    # BUG-T7: user-practice responses no longer echo user_id.
+    assert "user_id" not in data
     assert data["practice_id"] == practice.id
     assert data["stage_number"] == 1
     assert data["start_date"] is not None


### PR DESCRIPTION
## Summary

Implements `prompts/2026-04-18-bug-remediation/remediation-plan/07-normalize-idor-ordering.md`. Three atomic commits:

1. **`feat(backend): add ownership dependency + response DTO base (no user_id)`** — `backend/src/dependencies/ownership.py` (six per-resource deps codifying the canonical resolve→authorize / 404→403 split) and `backend/src/schemas/_base.OwnedResourcePublic`.
2. **`fix(backend): migrate routers to ownership dep + strip user_id from responses`** — wires habit / journal / course / goal-group / practice / practice-session / user-practice routers through the dep and the no-`user_id` DTO base.
3. **`test(backend): add IDOR probe matrix`** — 29 cases under `backend/tests/security/test_idor.py` that fail specifically on a 404↔403 ordering regression.

## BUG-IDs closed

- **BUG-COURSE-004** — locked-stage access on `/course/content/{id}` and `/content/{id}/mark-read` is masked as 404 (was 403), so an attacker cannot enumerate `content_id` via the locked-vs-missing oracle.
- **BUG-JOURNAL-002 / BUG-JOURNAL-006** — `GET/DELETE /journal/{id}` use the explicit 404→403 split via `require_owned_journal_entry`.
- **BUG-JOURNAL-004** — `JournalMessageResponse` (already stripped) is documented alongside the rest of the no-`user_id` family.
- **BUG-HABIT-001 / BUG-SCHEMA-001** — `Habit` / `HabitWithGoals` no longer echo `user_id`; cross-user `GET/PUT/DELETE /habits/{id}` returns 403.
- **BUG-GOAL-005** — `create_goal_group` sources ownership from `current_user`; `GoalGroupCreate` does not expose a `user_id` field, so a forged body silently fails to plant a row under another account.
- **BUG-GOAL-006** — `update_goal_group` / `delete_goal_group` go through `require_owned_goal_group`. Shared templates (`user_id IS NULL`) can no longer match `current_user` and always 403 instead of falling through the prior NULL-equals-owner short-circuit.
- **BUG-PRACTICE-001 / BUG-SCHEMA-010** — `GET /practices/{id}` returns 403 for unapproved drafts owned by someone else; `PracticeResponse` no longer leaks `submitted_by_user_id`.
- **BUG-T7 (cross-cutting)** — `UserPracticeResponse`, `UserPracticeDetail`, `PracticeSessionResponse`, `ContentCompletionResponse`, `GoalGroupResponse` all drop `user_id`. Existing per-resource access-control tests updated to expect 403 on cross-user reads/writes.

## Pattern

`backend/src/dependencies/ownership.py` exports six explicit per-resource deps (Option 2 from the prompt) — verbose but type-stable, no `inspect.Signature` rewrite, no `# type: ignore` shortcuts. Routers attach them via `Annotated[Model, Depends(require_owned_*)]`; helper functions `_get_habit_with_completions` / `_refetch_goal_group_with_goals` cover the eager-loading paths the bare dep can't satisfy with one query.

`backend/src/schemas/_base.OwnedResourcePublic` is the documentation hook for the no-`user_id` invariant; the `tests/security/test_idor.py::test_no_user_id_in_owned_resource_responses` body scrub is the runtime enforcement.

## Test plan

- [x] `pre-commit run --all-files` clean before each commit (ruff `select=ALL`, mypy strict, bandit, isort, ESLint, Prettier, frontend typecheck/tests, etc.).
- [x] `pytest --no-cov` — 711 passed, 16 subtests passed, 0 failures.
- [x] Coverage ≥ 90% (`pytest --cov` reports 93.51% line coverage).
- [x] New `tests/security/test_idor.py` matrix (29 cases, all passing): cross-user GET/PUT/DELETE for habit/journal/goal-group/user-practice, practice-session create + list, unapproved practice GET, shared-template mutation 403, missing-row 404 parametrise, BUG-COURSE-004 locked-content 404 mask, body scrub for `user_id` / `submitted_by_user_id` echoes.
- [ ] Smoke-test from a frontend client (no UI changes required by this prompt; the existing optimistic-mutation hook is unaffected).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrBA1psvepJ6JMsBqxBw8T)_