### PR TITLE
fix(frontend-api): close 8 BUG-API items (chatStream refresh, Zod, idempotency, SSE)

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -66,10 +66,11 @@ describe('API client request composition', () => {
 
   it('logs in via POST /auth/login', async () => {
     const creds = { email: 'u@example.com', password: 'p' }; // pragma: allowlist secret
-    global.fetch = jest
-      .fn()
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 'aaaaaaaa.bbbbbbbb.cccccccc', user_id: 1 }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockResolvedValue({ ok: true, json: async () => ({ token: 'tk', user_id: 1 }) }) as any;
+    }) as any;
     // Re-bind after overwriting global.fetch
     api = require('@/api');
     await api.auth.login(creds);
@@ -86,10 +87,11 @@ describe('API client request composition', () => {
 
   it('signs up via POST /auth/signup', async () => {
     const creds = { email: 'u@example.com', password: 'p' }; // pragma: allowlist secret
-    global.fetch = jest
-      .fn()
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 'aaaaaaaa.bbbbbbbb.cccccccc', user_id: 1 }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockResolvedValue({ ok: true, json: async () => ({ token: 'tk', user_id: 1 }) }) as any;
+    }) as any;
     api = require('@/api');
     await api.auth.signup(creds);
     expect(fetch).toHaveBeenCalledWith(

--- a/frontend/src/api/__tests__/botmason-stream.test.ts
+++ b/frontend/src/api/__tests__/botmason-stream.test.ts
@@ -203,4 +203,71 @@ describe('botmason.chatStream', () => {
 
     expect(errors).toEqual([{ status: 502, detail: 'malformed_stream_frame' }]);
   });
+
+  test('BUG-API-002: 401 triggers token refresh and retries the stream once', async () => {
+    // First fetch hits the SSE endpoint and returns 401.
+    // Second fetch is the /auth/refresh call.
+    // Third fetch retries the SSE endpoint and succeeds.
+    const refreshedToken = `${'a'.repeat(8)}.${'b'.repeat(8)}.${'c'.repeat(8)}`;
+    mockFetch
+      .mockReturnValueOnce(
+        Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ detail: 'unauthorized' }),
+        }),
+      )
+      .mockReturnValueOnce(
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ token: refreshedToken, user_id: 1 }),
+        }),
+      )
+      .mockReturnValueOnce(
+        streamResponse([`event: complete\ndata: ${JSON.stringify(sampleComplete)}\n\n`]),
+      );
+
+    const onComplete = jest.fn();
+    await botmason.chatStream(
+      { message: 'hi' },
+      { onChunk: jest.fn(), onComplete, onStreamError: jest.fn() },
+    );
+
+    // Three fetches: original SSE 401, /auth/refresh, retry SSE.
+    const expectedCallCount = 3;
+    expect(mockFetch).toHaveBeenCalledTimes(expectedCallCount);
+    const [, refreshInit] = mockFetch.mock.calls[1];
+    expect(mockFetch.mock.calls[1][0]).toContain('/auth/refresh');
+    expect(refreshInit.method).toBe('POST');
+    // Retry SSE call must use the new token, not the stale one.
+    const [, retryInit] = mockFetch.mock.calls[2];
+    expect(retryInit.headers.Authorization).toBe(`Bearer ${refreshedToken}`);
+    expect(onComplete).toHaveBeenCalledWith(sampleComplete);
+  });
+
+  test('BUG-API-002: refresh failure surfaces ApiError without re-querying the stream', async () => {
+    // 401 on the SSE endpoint, then 401 on /auth/refresh too.
+    mockFetch
+      .mockReturnValueOnce(
+        Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ detail: 'unauthorized' }),
+        }),
+      )
+      .mockReturnValueOnce(
+        Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({}) }),
+      );
+
+    await expect(
+      botmason.chatStream(
+        { message: 'hi' },
+        { onChunk: jest.fn(), onComplete: jest.fn(), onStreamError: jest.fn() },
+      ),
+    ).rejects.toBeInstanceOf(ApiError);
+    // Must not retry the stream when refresh failed.
+    const expectedCallCount = 2;
+    expect(mockFetch).toHaveBeenCalledTimes(expectedCallCount);
+  });
 });

--- a/frontend/src/api/__tests__/botmason-stream.test.ts
+++ b/frontend/src/api/__tests__/botmason-stream.test.ts
@@ -5,6 +5,7 @@ import {
   botmason,
   LLM_API_KEY_HEADER,
   setLlmApiKeyGetter,
+  setOnUnauthorized,
   setTokenGetter,
   StreamingUnsupportedError,
 } from '../index';
