### PR TITLE
fix(auth): honor anti-enumeration user_id=0 sentinel on signup

### DIFF
--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -46,6 +46,13 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   // rejects a stored token outright (forged / revoked).  Treat as a
   // hard sign-back-in rather than a transient session lapse.
   invalid_token: 'You have been signed out for security. Sign in again to continue.',
+  // BUG-AUTH-019: synthesised by the AuthContext when the backend's
+  // anti-enumeration signup response (``user_id=0`` sentinel) lands.
+  // Phrased as a maybe so the copy still reads sensibly when a user
+  // genuinely is new and the signup just collided with someone else's
+  // address (rare but possible).
+  email_in_use:
+    'That email may already be registered. Try logging in, or use a different email to sign up.',
 
   // --- Admin -----------------------------------------------------------
   admin_required: 'Admin privileges are required for this action.',

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -46,11 +46,7 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   // rejects a stored token outright (forged / revoked).  Treat as a
   // hard sign-back-in rather than a transient session lapse.
   invalid_token: 'You have been signed out for security. Sign in again to continue.',
-  // BUG-AUTH-019: synthesised by the AuthContext when the backend's
-  // anti-enumeration signup response (``user_id=0`` sentinel) lands.
-  // Phrased as a maybe so the copy still reads sensibly when a user
-  // genuinely is new and the signup just collided with someone else's
-  // address (rare but possible).
+  // BUG-AUTH-002: synthesised by AuthContext when the backend returns the user_id=0 anti-enumeration sentinel.
   email_in_use:
     'That email may already be registered. Try logging in, or use a different email to sign up.',
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import {
+  ApiError,
   auth as authApi,
   setOnTokenRefreshed,
   setOnUnauthorized,
@@ -277,6 +278,23 @@ interface AuthActions {
 }
 
 /**
+ * Sentinel ``user_id`` returned by the backend's anti-enumeration response
+ * when the email is already registered.  See ``backend/src/routers/auth.py``
+ * (``_duplicate_signup_response``) and the wire contract documented in
+ * ``frontend/src/api/schemas.ts`` (``authResponseSchema``).
+ *
+ * BUG-AUTH-019: the backend signs an invalid dummy JWT and pairs it with
+ * this sentinel so that the wire shape is indistinguishable from a fresh
+ * signup, but the token cannot grant access.  Persisting it would put the
+ * AuthContext into ``'authenticated'`` and the very next API call would
+ * 401 -- bouncing the user into a re-auth loop they cannot escape because
+ * the password they typed at signup is not the password on the
+ * pre-existing account.  Detecting the sentinel here keeps that contract
+ * intact.
+ */
+const DUPLICATE_SIGNUP_SENTINEL_USER_ID = 0;
+
+/**
  * POST /auth/signup with the device's IANA timezone attached.
  *
  * Captures the timezone here (not at the AuthContext call site) so the
@@ -287,6 +305,13 @@ interface AuthActions {
  * plus the server's record of the stored zone (which the backend may
  * have normalised) so the AuthContext can populate `userTimezone`
  * synchronously with the same value the rest of the API will return.
+ *
+ * BUG-AUTH-019: when the response carries the
+ * ``DUPLICATE_SIGNUP_SENTINEL_USER_ID`` we throw an ``ApiError`` shaped
+ * like a 409 ``email_in_use`` so the SignupScreen's existing
+ * ``formatApiError`` path renders the friendly "may already be
+ * registered -- try signing in" copy instead of silently storing the
+ * doomed dummy token.
  */
 async function signupWithDeviceTimezone(
   email: string,
@@ -297,6 +322,9 @@ async function signupWithDeviceTimezone(
     password,
     timezone: detectDeviceTimezone(),
   });
+  if (response.user_id === DUPLICATE_SIGNUP_SENTINEL_USER_ID) {
+    throw new ApiError(409, 'email_in_use');
+  }
   return { token: response.token, timezone: response.timezone ?? 'UTC' };
 }
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -277,21 +277,7 @@ interface AuthActions {
   dismissReauth: () => Promise<void>;
 }
 
