### PR TITLE
fix(backend): 12A wave 2 - stage / course / prompts (8 BUG-IDs)

### DIFF
--- a/backend/src/domain/course.py
+++ b/backend/src/domain/course.py
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 def compute_days_elapsed(stage_started_at: datetime) -> int:
     """Return whole days elapsed; clamps a future ``stage_started_at`` to 0 + WARNING."""
     now = datetime.now(UTC)
+    # SQLite drops tzinfo on round-trip, so coerce naive values to UTC
+    # before subtraction to avoid TypeError under the test fixture.
     if stage_started_at.tzinfo is None:
         stage_started_at = stage_started_at.replace(tzinfo=UTC)
     delta = now - stage_started_at

--- a/backend/src/domain/course.py
+++ b/backend/src/domain/course.py
@@ -10,16 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def compute_days_elapsed(stage_started_at: datetime) -> int:
-    """Return whole days since the user started the current stage; clamped to >=0.
-
-    BUG-COURSE-005: a future-dated ``stage_started_at`` (clock skew,
-    admin backfill bug, partial migration) produces a negative
-    ``timedelta`` whose ``.days`` floors to ``-1`` or further; the
-    pre-fix ``max(0, .days)`` quietly returned ``0``, opening every
-    ``release_day == 0`` item.  Now we structured-log a warning so
-    operators can spot the data-integrity smell without re-introducing
-    a 500 path on what is still a clamping fallback.
-    """
+    """Return whole days elapsed; clamps a future ``stage_started_at`` to 0 + WARNING."""
     now = datetime.now(UTC)
     if stage_started_at.tzinfo is None:
         stage_started_at = stage_started_at.replace(tzinfo=UTC)

--- a/backend/src/domain/course.py
+++ b/backend/src/domain/course.py
@@ -2,18 +2,35 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
 
+logger = logging.getLogger(__name__)
+
 
 def compute_days_elapsed(stage_started_at: datetime) -> int:
-    """Return whole days since the user started the current stage."""
+    """Return whole days since the user started the current stage; clamped to >=0.
+
+    BUG-COURSE-005: a future-dated ``stage_started_at`` (clock skew,
+    admin backfill bug, partial migration) produces a negative
+    ``timedelta`` whose ``.days`` floors to ``-1`` or further; the
+    pre-fix ``max(0, .days)`` quietly returned ``0``, opening every
+    ``release_day == 0`` item.  Now we structured-log a warning so
+    operators can spot the data-integrity smell without re-introducing
+    a 500 path on what is still a clamping fallback.
+    """
     now = datetime.now(UTC)
-    # SQLite drops timezone info, so ensure both are tz-aware for subtraction
     if stage_started_at.tzinfo is None:
         stage_started_at = stage_started_at.replace(tzinfo=UTC)
     delta = now - stage_started_at
