### PR TITLE
docs(ritual-practice): epic plan for build-your-own ritual screen

### DIFF
--- a/prompts/github-issues/ritual-practice/README.md
+++ b/prompts/github-issues/ritual-practice/README.md
@@ -1,0 +1,127 @@
+# Ritual Practice Screen — Epic Plan
+
+> A "build-your-own ritual" practice surface: meditation timer, rep counter,
+> metronome-with-timer, and configurable interval-bell clock — with 10 stage-aligned
+> presets, per-user customization, post-session insight capture, and a BotMason
+> journaling deep-link.
+
+This epic supersedes the original `phase-3-09-practice-screen.md` once delivered.
+Each sub-issue is atomized to **≤ 700 LoC of net change** (code + tests + docs)
+so the stay-green workflow remains tractable.
+
+## Vision
+
+The Practice screen is currently a single-mode countdown timer with a fixed
+catalog. The product spec calls for a **ritual workshop**: users craft their
+own practice from primitives (timer, metronome, interval bells, rep counter,
+sense-grounding prompts, card meditations) while the app ships 10 opinionated
+**presets** that activate as the user advances through the 36-week course
+(roughly one new preset every three weeks, aligned to the 10 APTITUDE stages).
+
+Only one practice is displayed at any time. A frequency banner contextualises
+the current stage, e.g.
+
+> "You are in the **Orange** frequency of APTITUDE. That means you are working
+> on **Mind**. Your practice is **Concentration practice** but you are
+> encouraged to replace it if another tradition has a practice that deals
+> with **Mind** that calls to you more."
+
+After every session the user can capture insights and tap through to BotMason
+to journal — sessions and insights flow back into analytics rollups.
+
+## Stage → Preset Map
+
+| Stage | Color        | Aspect  | Default Preset                 | Mode                       | Default Duration |
+|-------|--------------|---------|--------------------------------|----------------------------|------------------|
+| 1     | Beige        | Body    | 5-4-3-2-1 grounding            | `sense_grounding`          | n/a (5 prompts)  |
+| 2     | Purple       | Body    | Tarot meditation (Major Arcana)| `tarot`                    | 5 min            |
+| 3     | Red          | Emotion | Belly breathing                | `meditation_timer`         | 10 min           |
+| 4     | Blue         | Emotion | Metta (loving-kindness)        | `meditation_timer`         | 15 min           |
+| 5     | Orange       | Mind    | Wim Hof method                 | `meditation_timer`         | 20 min           |
+| 6     | Green        | Mind    | Shadow work                    | `meditation_timer + metronome` | 30 min       |
+| 7     | Yellow       | Spirit  | Blissy meditation              | `meditation_timer`         | 45 min           |
+| 8     | Turquoise    | Spirit  | Dog Walkin' Shamanism          | `count_up`                 | open (no target) |
+| 9     | Ultraviolet  | Nondual | Concentration practice         | `meditation_timer`         | 45 min           |
+| 10    | Clear Light  | Nondual | Insight practice               | `meditation_timer`         | 45 min           |
+
+Every preset is **replaceable**: users can swap in any approved practice for
+the current stage, or submit their own (existing flow, `POST /practices/`).
+
+## Issue Index
+
+### Backend (data + API)
+| #  | File | Scope | Est. LoC |
+|----|------|-------|----------|
+| 01 | [Practice modes + mode_config schema](ritual-01-practice-modes-schema.md)        | Backend | ~400 |
+| 02 | [Seed 10 preset practices](ritual-02-seed-preset-practices.md)                   | Backend | ~300 |
+| 03 | [User-practice customization (overrides)](ritual-03-user-practice-customization.md) | Backend | ~400 |
+| 04 | [Session analytics + insights](ritual-04-session-analytics-insights.md)          | Backend | ~500 |
+| 05 | [Frequency / aspect copy endpoint](ritual-05-frequency-copy-endpoint.md)         | Backend | ~250 |
+
+### Frontend (engine + UI)
+| #  | File | Scope | Est. LoC |
+|----|------|-------|----------|
+| 06 | [useRitualEngine hook (state machine)](ritual-06-ritual-engine-hook.md)          | Frontend | ~600 |
+| 07 | [Mode view primitives](ritual-07-mode-views.md)                                  | Frontend | ~600 |
+| 08 | [Preset views: 5-4-3-2-1 + Tarot](ritual-08-preset-views.md)                     | Frontend | ~500 |
+| 09 | [Ritual configurator UI](ritual-09-ritual-configurator.md)                       | Frontend | ~600 |
+| 10 | [Frequency banner + practice switcher](ritual-10-frequency-banner-switcher.md)   | Frontend | ~400 |
+| 11 | [PracticeScreen integration](ritual-11-screen-integration.md)                    | Frontend | ~500 |
+| 12 | [Post-session insight + BotMason CTA](ritual-12-post-session-insight-botmason.md) | Frontend | ~300 |
+
+## Dependency Graph
+
+```
+ritual-01 (modes schema)
+  ├── ritual-02 (seed presets)
+  ├── ritual-03 (user customization)
+  └── ritual-04 (session analytics)
+        └── ritual-12 (insight capture + BotMason)
+
+ritual-05 (frequency copy)  ── ritual-10 (banner)
+
+ritual-06 (engine hook)
+  ├── ritual-07 (mode views)
+  ├── ritual-08 (preset views)
+  └── ritual-09 (configurator)
+
+ritual-07, ritual-08, ritual-09, ritual-10 ── ritual-11 (screen integration)
+                                                    └── ritual-12
+```
+
+The two halves can land in parallel. Backend lands first if a single agent
+picks up the epic; frontend can be developed against in-memory mocks of the
+new endpoints once the schemas are agreed in `ritual-01`.
+
+## Cross-Cutting Quality Gates
+
+Every issue must:
+
+1. **Stay green** — `pre-commit run --all-files` clean before commit, full test
+   suite + coverage gates green before push.
+2. **Hit coverage thresholds** — backend 90% line / 80% branch, frontend Jest
+   coverage at the project default. New modules ship with their own tests in
+   the same PR.
+3. **Stay under 700 net LoC** — if a sub-issue grows past the budget, split
+   along the seam noted in its "If you blow the budget" section before
+   committing.
+4. **Avoid suppressions** — no new `# noqa`, `# type: ignore`, `// @ts-ignore`,
+   `// eslint-disable`, or `any` types. Refactor instead.
+5. **TDD** — failing test first, watch it red, implement, watch it green.
+6. **Conventional commits** — `feat(backend): …`, `feat(frontend): …`,
+   `test(frontend): …` etc.
+
+## Out of Scope (this epic)
+
+- Audio asset bundling / licensing for bell + metronome sounds. The engine
+  exposes injectable audio adapters; ritual-07 ships a stub adapter and an
+  expo-av implementation that loads existing assets if present, otherwise
+  no-ops with a logged warning. A separate "audio production" task can fill
+  in licensed cues.
+- Background-mode timers (lock-screen continuation). The current
+  `expo-keep-awake` keeps the screen on; true background scheduling is
+  deferred.
+- Push notifications for "time to practice" reminders — handled by the
+  existing notifications backlog (phase-4-04).
+- Social / sharing of insights. Captured insights are private to the user
+  and the BotMason context.

