### PR TITLE
fix(db): replace check-then-insert with DB-level unique constraints (T5 TOCTOU)

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -59,16 +59,12 @@ _SQLITE_PORTABLE_UNIQUE_INDEXES: tuple[str, ...] = (
     # uses ``((timestamp AT TIME ZONE 'UTC')::date)`` for IMMUTABLE-ness
     # under a non-UTC server zone; SQLite stores ``timestamp`` as ISO
     # text and ``date(timestamp)`` is sufficient at test scale.  The
-    # ``contentcompletion`` table's unique constraint lives on the model
-    # itself (``__table_args__``) so it is created by
-    # ``metadata.create_all`` everywhere and does not need a test-only
+    # ``contentcompletion`` and ``userpractice`` constraints live on
+    # their respective models' ``__table_args__`` so they are created
+    # by ``metadata.create_all`` everywhere and do not need a test-only
     # mirror here.
     'CREATE UNIQUE INDEX IF NOT EXISTS "ix_goal_completion_unique_per_day_test" '
     "ON goalcompletion (goal_id, user_id, date(timestamp))",
-    # user_practice: at most one open row per (user, stage).  SQLite
-    # supports the same partial-index syntax as Postgres for this.
-    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_user_practice_active_stage_test" '
-    "ON userpractice (user_id, stage_number) WHERE end_date IS NULL",
 )
 
 

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -15,9 +15,10 @@ sys.path.insert(0, str(REPO_ROOT / "backend/src"))
 import pytest  # noqa: E402
 import pytest_asyncio  # noqa: E402
 from httpx import ASGITransport, AsyncClient  # noqa: E402