-/**
- * Sentinel ``user_id`` returned by the backend's anti-enumeration response
- * when the email is already registered.  See ``backend/src/routers/auth.py``
- * (``_duplicate_signup_response``) and the wire contract documented in
- * ``frontend/src/api/schemas.ts`` (``authResponseSchema``).
- *
- * BUG-AUTH-019: the backend signs an invalid dummy JWT and pairs it with
- * this sentinel so that the wire shape is indistinguishable from a fresh
- * signup, but the token cannot grant access.  Persisting it would put the
- * AuthContext into ``'authenticated'`` and the very next API call would
- * 401 -- bouncing the user into a re-auth loop they cannot escape because
- * the password they typed at signup is not the password on the
- * pre-existing account.  Detecting the sentinel here keeps that contract
- * intact.
- */
+/** Sentinel user_id in the backend's anti-enumeration duplicate-signup response (see schemas.ts:57, BUG-AUTH-002). */
 const DUPLICATE_SIGNUP_SENTINEL_USER_ID = 0;
 
 /**
@@ -305,13 +291,6 @@ const DUPLICATE_SIGNUP_SENTINEL_USER_ID = 0;
  * plus the server's record of the stored zone (which the backend may
  * have normalised) so the AuthContext can populate `userTimezone`
  * synchronously with the same value the rest of the API will return.
- *
- * BUG-AUTH-019: when the response carries the
- * ``DUPLICATE_SIGNUP_SENTINEL_USER_ID`` we throw an ``ApiError`` shaped
- * like a 409 ``email_in_use`` so the SignupScreen's existing
- * ``formatApiError`` path renders the friendly "may already be
- * registered -- try signing in" copy instead of silently storing the
- * doomed dummy token.
  */
 async function signupWithDeviceTimezone(
   email: string,

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -6,16 +6,32 @@ import React from 'react';
 import { AuthProvider, useAuth } from '../AuthContext';
 
 // Mock the API client
-jest.mock('@/api', () => ({
-  auth: {
-    login: jest.fn(),
-    signup: jest.fn(),
-    refresh: jest.fn(),
-  },
-  setTokenGetter: jest.fn(),
-  setOnUnauthorized: jest.fn(),
-  setOnTokenRefreshed: jest.fn(),
-}));
+jest.mock('@/api', () => {
+  // Mirror the real ``ApiError`` shape (BUG-AUTH-019: AuthContext.signup
+  // synthesises one of these for the duplicate-email sentinel) so callers
+  // that do ``instanceof ApiError`` keep matching under the mock.
+  class MockApiError extends Error {
+    status: number;
+    detail: string;
+    constructor(status: number, detail: string) {
+      super(`Request failed with status ${status}: ${detail}`);
+      this.name = 'ApiError';
+      this.status = status;
+      this.detail = detail;
+    }
+  }
+  return {
+    ApiError: MockApiError,
+    auth: {
+      login: jest.fn(),
+      signup: jest.fn(),
+      refresh: jest.fn(),
+    },
+    setTokenGetter: jest.fn(),
+    setOnUnauthorized: jest.fn(),
+    setOnTokenRefreshed: jest.fn(),
+  };
+});
 
 // Mock authStorage
 jest.mock('@/storage/authStorage', () => ({
@@ -166,6 +182,30 @@ describe('AuthContext', () => {
       });
       expect(mockSaveToken).toHaveBeenCalledWith('signup-jwt');
       expect(result.current.token).toBe('signup-jwt');
+    });
+
+    // BUG-AUTH-019: the backend returns an anti-enumeration dummy token with
+    // ``user_id=0`` when the email is already registered (see
+    // ``backend/tests/test_auth.py::test_signup_duplicate_email_returns_same_shape``).
+    // The frontend must NOT persist that token or transition to authenticated --
+    // doing so cascades into a 401 on the first authed request and an
+    // unrecoverable re-auth loop because the user does not actually own the
+    // pre-existing account's password.
+    it('rejects the anti-enumeration sentinel without persisting the token', async () => {
+      mockAuth.signup.mockResolvedValue({ token: 'dummy-jwt', user_id: 0 });
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await expect(
+        act(async () => {
+          await result.current.signup('taken@test.com', 'password123');
+        }),
+      ).rejects.toMatchObject({ status: 409, detail: 'email_in_use' });
+
+      expect(mockSaveToken).not.toHaveBeenCalled();
+      expect(result.current.token).toBeNull();
+      expect(result.current.authStatus).toBe('anonymous');
     });
   });
 

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -7,21 +7,9 @@ import { AuthProvider, useAuth } from '../AuthContext';
 
 // Mock the API client
 jest.mock('@/api', () => {
-  // Mirror the real ``ApiError`` shape (BUG-AUTH-019: AuthContext.signup
-  // synthesises one of these for the duplicate-email sentinel) so callers
-  // that do ``instanceof ApiError`` keep matching under the mock.
-  class MockApiError extends Error {
-    status: number;
-    detail: string;
-    constructor(status: number, detail: string) {
-      super(`Request failed with status ${status}: ${detail}`);
-      this.name = 'ApiError';
-      this.status = status;
-      this.detail = detail;
-    }
-  }
+  const { ApiError } = jest.requireActual('@/api');
   return {
-    ApiError: MockApiError,
+    ApiError,
     auth: {
       login: jest.fn(),
       signup: jest.fn(),
@@ -184,13 +172,7 @@ describe('AuthContext', () => {
       expect(result.current.token).toBe('signup-jwt');
     });
 
-    // BUG-AUTH-019: the backend returns an anti-enumeration dummy token with
-    // ``user_id=0`` when the email is already registered (see
-    // ``backend/tests/test_auth.py::test_signup_duplicate_email_returns_same_shape``).
-    // The frontend must NOT persist that token or transition to authenticated --
-    // doing so cascades into a 401 on the first authed request and an
-    // unrecoverable re-auth loop because the user does not actually own the
-    // pre-existing account's password.
+    // BUG-AUTH-002: must not persist the user_id=0 anti-enumeration token (see schemas.ts:57).
     it('rejects the anti-enumeration sentinel without persisting the token', async () => {
       mockAuth.signup.mockResolvedValue({ token: 'dummy-jwt', user_id: 0 });
       const { result } = renderHook(() => useAuth(), { wrapper });


### PR DESCRIPTION
The backend's /auth/signup returns a dummy JWT and user_id=0 when the
email is already registered (anti-enumeration; locked in by
backend/tests/test_auth.py:216-282). The frontend was supposed to
detect this sentinel and refuse to enter the authenticated state --
both schemas.ts:55-67 and the backend test at line 242-246 explicitly
document this contract -- but AuthContext.signup ignored user_id and
persisted the dummy token regardless.

That cascaded into all three of the user-reported symptoms:
- duplicate signup silently "succeeded"
- the first authed request after signup 401'd, popping ReauthSheet
  (the "tab change → sign out" the user described)
- retrying with the same credentials failed because the real account
  carries the original signup's password, not the duplicate attempt's

AuthContext.signup now throws ApiError(409, "email_in_use") on the
sentinel so SignupScreen renders the new friendly copy via the
existing formatApiError path without persisting the doomed token.

Backend security contract is unchanged.