### PR TITLE
feat(frontend): add lucide tab bar icons for bottom navigation

### DIFF
--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -3,6 +3,14 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import {
+  BookOpen,
+  Compass,
+  Flower2,
+  NotebookPen,
+  Sprout,
+  type LucideIcon,
+} from 'lucide-react-native';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -62,6 +70,32 @@ const CourseTab = withBoundary('Course', CourseScreen);
 const JournalTab = withBoundary('Journal', JournalScreen);
 const MapTab = withBoundary('Map', MapScreen);
 
+const TAB_ICON_SIZE = 24;
+const TAB_ICON_STROKE = 2;
+
+/**
+ * Render a lucide icon for a tab bar entry. The wrapper keeps each tab's
+ * ``tabBarIcon`` definition declarative and ensures every icon shares the
+ * same size/stroke so the bar reads as a consistent set.
+ */
+const makeTabIcon =
+  (Icon: LucideIcon) =>
+  ({ color }: { color: string }): React.JSX.Element => (
+    <Icon color={color} size={TAB_ICON_SIZE} strokeWidth={TAB_ICON_STROKE} />
+  );
+
+const TAB_CONFIGS: ReadonlyArray<{
+  name: keyof RootTabParamList;
+  component: React.ComponentType<object>;
+  icon: LucideIcon;
+}> = [
+  { name: 'Habits', component: HabitsTab, icon: Sprout },
+  { name: 'Practice', component: PracticeTab, icon: Flower2 },
+  { name: 'Course', component: CourseTab, icon: BookOpen },
+  { name: 'Journal', component: JournalTab, icon: NotebookPen },
+  { name: 'Map', component: MapTab, icon: Compass },
+];
+
 /**
  * Application-wide bottom tab navigation.
  * Each tab corresponds to a major feature area.
@@ -78,6 +112,8 @@ const BottomTabs = (): React.JSX.Element => {
     <Tab.Navigator
       initialRouteName="Habits"
       screenOptions={{
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.text.tertiaryAccessible,
         headerRight: () => (
           <View style={styles.headerRight}>
             <TouchableOpacity
@@ -102,11 +138,14 @@ const BottomTabs = (): React.JSX.Element => {
         ),
       }}
     >
-      <Tab.Screen name="Habits" component={HabitsTab} />
-      <Tab.Screen name="Practice" component={PracticeTab} />
-      <Tab.Screen name="Course" component={CourseTab} />
-      <Tab.Screen name="Journal" component={JournalTab} />
-      <Tab.Screen name="Map" component={MapTab} />
+      {TAB_CONFIGS.map(({ name, component, icon }) => (
+        <Tab.Screen
+          key={name}
+          name={name}
+          component={component}
+          options={{ tabBarIcon: makeTabIcon(icon) }}
+        />
+      ))}
     </Tab.Navigator>
   );
 };

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -73,11 +73,7 @@ const MapTab = withBoundary('Map', MapScreen);
 const TAB_ICON_SIZE = 24;
 const TAB_ICON_STROKE = 2;
 
-/**
- * Render a lucide icon for a tab bar entry. The wrapper keeps each tab's
- * ``tabBarIcon`` definition declarative and ensures every icon shares the
- * same size/stroke so the bar reads as a consistent set.
- */
+/** Returns a tab-bar icon renderer with shared size/stroke for every entry. */
 const makeTabIcon =
   (Icon: LucideIcon) =>
   ({ color }: { color: string }): React.JSX.Element => (

--- a/frontend/src/navigation/__tests__/BottomTabs.test.tsx
+++ b/frontend/src/navigation/__tests__/BottomTabs.test.tsx
@@ -2,6 +2,7 @@
 /* global describe, it, expect, beforeEach, jest */
 import { NavigationContainer } from '@react-navigation/native';
 import { render, fireEvent } from '@testing-library/react-native';
+import { BookOpen, Compass, Flower2, NotebookPen, Sprout } from 'lucide-react-native';
 import React from 'react';
 
 const mockLogout = jest.fn(() => Promise.resolve());
@@ -52,5 +53,21 @@ describe('BottomTabs', () => {
 
     fireEvent.press(getByText('Logout'));
     expect(mockLogout).toHaveBeenCalled();
+  });
+
+  it('renders a lucide icon for each of the five tabs', () => {
+    const { UNSAFE_getAllByType } = render(
+      <NavigationContainer>
+        <BottomTabs />
+      </NavigationContainer>,
+    );
+
+    // The focused tab's icon may render more than once (active-state
+    // animation in @react-navigation/bottom-tabs); only assert each icon
+    // appears at least once, which is what makeTabIcon being invoked
+    // for every TAB_CONFIGS entry guarantees.
+    for (const Icon of [Sprout, Flower2, BookOpen, NotebookPen, Compass]) {
+      expect(UNSAFE_getAllByType(Icon).length).toBeGreaterThanOrEqual(1);
+    }
   });
 });


### PR DESCRIPTION
The five bottom tabs previously rendered as text-only labels. Wire each
to a lucide-react-native icon (already in deps) so the nav reads at a
glance: Sprout (Habits / growth), Flower2 (Practice / meditation),
BookOpen (Course), NotebookPen (Journal), Compass (Map / journey).
Active/inactive tints use existing design tokens for WCAG AA contrast.

https://claude.ai/code/session_01Lfn1HbBTp9vLUMjTKQKLD6