--- a/prompts/github-issues/ritual-practice/ritual-01-practice-modes-schema.md
+++ b/prompts/github-issues/ritual-practice/ritual-01-practice-modes-schema.md
@@ -1,0 +1,119 @@
+# ritual-01: Practice modes + mode_config schema
+
+**Labels:** `ritual-practice`, `backend`, `feature`, `priority-high`
+**Epic:** Ritual Practice Screen
+**Depends on:** phase-3-04 (Practice/UserPractice/PracticeSession exist)
+**Estimated LoC:** ~400 (model + migration + schemas + tests)
+
+## Problem
+
+`Practice` today only knows `default_duration_minutes` — enough for a generic
+countdown but not for a metronome (needs BPM), an interval bell clock (needs
+a list of cue offsets), a rep counter (needs a target / unit label), a
+sense-grounding sequence (needs ordered prompts), a tarot meditation (needs a
+card deck reference), or a count-up timer (no target at all).
+
+We need a **mode discriminator** plus a per-mode configuration payload, both
+on the catalog row (`Practice`) and overridable per user (`UserPractice`,
+covered in `ritual-03`).
+
+## Scope
+
+Add a `mode` enum and a `mode_config` JSON column to `Practice`. Validate the
+config payload per mode at the schema layer so bad presets fail at write time,
+not in the UI.
+
+## Tasks
+
+1. **Define the mode enum** in `backend/src/domain/practice_modes.py`
+   - Values: `meditation_timer`, `count_up`, `metronome`, `interval_bell`,
+     `rep_counter`, `sense_grounding`, `tarot`.
+   - Pure-Python `StrEnum`; expose `ALL_MODES` for serialization.
+
+2. **Define `ModeConfig` Pydantic discriminated union** in
+   `backend/src/schemas/practice_mode_config.py`
+   - One model per mode, each with the minimum fields needed:
+     - `MeditationTimerConfig`: `duration_minutes: float >= 0.5`,
+       `start_bell: bool = True`, `halfway_bell: bool = False`,
+       `end_bell: bool = True`.
+     - `CountUpConfig`: `soft_cap_minutes: float | None` (used for "you've been
+       at it an hour" gentle nudges).
+     - `MetronomeConfig`: `bpm: int 20..240`, plus an embedded
+       `MeditationTimerConfig` for the surrounding session window.
+     - `IntervalBellConfig`: `duration_minutes: float`, `interval_minutes:
+       float >= 0.5` OR `cue_offsets_minutes: list[float]` (mutually
+       exclusive — validator), `bell_tone: Literal["bowl", "chime", "gong"]`.
+     - `RepCounterConfig`: `target_reps: int >= 1`, `unit_label: str` (e.g.
+       "breath cycles", "prostrations"), `time_cap_minutes: float | None`.
+     - `SenseGroundingConfig`: `prompts: list[SensePrompt]` where
+       `SensePrompt = {sense: Literal["sight","touch","hearing","smell","taste"],
+       label: str}`. Default is the 5-4-3-2-1 ordering.
+     - `TarotConfig`: `deck: Literal["major_arcana"]`,
+       `per_card_minutes: float = 5`, `hide_timer_during_meditation: bool =
+       True`.
+   - Wrap them in `ModeConfig = Annotated[Union[...], Field(discriminator="mode")]`.
+     Each model carries a `mode: Literal["..."]` field so the union tags
+     itself, no hand-rolled if/else.
+
+3. **Extend the `Practice` model** (`backend/src/models/practice.py`)
+   - Add `mode: str` (StrEnum value) with a non-null DB constraint.
+   - Add `mode_config: dict[str, Any]` mapped to a JSON column. Use
+     `sa_column=Column(JSON, nullable=False, server_default="{}")` so the
+     existing rows can be backfilled with a dict per their default mode in
+     the migration.
+   - Keep `default_duration_minutes` as the canonical "show me a number on
+     the catalog tile" hint; treat `mode_config` as the source of truth for
+     the engine.
+
+4. **Alembic migration** (`backend/alembic/versions/<rev>_practice_modes.py`)
+   - Add the two columns nullable, backfill every existing row with
+     `mode='meditation_timer'` and a `MeditationTimerConfig` derived from
+     `default_duration_minutes`, then alter to `NOT NULL`.
+   - Reversible `downgrade()` drops the columns.
+
+5. **Refresh the response schema** (`backend/src/schemas/practice.py`)
+   - `PracticeResponse` gains `mode: str` and `mode_config: ModeConfig`.
+   - `PracticeCreate` (user submissions) accepts both; default mode is
+     `meditation_timer` if omitted, with `mode_config` derived from the
+     submitted `default_duration_minutes`.
+   - Reject `mode_config.mode != mode` mismatches at the validator layer.
+
+6. **Tests** (target: 100% branch coverage on the new files)
+   - `backend/tests/test_practice_mode_config.py`
+     - Each mode round-trips through `ModeConfig.model_validate()`.
+     - Mismatched `mode` discriminator raises.
+     - `IntervalBellConfig` rejects "both `interval_minutes` and
+       `cue_offsets_minutes`" and "neither set".
+     - `MetronomeConfig.bpm` rejects 0 / 19 / 241.
+     - `SenseGroundingConfig` rejects empty `prompts` and unknown sense
+       literals.
+   - `backend/tests/test_practices_api.py` — extend
+     - `POST /practices/` accepts every mode + a valid config.
+     - `POST /practices/` rejects invalid configs with 422.
+     - `GET /practices/{id}` echoes `mode` + `mode_config`.
+
+## Acceptance Criteria
+
+- Migration applies cleanly forward and backward against the seeded DB.
+- Existing data is preserved; every pre-existing `Practice` row reads back as
+  `mode='meditation_timer'` with a valid `mode_config`.
+- `pre-commit run --all-files` is clean; coverage ≥ 90% line / 80% branch on
+  changed modules; no new suppressions.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/domain/practice_modes.py` | **Create** |
+| `backend/src/schemas/practice_mode_config.py` | **Create** |
+| `backend/src/schemas/practice.py` | Modify |
+| `backend/src/models/practice.py` | Modify |
+| `backend/alembic/versions/<rev>_practice_modes.py` | **Create** |
+| `backend/tests/test_practice_mode_config.py` | **Create** |
+| `backend/tests/test_practices_api.py` | Modify |
+
+## If you blow the budget
+
+Split as `01a` (model + migration + enum) and `01b` (Pydantic
+discriminated-union schemas + validators + tests). The migration must land
+first because every other backend issue assumes the columns exist.

--- a/prompts/github-issues/ritual-practice/ritual-02-seed-preset-practices.md
+++ b/prompts/github-issues/ritual-practice/ritual-02-seed-preset-practices.md
@@ -1,0 +1,94 @@
+# ritual-02: Seed 10 preset practices aligned to stages
+
+**Labels:** `ritual-practice`, `backend`, `feature`, `priority-high`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-01 (mode + mode_config columns exist)
+**Estimated LoC:** ~300 (seed module + tests)
+
+## Problem
+
+The catalog needs 10 stage-aligned defaults so a user advancing through the
+course always has a concrete recommended practice. The seed must be
+**idempotent** (re-runnable without duplicates) and aligned to the existing
+`seed_stages.py` conventions.
+
+## Scope
+
+Add a `seed_practices.py` module that inserts the 10 presets if missing,
+mapped to stages 1–10, with mode-correct configs. The seed runs at app
+startup behind the same flag as `seed_stages` (or whatever existing seeding
+hook lives in `main.py` / `database.py`).
+
+## Tasks
+
+1. **Create `backend/src/seed_practices.py`**
+   - Module-level constant `PRESET_PRACTICES: list[dict[str, Any]]`, one
+     entry per stage. Each entry is plain JSON (no SQLModel imports at
+     definition time) so it round-trips through the Pydantic validators.
+   - Use the table below as the source of truth.
+
+   | Stage | Name                       | Mode               | mode_config (key fields)                                            |
+   |-------|----------------------------|--------------------|---------------------------------------------------------------------|
+   | 1     | 5-4-3-2-1 grounding        | `sense_grounding`  | prompts: 5×Sight → 4×Touch → 3×Hearing → 2×Smell → 1×Taste          |
+   | 2     | Tarot meditation           | `tarot`            | deck=major_arcana, per_card_minutes=5, hide_timer_during_meditation=true |
+   | 3     | Belly breathing            | `meditation_timer` | duration_minutes=10, halfway_bell=false, end_bell=true              |
+   | 4     | Metta                      | `meditation_timer` | duration_minutes=15, halfway_bell=true, end_bell=true               |
+   | 5     | Wim Hof method             | `meditation_timer` | duration_minutes=20                                                  |
+   | 6     | Shadow work                | `metronome`        | bpm=60, timer={duration_minutes=30, halfway_bell=true}              |
+   | 7     | Blissy meditation          | `meditation_timer` | duration_minutes=45                                                  |
+   | 8     | Dog Walkin' Shamanism      | `count_up`         | soft_cap_minutes=null                                                |
+   | 9     | Concentration practice     | `meditation_timer` | duration_minutes=45, halfway_bell=true                              |
+   | 10    | Insight practice           | `meditation_timer` | duration_minutes=45                                                  |
+
+   - Each entry also carries `description` and `instructions` (≤2k / ≤10k
+     chars per the model). Keep them tight; product copy can be edited later
+     by amending the seed.
+   - `submitted_by_user_id=None`, `approved=True`.
+
+2. **`async def seed_practices(session: AsyncSession) -> int`**
+   - Mirror `seed_stages`: `select(Practice.name, Practice.stage_number)`
+     to find what's already there; insert only what's missing. Match by
+     `(stage_number, name)` so a user with the same name as a preset doesn't
+     collide.
+   - Validate each preset through the new `ModeConfig` discriminated union
+     before insert — a typo in the seed must crash the seeder, not the
+     runtime.
+   - Return the number of rows inserted (callers log it).
+
+3. **Wire into the existing seed hook**
+   - Find where `seed_stages` is invoked (likely `database.py` startup or a
+     `seed_all` helper) and add `seed_practices` next to it. Keep the order:
+     stages → practices, since the latter conceptually depends on stage
+     numbers existing (though not via FK).
+
+4. **Tests** (`backend/tests/test_seed_practices.py`)
+   - `seed_practices` inserts 10 rows on an empty DB and returns 10.
+   - Re-running on a populated DB inserts 0 rows and returns 0.
+   - Each preset's `mode_config` round-trips through `ModeConfig`.
+   - All 10 stage numbers (1..10) are covered exactly once.
+   - Sense-grounding preset has exactly 5 prompts in 5/4/3/2/1 sense order.
+   - Metronome preset's BPM is in [20, 240] and embedded timer
+     `duration_minutes > 0`.
+
+## Acceptance Criteria
+
+- Fresh DB → 10 presets seeded after first startup.
+- `pytest backend/tests/test_seed_practices.py -q` passes locally.
+- Re-running the seeder is a no-op (no duplicates, no exceptions).
+- The seeded rows are visible via `GET /practices/?stage_number=N`.
+- Coverage on `seed_practices.py` ≥ 95% line.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | **Create** |
+| `backend/src/database.py` *(or wherever `seed_stages` is invoked)* | Modify |
+| `backend/tests/test_seed_practices.py` | **Create** |
+
+## If you blow the budget
+
+The 10 preset definitions can grow large because of the `instructions` field.
+Move long-form copy into `backend/src/seed_practice_copy.py` (a pure data
+module imported by the seeder) so the seeder logic stays small and the copy
+becomes diff-friendly for product edits.

--- a/prompts/github-issues/ritual-practice/ritual-03-user-practice-customization.md
+++ b/prompts/github-issues/ritual-practice/ritual-03-user-practice-customization.md
@@ -1,0 +1,103 @@
+# ritual-03: User practice customization (per-user overrides)
+
+**Labels:** `ritual-practice`, `backend`, `feature`, `priority-high`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-01 (mode_config exists)
+**Estimated LoC:** ~400
+
+## Problem
+
+Presets are a starting point — the spec says "Practices can be changed".
+A user should be able to rename their preset ("My Morning Sit"), shorten the
+duration, change the BPM, add or remove interval bells, or rewrite the
+sense-grounding prompts — **without** mutating the shared catalog row.
+
+We already have `UserPractice` mapping `(user, stage) → practice`. We need
+optional per-user override fields layered on top.
+
+## Scope
+
+Add nullable override columns to `UserPractice`, expose a `PATCH` endpoint
+for editing them, and provide a single `effective_config()` resolver so the
+frontend never has to merge by hand.
+
+## Tasks
+
+1. **Extend `UserPractice` model** (`backend/src/models/user_practice.py`)
+   - Add nullable columns:
+     - `custom_name: str | None` (≤255 chars).
+     - `mode_config_override: dict[str, Any] | None` (JSON column, nullable).
+   - Do **not** allow overriding `mode` itself. A user who wants a different
+     mode should select a different preset / submit a new practice. Document
+     this in the model docstring.
+
+2. **Alembic migration** — additive, no backfill needed.
+
+3. **Resolver** — `backend/src/domain/practice_resolution.py`
+   - `def effective_config(practice: Practice, user_practice: UserPractice |
+     None) -> ModeConfig`
+     - Returns the catalog config when no override is set.
+     - When an override is set, validate it against the catalog `mode` via
+       the existing discriminated union; raise `ValueError` on mismatch (a
+       request handler maps to 400; the seed and migration paths must never
+       hit this branch).
+   - `def effective_name(...) -> str` — `custom_name or practice.name`.
+   - Both helpers are pure functions (no DB access) so they're trivially
+     testable.
+
+4. **Schema additions** — `backend/src/schemas/user_practice.py`
+   - `UserPracticeCustomize`:
+     - `custom_name: str | None = None`
+     - `mode_config_override: ModeConfig | None = None`
+     - Both nullable so a request can clear an override by passing `null`.
+   - `UserPracticeDetail` (response) gains `effective_name: str` and
+     `effective_config: ModeConfig` so the frontend doesn't merge on its
+     own.
+
+5. **Endpoint** — `backend/src/routers/user_practices.py`
+   - `PATCH /user-practices/{id}/customize` with `UserPracticeCustomize`
+     body.
+   - Reuse the existing `require_owned_user_practice` dependency for
+     authorization.
+   - Validate `mode_config_override.mode == practice.mode` before commit.
+     Return 400 `mode_mismatch` if the client tries to flip the mode.
+   - On success, return the updated `UserPracticeDetail`.
+
+6. **Tests** (`backend/tests/test_user_practice_customization.py`)
+   - PATCH with `custom_name='My Sit'` updates the name and is reflected on
+     subsequent GETs.
+   - PATCH with a valid `mode_config_override` returns the override in
+     `effective_config`.
+   - PATCH with `mode_config_override=null` clears the override (subsequent
+     GETs return the catalog config).
+   - PATCH with a mismatched mode returns 400 `mode_mismatch`.
+   - PATCH on someone else's `UserPractice` returns 403 (existing ownership
+     dep).
+   - PATCH on a missing id returns 404.
+   - Unit test the pure resolver against all 7 modes.
+
+## Acceptance Criteria
+
+- Customization round-trips: PATCH → GET shows the change.
+- Catalog `Practice` row is never mutated by user actions.
+- `effective_config` is the single source of truth for the UI.
+- Coverage targets met; no new suppressions.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/models/user_practice.py` | Modify |
+| `backend/alembic/versions/<rev>_user_practice_overrides.py` | **Create** |
+| `backend/src/domain/practice_resolution.py` | **Create** |
+| `backend/src/schemas/user_practice.py` | Modify |
+| `backend/src/routers/user_practices.py` | Modify |
+| `backend/tests/test_user_practice_customization.py` | **Create** |
+| `backend/tests/test_practice_resolution.py` | **Create** |
+
+## If you blow the budget
+
+Land the model + migration + resolver in one PR (≈250 LoC) and the PATCH
+endpoint + integration tests in a second PR (≈250 LoC). Both halves are
+useful independently — the resolver is consumed by `ritual-04` analytics
+even before the PATCH endpoint ships.

--- a/prompts/github-issues/ritual-practice/ritual-04-session-analytics-insights.md
+++ b/prompts/github-issues/ritual-practice/ritual-04-session-analytics-insights.md
@@ -1,0 +1,129 @@
+# ritual-04: Session analytics + insights
+
+**Labels:** `ritual-practice`, `backend`, `feature`, `priority-high`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-01 (modes), ritual-03 (effective_config resolver)
+**Estimated LoC:** ~500
+
+## Problem
+
+`PracticeSession` today stores `(user_practice_id, duration_minutes,
+timestamp, reflection)` — fine for a generic timer, but blind to mode-specific
+data: how many reps did the user log? Did the metronome run at the catalog
+BPM or a customized one? Which tarot card was up? Did they finish or abort?
+
+The product spec also says **"capture insights and analytics"** — we need a
+rollup endpoint the screen can show ("you've meditated 4×/week for 3 weeks
+running, average duration 18 minutes") without n-queries on the client.
+
+## Scope
+
+Extend `PracticeSession` with mode-aware metadata + an `insight` column,
+expose `POST /practice-sessions/` to accept the new payload, and add a
+`GET /practice-sessions/insights` rollup.
+
+## Tasks
+
+1. **Extend `PracticeSession` model**
+   - Add nullable columns:
+     - `mode: str` (the resolved mode at session time — denormalized so the
+       rollup doesn't have to join through `Practice` on every query, and so
+       a future catalog edit doesn't retro-rewrite history).
+     - `mode_metadata: dict[str, Any]` (JSON, nullable). Stores e.g.
+       `{rep_count: 108}`, `{bpm_used: 72}`, `{tarot_card_index: 5}`,
+       `{intervals_struck: 4, total_intervals: 6}`,
+       `{senses_completed: ["sight","touch"]}`.
+     - `completed: bool = True` — false if the user cancelled before the
+       target was reached.
+     - `insight: str | None` (≤2k) — short user-captured takeaway,
+     - distinct from the existing long-form `reflection`.
+   - Migration: additive; backfill `mode='meditation_timer'`, `completed=true`,
+     leave `mode_metadata` and `insight` null.
+
+2. **Per-mode metadata schemas** in
+   `backend/src/schemas/practice_session_metadata.py`
+   - One Pydantic model per mode mirroring the engine outputs (e.g.
+     `RepCounterMetadata { rep_count: int >= 0 }`,
+     `MetronomeMetadata { bpm_used: int }`,
+     `IntervalBellMetadata { intervals_struck: int, total_intervals: int }`,
+     `TarotMetadata { card_index: int 0..21 }`,
+     `SenseGroundingMetadata { senses_completed: list[Sense] }`,
+     `MeditationTimerMetadata { /* empty by design */ }`,
+     `CountUpMetadata { /* empty by design */ }`).
+   - Discriminated union `SessionMetadata` keyed on `mode`.
+   - Validator: `mode` must equal the parent session's `mode`.
+
+3. **Update `SessionCreate`** in `backend/src/schemas/practice_session.py`
+   - Accepts `mode_metadata: SessionMetadata | None`, `completed: bool =
+     True`, `insight: str | None = None`.
+   - Server-side derivation: if `mode_metadata` is provided, its
+     discriminator must match the resolved practice mode (use
+     `effective_config` from ritual-03). Otherwise `mode_metadata` stays
+     null. Mismatch → 400 `mode_metadata_mismatch`.
+   - The session's `mode` column is set from the resolved practice mode at
+     write time (not from the client) — clients can't mislabel sessions.
+
+4. **Insights rollup** — `backend/src/domain/practice_insights.py`
+   - Pure-Python aggregator over a list of `PracticeSession` rows. Returns:
+     - `weekly_counts: list[{week_start: date, count: int}]` — last 8 weeks.
+     - `streak_weeks: int` — consecutive weeks meeting the 4×/week target.
+     - `total_minutes_30d: float`.
+     - `avg_duration_minutes_30d: float | None` (null if no sessions).
+     - `per_mode_counts: dict[str, int]` — last 30 days, keyed by mode.
+     - `last_insight: str | None` — most recent non-null `insight`.
+   - Keep the date math in `domain/dates.py` helpers (already exist for
+     `today_in_tz`); the rollup must respect the user's timezone.
+
+5. **Endpoint** — `backend/src/routers/practice_sessions.py`
+   - `GET /practice-sessions/insights` returns the rollup for the current
+     user.
+   - Single SQL query selects sessions in the last 60 days; aggregator does
+     the rest in memory (cheap; max ~hundreds of rows per user).
+   - Cache-control header set to `private, max-age=60` so the client can
+     poll without hammering the DB.
+
+6. **Tests** (`backend/tests/test_practice_session_metadata.py`,
+   `test_practice_insights.py`, extend `test_practice_sessions.py`)
+   - Each metadata model round-trips; mismatched discriminator rejected.
+   - `POST /practice-sessions/` with rep counter metadata stores
+     `mode_metadata` correctly; subsequent `GET /…?user_practice_id=X`
+     echoes it back.
+   - `POST` with `completed=false` is recorded and counted toward weekly
+     totals iff `duration_minutes > 0` (decision: count partial sessions but
+     flag them).
+   - `POST` with `insight="..."` persists; `GET …/insights.last_insight` is
+     the most recent non-null insight across all the user's practices.
+   - Insights rollup: 5 sessions across 3 weeks → `weekly_counts` has 8
+     entries, the most recent non-zero ones in the right buckets;
+     `streak_weeks` reflects the 4×/week threshold correctly (test the
+     boundary: exactly 4 counts, 3 doesn't).
+
+## Acceptance Criteria
+
+- Session POST accepts mode-specific metadata and an insight string.
+- Insights endpoint returns the documented shape and respects the user's
+  timezone.
+- Existing session POST clients continue working (new fields are optional,
+  backfill handled).
+- Coverage targets met.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/models/practice_session.py` | Modify |
+| `backend/alembic/versions/<rev>_practice_session_metadata.py` | **Create** |
+| `backend/src/schemas/practice_session_metadata.py` | **Create** |
+| `backend/src/schemas/practice_session.py` | Modify |
+| `backend/src/domain/practice_insights.py` | **Create** |
+| `backend/src/routers/practice_sessions.py` | Modify |
+| `backend/tests/test_practice_session_metadata.py` | **Create** |
+| `backend/tests/test_practice_insights.py` | **Create** |
+| `backend/tests/test_practice_sessions.py` | Modify |
+
+## If you blow the budget
+
+Split as `04a` (model + migration + per-mode metadata schemas + POST
+acceptance) and `04b` (insights rollup module + endpoint + tests). The POST
+side blocks `ritual-12` (frontend insight capture); the rollup side blocks
+`ritual-11` (weekly progress display).

--- a/prompts/github-issues/ritual-practice/ritual-05-frequency-copy-endpoint.md
+++ b/prompts/github-issues/ritual-practice/ritual-05-frequency-copy-endpoint.md
@@ -1,0 +1,95 @@
+# ritual-05: Frequency / aspect copy endpoint
+
+**Labels:** `ritual-practice`, `backend`, `feature`, `priority-medium`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-02 (preset practices seeded), `CourseStage` rows seeded
+**Estimated LoC:** ~250
+
+## Problem
+
+The Practice screen needs to render this exact copy:
+
+> "You are in the **<color>** frequency of APTITUDE. That means you are
+> working on **<aspect of wholeness for that color>**. Your practice is
+> **<practice>** but you are encouraged to replace it if another tradition
+> has a practice that deals with **<aspect>** that calls to you more."
+
+Today the frontend would have to fetch the user's current stage, then the
+matching `CourseStage` for color/aspect, then their `UserPractice`, then the
+underlying `Practice` for the name — four round trips and a string assembly
+in the client. Move that into one server endpoint so the copy is consistent
+and the client can render it from a single payload.
+
+## Scope
+
+Add `GET /user-practices/current/frequency` returning the assembled banner
+data plus the structured fields for client formatting.
+
+## Tasks
+
+1. **Endpoint** — `backend/src/routers/user_practices.py`
+   - `GET /user-practices/current/frequency`
+   - Resolves `current_stage` from `StageProgress` (default 1 if no progress
+     row yet).
+   - Loads the matching `CourseStage` (`spiral_dynamics_color`, `aspect`).
+   - Loads the user's active `UserPractice` for that stage (the partial
+     unique index from existing code guarantees ≤ 1 active row).
+   - If no active `UserPractice`, falls back to the seeded preset for that
+     stage (look up `Practice` by `(stage_number, name)` matching the
+     `PRESET_PRACTICES` table — keep the lookup keyed on a small
+     `STAGE_TO_PRESET_NAME` map exported from `seed_practices.py` so the
+     two stay in sync).
+
+2. **Response schema** — `backend/src/schemas/frequency.py`
+   ```python
+   class FrequencyResponse(BaseModel):
+       stage_number: int
+       color: str            # e.g. "Orange"
+       aspect: str           # e.g. "Mind"
+       practice_name: str    # effective_name (custom or catalog)
+       practice_id: int
+       user_practice_id: int | None  # null if showing the unselected default
+       banner_text: str      # fully formatted English string
+   ```
+   - `banner_text` is rendered server-side from a constant template so
+     wording changes happen in one place. Keep the template as a module-level
+     constant string with `{color} / {aspect} / {practice_name}` slots.
+
+3. **Empty-progress edge case**
+   - If `StageProgress` doesn't exist for the user yet, treat them as stage
+     1 (matches the existing `is_stage_unlocked` invariant). The fallback
+     logic above naturally handles "no UserPractice yet" by surfacing the
+     preset.
+
+4. **Tests** (`backend/tests/test_frequency_endpoint.py`)
+   - User at stage 1 with no `UserPractice` returns the seeded preset and
+     the Beige/Body banner.
+   - User at stage 5 with a `UserPractice` selected returns the user's
+     practice name, Orange/Mind banner.
+   - User with `custom_name` set on their `UserPractice` returns the
+     `custom_name` (verifies `effective_name` plumbing from ritual-03).
+   - Banner template renders the three slots in the documented order; a
+     snapshot test pins the exact wording so accidental copy changes show up
+     in PR diffs.
+   - Unauthenticated request returns 401.
+
+## Acceptance Criteria
+
+- Single GET returns everything the banner needs.
+- Copy template lives server-side; clients never assemble it from parts.
+- Coverage targets met.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/routers/user_practices.py` | Modify (add endpoint) |
+| `backend/src/schemas/frequency.py` | **Create** |
+| `backend/src/seed_practices.py` | Modify (export `STAGE_TO_PRESET_NAME`) |
+| `backend/tests/test_frequency_endpoint.py` | **Create** |
+
+## If you blow the budget
+
+This issue is small enough that splitting is unlikely to help. If lookups get
+chatty (more than one DB round-trip per call), consolidate via a single
+joined query rather than splitting the issue.

--- a/prompts/github-issues/ritual-practice/ritual-06-ritual-engine-hook.md
+++ b/prompts/github-issues/ritual-practice/ritual-06-ritual-engine-hook.md
@@ -1,0 +1,134 @@
+# ritual-06: useRitualEngine hook (state machine)
+
+**Labels:** `ritual-practice`, `frontend`, `feature`, `priority-high`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-01 (mode_config shape)
+**Estimated LoC:** ~600 (hook + reducer + tests)
+
+## Problem
+
+Each preset uses one of seven modes (`meditation_timer`, `count_up`,
+`metronome`, `interval_bell`, `rep_counter`, `sense_grounding`, `tarot`).
+Every mode shares the same lifecycle (`idle → running → paused → complete`),
+the same need for a wall-clock-aware tick, the same need to schedule audio /
+haptic cues, and the same need to emit a `SessionMetadata` payload at the
+end. Implementing this per-mode would duplicate logic and tests.
+
+Build one engine that takes a `ModeConfig`, drives a state machine, and
+exposes the fields and callbacks every mode view needs.
+
+## Scope
+
+`useRitualEngine(config: ModeConfig, deps: EngineDeps)` returns a `RitualState`
++ a small `RitualControls` API. Pure logic with injected adapters for time,
+audio, and haptics so it's testable with `jest.useFakeTimers()`.
+
+## Tasks
+
+1. **Create `frontend/src/features/Practice/engine/types.ts`**
+   - `EngineStatus = 'idle' | 'running' | 'paused' | 'complete'`
+   - `RitualState`:
+     - `status: EngineStatus`
+     - `elapsedMs: number`
+     - `remainingMs: number | null` (null for `count_up`)
+     - `progress: number` (0..1; 0 for `count_up` and modes without a target)
+     - `repCount: number` (only meaningful for `rep_counter`)
+     - `currentStepIndex: number` (sense-grounding step / tarot card index)
+     - `nextCueAtMs: number | null` (next bell offset, for interval bell view)
+     - `cuesStruck: number` (count of bells/intervals played so far)
+   - `RitualControls`:
+     - `start()`, `pause()`, `resume()`, `cancel()`, `complete()`
+     - `tap()` — used by `rep_counter` (and by sense-grounding for "mark
+       sense done").
+     - `advanceStep()` — used by sense-grounding / tarot when stepping past
+       the per-step interval.
+   - `EngineDeps`:
+     - `now: () => number` (wraps `Date.now`).
+     - `setIntervalMs: (cb, ms) => Handle`, `clearInterval: (h) => void`.
+     - `audio: AudioAdapter` (see ritual-07).
+     - `haptics: HapticsAdapter`.
+     - All optional with safe defaults so tests can inject mocks and prod
+       code wires through `expo-av` / `expo-haptics`.
+
+2. **Create `engine/reducer.ts`**
+   - Pure reducer `(state, action) -> state` covering:
+     - `START`, `PAUSE`, `RESUME`, `CANCEL`, `COMPLETE`,
+     - `TICK { now }` (recomputes `elapsedMs`, `remainingMs`, `progress`,
+       `nextCueAtMs`, possibly emits a `cue`),
+     - `TAP` (rep_counter: bump `repCount`; sense_grounding: advance step),
+     - `ADVANCE_STEP` (tarot: reveal next card / move to next interval).
+   - Reducer is mode-aware via the discriminated `config` it receives — keep
+     all mode logic in small per-mode `reduce<Mode>(state, action, config)`
+     functions called from a top-level switch on `config.mode`. This keeps
+     each mode reducer small and independently testable.
+
+3. **Cue scheduler** — `engine/cues.ts`
+   - Pure function `scheduledCues(config: ModeConfig): Cue[]` returning
+     a sorted list of `{ atMs: number, kind: 'start_bell' | 'halfway_bell'
+     | 'end_bell' | 'interval_bell' | 'metronome_tick' }`.
+   - For `metronome`, the schedule yields ticks every `60_000 / bpm` ms
+     until `duration_minutes * 60_000` (cap at 10k ticks defensively).
+   - For `interval_bell`, expands `interval_minutes` or `cue_offsets_minutes`
+     into discrete `interval_bell` cues.
+   - The reducer's `TICK` handler walks the (sorted, immutable) cue list with
+     a single index pointer; never re-iterates the whole list.
+
+4. **The hook** — `engine/useRitualEngine.ts`
+   - `useReducer` over the reducer + a `useEffect` that owns the interval
+     ticker and disposes it on unmount.
+   - Tick frequency: 100ms (smooth UI, cheap CPU). Document the choice.
+   - Auto-completes when `remainingMs <= 0` (modes with a target).
+   - Calls `deps.audio.play(cue.kind)` and `deps.haptics.cue(cue.kind)` as
+     cues fire.
+   - Returns `[state, controls]`.
+
+5. **Tests** — `engine/__tests__/`
+   - `reducer.test.ts` (the lion's share):
+     - `meditation_timer` 10-min: ticks, halfway cue at 5min iff
+       `halfway_bell`, end cue at 10min, status → `complete`.
+     - `count_up`: never auto-completes; `progress` stays 0; `complete()`
+       transitions to `complete` and freezes `elapsedMs`.
+     - `metronome`: with bpm=60, exactly 600 ticks across 10 minutes;
+       embedded timer's halfway/end cues still fire.
+     - `interval_bell`: `interval_minutes=5`, `duration_minutes=20` → 4
+       interval cues + start + end. `cue_offsets_minutes=[3,7,12]` mode
+       fires only those three plus start/end.
+     - `rep_counter`: `tap()` increments `repCount`; auto-completes on
+       reaching `target_reps`; if `time_cap_minutes` set, also
+     - completes when cap hits.
+     - `sense_grounding`: `tap()` advances `currentStepIndex` through every
+       prompt; auto-completes after the last.
+     - `tarot`: `per_card_minutes=5` → after `start()`, status stays
+       running, end cue at 5min, `currentStepIndex` lands on the day's card
+       (engine takes a `startCardIndex` from the hook caller — see ritual-08).
+     - Pause/resume preserves elapsed; cancel resets to idle without
+     - emitting `complete`.
+   - `cues.test.ts` — pure scheduler; snapshot the cue list per mode.
+   - `useRitualEngine.test.tsx` — render-hook test verifying ticker
+     wiring + cleanup; uses `jest.useFakeTimers()`.
+
+## Acceptance Criteria
+
+- All 7 modes drive correctly through pause/resume/cancel/complete.
+- Cue scheduler is deterministic and pure.
+- No real timers leak between tests.
+- 100% line coverage on `reducer.ts` and `cues.ts`; ≥ 90% on the hook.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/engine/types.ts` | **Create** |
+| `frontend/src/features/Practice/engine/reducer.ts` | **Create** |
+| `frontend/src/features/Practice/engine/cues.ts` | **Create** |
+| `frontend/src/features/Practice/engine/useRitualEngine.ts` | **Create** |
+| `frontend/src/features/Practice/engine/__tests__/reducer.test.ts` | **Create** |
+| `frontend/src/features/Practice/engine/__tests__/cues.test.ts` | **Create** |
+| `frontend/src/features/Practice/engine/__tests__/useRitualEngine.test.tsx` | **Create** |
+
+## If you blow the budget
+
+Likely split: `06a` ships types + reducer + cues + their tests (~400 LoC,
+pure logic, no React). `06b` ships the hook itself + ticker effect + the
+render-hook test (~200 LoC). `06b` blocks the mode views; `06a` is enough to
+unblock validation and prototyping.

--- a/prompts/github-issues/ritual-practice/ritual-07-mode-views.md
+++ b/prompts/github-issues/ritual-practice/ritual-07-mode-views.md
@@ -1,0 +1,123 @@
+# ritual-07: Mode view primitives + audio/haptics adapters
+
+**Labels:** `ritual-practice`, `frontend`, `feature`, `priority-high`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-06 (engine hook)
+**Estimated LoC:** ~600 (5 small components + 2 adapters + tests)
+
+## Problem
+
+The engine emits a `RitualState`; we now need the visual layer that consumes
+it for the four "primitive" modes. Each view is intentionally small —
+presentation only — so that swapping audio adapters or restyling doesn't
+ripple into engine logic.
+
+This issue also ships the audio + haptics adapters so the engine has
+something real to call in production. Tarot and 5-4-3-2-1 are deferred to
+ritual-08 (their UX is meaningfully different and pulls in card data).
+
+## Scope
+
+Five view components, two adapters, one shared "controls bar". All
+presentational; engine-pure tests live in ritual-06.
+
+## Tasks
+
+1. **Adapters** in `frontend/src/features/Practice/engine/adapters/`
+   - `audio.ts`:
+     - `AudioAdapter = { play(kind: CueKind): Promise<void>, dispose():
+       void }`.
+     - `createNoopAudioAdapter()` — returns resolved promises; logs nothing
+       (used in tests + when assets are missing).
+     - `createExpoAudioAdapter()` — uses `expo-av` to load three small
+       static cues (`bell-start.mp3`, `bell-half.mp3`, `bell-end.mp3`,
+       `metronome-tick.wav`) from `frontend/assets/sounds/`. If a file is
+       missing at load time, fall back to no-op for that cue and log a
+       single warning per missing file. Do **not** throw — a missing asset
+       must not break the practice.
+   - `haptics.ts`:
+     - `HapticsAdapter = { cue(kind: CueKind): void }`.
+     - Wraps `expo-haptics` `notificationAsync(Success)` for end cues,
+       `impactAsync(Light)` for ticks, `impactAsync(Medium)` for interval
+       bells, no-op for `metronome_tick` (haptics-on-every-beat is awful).
+     - `createNoopHapticsAdapter()` for tests.
+
+2. **Shared `RitualControls` bar** —
+   `frontend/src/features/Practice/views/RitualControlsBar.tsx`
+   - Renders Start / Pause / Resume / Cancel based on `status`.
+   - Accessible labels (`accessibilityLabel`, `accessibilityRole="button"`).
+   - Re-used by every mode view to keep visual consistency.
+
+3. **`MeditationTimerView.tsx`**
+   - Circular progress ring (use `react-native-svg` if present in
+     `package.json`; otherwise a simple `<View>`-based ring with absolute
+     positioning to avoid adding a dep — pick one and document the choice).
+   - Centre text: `mm:ss` remaining.
+   - Pure consumer of `RitualState` + `RitualControls` props (no engine
+     coupling — testable with hand-rolled props).
+
+4. **`CountUpTimerView.tsx`**
+   - Centre text: `mm:ss` elapsed.
+   - No ring (or a faint indeterminate animation behind the digits — pick
+     one). "End session" button calls `controls.complete()`.
+
+5. **`MetronomeView.tsx`**
+   - Big BPM display, animated dot pulsing on each `metronome_tick` cue
+     (use `Animated.Value` driven from `state.cuesStruck`).
+   - Embedded mini timer (`mm:ss`) below.
+
+6. **`RepCounterView.tsx`**
+   - Large `repCount` digits.
+   - "+1" tap-anywhere area (`Pressable` over the whole frame) calling
+     `controls.tap()`.
+   - Subtitle showing `unit_label` from config.
+   - Optional time cap mini-display.
+
+7. **`IntervalBellView.tsx`**
+   - Centre text: `mm:ss` until next bell (derived from
+     `state.nextCueAtMs - state.elapsedMs`).
+   - Below: small list of all interval offsets with the upcoming one
+     highlighted, struck ones checked.
+
+8. **Tests** — `frontend/src/features/Practice/views/__tests__/`
+   - One snapshot/render test per view that:
+     - Renders with a fabricated `RitualState`/`RitualControls`.
+     - Asserts the right buttons appear per `status`.
+     - Fires the documented controls (e.g. tap on `RepCounterView` triggers
+       `controls.tap`).
+   - Adapter tests:
+     - `createNoopAudioAdapter().play('start_bell')` resolves without
+       throwing.
+     - `createExpoAudioAdapter()` is mocked in jest setup
+       (`__mocks__/expo-av.ts` if not already there); a missing-asset
+       scenario logs a single warning and falls back to no-op.
+
+## Acceptance Criteria
+
+- Each view renders correctly for all four lifecycle statuses.
+- Adapters are mockable; tests don't pull in real audio.
+- No engine state lives inside view components — they are pure consumers.
+- Coverage targets met.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/engine/adapters/audio.ts` | **Create** |
+| `frontend/src/features/Practice/engine/adapters/haptics.ts` | **Create** |
+| `frontend/src/features/Practice/views/RitualControlsBar.tsx` | **Create** |
+| `frontend/src/features/Practice/views/MeditationTimerView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/CountUpTimerView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/MetronomeView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/RepCounterView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/IntervalBellView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/__tests__/*.test.tsx` | **Create** |
+| `frontend/assets/sounds/` | **Create** *(empty placeholder; real files in a separate audio task)* |
+| `frontend/package.json` | Modify *(add `expo-av`, `expo-haptics`, `expo-keep-awake` if not already present)* |
+
+## If you blow the budget
+
+Most likely overflow is the SVG ring math. Lift the ring into its own
+`ProgressRing.tsx` component (~100 LoC) with its own snapshot tests, and
+ship it as `07a`. The remaining four views + adapters fit comfortably in
+`07b`.

--- a/prompts/github-issues/ritual-practice/ritual-08-preset-views.md
+++ b/prompts/github-issues/ritual-practice/ritual-08-preset-views.md
@@ -1,0 +1,112 @@
+# ritual-08: Preset views — 5-4-3-2-1 grounding + Tarot meditation
+
+**Labels:** `ritual-practice`, `frontend`, `feature`, `priority-medium`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-06 (engine), ritual-07 (controls bar)
+**Estimated LoC:** ~500 (two views + tarot data + tests)
+
+## Problem
+
+Two presets have UX that doesn't fit the generic timer/metronome/counter
+mould:
+
+- **5-4-3-2-1 grounding** — the spec wants the header `"5-4-3-2-1"` and a
+  button labelled `"Mark sight done"` that becomes `"Mark touch done"`,
+  `"Mark hearing done"`, `"Mark smell done"`, `"Mark taste done"` as the
+  user steps through the senses. It's a *sequence-tap* UI, not a clock.
+- **Tarot meditation** — the spec wants a card from the major arcana
+  displayed for a 5-minute timer. The timer must be **hidden during
+  meditation** and revealed at completion. The deck progresses from "The
+  Fool" to "The World" over 22 days.
+
+Both consume `useRitualEngine` (sense_grounding / tarot modes) but render
+their own custom layouts.
+
+## Scope
+
+Build the two preset views, plus a small tarot-data module + a deterministic
+"day index → card" resolver.
+
+## Tasks
+
+1. **Tarot data** — `frontend/src/features/Practice/data/tarot.ts`
+   - Constant `MAJOR_ARCANA: TarotCard[]` of length 22:
+     `{ index: 0..21, name: 'The Fool' … 'The World', keyword: string,
+     symbolism: string }`. Keep `keyword` and `symbolism` short (≤ 80 chars).
+   - Helper `cardForDayIndex(daysSinceStart: number): TarotCard` returning
+     `MAJOR_ARCANA[daysSinceStart % 22]`. Pure function; tested.
+   - **No image assets in this issue.** The view renders the card name + a
+     stylised border + the keyword. A future asset task can swap in
+     illustrations once licensing is sorted.
+
+2. **`SenseGroundingView.tsx`**
+   - Header: large `5-4-3-2-1` badge + the current sense's count
+     (e.g. "5 things you can SEE").
+   - Per-sense prompt text from `config.prompts[currentStepIndex]`.
+   - Big primary button: `"Mark {sense} done"` → calls `controls.tap()`
+     which the sense_grounding reducer interprets as `advanceStep`.
+   - When `currentStepIndex === prompts.length`, status auto-completes (the
+     engine handles that in ritual-06); the view shows a "Grounding
+     complete" final card with the Save button.
+   - Accessibility: `accessibilityLabel` updates per step; the header is a
+     `accessibilityRole="header"`.
+
+3. **`TarotMeditationView.tsx`**
+   - Props: `state`, `controls`, `card: TarotCard`, `hideTimer: boolean`.
+   - When `status === 'idle'`: show the card with name + keyword + a
+     "Begin meditation" button.
+   - When `status === 'running'` and `hideTimer`: render only the card
+     (no timer, no controls bar) plus a long-press "Cancel" affordance
+     (so the user has an exit but can't see the clock).
+   - When `status === 'paused'`: timer + standard controls visible
+     (paused state is escape hatch; honesty over purism).
+   - When `status === 'complete'`: show the timer reading (now visible),
+     the card, and the post-session entry-point CTA.
+
+4. **Day-index plumbing**
+   - `TarotMeditationView` receives `card` from its parent — the view never
+     reads from a clock itself. The parent (`PracticeScreen` in ritual-11)
+     computes `daysSinceStart` from `UserPractice.start_date` and the
+     user's local timezone, then calls `cardForDayIndex` to pick the card.
+   - Document this contract in the view's prop docstring so future callers
+     don't accidentally re-compute the date inside the view.
+
+5. **Tests** — `frontend/src/features/Practice/views/__tests__/`
+   - `tarot.test.ts`:
+     - `MAJOR_ARCANA` has length 22, indices 0..21 unique, names in
+       traditional order (snapshot the names).
+     - `cardForDayIndex(0) === The Fool`, `cardForDayIndex(21) === The
+       World`, `cardForDayIndex(22) === The Fool` (wrap), `cardForDayIndex(
+       100) === MAJOR_ARCANA[100 % 22]`.
+   - `SenseGroundingView.test.tsx`:
+     - Renders the right "Mark <sense> done" label per `currentStepIndex`.
+     - Tap fires `controls.tap()`.
+     - At `status='complete'` shows the completion card.
+   - `TarotMeditationView.test.tsx`:
+     - `status='running' && hideTimer` → no `mm:ss` text in tree.
+     - `status='paused'` shows controls + timer.
+     - `status='complete'` shows timer + Save CTA.
+     - Card name + keyword always visible.
+
+## Acceptance Criteria
+
+- 5-4-3-2-1 view drives the engine through five taps and finishes.
+- Tarot view never leaks the clock during the meditative window.
+- Card rotation is deterministic and wraps after 22 days.
+- Coverage targets met.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/data/tarot.ts` | **Create** |
+| `frontend/src/features/Practice/views/SenseGroundingView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/TarotMeditationView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/__tests__/tarot.test.ts` | **Create** |
+| `frontend/src/features/Practice/views/__tests__/SenseGroundingView.test.tsx` | **Create** |
+| `frontend/src/features/Practice/views/__tests__/TarotMeditationView.test.tsx` | **Create** |
+
+## If you blow the budget
+
+Move the 22-card data table into a JSON file (`tarot.json`) imported via
+TypeScript's `resolveJsonModule` so the LoC count drops to just the helper.

--- a/prompts/github-issues/ritual-practice/ritual-09-ritual-configurator.md
+++ b/prompts/github-issues/ritual-practice/ritual-09-ritual-configurator.md
@@ -1,0 +1,102 @@
+# ritual-09: Ritual configurator UI
+
+**Labels:** `ritual-practice`, `frontend`, `feature`, `priority-medium`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-03 (PATCH endpoint), ritual-06 (engine config types)
+**Estimated LoC:** ~600
+
+## Problem
+
+Users must be able to "build their own ritual": rename the practice, change
+durations, edit the metronome BPM, add or remove interval bells, and edit
+sense-grounding prompts — and persist those edits per-user via the new
+`PATCH /user-practices/{id}/customize` endpoint.
+
+Mode is **not** editable here (the spec says practices can be replaced;
+mode-shifting is a replacement, not a tweak — see ritual-10).
+
+## Scope
+
+A `RitualConfiguratorSheet` modal that takes the active practice + its
+effective config and renders a per-mode editor. On save it calls the
+customization endpoint and refreshes the parent's practice state.
+
+## Tasks
+
+1. **`RitualConfiguratorSheet.tsx`**
+   - Bottom-sheet modal (use the project's existing modal primitive — check
+     `frontend/src/components/` first; if none exists, a simple `Modal`
+     with a styled card is fine).
+   - Header: practice name (editable inline), aspect chip, "Cancel" / "Save".
+   - Body: dispatches to a per-mode form by `effective_config.mode`:
+     - `<MeditationTimerForm>`: duration slider/numeric input (minutes,
+       0.5–120), three checkbox toggles for start/halfway/end bells.
+     - `<MetronomeForm>`: BPM stepper (20–240 with ±1 / ±5 buttons) +
+       embedded `<MeditationTimerForm>` for the surrounding window.
+     - `<IntervalBellForm>`: choice between "even intervals" (single
+       `interval_minutes` numeric) and "custom offsets" (chip list with
+       add/remove); duration slider; tone picker.
+     - `<RepCounterForm>`: target reps numeric, unit label text, optional
+       time cap minutes.
+     - `<SenseGroundingForm>`: reorderable list of prompts, edit text per
+       prompt, add/remove. Sense picker per row (constrained to the 5
+       literals).
+     - `<CountUpForm>`: optional soft-cap minutes.
+     - `<TarotForm>`: per-card minutes, hide-timer toggle.
+
+2. **State + validation**
+   - Local form state initialised from `effective_config`.
+   - Save button disabled when:
+     - No fields changed, OR
+     - Validation fails — reuse the Pydantic-side rules in TS (e.g. BPM
+       20..240, duration ≥ 0.5, prompts non-empty). Centralise in
+       `frontend/src/features/Practice/engine/validation.ts` so the rules
+       have one home. Tests cover each rule.
+   - On save: build a `mode_config_override` payload, call
+     `userPractices.customize(userPracticeId, { custom_name, mode_config_override })`,
+     toast on success, surface API error via `formatApiError`.
+
+3. **API client** — extend `frontend/src/api/index.ts`
+   - Add `userPractices.customize(id, payload)` POSTing to
+     `PATCH /user-practices/{id}/customize` (HTTP method PATCH).
+   - Add `clear` semantics: passing `mode_config_override: null` clears the
+     override. The form's "Reset to default" button uses this.
+
+4. **Tests** — `__tests__/RitualConfiguratorSheet.test.tsx` plus
+   per-form tests
+   - For each mode, the right form renders given the mode config.
+   - Editing fields builds the right payload on save.
+   - Validation blocks save when out-of-range; error text is displayed.
+   - "Reset to default" sends `mode_config_override: null`.
+   - API error response renders the formatted error.
+   - `validation.test.ts` covers each rule round-trip with the backend
+     spec table from ritual-01.
+
+## Acceptance Criteria
+
+- Each of the 7 modes has a working form.
+- Saving updates the active `UserPractice` via PATCH.
+- "Reset to default" clears the override.
+- All numeric ranges match the backend Pydantic constraints (regression
+  test for any future drift).
+- Coverage targets met.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx` | **Create** |
+| `frontend/src/features/Practice/configurator/forms/*.tsx` | **Create** (7 forms) |
+| `frontend/src/features/Practice/engine/validation.ts` | **Create** |
+| `frontend/src/api/index.ts` | Modify (add `customize`) |
+| `frontend/src/features/Practice/configurator/__tests__/*.test.tsx` | **Create** |
+| `frontend/src/features/Practice/engine/__tests__/validation.test.ts` | **Create** |
+
+## If you blow the budget
+
+Forms are the obvious split. Land the sheet shell + 3 forms (timer,
+metronome, interval-bell — covers 6 of 10 presets) as `09a`; ship the
+remaining 4 forms (rep counter, sense grounding, count-up, tarot) as `09b`.
+The sheet must guard against an unknown mode by rendering a "configuration
+not yet available — long-press to replace" message so 09a doesn't crash for
+unimplemented modes.

--- a/prompts/github-issues/ritual-practice/ritual-10-frequency-banner-switcher.md
+++ b/prompts/github-issues/ritual-practice/ritual-10-frequency-banner-switcher.md
@@ -1,0 +1,105 @@
+# ritual-10: Frequency banner + practice switcher
+
+**Labels:** `ritual-practice`, `frontend`, `feature`, `priority-medium`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-05 (frequency endpoint)
+**Estimated LoC:** ~400
+
+## Problem
+
+Two pieces of UI sit above the active practice:
+
+1. The **frequency banner** that tells the user what colour / aspect they're
+   in and names their current practice with the spec-mandated wording.
+2. The **practice switcher** — a "Replace this practice" entry point that
+   lets the user pick another approved practice for the current stage (or
+   navigate to the existing user-submission flow).
+
+Only one practice is displayed at a time, per the spec.
+
+## Scope
+
+Two components: `FrequencyBanner` (display-only) and `PracticeSwitcherSheet`
+(modal list of replacement options). Wire both via a small `useFrequency`
+hook.
+
+## Tasks
+
+1. **`useFrequency` hook** —
+   `frontend/src/features/Practice/hooks/useFrequency.ts`
+   - Fetches `GET /user-practices/current/frequency` on mount and on
+     refresh-trigger changes.
+   - Returns `{ data, isLoading, error, refetch }`.
+   - Uses the existing `useOptimisticMutation` / fetcher patterns in the
+     codebase — do not introduce React Query if the codebase doesn't
+     already use it (check first).
+
+2. **`FrequencyBanner.tsx`**
+   - Reads from `useFrequency` (or accepts `data` as a prop for
+     storybook/testing — same pattern as the existing components).
+   - Renders the server-formatted `banner_text` exactly as returned. The
+     view does **no** string assembly — that's the whole point of the
+     server endpoint from ritual-05.
+   - Visual: aspect chip + colour swatch (mapped from
+     `spiral_dynamics_color`; map lives in
+     `frontend/src/features/Practice/data/colorPalette.ts` — Beige, Purple,
+     Red, Blue, Orange, Green, Yellow, Turquoise, Ultraviolet, Clear Light
+     → hex codes for both backgrounds and accessible-contrast text).
+   - Skeleton state while loading; inline error (with retry) on failure.
+   - Tap target: opens `PracticeSwitcherSheet` (callback prop).
+
+3. **`PracticeSwitcherSheet.tsx`**
+   - Bottom-sheet listing all approved practices for the current stage
+     (`practices.list(stageNumber)`).
+   - Currently selected one shown with a check; tap on a different one
+     calls `userPractices.create({ practice_id, stage_number })`. The
+     existing partial-unique-index handling on the backend will close the
+     prior selection (see `ritual-03` model docs).
+   - "Submit my own" CTA navigates to the existing practice-submission
+     flow (already implemented in `phase-3-09`); reuse its route / nav
+     name.
+   - On selection, calls `onReplaced(newUserPractice)` so the parent can
+     refresh the banner + the active-practice view.
+
+4. **Colour palette accessibility**
+   - Each colour has a `bg` and `text` value chosen for ≥ 4.5:1 contrast
+     (WCAG AA for body text). Test the contrast in
+     `__tests__/colorPalette.test.ts` using a small `relativeLuminance`
+     helper — keeps the brand palette honest as designers tweak it.
+
+5. **Tests**
+   - `useFrequency.test.tsx` — fetch success / failure / refetch.
+   - `FrequencyBanner.test.tsx`:
+     - Loading state shows skeleton.
+     - Error state shows retry button; pressing it calls `refetch`.
+     - Success state renders `banner_text` verbatim (snapshot).
+     - Tapping the banner invokes the switcher callback.
+   - `PracticeSwitcherSheet.test.tsx`:
+     - Lists all returned practices; current one is checked.
+     - Tap on another practice posts to `userPractices.create` with the
+       right payload and fires `onReplaced`.
+     - "Submit my own" navigates to the submission route.
+   - `colorPalette.test.ts` — contrast assertions, all 10 colours mapped.
+
+## Acceptance Criteria
+
+- Banner copy matches the spec verbatim (server-controlled).
+- Colour swatches are accessible.
+- Switcher posts a new selection and the banner updates.
+- Coverage targets met.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/hooks/useFrequency.ts` | **Create** |
+| `frontend/src/features/Practice/components/FrequencyBanner.tsx` | **Create** |
+| `frontend/src/features/Practice/components/PracticeSwitcherSheet.tsx` | **Create** |
+| `frontend/src/features/Practice/data/colorPalette.ts` | **Create** |
+| `frontend/src/api/index.ts` | Modify (already has `practices.list` + `userPractices.create`; add `frequency.current` if missing) |
+| `frontend/src/features/Practice/__tests__/*.test.tsx` | **Create** |
+
+## If you blow the budget
+
+The colour palette + contrast tests can ship as their own micro-PR (`10a`)
+ahead of the banner. Otherwise everything fits.

--- a/prompts/github-issues/ritual-practice/ritual-11-screen-integration.md
+++ b/prompts/github-issues/ritual-practice/ritual-11-screen-integration.md
@@ -1,0 +1,103 @@
+# ritual-11: PracticeScreen integration
+
+**Labels:** `ritual-practice`, `frontend`, `feature`, `priority-high`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-06, ritual-07, ritual-08, ritual-09, ritual-10
+**Estimated LoC:** ~500
+
+## Problem
+
+Glue everything from this epic into a single screen that replaces the
+current `PracticeScreen.tsx` (729 LoC monolith). Only one practice is shown
+at a time — banner + active practice + a small footer with the configure /
+switch / start affordances.
+
+## Scope
+
+Rewrite `PracticeScreen.tsx` to compose the new pieces. Move the existing
+selection-only / weekly-progress logic into hooks so the screen stays under
+~250 LoC of JSX.
+
+## Tasks
+
+1. **Decompose existing `PracticeScreen.tsx`**
+   - Extract `useActivePractice` hook from the current
+     `usePracticeListState` + `usePracticeSelect` blob:
+     `frontend/src/features/Practice/hooks/useActivePractice.ts`.
+     Returns `{ activeUserPractice, effectiveConfig, effectiveName,
+     practice, isLoading, error, refresh }`.
+   - Extract `useWeeklyProgress` hook (already partially there) into its
+     own file for reuse with the new analytics endpoint from ritual-04.
+
+2. **`PracticeScreen.tsx` (rewrite)** — composition only
+   - Layout (top to bottom):
+     1. `<FrequencyBanner onReplace={openSwitcher} />` (ritual-10)
+     2. Active practice card:
+        - Header: effective name + small "configure" gear (opens
+          `RitualConfiguratorSheet`).
+        - Body: switches on `effectiveConfig.mode` to render one of:
+          `MeditationTimerView` / `CountUpTimerView` / `MetronomeView` /
+          `RepCounterView` / `IntervalBellView` /
+          `SenseGroundingView` / `TarotMeditationView`.
+          - The Tarot view receives the day-index card via
+            `cardForDayIndex(daysSinceStart)` computed from
+            `activeUserPractice.start_date` + the user's TZ.
+        - Footer: `<RitualControlsBar />` (already inside each view, but
+          some compositions hoist it — pick one and document).
+     3. `<WeeklyProgress />` (existing, refactored to read from the new
+        insights endpoint; falls back to the old `week-count` if the new
+        endpoint isn't available — purely additive).
+   - Modal mounts:
+     - `<RitualConfiguratorSheet>` (ritual-09)
+     - `<PracticeSwitcherSheet>` (ritual-10)
+     - Insight capture modal (ritual-12 — wired here, content lives there)
+
+3. **Wire up the engine**
+   - One `useRitualEngine(effectiveConfig)` per active practice.
+   - On `status` transition to `'complete'`, open the insight capture
+     modal (ritual-12) prefilled with mode, duration, and any
+     mode-specific metadata harvested from `state` (e.g. `repCount`,
+     `cuesStruck`, `currentStepIndex`).
+   - On `cancel`, no insight modal; just reset to idle.
+
+4. **Keep-awake**
+   - `useKeepAwake()` from `expo-keep-awake` while `status === 'running'`.
+   - Disable on cancel / complete / unmount.
+
+5. **Tests** — `__tests__/PracticeScreen.test.tsx`
+   - Renders banner + active practice + weekly progress.
+   - Mode dispatch: each of the 7 modes mounts the right view (parameterized
+     test fed with fabricated `effectiveConfig`).
+   - On engine `complete`, the insight capture modal is mounted (assert via
+     test-id; modal contents tested in ritual-12).
+   - Configure gear opens the configurator sheet.
+   - Banner replace tap opens the switcher sheet.
+   - Existing hook-level tests (`usePracticeListState`,
+     `usePracticeSelect`) keep passing after extraction.
+
+## Acceptance Criteria
+
+- Screen renders only one practice at a time.
+- All 7 modes mount their correct view.
+- Configure / Switch / Insight modals open at the right triggers.
+- Existing weekly-count display still works during the rollover from
+  `week-count` to the insights endpoint.
+- No file in the rewritten module exceeds 250 LoC of JSX (hooks may be
+  longer); the previous 729-LoC monolith is gone.
+- Coverage targets met.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/PracticeScreen.tsx` | Rewrite |
+| `frontend/src/features/Practice/hooks/useActivePractice.ts` | **Create** (extract) |
+| `frontend/src/features/Practice/hooks/useWeeklyProgress.ts` | **Create** (extract) |
+| `frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx` | Modify |
+
+## If you blow the budget
+
+This issue is the most likely overflow because the rewrite touches lots of
+small wiring. If the PR creeps past 700 LoC, land the hook extractions
+first as `11a` (no behavior change, pure refactor — easy review), then ship
+the screen composition + mode-dispatch + tests as `11b`.

--- a/prompts/github-issues/ritual-practice/ritual-12-post-session-insight-botmason.md
+++ b/prompts/github-issues/ritual-practice/ritual-12-post-session-insight-botmason.md
@@ -1,0 +1,115 @@
+# ritual-12: Post-session insight capture + BotMason CTA
+
+**Labels:** `ritual-practice`, `frontend`, `feature`, `priority-medium`
+**Epic:** Ritual Practice Screen
+**Depends on:** ritual-04 (session POST accepts metadata + insight),
+ritual-11 (screen mounts the modal)
+**Estimated LoC:** ~300
+
+## Problem
+
+Two product requirements converge here:
+
+1. **Capture insights and analytics.** When a session completes, prompt the
+   user for a short insight (one sentence — distinct from the long-form
+   `reflection`) and POST it together with the mode-specific metadata.
+2. **Users may want to journal after each practice — provide a link to
+   BotMason.** A single CTA from the post-session modal that hands off to
+   the Journal screen with the new session's id pre-attached, so BotMason
+   can pick up the context.
+
+## Scope
+
+One modal, one analytics POST, one navigation hand-off. No new endpoints
+(ritual-04 already covers the POST shape).
+
+## Tasks
+
+1. **`InsightCaptureModal.tsx`** —
+   `frontend/src/features/Practice/components/InsightCaptureModal.tsx`
+   - Props: `{ visible, mode, durationMinutes, modeMetadata, onSave,
+     onSkip, onJournal }`.
+   - Body:
+     - "How did it land?" header.
+     - Single-line `TextInput` (multiline allowed; soft cap 200 chars,
+       hard cap 2,000 to match the backend column).
+     - Mode-specific summary line (e.g. "108 breath cycles in 12:34" for
+       rep counters, "BPM 60 for 30:00" for metronome). Compose via a tiny
+       formatter `formatModeSummary(mode, durationMinutes, metadata)` —
+       pure function, tested.
+     - Three primary actions:
+       - **"Save"** — calls `onSave(insight)`, which (in the parent screen)
+         posts the session via `practiceSessions.create({ user_practice_id,
+         duration_minutes, completed: true, mode_metadata, insight })`,
+         shows a toast, refreshes the weekly count, dismisses.
+       - **"Save & journal with BotMason"** — calls `onJournal(insight)`,
+         which posts the session, awaits the response (so we have the
+         `session.id`), then navigates to the Journal screen with
+         `{ practice_session_id, mode, durationMinutes, insight }` as nav
+         params (the existing journal-link plumbing from
+         `phase-3-10-practice-journal-link.md` defines the route name —
+         reuse it).
+       - **"Skip"** — calls `onSkip()`, which posts the session **without**
+         an `insight` and dismisses. Skipping must still log the session;
+         analytics matter even when the user doesn't want to write.
+
+2. **Mode summary formatter** — `frontend/src/features/Practice/insights/format.ts`
+   - `formatModeSummary(mode, durationMinutes, metadata): string` per mode:
+     - meditation_timer: `"{mm:ss} of stillness"`
+     - count_up: `"{mm:ss} of open practice"`
+     - metronome: `"BPM {bpm_used} for {mm:ss}"`
+     - interval_bell: `"{intervals_struck}/{total_intervals} bells over {mm:ss}"`
+     - rep_counter: `"{rep_count} {unit_label} in {mm:ss}"` (unit_label
+       comes from the parent — pass it through `metadata`).
+     - sense_grounding: `"Grounded through {n} senses"`
+     - tarot: `"{card_name} for {mm:ss}"`
+   - Pure; covered by parameterized tests.
+
+3. **Wire in `PracticeScreen.tsx` (already mounted in ritual-11)**
+   - On engine `complete`:
+     - Build `modeMetadata` from engine state.
+     - Open `InsightCaptureModal` with the metadata + duration.
+   - The three callbacks (`onSave`, `onSkip`, `onJournal`) live on the
+     screen so they can use the existing API client + nav helpers.
+   - Navigation prop name for journal hand-off: re-use whatever
+     `phase-3-10` defined; if not implemented yet, gate the
+     "Save & journal" button behind a `featureFlag.botmasonHandoff` (read
+     from build config) and ship the other two actions; document the
+     follow-up.
+
+4. **Tests** — `__tests__/InsightCaptureModal.test.tsx` +
+   `insights/format.test.ts`
+   - Modal renders the right summary per mode (parameterized).
+   - "Save" calls `onSave` with the typed insight.
+   - "Save & journal with BotMason" calls `onJournal`.
+   - "Skip" calls `onSkip` (no insight).
+   - Hard cap at 2,000 chars enforced (validation message shown beyond
+     that).
+   - `format.test.ts` snapshots the per-mode summary strings.
+
+## Acceptance Criteria
+
+- After every completed session the user is prompted with the modal.
+- All three actions log a session; only Skip omits the insight.
+- "Save & journal with BotMason" lands the user in Journal with the
+  session id attached so BotMason has context.
+- Backend POST shape matches ritual-04's accepted payload exactly.
+- Coverage targets met.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/components/InsightCaptureModal.tsx` | **Create** |
+| `frontend/src/features/Practice/insights/format.ts` | **Create** |
+| `frontend/src/features/Practice/PracticeScreen.tsx` | Modify (wire callbacks; bulk added in ritual-11) |
+| `frontend/src/features/Practice/__tests__/InsightCaptureModal.test.tsx` | **Create** |
+| `frontend/src/features/Practice/insights/__tests__/format.test.ts` | **Create** |
+
+## If you blow the budget
+
+This issue is small enough that splitting is unlikely. If the journal
+hand-off plumbing turns out to require new nav types (likely if
+phase-3-10 isn't merged yet), defer "Save & journal" to a follow-up
+`12b` and ship the other two actions in `12a` to keep the analytics path
+unblocked.


### PR DESCRIPTION
Adds prompts/github-issues/ritual-practice/ — a new epic that scopes the
practice screen rewrite into 12 atomized, ≤700-LoC sub-issues:

- Backend: mode + mode_config schema, 10 stage-aligned preset seeds,
  per-user customization (rename / override config), session analytics
  with mode metadata + insights rollup, and a frequency-banner copy
  endpoint.
- Frontend: useRitualEngine state machine covering all 7 modes, mode
  view primitives + audio/haptics adapters, sense-grounding + tarot
  preset views, ritual configurator UI, frequency banner + practice
  switcher, PracticeScreen integration, and post-session insight
  capture with a BotMason journaling hand-off.

Each issue spells out its dependency, acceptance criteria, file list,
and a "if you blow the budget" split so stay-green stays tractable.