### PR TITLE
fix(frontend): wrap long BotMason responses in journal bubbles

### DIFF
--- a/frontend/src/features/Journal/Journal.styles.ts
+++ b/frontend/src/features/Journal/Journal.styles.ts
@@ -45,6 +45,8 @@ const styles = StyleSheet.create({
   bubbleText: {
     fontSize: 15,
     lineHeight: 21,
+    // Lets Text shrink inside the bubble so the parent's width constraint
+    // propagates and long unbroken tokens (URLs) wrap instead of overflowing.
     flexShrink: 1,
   },
   bubbleTextUser: {

--- a/frontend/src/features/Journal/Journal.styles.ts
+++ b/frontend/src/features/Journal/Journal.styles.ts
@@ -30,6 +30,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.md,
     paddingVertical: SPACING.sm,
     borderRadius: radius.lg,
+    flexShrink: 1,
   },
   bubbleUser: {
     backgroundColor: colors.secondary,
@@ -44,6 +45,7 @@ const styles = StyleSheet.create({
   bubbleText: {
     fontSize: 15,
     lineHeight: 21,
+    flexShrink: 1,
   },
   bubbleTextUser: {
     color: colors.text.light,

--- a/frontend/src/features/Journal/MessageBubble.tsx
+++ b/frontend/src/features/Journal/MessageBubble.tsx
@@ -113,7 +113,7 @@ const MessageBubble = ({ message, errorLabel, onRetry }: MessageBubbleProps): Re
           <Text style={styles.botAvatarText}>B</Text>
         </View>
       )}
-      <View style={[styles.bubble, isUser ? styles.bubbleUser : styles.bubbleBot]}>
+      <View testID="bubble" style={[styles.bubble, isUser ? styles.bubbleUser : styles.bubbleBot]}>
         <Text
           testID={showCursor ? 'streaming-bubble-text' : undefined}
           style={[styles.bubbleText, isUser ? styles.bubbleTextUser : styles.bubbleTextBot]}

--- a/frontend/src/features/Journal/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/features/Journal/__tests__/MessageBubble.test.tsx
@@ -1,12 +1,17 @@
 /* eslint-env jest */
 import { describe, it, expect, jest } from '@jest/globals';
 import React from 'react';
+import { StyleSheet, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
 import renderer from 'react-test-renderer';
 
 import MessageBubble, { type ChatMessage } from '../MessageBubble';
 
 interface TextInstance {
-  props: { children: unknown };
+  props: { children: unknown; style?: StyleProp<TextStyle> };
+}
+
+interface ViewInstance {
+  props: { style?: StyleProp<ViewStyle> };
 }
 
 const makeMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
@@ -152,5 +157,34 @@ describe('MessageBubble', () => {
     const root = tree.root;
     const texts = root.findAllByType('Text') as TextInstance[];
     expect(texts.some((t) => t.props.children === 'Hello world')).toBe(true);
+  });
+
+  it('shrinks the bot bubble within its row so long text wraps', () => {
+    // Without flexShrink, a long unbroken word (URL, code identifier) would
+    // push the bubble past the row's maxWidth and Text would not wrap.
+    const longText = 'https://example.com/very/long/path/that/should/wrap/inside/the/bubble';
+    const msg = makeMessage({ sender: 'bot', message: longText });
+    const tree = renderer.create(<MessageBubble message={msg} />);
+    const root = tree.root;
+    const views = root.findAllByType('View') as ViewInstance[];
+    const bubble = views.find((v) => {
+      const flat = StyleSheet.flatten(v.props.style) as ViewStyle | undefined;
+      return flat?.borderBottomLeftRadius !== undefined;
+    });
+    expect(bubble).toBeTruthy();
+    const flatBubble = StyleSheet.flatten(bubble!.props.style) as ViewStyle;
+    expect(flatBubble.flexShrink).toBe(1);
+  });
+
+  it('wraps long bot text by applying a flexible text style', () => {
+    const longText = 'reticulatingsplinesreticulatingsplinesreticulatingsplines';
+    const msg = makeMessage({ sender: 'bot', message: longText });
+    const tree = renderer.create(<MessageBubble message={msg} />);
+    const root = tree.root;
+    const texts = root.findAllByType('Text') as TextInstance[];
+    const body = texts.find((t) => t.props.children === longText);
+    expect(body).toBeTruthy();
+    const flat = StyleSheet.flatten(body!.props.style) as TextStyle;
+    expect(flat.flexShrink).toBe(1);
   });
 });

--- a/frontend/src/features/Journal/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/features/Journal/__tests__/MessageBubble.test.tsx
@@ -165,14 +165,19 @@ describe('MessageBubble', () => {
     const longText = 'https://example.com/very/long/path/that/should/wrap/inside/the/bubble';
     const msg = makeMessage({ sender: 'bot', message: longText });
     const tree = renderer.create(<MessageBubble message={msg} />);
-    const root = tree.root;
-    const views = root.findAllByType('View') as ViewInstance[];
-    const bubble = views.find((v) => {
-      const flat = StyleSheet.flatten(v.props.style) as ViewStyle | undefined;
-      return flat?.borderBottomLeftRadius !== undefined;
-    });
-    expect(bubble).toBeTruthy();
-    const flatBubble = StyleSheet.flatten(bubble!.props.style) as ViewStyle;
+    const bubble = tree.root.findByProps({ testID: 'bubble' }) as ViewInstance;
+    const flatBubble = StyleSheet.flatten(bubble.props.style) as ViewStyle;
+    expect(flatBubble.flexShrink).toBe(1);
+  });
+
+  it('shrinks the user bubble within its row so long text wraps', () => {
+    // `bubble`/`bubbleText` are shared by both sender roles; guard the user
+    // side too so a future divergence cannot silently reintroduce overflow.
+    const longText = 'https://example.com/another/very/long/path/from/the/user';
+    const msg = makeMessage({ sender: 'user', message: longText });
+    const tree = renderer.create(<MessageBubble message={msg} />);
+    const bubble = tree.root.findByProps({ testID: 'bubble' }) as ViewInstance;
+    const flatBubble = StyleSheet.flatten(bubble.props.style) as ViewStyle;
     expect(flatBubble.flexShrink).toBe(1);
   });
 
@@ -180,11 +185,10 @@ describe('MessageBubble', () => {
     const longText = 'reticulatingsplinesreticulatingsplinesreticulatingsplines';
     const msg = makeMessage({ sender: 'bot', message: longText });
     const tree = renderer.create(<MessageBubble message={msg} />);
-    const root = tree.root;
-    const texts = root.findAllByType('Text') as TextInstance[];
+    const texts = tree.root.findAllByType('Text') as TextInstance[];
     const body = texts.find((t) => t.props.children === longText);
-    expect(body).toBeTruthy();
-    const flat = StyleSheet.flatten(body!.props.style) as TextStyle;
+    if (!body) throw new Error('expected to find body text node');
+    const flat = StyleSheet.flatten(body.props.style) as TextStyle;
     expect(flat.flexShrink).toBe(1);
   });
 });


### PR DESCRIPTION
Bubbles inside the row's 85% maxWidth had no flexShrink, so an
unbroken token (URL, code identifier) pushed the Text past the
boundary instead of wrapping. Add flexShrink:1 to bubble and
bubbleText so the Text knows its constrained width and wraps.

https://claude.ai/code/session_01A8m1ZkKnjVAgim7ZMXLbSU