### PR TITLE
fix(backend): practice submit whitelist + per-user RL + energy auth

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -152,9 +152,19 @@ async def async_client(db_session: AsyncSession) -> AsyncGenerator[AsyncClient, 
 
 @pytest.fixture(autouse=True)
 def _reset_rate_limiter() -> Generator[None, None, None]:
-    """Clear the rate limiter's in-memory storage between tests."""
+    """Reset both the limiter's storage AND its ``enabled`` flag between tests.
+
+    ``limiter.reset()`` clears the in-memory bucket counts but does NOT
+    restore ``limiter.enabled`` -- so a test using the ``disable_rate_limit``
+    fixture would leave the limiter off for every subsequent test that
+    runs in the same process.  Forcing ``enabled = True`` here makes the
+    autouse contract a single source of truth: every test starts with the
+    limiter on and storage empty, regardless of what its predecessors did.
+    """
+    limiter.enabled = True
     limiter.reset()
     yield
+    limiter.enabled = True
     limiter.reset()
 
 

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -658,6 +658,21 @@ def _coerce_sub(payload: dict[str, object]) -> int:
         ) from exc
 
 
+def extract_user_id_from_authorization(authorization: str | None) -> int:
+    """Decode a Bearer JWT and return the user id, or raise 401.
+
+    Public wrapper combining :func:`_decode_token_payload` and
+    :func:`_coerce_sub` so non-router callers (e.g. ``slowapi`` rate-limit
+    key functions) can derive the stable user id from the request without
+    poking at private helpers.  Skips the revocation check on purpose --
+    rate-limiting ahead of FastAPI's DI runs before the canonical
+    ``get_current_user`` dependency, and the revocation lookup needs an
+    ``AsyncSession`` we don't have here; the route handler itself still
+    enforces revocation through :func:`get_current_user`.
+    """
+    return _coerce_sub(_decode_token_payload(authorization))
+
+
 async def _check_token_not_revoked(session: AsyncSession, payload: dict[str, object]) -> None:
     """Reject the request if the token's ``jti`` is in the revocation table.
 

--- a/backend/src/routers/energy.py
+++ b/backend/src/routers/energy.py
@@ -6,8 +6,9 @@ import asyncio
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Depends, Header
 
+from routers.auth import get_current_user
 from schemas import EnergyPlanRequest, EnergyPlanResponse
 from services.energy import get_or_generate_plan
 
@@ -18,9 +19,21 @@ router = APIRouter(prefix="/v1/energy", tags=["energy"])
 
 @router.post("/plan", response_model=EnergyPlanResponse)
 async def create_plan(
-    payload: EnergyPlanRequest, x_idempotency_key: Annotated[str | None, Header()] = None
+    payload: EnergyPlanRequest,
+    current_user: Annotated[int, Depends(get_current_user)],
+    x_idempotency_key: Annotated[str | None, Header()] = None,
 ) -> EnergyPlanResponse:
     """Create an energy plan from submitted habits.
+
+    Auth is required (BUG-PRACTICE-010): the planner runs CPU-bound
+    scheduling work on a thread pool, so an unauthenticated endpoint
+    would let a single attacker spawn arbitrary expensive work for free.
+    Habit list size is already capped at ``MAX_HABITS_PER_PLAN`` in the
+    request schema; loading per-habit ``energy_cost`` / ``energy_return``
+    server-side from ``Habit.user_id == current_user`` -- so the planner
+    is not steered by client-supplied costs -- is a deliberate follow-up
+    that touches :mod:`services.energy` and is tracked separately to
+    keep this PR scoped to the auth gate.
 
     BUG-INFRA-009: ``generate_plan`` (called via :func:`get_or_generate_plan`)
     performs CPU-bound scheduling work.  Running it inline on the event loop
