### PR TITLE
feat(habits): explicit Save button + convex/recessed states for goal targets

### DIFF
--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -65,6 +65,15 @@ describe('design tokens', () => {
     it('exports border color', () => {
       expect(colors.border).toBe('#ddd');
     });
+
+    it('exports bevel palette for recessed controls', () => {
+      // Two-tone bevel is the only portable way to fake ``box-shadow: inset``
+      // in React Native; freezing these keeps the goal-target editor's
+      // sunken-input treatment stable across refactors.
+      expect(colors.bevel.recessedSurface).toBe('#e9e9e9');
+      expect(colors.bevel.edgeDark).toBe('#bcbcbc');
+      expect(colors.bevel.edgeLight).toBe('#ffffff');
+    });
   });
 
   describe('touchTarget (BUG-FE-UI-002)', () => {

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -68,6 +68,22 @@ export const colors = {
   successText: '#2e7d32',
 
   border: '#ddd',
+
+  /**
+   * Bevel palette for recessed (sunken) controls. React Native has no
+   * portable ``box-shadow: inset`` primitive, so depth is conveyed via the
+   * classic two-tone bevel: a darker edge along the top + left of the
+   * surface and a lighter edge along the bottom + right reads as a
+   * depression. Used by the goal-target editor's input field; pair with
+   * ``shadows.small`` on the saved-state chip for the convex counterpart.
+   * Dark-mode equivalents will live alongside the rest of ``darkColors``
+   * when that theme ships.
+   */
+  bevel: {
+    recessedSurface: '#e9e9e9',
+    edgeDark: '#bcbcbc',
+    edgeLight: '#ffffff',
+  },
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -21,7 +21,7 @@ import type {
 import EmojiSelector from 'react-native-emoji-selector';
 
 import { goalGroups as goalGroupsApi, type ApiGoalGroup } from '../../../api';
-import { colors, SPACING, STAGE_COLORS } from '../../../design/tokens';
+import { colors, SPACING, STAGE_COLORS, shadows } from '../../../design/tokens';
 import { TARGET_UNITS, FREQUENCY_UNITS } from '../constants';
 import styles from '../Habits.styles';
 import type { GoalModalProps, Goal } from '../Habits.types';
@@ -367,6 +367,17 @@ const GOAL_CHIP_FONT_SIZE = 12;
 const GOAL_FREQ_INPUT_WIDTH = 56;
 const GOAL_DISPLAY_VERTICAL_PADDING = 6;
 const GOAL_DISPLAY_HORIZONTAL_PADDING = 10;
+const GOAL_SAVE_BUTTON_VERTICAL_PADDING = 6;
+const GOAL_SAVE_BUTTON_HORIZONTAL_PADDING = 12;
+const GOAL_SAVE_BUTTON_FONT_SIZE = 13;
+
+// Bevel-border palette evoking a sunken / pressed-in input. RN has no
+// portable inset-shadow, so the classic two-tone trick is used: dark top +
+// left, light bottom + right reads as a depression in the surface, while
+// the convex chip uses ``shadows.small`` (raised) on a ``card`` surface.
+const RECESSED_BEVEL_DARK = '#bcbcbc';
+const RECESSED_BEVEL_LIGHT = '#ffffff';
+const RECESSED_SURFACE = '#e9e9e9';
 
 const goalEditorStyles = StyleSheet.create({
   container: {
@@ -394,27 +405,49 @@ const goalEditorStyles = StyleSheet.create({
     fontSize: GOAL_LABEL_FONT_SIZE,
     fontWeight: '500',
   },
+  /** Edit-mode field — recessed (sunken) bevel so it reads as "open for input". */
   input: {
     width: GOAL_INPUT_WIDTH,
     borderWidth: 1,
-    borderColor: colors.border,
+    borderTopColor: RECESSED_BEVEL_DARK,
+    borderLeftColor: RECESSED_BEVEL_DARK,
+    borderBottomColor: RECESSED_BEVEL_LIGHT,
+    borderRightColor: RECESSED_BEVEL_LIGHT,
     borderRadius: GOAL_INPUT_BORDER_RADIUS,
     paddingVertical: GOAL_INPUT_VERTICAL_PADDING,
     paddingHorizontal: SPACING.sm,
     textAlign: 'center',
     fontSize: GOAL_INPUT_FONT_SIZE,
     marginHorizontal: SPACING.sm,
+    backgroundColor: RECESSED_SURFACE,
   },
-  /** Saved-state chip — visually distinct from :class:`input` so users see settled vs editing. */
+  /** Saved-state chip — convex (raised) so users read it as a tappable button, not a label. */
   display: {
     width: GOAL_INPUT_WIDTH,
     borderRadius: GOAL_INPUT_BORDER_RADIUS,
     paddingVertical: GOAL_DISPLAY_VERTICAL_PADDING,
     paddingHorizontal: GOAL_DISPLAY_HORIZONTAL_PADDING,
-    backgroundColor: colors.background.accent,
+    backgroundColor: colors.background.card,
+    borderWidth: 1,
+    borderColor: colors.border,
     marginHorizontal: SPACING.sm,
     alignItems: 'center',
     justifyContent: 'center',
+    ...shadows.small,
+  },
+  saveButton: {
+    paddingVertical: GOAL_SAVE_BUTTON_VERTICAL_PADDING,
+    paddingHorizontal: GOAL_SAVE_BUTTON_HORIZONTAL_PADDING,
+    borderRadius: GOAL_INPUT_BORDER_RADIUS,
+    marginRight: SPACING.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.small,
+  },
+  saveButtonText: {
+    color: colors.text.light,
+    fontWeight: '600',
+    fontSize: GOAL_SAVE_BUTTON_FONT_SIZE,
   },
   displayText: {
     fontSize: GOAL_INPUT_FONT_SIZE,
@@ -473,16 +506,31 @@ interface GoalTargetRowProps {
   onCommit: (_target: number) => void;
 }
 
-/** Click-to-edit target row: chip → TextInput on tap, ``onEndEditing`` only (no double-write). */
-const GoalTargetRow = ({ goal, onCommit }: GoalTargetRowProps) => {
+/**
+ * Editing-state machine for a single tier goal's target value.
+ *
+ * ``submittedRef`` is the gate that collapses the Save-button-press →
+ * TextInput-blur double event into one ``onCommit``: ``setEditing(false)``
+ * is asynchronous so it can't guard the second call; the ref is set
+ * synchronously and reset on each ``startEdit``.
+ */
+const useTargetDraft = (goal: Goal, onCommit: (_target: number) => void) => {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(String(goal.target));
+  const submittedRef = useRef(false);
   // Skip sync mid-edit so out-of-band updates don't clobber in-flight typing.
   useEffect(() => {
     if (!editing) setDraft(String(goal.target));
   }, [goal.target, editing]);
-  const tierLabel = TIER_LABELS[goal.tier] ?? goal.tier;
-  const handleEnd = () => {
+
+  const startEdit = () => {
+    submittedRef.current = false;
+    setEditing(true);
+  };
+
+  const trySave = () => {
+    if (submittedRef.current) return;
+    submittedRef.current = true;
     setEditing(false);
     const parsed = Number.parseFloat(draft);
     if (!Number.isFinite(parsed) || parsed === goal.target) {
@@ -491,28 +539,57 @@ const GoalTargetRow = ({ goal, onCommit }: GoalTargetRowProps) => {
     }
     onCommit(parsed);
   };
+
+  return { editing, draft, setDraft, startEdit, trySave };
+};
+
+/**
+ * Click-to-edit target row. Two visual states convey the affordance:
+ *   - **convex chip** (saved): a raised, card-surface button — tap to edit.
+ *   - **recessed input + Save button** (editing): sunken field next to a
+ *     filled tier-colored Save button — tap Save (or press Return / blur)
+ *     to commit.
+ */
+const GoalTargetRow = ({ goal, onCommit }: GoalTargetRowProps) => {
+  const { editing, draft, setDraft, startEdit, trySave } = useTargetDraft(goal, onCommit);
+  const tierLabel = TIER_LABELS[goal.tier] ?? goal.tier;
   const tierColor = getTierColor(goal.tier);
+
   return (
     <View style={goalEditorStyles.row}>
       <Text style={[goalEditorStyles.label, { color: tierColor }]}>{tierLabel}</Text>
       {editing ? (
-        <TextInput
-          testID={`goal-target-input-${goal.tier}`}
-          style={goalEditorStyles.input}
-          value={draft}
-          onChangeText={setDraft}
-          // ``onEndEditing`` covers return-key + blur; ``onBlur`` would double-write on device.
-          onEndEditing={handleEnd}
-          autoFocus
-          keyboardType="numeric"
-          returnKeyType="done"
-        />
+        <>
+          <TextInput
+            testID={`goal-target-input-${goal.tier}`}
+            style={goalEditorStyles.input}
+            value={draft}
+            onChangeText={setDraft}
+            // Both events back the same commit so return-key, blur, and
+            // explicit Save-button taps each save reliably; the hook's
+            // ``submittedRef`` collapses duplicate fires into one commit.
+            onEndEditing={trySave}
+            onSubmitEditing={trySave}
+            autoFocus
+            keyboardType="numeric"
+            returnKeyType="done"
+          />
+          <TouchableOpacity
+            testID={`goal-target-save-${goal.tier}`}
+            accessibilityRole="button"
+            accessibilityLabel={`Save ${tierLabel} target`}
+            onPress={trySave}
+            style={[goalEditorStyles.saveButton, { backgroundColor: tierColor }]}
+          >
+            <Text style={goalEditorStyles.saveButtonText}>Save</Text>
+          </TouchableOpacity>
+        </>
       ) : (
         <TouchableOpacity
           testID={`goal-target-display-${goal.tier}`}
           accessibilityRole="button"
           accessibilityLabel={`Edit ${tierLabel} target, currently ${goal.target}`}
-          onPress={() => setEditing(true)}
+          onPress={startEdit}
           style={goalEditorStyles.display}
         >
           <Text style={[goalEditorStyles.displayText, { color: tierColor }]}>{goal.target}</Text>

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -371,14 +371,6 @@ const GOAL_SAVE_BUTTON_VERTICAL_PADDING = 6;
 const GOAL_SAVE_BUTTON_HORIZONTAL_PADDING = 12;
 const GOAL_SAVE_BUTTON_FONT_SIZE = 13;
 
-// Bevel-border palette evoking a sunken / pressed-in input. RN has no
-// portable inset-shadow, so the classic two-tone trick is used: dark top +
-// left, light bottom + right reads as a depression in the surface, while
-// the convex chip uses ``shadows.small`` (raised) on a ``card`` surface.
-const RECESSED_BEVEL_DARK = '#bcbcbc';
-const RECESSED_BEVEL_LIGHT = '#ffffff';
-const RECESSED_SURFACE = '#e9e9e9';
-
 const goalEditorStyles = StyleSheet.create({
   container: {
     marginVertical: SPACING.md,
@@ -409,17 +401,17 @@ const goalEditorStyles = StyleSheet.create({
   input: {
     width: GOAL_INPUT_WIDTH,
     borderWidth: 1,
-    borderTopColor: RECESSED_BEVEL_DARK,
-    borderLeftColor: RECESSED_BEVEL_DARK,
-    borderBottomColor: RECESSED_BEVEL_LIGHT,
-    borderRightColor: RECESSED_BEVEL_LIGHT,
+    borderTopColor: colors.bevel.edgeDark,
+    borderLeftColor: colors.bevel.edgeDark,
+    borderBottomColor: colors.bevel.edgeLight,
+    borderRightColor: colors.bevel.edgeLight,
     borderRadius: GOAL_INPUT_BORDER_RADIUS,
     paddingVertical: GOAL_INPUT_VERTICAL_PADDING,
     paddingHorizontal: SPACING.sm,
     textAlign: 'center',
     fontSize: GOAL_INPUT_FONT_SIZE,
     marginHorizontal: SPACING.sm,
-    backgroundColor: RECESSED_SURFACE,
+    backgroundColor: colors.bevel.recessedSurface,
   },
   /** Saved-state chip — convex (raised) so users read it as a tappable button, not a label. */
   display: {

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -127,6 +127,19 @@ describe('GoalModal goal-target editor', () => {
     expect(props.onUpdateGoal).toHaveBeenCalledTimes(1);
   });
 
+  it('collapses the Return-key-then-blur sequence into a single onUpdateGoal call', () => {
+    // Symmetric to the Save-then-blur test: pressing Return fires
+    // onSubmitEditing AND onEndEditing on most platforms; the submittedRef
+    // guard must dedupe that pair the same way it dedupes Save+blur.
+    const { getByTestId, props } = renderModal();
+    fireEvent.press(getByTestId('goal-target-display-low'));
+    const input = getByTestId('goal-target-input-low');
+    fireEvent.changeText(input, '9');
+    fireEvent(input, 'submitEditing');
+    fireEvent(input, 'endEditing');
+    expect(props.onUpdateGoal).toHaveBeenCalledTimes(1);
+  });
+
   it('reverts the draft and skips the commit when the input is non-numeric', () => {
     const { getByTestId, props } = renderModal();
     fireEvent.press(getByTestId('goal-target-display-low'));

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -78,14 +78,33 @@ describe('GoalModal goal-target editor', () => {
     expect(queryByTestId('goal-target-input-low')).toBeNull();
   });
 
-  it('switches the row to an editable input when the saved chip is tapped', () => {
+  it('switches the row to a recessed input plus Save button when the chip is tapped', () => {
     const { getByTestId } = renderModal();
     fireEvent.press(getByTestId('goal-target-display-low'));
     expect(getByTestId('goal-target-input-low')).toBeTruthy();
+    // Save is the explicit affordance the chip-on-blur design lacked --
+    // its presence is what tells the user their typed change is savable.
+    expect(getByTestId('goal-target-save-low')).toBeTruthy();
   });
 
-  it('commits the per-tier numeric target on blur and returns to the saved chip', () => {
+  it('commits the per-tier numeric target when the Save button is pressed', () => {
     const { getByTestId, queryByTestId, props } = renderModal();
+    fireEvent.press(getByTestId('goal-target-display-low'));
+    const input = getByTestId('goal-target-input-low');
+    fireEvent.changeText(input, '7');
+    fireEvent.press(getByTestId('goal-target-save-low'));
+    expect(props.onUpdateGoal).toHaveBeenCalledTimes(1);
+    expect(props.onUpdateGoal).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ tier: 'low', target: 7 }),
+    );
+    expect(getByTestId('goal-target-display-low')).toBeTruthy();
+    expect(queryByTestId('goal-target-input-low')).toBeNull();
+    expect(queryByTestId('goal-target-save-low')).toBeNull();
+  });
+
+  it('still commits on blur (endEditing) so keyboard-dismiss saves what the user typed', () => {
+    const { getByTestId, props } = renderModal();
     fireEvent.press(getByTestId('goal-target-display-low'));
     const input = getByTestId('goal-target-input-low');
     fireEvent.changeText(input, '7');
@@ -94,25 +113,35 @@ describe('GoalModal goal-target editor', () => {
       42,
       expect.objectContaining({ tier: 'low', target: 7 }),
     );
-    expect(getByTestId('goal-target-display-low')).toBeTruthy();
-    expect(queryByTestId('goal-target-input-low')).toBeNull();
   });
 
-  it('reverts the draft and skips the commit when the target input is non-numeric', () => {
+  it('collapses the Save-then-blur double event into a single onUpdateGoal call', () => {
+    // Tapping Save fires onPress, then the TextInput blurs and fires
+    // onEndEditing. Without the submittedRef guard we would PUT twice.
+    const { getByTestId, props } = renderModal();
+    fireEvent.press(getByTestId('goal-target-display-low'));
+    const input = getByTestId('goal-target-input-low');
+    fireEvent.changeText(input, '9');
+    fireEvent.press(getByTestId('goal-target-save-low'));
+    fireEvent(input, 'endEditing');
+    expect(props.onUpdateGoal).toHaveBeenCalledTimes(1);
+  });
+
+  it('reverts the draft and skips the commit when the input is non-numeric', () => {
     const { getByTestId, props } = renderModal();
     fireEvent.press(getByTestId('goal-target-display-low'));
     const input = getByTestId('goal-target-input-low');
     fireEvent.changeText(input, 'abc');
-    fireEvent(input, 'endEditing');
+    fireEvent.press(getByTestId('goal-target-save-low'));
     expect(props.onUpdateGoal).not.toHaveBeenCalled();
   });
 
-  it('skips the commit when the target input matches the current value', () => {
+  it('skips the commit when the input matches the current value', () => {
     const { getByTestId, props } = renderModal();
     fireEvent.press(getByTestId('goal-target-display-low'));
     const input = getByTestId('goal-target-input-low');
     fireEvent.changeText(input, '1'); // already 1
-    fireEvent(input, 'endEditing');
+    fireEvent.press(getByTestId('goal-target-save-low'));
     expect(props.onUpdateGoal).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The click-to-edit target row already saved on blur, but with no visible
"Save" affordance users reported "there's no way to save" — they tapped
the number, typed, and saw no commit signal. Two visual changes make the
state machine legible:

- Saved state renders as a convex chip: card-white surface, soft drop
  shadow (``shadows.small``), border — reads as a tappable button.
- Editing state renders as a recessed input (sunken grey + dark top/left,
  light bottom/right bevel borders) next to a tier-colored Save button.

Save is wired to ``onPress`` plus the existing ``onEndEditing`` /
``onSubmitEditing`` so blur and Return still save (forgiving UX); a
``submittedRef`` collapses the Save-tap → blur double event into one
``onUpdateGoal`` call. Hook extracted (``useTargetDraft``) to keep the
row component under the 50-line lint budget.