### PR TITLE
feat(frontend-practice): mode views + audio/haptics adapters (ritual-07)

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     '^@react-native-async-storage/async-storage$': '<rootDir>/src/__mocks__/async-storage.js',
     '^expo-secure-store$': '<rootDir>/src/__mocks__/expo-secure-store.js',
     '^expo-av$': '<rootDir>/src/__mocks__/expo-av.js',
+    '^expo-haptics$': '<rootDir>/src/__mocks__/expo-haptics.js',
     '^expo-keep-awake$': '<rootDir>/src/__mocks__/expo-keep-awake.js',
     '^@react-native-community/netinfo$': '<rootDir>/src/__mocks__/netinfo.js',
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,8 @@
         "@react-navigation/native-stack": "^7.14.11",
         "expo": "~52.0.43",
         "expo-av": "~15.0.2",
+        "expo-haptics": "~14.0.1",
+        "expo-keep-awake": "~14.0.3",
         "expo-notifications": "~0.29.14",
         "expo-secure-store": "^55.0.11",
         "expo-status-bar": "~2.0.1",
@@ -9795,6 +9797,15 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-14.0.1.tgz",
+      "integrity": "sha512-V81FZ7xRUfqM6uSI6FA1KnZ+QpEKnISqafob/xEfcx1ymwhm4V3snuLWWFjmAz+XaZQTqlYa8z3QbqEXz7G63w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
     "@react-navigation/native-stack": "^7.14.11",
     "expo": "~52.0.43",
     "expo-av": "~15.0.2",
+    "expo-haptics": "~14.0.1",
+    "expo-keep-awake": "~14.0.3",
     "expo-notifications": "~0.29.14",
     "expo-secure-store": "^55.0.11",
     "expo-status-bar": "~2.0.1",

--- a/frontend/src/__mocks__/expo-haptics.js
+++ b/frontend/src/__mocks__/expo-haptics.js
@@ -1,0 +1,11 @@
+/* global jest */
+const ImpactFeedbackStyle = { Light: 'light', Medium: 'medium', Heavy: 'heavy' };
+const NotificationFeedbackType = { Success: 'success', Warning: 'warning', Error: 'error' };
+
+module.exports = {
+  ImpactFeedbackStyle,
+  NotificationFeedbackType,
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+  selectionAsync: jest.fn().mockResolvedValue(undefined),
+};

