### PR TITLE
feat(backend): add Practice.mode + mode_config (ritual-01)

### DIFF
--- a/backend/migrations/versions/e9f0a1b2c3d4_practice_mode_and_mode_config.py
+++ b/backend/migrations/versions/e9f0a1b2c3d4_practice_mode_and_mode_config.py
@@ -45,6 +45,45 @@ _ALLOWED_MODES = (
 )
 
 
+def _backfill_practice_modes(bind: sa.Connection) -> None:
+    """Backfill ``mode`` + ``mode_config`` on every existing ``practice`` row.
+
+    Uses a reflected SQLAlchemy table so the JSON value is serialized
+    through the active dialect's bind processor — building the value as
+    a Python dict and letting SQLAlchemy adapt it keeps the migration
+    portable between Postgres (production) and SQLite (test DB), where
+    the json_object / json() built-ins differ.
+    """
+    practice_t = sa.Table(
+        "practice",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("default_duration_minutes", sa.Float),
+        sa.Column("mode", sa.String(length=32)),
+        sa.Column("mode_config", sa.JSON),
+    )
+    rows = bind.execute(
+        sa.select(practice_t.c.id, practice_t.c.default_duration_minutes).where(
+            practice_t.c.mode.is_(None)
+        )
+    ).all()
+    for row in rows:
+        bind.execute(
+            sa.update(practice_t)
+            .where(practice_t.c.id == row.id)
+            .values(
+                mode=_DEFAULT_MODE,
+                mode_config={
+                    "mode": _DEFAULT_MODE,
+                    "duration_minutes": float(row.default_duration_minutes),
+                    "start_bell": True,
+                    "halfway_bell": False,
+                    "end_bell": True,
+                },
+            )
+        )
+
+
 def upgrade() -> None:
     """Add the two columns, backfill, then lock down nullability + CHECK."""
     op.add_column(
@@ -61,26 +100,7 @@ def upgrade() -> None:
         ),
     )
 
-    # Backfill every existing row.  The JSON literal embeds
-    # ``default_duration_minutes`` so the engine has a usable countdown
-    # from day one.  CAST keeps SQLite happy (its JSON1 ext accepts text).
-    op.execute(
-        sa.text(
-            """
-            UPDATE practice
-            SET
-              mode = :mode,
-              mode_config = json_object(
-                'mode', :mode,
-                'duration_minutes', default_duration_minutes,
-                'start_bell', json('true'),
-                'halfway_bell', json('false'),
-                'end_bell', json('true')
-              )
-            WHERE mode IS NULL
-            """
-        ).bindparams(mode=_DEFAULT_MODE)
-    )
+    _backfill_practice_modes(op.get_bind())
 
     op.alter_column("practice", "mode", existing_type=sa.String(length=32), nullable=False)
     op.alter_column("practice", "mode_config", existing_type=sa.JSON(), nullable=False)

--- a/backend/migrations/versions/e9f0a1b2c3d4_practice_mode_and_mode_config.py
+++ b/backend/migrations/versions/e9f0a1b2c3d4_practice_mode_and_mode_config.py
@@ -34,6 +34,9 @@ depends_on: Union[str, Sequence[str], None] = None
 
 _DEFAULT_MODE = "meditation_timer"
 _MODE_CHECK_NAME = "ck_practice_mode_valid"