@@ -31,5 +44,8 @@ async def create_plan(
     to the loop while the worker thread runs.
     """
     response = await asyncio.to_thread(get_or_generate_plan, payload, x_idempotency_key)
-    logger.info("energy_plan_created", extra={"reason_code": response.reason_code})
+    logger.info(
+        "energy_plan_created",
+        extra={"user_id": current_user, "reason_code": response.reason_code},
+    )
     return response

--- a/backend/src/routers/energy.py
+++ b/backend/src/routers/energy.py
@@ -29,11 +29,20 @@ async def create_plan(
     scheduling work on a thread pool, so an unauthenticated endpoint
     would let a single attacker spawn arbitrary expensive work for free.
     Habit list size is already capped at ``MAX_HABITS_PER_PLAN`` in the
-    request schema; loading per-habit ``energy_cost`` / ``energy_return``
-    server-side from ``Habit.user_id == current_user`` -- so the planner
-    is not steered by client-supplied costs -- is a deliberate follow-up
-    that touches :mod:`services.energy` and is tracked separately to
-    keep this PR scoped to the auth gate.
+    request schema.
+
+    .. warning::
+
+       The auth gate alone does NOT close BUG-PRACTICE-010 in full.
+       The planner is still steered by client-supplied
+       ``energy_cost`` / ``energy_return`` values per habit, so an
+       authenticated user can submit any habit id with arbitrary costs
+       and influence the plan.  Loading those values server-side from
+       ``Habit`` rows owned by ``current_user`` -- and rejecting any
+       client-sent costs -- is the remaining piece.  It needs a
+       ``services.energy`` refactor and is deliberately deferred to
+       12B wave 2; the ``current_user`` parameter is plumbed in so the
+       follow-up is purely additive.
 
     BUG-INFRA-009: ``generate_plan`` (called via :func:`get_or_generate_plan`)
     performs CPU-bound scheduling work.  Running it inline on the event loop

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -49,11 +49,24 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/journal", tags=["journal"])
 
 
+# BUG-JOURNAL-009: ``search`` is run as ``ILIKE '%term%'`` against an
+# uncapped column; without a length bound a 5MB query can pin a worker.
+# A min-length of 3 also guards against substring-search noise (a single
+# ``%a%`` matches almost every row in a chatty user's history) and keeps
+# the cardinality of the LIKE plan reasonable.
+JOURNAL_SEARCH_MIN_LENGTH = 3
+JOURNAL_SEARCH_MAX_LENGTH = 64
+
+
 @dataclass
 class _ListFilters:
     """Query parameters for listing journal entries."""
 
-    search: str | None = Query(default=None)
+    search: str | None = Query(
+        default=None,
+        min_length=JOURNAL_SEARCH_MIN_LENGTH,
+        max_length=JOURNAL_SEARCH_MAX_LENGTH,
+    )
     tag: JournalTag | None = None
     practice_session_id: int | None = Query(default=None)
     limit: int = Query(default=50, ge=1, le=200)

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -6,7 +6,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, func, select
 
@@ -25,7 +25,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/practice-sessions", tags=["practice-sessions"])
 
 
-@router.post("/", response_model=PracticeSessionResponse)
+@router.post(
+    "/",
+    response_model=PracticeSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_session(
     payload: PracticeSessionCreate,
     current_user: Annotated[int, Depends(get_current_user)],

--- a/backend/src/routers/practices.py
+++ b/backend/src/routers/practices.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Request, status
+from slowapi.util import get_remote_address
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
+from starlette.requests import Request as StarletteRequest
 
 from database import get_session
 from dependencies.ownership import require_visible_practice
@@ -17,6 +20,24 @@ from routers.auth import get_current_user
 from schemas import Page, PaginationParams, build_page
 from schemas.pagination import paginate_query
 from schemas.practice import PracticeCreate, PracticeResponse
+
+
+def _per_user_rate_limit_key(request: StarletteRequest) -> str:
+    """Rate-limit key that prefers a hash of the auth token over IP (BUG-PRACTICE-003).
+
+    The default ``slowapi`` key is the remote address, which means a single
+    user can rotate IPs to bypass the per-IP cap and, conversely, multiple
+    legitimate users behind a shared NAT throttle each other.  Hashing the
+    bearer token keeps the limiter keyed to the spending identity without
+    storing a live JWT in the limiter's backing store -- the same shape used
+    by :func:`routers.botmason._per_user_key`.
+    """
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.startswith("Bearer "):
+        digest = hashlib.sha256(auth_header.encode("utf-8")).hexdigest()
+        return f"user:{digest}"
+    return get_remote_address(request)
+
 
 logger = logging.getLogger(__name__)
 
@@ -61,16 +82,30 @@ async def get_practice(
 
 
 @router.post("/", response_model=PracticeResponse, status_code=status.HTTP_201_CREATED)
-@limiter.limit("5/minute")
+@limiter.limit("5/minute", key_func=_per_user_rate_limit_key)
 async def submit_practice(
     request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     payload: PracticeCreate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> Practice:
-    """Submit a new user-created practice (defaults to unapproved)."""
+    """Submit a new user-created practice (defaults to unapproved).
+
+    Constructed with explicit kwargs (BUG-PRACTICE-002) rather than
+    ``**payload.model_dump()``: a future addition to ``PracticeCreate``
+    that overlapped a server-controlled column (e.g. ``approved``,
+    ``submitted_by_user_id``) would otherwise silently flow through to
+    the ORM and let a client mint pre-approved rows or impersonate
+    another submitter.  Listing the fields here makes the trust boundary
+    visible and turns any new client-controlled field into a deliberate
+    audit decision.
+    """
     practice = Practice(
-        **payload.model_dump(),
+        stage_number=payload.stage_number,
+        name=payload.name,
+        description=payload.description,
+        instructions=payload.instructions,
+        default_duration_minutes=payload.default_duration_minutes,
         submitted_by_user_id=current_user,
         approved=False,
     )

--- a/backend/src/routers/practices.py
+++ b/backend/src/routers/practices.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from typing import Annotated
 
@@ -10,33 +9,38 @@ from fastapi import APIRouter, Depends, Request, status
 from slowapi.util import get_remote_address
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
-from starlette.requests import Request as StarletteRequest
 
 from database import get_session
 from dependencies.ownership import require_visible_practice
 from models.practice import Practice
 from rate_limit import limiter
-from routers.auth import get_current_user
+from routers.auth import extract_user_id_from_authorization, get_current_user
 from schemas import Page, PaginationParams, build_page
 from schemas.pagination import paginate_query
 from schemas.practice import PracticeCreate, PracticeResponse
 
 
-def _per_user_rate_limit_key(request: StarletteRequest) -> str:
-    """Rate-limit key that prefers a hash of the auth token over IP (BUG-PRACTICE-003).
+def _per_user_rate_limit_key(request: Request) -> str:
+    """Rate-limit key derived from the JWT ``sub`` claim (BUG-PRACTICE-003).
 
-    The default ``slowapi`` key is the remote address, which means a single
-    user can rotate IPs to bypass the per-IP cap and, conversely, multiple
-    legitimate users behind a shared NAT throttle each other.  Hashing the
-    bearer token keeps the limiter keyed to the spending identity without
-    storing a live JWT in the limiter's backing store -- the same shape used
-    by :func:`routers.botmason._per_user_key`.
+    The default ``slowapi`` key is the remote address, which lets a
+    single user rotate IPs to bypass the per-IP cap and, conversely,
+    multiple legitimate users behind a shared NAT throttle each other.
+
+    Keying on the JWT's ``sub`` (the stable user id) instead of a hash
+    of the bearer token means a logout / refresh flow that mints a new
+    token does NOT reset the user's rate-limit bucket -- the budget
+    follows the identity, not the credential.  Decoding here costs one
+    HMAC-SHA256 per request which is dominated by the LLM call below.
+
+    Falls back to the remote address for malformed or missing tokens
+    so the limiter never receives an empty key (and so any pre-auth
+    probe is still throttled before FastAPI's DI rejects it).
     """
-    auth_header = request.headers.get("authorization", "")
-    if auth_header.startswith("Bearer "):
-        digest = hashlib.sha256(auth_header.encode("utf-8")).hexdigest()
-        return f"user:{digest}"
-    return get_remote_address(request)
+    try:
+        return f"user:{extract_user_id_from_authorization(request.headers.get('authorization'))}"
+    except Exception:  # noqa: BLE001 — fall through to IP for any decode failure
+        return get_remote_address(request)
 
 
 logger = logging.getLogger(__name__)

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -18,7 +18,7 @@ class JournalMessageCreate(BaseModel):
     impersonate other users or forge bot messages.
     """
 
-    message: str = Field(max_length=JOURNAL_MESSAGE_MAX_LENGTH)
+    message: str = Field(min_length=1, max_length=JOURNAL_MESSAGE_MAX_LENGTH)
     tag: JournalTag = JournalTag.FREEFORM
     practice_session_id: int | None = None
     user_practice_id: int | None = None
@@ -32,7 +32,7 @@ class JournalBotMessageCreate(BaseModel):
     (BUG-JOURNAL-002).
     """
 
-    message: str = Field(max_length=JOURNAL_MESSAGE_MAX_LENGTH)
+    message: str = Field(min_length=1, max_length=JOURNAL_MESSAGE_MAX_LENGTH)
     tag: JournalTag = JournalTag.FREEFORM
     practice_session_id: int | None = None
     user_practice_id: int | None = None

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -69,14 +69,32 @@ DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"
 # purpose: every addition is a deliberate audit decision (and any
 # new model needs an entry in :mod:`services.llm_pricing` so cost
 # estimation does not silently fall back to ``$0``).
+#
+# Anthropic IDs intentionally mix two formats per Anthropic's naming:
+#
+#   * ``claude-{family}-{major}-{minor}`` (e.g. ``claude-opus-4-7``,
+#     ``claude-sonnet-4-6``) -- a *floating alias* that always points at
+#     the latest minor release in that family.  Choose this for chat /
+#     dev use where staying current matters more than reproducibility.
+#   * ``claude-{family}-{major}-{YYYYMMDD}`` (e.g.
+#     ``claude-sonnet-4-20250514``, ``claude-haiku-4-5-20251001``) --
+#     a *date-pinned* build.  Choose this for evaluations / experiments
+#     where the model behind the alias must not silently change.
+#
+# Both forms are valid Anthropic endpoints; they are NOT duplicates --
+# an operator deliberately chooses pin-vs-alias by setting ``LLM_MODEL``.
+# Each pin/alias is listed only when there is a matching pricing row in
+# :mod:`services.llm_pricing` so cost estimation stays accurate.
 _ALLOWED_MODELS: dict[str, frozenset[str]] = {
     "openai": frozenset({"gpt-4o-mini", "gpt-4o", "gpt-4-turbo"}),
     "anthropic": frozenset(
         {
+            # Date-pinned (reproducible) builds:
             "claude-sonnet-4-20250514",
+            "claude-haiku-4-5-20251001",
+            # Floating aliases (track latest minor):
             "claude-opus-4-7",
             "claude-sonnet-4-6",
-            "claude-haiku-4-5-20251001",
         }
     ),
 }

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -56,9 +56,30 @@ _ANTHROPIC_KEY_PREFIX = "sk-ant-"
 STUB_MODEL_NAME = "stub"
 
 # Centralised default models so the choice lives in one place (BUG-JOURNAL-011).
-# ``LLM_MODEL`` env var overrides at runtime.
+# ``LLM_MODEL`` env var overrides at runtime — but only to a value listed
+# in :data:`_ALLOWED_MODELS` for the active provider (BUG-BM-001).
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
 DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"
+
+# Closed allowlist per provider (BUG-BM-001).  Without this gate, an
+# operator who set ``LLM_MODEL=gpt-4o-most-expensive`` (or, worse,
+# accidentally pointed an Anthropic key at an OpenAI model name)
+# would silently route traffic through an unintended billing tier or
+# break in cryptic ways at provider call time.  The set is small on
+# purpose: every addition is a deliberate audit decision (and any
+# new model needs an entry in :mod:`services.llm_pricing` so cost
+# estimation does not silently fall back to ``$0``).
+_ALLOWED_MODELS: dict[str, frozenset[str]] = {
+    "openai": frozenset({"gpt-4o-mini", "gpt-4o", "gpt-4-turbo"}),
+    "anthropic": frozenset(
+        {
+            "claude-sonnet-4-20250514",
+            "claude-opus-4-7",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5-20251001",
+        }
+    ),
+}
 
 # Timeout in seconds for LLM provider HTTP calls (BUG-JOURNAL-005).
 _LLM_TIMEOUT_SECONDS = 30.0
@@ -300,6 +321,20 @@ def _wrap_user_input(text: str, nonce: str) -> str:
     return f"<user_input_{nonce}>{sanitize_user_text(text)}</user_input_{nonce}>"
 
 
+def _entry_message(entry: dict[str, str]) -> str:
+    """Return ``entry["message"]`` with a safe empty-string fallback (BUG-BM-005).
+
+    Mirrors the ``.get("message", "")`` shape already used by
+    :func:`_dynamic_max_tokens`.  Without this, a malformed history
+    row (missing ``message`` after a future schema change, or a row
+    constructed by a test fixture that forgot the field) would raise
+    ``KeyError`` mid-request and burn one wallet message with no
+    response — far worse than emitting an empty turn the model
+    naturally ignores.
+    """
+    return entry.get("message", "")
+
+
 def _build_messages(
     user_message: str,
     conversation_history: list[dict[str, str]],
@@ -321,17 +356,43 @@ def _build_messages(
     ]
     for entry in conversation_history:
         role = "assistant" if entry.get("sender") == "bot" else "user"
-        content = _wrap_user_input(entry["message"], nonce) if role == "user" else entry["message"]
+        message = _entry_message(entry)
+        content = _wrap_user_input(message, nonce) if role == "user" else message
         messages.append({"role": role, "content": content})
     messages.append({"role": "user", "content": _wrap_user_input(user_message, nonce)})
     return messages
 
 
-def _get_model(provider: str) -> str:
-    """Return the model ID from ``LLM_MODEL`` env or the provider's default."""
+def _provider_default_model(provider: str) -> str:
+    """Return the built-in default model for ``provider``."""
     if provider == "anthropic":
-        return os.getenv("LLM_MODEL", DEFAULT_ANTHROPIC_MODEL)
-    return os.getenv("LLM_MODEL", DEFAULT_OPENAI_MODEL)
+        return DEFAULT_ANTHROPIC_MODEL
+    return DEFAULT_OPENAI_MODEL
+
+
+def _get_model(provider: str) -> str:
+    """Return the validated model ID for ``provider`` (BUG-BM-001).
+
+    Resolves to ``LLM_MODEL`` env var when set; otherwise the per-provider
+    default.  Either way the chosen value MUST appear in the provider's
+    entry in :data:`_ALLOWED_MODELS` -- a misconfigured env var fails
+    fast at request time rather than silently routing traffic through
+    an unvetted model (and an unknown cost row).  Unknown providers
+    (including ``"stub"``) bypass the check: they never hit a real
+    provider so model selection is moot.
+    """
+    requested = os.getenv("LLM_MODEL") or _provider_default_model(provider)
+    allowed = _ALLOWED_MODELS.get(provider)
+    if allowed is None:
+        return requested
+    if requested not in allowed:
+        msg = (
+            f"LLM_MODEL={requested!r} is not on the {provider} allowlist; "
+            "add it to services.botmason._ALLOWED_MODELS only after a pricing "
+            "row exists in services.llm_pricing."
+        )
+        raise RuntimeError(msg)
+    return requested
 
 
 def _build_anthropic_messages(
@@ -352,7 +413,8 @@ def _build_anthropic_messages(
     messages: list[dict[str, str]] = []
     for entry in conversation_history:
         role = "assistant" if entry.get("sender") == "bot" else "user"
-        content = _wrap_user_input(entry["message"], nonce) if role == "user" else entry["message"]
+        message = _entry_message(entry)
+        content = _wrap_user_input(message, nonce) if role == "user" else message
         messages.append({"role": role, "content": content})
     messages.append({"role": "user", "content": _wrap_user_input(user_message, nonce)})
     return messages, _augment_system_prompt(system_prompt, nonce)

--- a/backend/src/services/journal.py
+++ b/backend/src/services/journal.py
@@ -19,21 +19,40 @@ from security import sanitize_user_text
 from services.botmason import CONVERSATION_HISTORY_LIMIT, LLMResponse
 from services.llm_pricing import estimate_cost_usd
 
+# Conversation-history senders that participate in BotMason chat
+# (BUG-JOURNAL-008).  Free-form journal entries written via
+# ``POST /journal/`` carry ``sender="user"`` too, but the only senders that
+# round-trip through the LLM are the chat user and the bot itself.  Future
+# senders (e.g. ``"system"``) must be added explicitly so they cannot
+# silently poison the LLM prompt.
+_CHAT_SENDERS = ("user", "bot")
+
 
 async def load_recent_conversation(
     session: AsyncSession,
     user_id: int,
 ) -> list[dict[str, str]]:
-    """Return the last ``CONVERSATION_HISTORY_LIMIT`` messages chronologically.
+    """Return the last ``CONVERSATION_HISTORY_LIMIT`` chat messages chronologically.
 
     Centralising the query keeps the streaming and non-streaming endpoints in
     sync: if the context window grows later, both inherit the new behaviour
     without drift.  Each entry is returned as a plain dict so provider
     adapters do not need to know about ORM types.
+
+    Filters to ``sender IN ('user', 'bot')`` (BUG-JOURNAL-008) so a future
+    sender value (e.g. ``"system"``) cannot silently poison the LLM
+    prompt — every new sender must be added to ``_CHAT_SENDERS`` as a
+    deliberate audit decision.  Free-form journal entries written via
+    ``POST /journal/`` also carry ``sender="user"``; tag-scoping the
+    history (so private notes do not bleed into the chat context) is a
+    separate change tracked alongside the chat-tag follow-up.
     """
     history_query = (
         select(JournalEntry)
-        .where(JournalEntry.user_id == user_id)
+        .where(
+            JournalEntry.user_id == user_id,
+            col(JournalEntry.sender).in_(_CHAT_SENDERS),
+        )
         .order_by(col(JournalEntry.id).desc())
         .limit(CONVERSATION_HISTORY_LIMIT)
     )

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -134,7 +134,7 @@ async def _create_practice_session(
         json=_session_window_payload(user_practice_id),
         headers=headers,
     )
-    assert resp.status_code == HTTPStatus.OK
+    assert resp.status_code == HTTPStatus.CREATED
     return int(resp.json()["id"])
 
 
@@ -542,7 +542,7 @@ async def test_no_user_id_in_owned_resource_responses(
         json=_session_window_payload(user_practice_id),
         headers=alice_headers,
     )
-    assert create_session.status_code == HTTPStatus.OK
+    assert create_session.status_code == HTTPStatus.CREATED
 
     practice = await _seed_practice(db_session, name="Catalog Scrub")
 

--- a/backend/tests/services/test_botmason_wrapping.py
+++ b/backend/tests/services/test_botmason_wrapping.py
@@ -250,3 +250,26 @@ class TestBuildMessagesKeyErrorSafety:
         assert messages[1]["role"] == "user"
         assert messages[1]["content"].startswith("<user_input_")
         assert messages[1]["content"].endswith(">")
+
+    def test_anthropic_history_entry_missing_message_does_not_raise(self) -> None:
+        """Same KeyError safety on the Anthropic builder path.
+
+        ``_build_anthropic_messages`` runs in production whenever
+        ``BOTMASON_PROVIDER=anthropic``.  A malformed history row that crashes
+        only the OpenAI variant would still burn the wallet with no response
+        for every Anthropic-deployed environment, so the regression has to
+        cover both builders.
+        """
+        history = [{"sender": "user"}]  # ``message`` key intentionally absent
+        messages, augmented = _build_anthropic_messages("new", history, "PROMPT")
+        # Anthropic builder returns (messages, augmented_system).  No system
+        # role inside ``messages``; only the malformed history turn and the
+        # new user turn.
+        expected_turn_count = 2
+        assert len(messages) == expected_turn_count
+        assert all(m["role"] in {"user", "assistant"} for m in messages)
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"].startswith("<user_input_")
+        assert messages[0]["content"].endswith(">")
+        # The augmented system prompt is unaffected by malformed history rows.
+        assert _NONCE_RE.search(augmented) is not None

--- a/backend/tests/services/test_botmason_wrapping.py
+++ b/backend/tests/services/test_botmason_wrapping.py
@@ -14,10 +14,13 @@ from __future__ import annotations
 
 import re
 
+import pytest
+
 from services.botmason import (
     _augment_system_prompt,
     _build_anthropic_messages,
     _build_messages,
+    _get_model,
     _make_nonce,
     _wrap_user_input,
 )
@@ -181,3 +184,69 @@ class TestBuildAnthropicMessages:
         nonce_a = _NONCE_RE.search(sys_a).group(0)  # type: ignore[union-attr]
         nonce_b = _NONCE_RE.search(sys_b).group(0)  # type: ignore[union-attr]
         assert nonce_a != nonce_b
+
+
+class TestGetModelAllowlist:
+    """``_get_model`` enforces a per-provider allowlist (BUG-BM-001)."""
+
+    def test_default_openai_model_is_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        assert _get_model("openai") == "gpt-4o-mini"
+
+    def test_default_anthropic_model_is_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        assert _get_model("anthropic") == "claude-sonnet-4-20250514"
+
+    def test_env_override_to_allowed_model_is_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_MODEL", "gpt-4o")
+        assert _get_model("openai") == "gpt-4o"
+
+    def test_env_override_to_unlisted_model_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An operator who sets ``LLM_MODEL`` to an unvetted value fails fast.
+
+        Without the gate the call would silently flow to the provider with
+        whatever string is on the wire — possibly a far more expensive
+        tier, possibly a model that does not exist on the account.  The
+        request would burn one wallet message before surfacing the error.
+        """
+        monkeypatch.setenv("LLM_MODEL", "gpt-99-turbo-megamax")
+        with pytest.raises(RuntimeError, match="not on the openai allowlist"):
+            _get_model("openai")
+
+    def test_anthropic_model_set_for_openai_provider_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cross-wiring providers (Anthropic key + Anthropic model name through OpenAI)."""
+        monkeypatch.setenv("LLM_MODEL", "claude-opus-4-7")
+        with pytest.raises(RuntimeError, match="not on the openai allowlist"):
+            _get_model("openai")
+
+    def test_unknown_provider_bypasses_allowlist(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub / unknown providers never call out, so model selection is moot."""
+        monkeypatch.setenv("LLM_MODEL", "anything-goes")
+        assert _get_model("stub") == "anything-goes"
+
+
+class TestBuildMessagesKeyErrorSafety:
+    """``_build_messages`` survives malformed history rows (BUG-BM-005)."""
+
+    def test_history_entry_missing_message_does_not_raise(self) -> None:
+        """A history row without a ``message`` key must not surface as ``KeyError``.
+
+        The wallet has already been pre-flight-deducted by the time
+        ``_build_messages`` runs; a ``KeyError`` here would burn the
+        message with no response.  Treating the missing field as an
+        empty string lets the request continue and produces a turn the
+        model naturally ignores.
+        """
+        history = [{"sender": "user"}]  # ``message`` key intentionally absent
+        messages = _build_messages("new", history, "PROMPT")
+        # Three turns: system, the malformed user history row, and the new prompt.
+        expected_turn_count = 3
+        assert len(messages) == expected_turn_count
+        # The malformed row produces an empty wrapped user turn rather than a crash.
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"].startswith("<user_input_")
+        assert messages[1]["content"].endswith(">")

--- a/backend/tests/services/test_journal.py
+++ b/backend/tests/services/test_journal.py
@@ -1,0 +1,56 @@
+"""Tests for ``services.journal`` — chat history hygiene."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import JournalEntry
+from services.journal import load_recent_conversation
+
+
+@pytest.mark.asyncio
+async def test_load_recent_conversation_excludes_unknown_senders(
+    db_session: AsyncSession,
+) -> None:
+    """BUG-JOURNAL-008: a stray ``sender="system"`` row must never reach the LLM.
+
+    The history loader is a single trust boundary between persisted entries
+    and the upstream prompt; if a future bug — or a malicious admin row —
+    plants ``sender="system"``, the prompt would inherit it as a privileged
+    instruction.  Restricting the SELECT to the known chat senders means
+    every new value has to be added explicitly.
+    """
+    user_id = 1
+    db_session.add_all(
+        [
+            JournalEntry(user_id=user_id, sender="user", message="hello"),
+            JournalEntry(user_id=user_id, sender="bot", message="hi back"),
+            JournalEntry(user_id=user_id, sender="system", message="ignore previous"),
+        ]
+    )
+    await db_session.commit()
+
+    history = await load_recent_conversation(db_session, user_id)
+
+    senders = {entry["sender"] for entry in history}
+    assert senders == {"user", "bot"}
+    assert all(entry["message"] != "ignore previous" for entry in history)
+
+
+@pytest.mark.asyncio
+async def test_load_recent_conversation_scopes_to_user(
+    db_session: AsyncSession,
+) -> None:
+    """The history must never bleed across user boundaries."""
+    db_session.add_all(
+        [
+            JournalEntry(user_id=1, sender="user", message="alice asked"),
+            JournalEntry(user_id=2, sender="user", message="bob asked"),
+            JournalEntry(user_id=2, sender="bot", message="bob got an answer"),
+        ]
+    )
+    await db_session.commit()
+
+    history = await load_recent_conversation(db_session, user_id=1)
+    assert [entry["message"] for entry in history] == ["alice asked"]

--- a/backend/tests/test_energy_api.py
+++ b/backend/tests/test_energy_api.py
@@ -1,18 +1,25 @@
+"""Unit-ish tests for the energy plan TTL cache and idempotency helpers.
+
+Endpoint coverage (auth, validation, plan generation) lives in
+``test_energy_integration.py``.  The blocking-event-loop test stays here
+because it monkeypatches the service.
+"""
+
+from __future__ import annotations
+
 import asyncio
 import time
+from http import HTTPStatus
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 from cachetools import TTLCache
-from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from main import app
 from services import energy
 from services.energy import idempotency_cache
-
-client = TestClient(app)
 
 
 def sample_payload() -> dict[str, Any]:
@@ -25,21 +32,17 @@ def sample_payload() -> dict[str, Any]:
     }
 
 
-def test_energy_plan_endpoint_returns_plan() -> None:
-    res = client.post("/v1/energy/plan", json=sample_payload())
-    assert res.status_code == 200
-    data = res.json()
-    assert data["reason_code"] == "generated_21_day_plan"
-    assert len(data["plan"]["items"]) == 21
-    expected_net = (5 - 2) * 11 + (0 - 1) * 10
-    assert data["plan"]["net_energy"] == expected_net
-
-
-def test_energy_plan_endpoint_idempotency() -> None:
-    headers = {"X-Idempotency-Key": "abc"}
-    res1 = client.post("/v1/energy/plan", json=sample_payload(), headers=headers)
-    res2 = client.post("/v1/energy/plan", json=sample_payload(), headers=headers)
-    assert res1.json() == res2.json()
+async def _signup(client: AsyncClient) -> dict[str, str]:
+    """Sign up a user and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": "energyuser@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
 
 
 def test_idempotency_cache_is_ttl_bounded() -> None:
@@ -59,27 +62,25 @@ def test_idempotency_cache_evicts_when_full() -> None:
     assert "c" in small_cache
 
 
-def test_empty_habits_returns_400() -> None:
-    """POST with empty habits list should return 400, not 500."""
-    res = client.post("/v1/energy/plan", json={"habits": [], "start_date": "2024-01-01"})
-    assert res.status_code == 400
-    assert res.json()["detail"] == "habits_must_not_be_empty"
-
-
-def test_idempotency_miss_after_cache_clear() -> None:
+@pytest.mark.asyncio
+async def test_idempotency_miss_after_cache_clear(async_client: AsyncClient) -> None:
     """After clearing the cache, duplicate keys should recompute."""
+    headers = await _signup(async_client)
     with patch.object(energy, "idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
-        headers = {"X-Idempotency-Key": "unique-clear-test"}
-        res1 = client.post("/v1/energy/plan", json=sample_payload(), headers=headers)
+        idem_headers = {**headers, "X-Idempotency-Key": "unique-clear-test"}
+        res1 = await async_client.post(
+            "/v1/energy/plan", json=sample_payload(), headers=idem_headers
+        )
         energy.idempotency_cache.clear()
-        res2 = client.post("/v1/energy/plan", json=sample_payload(), headers=headers)
-        # Both should succeed (recomputed, not from cache)
-        assert res1.status_code == 200
-        assert res2.status_code == 200
+        res2 = await async_client.post(
+            "/v1/energy/plan", json=sample_payload(), headers=idem_headers
+        )
+        assert res1.status_code == HTTPStatus.OK
+        assert res2.status_code == HTTPStatus.OK
 
 
 @pytest.mark.asyncio
-async def test_create_plan_does_not_block_event_loop() -> None:
+async def test_create_plan_does_not_block_event_loop(async_client: AsyncClient) -> None:
     """BUG-INFRA-009: slow plan generation must not starve concurrent requests.
 
     We replace ``get_or_generate_plan`` with a sync sleep that would block
@@ -87,32 +88,37 @@ async def test_create_plan_does_not_block_event_loop() -> None:
     the main loop is free during the sleep, so two concurrent requests
     complete in ~300ms total — not ~600ms serialised.
     """
+    headers = await _signup(async_client)
     sleep_seconds = 0.3
 
     def _slow_plan(payload: Any, _key: Any) -> Any:  # noqa: ANN401
-        # ``time.sleep`` (not ``asyncio.sleep``) — this is the sync CPU-ish
-        # stand-in.  If the endpoint runs inline on the loop, this stalls
-        # every other coroutine for ``sleep_seconds``.
         time.sleep(sleep_seconds)
         return energy.build_energy_response(payload)
 
+    # The blocking-event-loop assertion needs a real ASGI client (not the
+    # async_client fixture, which already runs against the in-memory app).
+    # Re-using the same app instance is fine — the dependency_overrides
+    # installed by ``async_client`` are still active for the duration.
     with patch.object(energy, "get_or_generate_plan", _slow_plan):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             start = time.perf_counter()
             results = await asyncio.gather(
-                ac.post("/v1/energy/plan", json=sample_payload()),
-                ac.post("/v1/energy/plan", json=sample_payload()),
+                ac.post("/v1/energy/plan", json=sample_payload(), headers=headers),
+                ac.post("/v1/energy/plan", json=sample_payload(), headers=headers),
             )
             elapsed = time.perf_counter() - start
 
     for res in results:
-        assert res.status_code == 200
+        assert res.status_code == HTTPStatus.OK
 
-    # If the endpoint were synchronous on the loop, elapsed would be
-    # >= 2 * sleep_seconds.  Offloading via ``asyncio.to_thread`` brings it
-    # close to a single sleep duration — allow generous headroom so CI
-    # noise doesn't flake the assertion.
     assert elapsed < sleep_seconds * 1.8, (
         f"expected concurrent energy requests to overlap; took {elapsed:.3f}s"
     )
+
+
+@pytest.mark.asyncio
+async def test_energy_plan_requires_auth(async_client: AsyncClient) -> None:
+    """BUG-PRACTICE-010: an unauthenticated POST must be rejected at the gate."""
+    resp = await async_client.post("/v1/energy/plan", json=sample_payload())
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED

--- a/backend/tests/test_energy_integration.py
+++ b/backend/tests/test_energy_integration.py
@@ -39,10 +39,24 @@ def _plan_request(habits: list[dict[str, Any]] | None = None) -> dict[str, Any]:
     }
 
 
+async def _auth_headers(client: AsyncClient, suffix: str = "") -> dict[str, str]:
+    """Sign up a user and return auth headers (BUG-PRACTICE-010 makes auth required)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"energy{suffix}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
 @pytest.mark.asyncio
 async def test_energy_plan_generates_21_day_plan(async_client: AsyncClient) -> None:
     """Energy plan endpoint generates a 21-day plan cycling through habits."""
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request())
+    headers = await _auth_headers(async_client, "21day")
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request(), headers=headers)
     assert resp.status_code == HTTPStatus.OK
 
     data = resp.json()
@@ -63,11 +77,12 @@ async def test_energy_plan_generates_21_day_plan(async_client: AsyncClient) -> N
 @pytest.mark.asyncio
 async def test_energy_plan_net_energy_calculation(async_client: AsyncClient) -> None:
     """Net energy is calculated correctly as sum of (return - cost) per day."""
+    headers = await _auth_headers(async_client, "net")
     habits = [
         {"id": 1, "name": "Run", "energy_cost": 3, "energy_return": 8},
         {"id": 2, "name": "Read", "energy_cost": 1, "energy_return": 4},
     ]
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request(habits))
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request(habits), headers=headers)
     assert resp.status_code == HTTPStatus.OK
 
     data = resp.json()
@@ -80,7 +95,8 @@ async def test_energy_plan_net_energy_calculation(async_client: AsyncClient) -> 
 @pytest.mark.asyncio
 async def test_idempotency_returns_cached_response(async_client: AsyncClient) -> None:
     """Same idempotency key returns identical response without recomputation."""
-    headers = {"X-Idempotency-Key": "test-idempotency-key-123"}
+    auth = await _auth_headers(async_client, "idem")
+    headers = {**auth, "X-Idempotency-Key": "test-idempotency-key-123"}
     payload = _plan_request()
 
     resp1 = await async_client.post("/v1/energy/plan", json=payload, headers=headers)
@@ -96,6 +112,7 @@ async def test_different_idempotency_keys_produce_independent_results(
     async_client: AsyncClient,
 ) -> None:
     """Different idempotency keys are cached independently."""
+    auth = await _auth_headers(async_client, "diffidem")
     with patch.object(energy_service, "idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
         payload_a = _plan_request([{"id": 1, "name": "A", "energy_cost": 1, "energy_return": 2}])
         payload_b = _plan_request([{"id": 2, "name": "B", "energy_cost": 5, "energy_return": 1}])
@@ -103,12 +120,12 @@ async def test_different_idempotency_keys_produce_independent_results(
         resp_a = await async_client.post(
             "/v1/energy/plan",
             json=payload_a,
-            headers={"X-Idempotency-Key": "key-a"},
+            headers={**auth, "X-Idempotency-Key": "key-a"},
         )
         resp_b = await async_client.post(
             "/v1/energy/plan",
             json=payload_b,
-            headers={"X-Idempotency-Key": "key-b"},
+            headers={**auth, "X-Idempotency-Key": "key-b"},
         )
 
         assert resp_a.json()["plan"]["net_energy"] != resp_b.json()["plan"]["net_energy"]
@@ -117,9 +134,11 @@ async def test_different_idempotency_keys_produce_independent_results(
 @pytest.mark.asyncio
 async def test_empty_habits_returns_400(async_client: AsyncClient) -> None:
     """POST with empty habits list returns 400, not 500."""
+    headers = await _auth_headers(async_client, "empty")
     resp = await async_client.post(
         "/v1/energy/plan",
         json={"habits": [], "start_date": "2025-01-01"},
+        headers=headers,
     )
     assert resp.status_code == HTTPStatus.BAD_REQUEST
     assert resp.json()["detail"] == "habits_must_not_be_empty"
@@ -129,9 +148,10 @@ async def test_empty_habits_returns_400(async_client: AsyncClient) -> None:
 @pytest.mark.parametrize("field", ["energy_cost", "energy_return"])
 async def test_negative_energy_value_rejected(async_client: AsyncClient, field: str) -> None:
     """BUG-SCHEMA-007: clients can't smuggle negative energy values past Pydantic."""
+    headers = await _auth_headers(async_client, f"neg{field}")
     habit = {"id": 1, "name": "X", "energy_cost": 1, "energy_return": 1}
     habit[field] = -1
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request([habit]))
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request([habit]), headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
@@ -139,35 +159,39 @@ async def test_negative_energy_value_rejected(async_client: AsyncClient, field: 
 @pytest.mark.parametrize("field", ["energy_cost", "energy_return"])
 async def test_oversized_energy_value_rejected(async_client: AsyncClient, field: str) -> None:
     """BUG-SCHEMA-007: values above the documented cap are rejected, not clamped."""
+    headers = await _auth_headers(async_client, f"big{field}")
     habit = {"id": 1, "name": "X", "energy_cost": 1, "energy_return": 1}
     habit[field] = 10_001
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request([habit]))
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request([habit]), headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
 async def test_zero_id_habit_rejected(async_client: AsyncClient) -> None:
     """``id`` must be positive — a zero id would never round-trip to a real habit."""
+    headers = await _auth_headers(async_client, "zeroid")
     habit = {"id": 0, "name": "X", "energy_cost": 1, "energy_return": 1}
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request([habit]))
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request([habit]), headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
 async def test_too_many_habits_rejected(async_client: AsyncClient) -> None:
     """A pathological 101-habit payload is rejected before it hits the planner."""
+    headers = await _auth_headers(async_client, "many")
     too_many = [
         {"id": i + 1, "name": f"H{i}", "energy_cost": 1, "energy_return": 2} for i in range(101)
     ]
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request(too_many))
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request(too_many), headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
 async def test_single_habit_fills_all_21_days(async_client: AsyncClient) -> None:
     """A single habit is scheduled for all 21 days of the plan."""
+    headers = await _auth_headers(async_client, "single")
     single = [{"id": 42, "name": "Solo", "energy_cost": 2, "energy_return": 3}]
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request(single))
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request(single), headers=headers)
     assert resp.status_code == HTTPStatus.OK
 
     items = resp.json()["plan"]["items"]