@@ -244,6 +245,110 @@ describe('botmason.chatStream', () => {
     const [, retryInit] = mockFetch.mock.calls[2];
     expect(retryInit.headers.Authorization).toBe(`Bearer ${refreshedToken}`);
     expect(onComplete).toHaveBeenCalledWith(sampleComplete);
+  });
+
+  test('BUG-API-011: parses CRLF-terminated frames (production servers behind nginx)', async () => {
+    // A server that emits CRLF line endings + CRLF-CRLF frame terminators
+    // used to silently drop every event because the parser keyed only on
+    // ``"\n\n"`` and ``"\n"``.  This regression exercises the same
+    // sample_complete payload but with CRLF framing throughout.
+    const frames = [
+      'event: chunk\r\ndata: {"text":"Hello "}\r\n\r\n',
+      'event: chunk\r\ndata: {"text":"world"}\r\n\r\n',
+      `event: complete\r\ndata: ${JSON.stringify(sampleComplete)}\r\n\r\n`,
+    ];
+    mockFetch.mockReturnValueOnce(streamResponse(frames));
+
+    const events: Array<[string, unknown]> = [];
+    await botmason.chatStream(
+      { message: 'hi' },
+      {
+        onChunk: (t) => events.push(['chunk', t]),
+        onComplete: (r) => events.push(['complete', r]),
+        onStreamError: (e) => events.push(['error', e]),
+      },
+    );
+
+    expect(events).toEqual([
+      ['chunk', 'Hello '],
+      ['chunk', 'world'],
+      ['complete', sampleComplete],
+    ]);
+  });
+
+  test('BUG-API-012: an aborted signal cancels the reader so the stream returns promptly', async () => {
+    // Build a reader that would loop forever (server hung) so abort is the
+    // only way out.  After ``signal.abort()`` we expect ``reader.cancel``
+    // to fire and ``read()`` to resolve ``done: true`` so chatStream
+    // returns instead of hanging the test.
+    const cancelSpy = jest.fn();
+    let resolveRead: (val: { done: boolean; value?: Uint8Array }) => void = () => {};
+    const body = {
+      getReader: () => ({
+        read: () =>
+          new Promise<{ done: boolean; value?: Uint8Array }>((resolve) => {
+            resolveRead = resolve;
+          }),
+        cancel: () => {
+          cancelSpy();
+          // Wake the pending ``read()`` so the loop exits.
+          resolveRead({ done: true });
+          return Promise.resolve();
+        },
+      }),
+    };
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        body,
+        json: () => Promise.resolve({}),
+      } as unknown as Response),
+    );
+
+    const controller = new AbortController();
+    const streamPromise = botmason.chatStream(
+      { message: 'hi' },
+      { onChunk: jest.fn(), onComplete: jest.fn(), onStreamError: jest.fn() },
+      { signal: controller.signal },
+    );
+    // Wait for the reader to actually start reading so the abort listener
+    // is attached before we fire the abort.  Multiple microtask flushes
+    // because the chain is several ``await``s deep before
+    // ``readChatStream`` installs its listener.
+    for (let i = 0; i < 10; i += 1) await Promise.resolve();
+    controller.abort();
+    await streamPromise;
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('BUG-API-014: a 401 error frame mid-stream fires the unauthorized callback', async () => {
+    // The stream opens cleanly (200), but the server emits an
+    // ``event: error`` frame with status 401 because the token was
+    // revoked from another device.  The non-streaming path routes 401
+    // through the global callback; the streaming path now does the same
+    // so the AuthContext can react identically.
+    const onUnauthorized = jest.fn();
+    setOnUnauthorized(onUnauthorized);
+    try {
+      const frames = [
+        `event: error\ndata: ${JSON.stringify({ status: 401, detail: 'unauthorized' })}\n\n`,
+      ];
+      mockFetch.mockReturnValueOnce(streamResponse(frames));
+
+      const onStreamError = jest.fn();
+      await botmason.chatStream(
+        { message: 'hi' },
+        { onChunk: jest.fn(), onComplete: jest.fn(), onStreamError },
+      );
+
+      expect(onUnauthorized).toHaveBeenCalledWith('session_expired');
+      // Caller-supplied onStreamError still fires so the UI can show a
+      // mid-stream failure banner.
+      expect(onStreamError).toHaveBeenCalledWith({ status: 401, detail: 'unauthorized' });
+    } finally {
+      setOnUnauthorized(null);
+    }
   });
 
   test('BUG-API-002: refresh failure surfaces ApiError without re-querying the stream', async () => {

--- a/frontend/src/api/__tests__/botmason-stream.test.ts
+++ b/frontend/src/api/__tests__/botmason-stream.test.ts
@@ -353,6 +353,11 @@ describe('botmason.chatStream', () => {
 
   test('BUG-API-002: refresh failure surfaces ApiError without re-querying the stream', async () => {
     // 401 on the SSE endpoint, then 401 on /auth/refresh too.
+    // PR #297 review: assert the thrown ``error.detail`` carries the
+    // server's actual detail string ("unauthorized"), not the generic
+    // "Request failed" fallback that ``extractErrorDetail`` returns when
+    // the body has been consumed.  This pins the contract that the
+    // initial response body is read EXACTLY once.
     mockFetch
       .mockReturnValueOnce(
         Promise.resolve({
@@ -365,14 +370,51 @@ describe('botmason.chatStream', () => {
         Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({}) }),
       );
 
-    await expect(
-      botmason.chatStream(
+    const error: unknown = await botmason
+      .chatStream(
         { message: 'hi' },
         { onChunk: jest.fn(), onComplete: jest.fn(), onStreamError: jest.fn() },
-      ),
-    ).rejects.toBeInstanceOf(ApiError);
+      )
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(401);
+    expect((error as ApiError).detail).toBe('unauthorized');
     // Must not retry the stream when refresh failed.
     const expectedCallCount = 2;
     expect(mockFetch).toHaveBeenCalledTimes(expectedCallCount);
+  });
+
+  test('BUG-API-002: 401 + refresh fail does not double-read the response body', async () => {
+    // PR #297 review: in production fetch, calling ``.json()`` on a
+    // ``Response`` whose ``bodyUsed`` is true throws
+    // ``TypeError: body used already``.  This test mimics that semantic
+    // by throwing on a second read; the chatStream path MUST not trigger
+    // the throw -- it must thread the parsed detail back from
+    // ``retryStreamWithRefresh`` instead of re-reading.
+    let bodyUsed = false;
+    const initialRes = {
+      ok: false,
+      status: 401,
+      json: () => {
+        if (bodyUsed) return Promise.reject(new TypeError('body used already'));
+        bodyUsed = true;
+        return Promise.resolve({ detail: 'unauthorized' });
+      },
+    };
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(initialRes))
+      .mockReturnValueOnce(
+        Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({}) }),
+      );
+
+    const error: unknown = await botmason
+      .chatStream(
+        { message: 'hi' },
+        { onChunk: jest.fn(), onComplete: jest.fn(), onStreamError: jest.fn() },
+      )
+      .catch((e: unknown) => e);
+    // Must surface ``ApiError`` with the real detail, not a TypeError.
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).detail).toBe('unauthorized');
   });
 });

--- a/frontend/src/api/__tests__/habits-api.test.ts
+++ b/frontend/src/api/__tests__/habits-api.test.ts
@@ -1,6 +1,13 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
-import { habits, goalCompletions, goals, ApiError } from '../index';
+import {
+  habits,
+  goalCompletions,
+  goals,
+  ApiError,
+  IDEMPOTENCY_KEY_HEADER,
+  idempotencyKey,
+} from '../index';
 
 // Mock global fetch
 const mockFetch = jest.fn() as jest.Mock;