-from sqlalchemy import JSON  # noqa: E402
+from sqlalchemy import JSON, text  # noqa: E402
 from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY  # noqa: E402
 from sqlalchemy.ext.asyncio import (  # noqa: E402
+    AsyncConnection,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
@@ -46,6 +47,45 @@ def _replace_array_columns() -> None:
                 column.type = JSON()
 
 
+# Production-only Postgres functional / partial unique indexes that SQLite
+# cannot express in the same syntax.  Tests that exercise the
+# ``IntegrityError → idempotent / 409`` path must see equivalent
+# constraints on the test DB; we install SQLite-compatible variants below
+# after ``metadata.create_all``.  Each entry is a ``CREATE UNIQUE INDEX
+# IF NOT EXISTS …`` statement; the ``IF NOT EXISTS`` clause keeps the
+# helper idempotent across the per-test fixture lifecycle.
+_SQLITE_PORTABLE_UNIQUE_INDEXES: tuple[str, ...] = (
+    # goal_completion: one row per (goal, user, calendar day).  Production
+    # uses ``((timestamp AT TIME ZONE 'UTC')::date)`` for IMMUTABLE-ness
+    # under a non-UTC server zone; SQLite stores ``timestamp`` as ISO
+    # text and ``date(timestamp)`` is sufficient at test scale.
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_goal_completion_unique_per_day_test" '
+    "ON goalcompletion (goal_id, user_id, date(timestamp))",
+    # content_completion: one row per (user, content).  Plain composite
+    # constraint; identical semantics on both engines.
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_content_completion_unique_user_content_test" '
+    "ON contentcompletion (user_id, content_id)",
+    # user_practice: at most one open row per (user, stage).  SQLite
+    # supports the same partial-index syntax as Postgres for this.
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_user_practice_active_stage_test" '
+    "ON userpractice (user_id, stage_number) WHERE end_date IS NULL",
+)
+
+
+async def _install_test_only_unique_indexes(conn: AsyncConnection) -> None:
+    """Add SQLite-compatible variants of production functional indexes.
+
+    Skipped on every non-SQLite dialect; production runs the canonical
+    Alembic migrations and adding the test-only variants would be
+    redundant (or, for the user-practice partial index, conflict with
+    the migration's exact name).
+    """
+    if conn.dialect.name != "sqlite":
+        return
+    for stmt in _SQLITE_PORTABLE_UNIQUE_INDEXES:
+        await conn.execute(text(stmt))
+
+
 @pytest_asyncio.fixture
 async def db_session() -> AsyncGenerator[AsyncSession, None]:
     """Provide a clean async session with all tables created.
@@ -53,6 +93,13 @@ async def db_session() -> AsyncGenerator[AsyncSession, None]:
     BUG-INFRA-027: schema teardown lives in ``finally`` so tables are dropped
     even when a test raises mid-flight.  Without this, a failing test can
     leave residual rows that pollute the next test in the same engine.
+
+    The test-only unique indexes are intentionally **not** installed here:
+    streak / aggregation tests insert multiple ``GoalCompletion`` rows
+    per (goal, user, day) to exercise the bucketing logic, which the
+    production unique-per-day index would (correctly) reject.  The
+    concurrency fixture below opts in because its tests cover the
+    DB-level ``IntegrityError`` paths the indexes guard.
     """
     _replace_array_columns()
 
@@ -137,6 +184,7 @@ async def concurrent_async_client(tmp_path: Path) -> AsyncGenerator[AsyncClient,
     _replace_array_columns()
     async with concurrent_engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
+        await _install_test_only_unique_indexes(conn)
 
     async def _per_request_session() -> AsyncGenerator[AsyncSession, None]:
         async with concurrent_factory() as session:

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -58,13 +58,13 @@ _SQLITE_PORTABLE_UNIQUE_INDEXES: tuple[str, ...] = (
     # goal_completion: one row per (goal, user, calendar day).  Production
     # uses ``((timestamp AT TIME ZONE 'UTC')::date)`` for IMMUTABLE-ness
     # under a non-UTC server zone; SQLite stores ``timestamp`` as ISO
-    # text and ``date(timestamp)`` is sufficient at test scale.
+    # text and ``date(timestamp)`` is sufficient at test scale.  The
+    # ``contentcompletion`` table's unique constraint lives on the model
+    # itself (``__table_args__``) so it is created by
+    # ``metadata.create_all`` everywhere and does not need a test-only
+    # mirror here.
     'CREATE UNIQUE INDEX IF NOT EXISTS "ix_goal_completion_unique_per_day_test" '
     "ON goalcompletion (goal_id, user_id, date(timestamp))",
-    # content_completion: one row per (user, content).  Plain composite
-    # constraint; identical semantics on both engines.
-    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_content_completion_unique_user_content_test" '
-    "ON contentcompletion (user_id, content_id)",
     # user_practice: at most one open row per (user, stage).  SQLite
     # supports the same partial-index syntax as Postgres for this.
     'CREATE UNIQUE INDEX IF NOT EXISTS "ix_user_practice_active_stage_test" '

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -62,6 +62,15 @@ _RAW_SQL_MANAGED_INDEXES: frozenset[str] = frozenset(
     }
 )
 
+# Migration-internal archive tables created by dedup steps (see e.g.
+# ``e1f2a3b4c5d6_contentcompletion_unique_user_content``).  These hold
+# rows that were dropped to satisfy a freshly-added unique constraint
+# and are intentionally not modeled in SQLModel — there is no router or
+# RLS policy that exposes them.  We tell autogenerate / ``alembic check``
+# to leave them alone so a successful ``upgrade head`` does not register
+# as drift the next time the gate runs.
+_MIGRATION_ARCHIVE_TABLE_PREFIX = "_duplicates_"
+
 
 def _include_object(
     obj: Any,
@@ -70,14 +79,21 @@ def _include_object(
     reflected: bool,  # noqa: ARG001
     compare_to: Any,  # noqa: ARG001
 ) -> bool:
-    """Skip raw-SQL-managed indexes during autogenerate / check.
+    """Skip raw-SQL-managed indexes and dedup archive tables.
 
     Without this, ``alembic check`` reports drift for every functional /
-    partial index because the model declarations can't represent them
-    portably (SQLite would reject the expressions at table creation time
-    in the test fixture).  See :data:`_RAW_SQL_MANAGED_INDEXES`.
+    partial index (see :data:`_RAW_SQL_MANAGED_INDEXES`) and for every
+    ``_duplicates_*`` archive table left behind by a dedup migration.
+    Both are migration-owned artifacts that the model layer
+    intentionally does not declare.
     """
     if type_ == "index" and name in _RAW_SQL_MANAGED_INDEXES:
+        return False
+    if (
+        type_ == "table"
+        and name is not None
+        and name.startswith(_MIGRATION_ARCHIVE_TABLE_PREFIX)
+    ):
         return False
     return True
 

--- a/backend/migrations/versions/e1f2a3b4c5d6_contentcompletion_unique_user_content.py
+++ b/backend/migrations/versions/e1f2a3b4c5d6_contentcompletion_unique_user_content.py
@@ -1,0 +1,80 @@
+"""contentcompletion unique (user_id, content_id)
+
+Revision ID: e1f2a3b4c5d6
+Revises: d1e2f3a4b5c6
+Create Date: 2026-04-28 00:00:00.000000
+
+BUG-COURSE-002: ``mark_content_read`` did a SELECT-then-INSERT to enforce
+"read once per content."  Two concurrent mark-read requests could both
+pass the existence check before either committed and both write a row,
+inflating progress percentages and breaking the user-visible "read"
+toggle's invariant with the row count.
+
+This migration deduplicates legacy rows (keeping the earliest
+``id``-wise per ``(user_id, content_id)`` group) and adds a unique
+constraint at the database level so the application can safely drop
+the pre-check and rely on ``IntegrityError → idempotent response``.
+The duplicates are archived to ``_duplicates_contentcompletion`` for
+audit; the archive table is created in the database's default schema
+and is not exposed through any router or RLS policy, satisfying the
+prompt's "dedup archive must not be user-readable" requirement.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f2a3b4c5d6"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "d1e2f3a4b5c6"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_UNIQUE_CONSTRAINT = "uq_contentcompletion_user_content"
+
+
+def upgrade() -> None:
+    """Archive legacy duplicates, then add the unique constraint."""
+    # 1. Archive duplicates so the constraint creation cannot fail on
+    #    pre-existing data.  Keeps the earliest (lowest-id) row per
+    #    (user_id, content_id) pair on the assumption that the first
+    #    "mark read" is the canonical one.
+    op.execute(
+        "CREATE TABLE IF NOT EXISTS _duplicates_contentcompletion "
+        "AS SELECT * FROM contentcompletion WHERE false"
+    )
+    op.execute(
+        "INSERT INTO _duplicates_contentcompletion "
+        "SELECT * FROM contentcompletion cc "
+        "WHERE cc.id NOT IN ("
+        "  SELECT min(id) FROM contentcompletion "
+        "  GROUP BY user_id, content_id"
+        ")"
+    )
+    op.execute(
+        "DELETE FROM contentcompletion "
+        "WHERE id IN (SELECT id FROM _duplicates_contentcompletion)"
+    )
+
+    # 2. Add the constraint.  Using ``create_unique_constraint`` (rather
+    #    than a functional index) keeps the constraint discoverable via
+    #    ``information_schema.table_constraints`` and aligns with the
+    #    SQLModel ``__table_args__`` declaration on
+    #    :class:`models.ContentCompletion` so ``alembic check`` does not
+    #    flag drift after this lands.
+    op.create_unique_constraint(
+        _UNIQUE_CONSTRAINT,
+        "contentcompletion",
+        ["user_id", "content_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the unique constraint.
+
+    The archived duplicates are intentionally **not** re-inserted: the
+    archive is for audit only, and re-inserting would re-introduce the
+    very inconsistency the upgrade resolved.
+    """
+    op.drop_constraint(_UNIQUE_CONSTRAINT, "contentcompletion", type_="unique")

--- a/backend/src/models/content_completion.py
+++ b/backend/src/models/content_completion.py
@@ -2,12 +2,24 @@
 
 from datetime import UTC, datetime
 
-from sqlalchemy import Column, DateTime
+from sqlalchemy import Column, DateTime, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 
 class ContentCompletion(SQLModel, table=True):
-    """Records that a user has read a specific content item."""
+    """Records that a user has read a specific content item.
+
+    The ``(user_id, content_id)`` unique constraint enforces "read once
+    per content" at the database level (BUG-COURSE-002).  Without it the
+    application-level pre-check in ``mark_content_read`` was racy: two
+    concurrent calls could both pass the existence check and both
+    insert, leaving the row count out of step with the user-visible
+    "read" toggle.
+    """
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "content_id", name="uq_contentcompletion_user_content"),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     user_id: int = Field(foreign_key="user.id", index=True)

--- a/backend/src/models/user_practice.py
+++ b/backend/src/models/user_practice.py
@@ -1,17 +1,44 @@
 from datetime import date
 
+from sqlalchemy import Column, Date, Index
 from sqlmodel import Field, SQLModel
+
+# Bound at module scope so :class:`Index`'s ``*_where`` predicates can
+# resolve the column at table-creation time.  Both Postgres and SQLite
+# accept the same ``IS NULL`` form, so the predicate is identical
+# across dialects.
+_END_DATE_COLUMN = Column("end_date", Date, nullable=True)
 
 
 class UserPractice(SQLModel, table=True):
     """Connects a user to a selected Practice for a given stage.
 
     Tracks the time window of engagement with the practice.
+
+    The partial unique index ``ix_user_practice_active_stage`` enforces
+    "at most one open ``UserPractice`` per ``(user, stage)``" at the
+    database level (BUG-PRACTICE-005, BUG-PRACTICE-011).  ``end_date IS
+    NULL`` is the canonical "still active" predicate, so the index lets
+    historical (closed) selections accumulate while the live selection
+    remains a single row.  Mirrors the constraint from migration
+    ``f6a7b8c9d0e1`` so SQLite tests inherit the same enforcement via
+    ``metadata.create_all``.
     """
+
+    __table_args__ = (
+        Index(
+            "ix_user_practice_active_stage",
+            "user_id",
+            "stage_number",
+            unique=True,
+            postgresql_where=_END_DATE_COLUMN.is_(None),
+            sqlite_where=_END_DATE_COLUMN.is_(None),
+        ),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     user_id: int = Field(foreign_key="user.id")
     practice_id: int = Field(foreign_key="practice.id")
     stage_number: int
     start_date: date
-    end_date: date | None = None
+    end_date: date | None = Field(default=None, sa_column=_END_DATE_COLUMN)

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import os
 import secrets
+from collections import defaultdict
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -14,6 +18,8 @@ import bcrypt
 import jwt
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, EmailStr, field_validator
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -265,6 +271,72 @@ async def _is_account_locked(session: AsyncSession, email: str) -> bool:
     return all(not attempt.success for attempt in recent_attempts)
 
 
+# Per-process per-email asyncio lock used to serialize the lockout check +
+# attempt-record sequence so two concurrent failed attempts inside the same
+# worker cannot both pass the check at the threshold-1 boundary
+# (BUG-AUTH-007). For multi-worker deployments the matching PostgreSQL
+# advisory lock below closes the cross-process race.  The dict is unbounded
+# in principle but each entry is a bare ``asyncio.Lock`` (a few hundred
+# bytes) and the email keys are already gated by per-route rate limits, so
+# memory growth is naturally capped at the legitimate-user fan-out.
+_login_locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+# 8-byte advisory-lock key derived from a SHA-256 of the normalized email.
+# Pinned to int8 because pg_advisory_xact_lock(bigint) is the single-arg
+# form; truncating the digest is fine because collisions only cause spurious
+# serialization, not a security failure.
+_ADVISORY_LOCK_KEY_BYTES = 8
+
+
+async def _acquire_email_lock_pg(session: AsyncSession, email: str) -> None:
+    """Take a transaction-scoped advisory lock on ``email`` (PostgreSQL only).
+
+    Closes the cross-worker half of BUG-AUTH-007: in production the
+    ``_login_locks`` asyncio dictionary only serializes coroutines inside
+    one Uvicorn worker, so a fleet of workers can still race the lockout
+    check against the attempt insert.  ``pg_advisory_xact_lock`` lives in
+    the database, so every worker observes the same lock and the
+    check + record sequence is atomic per email.
+
+    SQLite (used in tests) does not implement advisory locks, so the
+    function is a no-op there; the in-process ``_login_locks`` is enough
+    because every test runs in a single Python process.
+    """
+    bind = session.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    digest = hashlib.sha256(email.encode("utf-8")).digest()[:_ADVISORY_LOCK_KEY_BYTES]
+    key = int.from_bytes(digest, "big", signed=True)
+    await session.execute(text("SELECT pg_advisory_xact_lock(:k)").bindparams(k=key))
+
+
+@asynccontextmanager
+async def _serialize_login(session: AsyncSession, email: str) -> AsyncIterator[None]:
+    """Acquire both the in-process and PG advisory locks for ``email``.
+
+    Held for the duration of the login flow so the lockout check, the
+    password verify, and the attempt-record commit run as one atomic
+    decision per email (BUG-AUTH-007).  The advisory lock is
+    transaction-scoped, so it releases when the session commits or rolls
+    back at the end of the request — no manual ``pg_advisory_unlock``
+    needed.
+    """
+    async with _login_locks[email]:
+        await _acquire_email_lock_pg(session, email)
+        yield
+
+
+def _duplicate_signup_response() -> AuthResponse:
+    """Identical-shape response for an email already in use.
+
+    Returned both when the pre-empted insert would conflict and when a
+    concurrent request wins the race and our insert raises
+    ``IntegrityError``.  The dummy token is signed with a random key so
+    it cannot be exchanged for access to the existing account.
+    """
+    return AuthResponse(token=_create_dummy_token(), user_id=0)
+
+
 @router.post("/signup", response_model=AuthResponse)
 @limiter.limit("3/minute")
 async def signup(
@@ -274,24 +346,28 @@ async def signup(
 ) -> AuthResponse:
     if len(payload.password) < _MIN_PASSWORD_LENGTH:
         raise bad_request("password_too_short")
-    result = await session.execute(select(User).where(User.email == payload.email))
-    if result.scalars().first() is not None:
-        # Perform a dummy hash so the response time is indistinguishable from
-        # a real signup (bcrypt takes ~250 ms). Without this, an attacker could
-        # use timing to detect whether the email already exists.
-        _hash_password(payload.password)
-        # Return an identical response shape to prevent account enumeration.
-        # The dummy token is signed with a random key and will fail validation,
-        # so it cannot be used to access the existing account.
-        return AuthResponse(token=_create_dummy_token(), user_id=0)
-
+    # Always pay the bcrypt cost so the response time is indistinguishable
+    # from the duplicate-email branch (bcrypt takes ~250 ms).  Without
+    # this, a timing oracle could distinguish "email exists" from "email
+    # is new" even though the response bodies match.
+    password_hash = _hash_password(payload.password)
     user = User(
         email=payload.email,
-        password_hash=_hash_password(payload.password),
+        password_hash=password_hash,
         timezone=payload.timezone,
     )
     session.add(user)
-    await session.commit()
+    try:
+        await session.commit()
+    except IntegrityError:
+        # The ``ix_user_lower_email_unique`` functional unique index (or
+        # the case-sensitive ``ix_user_email`` for legacy schemas) raised
+        # because either an earlier signup or a concurrent request won
+        # the race.  Either way the response is the anti-enumeration
+        # dummy — same shape, same timing — so the client cannot tell
+        # whether the email was new or already registered.
+        await session.rollback()
+        return _duplicate_signup_response()
     await session.refresh(user)
 
     if user.id is None:
@@ -310,29 +386,39 @@ async def login(
 ) -> AuthResponse:
     ip_address = _get_client_ip(request)
 
-    # Check lockout before even verifying credentials — prevents timing attacks
-    if await _is_account_locked(session, payload.email):
-        logger.info(
-            "auth_attempt_blocked",
-            extra={
-                "email_fingerprint": _email_log_fingerprint(payload.email),
-                "ip_address": ip_address,
-                "reason": "account_locked",
-                "timestamp": datetime.now(UTC).isoformat(),
-            },
-        )
-        # Return the same generic message to prevent account enumeration
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_credentials")
+    # Wrap the lockout-check + verify + record sequence in a per-email
+    # serialization so concurrent failed attempts cannot all pass the
+    # threshold-1 check before any of them inserts (BUG-AUTH-007).
+    async with _serialize_login(session, payload.email):
+        # Check lockout before even verifying credentials — prevents timing attacks
+        if await _is_account_locked(session, payload.email):
+            logger.info(
+                "auth_attempt_blocked",
+                extra={
+                    "email_fingerprint": _email_log_fingerprint(payload.email),
+                    "ip_address": ip_address,
+                    "reason": "account_locked",
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+            # Return the same generic message to prevent account enumeration
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid_credentials",
+            )
 
-    result = await session.execute(select(User).where(User.email == payload.email))
-    user = result.scalars().first()
+        result = await session.execute(select(User).where(User.email == payload.email))
+        user = result.scalars().first()
 
-    if user is None or not _verify_password(payload.password, user.password_hash):
-        await _record_attempt(session, payload.email, ip_address, success=False)
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_credentials")
+        if user is None or not _verify_password(payload.password, user.password_hash):
+            await _record_attempt(session, payload.email, ip_address, success=False)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid_credentials",
+            )
 
-    # Successful login — record and reset the failure window
-    await _record_attempt(session, payload.email, ip_address, success=True)
+        # Successful login — record and reset the failure window
+        await _record_attempt(session, payload.email, ip_address, success=True)
 
     if user.id is None:
         msg = "User ID unexpectedly None after database commit"

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -219,6 +219,61 @@ def _completion_response(completion: ContentCompletion) -> ContentCompletionResp
     )
 
 
+async def _resolve_unlocked_content(
+    session: AsyncSession,
+    user_id: int,
+    content_id: int,
+) -> StageContent:
+    """Fetch ``content_id`` and gate on the parent stage being unlocked.
+
+    Raises 404 if the content row is missing, 404 if its parent stage is
+    missing, and 403 if the stage is locked for ``user_id``.  Split out
+    of :func:`mark_content_read` so the route stays at xenon rank A and
+    the resolution / authorisation steps are independently testable.
+    """
+    result = await session.execute(select(StageContent).where(StageContent.id == content_id))
+    content_item = result.scalars().first()
+    if content_item is None:
+        raise not_found("content")
+    stage_result = await session.execute(
+        select(CourseStage).where(CourseStage.id == content_item.course_stage_id)
+    )
+    stage = stage_result.scalars().first()
+    if stage is None:
+        raise not_found("stage")
+    await _check_stage_unlocked(session, user_id, stage.stage_number)
+    return content_item
+
+
+async def _insert_or_resolve_completion(
+    session: AsyncSession,
+    user_id: int,
+    content_id: int,
+) -> ContentCompletion:
+    """Insert a new completion or return the winner's row on race.
+
+    ``begin_nested`` opens a SAVEPOINT so the unique-constraint
+    ``IntegrityError`` rolls back only the failed insert; the outer
+    transaction stays healthy enough for the follow-up SELECT.
+    Defensively raises if the constraint fired but the winner's row is
+    missing — that would mean the database invariant is broken and a
+    silent re-insert would compound the corruption.
+    """
+    completion = ContentCompletion(user_id=user_id, content_id=content_id)
+    try:
+        async with session.begin_nested():
+            session.add(completion)
+        await session.commit()
+        await session.refresh(completion)
+    except IntegrityError:
+        existing = await _existing_content_completion(session, user_id, content_id)
+        if existing is None:
+            msg = "ContentCompletion lost the race but the winner's row is missing"
+            raise RuntimeError(msg) from None
+        return existing
+    return completion
+
+
 @router.post("/content/{content_id}/mark-read", response_model=ContentCompletionResponse)
 async def mark_content_read(
     content_id: int,
@@ -233,50 +288,13 @@ async def mark_content_read(
     loser via ``IntegrityError`` and the existing row is returned —
     closes the BUG-COURSE-002 TOCTOU.
     """
-    # Verify content exists
-    result = await session.execute(select(StageContent).where(StageContent.id == content_id))
-    content_item = result.scalars().first()
-    if content_item is None:
-        raise not_found("content")
+    await _resolve_unlocked_content(session, current_user, content_id)
 
-    # BUG-COURSE-005: Look up the parent stage and verify unlock
-    stage_result = await session.execute(
-        select(CourseStage).where(CourseStage.id == content_item.course_stage_id)
-    )
-    stage = stage_result.scalars().first()
-    if stage is None:
-        raise not_found("stage")
-    await _check_stage_unlocked(session, current_user, stage.stage_number)
-
-    # Cheap fast path for the common retry / optimistic-UI case.
     existing = await _existing_content_completion(session, current_user, content_id)
     if existing is not None:
         return _completion_response(existing)
 
-    completion = ContentCompletion(user_id=current_user, content_id=content_id)
-    try:
-        # ``begin_nested`` opens a SAVEPOINT so the unique-constraint
-        # ``IntegrityError`` rolls back only the failed insert; the
-        # outer transaction stays healthy enough for the follow-up
-        # SELECT that fetches the winner's row.
-        async with session.begin_nested():
-            session.add(completion)
-        await session.commit()
-        await session.refresh(completion)
-    except IntegrityError:
-        # A concurrent call won the race and already inserted.  Return
-        # the existing row so the response is identical to the fast-path
-        # idempotent branch.  ``one()`` is safe because the unique
-        # constraint guarantees the row exists post-commit.
-        existing = await _existing_content_completion(session, current_user, content_id)
-        if existing is None:
-            # Defensive: the unique-constraint loser must see the
-            # winner's row.  If it isn't there the database state is
-            # corrupt; fail loudly rather than silently re-inserting.
-            msg = "ContentCompletion lost the race but the winner's row is missing"
-            raise RuntimeError(msg) from None
-        return _completion_response(existing)
-
+    completion = await _insert_or_resolve_completion(session, current_user, content_id)
     logger.info("content_marked_read", extra={"user_id": current_user, "content_id": content_id})
     return _completion_response(completion)
 

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -6,6 +6,7 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -196,13 +197,42 @@ async def get_content_item(
     return ContentItemResponse(**filtered[0])
 
 
+async def _existing_content_completion(
+    session: AsyncSession, user_id: int, content_id: int
+) -> ContentCompletion | None:
+    """Return the user's existing completion row for ``content_id`` if any."""
+    result = await session.execute(
+        select(ContentCompletion).where(
+            ContentCompletion.user_id == user_id,
+            ContentCompletion.content_id == content_id,
+        )
+    )
+    return result.scalars().first()
+
+
+def _completion_response(completion: ContentCompletion) -> ContentCompletionResponse:
+    return ContentCompletionResponse(
+        id=completion.id,
+        user_id=completion.user_id,
+        content_id=completion.content_id,
+        completed_at=completion.completed_at,
+    )
+
+
 @router.post("/content/{content_id}/mark-read", response_model=ContentCompletionResponse)
 async def mark_content_read(
     content_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ContentCompletionResponse:
-    """Mark a content item as read. Idempotent — repeated calls return existing record."""
+    """Mark a content item as read. Idempotent — repeated calls return existing record.
+
+    The pre-check is the fast path for the common retry / refresh case.
+    Two concurrent calls can both pass it; the
+    ``uq_contentcompletion_user_content`` constraint then catches the
+    loser via ``IntegrityError`` and the existing row is returned —
+    closes the BUG-COURSE-002 TOCTOU.
+    """
     # Verify content exists
     result = await session.execute(select(StageContent).where(StageContent.id == content_id))
     content_item = result.scalars().first()
@@ -218,33 +248,37 @@ async def mark_content_read(
         raise not_found("stage")
     await _check_stage_unlocked(session, current_user, stage.stage_number)
 
-    # Check for existing completion (idempotent)
-    existing_result = await session.execute(
-        select(ContentCompletion).where(
-            ContentCompletion.user_id == current_user,
-            ContentCompletion.content_id == content_id,
-        )
-    )
-    existing = existing_result.scalars().first()
+    # Cheap fast path for the common retry / optimistic-UI case.
+    existing = await _existing_content_completion(session, current_user, content_id)
     if existing is not None:
-        return ContentCompletionResponse(
-            id=existing.id,
-            user_id=existing.user_id,
-            content_id=existing.content_id,
-            completed_at=existing.completed_at,
-        )
+        return _completion_response(existing)
 
     completion = ContentCompletion(user_id=current_user, content_id=content_id)
-    session.add(completion)
-    await session.commit()
-    await session.refresh(completion)
+    try:
+        # ``begin_nested`` opens a SAVEPOINT so the unique-constraint
+        # ``IntegrityError`` rolls back only the failed insert; the
+        # outer transaction stays healthy enough for the follow-up
+        # SELECT that fetches the winner's row.
+        async with session.begin_nested():
+            session.add(completion)
+        await session.commit()
+        await session.refresh(completion)
+    except IntegrityError:
+        # A concurrent call won the race and already inserted.  Return
+        # the existing row so the response is identical to the fast-path
+        # idempotent branch.  ``one()`` is safe because the unique
+        # constraint guarantees the row exists post-commit.
+        existing = await _existing_content_completion(session, current_user, content_id)
+        if existing is None:
+            # Defensive: the unique-constraint loser must see the
+            # winner's row.  If it isn't there the database state is
+            # corrupt; fail loudly rather than silently re-inserting.
+            msg = "ContentCompletion lost the race but the winner's row is missing"
+            raise RuntimeError(msg) from None
+        return _completion_response(existing)
+
     logger.info("content_marked_read", extra={"user_id": current_user, "content_id": content_id})
-    return ContentCompletionResponse(
-        id=completion.id,
-        user_id=completion.user_id,
-        content_id=completion.content_id,
-        completed_at=completion.completed_at,
-    )
+    return _completion_response(completion)
 
 
 def _empty_progress() -> CourseProgressResponse:

--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -7,6 +7,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -85,6 +86,27 @@ async def _already_logged_today(
     return result.scalar_one_or_none() is not None
 
 
+async def _idempotent_already_logged_response(
+    session: AsyncSession,
+    goal_id: int,
+    user_id: int,
+    user_timezone: str,
+) -> CheckInResult:
+    """Build the ``already_logged_today`` response shape.
+
+    Reused by both the cheap pre-check fast path and the
+    ``IntegrityError`` slow path (BUG-GOAL-001 race) so the client sees
+    the same payload either way and the contract documented on
+    :func:`create_goal_completion` does not split.
+    """
+    streak = await compute_consecutive_streak(session, goal_id, user_id, user_timezone)
+    return CheckInResult(
+        streak=streak,
+        milestones=[],
+        reason_code="already_logged_today",
+    )
+
+
 @router.post("/", response_model=CheckInResult)
 async def create_goal_completion(
     payload: GoalCompletionRequest,
@@ -96,6 +118,12 @@ async def create_goal_completion(
     Idempotent: if a completion for the same goal/user/day already exists,
     returns the current streak with ``reason_code="already_logged_today"``
     instead of inserting a duplicate (BUG-HABITS-015 / BUG-GOAL-005).
+
+    The pre-check is the fast path for the common retry / optimistic-UI
+    case.  Two concurrent requests can both pass it; the unique-per-day
+    index on ``goalcompletion`` then catches the loser via
+    ``IntegrityError`` and the same idempotent response is returned —
+    closes the BUG-GOAL-001 TOCTOU.
     """
     goal = await _get_owned_goal(session, payload.goal_id, current_user)
 
@@ -114,27 +142,34 @@ async def create_goal_completion(
     # path; the streak query then only runs in the branch that actually
     # needs it for the response payload.
     if await _already_logged_today(session, payload.goal_id, current_user, user_tz):
-        old_streak = await compute_consecutive_streak(
-            session,
-            goal.id,
-            current_user,
-            user_tz,
-        )
-        return CheckInResult(
-            streak=old_streak,
-            milestones=[],
-            reason_code="already_logged_today",
-        )
+        return await _idempotent_already_logged_response(session, goal.id, current_user, user_tz)
 
     old_streak = await compute_consecutive_streak(session, goal.id, current_user, user_tz)
 
     completed_units = goal.target if payload.did_complete else 0
-    session.add(
-        GoalCompletion(
-            goal_id=payload.goal_id, user_id=current_user, completed_units=completed_units
-        )
+    completion = GoalCompletion(
+        goal_id=payload.goal_id,
+        user_id=current_user,
+        completed_units=completed_units,
     )
-    await session.commit()
+    try:
+        # ``begin_nested`` opens a SAVEPOINT so an ``IntegrityError`` from
+        # the unique-per-day index rolls back only the failed insert.
+        # The outer transaction stays active and the follow-up query in
+        # ``_idempotent_already_logged_response`` runs on a healthy
+        # session — without the SAVEPOINT, aiosqlite leaves the
+        # connection in a partially-aborted state that breaks the next
+        # ``await``.
+        async with session.begin_nested():
+            session.add(completion)
+        await session.commit()
+    except IntegrityError:
+        # A concurrent request for the same (goal, user, day) won the
+        # race and committed first.  The DB-level unique index keeps
+        # the duplicate out; we surface the same idempotent response
+        # the pre-check would have so the client cannot tell the two
+        # paths apart (BUG-GOAL-001).
+        return await _idempotent_already_logged_response(session, goal.id, current_user, user_tz)
 
     new_streak, reason = update_streak(old_streak, did_check_in=payload.did_complete)
 

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -14,7 +14,7 @@ from sqlmodel import col, select
 
 from database import get_session
 from domain.weekly_prompts import TOTAL_WEEKS, get_prompt_for_week
-from errors import bad_request, conflict, forbidden, not_found, unprocessable
+from errors import conflict, forbidden, not_found, unprocessable
 from models.journal_entry import JournalEntry, JournalTag
 from models.prompt_response import PromptResponse
 from routers.auth import get_current_user
@@ -190,21 +190,19 @@ async def submit_prompt_response(
     Paired with the ``count + 1``-based ``_get_user_week`` this makes
     the server-derived week a monotone function of *contiguous*
     completion, not the highest value the client has ever submitted.
+
+    Duplicate submissions are caught exclusively by the
+    ``uq_promptresponse_user_week`` constraint and surfaced as 409
+    Conflict (BUG-PROMPT-004).  The earlier 400-on-pre-check / 409-on-race
+    split exposed clients to two distinct status codes for what is
+    semantically one condition; the constraint is the only observer that
+    sees both rows in a TOCTOU race anyway, so we let it own the
+    decision and the response code stays uniform.
     """
     question = get_prompt_for_week(week_number)
     if question is None:
         raise not_found("prompt")
     await _check_week_unlocked(session, current_user, week_number)
-
-    # Prevent duplicate responses
-    result = await session.execute(
-        select(PromptResponse).where(
-            PromptResponse.user_id == current_user,
-            PromptResponse.week_number == week_number,
-        )
-    )
-    if result.scalars().first() is not None:
-        raise bad_request("already_responded")
 
     # Sanitize once at the boundary (BUG-PROMPT-003); both PromptResponse and
     # JournalEntry receive the cleaned text so the two rows agree byte-for-byte
@@ -239,9 +237,9 @@ async def submit_prompt_response(
 
     try:
         await session.commit()
-    except IntegrityError:
+    except IntegrityError as exc:
         await session.rollback()
-        raise conflict("already_responded") from None
+        raise conflict("already_responded") from exc
 
     await session.refresh(prompt_response)
 

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -313,6 +313,16 @@ async def update_progress(
     bootstrap response — so the ``payload.current_stage == 1`` +
     bootstrap-state check returns the existing row instead of trying to
     advance past it.
+
+    Edge case: if the winner *also* finished a second advance (stage 1 →
+    2) between two concurrent first-advance attempts, a loser arriving
+    with ``payload.current_stage == 1`` against an ``existing`` already
+    at stage 2 falls through to :func:`_advance_existing_progress` and
+    is rejected with ``stage_advance_mismatch`` (400).  This is a
+    deliberate non-idempotent outcome: the client's stale assertion no
+    longer matches the server-derived next stage, and quietly returning
+    an out-of-date bootstrap record would mask a real client / server
+    drift.
     """
     existing = await get_user_progress_for_update(session, current_user)
     if existing is None:

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -170,25 +171,61 @@ async def get_stage_history(
     )
 
 
+def _bootstrap_record(existing: StageProgress) -> StageProgressRecord:
+    """Build the ``StageProgressRecord`` for an idempotent bootstrap return."""
+    return StageProgressRecord(
+        id=existing.id,
+        user_id=existing.user_id,
+        current_stage=existing.current_stage,
+        completed_stages=existing.completed_stages,
+    )
+
+
+def _is_bootstrap_state(existing: StageProgress) -> bool:
+    """Return True when ``existing`` matches the freshly-created bootstrap row."""
+    return existing.current_stage == 1 and not existing.completed_stages
+
+
 async def _create_initial_progress(
     session: AsyncSession,
     user_id: int,
     payload: StageProgressUpdate,
 ) -> StageProgressRecord:
-    """Handle the no-prior-row case: must assert stage 1, then create."""
+    """Handle the no-prior-row case: must assert stage 1, then create.
+
+    Two concurrent first-advance requests for the same user could both
+    read ``progress is None`` and both attempt to insert a fresh
+    ``StageProgress`` row (BUG-STAGE-003).  The
+    ``UniqueConstraint(user_id)`` on ``stageprogress`` rejects the
+    second insert; we catch the ``IntegrityError``, re-fetch the
+    winner under ``FOR UPDATE``, and return the same bootstrap record
+    so the loser observes a consistent final state instead of
+    surfacing as a 500.
+    """
     if payload.current_stage != 1:
         raise bad_request("must_start_at_stage_one")
     progress = StageProgress(user_id=user_id, current_stage=1, completed_stages=[])
     session.add(progress)
-    await session.commit()
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        existing = await get_user_progress_for_update(session, user_id)
+        if existing is None:
+            # Defensive: the unique-constraint loser must see the
+            # winner's row.  If it is gone the database state is
+            # corrupt; surface 409 rather than re-attempt the insert.
+            raise conflict("stage_progress_race_unrecoverable") from None
+        if _is_bootstrap_state(existing):
+            return _bootstrap_record(existing)
+        # The winner already advanced past stage 1 — treat the loser's
+        # payload as an advance-from-1 request and let the normal
+        # derivation reject it with the appropriate 400 if the client
+        # raced past stage 1 with a stale assertion.
+        return await _advance_existing_progress(session, existing, payload)
     await session.refresh(progress)
     logger.info("stage_progress_started", extra={"user_id": user_id})
-    return StageProgressRecord(
-        id=progress.id,
-        user_id=progress.user_id,
-        current_stage=progress.current_stage,
-        completed_stages=progress.completed_stages,
-    )
+    return _bootstrap_record(progress)
 
 
 def _derive_next_stage(existing: StageProgress) -> tuple[int, list[int]]:
@@ -265,8 +302,19 @@ async def update_progress(
     A ``SELECT … FOR UPDATE`` row-lock prevents two concurrent advance
     requests from both reading the same ``current_stage`` and passing the
     derivation check (TOCTOU race).
+
+    BUG-STAGE-003: when several first-advance requests race, a winner
+    that committed between two losers' SELECT and INSERT means one
+    loser sees ``existing is None`` (handled inside
+    :func:`_create_initial_progress`) and another sees the winner's
+    bootstrap row.  Both losers must observe the same idempotent
+    bootstrap response — so the ``payload.current_stage == 1`` +
+    bootstrap-state check returns the existing row instead of trying to
+    advance past it.
     """
     existing = await get_user_progress_for_update(session, current_user)
     if existing is None:
         return await _create_initial_progress(session, current_user, payload)
+    if payload.current_stage == 1 and _is_bootstrap_state(existing):
+        return _bootstrap_record(existing)
     return await _advance_existing_progress(session, existing, payload)

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -6,13 +6,14 @@ import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
 from domain.dates import today_in_tz
 from domain.stage_progress import get_user_progress, is_stage_unlocked
-from errors import bad_request, forbidden, not_found
+from errors import bad_request, conflict, forbidden, not_found
 from models.practice import Practice
 from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
@@ -61,31 +62,24 @@ async def _check_stage_eligibility(
         raise forbidden("stage_locked")
 
 
-async def _check_no_active_practice(
-    session: AsyncSession, current_user: int, stage_number: int
-) -> None:
-    """Enforce at most one open UserPractice row per (user, stage)."""
-    existing = await session.execute(
-        select(UserPractice.id).where(
-            UserPractice.user_id == current_user,
-            UserPractice.stage_number == stage_number,
-            UserPractice.end_date.is_(None),  # type: ignore[union-attr]
-        )
-    )
-    if existing.scalar_one_or_none() is not None:
-        raise bad_request("active_practice_exists_for_stage")
-
-
 @router.post("/", response_model=UserPracticeResponse, status_code=status.HTTP_201_CREATED)
 async def create_user_practice(
     payload: UserPracticeCreate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> UserPractice:
-    """Select a practice for a stage, creating a UserPractice record."""
+    """Select a practice for a stage, creating a UserPractice record.
+
+    The ``ix_user_practice_active_stage`` partial unique index enforces
+    "at most one open ``UserPractice`` per ``(user, stage)``" at the
+    database level (BUG-PRACTICE-005).  The earlier application-level
+    pre-check raced: two concurrent calls could both pass the existence
+    check and both insert.  We now rely on the constraint and surface
+    the loser as 409 ``active_practice_exists_for_stage`` so the client
+    gets a single deterministic response code regardless of timing.
+    """
     practice = await _resolve_practice(session, payload.practice_id)
     await _check_stage_eligibility(session, current_user, practice, payload.stage_number)
-    await _check_no_active_practice(session, current_user, payload.stage_number)
 
     # ``start_date`` is the user-facing "I started this practice today"
     # label (BUG-HABIT-006), not an internal audit timestamp -- so it
@@ -100,7 +94,15 @@ async def create_user_practice(
         start_date=today_in_tz(user_tz),
     )
     session.add(user_practice)
-    await session.commit()
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        # The partial unique index fired because an open row already
+        # exists for ``(current_user, stage_number)``.  Return 409 so
+        # the client treats this as a state conflict, not a transient
+        # bad request.
+        raise conflict("active_practice_exists_for_stage") from exc
     await session.refresh(user_practice)
     logger.info(
         "user_practice_created",

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from unittest.mock import patch
@@ -9,7 +10,7 @@ from unittest.mock import patch
 import jwt
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
 from models.login_attempt import LoginAttempt
@@ -946,3 +947,105 @@ async def test_refresh_response_carries_stored_timezone(
     )
     assert refresh_resp.status_code == HTTPStatus.OK
     assert refresh_resp.json()["timezone"] == "Europe/Berlin"
+
+
+# ── Concurrency: signup race + lockout TOCTOU (BUG-AUTH-003 / -007) ────
+
+
+_CONCURRENT_SIGNUP_FANOUT = 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_signups_for_same_email_create_one_user(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Five simultaneous signups for the same email yield exactly one user row.
+
+    Closes BUG-AUTH-003: under the old SELECT-then-INSERT pattern two
+    concurrent signups could both pass the existence check and both
+    insert.  The case-insensitive unique index on ``lower(email)`` plus
+    the ``IntegrityError`` rollback keeps the row count at one and the
+    losing requests still receive the anti-enumeration dummy response.
+    """
+    payloads = [
+        {"email": "race@example.com", "password": "securepassword123"}  # pragma: allowlist secret
+        for _ in range(_CONCURRENT_SIGNUP_FANOUT)
+    ]
+    responses = await asyncio.gather(
+        *[concurrent_async_client.post(SIGNUP_URL, json=p) for p in payloads]
+    )
+
+    # Every attempt returns the same status + shape (anti-enumeration).
+    assert all(r.status_code == HTTPStatus.OK for r in responses)
+    assert all(set(r.json().keys()) >= {"token", "user_id"} for r in responses)
+
+    # Exactly one of them owns a real ``user_id``; the rest get the
+    # dummy ``user_id == 0`` so a timing/shape oracle cannot distinguish
+    # the winner from the duplicates.
+    real_ids = [r.json()["user_id"] for r in responses if r.json()["user_id"] != 0]
+    assert len(real_ids) == 1, real_ids
+
+    # The DB has exactly one row for the contested email.
+    async with concurrent_session_factory() as session:
+        result = await session.execute(select(User).where(User.email == "race@example.com"))
+        users = result.scalars().all()
+    assert len(users) == 1
+
+
+_CONCURRENT_FAILED_LOGIN_FANOUT = 10
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_failed_logins_cannot_outpace_lockout(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """BUG-AUTH-007: concurrent failed attempts must not all pass the lockout check.
+
+    Without per-email serialization, ten simultaneous wrong-password
+    attempts could each read "no failures yet" and each pay the bcrypt
+    cost before any of them recorded a row, defeating the
+    ``MAX_FAILED_ATTEMPTS`` cap.  The asyncio + ``pg_advisory_xact_lock``
+    serialization makes the lockout check + insert atomic per email, so
+    no more than ``MAX_FAILED_ATTEMPTS`` attempts complete with a 401
+    before subsequent ones are blocked.
+    """
+    await concurrent_async_client.post(
+        SIGNUP_URL,
+        json={
+            "email": "lockoutrace@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+
+    results = await asyncio.gather(
+        *[
+            concurrent_async_client.post(
+                LOGIN_URL,
+                json={
+                    "email": "lockoutrace@example.com",
+                    "password": "wrongpassword999",  # pragma: allowlist secret
+                },
+            )
+            for _ in range(_CONCURRENT_FAILED_LOGIN_FANOUT)
+        ]
+    )
+
+    # Every concurrent failed attempt returns 401, indistinguishable from a
+    # locked or wrong-password response.  The invariant that matters is on
+    # the persisted row count: serialized inserts can't write more than
+    # ``MAX_FAILED_ATTEMPTS`` rows before the lockout check starts winning.
+    assert all(r.status_code == HTTPStatus.UNAUTHORIZED for r in results)
+    async with concurrent_session_factory() as session:
+        result = await session.execute(
+            select(LoginAttempt).where(LoginAttempt.email == "lockoutrace@example.com")
+        )
+        attempts = list(result.scalars().all())
+    failed_attempts = [a for a in attempts if not a.success]
+    assert len(failed_attempts) <= MAX_FAILED_ATTEMPTS, (
+        f"expected ≤{MAX_FAILED_ATTEMPTS} failed inserts under serialization, "
+        f"got {len(failed_attempts)}"
+    )

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
 from models.content_completion import ContentCompletion
@@ -618,3 +619,72 @@ async def test_course_progress_no_next_unlock_when_not_on_stage(
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
     assert data["next_unlock_day"] is None
+
+
+# ── Concurrency: BUG-COURSE-002 mark-read TOCTOU ──────────────────────
+
+
+_CONCURRENT_MARK_READ_FANOUT = 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_mark_read_collapses_to_one_row(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Five simultaneous ``mark-read`` calls persist exactly one ``ContentCompletion``.
+
+    Closes BUG-COURSE-002: the SELECT-then-INSERT pre-check let two
+    concurrent calls both pass the existence check before either
+    committed; the new ``uq_contentcompletion_user_content`` constraint
+    plus the ``IntegrityError`` rollback collapses the race.  Every
+    response must carry the same ``id`` (the winner's row) so callers
+    can rely on the response shape regardless of which request actually
+    inserted.
+    """
+    signup_resp = await concurrent_async_client.post(
+        "/auth/signup",
+        json={
+            "email": "raceread@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    headers = {"Authorization": f"Bearer {signup_resp.json()['token']}"}
+
+    async with concurrent_session_factory() as session:
+        stage = CourseStage(**_stage_data(stage_number=1))
+        session.add(stage)
+        await session.flush()
+        item = StageContent(
+            course_stage_id=stage.id,
+            title="Day 1",
+            content_type="essay",
+            release_day=0,
+            url="https://cms.example.com/s1-day1",
+        )
+        session.add(item)
+        await session.commit()
+        await session.refresh(item)
+        content_id = item.id
+
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post(
+                f"/course/content/{content_id}/mark-read",
+                headers=headers,
+            )
+            for _ in range(_CONCURRENT_MARK_READ_FANOUT)
+        ]
+    )
+
+    assert all(r.status_code == HTTPStatus.OK for r in responses)
+    completion_ids = {r.json()["id"] for r in responses}
+    assert len(completion_ids) == 1, f"every response must surface the same row: {completion_ids}"
+
+    async with concurrent_session_factory() as session:
+        result = await session.execute(
+            select(ContentCompletion).where(ContentCompletion.content_id == content_id)
+        )
+        rows = list(result.scalars().all())
+    assert len(rows) == 1

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -658,6 +658,14 @@ async def test_concurrent_mark_read_collapses_to_one_row(
     response must carry the same ``id`` (the winner's row) so callers
     can rely on the response shape regardless of which request actually
     inserted.
+
+    Stage 1 is intentionally seeded without a ``StageProgress`` row for
+    the user: ``is_stage_unlocked`` treats stage 1 as universally
+    accessible (always-unlocked root, see ``domain.stage_progress``),
+    so ``_resolve_unlocked_content`` clears the BUG-COURSE-004 mask and
+    the race is actually exercised.  If that root invariant ever
+    changes this test will start returning 404s instead of 200s and the
+    assertion will surface the regression immediately.
     """
     signup_resp = await concurrent_async_client.post(
         "/auth/signup",

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, date, datetime, timedelta
 from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
 from models.goal import Goal
@@ -247,3 +248,93 @@ async def test_completion_is_persisted_in_db(
     completions = list(result.scalars().all())
     assert len(completions) == 1
     assert completions[0].user_id == user_id
+
+
+# ── Concurrency: BUG-GOAL-001 / BUG-DB-008 ─────────────────────────────
+
+
+_CONCURRENT_COMPLETION_FANOUT = 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_completions_yield_one_db_row(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Five simultaneous check-ins for the same goal/day persist exactly one row.
+
+    Closes BUG-GOAL-001: the application-level pre-check
+    (``_already_logged_today``) was the only guard against duplicate
+    daily completions, and two concurrent requests could both pass it
+    before either committed.  The unique-per-day index on
+    ``goalcompletion`` plus the ``IntegrityError → already_logged_today``
+    fallback keeps the row count at one.  Every loser gets the
+    idempotent response shape so retries don't have to special-case
+    409s.
+    """
+    signup_resp = await concurrent_async_client.post(
+        "/auth/signup",
+        json={
+            "email": "racegoal@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    headers = {"Authorization": f"Bearer {signup_resp.json()['token']}"}
+    user_id = signup_resp.json()["user_id"]
+
+    async with concurrent_session_factory() as session:
+        habit = Habit(
+            name="Concurrency drill",
+            icon="🏁",
+            start_date=date(2025, 1, 1),
+            energy_cost=1,
+            energy_return=1,
+            user_id=user_id,
+        )
+        session.add(habit)
+        await session.commit()
+        await session.refresh(habit)
+        goal = Goal(
+            habit_id=habit.id,
+            title="Race",
+            tier="clear",
+            target=1.0,
+            target_unit="reps",
+            frequency=1.0,
+            frequency_unit="per_day",
+            is_additive=True,
+        )
+        session.add(goal)
+        await session.commit()
+        await session.refresh(goal)
+        goal_id = goal.id
+
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post(
+                "/goal_completions/",
+                json={"goal_id": goal_id, "did_complete": True},
+                headers=headers,
+            )
+            for _ in range(_CONCURRENT_COMPLETION_FANOUT)
+        ]
+    )
+
+    # Every response is OK with the idempotent shape; the unique index
+    # collapses the race so the body is uniform regardless of who won.
+    assert all(r.status_code == HTTPStatus.OK for r in responses)
+    streaks = {r.json()["streak"] for r in responses}
+    assert streaks == {1}, streaks
+    reason_codes = {r.json()["reason_code"] for r in responses}
+    assert reason_codes <= {"streak_incremented", "already_logged_today"}
+    # At least one loser hit the IntegrityError / pre-check duplicate path,
+    # otherwise the test is not actually exercising the race.
+    assert "already_logged_today" in reason_codes
+
+    async with concurrent_session_factory() as session:
+        result = await session.execute(
+            select(GoalCompletion).where(GoalCompletion.goal_id == goal_id)
+        )
+        rows = list(result.scalars().all())
+    assert len(rows) == 1, [(r.id, r.timestamp) for r in rows]

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -139,7 +139,15 @@ async def test_submit_prompt_response(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_submit_duplicate_response_returns_error(async_client: AsyncClient) -> None:
+async def test_submit_duplicate_response_returns_409(async_client: AsyncClient) -> None:
+    """BUG-PROMPT-004: every duplicate submission must surface the same 409.
+
+    The earlier handler split into a 400 fast path (pre-check matched)
+    and a 409 race path (constraint fired).  Clients had to handle both
+    codes for one semantic condition.  The pre-check is gone and the
+    ``uq_promptresponse_user_week`` constraint is the single source of
+    truth for "already responded."
+    """
     headers = await _signup(async_client)
     await async_client.post(
         "/prompts/1/respond",
@@ -151,9 +159,7 @@ async def test_submit_duplicate_response_returns_error(async_client: AsyncClient
         json={"response": "Second response."},
         headers=headers,
     )
-    # Application-level check returns 400; DB constraint returns 409 — both
-    # report ``already_responded`` so the client can handle both uniformly.
-    assert resp.status_code in {HTTPStatus.BAD_REQUEST, HTTPStatus.CONFLICT}
+    assert resp.status_code == HTTPStatus.CONFLICT
     assert resp.json()["detail"] == "already_responded"
 
 
@@ -378,8 +384,9 @@ async def test_concurrent_prompt_responses_allow_exactly_one(
 
     status_codes = [r.status_code for r in responses]
     successes = status_codes.count(HTTPStatus.CREATED)
-    # The loser hits either the app-level 400 or the DB-level 409.
-    rejections = sum(1 for s in status_codes if s in {HTTPStatus.BAD_REQUEST, HTTPStatus.CONFLICT})
+    # With the pre-check gone the constraint is the only rejector; every
+    # loser hits exactly 409 (BUG-PROMPT-004).
+    rejections = status_codes.count(HTTPStatus.CONFLICT)
 
     assert successes == 1, f"Expected exactly 1 success, got {successes}"
-    assert rejections == 4, f"Expected 4 rejections, got {rejections}"
+    assert rejections == 4, f"Expected 4 conflicts, got {rejections}"

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -8,7 +8,8 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import select
 
 from models.course_stage import CourseStage
 from models.practice import Practice
@@ -666,3 +667,67 @@ async def test_stages_progress_isolated_per_user(
     data = resp.json()
     # Stage 2 should be locked for Bob (no progress record)
     assert data[1]["is_unlocked"] is False
+
+
+# ── BUG-STAGE-003: first-advance create-path TOCTOU ────────────────────
+
+
+_CONCURRENT_FIRST_ADVANCE_FANOUT = 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_first_advance_yields_one_progress_row(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Five simultaneous first-advances for a fresh user persist one progress row.
+
+    Closes BUG-STAGE-003: the create path used to ``SELECT … FROM
+    stageprogress`` and INSERT without locking, so two concurrent
+    requests could both see ``progress is None`` and both attempt the
+    insert.  ``UniqueConstraint(user_id)`` rejects the second insert;
+    the new ``IntegrityError`` handler rolls back, re-fetches the
+    winner under ``FOR UPDATE``, and returns the same shape so the
+    loser observes a consistent final state instead of a 500.
+    """
+    signup_resp = await concurrent_async_client.post(
+        "/auth/signup",
+        json={
+            "email": "racestage@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    headers = {"Authorization": f"Bearer {signup_resp.json()['token']}"}
+    user_id = signup_resp.json()["user_id"]
+
+    async with concurrent_session_factory() as session:
+        for stage_number in (1, 2):
+            session.add(CourseStage(**_stage_data(stage_number=stage_number)))
+        await session.commit()
+
+    results = await asyncio.gather(
+        *[
+            concurrent_async_client.put(
+                "/stages/progress",
+                json={"current_stage": 1},
+                headers=headers,
+            )
+            for _ in range(_CONCURRENT_FIRST_ADVANCE_FANOUT)
+        ]
+    )
+
+    # Every concurrent first-advance must terminate as a 2xx (the
+    # winner inserts; losers re-fetch and return).  The unique
+    # constraint guarantees exactly one row for ``user_id`` no matter
+    # how many tasks ran in parallel.
+    for r in results:
+        assert r.status_code in {HTTPStatus.OK, HTTPStatus.CREATED}, r.json()
+    async with concurrent_session_factory() as session:
+        result = await session.execute(
+            select(StageProgress).where(StageProgress.user_id == user_id)
+        )
+        rows = list(result.scalars().all())
+    assert len(rows) == 1
+    assert rows[0].current_stage == 1
+    assert rows[0].completed_stages == []

--- a/backend/tests/test_user_practices_api.py
+++ b/backend/tests/test_user_practices_api.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import select
 
 from models.practice import Practice
 from models.stage_progress import StageProgress
+from models.user_practice import UserPractice
 
 _EXPECTED_SELECTION_COUNT = 2
 _SESSION_DURATION = 10.0
@@ -268,3 +271,106 @@ async def test_get_other_users_practice_forbidden(
 
     resp = await async_client.get(f"/user-practices/{up_id}", headers=bob_headers)
     assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+# -- BUG-PRACTICE-005: single-active-practice TOCTOU --------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_active_selection_for_same_stage_returns_409(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Selecting a second active practice for the same stage must 409.
+
+    The partial unique index on ``userpractice (user_id, stage_number)
+    WHERE end_date IS NULL`` enforces the rule at the DB level; the
+    router's ``IntegrityError → 409 active_practice_exists_for_stage``
+    handler maps it to a deterministic response so the client cannot
+    win the race silently and end up with two open rows for the same
+    stage (BUG-PRACTICE-005).
+    """
+    headers, _ = await _signup(async_client, "doublepick")
+    p1 = await _seed_practice(db_session, name="First")
+    p2 = await _seed_practice(db_session, name="Second")
+
+    first = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": p1.id, "stage_number": 1},
+        headers=headers,
+    )
+    assert first.status_code == HTTPStatus.CREATED
+
+    second = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": p2.id, "stage_number": 1},
+        headers=headers,
+    )
+    assert second.status_code == HTTPStatus.CONFLICT
+    assert second.json()["detail"] == "active_practice_exists_for_stage"
+
+
+_CONCURRENT_PICK_FANOUT = 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_picks_for_same_stage_yield_one_open_row(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Five simultaneous selections for the same stage land exactly one open row.
+
+    The partial unique index closes the BUG-PRACTICE-005 race; without
+    it, both halves of the SELECT-then-INSERT pre-check could see "no
+    open row" and both insert.  The constraint catches all but one and
+    those losers surface as 409 ``active_practice_exists_for_stage``.
+    """
+    signup_resp = await concurrent_async_client.post(
+        "/auth/signup",
+        json={
+            "email": "racepick@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    headers = {"Authorization": f"Bearer {signup_resp.json()['token']}"}
+
+    async with concurrent_session_factory() as session:
+        practice = Practice(
+            stage_number=1,
+            name="RacePractice",
+            description="x",
+            instructions="y",
+            default_duration_minutes=5,
+            approved=True,
+        )
+        session.add(practice)
+        await session.commit()
+        await session.refresh(practice)
+        practice_id = practice.id
+
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post(
+                "/user-practices/",
+                json={"practice_id": practice_id, "stage_number": 1},
+                headers=headers,
+            )
+            for _ in range(_CONCURRENT_PICK_FANOUT)
+        ]
+    )
+
+    status_codes = [r.status_code for r in responses]
+    successes = status_codes.count(HTTPStatus.CREATED)
+    conflicts = status_codes.count(HTTPStatus.CONFLICT)
+    assert successes == 1, f"expected exactly one CREATED, got {successes}: {status_codes}"
+    assert successes + conflicts == _CONCURRENT_PICK_FANOUT, status_codes
+
+    async with concurrent_session_factory() as session:
+        result = await session.execute(
+            select(UserPractice).where(
+                UserPractice.practice_id == practice_id,
+                UserPractice.end_date.is_(None),  # type: ignore[union-attr]
+            )
+        )
+        open_rows = list(result.scalars().all())
+    assert len(open_rows) == 1

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -29,7 +29,7 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 | 03 | close-stage-skip-chain            | 2 | `claude/bug-fix-03-stage-skip-chain` / [#247](https://github.com/Geoffe-Ga/adepthood/pull/247) | [x] |
 | 04 | centralize-sanitize-user-text     | 3 | `claude/bug-fix-04-sanitize-user-text` | [x] |
 | 05 | centralize-date-utils-tz          | 3 | `claude/bug-fix-05-centralize-date-utils-tz` | [x] |
-| 06 | db-unique-constraints-toctou      | 3 | | [ ] |
+| 06 | db-unique-constraints-toctou      | 3 | `claude/bug-fix-06-db-unique-constraints-toctou` / [#266](https://github.com/Geoffe-Ga/adepthood/pull/266) | [x] |
 | 07 | normalize-idor-ordering           | 3 | | [ ] |
 | 08 | optimistic-mutation-hook          | 3 | | [ ] |
 | 09 | server-derived-timestamps         | 3 | `claude/09-server-derived-timestamps-cfvVc` / [#264](https://github.com/Geoffe-Ga/adepthood/pull/264) | [x] |


### PR DESCRIPTION
## Summary

Closes the Theme-5 TOCTOU bugs from the 2026-04-18 audit by collapsing every "check for duplicate, then insert" pattern in the API onto a DB-level unique constraint plus deterministic `IntegrityError → 409 / idempotent` handling.  Six atomic commits, one per table, plus one merge commit picking up `prompt 07` (IDOR) and `prompt 10` (observability) and addressing review feedback:

- **`fix(auth): drop signup pre-check, serialize login lockout`** — `BUG-AUTH-003`, `BUG-AUTH-007`. Signup relies on the existing `lower(email)` functional unique index and pays the bcrypt cost unconditionally so the duplicate / fresh paths look identical.  Login wraps the lockout-check + verify + record sequence in an in-process `asyncio.Lock` *and* a transaction-scoped `pg_advisory_xact_lock` so concurrent failed attempts cannot all pass the threshold-1 check.
- **`fix(goals): catch IntegrityError on daily completion`** — `BUG-GOAL-001`. Wraps the `goalcompletion` insert in a `SAVEPOINT` so a unique-per-day collision rolls back only the failed insert, then re-fetches the streak so both the pre-check and race paths return identical idempotent shapes.
- **`fix(course): add contentcompletion unique constraint + race-safe mark-read`** — `BUG-COURSE-002`. New Alembic migration `f1a2b3c4d5e6` adds `uq_contentcompletion_user_content` (with `_duplicates_contentcompletion` audit table for legacy dedup); model mirrors the constraint via `__table_args__` so SQLite tests inherit it.  Router refactored into resolve / fast-path / insert-or-resolve helpers (xenon A) with the BUG-COURSE-004 404-mask preserved.
- **`fix(prompts): collapse duplicate-response 400/409 split`** — `BUG-PROMPT-004`. Drops the application-level pre-check; the `uq_promptresponse_user_week` constraint is now the single source of truth and every duplicate surfaces as 409.
- **`fix(practices): rely on partial unique index for active-practice`** — `BUG-PRACTICE-005`. Mirrors the `ix_user_practice_active_stage` partial unique index on the `UserPractice` model so the `IntegrityError → 409 active_practice_exists_for_stage` handler is exercised by SQLite tests too.
- **`fix(stages): close first-advance create-path race`** — `BUG-STAGE-003`. The advance path was already `SELECT … FOR UPDATE` locked (BUG-STAGE-005); the create path now catches `IntegrityError` from `UniqueConstraint(user_id)` and lets concurrent first-advances converge on the bootstrap row instead of 500-ing the loser.
- **`chore(merge)`** — Rebases on top of #265 + #268 + #267 + #264 (which all merged after this PR opened) and tightens the lockout regression assertion + preserves `IntegrityError` chains per Claude bot review.
- **`docs(review)`** — Documents the deliberate non-idempotent stage-1→2 race outcome and the always-unlocked-stage-1 invariant the mark-read concurrency test depends on.

## Status code changes (frontend-visible)

| Endpoint | Old | New | Notes |
|---|---|---|---|
| `POST /user-practices/` (`active_practice_exists_for_stage`) | **400** | **409** | Frontend has no branching on 400 vs 409 for this detail string; falls through to status-fallback copy.  409's default copy ("That conflicts with something we already have. Refresh and try again.") is strictly better than 400's ("That didn't go through. Double-check what you entered and try again.") for this scenario. |
| `POST /prompts/{n}/respond` (`already_responded`) | 400 *or* 409 (race-dependent) | **409** uniformly | BUG-PROMPT-004: response code is now deterministic regardless of timing.  Frontend already maps the `already_responded` detail string to a specific message, so the status code change is invisible in the UI. |

No frontend changes required — verified `frontend/src/api/errorMessages.ts` does not branch on the old status codes for either endpoint.

## Test plan

- [x] `pre-commit run --all-files` — green (ruff, mypy, bandit, pip-audit, frontend eslint/typecheck/tests).
- [x] `pre-commit run --hook-stage pre-push --all-files` — xenon A across the board, radon MI ≥ B, backend coverage ≥ 90% / branch ≥ 80%.
- [x] `pytest backend/tests --no-cov` — 759 tests pass after merge (5 new concurrency regressions fanning out 5 simultaneous requests via `concurrent_async_client`).
- [x] **Manual `alembic upgrade head` + `alembic check` + `alembic downgrade -1` round-trip** verified locally against PostgreSQL 16 — no drift, downgrade restores prior state.
- [x] **CI on PR confirms the same gates against PostgreSQL + Python 3.11 / 3.12 / 3.13** — all 9 checks green on the latest commit.

## Follow-ups (filed)

- #273 — `_login_locks` is unbounded; switch to a TTL / LRU cache.
- #274 — Add a Postgres-backed regression test for the `pg_advisory_xact_lock` lockout path.

Closes / advances row 06 in `prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md`.

https://claude.ai/code/session_01JfHQ5fQxpRegod7wnJME1L