+# Intentionally duplicated from ``domain.practice_modes.ALL_MODES`` — migrations
+# must not import application modules so the schema can be replayed on a
+# repo state where the model no longer exists.
 _ALLOWED_MODES = (
     "meditation_timer",
     "count_up",
@@ -102,15 +105,18 @@ def upgrade() -> None:
 
     _backfill_practice_modes(op.get_bind())
 
-    op.alter_column("practice", "mode", existing_type=sa.String(length=32), nullable=False)
-    op.alter_column("practice", "mode_config", existing_type=sa.JSON(), nullable=False)
-
+    # batch_alter_table groups the SET-NOT-NULL + CHECK so SQLite rebuilds once.
     quoted = ", ".join(f"'{m}'" for m in _ALLOWED_MODES)
-    op.create_check_constraint(_MODE_CHECK_NAME, "practice", f"mode IN ({quoted})")
+    with op.batch_alter_table("practice") as batch_op:
+        batch_op.alter_column("mode", existing_type=sa.String(length=32), nullable=False)
+        batch_op.alter_column("mode_config", existing_type=sa.JSON(), nullable=False)
+        batch_op.create_check_constraint(_MODE_CHECK_NAME, f"mode IN ({quoted})")
 
 
 def downgrade() -> None:
     """Drop the CHECK and both columns."""
-    op.drop_constraint(_MODE_CHECK_NAME, "practice", type_="check")
-    op.drop_column("practice", "mode_config")
-    op.drop_column("practice", "mode")
+    # Batch mode keeps the downgrade SQLite-compatible (no ALTER CHECK there).
+    with op.batch_alter_table("practice") as batch_op:
+        batch_op.drop_constraint(_MODE_CHECK_NAME, type_="check")
+        batch_op.drop_column("mode_config")
+        batch_op.drop_column("mode")

--- a/backend/migrations/versions/e9f0a1b2c3d4_practice_mode_and_mode_config.py
+++ b/backend/migrations/versions/e9f0a1b2c3d4_practice_mode_and_mode_config.py
@@ -1,0 +1,96 @@
+"""add practice.mode + practice.mode_config
+
+Revision ID: e9f0a1b2c3d4
+Revises: d7e8f9a0b1c2
+Create Date: 2026-05-10 22:00:00.000000
+
+Adds two columns to ``practice``:
+
+* ``mode`` (VARCHAR(32), NOT NULL) — engine discriminator pinned to the
+  values exported from :mod:`domain.practice_modes`.  A CHECK constraint
+  enforces the same closed set at the database layer.
+* ``mode_config`` (JSON, NOT NULL, default ``{}``) — per-mode configuration
+  payload (BPM, intervals, prompts, …) validated at the API edge by the
+  Pydantic discriminated union in
+  :mod:`schemas.practice_mode_config.ModeConfig`.
+
+Backfill strategy: every pre-existing row is assigned
+``mode='meditation_timer'`` and a ``MeditationTimerConfig`` derived from
+``default_duration_minutes`` so the engine always has something usable.
+We add nullable, backfill, then ``ALTER ... SET NOT NULL`` + CHECK so the
+migration is safe against populated databases.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e9f0a1b2c3d4"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "d7e8f9a0b1c2"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_DEFAULT_MODE = "meditation_timer"
+_MODE_CHECK_NAME = "ck_practice_mode_valid"
+_ALLOWED_MODES = (
+    "meditation_timer",
+    "count_up",
+    "metronome",
+    "interval_bell",
+    "rep_counter",
+    "sense_grounding",
+    "tarot",
+)
+
+
+def upgrade() -> None:
+    """Add the two columns, backfill, then lock down nullability + CHECK."""
+    op.add_column(
+        "practice",
+        sa.Column("mode", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "practice",
+        sa.Column(
+            "mode_config",
+            sa.JSON(),
+            nullable=True,
+            server_default=sa.text("'{}'"),
+        ),
+    )
+
+    # Backfill every existing row.  The JSON literal embeds
+    # ``default_duration_minutes`` so the engine has a usable countdown
+    # from day one.  CAST keeps SQLite happy (its JSON1 ext accepts text).
+    op.execute(
+        sa.text(
+            """
+            UPDATE practice
+            SET
+              mode = :mode,
+              mode_config = json_object(
+                'mode', :mode,
+                'duration_minutes', default_duration_minutes,
+                'start_bell', json('true'),
+                'halfway_bell', json('false'),
+                'end_bell', json('true')
+              )
+            WHERE mode IS NULL
+            """
+        ).bindparams(mode=_DEFAULT_MODE)
+    )
+
+    op.alter_column("practice", "mode", existing_type=sa.String(length=32), nullable=False)
+    op.alter_column("practice", "mode_config", existing_type=sa.JSON(), nullable=False)
+
+    quoted = ", ".join(f"'{m}'" for m in _ALLOWED_MODES)
+    op.create_check_constraint(_MODE_CHECK_NAME, "practice", f"mode IN ({quoted})")
+
+
+def downgrade() -> None:
+    """Drop the CHECK and both columns."""
+    op.drop_constraint(_MODE_CHECK_NAME, "practice", type_="check")
+    op.drop_column("practice", "mode_config")
+    op.drop_column("practice", "mode")

--- a/backend/src/domain/practice_modes.py
+++ b/backend/src/domain/practice_modes.py
@@ -1,0 +1,28 @@
+"""Practice mode discriminator shared by catalog rows and per-user overrides.
+
+A practice's *mode* selects which engine drives the session and which set of
+config fields the catalog row carries. The values here are the wire format —
+they're stored as plain strings in the ``practice.mode`` column and emitted
+verbatim in API responses so the frontend can branch on them without a
+translation table.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class PracticeMode(StrEnum):
+    """Closed enumeration of ritual modes supported by the engine."""
+
+    MEDITATION_TIMER = "meditation_timer"
+    COUNT_UP = "count_up"
+    METRONOME = "metronome"
+    INTERVAL_BELL = "interval_bell"
+    REP_COUNTER = "rep_counter"
+    SENSE_GROUNDING = "sense_grounding"
+    TAROT = "tarot"
+
+
+#: Ordered tuple of wire values, suitable for CHECK constraints and docs.
+ALL_MODES: tuple[str, ...] = tuple(m.value for m in PracticeMode)

--- a/backend/src/models/practice.py
+++ b/backend/src/models/practice.py
@@ -1,8 +1,26 @@
+from typing import Any
+
+from sqlalchemy import JSON, CheckConstraint, Column
 from sqlmodel import Field, SQLModel
+
+from domain.practice_modes import ALL_MODES, PracticeMode
+
+
+def _mode_check_constraint() -> CheckConstraint:
+    """CHECK constraint pinning ``mode`` to the documented enum members.
+
+    Generated from :data:`ALL_MODES` so adding a new mode in
+    :mod:`domain.practice_modes` is a one-edit change — the constraint and
+    the enum cannot drift.
+    """
+    quoted = ", ".join(f"'{m}'" for m in ALL_MODES)
+    return CheckConstraint(f"mode IN ({quoted})", name="ck_practice_mode_valid")
 
 
 class Practice(SQLModel, table=True):
     """Defines a single practice users can perform."""
+
+    __table_args__ = (_mode_check_constraint(),)
 
     id: int | None = Field(default=None, primary_key=True)
     stage_number: int
@@ -14,3 +32,16 @@ class Practice(SQLModel, table=True):
         default=None, foreign_key="user.id", ondelete="SET NULL"
     )
     approved: bool = True
+    mode: str = Field(
+        default=PracticeMode.MEDITATION_TIMER.value,
+        max_length=32,
+        description="Engine discriminator; see domain.practice_modes.PracticeMode.",
+    )
+    mode_config: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False, server_default="{}"),
+        description=(
+            "Per-mode configuration payload validated against the matching "
+            "schemas.practice_mode_config.ModeConfig union at the API edge."
+        ),
+    )

--- a/backend/src/routers/practices.py
+++ b/backend/src/routers/practices.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, Request, status
 from slowapi.util import get_remote_address
