### PR TITLE
fix(habits): preserve drag order and stop date picker seizing the app

### DIFF
--- a/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
+++ b/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
@@ -1,5 +1,5 @@
-import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import type { ComponentType } from 'react';
 import { Modal, Platform, Text, TouchableOpacity, View } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 
@@ -7,6 +7,22 @@ import { STAGE_COLORS } from '../../../design/tokens';
 import styles from '../Habits.styles';
 import type { Habit, ReorderHabitsModalProps } from '../Habits.types';
 import { STAGE_ORDER, calculateHabitStartDate } from '../HabitUtils';
+
+// ``react-native-modal-datetime-picker`` ships as ES modules and isn't in the
+// jest ``transformIgnorePatterns`` allowlist. Mirror the lazy-require pattern
+// from ``src/components/DatePicker.tsx`` so screen tests that transitively
+// import this modal don't blow up at module-load time, while production still
+// gets the real picker with confirm/cancel affordances (fixes the iOS
+// app-seize bug where the previous ``<Modal><DateTimePicker/></Modal>`` had
+// no way to be dismissed).
+let DateTimePickerModal: ComponentType<Record<string, unknown>> = () => null;
+if (Platform.OS !== 'web') {
+  try {
+    DateTimePickerModal = require('react-native-modal-datetime-picker').default;
+  } catch {
+    DateTimePickerModal = () => null;
+  }
+}
 
 const formatDate = (date: Date): string =>
   date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