--- a/frontend/src/features/Practice/engine/adapters/__tests__/audio.test.ts
+++ b/frontend/src/features/Practice/engine/adapters/__tests__/audio.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Audio } from 'expo-av';
+
+import { createExpoAudioAdapter, createNoopAudioAdapter } from '../audio';
+
+const mockedCreateAsync = Audio.Sound.createAsync as jest.MockedFunction<
+  typeof Audio.Sound.createAsync
+>;
+
+describe('createNoopAudioAdapter', () => {
+  it('returns an adapter that resolves play without throwing and supports dispose', () => {
+    const adapter = createNoopAudioAdapter();
+    expect(() => adapter.play('start_bell')).not.toThrow();
+    expect(() => adapter.dispose?.()).not.toThrow();
+  });
+});
+
+describe('createExpoAudioAdapter', () => {
+  let warnSpy: jest.SpiedFunction<typeof console.warn>;
+  let replayMock: jest.Mock<() => Promise<void>>;
+  let unloadMock: jest.Mock<() => Promise<void>>;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    replayMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    unloadMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    mockedCreateAsync.mockReset();
+    mockedCreateAsync.mockResolvedValue({
+      sound: { replayAsync: replayMock, unloadAsync: unloadMock },
+    } as unknown as Awaited<ReturnType<typeof Audio.Sound.createAsync>>);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns once for the missing metronome_tick asset and degrades to no-op', async () => {
+    const adapter = createExpoAudioAdapter();
+    // Flush microtasks so the eager loaders settle.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('metronome_tick');
+
+    await adapter.play('metronome_tick');
+    await adapter.play('metronome_tick');
+    // Second play does not produce a second warning.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // No replay attempted for the failed cue.
+    expect(replayMock).not.toHaveBeenCalled();
+  });
+
+  it('plays loaded cues via replayAsync', async () => {
+    const adapter = createExpoAudioAdapter();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await adapter.play('start_bell');
+    await adapter.play('halfway_bell');
+    await adapter.play('end_bell');
+    expect(replayMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('marks a cue as failed and warns once when load rejects', async () => {
+    mockedCreateAsync.mockRejectedValueOnce(new Error('decode error'));
+    const adapter = createExpoAudioAdapter();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // 1 warn from the decode failure + 1 from the missing metronome_tick asset.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    await adapter.play('start_bell');
+    // First cue had its load fail → no replay.
+    expect(replayMock).not.toHaveBeenCalled();
+  });
+
+  it('disposes by unloading every loaded sound', async () => {
+    const adapter = createExpoAudioAdapter();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    adapter.dispose?.();
+    // Four cues bundle real assets; metronome_tick was never loaded.
+    expect(unloadMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('marks a cue as failed if replayAsync rejects, suppressing further warns', async () => {
+    replayMock.mockRejectedValueOnce(new Error('decoder gone'));
+    const adapter = createExpoAudioAdapter();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // 1 startup warn (metronome_tick).
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    await adapter.play('start_bell');
+    // +1 warn for the replay failure on start_bell.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    await adapter.play('start_bell');
+    // Subsequent plays are silenced — total warn count unchanged.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/features/Practice/engine/adapters/__tests__/haptics.test.ts
+++ b/frontend/src/features/Practice/engine/adapters/__tests__/haptics.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as Haptics from 'expo-haptics';
+
+import { createExpoHapticsAdapter, createNoopHapticsAdapter } from '../haptics';
+
+const impactMock = Haptics.impactAsync as jest.MockedFunction<typeof Haptics.impactAsync>;
+const notificationMock = Haptics.notificationAsync as jest.MockedFunction<
+  typeof Haptics.notificationAsync
+>;
+
+describe('createNoopHapticsAdapter', () => {
+  it('returns an adapter that ignores cue calls', () => {
+    const adapter = createNoopHapticsAdapter();
+    expect(() => adapter.cue('start_bell')).not.toThrow();
+  });
+});
+
+describe('createExpoHapticsAdapter', () => {
+  beforeEach(() => {
+    impactMock.mockClear();
+    notificationMock.mockClear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fires Light impact for start_bell and halfway_bell', async () => {
+    const adapter = createExpoHapticsAdapter();
+    adapter.cue('start_bell');
+    adapter.cue('halfway_bell');
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(impactMock).toHaveBeenCalledTimes(2);
+    expect(impactMock).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+  });
+
+  it('fires Medium impact for interval_bell', async () => {
+    const adapter = createExpoHapticsAdapter();
+    adapter.cue('interval_bell');
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(impactMock).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+  });
+
+  it('fires Success notification for end_bell', async () => {
+    const adapter = createExpoHapticsAdapter();
+    adapter.cue('end_bell');
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(notificationMock).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Success);
+  });
+
+  it('skips haptics for metronome_tick (would be a constant buzz)', async () => {
+    const adapter = createExpoHapticsAdapter();
+    adapter.cue('metronome_tick');
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(impactMock).not.toHaveBeenCalled();
+    expect(notificationMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows hardware errors silently', async () => {
+    impactMock.mockRejectedValueOnce(new Error('no taptic'));
+    const adapter = createExpoHapticsAdapter();
+    expect(() => adapter.cue('start_bell')).not.toThrow();
+    // Allow the swallowed rejection to settle.
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+});

--- a/frontend/src/features/Practice/engine/adapters/audio.ts
+++ b/frontend/src/features/Practice/engine/adapters/audio.ts
@@ -1,0 +1,108 @@
+// Audio adapter implementations for the ritual engine. Each cue kind maps to
+// a static asset bundled under `frontend/assets/sounds/`. If an asset is
+// missing at load time, the adapter logs a single warning per cue and falls
+// back to a no-op — a missing file must not break the practice session.
+
+import { Audio } from 'expo-av';
+
+import type { AudioAdapter, CueKind } from '../types';
+
+type SoundModule = number;
+
+/** Static asset map. `null` means "best-effort load; warn-then-noop if missing". */
+const CUE_ASSETS: Record<CueKind, SoundModule | null> = {
+  start_bell: require('../../../../../assets/sounds/bell-start.mp3') as SoundModule,
+  halfway_bell: require('../../../../../assets/sounds/bell-half.mp3') as SoundModule,
+  end_bell: require('../../../../../assets/sounds/bell-end.mp3') as SoundModule,
+  // interval_bell reuses the mid-tone bell asset; future polish can swap in
+  // tone-specific variants based on IntervalBellConfig.bell_tone.
+  interval_bell: require('../../../../../assets/sounds/bell-half.mp3') as SoundModule,
+  // metronome-tick.wav is not yet shipped; load is best-effort.
+  metronome_tick: null,
+};
+
+// Structural type for the subset of expo-av's Sound surface this adapter uses.
+// Avoids tangling with expo-av's class typing while keeping the contract clear.
+interface PlayableSound {
+  replayAsync: () => Promise<unknown>;
+  unloadAsync: () => Promise<unknown>;
+}
+
+interface SoundEntry {
+  sound: PlayableSound | null;
+  failed: boolean;
+}
+
+function makeEntry(): SoundEntry {
+  return { sound: null, failed: false };
+}
+
+/** No-op adapter for tests and when audio assets are intentionally absent. */
+export function createNoopAudioAdapter(): AudioAdapter {
+  return {
+    play: () => undefined,
+    dispose: () => undefined,
+  };
+}
+
+/**
+ * expo-av-backed adapter. Sound loading is fire-and-forget; if an asset
+ * fails to load, that cue degrades to a no-op and a single warning is
+ * emitted (subsequent plays do not re-warn).
+ */
+export function createExpoAudioAdapter(): AudioAdapter {
+  const entries = new Map<CueKind, SoundEntry>();
+  for (const kind of Object.keys(CUE_ASSETS) as CueKind[]) {
+    entries.set(kind, makeEntry());
+    void loadCue(kind, entries);
+  }
+
+  return {
+    play: (kind) => playCue(kind, entries),
+    dispose: () => disposeAll(entries),
+  };
+}
+
+async function loadCue(kind: CueKind, entries: Map<CueKind, SoundEntry>): Promise<void> {
+  const asset = CUE_ASSETS[kind];
+  const entry = entries.get(kind);
+  if (!entry) return;
+  if (asset === null) {
+    markFailed(entry, kind, 'asset not bundled');
+    return;
+  }
+  try {
+    const { sound } = await Audio.Sound.createAsync(asset);
+    // expo-av's `Sound` class implements Playback's methods structurally but
+    // TypeScript's class-side typing doesn't surface them as own members; cast
+    // through unknown rather than tighten the structural contract.
+    entry.sound = sound as unknown as PlayableSound;
+  } catch (err) {
+    markFailed(entry, kind, err);
+  }
+}
+
+function markFailed(entry: SoundEntry, kind: CueKind, reason: unknown): void {
+  if (entry.failed) return;
+  entry.failed = true;
+  console.warn(`[ritual-audio] cue "${kind}" unavailable — falling back to silent:`, reason);
+}
+
+async function playCue(kind: CueKind, entries: Map<CueKind, SoundEntry>): Promise<void> {
+  const entry = entries.get(kind);
+  if (!entry || entry.failed || !entry.sound) return;
+  try {
+    await entry.sound.replayAsync();
+  } catch (err) {
+    markFailed(entry, kind, err);
+  }
+}
+
+function disposeAll(entries: Map<CueKind, SoundEntry>): void {
+  for (const entry of entries.values()) {
+    if (entry.sound) {
+      void entry.sound.unloadAsync();
+      entry.sound = null;
+    }
+  }
+}

--- a/frontend/src/features/Practice/engine/adapters/haptics.ts
+++ b/frontend/src/features/Practice/engine/adapters/haptics.ts
@@ -33,6 +33,11 @@ async function fireHaptic(kind: CueKind): Promise<void> {
         return;
       case 'metronome_tick':
         return;
+      default:
+        // Exhaustiveness guard: if a new CueKind is added to the union, the
+        // assignment below fails to compile, forcing this switch to be updated.
+        ((_x: never): void => undefined)(kind);
+        return;
     }
   } catch {
     // Haptic hardware may be unavailable (web, simulator). Swallow silently;

--- a/frontend/src/features/Practice/engine/adapters/haptics.ts
+++ b/frontend/src/features/Practice/engine/adapters/haptics.ts
@@ -1,0 +1,41 @@
+// Haptic feedback adapter. Maps engine cue kinds to expo-haptics primitives.
+// metronome_tick is intentionally silent — haptics on every beat is awful.
+
+import * as Haptics from 'expo-haptics';
+
+import type { CueKind, HapticsAdapter } from '../types';
+
+/** No-op adapter for tests and platforms without haptic hardware. */
+export function createNoopHapticsAdapter(): HapticsAdapter {
+  return { cue: () => undefined };
+}
+
+export function createExpoHapticsAdapter(): HapticsAdapter {
+  return {
+    cue: (kind) => {
+      void fireHaptic(kind);
+    },
+  };
+}
+
+async function fireHaptic(kind: CueKind): Promise<void> {
+  try {
+    switch (kind) {
+      case 'start_bell':
+      case 'halfway_bell':
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        return;
+      case 'interval_bell':
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+        return;
+      case 'end_bell':
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        return;
+      case 'metronome_tick':
+        return;
+    }
+  } catch {
+    // Haptic hardware may be unavailable (web, simulator). Swallow silently;
+    // the practice continues without tactile feedback.
+  }
+}

--- a/frontend/src/features/Practice/engine/types.ts
+++ b/frontend/src/features/Practice/engine/types.ts
@@ -103,7 +103,9 @@ export interface RitualControls {
 }
 
 export interface AudioAdapter {
-  play: (kind: CueKind) => void;
+  play: (kind: CueKind) => void | Promise<void>;
+  /** Free any loaded sound resources. Optional; safe to omit for no-op adapters. */
+  dispose?: () => void;
 }
 
 export interface HapticsAdapter {

--- a/frontend/src/features/Practice/views/CountUpTimerView.tsx
+++ b/frontend/src/features/Practice/views/CountUpTimerView.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import type { RitualControls, RitualState } from '../engine/types';
+
+import { formatTime } from './formatTime';
+import RitualControlsBar from './RitualControlsBar';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+interface Props {
+  state: RitualState;
+  controls: RitualControls;
+}
+
+const CountUpTimerView = ({ state, controls }: Props): React.JSX.Element => (
+  <View style={styles.container} testID="count-up-timer-view">
+    <Text style={styles.time} testID="count-up-elapsed">
+      {formatTime(state.elapsedMs)}
+    </Text>
+    <Text style={styles.label}>elapsed</Text>
+    {state.status === 'running' && (
+      <TouchableOpacity
+        style={styles.endButton}
+        onPress={controls.complete}
+        testID="count-up-end"
+        accessibilityRole="button"
+        accessibilityLabel="End session"
+      >
+        <Text style={styles.endButtonText}>End session</Text>
+      </TouchableOpacity>
+    )}
+    <View style={styles.spacer} />
+    <RitualControlsBar status={state.status} controls={controls} />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl },
+  time: {
+    fontSize: 64,
+    fontWeight: '200',
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+    marginTop: SPACING.xxl,
+  },
+  label: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    marginTop: SPACING.xs,
+    marginBottom: SPACING.xl,
+    textTransform: 'uppercase',
+    letterSpacing: 2,
+  },
+  endButton: {
+    backgroundColor: colors.success,
+    paddingVertical: SPACING.md,
+    paddingHorizontal: SPACING.xl,
+    borderRadius: BORDER_RADIUS.lg,
+    marginBottom: SPACING.xl,
+  },
+  endButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
+  spacer: { height: SPACING.md },
+});
+
+export default CountUpTimerView;

--- a/frontend/src/features/Practice/views/IntervalBellView.tsx
+++ b/frontend/src/features/Practice/views/IntervalBellView.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { scheduledCues } from '../engine/cues';
+import type { IntervalBellConfig, RitualControls, RitualState } from '../engine/types';
+
+import { formatTime } from './formatTime';
+import RitualControlsBar from './RitualControlsBar';
+
+import { SPACING, colors } from '@/design/tokens';
+
+interface Props {
+  config: IntervalBellConfig;
+  state: RitualState;
+  controls: RitualControls;
+}
+
+const IntervalBellView = ({ config, state, controls }: Props): React.JSX.Element => {
+  const cues = scheduledCues(config);
+  const untilNextMs =
+    state.nextCueAtMs !== null ? Math.max(0, state.nextCueAtMs - state.elapsedMs) : 0;
+  return (
+    <View style={styles.container} testID="interval-bell-view">
+      <Text style={styles.label}>next bell</Text>
+      <Text style={styles.time} testID="interval-bell-next">
+        {formatTime(untilNextMs)}
+      </Text>
+      <ScrollView
+        style={styles.list}
+        contentContainerStyle={styles.listContent}
+        testID="interval-bell-offsets"
+      >
+        {cues.map((cue, idx) => (
+          <OffsetRow
+            key={`${cue.kind}-${cue.atMs}-${idx}`}
+            atMs={cue.atMs}
+            kind={cue.kind}
+            struck={idx < state.cuesStruck}
+            upcoming={idx === state.cuesStruck}
+          />
+        ))}
+      </ScrollView>
+      <RitualControlsBar status={state.status} controls={controls} />
+    </View>
+  );
+};
+
+interface OffsetRowProps {
+  atMs: number;
+  kind: string;
+  struck: boolean;
+  upcoming: boolean;
+}
+
+const OffsetRow = ({ atMs, kind, struck, upcoming }: OffsetRowProps): React.JSX.Element => (
+  <View style={[styles.row, upcoming && styles.rowUpcoming]} testID={`interval-bell-row-${atMs}`}>
+    <Text style={[styles.rowTime, struck && styles.rowStruck]}>{formatTime(atMs)}</Text>
+    <Text style={[styles.rowKind, struck && styles.rowStruck]}>{kind}</Text>
+    <Text style={styles.rowMark} testID={`interval-bell-row-mark-${atMs}`}>
+      {struck ? '✓' : upcoming ? '→' : ''}
+    </Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl, flex: 1 },
+  label: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    textTransform: 'uppercase',
+    letterSpacing: 2,
+    marginTop: SPACING.xl,
+  },
+  time: {
+    fontSize: 48,
+    fontWeight: '300',
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+    marginVertical: SPACING.md,
+  },
+  list: { width: '100%', maxHeight: 220, marginVertical: SPACING.md },
+  listContent: { paddingVertical: SPACING.sm },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    borderRadius: 8,
+  },
+  rowUpcoming: { backgroundColor: colors.background.accent },
+  rowTime: {
+    flex: 0,
+    width: 64,
+    fontSize: 16,
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+  },
+  rowKind: { flex: 1, fontSize: 14, color: colors.text.secondaryAccessible },
+  rowMark: { width: 24, textAlign: 'right', fontSize: 16, color: colors.success },
+  rowStruck: { color: colors.text.tertiaryAccessible, textDecorationLine: 'line-through' },
+});
+
+export default IntervalBellView;

--- a/frontend/src/features/Practice/views/IntervalBellView.tsx
+++ b/frontend/src/features/Practice/views/IntervalBellView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { scheduledCues } from '../engine/cues';
@@ -16,7 +16,9 @@ interface Props {
 }
 
 const IntervalBellView = ({ config, state, controls }: Props): React.JSX.Element => {
-  const cues = scheduledCues(config);
+  // Cue schedule is config-derived and pure; memoise so engine TICK re-renders
+  // (which arrive 10× per second) don't rebuild the list each time.
+  const cues = useMemo(() => scheduledCues(config), [config]);
   const untilNextMs =
     state.nextCueAtMs !== null ? Math.max(0, state.nextCueAtMs - state.elapsedMs) : 0;
   return (

--- a/frontend/src/features/Practice/views/MeditationTimerView.tsx
+++ b/frontend/src/features/Practice/views/MeditationTimerView.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+
+import type { RitualControls, RitualState } from '../engine/types';
+
+import { formatTime } from './formatTime';
+import RitualControlsBar from './RitualControlsBar';
+
+import { SPACING, colors, shadows } from '@/design/tokens';
+
+const RING_SIZE = 240;
+const STROKE_WIDTH = 8;
+const RADIUS = (RING_SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const CENTER = RING_SIZE / 2;
+
+interface Props {
+  state: RitualState;
+  controls: RitualControls;
+}
+
+const MeditationTimerView = ({ state, controls }: Props): React.JSX.Element => {
+  const dashOffset = CIRCUMFERENCE * (1 - Math.min(1, Math.max(0, state.progress)));
+  const remainingMs = state.remainingMs ?? 0;
+  return (
+    <View style={styles.container} testID="meditation-timer-view">
+      <View style={styles.ringContainer}>
+        <Svg width={RING_SIZE} height={RING_SIZE} testID="meditation-timer-ring">
+          <Circle
+            cx={CENTER}
+            cy={CENTER}
+            r={RADIUS}
+            stroke={colors.background.accent}
+            strokeWidth={STROKE_WIDTH}
+            fill={colors.background.card}
+          />
+          <Circle
+            cx={CENTER}
+            cy={CENTER}
+            r={RADIUS}
+            stroke={colors.success}
+            strokeWidth={STROKE_WIDTH}
+            fill="none"
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={dashOffset}
+            strokeLinecap="round"
+            transform={`rotate(-90 ${CENTER} ${CENTER})`}
+          />
+        </Svg>
+        <View style={styles.center} pointerEvents="none">
+          <Text style={styles.time} testID="meditation-time-remaining">
+            {formatTime(remainingMs)}
+          </Text>
+        </View>
+      </View>
+      <RitualControlsBar status={state.status} controls={controls} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl },
+  ringContainer: {
+    width: RING_SIZE,
+    height: RING_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: SPACING.xxl,
+    ...shadows.medium,
+  },
+  center: {
+    position: 'absolute',
+    width: RING_SIZE,
+    height: RING_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  time: {
+    fontSize: 42,
+    fontWeight: '300',
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+  },
+});
+
+export default MeditationTimerView;

--- a/frontend/src/features/Practice/views/MetronomeView.tsx
+++ b/frontend/src/features/Practice/views/MetronomeView.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, View } from 'react-native';
+
+import type { MetronomeConfig, RitualControls, RitualState } from '../engine/types';
+
+import { formatTime } from './formatTime';
+import RitualControlsBar from './RitualControlsBar';
+
+import { SPACING, colors } from '@/design/tokens';
+
+const PULSE_DURATION_MS = 120;
+const PULSE_MAX_SCALE = 1.6;
+
+interface Props {
+  config: MetronomeConfig;
+  state: RitualState;
+  controls: RitualControls;
+}
+
+const MetronomeView = ({ config, state, controls }: Props): React.JSX.Element => {
+  const pulse = useRef(new Animated.Value(1)).current;
+  const lastStruckRef = useRef(state.cuesStruck);
+
+  useEffect(() => {
+    if (state.cuesStruck === lastStruckRef.current) return;
+    lastStruckRef.current = state.cuesStruck;
+    Animated.sequence([
+      Animated.timing(pulse, {
+        toValue: PULSE_MAX_SCALE,
+        duration: PULSE_DURATION_MS / 2,
+        useNativeDriver: true,
+      }),
+      Animated.timing(pulse, {
+        toValue: 1,
+        duration: PULSE_DURATION_MS / 2,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [state.cuesStruck, pulse]);
+
+  const elapsedMs = state.elapsedMs;
+  return (
+    <View style={styles.container} testID="metronome-view">
+      <Text style={styles.bpm} testID="metronome-bpm">
+        {config.bpm}
+      </Text>
+      <Text style={styles.label}>bpm</Text>
+      <Animated.View
+        style={[styles.dot, { transform: [{ scale: pulse }] }]}
+        testID="metronome-pulse"
+      />
+      <Text style={styles.miniTimer} testID="metronome-mini-timer">
+        {formatTime(elapsedMs)}
+      </Text>
+      <View style={styles.spacer} />
+      <RitualControlsBar status={state.status} controls={controls} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl },
+  bpm: {
+    fontSize: 84,
+    fontWeight: '200',
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+    marginTop: SPACING.xl,
+  },
+  label: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    textTransform: 'uppercase',
+    letterSpacing: 2,
+    marginBottom: SPACING.xl,
+  },
+  dot: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: colors.success,
+    marginBottom: SPACING.xl,
+  },
+  miniTimer: {
+    fontSize: 24,
+    color: colors.text.secondary,
+    fontVariant: ['tabular-nums'],
+    marginBottom: SPACING.xl,
+  },
+  spacer: { height: SPACING.md },
+});
+
+export default MetronomeView;

--- a/frontend/src/features/Practice/views/RepCounterView.tsx
+++ b/frontend/src/features/Practice/views/RepCounterView.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import type { RepCounterConfig, RitualControls, RitualState } from '../engine/types';
+
+import { formatTime } from './formatTime';
+import RitualControlsBar from './RitualControlsBar';
+
+import { SPACING, colors } from '@/design/tokens';
+
+interface Props {
+  config: RepCounterConfig;
+  state: RitualState;
+  controls: RitualControls;
+}
+
+const RepCounterView = ({ config, state, controls }: Props): React.JSX.Element => {
+  const canTap = state.status === 'running';
+  const timeCapMs = config.time_cap_minutes != null ? config.time_cap_minutes * 60_000 : null;
+  const remaining = timeCapMs !== null ? Math.max(0, timeCapMs - state.elapsedMs) : null;
+  return (
+    <View style={styles.container} testID="rep-counter-view">
+      <Pressable
+        style={styles.tapZone}
+        onPress={canTap ? controls.tap : undefined}
+        testID="rep-counter-tap-zone"
+        accessibilityRole="button"
+        accessibilityLabel={`Add one ${config.unit_label}`}
+        accessibilityHint={canTap ? 'Double-tap to add a rep' : undefined}
+      >
+        <Text style={styles.count} testID="rep-counter-count">
+          {state.repCount}
+        </Text>
+        <Text style={styles.target}>of {config.target_reps}</Text>
+        <Text style={styles.unit} testID="rep-counter-unit">
+          {config.unit_label}
+        </Text>
+      </Pressable>
+      {remaining !== null && (
+        <Text style={styles.timeCap} testID="rep-counter-time-cap">
+          time cap: {formatTime(remaining)}
+        </Text>
+      )}
+      <RitualControlsBar status={state.status} controls={controls} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl },
+  tapZone: {
+    width: '100%',
+    minHeight: 260,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: SPACING.xl,
+    marginBottom: SPACING.xl,
+    backgroundColor: colors.background.card,
+    borderRadius: 24,
+  },
+  count: {
+    fontSize: 120,
+    fontWeight: '200',
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+  },
+  target: {
+    fontSize: 18,
+    color: colors.text.secondaryAccessible,
+    marginTop: SPACING.xs,
+  },
+  unit: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    textTransform: 'uppercase',
+    letterSpacing: 2,
+    marginTop: SPACING.xs,
+  },
+  timeCap: {
+    fontSize: 14,
+    color: colors.text.tertiaryAccessible,
+    marginBottom: SPACING.xl,
+    fontVariant: ['tabular-nums'],
+  },
+});
+
+export default RepCounterView;

--- a/frontend/src/features/Practice/views/RitualControlsBar.tsx
+++ b/frontend/src/features/Practice/views/RitualControlsBar.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import type { EngineStatus, RitualControls } from '../engine/types';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+type Variant = 'primary' | 'secondary' | 'danger';
+
+interface Props {
+  status: EngineStatus;
+  controls: Pick<RitualControls, 'start' | 'pause' | 'resume' | 'cancel'>;
+  /** Optional override for the START button label (e.g., "Begin"). */
+  startLabel?: string;
+}
+
+const RitualControlsBar = ({
+  status,
+  controls,
+  startLabel = 'Start',
+}: Props): React.JSX.Element => (
+  <View style={styles.row} testID="ritual-controls-bar">
+    {status === 'idle' && (
+      <Button variant="primary" label={startLabel} onPress={controls.start} testID="ritual-start" />
+    )}
+    {status === 'running' && (
+      <>
+        <Button variant="secondary" label="Pause" onPress={controls.pause} testID="ritual-pause" />
+        <Button variant="danger" label="Cancel" onPress={controls.cancel} testID="ritual-cancel" />
+      </>
+    )}
+    {status === 'paused' && (
+      <>
+        <Button variant="primary" label="Resume" onPress={controls.resume} testID="ritual-resume" />
+        <Button variant="danger" label="Cancel" onPress={controls.cancel} testID="ritual-cancel" />
+      </>
+    )}
+    {status === 'complete' && (
+      <Text style={styles.completeText} testID="ritual-complete-label">
+        Practice complete
+      </Text>
+    )}
+  </View>
+);
+
+interface ButtonProps {
+  variant: Variant;
+  label: string;
+  onPress: () => void;
+  testID: string;
+}
+
+const Button = ({ variant, label, onPress, testID }: ButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    style={[styles.button, styles[variant]]}
+    onPress={onPress}
+    testID={testID}
+    accessibilityRole="button"
+    accessibilityLabel={label}
+  >
+    <Text style={variant === 'danger' ? styles.dangerText : styles.lightText}>{label}</Text>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', gap: SPACING.md, alignItems: 'center', justifyContent: 'center' },
+  button: {
+    paddingVertical: SPACING.md,
+    paddingHorizontal: SPACING.xl,
+    borderRadius: BORDER_RADIUS.lg,
+    minWidth: 120,
+    alignItems: 'center',
+  },
+  primary: { backgroundColor: colors.primary },
+  secondary: { backgroundColor: colors.warning },
+  danger: { backgroundColor: 'transparent', borderWidth: 1, borderColor: colors.danger },
+  lightText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
+  dangerText: { color: colors.danger, fontSize: 16, fontWeight: '600' },
+  completeText: {
+    color: colors.success,
+    fontSize: 16,
+    fontWeight: '600',
+    paddingVertical: SPACING.md,
+  },
+});
+
+export default RitualControlsBar;

--- a/frontend/src/features/Practice/views/__tests__/CountUpTimerView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/CountUpTimerView.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import CountUpTimerView from '../CountUpTimerView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+describe('CountUpTimerView', () => {
+  it('shows the elapsed time formatted as mm:ss', () => {
+    const { getByTestId } = render(
+      <CountUpTimerView state={fakeState({ elapsedMs: 125_000 })} controls={fakeControls()} />,
+    );
+    expect(getByTestId('count-up-elapsed').props.children).toBe('02:05');
+  });
+
+  it('renders the "End session" button while running and routes to controls.complete', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <CountUpTimerView
+        state={fakeState({ status: 'running', elapsedMs: 60_000 })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('count-up-end'));
+    expect(controls.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the "End session" button when not running', () => {
+    const { queryByTestId } = render(
+      <CountUpTimerView state={fakeState({ status: 'idle' })} controls={fakeControls()} />,
+    );
+    expect(queryByTestId('count-up-end')).toBeNull();
+  });
+
+  it('renders the shared controls bar', () => {
+    const { getByTestId } = render(
+      <CountUpTimerView state={fakeState({ status: 'paused' })} controls={fakeControls()} />,
+    );
+    expect(getByTestId('ritual-resume')).toBeTruthy();
+    expect(getByTestId('ritual-cancel')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/IntervalBellView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/IntervalBellView.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { IntervalBellConfig } from '../../engine/types';
+import IntervalBellView from '../IntervalBellView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+const config: IntervalBellConfig = {
+  mode: 'interval_bell',
+  duration_minutes: 20,
+  interval_minutes: 5,
+  bell_tone: 'bowl',
+};
+
+describe('IntervalBellView', () => {
+  it('renders the time until the next bell from nextCueAtMs - elapsedMs', () => {
+    const { getByTestId } = render(
+      <IntervalBellView
+        config={config}
+        state={fakeState({
+          status: 'running',
+          elapsedMs: 4 * 60_000,
+          nextCueAtMs: 5 * 60_000,
+        })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('interval-bell-next').props.children).toBe('01:00');
+  });
+
+  it('lists every scheduled cue offset and marks the upcoming one', () => {
+    const { getByTestId } = render(
+      <IntervalBellView
+        config={config}
+        state={fakeState({ status: 'running', cuesStruck: 2, nextCueAtMs: 10 * 60_000 })}
+        controls={fakeControls()}
+      />,
+    );
+    // 4 intervals + start + end = 6 rows
+    expect(getByTestId('interval-bell-offsets')).toBeTruthy();
+    // First struck row shows the check mark
+    expect(getByTestId('interval-bell-row-mark-0').props.children).toBe('✓');
+    // Third row (index 2 after two struck) is the upcoming row
+    expect(getByTestId(`interval-bell-row-mark-${10 * 60_000}`).props.children).toBe('→');
+  });
+
+  it('renders 00:00 when there is no next cue (final bell struck)', () => {
+    const { getByTestId } = render(
+      <IntervalBellView
+        config={config}
+        state={fakeState({ status: 'complete', nextCueAtMs: null, cuesStruck: 6 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('interval-bell-next').props.children).toBe('00:00');
+  });
+
+  it('renders the shared controls bar', () => {
+    const { getByTestId } = render(
+      <IntervalBellView
+        config={config}
+        state={fakeState({ status: 'idle' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('ritual-start')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/MeditationTimerView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/MeditationTimerView.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import MeditationTimerView from '../MeditationTimerView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+describe('MeditationTimerView', () => {
+  it('renders the remaining time formatted as mm:ss', () => {
+    const { getByTestId } = render(
+      <MeditationTimerView
+        state={fakeState({ remainingMs: 305_000, progress: 0.5 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('meditation-time-remaining').props.children).toBe('05:05');
+  });
+
+  it('renders the ring and shows 00:00 when remainingMs is null', () => {
+    const { getByTestId } = render(
+      <MeditationTimerView state={fakeState()} controls={fakeControls()} />,
+    );
+    expect(getByTestId('meditation-timer-ring')).toBeTruthy();
+    expect(getByTestId('meditation-time-remaining').props.children).toBe('00:00');
+  });
+
+  it('renders the Start button while idle and triggers controls.start', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <MeditationTimerView state={fakeState({ status: 'idle' })} controls={controls} />,
+    );
+    fireEvent.press(getByTestId('ritual-start'));
+    expect(controls.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps progress > 1 and < 0 to the [0, 1] range for the ring offset', () => {
+    expect(() =>
+      render(
+        <MeditationTimerView
+          state={fakeState({ progress: 2, remainingMs: 0 })}
+          controls={fakeControls()}
+        />,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      render(
+        <MeditationTimerView
+          state={fakeState({ progress: -1, remainingMs: 0 })}
+          controls={fakeControls()}
+        />,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/MetronomeView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/MetronomeView.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { MetronomeConfig } from '../../engine/types';
+import MetronomeView from '../MetronomeView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+const config: MetronomeConfig = {
+  mode: 'metronome',
+  bpm: 80,
+  timer: { mode: 'meditation_timer', duration_minutes: 10 },
+};
+
+describe('MetronomeView', () => {
+  it('displays the BPM value and a mm:ss mini timer derived from elapsedMs', () => {
+    const { getByTestId } = render(
+      <MetronomeView
+        config={config}
+        state={fakeState({ status: 'running', elapsedMs: 45_000 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('metronome-bpm').props.children).toBe(80);
+    expect(getByTestId('metronome-mini-timer').props.children).toBe('00:45');
+    expect(getByTestId('metronome-pulse')).toBeTruthy();
+  });
+
+  it('re-renders cleanly when cuesStruck advances (Animated.sequence runs)', () => {
+    const controls = fakeControls();
+    const initialState = fakeState({ status: 'running', cuesStruck: 1, elapsedMs: 1000 });
+    const { rerender, getByTestId } = render(
+      <MetronomeView config={config} state={initialState} controls={controls} />,
+    );
+    const advanced = fakeState({ status: 'running', cuesStruck: 5, elapsedMs: 5000 });
+    rerender(<MetronomeView config={config} state={advanced} controls={controls} />);
+    expect(getByTestId('metronome-pulse')).toBeTruthy();
+  });
+
+  it('routes controls through the shared controls bar', () => {
+    const { getByTestId } = render(
+      <MetronomeView
+        config={config}
+        state={fakeState({ status: 'idle' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('ritual-start')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/RepCounterView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/RepCounterView.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { RepCounterConfig } from '../../engine/types';
+import RepCounterView from '../RepCounterView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+const config: RepCounterConfig = {
+  mode: 'rep_counter',
+  target_reps: 30,
+  unit_label: 'breaths',
+};
+
+describe('RepCounterView', () => {
+  it('renders the current rep count, target, and unit label', () => {
+    const { getByTestId, getByText } = render(
+      <RepCounterView
+        config={config}
+        state={fakeState({ status: 'running', repCount: 7 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('rep-counter-count').props.children).toBe(7);
+    expect(getByText('of 30')).toBeTruthy();
+    expect(getByTestId('rep-counter-unit').props.children).toBe('breaths');
+  });
+
+  it('fires controls.tap when the tap zone is pressed while running', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <RepCounterView
+        config={config}
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('rep-counter-tap-zone'));
+    expect(controls.tap).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire controls.tap when not running', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <RepCounterView config={config} state={fakeState({ status: 'idle' })} controls={controls} />,
+    );
+    fireEvent.press(getByTestId('rep-counter-tap-zone'));
+    expect(controls.tap).not.toHaveBeenCalled();
+  });
+
+  it('shows the time-cap countdown when time_cap_minutes is set', () => {
+    const capped: RepCounterConfig = { ...config, time_cap_minutes: 2 };
+    const { getByTestId } = render(
+      <RepCounterView
+        config={capped}
+        state={fakeState({ status: 'running', elapsedMs: 30_000 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('rep-counter-time-cap').props.children).toEqual(['time cap: ', '01:30']);
+  });
+
+  it('omits the time-cap row when time_cap_minutes is unset', () => {
+    const { queryByTestId } = render(
+      <RepCounterView
+        config={config}
+        state={fakeState({ status: 'running' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(queryByTestId('rep-counter-time-cap')).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/RitualControlsBar.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/RitualControlsBar.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import RitualControlsBar from '../RitualControlsBar';
+
+import { allStatuses, fakeControls } from './fixtures';
+
+describe('RitualControlsBar', () => {
+  it('renders Start only when idle and calls controls.start on press', () => {
+    const controls = fakeControls();
+    const { getByTestId, queryByTestId } = render(
+      <RitualControlsBar status="idle" controls={controls} />,
+    );
+    fireEvent.press(getByTestId('ritual-start'));
+    expect(controls.start).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('ritual-pause')).toBeNull();
+    expect(queryByTestId('ritual-resume')).toBeNull();
+  });
+
+  it('renders Pause + Cancel when running and wires both callbacks', () => {
+    const controls = fakeControls();
+    const { getByTestId, queryByTestId } = render(
+      <RitualControlsBar status="running" controls={controls} />,
+    );
+    fireEvent.press(getByTestId('ritual-pause'));
+    fireEvent.press(getByTestId('ritual-cancel'));
+    expect(controls.pause).toHaveBeenCalledTimes(1);
+    expect(controls.cancel).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('ritual-start')).toBeNull();
+  });
+
+  it('renders Resume + Cancel when paused', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(<RitualControlsBar status="paused" controls={controls} />);
+    fireEvent.press(getByTestId('ritual-resume'));
+    expect(controls.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the complete label without action buttons when status is complete', () => {
+    const controls = fakeControls();
+    const { getByTestId, queryByTestId } = render(
+      <RitualControlsBar status="complete" controls={controls} />,
+    );
+    expect(getByTestId('ritual-complete-label')).toBeTruthy();
+    expect(queryByTestId('ritual-start')).toBeNull();
+    expect(queryByTestId('ritual-cancel')).toBeNull();
+  });
+
+  it('honours the optional startLabel override on the start button', () => {
+    const controls = fakeControls();
+    const { getByText } = render(
+      <RitualControlsBar status="idle" controls={controls} startLabel="Begin" />,
+    );
+    expect(getByText('Begin')).toBeTruthy();
+  });
+
+  it.each(allStatuses)('renders without crashing for every status (%s)', (status) => {
+    const controls = fakeControls();
+    expect(() => render(<RitualControlsBar status={status} controls={controls} />)).not.toThrow();
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/fixtures.ts
+++ b/frontend/src/features/Practice/views/__tests__/fixtures.ts
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+
+import type { EngineStatus, RitualControls, RitualState } from '../../engine/types';
+
+export function fakeState(overrides: Partial<RitualState> = {}): RitualState {
+  return {
+    status: 'idle',
+    elapsedMs: 0,
+    remainingMs: null,
+    progress: 0,
+    repCount: 0,
+    currentStepIndex: 0,
+    nextCueAtMs: null,
+    cuesStruck: 0,
+    ...overrides,
+  };
+}
+
+export function fakeControls(): jest.Mocked<RitualControls> {
+  return {
+    start: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    cancel: jest.fn(),
+    complete: jest.fn(),
+    tap: jest.fn(),
+    advanceStep: jest.fn(),
+  };
+}
+
+export const allStatuses: readonly EngineStatus[] = ['idle', 'running', 'paused', 'complete'];

--- a/frontend/src/features/Practice/views/__tests__/formatTime.test.ts
+++ b/frontend/src/features/Practice/views/__tests__/formatTime.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { formatTime } from '../formatTime';
+
+describe('formatTime', () => {
+  it.each<[number, string]>([
+    [0, '00:00'],
+    [999, '00:00'],
+    [1000, '00:01'],
+    [59_000, '00:59'],
+    [60_000, '01:00'],
+    [615_000, '10:15'],
+  ])('formats %dms as %s', (ms, expected) => {
+    expect(formatTime(ms)).toBe(expected);
+  });
+
+  it('clamps negative inputs to 00:00 so late ticks never render negatives', () => {
+    expect(formatTime(-5000)).toBe('00:00');
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/formatTime.test.ts
+++ b/frontend/src/features/Practice/views/__tests__/formatTime.test.ts
@@ -17,4 +17,13 @@ describe('formatTime', () => {
   it('clamps negative inputs to 00:00 so late ticks never render negatives', () => {
     expect(formatTime(-5000)).toBe('00:00');
   });
+
+  // Sessions longer than 59:59 spill the minutes column past two digits rather
+  // than wrap to 00:00. The view layer relies on this so a 90-minute session
+  // displays "90:00" instead of pretending an hour didn't pass. If an
+  // hours-aware format is ever needed, this test pins the current contract.
+  it('does not wrap minutes above 59 (90 min renders as 90:00)', () => {
+    expect(formatTime(90 * 60_000)).toBe('90:00');
+    expect(formatTime(125 * 60_000 + 7_000)).toBe('125:07');
+  });
 });

--- a/frontend/src/features/Practice/views/formatTime.ts
+++ b/frontend/src/features/Practice/views/formatTime.ts
@@ -1,0 +1,12 @@
+// Format a millisecond duration as mm:ss for the on-screen timer displays.
+// Negative inputs are clamped to 0 so a late tick can never render "-01:23".
+
+const MS_PER_SECOND = 1000;
+const SECONDS_PER_MINUTE = 60;
+
+export function formatTime(ms: number): string {
+  const safe = Math.max(0, Math.floor(ms / MS_PER_SECOND));
+  const minutes = Math.floor(safe / SECONDS_PER_MINUTE);
+  const seconds = safe % SECONDS_PER_MINUTE;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}


### PR DESCRIPTION
## Summary

Implements [`ritual-07`](../blob/main/prompts/github-issues/ritual-practice/ritual-07-mode-views.md) — the visual layer for the four "primitive" preset modes plus the production audio + haptics adapters the engine calls into. Stops at the view boundary; `PracticeScreen` integration is ritual-11.

### Adapters (`engine/adapters/`)

| File | Surface |
| --- | --- |
| `audio.ts` | `createNoopAudioAdapter()` + `createExpoAudioAdapter()`. Eager load of bell-start/half/end + (currently missing) metronome-tick. Missing files **warn once** then degrade to no-op; subsequent plays are silent. Replay failures are also marked-once. `dispose()` unloads loaded sounds. |
| `haptics.ts` | `createNoopHapticsAdapter()` + `createExpoHapticsAdapter()`. Light impact for start/halfway, Medium for interval, Success notification for end. `metronome_tick` intentionally silent (haptics-on-every-beat is awful). |

### Views (`views/`)

| Component | Notes |
| --- | --- |
| `RitualControlsBar` | Shared Start / Pause / Resume / Cancel surface; renders "Practice complete" label on done. Accessible labels + roles. |
| `MeditationTimerView` | `react-native-svg` progress ring + `mm:ss` remaining (SVG was already a project dep). |
| `CountUpTimerView` | Large `mm:ss` elapsed + "End session" routed through `controls.complete`. |
| `MetronomeView` | BPM display + dot pulsed by `Animated.Value` driven from `state.cuesStruck` + embedded mini timer. |
| `RepCounterView` | Tap-anywhere `Pressable` bumps `controls.tap`; shows `repCount` / `target_reps` / `unit_label` + optional time-cap countdown. |
| `IntervalBellView` | Countdown to next bell from `state.nextCueAtMs - state.elapsedMs` + scrollable cue list with struck (✓) / upcoming (→) markers. |

### Tests

48 cases across 9 files. Coverage on the new code:

- `views/*` — **100% lines + functions + branches** on every view + `formatTime` + `fixtures`.
- `adapters/haptics.ts` — **100% / 100% / 100%**.
- `adapters/audio.ts` — **100% lines + functions**, 84.6% branches (two defensive guards on unreachable paths — `entries.get` `undefined` and re-entry of `markFailed`).

Adapter tests mock `expo-av` + `expo-haptics`; missing-asset warn-once contract is explicitly pinned, as is the silent fallback after hardware-unavailable rejection.

### Engine type widening

`AudioAdapter.play` now returns `void | Promise<void>` (was `void`) and gains optional `dispose?: () => void`. Backward-compatible with ritual-06's noop and tests.

### Deps

- Added `expo-haptics ~14.0.1` (new direct dep).
- Added `expo-keep-awake ~14.0.3` to direct deps (was already transitively installed; previously imported through indirect resolution by `PracticeTimer.tsx`).
- New `frontend/src/__mocks__/expo-haptics.js` + jest `moduleNameMapper` entry.

### Quality gates

- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (max-warnings=0)
- `npm test` ✅ (114 suites / 1069 tests)
- Pre-commit + pre-push ✅

### ⚠️ LoC overrun

Net change is **~1300 LoC** (5 view components + shared bar + 2 adapters + 8 test files + fixtures + mock), over the 700-LoC ceiling. The split proposal in the spec (lift the ring into its own `07a`) doesn't actually trim because the SVG math is already ~30 LoC inline in `MeditationTimerView`. Each view is essentially the smallest it can be while remaining readable. Flagging consistent with how ritual-06 (#309) shipped.

### Out of scope

- `metronome-tick.wav` asset (separate audio production task) — adapter handles its absence gracefully.
- PracticeScreen wiring — ritual-11.
- Tarot + 5-4-3-2-1 views — ritual-08.
- Configurator UI — ritual-09.

## Test plan

- [x] `cd frontend && npx tsc --noEmit`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm test` (1069 tests pass)
- [x] Each view renders correctly for every lifecycle status
- [x] Adapters mockable; no real audio/haptics pulled into tests
- [x] No engine state lives inside view components (pure consumers of `RitualState` + `RitualControls`)
- [x] Missing-asset audio fallback: warn once, then silent no-op

https://claude.ai/code/session_01FqtfNeSbMP8fNirreyrsji

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqtfNeSbMP8fNirreyrsji)_