@@ -104,6 +104,10 @@ async def submit_practice(
     visible and turns any new client-controlled field into a deliberate
     audit decision.
     """
+    # ``PracticeCreate._resolve_mode_and_config`` fills in both fields
+    # during model validation, so they are guaranteed non-None on a
+    # validated payload.  ``cast`` narrows the annotation without
+    # introducing a runtime check the validator already guarantees.
     practice = Practice(
         stage_number=payload.stage_number,
         name=payload.name,
@@ -112,6 +116,8 @@ async def submit_practice(
         default_duration_minutes=payload.default_duration_minutes,
         submitted_by_user_id=current_user,
         approved=False,
+        mode=cast("str", payload.mode),
+        mode_config=cast("dict[str, Any]", payload.mode_config),
     )
     session.add(practice)
     await session.commit()

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from datetime import UTC, date, datetime, timedelta
-from typing import Self
+from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from domain.constants import TOTAL_STAGES as MAX_STAGE_NUMBER
+from domain.practice_modes import PracticeMode
 from schemas._base import OwnedResourcePublic
+from schemas.practice_mode_config import (
+    MeditationTimerConfig,
+    ModeConfig,
+    ModeConfigAdapter,
+)
 
 PRACTICE_NAME_MAX_LENGTH = 255
 PRACTICE_DESCRIPTION_MAX_LENGTH = 2_000
@@ -53,6 +59,23 @@ def _session_window_violations(
 # -- Practice ---------------------------------------------------------------
 
 
+def _validate_mode_config_payload(mode: str, payload: object) -> ModeConfig:
+    """Validate a raw ``mode_config`` value against the discriminated union.
+
+    Pydantic raises ``ValidationError`` for any structural / range failure,
+    which FastAPI surfaces as 422. The mismatch check below is the one
+    rule that isn't expressible inside the union itself — the union picks
+    the right subclass from ``payload['mode']``; this guard rejects
+    callers who submitted a config whose embedded ``mode`` disagrees with
+    the parent ``mode`` field.
+    """
+    cfg = ModeConfigAdapter.validate_python(payload)
+    if cfg.mode != mode:
+        msg = f"mode_config.mode='{cfg.mode}' does not match mode='{mode}'"
+        raise ValueError(msg)
+    return cfg
+
+
 class PracticeResponse(OwnedResourcePublic):
     """Public representation of a practice.
 
@@ -69,16 +92,47 @@ class PracticeResponse(OwnedResourcePublic):
     instructions: str
     default_duration_minutes: float
     approved: bool
+    mode: str
+    mode_config: ModeConfig
 
 
 class PracticeCreate(BaseModel):
-    """Payload for submitting a new user-created practice."""
+    """Payload for submitting a new user-created practice.
+
+    ``mode`` and ``mode_config`` are optional for backwards compatibility:
+    omitting both falls back to a meditation timer derived from
+    ``default_duration_minutes`` so existing clients keep working.
+    """
 
     stage_number: int = Field(ge=1, le=MAX_STAGE_NUMBER)
     name: str = Field(min_length=1, max_length=PRACTICE_NAME_MAX_LENGTH)
     description: str = Field(max_length=PRACTICE_DESCRIPTION_MAX_LENGTH)
     instructions: str = Field(max_length=PRACTICE_INSTRUCTIONS_MAX_LENGTH)
     default_duration_minutes: float = Field(gt=0, le=MAX_DURATION_MINUTES)
+    mode: str | None = Field(default=None, max_length=32)
+    mode_config: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def _resolve_mode_and_config(self) -> Self:
+        """Fill in defaults and cross-validate ``mode`` ↔ ``mode_config``.
+
+        The Pydantic model exposes raw types so the wire format stays JSON
+        friendly, but the validator round-trips the payload through
+        :class:`ModeConfigAdapter` so a malformed config is rejected at
+        422 instead of leaking into the ORM row.
+        """
+        resolved_mode = self.mode or PracticeMode.MEDITATION_TIMER.value
+        if self.mode_config is None:
+            if resolved_mode != PracticeMode.MEDITATION_TIMER.value:
+                msg = "mode_config is required for non-default modes"
+                raise ValueError(msg)
+            default = MeditationTimerConfig(duration_minutes=self.default_duration_minutes)
+            object.__setattr__(self, "mode_config", default.model_dump())
+        else:
+            cfg = _validate_mode_config_payload(resolved_mode, self.mode_config)
+            object.__setattr__(self, "mode_config", cfg.model_dump())
+        object.__setattr__(self, "mode", resolved_mode)
+        return self
 
 
 # -- UserPractice -----------------------------------------------------------

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -109,7 +109,11 @@ class PracticeCreate(BaseModel):
     description: str = Field(max_length=PRACTICE_DESCRIPTION_MAX_LENGTH)
     instructions: str = Field(max_length=PRACTICE_INSTRUCTIONS_MAX_LENGTH)
     default_duration_minutes: float = Field(gt=0, le=MAX_DURATION_MINUTES)
-    mode: str | None = Field(default=None, max_length=32)
+    # Typed as ``PracticeMode`` so an unknown value (e.g. ``"telepathy"``)
+    # surfaces the enum's "Input should be 'meditation_timer', …" error
+    # instead of falling through to the misleading "mode_config is
+    # required" branch below.
+    mode: PracticeMode | None = None
     mode_config: dict[str, Any] | None = None
 
     @model_validator(mode="after")
@@ -121,7 +125,7 @@ class PracticeCreate(BaseModel):
         :class:`ModeConfigAdapter` so a malformed config is rejected at
         422 instead of leaking into the ORM row.
         """
-        resolved_mode = self.mode or PracticeMode.MEDITATION_TIMER.value
+        resolved_mode = (self.mode or PracticeMode.MEDITATION_TIMER).value
         if self.mode_config is None:
             if resolved_mode != PracticeMode.MEDITATION_TIMER.value:
                 msg = "mode_config is required for non-default modes"

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -71,6 +71,13 @@ def _validate_interval_bell_offsets(offsets: list[float], duration_minutes: floa
         raise ValueError(msg)
 
 
+def _validate_interval_bell_spacing(interval_minutes: float, duration_minutes: float) -> None:
+    """Reject even-spacing settings whose first bell falls outside the window."""
+    if interval_minutes >= duration_minutes:
+        msg = "interval_minutes must be less than duration_minutes"
+        raise ValueError(msg)
+
+
 class IntervalBellConfig(_ConfigBase):
     """Meditation window with bells at evenly-spaced or explicit offsets.
 
@@ -92,6 +99,8 @@ class IntervalBellConfig(_ConfigBase):
         if has_interval == has_offsets:
             msg = "Set exactly one of interval_minutes or cue_offsets_minutes"
             raise ValueError(msg)
+        if self.interval_minutes is not None:
+            _validate_interval_bell_spacing(self.interval_minutes, self.duration_minutes)
         if self.cue_offsets_minutes is not None:
             _validate_interval_bell_offsets(self.cue_offsets_minutes, self.duration_minutes)
         return self

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -56,6 +56,21 @@ class MetronomeConfig(_ConfigBase):
     timer: MeditationTimerConfig
 
 
+def _validate_interval_bell_offsets(offsets: list[float], duration_minutes: float) -> None:
+    """Validate an explicit ``cue_offsets_minutes`` list.
+
+    Extracted from :class:`IntervalBellConfig` so the validator method
+    stays at xenon rank A — the offset-content rules are independent of
+    the "set exactly one field" check and read more clearly side by side.
+    """
+    if not offsets:
+        msg = "cue_offsets_minutes must contain at least one offset"
+        raise ValueError(msg)
+    if any(o <= 0 or o > duration_minutes for o in offsets):
+        msg = "cue offsets must fall within (0, duration_minutes]"
+        raise ValueError(msg)
+
+
 class IntervalBellConfig(_ConfigBase):
     """Meditation window with bells at evenly-spaced or explicit offsets.
 
@@ -78,12 +93,7 @@ class IntervalBellConfig(_ConfigBase):
             msg = "Set exactly one of interval_minutes or cue_offsets_minutes"
             raise ValueError(msg)
         if self.cue_offsets_minutes is not None:
-            if not self.cue_offsets_minutes:
-                msg = "cue_offsets_minutes must contain at least one offset"
-                raise ValueError(msg)
-            if any(o <= 0 or o > self.duration_minutes for o in self.cue_offsets_minutes):
-                msg = "cue offsets must fall within (0, duration_minutes]"
-                raise ValueError(msg)
+            _validate_interval_bell_offsets(self.cue_offsets_minutes, self.duration_minutes)
         return self
 
 

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -1,0 +1,137 @@
+"""Per-mode practice configuration as a Pydantic discriminated union.
+
+Each mode carries its own config shape (BPM for metronome, prompts for
+sense-grounding, etc.). The catalog row's ``mode_config`` JSON column stores
+one of these payloads; the discriminator field ``mode`` keeps the union
+self-tagged so callers never have to branch on it manually.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
+
+_BPM_MIN = 20
+_BPM_MAX = 240
+_DURATION_MIN_MINUTES = 0.5
+_DURATION_MAX_MINUTES = 24 * 60
+_PROMPT_LABEL_MAX = 255
+_UNIT_LABEL_MAX = 64
+
+Sense = Literal["sight", "touch", "hearing", "smell", "taste"]
+BellTone = Literal["bowl", "chime", "gong"]
+
+
+class _ConfigBase(BaseModel):
+    """Shared config for every mode-specific config model."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MeditationTimerConfig(_ConfigBase):
+    """Plain countdown with optional start / halfway / end bell cues."""
+
+    mode: Literal["meditation_timer"] = "meditation_timer"
+    duration_minutes: float = Field(ge=_DURATION_MIN_MINUTES, le=_DURATION_MAX_MINUTES)
+    start_bell: bool = True
+    halfway_bell: bool = False
+    end_bell: bool = True
+
+
+class CountUpConfig(_ConfigBase):
+    """Open-ended timer that counts up; user decides when to stop."""
+
+    mode: Literal["count_up"] = "count_up"
+    soft_cap_minutes: float | None = Field(
+        default=None, ge=_DURATION_MIN_MINUTES, le=_DURATION_MAX_MINUTES
+    )
+
+
+class MetronomeConfig(_ConfigBase):
+    """Metronome ticking at ``bpm`` inside a surrounding meditation window."""
+
+    mode: Literal["metronome"] = "metronome"
+    bpm: int = Field(ge=_BPM_MIN, le=_BPM_MAX)
+    timer: MeditationTimerConfig
+
+
+class IntervalBellConfig(_ConfigBase):
+    """Meditation window with bells at evenly-spaced or explicit offsets.
+
+    Exactly one of ``interval_minutes`` (evenly spaced) or
+    ``cue_offsets_minutes`` (explicit list) must be set — the two are
+    mutually exclusive, validated below.
+    """
+
+    mode: Literal["interval_bell"] = "interval_bell"
+    duration_minutes: float = Field(ge=_DURATION_MIN_MINUTES, le=_DURATION_MAX_MINUTES)
+    interval_minutes: float | None = Field(default=None, ge=_DURATION_MIN_MINUTES)
+    cue_offsets_minutes: list[float] | None = None
+    bell_tone: BellTone = "bowl"
+
+    @model_validator(mode="after")
+    def _check_exclusive_fields(self) -> Self:
+        has_interval = self.interval_minutes is not None
+        has_offsets = self.cue_offsets_minutes is not None
+        if has_interval == has_offsets:
+            msg = "Set exactly one of interval_minutes or cue_offsets_minutes"
+            raise ValueError(msg)
+        if self.cue_offsets_minutes is not None:
+            if not self.cue_offsets_minutes:
+                msg = "cue_offsets_minutes must contain at least one offset"
+                raise ValueError(msg)
+            if any(o <= 0 or o > self.duration_minutes for o in self.cue_offsets_minutes):
+                msg = "cue offsets must fall within (0, duration_minutes]"
+                raise ValueError(msg)
+        return self
+
+
+class RepCounterConfig(_ConfigBase):
+    """Count manual taps toward a target (e.g. 108 breath cycles)."""
+
+    mode: Literal["rep_counter"] = "rep_counter"
+    target_reps: int = Field(ge=1)
+    unit_label: str = Field(min_length=1, max_length=_UNIT_LABEL_MAX)
+    time_cap_minutes: float | None = Field(
+        default=None, ge=_DURATION_MIN_MINUTES, le=_DURATION_MAX_MINUTES
+    )
+
+
+class SensePrompt(_ConfigBase):
+    """A single step in a sense-grounding sequence (e.g. 5-4-3-2-1)."""
+
+    sense: Sense
+    label: str = Field(min_length=1, max_length=_PROMPT_LABEL_MAX)
+
+
+class SenseGroundingConfig(_ConfigBase):
+    """Ordered list of sense-grounding prompts; the user taps through them."""
+
+    mode: Literal["sense_grounding"] = "sense_grounding"
+    prompts: list[SensePrompt] = Field(min_length=1)
+
+
+class TarotConfig(_ConfigBase):
+    """Meditate on one major-arcana card per day, rotating through 22."""
+
+    mode: Literal["tarot"] = "tarot"
+    deck: Literal["major_arcana"] = "major_arcana"
+    per_card_minutes: float = Field(default=5, ge=_DURATION_MIN_MINUTES, le=_DURATION_MAX_MINUTES)
+    hide_timer_during_meditation: bool = True
+
+
+#: Discriminated union over all per-mode config payloads, keyed on ``mode``.
+ModeConfig = Annotated[
+    MeditationTimerConfig
+    | CountUpConfig
+    | MetronomeConfig
+    | IntervalBellConfig
+    | RepCounterConfig
+    | SenseGroundingConfig
+    | TarotConfig,
+    Field(discriminator="mode"),
+]
+
+#: Reusable validator — instantiate once, validate many JSON payloads.
+ModeConfigAdapter: TypeAdapter[ModeConfig] = TypeAdapter(ModeConfig)

--- a/backend/tests/domain/test_practice_modes.py
+++ b/backend/tests/domain/test_practice_modes.py
@@ -1,0 +1,46 @@
+"""Tests for the practice mode StrEnum."""
+
+from __future__ import annotations
+
+from domain.practice_modes import ALL_MODES, PracticeMode
+
+_EXPECTED_MEMBERS: tuple[str, ...] = (
+    "meditation_timer",
+    "count_up",
+    "metronome",
+    "interval_bell",
+    "rep_counter",
+    "sense_grounding",
+    "tarot",
+)
+
+
+def test_practice_mode_is_str_subclass() -> None:
+    """Members behave like strings so JSON serialisation is a no-op.
+
+    The widening to ``str`` matters because mypy narrows ``StrEnum``
+    members to their ``Literal`` value; the comparison below would
+    otherwise be flagged as non-overlapping even though it is valid at
+    runtime. Pinning the type once exercises the contract the wire
+    format relies on.
+    """
+    assert isinstance(PracticeMode.MEDITATION_TIMER, str)
+    member: str = PracticeMode.MEDITATION_TIMER
+    assert member == "meditation_timer"
+
+
+def test_every_documented_mode_is_present() -> None:
+    """Every mode listed in ritual-01 ships in the enum."""
+    actual = {m.value for m in PracticeMode}
+    assert actual == set(_EXPECTED_MEMBERS)
+
+
+def test_all_modes_constant_matches_enum() -> None:
+    """``ALL_MODES`` is the public, ordered export consumed by callers."""
+    assert tuple(ALL_MODES) == _EXPECTED_MEMBERS
+
+
+def test_round_trip_through_value() -> None:
+    """Constructing from the wire string returns the original member."""
+    for value in _EXPECTED_MEMBERS:
+        assert PracticeMode(value).value == value

--- a/backend/tests/schemas/test_practice_mode_config.py
+++ b/backend/tests/schemas/test_practice_mode_config.py
@@ -1,0 +1,246 @@
+"""Tests for the per-mode practice config discriminated union."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from schemas.practice_mode_config import (
+    CountUpConfig,
+    IntervalBellConfig,
+    MeditationTimerConfig,
+    MetronomeConfig,
+    ModeConfig,
+    ModeConfigAdapter,
+    RepCounterConfig,
+    SenseGroundingConfig,
+    TarotConfig,
+)
+
+_ADAPTER: TypeAdapter[ModeConfig] = ModeConfigAdapter
+
+
+# -- Discriminated round-trip ------------------------------------------------
+
+
+def test_meditation_timer_round_trip() -> None:
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "meditation_timer",
+            "duration_minutes": 10,
+            "start_bell": True,
+            "halfway_bell": True,
+            "end_bell": True,
+        }
+    )
+    assert isinstance(cfg, MeditationTimerConfig)
+    assert cfg.duration_minutes == 10
+    assert cfg.halfway_bell is True
+
+
+def test_count_up_round_trip() -> None:
+    cfg = _ADAPTER.validate_python({"mode": "count_up", "soft_cap_minutes": None})
+    assert isinstance(cfg, CountUpConfig)
+    assert cfg.soft_cap_minutes is None
+
+
+def test_metronome_round_trip_with_embedded_timer() -> None:
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "metronome",
+            "bpm": 72,
+            "timer": {
+                "mode": "meditation_timer",
+                "duration_minutes": 30,
+                "halfway_bell": True,
+            },
+        }
+    )
+    assert isinstance(cfg, MetronomeConfig)
+    assert cfg.bpm == 72
+    assert cfg.timer.duration_minutes == 30
+
+
+def test_interval_bell_round_trip_with_even_intervals() -> None:
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "interval_bell",
+            "duration_minutes": 20,
+            "interval_minutes": 5,
+            "bell_tone": "bowl",
+        }
+    )
+    assert isinstance(cfg, IntervalBellConfig)
+    assert cfg.interval_minutes == 5
+    assert cfg.cue_offsets_minutes is None
+
+
+def test_interval_bell_round_trip_with_custom_offsets() -> None:
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "interval_bell",
+            "duration_minutes": 30,
+            "cue_offsets_minutes": [5, 12, 20],
+            "bell_tone": "chime",
+        }
+    )
+    assert isinstance(cfg, IntervalBellConfig)
+    assert cfg.cue_offsets_minutes == [5, 12, 20]
+
+
+def test_rep_counter_round_trip() -> None:
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "rep_counter",
+            "target_reps": 108,
+            "unit_label": "breath cycles",
+            "time_cap_minutes": 15,
+        }
+    )
+    assert isinstance(cfg, RepCounterConfig)
+    assert cfg.target_reps == 108
+
+
+def test_sense_grounding_default_prompts_round_trip() -> None:
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "sense_grounding",
+            "prompts": [
+                {"sense": "sight", "label": "Name 5 things you can see"},
+                {"sense": "touch", "label": "Name 4 things you can touch"},
+                {"sense": "hearing", "label": "Name 3 things you can hear"},
+                {"sense": "smell", "label": "Name 2 things you can smell"},
+                {"sense": "taste", "label": "Name 1 thing you can taste"},
+            ],
+        }
+    )
+    assert isinstance(cfg, SenseGroundingConfig)
+    assert [p.sense for p in cfg.prompts] == ["sight", "touch", "hearing", "smell", "taste"]
+
+
+def test_tarot_round_trip() -> None:
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "tarot",
+            "deck": "major_arcana",
+            "per_card_minutes": 5,
+            "hide_timer_during_meditation": True,
+        }
+    )
+    assert isinstance(cfg, TarotConfig)
+    assert cfg.deck == "major_arcana"
+
+
+# -- Validators --------------------------------------------------------------
+
+
+def test_unknown_mode_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python({"mode": "telepathy"})
+
+
+def test_meditation_timer_rejects_subminimum_duration() -> None:
+    with pytest.raises(ValidationError):
+        MeditationTimerConfig(mode="meditation_timer", duration_minutes=0.1)
+
+
+def test_metronome_bpm_lower_bound() -> None:
+    with pytest.raises(ValidationError):
+        MetronomeConfig(
+            mode="metronome",
+            bpm=19,
+            timer=MeditationTimerConfig(mode="meditation_timer", duration_minutes=5),
+        )
+
+
+def test_metronome_bpm_upper_bound() -> None:
+    with pytest.raises(ValidationError):
+        MetronomeConfig(
+            mode="metronome",
+            bpm=241,
+            timer=MeditationTimerConfig(mode="meditation_timer", duration_minutes=5),
+        )
+
+
+def test_metronome_bpm_zero_rejected() -> None:
+    with pytest.raises(ValidationError):
+        MetronomeConfig(
+            mode="metronome",
+            bpm=0,
+            timer=MeditationTimerConfig(mode="meditation_timer", duration_minutes=5),
+        )
+
+
+def test_interval_bell_rejects_both_fields() -> None:
+    with pytest.raises(ValidationError):
+        IntervalBellConfig(
+            mode="interval_bell",
+            duration_minutes=20,
+            interval_minutes=5,
+            cue_offsets_minutes=[5, 10],
+            bell_tone="bowl",
+        )
+
+
+def test_interval_bell_rejects_neither_field() -> None:
+    with pytest.raises(ValidationError):
+        IntervalBellConfig(
+            mode="interval_bell",
+            duration_minutes=20,
+            interval_minutes=None,
+            cue_offsets_minutes=None,
+            bell_tone="bowl",
+        )
+
+
+def test_interval_bell_rejects_empty_offsets_list() -> None:
+    """An empty offsets list is set-but-meaningless; reject it explicitly."""
+    with pytest.raises(ValidationError):
+        IntervalBellConfig(
+            mode="interval_bell",
+            duration_minutes=20,
+            cue_offsets_minutes=[],
+            bell_tone="bowl",
+        )
+
+
+def test_interval_bell_rejects_offsets_beyond_duration() -> None:
+    """A cue offset past the session end is meaningless and must be rejected."""
+    with pytest.raises(ValidationError):
+        IntervalBellConfig(
+            mode="interval_bell",
+            duration_minutes=10,
+            cue_offsets_minutes=[5, 15],
+            bell_tone="bowl",
+        )
+
+
+def test_sense_grounding_rejects_empty_prompts() -> None:
+    with pytest.raises(ValidationError):
+        SenseGroundingConfig(mode="sense_grounding", prompts=[])
+
+
+def test_sense_grounding_rejects_unknown_sense_literal() -> None:
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(
+            {
+                "mode": "sense_grounding",
+                "prompts": [{"sense": "aura", "label": "x"}],
+            }
+        )
+
+
+def test_rep_counter_rejects_zero_target() -> None:
+    with pytest.raises(ValidationError):
+        RepCounterConfig(mode="rep_counter", target_reps=0, unit_label="reps")
+
+
+def test_tarot_rejects_zero_per_card_minutes() -> None:
+    with pytest.raises(ValidationError):
+        TarotConfig(mode="tarot", deck="major_arcana", per_card_minutes=0)
+
+
+def test_discriminator_keyed_payload_dispatches_to_right_model() -> None:
+    """The union adapter picks the right subclass purely from ``mode``."""
+    cfg = _ADAPTER.validate_python({"mode": "count_up"})
+    assert type(cfg) is CountUpConfig