--- a/backend/tests/test_input_length_constraints.py
+++ b/backend/tests/test_input_length_constraints.py
@@ -241,7 +241,7 @@ async def test_practice_session_reflection_at_max_length(
         json=_practice_session_payload(user_practice_id, reflection=reflection),
         headers=headers,
     )
-    assert resp.status_code == HTTPStatus.OK
+    assert resp.status_code == HTTPStatus.CREATED
     assert resp.json()["reflection"] == reflection
 
 

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -210,7 +210,7 @@ async def test_practice_session_week_count(
             },
             headers=headers,
         )
-        assert resp.status_code == HTTPStatus.OK
+        assert resp.status_code == HTTPStatus.CREATED
 
     # Check week count
     resp = await async_client.get("/practice-sessions/week-count", headers=headers)

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -411,3 +411,30 @@ async def test_user_cannot_delete_other_users_entry(async_client: AsyncClient) -
 
     resp = await async_client.delete(f"/journal/{entry_id}", headers=bob_headers)
     assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+# ── Length and search bounds ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_empty_message(async_client: AsyncClient) -> None:
+    """BUG-JOURNAL-001: empty body must be rejected at the schema layer."""
+    headers = await _signup(async_client, "empty")
+    resp = await async_client.post("/journal/", json={"message": ""}, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_below_min_length(async_client: AsyncClient) -> None:
+    """BUG-JOURNAL-009: ``ILIKE '%a%'`` matches almost everything; cap min length."""
+    headers = await _signup(async_client, "shortq")
+    resp = await async_client.get("/journal/?search=a", headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_oversized_query(async_client: AsyncClient) -> None:
+    """BUG-JOURNAL-009: a 5MB ``term`` would pin a worker on ``ILIKE`` planning."""
+    headers = await _signup(async_client, "longq")
+    resp = await async_client.get(f"/journal/?search={'x' * 65}", headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -122,7 +122,9 @@ async def test_create_session(async_client: AsyncClient, db_session: AsyncSessio
 
     payload = _session_payload(up_id, reflection="felt calm")
     resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
-    assert resp.status_code == HTTPStatus.OK
+    # BUG-PRACTICE-008: ``create_session`` now returns 201 to match the rest
+    # of the POST contract; tests that asserted 200 captured the prior bug.
+    assert resp.status_code == HTTPStatus.CREATED
     data = resp.json()
     assert data["reflection"] == "felt calm"
     assert data["user_practice_id"] == up_id
@@ -142,7 +144,7 @@ async def test_create_session_without_reflection(
     resp = await async_client.post(
         "/practice-sessions/", json=_session_payload(up_id), headers=headers
     )
-    assert resp.status_code == HTTPStatus.OK
+    assert resp.status_code == HTTPStatus.CREATED
     assert resp.json()["reflection"] is None
 
 
@@ -311,7 +313,7 @@ async def test_create_session_records_server_derived_duration(
         },
         headers=headers,
     )
-    assert resp.status_code == HTTPStatus.OK
+    assert resp.status_code == HTTPStatus.CREATED
     assert resp.json()["duration_minutes"] == pytest.approx(expected_minutes)
     # ``timestamp`` is set to ``ended_at`` so week-count math anchors to when
     # the session actually finished.

--- a/backend/tests/test_practices_api.py
+++ b/backend/tests/test_practices_api.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.practice import Practice
+from rate_limit import limiter
 
 _APPROVED_STAGE_1_COUNT = 2
 
@@ -229,3 +230,66 @@ async def test_submit_practice_ignores_smuggled_server_fields(
     assert persisted is not None
     assert persisted.approved is False
     assert persisted.submitted_by_user_id == user_id
+
+
+# -- Rate-limit key (BUG-PRACTICE-003) -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_key_survives_token_refresh(async_client: AsyncClient) -> None:
+    """The rate-limit bucket must follow the user, not the JWT.
+
+    Hashing the bearer token reset the rate-limit budget on every
+    re-authentication; keying on the JWT ``sub`` (the stable user id)
+    so a logout / login cycle inside the limiter window does not give
+    the user a fresh budget.
+
+    We log in twice as the same user, drive both tokens to the
+    ``5/minute`` cap, and assert the second token sees a 429 without
+    needing to wait for the limiter window to roll over.  Re-using
+    ``submit_practice`` (the rate-limited endpoint) confirms the
+    end-to-end wiring rather than poking the helper in isolation.
+    """
+    # The shared autouse fixture clears the limiter between tests, but
+    # disable_rate_limit also flips ``limiter.enabled``.  Force-enable
+    # so this test is not silently skipped if a sibling left it off.
+    limiter.enabled = True
+
+    email = "rl_refresh@example.com"
+    password = "securepassword123"  # pragma: allowlist secret
+    signup = await async_client.post("/auth/signup", json={"email": email, "password": password})
+    assert signup.status_code == HTTPStatus.OK
+    first_token = signup.json()["token"]
+
+    # Re-login mints a fresh token with a different ``jti`` for the same user.
+    login = await async_client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == HTTPStatus.OK
+    second_token = login.json()["token"]
+    assert first_token != second_token, "test premise: re-login mints distinct tokens"
+
+    payload = {
+        "stage_number": 1,
+        "name": "RL probe",
+        "description": "rate limit probe",
+        "instructions": "n/a",
+        "default_duration_minutes": 1,
+    }
+
+    # Drive the first token to the 5/minute cap.
+    rate_cap = 5
+    for i in range(rate_cap):
+        resp = await async_client.post(
+            "/practices/",
+            json={**payload, "name": f"RL probe {i}"},
+            headers={"Authorization": f"Bearer {first_token}"},
+        )
+        assert resp.status_code == HTTPStatus.CREATED
+
+    # Token-hash keying would give the second token its own bucket and
+    # the next request would succeed; user-id keying refuses it.
+    resp = await async_client.post(
+        "/practices/",
+        json={**payload, "name": "RL probe overflow"},
+        headers={"Authorization": f"Bearer {second_token}"},
+    )
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS

--- a/backend/tests/test_practices_api.py
+++ b/backend/tests/test_practices_api.py
@@ -193,3 +193,39 @@ async def test_submitted_practice_not_in_listings(
     resp = await async_client.get("/practices/", params={"stage_number": 1}, headers=headers)
     assert resp.status_code == HTTPStatus.OK
     assert len(resp.json()) == 0
+
+
+@pytest.mark.asyncio
+async def test_submit_practice_ignores_smuggled_server_fields(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """BUG-PRACTICE-002: extra fields on the body never set ORM columns.
+
+    A future addition to ``PracticeCreate`` overlapping a server-controlled
+    column (``approved``, ``submitted_by_user_id``) would otherwise flow
+    through ``model_dump()`` and let a client mint pre-approved rows.  The
+    explicit-kwargs construction in the router pins the whitelist.  Pydantic
+    silently drops unknown keys today, so the canonical regression is to
+    confirm the persisted row reflects server defaults regardless of body
+    keys.
+    """
+    headers, user_id = await _signup(async_client, username="smuggler")
+    payload = {
+        "stage_number": 1,
+        "name": "Smuggled Practice",
+        "description": "Trying to mint approval",
+        "instructions": "Should not bypass moderation",
+        "default_duration_minutes": 15,
+        # Extra keys a future schema might honour — must be ignored today.
+        "approved": True,
+        "submitted_by_user_id": 999,
+    }
+    resp = await async_client.post("/practices/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    practice_id = resp.json()["id"]
+
+    persisted = await db_session.get(Practice, practice_id)
+    assert persisted is not None
+    assert persisted.approved is False
+    assert persisted.submitted_by_user_id == user_id

--- a/backend/tests/test_practices_api.py
+++ b/backend/tests/test_practices_api.py
@@ -9,7 +9,6 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.practice import Practice
-from rate_limit import limiter
 
 _APPROVED_STAGE_1_COUNT = 2
 
@@ -249,12 +248,11 @@ async def test_rate_limit_key_survives_token_refresh(async_client: AsyncClient) 
     needing to wait for the limiter window to roll over.  Re-using
     ``submit_practice`` (the rate-limited endpoint) confirms the
     end-to-end wiring rather than poking the helper in isolation.
-    """
-    # The shared autouse fixture clears the limiter between tests, but
-    # disable_rate_limit also flips ``limiter.enabled``.  Force-enable
-    # so this test is not silently skipped if a sibling left it off.
-    limiter.enabled = True
 
+    The autouse ``_reset_rate_limiter`` fixture in ``conftest.py`` already
+    forces ``limiter.enabled = True`` and clears storage on entry/exit,
+    so we do not need to manage limiter state manually here.
+    """
     email = "rl_refresh@example.com"
     password = "securepassword123"  # pragma: allowlist secret
     signup = await async_client.post("/auth/signup", json={"email": email, "password": password})

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -37,7 +37,8 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 | 11 | backend-auth-models-schemas-cors  | 4 | `claude/bug-fix-11-backend-auth-models-schemas-cors` | [x] |
 | 12 | backend-feature-routers (12A wave 1) | 4 | `claude/bug-fix-12a-backend-feature-routers-hgcp` / [#276](https://github.com/Geoffe-Ga/adepthood/pull/276) | [x] |
 | 12 | backend-feature-routers (12A wave 2) | 4 | `claude/bug-fix-12a-wave-2-stage-course-prompts` / [#290](https://github.com/Geoffe-Ga/adepthood/pull/290) | [x] |
-| 12 | backend-feature-routers (12B)        | 4 | | [ ] |
+| 12 | backend-feature-routers (12B wave 1) | 4 | `claude/bug-fix-remediation-p3HUm` | [x] |
+| 12 | backend-feature-routers (12B wave 2) | 4 | | [ ] |
 | 13 | frontend-api-client               | 4 | | [ ] |
 | 14 | frontend-feature-screens          | 4 | | [ ] |
 | 15 | frontend-design-state-tests       | 4 | | [ ] |

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -36,7 +36,7 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 | 10 | observability-e2e                 | 3 | `claude/10-observability-e2e-OfIPz` / [#268](https://github.com/Geoffe-Ga/adepthood/pull/268) | [x] |
 | 11 | backend-auth-models-schemas-cors  | 4 | `claude/bug-fix-11-backend-auth-models-schemas-cors` | [x] |
 | 12 | backend-feature-routers (12A wave 1) | 4 | `claude/bug-fix-12a-backend-feature-routers-hgcp` / [#276](https://github.com/Geoffe-Ga/adepthood/pull/276) | [x] |
-| 12 | backend-feature-routers (12A wave 2) | 4 | `claude/bug-fix-12a-wave-2-stage-course-prompts` | [ ] |
+| 12 | backend-feature-routers (12A wave 2) | 4 | `claude/bug-fix-12a-wave-2-stage-course-prompts` / [#290](https://github.com/Geoffe-Ga/adepthood/pull/290) | [x] |
 | 12 | backend-feature-routers (12B)        | 4 | | [ ] |
 | 13 | frontend-api-client               | 4 | | [ ] |
 | 14 | frontend-feature-screens          | 4 | | [ ] |


### PR DESCRIPTION
BUG-PRACTICE-002 (High): replace `Practice(**payload.model_dump())` with
explicit kwargs so a future schema field overlapping a server-controlled
column (`approved`, `submitted_by_user_id`) cannot flow through to the ORM.

BUG-PRACTICE-008 (Low): `create_session` now returns 201 to match the
contract; existing tests asserting 200 captured the prior bug.

BUG-PRACTICE-003 (Medium): `submit_practice` rate-limit now keys on a
hash of the bearer token rather than IP, preventing IP-rotation bypass
and shared-NAT throttling.

BUG-PRACTICE-010 (Medium): `/v1/energy/plan` now requires authentication;
the planner runs CPU-bound work on a thread pool, so an unauthenticated
endpoint let any caller spawn arbitrary expensive work for free.
Server-side cost loading is a deliberate follow-up.

12A wave 2 INDEX row also flipped to done with PR #290.