@@ -111,7 +118,7 @@ describe('goalCompletions API client', () => {
 
     const response = await goalCompletions.create(
       { goal_id: 42, did_complete: true },
-      'test-token',
+      { token: 'test-token' },
     );
 
     const [url, init] = mockFetch.mock.calls[0];
@@ -131,7 +138,35 @@ describe('goalCompletions API client', () => {
       }),
     );
 
-    await expect(goalCompletions.create({ goal_id: 999 }, 'test-token')).rejects.toThrow(ApiError);
+    await expect(goalCompletions.create({ goal_id: 999 }, { token: 'test-token' })).rejects.toThrow(
+      ApiError,
+    );
+  });
+
+  test('BUG-API-008: forwards an Idempotency-Key header when supplied', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ streak: 1, milestones: [], reason_code: 'ok' }));
+
+    await goalCompletions.create(
+      { goal_id: 7, did_complete: true },
+      { idempotencyKey: 'log-unit:7:2026-05-10' },
+    );
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers[IDEMPOTENCY_KEY_HEADER]).toBe('log-unit:7:2026-05-10');
+  });
+});
+
+describe('idempotencyKey helper (BUG-API-008)', () => {
+  test('formats intent + parts with colon delimiter', () => {
+    expect(idempotencyKey('log-unit', 42, '2026-05-10')).toBe('log-unit:42:2026-05-10');
+  });
+
+  test('returns intent alone when no parts are supplied', () => {
+    expect(idempotencyKey('reset-streak')).toBe('reset-streak');
+  });
+
+  test('rejects an empty intent so callers cannot mint a deduplicating-on-nothing key', () => {
+    expect(() => idempotencyKey('')).toThrow(/non-empty/);
   });
 });
 

--- a/frontend/src/api/__tests__/retryAndValidation.test.ts
+++ b/frontend/src/api/__tests__/retryAndValidation.test.ts
@@ -80,27 +80,56 @@ describe('BUG-024: Zod validation at the API boundary', () => {
   });
 
   test('auth.signup accepts user_id=0 (duplicate-email sentinel, BUG-AUTH-002)', async () => {
-    // The backend returns ``user_id: 0`` together with a dummy JWT when the
-    // email is already registered, so the response is indistinguishable in
-    // shape from a fresh signup and account enumeration is blocked. The
-    // frontend must accept this sentinel, not reject it as a validation
-    // failure.
-    mockFetch.mockReturnValueOnce(jsonResponse({ token: 'dummy', user_id: 0 }));
+    // The backend returns ``user_id: 0`` together with a JWT-shaped dummy
+    // token when the email is already registered, so the response is
+    // indistinguishable in shape from a fresh signup and account enumeration
+    // is blocked. The frontend must accept this sentinel, not reject it as
+    // a validation failure.  BUG-API-017 still requires the token's three
+    // base64url-segments shape.
+    const dummyJwt = `${'a'.repeat(8)}.${'b'.repeat(8)}.${'c'.repeat(8)}`;
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: dummyJwt, user_id: 0 }));
     const result = await auth.signup({
       email: 'u@test.com',
       password: 'securepass123', // pragma: allowlist secret
     });
     expect(result.user_id).toBe(0);
-    expect(result.token).toBe('dummy');
+    expect(result.token).toBe(dummyJwt);
   });
 
   test('auth.signup still rejects negative user_id', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({ token: 'x', user_id: -1 }));
+    const dummyJwt = `${'a'.repeat(8)}.${'b'.repeat(8)}.${'c'.repeat(8)}`;
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: dummyJwt, user_id: -1 }));
     await expect(
       auth.signup({
         email: 'u@test.com',
         password: 'securepass123', // pragma: allowlist secret
       }),
+    ).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('BUG-API-017: auth.signup rejects a token that is not three JWT segments', async () => {
+    // A backend bug or MITM that returns ``token: "dummy"`` (one segment,
+    // not three base64url segments) used to persist as a session and
+    // produce zombie 401s on the next request.  The schema now rejects
+    // it at the boundary.
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: 'dummy', user_id: 1 }));
+    await expect(
+      auth.signup({
+        email: 'u@test.com',
+        password: 'securepass123', // pragma: allowlist secret
+      }),
+    ).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('BUG-API-017: auth.login rejects user_id=0 (signup-only sentinel)', async () => {
+    // ``user_id == 0`` is the anti-enumeration sentinel for signup; a
+    // login response with that id would be a server bug or forged payload,
+    // never a legitimate session.  Reject it instead of letting it
+    // persist as a session that fails every subsequent authed call.
+    const dummyJwt = `${'a'.repeat(8)}.${'b'.repeat(8)}.${'c'.repeat(8)}`;
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: dummyJwt, user_id: 0 }));
+    await expect(
+      auth.login({ email: 'u@test.com', password: 'p' }), // pragma: allowlist secret
     ).rejects.toBeInstanceOf(ApiValidationError);
   });
 

--- a/frontend/src/api/__tests__/token-refresh.test.ts
+++ b/frontend/src/api/__tests__/token-refresh.test.ts
@@ -22,6 +22,18 @@ function jsonResponse(data: unknown, status = 200) {
   });
 }
 
+/**
+ * JWT-shaped fixture token (BUG-API-017): three base64url segments
+ * separated by dots.  The schema validator now rejects anything that
+ * does not match this shape, so test fixtures must use it too.
+ */
+function fixtureJwt(label = 'refreshed'): string {
+  // Base64url alphabet only; padding with the label keeps tests
+  // self-describing in failure output without adding any decode logic.
+  const seg = (s: string) => `${'a'.repeat(8)}${s}`;
+  return `${seg('h')}.${seg(label)}.${seg('s')}`;
+}
+
 let capturedToken: string | null = null;
 const mockOnUnauthorized = jest.fn();
 const mockOnTokenRefreshed = jest.fn();
