### PR TITLE
fix(habits): persist emoji + reorder, add goal frequency/unit editor

### DIFF
--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -19,6 +19,13 @@ export interface Habit {
   notificationFrequency?: 'daily' | 'weekly' | 'custom' | 'off';
   notificationDays?: string[];
   milestoneNotifications?: boolean;
+  /**
+   * Persisted display order. The list endpoint sorts ascending by this
+   * value, so the reorder modal needs to write it back through ``PUT
+   * /habits/{id}`` for the order to survive a logout. ``null`` means
+   * "unordered" — the backend buckets nulls last in ascending sort.
+   */
+  sort_order?: number | null;
 
   // --- Client-only fields (not from API) ---
   /**

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -520,7 +520,9 @@ const formatUnitLabel = (value: string): string => value.replace(/_/g, ' ');
  *
  * Each chip is exposed to assistive tech as a radio button — selection is
  * mutually exclusive within a row, so ``role="radio"`` + ``checked`` is the
- * accurate semantic, not a generic button toggle.
+ * accurate semantic, not a generic button toggle. The accessible name is
+ * pinned to the formatted label so VoiceOver / TalkBack announce e.g.
+ * "per day" rather than reading the raw "per_day" backend token.
  */
 const UnitChipRow = ({ options, selected, testID, onSelect }: UnitChipRowProps) => (
   <ScrollView
@@ -531,6 +533,7 @@ const UnitChipRow = ({ options, selected, testID, onSelect }: UnitChipRowProps) 
   >
     {options.map((opt) => {
       const isSelected = opt === selected;
+      const label = formatUnitLabel(opt);
       return (
         <TouchableOpacity
           key={opt}
@@ -538,30 +541,19 @@ const UnitChipRow = ({ options, selected, testID, onSelect }: UnitChipRowProps) 
           onPress={() => onSelect(opt)}
           style={[goalEditorStyles.chip, isSelected && goalEditorStyles.chipSelected]}
           accessibilityRole="radio"
+          accessibilityLabel={label}
           accessibilityState={{ checked: isSelected }}
         >
           <Text
             style={[goalEditorStyles.chipText, isSelected && goalEditorStyles.chipTextSelected]}
           >
-            {formatUnitLabel(opt)}
+            {label}
           </Text>
         </TouchableOpacity>
       );
     })}
   </ScrollView>
 );
-
-interface GoalUnitEditorProps {
-  /**
-   * All tier goals belonging to the habit. Any one is a valid display
-   * reference (units are normalized across tiers), but every commit fans
-   * out a PUT for each goal so the backend rows stay in lockstep with the
-   * client's normalized state.
-   */
-  goals: NonEmptyGoals;
-  habitId: number;
-  onUpdateGoal: GoalModalProps['onUpdateGoal'];
-}
 
 /**
  * Tier goals are constructed from the same fixed `TIER_ORDER` (`low`,
@@ -571,6 +563,18 @@ interface GoalUnitEditorProps {
  * honest if they ever try to pass `[]`.
  */
 type NonEmptyGoals = [Goal, ...Goal[]];
+
+interface GoalUnitEditorProps {
+  /**
+   * All tier goals belonging to the habit. Any one is a valid display
+   * reference (units are normalized across tiers via ``normalizeGoalUnits``),
+   * but every commit fans out a PUT for each goal so the backend rows
+   * stay in lockstep with the client's normalized state.
+   */
+  goals: NonEmptyGoals;
+  habitId: number;
+  onUpdateGoal: GoalModalProps['onUpdateGoal'];
+}
 
 interface FrequencyInputProps {
   draft: string;

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -558,20 +558,20 @@ interface GoalUnitEditorProps {
    * out a PUT for each goal so the backend rows stay in lockstep with the
    * client's normalized state.
    */
-  goals: Goal[];
+  goals: NonEmptyGoals;
   habitId: number;
   onUpdateGoal: GoalModalProps['onUpdateGoal'];
 }
 
 /**
- * Edits ``target_unit`` / ``frequency`` / ``frequency_unit`` for a habit's
- * goals. The fields are shared across tiers (``normalizeGoalUnits``
- * propagates a single edit to all three), so the editor surfaces them once
- * — but ``onUpdateGoal`` only PUTs the goal whose id is sent, so a commit
- * fans out one update per tier. Without the fan-out, the ``clear`` and
- * ``stretch`` rows would stay on their old units server-side even though
- * the local store displays them as normalized.
+ * Tier goals are constructed from the same fixed `TIER_ORDER` (`low`,
+ * `clear`, `stretch`) at habit creation, so the array always has at
+ * least one element. Encoding the non-empty contract in the type lets
+ * `goals[0]` resolve as `Goal` (no `!` assertion) and keeps callers
+ * honest if they ever try to pass `[]`.
  */
+type NonEmptyGoals = [Goal, ...Goal[]];
+
 interface FrequencyInputProps {
   draft: string;
   setDraft: (_v: string) => void;
@@ -590,8 +590,17 @@ const FrequencyInput = ({ draft, setDraft, onEnd }: FrequencyInputProps) => (
   />
 );
 
+/**
+ * Edits ``target_unit`` / ``frequency`` / ``frequency_unit`` for a habit's
+ * goals. The fields are shared across tiers (``normalizeGoalUnits``
+ * propagates a single edit to all three), so the editor surfaces them once
+ * — but ``onUpdateGoal`` only PUTs the goal whose id is sent, so a commit
+ * fans out one update per tier. Without the fan-out, the ``clear`` and
+ * ``stretch`` rows would stay on their old units server-side even though
+ * the local store displays them as normalized.
+ */
 const GoalUnitEditor = ({ goals, habitId, onUpdateGoal }: GoalUnitEditorProps) => {
-  const reference = goals[0]!;
+  const reference = goals[0];
   const [freqDraft, setFreqDraft] = useState(String(reference.frequency));
   useEffect(() => {
     setFreqDraft(String(reference.frequency));
@@ -658,18 +667,20 @@ const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
   const orderedGoals = TIER_ORDER.map((tier) => habit.goals.find((g) => g.tier === tier)).filter(
     (g): g is Goal => g !== undefined,
   );
-  if (orderedGoals.length === 0) return null;
+  const [head, ...tail] = orderedGoals;
+  if (head === undefined) return null;
+  const nonEmptyGoals: NonEmptyGoals = [head, ...tail];
   return (
     <View style={goalEditorStyles.container} testID="goal-target-editor">
       <Text style={goalEditorStyles.sectionTitle}>Goals</Text>
-      {orderedGoals.map((goal) => (
+      {nonEmptyGoals.map((goal) => (
         <GoalTargetRow
           key={goal.id ?? goal.tier}
           goal={goal}
           onCommit={(target) => onUpdateGoal(habitId, { ...goal, target })}
         />
       ))}
-      <GoalUnitEditor goals={orderedGoals} habitId={habitId} onUpdateGoal={onUpdateGoal} />
+      <GoalUnitEditor goals={nonEmptyGoals} habitId={habitId} onUpdateGoal={onUpdateGoal} />
     </View>
   );
 };

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -435,7 +435,7 @@ const goalEditorStyles = StyleSheet.create({
     color: colors.text.secondary,
   },
   chipTextSelected: {
-    color: '#fff',
+    color: colors.text.light,
     fontWeight: '600',
   },
   freqInput: {
@@ -517,6 +517,10 @@ const formatUnitLabel = (value: string): string => value.replace(/_/g, ' ');
  * A chip set fits the existing modal aesthetic without pulling in
  * ``@react-native-picker/picker``, and lets the user see all options in
  * one swipe rather than a modal-on-top-of-modal native picker.
+ *
+ * Each chip is exposed to assistive tech as a radio button — selection is
+ * mutually exclusive within a row, so ``role="radio"`` + ``checked`` is the
+ * accurate semantic, not a generic button toggle.
  */
 const UnitChipRow = ({ options, selected, testID, onSelect }: UnitChipRowProps) => (
   <ScrollView
@@ -533,8 +537,8 @@ const UnitChipRow = ({ options, selected, testID, onSelect }: UnitChipRowProps) 
           testID={`${testID}-${opt}`}
           onPress={() => onSelect(opt)}
           style={[goalEditorStyles.chip, isSelected && goalEditorStyles.chipSelected]}
-          accessibilityRole="button"
-          accessibilityState={{ selected: isSelected }}
+          accessibilityRole="radio"
+          accessibilityState={{ checked: isSelected }}
         >
           <Text
             style={[goalEditorStyles.chipText, isSelected && goalEditorStyles.chipTextSelected]}
@@ -548,8 +552,13 @@ const UnitChipRow = ({ options, selected, testID, onSelect }: UnitChipRowProps) 
 );
 
 interface GoalUnitEditorProps {
-  /** Reference goal — units are normalized across tiers, so any tier works. */
-  reference: Goal;
+  /**
+   * All tier goals belonging to the habit. Any one is a valid display
+   * reference (units are normalized across tiers), but every commit fans
+   * out a PUT for each goal so the backend rows stay in lockstep with the
+   * client's normalized state.
+   */
+  goals: Goal[];
   habitId: number;
   onUpdateGoal: GoalModalProps['onUpdateGoal'];
 }
@@ -558,17 +567,40 @@ interface GoalUnitEditorProps {
  * Edits ``target_unit`` / ``frequency`` / ``frequency_unit`` for a habit's
  * goals. The fields are shared across tiers (``normalizeGoalUnits``
  * propagates a single edit to all three), so the editor surfaces them once
- * rather than per-tier — closes the "no way to edit goal frequency and
- * unit" gap reported by users.
+ * — but ``onUpdateGoal`` only PUTs the goal whose id is sent, so a commit
+ * fans out one update per tier. Without the fan-out, the ``clear`` and
+ * ``stretch`` rows would stay on their old units server-side even though
+ * the local store displays them as normalized.
  */
-const GoalUnitEditor = ({ reference, habitId, onUpdateGoal }: GoalUnitEditorProps) => {
+interface FrequencyInputProps {
+  draft: string;
+  setDraft: (_v: string) => void;
+  onEnd: () => void;
+}
+
+const FrequencyInput = ({ draft, setDraft, onEnd }: FrequencyInputProps) => (
+  <TextInput
+    testID="goal-frequency-input"
+    style={goalEditorStyles.freqInput}
+    value={draft}
+    onChangeText={setDraft}
+    onEndEditing={onEnd}
+    keyboardType="numeric"
+    returnKeyType="done"
+  />
+);
+
+const GoalUnitEditor = ({ goals, habitId, onUpdateGoal }: GoalUnitEditorProps) => {
+  const reference = goals[0]!;
   const [freqDraft, setFreqDraft] = useState(String(reference.frequency));
   useEffect(() => {
     setFreqDraft(String(reference.frequency));
   }, [reference.frequency]);
 
   const commit = (changes: Partial<Pick<Goal, 'target_unit' | 'frequency' | 'frequency_unit'>>) => {
-    onUpdateGoal(habitId, { ...reference, ...changes });
+    for (const goal of goals) {
+      onUpdateGoal(habitId, { ...goal, ...changes });
+    }
   };
 
   const handleFreqEnd = () => {
@@ -593,15 +625,7 @@ const GoalUnitEditor = ({ reference, habitId, onUpdateGoal }: GoalUnitEditorProp
       </View>
       <View style={goalEditorStyles.row}>
         <Text style={goalEditorStyles.fieldLabel}>Every</Text>
-        <TextInput
-          testID="goal-frequency-input"
-          style={goalEditorStyles.freqInput}
-          value={freqDraft}
-          onChangeText={setFreqDraft}
-          onEndEditing={handleFreqEnd}
-          keyboardType="numeric"
-          returnKeyType="done"
-        />
+        <FrequencyInput draft={freqDraft} setDraft={setFreqDraft} onEnd={handleFreqEnd} />
         <UnitChipRow
           options={FREQUENCY_UNITS}
           selected={reference.frequency_unit}
@@ -635,9 +659,6 @@ const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
     (g): g is Goal => g !== undefined,
   );
   if (orderedGoals.length === 0) return null;
-  // Units / frequency are normalized across tiers, so any tier is a valid
-  // reference for the shared editor — pick the first one in tier order.
-  const reference = orderedGoals[0]!;
   return (
     <View style={goalEditorStyles.container} testID="goal-target-editor">
       <Text style={goalEditorStyles.sectionTitle}>Goals</Text>
@@ -648,7 +669,7 @@ const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
           onCommit={(target) => onUpdateGoal(habitId, { ...goal, target })}
         />
       ))}
-      <GoalUnitEditor reference={reference} habitId={habitId} onUpdateGoal={onUpdateGoal} />
+      <GoalUnitEditor goals={orderedGoals} habitId={habitId} onUpdateGoal={onUpdateGoal} />
     </View>
   );
 };

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Modal,
   Pressable,
+  ScrollView,
   Text,
   TextInput,
   TouchableOpacity,
@@ -21,6 +22,7 @@ import EmojiSelector from 'react-native-emoji-selector';
 
 import { goalGroups as goalGroupsApi, type ApiGoalGroup } from '../../../api';
 import { colors, SPACING, STAGE_COLORS } from '../../../design/tokens';
+import { TARGET_UNITS, FREQUENCY_UNITS } from '../constants';
 import styles from '../Habits.styles';
 import type { GoalModalProps, Goal } from '../Habits.types';
 import {
@@ -357,6 +359,12 @@ const GOAL_LABEL_FONT_SIZE = 14;
 const GOAL_INPUT_FONT_SIZE = 15;
 const GOAL_UNIT_FONT_SIZE = 13;
 const GOAL_SECTION_TITLE_LETTER_SPACING = 0.5;
+const GOAL_FIELD_LABEL_FONT_SIZE = 12;
+const GOAL_CHIP_VERTICAL_PADDING = 4;
+const GOAL_CHIP_HORIZONTAL_PADDING = 10;
+const GOAL_CHIP_BORDER_RADIUS = 14;
+const GOAL_CHIP_FONT_SIZE = 12;
+const GOAL_FREQ_INPUT_WIDTH = 56;
 
 const goalEditorStyles = StyleSheet.create({
   container: {
@@ -399,6 +407,47 @@ const goalEditorStyles = StyleSheet.create({
     fontSize: GOAL_UNIT_FONT_SIZE,
     color: colors.text.secondary,
     minWidth: GOAL_UNIT_MIN_WIDTH,
+  },
+  fieldLabel: {
+    fontSize: GOAL_FIELD_LABEL_FONT_SIZE,
+    color: colors.text.secondary,
+    marginRight: SPACING.sm,
+    minWidth: GOAL_UNIT_MIN_WIDTH,
+  },
+  chipRow: {
+    paddingVertical: SPACING.xs,
+  },
+  chip: {
+    paddingVertical: GOAL_CHIP_VERTICAL_PADDING,
+    paddingHorizontal: GOAL_CHIP_HORIZONTAL_PADDING,
+    borderRadius: GOAL_CHIP_BORDER_RADIUS,
+    borderWidth: 1,
+    borderColor: colors.border,
+    marginRight: SPACING.xs,
+    backgroundColor: 'transparent',
+  },
+  chipSelected: {
+    backgroundColor: colors.tier.clear,
+    borderColor: colors.tier.clear,
+  },
+  chipText: {
+    fontSize: GOAL_CHIP_FONT_SIZE,
+    color: colors.text.secondary,
+  },
+  chipTextSelected: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  freqInput: {
+    width: GOAL_FREQ_INPUT_WIDTH,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: GOAL_INPUT_BORDER_RADIUS,
+    paddingVertical: GOAL_INPUT_VERTICAL_PADDING,
+    paddingHorizontal: SPACING.sm,
+    textAlign: 'center',
+    fontSize: GOAL_INPUT_FONT_SIZE,
+    marginRight: SPACING.sm,
   },
 });
 
@@ -454,6 +503,116 @@ const GoalTargetRow = ({ goal, onCommit }: GoalTargetRowProps) => {
   );
 };
 
+interface UnitChipRowProps {
+  options: readonly string[];
+  selected: string;
+  testID: string;
+  onSelect: (_value: string) => void;
+}
+
+const formatUnitLabel = (value: string): string => value.replace(/_/g, ' ');
+
+/**
+ * Horizontal chip selector used for ``target_unit`` and ``frequency_unit``.
+ * A chip set fits the existing modal aesthetic without pulling in
+ * ``@react-native-picker/picker``, and lets the user see all options in
+ * one swipe rather than a modal-on-top-of-modal native picker.
+ */
+const UnitChipRow = ({ options, selected, testID, onSelect }: UnitChipRowProps) => (
+  <ScrollView
+    horizontal
+    showsHorizontalScrollIndicator={false}
+    style={goalEditorStyles.chipRow}
+    testID={testID}
+  >
+    {options.map((opt) => {
+      const isSelected = opt === selected;
+      return (
+        <TouchableOpacity
+          key={opt}
+          testID={`${testID}-${opt}`}
+          onPress={() => onSelect(opt)}
+          style={[goalEditorStyles.chip, isSelected && goalEditorStyles.chipSelected]}
+          accessibilityRole="button"
+          accessibilityState={{ selected: isSelected }}
+        >
+          <Text
+            style={[goalEditorStyles.chipText, isSelected && goalEditorStyles.chipTextSelected]}
+          >
+            {formatUnitLabel(opt)}
+          </Text>
+        </TouchableOpacity>
+      );
+    })}
+  </ScrollView>
+);
+
+interface GoalUnitEditorProps {
+  /** Reference goal — units are normalized across tiers, so any tier works. */
+  reference: Goal;
+  habitId: number;
+  onUpdateGoal: GoalModalProps['onUpdateGoal'];
+}
+
+/**
+ * Edits ``target_unit`` / ``frequency`` / ``frequency_unit`` for a habit's
+ * goals. The fields are shared across tiers (``normalizeGoalUnits``
+ * propagates a single edit to all three), so the editor surfaces them once
+ * rather than per-tier — closes the "no way to edit goal frequency and
+ * unit" gap reported by users.
+ */
+const GoalUnitEditor = ({ reference, habitId, onUpdateGoal }: GoalUnitEditorProps) => {
+  const [freqDraft, setFreqDraft] = useState(String(reference.frequency));
+  useEffect(() => {
+    setFreqDraft(String(reference.frequency));
+  }, [reference.frequency]);
+
+  const commit = (changes: Partial<Pick<Goal, 'target_unit' | 'frequency' | 'frequency_unit'>>) => {
+    onUpdateGoal(habitId, { ...reference, ...changes });
+  };
+
+  const handleFreqEnd = () => {
+    const parsed = Number.parseFloat(freqDraft);
+    if (!Number.isFinite(parsed) || parsed <= 0 || parsed === reference.frequency) {
+      setFreqDraft(String(reference.frequency));
+      return;
+    }
+    commit({ frequency: parsed });
+  };
+
+  return (
+    <View testID="goal-unit-editor">
+      <View style={goalEditorStyles.row}>
+        <Text style={goalEditorStyles.fieldLabel}>Unit</Text>
+        <UnitChipRow
+          options={TARGET_UNITS}
+          selected={reference.target_unit}
+          testID="goal-target-unit"
+          onSelect={(value) => commit({ target_unit: value })}
+        />
+      </View>
+      <View style={goalEditorStyles.row}>
+        <Text style={goalEditorStyles.fieldLabel}>Every</Text>
+        <TextInput
+          testID="goal-frequency-input"
+          style={goalEditorStyles.freqInput}
+          value={freqDraft}
+          onChangeText={setFreqDraft}
+          onEndEditing={handleFreqEnd}
+          keyboardType="numeric"
+          returnKeyType="done"
+        />
+        <UnitChipRow
+          options={FREQUENCY_UNITS}
+          selected={reference.frequency_unit}
+          testID="goal-frequency-unit"
+          onSelect={(value) => commit({ frequency_unit: value })}
+        />
+      </View>
+    </View>
+  );
+};
+
 interface GoalTargetEditorProps {
   habit: NonNullable<GoalModalProps['habit']>;
   onUpdateGoal: GoalModalProps['onUpdateGoal'];
@@ -476,6 +635,9 @@ const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
     (g): g is Goal => g !== undefined,
   );
   if (orderedGoals.length === 0) return null;
+  // Units / frequency are normalized across tiers, so any tier is a valid
+  // reference for the shared editor — pick the first one in tier order.
+  const reference = orderedGoals[0]!;
   return (
     <View style={goalEditorStyles.container} testID="goal-target-editor">
       <Text style={goalEditorStyles.sectionTitle}>Goals</Text>
@@ -486,6 +648,7 @@ const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
           onCommit={(target) => onUpdateGoal(habitId, { ...goal, target })}
         />
       ))}
+      <GoalUnitEditor reference={reference} habitId={habitId} onUpdateGoal={onUpdateGoal} />
     </View>
   );
 };

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -1,0 +1,214 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+// EmojiSelector pulls in native bindings; render a stub.
+jest.mock('react-native-emoji-selector', () => () => null);
+
+jest.mock('../../../../api', () => ({
+  __esModule: true,
+  goalGroups: {
+    get: jest.fn(() => Promise.resolve(null)),
+  },
+}));
+
+// Use real RN primitives — no global ``react-native`` mock — so
+// fireEvent.changeText / press behave as on a real device.
+
+import type { Goal, Habit } from '../../Habits.types';
+import { GoalModal } from '../GoalModal';
+
+const makeGoal = (tier: 'low' | 'clear' | 'stretch', overrides: Partial<Goal> = {}): Goal => ({
+  id: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  title: `${tier} goal`,
+  tier,
+  target: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  target_unit: 'units',
+  frequency: 1,
+  frequency_unit: 'per_day',
+  is_additive: true,
+  ...overrides,
+});
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 42,
+  stage: 'Beige',
+  name: 'Meditation',
+  icon: '🧘',
+  streak: 0,
+  energy_cost: 1,
+  energy_return: 2,
+  start_date: new Date('2025-01-01'),
+  goals: [makeGoal('low'), makeGoal('clear'), makeGoal('stretch')],
+  completions: [],
+  revealed: true,
+  ...overrides,
+});
+
+const renderModal = (
+  habit: Habit | null = makeHabit(),
+  overrides: Partial<React.ComponentProps<typeof GoalModal>> = {},
+) => {
+  const props = {
+    visible: true,
+    habit,
+    onClose: jest.fn(),
+    onUpdateGoal: jest.fn(),
+    onLogUnit: jest.fn(),
+    onUpdateHabit: jest.fn(),
+    ...overrides,
+  };
+  return { ...render(<GoalModal {...props} />), props };
+};
+
+describe('GoalModal goal-target editor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the inline goal-target editor when the habit has goals and an id', () => {
+    const { getByTestId } = renderModal();
+    expect(getByTestId('goal-target-editor')).toBeTruthy();
+    expect(getByTestId('goal-unit-editor')).toBeTruthy();
+  });
+
+  it('commits the per-tier numeric target on blur', () => {
+    const { getByTestId, props } = renderModal();
+    const input = getByTestId('goal-target-input-low');
+    fireEvent.changeText(input, '7');
+    fireEvent(input, 'endEditing');
+    expect(props.onUpdateGoal).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ tier: 'low', target: 7 }),
+    );
+  });
+
+  it('reverts the draft and skips the commit when the target input is non-numeric', () => {
+    const { getByTestId, props } = renderModal();
+    const input = getByTestId('goal-target-input-low');
+    fireEvent.changeText(input, 'abc');
+    fireEvent(input, 'endEditing');
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
+  });
+
+  it('skips the commit when the target input matches the current value', () => {
+    const { getByTestId, props } = renderModal();
+    const input = getByTestId('goal-target-input-low');
+    fireEvent.changeText(input, '1'); // already 1
+    fireEvent(input, 'endEditing');
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
+  });
+});
+
+describe('GoalModal unit + frequency editor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fans out a target_unit change to ALL three tier goals', () => {
+    // Regression guard for the reviewer-flagged bug: a unit edit must
+    // PUT every tier so the backend rows stay in lockstep with the
+    // locally-normalized state, not just the reference (low) tier.
+    const { getByTestId, props } = renderModal();
+    fireEvent.press(getByTestId('goal-target-unit-minutes'));
+
+    expect(props.onUpdateGoal).toHaveBeenCalledTimes(3);
+    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
+      1,
+      42,
+      expect.objectContaining({ tier: 'low', target_unit: 'minutes' }),
+    );
+    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
+      2,
+      42,
+      expect.objectContaining({ tier: 'clear', target_unit: 'minutes' }),
+    );
+    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
+      3,
+      42,
+      expect.objectContaining({ tier: 'stretch', target_unit: 'minutes' }),
+    );
+  });
+
+  it('fans out a frequency_unit change to ALL three tier goals', () => {
+    const { getByTestId, props } = renderModal();
+    fireEvent.press(getByTestId('goal-frequency-unit-per_week'));
+
+    expect(props.onUpdateGoal).toHaveBeenCalledTimes(3);
+    for (const tier of ['low', 'clear', 'stretch'] as const) {
+      expect(props.onUpdateGoal).toHaveBeenCalledWith(
+        42,
+        expect.objectContaining({ tier, frequency_unit: 'per_week' }),
+      );
+    }
+  });
+
+  it('commits a numeric frequency change on blur', () => {
+    const { getByTestId, props } = renderModal();
+    const input = getByTestId('goal-frequency-input');
+    fireEvent.changeText(input, '3');
+    fireEvent(input, 'endEditing');
+
+    expect(props.onUpdateGoal).toHaveBeenCalledTimes(3);
+    for (const tier of ['low', 'clear', 'stretch'] as const) {
+      expect(props.onUpdateGoal).toHaveBeenCalledWith(
+        42,
+        expect.objectContaining({ tier, frequency: 3 }),
+      );
+    }
+  });
+
+  it('drops a non-finite frequency without firing onUpdateGoal', () => {
+    const { getByTestId, props } = renderModal();
+    const input = getByTestId('goal-frequency-input');
+    fireEvent.changeText(input, 'abc');
+    fireEvent(input, 'endEditing');
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
+  });
+
+  it('drops a zero or negative frequency (positivity invariant)', () => {
+    const { getByTestId, props } = renderModal();
+    const input = getByTestId('goal-frequency-input');
+    fireEvent.changeText(input, '0');
+    fireEvent(input, 'endEditing');
+    fireEvent.changeText(input, '-2');
+    fireEvent(input, 'endEditing');
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
+  });
+
+  it('skips the commit when the frequency draft equals the current value', () => {
+    const { getByTestId, props } = renderModal();
+    const input = getByTestId('goal-frequency-input');
+    fireEvent.changeText(input, '1'); // already 1
+    fireEvent(input, 'endEditing');
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
+  });
+
+  it('marks the currently-selected unit chip as checked for screen readers', () => {
+    // Chips are mutually-exclusive radios, not generic toggle buttons —
+    // the accessibilityState must reflect ``checked`` so VoiceOver/
+    // TalkBack announce selection correctly.
+    const { getByTestId } = renderModal();
+    const selected = getByTestId('goal-target-unit-units');
+    const other = getByTestId('goal-target-unit-minutes');
+    expect(selected.props.accessibilityRole).toBe('radio');
+    expect(selected.props.accessibilityState).toEqual({ checked: true });
+    expect(other.props.accessibilityState).toEqual({ checked: false });
+  });
+});
+
+describe('GoalModal editor visibility guards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hides the editor when the habit has no id (synthetic onboarding state)', () => {
+    const { queryByTestId } = renderModal(makeHabit({ id: undefined as unknown as number }));
+    expect(queryByTestId('goal-target-editor')).toBeNull();
+  });
+
+  it('hides the editor when the habit has no goals', () => {
+    const { queryByTestId } = renderModal(makeHabit({ goals: [] }));
+    expect(queryByTestId('goal-target-editor')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -106,9 +106,10 @@ describe('GoalModal unit + frequency editor', () => {
   });
 
   it('fans out a target_unit change to ALL three tier goals', () => {
-    // Regression guard for the reviewer-flagged bug: a unit edit must
-    // PUT every tier so the backend rows stay in lockstep with the
-    // locally-normalized state, not just the reference (low) tier.
+    // Invariant: a unit edit must PUT every tier so the backend rows
+    // stay in lockstep with the locally-normalized state. ``onUpdateGoal``
+    // updates only the goal whose id is sent, so committing on the
+    // reference (low) tier alone leaves clear/stretch stale server-side.
     const { getByTestId, props } = renderModal();
     fireEvent.press(getByTestId('goal-target-unit-minutes'));
 

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -434,10 +434,10 @@ describe('habitManager', () => {
     });
 
     it('rolls back exactly once when any single PUT fails (consolidated Promise.all rollback)', async () => {
-      // Regression guard: the original implementation chained ``catch`` on
-      // every per-row PUT, so a 2-of-3 failure restored ``prev`` twice and
-      // clobbered the successful row. With ``Promise.all`` the first
-      // rejection triggers exactly one rollback.
+      // Invariant: a partial-failure reorder must restore the pre-write
+      // snapshot once and only once. Per-row ``.catch`` chains would
+      // restore ``prev`` per failure and clobber sibling writes that
+      // already landed in the store.
       const h1 = makeHabit({ id: 1, name: 'First' });
       const h2 = makeHabit({ id: 2, name: 'Second' });
       const original = [h1, h2];
@@ -735,6 +735,28 @@ describe('habitManager', () => {
 
       expect(useHabitStore.getState().habits[0]!.icon).toBe('A');
       expect(habitsApi.update).not.toHaveBeenCalled();
+    });
+
+    it('rolls the icon back when the API rejects the PUT', async () => {
+      // Invariant: an emoji edit is optimistic but must restore the
+      // previous icon (and the on-disk snapshot) when the server
+      // rejects the write — otherwise the next cold rehydrate diverges
+      // from the server state and the user keeps seeing an icon that
+      // isn't really persisted.
+      useHabitStore.setState({ habits: [makeHabit({ id: 1, icon: 'A' })] });
+      (habitsApi.update as jest.Mock).mockImplementationOnce(
+        () => Promise.reject(new Error('boom')) as never,
+      );
+
+      habitManager.setEmojiForHabit(0, '\u{2728}');
+      // Optimistic update lands first.
+      expect(useHabitStore.getState().habits[0]!.icon).toBe('\u{2728}');
+
+      // Let the rejected catch handler run.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(useHabitStore.getState().habits[0]!.icon).toBe('A');
+      expect(habitsApi.update).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -418,15 +418,19 @@ describe('habitManager', () => {
   });
 
   describe('saveHabitOrder', () => {
-    it('replaces habits and persists to storage', () => {
+    it('replaces habits, stamps sort_order, persists, and syncs each row to the API', () => {
       const h1 = makeHabit({ id: 1, name: 'First' });
       const h2 = makeHabit({ id: 2, name: 'Second' });
       useHabitStore.setState({ habits: [h1, h2] });
 
       habitManager.saveHabitOrder([h2, h1]);
 
-      expect(useHabitStore.getState().habits.map((h) => h.name)).toEqual(['Second', 'First']);
+      const stored = useHabitStore.getState().habits;
+      expect(stored.map((h) => h.name)).toEqual(['Second', 'First']);
+      expect(stored.map((h) => h.sort_order)).toEqual([0, 1]);
       expect(saveHabits).toHaveBeenCalled();
+      expect(habitsApi.update).toHaveBeenCalledWith(2, expect.objectContaining({ sort_order: 0 }));
+      expect(habitsApi.update).toHaveBeenCalledWith(1, expect.objectContaining({ sort_order: 1 }));
     });
   });
 
@@ -685,7 +689,7 @@ describe('habitManager', () => {
   });
 
   describe('setEmojiForHabit', () => {
-    it('updates the icon of the habit at the given index', () => {
+    it('updates the icon of the habit at the given index and syncs to the API', () => {
       useHabitStore.setState({
         habits: [makeHabit({ id: 1, icon: 'A' }), makeHabit({ id: 2, icon: 'B' })],
       });
@@ -694,6 +698,19 @@ describe('habitManager', () => {
 
       expect(useHabitStore.getState().habits[1]!.icon).toBe('\u{2728}');
       expect(useHabitStore.getState().habits[0]!.icon).toBe('A');
+      expect(habitsApi.update).toHaveBeenCalledWith(
+        2,
+        expect.objectContaining({ icon: '\u{2728}' }),
+      );
+    });
+
+    it('does nothing when the index is out of range', () => {
+      useHabitStore.setState({ habits: [makeHabit({ id: 1, icon: 'A' })] });
+
+      habitManager.setEmojiForHabit(7, '\u{2728}');
+
+      expect(useHabitStore.getState().habits[0]!.icon).toBe('A');
+      expect(habitsApi.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -432,6 +432,30 @@ describe('habitManager', () => {
       expect(habitsApi.update).toHaveBeenCalledWith(2, expect.objectContaining({ sort_order: 0 }));
       expect(habitsApi.update).toHaveBeenCalledWith(1, expect.objectContaining({ sort_order: 1 }));
     });
+
+    it('rolls back exactly once when any single PUT fails (consolidated Promise.all rollback)', async () => {
+      // Regression guard: the original implementation chained ``catch`` on
+      // every per-row PUT, so a 2-of-3 failure restored ``prev`` twice and
+      // clobbered the successful row. With ``Promise.all`` the first
+      // rejection triggers exactly one rollback.
+      const h1 = makeHabit({ id: 1, name: 'First' });
+      const h2 = makeHabit({ id: 2, name: 'Second' });
+      const original = [h1, h2];
+      useHabitStore.setState({ habits: original });
+      (habitsApi.update as jest.Mock)
+        .mockImplementationOnce(() => Promise.resolve({}) as never)
+        .mockImplementationOnce(() => Promise.reject(new Error('boom')) as never);
+
+      habitManager.saveHabitOrder([h2, h1]);
+      // Optimistic state lands first.
+      expect(useHabitStore.getState().habits.map((h) => h.name)).toEqual(['Second', 'First']);
+
+      // Let the rejected Promise.all settle.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Single rollback to the snapshot taken before the optimistic write.
+      expect(useHabitStore.getState().habits.map((h) => h.name)).toEqual(['First', 'Second']);
+    });
   });
 
   describe('logUnit primitives (apply / commit / rollback)', () => {

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -437,7 +437,9 @@ describe('habitManager', () => {
       // Invariant: a partial-failure reorder must restore the pre-write
       // snapshot once and only once. Per-row ``.catch`` chains would
       // restore ``prev`` per failure and clobber sibling writes that
-      // already landed in the store.
+      // already landed in the store. Restoration covers both the store
+      // AND the on-disk snapshot — a hot reload and a cold relaunch
+      // must agree with the rolled-back state.
       const h1 = makeHabit({ id: 1, name: 'First' });
       const h2 = makeHabit({ id: 2, name: 'Second' });
       const original = [h1, h2];
@@ -453,8 +455,17 @@ describe('habitManager', () => {
       // Let the rejected Promise.all settle.
       await new Promise((resolve) => setImmediate(resolve));
 
-      // Single rollback to the snapshot taken before the optimistic write.
+      // Single in-memory rollback to the snapshot taken before the
+      // optimistic write.
       expect(useHabitStore.getState().habits.map((h) => h.name)).toEqual(['First', 'Second']);
+      // AND the on-disk snapshot rolls back too, so a cold relaunch
+      // sees the same order as the in-memory store.
+      expect(saveHabits).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 1, name: 'First' }),
+          expect.objectContaining({ id: 2, name: 'Second' }),
+        ]),
+      );
     });
   });
 
@@ -737,26 +748,37 @@ describe('habitManager', () => {
       expect(habitsApi.update).not.toHaveBeenCalled();
     });
 
-    it('rolls the icon back when the API rejects the PUT', async () => {
-      // Invariant: an emoji edit is optimistic but must restore the
-      // previous icon (and the on-disk snapshot) when the server
-      // rejects the write — otherwise the next cold rehydrate diverges
-      // from the server state and the user keeps seeing an icon that
-      // isn't really persisted.
+    it('rolls the icon back IN MEMORY AND ON DISK when the API rejects the PUT', async () => {
+      // Invariant: an emoji edit is optimistic. The optimistic write
+      // lands in BOTH the in-memory store and AsyncStorage (so a hot
+      // reload reflects it). When the server rejects, the rollback
+      // must restore BOTH surfaces — without the on-disk rollback, a
+      // cold relaunch rehydrates the failed write and silently
+      // diverges from the server. That's the same cold-rehydrate
+      // failure mode this PR's emoji/order fixes set out to close.
       useHabitStore.setState({ habits: [makeHabit({ id: 1, icon: 'A' })] });
       (habitsApi.update as jest.Mock).mockImplementationOnce(
         () => Promise.reject(new Error('boom')) as never,
       );
 
       habitManager.setEmojiForHabit(0, '\u{2728}');
-      // Optimistic update lands first.
+      // Optimistic write hits both the store and the disk snapshot.
       expect(useHabitStore.getState().habits[0]!.icon).toBe('\u{2728}');
+      expect(saveHabits).toHaveBeenLastCalledWith(
+        expect.arrayContaining([expect.objectContaining({ id: 1, icon: '\u{2728}' })]),
+      );
 
       // Let the rejected catch handler run.
       await new Promise((resolve) => setImmediate(resolve));
 
+      // In-memory rollback.
       expect(useHabitStore.getState().habits[0]!.icon).toBe('A');
       expect(habitsApi.update).toHaveBeenCalledTimes(1);
+      // AND the on-disk snapshot rolls back to the original icon, so
+      // a cold relaunch sees the same state the user does.
+      expect(saveHabits).toHaveBeenLastCalledWith(
+        expect.arrayContaining([expect.objectContaining({ id: 1, icon: 'A' })]),
+      );
     });
   });
 });

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -376,10 +376,21 @@ const recoverStuckHabits = async (cached: Habit[]): Promise<void> => {
  * specific to the operation (e.g. "couldn't save that check-in") rather
  * than a generic "something went wrong" — users need to know whether to
  * retry or just refresh.
+ *
+ * Restores BOTH the in-memory store AND the on-disk snapshot. The
+ * mutation paths that call this helper (``updateHabit``, ``deleteHabit``,
+ * ``updateGoal``, ``setEmojiForHabit``, ``saveHabitOrder``) all
+ * optimistically ``persistHabits(next)`` before the API round-trip, so a
+ * pure ``setHabits(prev)`` rollback would leave AsyncStorage holding the
+ * failed write. A cold relaunch (process kill + reopen) would then
+ * rehydrate from disk and silently diverge from the server — exactly
+ * the cold-rehydrate failure mode this PR's emoji/order fixes set out
+ * to close. Mirrors the pattern in ``rollbackLogUnitContext``.
  */
 const revertOnFailure = (prev: Habit[], fallback: string): ((err: unknown) => void) => {
   return (err: unknown) => {
     setHabits(prev);
+    void persistHabits(prev);
     Alert.alert("Couldn't sync", formatApiError(err, { fallback }));
   };
 };

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -515,26 +515,33 @@ export const habitManager = {
   /**
    * Persist a user-chosen ordering. Stamps each habit with a positional
    * ``sort_order`` (the backend orders the list ascending by it) and PUTs
-   * the row so the order survives a logout — without the per-row PUT, the
+   * the rows so the order survives a logout — without the per-row PUT, the
    * reorder used to live only in AsyncStorage and was wiped on the next
    * cold rehydrate.
+   *
+   * Updates fan out via ``Promise.all`` so a single rejection triggers one
+   * deterministic rollback rather than one per failure: the previous
+   * implementation chained ``revertOnFailure`` on every PUT, so the second
+   * (and third…) failure each restored ``prev``, clobbering successful
+   * sibling writes that were already in the store.
    */
   saveHabitOrder: (ordered: Habit[]): void => {
     const prev = getHabits();
     const stamped = ordered.map((h, index) => ({ ...h, sort_order: index }));
     setHabits(stamped);
     void persistHabits(stamped);
+    const updates: Array<Promise<unknown>> = [];
     for (const habit of stamped) {
-      if (!habit.id) continue;
-      habitsApi
-        .update(habit.id, toApiPayload(habit))
-        .catch(
-          revertOnFailure(
-            prev,
-            "We couldn't save the new habit order. Your previous order was restored — check your connection and try again.",
-          ),
-        );
+      if (habit.id == null) continue;
+      updates.push(habitsApi.update(habit.id, toApiPayload(habit)));
     }
+    if (updates.length === 0) return;
+    Promise.all(updates).catch(
+      revertOnFailure(
+        prev,
+        "We couldn't save the new habit order. Your previous order was restored — check your connection and try again.",
+      ),
+    );
   },
 
   /**

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -80,6 +80,13 @@ const toApiPayload = (h: Habit): HabitCreatePayload => ({
   notification_frequency: h.notificationFrequency ?? null,
   notification_days: h.notificationDays ?? null,
   milestone_notifications: h.milestoneNotifications ?? false,
+  // ``sort_order`` and ``stage`` are persisted on PUT so reorder + emoji
+  // edits survive a logout/login round-trip — without these, the server
+  // happily replaces the row with the schema defaults (sort_order=null,
+  // stage="") and the next ``GET /habits`` returns the user's tiles in
+  // insertion order with the original onboarding stage label.
+  sort_order: h.sort_order ?? null,
+  stage: h.stage,
 });
 
 const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.list>>): Habit[] =>
@@ -110,6 +117,7 @@ const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.list>>): Ha
       (h.notification_frequency as Habit['notificationFrequency']) ?? undefined,
     notificationDays: h.notification_days ?? undefined,
     milestoneNotifications: h.milestone_notifications,
+    sort_order: h.sort_order ?? null,
   }));
 
 const normalizeGoalUnits = (goals: Goal[], updatedGoal: Goal): void => {
@@ -504,9 +512,29 @@ export const habitManager = {
       );
   },
 
+  /**
+   * Persist a user-chosen ordering. Stamps each habit with a positional
+   * ``sort_order`` (the backend orders the list ascending by it) and PUTs
+   * the row so the order survives a logout — without the per-row PUT, the
+   * reorder used to live only in AsyncStorage and was wiped on the next
+   * cold rehydrate.
+   */
   saveHabitOrder: (ordered: Habit[]): void => {
-    setHabits(ordered);
-    void persistHabits(ordered);
+    const prev = getHabits();
+    const stamped = ordered.map((h, index) => ({ ...h, sort_order: index }));
+    setHabits(stamped);
+    void persistHabits(stamped);
+    for (const habit of stamped) {
+      if (!habit.id) continue;
+      habitsApi
+        .update(habit.id, toApiPayload(habit))
+        .catch(
+          revertOnFailure(
+            prev,
+            "We couldn't save the new habit order. Your previous order was restored — check your connection and try again.",
+          ),
+        );
+    }
   },
 
   /**
@@ -645,8 +673,30 @@ export const habitManager = {
     void persistHabits(next);
   },
 
+  /**
+   * Update a habit's icon and sync to the backend. Previously only mutated
+   * the in-memory store, so the emoji was lost on the next ``GET /habits``
+   * (logout, app restart, or even a stuck-user re-fetch). Persists locally
+   * for instant rehydrate, then PUTs the row; on failure the rollback
+   * restores both the store and the on-disk snapshot.
+   */
   setEmojiForHabit: (index: number, emoji: string): void => {
-    setHabits(getHabits().map((h, i) => (i === index ? { ...h, icon: emoji } : h)));
+    const prev = getHabits();
+    const target = prev[index];
+    if (!target) return;
+    const updated: Habit = { ...target, icon: emoji };
+    const next = prev.map((h, i) => (i === index ? updated : h));
+    setHabits(next);
+    void persistHabits(next);
+    if (!updated.id) return;
+    habitsApi
+      .update(updated.id, toApiPayload(updated))
+      .catch(
+        revertOnFailure(
+          prev,
+          "We couldn't save the new icon. Your previous icon was restored — check your connection and try again.",
+        ),
+      );
   },
 };
 


### PR DESCRIPTION
The emoji picker and reorder modal updated only the in-memory store and
AsyncStorage, so a logout (or any cold ``GET /habits``) reverted both to
the server state. ``toApiPayload`` also dropped ``sort_order`` and
``stage`` on the wire, so even an explicit PUT discarded them. Wire
``setEmojiForHabit`` and ``saveHabitOrder`` through the existing
optimistic-write + rollback path; stamp positional sort_order on reorder.

Add an inline unit + frequency editor below the per-tier target rows so
users can change ``target_unit`` / ``frequency`` / ``frequency_unit``
after creation -- the only previously editable field was the numeric
``target``. Edits flow through the existing ``normalizeGoalUnits`` helper
so all three tiers stay in lockstep.

https://claude.ai/code/session_01WZEpuqwCsipqFQ6ss8TGB7