### PR TITLE
fix(habits): unblock log-units after onboarding + stop modal tap-to-close

### DIFF
--- a/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
@@ -274,3 +274,66 @@ describe('GoalModal target editor', () => {
     expect(onUpdateGoal).not.toHaveBeenCalled();
   });
 });
+
+describe('GoalModal backdrop close', () => {
+  // Reported on mobile web: tapping any TextInput inside the modal (the goal
+  // target inputs and the log-unit input) dismisses the modal instead of
+  // focusing the input. Root cause was a nested ``TouchableWithoutFeedback``
+  // that wrapped the body and called ``e.stopPropagation()`` — RN Web's
+  // responder system doesn't honor ``stopPropagation`` the way native does,
+  // so the outer ``onPress={onClose}`` fired anyway. The structural fix is a
+  // dedicated backdrop ``Pressable`` (testID ``goal-modal-backdrop``) that
+  // does not wrap the body.
+  it('exposes a dedicated backdrop element that closes when pressed', () => {
+    const onClose = jest.fn();
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={onClose}
+        onUpdateGoal={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    const backdrop = testRenderer.root.findByProps({ testID: 'goal-modal-backdrop' });
+    renderer.act(() => {
+      backdrop.props.onPress();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not wrap the body in a tap-handler that fires onClose', () => {
+    // Pin the structural fix: the body must not have any ancestor (other
+    // than the backdrop itself) that calls ``onClose`` on press. Tapping a
+    // descendant — like a TextInput — must not bubble to a close handler.
+    const onClose = jest.fn();
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={onClose}
+        onUpdateGoal={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    // The goal-target editor lives inside the body. Walking up the tree from
+    // any of its inputs must not encounter a TouchableWithoutFeedback whose
+    // onPress is ``onClose`` — that would re-introduce the regression.
+    const input = testRenderer.root.findByProps({ testID: 'goal-target-input-low' });
+    let node: typeof input | null = input.parent;
+    while (node) {
+      const press = (node.props as { onPress?: unknown }).onPress;
+      if (typeof press === 'function' && press === onClose) {
+        throw new Error('body has an ancestor whose onPress is onClose');
+      }
+      node = node.parent;
+    }
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
@@ -276,14 +276,6 @@ describe('GoalModal target editor', () => {
 });
 
 describe('GoalModal backdrop close', () => {
-  // Reported on mobile web: tapping any TextInput inside the modal (the goal
-  // target inputs and the log-unit input) dismisses the modal instead of
-  // focusing the input. Root cause was a nested ``TouchableWithoutFeedback``
-  // that wrapped the body and called ``e.stopPropagation()`` — RN Web's
-  // responder system doesn't honor ``stopPropagation`` the way native does,
-  // so the outer ``onPress={onClose}`` fired anyway. The structural fix is a
-  // dedicated backdrop ``Pressable`` (testID ``goal-modal-backdrop``) that
-  // does not wrap the body.
   it('exposes a dedicated backdrop element that closes when pressed', () => {
     const onClose = jest.fn();
     const testRenderer = renderer.create(
@@ -306,9 +298,6 @@ describe('GoalModal backdrop close', () => {
   });
 
   it('does not wrap the body in a tap-handler that fires onClose', () => {
-    // Pin the structural fix: the body must not have any ancestor (other
-    // than the backdrop itself) that calls ``onClose`` on press. Tapping a
-    // descendant — like a TextInput — must not bubble to a close handler.
     const onClose = jest.fn();
     const testRenderer = renderer.create(
       <GoalModal
@@ -321,9 +310,7 @@ describe('GoalModal backdrop close', () => {
       />,
     );
 
-    // The goal-target editor lives inside the body. Walking up the tree from
-    // any of its inputs must not encounter a TouchableWithoutFeedback whose
-    // onPress is ``onClose`` — that would re-introduce the regression.
+    // Walking up the tree from a body input must not hit ``onPress === onClose``.
     const input = testRenderer.root.findByProps({ testID: 'goal-target-input-low' });
     let node: typeof input | null = input.parent;
     while (node) {

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -2,10 +2,10 @@ import React, { useState, useRef, useEffect } from 'react';
 import {
   Alert,
   Modal,
+  Pressable,
   Text,
   TextInput,
   TouchableOpacity,
-  TouchableWithoutFeedback,
   View,
   PanResponder,
   StyleSheet,
@@ -784,19 +784,26 @@ export const GoalModal = ({
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <TouchableWithoutFeedback onPress={onClose}>
-        <View style={styles.modalOverlay}>
-          <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
-            <GoalModalBody
-              habit={habit}
-              onClose={onClose}
-              onUpdateGoal={onUpdateGoal}
-              onLogUnit={onLogUnit}
-              onUpdateHabit={onUpdateHabit}
-            />
-          </TouchableWithoutFeedback>
-        </View>
-      </TouchableWithoutFeedback>
+      <View style={styles.modalOverlay}>
+        {/*
+          Backdrop is a sibling of the body, not an ancestor — so taps inside
+          the body never bubble to ``onClose``. The previous structure wrapped
+          the body in ``TouchableWithoutFeedback`` and relied on
+          ``e.stopPropagation()`` to cancel the outer close handler, which RN
+          Web's responder system doesn't honor reliably; a tap on any
+          ``TextInput`` inside the modal dismissed it instead of focusing
+          (the goal-target editor and the log-unit input were both
+          unusable on mobile web).
+        */}
+        <Pressable testID="goal-modal-backdrop" onPress={onClose} style={StyleSheet.absoluteFill} />
+        <GoalModalBody
+          habit={habit}
+          onClose={onClose}
+          onUpdateGoal={onUpdateGoal}
+          onLogUnit={onLogUnit}
+          onUpdateHabit={onUpdateHabit}
+        />
+      </View>
     </Modal>
   );
 };

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -785,16 +785,7 @@ export const GoalModal = ({
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
       <View style={styles.modalOverlay}>
-        {/*
-          Backdrop is a sibling of the body, not an ancestor — so taps inside
-          the body never bubble to ``onClose``. The previous structure wrapped
-          the body in ``TouchableWithoutFeedback`` and relied on
-          ``e.stopPropagation()`` to cancel the outer close handler, which RN
-          Web's responder system doesn't honor reliably; a tap on any
-          ``TextInput`` inside the modal dismissed it instead of focusing
-          (the goal-target editor and the log-unit input were both
-          unusable on mobile web).
-        */}
+        {/* Sibling backdrop — body taps don't bubble to onClose (RN Web). */}
         <Pressable testID="goal-modal-backdrop" onPress={onClose} style={StyleSheet.absoluteFill} />
         <GoalModalBody
           habit={habit}

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -785,8 +785,14 @@ export const GoalModal = ({
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
       <View style={styles.modalOverlay}>
-        {/* Sibling backdrop — body taps don't bubble to onClose (RN Web). */}
-        <Pressable testID="goal-modal-backdrop" onPress={onClose} style={StyleSheet.absoluteFill} />
+        {/* Sibling backdrop, rendered first so the body stacks above it on web. */}
+        <Pressable
+          testID="goal-modal-backdrop"
+          onPress={onClose}
+          style={StyleSheet.absoluteFill}
+          accessibilityLabel="Close"
+          accessibilityRole="button"
+        />
         <GoalModalBody
           habit={habit}
           onClose={onClose}

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -117,15 +117,25 @@ describe('habitManager', () => {
     });
 
     it('does NOT seed FALLBACK_HABITS when the live store already has habits', async () => {
-      // Regression guard: post-onboarding ``loadHabits`` must not overwrite
-      // the user's just-built selection with the hardcoded FALLBACK list when
-      // the server briefly returns empty (transient network issue, sync-in-
-      // flight, or first-load race). Cache is empty, API returns [], but the
-      // live store already has the user's habits — leave them alone.
+      // Cache empty + API empty + live store has habits → leave them alone.
       const userBuilt: Habit[] = [makeHabit({ id: 1, name: 'My Habit' })];
       useHabitStore.setState({ habits: userBuilt });
       (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
       (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+
+      await habitManager.loadHabits();
+
+      const stored = useHabitStore.getState().habits;
+      expect(stored).toHaveLength(1);
+      expect(stored[0]!.name).toBe('My Habit');
+    });
+
+    it('does NOT seed FALLBACK_HABITS when the live store has habits and the API throws', async () => {
+      // Symmetric guard for ``handleApiError`` — same invariant as above.
+      const userBuilt: Habit[] = [makeHabit({ id: 1, name: 'My Habit' })];
+      useHabitStore.setState({ habits: userBuilt });
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.list as jest.Mock).mockRejectedValueOnce(new Error('boom') as never);
 
       await habitManager.loadHabits();
 
@@ -427,11 +437,8 @@ describe('habitManager', () => {
     });
 
     it('refreshes habits from the server after sync so local IDs match the wire', async () => {
-      // Bug — every newly-onboarded user saw "We couldn't find that goal" on
-      // every log attempt because the local store kept its synthetic IDs
-      // (``index + 1``) while the server assigned real auto-increment IDs to
-      // the habits we just POSTed. The fix is to ``loadHabits`` after sync so
-      // the store mirrors the server's authoritative IDs.
+      // Synthetic onboarding IDs would otherwise stay in the store while the
+      // server has its real autoincrement IDs — every log POST then 404s.
       const newHabits: OnboardingHabit[] = [
         {
           id: 'a',

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -116,6 +116,24 @@ describe('habitManager', () => {
       expect(useHabitStore.getState().habits.length).toBeGreaterThan(0);
     });
 
+    it('does NOT seed FALLBACK_HABITS when the live store already has habits', async () => {
+      // Regression guard: post-onboarding ``loadHabits`` must not overwrite
+      // the user's just-built selection with the hardcoded FALLBACK list when
+      // the server briefly returns empty (transient network issue, sync-in-
+      // flight, or first-load race). Cache is empty, API returns [], but the
+      // live store already has the user's habits — leave them alone.
+      const userBuilt: Habit[] = [makeHabit({ id: 1, name: 'My Habit' })];
+      useHabitStore.setState({ habits: userBuilt });
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+
+      await habitManager.loadHabits();
+
+      const stored = useHabitStore.getState().habits;
+      expect(stored).toHaveLength(1);
+      expect(stored[0]!.name).toBe('My Habit');
+    });
+
     it('uses cached habits when available and then replaces with API data', async () => {
       const cached: Habit[] = [makeHabit({ id: 99, name: 'Cached' })];
       (loadHabits as jest.Mock).mockResolvedValueOnce(cached as never);
@@ -406,6 +424,83 @@ describe('habitManager', () => {
       expect(useHabitStore.getState().habits[0]!.goals).toHaveLength(3);
       expect(habitsApi.create).toHaveBeenCalled();
       expect(showToast).toHaveBeenCalled();
+    });
+
+    it('refreshes habits from the server after sync so local IDs match the wire', async () => {
+      // Bug — every newly-onboarded user saw "We couldn't find that goal" on
+      // every log attempt because the local store kept its synthetic IDs
+      // (``index + 1``) while the server assigned real auto-increment IDs to
+      // the habits we just POSTed. The fix is to ``loadHabits`` after sync so
+      // the store mirrors the server's authoritative IDs.
+      const newHabits: OnboardingHabit[] = [
+        {
+          id: 'a',
+          name: 'Meditate',
+          icon: '\u{1F9D8}',
+          energy_cost: 1,
+          energy_return: 3,
+          stage: 'Beige',
+          start_date: new Date('2025-01-01'),
+        },
+      ];
+      // Server returns the habit with a real autoincrement id (47), real
+      // goal ids (101/102/103), and the same name we POSTed.
+      (habitsApi.list as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 47,
+          name: 'Meditate',
+          icon: '\u{1F9D8}',
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 3,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [
+            {
+              id: 101,
+              habit_id: 47,
+              title: 'Low',
+              tier: 'low',
+              target: 1,
+              target_unit: 'units',
+              frequency: 1,
+              frequency_unit: 'per_day',
+              is_additive: true,
+            },
+            {
+              id: 102,
+              habit_id: 47,
+              title: 'Clear',
+              tier: 'clear',
+              target: 2,
+              target_unit: 'units',
+              frequency: 1,
+              frequency_unit: 'per_day',
+              is_additive: true,
+            },
+            {
+              id: 103,
+              habit_id: 47,
+              title: 'Stretch',
+              tier: 'stretch',
+              target: 3,
+              target_unit: 'units',
+              frequency: 1,
+              frequency_unit: 'per_day',
+              is_additive: true,
+            },
+          ],
+        },
+      ] as never);
+
+      await habitManager.onboardingSave(newHabits, jest.fn());
+
+      // Store now reflects the server's IDs, not the synthetic ones.
+      const stored = useHabitStore.getState().habits;
+      expect(stored).toHaveLength(1);
+      expect(stored[0]!.id).toBe(47);
+      expect(stored[0]!.goals.map((g) => g.id)).toEqual([101, 102, 103]);
     });
   });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -323,15 +323,20 @@ const handleApiSuccess = async (
 
 const handleApiError = (err: unknown, hasCachedData: boolean): void => {
   console.error('Failed to load habits:', err);
-  if (!hasCachedData) {
-    setError(
-      formatApiError(err, {
-        fallback:
-          "We couldn't load your habits. Check your connection, then pull down to try again.",
-      }),
-    );
-    setHabits(FALLBACK_HABITS);
-  }
+  // Mirrors the live-store guard in ``handleApiSuccess``: only show the
+  // connection-error banner + seed FALLBACK_HABITS when the user has no
+  // habits anywhere (cache + live store both empty). Without the live-store
+  // check, a transient GET failure on the post-onboarding ``loadHabits``
+  // call (slow 3G, 5xx, dropped connection) replaced the user's just-built
+  // selection with the hardcoded defaults — the cache hasn't been
+  // populated yet because ``syncOnboardingHabits`` doesn't ``persistHabits``.
+  if (hasCachedData || getHabits().length > 0) return;
+  setError(
+    formatApiError(err, {
+      fallback: "We couldn't load your habits. Check your connection, then pull down to try again.",
+    }),
+  );
+  setHabits(FALLBACK_HABITS);
 };
 
 const fetchFromApi = async (hasCachedData: boolean): Promise<void> => {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -303,13 +303,7 @@ const handleApiSuccess = async (
   apiHabits: Awaited<ReturnType<typeof habitsApi.list>>,
   hasCachedData: boolean,
 ): Promise<void> => {
-  // Only seed the FALLBACK list when the user is truly fresh: no cache, no
-  // live store, and an empty server. Without the live-store check, calling
-  // ``loadHabits`` immediately after onboarding (which is the only way to
-  // round-trip the server's authoritative ids — see ``onboardingSave``)
-  // would overwrite the user's just-built selection with the hardcoded
-  // defaults, because ``persistHabits`` is best-effort and hasn't necessarily
-  // landed before this code runs.
+  // Only seed FALLBACK when the user is truly fresh: no cache, no live store, no API.
   if (apiHabits.length === 0 && !hasCachedData && getHabits().length === 0) {
     setHabits(FALLBACK_HABITS);
     return;
@@ -323,13 +317,7 @@ const handleApiSuccess = async (
 
 const handleApiError = (err: unknown, hasCachedData: boolean): void => {
   console.error('Failed to load habits:', err);
-  // Mirrors the live-store guard in ``handleApiSuccess``: only show the
-  // connection-error banner + seed FALLBACK_HABITS when the user has no
-  // habits anywhere (cache + live store both empty). Without the live-store
-  // check, a transient GET failure on the post-onboarding ``loadHabits``
-  // call (slow 3G, 5xx, dropped connection) replaced the user's just-built
-  // selection with the hardcoded defaults — the cache hasn't been
-  // populated yet because ``syncOnboardingHabits`` doesn't ``persistHabits``.
+  // Mirrors the live-store guard in ``handleApiSuccess`` for the error path.
   if (hasCachedData || getHabits().length > 0) return;
   setError(
     formatApiError(err, {
@@ -398,28 +386,30 @@ const replayPendingCheckIns = async (): Promise<void> => {
 // but not itself a hook. Every method is independently unit-testable.
 // ---------------------------------------------------------------------------
 
-export const habitManager = {
-  loadHabits: async (): Promise<void> => {
-    setLoading(true);
-    setError(null);
-    const cached = await loadCachedHabits();
-    const hasCachedData = cached !== null && cached.length > 0;
-    if (hasCachedData) {
-      setHabits(cached);
-      setLoading(false);
-    }
-    await fetchFromApi(hasCachedData);
+const loadHabits = async (): Promise<void> => {
+  setLoading(true);
+  setError(null);
+  const cached = await loadCachedHabits();
+  const hasCachedData = cached !== null && cached.length > 0;
+  if (hasCachedData) {
+    setHabits(cached);
     setLoading(false);
+  }
+  await fetchFromApi(hasCachedData);
+  setLoading(false);
 
-    // BUG-HABITS-007 + BUG-FE-HABIT-205 partial-success fix: replay
-    // pending check-ins queued during offline, and when one fails mid-
-    // batch only re-queue the suffix that didn't post. The previous
-    // implementation `return`ed from the first failure with the
-    // successful prefix still in the queue, so on the next load every
-    // check-in that had already posted would post AGAIN — silent
-    // duplication of the user's streak.
-    await replayPendingCheckIns();
-  },
+  // BUG-HABITS-007 + BUG-FE-HABIT-205 partial-success fix: replay
+  // pending check-ins queued during offline, and when one fails mid-
+  // batch only re-queue the suffix that didn't post. The previous
+  // implementation `return`ed from the first failure with the
+  // successful prefix still in the queue, so on the next load every
+  // check-in that had already posted would post AGAIN — silent
+  // duplication of the user's streak.
+  await replayPendingCheckIns();
+};
+
+export const habitManager = {
+  loadHabits,
 
   updateGoal: (habitId: number, updatedGoal: Goal): void => {
     setHabits(applyGoalUpdate(getHabits(), habitId, updatedGoal));
@@ -572,14 +562,8 @@ export const habitManager = {
       duration: INSTRUCTIONAL_TOAST_DURATION_MS,
     });
     await syncOnboardingHabits(fullHabits);
-    // Round-trip the server's authoritative IDs into the store. Without this,
-    // ``buildOnboardingHabits`` leaves the local habits with synthetic
-    // ``index + 1`` ids while the server assigns real autoincrement ids on
-    // ``POST /habits/`` — every later log POST then 404s with
-    // ``goal_not_found`` because the synthetic goal id doesn't exist on the
-    // server. Refreshing from the wire is the only place where the
-    // server-assigned ids enter the client.
-    await habitManager.loadHabits();
+    // Round-trip server-assigned ids — synthetic goal ids would 404 on log.
+    await loadHabits();
   },
 
   revealAllHabits: (): void => {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -303,7 +303,14 @@ const handleApiSuccess = async (
   apiHabits: Awaited<ReturnType<typeof habitsApi.list>>,
   hasCachedData: boolean,
 ): Promise<void> => {
-  if (apiHabits.length === 0 && !hasCachedData) {
+  // Only seed the FALLBACK list when the user is truly fresh: no cache, no
+  // live store, and an empty server. Without the live-store check, calling
+  // ``loadHabits`` immediately after onboarding (which is the only way to
+  // round-trip the server's authoritative ids — see ``onboardingSave``)
+  // would overwrite the user's just-built selection with the hardcoded
+  // defaults, because ``persistHabits`` is best-effort and hasn't necessarily
+  // landed before this code runs.
+  if (apiHabits.length === 0 && !hasCachedData && getHabits().length === 0) {
     setHabits(FALLBACK_HABITS);
     return;
   }
@@ -560,6 +567,14 @@ export const habitManager = {
       duration: INSTRUCTIONAL_TOAST_DURATION_MS,
     });
     await syncOnboardingHabits(fullHabits);
+    // Round-trip the server's authoritative IDs into the store. Without this,
+    // ``buildOnboardingHabits`` leaves the local habits with synthetic
+    // ``index + 1`` ids while the server assigns real autoincrement ids on
+    // ``POST /habits/`` — every later log POST then 404s with
+    // ``goal_not_found`` because the synthetic goal id doesn't exist on the
+    // server. Refreshing from the wire is the only place where the
+    // server-assigned ids enter the client.
+    await habitManager.loadHabits();
   },
 
   revealAllHabits: (): void => {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -563,6 +563,7 @@ export const habitManager = {
     });
     await syncOnboardingHabits(fullHabits);
     // Round-trip server-assigned ids — synthetic goal ids would 404 on log.
+    // If this GET fails, synthetic ids survive until the next launch — see #282.
     await loadHabits();
   },
 


### PR DESCRIPTION
Two follow-up bugs from PR #280, both reported with screenshots:

## Summary

### 1. `goal_not_found` toast on every log attempt

**Symptom**: User clicks "Log Units" (or "Quick Log") on any habit and immediately sees "We couldn't find that goal. Pull down to refresh and try again." No matter how many times they retry.

**Root cause**: `buildOnboardingHabits` populates the local store with **synthetic** ids (`index + 1` for habits, `index * 3 + tier + 1` for goals). `syncOnboardingHabits` POSTs each habit to `/habits/` but **discards the server response** — so the local store keeps the synthetic ids while the server has its own autoincrement ids. Every later `goal_completions` POST then 404s with `goal_not_found` because the synthetic goal id doesn't exist on the server.

**Fix**: `onboardingSave` now calls `loadHabits` after `syncOnboardingHabits`, replacing the local store with the server's authoritative habit list (real ids). Plus a defensive change to `handleApiSuccess` and `handleApiError`: only seed `FALLBACK_HABITS` when the live store **and** cache **and** API are all empty — without that guard, `loadHabits` running on a transient API blip (success path) or failure (error path) would clobber the user's just-built selection with the hardcoded defaults.

### 2. Tapping any TextInput inside the GoalModal closes it

**Symptom**: User taps a goal-target input or the log-unit input. Modal dismisses instead of focusing the input. Reported on mobile web (Mobile Safari at `app.aptitude.guru`).

**Root cause**: The modal body was wrapped in a nested `TouchableWithoutFeedback` that called `e.stopPropagation()` to cancel the outer `onPress={onClose}`. RN Web's responder system doesn't honor `stopPropagation` reliably, so the outer close handler fires anyway whenever a tap originates inside the body.

**Fix**: Restructured to a sibling layout. A dedicated `Pressable` backdrop (testID `goal-modal-backdrop`, `StyleSheet.absoluteFill`) handles tap-to-close; the modal body sits next to it. Taps on the body never bubble to a close handler.

## Test plan
- [x] `npm test` — 785 tests pass (+5 new)
- [x] `pre-commit run --all-files` — green (lint, typecheck, prettier, etc.)
- [ ] Manual on mobile web after merge: complete onboarding, tap a habit → modal opens → tap goal-target input → keyboard focus, no dismiss → tap "Log Units" → confirmation toast (not `goal_not_found`)

## Tests added
1. `GoalModal › backdrop close › exposes a dedicated backdrop element that closes when pressed` — pins the structural fix.
2. `GoalModal › backdrop close › does not wrap the body in a tap-handler that fires onClose` — walks ancestors of `goal-target-input-low` and fails if any has `onPress === onClose`.
3. `habitManager › onboardingSave › refreshes habits from the server after sync so local IDs match the wire` — server returns id `47` with goals `101/102/103`; assertion: store reflects those, not the synthetic `1/1/2/3`.
4. `habitManager › loadHabits › does NOT seed FALLBACK_HABITS when the live store already has habits` — regression guard for the `handleApiSuccess` tightening (API empty path).
5. `habitManager › loadHabits › does NOT seed FALLBACK_HABITS when the live store has habits and the API throws` — symmetric guard for `handleApiError` (API rejected path).

🤖 Generated with [Claude Code](https://claude.ai/code)