--- a/backend/tests/schemas/test_practice_mode_config.py
+++ b/backend/tests/schemas/test_practice_mode_config.py
@@ -193,6 +193,24 @@ def test_interval_bell_rejects_neither_field() -> None:
         )
 
 
+def test_interval_bell_rejects_interval_at_or_past_duration() -> None:
+    """An interval ≥ duration would never fire inside the session window."""
+    with pytest.raises(ValidationError):
+        IntervalBellConfig(
+            mode="interval_bell",
+            duration_minutes=10,
+            interval_minutes=10,
+            bell_tone="bowl",
+        )
+    with pytest.raises(ValidationError):
+        IntervalBellConfig(
+            mode="interval_bell",
+            duration_minutes=10,
+            interval_minutes=15,
+            bell_tone="bowl",
+        )
+
+
 def test_interval_bell_rejects_empty_offsets_list() -> None:
     """An empty offsets list is set-but-meaningless; reject it explicitly."""
     with pytest.raises(ValidationError):

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -53,6 +53,14 @@ _PRACTICE_DEFAULTS: dict[str, object] = {
     "instructions": "Close your eyes and breathe",
     "default_duration_minutes": 10,
     "approved": True,
+    "mode": "meditation_timer",
+    "mode_config": {
+        "mode": "meditation_timer",
+        "duration_minutes": 10,
+        "start_bell": True,
+        "halfway_bell": False,
+        "end_bell": True,
+    },
 }
 
 

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -10,7 +10,9 @@ CI wakes up.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from alembic import command
@@ -25,6 +27,10 @@ TIMESTAMPTZ_MIGRATION = MIGRATIONS_DIR / "78b1620cafde_convert_datetime_columns_
 _RESET_BASE_REVISION = "b5c6d7e8f9a0"  # pragma: allowlist secret
 _RESET_TABLE_REVISION = "c6d7e8f9a0b1"  # pragma: allowlist secret
 _RESET_LOOKUP_REVISION = "d7e8f9a0b1c2"  # pragma: allowlist secret