@@ -38,11 +50,12 @@ beforeEach(() => {
 
 describe('auth.refresh', () => {
   test('sends POST to /auth/refresh with token in header', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({ token: 'new-jwt', user_id: 1 }));
+    const newJwt = fixtureJwt('newjwt');
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: newJwt, user_id: 1 }));
 
     const result = await auth.refresh('my-token');
 
-    expect(result.token).toBe('new-jwt');
+    expect(result.token).toBe(newJwt);
     const [url, init] = mockFetch.mock.calls[0];
     expect(url).toBe('http://test/auth/refresh');
     expect(init.method).toBe('POST');
@@ -66,10 +79,11 @@ describe('retry-after-refresh on 401', () => {
       goals: [],
     };
 
+    const refreshedToken = fixtureJwt('refreshedtoken');
     // First call: 401 from /habits
     mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unauthorized' }, 401));
     // Second call: refresh succeeds
-    mockFetch.mockReturnValueOnce(jsonResponse({ token: 'refreshed-token', user_id: 1 }));
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: refreshedToken, user_id: 1 }));
     // Third call: retry /habits with new token succeeds
     mockFetch.mockReturnValueOnce(jsonResponse([sampleHabit]));
 
@@ -84,13 +98,13 @@ describe('retry-after-refresh on 401', () => {
 
     // Verify the retry uses the new token
     const [, retryInit] = mockFetch.mock.calls[2];
-    expect(retryInit.headers).toMatchObject({ Authorization: 'Bearer refreshed-token' });
+    expect(retryInit.headers).toMatchObject({ Authorization: `Bearer ${refreshedToken}` });
 
     // The onTokenRefreshed callback receives the new token plus the
     // server's stored timezone so the AuthContext can keep
     // ``userTimezone`` in sync.  ``undefined`` is the value when the
     // server omits the field (legacy / mocked responses).
-    expect(mockOnTokenRefreshed).toHaveBeenCalledWith('refreshed-token', undefined);
+    expect(mockOnTokenRefreshed).toHaveBeenCalledWith(refreshedToken, undefined);
 
     expect(result).toEqual([sampleHabit]);
   });
