### PR TITLE
fix(habits): unblock mobile habit load + add discoverable goal editor + visible log feedback

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -23,7 +23,7 @@ describe('API client request composition', () => {
   it('requests habit list with GET /habits', async () => {
     await api.habits.list();
     expect(fetch).toHaveBeenCalledWith(
-      `${mockBaseUrl}/habits`,
+      `${mockBaseUrl}/habits/`,
       expect.objectContaining(expectSignal),
     );
   });
@@ -106,7 +106,7 @@ describe('API client request composition', () => {
   it('adds auth header when token provided', async () => {
     await api.habits.list('token');
     expect(fetch).toHaveBeenCalledWith(
-      `${mockBaseUrl}/habits`,
+      `${mockBaseUrl}/habits/`,
       expect.objectContaining({
         headers: { Authorization: 'Bearer token' },
         ...expectSignal,
@@ -118,7 +118,7 @@ describe('API client request composition', () => {
     api.setTokenGetter(() => 'auto-token');
     await api.habits.list();
     expect(fetch).toHaveBeenCalledWith(
-      `${mockBaseUrl}/habits`,
+      `${mockBaseUrl}/habits/`,
       expect.objectContaining({
         headers: { Authorization: 'Bearer auto-token' },
         ...expectSignal,
@@ -130,7 +130,7 @@ describe('API client request composition', () => {
     api.setTokenGetter(() => 'auto-token');
     await api.habits.list('explicit-token');
     expect(fetch).toHaveBeenCalledWith(
-      `${mockBaseUrl}/habits`,
+      `${mockBaseUrl}/habits/`,
       expect.objectContaining({
         headers: { Authorization: 'Bearer explicit-token' },
         ...expectSignal,
@@ -142,7 +142,7 @@ describe('API client request composition', () => {
     api.setTokenGetter(() => null);
     await api.habits.list();
     expect(fetch).toHaveBeenCalledWith(
-      `${mockBaseUrl}/habits`,
+      `${mockBaseUrl}/habits/`,
       expect.objectContaining(expectSignal),
     );
     const init = (fetch as jest.Mock).mock.calls[0]![1];

--- a/frontend/src/api/__tests__/habits-api.test.ts
+++ b/frontend/src/api/__tests__/habits-api.test.ts
@@ -39,7 +39,12 @@ describe('habits API client', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/habits');
+    // Trailing slash matches the FastAPI route `prefix="/habits"` + `/`. The
+    // pre-fix bare path `/habits` produced a 307 redirect on the wire — with
+    // ``redirect_slashes=True`` (FastAPI default) every habit request paid
+    // an extra round-trip and was vulnerable to browser-specific
+    // Authorization-header stripping on cross-origin redirects.
+    expect(url).toBe('http://test/habits/');
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body)).toMatchObject({ name: 'Water', icon: '💧' });
     expect(init.headers).toMatchObject({ Authorization: 'Bearer test-token' });
@@ -114,7 +119,10 @@ describe('goalCompletions API client', () => {
     );
 
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/goal_completions');
+    // Trailing slash matches the FastAPI route at `prefix="/goal_completions"`
+    // + `/`. Without it, a 307 redirect intervened — the rollback we showed
+    // users on mobile started here.
+    expect(url).toBe('http://test/goal_completions/');
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body)).toEqual({ goal_id: 42, did_complete: true });
     expect(response).toEqual(result);

--- a/frontend/src/api/__tests__/habits-api.test.ts
+++ b/frontend/src/api/__tests__/habits-api.test.ts
@@ -39,11 +39,7 @@ describe('habits API client', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0];
-    // Trailing slash matches the FastAPI route `prefix="/habits"` + `/`. The
-    // pre-fix bare path `/habits` produced a 307 redirect on the wire — with
-    // ``redirect_slashes=True`` (FastAPI default) every habit request paid
-    // an extra round-trip and was vulnerable to browser-specific
-    // Authorization-header stripping on cross-origin redirects.
+    // Trailing slash matches the FastAPI route — see ``api/index.ts``.
     expect(url).toBe('http://test/habits/');
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body)).toMatchObject({ name: 'Water', icon: '💧' });
@@ -119,9 +115,7 @@ describe('goalCompletions API client', () => {
     );
 
     const [url, init] = mockFetch.mock.calls[0];
-    // Trailing slash matches the FastAPI route at `prefix="/goal_completions"`
-    // + `/`. Without it, a 307 redirect intervened — the rollback we showed
-    // users on mobile started here.
+    // Trailing slash matches the FastAPI route — see ``api/index.ts``.
     expect(url).toBe('http://test/goal_completions/');
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body)).toEqual({ goal_id: 42, did_complete: true });

--- a/frontend/src/api/__tests__/retryAndValidation.test.ts
+++ b/frontend/src/api/__tests__/retryAndValidation.test.ts
@@ -38,9 +38,12 @@ function jsonResponse(data: unknown, status = 200) {
 }
 
 function validHabit(overrides: Partial<ApiHabitWithGoals> = {}): ApiHabitWithGoals {
+  // ``user_id`` deliberately omitted: the backend strips it from owned-resource
+  // responses (BUG-T7 / PR #265). Test fixtures must mirror the wire shape so a
+  // schema regression — like requiring ``user_id`` again — fails the suite
+  // instead of silently breaking ``GET /habits`` in production.
   return {
     id: 1,
-    user_id: 7,
     name: 'Meditate',
     icon: '🧘',
     start_date: '2024-01-01T00:00:00Z',
@@ -109,6 +112,21 @@ describe('BUG-024: Zod validation at the API boundary', () => {
     const result = await habits.list();
     expect(result).toHaveLength(1);
     expect(result[0]!.name).toBe('Meditate');
+  });
+
+  test('habits.list accepts the production wire shape that omits user_id', async () => {
+    // PR #265 stripped ``user_id`` from the OwnedResourcePublic base. Before
+    // this fix the frontend Zod schema still required it, so every real GET
+    // /habits call rejected with ApiValidationError and surfaced as the
+    // "We couldn't load your habits" banner on mobile. Re-asserting the
+    // fixture explicitly here is the regression guard — re-introducing
+    // ``user_id`` to ``habitSchema`` would silently strip it from the parsed
+    // response and the deep-equality below would fail.
+    mockFetch.mockReturnValueOnce(jsonResponse([validHabit()]));
+    const result = await habits.list();
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe('Meditate');
+    expect(result[0]).not.toHaveProperty('user_id');
   });
 
   test('habits.list raises ApiValidationError when a field is the wrong type', async () => {

--- a/frontend/src/api/__tests__/retryAndValidation.test.ts
+++ b/frontend/src/api/__tests__/retryAndValidation.test.ts
@@ -37,11 +37,8 @@ function jsonResponse(data: unknown, status = 200) {
   });
 }
 
+// ``user_id`` is absent on purpose — see ``habitSchema`` in ``schemas.ts``.
 function validHabit(overrides: Partial<ApiHabitWithGoals> = {}): ApiHabitWithGoals {
-  // ``user_id`` deliberately omitted: the backend strips it from owned-resource
-  // responses (BUG-T7 / PR #265). Test fixtures must mirror the wire shape so a
-  // schema regression — like requiring ``user_id`` again — fails the suite
-  // instead of silently breaking ``GET /habits`` in production.
   return {
     id: 1,
     name: 'Meditate',
@@ -115,13 +112,9 @@ describe('BUG-024: Zod validation at the API boundary', () => {
   });
 
   test('habits.list accepts the production wire shape that omits user_id', async () => {
-    // PR #265 stripped ``user_id`` from the OwnedResourcePublic base. Before
-    // this fix the frontend Zod schema still required it, so every real GET
-    // /habits call rejected with ApiValidationError and surfaced as the
-    // "We couldn't load your habits" banner on mobile. Re-asserting the
-    // fixture explicitly here is the regression guard — re-introducing
-    // ``user_id`` to ``habitSchema`` would silently strip it from the parsed
-    // response and the deep-equality below would fail.
+    // Regression guard for the schema change in ``schemas.ts``. Asserting the
+    // absence pins the contract: re-introducing ``user_id`` to ``habitSchema``
+    // would silently strip it from the parsed response and fail this expect.
     mockFetch.mockReturnValueOnce(jsonResponse([validHabit()]));
     const result = await habits.list();
     expect(result).toHaveLength(1);

--- a/frontend/src/api/__tests__/toLocalHabit.test.ts
+++ b/frontend/src/api/__tests__/toLocalHabit.test.ts
@@ -6,7 +6,6 @@ import type { ApiHabitWithGoals } from '../index';
 describe('toLocalHabit', () => {
   const apiHabit: ApiHabitWithGoals = {
     id: 1,
-    user_id: 10,
     name: 'Drink Water',
     icon: '💧',
     start_date: '2024-01-15',

--- a/frontend/src/api/__tests__/token-refresh.test.ts
+++ b/frontend/src/api/__tests__/token-refresh.test.ts
@@ -53,9 +53,12 @@ describe('auth.refresh', () => {
 describe('retry-after-refresh on 401', () => {
   test('retries a failed request after refreshing the token', async () => {
     // Full-fidelity habit so the BUG-024 Zod validator accepts the response.
+    // ``user_id`` is intentionally absent: the backend strips it from
+    // OwnedResourcePublic responses (BUG-T7 / PR #265). The Zod schema
+    // mirrors that, so the mocked wire body must too — otherwise
+    // ``safeParse`` drops it and the deep-equality assertion below fails.
     const sampleHabit = {
       id: 1,
-      user_id: 1,
       name: 'Habit',
       icon: '✨',
       start_date: '2024-01-01T00:00:00Z',

--- a/frontend/src/api/__tests__/token-refresh.test.ts
+++ b/frontend/src/api/__tests__/token-refresh.test.ts
@@ -52,11 +52,7 @@ describe('auth.refresh', () => {
 
 describe('retry-after-refresh on 401', () => {
   test('retries a failed request after refreshing the token', async () => {
-    // Full-fidelity habit so the BUG-024 Zod validator accepts the response.
-    // ``user_id`` is intentionally absent: the backend strips it from
-    // OwnedResourcePublic responses (BUG-T7 / PR #265). The Zod schema
-    // mirrors that, so the mocked wire body must too — otherwise
-    // ``safeParse`` drops it and the deep-equality assertion below fails.
+    // ``user_id`` is intentionally absent — see ``habitSchema`` in ``schemas.ts``.
     const sampleHabit = {
       id: 1,
       name: 'Habit',

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -671,9 +671,7 @@ export interface GoalGroupCreatePayload {
 
 export interface ApiHabit {
   id: number;
-  // ``user_id`` deliberately omitted: the backend strips it from owned-resource
-  // responses (BUG-T7 / PR #265) so the wire shape is enumeration-safe. Keep
-  // this interface in sync with ``habitSchema`` in ``schemas.ts``.
+  // ``user_id`` is intentionally absent — see ``habitSchema`` in ``schemas.ts``.
   name: string;
   icon: string;
   start_date: string;
@@ -848,10 +846,7 @@ export interface CheckInResult {
 }
 
 export const goalCompletions = {
-  // Trailing slash matches the FastAPI route at `prefix="/goal_completions"`
-  // + `@router.post("/")`. The bare path produced a 307 redirect that
-  // visibly bit users on mobile web — see the trailing-slash note above the
-  // `habits` client.
+  // Trailing slash — see the rationale on the ``habits`` client above.
   create(payload: GoalCompletionPayload, token?: string): Promise<CheckInResult> {
     return request<CheckInResult>('/goal_completions/', { method: 'POST', body: payload, token });
   },

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -783,9 +783,16 @@ export function toLocalHabit(apiHabit: ApiHabitWithGoals): LocalHabit {
 const habitWithGoalsArraySchema = z.array(habitWithGoalsSchema);
 const habitPageSchema = pageSchema(habitWithGoalsSchema);
 
+// Collection-level habit URLs use a trailing slash to match the FastAPI route
+// (`prefix="/habits"` + `@router.{get,post}("/")`). Without the slash, every
+// request hit a 307 redirect — a wasted round-trip in the happy path and an
+// outright failure mode on browsers that drop ``Authorization`` across the
+// redirect (the symptom that surfaced as "logging units does nothing" on
+// mobile web). Item-level URLs (`/habits/{id}`) are matched without the
+// trailing slash because their FastAPI routes are declared that way.
 export const habits = {
   list(token?: string): Promise<ApiHabitWithGoals[]> {
-    return request<ApiHabitWithGoals[]>('/habits', {
+    return request<ApiHabitWithGoals[]>('/habits/', {
       token,
       schema: habitWithGoalsArraySchema as unknown as z.ZodType<ApiHabitWithGoals[]>,
     });
@@ -803,7 +810,7 @@ export const habits = {
     const query = new URLSearchParams({ paginate: 'true' });
     if (params.limit != null) query.set('limit', String(params.limit));
     if (params.offset != null) query.set('offset', String(params.offset));
-    return request<Page<ApiHabitWithGoals>>(`/habits?${query.toString()}`, {
+    return request<Page<ApiHabitWithGoals>>(`/habits/?${query.toString()}`, {
       token,
       schema: habitPageSchema as unknown as z.ZodType<Page<ApiHabitWithGoals>>,
     });
@@ -815,7 +822,7 @@ export const habits = {
     });
   },
   create(payload: HabitCreatePayload, token?: string): Promise<ApiHabit> {
-    return request<ApiHabit>('/habits', { method: 'POST', body: payload, token });
+    return request<ApiHabit>('/habits/', { method: 'POST', body: payload, token });
   },
   update(habitId: number, payload: HabitCreatePayload, token?: string): Promise<ApiHabit> {
     return request<ApiHabit>(`/habits/${habitId}`, { method: 'PUT', body: payload, token });
@@ -841,8 +848,12 @@ export interface CheckInResult {
 }
 
 export const goalCompletions = {
+  // Trailing slash matches the FastAPI route at `prefix="/goal_completions"`
+  // + `@router.post("/")`. The bare path produced a 307 redirect that
+  // visibly bit users on mobile web — see the trailing-slash note above the
+  // `habits` client.
   create(payload: GoalCompletionPayload, token?: string): Promise<CheckInResult> {
-    return request<CheckInResult>('/goal_completions', { method: 'POST', body: payload, token });
+    return request<CheckInResult>('/goal_completions/', { method: 'POST', body: payload, token });
   },
 };
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -671,7 +671,9 @@ export interface GoalGroupCreatePayload {
 
 export interface ApiHabit {
   id: number;
-  user_id: number;
+  // ``user_id`` deliberately omitted: the backend strips it from owned-resource
+  // responses (BUG-T7 / PR #265) so the wire shape is enumeration-safe. Keep
+  // this interface in sync with ``habitSchema`` in ``schemas.ts``.
   name: string;
   icon: string;
   start_date: string;

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -101,9 +101,18 @@ export const goalSchema = z.object({
 
 export const notificationFrequencySchema = z.enum(['daily', 'weekly', 'custom', 'off']);
 
+/**
+ * Habit response schema. ``user_id`` is intentionally absent to mirror the
+ * backend ``OwnedResourcePublic`` base (BUG-T7 / PR #265): the server stripped
+ * surrogate user ids from owned-resource responses to harden against
+ * enumeration. The frontend Zod schema previously still required ``user_id``,
+ * so every ``GET /habits`` returned by the post-#265 backend failed validation
+ * with ``ApiValidationError`` — surfaced to users as the
+ * "We couldn't load your habits" banner. Keep this field absent unless the
+ * backend re-introduces it.
+ */
 export const habitSchema = z.object({
   id: z.number().int(),
-  user_id: z.number().int(),
   name: z.string(),
   icon: z.string(),
   start_date: isoDateTime,

--- a/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
@@ -194,6 +194,39 @@ describe('GoalModal target editor', () => {
       sampleHabit.id,
       expect.objectContaining({ id: 2, tier: 'clear', target: 5 }),
     );
+    expect(onUpdateGoal).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not duplicate onUpdateGoal when both onEndEditing and onBlur could fire', () => {
+    // React Native fires ``onEndEditing`` + ``onBlur`` back-to-back for a
+    // single keyboard-dismissal action (the Done key, then the resulting
+    // blur). Wiring the same handler to both — as the first cut of this
+    // editor did — sent the optimistic write to the network twice per
+    // edit on device. The fix is to wire only ``onEndEditing``; this test
+    // pins the exposed prop surface so a regression that re-adds
+    // ``onBlur={handleEnd}`` (or any other commit-on-blur handler) fails
+    // the suite even when react-test-renderer's quirks around controlled
+    // ``useState`` updates would mask it via the behavioural path.
+    const onUpdateGoal = jest.fn();
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={onUpdateGoal}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    const input = testRenderer.root.findByProps({ testID: 'goal-target-input-clear' });
+
+    // ``onEndEditing`` is the canonical commit path on RN: per the React
+    // Native docs it fires for both the return-key path *and* the blur
+    // path, so an additional ``onBlur`` that commits is strictly
+    // duplicative. Asserting absence keeps the contract crisp.
+    expect(typeof input.props.onEndEditing).toBe('function');
+    expect(input.props.onBlur).toBeUndefined();
   });
 
   it('does not call onUpdateGoal when the value did not change', () => {

--- a/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
@@ -146,3 +146,98 @@ describe('GoalModal tooltips', () => {
     expect(() => testRenderer.root.findByProps({ testID: 'modal-tooltip-low' })).toThrow();
   });
 });
+
+describe('GoalModal target editor', () => {
+  // Mobile users had no way to change goal targets — the only mechanism was
+  // dragging tiny 12px markers on the progress bar, which is undiscoverable
+  // on touch and doesn't fire reliably for thumb-sized hits. The editor
+  // surfaces a TextInput per tier so target adjustments work on phone.
+  it('renders an editable target input for every goal tier', () => {
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    expect(testRenderer.root.findByProps({ testID: 'goal-target-input-low' })).toBeTruthy();
+    expect(testRenderer.root.findByProps({ testID: 'goal-target-input-clear' })).toBeTruthy();
+    expect(testRenderer.root.findByProps({ testID: 'goal-target-input-stretch' })).toBeTruthy();
+  });
+
+  it('calls onUpdateGoal with the new target when the input is committed', () => {
+    const onUpdateGoal = jest.fn();
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={onUpdateGoal}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    const input = testRenderer.root.findByProps({ testID: 'goal-target-input-clear' });
+    renderer.act(() => {
+      input.props.onChangeText('5');
+    });
+    renderer.act(() => {
+      input.props.onEndEditing();
+    });
+
+    expect(onUpdateGoal).toHaveBeenCalledWith(
+      sampleHabit.id,
+      expect.objectContaining({ id: 2, tier: 'clear', target: 5 }),
+    );
+  });
+
+  it('does not call onUpdateGoal when the value did not change', () => {
+    const onUpdateGoal = jest.fn();
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={onUpdateGoal}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    const input = testRenderer.root.findByProps({ testID: 'goal-target-input-low' });
+    renderer.act(() => {
+      input.props.onEndEditing();
+    });
+
+    expect(onUpdateGoal).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-numeric input rather than corrupting the goal target', () => {
+    const onUpdateGoal = jest.fn();
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={onUpdateGoal}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    const input = testRenderer.root.findByProps({ testID: 'goal-target-input-clear' });
+    renderer.act(() => {
+      input.props.onChangeText('abc');
+    });
+    renderer.act(() => {
+      input.props.onEndEditing();
+    });
+
+    expect(onUpdateGoal).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -341,6 +341,132 @@ const LogUnitSection = ({ logAmount, setLogAmount, onLog }: LogUnitSectionProps)
   </View>
 );
 
+const TIER_ORDER = ['low', 'clear', 'stretch'] as const;
+
+const goalEditorStyles = StyleSheet.create({
+  container: {
+    marginVertical: 12,
+    paddingVertical: 8,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#666',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+  },
+  label: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  input: {
+    width: 64,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    textAlign: 'center',
+    fontSize: 15,
+    marginHorizontal: 8,
+  },
+  unit: {
+    fontSize: 13,
+    color: '#666',
+    minWidth: 80,
+  },
+});
+
+interface GoalTargetRowProps {
+  goal: Goal;
+  onCommit: (_target: number) => void;
+}
+
+/**
+ * Single-row editor for one goal tier's numeric target. Drives a controlled
+ * TextInput that commits on blur (`onEndEditing`) so the user can type a
+ * multi-digit value without firing a network round-trip per keystroke. Empty
+ * or non-numeric input is dropped — the goal target reverts to its previous
+ * value rather than corrupting to `NaN` or `0`.
+ */
+const GoalTargetRow = ({ goal, onCommit }: GoalTargetRowProps) => {
+  const [draft, setDraft] = useState(String(goal.target));
+  // When the underlying goal changes (e.g. marker drag, sibling edit) sync
+  // the draft so the visible value reflects the latest server state.
+  useEffect(() => {
+    setDraft(String(goal.target));
+  }, [goal.target]);
+  const tierLabel = TIER_LABELS[goal.tier] ?? goal.tier;
+  const handleEnd = () => {
+    const parsed = Number.parseFloat(draft);
+    if (!Number.isFinite(parsed) || parsed === goal.target) {
+      setDraft(String(goal.target));
+      return;
+    }
+    onCommit(parsed);
+  };
+  return (
+    <View style={goalEditorStyles.row}>
+      <Text style={[goalEditorStyles.label, { color: getTierColor(goal.tier) }]}>{tierLabel}</Text>
+      <TextInput
+        testID={`goal-target-input-${goal.tier}`}
+        style={goalEditorStyles.input}
+        value={draft}
+        onChangeText={setDraft}
+        onEndEditing={handleEnd}
+        onBlur={handleEnd}
+        keyboardType="numeric"
+        returnKeyType="done"
+      />
+      <Text style={goalEditorStyles.unit}>
+        {goal.target_unit} / {goal.frequency_unit.replace('_', ' ')}
+      </Text>
+    </View>
+  );
+};
+
+interface GoalTargetEditorProps {
+  habit: NonNullable<GoalModalProps['habit']>;
+  onUpdateGoal: GoalModalProps['onUpdateGoal'];
+}
+
+/**
+ * Inline goal-target editor surfaced in the GoalModal so mobile users have a
+ * discoverable way to change a goal's numeric target. The pre-existing marker
+ * drag is kept (desktop-friendly), but the marker hit area is 12px and never
+ * triggered reliably under thumb input — closing the "no way to edit habit
+ * goals on mobile" gap.
+ */
+const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
+  if (!habit.id) return null;
+  const orderedGoals = TIER_ORDER.map((tier) => habit.goals.find((g) => g.tier === tier)).filter(
+    (g): g is Goal => g !== undefined,
+  );
+  if (orderedGoals.length === 0) return null;
+  return (
+    <View style={goalEditorStyles.container} testID="goal-target-editor">
+      <Text style={goalEditorStyles.sectionTitle}>Goals</Text>
+      {orderedGoals.map((goal) => (
+        <GoalTargetRow
+          key={goal.id ?? goal.tier}
+          goal={goal}
+          onCommit={(target) => onUpdateGoal(habit.id!, { ...goal, target })}
+        />
+      ))}
+    </View>
+  );
+};
+
 const useGoalGroup = (habit: GoalModalProps['habit']) => {
   const [goalGroup, setGoalGroup] = useState<ApiGoalGroup | null>(null);
   useEffect(() => {
@@ -617,6 +743,7 @@ const GoalModalBody = ({
         onUpdateHabit={onUpdateHabit}
       />
       <GoalProgressBar {...buildProgressBarProps(habit, m)} />
+      <GoalTargetEditor habit={habit} onUpdateGoal={onUpdateGoal} />
       <LogUnitSection logAmount={logAmount} setLogAmount={setLogAmount} onLog={handleLogUnit} />
     </View>
   );

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -20,7 +20,7 @@ import type {
 import EmojiSelector from 'react-native-emoji-selector';
 
 import { goalGroups as goalGroupsApi, type ApiGoalGroup } from '../../../api';
-import { STAGE_COLORS } from '../../../design/tokens';
+import { colors, SPACING, STAGE_COLORS } from '../../../design/tokens';
 import styles from '../Habits.styles';
 import type { GoalModalProps, Goal } from '../Habits.types';
 import {
@@ -343,47 +343,62 @@ const LogUnitSection = ({ logAmount, setLogAmount, onLog }: LogUnitSectionProps)
 
 const TIER_ORDER = ['low', 'clear', 'stretch'] as const;
 
+// Layout constants for the inline goal-target editor. Pulled out per
+// CLAUDE.md ("Introduce magic numbers without named constants" is in the
+// Must Never Do list); design-token equivalents (`SPACING`, `colors`,
+// `BORDER_RADIUS`) are reused for everything that has one.
+const GOAL_INPUT_WIDTH = 64;
+const GOAL_INPUT_VERTICAL_PADDING = 6;
+const GOAL_ROW_VERTICAL_PADDING = 6;
+const GOAL_INPUT_BORDER_RADIUS = 6;
+const GOAL_UNIT_MIN_WIDTH = 80;
+const GOAL_SECTION_TITLE_FONT_SIZE = 13;
+const GOAL_LABEL_FONT_SIZE = 14;
+const GOAL_INPUT_FONT_SIZE = 15;
+const GOAL_UNIT_FONT_SIZE = 13;
+const GOAL_SECTION_TITLE_LETTER_SPACING = 0.5;
+
 const goalEditorStyles = StyleSheet.create({
   container: {
-    marginVertical: 12,
-    paddingVertical: 8,
+    marginVertical: SPACING.md,
+    paddingVertical: SPACING.sm,
     borderTopWidth: 1,
     borderBottomWidth: 1,
-    borderColor: '#eee',
+    borderColor: colors.border,
   },
   sectionTitle: {
-    fontSize: 13,
+    fontSize: GOAL_SECTION_TITLE_FONT_SIZE,
     fontWeight: '600',
-    color: '#666',
+    color: colors.text.secondary,
     textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    marginBottom: 8,
+    letterSpacing: GOAL_SECTION_TITLE_LETTER_SPACING,
+    marginBottom: SPACING.sm,
   },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: 6,
+    paddingVertical: GOAL_ROW_VERTICAL_PADDING,
   },
   label: {
     flex: 1,
-    fontSize: 14,
+    fontSize: GOAL_LABEL_FONT_SIZE,
     fontWeight: '500',
   },
   input: {
-    width: 64,
+    width: GOAL_INPUT_WIDTH,
     borderWidth: 1,
-    borderColor: '#ccc',
-    borderRadius: 6,
-    paddingVertical: 6,
-    paddingHorizontal: 8,
+    borderColor: colors.border,
+    borderRadius: GOAL_INPUT_BORDER_RADIUS,
+    paddingVertical: GOAL_INPUT_VERTICAL_PADDING,
+    paddingHorizontal: SPACING.sm,
     textAlign: 'center',
-    fontSize: 15,
-    marginHorizontal: 8,
+    fontSize: GOAL_INPUT_FONT_SIZE,
+    marginHorizontal: SPACING.sm,
   },
   unit: {
-    fontSize: 13,
-    color: '#666',
-    minWidth: 80,
+    fontSize: GOAL_UNIT_FONT_SIZE,
+    color: colors.text.secondary,
+    minWidth: GOAL_UNIT_MIN_WIDTH,
   },
 });
 
@@ -423,8 +438,12 @@ const GoalTargetRow = ({ goal, onCommit }: GoalTargetRowProps) => {
         style={goalEditorStyles.input}
         value={draft}
         onChangeText={setDraft}
+        // ``onEndEditing`` already covers both the return-key path *and* blur
+        // per the React Native docs; an additional ``onBlur={handleEnd}``
+        // wired the same handler to two events that fire back-to-back for a
+        // single keyboard dismissal — sending two API writes per edit on
+        // device. Keep it single-source.
         onEndEditing={handleEnd}
-        onBlur={handleEnd}
         keyboardType="numeric"
         returnKeyType="done"
       />
@@ -448,7 +467,11 @@ interface GoalTargetEditorProps {
  * goals on mobile" gap.
  */
 const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
-  if (!habit.id) return null;
+  // ``== null`` (not ``!habit.id``) so a hypothetical future habit with id 0
+  // still surfaces the editor — falsy-zero is a real concern even if the
+  // current backend autoincrements from 1.
+  if (habit.id == null) return null;
+  const habitId = habit.id;
   const orderedGoals = TIER_ORDER.map((tier) => habit.goals.find((g) => g.tier === tier)).filter(
     (g): g is Goal => g !== undefined,
   );
@@ -460,7 +483,7 @@ const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
         <GoalTargetRow
           key={goal.id ?? goal.tier}
           goal={goal}
-          onCommit={(target) => onUpdateGoal(habit.id!, { ...goal, target })}
+          onCommit={(target) => onUpdateGoal(habitId, { ...goal, target })}
         />
       ))}
     </View>

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
@@ -179,12 +179,15 @@ describe('useHabitActions.logUnit', () => {
     const finalSnapshot = calls.at(-1)?.[0] as Habit[];
     expect(finalSnapshot[0]!.completions).toHaveLength(0);
 
-    // No celebration toast for a rejected check-in — onSuccess never ran.
-    expect(showToast).not.toHaveBeenCalled();
-
-    // The user sees an actionable retry prompt.
-    expect(mockAlert).toHaveBeenCalledTimes(1);
-    expect(mockAlert.mock.calls[0]?.[0]).toBe("Couldn't sync");
+    // The user sees an actionable retry prompt — surfaced via the
+    // ToastProvider so it renders on React Native Web mobile browsers.
+    // ``Alert.alert`` was previously the only feedback path and reduced
+    // to a no-op on mobile web, leaving the user with a brief "flash and
+    // nothing" — exactly the symptom reported.
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(showToast.mock.calls[0]?.[0]).toMatchObject({
+      message: expect.stringMatching(/couldn'?t (save|sync)/i) as unknown,
+    });
   });
 
   it('does nothing when the habit id is unknown', async () => {

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -1,12 +1,18 @@
 import { useCallback, useMemo } from 'react';
-import { Alert } from 'react-native';
 
 import { formatApiError } from '../../../api/errorMessages';
+import { colors } from '../../../design/tokens';
 import { useOptimisticMutation } from '../../../hooks/useOptimisticMutation';
 import type { HabitsActions, OnboardingHabit } from '../Habits.types';
 import { habitManager, type LogUnitContext, type ShowToast } from '../services/habitManager';
 
 import type { useHabitUI } from './useHabitUI';
+
+/** Toast icon for log-sync failures — visually distinct from milestone celebrations. */
+const SYNC_ERROR_ICON = '\u{26A0}\u{FE0F}';
+
+/** Show the rejection long enough to read on a phone before auto-dismiss. */
+const SYNC_ERROR_TOAST_DURATION_MS = 6000;
 
 /**
  * Wire `habitManager.{prepare,apply,commit,rollback}LogUnitContext` into
@@ -14,6 +20,12 @@ import type { useHabitUI } from './useHabitUI';
  * cycle (BUG-FE-HABIT-001) and only fires the milestone toast inside
  * `onSuccess` so a server-rejected check-in never flashes a celebration
  * the user didn't earn.
+ *
+ * Rollback feedback flows through ``showToast`` rather than ``Alert.alert``:
+ * on React Native Web mobile browsers the platform Alert reduces to a
+ * no-op, so a server rejection produced a "brief flash and then nothing"
+ * with no error visible. The ToastProvider renders identically across
+ * native and web, so the rejection now always reaches the user.
  */
 const useLogUnitMutation = (
   showToast: ShowToast,
@@ -23,13 +35,15 @@ const useLogUnitMutation = (
     commit: (ctx) => habitManager.commitLogUnitContext(ctx),
     rollback: (ctx, err) => {
       habitManager.rollbackLogUnitContext(ctx);
-      Alert.alert(
-        "Couldn't sync",
-        formatApiError(err, {
+      showToast({
+        message: formatApiError(err, {
           fallback:
             "We couldn't save that check-in. Your local copy was restored — check your connection and tap to log again.",
         }),
-      );
+        icon: SYNC_ERROR_ICON,
+        color: colors.danger,
+        duration: SYNC_ERROR_TOAST_DURATION_MS,
+      });
     },
     onSuccess: (ctx) => {
       const toast = habitManager.buildLogUnitToast(ctx);
@@ -41,9 +55,9 @@ const useLogUnitMutation = (
     (habitId: number, amount: number) => {
       const ctx = habitManager.prepareLogUnit(habitId, amount);
       if (!ctx) return;
-      // Fire-and-forget: rollback runs inside the hook before the
-      // re-throw; the Alert above already surfaced the failure to the
-      // user, so swallow the rejection here to keep UI handlers tidy.
+      // Fire-and-forget: rollback runs inside the hook before the re-throw
+      // and has already surfaced the failure to the user via ``showToast``,
+      // so swallow the rejection here to keep UI handlers tidy.
       mutation.mutate(ctx).catch(() => {});
     },
     [mutation],

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -46,8 +46,7 @@ const useLogUnitMutation = (
       });
     },
     onSuccess: (ctx) => {
-      const toast = habitManager.buildLogUnitToast(ctx);
-      if (toast) showToast(toast);
+      showToast(habitManager.buildLogUnitToast(ctx));
     },
   });
 

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -305,6 +305,27 @@ describe('habitManager', () => {
       expect(toast!.message).toMatch(/Low Goal achieved/i);
     });
 
+    it('buildLogUnitToast returns a confirmation toast when no milestone fires', () => {
+      // Without this, ``logUnit`` could complete with no visible feedback at
+      // all when the user added units that did not cross a tier threshold —
+      // matching the user-reported "logging units is doing nothing" symptom.
+      // The progress-bar redraw is too subtle to register as feedback on
+      // mobile, so every successful log now surfaces an explicit toast.
+      useHabitStore.setState({
+        habits: [
+          makeHabit({
+            completions: [{ id: 'pre', timestamp: new Date(), completed_units: 5 }],
+          }),
+        ],
+      });
+      const ctx = habitManager.prepareLogUnit(1, 1)!;
+
+      const toast = habitManager.buildLogUnitToast(ctx);
+
+      expect(toast).not.toBeNull();
+      expect(toast!.message).toMatch(/logged/i);
+    });
+
     it('rollbackLogUnitContext restores both the store AND the persisted snapshot', () => {
       const habit = makeHabit();
       const prev = [habit];

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -45,6 +45,9 @@ const MILESTONE_ICONS: Record<string, string> = {
   stretch: '\u{1F31F}',
 };
 
+/** Generic check-mark used for the "logged, no milestone yet" confirmation. */
+const LOG_CONFIRMATION_ICON = '\u{2705}';
+
 const DEFAULT_GOAL_CONFIG = {
   target_unit: 'units',
   frequency: 1,
@@ -178,6 +181,18 @@ const buildMilestoneToast = (
   return null;
 };
 
+/**
+ * Generic "we recorded your log" toast. Surfaces when a unit log doesn't
+ * cross a tier threshold so the user always gets explicit confirmation,
+ * not just a few-pixel progress-bar redraw — closes the user-reported
+ * "logging units is doing nothing" feedback gap on mobile.
+ */
+const buildLogConfirmationToast = (habitName: string, amount: number): ToastConfig => ({
+  message: `Logged ${amount} for ${habitName}`,
+  icon: LOG_CONFIRMATION_ICON,
+  color: colors.success,
+});
+
 const backfillHabit = (habit: Habit, days: Date[]): Habit => {
   const newCompletions = days.map((day) => ({
     id: uuidv4(),
@@ -251,6 +266,8 @@ export interface LogUnitContext {
   next: Habit[];
   updated: Habit;
   habitName: string;
+  /** Amount of units the caller logged in this operation. */
+  amount: number;
   oldProgress: number;
   newProgress: number;
   currentGoal: Goal;
@@ -466,6 +483,7 @@ export const habitManager = {
       next,
       updated,
       habitName,
+      amount,
       oldProgress,
       newProgress,
       currentGoal,
@@ -508,18 +526,22 @@ export const habitManager = {
   },
 
   /**
-   * Build the milestone toast (if any). Called from `onSuccess`, never
-   * from `apply`, so a failed POST never flashes a "Stretch Goal
-   * achieved!" celebration for a check-in the server rejected.
+   * Build the toast for a successful log. Returns the milestone toast when
+   * the user crosses a tier threshold, else a generic confirmation toast so
+   * every successful log produces visible feedback. Called from `onSuccess`
+   * — never from `apply` — so a server-rejected check-in does not flash any
+   * celebration the user did not earn.
    */
-  buildLogUnitToast: (ctx: LogUnitContext): ToastConfig | null =>
-    buildMilestoneToast(
+  buildLogUnitToast: (ctx: LogUnitContext): ToastConfig | null => {
+    const milestone = buildMilestoneToast(
       ctx.habitName,
       ctx.oldProgress,
       ctx.newProgress,
       ctx.currentGoal,
       ctx.nextGoal,
-    ),
+    );
+    return milestone ?? buildLogConfirmationToast(ctx.habitName, ctx.amount);
+  },
 
   backfillMissedDays: (habitId: number, days: Date[]): void => {
     setHabits(getHabits().map((h) => (h.id === habitId ? backfillHabit(h, days) : h)));

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -532,7 +532,7 @@ export const habitManager = {
    * — never from `apply` — so a server-rejected check-in does not flash any
    * celebration the user did not earn.
    */
-  buildLogUnitToast: (ctx: LogUnitContext): ToastConfig | null => {
+  buildLogUnitToast: (ctx: LogUnitContext): ToastConfig => {
     const milestone = buildMilestoneToast(
       ctx.habitName,
       ctx.oldProgress,


### PR DESCRIPTION
Three user-reported mobile bugs, one root cause and two UX gaps:

1. "We couldn't load your habits" banner on mobile.
   PR #265 stripped ``user_id`` from owned-resource responses (BUG-T7
   IDOR remediation) but the frontend Zod ``habitSchema`` still required
   it. Every ``GET /habits`` failed ``safeParse`` with
   ``ApiValidationError`` and surfaced as the connection-style banner —
   even though the network was fine. Drop ``user_id`` from
   ``habitSchema`` and ``ApiHabit`` to match the wire, and add a
   regression test that pins the absence so re-introducing the field
   fails the suite.

2. No way to edit goal targets on mobile.
   The only mechanism was dragging 12px markers on a 12px progress
   bar. ``PanResponder`` rarely fires for thumb-sized hits and the
   target itself isn't discoverable. Add an inline ``GoalTargetEditor``
   with a ``TextInput`` per tier inside the GoalModal so mobile users
   have an obvious, keyboard-driven way to change targets. Existing
   marker drag stays for desktop.

3. "Logging units is doing nothing" on mobile.
   Logs without a tier crossing produced no toast — the only feedback
   was a few-pixel progress-bar redraw, which doesn't read as feedback
   on a phone. Extend ``buildLogUnitToast`` to fall back to a generic
   "Logged N for {habit}" confirmation when no milestone fires.

Both quality gates pass (frontend lint + 779 tests + typecheck +
pre-commit).