### PR TITLE
feat(frontend-habits): add habit, paginate, confirm delete

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -266,6 +266,9 @@ const HabitHeader = ({
 
 const TOTAL_HABITS = 10;
 
+/** Tile border thickness so the aptitude/stage color reads clearly at a glance. */
+export const TILE_BORDER_WIDTH = 3;
+
 const useTileLayout = () => {
   const { width, height, columns, scale, gridGutter } = useResponsive();
   const rows = columns === 2 ? TOTAL_HABITS / columns : TOTAL_HABITS;
@@ -533,7 +536,7 @@ const getLockedTileStyle = (
   tileMinHeight: number,
 ) => ({
   flex: 1 as const,
-  borderWidth: 1,
+  borderWidth: TILE_BORDER_WIDTH,
   borderColor: stageColor,
   padding: spacing(1, scale),
   margin: gridGutter / 2,
@@ -611,7 +614,7 @@ const UnlockedTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: Unlocked
       testID="habit-tile"
       style={{
         flex: 1,
-        borderWidth: 1,
+        borderWidth: TILE_BORDER_WIDTH,
         borderColor: stageColor,
         borderStyle: earlyUnlocked ? 'dashed' : undefined,
         padding: spacing(1, scale),

--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -1290,6 +1290,31 @@ export const styles = StyleSheet.create({
     color: COLORS.text.tertiary,
   },
 
+  // ===== Pagination =====
+  paginationBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+  },
+  paginationButton: {
+    backgroundColor: COLORS.secondary,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    borderRadius: BORDER_RADIUS.xs,
+    ...SHADOWS.small,
+  },
+  paginationButtonText: {
+    color: COLORS.text.light,
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  paginationLabel: {
+    color: COLORS.text.primary,
+    fontWeight: '600',
+  },
+
   // ===== Overflow Menu =====
   topBar: {
     flexDirection: 'row',

--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -1308,7 +1308,6 @@ export const styles = StyleSheet.create({
   paginationButtonText: {
     color: COLORS.text.light,
     fontWeight: '600',
-    fontSize: 14,
   },
   paginationLabel: {
     color: COLORS.text.primary,

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -160,12 +160,20 @@ export interface ReorderHabitsModalProps {
   onSaveOrder: (_habits: Habit[]) => void;
 }
 
+export interface AddHabitInput {
+  name: string;
+  icon: string;
+  energy_cost?: number;
+  energy_return?: number;
+}
+
 export interface HabitsActions {
   loadHabits: () => Promise<void>;
   updateGoal: (_habitId: number, _updatedGoal: Goal) => void;
   logUnit: (_habitId: number, _amount: number) => void;
   updateHabit: (_updatedHabit: Habit) => void;
   deleteHabit: (_habitId: number) => void;
+  addHabit: (_input: AddHabitInput) => Promise<void>;
   saveHabitOrder: (_orderedHabits: Habit[]) => void;
   backfillMissedDays: (_habitId: number, _days: Date[]) => void;
   setNewStartDate: (_habitId: number, _newDate: Date) => void;

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -1,7 +1,7 @@
 // HabitsScreen.tsx
 
-import { BarChart2, Check, Lock, MoreHorizontal, Pencil, Unlock, Zap } from 'lucide-react';
-import React, { useCallback, useEffect, useState } from 'react';
+import { BarChart2, Check, Lock, MoreHorizontal, Pencil, Plus, Unlock, Zap } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, FlatList, Text, TouchableOpacity, View, Modal } from 'react-native';
 import EmojiSelector from 'react-native-emoji-selector';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -11,6 +11,7 @@ import { useAuth } from '../../context/AuthContext';
 import { spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 
+import AddHabitModal from './components/AddHabitModal';
 import GoalModal from './components/GoalModal';
 import HabitSettingsModal from './components/HabitSettingsModal';
 import MissedDaysModal from './components/MissedDaysModal';
@@ -23,6 +24,9 @@ import HabitTile from './HabitTile';
 import { generateStatsForHabit, toLocalHabitStats, calculateMissedDays } from './HabitUtils';
 import { useHabits } from './hooks/useHabits';
 import { useModalCoordinator } from './hooks/useModalCoordinator';
+
+/** Habits per page. Ten is the design ceiling that fills the screen 1-up on mobile and 2x5 on landscape/desktop. */
+const HABITS_PER_PAGE = 10;
 
 export { DEFAULT_ICONS, TARGET_UNITS, FREQUENCY_UNITS, DAYS_OF_WEEK } from './constants';
 export { calculateNetEnergy } from './HabitUtils';
@@ -78,20 +82,63 @@ interface OverflowMenuProps {
   onToggle: () => void;
   onSelectMode: (_mode: 'quickLog' | 'stats' | 'edit') => void;
   onOpenOnboarding: () => void;
+  onOpenAddHabit: () => void;
   allRevealed: boolean;
   onToggleReveal: () => void;
 }
 
+type MenuAction = 'quickLog' | 'stats' | 'edit' | 'addHabit' | 'onboarding';
+
 const MENU_ITEMS: Array<{
   Icon: typeof Check;
   label: string;
-  mode: 'quickLog' | 'stats' | 'edit' | null;
+  action: MenuAction;
 }> = [
-  { Icon: Check, label: 'Quick Log', mode: 'quickLog' },
-  { Icon: BarChart2, label: 'Stats', mode: 'stats' },
-  { Icon: Pencil, label: 'Edit', mode: 'edit' },
-  { Icon: Zap, label: 'Energy Scaffolding', mode: null },
+  { Icon: Check, label: 'Quick Log', action: 'quickLog' },
+  { Icon: BarChart2, label: 'Stats', action: 'stats' },
+  { Icon: Pencil, label: 'Edit', action: 'edit' },
+  { Icon: Plus, label: 'Add Habit', action: 'addHabit' },
+  { Icon: Zap, label: 'Energy Scaffolding', action: 'onboarding' },
 ];
+
+interface OverflowMenuListProps {
+  scale: number;
+  iconMargin: { marginRight: number };
+  handleMenuPress: (_action: MenuAction) => void;
+  allRevealed: boolean;
+  onToggleReveal: () => void;
+}
+
+const OverflowMenuList = ({
+  scale,
+  iconMargin,
+  handleMenuPress,
+  allRevealed,
+  onToggleReveal,
+}: OverflowMenuListProps) => {
+  const RevealIcon = allRevealed ? Lock : Unlock;
+  const revealLabel = allRevealed ? 'Lock Unstarted Habits' : 'Reveal All Habits';
+  return (
+    <View testID="overflow-menu" style={[styles.mobileMenu, { top: spacing(4, scale), right: 0 }]}>
+      {MENU_ITEMS.map((item) => (
+        <MenuItem
+          key={item.label}
+          icon={<item.Icon size={spacing(2, scale)} style={iconMargin} />}
+          label={item.label}
+          onPress={() => handleMenuPress(item.action)}
+          scale={scale}
+        />
+      ))}
+      <MenuItem
+        key="reveal-toggle"
+        icon={<RevealIcon size={spacing(2, scale)} style={iconMargin} />}
+        label={revealLabel}
+        onPress={onToggleReveal}
+        scale={scale}
+      />
+    </View>
+  );
+};
 
 const OverflowMenu = ({
   scale,
@@ -99,12 +146,16 @@ const OverflowMenu = ({
   onToggle,
   onSelectMode,
   onOpenOnboarding,
+  onOpenAddHabit,
   allRevealed,
   onToggleReveal,
 }: OverflowMenuProps) => {
   const iconMargin = { marginRight: spacing(1, scale) };
-  const RevealIcon = allRevealed ? Lock : Unlock;
-  const revealLabel = allRevealed ? 'Lock Unstarted Habits' : 'Reveal All Habits';
+  const handleMenuPress = (action: MenuAction) => {
+    if (action === 'onboarding') onOpenOnboarding();
+    else if (action === 'addHabit') onOpenAddHabit();
+    else onSelectMode(action);
+  };
   return (
     <View style={styles.overflowMenuContainer} testID="overflow-menu-wrapper">
       <TouchableOpacity
@@ -115,27 +166,13 @@ const OverflowMenu = ({
         <MoreHorizontal size={spacing(3, scale)} />
       </TouchableOpacity>
       {menuVisible && (
-        <View
-          testID="overflow-menu"
-          style={[styles.mobileMenu, { top: spacing(4, scale), right: 0 }]}
-        >
-          {MENU_ITEMS.map((item) => (
-            <MenuItem
-              key={item.label}
-              icon={<item.Icon size={spacing(2, scale)} style={iconMargin} />}
-              label={item.label}
-              onPress={item.mode ? () => onSelectMode(item.mode!) : onOpenOnboarding}
-              scale={scale}
-            />
-          ))}
-          <MenuItem
-            key="reveal-toggle"
-            icon={<RevealIcon size={spacing(2, scale)} style={iconMargin} />}
-            label={revealLabel}
-            onPress={onToggleReveal}
-            scale={scale}
-          />
-        </View>
+        <OverflowMenuList
+          scale={scale}
+          iconMargin={iconMargin}
+          handleMenuPress={handleMenuPress}
+          allRevealed={allRevealed}
+          onToggleReveal={onToggleReveal}
+        />
       )}
     </View>
   );
@@ -234,6 +271,11 @@ const HabitModals = ({ modals, selectedHabit, habitStats, habits, actions }: Hab
       onClose={() => modals.close('onboarding')}
       onSaveHabits={actions.onboardingSave}
     />
+    <AddHabitModal
+      visible={modals.addHabit}
+      onClose={() => modals.close('addHabit')}
+      onAdd={actions.addHabit}
+    />
     {modals.emojiPicker && (
       <EmojiPickerModal
         onSelect={actions.emojiSelect}
@@ -300,6 +342,42 @@ const HabitList = ({ habits, columns, gridGutter, renderItem }: HabitListProps) 
   />
 );
 
+interface PaginationBarProps {
+  page: number;
+  pageCount: number;
+  onPrev: () => void;
+  onNext: () => void;
+  scale: number;
+}
+
+const PaginationBar = ({ page, pageCount, onPrev, onNext, scale }: PaginationBarProps) => {
+  const canPrev = page > 0;
+  const canNext = page < pageCount - 1;
+  return (
+    <View style={styles.paginationBar} testID="habits-pagination">
+      <TouchableOpacity
+        testID="pagination-prev"
+        onPress={onPrev}
+        disabled={!canPrev}
+        style={[styles.paginationButton, !canPrev && styles.disabledButton]}
+      >
+        <Text style={styles.paginationButtonText}>Prev</Text>
+      </TouchableOpacity>
+      <Text style={[styles.paginationLabel, { fontSize: spacing(1.75, scale) }]}>
+        Page {page + 1} of {pageCount}
+      </Text>
+      <TouchableOpacity
+        testID="pagination-next"
+        onPress={onNext}
+        disabled={!canNext}
+        style={[styles.paginationButton, !canNext && styles.disabledButton]}
+      >
+        <Text style={styles.paginationButtonText}>Next</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
 interface EnergyFooterProps {
   showCTA: boolean;
   showArchive: boolean;
@@ -331,9 +409,11 @@ const useHabitTileRenderer = (
   modals: ReturnType<typeof useModalCoordinator>,
   actions: ReturnType<typeof useHabits>['actions'],
   setSelectedHabit: (_h: Habit) => void,
+  pageOffset = 0,
 ) => {
   const renderHabitTile = ({ item, index }: { item: Habit; index: number }) => {
     const isLocked = item.revealed === false;
+    const globalIndex = pageOffset + index;
     return (
       <HabitTile
         habit={item}
@@ -358,7 +438,7 @@ const useHabitTileRenderer = (
           isLocked
             ? undefined
             : () => {
-                actions.iconPress(index);
+                actions.iconPress(globalIndex);
                 modals.open('emojiPicker');
               }
         }
@@ -437,6 +517,13 @@ interface HabitsContentProps {
   gridGutter: number;
   renderItem: (_info: { item: Habit; index: number }) => React.ReactElement;
   onRetry: () => void;
+  pagination: {
+    page: number;
+    pageCount: number;
+    onPrev: () => void;
+    onNext: () => void;
+    scale: number;
+  } | null;
 }
 
 const HabitsContent = ({
@@ -447,33 +534,66 @@ const HabitsContent = ({
   gridGutter,
   renderItem,
   onRetry,
+  pagination,
 }: HabitsContentProps) => (
   <>
     {error && <ErrorBanner error={error} onRetry={onRetry} />}
     {loading ? (
       <LoadingSpinner />
     ) : (
-      <HabitList
-        habits={habits}
-        columns={columns}
-        gridGutter={gridGutter}
-        renderItem={renderItem}
-      />
+      <>
+        <HabitList
+          habits={habits}
+          columns={columns}
+          gridGutter={gridGutter}
+          renderItem={renderItem}
+        />
+        {pagination && (
+          <PaginationBar
+            page={pagination.page}
+            pageCount={pagination.pageCount}
+            onPrev={pagination.onPrev}
+            onNext={pagination.onNext}
+            scale={pagination.scale}
+          />
+        )}
+      </>
     )}
   </>
 );
+
+const usePagination = (habitCount: number) => {
+  const pageCount = Math.max(1, Math.ceil(habitCount / HABITS_PER_PAGE));
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    if (page > pageCount - 1) setPage(Math.max(0, pageCount - 1));
+  }, [page, pageCount]);
+
+  const goPrev = useCallback(() => setPage((p) => Math.max(0, p - 1)), []);
+  const goNext = useCallback(() => setPage((p) => Math.min(pageCount - 1, p + 1)), [pageCount]);
+
+  return { page: Math.min(page, pageCount - 1), pageCount, goPrev, goNext };
+};
 
 const useHabitsScreenState = () => {
   const habitsReturn = useHabits();
   const modals = useModalCoordinator();
   const habitStats = useHabitStats(modals.stats, habitsReturn.selectedHabit);
   const responsive = useResponsive();
+  const pagination = usePagination(habitsReturn.habits.length);
+  const pageOffset = pagination.page * HABITS_PER_PAGE;
+  const pagedHabits = useMemo(
+    () => habitsReturn.habits.slice(pageOffset, pageOffset + HABITS_PER_PAGE),
+    [habitsReturn.habits, pageOffset],
+  );
   const handleSelectMode = useSelectMode(habitsReturn.setMode, modals.closeAll);
   const renderHabitTile = useHabitTileRenderer(
     habitsReturn.mode,
     modals,
     habitsReturn.actions,
     habitsReturn.setSelectedHabit,
+    pageOffset,
   );
   const reveal = useToggleReveal(habitsReturn.habits, habitsReturn.actions, modals.closeAll);
   return {
@@ -481,16 +601,34 @@ const useHabitsScreenState = () => {
     modals,
     habitStats,
     responsive,
+    pagination,
+    pagedHabits,
     handleSelectMode,
     renderHabitTile,
     ...reveal,
   };
 };
 
+const buildPaginationProps = (
+  pagination: ReturnType<typeof usePagination>,
+  scale: number,
+): PaginationBarProps | null =>
+  pagination.pageCount > 1
+    ? {
+        page: pagination.page,
+        pageCount: pagination.pageCount,
+        onPrev: pagination.goPrev,
+        onNext: pagination.goNext,
+        scale,
+      }
+    : null;
+
 const HabitsScreen = () => {
   const state = useHabitsScreenState();
-  const { habits, loading, error, modals, actions, ui, responsive } = state;
+  const { habits, loading, error, modals, actions, ui, responsive, pagination, pagedHabits } =
+    state;
   const { columns, gridGutter, scale, isLG, isXL } = responsive;
+  const paginationProps = buildPaginationProps(pagination, scale);
   return (
     <SafeAreaView style={[styles.container, { padding: spacing(isLG || isXL ? 2 : 1, scale) }]}>
       <View style={styles.topBar}>
@@ -500,18 +638,20 @@ const HabitsScreen = () => {
           onToggle={modals.toggleMenu}
           onSelectMode={state.handleSelectMode}
           onOpenOnboarding={() => modals.open('onboarding')}
+          onOpenAddHabit={() => modals.open('addHabit')}
           allRevealed={state.allRevealed}
           onToggleReveal={state.handleToggleReveal}
         />
       </View>
       <HabitsContent
-        habits={habits}
+        habits={pagedHabits}
         loading={loading}
         error={error}
         columns={columns}
         gridGutter={gridGutter}
         renderItem={state.renderHabitTile}
         onRetry={() => void actions.loadHabits()}
+        pagination={paginationProps}
       />
       <EnergyFooter
         showCTA={ui.showEnergyCTA}

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -19,11 +19,12 @@ import OnboardingModal from './components/OnboardingModal';
 import ReorderHabitsModal from './components/ReorderHabitsModal';
 import StatsModal from './components/StatsModal';
 import styles from './Habits.styles';
-import type { Habit, HabitStatsData } from './Habits.types';
+import type { AddHabitInput, Habit, HabitStatsData } from './Habits.types';
 import HabitTile from './HabitTile';
 import { generateStatsForHabit, toLocalHabitStats, calculateMissedDays } from './HabitUtils';
 import { useHabits } from './hooks/useHabits';
 import { useModalCoordinator } from './hooks/useModalCoordinator';
+import { usePagination } from './hooks/usePagination';
 
 /** Habits per page. Ten is the design ceiling that fills the screen 1-up on mobile and 2x5 on landscape/desktop. */
 const HABITS_PER_PAGE = 10;
@@ -206,6 +207,7 @@ interface HabitModalsProps {
   habitStats: HabitStatsData | null;
   habits: Habit[];
   actions: ReturnType<typeof useHabits>['actions'];
+  onAddHabit: (_input: AddHabitInput) => Promise<void>;
 }
 
 const HabitDataModals = ({
@@ -213,7 +215,7 @@ const HabitDataModals = ({
   selectedHabit,
   habitStats,
   actions,
-}: Omit<HabitModalsProps, 'habits'>) => (
+}: Omit<HabitModalsProps, 'habits' | 'onAddHabit'>) => (
   <>
     <GoalModal
       visible={modals.goal}
@@ -240,14 +242,14 @@ const HabitDataModals = ({
   </>
 );
 
-const HabitModals = ({ modals, selectedHabit, habitStats, habits, actions }: HabitModalsProps) => (
+const HabitWriteModals = ({
+  modals,
+  selectedHabit,
+  habits,
+  actions,
+  onAddHabit,
+}: Omit<HabitModalsProps, 'habitStats'>) => (
   <>
-    <HabitDataModals
-      modals={modals}
-      selectedHabit={selectedHabit}
-      habitStats={habitStats}
-      actions={actions}
-    />
     <HabitSettingsModal
       visible={modals.settings}
       habit={selectedHabit}
@@ -274,7 +276,7 @@ const HabitModals = ({ modals, selectedHabit, habitStats, habits, actions }: Hab
     <AddHabitModal
       visible={modals.addHabit}
       onClose={() => modals.close('addHabit')}
-      onAdd={actions.addHabit}
+      onAdd={onAddHabit}
     />
     {modals.emojiPicker && (
       <EmojiPickerModal
@@ -282,6 +284,24 @@ const HabitModals = ({ modals, selectedHabit, habitStats, habits, actions }: Hab
         onClose={() => modals.close('emojiPicker')}
       />
     )}
+  </>
+);
+
+const HabitModals = (props: HabitModalsProps) => (
+  <>
+    <HabitDataModals
+      modals={props.modals}
+      selectedHabit={props.selectedHabit}
+      habitStats={props.habitStats}
+      actions={props.actions}
+    />
+    <HabitWriteModals
+      modals={props.modals}
+      selectedHabit={props.selectedHabit}
+      habits={props.habits}
+      actions={props.actions}
+      onAddHabit={props.onAddHabit}
+    />
   </>
 );
 
@@ -353,6 +373,7 @@ interface PaginationBarProps {
 const PaginationBar = ({ page, pageCount, onPrev, onNext, scale }: PaginationBarProps) => {
   const canPrev = page > 0;
   const canNext = page < pageCount - 1;
+  const textSize = { fontSize: spacing(1.75, scale) };
   return (
     <View style={styles.paginationBar} testID="habits-pagination">
       <TouchableOpacity
@@ -361,9 +382,9 @@ const PaginationBar = ({ page, pageCount, onPrev, onNext, scale }: PaginationBar
         disabled={!canPrev}
         style={[styles.paginationButton, !canPrev && styles.disabledButton]}
       >
-        <Text style={styles.paginationButtonText}>Prev</Text>
+        <Text style={[styles.paginationButtonText, textSize]}>Prev</Text>
       </TouchableOpacity>
-      <Text style={[styles.paginationLabel, { fontSize: spacing(1.75, scale) }]}>
+      <Text style={[styles.paginationLabel, textSize]}>
         Page {page + 1} of {pageCount}
       </Text>
       <TouchableOpacity
@@ -372,7 +393,7 @@ const PaginationBar = ({ page, pageCount, onPrev, onNext, scale }: PaginationBar
         disabled={!canNext}
         style={[styles.paginationButton, !canNext && styles.disabledButton]}
       >
-        <Text style={styles.paginationButtonText}>Next</Text>
+        <Text style={[styles.paginationButtonText, textSize]}>Next</Text>
       </TouchableOpacity>
     </View>
   );
@@ -517,13 +538,7 @@ interface HabitsContentProps {
   gridGutter: number;
   renderItem: (_info: { item: Habit; index: number }) => React.ReactElement;
   onRetry: () => void;
-  pagination: {
-    page: number;
-    pageCount: number;
-    onPrev: () => void;
-    onNext: () => void;
-    scale: number;
-  } | null;
+  pagination: PaginationBarProps | null;
 }
 
 const HabitsContent = ({
@@ -562,26 +577,12 @@ const HabitsContent = ({
   </>
 );
 
-const usePagination = (habitCount: number) => {
-  const pageCount = Math.max(1, Math.ceil(habitCount / HABITS_PER_PAGE));
-  const [page, setPage] = useState(0);
-
-  useEffect(() => {
-    if (page > pageCount - 1) setPage(Math.max(0, pageCount - 1));
-  }, [page, pageCount]);
-
-  const goPrev = useCallback(() => setPage((p) => Math.max(0, p - 1)), []);
-  const goNext = useCallback(() => setPage((p) => Math.min(pageCount - 1, p + 1)), [pageCount]);
-
-  return { page: Math.min(page, pageCount - 1), pageCount, goPrev, goNext };
-};
-
 const useHabitsScreenState = () => {
   const habitsReturn = useHabits();
   const modals = useModalCoordinator();
   const habitStats = useHabitStats(modals.stats, habitsReturn.selectedHabit);
   const responsive = useResponsive();
-  const pagination = usePagination(habitsReturn.habits.length);
+  const pagination = usePagination(habitsReturn.habits.length, HABITS_PER_PAGE);
   const pageOffset = pagination.page * HABITS_PER_PAGE;
   const pagedHabits = useMemo(
     () => habitsReturn.habits.slice(pageOffset, pageOffset + HABITS_PER_PAGE),
@@ -596,6 +597,18 @@ const useHabitsScreenState = () => {
     pageOffset,
   );
   const reveal = useToggleReveal(habitsReturn.habits, habitsReturn.actions, modals.closeAll);
+  /**
+   * Wrap addHabit so the modal can await it, the screen jumps to the page
+   * containing the newly added row, and any in-flight failure surfaces via
+   * the existing rollback toast before the modal closes.
+   */
+  const handleAddHabit = useCallback(
+    async (input: AddHabitInput) => {
+      await habitsReturn.actions.addHabit(input);
+      pagination.goLast();
+    },
+    [habitsReturn.actions, pagination],
+  );
   return {
     ...habitsReturn,
     modals,
@@ -605,6 +618,7 @@ const useHabitsScreenState = () => {
     pagedHabits,
     handleSelectMode,
     renderHabitTile,
+    handleAddHabit,
     ...reveal,
   };
 };
@@ -667,6 +681,7 @@ const HabitsScreen = () => {
         habitStats={state.habitStats}
         habits={habits}
         actions={actions}
+        onAddHabit={state.handleAddHabit}
       />
     </SafeAreaView>
   );

--- a/frontend/src/features/Habits/__tests__/useModalCoordinator.test.ts
+++ b/frontend/src/features/Habits/__tests__/useModalCoordinator.test.ts
@@ -13,6 +13,7 @@ describe('useModalCoordinator', () => {
     expect(result.current.reorder).toBe(false);
     expect(result.current.missedDays).toBe(false);
     expect(result.current.onboarding).toBe(false);
+    expect(result.current.addHabit).toBe(false);
     expect(result.current.emojiPicker).toBe(false);
     expect(result.current.menu).toBe(false);
   });
@@ -42,7 +43,19 @@ describe('useModalCoordinator', () => {
     expect(result.current.reorder).toBe(false);
     expect(result.current.missedDays).toBe(false);
     expect(result.current.onboarding).toBe(false);
+    expect(result.current.addHabit).toBe(false);
     expect(result.current.emojiPicker).toBe(false);
+    expect(result.current.menu).toBe(false);
+  });
+
+  it('open("addHabit") opens the AddHabit modal and collapses the menu', () => {
+    const { result } = renderHook(() => useModalCoordinator());
+
+    act(() => result.current.toggleMenu());
+    expect(result.current.menu).toBe(true);
+
+    act(() => result.current.open('addHabit'));
+    expect(result.current.addHabit).toBe(true);
     expect(result.current.menu).toBe(false);
   });
 

--- a/frontend/src/features/Habits/components/AddHabitModal.tsx
+++ b/frontend/src/features/Habits/components/AddHabitModal.tsx
@@ -1,0 +1,244 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import EmojiSelector from 'react-native-emoji-selector';
+
+import { DEFAULT_ICONS } from '../constants';
+import styles from '../Habits.styles';
+import type { AddHabitInput } from '../Habits.types';
+import { calculateNetEnergy } from '../HabitUtils';
+
+interface AddHabitModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onAdd: (_input: AddHabitInput) => void | Promise<void>;
+}
+
+const ENERGY_MIN = 0;
+const ENERGY_MAX = 10;
+const DEFAULT_ENERGY = 5;
+
+const parseEnergy = (text: string): number | null => {
+  const value = parseInt(text, 10);
+  if (Number.isNaN(value)) return null;
+  if (value < ENERGY_MIN || value > ENERGY_MAX) return null;
+  return value;
+};
+
+const randomDefaultIcon = (): string =>
+  DEFAULT_ICONS[Math.floor(Math.random() * DEFAULT_ICONS.length)] ?? '⭐';
+
+const AddHabitHeader = ({ onClose }: { onClose: () => void }) => (
+  <View style={styles.modalHeader}>
+    <Text style={styles.modalTitle}>Add Habit</Text>
+    <TouchableOpacity onPress={onClose} style={styles.closeButton} testID="add-habit-close">
+      <Text style={styles.closeButtonText}>×</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+interface NameRowProps {
+  name: string;
+  setName: (_v: string) => void;
+}
+
+const NameRow = ({ name, setName }: NameRowProps) => (
+  <View style={styles.settingRow}>
+    <Text style={styles.settingLabel}>Name:</Text>
+    <TextInput
+      testID="add-habit-name"
+      style={styles.settingInput}
+      value={name}
+      onChangeText={setName}
+      placeholder="e.g. Morning Walk"
+      autoFocus
+    />
+  </View>
+);
+
+interface IconRowProps {
+  icon: string;
+  showEmojiPicker: boolean;
+  setShowEmojiPicker: (_v: boolean) => void;
+  setIcon: (_v: string) => void;
+}
+
+const IconRow = ({ icon, showEmojiPicker, setShowEmojiPicker, setIcon }: IconRowProps) => (
+  <>
+    <View style={styles.settingRow}>
+      <Text style={styles.settingLabel}>Icon:</Text>
+      <TouchableOpacity
+        testID="add-habit-icon"
+        onPress={() => setShowEmojiPicker(!showEmojiPicker)}
+      >
+        <Text style={styles.currentIcon}>{icon}</Text>
+      </TouchableOpacity>
+    </View>
+    {showEmojiPicker && (
+      <View style={styles.emojiSelectorContainer}>
+        <EmojiSelector
+          onEmojiSelected={(emoji) => {
+            setIcon(emoji);
+            setShowEmojiPicker(false);
+          }}
+          showSearchBar
+          columns={6}
+          emojiSize={28}
+          placeholder="Search emoji..."
+        />
+      </View>
+    )}
+  </>
+);
+
+interface EnergyRowProps {
+  energyCost: number;
+  energyReturn: number;
+  setEnergyCost: (_v: number) => void;
+  setEnergyReturn: (_v: number) => void;
+}
+
+const EnergyRow = ({
+  energyCost,
+  energyReturn,
+  setEnergyCost,
+  setEnergyReturn,
+}: EnergyRowProps) => (
+  <View style={styles.energyContainer}>
+    <View style={styles.energyHeader}>
+      <Text style={styles.energyHeaderText}>Cost</Text>
+      <Text style={styles.energyHeaderText}>Return</Text>
+      <Text style={styles.energyHeaderText}>Net</Text>
+    </View>
+    <View style={styles.energyRow}>
+      <TextInput
+        testID="add-habit-cost"
+        style={styles.energyInput}
+        value={energyCost.toString()}
+        onChangeText={(text) => {
+          const value = parseEnergy(text);
+          if (value !== null) setEnergyCost(value);
+        }}
+        keyboardType="numeric"
+      />
+      <TextInput
+        testID="add-habit-return"
+        style={styles.energyInput}
+        value={energyReturn.toString()}
+        onChangeText={(text) => {
+          const value = parseEnergy(text);
+          if (value !== null) setEnergyReturn(value);
+        }}
+        keyboardType="numeric"
+      />
+      <Text style={styles.netEnergyValue}>{calculateNetEnergy(energyCost, energyReturn)}</Text>
+    </View>
+    <View style={styles.validationNote}>
+      <Text style={styles.validationText}>Enter a whole number from 0 to 10.</Text>
+    </View>
+  </View>
+);
+
+interface SaveRowProps {
+  canSave: boolean;
+  onSave: () => void;
+}
+
+const SaveRow = ({ canSave, onSave }: SaveRowProps) => (
+  <View style={styles.buttonGroup}>
+    <TouchableOpacity
+      testID="add-habit-save"
+      style={[styles.onboardingContinueButton, !canSave && styles.disabledButton]}
+      onPress={onSave}
+      disabled={!canSave}
+    >
+      <Text style={styles.onboardingContinueButtonText}>Add Habit</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+interface AddHabitFormState {
+  name: string;
+  icon: string;
+  energyCost: number;
+  energyReturn: number;
+  showEmojiPicker: boolean;
+  setName: (_v: string) => void;
+  setIcon: (_v: string) => void;
+  setEnergyCost: (_v: number) => void;
+  setEnergyReturn: (_v: number) => void;
+  setShowEmojiPicker: (_v: boolean) => void;
+}
+
+const useAddHabitForm = (visible: boolean): AddHabitFormState => {
+  const [name, setName] = useState('');
+  const [icon, setIcon] = useState<string>(randomDefaultIcon());
+  const [energyCost, setEnergyCost] = useState<number>(DEFAULT_ENERGY);
+  const [energyReturn, setEnergyReturn] = useState<number>(DEFAULT_ENERGY);
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setName('');
+      setIcon(randomDefaultIcon());
+      setEnergyCost(DEFAULT_ENERGY);
+      setEnergyReturn(DEFAULT_ENERGY);
+      setShowEmojiPicker(false);
+    }
+  }, [visible]);
+
+  return {
+    name,
+    icon,
+    energyCost,
+    energyReturn,
+    showEmojiPicker,
+    setName,
+    setIcon,
+    setEnergyCost,
+    setEnergyReturn,
+    setShowEmojiPicker,
+  };
+};
+
+export const AddHabitModal = ({ visible, onClose, onAdd }: AddHabitModalProps) => {
+  const f = useAddHabitForm(visible);
+  const trimmed = f.name.trim();
+  const canSave = trimmed.length > 0;
+
+  const handleSave = () => {
+    if (!canSave) return;
+    void onAdd({
+      name: trimmed,
+      icon: f.icon,
+      energy_cost: f.energyCost,
+      energy_return: f.energyReturn,
+    });
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.modalOverlay}>
+        <View style={styles.settingsModalContent} testID="add-habit-modal">
+          <AddHabitHeader onClose={onClose} />
+          <NameRow name={f.name} setName={f.setName} />
+          <IconRow
+            icon={f.icon}
+            showEmojiPicker={f.showEmojiPicker}
+            setShowEmojiPicker={f.setShowEmojiPicker}
+            setIcon={f.setIcon}
+          />
+          <EnergyRow
+            energyCost={f.energyCost}
+            energyReturn={f.energyReturn}
+            setEnergyCost={f.setEnergyCost}
+            setEnergyReturn={f.setEnergyReturn}
+          />
+          <SaveRow canSave={canSave} onSave={handleSave} />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default AddHabitModal;

--- a/frontend/src/features/Habits/components/AddHabitModal.tsx
+++ b/frontend/src/features/Habits/components/AddHabitModal.tsx
@@ -13,7 +13,12 @@ interface AddHabitModalProps {
   onAdd: (_input: AddHabitInput) => void | Promise<void>;
 }
 
-const ENERGY_MIN = 0;
+/**
+ * Energy bounds match `HabitSettingsModal` so a habit created here can be
+ * tuned to the same negative-cost / negative-return range an existing habit
+ * supports — a previous version capped at 0 and produced an inconsistency.
+ */
+const ENERGY_MIN = -10;
 const ENERGY_MAX = 10;
 const DEFAULT_ENERGY = 5;
 
@@ -133,28 +138,32 @@ const EnergyRow = ({
       <Text style={styles.netEnergyValue}>{calculateNetEnergy(energyCost, energyReturn)}</Text>
     </View>
     <View style={styles.validationNote}>
-      <Text style={styles.validationText}>Enter a whole number from 0 to 10.</Text>
+      <Text style={styles.validationText}>Enter a whole number from -10 to 10.</Text>
     </View>
   </View>
 );
 
 interface SaveRowProps {
+  saving: boolean;
   canSave: boolean;
   onSave: () => void;
 }
 
-const SaveRow = ({ canSave, onSave }: SaveRowProps) => (
-  <View style={styles.buttonGroup}>
-    <TouchableOpacity
-      testID="add-habit-save"
-      style={[styles.onboardingContinueButton, !canSave && styles.disabledButton]}
-      onPress={onSave}
-      disabled={!canSave}
-    >
-      <Text style={styles.onboardingContinueButtonText}>Add Habit</Text>
-    </TouchableOpacity>
-  </View>
-);
+const SaveRow = ({ saving, canSave, onSave }: SaveRowProps) => {
+  const disabled = saving || !canSave;
+  return (
+    <View style={styles.buttonGroup}>
+      <TouchableOpacity
+        testID="add-habit-save"
+        style={[styles.onboardingContinueButton, disabled && styles.disabledButton]}
+        onPress={onSave}
+        disabled={disabled}
+      >
+        <Text style={styles.onboardingContinueButtonText}>{saving ? 'Adding…' : 'Add Habit'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
 
 interface AddHabitFormState {
   name: string;
@@ -202,18 +211,35 @@ const useAddHabitForm = (visible: boolean): AddHabitFormState => {
 
 export const AddHabitModal = ({ visible, onClose, onAdd }: AddHabitModalProps) => {
   const f = useAddHabitForm(visible);
+  const [saving, setSaving] = useState(false);
   const trimmed = f.name.trim();
   const canSave = trimmed.length > 0;
 
-  const handleSave = () => {
-    if (!canSave) return;
-    void onAdd({
-      name: trimmed,
-      icon: f.icon,
-      energy_cost: f.energyCost,
-      energy_return: f.energyReturn,
-    });
-    onClose();
+  /**
+   * Await `onAdd` before closing so the optimistic toast (or the rollback
+   * error toast on failure) lands while the modal is still around for the
+   * user to read. Holding `saving` also disables the button so a double-tap
+   * cannot double-submit while the network round-trip is in flight. The
+   * rejection is intentionally swallowed: `habitManager.addHabit` already
+   * routes failures through the rollback toast, so re-throwing here would
+   * surface a duplicate unhandled-promise warning to no user benefit.
+   */
+  const handleSave = async () => {
+    if (!canSave || saving) return;
+    setSaving(true);
+    try {
+      await onAdd({
+        name: trimmed,
+        icon: f.icon,
+        energy_cost: f.energyCost,
+        energy_return: f.energyReturn,
+      });
+    } catch {
+      // already reported by the service layer
+    } finally {
+      setSaving(false);
+      onClose();
+    }
   };
 
   return (
@@ -234,7 +260,7 @@ export const AddHabitModal = ({ visible, onClose, onAdd }: AddHabitModalProps) =
             setEnergyCost={f.setEnergyCost}
             setEnergyReturn={f.setEnergyReturn}
           />
-          <SaveRow canSave={canSave} onSave={handleSave} />
+          <SaveRow saving={saving} canSave={canSave} onSave={() => void handleSave()} />
         </View>
       </View>
     </Modal>

--- a/frontend/src/features/Habits/components/ConfirmDialog.tsx
+++ b/frontend/src/features/Habits/components/ConfirmDialog.tsx
@@ -21,6 +21,10 @@ export interface ConfirmDialogProps {
  * Cross-platform confirmation dialog. `Alert.alert` collapses to a no-op on
  * React Native Web mobile browsers, so destructive flows that depend on the
  * user explicitly confirming need a rendered modal — this is that modal.
+ *
+ * `visible` is forwarded to the underlying `<Modal>` (rather than gating the
+ * body with an early `return null`) so React Native drives the fade animation
+ * on close. The body content is still gated so it's not rendered while hidden.
  */
 export const ConfirmDialog = ({
   visible,
@@ -34,10 +38,9 @@ export const ConfirmDialog = ({
   destructive = false,
   onCancel,
   onConfirm,
-}: ConfirmDialogProps) => {
-  if (!visible) return null;
-  return (
-    <Modal transparent animationType="fade" onRequestClose={onCancel}>
+}: ConfirmDialogProps) => (
+  <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
+    {visible && (
       <View style={styles.modalOverlay} testID={testID}>
         <View style={styles.discardModal}>
           <Text style={styles.discardTitle}>{title}</Text>
@@ -58,8 +61,8 @@ export const ConfirmDialog = ({
           </View>
         </View>
       </View>
-    </Modal>
-  );
-};
+    )}
+  </Modal>
+);
 
 export default ConfirmDialog;

--- a/frontend/src/features/Habits/components/ConfirmDialog.tsx
+++ b/frontend/src/features/Habits/components/ConfirmDialog.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Modal, Text, TouchableOpacity, View } from 'react-native';
+
+import styles from '../Habits.styles';
+
+export interface ConfirmDialogProps {
+  visible: boolean;
+  title: string;
+  message?: string;
+  testID?: string;
+  cancelTestID?: string;
+  confirmTestID?: string;
+  cancelLabel?: string;
+  confirmLabel?: string;
+  destructive?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Cross-platform confirmation dialog. `Alert.alert` collapses to a no-op on
+ * React Native Web mobile browsers, so destructive flows that depend on the
+ * user explicitly confirming need a rendered modal — this is that modal.
+ */
+export const ConfirmDialog = ({
+  visible,
+  title,
+  message,
+  testID,
+  cancelTestID,
+  confirmTestID,
+  cancelLabel = 'Cancel',
+  confirmLabel = 'Confirm',
+  destructive = false,
+  onCancel,
+  onConfirm,
+}: ConfirmDialogProps) => {
+  if (!visible) return null;
+  return (
+    <Modal transparent animationType="fade" onRequestClose={onCancel}>
+      <View style={styles.modalOverlay} testID={testID}>
+        <View style={styles.discardModal}>
+          <Text style={styles.discardTitle}>{title}</Text>
+          {message && <Text style={styles.discardMessage}>{message}</Text>}
+          <View style={styles.discardActions}>
+            <TouchableOpacity onPress={onCancel} style={styles.discardButton} testID={cancelTestID}>
+              <Text style={styles.discardButtonText}>{cancelLabel}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={onConfirm}
+              style={styles.discardButton}
+              testID={confirmTestID}
+            >
+              <Text style={destructive ? styles.discardExitText : styles.discardButtonText}>
+                {confirmLabel}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default ConfirmDialog;

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -4,7 +4,6 @@ import {
   View,
   Text,
   TouchableOpacity,
-  Alert,
   Modal,
   TextInput,
   Platform,
@@ -18,6 +17,8 @@ import { DAYS_OF_WEEK } from '../constants';
 import styles from '../Habits.styles';
 import type { Habit, HabitSettingsModalProps } from '../Habits.types';
 import { calculateNetEnergy } from '../HabitUtils';
+
+import ConfirmDialog from './ConfirmDialog';
 
 const ENERGY_MIN = -10;
 const ENERGY_MAX = 10;
@@ -505,6 +506,7 @@ const useSettingsHandlers = (
   handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void,
 ) => {
   const notif = useNotificationHandlers(editedHabit, handleChange);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const handleSave = () => {
     if (editedHabit && habit?.id) {
@@ -515,20 +517,24 @@ const useSettingsHandlers = (
 
   const handleDelete = () => {
     if (!habit?.id) return;
-    Alert.alert('Delete Habit', `Are you sure you want to delete "${habit.name}"?`, [
-      { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Delete',
-        style: 'destructive',
-        onPress: () => {
-          onDeleteProp(habit.id!);
-          onClose();
-        },
-      },
-    ]);
+    setShowDeleteConfirm(true);
   };
 
-  return { ...notif, handleSave, handleDelete };
+  const confirmDelete = () => {
+    if (!habit?.id) return;
+    setShowDeleteConfirm(false);
+    onDeleteProp(habit.id);
+    onClose();
+  };
+
+  return {
+    ...notif,
+    handleSave,
+    handleDelete,
+    showDeleteConfirm,
+    setShowDeleteConfirm,
+    confirmDelete,
+  };
 };
 
 const SettingsModalHeader = ({ onClose }: { onClose: () => void }) => (
@@ -537,6 +543,55 @@ const SettingsModalHeader = ({ onClose }: { onClose: () => void }) => (
     <TouchableOpacity onPress={onClose} style={styles.closeButton}>
       <Text style={styles.closeButtonText}>×</Text>
     </TouchableOpacity>
+  </View>
+);
+
+interface SettingsBodyProps {
+  editedHabit: Habit;
+  showEmojiSelector: boolean;
+  setShowEmojiSelector: (_v: boolean) => void;
+  handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
+  allHabits: Habit[];
+  onClose: () => void;
+  onOpenReorderModal: HabitSettingsModalProps['onOpenReorderModal'];
+  h: ReturnType<typeof useSettingsHandlers>;
+}
+
+const SettingsModalBody = ({
+  editedHabit,
+  showEmojiSelector,
+  setShowEmojiSelector,
+  handleChange,
+  allHabits,
+  onClose,
+  onOpenReorderModal,
+  h,
+}: SettingsBodyProps) => (
+  <View style={styles.modalOverlay}>
+    <View
+      style={[styles.settingsModalContent, { borderTopColor: STAGE_COLORS[editedHabit.stage] }]}
+    >
+      <SettingsModalHeader onClose={onClose} />
+      <SettingsForm
+        editedHabit={editedHabit}
+        showEmojiSelector={showEmojiSelector}
+        setShowEmojiSelector={setShowEmojiSelector}
+        handleChange={handleChange}
+        allHabits={allHabits}
+        onOpenReorderModal={onOpenReorderModal}
+        notificationTime={h.notificationTime}
+        showTimePicker={h.showTimePicker}
+        showDaysPicker={h.showDaysPicker}
+        setShowTimePicker={h.setShowTimePicker}
+        setShowDaysPicker={h.setShowDaysPicker}
+        onTimeChange={h.handleTimeChange}
+        onAddTime={h.handleAddTime}
+        onRemoveTime={h.handleRemoveTime}
+        onToggleDay={h.handleToggleDay}
+        onSave={h.handleSave}
+        onDelete={h.handleDelete}
+      />
+    </View>
   </View>
 );
 
@@ -566,32 +621,28 @@ export const HabitSettingsModal = ({
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <View style={styles.modalOverlay}>
-        <View
-          style={[styles.settingsModalContent, { borderTopColor: STAGE_COLORS[editedHabit.stage] }]}
-        >
-          <SettingsModalHeader onClose={onClose} />
-          <SettingsForm
-            editedHabit={editedHabit}
-            showEmojiSelector={showEmojiSelector}
-            setShowEmojiSelector={setShowEmojiSelector}
-            handleChange={handleChange}
-            allHabits={allHabits}
-            onOpenReorderModal={onOpenReorderModal}
-            notificationTime={h.notificationTime}
-            showTimePicker={h.showTimePicker}
-            showDaysPicker={h.showDaysPicker}
-            setShowTimePicker={h.setShowTimePicker}
-            setShowDaysPicker={h.setShowDaysPicker}
-            onTimeChange={h.handleTimeChange}
-            onAddTime={h.handleAddTime}
-            onRemoveTime={h.handleRemoveTime}
-            onToggleDay={h.handleToggleDay}
-            onSave={h.handleSave}
-            onDelete={h.handleDelete}
-          />
-        </View>
-      </View>
+      <SettingsModalBody
+        editedHabit={editedHabit}
+        showEmojiSelector={showEmojiSelector}
+        setShowEmojiSelector={setShowEmojiSelector}
+        handleChange={handleChange}
+        allHabits={allHabits}
+        onClose={onClose}
+        onOpenReorderModal={onOpenReorderModal}
+        h={h}
+      />
+      <ConfirmDialog
+        visible={h.showDeleteConfirm}
+        title="Are you sure?"
+        message="This is permanent."
+        testID="delete-habit-confirm"
+        cancelTestID="delete-habit-cancel"
+        confirmTestID="delete-habit-confirm-button"
+        confirmLabel="Delete"
+        destructive
+        onCancel={() => h.setShowDeleteConfirm(false)}
+        onConfirm={h.confirmDelete}
+      />
     </Modal>
   );
 };

--- a/frontend/src/features/Habits/components/__tests__/AddHabitModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/AddHabitModal.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import React from 'react';
+
+import AddHabitModal from '../AddHabitModal';
+
+jest.mock('../../constants', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+const flushPromises = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('AddHabitModal', () => {
+  const noopAdd = () => Promise.resolve();
+
+  it('disables the save button while the name is empty', () => {
+    const { getByTestId } = render(<AddHabitModal visible onClose={jest.fn()} onAdd={noopAdd} />);
+    const save = getByTestId('add-habit-save');
+    expect(save.props.accessibilityState?.disabled ?? save.props.disabled).toBe(true);
+  });
+
+  it('enables save once a name is typed and emits a trimmed payload', async () => {
+    const onAdd = jest.fn(() => Promise.resolve());
+    const onClose = jest.fn();
+    const { getByTestId } = render(<AddHabitModal visible onClose={onClose} onAdd={onAdd} />);
+    fireEvent.changeText(getByTestId('add-habit-name'), '  Morning Walk  ');
+    fireEvent.changeText(getByTestId('add-habit-cost'), '3');
+    fireEvent.changeText(getByTestId('add-habit-return'), '7');
+    await act(async () => {
+      fireEvent.press(getByTestId('add-habit-save'));
+      await flushPromises();
+    });
+    expect(onAdd).toHaveBeenCalledWith({
+      name: 'Morning Walk',
+      icon: '⭐',
+      energy_cost: 3,
+      energy_return: 7,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects out-of-range energy inputs and keeps the previous value', () => {
+    const { getByTestId } = render(<AddHabitModal visible onClose={jest.fn()} onAdd={noopAdd} />);
+    const cost = getByTestId('add-habit-cost');
+    fireEvent.changeText(cost, '5');
+    expect(cost.props.value).toBe('5');
+    fireEvent.changeText(cost, '99');
+    expect(cost.props.value).toBe('5');
+    fireEvent.changeText(cost, '-3');
+    expect(cost.props.value).toBe('-3');
+    fireEvent.changeText(cost, '-99');
+    expect(cost.props.value).toBe('-3');
+  });
+
+  it('closes the modal even when onAdd rejects', async () => {
+    const onAdd = jest.fn(() => Promise.reject(new Error('boom')));
+    const onClose = jest.fn();
+    const { getByTestId } = render(<AddHabitModal visible onClose={onClose} onAdd={onAdd} />);
+    fireEvent.changeText(getByTestId('add-habit-name'), 'Read');
+    await act(async () => {
+      fireEvent.press(getByTestId('add-habit-save'));
+      await flushPromises();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the form when the modal is reopened', () => {
+    const onAdd = jest.fn(() => Promise.resolve());
+    const { getByTestId, rerender } = render(
+      <AddHabitModal visible onClose={jest.fn()} onAdd={onAdd} />,
+    );
+    fireEvent.changeText(getByTestId('add-habit-name'), 'Read');
+    expect(getByTestId('add-habit-name').props.value).toBe('Read');
+    rerender(<AddHabitModal visible={false} onClose={jest.fn()} onAdd={onAdd} />);
+    rerender(<AddHabitModal visible onClose={jest.fn()} onAdd={onAdd} />);
+    expect(getByTestId('add-habit-name').props.value).toBe('');
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/ConfirmDialog.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+
+import styles from '../../Habits.styles';
+import ConfirmDialog from '../ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    title: 'Are you sure?',
+    message: 'This is permanent.',
+    testID: 'confirm-dialog',
+    cancelTestID: 'confirm-cancel',
+    confirmTestID: 'confirm-ok',
+    onCancel: jest.fn(),
+    onConfirm: jest.fn(),
+  };
+
+  it('renders title and message when visible', () => {
+    const { getByText } = render(<ConfirmDialog visible {...defaultProps} />);
+    expect(getByText('Are you sure?')).toBeTruthy();
+    expect(getByText('This is permanent.')).toBeTruthy();
+  });
+
+  it('omits the message when not provided', () => {
+    const { queryByText } = render(<ConfirmDialog visible {...defaultProps} message={undefined} />);
+    expect(queryByText('This is permanent.')).toBeNull();
+  });
+
+  it('uses provided labels (Cancel/Delete) instead of defaults', () => {
+    const { getByText } = render(
+      <ConfirmDialog visible {...defaultProps} cancelLabel="Cancel" confirmLabel="Delete" />,
+    );
+    expect(getByText('Cancel')).toBeTruthy();
+    expect(getByText('Delete')).toBeTruthy();
+  });
+
+  it('invokes onCancel and onConfirm when buttons are pressed', () => {
+    const onCancel = jest.fn();
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <ConfirmDialog visible {...defaultProps} onCancel={onCancel} onConfirm={onConfirm} />,
+    );
+    fireEvent.press(getByTestId('confirm-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    fireEvent.press(getByTestId('confirm-ok'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the destructive style to the confirm label when destructive=true', () => {
+    const { getByText } = render(
+      <ConfirmDialog visible {...defaultProps} destructive confirmLabel="Delete" />,
+    );
+    const label = getByText('Delete');
+    expect(label.props.style).toEqual(styles.discardExitText);
+  });
+
+  it('uses the neutral style for the confirm label when destructive=false', () => {
+    const { getByText } = render(
+      <ConfirmDialog visible {...defaultProps} destructive={false} confirmLabel="OK" />,
+    );
+    const label = getByText('OK');
+    expect(label.props.style).toEqual(styles.discardButtonText);
+  });
+
+  it('does not render its body when visible is false', () => {
+    const { queryByTestId, queryByText } = render(
+      <ConfirmDialog visible={false} {...defaultProps} />,
+    );
+    // The body is gated with `{visible && ...}` so neither the testID
+    // overlay nor the title text should be in the tree.
+    expect(queryByTestId('confirm-dialog')).toBeNull();
+    expect(queryByText('Are you sure?')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
@@ -47,7 +47,7 @@ jest.mock('react-native', () => ({
   StyleSheet: { create: (s: Record<string, unknown>) => s },
 }));
 
-import { goalCompletions as goalCompletionsApi } from '../../../../api';
+import { goalCompletions as goalCompletionsApi, habits as habitsApi } from '../../../../api';
 import { saveHabits } from '../../../../storage/habitStorage';
 import { useHabitStore } from '../../../../store/useHabitStore';
 import type { Habit } from '../../Habits.types';
@@ -205,6 +205,21 @@ describe('useHabitActions.logUnit', () => {
     expect(useHabitStore.getState().habits[0]!.completions).toHaveLength(0);
     expect(goalCompletionsApi.create).not.toHaveBeenCalled();
     expect(showToast).not.toHaveBeenCalled();
+  });
+});
+
+describe('useHabitActions.addHabit', () => {
+  it('forwards to the manager and POSTs the new habit to /habits/', async () => {
+    useHabitStore.setState({ habits: [] });
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.actions.addHabit({ name: 'Brand New', icon: '🆕' });
+    });
+
+    expect(habitsApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Brand New', icon: '🆕' }),
+    );
   });
 });
 

--- a/frontend/src/features/Habits/hooks/__tests__/usePagination.test.ts
+++ b/frontend/src/features/Habits/hooks/__tests__/usePagination.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from '@jest/globals';
+import { renderHook, act } from '@testing-library/react-native';
+
+import { usePagination } from '../usePagination';
+
+const PAGE_SIZE = 10;
+
+describe('usePagination', () => {
+  it('starts on page 0 with at least 1 page even for an empty list', () => {
+    const { result } = renderHook(() => usePagination(0, PAGE_SIZE));
+    expect(result.current.page).toBe(0);
+    expect(result.current.pageCount).toBe(1);
+  });
+
+  it('reports the correct page count for a partially filled last page', () => {
+    const { result } = renderHook(() => usePagination(23, PAGE_SIZE));
+    expect(result.current.pageCount).toBe(3);
+  });
+
+  it('clamps prev at 0 and next at pageCount - 1', () => {
+    const { result } = renderHook(() => usePagination(25, PAGE_SIZE));
+    expect(result.current.page).toBe(0);
+    act(() => result.current.goPrev());
+    expect(result.current.page).toBe(0);
+    act(() => result.current.goNext());
+    expect(result.current.page).toBe(1);
+    act(() => result.current.goNext());
+    expect(result.current.page).toBe(2);
+    act(() => result.current.goNext());
+    expect(result.current.page).toBe(2);
+  });
+
+  it('goLast jumps to the last page (clamped via internal state)', () => {
+    const { result } = renderHook(() => usePagination(35, PAGE_SIZE));
+    act(() => result.current.goLast());
+    expect(result.current.page).toBe(3);
+  });
+
+  it('clamps the read value when habitCount shrinks below current page', () => {
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => usePagination(count, PAGE_SIZE),
+      { initialProps: { count: 25 } },
+    );
+    act(() => result.current.goNext());
+    act(() => result.current.goNext());
+    expect(result.current.page).toBe(2);
+
+    // List shrinks to a single page; the read value clamps without an extra render.
+    rerender({ count: 5 });
+    expect(result.current.pageCount).toBe(1);
+    expect(result.current.page).toBe(0);
+  });
+
+  it('goLast is bound to the latest habitCount across renders', () => {
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => usePagination(count, PAGE_SIZE),
+      { initialProps: { count: 5 } },
+    );
+    rerender({ count: 25 });
+    act(() => result.current.goLast());
+    expect(result.current.page).toBe(2);
+  });
+});

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -96,6 +96,7 @@ export const useHabitActions = (
       logUnit,
       updateHabit: habitManager.updateHabit,
       deleteHabit: habitManager.deleteHabit,
+      addHabit: habitManager.addHabit,
       saveHabitOrder: habitManager.saveHabitOrder,
       backfillMissedDays: habitManager.backfillMissedDays,
       setNewStartDate: habitManager.setNewStartDate,

--- a/frontend/src/features/Habits/hooks/useModalCoordinator.ts
+++ b/frontend/src/features/Habits/hooks/useModalCoordinator.ts
@@ -7,6 +7,7 @@ export type ModalName =
   | 'reorder'
   | 'missedDays'
   | 'onboarding'
+  | 'addHabit'
   | 'emojiPicker';
 
 interface ModalState {
@@ -16,6 +17,7 @@ interface ModalState {
   reorder: boolean;
   missedDays: boolean;
   onboarding: boolean;
+  addHabit: boolean;
   emojiPicker: boolean;
 }
 
@@ -26,6 +28,7 @@ const INITIAL_STATE: ModalState = {
   reorder: false,
   missedDays: false,
   onboarding: false,
+  addHabit: false,
   emojiPicker: false,
 };
 

--- a/frontend/src/features/Habits/hooks/usePagination.ts
+++ b/frontend/src/features/Habits/hooks/usePagination.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Window a list into fixed-size pages. Returns a clamped `page` so callers
+ * always read a valid index even when `habitCount` shrinks beneath the
+ * current internal state — that's the reason there is no corrective effect:
+ * the clamp at the read site is sufficient and avoids an extra render.
+ *
+ * `goLast` sets internal state to `habitCount`, which is always above
+ * `pageCount - 1`; the clamp resolves it to the actual last page on the next
+ * read. Use this after appending a new item so the user lands on the page
+ * that contains it.
+ */
+export interface PaginationState {
+  /** Clamped current page (0-based). */
+  page: number;
+  /** Number of pages (always >= 1). */
+  pageCount: number;
+  goPrev: () => void;
+  goNext: () => void;
+  goLast: () => void;
+}
+
+export const usePagination = (habitCount: number, pageSize: number): PaginationState => {
+  const pageCount = Math.max(1, Math.ceil(habitCount / pageSize));
+  const [page, setPage] = useState(0);
+
+  const goPrev = useCallback(() => setPage((p) => Math.max(0, p - 1)), []);
+  const goNext = useCallback(() => setPage((p) => Math.min(pageCount - 1, p + 1)), [pageCount]);
+  const goLast = useCallback(() => setPage(habitCount), [habitCount]);
+
+  return {
+    page: Math.min(page, pageCount - 1),
+    pageCount,
+    goPrev,
+    goNext,
+    goLast,
+  };
+};
+
+export default usePagination;

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -417,6 +417,83 @@ describe('habitManager', () => {
     });
   });
 
+  describe('addHabit', () => {
+    it('optimistically appends the habit before the API resolves', async () => {
+      useHabitStore.setState({ habits: [makeHabit({ id: 1, name: 'Existing' })] });
+      let resolveCreate: (() => void) | undefined;
+      (habitsApi.create as jest.Mock).mockImplementationOnce(
+        () => new Promise<unknown>((r) => (resolveCreate = () => r({}))),
+      );
+
+      const inFlight = habitManager.addHabit({ name: 'Brand New', icon: '🆕' });
+
+      // Optimistic insert: present in the store before the API resolves.
+      const optimistic = useHabitStore.getState().habits;
+      expect(optimistic).toHaveLength(2);
+      expect(optimistic[1]!.name).toBe('Brand New');
+      expect(optimistic[1]!.icon).toBe('🆕');
+      expect(optimistic[1]!.sort_order).toBe(1);
+
+      resolveCreate?.();
+      await inFlight;
+    });
+
+    it('cycles new habits through STAGE_ORDER for their aptitude color', async () => {
+      useHabitStore.setState({ habits: [] });
+      await habitManager.addHabit({ name: 'First', icon: '1️⃣' });
+      const { habits } = useHabitStore.getState();
+      expect(habits[habits.length - 1]!.stage).toBe('Beige');
+    });
+
+    it('posts the new habit to the server and reloads to pick up server ids', async () => {
+      useHabitStore.setState({ habits: [makeHabit({ id: 1 })] });
+      const serverHabit = {
+        ...makeHabit({ id: 99, name: 'Brand New' }),
+        start_date: '2026-05-10',
+        milestone_notifications: false,
+      };
+      (habitsApi.list as jest.Mock).mockImplementationOnce(() => Promise.resolve([serverHabit]));
+
+      await habitManager.addHabit({
+        name: 'Brand New',
+        icon: '🆕',
+        energy_cost: 4,
+        energy_return: 8,
+      });
+
+      expect(habitsApi.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Brand New',
+          icon: '🆕',
+          energy_cost: 4,
+          energy_return: 8,
+        }),
+      );
+      // loadHabits ran, so the temporary negative id was replaced by id: 99.
+      expect(useHabitStore.getState().habits[0]!.id).toBe(99);
+    });
+
+    it('rolls the store back and surfaces an error toast on API failure', async () => {
+      const previousHabits = [makeHabit({ id: 1, name: 'Existing' })];
+      useHabitStore.setState({ habits: previousHabits });
+      (habitsApi.create as jest.Mock).mockImplementationOnce(() =>
+        Promise.reject(new Error('offline')),
+      );
+      const { Alert } = require('react-native');
+
+      await habitManager.addHabit({ name: 'Will Fail', icon: '🛑' });
+
+      const { habits } = useHabitStore.getState();
+      expect(habits).toHaveLength(1);
+      expect(habits[0]!.name).toBe('Existing');
+      expect(saveHabits).toHaveBeenLastCalledWith(previousHabits);
+      expect(Alert.alert).toHaveBeenCalledWith(
+        "Couldn't sync",
+        expect.stringContaining("couldn't create that habit"),
+      );
+    });
+  });
+
   describe('saveHabitOrder', () => {
     it('replaces habits, stamps sort_order, persists, and syncs each row to the API', () => {
       const h1 = makeHabit({ id: 1, name: 'First' });

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../storage/habitStorage';
 import { useHabitStore } from '../../../store/useHabitStore';
 import { HABIT_DEFAULTS } from '../HabitDefaults';
-import type { Goal, Habit, OnboardingHabit } from '../Habits.types';
+import type { AddHabitInput, Goal, Habit, OnboardingHabit } from '../Habits.types';
 import { getGoalTier, getGoalTarget, calculateHabitProgress, logHabitUnits } from '../HabitUtils';
 import { updateHabitNotifications, cancelForHabit } from '../hooks/useHabitNotifications';
 
@@ -247,13 +247,6 @@ const buildOnboardingHabits = (newHabits: OnboardingHabit[]) =>
       target: t.target,
     })),
   }));
-
-export interface AddHabitInput {
-  name: string;
-  icon: string;
-  energy_cost?: number;
-  energy_return?: number;
-}
 
 /**
  * Build a brand-new habit row from a minimal user input. Stage cycles through

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -19,7 +19,7 @@ import type { CheckInResult, GoalUpdatePayload, HabitCreatePayload } from '../..
 import { formatApiError } from '../../../api/errorMessages';
 import { flattenGoalCompletions } from '../../../api/flattenGoalCompletions';
 import type { ToastConfig } from '../../../components/Toast';
-import { colors } from '../../../design/tokens';
+import { colors, STAGE_ORDER } from '../../../design/tokens';
 import {
   saveHabits as persistHabits,
   loadHabits as loadCachedHabits,
@@ -247,6 +247,44 @@ const buildOnboardingHabits = (newHabits: OnboardingHabit[]) =>
       target: t.target,
     })),
   }));
+
+export interface AddHabitInput {
+  name: string;
+  icon: string;
+  energy_cost?: number;
+  energy_return?: number;
+}
+
+/**
+ * Build a brand-new habit row from a minimal user input. Stage cycles through
+ * STAGE_ORDER so habits added after the original ten still pick up an
+ * aptitude color; ids are negative placeholders that get replaced when the
+ * server round-trip succeeds and `loadHabits` rehydrates from the API.
+ */
+const buildAddedHabit = (input: AddHabitInput, existingCount: number): Habit => {
+  const stage = STAGE_ORDER[existingCount % STAGE_ORDER.length] ?? 'Clear Light';
+  const tempId = -Date.now();
+  return {
+    id: tempId,
+    stage,
+    name: input.name.trim(),
+    icon: input.icon,
+    streak: 0,
+    energy_cost: input.energy_cost ?? 5,
+    energy_return: input.energy_return ?? 5,
+    start_date: new Date(),
+    goals: GOAL_TIERS.map((t, ti) => ({
+      id: tempId - ti - 1,
+      title: `${t.label} goal for ${input.name.trim()}`,
+      ...DEFAULT_GOAL_CONFIG,
+      tier: t.tier,
+      target: t.target,
+    })),
+    completions: [],
+    revealed: true,
+    sort_order: existingCount,
+  };
+};
 
 const syncOnboardingHabits = async (fullHabits: ReturnType<typeof buildOnboardingHabits>) => {
   for (const habit of fullHabits) {
@@ -523,6 +561,30 @@ export const habitManager = {
           "We couldn't delete that habit on the server. It's back in your list — check your connection and try again.",
         ),
       );
+  },
+
+  /**
+   * Create a single habit outside the onboarding scaffolding flow. Optimistically
+   * appends a placeholder row to the store so the user sees instant feedback,
+   * then POSTs to ``/habits/`` and re-runs ``loadHabits`` so the temporary
+   * negative ids are replaced with the server-assigned ones (otherwise the
+   * goal-completion POSTs would 404 on the next log).
+   */
+  addHabit: async (input: AddHabitInput): Promise<void> => {
+    const prev = getHabits();
+    const newHabit = buildAddedHabit(input, prev.length);
+    const next = [...prev, newHabit];
+    setHabits(next);
+    void persistHabits(next);
+    try {
+      await habitsApi.create(toApiPayload(newHabit));
+      await loadHabits();
+    } catch (err) {
+      revertOnFailure(
+        prev,
+        "We couldn't create that habit on the server. Check your connection and try again.",
+      )(err);
+    }
   },
 
   /**


### PR DESCRIPTION
- Adds an "Add Habit" item to the Habits overflow menu plus an AddHabitModal
  (name + emoji + cost/return) so users no longer have to run the full energy
  scaffolding flow to add a single habit. habitManager.addHabit cycles the new
  habit through STAGE_ORDER for its aptitude color, optimistically inserts it,
  POSTs to /habits/, then reloads to pick up server-assigned ids.
- Replaces the React Native Alert in HabitSettingsModal's delete flow with a
  custom ConfirmDialog ("Are you sure? / This is permanent.") so the
  confirmation actually renders on RN-Web mobile browsers where Alert is a
  no-op.
- Paginates the habits grid at 10 per page (sized to fill the screen 1-up on
  mobile and 2x5 on landscape/desktop) with prev/next controls; the tile
  renderer now offsets its index so emoji edits on later pages still write
  through to the right habit.
- Thickens habit tile borders from 1px to 3px so the stage/aptitude color
  reads at a glance.