@@ -110,7 +124,7 @@ describe('retry-after-refresh on 401', () => {
     // First call: 401
     mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unauthorized' }, 401));
     // Refresh succeeds
-    mockFetch.mockReturnValueOnce(jsonResponse({ token: 'new-token', user_id: 1 }));
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: fixtureJwt('newtok'), user_id: 1 }));
     // Retry also returns 401
     mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unauthorized' }, 401));
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -459,30 +459,50 @@ async function attemptTokenRefresh(): Promise<{ token: string | null; hadToken: 
  * can be unit-tested in isolation against a mocked fetch and so the
  * router stays declarative.
  */
+/**
+ * Outcome of a refresh-then-retry attempt on the SSE channel.  Returning
+ * the extracted detail alongside the response lets ``chatStream`` reuse
+ * the value when the retry also fails -- ``Response.json()`` on an
+ * already-consumed body throws ``TypeError: body used already`` in any
+ * spec-conforming fetch implementation, so the body MUST be read once.
+ */
+interface StreamRetryOutcome {
+  /** Refreshed and reopened stream response, or ``null`` when refresh failed. */
+  res: Response | null;
+  /** Detail string parsed from ``initialRes`` body before refresh ran. */
+  initialDetail: string;
+}
+
 async function retryStreamWithRefresh(
   payload: ChatRequest,
   options: { token?: string; signal?: AbortSignal },
   initialRes: Response,
-): Promise<Response | null> {
-  const refresh = await attemptTokenRefresh();
-  // ``initialRes`` already gave us the 401 detail; reuse it so the
-  // unauthorized-callback reason matches what the server actually said.
+): Promise<StreamRetryOutcome> {
+  // BUG-API-002 review fix: read the body EXACTLY once and thread the
+  // result back to the caller.  The previous implementation also called
+  // ``extractErrorDetail(initialRes)`` here, then ``chatStream`` did the
+  // same on the failure path -- ``Response.json()`` rejects the second
+  // call with ``TypeError: body used already`` in production fetch, so
+  // the thrown ``ApiError`` would be replaced by an uncaught TypeError.
+  // Mocks in Jest do not enforce single-read semantics, which is why the
+  // unit tests passed.
   const initialDetail = await extractErrorDetail(initialRes);
+  const refresh = await attemptTokenRefresh();
   if (refresh.token === null) {
     onUnauthorizedCallback?.(reasonForUnauthorized(initialDetail, refresh.hadToken));
-    return null;
+    return { res: null, initialDetail };
   }
   const retryRes = await openChatStream(payload, { ...options, token: refresh.token });
-  if (retryRes.ok) return retryRes;
+  if (retryRes.ok) return { res: retryRes, initialDetail };
   if (retryRes.status === 401) {
     const retryDetail = await extractErrorDetail(retryRes);
     onUnauthorizedCallback?.(reasonForUnauthorized(retryDetail, true));
-    return null;
+    return { res: null, initialDetail };
   }
   // Non-401 retry failure -- propagate to the caller through
   // ``handleErrorResponse`` for a uniform ``ApiError`` shape.
   await handleErrorResponse(retryRes);
-  return null; // unreachable; ``handleErrorResponse`` always throws
+  return { res: null, initialDetail }; // unreachable; ``handleErrorResponse`` always throws
 }
 
 function doFetch(
@@ -1330,20 +1350,19 @@ export const botmason = {
       // path fired the unauthorized callback on the first 401 and gave
       // up, so a transient blip (token aged out mid-keystroke) logged
       // the user out instead of recovering silently.
-      const refreshedRes = await retryStreamWithRefresh(payload, options, res);
-      if (refreshedRes !== null) {
-        const readable = asReadableStream(refreshedRes.body);
+      //
+      // ``retryStreamWithRefresh`` reads ``res`` body once and threads
+      // the detail back via ``initialDetail`` so this failure path can
+      // throw the real ``ApiError`` without re-reading an already
+      // consumed body (review fix for PR #297).
+      const outcome = await retryStreamWithRefresh(payload, options, res);
+      if (outcome.res !== null) {
+        const readable = asReadableStream(outcome.res.body);
         if (!readable) throw new StreamingUnsupportedError();
         await readChatStream(readable, callbacks, options.signal);
         return;
       }
-      // Refresh path failed -- the unauthorized callback (and the
-      // structured ``UnauthorizedReason``) was already fired inside
-      // ``retryStreamWithRefresh`` so the auth context can react.  Mirror
-      // ``handleErrorResponse`` shape so callers see ``ApiError`` either
-      // way.
-      const detail = await extractErrorDetail(res);
-      throw new ApiError(res.status, detail);
+      throw new ApiError(res.status, outcome.initialDetail);
     }
     return handleErrorResponse(res);
   },

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -4,6 +4,7 @@ import {
   authResponseSchema,
   habitWithGoalsSchema,
   isTier,
+  loginAuthResponseSchema,
   pageSchema,
   passwordResetAcceptedSchema,
   type Page,
@@ -389,7 +390,25 @@ async function attemptTokenRefresh(): Promise<{ token: string | null; hadToken: 
       headers: { Authorization: `Bearer ${currentToken}` },
     });
     if (!refreshRes.ok) return { token: null, hadToken: true };
-    const data = (await refreshRes.json()) as AuthResponse;
+    const raw: unknown = await refreshRes.json();
+    // BUG-API-007 / BUG-API-017: the prior cast (``as AuthResponse``)
+    // accepted any JSON shape -- a ``{}`` body would set ``data.token``
+    // to ``undefined`` and the bearer header on the next request would
+    // become ``Bearer undefined``, producing a zombie 401.  ``loginAuth
+    // ResponseSchema`` enforces (i) the JWT three-segment shape and
+    // (ii) ``user_id > 0`` (the ``user_id=0`` signup sentinel never
+    // reaches /auth/refresh).  ``safeParse`` keeps us inside the
+    // existing error path -- a malformed body becomes a refresh failure,
+    // not an uncaught exception, so the 401 retry loop continues to
+    // surface ``not_authenticated`` rather than crashing.
+    const parsed = loginAuthResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+      console.warn('[api] /auth/refresh response failed validation', {
+        issues: parsed.error.issues,
+      });
+      return { token: null, hadToken: true };
+    }
+    const data = parsed.data;
     // Forward the server's stored timezone so the AuthContext can keep
     // ``userTimezone`` in sync after a cold-start refresh.  Without
     // this, ``userTimezone`` would stay at its ``"UTC"`` default until
@@ -1533,10 +1552,15 @@ export interface PasswordResetCancelPayload {
 
 export const auth = {
   login(credentials: AuthRequest): Promise<AuthResponse> {
+    // BUG-API-017: ``loginAuthResponseSchema`` enforces ``user_id > 0``
+    // because the ``user_id == 0`` anti-enumeration sentinel only fires
+    // on the signup endpoint.  A login that returned zero would be a
+    // server bug, so we reject it at the boundary instead of letting
+    // the AuthContext persist a zombie session.
     return request<AuthResponse>('/auth/login', {
       method: 'POST',
       body: credentials,
-      schema: authResponseSchema,
+      schema: loginAuthResponseSchema,
     });
   },
   signup(credentials: SignupRequest): Promise<AuthResponse> {
@@ -1547,10 +1571,11 @@ export const auth = {
     });
   },
   refresh(token: string): Promise<AuthResponse> {
+    // BUG-API-017: refresh, like login, must never see ``user_id == 0``.
     return request<AuthResponse>('/auth/refresh', {
       method: 'POST',
       token,
-      schema: authResponseSchema,
+      schema: loginAuthResponseSchema,
     });
   },
   /**
@@ -1572,10 +1597,12 @@ export const auth = {
    * (SPEC R7).
    */
   confirmPasswordReset(payload: PasswordResetConfirmPayload): Promise<AuthResponse> {
+    // Mints a real session for an existing user; BUG-API-017 rejects
+    // ``user_id == 0`` here too.
     return request<AuthResponse>('/auth/password-reset/confirm', {
       method: 'POST',
       body: payload,
-      schema: authResponseSchema,
+      schema: loginAuthResponseSchema,
     });
   },
   /**

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -142,6 +142,35 @@ let llmApiKeyGetter: (() => string | null) | null = null;
 /** Header used to forward a user-provided LLM API key (BYOK, issue #185). */
 export const LLM_API_KEY_HEADER = 'X-LLM-API-Key'; // pragma: allowlist secret
 
+/**
+ * Canonical header name for client-supplied idempotency keys (BUG-API-008).
+ * Matches the IETF draft (``draft-ietf-httpapi-idempotency-key-header``)
+ * the backend already routes through its dedupe middleware.
+ */
+export const IDEMPOTENCY_KEY_HEADER = 'Idempotency-Key';
+
+/**
+ * Build a deterministic idempotency key for a mutation (BUG-API-008).
+ *
+ * The shape ``intent[:part]*`` is intentional: a key derived from the
+ * user's INTENT (e.g. ``log-unit:42:2026-05-10``) is stable across the
+ * built-in retry loop and across the user retrying after a network blip
+ * -- both surface the same key, so the backend dedupes the duplicate
+ * write instead of recording it twice.  Wall-clock values are forbidden
+ * here on purpose: a UUID or ``Date.now()`` would defeat dedup by
+ * minting a fresh key on every attempt.
+ *
+ * Callers pass the result via ``headers: { [IDEMPOTENCY_KEY_HEADER]: ... }``
+ * on POST/PUT/PATCH; the existing ``hasIdempotencyHeader`` check then
+ * promotes the request into the retry-eligible set automatically.
+ */
+export function idempotencyKey(intent: string, ...parts: (string | number)[]): string {
+  if (!intent) {
+    throw new Error('idempotencyKey: intent must be non-empty');
+  }
+  return parts.length === 0 ? intent : `${intent}:${parts.join(':')}`;
+}
+
 export function setTokenGetter(getter: (() => string | null) | null) {
   tokenGetter = getter;
 }
@@ -904,8 +933,26 @@ export interface CheckInResult {
 
 export const goalCompletions = {
   // Trailing slash — see the rationale on the ``habits`` client above.
-  create(payload: GoalCompletionPayload, token?: string): Promise<CheckInResult> {
-    return request<CheckInResult>('/goal_completions/', { method: 'POST', body: payload, token });
+  //
+  // BUG-API-008: ``options.idempotencyKey`` lets the caller (the check-in
+  // screen) pass a deterministic key built via :func:`idempotencyKey`
+  // (e.g. ``log-unit:${goalId}:${dayISO}``).  Without it, a network blip
+  // mid-tap or the user mashing the button surfaces as duplicate
+  // completions; with it, the backend's dedupe layer reuses the prior
+  // result.  Optional for back-compat with screens that have not yet
+  // adopted the helper.
+  create(
+    payload: GoalCompletionPayload,
+    options: { token?: string; idempotencyKey?: string } = {},
+  ): Promise<CheckInResult> {
+    return request<CheckInResult>('/goal_completions/', {
+      method: 'POST',
+      body: payload,
+      token: options.token,
+      headers: options.idempotencyKey
+        ? { [IDEMPOTENCY_KEY_HEADER]: options.idempotencyKey }
+        : undefined,
+    });
   },
 };
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1112,9 +1112,17 @@ export class StreamingUnsupportedError extends Error {
   }
 }
 
-// Server-Sent Events frame separator (blank line). Extracted as a constant so
-// the parser and splitter stay in lock-step.
-const SSE_FRAME_SEPARATOR = '\n\n';
+// Server-Sent Events frame separator: a blank line.  Per the spec
+// (RFC EventSource / WHATWG HTML), a frame ends at LF-LF, CR-CR, or
+// CRLF-CRLF -- production servers behind Cloudflare or nginx commonly
+// emit CRLF-terminated frames, so a parser keyed only on ``\n\n``
+// silently dropped every event from a CRLF source (BUG-API-011).
+//
+// The regex captures any of the three terminators; ``SSE_FRAME_SEPARATOR_RE``
+// is what the buffer scanner uses while ``SSE_LINE_BREAK`` is used to
+// split a single frame into its ``event:`` / ``data:`` lines.
+const SSE_FRAME_SEPARATOR_RE = /\r\n\r\n|\n\n|\r\r/;
+const SSE_LINE_BREAK_RE = /\r\n|\n|\r/;
 const SSE_EVENT_PREFIX = 'event: ';
 const SSE_DATA_PREFIX = 'data: ';
 
@@ -1141,7 +1149,9 @@ function parseSseFrame(frame: string): SsePayload | null {
   if (!frame.trim()) return null;
   let event = '';
   let data = '';
-  for (const line of frame.split('\n')) {
+  // BUG-API-011: split on any line break (LF / CRLF / CR) so a frame
+  // emitted by a server using CRLF line endings is parsed correctly.
+  for (const line of frame.split(SSE_LINE_BREAK_RE)) {
     if (line.startsWith(SSE_EVENT_PREFIX)) event = line.slice(SSE_EVENT_PREFIX.length);
     else if (line.startsWith(SSE_DATA_PREFIX)) data = line.slice(SSE_DATA_PREFIX.length);
   }
@@ -1170,9 +1180,22 @@ function dispatchSseFrame(frame: string, callbacks: ChatStreamCallbacks): void {
   } else if (parsed.event === 'complete') {
     callbacks.onComplete(payload as ChatResponse);
   } else if (parsed.event === 'error') {
-    callbacks.onStreamError(payload as { status: number; detail: string });
+    const errPayload = payload as { status: number; detail: string };
+    // BUG-API-014: a 401 inside a stream means the session expired
+    // mid-reply (token aged out, or the user signed out from another
+    // device).  The error frame is the only auth signal we get on the
+    // SSE channel, so route it through the same global unauthorized
+    // callback as the non-streaming path.  ``hadToken=true`` because
+    // the stream could not have opened without a session token.
+    if (errPayload.status === HTTP_UNAUTHORIZED) {
+      onUnauthorizedCallback?.(reasonForUnauthorized(errPayload.detail ?? null, true));
+    }
+    callbacks.onStreamError(errPayload);
   }
 }
+
+/** HTTP status that indicates an authorization failure. */
+const HTTP_UNAUTHORIZED = 401;
 
 /** Server-reported detail string when a single SSE frame can't be parsed as JSON. */
 const MALFORMED_FRAME_DETAIL = 'malformed_stream_frame';
@@ -1208,31 +1231,59 @@ async function openChatStream(
 async function readChatStream(
   readable: MinimalReadable,
   callbacks: ChatStreamCallbacks,
+  signal?: AbortSignal,
 ): Promise<void> {
   const reader = readable.getReader();
+  // BUG-API-012: ``fetchWithTimeout`` already wires the signal to the
+  // underlying ``fetch``'s AbortController -- but in some runtimes the
+  // body reader is not torn down until the underlying socket actually
+  // closes, so the user-perceived "Stop" tap takes seconds to fire.
+  // Cancelling the reader directly on abort makes ``reader.read()``
+  // resolve with ``done: true`` immediately so the loop exits and the
+  // SSE generator yields control back to the caller.
+  const cancelOnAbort = (): void => {
+    void reader.cancel?.();
+  };
+  if (signal) {
+    if (signal.aborted) cancelOnAbort();
+    else signal.addEventListener('abort', cancelOnAbort, { once: true });
+  }
   const decoder = new TextDecoder();
   let buffer = '';
   let done = false;
-  while (!done) {
-    const chunk = await reader.read();
-    done = chunk.done;
-    if (chunk.value) buffer += decoder.decode(chunk.value, { stream: true });
-    buffer = drainCompletedFrames(buffer, callbacks);
+  try {
+    while (!done) {
+      const chunk = await reader.read();
+      done = chunk.done;
+      if (chunk.value) buffer += decoder.decode(chunk.value, { stream: true });
+      buffer = drainCompletedFrames(buffer, callbacks);
+    }
+    // Any trailing bytes that arrived without a terminating blank line still
+    // need to be dispatched — servers may elide the final separator.
+    if (buffer.trim()) dispatchSseFrame(buffer, callbacks);
+  } finally {
+    signal?.removeEventListener('abort', cancelOnAbort);
   }
-  // Any trailing bytes that arrived without a terminating blank line still
-  // need to be dispatched — servers may elide the final separator.
-  if (buffer.trim()) dispatchSseFrame(buffer, callbacks);
 }
 
+/**
+ * Walk ``buffer`` for completed SSE frames, dispatch each, and return the
+ * trailing partial-frame remainder for the next read.
+ *
+ * BUG-API-011: scans for any of LF-LF / CR-CR / CRLF-CRLF (per the
+ * EventSource spec) so a server using CRLF terminators is parsed.
+ * Previous version keyed on ``"\n\n"`` only and silently swallowed the
+ * entire stream.
+ */
 function drainCompletedFrames(buffer: string, callbacks: ChatStreamCallbacks): string {
-  const separatorIndex = buffer.lastIndexOf(SSE_FRAME_SEPARATOR);
-  if (separatorIndex === -1) return buffer;
-  const complete = buffer.slice(0, separatorIndex);
-  const remainder = buffer.slice(separatorIndex + SSE_FRAME_SEPARATOR.length);
-  for (const frame of complete.split(SSE_FRAME_SEPARATOR)) {
+  let remainder = buffer;
+  while (true) {
+    const match = SSE_FRAME_SEPARATOR_RE.exec(remainder);
+    if (match === null) return remainder;
+    const frame = remainder.slice(0, match.index);
     dispatchSseFrame(frame, callbacks);
+    remainder = remainder.slice(match.index + match[0].length);
   }
-  return remainder;
 }
 
 export const botmason = {
@@ -1270,7 +1321,7 @@ export const botmason = {
     if (res.ok) {
       const readable = asReadableStream(res.body);
       if (!readable) throw new StreamingUnsupportedError();
-      await readChatStream(readable, callbacks);
+      await readChatStream(readable, callbacks, options.signal);
       return;
     }
     if (res.status === 401) {
@@ -1283,7 +1334,7 @@ export const botmason = {
       if (refreshedRes !== null) {
         const readable = asReadableStream(refreshedRes.body);
         if (!readable) throw new StreamingUnsupportedError();
-        await readChatStream(readable, callbacks);
+        await readChatStream(readable, callbacks, options.signal);
         return;
       }
       // Refresh path failed -- the unauthorized callback (and the

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -401,6 +401,42 @@ async function attemptTokenRefresh(): Promise<{ token: string | null; hadToken: 
   }
 }
 
+/**
+ * Re-open the SSE stream after a 401 with a freshly refreshed token, or
+ * fire the unauthorized callback and return ``null`` if refresh is not
+ * possible.  Closes BUG-API-002 by sharing the refresh-then-retry
+ * semantics with the non-streaming :func:`request` path.
+ *
+ * Lives here -- not inside :func:`botmason.chatStream` -- so the helper
+ * can be unit-tested in isolation against a mocked fetch and so the
+ * router stays declarative.
+ */
+async function retryStreamWithRefresh(
+  payload: ChatRequest,
+  options: { token?: string; signal?: AbortSignal },
+  initialRes: Response,
+): Promise<Response | null> {
+  const refresh = await attemptTokenRefresh();
+  // ``initialRes`` already gave us the 401 detail; reuse it so the
+  // unauthorized-callback reason matches what the server actually said.
+  const initialDetail = await extractErrorDetail(initialRes);
+  if (refresh.token === null) {
+    onUnauthorizedCallback?.(reasonForUnauthorized(initialDetail, refresh.hadToken));
+    return null;
+  }
+  const retryRes = await openChatStream(payload, { ...options, token: refresh.token });
+  if (retryRes.ok) return retryRes;
+  if (retryRes.status === 401) {
+    const retryDetail = await extractErrorDetail(retryRes);
+    onUnauthorizedCallback?.(reasonForUnauthorized(retryDetail, true));
+    return null;
+  }
+  // Non-401 retry failure -- propagate to the caller through
+  // ``handleErrorResponse`` for a uniform ``ApiError`` shape.
+  await handleErrorResponse(retryRes);
+  return null; // unreachable; ``handleErrorResponse`` always throws
+}
+
 function doFetch(
   url: string,
   init: RequestInit | undefined,
@@ -1165,27 +1201,34 @@ export const botmason = {
     options: { token?: string; signal?: AbortSignal } = {},
   ): Promise<void> {
     const res = await openChatStream(payload, options);
-    if (!res.ok) {
-      if (res.status === 401) {
-        // BUG-API-018: route the streaming 401 through the same
-        // classifier as the non-streaming path so the AuthContext sees
-        // a structured reason rather than a vague "session expired"
-        // for an anonymous caller hitting /journal/chat/stream.
-        // ``resolveToken(options.token)`` mirrors the non-streaming
-        // path so an implicit (getter-supplied) session token is
-        // counted as ``hadToken`` even when the caller did not pass
-        // ``options.token`` explicitly.
-        const detail = await extractErrorDetail(res);
-        onUnauthorizedCallback?.(
-          reasonForUnauthorized(detail, resolveToken(options.token) !== null),
-        );
-        throw new ApiError(res.status, detail);
-      }
-      return handleErrorResponse(res);
+    if (res.ok) {
+      const readable = asReadableStream(res.body);
+      if (!readable) throw new StreamingUnsupportedError();
+      await readChatStream(readable, callbacks);
+      return;
     }
-    const readable = asReadableStream(res.body);
-    if (!readable) throw new StreamingUnsupportedError();
-    await readChatStream(readable, callbacks);
+    if (res.status === 401) {
+      // BUG-API-002: a 401 on the streaming endpoint MUST go through the
+      // same refresh-once-then-fail flow as ``request``.  The previous
+      // path fired the unauthorized callback on the first 401 and gave
+      // up, so a transient blip (token aged out mid-keystroke) logged
+      // the user out instead of recovering silently.
+      const refreshedRes = await retryStreamWithRefresh(payload, options, res);
+      if (refreshedRes !== null) {
+        const readable = asReadableStream(refreshedRes.body);
+        if (!readable) throw new StreamingUnsupportedError();
+        await readChatStream(readable, callbacks);
+        return;
+      }
+      // Refresh path failed -- the unauthorized callback (and the
+      // structured ``UnauthorizedReason``) was already fired inside
+      // ``retryStreamWithRefresh`` so the auth context can react.  Mirror
+      // ``handleErrorResponse`` shape so callers see ``ApiError`` either
+      // way.
+      const detail = await extractErrorDetail(res);
+      throw new ApiError(res.status, detail);
+    }
+    return handleErrorResponse(res);
   },
   getBalance(token?: string): Promise<BalanceResponse> {
     return request<BalanceResponse>('/user/balance', { token });

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -52,12 +52,29 @@ export type Page<T> = {
 // Auth schemas
 // ---------------------------------------------------------------------------
 
+/**
+ * JWT structural shape: three URL-safe-base64 segments joined by dots
+ * (``header.payload.signature``).  Reject anything else at the client
+ * boundary so a dummy token cannot pass the auth-response gate
+ * (BUG-API-017).  This is a STRUCTURAL check, not a signature check --
+ * cryptographic verification still belongs to the backend; the regex
+ * exists so a payload like ``{"token": "x"}`` cannot persist as a
+ * "valid" session and produce zombie auth state on the next request.
+ */
+const JWT_REGEX = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+export const jwtSchema = z.string().regex(JWT_REGEX, {
+  message: 'token must be three base64url segments separated by dots',
+});
+
 export const authResponseSchema = z.object({
-  token: z.string().min(1),
+  token: jwtSchema,
   // ``user_id`` is ``0`` in the anti-enumeration signup response (BUG-AUTH-002):
   // when a caller signs up with an already-registered email the backend returns
   // a dummy token and ``user_id=0`` so the wire shape is indistinguishable from
-  // a fresh signup. Real signups return a positive autoincrement id.
+  // a fresh signup. Real signups return a positive autoincrement id.  Login
+  // and refresh paths use ``loginAuthResponseSchema`` below which rejects
+  // ``user_id=0`` -- a refreshed session whose user id is zero would be a
+  // zombie token, never the anti-enumeration sentinel.
   user_id: z.number().int().nonnegative(),
   // IANA timezone the server has on record so the frontend can compute
   // "today" in the user's calendar without a follow-up ``GET /users/me``.
@@ -66,7 +83,21 @@ export const authResponseSchema = z.object({
   timezone: z.string().optional(),
 });
 
+/**
+ * Strict variant for ``/auth/login`` and ``/auth/refresh`` (BUG-API-017):
+ * ``user_id`` MUST be positive.  The signup endpoint deliberately echoes
+ * ``user_id=0`` for already-registered emails so the wire shape stays
+ * indistinguishable; no other auth path has that affordance, so a
+ * zero-id login or refresh is by definition a server bug or a forged
+ * payload and we reject it at the boundary instead of letting it
+ * persist as a zombie session.
+ */
+export const loginAuthResponseSchema = authResponseSchema.extend({
+  user_id: z.number().int().positive(),
+});
+
 export type AuthResponseT = z.infer<typeof authResponseSchema>;
+export type LoginAuthResponseT = z.infer<typeof loginAuthResponseSchema>;
 
 /**
  * Response for ``POST /auth/password-reset/request``.  Always 202 with

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -39,7 +39,7 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 | 12 | backend-feature-routers (12A wave 2) | 4 | `claude/bug-fix-12a-wave-2-stage-course-prompts` / [#290](https://github.com/Geoffe-Ga/adepthood/pull/290) | [x] |
 | 12 | backend-feature-routers (12B wave 1) | 4 | `claude/bug-fix-remediation-p3HUm` | [x] |
 | 12 | backend-feature-routers (12B wave 2) | 4 | | [ ] |
-| 13 | frontend-api-client               | 4 | | [ ] |
+| 13 | frontend-api-client               | 4 | `claude/bug-fix-13-frontend-api-client` | [x] |
 | 14 | frontend-feature-screens          | 4 | | [ ] |
 | 15 | frontend-design-state-tests       | 4 | | [ ] |
 


### PR DESCRIPTION
Closes 8 BUG-IDs in `prompts/2026-04-18-bug-remediation/04-frontend-api-client.md` (prompt 13).

## Commits

1. **`61aa4bb`** — `chatStream` 401 path now mirrors `request`'s refresh-once-then-fail loop. **BUG-API-002**.
2. **`3a93354`** — Replace `as AuthResponse` cast on `/auth/refresh` with Zod validation; add `jwtSchema` (three URL-safe-base64 segments) and `loginAuthResponseSchema` (rejects `user_id == 0`). **BUG-API-007 / BUG-API-017**.
3. **`c8c68b3`** — Expose `IDEMPOTENCY_KEY_HEADER` constant and `idempotencyKey(intent, ...parts)` helper for deterministic intent-based keys. Wire into `goalCompletions.create` as the template. **BUG-API-008**.
4. **`1db905e`** — SSE parser accepts CRLF/LF/CR frame terminators; reader cancels on `AbortSignal`; mid-stream 401 routes to `onUnauthorizedCallback`. **BUG-API-011 / BUG-API-012 / BUG-API-014**.
5. **`b6f0658`** — Mark prompt 13 done in INDEX.

## Test plan

- All 848 frontend Jest tests pass; pre-push gate green (no coverage regression).
- New regressions:
  - `botmason-stream`: refresh-on-401 (success + failure paths), CRLF framing, abort propagation, mid-stream 401.
  - `retryAndValidation`: rejects non-JWT token, rejects `user_id == 0` on login, accepts JWT-shaped duplicate-email sentinel on signup.
  - `habits-api`: `idempotencyKey` helper edges + `Idempotency-Key` header surface on `goalCompletions.create`.

## Deferred / out-of-scope

- BUG-API-018 was already closed by earlier work; verified the existing classification already distinguishes `session_expired` / `invalid_token` / `not_authenticated` reasons.
- Threading `idempotencyKey()` through the rest of the mutation surface (habits.create, journal.create, etc.) is owned by prompt 14 (frontend-feature-screens) where the call sites live.

---
_Generated by [Claude Code](https://claude.ai/code/session_011JvxjW4m5jw6u77eKrrYjz)_