### PR TITLE
fix(backend): auth + cors + db + models hardening (Prompt 11)

### DIFF
--- a/backend/migrations/versions/a4b5c6d7e8f9_add_user_state_flags.py
+++ b/backend/migrations/versions/a4b5c6d7e8f9_add_user_state_flags.py
@@ -1,0 +1,60 @@
+"""add user.is_active, email_verified, deleted_at
+
+Revision ID: a4b5c6d7e8f9
+Revises: f3a4b5c6d7e8
+Create Date: 2026-04-28 23:00:00.000000
+
+BUG-MODEL-001: the User row had no soft-disable / verification /
+soft-delete surface.  Adding three columns here lets the auth and
+admin layers gate users without hard-deleting rows:
+
+  * ``is_active`` -- ``NOT NULL`` with ``server_default=true`` so
+    every existing user remains active.
+  * ``email_verified`` -- ``NOT NULL`` with ``server_default=false``
+    so existing users land in the unverified state and start to flow
+    through whatever verification UX ships next.
+  * ``deleted_at`` -- nullable timestamp; ``NULL`` means "not deleted".
+
+Reversible.  All three column additions are safe on a live DB --
+``server_default`` populates existing rows during the ALTER, no
+backfill required.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a4b5c6d7e8f9"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "f3a4b5c6d7e8"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add ``is_active``, ``email_verified``, ``deleted_at`` to ``user``."""
+    op.add_column(
+        "user",
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column(
+        "user",
+        sa.Column(
+            "email_verified",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "user",
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the three account-state columns."""
+    op.drop_column("user", "deleted_at")
+    op.drop_column("user", "email_verified")
+    op.drop_column("user", "is_active")

--- a/backend/migrations/versions/e2f3a4b5c6d7_add_revoked_tokens.py
+++ b/backend/migrations/versions/e2f3a4b5c6d7_add_revoked_tokens.py
@@ -1,0 +1,54 @@
+"""add revokedtoken table
+
+Revision ID: e2f3a4b5c6d7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-04-28 21:00:00.000000
+
+Persists JWT ``jti`` claims that have been explicitly revoked (e.g. by
+``/auth/refresh``).  ``get_current_user`` consults this table on every
+authenticated request so a stolen-and-refreshed token can no longer be
+replayed for the rest of its original ``exp`` window (BUG-AUTH-013).
+
+Tokens minted before this column existed have no ``jti`` and are
+treated as legacy-but-valid for the duration of their 1-hour TTL — the
+required grace window for the JWT-shape change so existing sessions
+don't all 401 at once on deploy.
+
+The table is small by construction (one row per refresh, expires with
+the original token's ``exp``).  An index on ``expires_at`` lets a
+periodic cleanup job prune past-due rows efficiently; the primary-key
+index on ``jti`` carries the per-request lookup.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e2f3a4b5c6d7"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "f1a2b3c4d5e6"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the ``revokedtoken`` table."""
+    op.create_table(
+        "revokedtoken",
+        sa.Column("jti", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("jti"),
+    )
+    op.create_index(
+        "ix_revokedtoken_expires_at",
+        "revokedtoken",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``revokedtoken`` table."""
+    op.drop_index("ix_revokedtoken_expires_at", table_name="revokedtoken")
+    op.drop_table("revokedtoken")

--- a/backend/migrations/versions/f3a4b5c6d7e8_add_user_fk_ondelete.py
+++ b/backend/migrations/versions/f3a4b5c6d7e8_add_user_fk_ondelete.py
@@ -1,0 +1,91 @@
+"""add ondelete to every user-id foreign key
+
+Revision ID: f3a4b5c6d7e8
+Revises: e2f3a4b5c6d7
+Create Date: 2026-04-28 22:00:00.000000
+
+BUG-DB-003 / BUG-MODEL-002: every per-user table held an unconfigured
+foreign key to ``user.id``, so deleting a user row left orphaned
+children behind (or 23503 errors that masked the actual constraint
+violation in production logs).
+
+Per-user data tables get ``ON DELETE CASCADE``: deleting a user wipes
+their habits, completions, journal entries, etc.  The right-to-be-
+forgotten model is the cleanest default for a personal-development
+product where a user's data has no value separate from the user.
+
+The two nullable / catalog tables get ``ON DELETE SET NULL`` instead
+so historical context survives the deletion of its creator:
+
+  * ``goalgroup.user_id`` -- shared template groups outlive any
+    individual creator.
+  * ``practice.submitted_by_user_id`` -- catalog practices stay in
+    the library; the attribution becomes anonymous.
+
+Existing user FKs were defined without ``ondelete``, so this migration
+drops and re-creates each one.  ``op.batch_alter_table`` keeps the DDL
+portable across Postgres (production) and SQLite (test).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3a4b5c6d7e8"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e2f3a4b5c6d7"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (table, fk_column, on_delete) -- ordered alphabetically for review.
+_USER_FK_TABLES: tuple[tuple[str, str, str], ...] = (
+    ("contentcompletion", "user_id", "CASCADE"),
+    ("goalcompletion", "user_id", "CASCADE"),
+    ("goalgroup", "user_id", "SET NULL"),
+    ("habit", "user_id", "CASCADE"),
+    ("journalentry", "user_id", "CASCADE"),
+    ("llmusagelog", "user_id", "CASCADE"),
+    ("practice", "submitted_by_user_id", "SET NULL"),
+    ("practicesession", "user_id", "CASCADE"),
+    ("promptresponse", "user_id", "CASCADE"),
+    ("stageprogress", "user_id", "CASCADE"),
+    ("userpractice", "user_id", "CASCADE"),
+    ("walletaudit", "user_id", "CASCADE"),
+    ("walletaudit", "actor_user_id", "CASCADE"),
+)
+
+
+def _fk_constraint_name(table: str, column: str) -> str:
+    """Naming pattern Alembic + SQLAlchemy default to for legacy FKs."""
+    return f"fk_{table}_{column}_user"
+
+
+def upgrade() -> None:
+    """Drop and re-create each user FK with the appropriate ondelete clause."""
+    for table, column, on_delete in _USER_FK_TABLES:
+        with op.batch_alter_table(table) as batch:
+            # The original FK had no explicit name, so we drop by inspecting
+            # the table; ``batch_alter_table`` rebuilds the table on SQLite
+            # which clears any anonymous constraints, and on Postgres uses
+            # naming conventions to find the existing FK.
+            batch.create_foreign_key(
+                _fk_constraint_name(table, column),
+                "user",
+                [column],
+                ["id"],
+                ondelete=on_delete,
+            )
+
+
+def downgrade() -> None:
+    """Drop the named ondelete FKs (does not restore the unnamed legacy FK)."""
+    for table, column, _ in reversed(_USER_FK_TABLES):
+        with op.batch_alter_table(table) as batch:
+            batch.drop_constraint(_fk_constraint_name(table, column), type_="foreignkey")
+
+
+# Imported only so SQLAlchemy types are available for any future reflection
+# tests that need to assert the constraint shape; otherwise unused.
+_ = sa

--- a/backend/migrations/versions/f3a4b5c6d7e8_add_user_fk_ondelete.py
+++ b/backend/migrations/versions/f3a4b5c6d7e8_add_user_fk_ondelete.py
@@ -22,14 +22,19 @@ so historical context survives the deletion of its creator:
   * ``practice.submitted_by_user_id`` -- catalog practices stay in
     the library; the attribution becomes anonymous.
 
-Existing user FKs were defined without ``ondelete``, so this migration
-drops and re-creates each one.  ``op.batch_alter_table`` keeps the DDL
-portable across Postgres (production) and SQLite (test).
+Drops and re-creates each user FK with the Postgres default name
+(``<table>_<column>_fkey``) so the constraint name on disk matches
+what Alembic's autogenerate produces from the model metadata --
+otherwise ``alembic check`` would diff every FK as a "remove + add"
+pair and the migration-drift CI would fail.
+
+Tests run against SQLite via ``metadata.create_all`` and do not
+execute this migration; production / CI use Postgres so the
+drop-then-create pattern is portable for the targets that matter.
 """
 
 from typing import Sequence, Union
 
-import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -57,35 +62,29 @@ _USER_FK_TABLES: tuple[tuple[str, str, str], ...] = (
 )
 
 
-def _fk_constraint_name(table: str, column: str) -> str:
-    """Naming pattern Alembic + SQLAlchemy default to for legacy FKs."""
-    return f"fk_{table}_{column}_user"
+def _fk_name(table: str, column: str) -> str:
+    """Postgres' default name for an auto-named FK on ``<table>.<column>``."""
+    return f"{table}_{column}_fkey"
 
 
 def upgrade() -> None:
-    """Drop and re-create each user FK with the appropriate ondelete clause."""
+    """Replace each user FK with one that carries the appropriate ondelete."""
     for table, column, on_delete in _USER_FK_TABLES:
-        with op.batch_alter_table(table) as batch:
-            # The original FK had no explicit name, so we drop by inspecting
-            # the table; ``batch_alter_table`` rebuilds the table on SQLite
-            # which clears any anonymous constraints, and on Postgres uses
-            # naming conventions to find the existing FK.
-            batch.create_foreign_key(
-                _fk_constraint_name(table, column),
-                "user",
-                [column],
-                ["id"],
-                ondelete=on_delete,
-            )
+        name = _fk_name(table, column)
+        op.drop_constraint(name, table, type_="foreignkey")
+        op.create_foreign_key(
+            name,
+            table,
+            "user",
+            [column],
+            ["id"],
+            ondelete=on_delete,
+        )
 
 
 def downgrade() -> None:
-    """Drop the named ondelete FKs (does not restore the unnamed legacy FK)."""
+    """Restore each user FK without an ondelete clause."""
     for table, column, _ in reversed(_USER_FK_TABLES):
-        with op.batch_alter_table(table) as batch:
-            batch.drop_constraint(_fk_constraint_name(table, column), type_="foreignkey")
-
-
-# Imported only so SQLAlchemy types are available for any future reflection
-# tests that need to assert the constraint shape; otherwise unused.
-_ = sa
+        name = _fk_name(table, column)
+        op.drop_constraint(name, table, type_="foreignkey")
+        op.create_foreign_key(name, table, "user", [column], ["id"])

--- a/backend/migrations/versions/f3a4b5c6d7e8_add_user_fk_ondelete.py
+++ b/backend/migrations/versions/f3a4b5c6d7e8_add_user_fk_ondelete.py
@@ -14,13 +14,17 @@ their habits, completions, journal entries, etc.  The right-to-be-
 forgotten model is the cleanest default for a personal-development
 product where a user's data has no value separate from the user.
 
-The two nullable / catalog tables get ``ON DELETE SET NULL`` instead
-so historical context survives the deletion of its creator:
+The catalog / audit tables get ``ON DELETE SET NULL`` instead so
+historical context survives the deletion of its creator or actor:
 
   * ``goalgroup.user_id`` -- shared template groups outlive any
     individual creator.
   * ``practice.submitted_by_user_id`` -- catalog practices stay in
     the library; the attribution becomes anonymous.
+  * ``walletaudit.actor_user_id`` -- financial-audit history must
+    outlive the deletion of an admin who acted on someone else's
+    wallet; ``user_id`` (the wallet owner) still cascades because
+    the audit row is meaningless without that anchor.
 
 Drops and re-creates each user FK with the Postgres default name
 (``<table>_<column>_fkey``) so the constraint name on disk matches
@@ -35,6 +39,7 @@ drop-then-create pattern is portable for the targets that matter.
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -58,7 +63,7 @@ _USER_FK_TABLES: tuple[tuple[str, str, str], ...] = (
     ("stageprogress", "user_id", "CASCADE"),
     ("userpractice", "user_id", "CASCADE"),
     ("walletaudit", "user_id", "CASCADE"),
-    ("walletaudit", "actor_user_id", "CASCADE"),
+    ("walletaudit", "actor_user_id", "SET NULL"),
 )
 
 
@@ -69,6 +74,11 @@ def _fk_name(table: str, column: str) -> str:
 
 def upgrade() -> None:
     """Replace each user FK with one that carries the appropriate ondelete."""
+    # ``walletaudit.actor_user_id`` must be nullable for ``SET NULL`` to have
+    # a target.  The column landed as ``NOT NULL`` in the wallet-audit
+    # migration; relax it before swapping the FK so a future actor-user
+    # deletion can null the row without violating the column constraint.
+    op.alter_column("walletaudit", "actor_user_id", existing_type=sa.Integer(), nullable=True)
     for table, column, on_delete in _USER_FK_TABLES:
         name = _fk_name(table, column)
         op.drop_constraint(name, table, type_="foreignkey")
@@ -88,3 +98,4 @@ def downgrade() -> None:
         name = _fk_name(table, column)
         op.drop_constraint(name, table, type_="foreignkey")
         op.create_foreign_key(name, table, "user", [column], ["id"])
+    op.alter_column("walletaudit", "actor_user_id", existing_type=sa.Integer(), nullable=False)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -174,6 +174,14 @@ install_trace_id_logging()
 async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     """Startup/shutdown lifecycle for the application."""
     import models  # noqa: F401, PLC0415
+    from routers.auth import _get_secret_key  # noqa: PLC0415
+
+    # BUG-AUTH-011: validate ``SECRET_KEY`` once at startup so a misconfigured
+    # deployment fails the orchestrator's health probe immediately rather than
+    # silently serving traffic and crashing on the first auth request.  The
+    # underlying check is the same lazy guard ``_get_secret_key`` already does;
+    # invoking it here turns "first user pays" into "deploy never goes live".
+    _get_secret_key()
 
     yield
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,10 +1,13 @@
 """Main FastAPI application instance."""
 
+import asyncio
+import ipaddress
 import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Annotated
+from urllib.parse import urlparse
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -71,11 +74,58 @@ ALLOWED_HEADERS = [
 EXPOSED_HEADERS = ["X-Request-ID"]
 
 
+def _validate_prod_origin(origin: str) -> None:
+    """Reject obviously-wrong production origins (BUG-APP-003).
+
+    The previous ``startswith("https://")`` check let through bare IPs,
+    ``https://localhost``, embedded userinfo  # pragma: allowlist secret
+    (``https://user@host`` style URLs with credentials in the netloc),
+    wildcards (``https://*.example.com``), and trailing-slash typos --
+    each of which silently broke or weakened the CORS allow-list.
+
+    The strict ruleset:
+
+    * Scheme must be ``https`` (already covered, kept).
+    * Hostname must be set, must not be a literal IP address, must
+      not be ``localhost`` / ``127.0.0.1``.
+    * No wildcards (``*``) or userinfo (``@``) in the URL.
+
+    A misconfigured deployment fails the readiness probe at startup
+    rather than serving traffic with a hole in the allow-list.
+    """
+    parsed = urlparse(origin)
+    if parsed.scheme != "https":
+        msg = f"PROD_DOMAIN entries must use HTTPS, got '{origin}'"
+        raise RuntimeError(msg)
+    hostname = parsed.hostname
+    if not hostname:
+        msg = f"PROD_DOMAIN entry has no hostname: '{origin}'"
+        raise RuntimeError(msg)
+    if hostname in {"localhost", "127.0.0.1", "::1"}:
+        msg = f"PROD_DOMAIN cannot point at loopback: '{origin}'"
+        raise RuntimeError(msg)
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        # Hostname is not a bare IP literal -- this is the good case.
+        pass
+    else:
+        msg = f"PROD_DOMAIN cannot be a bare IP: '{origin}'"
+        raise RuntimeError(msg)
+    if "*" in origin or "@" in origin:
+        msg = f"PROD_DOMAIN cannot contain wildcard or userinfo: '{origin}'"
+        raise RuntimeError(msg)
+
+
 def _validate_https_origins(origins: list[str]) -> None:
-    """Ensure every origin uses HTTPS; raise RuntimeError otherwise."""
+    """Validate every origin against ``_validate_prod_origin``.
+
+    Wraps the per-origin check so callers iterate once over the parsed
+    list and the per-origin failure message is rich enough to identify
+    which entry is bad.
+    """
     for origin in origins:
-        if not origin.startswith("https://"):
-            raise RuntimeError(f"PROD_DOMAIN entries must use HTTPS, got '{origin}'")
+        _validate_prod_origin(origin)
 
 
 def _parse_prod_origins() -> list[str]:
@@ -246,24 +296,73 @@ app.include_router(goal_groups_router)
 app.include_router(stages_router)
 
 
+# BUG-APP-004: separate liveness from readiness so the orchestrator can
+# distinguish "process is up" from "process can serve traffic".  A
+# liveness probe that fails the way a readiness probe should (DB hiccup,
+# slow query, etc.) restarts the container; a readiness probe that
+# fails takes the pod out of rotation without restarting it, which is
+# what we actually want during a transient DB blip.  Combined ``/health``
+# kept for backwards compatibility (Railway / existing dashboards) --
+# behaves like the readiness probe so a healthy old-style monitor is
+# still meaningful.
+_DB_PROBE_TIMEOUT_SECONDS = 2.0
+
+
+@app.get("/health/live")
+async def liveness() -> dict[str, str]:
+    """Liveness probe: process is responsive (no DB dependency).
+
+    Always returns ``{"status": "alive"}`` 200 as long as the event
+    loop can dispatch a request.  An orchestrator restart on this
+    failing means the *process* is wedged -- restart is the right
+    response.  A DB outage should NOT trip this probe.
+    """
+    return {"status": "alive"}
+
+
+@app.get("/health/ready")
+async def readiness(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> dict[str, str]:
+    """Readiness probe: app + DB are both serving traffic.
+
+    Bounded by ``_DB_PROBE_TIMEOUT_SECONDS`` so a slow database does
+    not hang the probe forever and silently keep an unhealthy pod in
+    rotation.  Failures (timeout or query error) return 503 so the
+    orchestrator drops the pod from the load-balancer pool until the
+    next successful probe.
+
+    Session lifecycle is owned by ``Depends(get_session)`` -- we don't
+    open or close the session here, so a failed ``SELECT 1`` cannot
+    leak a connection.  The dependency's ``async with`` (in
+    ``database.py``) guarantees ``close()`` runs even when the handler
+    raises.
+    """
+    try:
+        async with asyncio.timeout(_DB_PROBE_TIMEOUT_SECONDS):
+            await session.execute(text("SELECT 1"))
+    except (TimeoutError, Exception) as exc:
+        logger.exception("readiness_check_failed")
+        raise HTTPException(status_code=503, detail="not_ready") from exc
+    return {"status": "ready", "database": "connected"}
+
+
 @app.get("/health")
 async def health_check(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> dict[str, str]:
-    """Health check that validates database connectivity.
+    """Combined probe (legacy): mirrors ``/health/ready`` for back-compat.
 
-    Returns a 200 with ``{"status": "healthy", "database": "connected"}`` when
-    the database is reachable.  Railway pings this endpoint to determine
-    service health; a 503 signals an unhealthy container.
-
-    BUG-INFRA-021: session lifecycle is owned by ``Depends(get_session)`` —
-    we don't open or close the session here, so a failed ``SELECT 1`` cannot
-    leak a connection.  The dependency's ``async with`` (in ``database.py``)
-    guarantees ``close()`` runs even when the handler raises.
+    Existing Railway / dashboard probes hit this path; rather than
+    breaking them, the response shape is preserved (``status: healthy``
+    + ``database: connected``).  New deployments should hit
+    ``/health/live`` and ``/health/ready`` directly so liveness and
+    readiness can be configured independently (BUG-APP-004).
     """
     try:
-        await session.execute(text("SELECT 1"))
-    except Exception as exc:
+        async with asyncio.timeout(_DB_PROBE_TIMEOUT_SECONDS):
+            await session.execute(text("SELECT 1"))
+    except (TimeoutError, Exception) as exc:
         logger.exception("health_check_failed")
         raise HTTPException(status_code=503, detail="Database unavailable") from exc
     return {"status": "healthy", "database": "connected"}

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -74,6 +74,32 @@ ALLOWED_HEADERS = [
 EXPOSED_HEADERS = ["X-Request-ID"]
 
 
+_LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _check_origin_hostname(origin: str, hostname: str | None) -> None:
+    """Hostname-related slice of the CORS allow-list checks (BUG-APP-003).
+
+    Split out so the parent ``_validate_prod_origin`` stays at xenon
+    rank A; the IP-literal try/except plus the loopback set membership
+    plus the empty-hostname guard add up to four branches that read
+    cleaner here.
+    """
+    if not hostname:
+        msg = f"PROD_DOMAIN entry has no hostname: '{origin}'"
+        raise RuntimeError(msg)
+    if hostname in _LOOPBACK_HOSTNAMES:
+        msg = f"PROD_DOMAIN cannot point at loopback: '{origin}'"
+        raise RuntimeError(msg)
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        # Hostname is not a bare IP literal -- this is the good case.
+        return
+    msg = f"PROD_DOMAIN cannot be a bare IP: '{origin}'"
+    raise RuntimeError(msg)
+
+
 def _validate_prod_origin(origin: str) -> None:
     """Reject obviously-wrong production origins (BUG-APP-003).
 
@@ -97,21 +123,7 @@ def _validate_prod_origin(origin: str) -> None:
     if parsed.scheme != "https":
         msg = f"PROD_DOMAIN entries must use HTTPS, got '{origin}'"
         raise RuntimeError(msg)
-    hostname = parsed.hostname
-    if not hostname:
-        msg = f"PROD_DOMAIN entry has no hostname: '{origin}'"
-        raise RuntimeError(msg)
-    if hostname in {"localhost", "127.0.0.1", "::1"}:
-        msg = f"PROD_DOMAIN cannot point at loopback: '{origin}'"
-        raise RuntimeError(msg)
-    try:
-        ipaddress.ip_address(hostname)
-    except ValueError:
-        # Hostname is not a bare IP literal -- this is the good case.
-        pass
-    else:
-        msg = f"PROD_DOMAIN cannot be a bare IP: '{origin}'"
-        raise RuntimeError(msg)
+    _check_origin_hostname(origin, parsed.hostname)
     if "*" in origin or "@" in origin:
         msg = f"PROD_DOMAIN cannot contain wildcard or userinfo: '{origin}'"
         raise RuntimeError(msg)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import get_session
@@ -353,7 +354,7 @@ async def readiness(
     try:
         async with asyncio.timeout(_DB_PROBE_TIMEOUT_SECONDS):
             await session.execute(text("SELECT 1"))
-    except (TimeoutError, Exception) as exc:
+    except (TimeoutError, OSError, SQLAlchemyError) as exc:
         logger.exception("readiness_check_failed")
         raise HTTPException(status_code=503, detail="not_ready") from exc
     return {"status": "ready", "database": "connected"}
@@ -374,7 +375,7 @@ async def health_check(
     try:
         async with asyncio.timeout(_DB_PROBE_TIMEOUT_SECONDS):
             await session.execute(text("SELECT 1"))
-    except (TimeoutError, Exception) as exc:
+    except (TimeoutError, OSError, SQLAlchemyError) as exc:
         logger.exception("health_check_failed")
         raise HTTPException(status_code=503, detail="Database unavailable") from exc
     return {"status": "healthy", "database": "connected"}

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -12,6 +12,7 @@ from .login_attempt import LoginAttempt
 from .practice import Practice
 from .practice_session import PracticeSession
 from .prompt_response import PromptResponse
+from .revoked_token import RevokedToken
 from .stage_content import StageContent
 from .stage_progress import StageProgress
 from .user import User
@@ -31,6 +32,7 @@ __all__ = [
     "Practice",
     "PracticeSession",
     "PromptResponse",
+    "RevokedToken",
     "StageContent",
     "StageProgress",
     "User",

--- a/backend/src/models/content_completion.py
+++ b/backend/src/models/content_completion.py
@@ -22,7 +22,7 @@ class ContentCompletion(SQLModel, table=True):
     )
 
     id: int | None = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="user.id", index=True)
+    user_id: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
     content_id: int = Field(foreign_key="stagecontent.id", index=True)
     completed_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),

--- a/backend/src/models/goal_completion.py
+++ b/backend/src/models/goal_completion.py
@@ -24,7 +24,7 @@ class GoalCompletion(SQLModel, table=True):
     goal_id: int = Field(
         sa_column=Column(ForeignKey("goal.id", ondelete="CASCADE"), nullable=False),
     )
-    user_id: int = Field(foreign_key="user.id")
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),

--- a/backend/src/models/goal_group.py
+++ b/backend/src/models/goal_group.py
@@ -27,7 +27,7 @@ class GoalGroup(SQLModel, table=True):
     name: str = Field(max_length=255)
     icon: str | None = Field(default=None, max_length=100)
     description: str | None = Field(default=None, max_length=2_000)
-    user_id: int | None = Field(default=None, foreign_key="user.id")
+    user_id: int | None = Field(default=None, foreign_key="user.id", ondelete="SET NULL")
     shared_template: bool = False
     source: str | None = Field(default=None, max_length=255)
     goals: list["Goal"] = Relationship(back_populates="goal_group")

--- a/backend/src/models/habit.py
+++ b/backend/src/models/habit.py
@@ -20,7 +20,7 @@ class Habit(SQLModel, table=True):
     start_date: date
     energy_cost: int
     energy_return: int
-    user_id: int = Field(foreign_key="user.id")
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     notification_times: list[str] | None = Field(
         default=None, sa_column=Column(PG_ARRAY(String), nullable=True)
     )

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -45,7 +45,7 @@ class JournalEntry(SQLModel, table=True):
     )
     message: str = Field(max_length=10_000)
     sender: str = Field(max_length=10)  # 'user' or 'bot'
-    user_id: int = Field(foreign_key="user.id")
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     tag: str = Field(default=JournalTag.FREEFORM, max_length=50)
     practice_session_id: int | None = Field(default=None, foreign_key="practicesession.id")
     user_practice_id: int | None = Field(default=None, foreign_key="userpractice.id")

--- a/backend/src/models/llm_usage_log.py
+++ b/backend/src/models/llm_usage_log.py
@@ -51,7 +51,7 @@ class LLMUsageLog(SQLModel, table=True):
     """
 
     id: int | None = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="user.id", index=True)
+    user_id: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False, index=True),

--- a/backend/src/models/practice.py
+++ b/backend/src/models/practice.py
@@ -10,5 +10,7 @@ class Practice(SQLModel, table=True):
     description: str = Field(max_length=2_000)
     instructions: str = Field(max_length=10_000)
     default_duration_minutes: float
-    submitted_by_user_id: int | None = Field(default=None, foreign_key="user.id")
+    submitted_by_user_id: int | None = Field(
+        default=None, foreign_key="user.id", ondelete="SET NULL"
+    )
     approved: bool = True

--- a/backend/src/models/practice_session.py
+++ b/backend/src/models/practice_session.py
@@ -12,7 +12,7 @@ class PracticeSession(SQLModel, table=True):
     """
 
     id: int | None = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="user.id")
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     user_practice_id: int = Field(foreign_key="userpractice.id")
     duration_minutes: float
     timestamp: datetime = Field(

--- a/backend/src/models/prompt_response.py
+++ b/backend/src/models/prompt_response.py
@@ -28,5 +28,5 @@ class PromptResponse(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
-    user_id: int = Field(foreign_key="user.id")
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     user: "User" = Relationship(back_populates="responses")

--- a/backend/src/models/revoked_token.py
+++ b/backend/src/models/revoked_token.py
@@ -1,0 +1,38 @@
+"""Tracks revoked JWT IDs (jti) so a refreshed token cannot be replayed.
+
+BUG-AUTH-013: ``/auth/refresh`` previously minted a new token without
+invalidating the old one, so a stolen-and-refreshed token kept working
+until its original ``exp``.  Storing the old ``jti`` here on every
+refresh closes that window: ``get_current_user`` now consults this
+table and rejects any token whose ``jti`` is present.
+
+Rows expire naturally at ``expires_at`` (the same instant as the
+revoked token's ``exp``); a periodic cleanup job can prune past-due
+rows but is not required for correctness — the lookup is keyed on
+``jti`` so an unbounded table only costs disk, not query time.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, DateTime
+from sqlmodel import Field, SQLModel
+
+
+class RevokedToken(SQLModel, table=True):
+    """A JWT ``jti`` that was explicitly revoked (refreshed away).
+
+    Tokens minted before this column existed have no ``jti`` claim and
+    are treated as legacy-but-valid by ``get_current_user`` for the
+    duration of their original 1-hour TTL — that's the grace window
+    the prompt requires for the JWT-shape change so existing sessions
+    don't all 401 at once on deploy.
+    """
+
+    jti: str = Field(primary_key=True, max_length=64)
+    expires_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
+    )
+    revoked_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/src/models/stage_progress.py
+++ b/backend/src/models/stage_progress.py
@@ -22,5 +22,5 @@ class StageProgress(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
-    user_id: int = Field(foreign_key="user.id", unique=True)
+    user_id: int = Field(foreign_key="user.id", unique=True, ondelete="CASCADE")
     user: "User" = Relationship(back_populates="stage_progress")

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -56,7 +56,14 @@ class User(SQLModel, table=True):
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
     email: str = Field(unique=True, index=True, max_length=254)
-    password_hash: str = Field(default="")
+    # BUG-AUTH-018: ``password_hash`` previously defaulted to ``""`` so a
+    # row could (in test fixtures, badly-written admin scripts, or a future
+    # signup-flow regression) be persisted without a real hash.  An empty
+    # string is not a valid bcrypt digest -- ``_verify_password`` would
+    # raise on it -- but the column itself was happy to accept it.  Drop
+    # the default so SQLModel forces every caller to supply a hash and a
+    # blank-password account becomes impossible at the schema level.
+    password_hash: str = Field(min_length=1)
     timezone: str = Field(
         default=DEFAULT_USER_TIMEZONE,
         sa_column=Column(

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Column, DateTime, String
+from sqlalchemy import Boolean, Column, DateTime, String
 from sqlmodel import Field, Relationship, SQLModel
 
 from services.usage import compute_next_reset
@@ -75,6 +75,38 @@ class User(SQLModel, table=True):
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    # BUG-MODEL-001: account-state flags so the auth + admin layers
+    # have a soft-disable / verification surface without hard-deleting
+    # rows.  All three default to "active fresh user" so existing
+    # signups keep working without a backfill.
+    #
+    # ``is_active`` -- false means the account is soft-disabled (banned,
+    # paused, awaiting moderation).  Auth helpers consult this to
+    # reject login on a row that exists but is gated.
+    #
+    # ``email_verified`` -- false until the user clicks the
+    # verification link.  Routers that gate sensitive actions (wallet
+    # top-up, BotMason, etc.) can require ``email_verified=True`` once
+    # the verification flow ships.
+    #
+    # ``deleted_at`` -- soft-delete timestamp.  When set, the account
+    # is treated as gone for query purposes (login fails, lookups
+    # filter it out) but the row sticks around for audit trail and
+    # GDPR retention windows.  Hard-delete via right-to-be-forgotten
+    # remains available; soft-delete is for the common case where a
+    # user pauses their account and may return.
+    is_active: bool = Field(
+        default=True,
+        sa_column=Column(Boolean(), nullable=False, server_default="1"),
+    )
+    email_verified: bool = Field(
+        default=False,
+        sa_column=Column(Boolean(), nullable=False, server_default="0"),
+    )
+    deleted_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
     )
     habits: list["Habit"] = Relationship(back_populates="user")
     journals: list["JournalEntry"] = Relationship(back_populates="user")

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -86,9 +86,11 @@ class User(SQLModel, table=True):
     # reject login on a row that exists but is gated.
     #
     # ``email_verified`` -- false until the user clicks the
-    # verification link.  Routers that gate sensitive actions (wallet
-    # top-up, BotMason, etc.) can require ``email_verified=True`` once
-    # the verification flow ships.
+    # verification link.  Reserved for the verification-flow phase:
+    # routers that gate sensitive actions (wallet top-up, BotMason,
+    # etc.) will consult this once the verification UX ships.  No
+    # auth helper currently reads it, so existing signups continue
+    # to authenticate exactly as before.
     #
     # ``deleted_at`` -- soft-delete timestamp.  When set, the account
     # is treated as gone for query purposes (login fails, lookups

--- a/backend/src/models/user_practice.py
+++ b/backend/src/models/user_practice.py
@@ -37,7 +37,7 @@ class UserPractice(SQLModel, table=True):
     )
 
     id: int | None = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="user.id")
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     practice_id: int = Field(foreign_key="practice.id")
     stage_number: int
     start_date: date

--- a/backend/src/models/wallet_audit.py
+++ b/backend/src/models/wallet_audit.py
@@ -97,8 +97,8 @@ class WalletAudit(SQLModel, table=True):
     __tablename__ = "walletaudit"
 
     id: int | None = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="user.id", index=True)
-    actor_user_id: int = Field(foreign_key="user.id", index=True)
+    user_id: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
+    actor_user_id: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
     bucket: str = Field(
         sa_column=Column(String(_TOKEN_COLUMN_WIDTH), nullable=False, index=True),
     )

--- a/backend/src/models/wallet_audit.py
+++ b/backend/src/models/wallet_audit.py
@@ -98,7 +98,19 @@ class WalletAudit(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     user_id: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
-    actor_user_id: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
+    # ``actor_user_id`` uses ``ON DELETE SET NULL`` rather than ``CASCADE`` so
+    # an admin's deletion does not silently destroy audit rows for actions
+    # they took on *other* users' wallets.  Financial-audit history outlives
+    # the actor; the row's ``user_id`` link still anchors it to the wallet
+    # owner, and a NULL actor reads as "the original actor has been removed
+    # from the system" without losing the trail.
+    actor_user_id: int | None = Field(
+        default=None,
+        foreign_key="user.id",
+        index=True,
+        ondelete="SET NULL",
+        nullable=True,
+    )
     bucket: str = Field(
         sa_column=Column(String(_TOKEN_COLUMN_WIDTH), nullable=False, index=True),
     )

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -26,6 +26,7 @@ from sqlmodel import select
 from database import get_session
 from errors import bad_request
 from models.login_attempt import LoginAttempt
+from models.revoked_token import RevokedToken
 from models.user import DEFAULT_USER_TIMEZONE, User
 from rate_limit import limiter
 from services.users import get_user_timezone
@@ -226,13 +227,38 @@ def _verify_password(password: str, password_hash: str) -> bool:
     return bool(bcrypt.checkpw(password.encode(), password_hash.encode("utf-8")))
 
 
-def _create_token(user_id: int) -> str:
+def _new_jti() -> str:
+    """Return a fresh per-token unique identifier.
+
+    Used as the ``jti`` claim on every issued JWT so ``/auth/refresh``
+    can revoke the old token by storing this value in
+    :class:`models.revoked_token.RevokedToken` (BUG-AUTH-013).
+    16 bytes of entropy (32 hex chars) is plenty -- the value is
+    namespaced by user, so collision is irrelevant for security and
+    only needs to be unique enough that two tokens issued within the
+    same millisecond don't share a row.
+    """
+    return secrets.token_hex(16)
+
+
+def _create_token(user_id: int) -> tuple[str, str]:
+    """Mint a fresh JWT with a per-token ``jti`` claim.
+
+    Returns ``(token, jti)`` so callers that need to revoke the
+    previous token (e.g. ``/auth/refresh``) can persist the old jti
+    before swapping in the new one.  Tokens minted before the jti
+    column existed have no claim and are treated as legacy-but-valid
+    by ``get_current_user`` -- the 1-hour TTL is the grace window.
+    """
+    jti = _new_jti()
     payload = {
         "sub": str(user_id),
         "exp": datetime.now(UTC) + _TOKEN_TTL,
         "iat": datetime.now(UTC),
+        "jti": jti,
     }
-    return str(jwt.encode(payload, _get_secret_key(), algorithm=_JWT_ALGORITHM))
+    token = str(jwt.encode(payload, _get_secret_key(), algorithm=_JWT_ALGORITHM))
+    return token, jti
 
 
 def _create_dummy_token() -> str:
@@ -418,7 +444,7 @@ async def signup(
     if user.id is None:
         msg = "User ID unexpectedly None after database commit"
         raise RuntimeError(msg)
-    token = _create_token(user.id)
+    token, _ = _create_token(user.id)
     return AuthResponse(token=token, user_id=user.id, timezone=user.timezone)
 
 
@@ -475,16 +501,18 @@ async def login(
     if user.id is None:
         msg = "User ID unexpectedly None after database commit"
         raise RuntimeError(msg)
-    token = _create_token(user.id)
+    token, _ = _create_token(user.id)
     return AuthResponse(token=token, user_id=user.id, timezone=user.timezone)
 
 
-def get_current_user(authorization: str | None = Header(default=None)) -> int:
-    """Extract and validate the JWT from the Authorization header.
+def _decode_token_payload(authorization: str | None) -> dict[str, object]:
+    """Decode the bearer JWT and return its payload, or raise 401.
 
-    All rejection scenarios return an identical 401 with detail="unauthorized"
-    to prevent attackers from distinguishing token states (OWASP A07:2021,
-    sec-04). The specific reason is logged server-side for debugging.
+    Split out from ``get_current_user`` so the JWT-decode + ``sub``
+    coercion logic stays at xenon rank A while the async revocation
+    check lives in the wrapper.  All rejection paths return an
+    identical 401 ``unauthorized`` (OWASP A07:2021) so attackers
+    cannot distinguish "token expired" from "token forged".
     """
     if not authorization or not authorization.startswith("Bearer "):
         logger.info("token_rejected", extra={"reason": "missing_or_malformed_header"})
@@ -498,12 +526,16 @@ def get_current_user(authorization: str | None = Header(default=None)) -> int:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
         ) from exc
-    # ``sub`` may be missing or non-numeric on a forged / corrupted token
-    # (BUG-AUTH-012).  Without this guard the bare ``int(payload["sub"])``
-    # call raised ``KeyError`` / ``ValueError`` uncaught and Starlette
-    # surfaced it as 500 -- leaking "your token confused us" diagnostics
-    # to the attacker.  Convert into the same 401 every other auth path
-    # uses so the rejection looks identical.
+    return payload
+
+
+def _coerce_sub(payload: dict[str, object]) -> int:
+    """Convert the ``sub`` claim to ``int`` or raise 401 (BUG-AUTH-012).
+
+    Without this guard the bare ``int(payload["sub"])`` call raised
+    ``KeyError`` / ``ValueError`` uncaught and Starlette surfaced 500
+    -- leaking "your token confused us" diagnostics to the attacker.
+    """
     sub = payload.get("sub")
     if not isinstance(sub, str | int):
         logger.info("token_rejected", extra={"reason": "malformed_sub"})
@@ -517,23 +549,106 @@ def get_current_user(authorization: str | None = Header(default=None)) -> int:
         ) from exc
 
 
+async def _check_token_not_revoked(session: AsyncSession, payload: dict[str, object]) -> None:
+    """Reject the request if the token's ``jti`` is in the revocation table.
+
+    Tokens minted before the ``jti`` claim existed are treated as
+    legacy-but-valid -- the missing claim short-circuits without a DB
+    hit, and the 1-hour TTL is the grace window the prompt requires
+    so existing sessions do not all 401 at once on deploy
+    (BUG-AUTH-013).
+    """
+    jti = payload.get("jti")
+    if not isinstance(jti, str) or not jti:
+        return  # Legacy token -- no revocation possible.
+    result = await session.execute(select(RevokedToken.jti).where(RevokedToken.jti == jti))
+    if result.scalar_one_or_none() is not None:
+        logger.info("token_rejected", extra={"reason": "revoked"})
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
+
+
+async def get_current_user(
+    session: Annotated[AsyncSession, Depends(get_session)],
+    authorization: str | None = Header(default=None),
+) -> int:
+    """Extract, validate, and revocation-check the JWT.
+
+    Async because ``BUG-AUTH-013`` requires a DB lookup against the
+    ``revokedtoken`` table on every authenticated request.  The check
+    is keyed on the primary-key ``jti`` so the cost is one indexed
+    SELECT per request, not a full scan.
+
+    All rejection scenarios return an identical 401 with
+    ``detail="unauthorized"`` to prevent attackers from distinguishing
+    token states (OWASP A07:2021, sec-04). The specific reason is
+    logged server-side for debugging.
+    """
+    payload = _decode_token_payload(authorization)
+    await _check_token_not_revoked(session, payload)
+    return _coerce_sub(payload)
+
+
+async def _revoke_token_payload(
+    session: AsyncSession,
+    payload: dict[str, object],
+) -> None:
+    """Persist the token's ``jti`` to ``revokedtoken`` so it cannot be reused.
+
+    Tokens minted before the ``jti`` claim existed are silently passed
+    through (no row to insert) -- the 1-hour TTL is the grace window.
+    The ``exp`` claim is mirrored into ``expires_at`` so a periodic
+    cleanup job can prune past-due rows without re-decoding the JWT.
+    Conflicting writes (same jti revoked twice) are caught and ignored
+    so an idempotent retry of ``/auth/refresh`` does not 500.
+    """
+    jti = payload.get("jti")
+    exp = payload.get("exp")
+    if not isinstance(jti, str) or not jti:
+        return  # legacy token, no jti
+    expires_at = (
+        datetime.fromtimestamp(exp, tz=UTC)
+        if isinstance(exp, int | float)
+        else datetime.now(UTC) + _TOKEN_TTL
+    )
+    session.add(RevokedToken(jti=jti, expires_at=expires_at))
+    try:
+        await session.commit()
+    except IntegrityError:
+        # Already revoked (e.g. double-clicked refresh); same outcome.
+        await session.rollback()
+
+
 @router.post("/refresh", response_model=AuthResponse)
 @limiter.limit("1/minute")
 async def refresh_token(
-    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    request: Request,
     user_id: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> AuthResponse:
     """Exchange a valid JWT for a fresh one.
 
-    Rate-limited to 1 request per minute to prevent abuse. The caller must
-    present a valid, non-expired token in the Authorization header; the
-    response contains a new token with a reset TTL for the same user.
+    Rate-limited to 1 request per minute to prevent abuse. The caller
+    must present a valid, non-expired token in the Authorization
+    header; the response contains a new token with a reset TTL for the
+    same user.
+
+    The old token's ``jti`` is revoked (BUG-AUTH-013) before the new
+    one is minted so a stolen-and-refreshed token cannot be replayed
+    until its original ``exp``.  Tokens minted before the jti claim
+    existed are passed through transparently for the duration of their
+    TTL -- the 1-hour grace window the prompt requires for the
+    JWT-shape change.
 
     The response also re-asserts the stored ``timezone`` so a frontend
     that hot-reloads or evicts its auth context receives the correct
     user-local zone after a refresh, not a stale ``"UTC"`` default.
     """
-    new_token = _create_token(user_id)
+    # Re-decode the header (``get_current_user`` only surfaces the int
+    # ``sub``) so we can persist the old ``jti`` against
+    # ``revokedtoken`` before minting the new one.
+    old_payload = _decode_token_payload(request.headers.get("Authorization"))
+    await _revoke_token_payload(session, old_payload)
+
+    new_token, _ = _create_token(user_id)
     user_timezone = await get_user_timezone(session, user_id)
     return AuthResponse(token=new_token, user_id=user_id, timezone=user_timezone)

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -17,7 +17,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import bcrypt
 import jwt
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -43,6 +43,20 @@ _JWT_ALGORITHM = "HS256"
 _TOKEN_TTL = timedelta(hours=1)
 
 _MIN_PASSWORD_LENGTH = 8
+
+# bcrypt silently truncates input at 72 bytes (BUG-AUTH-004): a user who
+# signs up with a 100-char passphrase has the last 28 bytes ignored, and
+# any subsequent login that types those same bytes succeeds even on a
+# typo'd suffix.  Reject before hashing so the failure is loud at
+# signup/login rather than a silent security regression.
+_BCRYPT_MAX_PASSWORD_BYTES = 72
+
+# Cap on the application-level password length.  Lower than the bcrypt
+# limit so the "password too long" error surfaces cleanly via Pydantic's
+# 422 validation envelope rather than a 500 from the bcrypt helper, and
+# high enough to comfortably support passphrases (NIST SP 800-63B
+# encourages long passphrases).
+_MAX_PASSWORD_LENGTH = 64
 
 # Account lockout: lock after this many consecutive failed attempts.
 MAX_FAILED_ATTEMPTS = 5
@@ -79,8 +93,19 @@ def _email_log_fingerprint(email: str) -> str:
 
 
 class AuthRequest(BaseModel):
+    """Login payload — email + password.
+
+    ``password`` carries explicit length bounds (BUG-AUTH-017): an
+    unbounded ``str`` field accepts arbitrarily large inputs, which both
+    wastes the bcrypt cost on a guaranteed-rejected request and gives an
+    attacker a free DoS lever (each attempt costs ~250 ms server-side).
+    The bounds also keep the field aligned with the
+    ``_BCRYPT_MAX_PASSWORD_BYTES`` ceiling so a request that would
+    silently be truncated by bcrypt is rejected with 422 instead.
+    """
+
     email: EmailStr
-    password: str
+    password: str = Field(min_length=_MIN_PASSWORD_LENGTH, max_length=_MAX_PASSWORD_LENGTH)
 
     @field_validator("email", mode="before")
     @classmethod
@@ -174,10 +199,26 @@ class AuthResponse(BaseModel):
 
 
 def _hash_password(password: str) -> str:
-    # 12 rounds of bcrypt hashing (~250 ms on modern hardware). This is the
-    # OWASP-recommended minimum; it makes brute-force attacks prohibitively
-    # expensive while keeping login latency acceptable for users.
-    hashed: bytes = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12))
+    """Hash ``password`` with bcrypt-12 after enforcing the 72-byte input cap.
+
+    bcrypt silently truncates input at 72 bytes (BUG-AUTH-004), so a
+    user who typed a 100-char passphrase would later be authenticated by
+    any string that shares the same first 72 bytes.  Reject explicitly
+    here -- callers reach this helper after Pydantic's
+    ``_MAX_PASSWORD_LENGTH`` cap so this branch only fires for
+    multi-byte UTF-8 input that fits character-wise but overflows
+    byte-wise (a 64-char password of 4-byte characters is 256 bytes).
+
+    12 rounds of bcrypt hashing (~250 ms on modern hardware).  This is
+    the OWASP-recommended minimum; it makes brute-force attacks
+    prohibitively expensive while keeping login latency acceptable for
+    users.
+    """
+    encoded = password.encode("utf-8")
+    if len(encoded) > _BCRYPT_MAX_PASSWORD_BYTES:
+        msg = f"password exceeds bcrypt's {_BCRYPT_MAX_PASSWORD_BYTES}-byte limit"
+        raise ValueError(msg)
+    hashed: bytes = bcrypt.hashpw(encoded, bcrypt.gensalt(rounds=12))
     return hashed.decode("utf-8")
 
 
@@ -344,13 +385,17 @@ async def signup(
     payload: SignupRequest,
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> AuthResponse:
-    if len(payload.password) < _MIN_PASSWORD_LENGTH:
-        raise bad_request("password_too_short")
-    # Always pay the bcrypt cost so the response time is indistinguishable
-    # from the duplicate-email branch (bcrypt takes ~250 ms).  Without
-    # this, a timing oracle could distinguish "email exists" from "email
-    # is new" even though the response bodies match.
-    password_hash = _hash_password(payload.password)
+    # Pydantic enforces ``_MIN_PASSWORD_LENGTH`` / ``_MAX_PASSWORD_LENGTH``
+    # before we get here (BUG-AUTH-017), so the only failure mode left is a
+    # multi-byte UTF-8 password whose char-count fits the cap but whose
+    # byte-length blows the bcrypt 72-byte limit.  Translate that into a
+    # 422 instead of a 500 so the client gets a uniform validation
+    # response and we never store a row that bcrypt has silently
+    # truncated (BUG-AUTH-004).
+    try:
+        password_hash = _hash_password(payload.password)
+    except ValueError as exc:
+        raise bad_request("password_too_long") from exc
     user = User(
         email=payload.email,
         password_hash=password_hash,
@@ -392,6 +437,13 @@ async def login(
     async with _serialize_login(session, payload.email):
         # Check lockout before even verifying credentials — prevents timing attacks
         if await _is_account_locked(session, payload.email):
+            # Record the blocked attempt so a continuous attacker cannot
+            # silently wait out the rolling window (BUG-AUTH-006): without
+            # this row the oldest-of-last-N timestamp keeps aging out and
+            # the lock can expire even while attempts are still arriving.
+            # Recording each blocked try keeps the window fresh for as long
+            # as the attacker keeps trying.
+            await _record_attempt(session, payload.email, ip_address, success=False)
             logger.info(
                 "auth_attempt_blocked",
                 extra={
@@ -446,7 +498,23 @@ def get_current_user(authorization: str | None = Header(default=None)) -> int:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
         ) from exc
-    return int(payload["sub"])
+    # ``sub`` may be missing or non-numeric on a forged / corrupted token
+    # (BUG-AUTH-012).  Without this guard the bare ``int(payload["sub"])``
+    # call raised ``KeyError`` / ``ValueError`` uncaught and Starlette
+    # surfaced it as 500 -- leaking "your token confused us" diagnostics
+    # to the attacker.  Convert into the same 401 every other auth path
+    # uses so the rejection looks identical.
+    sub = payload.get("sub")
+    if not isinstance(sub, str | int):
+        logger.info("token_rejected", extra={"reason": "malformed_sub"})
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
+    try:
+        return int(sub)
+    except (TypeError, ValueError) as exc:
+        logger.info("token_rejected", extra={"reason": "malformed_sub"})
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
+        ) from exc
 
 
 @router.post("/refresh", response_model=AuthResponse)

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -448,6 +448,71 @@ async def signup(
     return AuthResponse(token=token, user_id=user.id, timezone=user.timezone)
 
 
+def _log_blocked_attempt(email: str, ip_address: str, reason: str) -> None:
+    """Emit the ``auth_attempt_blocked`` audit log line.
+
+    Extracted from :func:`login` so the body stays at xenon rank A
+    after the BUG-MODEL-001 disabled-user gate added a third blocked
+    branch (lockout, missing/wrong-password, disabled / deleted).
+    """
+    logger.info(
+        "auth_attempt_blocked",
+        extra={
+            "email_fingerprint": _email_log_fingerprint(email),
+            "ip_address": ip_address,
+            "reason": reason,
+            "timestamp": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
+def _user_state_reject_reason(user: User) -> str | None:
+    """Return the audit reason if the user is disabled / deleted, else ``None``.
+
+    Centralises the BUG-MODEL-001 gate so the same classification is
+    used in :func:`login` (after credential verification) and
+    :func:`_check_user_active` (on every authenticated request).
+    """
+    if user.deleted_at is not None:
+        return "user_deleted"
+    if not user.is_active:
+        return "user_disabled"
+    return None
+
+
+async def _verify_login_or_raise(
+    session: AsyncSession, payload: AuthRequest, ip_address: str
+) -> User:
+    """Run the lockout + credential + account-state gates for ``login``.
+
+    Each rejection raises ``invalid_credentials`` with the same shape
+    so the caller cannot distinguish "locked" from "wrong password"
+    from "disabled" -- only the server-side log records the specific
+    reason.  The state gate runs *after* the password check so the
+    response timing matches that of an ordinary wrong-password attempt
+    against a regular account.
+    """
+    if await _is_account_locked(session, payload.email):
+        await _record_attempt(session, payload.email, ip_address, success=False)
+        _log_blocked_attempt(payload.email, ip_address, "account_locked")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_credentials")
+
+    result = await session.execute(select(User).where(User.email == payload.email))
+    user = result.scalars().first()
+
+    if user is None or not _verify_password(payload.password, user.password_hash):
+        await _record_attempt(session, payload.email, ip_address, success=False)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_credentials")
+
+    reject_reason = _user_state_reject_reason(user)
+    if reject_reason is not None:
+        _log_blocked_attempt(payload.email, ip_address, reject_reason)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_credentials")
+
+    await _record_attempt(session, payload.email, ip_address, success=True)
+    return user
+
+
 @router.post("/login", response_model=AuthResponse)
 @limiter.limit("5/minute")
 async def login(
@@ -461,66 +526,7 @@ async def login(
     # serialization so concurrent failed attempts cannot all pass the
     # threshold-1 check before any of them inserts (BUG-AUTH-007).
     async with _serialize_login(session, payload.email):
-        # Check lockout before even verifying credentials — prevents timing attacks
-        if await _is_account_locked(session, payload.email):
-            # Record the blocked attempt so a continuous attacker cannot
-            # silently wait out the rolling window (BUG-AUTH-006): without
-            # this row the oldest-of-last-N timestamp keeps aging out and
-            # the lock can expire even while attempts are still arriving.
-            # Recording each blocked try keeps the window fresh for as long
-            # as the attacker keeps trying.
-            await _record_attempt(session, payload.email, ip_address, success=False)
-            logger.info(
-                "auth_attempt_blocked",
-                extra={
-                    "email_fingerprint": _email_log_fingerprint(payload.email),
-                    "ip_address": ip_address,
-                    "reason": "account_locked",
-                    "timestamp": datetime.now(UTC).isoformat(),
-                },
-            )
-            # Return the same generic message to prevent account enumeration
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="invalid_credentials",
-            )
-
-        result = await session.execute(select(User).where(User.email == payload.email))
-        user = result.scalars().first()
-
-        if user is None or not _verify_password(payload.password, user.password_hash):
-            await _record_attempt(session, payload.email, ip_address, success=False)
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="invalid_credentials",
-            )
-
-        # Account-state gate (BUG-MODEL-001).  Done after credential
-        # verification so a probe with a wrong password against a
-        # disabled account still gets the same 401 path as any other
-        # bad guess -- otherwise the response timing would distinguish
-        # "exists but disabled" from "exists with wrong password" and
-        # leak existence information.  ``invalid_credentials`` is
-        # reused for the same reason; only the server log records the
-        # specific reason.
-        if not user.is_active or user.deleted_at is not None:
-            reason = "user_deleted" if user.deleted_at is not None else "user_disabled"
-            logger.info(
-                "auth_attempt_blocked",
-                extra={
-                    "email_fingerprint": _email_log_fingerprint(payload.email),
-                    "ip_address": ip_address,
-                    "reason": reason,
-                    "timestamp": datetime.now(UTC).isoformat(),
-                },
-            )
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="invalid_credentials",
-            )
-
-        # Successful login — record and reset the failure window
-        await _record_attempt(session, payload.email, ip_address, success=True)
+        user = await _verify_login_or_raise(session, payload, ip_address)
 
     if user.id is None:
         msg = "User ID unexpectedly None after database commit"
@@ -591,6 +597,23 @@ async def _check_token_not_revoked(session: AsyncSession, payload: dict[str, obj
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
 
 
+def _user_row_reject_reason(row: object | None) -> str | None:
+    """Return the rejection reason for a user-state row (or ``None`` if OK).
+
+    Split out from :func:`_check_user_active` so that helper stays at
+    xenon rank A while keeping the three distinct outcomes
+    (``user_missing``, ``user_deleted``, ``user_disabled``) for
+    server-side logging.
+    """
+    if row is None:
+        return "user_missing"
+    if getattr(row, "deleted_at", None) is not None:
+        return "user_deleted"
+    if not getattr(row, "is_active", True):
+        return "user_disabled"
+    return None
+
+
 async def _check_user_active(session: AsyncSession, user_id: int) -> None:
     """Reject the request if the user is soft-disabled or soft-deleted.
 
@@ -611,13 +634,8 @@ async def _check_user_active(session: AsyncSession, user_id: int) -> None:
     result = await session.execute(
         select(User.is_active, User.deleted_at).where(User.id == user_id)
     )
-    row = result.first()
-    if row is None or not row.is_active or row.deleted_at is not None:
-        reason = (
-            "user_missing"
-            if row is None
-            else ("user_deleted" if row.deleted_at is not None else "user_disabled")
-        )
+    reason = _user_row_reject_reason(result.first())
+    if reason is not None:
         logger.info("token_rejected", extra={"reason": reason})
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
 

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -495,6 +495,30 @@ async def login(
                 detail="invalid_credentials",
             )
 
+        # Account-state gate (BUG-MODEL-001).  Done after credential
+        # verification so a probe with a wrong password against a
+        # disabled account still gets the same 401 path as any other
+        # bad guess -- otherwise the response timing would distinguish
+        # "exists but disabled" from "exists with wrong password" and
+        # leak existence information.  ``invalid_credentials`` is
+        # reused for the same reason; only the server log records the
+        # specific reason.
+        if not user.is_active or user.deleted_at is not None:
+            reason = "user_deleted" if user.deleted_at is not None else "user_disabled"
+            logger.info(
+                "auth_attempt_blocked",
+                extra={
+                    "email_fingerprint": _email_log_fingerprint(payload.email),
+                    "ip_address": ip_address,
+                    "reason": reason,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid_credentials",
+            )
+
         # Successful login — record and reset the failure window
         await _record_attempt(session, payload.email, ip_address, success=True)
 
@@ -567,6 +591,37 @@ async def _check_token_not_revoked(session: AsyncSession, payload: dict[str, obj
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
 
 
+async def _check_user_active(session: AsyncSession, user_id: int) -> None:
+    """Reject the request if the user is soft-disabled or soft-deleted.
+
+    Mirrors the gate the column docstrings on ``User.is_active`` /
+    ``User.deleted_at`` promise: an operator who flips ``is_active`` or
+    sets ``deleted_at`` expects the affected user's existing tokens to
+    stop authenticating immediately (BUG-MODEL-001).  Looked up by
+    primary key so the cost is a single indexed SELECT per
+    authenticated request, paired with the revocation lookup in
+    :func:`_check_token_not_revoked` -- the alternative (joining the
+    user row into the revocation query) would couple two unrelated
+    tables for marginal savings.
+
+    Returns the same 401 ``unauthorized`` as every other rejection path
+    so attackers cannot distinguish disabled-account from
+    invalid-token (OWASP A07:2021).
+    """
+    result = await session.execute(
+        select(User.is_active, User.deleted_at).where(User.id == user_id)
+    )
+    row = result.first()
+    if row is None or not row.is_active or row.deleted_at is not None:
+        reason = (
+            "user_missing"
+            if row is None
+            else ("user_deleted" if row.deleted_at is not None else "user_disabled")
+        )
+        logger.info("token_rejected", extra={"reason": reason})
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
+
+
 async def get_current_user(
     session: Annotated[AsyncSession, Depends(get_session)],
     authorization: str | None = Header(default=None),
@@ -578,6 +633,11 @@ async def get_current_user(
     is keyed on the primary-key ``jti`` so the cost is one indexed
     SELECT per request, not a full scan.
 
+    Also gates on the account-state flags landed in BUG-MODEL-001: a
+    soft-disabled (``is_active=False``) or soft-deleted
+    (``deleted_at IS NOT NULL``) user cannot ride an existing token
+    past the deletion / disable boundary.
+
     All rejection scenarios return an identical 401 with
     ``detail="unauthorized"`` to prevent attackers from distinguishing
     token states (OWASP A07:2021, sec-04). The specific reason is
@@ -585,7 +645,9 @@ async def get_current_user(
     """
     payload = _decode_token_payload(authorization)
     await _check_token_not_revoked(session, payload)
-    return _coerce_sub(payload)
+    user_id = _coerce_sub(payload)
+    await _check_user_active(session, user_id)
+    return user_id
 
 
 async def _revoke_token_payload(

--- a/backend/src/schemas/checkin.py
+++ b/backend/src/schemas/checkin.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 from datetime import date
+from typing import Literal
 
 from pydantic import BaseModel
 
 from .milestone import Milestone
+
+# BUG-SCHEMA-003: the server emits a fixed set of reason codes from
+# ``services.streaks`` and ``routers.goal_completions``; promoting the
+# field to ``Literal`` pins the API contract so a typo at the emit site
+# fails type-check before the client gets a value it cannot route.
+CheckInReasonCode = Literal[
+    "streak_incremented",
+    "streak_reset",
+    "already_logged_today",
+]
 
 
 class CheckInRequest(BaseModel):
@@ -17,4 +28,4 @@ class CheckInRequest(BaseModel):
 class CheckInResult(BaseModel):
     streak: int
     milestones: list[Milestone] = []
-    reason_code: str
+    reason_code: CheckInReasonCode

--- a/backend/src/schemas/milestone.py
+++ b/backend/src/schemas/milestone.py
@@ -1,9 +1,48 @@
-"""Milestone schemas."""
+"""Milestone schemas — streak-day thresholds the UI surfaces as toasts."""
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# Built-in milestone names the streak engine emits.  ``Literal`` rather
+# than free string so the API contract is explicit and a typo at the
+# emit site fails type-check before it surfaces as a missing-toast UX
+# bug (BUG-SCHEMA-002).
+MilestoneKind = Literal[
+    "streak_started",
+    "streak_milestone",
+    "personal_best",
+    "comeback",
+]
 
 
 class Milestone(BaseModel):
-    threshold: int
+    """A streak event the UI may surface as a celebratory toast.
+
+    The original schema carried a single ``threshold: int`` field with
+    no kind, label, or timestamp -- consumers had no way to know
+    *which* milestone fired or render an appropriate copy.
+
+    ``threshold`` -- the consecutive-day count that triggered the
+    milestone (e.g. 3, 7, 30).  Always positive.
+
+    ``kind`` -- one of :data:`MilestoneKind`.  Defaults to
+    ``"streak_milestone"`` so existing call sites that emit only the
+    threshold continue to work without forcing a producer change.
+
+    ``label`` -- optional human-readable copy for the toast.  When
+    present, the UI renders it verbatim; when absent, the UI looks up
+    a default for ``kind`` + ``threshold``.
+
+    ``achieved_at`` -- when the milestone fired (server-side).  Helps
+    clients dedupe rapid back-to-back submissions and order recent
+    milestones in a history view.
+    """
+
+    threshold: int = Field(ge=1)
+    kind: MilestoneKind = "streak_milestone"
+    label: str | None = Field(default=None, max_length=120)
+    achieved_at: datetime | None = None

--- a/backend/tests/services/test_streaks.py
+++ b/backend/tests/services/test_streaks.py
@@ -54,7 +54,9 @@ async def _make_goal(session: AsyncSession, user_id: int) -> Goal:
 
 
 async def _make_user(session: AsyncSession) -> User:
-    user = User(email="streaks@example.com")
+    # ``password_hash`` is required at the model level (BUG-AUTH-018);
+    # streak tests don't authenticate so any non-empty sentinel is fine.
+    user = User(email="streaks@example.com", password_hash="x")
     session.add(user)
     await session.commit()
     await session.refresh(user)

--- a/backend/tests/services/test_wallet.py
+++ b/backend/tests/services/test_wallet.py
@@ -70,8 +70,11 @@ async def _make_user(
     service-under-test to re-read the row through ``get_user_fresh``.
     """
     now_naive = datetime.now(UTC).replace(tzinfo=None)
+    # ``password_hash`` is required at the model level (BUG-AUTH-018);
+    # wallet tests don't authenticate so any non-empty sentinel works.
     user = User(
         email=email,
+        password_hash="x",
         monthly_messages_used=monthly_used,
         offering_balance=offering_balance,
         monthly_reset_date=now_naive + timedelta(days=reset_in_days),

--- a/backend/tests/test_admin_usage_stats.py
+++ b/backend/tests/test_admin_usage_stats.py
@@ -331,5 +331,8 @@ async def test_admin_endpoint_rejects_deleted_admin(
     await db_session.commit()
 
     resp = await async_client.get("/admin/usage-stats", headers=headers)
-    assert resp.status_code == HTTPStatus.FORBIDDEN
-    assert resp.json()["detail"] == "user_not_found"
+    # BUG-MODEL-001: ``get_current_user`` now gates on ``is_active`` /
+    # ``deleted_at`` so a missing-user JWT 401s at the auth dependency
+    # before the downstream admin lookup runs.
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+    assert resp.json()["detail"] == "unauthorized"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -791,16 +791,31 @@ async def test_refresh_with_invalid_token_returns_401(async_client: AsyncClient)
 
 @pytest.mark.asyncio
 async def test_refresh_rate_limit_returns_429(async_client: AsyncClient) -> None:
-    """Refresh endpoint returns 429 after exceeding 1 request/minute."""
-    data = await _signup(async_client)
-    headers = {"Authorization": f"Bearer {data['token']}"}
+    """Refresh endpoint returns 429 after exceeding 1 request/minute.
 
-    # First request should succeed
-    resp = await async_client.post(REFRESH_URL, headers=headers)
+    Each refresh revokes the old token's ``jti`` (BUG-AUTH-013), so a
+    second refresh with the *same* token would 401 before the rate
+    limiter saw it.  We sign up a second account to get a fresh,
+    non-revoked token for the rate-limit-triggering request -- the
+    1/minute slowapi limit is per-IP so the second request from the
+    same TestClient still trips it.
+    """
+    first = await _signup(async_client, email="rl1@example.com")
+    second = await _signup(async_client, email="rl2@example.com")
+
+    # First request consumes the per-IP slot.
+    resp = await async_client.post(
+        REFRESH_URL,
+        headers={"Authorization": f"Bearer {first['token']}"},
+    )
     assert resp.status_code == HTTPStatus.OK
 
-    # Second request within the same minute should be rate-limited
-    resp = await async_client.post(REFRESH_URL, headers=headers)
+    # Second request from the same IP is rate-limited regardless of
+    # which (non-revoked) token it carries.
+    resp = await async_client.post(
+        REFRESH_URL,
+        headers={"Authorization": f"Bearer {second['token']}"},
+    )
     assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
 
 
@@ -1224,3 +1239,79 @@ async def test_blocked_login_attempt_is_recorded(
     attempts = list(result.scalars().all())
     # MAX_FAILED_ATTEMPTS verify-failed + at least 1 blocked-and-recorded.
     assert len(attempts) > MAX_FAILED_ATTEMPTS
+
+
+# ── BUG-AUTH-013: refresh revokes the old token's jti ─────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_refresh_revokes_previous_token(
+    async_client: AsyncClient,
+) -> None:
+    """A token cannot be replayed after a successful refresh.
+
+    The first refresh succeeds and stores the old ``jti`` in the
+    revocation table.  Replaying the original token afterwards must
+    400/401, not return a fresh response -- otherwise a stolen token
+    keeps working until its original 1-hour ``exp``.
+    """
+    data = await _signup(async_client, email="revoke@example.com")
+    old_token = data["token"]
+
+    # First refresh -- old token is consumed and revoked.
+    first = await async_client.post(
+        REFRESH_URL,
+        headers={"Authorization": f"Bearer {old_token}"},
+    )
+    assert first.status_code == HTTPStatus.OK
+    new_token = first.json()["token"]
+    assert new_token != old_token
+
+    # Replaying the OLD token -- now revoked -- must be rejected.
+    replayed = await async_client.post(
+        REFRESH_URL,
+        headers={"Authorization": f"Bearer {old_token}"},
+    )
+    assert replayed.status_code == HTTPStatus.UNAUTHORIZED
+
+    # The NEW token still works.
+    second = await async_client.post(
+        REFRESH_URL,
+        headers={"Authorization": f"Bearer {new_token}"},
+    )
+    assert second.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_legacy_token_without_jti_still_authenticates(
+    async_client: AsyncClient,
+) -> None:
+    """BUG-AUTH-013 grace window: tokens minted before the jti claim work.
+
+    A deployment landing this PR cannot revoke every active session at
+    once.  Tokens whose payload omits ``jti`` are passed through the
+    revocation check transparently -- the 1-hour TTL is the grace
+    window, after which every new token has a jti and the legacy path
+    naturally drops.
+    """
+    # Create a corresponding user so the int sub maps to a real row.
+    data = await _signup(async_client, email="legacy@example.com")
+    user_id = data["user_id"]
+    legacy = jwt.encode(
+        {
+            "sub": str(user_id),
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+            "iat": datetime.now(UTC),
+            # No ``jti`` claim -- legacy shape.
+        },
+        SECRET_KEY,
+        algorithm="HS256",
+    )
+    resp = await async_client.post(
+        REFRESH_URL,
+        headers={"Authorization": f"Bearer {legacy}"},
+    )
+    # Accepts the request -- the auth dep does not 401 a missing jti.
+    assert resp.status_code == HTTPStatus.OK

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -15,7 +15,12 @@ from sqlmodel import select
 
 from models.login_attempt import LoginAttempt
 from models.user import User
-from routers.auth import LOCKOUT_DURATION, MAX_FAILED_ATTEMPTS
+from routers.auth import (
+    _SECRET_PLACEHOLDER,
+    LOCKOUT_DURATION,
+    MAX_FAILED_ATTEMPTS,
+    _get_secret_key,
+)
 
 SIGNUP_URL = "/auth/signup"
 LOGIN_URL = "/auth/login"
@@ -278,13 +283,38 @@ async def test_signup_duplicate_email_token_is_not_valid(async_client: AsyncClie
 
 
 @pytest.mark.asyncio
-async def test_signup_short_password_returns_400(async_client: AsyncClient) -> None:
+async def test_signup_short_password_returns_422(async_client: AsyncClient) -> None:
+    """BUG-AUTH-017: ``AuthRequest.password`` enforces length bounds via Pydantic.
+
+    The pre-bound implementation raised a 400 from a manual check inside
+    the handler.  Moving the bound to the schema field surfaces the
+    rejection at the trust boundary (matching the timezone field's
+    422 contract) and prevents the bcrypt cost from running on input
+    that would always be rejected.
+    """
     resp = await async_client.post(
         SIGNUP_URL,
         json={"email": "short@example.com", "password": "short"},  # pragma: allowlist secret
     )
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
-    assert resp.json()["detail"] == "password_too_short"
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_signup_long_password_returns_422(async_client: AsyncClient) -> None:
+    """BUG-AUTH-017: passwords beyond the upper bound are rejected too.
+
+    Without the upper cap the bcrypt cost (~250 ms) ran on every
+    request and gave an attacker a free CPU-burn lever.  64 chars is
+    the cleanly-rejected boundary; longer values 422.
+    """
+    resp = await async_client.post(
+        SIGNUP_URL,
+        json={
+            "email": "longpw@example.com",
+            "password": "a" * 200,  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 # ── Login ───────────────────────────────────────────────────────────────
@@ -1035,9 +1065,12 @@ async def test_concurrent_failed_logins_cannot_outpace_lockout(
     )
 
     # Every concurrent failed attempt returns 401, indistinguishable from a
-    # locked or wrong-password response.  The invariant that matters is on
-    # the persisted row count: serialized inserts can't write more than
-    # ``MAX_FAILED_ATTEMPTS`` rows before the lockout check starts winning.
+    # locked or wrong-password response.  Serialization (BUG-AUTH-007)
+    # prevents the bcrypt cost from being paid more than
+    # ``MAX_FAILED_ATTEMPTS`` times -- each task must wait its turn at the
+    # per-email lock before reading the lockout state, so no more than
+    # ``MAX_FAILED_ATTEMPTS`` can pass the check before subsequent
+    # attempts hit the locked branch.
     assert all(r.status_code == HTTPStatus.UNAUTHORIZED for r in results)
     async with concurrent_session_factory() as session:
         result = await session.execute(
@@ -1045,16 +1078,149 @@ async def test_concurrent_failed_logins_cannot_outpace_lockout(
         )
         attempts = list(result.scalars().all())
     failed_attempts = [a for a in attempts if not a.success]
-    # Strict ``<`` against the fan-out (not ``<=`` against the threshold)
-    # so the assertion stays meaningful regardless of how
-    # ``MAX_FAILED_ATTEMPTS`` is configured: an unserialized loop would
-    # write ``_CONCURRENT_FAILED_LOGIN_FANOUT`` rows because every task
-    # would pass the lockout check before any of them inserted.
-    assert len(failed_attempts) < _CONCURRENT_FAILED_LOGIN_FANOUT, (
-        f"expected <{_CONCURRENT_FAILED_LOGIN_FANOUT} failed inserts under serialization, "
+    # BUG-AUTH-006: blocked attempts are now also recorded so the
+    # rolling lockout window stays fresh against an attacker who keeps
+    # hammering the endpoint.  Pre-006 only the first
+    # ``MAX_FAILED_ATTEMPTS`` rows landed; post-006 every fanout request
+    # records a row, but only the first ``MAX_FAILED_ATTEMPTS`` of them
+    # paid the bcrypt cost.  The invariant we keep is "no row count
+    # exceeds the fanout" -- bug-006 + bug-007 together mean exactly
+    # one row per request.
+    assert len(failed_attempts) == _CONCURRENT_FAILED_LOGIN_FANOUT, (
+        f"expected exactly {_CONCURRENT_FAILED_LOGIN_FANOUT} rows "
+        f"(one per request, BUG-AUTH-006 records blocked attempts), "
         f"got {len(failed_attempts)}"
     )
-    assert len(failed_attempts) <= MAX_FAILED_ATTEMPTS, (
-        f"once the threshold is reached the lockout branch must short-circuit "
-        f"before recording another attempt; got {len(failed_attempts)}"
+
+
+# ── Auth hardening (Prompt 11) ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_signup_multibyte_password_over_72_bytes_returns_400(
+    async_client: AsyncClient,
+) -> None:
+    """BUG-AUTH-004: bcrypt silently truncates beyond 72 bytes.
+
+    A 64-character password of 4-byte UTF-8 emoji is 256 bytes -- well
+    past the bcrypt limit.  The Pydantic ``max_length`` cap would let it
+    through (it counts characters, not bytes), so the helper itself must
+    reject before hashing.  Translated to 400 ``password_too_long`` so a
+    truncation never makes it into the database.
+    """
+    resp = await async_client.post(
+        SIGNUP_URL,
+        json={
+            "email": "multibyte@example.com",
+            "password": "🔥" * 30,  # 30 chars, 120 bytes (each emoji is 4 bytes)
+        },
     )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "password_too_long"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_malformed_sub_returns_401(
+    async_client: AsyncClient,
+) -> None:
+    """BUG-AUTH-012: a token whose ``sub`` is missing or non-numeric used to 500.
+
+    Forge a JWT signed with the test secret but carrying ``sub: "not-an-int"``
+    so it decodes cleanly but ``int(sub)`` raises.  The handler now wraps
+    that in the same 401 every other rejection uses.
+    """
+    forged = jwt.encode(
+        {
+            "sub": "not-an-int",
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+            "iat": datetime.now(UTC),
+        },
+        SECRET_KEY,
+        algorithm="HS256",
+    )
+    resp = await async_client.get(
+        "/auth/refresh",
+        headers={"Authorization": f"Bearer {forged}"},
+    )
+    # Either 401 (auth rejected) or 405 (method-not-allowed on refresh GET).
+    # The protected endpoint test below exercises the 401 path explicitly.
+    # We use a method that exists: POST /auth/refresh.
+    resp = await async_client.post(
+        "/auth/refresh",
+        headers={"Authorization": f"Bearer {forged}"},
+    )
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_missing_sub_returns_401(
+    async_client: AsyncClient,
+) -> None:
+    """A token whose payload omits ``sub`` entirely also returns 401."""
+    forged = jwt.encode(
+        {
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+            "iat": datetime.now(UTC),
+        },
+        SECRET_KEY,
+        algorithm="HS256",
+    )
+    resp = await async_client.post(
+        "/auth/refresh",
+        headers={"Authorization": f"Bearer {forged}"},
+    )
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_get_secret_key_raises_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BUG-AUTH-011: misconfigured SECRET_KEY raises eagerly.
+
+    The helper is called once from the FastAPI lifespan (see
+    ``main.lifespan``) so a deployment that forgot to set the env var
+    fails the readiness probe at startup rather than serving traffic
+    until the first auth request and then crashing 500.
+    """
+    monkeypatch.setattr("routers.auth.SECRET_KEY", "")
+    with pytest.raises(RuntimeError, match="SECRET_KEY"):
+        _get_secret_key()
+
+
+def test_get_secret_key_raises_when_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The placeholder string also fails the startup check."""
+    monkeypatch.setattr("routers.auth.SECRET_KEY", _SECRET_PLACEHOLDER)
+    with pytest.raises(RuntimeError, match="SECRET_KEY"):
+        _get_secret_key()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_blocked_login_attempt_is_recorded(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-AUTH-006: blocked attempts are recorded so the lockout window stays fresh.
+
+    Drive the user into lockout, then issue one more wrong-password
+    attempt and confirm a row was inserted.  Pre-006 the blocked branch
+    short-circuited without recording, letting the rolling window
+    expire under continuous attack.
+    """
+    email = "lockedrec@example.com"
+    await async_client.post(
+        SIGNUP_URL,
+        json={"email": email, "password": "rightpass123"},  # pragma: allowlist secret
+    )
+    # Drive past the threshold.
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        await _fail_login(async_client, email=email)
+    # One more attempt -- this one is blocked.
+    blocked = await async_client.post(
+        LOGIN_URL,
+        json={"email": email, "password": "wrongpw999"},  # pragma: allowlist secret
+    )
+    assert blocked.status_code == HTTPStatus.UNAUTHORIZED
+
+    result = await db_session.execute(select(LoginAttempt).where(LoginAttempt.email == email))
+    attempts = list(result.scalars().all())
+    # MAX_FAILED_ATTEMPTS verify-failed + at least 1 blocked-and-recorded.
+    assert len(attempts) > MAX_FAILED_ATTEMPTS

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1153,13 +1153,6 @@ async def test_get_current_user_malformed_sub_returns_401(
         SECRET_KEY,
         algorithm="HS256",
     )
-    resp = await async_client.get(
-        "/auth/refresh",
-        headers={"Authorization": f"Bearer {forged}"},
-    )
-    # Either 401 (auth rejected) or 405 (method-not-allowed on refresh GET).
-    # The protected endpoint test below exercises the 401 path explicitly.
-    # We use a method that exists: POST /auth/refresh.
     resp = await async_client.post(
         "/auth/refresh",
         headers={"Authorization": f"Bearer {forged}"},
@@ -1315,3 +1308,123 @@ async def test_legacy_token_without_jti_still_authenticates(
     )
     # Accepts the request -- the auth dep does not 401 a missing jti.
     assert resp.status_code == HTTPStatus.OK
+
+
+# ── BUG-MODEL-001: is_active / deleted_at enforcement ───────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_login_rejects_disabled_user(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A user with ``is_active=False`` cannot log in even with the right password."""
+    await _signup(async_client, email="banned@example.com")
+    user = (
+        (await db_session.execute(select(User).where(User.email == "banned@example.com")))
+        .scalars()
+        .first()
+    )
+    assert user is not None
+    user.is_active = False
+    db_session.add(user)
+    await db_session.commit()
+
+    resp = await async_client.post(
+        LOGIN_URL,
+        json={
+            "email": "banned@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+    assert resp.json()["detail"] == "invalid_credentials"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_login_rejects_soft_deleted_user(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A user with ``deleted_at`` set cannot log in."""
+    await _signup(async_client, email="gone@example.com")
+    user = (
+        (await db_session.execute(select(User).where(User.email == "gone@example.com")))
+        .scalars()
+        .first()
+    )
+    assert user is not None
+    user.deleted_at = datetime.now(UTC)
+    db_session.add(user)
+    await db_session.commit()
+
+    resp = await async_client.post(
+        LOGIN_URL,
+        json={
+            "email": "gone@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+    assert resp.json()["detail"] == "invalid_credentials"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_existing_token_rejected_after_user_disabled(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A live token stops authenticating once the user is soft-disabled."""
+    data = await _signup(async_client, email="active@example.com")
+    token = data["token"]
+    # Token works initially.
+    pre = await async_client.post(
+        REFRESH_URL,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert pre.status_code == HTTPStatus.OK
+
+    user = (
+        (await db_session.execute(select(User).where(User.email == "active@example.com")))
+        .scalars()
+        .first()
+    )
+    assert user is not None
+    user.is_active = False
+    db_session.add(user)
+    await db_session.commit()
+
+    # The fresh token from the prior refresh is now invalidated by the
+    # account-state gate, even though it has not been explicitly revoked.
+    new_token = pre.json()["token"]
+    post = await async_client.post(
+        REFRESH_URL,
+        headers={"Authorization": f"Bearer {new_token}"},
+    )
+    assert post.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_existing_token_rejected_after_user_soft_deleted(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A live token stops authenticating once the user is soft-deleted."""
+    data = await _signup(async_client, email="leaving@example.com")
+    token = data["token"]
+
+    user = (
+        (await db_session.execute(select(User).where(User.email == "leaving@example.com")))
+        .scalars()
+        .first()
+    )
+    assert user is not None
+    user.deleted_at = datetime.now(UTC)
+    db_session.add(user)
+    await db_session.commit()
+
+    resp = await async_client.post(
+        REFRESH_URL,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -166,17 +166,23 @@ async def test_add_balance_non_admin_returns_403(async_client: AsyncClient) -> N
 
 
 @pytest.mark.asyncio
-async def test_add_balance_deleted_admin_returns_403(
+async def test_add_balance_deleted_admin_returns_401(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """A valid JWT whose admin row was deleted must not pass the auth gate."""
+    """A valid JWT whose admin row was deleted now 401s at the auth gate.
+
+    BUG-MODEL-001: ``get_current_user`` queries ``is_active`` /
+    ``deleted_at`` so a missing-user lookup short-circuits with 401
+    ``unauthorized`` (the correct OWASP A07 response for a JWT that
+    cannot be resolved to a user) before reaching the admin check.
+    """
     headers = await _signup_admin(async_client, db_session)
     await db_session.execute(delete(User).where(col(User.email) == "alice@example.com"))
     await db_session.commit()
 
     resp = await async_client.post("/user/balance/add", json={"amount": 5}, headers=headers)
-    assert resp.status_code == HTTPStatus.FORBIDDEN
-    assert resp.json()["detail"] == "user_not_found"
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+    assert resp.json()["detail"] == "unauthorized"
 
 
 # ── Offering balance ───────────────────────────────────────────────────

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -243,3 +243,46 @@ def test_preflight_disallowed_method() -> None:
     }
     response = client.options("/auth/login", headers=headers)
     assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+# ── BUG-APP-003: PROD_DOMAIN URL-validation hardening ─────────────────────
+
+
+import pytest  # noqa: E402
+
+from main import _validate_prod_origin  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://example.com",  # not https
+        "https://localhost",  # loopback
+        "https://127.0.0.1",  # bare IPv4
+        "https://[::1]",  # bare IPv6 loopback
+        "https://10.0.0.5",  # bare IP
+        "https://*.example.com",  # wildcard
+        "https://user:pass@example.com",  # userinfo  # pragma: allowlist secret
+        "https://",  # no hostname
+    ],
+    ids=[
+        "http-scheme",
+        "loopback-localhost",
+        "loopback-ipv4",
+        "loopback-ipv6",
+        "bare-ip",
+        "wildcard",
+        "userinfo",
+        "no-hostname",
+    ],
+)
+def test_validate_prod_origin_rejects_unsafe_inputs(origin: str) -> None:
+    """Each form should fail fast at startup so misconfig never serves traffic."""
+    with pytest.raises(RuntimeError):
+        _validate_prod_origin(origin)
+
+
+def test_validate_prod_origin_accepts_well_formed_https() -> None:
+    """A vanilla https://host.tld passes the gauntlet."""
+    _validate_prod_origin("https://app.example.com")
+    _validate_prod_origin("https://api.example.org:8443")

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -6,7 +6,13 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from main import DEV_ORIGINS, _assert_credentials_safe, app, get_cors_origins
+from main import (
+    DEV_ORIGINS,
+    _assert_credentials_safe,
+    _validate_prod_origin,
+    app,
+    get_cors_origins,
+)
 
 client = TestClient(app)
 
@@ -246,11 +252,6 @@ def test_preflight_disallowed_method() -> None:
 
 
 # ── BUG-APP-003: PROD_DOMAIN URL-validation hardening ─────────────────────
-
-
-import pytest  # noqa: E402
-
-from main import _validate_prod_origin  # noqa: E402
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -96,7 +96,13 @@ async def test_completion_increments_streak_and_returns_milestone(
     data = resp.json()
     assert data["streak"] == 1
     assert data["reason_code"] == "streak_incremented"
-    assert data["milestones"] == [{"threshold": 1}]
+    # ``Milestone`` schema expanded (BUG-SCHEMA-002): assert on the
+    # threshold + the default ``kind`` rather than dict-equality so a
+    # future field addition (e.g. ``label``) does not break this test.
+    assert len(data["milestones"]) == 1
+    milestone = data["milestones"][0]
+    assert milestone["threshold"] == 1
+    assert milestone["kind"] == "streak_milestone"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,4 +1,6 @@
+import pytest
 from fastapi.testclient import TestClient
+from httpx import AsyncClient
 
 from main import app
 
@@ -14,3 +16,34 @@ def test_root_returns_404() -> None:
     response = client.get("/")
     not_found_status = 404
     assert response.status_code == not_found_status
+
+
+# ── BUG-APP-004: liveness + readiness split ────────────────────────────────
+
+
+def test_liveness_returns_alive() -> None:
+    """``/health/live`` does not depend on the DB.
+
+    A liveness probe failing should mean "process is wedged" so the
+    orchestrator restarts the container.  A DB outage must NOT flip
+    this probe -- a transient DB blip should drop the pod from the
+    LB pool (readiness) without restarting it (liveness).
+    """
+    response = client.get("/health/live")
+    assert response.status_code == 200
+    assert response.json() == {"status": "alive"}
+
+
+@pytest.mark.asyncio
+async def test_readiness_returns_ready_when_db_up(async_client: AsyncClient) -> None:
+    """``/health/ready`` exercises the DB probe with a 2 s timeout.
+
+    Uses the ``async_client`` fixture (which wires the SQLite test DB
+    via ``Depends(get_session)`` override) rather than the bare
+    ``TestClient`` so the readiness query has a real session to probe.
+    """
+    response = await async_client.get("/health/ready")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["database"] == "connected"

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -30,11 +30,11 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 | 04 | centralize-sanitize-user-text     | 3 | `claude/bug-fix-04-sanitize-user-text` | [x] |
 | 05 | centralize-date-utils-tz          | 3 | `claude/bug-fix-05-centralize-date-utils-tz` | [x] |
 | 06 | db-unique-constraints-toctou      | 3 | `claude/bug-fix-06-db-unique-constraints-toctou` / [#266](https://github.com/Geoffe-Ga/adepthood/pull/266) | [x] |
-| 07 | normalize-idor-ordering           | 3 | | [ ] |
-| 08 | optimistic-mutation-hook          | 3 | | [ ] |
+| 07 | normalize-idor-ordering           | 3 | `claude/bug-fix-07-normalize-idor-ordering` / [#265](https://github.com/Geoffe-Ga/adepthood/pull/265) | [x] |
+| 08 | optimistic-mutation-hook          | 3 | `claude/bug-fix-08-optimistic-mutation-hook` / [#263](https://github.com/Geoffe-Ga/adepthood/pull/263) | [x] |
 | 09 | server-derived-timestamps         | 3 | `claude/09-server-derived-timestamps-cfvVc` / [#264](https://github.com/Geoffe-Ga/adepthood/pull/264) | [x] |
 | 10 | observability-e2e                 | 3 | `claude/10-observability-e2e-OfIPz` / [#268](https://github.com/Geoffe-Ga/adepthood/pull/268) | [x] |
-| 11 | backend-auth-models-schemas-cors  | 4 | | [ ] |
+| 11 | backend-auth-models-schemas-cors  | 4 | `claude/bug-fix-11-backend-auth-models-schemas-cors` | [x] |
 | 12 | backend-feature-routers           | 4 | | [ ] |
 | 13 | frontend-api-client               | 4 | | [ ] |
 | 14 | frontend-feature-screens          | 4 | | [ ] |


### PR DESCRIPTION
## Summary

Implements **Prompt 11 — backend-auth-models-schemas-cors** plus the deferred status-row updates for Prompts 07 and 08 (whose PRs merged earlier without ticking the INDEX). Six functional commits + one refactor + one INDEX update.

```
80bd75e  fix(backend): auth hardening (bcrypt/lockout/sub/bounds/blank/secret_key)
49c3201  fix(backend): refresh revokes JWT jti via revokedtoken table (BUG-AUTH-013)
377d4d7  fix(backend): cors origin validation + health split (bug-app-003/-004)
ec1ad89  fix(db): add ondelete to every user-id foreign key (bug-db-003 / bug-model-002)
08c4e04  feat(backend): user state flags + tightened milestone/checkin schemas
9054f42  chore(prompts): mark prompts 07, 08, and 11 as complete
86546a1  refactor(backend): split origin hostname helper
```

## What changed

### Commit 1 — Auth hardening (`80bd75e`)

Closes **BUG-AUTH-004 / -006 / -011 / -012 / -017 / -018**.

- **bcrypt 72-byte guard** — `_hash_password` rejects multi-byte input that would silently truncate. Multi-byte UTF-8 passwords (4-byte emoji etc.) that pass char-count caps but blow byte caps surface as `400 password_too_long` instead of being silently truncated.
- **Lockout records blocked attempts** — the rolling window now stays fresh under continuous attack. Previously the blocked branch short-circuited without persisting, letting attempts age out.
- **Startup `SECRET_KEY` check** — `main.lifespan` calls `_get_secret_key` so a misconfigured deployment fails the readiness probe immediately rather than serving traffic until the first auth request.
- **`get_current_user` malformed-`sub` → 401** — type-checks `sub` and wraps `int()` in try/except so a forged token returns the same generic 401 instead of leaking 500 diagnostics.
- **`AuthRequest.password` length bounds** — Pydantic `Field(min_length=8, max_length=64)` rejects at the trust boundary so the bcrypt cost never runs on guaranteed-rejected input.
- **No blank password hashes** — `User.password_hash` requires `min_length=1`. Two test fixtures updated to pass a sentinel since they don't authenticate.

8 new auth tests + 1 invariant update on the existing concurrency lockout test.

### Commit 2 — Refresh JTI + revocation table (`49c3201`)

Closes **BUG-AUTH-013**.

- New `RevokedToken` model + Alembic migration `e2f3a4b5c6d7`. PK is `jti`; `expires_at` mirrors the original token's `exp` so a future cleanup job can prune past-due rows.
- `_create_token` mints a 16-byte hex `jti` claim and returns `(token, jti)` so callers that revoke can persist the value.
- `get_current_user` decomposed into `_decode_token_payload` / `_check_token_not_revoked` / `_coerce_sub` (xenon rank A) and now async with a session dep.
- `refresh_token` re-decodes the inbound header, persists the old `jti` (idempotent under `IntegrityError` so a double-clicked refresh doesn't 500), then mints a fresh token.

**Grace window:** Tokens minted before this commit have no `jti` claim. The revocation check short-circuits without a DB hit, so existing 1-hour sessions continue to work; after the TTL, every new token has a jti and the legacy path naturally drops.

3 new tests pin the revocation, the legacy-token grace path, and re-do the rate-limit invariant since the original second-call now hits revocation 401 before slowapi counts it.

### Commit 3 — CORS origin validation + health split (`377d4d7`)

Closes **BUG-APP-003 / -004**. (BUG-APP-009 was a no-op against current code.)

- **`_validate_prod_origin`** parses with `urllib.parse.urlparse`, rejects non-https schemes, missing hostnames, loopback (`localhost` / `127.0.0.1` / `::1`), bare IPv4/IPv6 literals, wildcard `*`, and embedded userinfo `@`.
- **Health split**: `/health/live` (no DB dep), `/health/ready` (DB probe with 2 s `asyncio.timeout`), `/health` (legacy combined probe preserved for back-compat).

8 parametrised origin-rejection cases + 2 health probe tests.

### Commit 4 — FK ondelete (`ec1ad89`)

Closes **BUG-DB-003 / BUG-MODEL-002**.

- 13 user FK declarations across 12 models now carry explicit `ondelete`:
  - **CASCADE** for per-user data (habit, goalcompletion, contentcompletion, journalentry, llmusagelog, promptresponse, stageprogress, practicesession, userpractice, walletaudit ×2).
  - **SET NULL** for catalog-shared rows (goalgroup.user_id, practice.submitted_by_user_id).
- Migration `f3a4b5c6d7e8` re-creates each FK with `op.batch_alter_table` (portable across Postgres + SQLite).

**Deferred / no-op**:
- BUG-DB-006 (downgrade truncation) — the surveyed migration `78b1620cafde` already uses matching `AT TIME ZONE 'UTC'` clauses on both sides.
- BUG-DB-010 (enum normalization) — the `c3d4e5f6a7b8` constraint is already in place; no out-of-range values can sneak in via the ORM. Not retroactively edited.

### Commit 5 — User state flags + schema tightening (`08c4e04`)

Closes **BUG-MODEL-001 / BUG-SCHEMA-002 / BUG-SCHEMA-003**.

- **User** gains `is_active` / `email_verified` / `deleted_at` (migration `a4b5c6d7e8f9`) — soft-disable, verification, soft-delete with audit trail.
- **`Milestone`** schema expanded: `threshold` + `kind` Literal + `label` + `achieved_at`. Defaults preserve back-compat with bare `{threshold: int}` emitters.
- **`CheckInResult.reason_code`** widened from `str` to `Literal["streak_incremented", "streak_reset", "already_logged_today"]`.

### Commit 6 — INDEX update (`9054f42`)

Marks Prompts **07** (#265, IDOR ordering) and **08** (#263, optimistic-mutation hook) as complete — both merged earlier without ticking the INDEX. Marks **11** as complete pending merge of this PR.

### Commit 7 — Xenon refactor (`86546a1`)

Pre-push xenon flagged `_validate_prod_origin` at rank B; extracted `_check_origin_hostname` (+ `_LOOPBACK_HOSTNAMES` frozenset) to bring the parent back to rank A. Pure refactor, all 9 origin-validation tests pass unchanged.

## Test plan

- [x] Backend full suite: **779 passed** (was 743 pre-PR, +36 new tests)
- [x] Frontend untouched (no diff)
- [x] `pre-commit run --files <changed>` clean for every commit
- [x] Pre-push gates green: xenon rank A, radon, ruff `select=ALL`, mypy, bandit, detect-secrets, backend coverage gate

## BUG-IDs closed

| Cluster | IDs | Severity |
|---|---|---|
| Auth | BUG-AUTH-004, -006, -011, -012, -013, -017, -018 | High |
| App/CORS | BUG-APP-003, -004 (BUG-APP-009 no-op) | High / Medium |
| DB | BUG-DB-003 (BUG-DB-006/-010 no-op or deferred) | High |
| Models/Schemas | BUG-MODEL-001, -002, BUG-SCHEMA-002, -003 | High / Medium |

## Coordination

- Compatible with merged Wave-3 PRs #263 / #265 / #266 / #268.
- Wave 4 prompts 12-15 still pending; this PR does not touch their files.
- INDEX retroactively updated for Prompts 07 (#265) and 08 (#263).

https://claude.ai/code/session_011JvxjW4m5jw6u77eKrrYjz

---
_Generated by [Claude Code](https://claude.ai/code/session_011JvxjW4m5jw6u77eKrrYjz)_