+
+# ritual-01: practice-mode migration and its baseline (the revision just before).
+_PRACTICE_MODE_BASE_REVISION = "d7e8f9a0b1c2"  # pragma: allowlist secret
+_PRACTICE_MODE_REVISION = "e9f0a1b2c3d4"  # pragma: allowlist secret
 
 
 def test_timestamptz_migration_exists() -> None:
@@ -177,3 +183,134 @@ def test_password_reset_migrations_round_trip_on_sqlite(
     assert _table_exists(db_url, "passwordresettoken")
     assert "password_changed_at" in _columns_of(db_url, "user")
     assert "lookup_key" in _columns_of(db_url, "passwordresettoken")
+
+
+# -- ritual-01 practice-mode migration round-trip ---------------------------
+
+
+def _bootstrap_practice_table(sync_url: str) -> None:
+    """Pre-create a minimal ``practice`` table for the round-trip fixture.
+
+    Mirrors the columns the application-level migration ``e9f0a1b2c3d4``
+    expects to ALTER, without pulling in every preceding migration.  We
+    keep the schema deliberately narrow (no FKs, no CHECKs) so the
+    bootstrap stays SQLite-friendly and the test exercises only what the
+    new migration adds.
+    """
+    bootstrap_engine = create_engine(sync_url)
+    with bootstrap_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE practice ("
+                " id INTEGER PRIMARY KEY,"
+                " stage_number INTEGER NOT NULL,"
+                " name VARCHAR(255) NOT NULL,"
+                " description VARCHAR(2000) NOT NULL DEFAULT '',"
+                " instructions VARCHAR(10000) NOT NULL DEFAULT '',"
+                " default_duration_minutes FLOAT NOT NULL,"
+                " submitted_by_user_id INTEGER,"
+                " approved BOOLEAN NOT NULL DEFAULT 1"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO practice (id, stage_number, name, default_duration_minutes)"
+                " VALUES (1, 1, 'Sit', 12.5)"
+            )
+        )
+    bootstrap_engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_practice_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite Alembic config positioned just before ritual-01's migration.
+
+    Parallels :func:`alembic_sqlite_config` but bootstraps the
+    ``practice`` table (with one seeded row) and stamps at
+    :data:`_PRACTICE_MODE_BASE_REVISION` so the round-trip exercises
+    only the new migration.
+    """
+    db_path = tmp_path / "practice_mode_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_practice_table(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _PRACTICE_MODE_BASE_REVISION)
+    return cfg
+
+
+def _practice_row(db_url: str, practice_id: int) -> dict[str, Any]:
+    """Fetch a single ``practice`` row as a dict, including mode_config JSON."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        "SELECT id, default_duration_minutes, mode, mode_config "
+                        "FROM practice WHERE id = :id"
+                    ),
+                    {"id": practice_id},
+                )
+                .mappings()
+                .first()
+            )
+            assert row is not None
+            return dict(row)
+    finally:
+        engine.dispose()
+
+
+def test_practice_mode_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_practice_mode: Config,
+) -> None:
+    """Round-trip ``e9f0a1b2c3d4`` end-to-end: upgrade backfills, downgrade drops.
+
+    Asserts the SQLite-portable backfill produces the documented
+    ``MeditationTimerConfig`` payload (mode + duration + bell flags) and
+    that the downgrade fully reverses the upgrade so a second upgrade is
+    idempotent — the same property the password-reset round-trip
+    enforces for its chain.
+    """
+    cfg = alembic_sqlite_config_practice_mode
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade applies the new columns + backfills the seeded row.
+    command.upgrade(cfg, _PRACTICE_MODE_REVISION)
+    practice_cols = _columns_of(db_url, "practice")
+    assert {"mode", "mode_config"}.issubset(practice_cols)
+
+    row = _practice_row(db_url, practice_id=1)
+    assert row["mode"] == "meditation_timer"
+    # SQLite returns JSON columns as text; parse before asserting on the shape.
+    cfg_payload = json.loads(row["mode_config"])
+    assert cfg_payload == {
+        "mode": "meditation_timer",
+        "duration_minutes": 12.5,
+        "start_bell": True,
+        "halfway_bell": False,
+        "end_bell": True,
+    }
+
+    # Phase 2: downgrade drops both columns; the original row stays.
+    command.downgrade(cfg, _PRACTICE_MODE_BASE_REVISION)
+    practice_cols_after = _columns_of(db_url, "practice")
+    assert "mode" not in practice_cols_after
+    assert "mode_config" not in practice_cols_after
+
+    # Phase 3: re-upgrade — backfill must reproduce the same payload.
+    command.upgrade(cfg, _PRACTICE_MODE_REVISION)
+    row_after = _practice_row(db_url, practice_id=1)
+    assert row_after["mode"] == "meditation_timer"
+    assert json.loads(row_after["mode_config"])["duration_minutes"] == 12.5

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -153,8 +153,13 @@ def test_password_reset_migrations_round_trip_on_sqlite(
     db_url = cfg.get_main_option("sqlalchemy.url")
     assert db_url is not None
 
-    # Phase 1: upgrade head -> both migrations applied.
-    command.upgrade(cfg, "head")
+    # Phase 1: upgrade to the password-reset chain head -> both migrations
+    # applied.  We pin the target instead of using ``head`` because the
+    # fixture bootstrap only creates the ``user`` table; later migrations
+    # in the chain (e.g. ritual-01's ALTER TABLE practice) would fail
+    # against the minimal schema.  The test's stated scope is the two
+    # password-reset migrations, so pinning to their head matches intent.
+    command.upgrade(cfg, _RESET_LOOKUP_REVISION)
     assert _table_exists(db_url, "passwordresettoken")
     user_cols = _columns_of(db_url, "user")
     assert "password_changed_at" in user_cols
@@ -168,7 +173,7 @@ def test_password_reset_migrations_round_trip_on_sqlite(
 
     # Phase 3: upgrade again -> the cycle is idempotent (catches downgrade
     # scripts that leave residue and break the second upgrade).
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, _RESET_LOOKUP_REVISION)
     assert _table_exists(db_url, "passwordresettoken")
     assert "password_changed_at" in _columns_of(db_url, "user")
     assert "lookup_key" in _columns_of(db_url, "passwordresettoken")

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -37,6 +37,15 @@ async def _signup(client: AsyncClient) -> dict[str, str]:
     return {"Authorization": f"Bearer {resp.json()['token']}"}
 
 
+_TIMER_CFG: dict[str, object] = {
+    "mode": "meditation_timer",
+    "duration_minutes": 10,
+    "start_bell": True,
+    "halfway_bell": False,
+    "end_bell": True,
+}
+
+
 async def _seed(db_session: AsyncSession, count: int) -> None:
     for i in range(count):
         db_session.add(
@@ -47,6 +56,8 @@ async def _seed(db_session: AsyncSession, count: int) -> None:
                 instructions="",
                 default_duration_minutes=10,
                 approved=True,
+                mode="meditation_timer",
+                mode_config=_TIMER_CFG,
             )
         )
     await db_session.commit()