-    return max(0, delta.days)
+    if delta.total_seconds() < 0:
+        logger.warning(
+            "stage_started_at_in_future",
+            extra={"stage_started_at": stage_started_at.isoformat(), "now": now.isoformat()},
+        )
+        return 0
+    return delta.days
 
 
 def filter_content_for_user(

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -68,7 +68,13 @@ async def get_user_progress_for_update(session: AsyncSession, user_id: int) -> S
 
 
 def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool:
-    """Return True iff ``N <= current_stage`` (or N is stage 1)."""
+    """Return True iff ``N <= current_stage`` (or N is stage 1).
+
+    Relies on the invariant that ``current_stage`` is only advanced via
+    the validated router path (advance must equal ``current + 1``); a
+    direct DB write that bumps ``current_stage`` would unlock prior
+    stages without their prerequisites being completed.
+    """
     if stage_number == _STAGE_1:
         return True
     if progress is None:

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -70,42 +70,37 @@ async def get_user_progress_for_update(session: AsyncSession, user_id: int) -> S
 def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool:
     """Determine if a stage is unlocked for the user.
 
-    Stage 1 is always unlocked.  For stage N > 1, **every** prior stage must
-    be in ``completed_stages`` — not just the immediate predecessor.  The
-    single-predecessor shortcut (``(N-1) in completed_stages``) lets any
-    admin tool, data import, or legacy row with a hole in the chain (e.g.
-    ``[35]``) expose every intermediate stage it never actually completed.
-    The chain check closes that gap without depending on the separate
-    ``current_stage`` signal, which can drift out of sync with
-    ``completed_stages`` independently.
+    Stage 1 is always unlocked.  For stage ``N > 1`` the canonical
+    invariant is ``N <= current_stage``; ``current_stage`` is the
+    single source of truth (BUG-STAGE-002), so the stored
+    ``completed_stages`` list is intentionally ignored here -- it can
+    drift on legacy rows or admin scripts that update one field
+    without the other, and the chain-of-prior-stages check used to
+    silently flip the answer between the unlock and display paths.
     """
     if stage_number == _STAGE_1:
         return True
     if progress is None:
         return False
-    required = set(range(1, stage_number))
-    return required.issubset(set(progress.completed_stages or []))
+    return stage_number <= progress.current_stage
 
 
 def next_stage_for(progress: StageProgress | None) -> int:
     """Return the first unfinished stage for ``progress``.
 
-    Fresh users (``progress is None``) start at stage 1.  Otherwise we take
-    ``min({1..TOTAL_STAGES} - completed_stages)`` — the first *hole* in the
-    completion set, not ``max(completed) + 1``.  The distinction matters for
-    legacy rows like ``completed_stages=[1, 3]``: ``max+1`` would advance
-    past stage 2 silently; ``min(missing)`` returns 2 and keeps the chain-
-    validation invariant aligned with unlock-checking on dirty data.  Raises
-    :class:`AllStagesCompletedError` when every stage is already completed
-    so the caller cannot blindly advance past the curriculum.
+    Fresh users (``progress is None``) start at stage 1.  Otherwise
+    the next stage is ``current_stage + 1`` -- ``current_stage`` is the
+    single source of truth (BUG-STAGE-002) so the helper does not
+    consult the stored ``completed_stages`` list.  Raises
+    :class:`AllStagesCompletedError` when the user is already at the
+    final stage so the caller cannot blindly advance past the
+    curriculum.
     """
     if progress is None:
         return _STAGE_1
-    completed = set(progress.completed_stages or [])
-    missing = set(range(1, TOTAL_STAGES + 1)) - completed
-    if not missing:
+    if progress.current_stage >= TOTAL_STAGES:
         raise AllStagesCompletedError
-    return min(missing)
+    return progress.current_stage + 1
 
 
 async def _compute_habits_progress(session: AsyncSession, user_id: int, stage_number: int) -> float:

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -68,16 +68,7 @@ async def get_user_progress_for_update(session: AsyncSession, user_id: int) -> S
 
 
 def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool:
-    """Determine if a stage is unlocked for the user.
-
-    Stage 1 is always unlocked.  For stage ``N > 1`` the canonical
-    invariant is ``N <= current_stage``; ``current_stage`` is the
-    single source of truth (BUG-STAGE-002), so the stored
-    ``completed_stages`` list is intentionally ignored here -- it can
-    drift on legacy rows or admin scripts that update one field
-    without the other, and the chain-of-prior-stages check used to
-    silently flip the answer between the unlock and display paths.
-    """
+    """Return True iff ``N <= current_stage`` (or N is stage 1)."""
     if stage_number == _STAGE_1:
         return True
     if progress is None:
@@ -86,16 +77,7 @@ def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool
 
 
 def next_stage_for(progress: StageProgress | None) -> int:
-    """Return the first unfinished stage for ``progress``.
-
-    Fresh users (``progress is None``) start at stage 1.  Otherwise
-    the next stage is ``current_stage + 1`` -- ``current_stage`` is the
-    single source of truth (BUG-STAGE-002) so the helper does not
-    consult the stored ``completed_stages`` list.  Raises
-    :class:`AllStagesCompletedError` when the user is already at the
-    final stage so the caller cannot blindly advance past the
-    curriculum.
-    """
+    """Return ``current_stage + 1`` (or 1 for fresh users); raises at the curriculum end."""
     if progress is None:
         return _STAGE_1
     if progress.current_stage >= TOTAL_STAGES:

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -29,10 +29,9 @@ class JournalTag(enum.StrEnum):
     STAGE_REFLECTION = "stage_reflection"
     PRACTICE_NOTE = "practice_note"
     HABIT_NOTE = "habit_note"
-    # BUG-PROMPT-008: weekly-prompt submissions used to share
-    # ``STAGE_REFLECTION`` with stage-transition reflections, polluting
-    # any stage-scoped journal aggregate.  ``WEEKLY_PROMPT`` separates
-    # the cadences so downstream filters can tell them apart.
+    # Weekly-prompt submissions share the journal stream but need a
+    # distinct tag so stage-scoped aggregates (filtered by
+    # ``STAGE_REFLECTION``) do not double-count them.
     WEEKLY_PROMPT = "weekly_prompt"
 
 

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -29,6 +29,11 @@ class JournalTag(enum.StrEnum):
     STAGE_REFLECTION = "stage_reflection"
     PRACTICE_NOTE = "practice_note"
     HABIT_NOTE = "habit_note"
+    # BUG-PROMPT-008: weekly-prompt submissions used to share
+    # ``STAGE_REFLECTION`` with stage-transition reflections, polluting
+    # any stage-scoped journal aggregate.  ``WEEKLY_PROMPT`` separates
+    # the cadences so downstream filters can tell them apart.
+    WEEKLY_PROMPT = "weekly_prompt"
 
 
 class JournalEntry(SQLModel, table=True):

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -349,14 +349,7 @@ async def get_course_progress(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> CourseProgressResponse:
-    """Get read-progress for a stage's content; gated on the caller's unlock state.
-
-    BUG-COURSE-003: previously this endpoint returned ``total_items`` and
-    ``next_unlock_day`` without checking unlock, letting any authenticated
-    client reconstruct the full 36-stage drip schedule by walking
-    stage_number 1..36.  Now the caller must have the stage unlocked or
-    they get the same 403 the sibling endpoints already issue.
-    """
+    """Get read-progress for a stage's content; 403 when the caller has not unlocked it."""
     stage = await _get_stage_by_number(session, stage_number)
     await _check_stage_unlocked(session, current_user, stage_number)
     result = await session.execute(

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -12,7 +12,7 @@ from sqlmodel import col, select
 
 from database import get_session
 from domain.course import compute_days_elapsed, filter_content_for_user, next_unlock_day
-from domain.stage_progress import get_user_progress, is_stage_unlocked, stage_exists
+from domain.stage_progress import get_user_progress, is_stage_unlocked
 from errors import forbidden, not_found
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
@@ -349,11 +349,16 @@ async def get_course_progress(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> CourseProgressResponse:
-    """Get read-progress for a stage's content."""
-    if not await stage_exists(session, stage_number):
-        raise not_found("stage")
+    """Get read-progress for a stage's content; gated on the caller's unlock state.
 
+    BUG-COURSE-003: previously this endpoint returned ``total_items`` and
+    ``next_unlock_day`` without checking unlock, letting any authenticated
+    client reconstruct the full 36-stage drip schedule by walking
+    stage_number 1..36.  Now the caller must have the stage unlocked or
+    they get the same 403 the sibling endpoints already issue.
+    """
     stage = await _get_stage_by_number(session, stage_number)
+    await _check_stage_unlocked(session, current_user, stage_number)
     result = await session.execute(
         select(StageContent).where(StageContent.course_stage_id == stage.id)
     )

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, status
-from sqlalchemy import func
+from sqlalchemy import Select, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -109,6 +109,42 @@ class _HistoryFilters:
     include_total: bool = Query(default=True)
 
 
+def _history_detail(pr: PromptResponse) -> PromptDetail:
+    """Serialize a ``PromptResponse`` row, deriving ``question`` from the live dict.
+
+    BUG-PROMPT-010: falls back to the persisted ``question`` snapshot
+    only when the live dict lookup is ``None`` (a week that was retired
+    entirely) so history cannot drift from ``/current``.
+    """
+    return PromptDetail(
+        week_number=pr.week_number,
+        question=get_prompt_for_week(pr.week_number) or pr.question,
+        has_responded=True,
+        response=pr.response,
+        timestamp=pr.timestamp,
+    )
+
+
+async def _maybe_total(
+    session: AsyncSession,
+    query: Select[tuple[PromptResponse]],
+    *,
+    include_total: bool,
+) -> int:
+    """Run the count subquery only when the caller opted in (BUG-PROMPT-006)."""
+    if not include_total:
+        return 0
+    count_query = select(func.count()).select_from(query.subquery())
+    return int((await session.execute(count_query)).scalar() or 0)
+
+
+def _has_more(items_len: int, filters: _HistoryFilters, total: int) -> bool:
+    """Resolve ``has_more`` against either the cursor or the total."""
+    if not filters.include_total:
+        return items_len == filters.limit
+    return (filters.offset + filters.limit) < total
+
+
 @router.get("/history", response_model=PromptListResponse)
 async def list_prompt_history(
     current_user: Annotated[int, Depends(get_current_user)],
@@ -121,39 +157,13 @@ async def list_prompt_history(
         .where(PromptResponse.user_id == current_user)
         .order_by(col(PromptResponse.week_number).desc())
     )
-
-    if filters.include_total:
-        count_query = select(func.count()).select_from(query.subquery())
-        total = (await session.execute(count_query)).scalar() or 0
-    else:
-        total = 0  # caller opted out; client computes from the page
-
-    query = query.offset(filters.offset).limit(filters.limit)
-    result = await session.execute(query)
-    items = list(result.scalars().all())
-
+    total = await _maybe_total(session, query, include_total=filters.include_total)
+    page_query = query.offset(filters.offset).limit(filters.limit)
+    items = list((await session.execute(page_query)).scalars().all())
     return PromptListResponse(
-        items=[
-            PromptDetail(
-                week_number=pr.week_number,
-                # BUG-PROMPT-010: derive ``question`` from the live
-                # ``WEEKLY_PROMPTS`` dict so history and ``/current``
-                # cannot drift when prompts are revised.  Falls back to
-                # the persisted snapshot only if the dict lookup is
-                # ``None`` (a week that was retired entirely).
-                question=get_prompt_for_week(pr.week_number) or pr.question,
-                has_responded=True,
-                response=pr.response,
-                timestamp=pr.timestamp,
-            )
-            for pr in items
-        ],
+        items=[_history_detail(pr) for pr in items],
         total=total,
-        has_more=(
-            len(items) == filters.limit
-            if not filters.include_total
-            else (filters.offset + filters.limit) < total
-        ),
+        has_more=_has_more(len(items), filters, total),
     )
 
 

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -126,17 +126,8 @@ async def _maybe_total(
     return int((await session.execute(count_query)).scalar() or 0)
 
 
-def _has_more(items_len: int, filters: _HistoryFilters, total: int) -> bool:
-    """Resolve ``has_more`` against either the cursor or the total.
-
-    The cursor branch is also capped by ``TOTAL_WEEKS`` so a final-page
-    request that happens to fill ``limit`` exactly does not lie about a
-    37th item being available.
-    """
-    if not filters.include_total:
-        page_full = items_len == filters.limit
-        more_remain = (filters.offset + filters.limit) < TOTAL_WEEKS
-        return page_full and more_remain
+def _has_more_with_total(filters: _HistoryFilters, total: int) -> bool:
+    """``has_more`` for the count-aware branch -- compare against the known total."""
     return (filters.offset + filters.limit) < total
 
 
@@ -146,19 +137,45 @@ async def list_prompt_history(
     session: Annotated[AsyncSession, Depends(get_session)],
     filters: Annotated[_HistoryFilters, Depends()],
 ) -> PromptListResponse:
-    """List all past prompts and responses for the user, paginated."""
+    """List all past prompts and responses for the user, paginated.
+
+    ``include_total=true`` (default) runs the count subquery and uses
+    ``offset + limit < total`` for ``has_more``.
+
+    ``include_total=false`` opts out of the count and uses a peek
+    pattern: fetch ``limit + 1`` rows, return at most ``limit`` items,
+    and report ``has_more`` from whether the peek row materialised.
+    This produces an accurate cursor signal without paying for the
+    extra ``COUNT(*)`` -- a 37th item could not exist (offset is capped
+    at ``TOTAL_WEEKS``), but mid-curriculum users with fewer responses
+    than the curriculum length now also get ``has_more=False`` on
+    their last real page.
+
+    When ``include_total=false`` the response carries ``total=0`` as a
+    documented "count not requested" sentinel; clients that need an
+    exact count must opt in or compute from accumulated pages.
+    """
     query = (
         select(PromptResponse)
         .where(PromptResponse.user_id == current_user)
         .order_by(col(PromptResponse.week_number).desc())
     )
     total = await _maybe_total(session, query, include_total=filters.include_total)
-    page_query = query.offset(filters.offset).limit(filters.limit)
-    items = list((await session.execute(page_query)).scalars().all())
+    if filters.include_total:
+        page_query = query.offset(filters.offset).limit(filters.limit)
+        items = list((await session.execute(page_query)).scalars().all())
+        has_more = _has_more_with_total(filters, total)
+    else:
+        # Cursor mode: fetch one extra row so we can tell whether a
+        # follow-up page would have any real items.
+        peek_query = query.offset(filters.offset).limit(filters.limit + 1)
+        rows = list((await session.execute(peek_query)).scalars().all())
+        has_more = len(rows) > filters.limit
+        items = rows[: filters.limit]
     return PromptListResponse(
         items=[_history_detail(pr) for pr in items],
         total=total,
-        has_more=_has_more(len(items), filters, total),
+        has_more=has_more,
     )
 
 

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -95,10 +95,18 @@ async def get_current_prompt(
 
 @dataclass
 class _HistoryFilters:
-    """Query parameters for prompt history pagination."""
+    """Query parameters for prompt history pagination.
+
+    ``offset`` is capped at ``TOTAL_WEEKS`` (BUG-PROMPT-006): a
+    well-behaved client never goes past the curriculum length, and a
+    misbehaving one cannot force the DB to skip a billion rows.
+    ``include_total=false`` opts out of the count subquery for cursor-
+    style pagination over a small (<= 36) list.
+    """
 
     limit: int = Query(default=50, ge=1, le=200)
-    offset: int = Query(default=0, ge=0)
+    offset: int = Query(default=0, ge=0, le=TOTAL_WEEKS)
+    include_total: bool = Query(default=True)
 
 
 @router.get("/history", response_model=PromptListResponse)
@@ -114,8 +122,11 @@ async def list_prompt_history(
         .order_by(col(PromptResponse.week_number).desc())
     )
 
-    count_query = select(func.count()).select_from(query.subquery())
-    total = (await session.execute(count_query)).scalar() or 0
+    if filters.include_total:
+        count_query = select(func.count()).select_from(query.subquery())
+        total = (await session.execute(count_query)).scalar() or 0
+    else:
+        total = 0  # caller opted out; client computes from the page
 
     query = query.offset(filters.offset).limit(filters.limit)
     result = await session.execute(query)
@@ -125,7 +136,12 @@ async def list_prompt_history(
         items=[
             PromptDetail(
                 week_number=pr.week_number,
-                question=pr.question,
+                # BUG-PROMPT-010: derive ``question`` from the live
+                # ``WEEKLY_PROMPTS`` dict so history and ``/current``
+                # cannot drift when prompts are revised.  Falls back to
+                # the persisted snapshot only if the dict lookup is
+                # ``None`` (a week that was retired entirely).
+                question=get_prompt_for_week(pr.week_number) or pr.question,
                 has_responded=True,
                 response=pr.response,
                 timestamp=pr.timestamp,
@@ -133,7 +149,11 @@ async def list_prompt_history(
             for pr in items
         ],
         total=total,
-        has_more=(filters.offset + filters.limit) < total,
+        has_more=(
+            len(items) == filters.limit
+            if not filters.include_total
+            else (filters.offset + filters.limit) < total
+        ),
     )
 
 
@@ -226,12 +246,14 @@ async def submit_prompt_response(
     )
     session.add(prompt_response)
 
-    # Also create a journal entry so the response appears in journal history
+    # Also create a journal entry so the response appears in journal history.
+    # BUG-PROMPT-008: tag as WEEKLY_PROMPT so stage-scoped aggregates that
+    # filter by STAGE_REFLECTION do not double-count weekly cadence rows.
     journal_entry = JournalEntry(
         message=cleaned_response,
         sender="user",
         user_id=current_user,
-        tag=JournalTag.STAGE_REFLECTION,
+        tag=JournalTag.WEEKLY_PROMPT,
     )
     session.add(journal_entry)
 

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -118,17 +118,12 @@ async def _maybe_total(
     query: Select[tuple[PromptResponse]],
     *,
     include_total: bool,
-) -> int:
-    """Run the count subquery only when the caller opted in."""
+) -> int | None:
+    """Run the count subquery only when the caller opted in; ``None`` signals opt-out."""
     if not include_total:
-        return 0
+        return None
     count_query = select(func.count()).select_from(query.subquery())
     return int((await session.execute(count_query)).scalar() or 0)
-
-
-def _has_more_with_total(filters: _HistoryFilters, total: int) -> bool:
-    """``has_more`` for the count-aware branch -- compare against the known total."""
-    return (filters.offset + filters.limit) < total
 
 
 @router.get("/history", response_model=PromptListResponse)
@@ -139,21 +134,13 @@ async def list_prompt_history(
 ) -> PromptListResponse:
     """List all past prompts and responses for the user, paginated.
 
-    ``include_total=true`` (default) runs the count subquery and uses
-    ``offset + limit < total`` for ``has_more``.
-
-    ``include_total=false`` opts out of the count and uses a peek
-    pattern: fetch ``limit + 1`` rows, return at most ``limit`` items,
-    and report ``has_more`` from whether the peek row materialised.
-    This produces an accurate cursor signal without paying for the
-    extra ``COUNT(*)`` -- a 37th item could not exist (offset is capped
-    at ``TOTAL_WEEKS``), but mid-curriculum users with fewer responses
-    than the curriculum length now also get ``has_more=False`` on
-    their last real page.
-
-    When ``include_total=false`` the response carries ``total=0`` as a
-    documented "count not requested" sentinel; clients that need an
-    exact count must opt in or compute from accumulated pages.
+    With ``include_total=true`` (default) the count subquery runs and
+    ``has_more`` is ``offset + limit < total``.  With
+    ``include_total=false`` the response carries ``total=None`` and
+    uses a peek pattern -- fetch ``limit + 1`` rows, return at most
+    ``limit`` items, set ``has_more`` from whether the peek row
+    materialised -- so cursor pagination stays accurate for mid-
+    curriculum users without paying for ``COUNT(*)``.
     """
     query = (
         select(PromptResponse)
@@ -161,17 +148,15 @@ async def list_prompt_history(
         .order_by(col(PromptResponse.week_number).desc())
     )
     total = await _maybe_total(session, query, include_total=filters.include_total)
-    if filters.include_total:
+    if total is not None:
         page_query = query.offset(filters.offset).limit(filters.limit)
         items = list((await session.execute(page_query)).scalars().all())
-        has_more = _has_more_with_total(filters, total)
+        has_more = (filters.offset + filters.limit) < total
     else:
-        # Cursor mode: fetch one extra row so we can tell whether a
-        # follow-up page would have any real items.
         peek_query = query.offset(filters.offset).limit(filters.limit + 1)
         rows = list((await session.execute(peek_query)).scalars().all())
-        has_more = len(rows) > filters.limit
         items = rows[: filters.limit]
+        has_more = len(rows) > filters.limit
     return PromptListResponse(
         items=[_history_detail(pr) for pr in items],
         total=total,

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -95,14 +95,7 @@ async def get_current_prompt(
 
 @dataclass
 class _HistoryFilters:
-    """Query parameters for prompt history pagination.
-
-    ``offset`` is capped at ``TOTAL_WEEKS`` (BUG-PROMPT-006): a
-    well-behaved client never goes past the curriculum length, and a
-    misbehaving one cannot force the DB to skip a billion rows.
-    ``include_total=false`` opts out of the count subquery for cursor-
-    style pagination over a small (<= 36) list.
-    """
+    """Query parameters for prompt history pagination; ``offset`` is capped by curriculum length."""
 
     limit: int = Query(default=50, ge=1, le=200)
     offset: int = Query(default=0, ge=0, le=TOTAL_WEEKS)
@@ -110,12 +103,7 @@ class _HistoryFilters:
 
 
 def _history_detail(pr: PromptResponse) -> PromptDetail:
-    """Serialize a ``PromptResponse`` row, deriving ``question`` from the live dict.
-
-    BUG-PROMPT-010: falls back to the persisted ``question`` snapshot
-    only when the live dict lookup is ``None`` (a week that was retired
-    entirely) so history cannot drift from ``/current``.
-    """
+    """Serialize a ``PromptResponse``; live dict wins, snapshot is the retired-week fallback."""
     return PromptDetail(
         week_number=pr.week_number,
         question=get_prompt_for_week(pr.week_number) or pr.question,
@@ -131,7 +119,7 @@ async def _maybe_total(
     *,
     include_total: bool,
 ) -> int:
-    """Run the count subquery only when the caller opted in (BUG-PROMPT-006)."""
+    """Run the count subquery only when the caller opted in."""
     if not include_total:
         return 0
     count_query = select(func.count()).select_from(query.subquery())
@@ -139,9 +127,16 @@ async def _maybe_total(
 
 
 def _has_more(items_len: int, filters: _HistoryFilters, total: int) -> bool:
-    """Resolve ``has_more`` against either the cursor or the total."""
+    """Resolve ``has_more`` against either the cursor or the total.
+
+    The cursor branch is also capped by ``TOTAL_WEEKS`` so a final-page
+    request that happens to fill ``limit`` exactly does not lie about a
+    37th item being available.
+    """
     if not filters.include_total:
-        return items_len == filters.limit
+        page_full = items_len == filters.limit
+        more_remain = (filters.offset + filters.limit) < TOTAL_WEEKS
+        return page_full and more_remain
     return (filters.offset + filters.limit) < total
 
 
@@ -256,9 +251,9 @@ async def submit_prompt_response(
     )
     session.add(prompt_response)
 
-    # Also create a journal entry so the response appears in journal history.
-    # BUG-PROMPT-008: tag as WEEKLY_PROMPT so stage-scoped aggregates that
-    # filter by STAGE_REFLECTION do not double-count weekly cadence rows.
+    # Mirror the response into the journal stream tagged as a weekly cadence
+    # row so stage-scoped aggregates (filtered by STAGE_REFLECTION) do not
+    # double-count it.
     journal_entry = JournalEntry(
         message=cleaned_response,
         sender="user",

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -230,15 +230,7 @@ async def _create_initial_progress(
 
 
 def _derive_next_stage(existing: StageProgress) -> tuple[int, list[int]]:
-    """Derive the server-expected next stage from ``existing``.
-
-    ``current_stage`` is the single source of truth (BUG-STAGE-002):
-    the next stage is ``current_stage + 1`` capped by the curriculum
-    length.  ``completed_stages`` is recomputed canonically as
-    ``[1..derived_next - 1]`` so the persisted value stays aligned
-    with the wire contract for any legacy admin code that still
-    reads it.
-    """
+    """Return ``(current_stage + 1, [1..current_stage])``; raises 409 at curriculum end."""
     if existing.current_stage >= TOTAL_STAGES:
         raise conflict("all_stages_completed")
     derived_next = existing.current_stage + 1

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -12,15 +12,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from domain.constants import TOTAL_STAGES
 from domain.stage_progress import (
-    AllStagesCompletedError,
     compute_stage_progress,
     get_stage_habit_history,
     get_stage_practice_history,
     get_user_progress,
     get_user_progress_for_update,
     is_stage_unlocked,
-    next_stage_for,
     stage_exists,
 )
 from errors import bad_request, conflict, forbidden, not_found
@@ -231,21 +230,19 @@ async def _create_initial_progress(
 
 
 def _derive_next_stage(existing: StageProgress) -> tuple[int, list[int]]:
-    """Derive the server-expected next stage from ``existing``'s completion set.
+    """Derive the server-expected next stage from ``existing``.
 
-    Simulates marking ``existing.current_stage`` complete on a detached copy so
-    we can run :func:`next_stage_for` without mutating the tracked ORM row.
+    ``current_stage`` is the single source of truth (BUG-STAGE-002):
+    the next stage is ``current_stage + 1`` capped by the curriculum
+    length.  ``completed_stages`` is recomputed canonically as
+    ``[1..derived_next - 1]`` so the persisted value stays aligned
+    with the wire contract for any legacy admin code that still
+    reads it.
     """
-    candidate_completed = sorted(set(existing.completed_stages or []) | {existing.current_stage})
-    candidate = StageProgress(
-        user_id=existing.user_id,
-        current_stage=existing.current_stage,
-        completed_stages=candidate_completed,
-    )
-    try:
-        derived_next = next_stage_for(candidate)
-    except AllStagesCompletedError as exc:
-        raise conflict("all_stages_completed") from exc
+    if existing.current_stage >= TOTAL_STAGES:
+        raise conflict("all_stages_completed")
+    derived_next = existing.current_stage + 1
+    candidate_completed = list(range(1, derived_next))
     return derived_next, candidate_completed
 
 

--- a/backend/src/schemas/prompt.py
+++ b/backend/src/schemas/prompt.py
@@ -11,7 +11,9 @@ PROMPT_RESPONSE_MAX_LENGTH = 10_000
 # Threshold checked *after* ``str.strip()`` so a whitespace-padded
 # payload cannot dodge the bound; ``min_length`` alone counts raw
 # characters and would accept three spaces as a valid reflection.
-_PROMPT_RESPONSE_MIN_STRIPPED_LENGTH = 10
+# Exported so the frontend can mirror the same bound client-side
+# without duplicating the magic number.
+PROMPT_RESPONSE_MIN_STRIPPED_LENGTH = 10
 
 
 class PromptDetail(BaseModel):
@@ -38,9 +40,9 @@ class PromptSubmit(BaseModel):
         canonical ``sanitize_user_text`` -> NFC/strip pipeline remains
         the single normalisation step that touches the persisted bytes.
         """
-        if len(value.strip()) < _PROMPT_RESPONSE_MIN_STRIPPED_LENGTH:
+        if len(value.strip()) < PROMPT_RESPONSE_MIN_STRIPPED_LENGTH:
             msg = (
-                f"response must contain at least {_PROMPT_RESPONSE_MIN_STRIPPED_LENGTH} "
+                f"response must contain at least {PROMPT_RESPONSE_MIN_STRIPPED_LENGTH} "
                 "non-whitespace characters"
             )
             raise ValueError(msg)
@@ -48,14 +50,8 @@ class PromptSubmit(BaseModel):
 
 
 class PromptListResponse(BaseModel):
-    """Paginated list of prompt responses.
-
-    ``total`` is ``0`` when the caller requested ``?include_total=false``;
-    the cursor-mode response uses ``has_more`` (driven by a peek row)
-    to signal whether a follow-up page exists, so clients that opted
-    out of counting must not infer a true row count from ``total``.
-    """
+    """Paginated list of prompt responses; ``total`` is ``None`` when not requested."""
 
     items: list[PromptDetail]
-    total: int
+    total: int | None
     has_more: bool

--- a/backend/src/schemas/prompt.py
+++ b/backend/src/schemas/prompt.py
@@ -48,7 +48,13 @@ class PromptSubmit(BaseModel):
 
 
 class PromptListResponse(BaseModel):
-    """Paginated list of prompt responses."""
+    """Paginated list of prompt responses.
+
+    ``total`` is ``0`` when the caller requested ``?include_total=false``;
+    the cursor-mode response uses ``has_more`` (driven by a peek row)
+    to signal whether a follow-up page exists, so clients that opted
+    out of counting must not infer a true row count from ``total``.
+    """
 
     items: list[PromptDetail]
     total: int

--- a/backend/src/schemas/prompt.py
+++ b/backend/src/schemas/prompt.py
@@ -8,11 +8,9 @@ from pydantic import BaseModel, Field, field_validator
 
 PROMPT_RESPONSE_MAX_LENGTH = 10_000
 
-# BUG-PROMPT-005: ``min_length`` counts raw characters including
-# whitespace, so a payload of three spaces was previously accepted as a
-# valid reflection.  Rejecting anything shorter than this threshold
-# after ``str.strip()`` blocks the trivial auto-advance script without
-# preventing genuinely terse-but-meaningful entries.
+# Threshold checked *after* ``str.strip()`` so a whitespace-padded
+# payload cannot dodge the bound; ``min_length`` alone counts raw
+# characters and would accept three spaces as a valid reflection.
 _PROMPT_RESPONSE_MIN_STRIPPED_LENGTH = 10
 
 
@@ -34,7 +32,12 @@ class PromptSubmit(BaseModel):
     @field_validator("response")
     @classmethod
     def _reject_whitespace_only(cls, value: str) -> str:
-        """Reject responses whose stripped length falls below the threshold."""
+        """Reject responses whose stripped length falls below the threshold.
+
+        The original (unstripped) value is returned so the router's
+        canonical ``sanitize_user_text`` -> NFC/strip pipeline remains
+        the single normalisation step that touches the persisted bytes.
+        """
         if len(value.strip()) < _PROMPT_RESPONSE_MIN_STRIPPED_LENGTH:
             msg = (
                 f"response must contain at least {_PROMPT_RESPONSE_MIN_STRIPPED_LENGTH} "

--- a/backend/src/schemas/prompt.py
+++ b/backend/src/schemas/prompt.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 PROMPT_RESPONSE_MAX_LENGTH = 10_000
+
+# BUG-PROMPT-005: ``min_length`` counts raw characters including
+# whitespace, so a payload of three spaces was previously accepted as a
+# valid reflection.  Rejecting anything shorter than this threshold
+# after ``str.strip()`` blocks the trivial auto-advance script without
+# preventing genuinely terse-but-meaningful entries.
+_PROMPT_RESPONSE_MIN_STRIPPED_LENGTH = 10
 
 
 class PromptDetail(BaseModel):
@@ -23,6 +30,18 @@ class PromptSubmit(BaseModel):
     """Payload for submitting a response to a weekly prompt."""
 
     response: str = Field(min_length=1, max_length=PROMPT_RESPONSE_MAX_LENGTH)
+
+    @field_validator("response")
+    @classmethod
+    def _reject_whitespace_only(cls, value: str) -> str:
+        """Reject responses whose stripped length falls below the threshold."""
+        if len(value.strip()) < _PROMPT_RESPONSE_MIN_STRIPPED_LENGTH:
+            msg = (
+                f"response must contain at least {_PROMPT_RESPONSE_MIN_STRIPPED_LENGTH} "
+                "non-whitespace characters"
+            )
+            raise ValueError(msg)
+        return value
 
 
 class PromptListResponse(BaseModel):

--- a/backend/tests/domain/test_next_stage_for.py
+++ b/backend/tests/domain/test_next_stage_for.py
@@ -1,9 +1,8 @@
 """Tests for ``next_stage_for``.
 
-``next_stage_for`` returns the first *hole* in ``completed_stages`` — i.e.
-``min({1..TOTAL_STAGES} - completed_stages)`` — not ``max(completed) + 1``.
-The distinction matters for legacy rows with gaps (e.g. ``[1, 3]`` where
-``max+1`` would incorrectly advance past stage 2).
+Under BUG-STAGE-002's single-source-of-truth model the helper derives
+the next stage from ``current_stage`` alone (``current_stage + 1``,
+capped by ``TOTAL_STAGES``).  ``completed_stages`` is ignored.
 """
 
 from __future__ import annotations
@@ -18,9 +17,9 @@ from domain.stage_progress import (
 from models.stage_progress import StageProgress
 
 
-def _progress(completed: list[int]) -> StageProgress:
-    """Build a StageProgress with the given completed_stages."""
-    return StageProgress(id=1, user_id=1, current_stage=1, completed_stages=completed)
+def _progress(current: int) -> StageProgress:
+    """Build a StageProgress at the given current stage."""
+    return StageProgress(id=1, user_id=1, current_stage=current, completed_stages=[])
 
 
 def test_no_progress_returns_stage_1() -> None:
@@ -28,44 +27,33 @@ def test_no_progress_returns_stage_1() -> None:
     assert next_stage_for(None) == 1
 
 
-def test_empty_completed_returns_stage_1() -> None:
-    """Progress row with empty completed_stages also starts at stage 1."""
-    assert next_stage_for(_progress([])) == 1
+def test_current_stage_one_returns_two() -> None:
+    """A user at stage 1 advances to stage 2."""
+    assert next_stage_for(_progress(1)) == 2
 
 
-def test_sequential_completions_return_next() -> None:
-    """``[1, 2, 3]`` → 4 (the first unfinished stage)."""
-    assert next_stage_for(_progress([1, 2, 3])) == 4
+def test_current_stage_three_returns_four() -> None:
+    """``current_stage=3`` advances to 4 -- the helper does not consult ``completed_stages``."""
+    assert next_stage_for(_progress(3)) == 4
 
 
-def test_gap_returns_min_missing_not_max_plus_one() -> None:
-    """``[1, 3]`` → 2, not 4 — legacy-gap robustness (BUG-STAGE-001)."""
-    assert next_stage_for(_progress([1, 3])) == 2
+def test_completed_stages_drift_is_ignored() -> None:
+    """A drifted ``completed_stages`` value cannot tilt the answer.
 
-
-def test_single_completion_returns_next() -> None:
-    """``[1]`` → 2."""
-    assert next_stage_for(_progress([1])) == 2
-
-
-def test_mid_chain_gap_returns_earliest_hole() -> None:
-    """``[1, 2, 4, 5]`` → 3, the earliest hole."""
-    assert next_stage_for(_progress([1, 2, 4, 5])) == 3
-
-
-def test_all_stages_completed_raises_domain_error() -> None:
-    """Every stage completed → :class:`AllStagesCompletedError` (not HTTP).
-
-    Router code is responsible for translating this to a 409; keeping the
-    domain exception plain lets non-HTTP callers use ``next_stage_for``
-    without importing FastAPI.
+    Pre-fix this would have read the list and returned the first hole;
+    under the BUG-STAGE-002 contract ``current_stage + 1`` is the only
+    signal that matters.
     """
-    everything = list(range(1, TOTAL_STAGES + 1))
+    progress = StageProgress(id=1, user_id=1, current_stage=5, completed_stages=[1, 99])
+    assert next_stage_for(progress) == 6
+
+
+def test_at_final_stage_raises_domain_error() -> None:
+    """``current_stage == TOTAL_STAGES`` -> :class:`AllStagesCompletedError`."""
     with pytest.raises(AllStagesCompletedError):
-        next_stage_for(_progress(everything))
+        next_stage_for(_progress(TOTAL_STAGES))
 
 
-def test_last_stage_missing_returns_total_stages() -> None:
-    """Only the final stage missing → returns ``TOTAL_STAGES``."""
-    all_but_last = list(range(1, TOTAL_STAGES))
-    assert next_stage_for(_progress(all_but_last)) == TOTAL_STAGES
+def test_one_before_last_returns_total_stages() -> None:
+    """``current_stage = TOTAL_STAGES - 1`` advances to ``TOTAL_STAGES``."""
+    assert next_stage_for(_progress(TOTAL_STAGES - 1)) == TOTAL_STAGES

--- a/backend/tests/domain/test_next_stage_for.py
+++ b/backend/tests/domain/test_next_stage_for.py
@@ -1,9 +1,4 @@
-"""Tests for ``next_stage_for``.
-
-Under BUG-STAGE-002's single-source-of-truth model the helper derives
-the next stage from ``current_stage`` alone (``current_stage + 1``,
-capped by ``TOTAL_STAGES``).  ``completed_stages`` is ignored.
-"""
+"""Tests for ``next_stage_for`` -- derives ``current_stage + 1`` (capped by ``TOTAL_STAGES``)."""
 
 from __future__ import annotations
 
@@ -38,12 +33,7 @@ def test_current_stage_three_returns_four() -> None:
 
 
 def test_completed_stages_drift_is_ignored() -> None:
-    """A drifted ``completed_stages`` value cannot tilt the answer.
-
-    Pre-fix this would have read the list and returned the first hole;
-    under the BUG-STAGE-002 contract ``current_stage + 1`` is the only
-    signal that matters.
-    """
+    """A drifted ``completed_stages`` value cannot tilt the answer."""
     progress = StageProgress(id=1, user_id=1, current_stage=5, completed_stages=[1, 99])
     assert next_stage_for(progress) == 6
 

--- a/backend/tests/domain/test_stage_unlock.py
+++ b/backend/tests/domain/test_stage_unlock.py
@@ -1,7 +1,10 @@
-"""Table-driven tests for is_stage_unlocked (BUG-STAGE-002).
+"""Table-driven tests for is_stage_unlocked.
 
-Every combination of current_stage and completed_stages is tested to
-prevent regressions in the unlock predicate.
+Under BUG-STAGE-002's single-source-of-truth model ``current_stage``
+is the only signal the unlock predicate consults; ``completed_stages``
+is intentionally ignored so that legacy rows or admin scripts that
+update one field without the other cannot make the unlock decision
+disagree with the display path.
 """
 
 from __future__ import annotations
@@ -21,29 +24,21 @@ _CASES: list[tuple[str, int, StageProgress | None, bool]] = [
     ("stage 1 always unlocked (no progress)", 1, None, True),
     ("stage 1 always unlocked (with progress)", 1, _progress(3, [1, 2]), True),
     ("stage 2 locked without progress", 2, None, False),
-    ("stage 2 unlocked when current=2 and 1 completed", 2, _progress(2, [1]), True),
-    ("stage 2 locked when current=2 but 1 NOT completed", 2, _progress(2, []), False),
-    ("stage 3 locked when current=2 (not yet reached)", 3, _progress(2, [1]), False),
-    ("stage 3 unlocked when 2 completed", 3, _progress(2, [1, 2]), True),
-    ("stage 3 unlocked when current=3 and 2 completed", 3, _progress(3, [1, 2]), True),
-    ("stage 3 locked when current=3 but 2 NOT completed", 3, _progress(3, [1]), False),
-    ("stage 4 locked when current=3 and 3 not completed", 4, _progress(3, [1, 2]), False),
-    ("stage 4 unlocked when 3 completed", 4, _progress(3, [1, 2, 3]), True),
-    # Edge: current_stage jumped ahead (DB mutation) without completing predecessors
-    ("stage 5 locked despite current=5 if 4 not completed", 5, _progress(5, [1, 2, 3]), False),
-    ("stage 5 unlocked when current=5 and 4 completed", 5, _progress(5, [1, 2, 3, 4]), True),
-    # BUG-STAGE-001: chain-validation — the immediate predecessor alone is not
-    # enough.  ``completed_stages=[4]`` used to unlock stage 5 under the old
-    # single-step check; the chain check requires every stage in {1..4}.
-    ("BUG-STAGE-001 stage 5 locked when only 4 completed", 5, _progress(5, [4]), False),
-    ("BUG-STAGE-001 stage 5 locked with mid-chain gap", 5, _progress(5, [1, 2, 4]), False),
-    ("BUG-STAGE-001 stage 36 locked when only 35 completed", 36, _progress(36, [35]), False),
-    (
-        "BUG-STAGE-001 stage 5 unlocked only when {1,2,3,4} all completed",
-        5,
-        _progress(5, [1, 2, 3, 4]),
-        True,
-    ),
+    ("stage 2 unlocked when current=2", 2, _progress(2, [1]), True),
+    ("stage 2 unlocked when current=2 (drifted completed list)", 2, _progress(2, []), True),
+    ("stage 3 locked when current=2", 3, _progress(2, [1]), False),
+    ("stage 3 unlocked when current=3", 3, _progress(3, [1, 2]), True),
+    ("stage 3 unlocked when current=3 (drifted completed list)", 3, _progress(3, [1]), True),
+    ("stage 4 locked when current=3", 4, _progress(3, [1, 2]), False),
+    ("stage 4 unlocked when current=4", 4, _progress(4, [1, 2, 3]), True),
+    # ``completed_stages`` is ignored; ``current_stage`` is the single
+    # source of truth (BUG-STAGE-002).  These cases would have flipped
+    # under the old chain-validation contract -- under the new contract
+    # the answer derives from ``current_stage`` alone.
+    ("stage 5 unlocked when current=5 (drifted completed list)", 5, _progress(5, [1, 2, 3]), True),
+    ("stage 5 unlocked when current=5 (canonical)", 5, _progress(5, [1, 2, 3, 4]), True),
+    ("stage 5 locked when current=4", 5, _progress(4, [1, 2, 3, 4]), False),
+    ("stage 36 unlocked when current=36", 36, _progress(36, [35]), True),
 ]
 
 

--- a/backend/tests/domain/test_stage_unlock.py
+++ b/backend/tests/domain/test_stage_unlock.py
@@ -1,11 +1,4 @@
-"""Table-driven tests for is_stage_unlocked.
-
-Under BUG-STAGE-002's single-source-of-truth model ``current_stage``
-is the only signal the unlock predicate consults; ``completed_stages``
-is intentionally ignored so that legacy rows or admin scripts that
-update one field without the other cannot make the unlock decision
-disagree with the display path.
-"""
+"""Table-driven tests for ``is_stage_unlocked`` -- ``current_stage`` is the only signal."""
 
 from __future__ import annotations
 
@@ -31,10 +24,9 @@ _CASES: list[tuple[str, int, StageProgress | None, bool]] = [
     ("stage 3 unlocked when current=3 (drifted completed list)", 3, _progress(3, [1]), True),
     ("stage 4 locked when current=3", 4, _progress(3, [1, 2]), False),
     ("stage 4 unlocked when current=4", 4, _progress(4, [1, 2, 3]), True),
-    # ``completed_stages`` is ignored; ``current_stage`` is the single
-    # source of truth (BUG-STAGE-002).  These cases would have flipped
-    # under the old chain-validation contract -- under the new contract
-    # the answer derives from ``current_stage`` alone.
+    # ``completed_stages`` is ignored.  These cases would have flipped
+    # under the old chain-validation contract; the new contract derives
+    # the answer from ``current_stage`` alone.
     ("stage 5 unlocked when current=5 (drifted completed list)", 5, _progress(5, [1, 2, 3]), True),
     ("stage 5 unlocked when current=5 (canonical)", 5, _progress(5, [1, 2, 3, 4]), True),
     ("stage 5 locked when current=4", 5, _progress(4, [1, 2, 3, 4]), False),

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -721,13 +721,7 @@ async def test_progress_endpoint_rejects_locked_stage(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """BUG-COURSE-003: ``/course/stages/{n}/progress`` must 403 on a locked stage.
-
-    Pre-fix the endpoint returned ``total_items`` and ``next_unlock_day``
-    for any stage the user could name, letting them reconstruct the full
-    drip schedule by walking 1..36.  Now a locked stage gets the same
-    ``stage_locked`` 403 the sibling list endpoint already issues.
-    """
+    """``/course/stages/{n}/progress`` must 403 on a locked stage."""
     headers, _ = await _signup(async_client, "locked_progress")
     await _seed_stage_with_content(db_session, stage_number=2)
     resp = await async_client.get("/course/stages/2/progress", headers=headers)
@@ -738,7 +732,7 @@ async def test_progress_endpoint_rejects_locked_stage(
 def test_compute_days_elapsed_logs_on_future_timestamp(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """BUG-COURSE-005: a future ``stage_started_at`` clamps to 0 + WARNING."""
+    """A future ``stage_started_at`` clamps to 0 and emits a WARNING."""
     future = datetime.now(UTC) + timedelta(hours=2)
     with caplog.at_level(logging.WARNING, logger="domain.course"):
         days = compute_days_elapsed(future)

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
@@ -11,6 +12,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
+from domain.course import compute_days_elapsed
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
@@ -712,3 +714,34 @@ async def test_concurrent_mark_read_collapses_to_one_row(
         )
         rows = list(result.scalars().all())
     assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_progress_endpoint_rejects_locked_stage(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-COURSE-003: ``/course/stages/{n}/progress`` must 403 on a locked stage.
+
+    Pre-fix the endpoint returned ``total_items`` and ``next_unlock_day``
+    for any stage the user could name, letting them reconstruct the full
+    drip schedule by walking 1..36.  Now a locked stage gets the same
+    ``stage_locked`` 403 the sibling list endpoint already issues.
+    """
+    headers, _ = await _signup(async_client, "locked_progress")
+    await _seed_stage_with_content(db_session, stage_number=2)
+    resp = await async_client.get("/course/stages/2/progress", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "stage_locked"
+
+
+def test_compute_days_elapsed_logs_on_future_timestamp(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """BUG-COURSE-005: a future ``stage_started_at`` clamps to 0 + WARNING."""
+    future = datetime.now(UTC) + timedelta(hours=2)
+    with caplog.at_level(logging.WARNING, logger="domain.course"):
+        days = compute_days_elapsed(future)
+    assert days == 0
+    smell_logs = [r for r in caplog.records if r.message == "stage_started_at_in_future"]
+    assert smell_logs, "expected a stage_started_at_in_future warning"

--- a/backend/tests/test_input_sanitization.py
+++ b/backend/tests/test_input_sanitization.py
@@ -128,8 +128,8 @@ async def test_prompt_response_journal_entry_matches_sanitized(
     # Filter by the stage_reflection tag rather than indexing items[0] so the
     # assertion does not depend on list-ordering (a future change to the
     # default journal sort would otherwise break this test silently).
-    reflections = [e for e in journal.json()["items"] if e["tag"] == "stage_reflection"]
-    assert reflections, "stage-reflection journal entry should exist"
+    reflections = [e for e in journal.json()["items"] if e["tag"] == "weekly_prompt"]
+    assert reflections, "weekly-prompt journal entry should exist"
     assert reflections[0]["message"] == "helloworld"
 
 
@@ -174,7 +174,7 @@ async def test_prompt_response_too_long_returns_422(
     ):
         resp = await async_client.post(
             "/prompts/1/respond",
-            json={"response": "hello"},
+            json={"response": "hello world friend"},
             headers=headers,
         )
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -40,7 +40,7 @@ async def test_unauthenticated_history_returns_401(async_client: AsyncClient) ->
 
 @pytest.mark.asyncio
 async def test_unauthenticated_respond_returns_401(async_client: AsyncClient) -> None:
-    resp = await async_client.post("/prompts/1/respond", json={"response": "test"})
+    resp = await async_client.post("/prompts/1/respond", json={"response": "a thoughtful answer"})
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
 
 
@@ -168,7 +168,7 @@ async def test_submit_response_invalid_week_returns_404(async_client: AsyncClien
     headers = await _signup(async_client)
     resp = await async_client.post(
         "/prompts/99/respond",
-        json={"response": "test"},
+        json={"response": "a thoughtful response"},
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.NOT_FOUND
@@ -224,7 +224,7 @@ async def test_current_week_derives_from_response_count_not_max(
     # Submit a response for week 1 successfully.
     resp1 = await async_client.post(
         "/prompts/1/respond",
-        json={"response": "Ground."},
+        json={"response": "Grounding feels like home."},
         headers=headers,
     )
     assert resp1.status_code == HTTPStatus.CREATED
@@ -232,7 +232,7 @@ async def test_current_week_derives_from_response_count_not_max(
     # Attempt a future week — must fail and NOT be persisted.
     resp_skip = await async_client.post(
         "/prompts/10/respond",
-        json={"response": "sneaky"},
+        json={"response": "sneaky attempt to skip"},
         headers=headers,
     )
     assert resp_skip.status_code == HTTPStatus.FORBIDDEN
@@ -245,7 +245,12 @@ async def test_current_week_derives_from_response_count_not_max(
 
 @pytest.mark.asyncio
 async def test_submit_response_creates_journal_entry(async_client: AsyncClient) -> None:
-    """Submitting a prompt response also creates a journal entry with stage_reflection tag."""
+    """Submitting a prompt response creates a journal entry tagged ``weekly_prompt``.
+
+    BUG-PROMPT-008: weekly cadence rows used to share the
+    ``stage_reflection`` tag with stage-transition reflections,
+    polluting any stage-scoped journal aggregate.
+    """
     headers = await _signup(async_client)
     await async_client.post(
         "/prompts/1/respond",
@@ -253,14 +258,13 @@ async def test_submit_response_creates_journal_entry(async_client: AsyncClient) 
         headers=headers,
     )
 
-    # Check journal entries
     journal_resp = await async_client.get("/journal/", headers=headers)
     assert journal_resp.status_code == HTTPStatus.OK
     journal_data = journal_resp.json()
     assert journal_data["total"] == 1
     entry = journal_data["items"][0]
     assert entry["message"] == "I reflected on grounding."
-    assert entry["tag"] == "stage_reflection"
+    assert entry["tag"] == "weekly_prompt"
     assert entry["sender"] == "user"
 
 
@@ -375,7 +379,7 @@ async def test_concurrent_prompt_responses_allow_exactly_one(
         *[
             concurrent_async_client.post(
                 "/prompts/1/respond",
-                json={"response": f"Attempt {i}"},
+                json={"response": f"A meaningful attempt #{i}"},
                 headers=headers,
             )
             for i in range(5)
@@ -390,3 +394,81 @@ async def test_concurrent_prompt_responses_allow_exactly_one(
 
     assert successes == 1, f"Expected exactly 1 success, got {successes}"
     assert rejections == 4, f"Expected 4 conflicts, got {rejections}"
+
+
+@pytest.mark.asyncio
+async def test_response_rejects_whitespace_only(async_client: AsyncClient) -> None:
+    """BUG-PROMPT-005: a stripped response shorter than the threshold is rejected."""
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "   "},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_response_rejects_short_answer(async_client: AsyncClient) -> None:
+    """BUG-PROMPT-005: a short stripped response (< threshold) is rejected."""
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "ok."},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_history_offset_is_capped(async_client: AsyncClient) -> None:
+    """BUG-PROMPT-006: out-of-range ``offset`` is rejected at the schema layer."""
+    headers = await _signup(async_client)
+    resp = await async_client.get("/prompts/history?offset=1000000000&limit=1", headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_history_skips_count_when_total_disabled(async_client: AsyncClient) -> None:
+    """BUG-PROMPT-006: ``include_total=false`` returns ``total=0`` and skips the count subquery."""
+    headers = await _signup(async_client)
+    await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "A meaningful first reflection."},
+        headers=headers,
+    )
+    resp = await async_client.get("/prompts/history?include_total=false", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["total"] == 0  # caller opted out
+    assert len(body["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_history_question_uses_live_dict(
+    async_client: AsyncClient,
+) -> None:
+    """BUG-PROMPT-010: the persisted ``question`` snapshot is overridden by the live dict.
+
+    Submit with one snapshot text, then patch the live dict to a new
+    text -- the history endpoint serves the new text so it cannot drift
+    from ``/current``.
+    """
+    from domain import weekly_prompts  # noqa: PLC0415 -- localised monkeypatch
+
+    headers = await _signup(async_client)
+    await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "A meaningful first reflection."},
+        headers=headers,
+    )
+
+    original = weekly_prompts.WEEKLY_PROMPTS[1]
+    weekly_prompts.WEEKLY_PROMPTS[1] = "REVISED prompt for week 1."
+    try:
+        resp = await async_client.get("/prompts/history", headers=headers)
+        assert resp.status_code == HTTPStatus.OK
+        body = resp.json()
+        assert body["items"][0]["question"] == "REVISED prompt for week 1."
+    finally:
+        weekly_prompts.WEEKLY_PROMPTS[1] = original

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -8,6 +8,8 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 
+from domain import weekly_prompts
+
 
 async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
     """Create a user and return auth headers."""
@@ -245,12 +247,7 @@ async def test_current_week_derives_from_response_count_not_max(
 
 @pytest.mark.asyncio
 async def test_submit_response_creates_journal_entry(async_client: AsyncClient) -> None:
-    """Submitting a prompt response creates a journal entry tagged ``weekly_prompt``.
-
-    BUG-PROMPT-008: weekly cadence rows used to share the
-    ``stage_reflection`` tag with stage-transition reflections,
-    polluting any stage-scoped journal aggregate.
-    """
+    """Submitting a prompt response creates a journal entry tagged ``weekly_prompt``."""
     headers = await _signup(async_client)
     await async_client.post(
         "/prompts/1/respond",
@@ -398,7 +395,7 @@ async def test_concurrent_prompt_responses_allow_exactly_one(
 
 @pytest.mark.asyncio
 async def test_response_rejects_whitespace_only(async_client: AsyncClient) -> None:
-    """BUG-PROMPT-005: a stripped response shorter than the threshold is rejected."""
+    """A whitespace-only response is rejected at the schema layer."""
     headers = await _signup(async_client)
     resp = await async_client.post(
         "/prompts/1/respond",
@@ -410,7 +407,7 @@ async def test_response_rejects_whitespace_only(async_client: AsyncClient) -> No
 
 @pytest.mark.asyncio
 async def test_response_rejects_short_answer(async_client: AsyncClient) -> None:
-    """BUG-PROMPT-005: a short stripped response (< threshold) is rejected."""
+    """A short stripped response (< threshold) is rejected."""
     headers = await _signup(async_client)
     resp = await async_client.post(
         "/prompts/1/respond",
@@ -421,8 +418,32 @@ async def test_response_rejects_short_answer(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_response_rejects_at_threshold_minus_one(async_client: AsyncClient) -> None:
+    """Boundary: 9 stripped chars is below the 10-char threshold and is rejected."""
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "  abcdefghi  "},  # strip()-> 9 chars
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_response_accepts_at_threshold(async_client: AsyncClient) -> None:
+    """Boundary: 10 stripped chars meets the threshold and is accepted."""
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "  abcdefghij  "},  # strip()-> 10 chars
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+
+@pytest.mark.asyncio
 async def test_history_offset_is_capped(async_client: AsyncClient) -> None:
-    """BUG-PROMPT-006: out-of-range ``offset`` is rejected at the schema layer."""
+    """Out-of-range ``offset`` is rejected at the schema layer."""
     headers = await _signup(async_client)
     resp = await async_client.get("/prompts/history?offset=1000000000&limit=1", headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
@@ -430,7 +451,7 @@ async def test_history_offset_is_capped(async_client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_history_skips_count_when_total_disabled(async_client: AsyncClient) -> None:
-    """BUG-PROMPT-006: ``include_total=false`` returns ``total=0`` and skips the count subquery."""
+    """``include_total=false`` returns ``total=0`` and skips the count subquery."""
     headers = await _signup(async_client)
     await async_client.post(
         "/prompts/1/respond",
@@ -448,14 +469,11 @@ async def test_history_skips_count_when_total_disabled(async_client: AsyncClient
 async def test_history_question_uses_live_dict(
     async_client: AsyncClient,
 ) -> None:
-    """BUG-PROMPT-010: the persisted ``question`` snapshot is overridden by the live dict.
+    """The persisted ``question`` snapshot is overridden by the live dict.
 
-    Submit with one snapshot text, then patch the live dict to a new
-    text -- the history endpoint serves the new text so it cannot drift
-    from ``/current``.
+    Submit a response, then patch ``WEEKLY_PROMPTS`` -- the history
+    endpoint serves the new text so it cannot drift from ``/current``.
     """
-    from domain import weekly_prompts  # noqa: PLC0415 -- localised monkeypatch
-
     headers = await _signup(async_client)
     await async_client.post(
         "/prompts/1/respond",

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -451,7 +451,7 @@ async def test_history_offset_is_capped(async_client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_history_skips_count_when_total_disabled(async_client: AsyncClient) -> None:
-    """``include_total=false`` returns ``total=0`` and skips the count subquery."""
+    """``include_total=false`` returns ``total=None`` (opt-out) and skips the count subquery."""
     headers = await _signup(async_client)
     await async_client.post(
         "/prompts/1/respond",

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -466,13 +466,66 @@ async def test_history_skips_count_when_total_disabled(async_client: AsyncClient
 
 
 @pytest.mark.asyncio
+async def test_history_cursor_has_more_false_when_no_more_items(
+    async_client: AsyncClient,
+) -> None:
+    """Cursor mode reports ``has_more=False`` on the last real page.
+
+    Submit one response, then page with ``limit=1&offset=1`` -- the
+    peek pattern (``limit + 1`` fetch) returns zero rows, so the
+    response correctly says no more pages exist even though
+    ``offset + limit < TOTAL_WEEKS``.
+    """
+    headers = await _signup(async_client)
+    await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "A meaningful first reflection."},
+        headers=headers,
+    )
+    resp = await async_client.get(
+        "/prompts/history?include_total=false&limit=1&offset=1",
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["items"] == []
+    assert body["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_history_cursor_has_more_true_when_more_remain(
+    async_client: AsyncClient,
+) -> None:
+    """Cursor mode reports ``has_more=True`` when a peek row materialises."""
+    headers = await _signup(async_client)
+    for week in range(1, 4):
+        resp = await async_client.post(
+            f"/prompts/{week}/respond",
+            json={"response": f"Week {week} reflection text."},
+            headers=headers,
+        )
+        assert resp.status_code == HTTPStatus.CREATED
+
+    resp = await async_client.get(
+        "/prompts/history?include_total=false&limit=1&offset=0",
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert len(body["items"]) == 1
+    assert body["has_more"] is True
+
+
+@pytest.mark.asyncio
 async def test_history_question_uses_live_dict(
     async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The persisted ``question`` snapshot is overridden by the live dict.
 
-    Submit a response, then patch ``WEEKLY_PROMPTS`` -- the history
-    endpoint serves the new text so it cannot drift from ``/current``.
+    Submit a response, then patch ``WEEKLY_PROMPTS`` via ``monkeypatch.setitem``
+    -- the fixture restores the dict on test exit so the mutation cannot
+    leak into a parallel run.
     """
     headers = await _signup(async_client)
     await async_client.post(
@@ -481,12 +534,8 @@ async def test_history_question_uses_live_dict(
         headers=headers,
     )
 
-    original = weekly_prompts.WEEKLY_PROMPTS[1]
-    weekly_prompts.WEEKLY_PROMPTS[1] = "REVISED prompt for week 1."
-    try:
-        resp = await async_client.get("/prompts/history", headers=headers)
-        assert resp.status_code == HTTPStatus.OK
-        body = resp.json()
-        assert body["items"][0]["question"] == "REVISED prompt for week 1."
-    finally:
-        weekly_prompts.WEEKLY_PROMPTS[1] = original
+    monkeypatch.setitem(weekly_prompts.WEEKLY_PROMPTS, 1, "REVISED prompt for week 1.")
+    resp = await async_client.get("/prompts/history", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["items"][0]["question"] == "REVISED prompt for week 1."

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -461,7 +461,7 @@ async def test_history_skips_count_when_total_disabled(async_client: AsyncClient
     resp = await async_client.get("/prompts/history?include_total=false", headers=headers)
     assert resp.status_code == HTTPStatus.OK
     body = resp.json()
-    assert body["total"] == 0  # caller opted out
+    assert body["total"] is None  # opt-out sentinel; ``has_more`` drives pagination
     assert len(body["items"]) == 1
 
 
@@ -514,6 +514,36 @@ async def test_history_cursor_has_more_true_when_more_remain(
     body = resp.json()
     assert len(body["items"]) == 1
     assert body["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_history_total_aware_has_more_false_at_boundary(
+    async_client: AsyncClient,
+) -> None:
+    """Count-aware mode reports ``has_more=False`` when ``offset + limit == total``.
+
+    Pins the strict-less-than comparison in the count-aware branch so a
+    future ``<=`` regression would fail this test instead of inflating
+    ``has_more`` for clients that have read every row.
+    """
+    headers = await _signup(async_client)
+    for week in range(1, 4):
+        resp = await async_client.post(
+            f"/prompts/{week}/respond",
+            json={"response": f"Week {week} reflection text."},
+            headers=headers,
+        )
+        assert resp.status_code == HTTPStatus.CREATED
+
+    resp = await async_client.get(
+        "/prompts/history?include_total=true&limit=3&offset=0",
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["total"] == 3
+    assert len(body["items"]) == 3
+    assert body["has_more"] is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -473,13 +473,7 @@ async def test_update_progress_advances_from_current_stage_only(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """BUG-STAGE-002: advance is derived from ``current_stage`` alone.
-
-    A drifted ``completed_stages`` list cannot tilt the server's
-    derived next stage.  ``current_stage=5`` advances to 6 regardless
-    of what ``completed_stages`` looks like; the client asserting 6
-    succeeds.
-    """
+    """Advance derives from ``current_stage`` alone; drift in ``completed_stages`` is ignored."""
     headers, user_id = await _signup(async_client, "dirty")
     progress = StageProgress(user_id=user_id, current_stage=5, completed_stages=[1, 2, 4])
     db_session.add(progress)
@@ -590,7 +584,7 @@ async def test_history_rejects_locked_stage(
     assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
-# ── BUG-STAGE-002: is_stage_unlocked correctness ───────────────────────
+# ── is_stage_unlocked correctness ──────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -598,7 +592,7 @@ async def test_stage_unlocked_uses_current_stage(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """Stage N is unlocked iff ``N <= current_stage`` (BUG-STAGE-002)."""
+    """Stage N is unlocked iff ``N <= current_stage``."""
     headers, user_id = await _signup(async_client)
     await _seed_stages(db_session, count=3)
     progress = StageProgress(user_id=user_id, current_stage=3, completed_stages=[1, 2])
@@ -618,14 +612,7 @@ async def test_stage_unlocked_uses_current_stage_only(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """BUG-STAGE-002: ``current_stage`` is the single source of truth.
-
-    A drifted ``completed_stages`` list (here ``[2]`` with
-    ``current_stage=3``) cannot block the unlock decision -- the
-    display path and the unlock path agree on ``current_stage`` so a
-    legacy DB mutation that touched only one field does not flip
-    stages between locked and unlocked.
-    """
+    """``current_stage`` is the source of truth; a drifted ``completed_stages`` is ignored."""
     headers, user_id = await _signup(async_client)
     await _seed_stages(db_session, count=3)
     progress = StageProgress(user_id=user_id, current_stage=3, completed_stages=[2])

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -469,17 +469,16 @@ async def test_update_progress_rejects_completed_stages_injection(
 
 
 @pytest.mark.asyncio
-async def test_update_progress_ignores_client_on_dirty_data(
+async def test_update_progress_advances_from_current_stage_only(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """BUG-SCHEMA-006: client cannot skip past a legacy gap.
+    """BUG-STAGE-002: advance is derived from ``current_stage`` alone.
 
-    A pre-existing row with ``completed_stages=[1, 2, 4]`` and
-    ``current_stage=5`` encodes a missing stage-3 credit.  The server's
-    derived expectation after "completing" stage 5 is the first hole = 3,
-    not 6.  The client asserting 6 gets ``stage_advance_mismatch`` so the
-    gap must be repaired via the admin helper before advancement resumes.
+    A drifted ``completed_stages`` list cannot tilt the server's
+    derived next stage.  ``current_stage=5`` advances to 6 regardless
+    of what ``completed_stages`` looks like; the client asserting 6
+    succeeds.
     """
     headers, user_id = await _signup(async_client, "dirty")
     progress = StageProgress(user_id=user_id, current_stage=5, completed_stages=[1, 2, 4])
@@ -491,8 +490,8 @@ async def test_update_progress_ignores_client_on_dirty_data(
         json={"current_stage": 6},
         headers=headers,
     )
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
-    assert resp.json()["detail"] == "stage_advance_mismatch"
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["current_stage"] == 6
 
 
 @pytest.mark.asyncio
@@ -595,52 +594,49 @@ async def test_history_rejects_locked_stage(
 
 
 @pytest.mark.asyncio
-async def test_stage_unlocked_via_completed_stages(
+async def test_stage_unlocked_uses_current_stage(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """Stage N+1 unlocks when N is in completed_stages."""
+    """Stage N is unlocked iff ``N <= current_stage`` (BUG-STAGE-002)."""
     headers, user_id = await _signup(async_client)
     await _seed_stages(db_session, count=3)
-    # completed_stages includes 1 and 2, current is 2
-    progress = StageProgress(user_id=user_id, current_stage=2, completed_stages=[1, 2])
+    progress = StageProgress(user_id=user_id, current_stage=3, completed_stages=[1, 2])
     db_session.add(progress)
     await db_session.commit()
 
     resp = await async_client.get("/stages", headers=headers)
     data = resp.json()
-    # Stage 3 should be unlocked because stage 2 is in completed_stages
+    # current_stage=3 unlocks stages 1..3.
+    assert data[0]["is_unlocked"] is True
+    assert data[1]["is_unlocked"] is True
     assert data[2]["is_unlocked"] is True
 
 
 @pytest.mark.asyncio
-async def test_stage_unlocked_requires_predecessor_completed(
+async def test_stage_unlocked_uses_current_stage_only(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """BUG-STAGE-001/002: every prior stage must be in ``completed_stages``.
+    """BUG-STAGE-002: ``current_stage`` is the single source of truth.
 
-    Seeding ``completed_stages=[2]`` with ``current_stage=3`` leaves stage 1
-    uncredited.  Under the chain-validation rule, stage 2 requires ``{1}`` and
-    stage 3 requires ``{1, 2}``; both fail when stage 1 is missing, so only
-    stage 1 (the always-unlocked root) stays open.
+    A drifted ``completed_stages`` list (here ``[2]`` with
+    ``current_stage=3``) cannot block the unlock decision -- the
+    display path and the unlock path agree on ``current_stage`` so a
+    legacy DB mutation that touched only one field does not flip
+    stages between locked and unlocked.
     """
     headers, user_id = await _signup(async_client)
     await _seed_stages(db_session, count=3)
-    # current_stage=3 but completed_stages is missing stage 1.
-    # This simulates a DB-level mutation that skipped the completion list.
     progress = StageProgress(user_id=user_id, current_stage=3, completed_stages=[2])
     db_session.add(progress)
     await db_session.commit()
 
     resp = await async_client.get("/stages", headers=headers)
     data = resp.json()
-    # Stage 1: always unlocked
     assert data[0]["is_unlocked"] is True
-    # Stage 2: chain requires {1} ⊆ completed; {2} fails → locked
-    assert data[1]["is_unlocked"] is False
-    # Stage 3: chain requires {1, 2} ⊆ completed; {2} fails → locked (BUG-STAGE-001)
-    assert data[2]["is_unlocked"] is False
+    assert data[1]["is_unlocked"] is True  # current_stage=3 unlocks 1..3
+    assert data[2]["is_unlocked"] is True
 
 
 # ── User isolation ──────────────────────────────────────────────────────

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -35,7 +35,9 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 | 09 | server-derived-timestamps         | 3 | `claude/09-server-derived-timestamps-cfvVc` / [#264](https://github.com/Geoffe-Ga/adepthood/pull/264) | [x] |
 | 10 | observability-e2e                 | 3 | `claude/10-observability-e2e-OfIPz` / [#268](https://github.com/Geoffe-Ga/adepthood/pull/268) | [x] |
 | 11 | backend-auth-models-schemas-cors  | 4 | `claude/bug-fix-11-backend-auth-models-schemas-cors` | [x] |
-| 12 | backend-feature-routers           | 4 | | [ ] |
+| 12 | backend-feature-routers (12A wave 1) | 4 | `claude/bug-fix-12a-backend-feature-routers-hgcp` / [#276](https://github.com/Geoffe-Ga/adepthood/pull/276) | [x] |
+| 12 | backend-feature-routers (12A wave 2) | 4 | `claude/bug-fix-12a-wave-2-stage-course-prompts` | [ ] |
+| 12 | backend-feature-routers (12B)        | 4 | | [ ] |
 | 13 | frontend-api-client               | 4 | | [ ] |
 | 14 | frontend-feature-screens          | 4 | | [ ] |
 | 15 | frontend-design-state-tests       | 4 | | [ ] |


### PR DESCRIPTION
## Summary

Closes the deferred half of prompt 12A: **stage**, **course**, and **weekly-prompt** clusters. Three High / Medium / Low BUG-IDs across `domain/{stage_progress,course}`, `routers/{stages,course,prompts}`, and `schemas/prompt`.

12A wave 1 (habits + goals) shipped in #276. With this PR, prompt 12A is complete.

## Commits

### `22a9ce6` fix(backend): stage_progress drift fix (BUG-STAGE-002)
- `current_stage` is now the single source of truth: `is_stage_unlocked` returns `N <= current_stage`, `next_stage_for` returns `current_stage + 1`. `completed_stages` is intentionally ignored on the read path so legacy rows or admin scripts that update one field without the other cannot make the unlock decision disagree with the display path.
- Router still writes a canonical `completed_stages = [1..current-1]` on every advance for backward compat with admin audit / repair endpoints; full column drop is a follow-up migration.
- BUG-STAGE-001 chain-validation tests updated to reflect the new contract — forward-only enforcement now lives at the router (advance must equal `current+1`).

### `75fe9c1` fix(backend): course router hardening (BUG-COURSE-003 / -005)
- **BUG-COURSE-003**: `GET /course/stages/{n}/progress` now gates on `_check_stage_unlocked` so an authenticated client can no longer reconstruct the full 36-stage drip schedule by walking 1..36. Drops the redundant `stage_exists` call (`_get_stage_by_number` already raises 404).
- **BUG-COURSE-005**: `compute_days_elapsed` structured-logs a WARNING when `stage_started_at` is in the future before clamping to 0. Operators can now spot clock-skew / admin-backfill data smells in SIEM.

### `8943bf1` fix(backend): weekly-prompt UX + pagination (BUG-PROMPT-005/-006/-008/-010)
- **BUG-PROMPT-005**: `PromptSubmit.response` rejects whitespace-only or below-threshold (10 stripped chars) inputs at the schema layer, blocking the trivial 36-call auto-advance via three-spaces payloads.
- **BUG-PROMPT-006**: `list_prompt_history` caps `offset` at `TOTAL_WEEKS=36` (no billion-row OFFSET DoS) and adds `include_total=false` for cursor-style pagination that skips the count subquery on small lists.
- **BUG-PROMPT-008**: weekly-prompt journal entries use new `JournalTag.WEEKLY_PROMPT` instead of `STAGE_REFLECTION` so stage-scoped aggregates stop double-counting weekly cadence rows.
- **BUG-PROMPT-010**: history endpoint derives `question` from the live `WEEKLY_PROMPTS` dict (snapshot fallback only on retired weeks), eliminating drift between `/current` and `/history` after prompt revisions.

### `8af4a82` refactor(backend): extract list_prompt_history helpers
- Splits `_history_detail`, `_maybe_total`, `_has_more` so the route stays at xenon rank A.

### `9fd9d9a` chore(prompts): mark 12A wave 1 complete + register wave 2 branch in INDEX

## Coverage

- 873 tests passing (was 866 in main; +7 regression tests for the new contracts).
- Pre-commit clean (ruff `select=ALL`, mypy strict, bandit, detect-secrets, xenon rank A, radon B+, 93%+ coverage).

## Test plan

- [x] Backend test suite (`pytest`) — 873 passed
- [x] Pre-commit (`pre-commit run --all-files`) clean
- [x] Coverage ≥ 90%
- [ ] CI workflows green
- [ ] Claude review LGTM

## Out of scope

- BUG-STAGE-002 column drop migration (current commit makes the column functionally redundant; physical drop is a follow-up).
- 12B (practices/journal/botmason) — separate PR.
- 13/14/15 frontend tracks.

https://claude.ai/code/session_011JvxjW4m5jw6u77eKrrYjz

---
_Generated by [Claude Code](https://claude.ai/code/session_011JvxjW4m5jw6u77eKrrYjz)_