### PR TITLE
docs(qa): mark prompt 09 complete in remediation index

### DIFF
--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -32,7 +32,7 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 | 06 | db-unique-constraints-toctou      | 3 | | [ ] |
 | 07 | normalize-idor-ordering           | 3 | | [ ] |
 | 08 | optimistic-mutation-hook          | 3 | | [ ] |
-| 09 | server-derived-timestamps         | 3 | | [ ] |
+| 09 | server-derived-timestamps         | 3 | `claude/09-server-derived-timestamps-cfvVc` / [#264](https://github.com/Geoffe-Ga/adepthood/pull/264) | [x] |
 | 10 | observability-e2e                 | 3 | | [ ] |
 | 11 | backend-auth-models-schemas-cors  | 4 | | [ ] |
 | 12 | backend-feature-routers           | 4 | | [ ] |


### PR DESCRIPTION
## Summary
- Flip the row for prompt 09 from `[ ]` to `[x]` and link the merged branch / [#264](https://github.com/Geoffe-Ga/adepthood/pull/264).

The plan asked for this update as the final commit of the prompt-09 PR; that PR merged before the index touch landed, so this is a tiny follow-up.

## Test plan
- [x] `pre-commit run --all-files` (file-only change, no test surface affected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjhM5SanPBH1YEF3ky1JXd)_