@@ -44,32 +60,35 @@ const ReorderHabitItem = ({ item, drag, isActive }: ReorderItemProps) => (
 
 interface ReorderDatePickerProps {
   startDate: Date;
-  showDatePicker: boolean;
-  setShowDatePicker: (_v: boolean) => void;
-  onDateChange: (_event: DateTimePickerEvent, _date?: Date) => void;
+  pickerVisible: boolean;
+  onOpenPicker: () => void;
+  onConfirm: (_date: Date) => void;
+  onCancel: () => void;
 }
 
 const ReorderDatePicker = ({
   startDate,
-  showDatePicker,
-  setShowDatePicker,
-  onDateChange,
+  pickerVisible,
+  onOpenPicker,
+  onConfirm,
+  onCancel,
 }: ReorderDatePickerProps) => (
   <View style={styles.datePickerContainer}>
     <Text style={styles.datePickerLabel}>First Habit Start Date:</Text>
     <TouchableOpacity
       testID="reorder-start-date"
       style={styles.datePickerButton}
-      onPress={() => setShowDatePicker(true)}
+      onPress={onOpenPicker}
     >
       <Text style={styles.datePickerButtonText}>{formatDate(startDate)}</Text>
     </TouchableOpacity>
-
-    {showDatePicker && (
-      <Modal transparent testID="reorder-date-picker-modal">
-        <DateTimePicker value={startDate} mode="date" display="default" onChange={onDateChange} />
-      </Modal>
-    )}
+    <DateTimePickerModal
+      isVisible={pickerVisible}
+      mode="date"
+      date={startDate}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
   </View>
 );
 
@@ -99,59 +118,82 @@ interface ReorderBodyProps {
   onSaveOrder: (_habits: Habit[]) => void;
 }
 
-const ReorderBody = ({ habits, visible, onClose, onSaveOrder }: ReorderBodyProps) => {
+interface ReorderState {
+  orderedHabits: Habit[];
+  startDate: Date;
+  pickerVisible: boolean;
+  setPickerVisible: (_v: boolean) => void;
+  handleDragEnd: (_a: { data: Habit[] }) => void;
+  handleConfirmDate: (_d: Date) => void;
+  handleCancelDate: () => void;
+  handleSave: () => void;
+}
+
+const useReorderState = ({
+  habits,
+  visible,
+  onClose,
+  onSaveOrder,
+}: ReorderBodyProps): ReorderState => {
   const [orderedHabits, setOrderedHabits] = useState<Habit[]>([]);
   const [startDate, setStartDate] = useState(new Date());
-  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const wasVisibleRef = useRef(false);
 
+  // Initialise the ordering only on the open transition. The previous
+  // implementation re-fired on every ``startDate`` change and clobbered the
+  // user's drag order, which felt like a "frozen" reorder.
   useEffect(() => {
-    if (!visible || habits.length === 0) return;
+    const justOpened = visible && !wasVisibleRef.current;
+    wasVisibleRef.current = visible;
+    if (!justOpened || habits.length === 0) return;
     const sortedHabits = [...habits].sort(
       (a, b) => STAGE_ORDER.indexOf(a.stage) - STAGE_ORDER.indexOf(b.stage),
     );
     setOrderedHabits(updateStartDates(sortedHabits, startDate));
   }, [visible, habits, startDate]);
 
-  const handleDragEnd = ({ data }: { data: Habit[] }) => {
-    setOrderedHabits(updateStartDates(data, startDate));
-  };
-
-  const handleDateChange = (event: DateTimePickerEvent, selectedDate?: Date) => {
-    setShowDatePicker(Platform.OS === 'ios');
-    if (selectedDate) {
+  return {
+    orderedHabits,
+    startDate,
+    pickerVisible,
+    setPickerVisible,
+    handleDragEnd: ({ data }) => setOrderedHabits(updateStartDates(data, startDate)),
+    handleConfirmDate: (selectedDate) => {
+      setPickerVisible(false);
       setStartDate(selectedDate);
-      setOrderedHabits(updateStartDates(orderedHabits, selectedDate));
-    }
+      setOrderedHabits((prev) => updateStartDates(prev, selectedDate));
+    },
+    handleCancelDate: () => setPickerVisible(false),
+    handleSave: () => {
+      onSaveOrder(orderedHabits);
+      onClose();
+    },
   };
+};
 
-  const handleSave = () => {
-    onSaveOrder(orderedHabits);
-    onClose();
-  };
-
+const ReorderBody = (props: ReorderBodyProps) => {
+  const s = useReorderState(props);
   return (
     <View style={styles.reorderModalContent}>
       <View style={styles.modalHeader}>
         <Text style={styles.modalTitle}>Reorder Habits</Text>
-        <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+        <TouchableOpacity onPress={props.onClose} style={styles.closeButton}>
           <Text style={styles.closeButtonText}>×</Text>
         </TouchableOpacity>
       </View>
-
       <ReorderDatePicker
-        startDate={startDate}
-        showDatePicker={showDatePicker}
-        setShowDatePicker={setShowDatePicker}
-        onDateChange={handleDateChange}
+        startDate={s.startDate}
+        pickerVisible={s.pickerVisible}
+        onOpenPicker={() => s.setPickerVisible(true)}
+        onConfirm={s.handleConfirmDate}
+        onCancel={s.handleCancelDate}
       />
-
       <Text style={styles.reorderInstructions}>
         Drag habits to reorder. Habits 1-8 start 21 days apart, habits 9-10 start 42 days apart.
       </Text>
-
-      <ReorderList orderedHabits={orderedHabits} onDragEnd={handleDragEnd} />
-
-      <TouchableOpacity style={styles.saveOrderButton} onPress={handleSave}>
+      <ReorderList orderedHabits={s.orderedHabits} onDragEnd={s.handleDragEnd} />
+      <TouchableOpacity style={styles.saveOrderButton} onPress={s.handleSave}>
         <Text style={styles.saveOrderButtonText}>Save Order</Text>
       </TouchableOpacity>
     </View>

--- a/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
@@ -1,0 +1,196 @@
+/* eslint-env jest */
+/**
+ * Regression tests for ``ReorderHabitsModal`` covering two bugs reported
+ * on the habits screen:
+ *
+ *  1. The order would snap back to the stage-default after the user
+ *     dragged a habit and then picked a new start date (or any other
+ *     state change that re-fired the initialisation effect). To users
+ *     the manual reorder appeared to "freeze" because their drags had
+ *     no visible effect once they touched anything else.
+ *  2. Tapping the start-date button opened a date picker wrapped in a
+ *     bare ``<Modal>`` with no dismissal affordance. On iOS the picker
+ *     stayed on screen with no way to back out and the whole app froze.
+ *     The fix swaps in the shared ``<DatePicker>`` component (which
+ *     already wraps ``react-native-modal-datetime-picker`` with proper
+ *     confirm/cancel handling) and is exercised here through its
+ *     accessibility label.
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render, act } from '@testing-library/react-native';
+import React from 'react';
+
+import type { Habit } from '../../Habits.types';
+
+jest.mock('react-native-draggable-flatlist', () => {
+  const ReactLib = require('react');
+  const { View } = require('react-native');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ({ data, renderItem, onDragEnd, testID }: any) =>
+    ReactLib.createElement(
+      View,
+      { testID: testID ?? 'reorder-list', data, onDragEnd },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.map((item: any, index: number) =>
+        ReactLib.cloneElement(
+          renderItem({ item, index, drag: jest.fn(), isActive: false, getIndex: () => index }),
+          { key: item.id ?? index },
+        ),
+      ),
+    );
+});
+
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+
+jest.mock('react-native-modal-datetime-picker', () => {
+  const ReactLib = require('react');
+  const { Text, TouchableOpacity } = require('react-native');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ModalDatePickerMock = ({ isVisible, onConfirm, onCancel }: any) =>
+    isVisible
+      ? ReactLib.createElement(
+          ReactLib.Fragment,
+          null,
+          ReactLib.createElement(
+            TouchableOpacity,
+            { testID: 'modal-datetime-confirm', onPress: () => onConfirm(new Date('2026-06-01')) },
+            ReactLib.createElement(Text, null, 'Confirm'),
+          ),
+          ReactLib.createElement(
+            TouchableOpacity,
+            { testID: 'modal-datetime-cancel', onPress: onCancel },
+            ReactLib.createElement(Text, null, 'Cancel'),
+          ),
+        )
+      : null;
+  return { __esModule: true, default: ModalDatePickerMock };
+});
+
+const ReorderHabitsModal = require('../ReorderHabitsModal').default;
+
+const makeHabit = (id: number, stage: string, name: string): Habit => ({
+  id,
+  stage,
+  name,
+  icon: '⭐',
+  streak: 0,
+  energy_cost: 1,
+  energy_return: 1,
+  start_date: new Date('2026-01-01'),
+  goals: [],
+});
+
+const HABITS: Habit[] = [
+  makeHabit(1, 'Beige', 'A'),
+  makeHabit(2, 'Purple', 'B'),
+  makeHabit(3, 'Red', 'C'),
+];
+
+const getOrderedIds = (list: ReturnType<typeof render>): number[] => {
+  const data = list.getByTestId('reorder-list').props.data as Habit[];
+  return data.map((h) => h.id);
+};
+
+describe('ReorderHabitsModal — drag persistence (BUG: re-sort freezes)', () => {
+  it('preserves the dragged order across multiple consecutive drags', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    const list = result.getByTestId('reorder-list');
+
+    // First drag: move habit 3 (Red) to the front.
+    act(() => {
+      list.props.onDragEnd({ data: [HABITS[2], HABITS[0], HABITS[1]] });
+    });
+    expect(getOrderedIds(result)).toEqual([3, 1, 2]);
+
+    // Second drag: move habit 2 (Purple) to the front of the current order.
+    const afterFirst = result.getByTestId('reorder-list').props.data as Habit[];
+    act(() => {
+      list.props.onDragEnd({ data: [afterFirst[2], afterFirst[0], afterFirst[1]] });
+    });
+    expect(getOrderedIds(result)).toEqual([2, 3, 1]);
+
+    // Third drag: swap the first two.
+    const afterSecond = result.getByTestId('reorder-list').props.data as Habit[];
+    act(() => {
+      list.props.onDragEnd({ data: [afterSecond[1], afterSecond[0], afterSecond[2]] });
+    });
+    expect(getOrderedIds(result)).toEqual([3, 2, 1]);
+  });
+
+  it('keeps the manual order when the start date changes', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    const list = result.getByTestId('reorder-list');
+    act(() => {
+      list.props.onDragEnd({ data: [HABITS[2], HABITS[0], HABITS[1]] });
+    });
+    expect(getOrderedIds(result)).toEqual([3, 1, 2]);
+
+    // Open the date picker and confirm a new date.
+    fireEvent.press(result.getByTestId('reorder-start-date'));
+    fireEvent.press(result.getByTestId('modal-datetime-confirm'));
+
+    // The user's manual order must survive the date change.
+    expect(getOrderedIds(result)).toEqual([3, 1, 2]);
+  });
+});
+
+describe('ReorderHabitsModal — date picker dismissal (BUG: app seizes)', () => {
+  it('mounts the date picker only after the user opens it and dismisses cleanly on cancel', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    expect(result.queryByTestId('modal-datetime-confirm')).toBeNull();
+
+    fireEvent.press(result.getByTestId('reorder-start-date'));
+    expect(result.getByTestId('modal-datetime-cancel')).toBeTruthy();
+
+    fireEvent.press(result.getByTestId('modal-datetime-cancel'));
+    expect(result.queryByTestId('modal-datetime-confirm')).toBeNull();
+    // Order is unchanged after cancel.
+    expect(getOrderedIds(result)).toEqual([1, 2, 3]);
+  });
+
+  it('persists the chosen date and recomputes start_date offsets', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    fireEvent.press(result.getByTestId('reorder-start-date'));
+    fireEvent.press(result.getByTestId('modal-datetime-confirm'));
+
+    const data = result.getByTestId('reorder-list').props.data as Habit[];
+    // First habit should anchor to the confirmed date (2026-06-01 in mock).
+    expect(new Date(data[0]!.start_date).toISOString().slice(0, 10)).toBe('2026-06-01');
+    // Second habit is 21 days later.
+    expect(new Date(data[1]!.start_date).toISOString().slice(0, 10)).toBe('2026-06-22');
+  });
+});
+
+describe('ReorderHabitsModal — save flow', () => {
+  it('calls onSaveOrder with the current order and closes', () => {
+    const onSave = jest.fn();
+    const onClose = jest.fn();
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={onClose} onSaveOrder={onSave} />,
+    );
+
+    const list = result.getByTestId('reorder-list');
+    act(() => {
+      list.props.onDragEnd({ data: [HABITS[1], HABITS[2], HABITS[0]] });
+    });
+
+    fireEvent.press(result.getByText('Save Order'));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0]![0] as Habit[];
+    expect(saved.map((h) => h.id)).toEqual([2, 3, 1]);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
ReorderHabitsModal had two compounding bugs reported on the habits screen.

The initialisation ``useEffect`` carried ``startDate`` in its dependency
array, so every date selection (and any parent re-render that fed back a
fresh ``habits`` reference) re-ran the stage-default sort and clobbered
the user's manual drag order. To users the reorder appeared to "freeze"
because their drags had no visible effect once they touched anything
else. Guard the effect with a ``wasVisibleRef`` so it fires only on the
modal's open transition; ``handleDragEnd`` and ``handleConfirmDate`` now
own the in-flight order.

The start-date affordance opened a raw ``@react-native-community/date
timepicker`` wrapped in a bare ``<Modal>`` with no confirm/cancel button,
no overlay press, and no ``onRequestClose`` -- on iOS the picker stayed
on screen with no way to back out and the whole app seized. Swap in
``react-native-modal-datetime-picker`` (already a dependency, used by
``DatePicker``) which surfaces proper confirm/cancel handlers; the
component is loaded via the same lazy ``require`` pattern as
``DatePicker.tsx`` so jest doesn't trip on its ES module entry point.

Tests cover three drags in a row, drag-then-date-change, picker mount
and cancel, confirm-recomputes-offsets, and the save flow.