### PR TITLE
fix(habits): reset progress bar at local midnight, not all-time

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -11,6 +11,7 @@ import {
 
 import { STAGE_COLORS, spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
+import { DEFAULT_TIMEZONE } from '../../utils/dateUtils';
 
 import type { HabitTileProps, Goal, Habit } from './Habits.types';
 import {
@@ -21,7 +22,7 @@ import {
   getProgressBarColor,
   getTierColor,
   isEarlyUnlocked,
-  calculateHabitProgress,
+  calculateTodaysProgress,
 } from './HabitUtils';
 
 type TierType = 'low' | 'clear' | 'stretch';
@@ -43,9 +44,9 @@ const computeTranslateX = (pct: number): number => {
   return pct === 100 ? -12 : -6;
 };
 
-const formatGoalTooltip = (goal: Goal, habit: Habit): string => {
+const formatGoalTooltip = (goal: Goal, habit: Habit, tz: string): string => {
   const label = TIER_LABELS[goal.tier];
-  const progress = calculateHabitProgress(habit);
+  const progress = calculateTodaysProgress(habit, tz);
   return `${label}: ${progress}/${goal.target} ${goal.target_unit}`;
 };
 
@@ -54,9 +55,10 @@ interface GoalTooltipProps {
   habit: Habit;
   tier: TierType;
   scale: number;
+  tz: string;
 }
 
-const GoalTooltipContent = ({ goal, habit, tier, scale }: GoalTooltipProps) => (
+const GoalTooltipContent = ({ goal, habit, tier, scale, tz }: GoalTooltipProps) => (
   <View
     testID={`tooltip-${tier}`}
     style={{
@@ -79,7 +81,7 @@ const GoalTooltipContent = ({ goal, habit, tier, scale }: GoalTooltipProps) => (
         letterSpacing: 0.5,
       }}
     >
-      {formatGoalTooltip(goal, habit)}
+      {formatGoalTooltip(goal, habit, tz)}
     </Text>
   </View>
 );
@@ -94,6 +96,7 @@ interface GoalMarkerProps {
   scale: number;
   tooltip: TierType | null;
   setTooltip: (_v: TierType | null) => void;
+  tz: string;
 }
 
 const GoalMarker = ({
@@ -106,6 +109,7 @@ const GoalMarker = ({
   scale,
   tooltip,
   setTooltip,
+  tz,
 }: GoalMarkerProps) => {
   const clamped = clampPercentage(markerPosition);
   return (
@@ -120,7 +124,7 @@ const GoalMarker = ({
       }}
     >
       {tooltip === tier && (
-        <GoalTooltipContent goal={goal} habit={habit} tier={tier} scale={scale} />
+        <GoalTooltipContent goal={goal} habit={habit} tier={tier} scale={scale} tz={tz} />
       )}
       <TouchableOpacity
         testID={`marker-${tier}`}
@@ -292,6 +296,7 @@ interface ProgressBarProps {
   scale: number;
   tooltip: TierType | null;
   setTooltip: (_v: TierType | null) => void;
+  tz: string;
 }
 
 interface MarkerListProps {
@@ -301,9 +306,18 @@ interface MarkerListProps {
   scale: number;
   tooltip: TierType | null;
   setTooltip: (_v: TierType | null) => void;
+  tz: string;
 }
 
-const MarkerList = ({ markers, habit, barHeight, scale, tooltip, setTooltip }: MarkerListProps) => (
+const MarkerList = ({
+  markers,
+  habit,
+  barHeight,
+  scale,
+  tooltip,
+  setTooltip,
+  tz,
+}: MarkerListProps) => (
   <>
     {markers
       .filter((m) => m.visible)
@@ -319,6 +333,7 @@ const MarkerList = ({ markers, habit, barHeight, scale, tooltip, setTooltip }: M
           scale={scale}
           tooltip={tooltip}
           setTooltip={setTooltip}
+          tz={tz}
         />
       ))}
   </>
@@ -405,6 +420,7 @@ const ProgressBar = ({
   scale,
   tooltip,
   setTooltip,
+  tz,
 }: ProgressBarProps) => {
   const { fadeAnim, prevColor } = useColorTransition(progressBarColor);
   const widthStyle: DimensionValue = `${progressPercentage}%`;
@@ -436,6 +452,7 @@ const ProgressBar = ({
           scale={scale}
           tooltip={tooltip}
           setTooltip={setTooltip}
+          tz={tz}
         />
       </View>
       <View style={{ position: 'relative', marginTop: spacing(0.5, scale) }}>
@@ -445,14 +462,14 @@ const ProgressBar = ({
   );
 };
 
-const useHabitTileData = (habit: Habit) => {
+const useHabitTileData = (habit: Habit, tz: string) => {
   const lowGoal = habit.goals.find((g) => g.tier === 'low');
   const clearGoal = habit.goals.find((g) => g.tier === 'clear');
   const stretchGoal = habit.goals.find((g) => g.tier === 'stretch');
 
-  const { currentGoal, completedAllGoals } = getGoalTier(habit);
-  const progressPercentage = clampPercentage(getProgressPercentage(habit, currentGoal));
-  const progressBarColor = getProgressBarColor(habit);
+  const { currentGoal, completedAllGoals } = getGoalTier(habit, tz);
+  const progressPercentage = clampPercentage(getProgressPercentage(habit, currentGoal, tz));
+  const progressBarColor = getProgressBarColor(habit, tz);
   const hasCompletedGoal = completedAllGoals || progressPercentage >= 100;
 
   const {
@@ -592,14 +609,35 @@ interface UnlockedTileProps {
   onOpenGoals?: () => void;
   onLongPress?: () => void;
   onIconPress?: () => void;
+  tz: string;
 }
 
-const UnlockedTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: UnlockedTileProps) => {
+const buildUnlockedTileStyle = (
+  stageColor: string,
+  earlyUnlocked: boolean,
+  scale: number,
+  gridGutter: number,
+  tileMinHeight: number,
+) => ({
+  flex: 1 as const,
+  borderWidth: 1,
+  borderColor: stageColor,
+  borderStyle: (earlyUnlocked ? 'dashed' : undefined) as 'dashed' | undefined,
+  padding: spacing(1, scale),
+  margin: gridGutter / 2,
+  minHeight: tileMinHeight,
+  borderRadius: spacing(1, scale),
+  backgroundColor: '#f8f8f8',
+});
+
+const UnlockedTile = ({ habit, onOpenGoals, onLongPress, onIconPress, tz }: UnlockedTileProps) => {
   const { scale, gridGutter, tileMinHeight, iconInline } = useTileLayout();
   const stageColor = STAGE_COLORS[habit.stage] ?? '#000';
   const [tooltip, setTooltip] = useState<TierType | null>(null);
-  const { progressPercentage, progressBarColor, hasCompletedGoal, markers } =
-    useHabitTileData(habit);
+  const { progressPercentage, progressBarColor, hasCompletedGoal, markers } = useHabitTileData(
+    habit,
+    tz,
+  );
 
   const streakText =
     `${habit.streak} days${hasCompletedGoal ? ' — Achieved Today!' : ''}`.toUpperCase();
@@ -609,17 +647,7 @@ const UnlockedTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: Unlocked
   return (
     <TouchableOpacity
       testID="habit-tile"
-      style={{
-        flex: 1,
-        borderWidth: 1,
-        borderColor: stageColor,
-        borderStyle: earlyUnlocked ? 'dashed' : undefined,
-        padding: spacing(1, scale),
-        margin: gridGutter / 2,
-        minHeight: tileMinHeight,
-        borderRadius: spacing(1, scale),
-        backgroundColor: '#f8f8f8',
-      }}
+      style={buildUnlockedTileStyle(stageColor, earlyUnlocked, scale, gridGutter, tileMinHeight)}
       onPress={onOpenGoals}
       onLongPress={onLongPress}
     >
@@ -641,6 +669,7 @@ const UnlockedTile = ({ habit, onOpenGoals, onLongPress, onIconPress }: Unlocked
         scale={scale}
         tooltip={tooltip}
         setTooltip={setTooltip}
+        tz={tz}
       />
     </TouchableOpacity>
   );
@@ -653,6 +682,7 @@ export const HabitTile = ({
   onLongPress,
   onIconPress,
   onUnlockHabit,
+  tz = DEFAULT_TIMEZONE,
 }: HabitTileProps) => {
   const { scale, gridGutter, tileMinHeight } = useTileLayout();
   const stageColor = STAGE_COLORS[habit.stage] ?? '#000';
@@ -676,6 +706,7 @@ export const HabitTile = ({
       onOpenGoals={onOpenGoals}
       onLongPress={onLongPress}
       onIconPress={onIconPress}
+      tz={tz}
     />
   );
 };

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -2,7 +2,12 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { ApiHabitStats } from '../../api';
 import { colors, STAGE_COLORS, STAGE_ORDER, VICTORY_COLOR } from '../../design/tokens';
-import { DEFAULT_TIMEZONE, dayKeyInTZ, streakFromCompletions } from '../../utils/dateUtils';
+import {
+  DEFAULT_TIMEZONE,
+  dayKeyInTZ,
+  streakFromCompletions,
+  todayInUserTZ,
+} from '../../utils/dateUtils';
 
 import type { Goal, Habit, Completion, HabitStatsData } from './Habits.types';
 
@@ -58,10 +63,14 @@ export const getTierColor = (tier: 'low' | 'clear' | 'stretch') => {
 
 export const clampPercentage = (value: number): number => Math.min(100, Math.max(0, value));
 
-export const isGoalAchieved = (goal: Goal, habit: Habit): boolean => {
-  const totalProgress = calculateHabitProgress(habit);
+export const isGoalAchieved = (
+  goal: Goal,
+  habit: Habit,
+  tz: string = DEFAULT_TIMEZONE,
+): boolean => {
+  const todayProgress = calculateTodaysProgress(habit, tz);
   const targetValue = getGoalTarget(goal);
-  return goal.is_additive ? totalProgress >= targetValue : totalProgress <= targetValue;
+  return goal.is_additive ? todayProgress >= targetValue : todayProgress <= targetValue;
 };
 
 /** LG/CG/SG on a unified 0-100 bar; missing-tier collapses to {0,0,0} as a failure signal. */
@@ -147,12 +156,43 @@ export const getGoalTarget = (goal: Goal): number => {
   return goal.target;
 };
 
-/** All-time accumulator (NOT today-only) -- a date filter regresses BUG-FE-HABIT-301. See #294. */
+/**
+ * All-time accumulator over the persisted completions array.
+ *
+ * Kept separate from `calculateTodaysProgress` (BUG-FE-HABIT-301 / #294) so
+ * streak / stats / lifetime-total call sites still see every check-in. The
+ * progress-bar and "Achieved Today" display path must use the today-only
+ * helper so yesterday's completions don't keep today's tile lit up.
+ */
 export const calculateHabitProgress = (habit: Habit): number => {
   if (!habit.completions || habit.completions.length === 0) {
     return 0;
   }
   return habit.completions.reduce((sum, c) => sum + c.completed_units, 0);
+};
+
+/**
+ * Sum of completion units logged on the user's *current* calendar day.
+ *
+ * Drives the progress bar fill, tier resolution, victory color, and the
+ * "Achieved Today!" banner so they reset at local midnight even though the
+ * persisted `completions` array retains the full history. `tz` defaults to
+ * UTC for legacy callers; screens reading from `useAuth()` should pass the
+ * authenticated user's IANA zone so the day boundary matches what the user
+ * sees on their wall clock.
+ */
+export const calculateTodaysProgress = (habit: Habit, tz: string = DEFAULT_TIMEZONE): number => {
+  if (!habit.completions || habit.completions.length === 0) {
+    return 0;
+  }
+  const todayKey = todayInUserTZ(tz);
+  let total = 0;
+  for (const c of habit.completions) {
+    if (dayKeyInTZ(c.timestamp, tz) === todayKey) {
+      total += c.completed_units;
+    }
+  }
+  return total;
 };
 
 interface GoalTierResult {
@@ -207,7 +247,7 @@ const resolveSubtractiveTier = (
 
 const TIER_ORDER = { low: 1, clear: 2, stretch: 3 } as const;
 
-export const getGoalTier = (habit: Habit): GoalTierResult => {
+export const getGoalTier = (habit: Habit, tz: string = DEFAULT_TIMEZONE): GoalTierResult => {
   const sortedGoals = [...habit.goals].sort((a, b) => TIER_ORDER[a.tier] - TIER_ORDER[b.tier]);
 
   const lowGoal = sortedGoals[0];
@@ -218,44 +258,48 @@ export const getGoalTier = (habit: Habit): GoalTierResult => {
     return { currentGoal: habit.goals[0]!, nextGoal: null, completedAllGoals: false };
   }
 
-  const totalProgress = calculateHabitProgress(habit);
+  const todayProgress = calculateTodaysProgress(habit, tz);
   return lowGoal.is_additive
-    ? resolveAdditiveTier(totalProgress, lowGoal, clearGoal, stretchGoal)
-    : resolveSubtractiveTier(totalProgress, lowGoal, clearGoal, stretchGoal);
+    ? resolveAdditiveTier(todayProgress, lowGoal, clearGoal, stretchGoal)
+    : resolveSubtractiveTier(todayProgress, lowGoal, clearGoal, stretchGoal);
 };
 
 /** Progress on the unified 0-100 scale shared with :func:`getMarkerPositions`. */
-export const getProgressPercentage = (habit: Habit, currentGoal: Goal): number => {
-  const totalProgress = calculateHabitProgress(habit);
+export const getProgressPercentage = (
+  habit: Habit,
+  currentGoal: Goal,
+  tz: string = DEFAULT_TIMEZONE,
+): number => {
+  const todayProgress = calculateTodaysProgress(habit, tz);
   const stretchGoal = habit.goals.find((g) => g.tier === 'stretch') ?? currentGoal;
   const stretchTarget = getGoalTarget(stretchGoal);
 
   if (currentGoal.is_additive) {
     if (stretchTarget <= 0) return 100;
-    return clampPercentage((totalProgress / stretchTarget) * 100);
+    return clampPercentage((todayProgress / stretchTarget) * 100);
   }
 
   const lowGoal = habit.goals.find((g) => g.tier === 'low') ?? currentGoal;
   const range = getGoalTarget(lowGoal) - stretchTarget;
-  if (range <= 0) return totalProgress <= stretchTarget ? 100 : 0;
-  return clampPercentage(100 - ((totalProgress - stretchTarget) / range) * 100);
+  if (range <= 0) return todayProgress <= stretchTarget ? 100 : 0;
+  return clampPercentage(100 - ((todayProgress - stretchTarget) / range) * 100);
 };
 
-export const getProgressBarColor = (habit: Habit): string => {
+export const getProgressBarColor = (habit: Habit, tz: string = DEFAULT_TIMEZONE): string => {
   const stageColor = STAGE_COLORS[habit.stage] ?? '#000';
   const clearGoal = habit.goals.find((g) => g.tier === 'clear');
 
   if (!clearGoal) return stageColor;
 
-  const progress = calculateHabitProgress(habit);
+  const todayProgress = calculateTodaysProgress(habit, tz);
 
   if (clearGoal.is_additive) {
-    return progress >= getGoalTarget(clearGoal) ? VICTORY_COLOR : stageColor;
+    return todayProgress >= getGoalTarget(clearGoal) ? VICTORY_COLOR : stageColor;
   }
 
   // Subtractive: victory when staying at or under stretch target
   const stretchGoal = habit.goals.find((g) => g.tier === 'stretch');
-  if (stretchGoal && progress <= getGoalTarget(stretchGoal)) {
+  if (stretchGoal && todayProgress <= getGoalTarget(stretchGoal)) {
     return VICTORY_COLOR;
   }
 

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -156,14 +156,7 @@ export const getGoalTarget = (goal: Goal): number => {
   return goal.target;
 };
 
-/**
- * All-time accumulator over the persisted completions array.
- *
- * Kept separate from `calculateTodaysProgress` (BUG-FE-HABIT-301 / #294) so
- * streak / stats / lifetime-total call sites still see every check-in. The
- * progress-bar and "Achieved Today" display path must use the today-only
- * helper so yesterday's completions don't keep today's tile lit up.
- */
+/** All-time sum across all completions (BUG-FE-HABIT-301); display paths use `calculateTodaysProgress`. */
 export const calculateHabitProgress = (habit: Habit): number => {
   if (!habit.completions || habit.completions.length === 0) {
     return 0;
@@ -171,16 +164,7 @@ export const calculateHabitProgress = (habit: Habit): number => {
   return habit.completions.reduce((sum, c) => sum + c.completed_units, 0);
 };
 
-/**
- * Sum of completion units logged on the user's *current* calendar day.
- *
- * Drives the progress bar fill, tier resolution, victory color, and the
- * "Achieved Today!" banner so they reset at local midnight even though the
- * persisted `completions` array retains the full history. `tz` defaults to
- * UTC for legacy callers; screens reading from `useAuth()` should pass the
- * authenticated user's IANA zone so the day boundary matches what the user
- * sees on their wall clock.
- */
+/** Sum of completion units bucketed into the user's `tz` calendar day (drives the progress bar reset). */
 export const calculateTodaysProgress = (habit: Habit, tz: string = DEFAULT_TIMEZONE): number => {
   if (!habit.completions || habit.completions.length === 0) {
     return 0;

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -126,6 +126,12 @@ export interface HabitTileProps {
   onLongPress?: () => void;
   onIconPress?: () => void;
   onUnlockHabit?: (_habitId: number) => void;
+  /**
+   * IANA timezone used to bucket completions into the user's calendar day
+   * for the progress bar / "Achieved Today" display. Defaults to UTC when
+   * absent so legacy tests render without an auth context.
+   */
+  tz?: string;
 }
 
 export interface HabitSettingsModalProps {

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -331,6 +331,7 @@ const useHabitTileRenderer = (
   modals: ReturnType<typeof useModalCoordinator>,
   actions: ReturnType<typeof useHabits>['actions'],
   setSelectedHabit: (_h: Habit) => void,
+  tz: string,
 ) => {
   const renderHabitTile = ({ item, index }: { item: Habit; index: number }) => {
     const isLocked = item.revealed === false;
@@ -363,6 +364,7 @@ const useHabitTileRenderer = (
               }
         }
         onUnlockHabit={actions.unlockHabit}
+        tz={tz}
       />
     );
   };
@@ -468,12 +470,14 @@ const useHabitsScreenState = () => {
   const modals = useModalCoordinator();
   const habitStats = useHabitStats(modals.stats, habitsReturn.selectedHabit);
   const responsive = useResponsive();
+  const { userTimezone } = useAuth();
   const handleSelectMode = useSelectMode(habitsReturn.setMode, modals.closeAll);
   const renderHabitTile = useHabitTileRenderer(
     habitsReturn.mode,
     modals,
     habitsReturn.actions,
     habitsReturn.setSelectedHabit,
+    userTimezone,
   );
   const reveal = useToggleReveal(habitsReturn.habits, habitsReturn.actions, modals.closeAll);
   return {

--- a/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
@@ -9,6 +9,9 @@ import type { Habit, Goal } from '../Habits.types';
 import { logHabitUnits } from '../HabitUtils';
 
 jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
 
 const sampleGoals: Goal[] = [
   {

--- a/frontend/src/features/Habits/__tests__/HabitTileTooltip.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileTooltip.test.tsx
@@ -104,3 +104,58 @@ describe('HabitTile markers', () => {
     expect(component.root.findByProps({ testID: 'marker-stretch' })).toBeTruthy();
   });
 });
+
+// User-visible symptom of the daily-reset bug: the streak chip read
+// "...— Achieved Today!" the morning after a stretch-goal was met,
+// before the user logged anything new. The fix is anchored at the
+// progress-utility layer, so render-test the chip text to keep the
+// regression nailed at the UI boundary too.
+describe('HabitTile achieved-today banner does not leak across days', () => {
+  const yesterday = (): Date => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - 1);
+    d.setUTCHours(12, 0, 0, 0);
+    return d;
+  };
+
+  const findChipText = (component: ReturnType<typeof renderer.create>): string => {
+    const header = component.root.findByProps({ testID: 'habit-header' });
+    // The chip is the second Text child of the header row.
+    const texts = header.findAllByType('Text' as unknown as React.ComponentType);
+    return texts
+      .map((t: { props: { children: unknown } }) => {
+        const children = t.props.children;
+        return Array.isArray(children) ? children.join('') : String(children);
+      })
+      .join('|');
+  };
+
+  it("does not show 'Achieved Today!' when only yesterday hit the stretch goal", () => {
+    const stretchedYesterday: Habit = {
+      ...habit,
+      streak: 7,
+      // 60 oz logged yesterday is well past the 30 oz stretch target.
+      completions: [{ id: 'y-1', timestamp: yesterday(), completed_units: 60 }],
+    };
+    const component = renderer.create(
+      <HabitTile habit={stretchedYesterday} onOpenGoals={() => {}} tz="UTC" />,
+    );
+    // The chip is rendered upper-cased; match insensitively.
+    expect(findChipText(component).toLowerCase()).not.toContain('achieved today');
+  });
+
+  it("shows 'Achieved Today!' when today's logs hit the stretch goal", () => {
+    const stretchedToday: Habit = {
+      ...habit,
+      streak: 8,
+      completions: [
+        { id: 'y-1', timestamp: yesterday(), completed_units: 60 },
+        { id: 't-1', timestamp: new Date(), completed_units: 30 },
+      ],
+    };
+    const component = renderer.create(
+      <HabitTile habit={stretchedToday} onOpenGoals={() => {}} tz="UTC" />,
+    );
+    expect(findChipText(component).toLowerCase()).toContain('achieved today');
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -2,12 +2,15 @@
 /* global describe, test, expect */
 import { validate as uuidValidate } from 'uuid';
 
+import { VICTORY_COLOR } from '../../../design/tokens';
 import type { Habit, Goal } from '../Habits.types';
 import {
   getProgressPercentage,
   getMarkerPositions,
   getGoalTier,
   calculateHabitProgress,
+  calculateTodaysProgress,
+  getProgressBarColor,
   logHabitUnits,
   calculateHabitStartDate,
   STAGE_DURATIONS_DAYS,
@@ -354,5 +357,113 @@ describe('HabitUtils', () => {
     expect(ids[0]).not.toBe(ids[1]);
     expect(uuidValidate(ids[0]!)).toBe(true);
     expect(uuidValidate(ids[1]!)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Daily reset: yesterday's completions must NOT keep today's progress bar
+  // full or the "Achieved Today" banner lit. See git branch
+  // claude/fix-habit-daily-reset-hn8v3.
+  // -------------------------------------------------------------------------
+  describe('daily reset of progress display', () => {
+    const additiveGoals: Goal[] = [
+      {
+        id: 1,
+        tier: 'low',
+        title: 'low',
+        target: 1,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 2,
+        tier: 'clear',
+        title: 'clear',
+        target: 2,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 3,
+        tier: 'stretch',
+        title: 'stretch',
+        target: 3,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+    ];
+
+    const yesterdayUtc = (): Date => {
+      const d = new Date();
+      d.setUTCDate(d.getUTCDate() - 1);
+      // Anchor at noon UTC so any reasonable user TZ still sees this as
+      // "yesterday" rather than today's local hours.
+      d.setUTCHours(12, 0, 0, 0);
+      return d;
+    };
+
+    test('calculateTodaysProgress ignores completions logged on a previous day', () => {
+      const habit: Habit = {
+        ...baseHabit,
+        goals: additiveGoals,
+        completions: [{ id: 'y-1', timestamp: yesterdayUtc(), completed_units: 5 }],
+      };
+      expect(calculateTodaysProgress(habit, 'UTC')).toBe(0);
+      // The all-time accumulator still sees yesterday's log -- streaks /
+      // stats rely on it. Pinned to keep the two helpers distinct.
+      expect(calculateHabitProgress(habit)).toBe(5);
+    });
+
+    test('getGoalTier reports incomplete when only yesterday hit the stretch goal', () => {
+      const habit: Habit = {
+        ...baseHabit,
+        goals: additiveGoals,
+        completions: [{ id: 'y-1', timestamp: yesterdayUtc(), completed_units: 5 }],
+      };
+      const { currentGoal, completedAllGoals } = getGoalTier(habit, 'UTC');
+      expect(currentGoal.tier).toBe('low');
+      expect(completedAllGoals).toBe(false);
+    });
+
+    test('getProgressPercentage resets to 0 on the new day for additive habits', () => {
+      const habit: Habit = {
+        ...baseHabit,
+        goals: additiveGoals,
+        completions: [{ id: 'y-1', timestamp: yesterdayUtc(), completed_units: 5 }],
+      };
+      const { currentGoal } = getGoalTier(habit, 'UTC');
+      expect(getProgressPercentage(habit, currentGoal, 'UTC')).toBe(0);
+    });
+
+    test('getProgressBarColor drops victory color the day after the goal was met', () => {
+      const habit: Habit = {
+        ...baseHabit,
+        stage: 'Beige',
+        goals: additiveGoals,
+        completions: [{ id: 'y-1', timestamp: yesterdayUtc(), completed_units: 5 }],
+      };
+      expect(getProgressBarColor(habit, 'UTC')).not.toBe(VICTORY_COLOR);
+    });
+
+    test('today-only progress combined with all-time history advances the tier on todays log', () => {
+      const habit: Habit = {
+        ...baseHabit,
+        goals: additiveGoals,
+        completions: [
+          { id: 'y-1', timestamp: yesterdayUtc(), completed_units: 5 },
+          { id: 't-1', timestamp: new Date(), completed_units: 1 },
+        ],
+      };
+      // Today contributed 1 unit -- meets the low goal target (1) but not clear (2).
+      expect(calculateTodaysProgress(habit, 'UTC')).toBe(1);
+      const { currentGoal, completedAllGoals } = getGoalTier(habit, 'UTC');
+      expect(currentGoal.tier).toBe('low');
+      expect(completedAllGoals).toBe(false);
+    });
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -11,6 +11,7 @@ import {
   calculateHabitProgress,
   calculateTodaysProgress,
   getProgressBarColor,
+  isGoalAchieved,
   logHabitUnits,
   calculateHabitStartDate,
   STAGE_DURATIONS_DAYS,
@@ -461,6 +462,131 @@ describe('HabitUtils', () => {
       };
       // Today contributed 1 unit -- meets the low goal target (1) but not clear (2).
       expect(calculateTodaysProgress(habit, 'UTC')).toBe(1);
+      const { currentGoal, completedAllGoals } = getGoalTier(habit, 'UTC');
+      expect(currentGoal.tier).toBe('low');
+      expect(completedAllGoals).toBe(false);
+    });
+
+    test("calculateTodaysProgress sums today's logs across multiple check-ins", () => {
+      const habit: Habit = {
+        ...baseHabit,
+        goals: additiveGoals,
+        completions: [
+          { id: 'y-1', timestamp: yesterdayUtc(), completed_units: 99 },
+          { id: 't-1', timestamp: new Date(), completed_units: 1.5 },
+          { id: 't-2', timestamp: new Date(), completed_units: 0.5 },
+        ],
+      };
+      // Two of-today logs sum to 2.0; yesterday's 99 is excluded.
+      expect(calculateTodaysProgress(habit, 'UTC')).toBe(2);
+    });
+
+    // -----------------------------------------------------------------------
+    // Subtractive habits ("drink less than X / day"): yesterday's drinks must
+    // not count against today's "stayed under stretch" status either.
+    // -----------------------------------------------------------------------
+    const subtractiveGoals: Goal[] = [
+      {
+        id: 1,
+        tier: 'low',
+        title: 'low',
+        target: 10,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 2,
+        tier: 'clear',
+        title: 'clear',
+        target: 5,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 3,
+        tier: 'stretch',
+        title: 'stretch',
+        target: 2,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+    ];
+
+    test('subtractive habit re-enters victory state at local midnight', () => {
+      const habit: Habit = {
+        ...baseHabit,
+        stage: 'Blue',
+        goals: subtractiveGoals,
+        // Yesterday the user blew past the low goal; today they have nothing
+        // logged yet so they should be back at "under stretch" (full bar).
+        completions: [{ id: 'y-1', timestamp: yesterdayUtc(), completed_units: 20 }],
+      };
+      const { currentGoal, completedAllGoals } = getGoalTier(habit, 'UTC');
+      expect(currentGoal.tier).toBe('stretch');
+      expect(completedAllGoals).toBe(true);
+      expect(getProgressPercentage(habit, currentGoal, 'UTC')).toBe(100);
+      expect(getProgressBarColor(habit, 'UTC')).toBe(VICTORY_COLOR);
+    });
+
+    test('subtractive habit drops out of victory once today crosses stretch', () => {
+      const habit: Habit = {
+        ...baseHabit,
+        stage: 'Blue',
+        goals: subtractiveGoals,
+        completions: [
+          { id: 'y-1', timestamp: yesterdayUtc(), completed_units: 20 },
+          { id: 't-1', timestamp: new Date(), completed_units: 3 },
+        ],
+      };
+      const { completedAllGoals } = getGoalTier(habit, 'UTC');
+      // Today's 3 units are above stretch (2) but below clear (5) -> still
+      // achieved-clear-not-stretch, so the "all goals" flag flips to false.
+      expect(completedAllGoals).toBe(false);
+    });
+
+    // -----------------------------------------------------------------------
+    // Timezone handling: a completion logged 23:00 wall-clock in NY must be
+    // bucketed into NY's calendar day, not UTC's.
+    // -----------------------------------------------------------------------
+    test('calculateTodaysProgress buckets by the supplied IANA timezone', () => {
+      // 04:00 UTC on a given day == midnight previous day in America/Anchorage
+      // (UTC-9 in winter, UTC-8 in summer -- both flip the calendar date).
+      const earlyUtc = new Date();
+      earlyUtc.setUTCHours(4, 0, 0, 0);
+      const habit: Habit = {
+        ...baseHabit,
+        goals: additiveGoals,
+        completions: [{ id: 'tz-1', timestamp: earlyUtc, completed_units: 2 }],
+      };
+      // In UTC: today.
+      expect(calculateTodaysProgress(habit, 'UTC')).toBe(2);
+      // In Anchorage: still yesterday.
+      expect(calculateTodaysProgress(habit, 'America/Anchorage')).toBe(0);
+    });
+
+    test('isGoalAchieved tracks today, not all-time', () => {
+      const habit: Habit = {
+        ...baseHabit,
+        goals: additiveGoals,
+        completions: [{ id: 'y-1', timestamp: yesterdayUtc(), completed_units: 99 }],
+      };
+      const stretchGoal = additiveGoals.find((g) => g.tier === 'stretch')!;
+      expect(isGoalAchieved(stretchGoal, habit, 'UTC')).toBe(false);
+    });
+
+    test('habit with no completions reports zero today and no achievement', () => {
+      const habit: Habit = {
+        ...baseHabit,
+        goals: additiveGoals,
+        completions: [],
+      };
+      expect(calculateTodaysProgress(habit, 'UTC')).toBe(0);
       const { currentGoal, completedAllGoals } = getGoalTier(habit, 'UTC');
       expect(currentGoal.tier).toBe('low');
       expect(completedAllGoals).toBe(false);

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -360,11 +360,6 @@ describe('HabitUtils', () => {
     expect(uuidValidate(ids[1]!)).toBe(true);
   });
 
-  // -------------------------------------------------------------------------
-  // Daily reset: yesterday's completions must NOT keep today's progress bar
-  // full or the "Achieved Today" banner lit. See git branch
-  // claude/fix-habit-daily-reset-hn8v3.
-  // -------------------------------------------------------------------------
   describe('daily reset of progress display', () => {
     const additiveGoals: Goal[] = [
       {

--- a/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
@@ -79,6 +79,10 @@ jest.mock('expo-notifications', () => ({
   SchedulableTriggerInputTypes: { DAILY: 'daily', WEEKLY: 'weekly' },
 }));
 
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
 const makeGoal = (tier: 'low' | 'clear' | 'stretch', target: number): Goal => ({
   id: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
   title: tier,

--- a/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
@@ -62,6 +62,10 @@ jest.mock('react-native', () => ({
   Text: 'Text',
 }));
 
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
 // ---------------------------------------------------------------------------
 // Fixtures — simulate what OnboardingModal produces
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Habits/__tests__/useHabits.test.ts
+++ b/frontend/src/features/Habits/__tests__/useHabits.test.ts
@@ -53,6 +53,10 @@ jest.mock('react-native', () => ({
   Text: 'Text',
 }));
 
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
 const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
   id: 1,
   stage: 'Beige',

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -21,6 +21,7 @@ import type {
 import EmojiSelector from 'react-native-emoji-selector';
 
 import { goalGroups as goalGroupsApi, type ApiGoalGroup } from '../../../api';
+import { useAuth } from '../../../context/AuthContext';
 import { colors, SPACING, STAGE_COLORS } from '../../../design/tokens';
 import { TARGET_UNITS, FREQUENCY_UNITS } from '../constants';
 import styles from '../Habits.styles';
@@ -31,7 +32,7 @@ import {
   clampPercentage,
   getTierColor,
   getGoalTarget,
-  calculateHabitProgress,
+  calculateTodaysProgress,
 } from '../HabitUtils';
 
 const markerContainerStyle = (leftPct: number, z: number): ViewStyle => ({
@@ -941,9 +942,14 @@ const buildGoalMaps = (m: ReturnType<typeof useGoalMarkers>) => ({
 const buildProgressBarProps = (
   habit: NonNullable<GoalModalProps['habit']>,
   m: ReturnType<typeof useGoalMarkers>,
+  tz: string,
 ) => ({
-  progressPercentage: computeProgressPct(calculateHabitProgress(habit), m.lowGoal, m.stretchGoal),
-  progressBarColor: getProgressBarColor(habit),
+  progressPercentage: computeProgressPct(
+    calculateTodaysProgress(habit, tz),
+    m.lowGoal,
+    m.stretchGoal,
+  ),
+  progressBarColor: getProgressBarColor(habit, tz),
   lowGoal: m.lowGoal,
   clearGoal: m.clearGoal,
   stretchGoal: m.stretchGoal,
@@ -969,6 +975,7 @@ const GoalModalBody = ({
   const [showEmojiSelector, setShowEmojiSelector] = useState(false);
   const goalGroup = useGoalGroup(habit);
   const m = useGoalMarkers(habit, onUpdateGoal);
+  const { userTimezone } = useAuth();
 
   const handleLogUnit = () => {
     if (!habit.id) return;
@@ -986,7 +993,7 @@ const GoalModalBody = ({
         onClose={onClose}
         onUpdateHabit={onUpdateHabit}
       />
-      <GoalProgressBar {...buildProgressBarProps(habit, m)} />
+      <GoalProgressBar {...buildProgressBarProps(habit, m, userTimezone)} />
       <GoalTargetEditor habit={habit} onUpdateGoal={onUpdateGoal} />
       <LogUnitSection logAmount={logAmount} setLogAmount={setLogAmount} onLog={handleLogUnit} />
     </View>

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -234,3 +234,38 @@ describe('GoalModal editor visibility guards', () => {
     expect(queryByTestId('goal-target-editor')).toBeNull();
   });
 });
+
+describe('GoalModal progress bar daily reset', () => {
+  const yesterdayUtc = (): Date => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - 1);
+    d.setUTCHours(12, 0, 0, 0);
+    return d;
+  };
+
+  const getFillWidth = (
+    queryByTestId: (id: string) => { props: { style: { width: string } } } | null,
+  ): string => {
+    const fill = queryByTestId('modal-progress-fill');
+    return fill?.props.style.width ?? '';
+  };
+
+  it('renders the progress bar empty when only yesterday hit the stretch goal', () => {
+    const stretchedYesterday = makeHabit({
+      completions: [{ id: 'y-1', timestamp: yesterdayUtc(), completed_units: 9 }],
+    });
+    const { queryByTestId } = renderModal(stretchedYesterday);
+    expect(getFillWidth(queryByTestId as never)).toBe('0%');
+  });
+
+  it("fills the progress bar when today's completions hit the stretch goal", () => {
+    const stretchedToday = makeHabit({
+      completions: [
+        { id: 'y-1', timestamp: yesterdayUtc(), completed_units: 9 },
+        { id: 't-1', timestamp: new Date(), completed_units: 3 },
+      ],
+    });
+    const { queryByTestId } = renderModal(stretchedToday);
+    expect(getFillWidth(queryByTestId as never)).toBe('100%');
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -12,6 +12,10 @@ jest.mock('../../../../api', () => ({
   },
 }));
 
+jest.mock('../../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
 // Use real RN primitives — no global ``react-native`` mock — so
 // fireEvent.changeText / press behave as on a real device.
 

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
@@ -104,7 +104,7 @@ const renderActions = () => {
   const showToast = jest.fn();
   const { result } = renderHook(() => {
     const ui = useHabitUI();
-    const actions = useHabitActions(ui, showToast);
+    const actions = useHabitActions(ui, showToast, 'UTC');
     return { ui, actions };
   });
   return { result, showToast };

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -29,6 +29,7 @@ const SYNC_ERROR_TOAST_DURATION_MS = 6000;
  */
 const useLogUnitMutation = (
   showToast: ShowToast,
+  tz: string,
 ): ((_habitId: number, _amount: number) => void) => {
   const mutation = useOptimisticMutation<LogUnitContext, unknown>({
     apply: (ctx) => habitManager.applyLogUnitContext(ctx),
@@ -52,14 +53,14 @@ const useLogUnitMutation = (
 
   return useCallback(
     (habitId: number, amount: number) => {
-      const ctx = habitManager.prepareLogUnit(habitId, amount);
+      const ctx = habitManager.prepareLogUnit(habitId, amount, tz);
       if (!ctx) return;
       // Fire-and-forget: rollback runs inside the hook before the re-throw
       // and has already surfaced the failure to the user via ``showToast``,
       // so swallow the rejection here to keep UI handlers tidy.
       mutation.mutate(ctx).catch(() => {});
     },
-    [mutation],
+    [mutation, tz],
   );
 };
 
@@ -71,8 +72,9 @@ const useLogUnitMutation = (
 export const useHabitActions = (
   ui: ReturnType<typeof useHabitUI>,
   showToast: ShowToast,
+  tz: string,
 ): HabitsActions => {
-  const logUnit = useLogUnitMutation(showToast);
+  const logUnit = useLogUnitMutation(showToast, tz);
 
   const iconPress = useCallback((index: number) => ui.setEmojiHabitIndex(index), [ui]);
 

--- a/frontend/src/features/Habits/hooks/useHabits.ts
+++ b/frontend/src/features/Habits/hooks/useHabits.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { useToast } from '../../../components/ToastProvider';
+import { useAuth } from '../../../context/AuthContext';
 import { useHabitStore } from '../../../store/useHabitStore';
 import type { UseHabitsReturn } from '../Habits.types';
 import { habitManager } from '../services/habitManager';
@@ -32,9 +33,10 @@ export const useHabits = (): UseHabitsReturn => {
   const error = useHabitStore((s) => s.error);
   const storeSetHabits = useHabitStore((s) => s.setHabits);
   const { showToast } = useToast();
+  const { userTimezone } = useAuth();
   const ui = useHabitUI();
   useBootstrapHabits();
-  const actions = useHabitActions(ui, showToast);
+  const actions = useHabitActions(ui, showToast, userTimezone);
 
   return {
     habits,

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -473,7 +473,7 @@ describe('habitManager', () => {
     it('prepareLogUnit + applyLogUnitContext appends a completion and returns the updated habit', () => {
       useHabitStore.setState({ habits: [makeHabit()] });
 
-      const ctx = habitManager.prepareLogUnit(1, 1);
+      const ctx = habitManager.prepareLogUnit(1, 1, 'UTC');
       expect(ctx).not.toBeNull();
       habitManager.applyLogUnitContext(ctx!);
 
@@ -483,7 +483,7 @@ describe('habitManager', () => {
 
     it('commitLogUnitContext POSTs the goal completion to the API', async () => {
       useHabitStore.setState({ habits: [makeHabit()] });
-      const ctx = habitManager.prepareLogUnit(1, 1)!;
+      const ctx = habitManager.prepareLogUnit(1, 1, 'UTC')!;
       habitManager.applyLogUnitContext(ctx);
 
       await habitManager.commitLogUnitContext(ctx);
@@ -496,7 +496,7 @@ describe('habitManager', () => {
 
     it('buildLogUnitToast returns a milestone config when a tier is reached', () => {
       useHabitStore.setState({ habits: [makeHabit()] });
-      const ctx = habitManager.prepareLogUnit(1, 1)!;
+      const ctx = habitManager.prepareLogUnit(1, 1, 'UTC')!;
 
       const toast = habitManager.buildLogUnitToast(ctx);
 
@@ -517,7 +517,7 @@ describe('habitManager', () => {
           }),
         ],
       });
-      const ctx = habitManager.prepareLogUnit(1, 1)!;
+      const ctx = habitManager.prepareLogUnit(1, 1, 'UTC')!;
 
       const toast = habitManager.buildLogUnitToast(ctx);
 
@@ -530,7 +530,7 @@ describe('habitManager', () => {
       const prev = [habit];
       useHabitStore.setState({ habits: prev });
 
-      const ctx = habitManager.prepareLogUnit(1, 1)!;
+      const ctx = habitManager.prepareLogUnit(1, 1, 'UTC')!;
       habitManager.applyLogUnitContext(ctx);
       expect(useHabitStore.getState().habits[0]!.completions).toHaveLength(1);
 
@@ -548,9 +548,47 @@ describe('habitManager', () => {
     it('prepareLogUnit returns null when no habit matches the id', () => {
       useHabitStore.setState({ habits: [makeHabit({ id: 1 })] });
 
-      const ctx = habitManager.prepareLogUnit(999, 1);
+      const ctx = habitManager.prepareLogUnit(999, 1, 'UTC');
 
       expect(ctx).toBeNull();
+    });
+
+    // Regression: when the tz arg was hardcoded UTC, milestone toasts could
+    // re-fire (or fire on the wrong baseline) when the user's local day
+    // boundary disagreed with UTC's. Pinning the bucketing in two zones with
+    // an inverted boundary proves the tz parameter actually reaches the
+    // calc, not just the function signature.
+    it('prepareLogUnit buckets oldProgress in the supplied IANA zone', () => {
+      // 04:00 UTC is "today" in UTC but "yesterday" in America/Anchorage
+      // (UTC-9 in winter, UTC-8 in summer; both flip the calendar date).
+      const earlyUtc = new Date();
+      earlyUtc.setUTCHours(4, 0, 0, 0);
+
+      useHabitStore.setState({
+        habits: [
+          makeHabit({
+            completions: [{ id: 'pre', timestamp: earlyUtc, completed_units: 1 }],
+          }),
+        ],
+      });
+
+      const utcCtx = habitManager.prepareLogUnit(1, 1, 'UTC')!;
+      // In UTC, the prior completion is in today's bucket -> oldProgress = 1.
+      expect(utcCtx.oldProgress).toBe(1);
+
+      // Reset the store so the second prepareLogUnit sees the same baseline.
+      useHabitStore.setState({
+        habits: [
+          makeHabit({
+            completions: [{ id: 'pre', timestamp: earlyUtc, completed_units: 1 }],
+          }),
+        ],
+      });
+
+      const anchorageCtx = habitManager.prepareLogUnit(1, 1, 'America/Anchorage')!;
+      // In Anchorage, the prior completion landed in yesterday's bucket ->
+      // oldProgress = 0, so milestone detection treats this as a fresh start.
+      expect(anchorageCtx.oldProgress).toBe(0);
     });
   });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -30,7 +30,7 @@ import {
 import { useHabitStore } from '../../../store/useHabitStore';
 import { HABIT_DEFAULTS } from '../HabitDefaults';
 import type { Goal, Habit, OnboardingHabit } from '../Habits.types';
-import { getGoalTier, getGoalTarget, calculateHabitProgress, logHabitUnits } from '../HabitUtils';
+import { getGoalTier, getGoalTarget, calculateTodaysProgress, logHabitUnits } from '../HabitUtils';
 import { updateHabitNotifications, cancelForHabit } from '../hooks/useHabitNotifications';
 
 export type ShowToast = (_config: ToastConfig) => void;
@@ -262,9 +262,12 @@ const applyLogUnit = (
   habit: Habit,
   amount: number,
 ): { updatedHabit: Habit; oldProgress: number; newProgress: number } => {
-  const oldProgress = calculateHabitProgress(habit);
+  // Today-only progress so milestone toasts fire when the user crosses a
+  // tier *today*, not based on yesterday's all-time total. Default UTC bucket
+  // is sufficient here -- the toast just needs same-day pre/post deltas.
+  const oldProgress = calculateTodaysProgress(habit);
   const updatedHabit = logHabitUnits(habit, amount);
-  const newProgress = calculateHabitProgress(updatedHabit);
+  const newProgress = calculateTodaysProgress(updatedHabit);
   return { updatedHabit, oldProgress, newProgress };
 };
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -261,13 +261,14 @@ const syncOnboardingHabits = async (fullHabits: ReturnType<typeof buildOnboardin
 const applyLogUnit = (
   habit: Habit,
   amount: number,
+  tz: string,
 ): { updatedHabit: Habit; oldProgress: number; newProgress: number } => {
   // Today-only progress so milestone toasts fire when the user crosses a
-  // tier *today*, not based on yesterday's all-time total. Default UTC bucket
-  // is sufficient here -- the toast just needs same-day pre/post deltas.
-  const oldProgress = calculateTodaysProgress(habit);
+  // tier *today*, not based on yesterday's all-time total. The caller
+  // forwards the user's IANA zone so the bucket boundary matches the tile.
+  const oldProgress = calculateTodaysProgress(habit, tz);
   const updatedHabit = logHabitUnits(habit, amount);
-  const newProgress = calculateTodaysProgress(updatedHabit);
+  const newProgress = calculateTodaysProgress(updatedHabit, tz);
   return { updatedHabit, oldProgress, newProgress };
 };
 
@@ -570,7 +571,7 @@ export const habitManager = {
    * is captured by value before the optimistic write, so a later
    * concurrent mutate cannot clobber it.
    */
-  prepareLogUnit: (habitId: number, amount: number): LogUnitContext | null => {
+  prepareLogUnit: (habitId: number, amount: number, tz: string): LogUnitContext | null => {
     const prev = getHabits();
     let updated: Habit | null = null;
     let oldProgress = 0;
@@ -579,14 +580,14 @@ export const habitManager = {
     const next = prev.map((h) => {
       if (h.id !== habitId) return h;
       habitName = h.name;
-      const result = applyLogUnit(h, amount);
+      const result = applyLogUnit(h, amount, tz);
       oldProgress = result.oldProgress;
       newProgress = result.newProgress;
       updated = result.updatedHabit;
       return result.updatedHabit;
     });
     if (!updated) return null;
-    const { currentGoal, nextGoal } = getGoalTier(updated);
+    const { currentGoal, nextGoal } = getGoalTier(updated, tz);
     return {
       prev,
       next,

--- a/frontend/src/store/__tests__/storeIntegration.test.ts
+++ b/frontend/src/store/__tests__/storeIntegration.test.ts
@@ -57,6 +57,10 @@ jest.mock('react-native', () => ({
   Text: 'Text',
 }));
 
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
 const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
   id: 1,
   stage: 'Beige',


### PR DESCRIPTION
The progress bar fill, victory color, and "Achieved Today!" banner all
read from `calculateHabitProgress`, which was changed to an all-time sum
in #293 to keep persisted completions visible after cold rehydrate. That
fix conflated persistence (the data) with display (the bar): a habit
completed yesterday kept the tile lit up today even before the user had
logged anything.

Add `calculateTodaysProgress(habit, tz)`, which buckets the persisted
completion timestamps into the user's local calendar day. Switch
`getGoalTier`, `getProgressPercentage`, `getProgressBarColor`,
`isGoalAchieved`, and the milestone-toast detector in `habitManager` to
read today's progress instead. Streak / stats / lifetime totals still
read `calculateHabitProgress` so the BUG-FE-HABIT-301 / #294 contract
holds.

Thread `userTimezone` from the auth context through `HabitsScreen ->
HabitTile` and `GoalModal` so the day boundary is the user's local
midnight rather than UTC.

https://claude.ai/code/session_01VXrSskwhZ7MAq2m2VSt7t7