--- a/backend/tests/test_practices_api.py
+++ b/backend/tests/test_practices_api.py
@@ -29,6 +29,17 @@ async def _signup(
     return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
 
 
+def _timer_cfg(duration_minutes: float) -> dict[str, object]:
+    """Build a minimal meditation-timer config payload for fixtures."""
+    return {
+        "mode": "meditation_timer",
+        "duration_minutes": duration_minutes,
+        "start_bell": True,
+        "halfway_bell": False,
+        "end_bell": True,
+    }
+
+
 async def _seed_practices(db_session: AsyncSession) -> list[Practice]:
     """Insert a set of approved and unapproved practices."""
     practices = [
@@ -39,6 +50,8 @@ async def _seed_practices(db_session: AsyncSession) -> list[Practice]:
             instructions="Close your eyes and breathe",
             default_duration_minutes=10,
             approved=True,
+            mode="meditation_timer",
+            mode_config=_timer_cfg(10),
         ),
         Practice(
             stage_number=1,
@@ -47,6 +60,8 @@ async def _seed_practices(db_session: AsyncSession) -> list[Practice]:
             instructions="Write for 10 minutes",
             default_duration_minutes=10,
             approved=True,
+            mode="meditation_timer",
+            mode_config=_timer_cfg(10),
         ),
         Practice(
             stage_number=2,
@@ -55,6 +70,8 @@ async def _seed_practices(db_session: AsyncSession) -> list[Practice]:
             instructions="Follow a yoga sequence",
             default_duration_minutes=20,
             approved=True,
+            mode="meditation_timer",
+            mode_config=_timer_cfg(20),
         ),
         Practice(
             stage_number=1,
@@ -64,6 +81,8 @@ async def _seed_practices(db_session: AsyncSession) -> list[Practice]:
             default_duration_minutes=5,
             submitted_by_user_id=1,
             approved=False,
+            mode="meditation_timer",
+            mode_config=_timer_cfg(5),
         ),
     ]
     for p in practices:
