### PR TITLE
fix(frontend-habits/journal): prompt 14A — modal/onboarding/notif/journal hardening

### DIFF
--- a/frontend/src/features/Habits/__tests__/useModalCoordinator.test.ts
+++ b/frontend/src/features/Habits/__tests__/useModalCoordinator.test.ts
@@ -18,7 +18,11 @@ describe('useModalCoordinator', () => {
     expect(result.current.menu).toBe(false);
   });
 
-  it('opens exactly one modal at a time', () => {
+  it('BUG-FE-HABIT-008: open() preserves prior modal flags', () => {
+    // Before the fix, ``open('stats')`` would close ``goal``.  Stacking
+    // a count-warning toast inside the onboarding flow then dismissed
+    // onboarding itself.  ``open`` now ORs the requested flag onto
+    // existing state; callers that need exclusivity ``closeAll()`` first.
     const { result } = renderHook(() => useModalCoordinator());
 
     act(() => result.current.open('goal'));
@@ -27,7 +31,7 @@ describe('useModalCoordinator', () => {
 
     act(() => result.current.open('stats'));
     expect(result.current.stats).toBe(true);
-    expect(result.current.goal).toBe(false);
+    expect(result.current.goal).toBe(true);
   });
 
   it('closeAll resets every modal to false', () => {

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -30,7 +30,17 @@ const cycleFrequency = (current: string | undefined): 'daily' | 'weekly' | 'cust
 };
 
 const parseEnergyValue = (text: string): number | null => {
-  const value = parseInt(text) || 0;
+  // BUG-FE-HABIT-201: ``parseInt(text) || 0`` silently coerced garbage
+  // ("foo", "1.5e10", "") to ``0`` and accepted it as a valid energy
+  // value, then propagated through to the planner as a real cost --
+  // which the user did not type.  The empty-string allowance is
+  // preserved (it represents "user is mid-edit") but every non-integer
+  // is now rejected so the caller can surface a validation error
+  // instead of silently writing 0.
+  if (text.trim() === '') return null;
+  if (!/^-?\d+$/.test(text.trim())) return null;
+  const value = Number.parseInt(text.trim(), 10);
+  if (!Number.isFinite(value)) return null;
   return value >= ENERGY_MIN && value <= ENERGY_MAX ? value : null;
 };
 

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -19,29 +19,14 @@ import type { Habit, HabitSettingsModalProps } from '../Habits.types';
 import { calculateNetEnergy } from '../HabitUtils';
 
 import ConfirmDialog from './ConfirmDialog';
-
-const ENERGY_MIN = -10;
-const ENERGY_MAX = 10;
+// BUG-FE-HABIT-201: parser lives in its own module so unit tests can
+// import without the RN component tree (see ``parseEnergyValue.ts``).
+import { parseEnergyValue } from './parseEnergyValue';
 
 const cycleFrequency = (current: string | undefined): 'daily' | 'weekly' | 'custom' => {
   if (current === 'daily') return 'weekly';
   if (current === 'weekly') return 'custom';
   return 'daily';
-};
-
-const parseEnergyValue = (text: string): number | null => {
-  // BUG-FE-HABIT-201: ``parseInt(text) || 0`` silently coerced garbage
-  // ("foo", "1.5e10", "") to ``0`` and accepted it as a valid energy
-  // value, then propagated through to the planner as a real cost --
-  // which the user did not type.  The empty-string allowance is
-  // preserved (it represents "user is mid-edit") but every non-integer
-  // is now rejected so the caller can surface a validation error
-  // instead of silently writing 0.
-  if (text.trim() === '') return null;
-  if (!/^-?\d+$/.test(text.trim())) return null;
-  const value = Number.parseInt(text.trim(), 10);
-  if (!Number.isFinite(value)) return null;
-  return value >= ENERGY_MIN && value <= ENERGY_MAX ? value : null;
 };
 
 interface EnergySettingsProps {

--- a/frontend/src/features/Habits/components/MissedDaysModal.tsx
+++ b/frontend/src/features/Habits/components/MissedDaysModal.tsx
@@ -52,6 +52,43 @@ const MissedDaysText = ({ habitName, missedCount }: { habitName: string; missedC
   );
 };
 
+/**
+ * BUG-FE-HABIT-202: holds the user's calendar pick until they confirm.
+ * Tapping a day used to immediately wipe every prior completion -- the
+ * confirm step makes the data-loss explicit.
+ */
+const useResetFlow = (
+  habit: { id?: number },
+  onNewStartDate: MissedDaysModalProps['onNewStartDate'],
+  onClose: () => void,
+) => {
+  const [pendingDate, setPendingDate] = useState<Date | null>(null);
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [showCalendar, setShowCalendar] = useState(false);
+  const onPick = (date: DateData) => {
+    const picked = new Date(date.dateString);
+    setSelectedDate(picked);
+    setPendingDate(picked);
+  };
+  const onConfirm = () => {
+    if (pendingDate && habit.id) {
+      onNewStartDate(habit.id, pendingDate);
+      setPendingDate(null);
+      setShowCalendar(false);
+      onClose();
+    }
+  };
+  return {
+    pendingDate,
+    selectedDate,
+    showCalendar,
+    setShowCalendar,
+    onPick,
+    onConfirm,
+    onCancel: () => setPendingDate(null),
+  };
+};
+
 const MissedDaysBody = ({
   habit,
   missedDays,
@@ -59,8 +96,7 @@ const MissedDaysBody = ({
   onBackfill,
   onNewStartDate,
 }: MissedDaysBodyProps) => {
-  const [showCalendar, setShowCalendar] = useState(false);
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const reset = useResetFlow(habit, onNewStartDate, onClose);
 
   const handleBackfill = () => {
     if (habit.id) {
@@ -69,23 +105,21 @@ const MissedDaysBody = ({
     }
   };
 
-  const handleDateSelect = (date: DateData) => {
-    setSelectedDate(new Date(date.dateString));
-    setShowCalendar(false);
-    if (habit.id) {
-      onNewStartDate(habit.id, new Date(date.dateString));
-      onClose();
-    }
-  };
-
-  const selectedDateString = selectedDate.toISOString().split('T')[0]!;
+  const selectedDateString = reset.selectedDate.toISOString().split('T')[0]!;
 
   return (
     <View style={styles.missedDaysContent}>
       <MissedDaysText habitName={habit.name} missedCount={missedDays.length} />
-      {showCalendar ? (
+      {reset.pendingDate ? (
+        <ResetConfirmation
+          habitName={habit.name}
+          pendingDate={reset.pendingDate}
+          onConfirm={reset.onConfirm}
+          onCancel={reset.onCancel}
+        />
+      ) : reset.showCalendar ? (
         <Calendar
-          onDayPress={handleDateSelect}
+          onDayPress={reset.onPick}
           markedDates={{
             [selectedDateString ?? '']: {
               selected: true,
@@ -97,13 +131,47 @@ const MissedDaysBody = ({
       ) : (
         <MissedDaysActions
           onBackfill={handleBackfill}
-          onSelectNewDate={() => setShowCalendar(true)}
+          onSelectNewDate={() => reset.setShowCalendar(true)}
           onClose={onClose}
         />
       )}
     </View>
   );
 };
+
+interface ResetConfirmationProps {
+  habitName: string;
+  pendingDate: Date;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ResetConfirmation = ({
+  habitName,
+  pendingDate,
+  onConfirm,
+  onCancel,
+}: ResetConfirmationProps) => (
+  <View style={styles.missedDaysButtons}>
+    <Text style={styles.missedDaysQuestion} testID="reset-confirm-warning">
+      {`Reset start date for '${habitName}' to ${pendingDate.toDateString()}? This wipes every prior completion.`}
+    </Text>
+    <TouchableOpacity
+      style={[styles.missedDaysButton, styles.resetButton]}
+      onPress={onConfirm}
+      testID="reset-confirm-yes"
+    >
+      <Text style={styles.missedDaysButtonText}>Yes, reset and erase progress</Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      style={[styles.missedDaysButton, styles.cancelButton]}
+      onPress={onCancel}
+      testID="reset-confirm-cancel"
+    >
+      <Text style={styles.missedDaysButtonText}>Cancel</Text>
+    </TouchableOpacity>
+  </View>
+);
 
 export const MissedDaysModal = ({
   visible,

--- a/frontend/src/features/Habits/components/MissedDaysModal.tsx
+++ b/frontend/src/features/Habits/components/MissedDaysModal.tsx
@@ -146,7 +146,7 @@ interface ResetConfirmationProps {
   onCancel: () => void;
 }
 
-const ResetConfirmation = ({
+export const ResetConfirmation = ({
   habitName,
   pendingDate,
   onConfirm,

--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -23,7 +23,6 @@ import Animated from 'react-native-reanimated';
 import { goalGroups as goalGroupsApi, type ApiGoalGroup } from '../../../api';
 import DatePicker, { parseISODate, toISODate } from '../../../components/DatePicker';
 import { colors, STAGE_COLORS } from '../../../design/tokens';
-import { DEFAULT_ICONS } from '../constants';
 import styles from '../Habits.styles';
 import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
 import { STAGE_ORDER, calculateHabitStartDate } from '../HabitUtils';
@@ -38,10 +37,9 @@ interface SmoothSliderProps extends SliderProps {
   animationConfig?: Record<string, unknown>;
 }
 
-const SmoothSlider = Slider as React.ComponentType<SmoothSliderProps>;
+import { HABIT_NAME_MAX_LENGTH, MAX_HABITS, validateAndAddHabit } from './onboardingValidation';
 
-const MAX_HABITS = 10;
-const DEFAULT_ENERGY = 5;
+const SmoothSlider = Slider as React.ComponentType<SmoothSliderProps>;
 
 const REVEAL_STAGGER_MS = 150;
 const REVEAL_SORT_PAUSE_MS = 500;
@@ -717,70 +715,6 @@ const useOnboardingActions = (
   };
 };
 
-// BUG-FE-HABIT-105: maximum length for an onboarding habit name.  TextInput
-// also enforces the cap; the parse-time guard is defence in depth so a
-// programmatic ``setHabits`` cannot smuggle a 10k-char name past the UI.
-const HABIT_NAME_MAX_LENGTH = 80;
-
-let habitIdCounter = 0;
-
-const generateHabitId = (): string => {
-  habitIdCounter += 1;
-  // ``Date.now()`` alone collided on rapid taps within the same
-  // millisecond (common on web with React 18 auto-batching), breaking
-  // ``DraggableFlatList`` keys.  Pairing with a monotonically-increasing
-  // counter guarantees uniqueness even when ``Date.now()`` is identical.
-  return `${Date.now()}-${habitIdCounter}`;
-};
-
-/**
- * Strip control / newline / tab characters and clamp to the max length.
- * Matches the backend ``sanitize_user_text`` shape from prompt 04 so a
- * round-trip does not silently rewrite the displayed name.
- */
-const sanitizeHabitName = (raw: string): string => {
-  // Strip control characters (0x00-0x1F + 0x7F) including newlines and
-  // tabs so a 10k-char one-liner cannot smuggle past the input cap.
-  let out = '';
-  for (let i = 0; i < raw.length; i += 1) {
-    const code = raw.charCodeAt(i);
-    if (code <= 31 || code === 127) continue;
-    out += raw[i];
-  }
-  return out.trim().slice(0, HABIT_NAME_MAX_LENGTH);
-};
-
-const createNewHabit = (name: string): OnboardingHabit => ({
-  id: generateHabitId(),
-  name: sanitizeHabitName(name),
-  icon: DEFAULT_ICONS[Math.floor(Math.random() * DEFAULT_ICONS.length)] ?? '⭐',
-  energy_cost: DEFAULT_ENERGY,
-  energy_return: DEFAULT_ENERGY,
-  stage: 'Beige',
-  start_date: new Date(),
-});
-
-type AddHabitOutcome = { ok: true } | { ok: false; error: string };
-
-const validateAndAddHabit = (
-  raw: string,
-  habits: OnboardingHabit[],
-): AddHabitOutcome | { habit: OnboardingHabit } => {
-  const cleaned = sanitizeHabitName(raw);
-  if (cleaned === '') return { ok: true } as AddHabitOutcome;
-  if (habits.length >= MAX_HABITS) {
-    return {
-      ok: false,
-      error: `You've hit the ${MAX_HABITS}-habit limit for onboarding. Remove one you don't need to add a different habit.`,
-    };
-  }
-  const lower = cleaned.toLowerCase();
-  if (habits.some((h) => h.name.toLowerCase() === lower)) {
-    return { ok: false, error: "You've already added that one. Pick a different name." };
-  }
-  return { habit: createNewHabit(cleaned) };
-};
-
 const useHabitInput = (
   habits: OnboardingHabit[],
   setHabits: React.Dispatch<React.SetStateAction<OnboardingHabit[]>>,
@@ -793,14 +727,14 @@ const useHabitInput = (
 
   const handleAddHabit = () => {
     const outcome = validateAndAddHabit(newHabitName, habits);
-    if ('habit' in outcome) {
+    if (outcome.kind === 'add') {
       setHabits((prev) => [...prev, outcome.habit]);
       setNewHabitName('');
       setError('');
       inputRef.current?.focus();
       return;
     }
-    if (!outcome.ok) setError(outcome.error);
+    if (outcome.kind === 'error') setError(outcome.message);
   };
 
   const handleKeyPress = (

--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -306,6 +306,7 @@ const HabitInputRow = ({
       placeholder="Enter habit name"
       blurOnSubmit={false}
       onKeyPress={onKeyPress}
+      maxLength={HABIT_NAME_MAX_LENGTH}
       testID="habit-input"
     />
     <TouchableOpacity
@@ -716,15 +717,69 @@ const useOnboardingActions = (
   };
 };
 
+// BUG-FE-HABIT-105: maximum length for an onboarding habit name.  TextInput
+// also enforces the cap; the parse-time guard is defence in depth so a
+// programmatic ``setHabits`` cannot smuggle a 10k-char name past the UI.
+const HABIT_NAME_MAX_LENGTH = 80;
+
+let habitIdCounter = 0;
+
+const generateHabitId = (): string => {
+  habitIdCounter += 1;
+  // ``Date.now()`` alone collided on rapid taps within the same
+  // millisecond (common on web with React 18 auto-batching), breaking
+  // ``DraggableFlatList`` keys.  Pairing with a monotonically-increasing
+  // counter guarantees uniqueness even when ``Date.now()`` is identical.
+  return `${Date.now()}-${habitIdCounter}`;
+};
+
+/**
+ * Strip control / newline / tab characters and clamp to the max length.
+ * Matches the backend ``sanitize_user_text`` shape from prompt 04 so a
+ * round-trip does not silently rewrite the displayed name.
+ */
+const sanitizeHabitName = (raw: string): string => {
+  // Strip control characters (0x00-0x1F + 0x7F) including newlines and
+  // tabs so a 10k-char one-liner cannot smuggle past the input cap.
+  let out = '';
+  for (let i = 0; i < raw.length; i += 1) {
+    const code = raw.charCodeAt(i);
+    if (code <= 31 || code === 127) continue;
+    out += raw[i];
+  }
+  return out.trim().slice(0, HABIT_NAME_MAX_LENGTH);
+};
+
 const createNewHabit = (name: string): OnboardingHabit => ({
-  id: Date.now().toString(),
-  name: name.trim(),
+  id: generateHabitId(),
+  name: sanitizeHabitName(name),
   icon: DEFAULT_ICONS[Math.floor(Math.random() * DEFAULT_ICONS.length)] ?? '⭐',
   energy_cost: DEFAULT_ENERGY,
   energy_return: DEFAULT_ENERGY,
   stage: 'Beige',
   start_date: new Date(),
 });
+
+type AddHabitOutcome = { ok: true } | { ok: false; error: string };
+
+const validateAndAddHabit = (
+  raw: string,
+  habits: OnboardingHabit[],
+): AddHabitOutcome | { habit: OnboardingHabit } => {
+  const cleaned = sanitizeHabitName(raw);
+  if (cleaned === '') return { ok: true } as AddHabitOutcome;
+  if (habits.length >= MAX_HABITS) {
+    return {
+      ok: false,
+      error: `You've hit the ${MAX_HABITS}-habit limit for onboarding. Remove one you don't need to add a different habit.`,
+    };
+  }
+  const lower = cleaned.toLowerCase();
+  if (habits.some((h) => h.name.toLowerCase() === lower)) {
+    return { ok: false, error: "You've already added that one. Pick a different name." };
+  }
+  return { habit: createNewHabit(cleaned) };
+};
 
 const useHabitInput = (
   habits: OnboardingHabit[],
@@ -737,17 +792,15 @@ const useHabitInput = (
   const inputRef = useRef<TextInput>(null);
 
   const handleAddHabit = () => {
-    if (newHabitName.trim() === '') return;
-    if (habits.length >= MAX_HABITS) {
-      setError(
-        `You've hit the ${MAX_HABITS}-habit limit for onboarding. Remove one you don't need to add a different habit.`,
-      );
+    const outcome = validateAndAddHabit(newHabitName, habits);
+    if ('habit' in outcome) {
+      setHabits((prev) => [...prev, outcome.habit]);
+      setNewHabitName('');
+      setError('');
+      inputRef.current?.focus();
       return;
     }
-    setHabits((prev) => [...prev, createNewHabit(newHabitName)]);
-    setNewHabitName('');
-    setError('');
-    inputRef.current?.focus();
+    if (!outcome.ok) setError(outcome.error);
   };
 
   const handleKeyPress = (
@@ -793,20 +846,33 @@ const useOnboardingNavigation = (
     setShowDiscardDialog(false);
     onClose();
   };
+  // BUG-FE-HABIT-103: track in-flight templates request so a second tap
+  // (or a stale callback after navigation) cannot route a successful
+  // fetch into the error branch or step the user past 5 unintentionally.
+  const templatesRequestRef = useRef(0);
   const handleGoToTemplates = () => {
+    const myRequest = templatesRequestRef.current + 1;
+    templatesRequestRef.current = myRequest;
     goalGroupsApi
       .list()
       .then((templates) => {
+        if (templatesRequestRef.current !== myRequest) return;
         setGoalGroupTemplates(templates.filter((t) => t.shared_template));
         setStep(5);
       })
       .catch(() => {
+        if (templatesRequestRef.current !== myRequest) return;
         onSaveHabits(habits);
         onClose();
       });
   };
+  // BUG-FE-HABIT-101: reset onboarding state on finish so reopening the
+  // modal starts at step 1 with an empty habit list, instead of resuming
+  // at step 5 with already-persisted habits.
   const handleFinish = () => {
     onSaveHabits(habits);
+    setStep(1);
+    setHabits([]);
     onClose();
   };
   return {

--- a/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
+++ b/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
@@ -140,9 +140,12 @@ const useReorderState = ({
   const [pickerVisible, setPickerVisible] = useState(false);
   const wasVisibleRef = useRef(false);
 
-  // Initialise the ordering only on the open transition. The previous
-  // implementation re-fired on every ``startDate`` change and clobbered the
-  // user's drag order, which felt like a "frozen" reorder.
+  // BUG-FE-HABIT-204: initialise the ordering only on the open transition;
+  // the previous implementation re-fired on every ``startDate`` change and
+  // clobbered the user's drag.  Date-picker changes go through
+  // ``handleConfirmDate`` below, which calls ``updateStartDates`` directly,
+  // so the start-date propagation handled by PR #302's dedicated effect is
+  // already covered here without a second effect.
   useEffect(() => {
     const justOpened = visible && !wasVisibleRef.current;
     wasVisibleRef.current = visible;

--- a/frontend/src/features/Habits/components/__tests__/MissedDaysModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/MissedDaysModal.test.tsx
@@ -1,0 +1,72 @@
+/* eslint-env jest */
+/* global describe, it, expect, jest */
+
+/**
+ * Render tests for the ``ResetConfirmation`` component introduced in
+ * PR #302 (BUG-FE-HABIT-202).  The component is the explicit-confirm
+ * gate between a calendar pick and the destructive
+ * ``onNewStartDate`` call that wipes completions.
+ */
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+// ``react-native-calendars`` ships as ESM; the parent module is only used
+// at runtime for the date-picker calendar so a stub is fine for the
+// ``ResetConfirmation``-only render tests.
+jest.mock('react-native-calendars', () => ({
+  Calendar: () => null,
+}));
+
+import { ResetConfirmation } from '../MissedDaysModal';
+
+describe('ResetConfirmation (BUG-FE-HABIT-202)', () => {
+  const pendingDate = new Date(2026, 4, 15); // May 15 2026 in local TZ
+
+  it('renders a warning that names the habit and the chosen date', () => {
+    const { getByTestId } = render(
+      <ResetConfirmation
+        habitName="Morning meditation"
+        pendingDate={pendingDate}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    const warning = getByTestId('reset-confirm-warning');
+    expect(warning).toHaveTextContent(/Morning meditation/);
+    // Date formatting depends on local TZ; just confirm the year appears.
+    expect(warning).toHaveTextContent(/2026/);
+    expect(warning).toHaveTextContent(/wipes every prior completion/i);
+  });
+
+  it('fires onConfirm only when the destructive button is pressed', () => {
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+    const { getByTestId } = render(
+      <ResetConfirmation
+        habitName="X"
+        pendingDate={pendingDate}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.press(getByTestId('reset-confirm-yes'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('fires onCancel only when the cancel button is pressed', () => {
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+    const { getByTestId } = render(
+      <ResetConfirmation
+        habitName="X"
+        pendingDate={pendingDate}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.press(getByTestId('reset-confirm-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.step1.test.tsx
@@ -78,4 +78,18 @@ describe('OnboardingModal Step 1 interactions', () => {
     fireEvent.press(getByTestId('count-warning-continue'));
     getByText('Energy Cost');
   });
+
+  it('BUG-FE-HABIT-105: rejects a case-insensitive duplicate name with an inline error', () => {
+    const { getByPlaceholderText, getByTestId, getByText } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, 'Meditate');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    expect(getByTestId('habit-count')).toHaveTextContent('1 / 10');
+    fireEvent.changeText(input, 'meditate');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    getByText(/already added/i);
+    expect(getByTestId('habit-count')).toHaveTextContent('1 / 10');
+  });
 });

--- a/frontend/src/features/Habits/components/__tests__/pureHelpers.test.ts
+++ b/frontend/src/features/Habits/components/__tests__/pureHelpers.test.ts
@@ -1,0 +1,121 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+
+/**
+ * Unit tests for the pure-function tier extracted from the modal
+ * components in PR #302.  ``onboardingValidation`` is intentionally
+ * RN-free so this test file imports the helpers directly without
+ * mocking ESM-only RN modules.  ``parseEnergyValue`` lives in
+ * ``HabitSettingsModal`` -- which DOES pull in RN -- so the test
+ * imports it via a thin barrel module that re-exports without the
+ * heavy component tree.
+ */
+import type { OnboardingHabit } from '../../Habits.types';
+import {
+  HABIT_NAME_MAX_LENGTH,
+  sanitizeHabitName,
+  validateAndAddHabit,
+} from '../onboardingValidation';
+import { parseEnergyValue } from '../parseEnergyValue';
+
+describe('parseEnergyValue (BUG-FE-HABIT-201)', () => {
+  it('accepts a valid integer inside the [-10, 10] window', () => {
+    expect(parseEnergyValue('5')).toBe(5);
+    expect(parseEnergyValue('0')).toBe(0);
+    expect(parseEnergyValue('-10')).toBe(-10);
+    expect(parseEnergyValue('10')).toBe(10);
+  });
+
+  it('returns null for an empty / whitespace string (mid-edit allowance)', () => {
+    expect(parseEnergyValue('')).toBeNull();
+    expect(parseEnergyValue('   ')).toBeNull();
+  });
+
+  it('rejects non-integer garbage that previously coerced to 0', () => {
+    // The original ``parseInt(text) || 0`` silently turned every one of
+    // these into a legitimate 0.  The new parser surfaces them as
+    // ``null`` so the caller can show a validation error.
+    expect(parseEnergyValue('foo')).toBeNull();
+    expect(parseEnergyValue('abc')).toBeNull();
+    expect(parseEnergyValue('1.5')).toBeNull();
+    expect(parseEnergyValue('1.5e10')).toBeNull();
+    expect(parseEnergyValue('NaN')).toBeNull();
+    expect(parseEnergyValue('Infinity')).toBeNull();
+  });
+
+  it('rejects integers outside the [-10, 10] window', () => {
+    expect(parseEnergyValue('-11')).toBeNull();
+    expect(parseEnergyValue('11')).toBeNull();
+    expect(parseEnergyValue('1000')).toBeNull();
+  });
+});
+
+describe('sanitizeHabitName (BUG-FE-HABIT-105)', () => {
+  it('passes a plain valid name through unchanged', () => {
+    expect(sanitizeHabitName('Meditate')).toBe('Meditate');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizeHabitName('  Meditate  ')).toBe('Meditate');
+  });
+
+  it('strips ASCII control characters (newlines, tabs, NUL, DEL)', () => {
+    expect(sanitizeHabitName('Hello\nWorld')).toBe('HelloWorld');
+    expect(sanitizeHabitName('Hello\tWorld')).toBe('HelloWorld');
+    expect(sanitizeHabitName('Hello\x00World\x7f!')).toBe('HelloWorld!');
+  });
+
+  it(`clamps to the ${HABIT_NAME_MAX_LENGTH}-char max length`, () => {
+    const result = sanitizeHabitName('a'.repeat(HABIT_NAME_MAX_LENGTH + 40));
+    expect(result.length).toBe(HABIT_NAME_MAX_LENGTH);
+  });
+
+  it('returns empty string when input contains only control characters', () => {
+    expect(sanitizeHabitName('\n\t\r ')).toBe('');
+  });
+});
+
+function fakeHabit(name: string): OnboardingHabit {
+  return {
+    id: `id-${name}`,
+    name,
+    icon: '⭐',
+    energy_cost: 0,
+    energy_return: 0,
+    stage: 'Beige',
+    start_date: new Date(),
+  };
+}
+
+describe('validateAndAddHabit (BUG-FE-HABIT-105)', () => {
+  it("returns 'noop' for an empty / whitespace-only name", () => {
+    expect(validateAndAddHabit('', [])).toEqual({ kind: 'noop' });
+    expect(validateAndAddHabit('   ', [])).toEqual({ kind: 'noop' });
+  });
+
+  it("returns 'add' with the sanitized name for a valid new habit", () => {
+    const result = validateAndAddHabit('  Meditate  ', []);
+    expect(result.kind).toBe('add');
+    if (result.kind === 'add') {
+      expect(result.habit.name).toBe('Meditate');
+    }
+  });
+
+  it("returns 'error' when a case-insensitive duplicate exists", () => {
+    const existing = [fakeHabit('Meditate')];
+    const result = validateAndAddHabit('meditate', existing);
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.message).toMatch(/already added/i);
+    }
+  });
+
+  it("returns 'error' when the MAX_HABITS limit is reached", () => {
+    const fullList = Array.from({ length: 10 }, (_, i) => fakeHabit(`H${i}`));
+    const result = validateAndAddHabit('NewOne', fullList);
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.message).toMatch(/10-habit limit/i);
+    }
+  });
+});

--- a/frontend/src/features/Habits/components/onboardingValidation.ts
+++ b/frontend/src/features/Habits/components/onboardingValidation.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure validation + sanitisation helpers for the OnboardingModal.
+ *
+ * Kept in a separate file so unit tests can import them without pulling
+ * in the modal's React Native + reanimated + gesture-handler tree.  The
+ * modal re-exports the same names for its own use.
+ */
+import { DEFAULT_ICONS } from '../constants';
+import type { OnboardingHabit } from '../Habits.types';
+
+export const MAX_HABITS = 10;
+const DEFAULT_ENERGY = 5;
+
+// BUG-FE-HABIT-105: maximum length for an onboarding habit name.  TextInput
+// also enforces the cap; the parse-time guard is defence in depth so a
+// programmatic ``setHabits`` cannot smuggle a 10k-char name past the UI.
+export const HABIT_NAME_MAX_LENGTH = 80;
+
+let habitIdCounter = 0;
+
+export const generateHabitId = (): string => {
+  habitIdCounter += 1;
+  // ``Date.now()`` alone collided on rapid taps within the same
+  // millisecond (common on web with React 18 auto-batching).  Pairing
+  // with a monotonically-increasing counter guarantees uniqueness even
+  // when ``Date.now()`` is identical.
+  return `${Date.now()}-${habitIdCounter}`;
+};
+
+export const sanitizeHabitName = (raw: string): string => {
+  // Strip ASCII control characters (0x00-0x1F + 0x7F) including newlines
+  // and tabs; the displayed habit name is single-line.  Implemented with
+  // ``charCodeAt`` so ESLint's ``no-control-regex`` stays clean.
+  let out = '';
+  for (let i = 0; i < raw.length; i += 1) {
+    const code = raw.charCodeAt(i);
+    if (code <= 31 || code === 127) continue;
+    out += raw[i];
+  }
+  return out.trim().slice(0, HABIT_NAME_MAX_LENGTH);
+};
+
+export const createNewHabit = (name: string): OnboardingHabit => ({
+  id: generateHabitId(),
+  name: sanitizeHabitName(name),
+  icon: DEFAULT_ICONS[Math.floor(Math.random() * DEFAULT_ICONS.length)] ?? '⭐',
+  energy_cost: DEFAULT_ENERGY,
+  energy_return: DEFAULT_ENERGY,
+  stage: 'Beige',
+  start_date: new Date(),
+});
+
+// Three-way discriminated union by ``kind`` makes the call site easier
+// to read than the prior mixed shape.
+export type ValidateAddHabitResult =
+  | { kind: 'noop' }
+  | { kind: 'error'; message: string }
+  | { kind: 'add'; habit: OnboardingHabit };
+
+export const validateAndAddHabit = (
+  raw: string,
+  habits: OnboardingHabit[],
+): ValidateAddHabitResult => {
+  const cleaned = sanitizeHabitName(raw);
+  if (cleaned === '') return { kind: 'noop' };
+  if (habits.length >= MAX_HABITS) {
+    return {
+      kind: 'error',
+      message: `You've hit the ${MAX_HABITS}-habit limit for onboarding. Remove one you don't need to add a different habit.`,
+    };
+  }
+  const lower = cleaned.toLowerCase();
+  if (habits.some((h) => h.name.toLowerCase() === lower)) {
+    return { kind: 'error', message: "You've already added that one. Pick a different name." };
+  }
+  return { kind: 'add', habit: createNewHabit(cleaned) };
+};

--- a/frontend/src/features/Habits/components/parseEnergyValue.ts
+++ b/frontend/src/features/Habits/components/parseEnergyValue.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure parser for the energy-cost / energy-return text inputs in the
+ * habit settings modal.  Lives in its own file so unit tests can import
+ * without pulling in the RN component tree.
+ *
+ * BUG-FE-HABIT-201: the prior ``parseInt(text) || 0`` silently coerced
+ * "foo", "1.5", "" all to ``0`` and accepted them as valid energy
+ * values.  Strict integer regex + finite check + range guard rejects
+ * the malformed cases so the caller can surface a validation error
+ * instead of writing 0 to the planner.
+ */
+// Bounds mirror those expressed in ``HabitSettingsModal``; kept here so
+// the parser stays a single source of truth across the input row + the
+// dedicated unit tests.
+const ENERGY_MIN = -10;
+const ENERGY_MAX = 10;
+
+export const parseEnergyValue = (text: string): number | null => {
+  if (text.trim() === '') return null;
+  if (!/^-?\d+$/.test(text.trim())) return null;
+  const value = Number.parseInt(text.trim(), 10);
+  if (!Number.isFinite(value)) return null;
+  return value >= ENERGY_MIN && value <= ENERGY_MAX ? value : null;
+};

--- a/frontend/src/features/Habits/hooks/useModalCoordinator.ts
+++ b/frontend/src/features/Habits/hooks/useModalCoordinator.ts
@@ -45,7 +45,14 @@ export const useModalCoordinator = (): ModalCoordinator => {
   const [menu, setMenu] = useState(false);
 
   const open = useCallback((name: ModalName) => {
-    setModals({ ...INITIAL_STATE, [name]: true });
+    // BUG-FE-HABIT-008: previously this resolved to ``{ [name]: true }``
+    // -- which silently closed every other open modal.  ``onboarding``
+    // raising the ``stats`` modal mid-flow would dismiss onboarding,
+    // and the count-warning toast inside ``OnboardingModal`` would
+    // close its host.  Preserving prior flags lets the screen stack
+    // modals when the UX requires it; callers that need exclusivity
+    // call ``closeAll`` first.
+    setModals((prev) => ({ ...prev, [name]: true }));
     setMenu(false);
   }, []);
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -339,6 +339,36 @@ const setError = (error: string | null): void => {
 
 const getHabits = (): Habit[] => useHabitStore.getState().habits;
 
+/**
+ * Per-habit promise mutex for notification rescheduling (BUG-FE-HABIT-005).
+ *
+ * Two rapid ``updateHabit`` calls on the same habit used to interleave:
+ * the second would read the pre-first-edit ``notificationIds`` (still in
+ * the store because the first call had not yet flushed its return value)
+ * and double-schedule on the device.  Chaining each habit's reschedule
+ * onto the prior one and then writing the returned ids back into the
+ * store before persisting closes both halves of the race.
+ */
+const rescheduleQueue: Map<number, Promise<void>> = new Map();
+
+const rescheduleAndPersist = (habit: Habit): Promise<void> => {
+  if (!habit.id) return Promise.resolve();
+  const habitId = habit.id;
+  const prior = rescheduleQueue.get(habitId) ?? Promise.resolve();
+  const next = prior
+    .catch(() => undefined)
+    .then(async () => {
+      const live = getHabits().find((h) => h.id === habitId);
+      const target: Habit = live ?? habit;
+      const ids = await updateHabitNotifications(target);
+      const refreshed: Habit = { ...target, notificationIds: ids };
+      setHabits(getHabits().map((h) => (h.id === habitId ? refreshed : h)));
+      await persistHabits(getHabits());
+    });
+  rescheduleQueue.set(habitId, next);
+  return next;
+};
+
 // ---------------------------------------------------------------------------
 // API sync helpers — every mutation optimistically updates the store and
 // rolls back on network failure.
@@ -527,8 +557,13 @@ export const habitManager = {
     const prev = getHabits();
     const next = prev.map((h) => (h.id === updatedHabit.id ? updatedHabit : h));
     setHabits(next);
-    void updateHabitNotifications(updatedHabit);
-    void persistHabits(next);
+    // BUG-FE-HABIT-005: serialize per-habit notification rescheduling and
+    // write the freshly-returned ids back onto the habit before
+    // persisting.  The previous ``void updateHabitNotifications(...)``
+    // discarded the return value, so a second rapid edit would still
+    // see the pre-first-edit ``notificationIds`` and double-schedule.
+    if (updatedHabit.id) void rescheduleAndPersist(updatedHabit);
+    else void persistHabits(next);
     if (!updatedHabit.id) return;
     habitsApi
       .update(updatedHabit.id, toApiPayload(updatedHabit))

--- a/frontend/src/features/Journal/ChatInput.tsx
+++ b/frontend/src/features/Journal/ChatInput.tsx
@@ -6,6 +6,12 @@ import { colors } from '../../design/tokens';
 
 import styles from './Journal.styles';
 
+// BUG-FE-JOURNAL-101: server caps the message at 10_000 chars
+// (``JOURNAL_MESSAGE_MAX_LENGTH`` in ``schemas/journal.py``).  Mirroring
+// the cap on the input prevents the user from typing a 50k-char
+// reflection that would surface as a 422 only after Send.
+export const JOURNAL_MESSAGE_MAX_LENGTH = 10_000;
+
 const TAG_OPTIONS: Array<{ value: JournalTag; label: string }> = [
   { value: 'stage_reflection', label: 'Reflection' },
   { value: 'practice_note', label: 'Practice' },
@@ -76,6 +82,7 @@ const InputRow = ({
       placeholderTextColor={colors.text.tertiary}
       multiline
       editable={!disabled}
+      maxLength={JOURNAL_MESSAGE_MAX_LENGTH}
     />
     <TouchableOpacity
       testID="tag-toggle"

--- a/frontend/src/features/Journal/JournalScreen.tsx
+++ b/frontend/src/features/Journal/JournalScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, FlatList, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { v4 as uuidv4 } from 'uuid';
@@ -480,6 +480,7 @@ async function runChatStream(
   botPlaceholderId: number | string,
   onFirstChunk: () => void,
   deps: BotSendDeps,
+  signal?: AbortSignal,
 ): Promise<StreamOutcome> {
   const outcome: StreamOutcome = { completed: false, streamError: null };
   let sawFirstChunk = false;
@@ -487,6 +488,11 @@ async function runChatStream(
     { message: text },
     {
       onChunk: (chunk) => {
+        // BUG-FE-JOURNAL-001: skip state updates after the user has
+        // navigated away or fired a fresh send -- without this the
+        // closure keeps writing to an unmounted tree (React warning)
+        // and the wallet keeps draining for a reply nobody will see.
+        if (signal?.aborted) return;
         if (!sawFirstChunk) {
           sawFirstChunk = true;
           onFirstChunk();
@@ -494,6 +500,7 @@ async function runChatStream(
         deps.actions.appendChunk(botPlaceholderId, chunk);
       },
       onComplete: (result) => {
+        if (signal?.aborted) return;
         outcome.completed = true;
         deps.actions.replaceOptimistic(
           botPlaceholderId,
@@ -503,9 +510,11 @@ async function runChatStream(
         deps.setRemainingMessages(result.remaining_messages);
       },
       onStreamError: (err) => {
+        if (signal?.aborted) return;
         outcome.streamError = err.detail;
       },
     },
+    { signal },
   );
   return outcome;
 }
@@ -582,9 +591,25 @@ function useBotSend(deps: BotSendDeps) {
   // bot placeholder itself communicates progress, so the standalone indicator
   // hides to avoid double-signalling.
   const [awaitingBot, setAwaitingBot] = useState(false);
+  // BUG-FE-JOURNAL-001: per-mount AbortController so navigation-away (or a
+  // rapid second send) cancels any in-flight stream, severing the SSE
+  // socket and freeing wallet credit that would otherwise drain for a
+  // reply nobody will see.
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+    },
+    [],
+  );
 
   const sendWithBot = useCallback(
     async (text: string, tag: JournalTag, optimisticUserId: number | string) => {
+      // Cancel any prior in-flight stream so a rapid second send does not
+      // race against an outdated reply landing on top of the new one.
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
       const botPlaceholder = createBotPlaceholder();
       deps.actions.prependMessage(botPlaceholder);
       setAwaitingBot(true);
@@ -594,7 +619,9 @@ function useBotSend(deps: BotSendDeps) {
           botPlaceholder.id,
           () => setAwaitingBot(false),
           deps,
+          controller.signal,
         );
+        if (controller.signal.aborted) return;
         if (!outcome.completed) {
           // Stream closed early — either a provider error event arrived or
           // the socket dropped without a ``complete``. Either way we treat
@@ -608,9 +635,10 @@ function useBotSend(deps: BotSendDeps) {
           );
         }
       } catch (err) {
+        if (controller.signal.aborted) return;
         await handleStreamError(err, text, tag, optimisticUserId, botPlaceholder.id, deps);
       } finally {
-        setAwaitingBot(false);
+        if (!controller.signal.aborted) setAwaitingBot(false);
       }
     },
     [deps],

--- a/frontend/src/features/Journal/SearchBar.tsx
+++ b/frontend/src/features/Journal/SearchBar.tsx
@@ -88,6 +88,15 @@ const SearchBar = ({ onSearch, resultCount, searchQuery }: SearchBarProps): Reac
   const [text, setText] = useState(searchQuery ?? '');
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // BUG-FE-JOURNAL-105: keep local ``text`` in sync with the controlling
+  // ``searchQuery`` prop.  Without this, a parent that programmatically
+  // resets the query (e.g. clearing on tab change) leaves the input
+  // showing the stale text -- and a pending debounce would then re-fire
+  // ``onSearch(stale)`` and clobber the parent's reset.
+  useEffect(() => {
+    setText((current) => (current === (searchQuery ?? '') ? current : searchQuery ?? ''));
+  }, [searchQuery]);
+
   useEffect(() => {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);

--- a/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
@@ -250,6 +250,9 @@ describe('JournalScreen', () => {
 
     // Streaming is the default transport; the legacy ``chat()`` is reserved
     // for the StreamingUnsupportedError fallback which this test doesn't hit.
+    // BUG-FE-JOURNAL-001 added an AbortController so the third arg now
+    // carries ``{ signal }`` -- assertion accepts the additional arg
+    // without pinning its exact shape (AbortSignals don't equality-match).
     expect(mockBotmasonChatStream).toHaveBeenCalledWith(
       { message: 'New message' },
       expect.objectContaining({
@@ -257,6 +260,7 @@ describe('JournalScreen', () => {
         onComplete: expect.any(Function),
         onStreamError: expect.any(Function),
       }),
+      expect.objectContaining({ signal: expect.anything() }),
     );
     expect(mockBotmasonChat).not.toHaveBeenCalled();
   });

--- a/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
+++ b/prompts/2026-04-18-bug-remediation/remediation-plan/00-INDEX.md
@@ -40,7 +40,8 @@ Either way, treat the `main` copy of this table as truth. A branch-local tick is
 | 12 | backend-feature-routers (12B wave 1) | 4 | `claude/bug-fix-remediation-p3HUm` | [x] |
 | 12 | backend-feature-routers (12B wave 2) | 4 | | [ ] |
 | 13 | frontend-api-client               | 4 | `claude/bug-fix-13-frontend-api-client` | [x] |
-| 14 | frontend-feature-screens          | 4 | | [ ] |
+| 14 | frontend-feature-screens (14A: Habits + Journal) | 4 | `claude/bug-fix-14a-frontend-habits-journal` | [x] |
+| 14 | frontend-feature-screens (14B: Practice + Course + Map) | 4 | | [ ] |
 | 15 | frontend-design-state-tests       | 4 | `claude/bug-fix-15-frontend-design-state-tests` | [x] |
 
 ## Wave ordering and parallelism


### PR DESCRIPTION
Closes 12 BUG-FE-* items from prompt 14A (Habits + Journal sub-prompt of report 16). Self-contained frontend work; 14B (Practice/Course/Map) deferred to a separate PR.

## Commits

1. **`411fda5`** — modal coordinator preserves prior flags; per-habit notification reschedule mutex with id-write-back; OnboardingModal hardening (state reset on finish, in-flight templates request guarded, monotonic IDs + dedupe + length cap + control-char strip on `handleAddHabit`). **BUG-FE-HABIT-005 / -008 / -101 / -103 / -105**.
2. **`6c28a9d`** — `parseEnergyValue` rejects non-integers (no more silent NaN→0); MissedDaysModal calendar pick now requires explicit confirm before wiping completions; ReorderHabitsModal seeds drag buffer only on the false→true visibility transition (extracted into `useReorderState` hook). **BUG-FE-HABIT-201 / -202 / -204**.
3. **`36f7421`** — Journal `useBotSend` runs each stream under a per-mount `AbortController`, aborted on unmount or by a fresh send; `runChatStream` short-circuits chunk/complete callbacks when the signal is aborted; `ChatInput` enforces the backend's `JOURNAL_MESSAGE_MAX_LENGTH=10_000` server-side cap as `maxLength`; `SearchBar` re-syncs local text from `searchQuery` prop changes so a parent reset doesn't get clobbered by a pending debounce. **BUG-FE-JOURNAL-001 / -101 / -105** (BUG-FE-JOURNAL-102 already gated by `disabled` on the Send button).
4. **`95cbc9b`** — INDEX: split prompt 14 into 14A (this PR, done) and 14B (deferred).

## Test plan

- 897 frontend Jest tests pass; pre-push gate green.
- New regressions:
  - `useModalCoordinator`: BUG-FE-HABIT-008 — `open()` preserves prior flags.
  - `OnboardingModal.step1`: BUG-FE-HABIT-105 — case-insensitive duplicate name rejected with inline error.
- Updated existing `JournalScreen` test to accept the new `{ signal }` arg passed to `chatStream`.

## Deferred / out-of-scope

- **14B** (Practice + Course + Map): separate sub-prompt, separate branch.
- **BUG-FE-HABIT-102/-104/-106 (Medium)**: count-warning double-modal, reveal-effect stale deps, focus management. Tracked for a polish PR.
- **BUG-FE-JOURNAL-102 (double-submit)**: already prevented today by `ChatInput.canSend` gating on the parent's `disabled={j.sending}` flag — no code change needed; verified via existing tests.
- **BUG-FE-JOURNAL-002**: orphaned optimistic message on stream failure — needs a pending/retry-list refactor; tracked separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_011JvxjW4m5jw6u77eKrrYjz)_