### PR TITLE
fix(habits): persist goal edits + auto-create default goals + recover stuck users

### DIFF
--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -57,13 +57,21 @@ async def require_owned_goal(
 
     Goal ownership rides on the parent habit's ``user_id`` -- the goal table
     itself has no ``user_id`` column.  We collapse "missing goal" and "not
-    yours" into a single 404 to deny enumeration (BUG-T7 / PR #265).
+    yours" into a single 404 to deny enumeration (BUG-T7 / PR #265).  The
+    orphaned-FK branch (goal exists, parent habit gone) is a distinct
+    integrity-violation signal so it gets its own audit row.
     """
     goal = await session.get(Goal, goal_id)
     if goal is None:
         raise not_found("goal")
     habit = await session.get(Habit, goal.habit_id)
-    if habit is None or habit.user_id != current_user:
+    if habit is None:
+        logger.warning(
+            "orphaned_goal_fk",
+            extra={"goal_id": goal_id, "habit_id": goal.habit_id, "user_id": current_user},
+        )
+        raise not_found("goal")
+    if habit.user_id != current_user:
         log_ownership_denied("goal", goal_id, current_user)
         raise not_found("goal")
     return goal

--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import get_session
 from errors import forbidden, not_found
+from models.goal import Goal
 from models.goal_group import GoalGroup
 from models.habit import Habit
 from models.journal_entry import JournalEntry
@@ -45,6 +46,27 @@ async def require_owned_habit(
         log_ownership_denied("habit", habit_id, current_user)
         raise forbidden("forbidden")
     return habit
+
+
+async def require_owned_goal(
+    goal_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> Goal:
+    """Resolve ``goal_id`` and verify the caller owns the parent habit.
+
+    Goal ownership rides on the parent habit's ``user_id`` -- the goal table
+    itself has no ``user_id`` column.  We collapse "missing goal" and "not
+    yours" into a single 404 to deny enumeration (BUG-T7 / PR #265).
+    """
+    goal = await session.get(Goal, goal_id)
+    if goal is None:
+        raise not_found("goal")
+    habit = await session.get(Habit, goal.habit_id)
+    if habit is None or habit.user_id != current_user:
+        log_ownership_denied("goal", goal_id, current_user)
+        raise not_found("goal")
+    return goal
 
 
 async def require_owned_journal_entry(

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -34,6 +34,7 @@ from routers.course import router as course_router
 from routers.energy import router as energy_router
 from routers.goal_completions import router as goal_completion_router
 from routers.goal_groups import router as goal_groups_router
+from routers.goals import router as goals_router
 from routers.habits import router as habits_router
 from routers.journal import router as journal_router
 from routers.practice_sessions import router as practice_sessions_router
@@ -306,6 +307,7 @@ app.include_router(prompts_router)
 app.include_router(energy_router)
 app.include_router(goal_completion_router)
 app.include_router(goal_groups_router)
+app.include_router(goals_router)
 app.include_router(stages_router)
 
 

--- a/backend/src/routers/goals.py
+++ b/backend/src/routers/goals.py
@@ -1,0 +1,49 @@
+"""Per-goal CRUD API endpoints backed by the database.
+
+The original API only mutated goals via the habits PUT endpoint, but
+``HabitCreate`` does not include goal fields, so target / unit / frequency /
+is_additive could not be edited from the client.  This router fills that
+gap with a single ``PUT /goals/{goal_id}`` endpoint scoped to the parent
+habit's owner.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from dependencies.ownership import require_owned_goal
+from models.goal import Goal
+from routers.auth import get_current_user
+from schemas.goal import Goal as GoalSchema
+from schemas.goal import GoalUpdate
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/goals", tags=["goals"])
+
+
+@router.put("/{goal_id}", response_model=GoalSchema)
+async def update_goal(
+    payload: GoalUpdate,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    goal: Annotated[Goal, Depends(require_owned_goal)],
+) -> Goal:
+    """Update an existing goal's editable fields.
+
+    ``habit_id`` is intentionally not part of ``GoalUpdate`` so the parent
+    habit cannot be swapped via this endpoint -- a goal is bound to its
+    habit for life.
+    """
+    for key, value in payload.model_dump().items():
+        setattr(goal, key, value)
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    logger.info("goal_updated", extra={"user_id": current_user, "goal_id": goal.id})
+    return goal

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -93,15 +93,18 @@ async def _ensure_unique_name(session: AsyncSession, current_user: int, name: st
         raise conflict("duplicate_habit_name")
 
 
-async def _persist_habit_with_default_goals(session: AsyncSession, habit: Habit) -> None:
+async def _persist_habit_with_default_goals(session: AsyncSession, habit: Habit) -> int:
     """Insert the habit + three default goals in a single savepoint."""
     try:
         async with session.begin_nested():
             session.add(habit)
             await session.flush()  # populate habit.id for the goals' FK
-            assert habit.id is not None  # noqa: S101
+            if habit.id is None:
+                msg = "session.flush() did not populate habit.id"
+                raise RuntimeError(msg)
             for goal in _build_default_goals(habit.id, habit.name):
                 session.add(goal)
+            new_id = habit.id
         await session.commit()
     except IntegrityError as exc:
         # A concurrent request for the same (user_id, normalized name)
@@ -109,6 +112,7 @@ async def _persist_habit_with_default_goals(session: AsyncSession, habit: Habit)
         # surface the same 409 the pre-check would have so callers
         # cannot tell the two paths apart.
         raise conflict("duplicate_habit_name") from exc
+    return new_id
 
 
 async def _refetch_with_goals(session: AsyncSession, habit_id: int) -> Habit:
@@ -116,7 +120,12 @@ async def _refetch_with_goals(session: AsyncSession, habit_id: int) -> Habit:
     statement = select(Habit).where(Habit.id == habit_id).options(HABIT_WITH_GOALS_AND_COMPLETIONS)
     result = await session.execute(statement)
     refreshed = result.scalars().first()
-    assert refreshed is not None  # noqa: S101
+    if refreshed is None:
+        # Should be unreachable: habit was committed in the same session
+        # one statement ago. Surface as a 500 with a stable detail rather
+        # than a confusing 200/empty.
+        msg = f"habit {habit_id} disappeared between commit and refetch"
+        raise RuntimeError(msg)
     return refreshed
 
 
@@ -130,9 +139,8 @@ async def create_habit(
     await _ensure_under_quota(session, current_user)
     await _ensure_unique_name(session, current_user, payload.name)
     habit = Habit(user_id=current_user, **payload.model_dump())
-    await _persist_habit_with_default_goals(session, habit)
-    assert habit.id is not None  # noqa: S101
-    refreshed = await _refetch_with_goals(session, habit.id)
+    new_id = await _persist_habit_with_default_goals(session, habit)
+    refreshed = await _refetch_with_goals(session, new_id)
     logger.info("habit_created", extra={"user_id": current_user, "habit_id": refreshed.id})
     return refreshed
 

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -119,7 +119,7 @@ async def _refetch_with_goals(session: AsyncSession, habit_id: int) -> Habit:
     """Re-load a habit with eager goals to avoid greenlet lazy-load errors."""
     statement = select(Habit).where(Habit.id == habit_id).options(HABIT_WITH_GOALS_AND_COMPLETIONS)
     result = await session.execute(statement)
-    refreshed = result.scalars().first()
+    refreshed = result.scalars().one_or_none()
     if refreshed is None:
         # Should be unreachable: habit was committed in the same session
         # one statement ago. Surface as a 500 with a stable detail rather

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -35,6 +35,18 @@ router = APIRouter(prefix="/habits", tags=["habits"])
 # Per-user cap on habit rows; surfaces as 409 ``habit_quota_exceeded``.
 _MAX_HABITS_PER_USER = 100
 
+# Default goals seeded for every newly-created habit. Three tiers (low / clear
+# / stretch) so the habits feature is functional from the moment a habit
+# exists -- without these, ``POST /goal_completions`` always 404'd because no
+# goal endpoint ever wrote a row, and the editor's PUT /goals/{id} had nothing
+# to update. The frontend's onboarding code builds the same shape locally; we
+# now mirror it server-side so ids round-trip correctly.
+_DEFAULT_GOAL_TIERS: tuple[tuple[str, str, float], ...] = (
+    ("low", "Low", 1.0),
+    ("clear", "Clear", 2.0),
+    ("stretch", "Stretch", 3.0),
+)
+
 
 def _populate_streak(habit: Habit, current_user: int, user_timezone: str) -> None:
     """Set ``habit.streak`` from the goal completions loaded in memory."""
@@ -42,20 +54,35 @@ def _populate_streak(habit: Habit, current_user: int, user_timezone: str) -> Non
     habit.streak = compute_habit_streak(completions, user_timezone)
 
 
-@router.post("/", response_model=HabitSchema)
-async def create_habit(
-    payload: HabitCreate,
-    current_user: Annotated[int, Depends(get_current_user)],
-    session: Annotated[AsyncSession, Depends(get_session)],
-) -> Habit:
-    """Create a habit; 409 over-quota (best-effort) or duplicate-name (DB-enforced)."""
+def _build_default_goals(habit_id: int, habit_name: str) -> list[Goal]:
+    """Three-tier default goals for a newly-created habit."""
+    return [
+        Goal(
+            habit_id=habit_id,
+            title=f"{label} goal for {habit_name}",
+            tier=tier,
+            target=target,
+            target_unit="units",
+            frequency=1.0,
+            frequency_unit="per_day",
+            is_additive=True,
+        )
+        for tier, label, target in _DEFAULT_GOAL_TIERS
+    ]
+
+
+async def _ensure_under_quota(session: AsyncSession, current_user: int) -> None:
+    """Raise 409 if the caller already owns the per-user habit cap."""
     count = await session.scalar(
         select(func.count()).select_from(Habit).where(Habit.user_id == current_user)
     )
     if (count or 0) >= _MAX_HABITS_PER_USER:
         raise conflict("habit_quota_exceeded")
 
-    candidate_name = payload.name.strip().lower()
+
+async def _ensure_unique_name(session: AsyncSession, current_user: int, name: str) -> None:
+    """Raise 409 if the caller already owns a habit with the same normalized name."""
+    candidate_name = name.strip().lower()
     duplicate = await session.scalar(
         select(Habit.id).where(
             Habit.user_id == current_user,
@@ -65,10 +92,16 @@ async def create_habit(
     if duplicate is not None:
         raise conflict("duplicate_habit_name")
 
-    habit = Habit(user_id=current_user, **payload.model_dump())
+
+async def _persist_habit_with_default_goals(session: AsyncSession, habit: Habit) -> None:
+    """Insert the habit + three default goals in a single savepoint."""
     try:
         async with session.begin_nested():
             session.add(habit)
+            await session.flush()  # populate habit.id for the goals' FK
+            assert habit.id is not None  # noqa: S101
+            for goal in _build_default_goals(habit.id, habit.name):
+                session.add(goal)
         await session.commit()
     except IntegrityError as exc:
         # A concurrent request for the same (user_id, normalized name)
@@ -76,9 +109,32 @@ async def create_habit(
         # surface the same 409 the pre-check would have so callers
         # cannot tell the two paths apart.
         raise conflict("duplicate_habit_name") from exc
-    await session.refresh(habit)
-    logger.info("habit_created", extra={"user_id": current_user, "habit_id": habit.id})
-    return habit
+
+
+async def _refetch_with_goals(session: AsyncSession, habit_id: int) -> Habit:
+    """Re-load a habit with eager goals to avoid greenlet lazy-load errors."""
+    statement = select(Habit).where(Habit.id == habit_id).options(HABIT_WITH_GOALS_AND_COMPLETIONS)
+    result = await session.execute(statement)
+    refreshed = result.scalars().first()
+    assert refreshed is not None  # noqa: S101
+    return refreshed
+
+
+@router.post("/", response_model=HabitWithGoals)
+async def create_habit(
+    payload: HabitCreate,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> Habit:
+    """Create a habit + three default goals; 409 over-quota or duplicate name."""
+    await _ensure_under_quota(session, current_user)
+    await _ensure_unique_name(session, current_user, payload.name)
+    habit = Habit(user_id=current_user, **payload.model_dump())
+    await _persist_habit_with_default_goals(session, habit)
+    assert habit.id is not None  # noqa: S101
+    refreshed = await _refetch_with_goals(session, habit.id)
+    logger.info("habit_created", extra={"user_id": current_user, "habit_id": refreshed.id})
+    return refreshed
 
 
 @router.get("/", response_model=None)

--- a/backend/src/schemas/goal.py
+++ b/backend/src/schemas/goal.py
@@ -30,6 +30,12 @@ class Goal(BaseModel):
 class GoalUpdate(BaseModel):
     """Payload for ``PUT /goals/{goal_id}``.
 
+    Full-replace REST PUT semantics: every field is required (or has an
+    explicit default) and ``model_dump()`` writes them all to the row.
+    Optional fields like ``description`` revert to ``None`` if omitted —
+    callers building partial-update UIs must read the current goal first
+    and resend its values.
+
     ``habit_id`` is deliberately excluded -- a goal is permanently bound to its
     parent habit.  Allowing the caller to forge ``habit_id`` would let them
     reparent goals across habits (and across tenants if combined with an IDOR).

--- a/backend/src/schemas/goal.py
+++ b/backend/src/schemas/goal.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from models.goal import GoalTier
 
@@ -23,5 +23,28 @@ class Goal(BaseModel):
     target_unit: str
     frequency: float
     frequency_unit: str
+    is_additive: bool = True
+    goal_group_id: int | None = None
+
+
+class GoalUpdate(BaseModel):
+    """Payload for ``PUT /goals/{goal_id}``.
+
+    ``habit_id`` is deliberately excluded -- a goal is permanently bound to its
+    parent habit.  Allowing the caller to forge ``habit_id`` would let them
+    reparent goals across habits (and across tenants if combined with an IDOR).
+    The schema rejects unknown fields so the server doesn't silently accept a
+    spoofed ``habit_id`` and discard it -- callers see a 422 instead.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=2_000)
+    tier: GoalTier
+    target: float
+    target_unit: str = Field(min_length=1, max_length=50)
+    frequency: float
+    frequency_unit: str = Field(min_length=1, max_length=50)
     is_additive: bool = True
     goal_group_id: int | None = None

--- a/backend/src/schemas/goal.py
+++ b/backend/src/schemas/goal.py
@@ -42,9 +42,13 @@ class GoalUpdate(BaseModel):
     title: str = Field(min_length=1, max_length=255)
     description: str | None = Field(default=None, max_length=2_000)
     tier: GoalTier
-    target: float
+    # ``ge=0`` (not ``gt=0``): target=0 is legitimate for subtractive
+    # "abstinence" goals — e.g. the stretch tier of caffeine / alcohol /
+    # scrolling. ``frequency`` is strictly positive: "do X zero times
+    # per week" is meaningless on every tier.
+    target: float = Field(ge=0)
     target_unit: str = Field(min_length=1, max_length=50)
-    frequency: float
+    frequency: float = Field(gt=0)
     frequency_unit: str = Field(min_length=1, max_length=50)
     is_additive: bool = True
     goal_group_id: int | None = None

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -1,0 +1,186 @@
+"""Tests for the per-goal CRUD API — DB-backed with authentication.
+
+Goals are nested under habits and were originally only mutable via the
+habits PUT endpoint, but ``HabitCreate`` does not include goal fields, so
+target / target_unit / frequency / is_additive could not be updated from
+the client.  This module covers the ``PUT /goals/{goal_id}`` endpoint
+that closes that gap.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.goal import Goal
+from models.habit import Habit
+
+
+async def _signup(client: AsyncClient, username: str = "goaluser") -> tuple[dict[str, str], int]:
+    """Create a user and return ``(auth headers, user_id)``."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+async def _seed_goal(
+    db_session: AsyncSession,
+    user_id: int,
+    *,
+    habit_name: str = "Meditation",
+) -> Goal:
+    """Create a habit + goal in the DB and return the goal."""
+    habit = Habit(
+        name=habit_name,
+        icon="\U0001f9d8",
+        start_date=date(2025, 1, 1),
+        energy_cost=10,
+        energy_return=20,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+
+    goal = Goal(
+        habit_id=habit.id,
+        title="Daily sit",
+        tier="clear",
+        target=10.0,
+        target_unit="minutes",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    db_session.add(goal)
+    await db_session.commit()
+    await db_session.refresh(goal)
+    return goal
+
+
+def _update_payload(**overrides: object) -> dict[str, object]:
+    """Default payload — every field the editor exposes."""
+    payload: dict[str, object] = {
+        "title": "Daily sit",
+        "tier": "clear",
+        "target": 20.0,
+        "target_unit": "minutes",
+        "frequency": 1.0,
+        "frequency_unit": "per_day",
+        "is_additive": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ── Unauthenticated + ownership ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_goal_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.put("/goals/1", json=_update_payload())
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_update_goal_404_when_goal_missing(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    resp = await async_client.put("/goals/999", json=_update_payload(), headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_update_goal_403_when_caller_not_owner(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Cross-tenant probe: alice's goal cannot be updated by bob."""
+    _, alice_id = await _signup(async_client, "alice")
+    bob_headers, _ = await _signup(async_client, "bob")
+    goal = await _seed_goal(db_session, alice_id, habit_name="Alice habit")
+
+    resp = await async_client.put(f"/goals/{goal.id}", json=_update_payload(), headers=bob_headers)
+    # Same 404 the not-found path returns — the IDOR remediation
+    # (BUG-T7 / PR #265) collapses "doesn't exist" + "not yours" into a
+    # single status to deny enumeration.
+    assert resp.status_code in {HTTPStatus.NOT_FOUND, HTTPStatus.FORBIDDEN}
+
+
+# ── Successful update ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_goal_persists_target(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(target=42.0),
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["target"] == 42.0
+    assert body["id"] == goal.id
+
+
+@pytest.mark.asyncio
+async def test_update_goal_persists_target_unit_frequency_and_is_additive(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The whole editor surface — unit / frequency / additive — round-trips."""
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(
+            target_unit="reps",
+            frequency=3.0,
+            frequency_unit="per_week",
+            is_additive=False,
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["target_unit"] == "reps"
+    assert body["frequency"] == 3.0
+    assert body["frequency_unit"] == "per_week"
+    assert body["is_additive"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_goal_does_not_change_habit_id(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Caller cannot reparent a goal to a different habit via the PUT."""
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+    original_habit_id = goal.habit_id
+
+    # ``habit_id`` is intentionally absent from the GoalUpdate schema, so the
+    # server should ignore any attempt to forge it. ``model_dump`` on the
+    # request body strips unknown fields — assert the goal still belongs to
+    # its original habit afterwards.
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json={**_update_payload(target=99.0), "habit_id": 9999},
+        headers=headers,
+    )
+    assert resp.status_code in {HTTPStatus.OK, HTTPStatus.UNPROCESSABLE_ENTITY}
+    if resp.status_code == HTTPStatus.OK:
+        assert resp.json()["habit_id"] == original_habit_id

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -104,16 +104,19 @@ async def test_update_goal_404_when_goal_missing(async_client: AsyncClient) -> N
 async def test_update_goal_403_when_caller_not_owner(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """Cross-tenant probe: alice's goal cannot be updated by bob."""
+    """Cross-tenant probe: alice's goal cannot be updated by bob.
+
+    Strict 404 — the IDOR remediation (BUG-T7 / PR #265) collapses
+    "doesn't exist" + "not yours" into a single status to deny
+    enumeration. A 403 here would mean ownership leaked back into the
+    response.
+    """
     _, alice_id = await _signup(async_client, "alice")
     bob_headers, _ = await _signup(async_client, "bob")
     goal = await _seed_goal(db_session, alice_id, habit_name="Alice habit")
 
     resp = await async_client.put(f"/goals/{goal.id}", json=_update_payload(), headers=bob_headers)
-    # Same 404 the not-found path returns — the IDOR remediation
-    # (BUG-T7 / PR #265) collapses "doesn't exist" + "not yours" into a
-    # single status to deny enumeration.
-    assert resp.status_code in {HTTPStatus.NOT_FOUND, HTTPStatus.FORBIDDEN}
+    assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
 # ── Successful update ───────────────────────────────────────────────────
@@ -164,23 +167,23 @@ async def test_update_goal_persists_target_unit_frequency_and_is_additive(
 
 
 @pytest.mark.asyncio
-async def test_update_goal_does_not_change_habit_id(
+async def test_update_goal_rejects_forged_habit_id(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """Caller cannot reparent a goal to a different habit via the PUT."""
+    """Caller cannot reparent a goal to a different habit via the PUT.
+
+    Strict 422 — ``GoalUpdate`` has ``model_config = ConfigDict(extra="forbid")``
+    so any extra field (including a forged ``habit_id``) MUST trigger a
+    validation error. A 200 here would mean the schema silently accepted
+    the field, which would let a malicious caller reparent goals across
+    tenants if combined with another flaw.
+    """
     headers, user_id = await _signup(async_client)
     goal = await _seed_goal(db_session, user_id)
-    original_habit_id = goal.habit_id
 
-    # ``habit_id`` is intentionally absent from the GoalUpdate schema, so the
-    # server should ignore any attempt to forge it. ``model_dump`` on the
-    # request body strips unknown fields — assert the goal still belongs to
-    # its original habit afterwards.
     resp = await async_client.put(
         f"/goals/{goal.id}",
         json={**_update_payload(target=99.0), "habit_id": 9999},
         headers=headers,
     )
-    assert resp.status_code in {HTTPStatus.OK, HTTPStatus.UNPROCESSABLE_ENTITY}
-    if resp.status_code == HTTPStatus.OK:
-        assert resp.json()["habit_id"] == original_habit_id
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/backend/tests/test_habits_api.py
+++ b/backend/tests/test_habits_api.py
@@ -116,6 +116,28 @@ async def test_get_habit(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_habit_seeds_three_default_goals(async_client: AsyncClient) -> None:
+    """``POST /habits/`` returns the new habit with low/clear/stretch defaults.
+
+    Without this, ``POST /goal_completions/`` always 404'd because the
+    server never had goals to look up -- there was no goal-creation
+    endpoint at all and the frontend's local goals never made the wire.
+    Pinning the contract here so a future refactor that drops the
+    auto-seed (or changes the tier set) fails the suite instead of
+    silently breaking habit logging end-to-end.
+    """
+    headers = await _signup(async_client)
+    resp = await async_client.post("/habits/", json=sample_payload(), headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    tiers = sorted(g["tier"] for g in body["goals"])
+    assert tiers == ["clear", "low", "stretch"]
+    # Each default goal carries a real autoincrement id so the frontend
+    # can immediately ``PUT /goals/{id}`` against any of them.
+    assert all(isinstance(g["id"], int) and g["id"] > 0 for g in body["goals"])
+
+
+@pytest.mark.asyncio
 async def test_update_habit(async_client: AsyncClient) -> None:
     headers = await _signup(async_client)
     create_resp = await async_client.post("/habits/", json=sample_payload(), headers=headers)
@@ -211,12 +233,12 @@ async def test_create_habit_defaults_streak_to_zero(async_client: AsyncClient) -
 async def test_get_habit_includes_goals(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """GET /habits/{id} returns nested goals list."""
+    """GET /habits/{id} returns nested goals list (defaults + any added)."""
     headers = await _signup(async_client)
     create_resp = await async_client.post("/habits/", json=sample_payload(), headers=headers)
     habit_id = create_resp.json()["id"]
 
-    # Insert a goal directly via DB
+    # Insert an extra goal beyond the three defaults seeded by ``POST /habits/``.
     goal = Goal(
         habit_id=habit_id,
         title="Drink 8 glasses",
@@ -234,15 +256,15 @@ async def test_get_habit_includes_goals(
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
     assert "goals" in data
-    assert len(data["goals"]) == 1
-    assert data["goals"][0]["title"] == "Drink 8 glasses"
+    titles = [g["title"] for g in data["goals"]]
+    assert "Drink 8 glasses" in titles
 
 
 @pytest.mark.asyncio
 async def test_list_habits_includes_goals(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """GET /habits/ returns nested goals in each habit."""
+    """GET /habits/ returns nested goals in each habit (defaults + any added)."""
     headers = await _signup(async_client)
     create_resp = await async_client.post("/habits/", json=sample_payload(), headers=headers)
     habit_id = create_resp.json()["id"]
@@ -264,7 +286,8 @@ async def test_list_habits_includes_goals(
     assert resp.status_code == HTTPStatus.OK
     habits_list = resp.json()
     assert len(habits_list) == 1
-    assert len(habits_list[0]["goals"]) == 1
+    titles = [g["title"] for g in habits_list[0]["goals"]]
+    assert "Drink 8 glasses" in titles
 
 
 @pytest.mark.asyncio
@@ -344,7 +367,8 @@ async def test_delete_habit_logs_cascade_counts(
     assert resp.status_code == HTTPStatus.NO_CONTENT
     cascade_logs = [r for r in caplog.records if r.message == "habit_deleted"]
     assert cascade_logs, "expected a habit_deleted audit log entry"
-    assert getattr(cascade_logs[0], "cascade_goals", None) == 1
+    # Three default goals (auto-seeded by POST /habits/) + one manually added.
+    assert getattr(cascade_logs[0], "cascade_goals", None) == 4
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/__tests__/habits-api.test.ts
+++ b/frontend/src/api/__tests__/habits-api.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
-import { habits, goalCompletions, ApiError } from '../index';
+import { habits, goalCompletions, goals, ApiError } from '../index';
 
 // Mock global fetch
 const mockFetch = jest.fn() as jest.Mock;
@@ -132,5 +132,70 @@ describe('goalCompletions API client', () => {
     );
 
     await expect(goalCompletions.create({ goal_id: 999 }, 'test-token')).rejects.toThrow(ApiError);
+  });
+});
+
+describe('goals API client', () => {
+  test('goals.update sends PUT to /goals/{id} with the editor payload', async () => {
+    const updated = {
+      id: 7,
+      habit_id: 1,
+      title: 'Drink 8 glasses',
+      tier: 'clear',
+      target: 16,
+      target_unit: 'glasses',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(updated));
+
+    const result = await goals.update(
+      7,
+      {
+        title: 'Drink 8 glasses',
+        tier: 'clear',
+        target: 16,
+        target_unit: 'glasses',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      'test-token',
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/goals/7');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toMatchObject({ target: 16, target_unit: 'glasses' });
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer test-token' });
+    expect(result).toEqual(updated);
+  });
+
+  test('goals.update throws ApiError when the goal does not exist', async () => {
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ detail: 'goal_not_found' }),
+      }),
+    );
+
+    await expect(
+      goals.update(
+        999,
+        {
+          title: 'X',
+          tier: 'clear',
+          target: 1,
+          target_unit: 'units',
+          frequency: 1,
+          frequency_unit: 'per_day',
+          is_additive: true,
+        },
+        'test-token',
+      ),
+    ).rejects.toThrow(ApiError);
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -852,6 +852,27 @@ export const goalCompletions = {
   },
 };
 
+// Goal write payload — fields the editor exposes. ``habit_id`` is omitted
+// because a goal is bound to its parent habit for life and the server's
+// ``GoalUpdate`` schema rejects any attempt to forge it.
+export interface GoalUpdatePayload {
+  title: string;
+  description?: string | null;
+  tier: string;
+  target: number;
+  target_unit: string;
+  frequency: number;
+  frequency_unit: string;
+  is_additive: boolean;
+  goal_group_id?: number | null;
+}
+
+export const goals = {
+  update(goalId: number, payload: GoalUpdatePayload, token?: string): Promise<ApiGoal> {
+    return request<ApiGoal>(`/goals/${goalId}`, { method: 'PUT', body: payload, token });
+  },
+};
+
 // Goal group client
 export const goalGroups = {
   list(token?: string): Promise<ApiGoalGroup[]> {
@@ -1487,6 +1508,7 @@ export default {
   habits,
   goalCompletions,
   goalGroups,
+  goals,
   journal,
   botmason,
   prompts,

--- a/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
@@ -41,6 +41,9 @@ jest.mock('../../../api', () => ({
   goalCompletions: {
     create: jest.fn(() => Promise.resolve({ streak: 1, milestones: [], reason_code: 'ok' })),
   },
+  goals: {
+    update: jest.fn(() => Promise.resolve({})),
+  },
 }));
 
 jest.mock('../../../storage/habitStorage', () => ({

--- a/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
@@ -25,6 +25,9 @@ jest.mock('../../../api', () => ({
   goalCompletions: {
     create: jest.fn(() => Promise.resolve({})),
   },
+  goals: {
+    update: jest.fn(() => Promise.resolve({})),
+  },
 }));
 
 jest.mock('../../../storage/habitStorage', () => ({

--- a/frontend/src/features/Habits/__tests__/useHabits.test.ts
+++ b/frontend/src/features/Habits/__tests__/useHabits.test.ts
@@ -16,6 +16,9 @@ jest.mock('../../../api', () => ({
   goalCompletions: {
     create: jest.fn(() => Promise.resolve({})),
   },
+  goals: {
+    update: jest.fn(() => Promise.resolve({})),
+  },
 }));
 
 jest.mock('../../../storage/habitStorage', () => ({

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
@@ -19,6 +19,9 @@ jest.mock('../../../../api', () => ({
   goalCompletions: {
     create: jest.fn(() => Promise.resolve({ streak: 1, milestones: [], reason_code: 'ok' })),
   },
+  goals: {
+    update: jest.fn(() => Promise.resolve({})),
+  },
 }));
 
 jest.mock('../../../../storage/habitStorage', () => ({

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -11,6 +11,9 @@ jest.mock('../../../../api', () => ({
   goalCompletions: {
     create: jest.fn(() => Promise.resolve({})),
   },
+  goals: {
+    update: jest.fn(() => Promise.resolve({})),
+  },
 }));
 
 jest.mock('../../../../storage/habitStorage', () => ({
@@ -37,7 +40,11 @@ jest.mock('react-native', () => ({
   StyleSheet: { create: (s: Record<string, unknown>) => s },
 }));
 
-import { habits as habitsApi, goalCompletions as goalCompletionsApi } from '../../../../api';
+import {
+  habits as habitsApi,
+  goalCompletions as goalCompletionsApi,
+  goals as goalsApi,
+} from '../../../../api';
 import {
   saveHabits,
   loadHabits,
@@ -144,6 +151,66 @@ describe('habitManager', () => {
       expect(stored[0]!.name).toBe('My Habit');
     });
 
+    it('recovers stuck users by pushing cached habits when the server has none', async () => {
+      // Stuck-user state: the user's original onboarding sync silently
+      // failed long ago (e.g. against the broken pre-#280 schema), so the
+      // cache holds habits with synthetic ids while the server has zero
+      // habits. Without recovery, every log POST 404s forever — the
+      // server has nothing to match the synthetic ``goal_id`` against.
+      const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
+      (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
+      // First GET: empty (stuck state). Second GET (after recovery push):
+      // the habit re-appears with its newly-assigned server id.
+      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+        {
+          id: 99,
+          name: 'Pranayama',
+          icon: cachedHabit.icon,
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      // The recovery push went out for the stuck habit.
+      expect(habitsApi.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Pranayama' }));
+      // And the store now reflects the server's real autoincrement id.
+      const stored = useHabitStore.getState().habits;
+      expect(stored).toHaveLength(1);
+      expect(stored[0]!.id).toBe(99);
+    });
+
+    it('does NOT push cached habits when the server already has habits', async () => {
+      // Sanity check: ordinary "API has my habits" path must not retrigger
+      // the recovery push — that would create duplicates server-side.
+      const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
+      (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
+      (habitsApi.list as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 99,
+          name: 'Pranayama',
+          icon: cachedHabit.icon,
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(habitsApi.create).not.toHaveBeenCalled();
+    });
+
     it('uses cached habits when available and then replaces with API data', async () => {
       const cached: Habit[] = [makeHabit({ id: 99, name: 'Cached' })];
       (loadHabits as jest.Mock).mockResolvedValueOnce(cached as never);
@@ -245,6 +312,71 @@ describe('habitManager', () => {
       const stretch = goals.find((g) => g.tier === 'stretch')!;
       expect(clear.target).toBeGreaterThanOrEqual(5);
       expect(stretch.target).toBeGreaterThanOrEqual(clear.target);
+    });
+
+    it('POSTs the goal change to /goals/{id} so edits survive the next load', async () => {
+      useHabitStore.setState({ habits: [makeHabit()] });
+
+      const updatedLow: Goal = {
+        id: 1,
+        title: 'Low',
+        tier: 'low',
+        target: 7,
+        target_unit: 'glasses',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      };
+
+      habitManager.updateGoal(1, updatedLow);
+      await Promise.resolve();
+
+      expect(goalsApi.update).toHaveBeenCalledWith(1, expect.objectContaining({ target: 7 }));
+    });
+
+    it('rolls the store back when the API rejects the goal update', async () => {
+      const original = makeHabit();
+      const baseline = [original];
+      useHabitStore.setState({ habits: baseline });
+      (goalsApi.update as jest.Mock).mockRejectedValueOnce(new Error('server down') as never);
+
+      const edited: Goal = {
+        ...original.goals.find((g) => g.tier === 'low')!,
+        target: 99,
+      };
+
+      habitManager.updateGoal(1, edited);
+      // Optimistic write lands first.
+      expect(useHabitStore.getState().habits[0]!.goals.find((g) => g.tier === 'low')!.target).toBe(
+        99,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Rollback restores the baseline target.
+      expect(useHabitStore.getState().habits[0]!.goals.find((g) => g.tier === 'low')!.target).toBe(
+        1,
+      );
+    });
+
+    it('skips the network call for synthetic goals with no id', async () => {
+      useHabitStore.setState({ habits: [makeHabit()] });
+
+      const synthetic: Goal = {
+        // Intentionally omit ``id`` to mimic an unsynced cache entry.
+        title: 'Low',
+        tier: 'low',
+        target: 7,
+        target_unit: 'units',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      } as unknown as Goal;
+
+      habitManager.updateGoal(1, synthetic);
+      await Promise.resolve();
+
+      expect(goalsApi.update).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -314,7 +314,7 @@ describe('habitManager', () => {
       expect(stretch.target).toBeGreaterThanOrEqual(clear.target);
     });
 
-    it('POSTs the goal change to /goals/{id} so edits survive the next load', async () => {
+    it('PUTs the goal change to /goals/{id} so edits survive the next load', async () => {
       useHabitStore.setState({ habits: [makeHabit()] });
 
       const updatedLow: Goal = {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -345,14 +345,7 @@ const fetchFromApi = async (hasCachedData: boolean): Promise<FetchResult> => {
   }
 };
 
-/**
- * Stuck-user recovery: when a user's original ``syncOnboardingHabits`` failed
- * silently long ago (e.g. against the broken pre-#280 schema), their cache
- * holds habits with synthetic ids while the server has none -- every log
- * POST 404s. Push the cached habits back to ``/habits/`` so the server now
- * has them with real autoincrement ids; the caller re-fetches to refresh
- * the local store.
- */
+/** Re-push cached habits when the server has none — the caller re-fetches. */
 const recoverStuckHabits = async (cached: Habit[]): Promise<void> => {
   for (const habit of cached) {
     try {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -10,8 +10,12 @@
 import { Alert } from 'react-native';
 import { v4 as uuidv4 } from 'uuid';
 
-import { habits as habitsApi, goalCompletions as goalCompletionsApi } from '../../../api';
-import type { CheckInResult, HabitCreatePayload } from '../../../api';
+import {
+  habits as habitsApi,
+  goalCompletions as goalCompletionsApi,
+  goals as goalsApi,
+} from '../../../api';
+import type { CheckInResult, GoalUpdatePayload, HabitCreatePayload } from '../../../api';
 import { formatApiError } from '../../../api/errorMessages';
 import type { ToastConfig } from '../../../components/Toast';
 import { colors } from '../../../design/tokens';
@@ -327,13 +331,35 @@ const handleApiError = (err: unknown, hasCachedData: boolean): void => {
   setHabits(FALLBACK_HABITS);
 };
 
-const fetchFromApi = async (hasCachedData: boolean): Promise<void> => {
+type FetchResult = { kind: 'ok'; count: number } | { kind: 'error' };
+
+const fetchFromApi = async (hasCachedData: boolean): Promise<FetchResult> => {
   try {
     const apiHabits = await habitsApi.list();
     await handleApiSuccess(apiHabits, hasCachedData);
     setError(null);
+    return { kind: 'ok', count: apiHabits.length };
   } catch (err) {
     handleApiError(err, hasCachedData);
+    return { kind: 'error' };
+  }
+};
+
+/**
+ * Stuck-user recovery: when a user's original ``syncOnboardingHabits`` failed
+ * silently long ago (e.g. against the broken pre-#280 schema), their cache
+ * holds habits with synthetic ids while the server has none -- every log
+ * POST 404s. Push the cached habits back to ``/habits/`` so the server now
+ * has them with real autoincrement ids; the caller re-fetches to refresh
+ * the local store.
+ */
+const recoverStuckHabits = async (cached: Habit[]): Promise<void> => {
+  for (const habit of cached) {
+    try {
+      await habitsApi.create(toApiPayload(habit));
+    } catch {
+      // Best-effort; partial recovery is still better than the stuck state.
+    }
   }
 };
 
@@ -392,19 +418,24 @@ const loadHabits = async (): Promise<void> => {
   const cached = await loadCachedHabits();
   const hasCachedData = cached !== null && cached.length > 0;
   if (hasCachedData) {
-    setHabits(cached);
+    setHabits(cached!);
     setLoading(false);
   }
-  await fetchFromApi(hasCachedData);
+  const result = await fetchFromApi(hasCachedData);
+  // Stuck-user recovery: cache has habits, server returned an empty list.
+  // Push the cache back, then re-fetch so the store gets the server's ids.
+  if (result.kind === 'ok' && result.count === 0 && hasCachedData) {
+    await recoverStuckHabits(cached!);
+    await fetchFromApi(true);
+  }
   setLoading(false);
 
-  // BUG-HABITS-007 + BUG-FE-HABIT-205 partial-success fix: replay
-  // pending check-ins queued during offline, and when one fails mid-
-  // batch only re-queue the suffix that didn't post. The previous
-  // implementation `return`ed from the first failure with the
-  // successful prefix still in the queue, so on the next load every
-  // check-in that had already posted would post AGAIN — silent
-  // duplication of the user's streak.
+  // BUG-HABITS-007 + BUG-FE-HABIT-205 partial-success fix: replay pending
+  // check-ins queued during offline, and when one fails mid-batch only re-
+  // queue the suffix that didn't post. The previous implementation
+  // ``return``-ed from the first failure with the successful prefix still
+  // in the queue, so on the next load every check-in that had already
+  // posted would post AGAIN — silent duplication of the user's streak.
   await replayPendingCheckIns();
 };
 
@@ -412,7 +443,33 @@ export const habitManager = {
   loadHabits,
 
   updateGoal: (habitId: number, updatedGoal: Goal): void => {
-    setHabits(applyGoalUpdate(getHabits(), habitId, updatedGoal));
+    const prev = getHabits();
+    const next = applyGoalUpdate(prev, habitId, updatedGoal);
+    setHabits(next);
+    void persistHabits(next);
+    // The optimistic write above + the local-only fallback for synthetic
+    // ids (no ``id`` from the server) keep the UI responsive. With a real
+    // id we POST to ``/goals/{id}`` and roll the store back if the wire
+    // rejects the change — same pattern as ``updateHabit``.
+    if (!updatedGoal.id) return;
+    const payload: GoalUpdatePayload = {
+      title: updatedGoal.title,
+      tier: updatedGoal.tier,
+      target: updatedGoal.target,
+      target_unit: updatedGoal.target_unit,
+      frequency: updatedGoal.frequency,
+      frequency_unit: updatedGoal.frequency_unit,
+      is_additive: updatedGoal.is_additive,
+      goal_group_id: updatedGoal.goal_group_id ?? null,
+    };
+    goalsApi
+      .update(updatedGoal.id, payload)
+      .catch(
+        revertOnFailure(
+          prev,
+          "We couldn't save that goal change. Your local copy was restored — check your connection and try again.",
+        ),
+      );
   },
 
   updateHabit: (updatedHabit: Habit): void => {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -349,9 +349,15 @@ const fetchFromApi = async (hasCachedData: boolean): Promise<FetchResult> => {
 const recoverStuckHabits = async (cached: Habit[]): Promise<void> => {
   for (const habit of cached) {
     try {
+      // ``POST /habits/`` seeds default goal targets (1/2/3 units / per day)
+      // — any custom targets in the cache are lost on the re-fetch. Tracked
+      // in #286; for now the previous "every log 404s" state is strictly
+      // worse than reverted defaults.
       await habitsApi.create(toApiPayload(habit));
-    } catch {
+    } catch (err) {
       // Best-effort; partial recovery is still better than the stuck state.
+      // Surface to console so Sentry / CI can flag chronic recovery failures.
+      console.warn('recoverStuckHabits: failed to re-push', habit.name, err);
     }
   }
 };


### PR DESCRIPTION
Two compounded bugs from the previous habit-fix series, plus the underlying root cause that made every newly-onboarded user fail the same way.

## Summary

### 1. Goal target / unit / additive edits never saved

PR #280 wired the inline goal editor in `GoalModal` to call `habitManager.updateGoal`, but that method only called `setHabits` against the local store — there was no API call. **The backend had no goal endpoint at all** (only `/habits`, `/goal-groups`, `/goal_completions`). Every edit landed in the store and got overwritten on the next `loadHabits`.

**Fix**: added `PUT /goals/{goal_id}` on the backend with the same ownership pattern as the other resources (collapses 404+403 per BUG-T7), a `goals.update` frontend client, and an optimistic POST + rollback in `habitManager.updateGoal`. Synthetic-id goals (no server id yet) skip the network call so they don't 404 — the recovery path below replaces them with real ids.

### 2. `goal_not_found` on every log attempt for everyone

The root cause was deeper than the previous PRs caught: `POST /habits/` created a habit and **zero goals** — there was no goal-creation API at all, and `syncOnboardingHabits` only POSTed habits. Every user's server-side state was "habits with empty goals," so every `POST /goal_completions/` 404'd against a synthetic local goal id that had never been written.

**Fix**: `POST /habits/` now seeds three default goals (low/clear/stretch, matching the frontend onboarding shape) and returns `HabitWithGoals` so the frontend's post-onboarding `loadHabits` round-trip immediately gets real goal ids.

### 3. Stuck-user recovery for `geoffega@gmail.com`-class users

Users who onboarded before #280 (against the broken Zod schema) have synthetic-id habits in their AsyncStorage cache and zero habits server-side because their original `syncOnboardingHabits` failed silently. Without recovery, they stay stuck forever.

**Fix**: `loadHabits` now detects `cached.length > 0 && api.length === 0`, re-runs the sync push for each cached habit, then re-fetches. The second GET returns the freshly-created habits (with the auto-seeded goals from change 2) and the local store flips out of the synthetic state.

## Test plan
- [x] `pytest` — 816 backend tests pass at 94% coverage (+7 new)
- [x] `npm test` — 792 frontend tests pass (+6 new)
- [x] `pre-commit run --all-files --hook-stage push` — green (lint, typecheck, mypy, xenon, radon, prettier)
- [ ] Manual on `geoffega@gmail.com`'s account: open the app → loadHabits sees stuck state → recovery push fires → habits reload with real ids → tap Pranayama → tap Log Units → confirmation toast (not `goal_not_found`) → tap a goal target input → focus, no dismiss → edit + blur → server PUT lands

## Tests added

**Backend (`tests/test_goals_api.py`, 6 tests):**
- `test_update_goal_requires_auth`
- `test_update_goal_404_when_goal_missing`
- `test_update_goal_403_when_caller_not_owner` (cross-tenant probe)
- `test_update_goal_persists_target`
- `test_update_goal_persists_target_unit_frequency_and_is_additive` (full editor surface)
- `test_update_goal_does_not_change_habit_id` (rejects forged `habit_id`)

**Backend (`tests/test_habits_api.py`):**
- `test_create_habit_seeds_three_default_goals` — pins the auto-seed contract.
- Updated `test_get_habit_includes_goals`, `test_list_habits_includes_goals`, `test_delete_habit_logs_cascade_counts` for the new "always at least 3 goals per habit" invariant.

**Frontend (`api/__tests__/habits-api.test.ts`):**
- `goals.update sends PUT to /goals/{id} with the editor payload`
- `goals.update throws ApiError when the goal does not exist`

**Frontend (`features/Habits/services/__tests__/habitManager.test.ts`, 5 tests):**
- `updateGoal POSTs the goal change to /goals/{id} so edits survive the next load`
- `updateGoal rolls the store back when the API rejects the goal update`
- `updateGoal skips the network call for synthetic goals with no id`
- `loadHabits recovers stuck users by pushing cached habits when the server has none`
- `loadHabits does NOT push cached habits when the server already has habits`

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017u8pnqhFZEk6y6r2iNHYL8)_