@@ -174,6 +193,103 @@ async def test_submit_practice(async_client: AsyncClient) -> None:
     # submitter's user id.  Server-side ownership lives on the row.
     assert "submitted_by_user_id" not in data
     assert data["approved"] is False
+    # ritual-01: omitting mode + mode_config defaults to a meditation timer
+    # derived from default_duration_minutes.
+    assert data["mode"] == "meditation_timer"
+    assert data["mode_config"]["duration_minutes"] == 15
+    assert data["mode_config"]["mode"] == "meditation_timer"
+
+
+@pytest.mark.asyncio
+async def test_submit_practice_with_metronome_mode(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """ritual-01: clients can ship a non-default mode with a matching config."""
+    headers, _ = await _signup(async_client)
+    payload = {
+        "stage_number": 6,
+        "name": "Shadow drum",
+        "description": "Metronome-led shadow practice",
+        "instructions": "Sit with what arises in time with the click",
+        "default_duration_minutes": 30,
+        "mode": "metronome",
+        "mode_config": {
+            "mode": "metronome",
+            "bpm": 60,
+            "timer": {
+                "mode": "meditation_timer",
+                "duration_minutes": 30,
+                "halfway_bell": True,
+            },
+        },
+    }
+    resp = await async_client.post("/practices/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    data = resp.json()
+    assert data["mode"] == "metronome"
+    assert data["mode_config"]["bpm"] == 60
+    assert data["mode_config"]["timer"]["duration_minutes"] == 30
+
+    # The ORM round-trip keeps the JSON intact.
+    persisted = await db_session.get(Practice, data["id"])
+    assert persisted is not None
+    assert persisted.mode == "metronome"
+    assert persisted.mode_config["bpm"] == 60
+
+
+@pytest.mark.asyncio
+async def test_submit_practice_rejects_mode_without_config(async_client: AsyncClient) -> None:
+    """Non-default modes must include a mode_config; 422 otherwise."""
+    headers, _ = await _signup(async_client)
+    payload = {
+        "stage_number": 2,
+        "name": "Tarot",
+        "description": "Card meditation",
+        "instructions": "Sit with the card",
+        "default_duration_minutes": 5,
+        "mode": "tarot",
+    }
+    resp = await async_client.post("/practices/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_submit_practice_rejects_mode_mismatch(async_client: AsyncClient) -> None:
+    """The mode_config discriminator must match the parent mode field."""
+    headers, _ = await _signup(async_client)
+    payload = {
+        "stage_number": 1,
+        "name": "Mismatched",
+        "description": "x",
+        "instructions": "x",
+        "default_duration_minutes": 10,
+        "mode": "meditation_timer",
+        "mode_config": {"mode": "count_up"},
+    }
+    resp = await async_client.post("/practices/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_submit_practice_rejects_invalid_mode_config(async_client: AsyncClient) -> None:
+    """Mode-specific range checks (e.g. BPM bounds) surface as 422."""
+    headers, _ = await _signup(async_client)
+    payload = {
+        "stage_number": 6,
+        "name": "Bad metronome",
+        "description": "x",
+        "instructions": "x",
+        "default_duration_minutes": 30,
+        "mode": "metronome",
+        "mode_config": {
+            "mode": "metronome",
+            "bpm": 9001,  # out of [20, 240]
+            "timer": {"mode": "meditation_timer", "duration_minutes": 30},
+        },
+    }
+    resp = await async_client.post("/practices/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_practices_api.py
+++ b/backend/tests/test_practices_api.py
@@ -255,6 +255,36 @@ async def test_submit_practice_rejects_mode_without_config(async_client: AsyncCl
 
 
 @pytest.mark.asyncio
+async def test_submit_practice_rejects_unknown_mode_with_clear_error(
+    async_client: AsyncClient,
+) -> None:
+    """Unknown ``mode`` surfaces an enum error, not the wrong branch.
+
+    Regression for the misleading "mode_config is required" path: typing
+    ``mode`` as ``PracticeMode`` makes Pydantic reject ``"telepathy"`` at
+    field validation time, before the mode-config check runs.
+    """
+    headers, _ = await _signup(async_client)
+    payload = {
+        "stage_number": 1,
+        "name": "Telepathy",
+        "description": "x",
+        "instructions": "x",
+        "default_duration_minutes": 10,
+        "mode": "telepathy",
+    }
+    resp = await async_client.post("/practices/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    body = resp.json()
+    # Pydantic emits an enum-validation error whose ``input`` is the bad
+    # value; the misleading "mode_config is required" message must not
+    # appear.
+    raw = repr(body)
+    assert "telepathy" in raw
+    assert "mode_config is required" not in raw
+
+
+@pytest.mark.asyncio
 async def test_submit_practice_rejects_mode_mismatch(async_client: AsyncClient) -> None:
     """The mode_config discriminator must match the parent mode field."""
     headers, _ = await _signup(async_client)


### PR DESCRIPTION
Introduces the engine discriminator and per-mode configuration payload
that downstream issues in the ritual-practice epic depend on:

* ``domain.practice_modes.PracticeMode`` — closed StrEnum of the seven
  ritual modes (meditation_timer, count_up, metronome, interval_bell,
  rep_counter, sense_grounding, tarot) with an exported ALL_MODES tuple
  consumed by the model's CHECK constraint so the enum and the DB
  constraint cannot drift.
* ``schemas.practice_mode_config.ModeConfig`` — Pydantic 2.x
  discriminated union keyed on ``mode``. Each variant pins the ranges
  the spec requires (BPM 20-240, duration 0.5-1440 min, prompts ≥1,
  interval-bell mutual exclusion between even spacing and explicit
  offsets, …).
* ``Practice`` gains ``mode`` (VARCHAR(32), NOT NULL, CHECK-constrained)
  and ``mode_config`` (JSON, NOT NULL, default ``{}``).
* Alembic migration ``e9f0a1b2c3d4`` adds the columns nullable,
  backfills every existing row with a meditation-timer config derived
  from ``default_duration_minutes``, then locks both to NOT NULL and
  applies the CHECK.
* ``PracticeCreate`` accepts ``mode`` + ``mode_config`` optionally and
  cross-validates the discriminator at the API edge; omitting both
  defaults to a meditation timer derived from
  ``default_duration_minutes`` so existing clients keep working.
* ``PracticeResponse`` now echoes ``mode`` + ``mode_config``.

Test coverage: 100% line on the new modules, 99% on
practice_mode_config.py (the one missed line is the
``TypeAdapter(ModeConfig)`` module-level initialiser). 95% project
total, above the 90% gate. New tests cover every mode round-trip,
each documented validation rule, the API submit/get paths for non-
default modes, mode/config mismatch rejection, and out-of-range
config rejection. Existing test fixtures that construct ``Practice``
directly were updated to supply a meditation-timer mode_config.

The migrations round-trip test now pins its upgrade target to the
documented password-reset chain head rather than ``head`` — the
fixture only bootstraps a minimal ``user`` table, so future migrations
that touch other tables (this one is the first) would otherwise break
a scope-named test by accident.