### PR TITLE
feat(backend): session analytics + insights endpoint (ritual-04)

### DIFF
--- a/backend/migrations/versions/f0a1b2c3d4e5_practice_session_metadata.py
+++ b/backend/migrations/versions/f0a1b2c3d4e5_practice_session_metadata.py
@@ -1,0 +1,84 @@
+"""add practicesession mode + mode_metadata + completed + insight
+
+Revision ID: f0a1b2c3d4e5
+Revises: e9f0a1b2c3d4
+Create Date: 2026-05-11 10:00:00.000000
+
+Adds four columns to ``practicesession`` for the ritual-04 mode-aware
+session log:
+
+* ``mode`` (VARCHAR(32), NOT NULL) — denormalized resolved practice mode
+  at session time.  Backfilled to ``'meditation_timer'`` because every
+  pre-existing row predates the per-mode engine and was effectively a
+  plain countdown.
+* ``mode_metadata`` (JSON, NULL) — engine-specific outputs (rep count,
+  bpm used, tarot card index, …).  Left ``NULL`` on backfill so historical
+  rows are clearly distinguishable from "explicitly empty".
+* ``completed`` (BOOLEAN, NOT NULL, default TRUE) — whether the user
+  reached the target.  Backfilled to ``TRUE`` since the legacy POST had
+  no abort path.
+* ``insight`` (VARCHAR(2000), NULL) — short user-captured takeaway,
+  distinct from the long-form ``reflection`` column.
+
+The two NOT-NULL columns are added nullable, backfilled, then locked
+down inside a single ``batch_alter_table`` block so SQLite (used by the
+round-trip test) rebuilds the table once.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f0a1b2c3d4e5"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e9f0a1b2c3d4"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_DEFAULT_MODE = "meditation_timer"
+
+
+def upgrade() -> None:
+    """Add the four columns, backfill, then lock NOT-NULL constraints."""
+    op.add_column(
+        "practicesession",
+        sa.Column("mode", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "practicesession",
+        sa.Column("mode_metadata", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "practicesession",
+        sa.Column("completed", sa.Boolean(), nullable=True),
+    )
+    op.add_column(
+        "practicesession",
+        sa.Column("insight", sa.String(length=2_000), nullable=True),
+    )
+
+    # Backfill every pre-existing row with the documented defaults.  We
+    # leave ``mode_metadata`` and ``insight`` NULL on purpose so historical
+    # rows stay distinguishable from "explicitly empty payload".
+    op.execute(
+        sa.text("UPDATE practicesession SET mode = :mode WHERE mode IS NULL").bindparams(
+            mode=_DEFAULT_MODE
+        )
+    )
+    op.execute(sa.text("UPDATE practicesession SET completed = TRUE WHERE completed IS NULL"))
+
+    # Lock down NOT-NULL for ``mode`` and ``completed``.  batch_alter_table
+    # groups the ALTERs so SQLite rebuilds the table once.
+    with op.batch_alter_table("practicesession") as batch_op:
+        batch_op.alter_column("mode", existing_type=sa.String(length=32), nullable=False)
+        batch_op.alter_column("completed", existing_type=sa.Boolean(), nullable=False)
+
+
+def downgrade() -> None:
+    """Drop the four added columns."""
+    with op.batch_alter_table("practicesession") as batch_op:
+        batch_op.drop_column("insight")
+        batch_op.drop_column("completed")
+        batch_op.drop_column("mode_metadata")
+        batch_op.drop_column("mode")

--- a/backend/src/domain/practice_insights.py
+++ b/backend/src/domain/practice_insights.py
@@ -143,10 +143,17 @@ def _rolling_30d_stats(
     today: date,
     tz: str | None,
 ) -> tuple[float, float | None, dict[str, int]]:
-    """Total minutes, average duration, and per-mode counts over the last 30 days."""
+    """Total minutes, average duration, and per-mode counts over the last 30 days.
+
+    Mirrors the ``duration_minutes <= 0`` guard from :func:`_bucket_by_week`
+    so a quick-cancel session never inflates ``per_mode_counts`` or drags
+    the average toward zero while the weekly cadence is unchanged.
+    """
     durations: list[float] = []
     per_mode: Counter[str] = Counter()
     for session in sessions:
+        if session.duration_minutes <= 0:
+            continue
         if not _is_in_30d_window(session, today, tz):
             continue
         durations.append(session.duration_minutes)
@@ -163,6 +170,12 @@ def _last_insight(sessions: Iterable[PracticeSession]) -> str | None:
     timestamp via :func:`max` so the caller doesn't have to pre-sort.
     Naive SQLite timestamps are normalized to UTC so the comparison key
     never mixes aware/naive datetimes.
+
+    The router supplies the full 60-day fetch window — wider than the
+    30-day rollup — on purpose: a user who took a multi-week pause should
+    still see their last takeaway when they return rather than a blank
+    card.  Narrowing this to 30 days would silently hide insights during
+    onboarding-back-from-lull.
     """
     with_insight = [s for s in sessions if s.insight is not None]
     if not with_insight:

--- a/backend/src/domain/practice_insights.py
+++ b/backend/src/domain/practice_insights.py
@@ -1,0 +1,204 @@
+"""Pure-Python rollup over a user's recent :class:`PracticeSession` rows.
+
+The router fetches the last 60 days of the user's sessions in a single
+query and hands them to :func:`build_insights`.  Keeping the aggregator
+DB-free keeps it cheap to test (no fixtures), and forces the SQL layer
+to stay a thin "select by user and date window".
+
+All week math is performed in the user's timezone so a Pacific user
+doesn't see a week-boundary jump at 5 PM Sunday (when UTC rolls over).
+``today_in_tz`` and ``to_user_date`` from :mod:`domain.dates` are the
+only date helpers used here so the bucket math is consistent with the
+rest of the app's calendar logic (BUG-STREAK-002).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+
+from domain.dates import to_user_date, today_in_tz
+from models.practice_session import PracticeSession
+
+# Weekly cadence the spec defines as "meeting the practice goal" (≥ 4 sessions
+# in the user's local calendar week).
+WEEKLY_TARGET_SESSIONS = 4
+
+# Rolling window for the weekly bar chart.  ``8`` is the spec value —
+# enough to spot a 6-week streak with a soft on-ramp at the head of the
+# series.
+WEEKLY_HISTORY_WEEKS = 8
+
+# 30-day rolling window for total / average / per-mode rollups.  Keep
+# this as a named constant so the SQL window in the router stays in lock-step.
+ROLLING_30D_WINDOW_DAYS = 30
+
+
+@dataclass(frozen=True, slots=True)
+class WeeklyCount:
+    """Sessions completed in the calendar week that starts on ``week_start``."""
+
+    week_start: date
+    count: int
+
+
+@dataclass(frozen=True, slots=True)
+class PracticeInsights:
+    """Insights rollup payload returned by :func:`build_insights`.
+
+    Mirrors the wire schema in
+    :class:`schemas.practice.PracticeInsightsResponse` so the router can
+    re-shape with a single ``model_validate`` call.
+    """
+
+    weekly_counts: list[WeeklyCount]
+    streak_weeks: int
+    total_minutes_30d: float
+    avg_duration_minutes_30d: float | None
+    per_mode_counts: dict[str, int]
+    last_insight: str | None
+
+
+def _as_utc_aware(moment: datetime) -> datetime:
+    """Return ``moment`` re-anchored as UTC if it arrived naive.
+
+    Production Postgres ``timestamptz`` columns yield tz-aware datetimes,
+    but SQLite (the test DB) silently drops the tzinfo on read.  The
+    stored value is always the UTC instant we wrote, so re-attaching UTC
+    is correct rather than a band-aid.  ``to_user_date`` raises on naive
+    input — funneling every session timestamp through this helper keeps
+    that strict guard intact without forcing every test fixture to know
+    the storage-layer quirk.
+    """
+    return moment.replace(tzinfo=UTC) if moment.tzinfo is None else moment
+
+
+def _monday_of(day: date) -> date:
+    """Return the Monday on or before ``day``.
+
+    Sessions are bucketed by ISO week (Monday→Sunday) so the boundary
+    matches the practice-cadence rule users see in habit tooling
+    elsewhere in the app.
+    """
+    return day - timedelta(days=day.weekday())
+
+
+def _local_week_starts(today: date, *, history_weeks: int) -> list[date]:
+    """Return the ``history_weeks`` Monday-start dates ending at this week.
+
+    Ordered oldest-first so the chart reads left-to-right without the
+    consumer having to reverse it.
+    """
+    current_monday = _monday_of(today)
+    return [current_monday - timedelta(weeks=history_weeks - 1 - i) for i in range(history_weeks)]
+
+
+def _bucket_by_week(
+    sessions: Iterable[PracticeSession],
+    *,
+    tz: str | None,
+) -> Counter[date]:
+    """Count sessions per Monday-start week in the user's timezone."""
+    buckets: Counter[date] = Counter()
+    for session in sessions:
+        if session.duration_minutes <= 0:
+            # Spec: partial sessions count toward weekly totals *iff* duration > 0.
+            # Zero-duration aborts don't move the cadence needle.
+            continue
+        local_day = to_user_date(tz, _as_utc_aware(session.timestamp))
+        buckets[_monday_of(local_day)] += 1
+    return buckets
+
+
+def _streak_weeks(
+    weekly_counts: list[WeeklyCount],
+    *,
+    target: int = WEEKLY_TARGET_SESSIONS,
+) -> int:
+    """How many consecutive weeks ending now have hit ``target`` sessions.
+
+    The current week counts even if it's still in progress — the spec's
+    "4 x/week for 3 weeks running" UX shows users their momentum as it
+    accrues, not after a week boundary.
+    """
+    streak = 0
+    for bucket in reversed(weekly_counts):
+        if bucket.count >= target:
+            streak += 1
+        else:
+            break
+    return streak
+
+
+def _is_in_30d_window(session: PracticeSession, today: date, tz: str | None) -> bool:
+    """``True`` if the session's local date is within the rolling 30-day window."""
+    local_day = to_user_date(tz, _as_utc_aware(session.timestamp))
+    return today - timedelta(days=ROLLING_30D_WINDOW_DAYS) <= local_day <= today
+
+
+def _rolling_30d_stats(
+    sessions: Iterable[PracticeSession],
+    today: date,
+    tz: str | None,
+) -> tuple[float, float | None, dict[str, int]]:
+    """Total minutes, average duration, and per-mode counts over the last 30 days."""
+    durations: list[float] = []
+    per_mode: Counter[str] = Counter()
+    for session in sessions:
+        if not _is_in_30d_window(session, today, tz):
+            continue
+        durations.append(session.duration_minutes)
+        per_mode[session.mode] += 1
+    total = float(sum(durations))
+    average = total / len(durations) if durations else None
+    return total, average, dict(per_mode)
+
+
+def _last_insight(sessions: Iterable[PracticeSession]) -> str | None:
+    """Most recent non-null ``insight`` across all the user's sessions.
+
+    ``sessions`` is assumed unsorted; we scan and pick the maximum
+    timestamp via :func:`max` so the caller doesn't have to pre-sort.
+    Naive SQLite timestamps are normalized to UTC so the comparison key
+    never mixes aware/naive datetimes.
+    """
+    with_insight = [s for s in sessions if s.insight is not None]
+    if not with_insight:
+        return None
+    latest = max(with_insight, key=lambda s: _as_utc_aware(s.timestamp))
+    return latest.insight
+
+
+def build_insights(
+    sessions: Iterable[PracticeSession],
+    *,
+    tz: str | None,
+) -> PracticeInsights:
+    """Aggregate a list of session rows into the rollup payload.
+
+    ``sessions`` may be any iterable (the router passes a list of ORM
+    rows); the aggregator never re-queries.  ``tz`` accepts the same
+    shapes as :mod:`domain.dates` so callers can pass the raw
+    ``User.timezone`` string or the loaded ORM row.
+    """
+    materialized = list(sessions)
+
+    today = today_in_tz(tz)
+    week_starts = _local_week_starts(today, history_weeks=WEEKLY_HISTORY_WEEKS)
+    bucket_counts = _bucket_by_week(materialized, tz=tz)
+    weekly_counts = [
+        WeeklyCount(week_start=ws, count=bucket_counts.get(ws, 0)) for ws in week_starts
+    ]
+
+    total_30d, avg_30d, per_mode = _rolling_30d_stats(materialized, today, tz)
+
+    return PracticeInsights(
+        weekly_counts=weekly_counts,
+        streak_weeks=_streak_weeks(weekly_counts),
+        total_minutes_30d=total_30d,
+        avg_duration_minutes_30d=avg_30d,
+        per_mode_counts=per_mode,
+        last_insight=_last_insight(materialized),
+    )

--- a/backend/src/models/practice_session.py
+++ b/backend/src/models/practice_session.py
@@ -1,14 +1,34 @@
 from datetime import UTC, datetime
+from typing import Any
 
-from sqlalchemy import Column, DateTime
+from sqlalchemy import JSON, Column, DateTime
 from sqlmodel import Field, SQLModel
+
+from domain.practice_modes import PracticeMode
+
+# Insight is the short user-captured takeaway distinct from the long-form
+# ``reflection``.  The cap mirrors the ritual-04 spec ("≤2k").
+_INSIGHT_MAX_LENGTH = 2_000
 
 
 class PracticeSession(SQLModel, table=True):
     """A single session log linked to a UserPractice selection.
 
     Sessions track duration and timestamp for consistency evaluation
-    (target: minimum 4x/week).
+    (target: minimum 4x/week) plus the ritual-04 mode-aware analytics
+    columns:
+
+    * ``mode`` is denormalized at write time from the resolved practice
+      mode so the insights rollup can filter without a join — and so a
+      future catalog edit cannot retro-rewrite session history.
+    * ``mode_metadata`` carries engine-specific outputs (rep_count,
+      bpm_used, tarot card index, …) validated by the matching
+      :mod:`schemas.practice_session_metadata` discriminated-union model.
+    * ``completed`` is ``False`` if the user cancelled before the target
+      was reached.  Partial sessions still count toward weekly totals
+      iff their duration is positive.
+    * ``insight`` is a short user-captured takeaway, distinct from the
+      long-form ``reflection``.
     """
 
     id: int | None = Field(default=None, primary_key=True)
@@ -20,3 +40,21 @@ class PracticeSession(SQLModel, table=True):
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
     reflection: str | None = Field(default=None, max_length=5_000)
+    mode: str = Field(
+        default=PracticeMode.MEDITATION_TIMER.value,
+        max_length=32,
+        description="Resolved practice mode at session time (denormalized).",
+    )
+    mode_metadata: dict[str, Any] | None = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+        description=(
+            "Engine-specific outputs (rep_count, bpm_used, …) validated at the "
+            "API edge by schemas.practice_session_metadata.SessionMetadata."
+        ),
+    )
+    completed: bool = Field(
+        default=True,
+        description="False if the user cancelled before reaching the target.",
+    )
+    insight: str | None = Field(default=None, max_length=_INSIGHT_MAX_LENGTH)

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -6,23 +6,93 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, func, select
 
 from database import get_session
 from dependencies.ownership import require_owned_user_practice
-from errors import forbidden, not_found
+from domain.practice_insights import build_insights
+from errors import bad_request, forbidden, not_found
+from models.practice import Practice
 from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
 from schemas import Page, PaginationParams, build_page
 from schemas.pagination import paginate_query
-from schemas.practice import PracticeSessionCreate, PracticeSessionResponse
+from schemas.practice import (
+    PracticeInsightsResponse,
+    PracticeSessionCreate,
+    PracticeSessionResponse,
+)
+from services.users import get_user_timezone
+
+# Window for the insights SQL fetch.  Slightly larger than the 8-week rollup
+# (~56 days) so a session logged late in the oldest bucket still lands in
+# the right week after timezone normalization.
+_INSIGHTS_LOOKBACK_DAYS = 60
+
+# ``Cache-Control`` for the insights endpoint: each client may cache for one
+# minute so a chatty frontend doesn't hammer the DB while a user idles on
+# the screen.  ``private`` keeps shared proxies from cross-pollinating
+# per-user rollups.
+_INSIGHTS_CACHE_CONTROL = "private, max-age=60"
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/practice-sessions", tags=["practice-sessions"])
+
+
+async def _resolve_user_practice_for_session(
+    session: AsyncSession,
+    user_practice_id: int,
+    current_user: int,
+) -> UserPractice:
+    """Fetch the target ``UserPractice`` and enforce the 404→403 split.
+
+    Pulled out of :func:`create_session` because the body-parameter
+    ownership check can't ride :func:`require_owned_user_practice`
+    (FastAPI's DI cannot extract body fields into sub-deps).  Keeping
+    the lookup here keeps the handler's branching shallow enough for
+    xenon rank A while preserving the canonical 404-then-403 order the
+    IDOR matrix test relies on.
+    """
+    user_practice = (
+        (await session.execute(select(UserPractice).where(UserPractice.id == user_practice_id)))
+        .scalars()
+        .first()
+    )
+    if user_practice is None:
+        raise not_found("user_practice")
+    if user_practice.user_id != current_user:
+        raise forbidden("forbidden")
+    return user_practice
+
+
+async def _resolve_practice_with_mode(
+    session: AsyncSession,
+    user_practice: UserPractice,
+    payload: PracticeSessionCreate,
+) -> Practice:
+    """Load the catalog practice and validate the metadata discriminator.
+
+    A 400 ``mode_metadata_mismatch`` is returned when the request's
+    ``mode_metadata`` references a mode that disagrees with the resolved
+    practice — distinct from a 422 schema failure: the union deserialized
+    cleanly; the caller just targeted the wrong practice.
+    """
+    practice = (
+        (await session.execute(select(Practice).where(Practice.id == user_practice.practice_id)))
+        .scalars()
+        .first()
+    )
+    if practice is None:
+        # Defensive: a UserPractice row whose practice was deleted is a
+        # data-integrity issue.  Surface as 404 so the client retries.
+        raise not_found("practice")
+    if payload.mode_metadata is not None and payload.mode_metadata.mode != practice.mode:
+        raise bad_request("mode_metadata_mismatch")
+    return practice
 
 
 @router.post(
@@ -43,14 +113,10 @@ async def create_session(
     sub-dependencies.  The ordering and exception types match the shared
     dep so the IDOR matrix test sees the same 403 for cross-user calls.
     """
-    result = await session.execute(
-        select(UserPractice).where(UserPractice.id == payload.user_practice_id)
+    user_practice = await _resolve_user_practice_for_session(
+        session, payload.user_practice_id, current_user
     )
-    user_practice = result.scalars().first()
-    if user_practice is None:
-        raise not_found("user_practice")
-    if user_practice.user_id != current_user:
-        raise forbidden("forbidden")
+    practice = await _resolve_practice_with_mode(session, user_practice, payload)
 
     duration_minutes = payload.duration_minutes
     practice_session = PracticeSession(
@@ -59,6 +125,12 @@ async def create_session(
         duration_minutes=duration_minutes,
         reflection=payload.reflection,
         timestamp=payload.ended_at,
+        mode=practice.mode,
+        mode_metadata=(
+            payload.mode_metadata.model_dump() if payload.mode_metadata is not None else None
+        ),
+        completed=payload.completed,
+        insight=payload.insight,
     )
     session.add(practice_session)
     await session.commit()
@@ -69,6 +141,8 @@ async def create_session(
             "user_id": current_user,
             "user_practice_id": payload.user_practice_id,
             "duration_minutes": duration_minutes,
+            "mode": practice.mode,
+            "completed": payload.completed,
         },
     )
     return practice_session
@@ -105,6 +179,43 @@ async def list_sessions(
     if pagination.paginate:
         return build_page(serialized, total, pagination)
     return serialized
+
+
+@router.get("/insights", response_model=PracticeInsightsResponse)
+async def get_insights(
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    response: Response,
+) -> PracticeInsightsResponse:
+    """Return the mode-aware analytics rollup for the authenticated user.
+
+    Single query fetches the last :data:`_INSIGHTS_LOOKBACK_DAYS` of the
+    user's sessions; :func:`domain.practice_insights.build_insights` does
+    the bucketing in memory (cheap — a heavy user accrues hundreds of
+    rows in this window, not millions).
+
+    The response carries a private one-minute ``Cache-Control`` so the
+    frontend can poll the screen without thrashing the DB.
+    """
+    response.headers["Cache-Control"] = _INSIGHTS_CACHE_CONTROL
+    user_tz = await get_user_timezone(session, current_user)
+    cutoff = datetime.now(UTC) - timedelta(days=_INSIGHTS_LOOKBACK_DAYS)
+    rows = (
+        (
+            await session.execute(
+                select(PracticeSession)
+                .where(
+                    PracticeSession.user_id == current_user,
+                    PracticeSession.timestamp >= cutoff,
+                )
+                .order_by(col(PracticeSession.timestamp).desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    insights = build_insights(rows, tz=user_tz)
+    return PracticeInsightsResponse.model_validate(insights, from_attributes=True)
 
 
 @router.get("/week-count")

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -198,6 +198,10 @@ async def get_insights(
     frontend can poll the screen without thrashing the DB.
     """
     response.headers["Cache-Control"] = _INSIGHTS_CACHE_CONTROL
+    # Defense-in-depth: a misconfigured upstream that ignores ``private``
+    # still has the right cache key when ``Vary: Authorization`` is set,
+    # so one user's rollup cannot leak to another sharing the proxy.
+    response.headers["Vary"] = "Authorization"
     user_tz = await get_user_timezone(session, current_user)
     cutoff = datetime.now(UTC) - timedelta(days=_INSIGHTS_LOOKBACK_DAYS)
     rows = (

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -15,11 +15,13 @@ from schemas.practice_mode_config import (
     ModeConfig,
     ModeConfigAdapter,
 )
+from schemas.practice_session_metadata import SessionMetadata
 
 PRACTICE_NAME_MAX_LENGTH = 255
 PRACTICE_DESCRIPTION_MAX_LENGTH = 2_000
 PRACTICE_INSTRUCTIONS_MAX_LENGTH = 10_000
 PRACTICE_REFLECTION_MAX_LENGTH = 5_000
+PRACTICE_INSIGHT_MAX_LENGTH = 2_000
 
 MAX_DURATION_MINUTES = 24 * 60
 
@@ -202,6 +204,12 @@ class PracticeSessionCreate(BaseModel):
     bug cannot resurface invisibly on a stale build.
 
     ``user_id`` is derived from the authenticated user's token.
+
+    The ritual-04 fields (``mode_metadata``, ``completed``, ``insight``)
+    are optional so existing clients keep working.  The session's stored
+    ``mode`` is set server-side from the resolved practice mode at write
+    time; the discriminator on ``mode_metadata`` must match it or the
+    request is rejected with 400 ``mode_metadata_mismatch``.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -210,6 +218,9 @@ class PracticeSessionCreate(BaseModel):
     started_at: datetime
     ended_at: datetime
     reflection: str | None = Field(default=None, max_length=PRACTICE_REFLECTION_MAX_LENGTH)
+    mode_metadata: SessionMetadata | None = None
+    completed: bool = True
+    insight: str | None = Field(default=None, max_length=PRACTICE_INSIGHT_MAX_LENGTH)
 
     @model_validator(mode="after")
     def _check_times(self) -> Self:
@@ -236,3 +247,25 @@ class PracticeSessionResponse(OwnedResourcePublic):
     duration_minutes: float
     timestamp: datetime
     reflection: str | None = None
+    mode: str
+    mode_metadata: dict[str, Any] | None = None
+    completed: bool = True
+    insight: str | None = None
+
+
+class PracticeSessionWeeklyCount(BaseModel):
+    """One bucket of the rolling weekly-count series for the insights endpoint."""
+
+    week_start: date
+    count: int
+
+
+class PracticeInsightsResponse(BaseModel):
+    """Rollup payload returned by ``GET /practice-sessions/insights``."""
+
+    weekly_counts: list[PracticeSessionWeeklyCount]
+    streak_weeks: int
+    total_minutes_30d: float
+    avg_duration_minutes_30d: float | None = None
+    per_mode_counts: dict[str, int]
+    last_insight: str | None = None

--- a/backend/src/schemas/practice_session_metadata.py
+++ b/backend/src/schemas/practice_session_metadata.py
@@ -1,0 +1,93 @@
+"""Per-mode practice **session** metadata as a Pydantic discriminated union.
+
+The engine emits a per-mode payload at the *end* of a session (how many
+reps were logged, which tarot card was up, …).  These shapes mirror the
+mode-config types in :mod:`schemas.practice_mode_config` but capture
+runtime *outputs* rather than authoring inputs.  Keeping them in a separate
+union avoids loading the config schema with fields that only make sense
+post-session.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+
+from schemas.practice_mode_config import Sense
+
+_MAX_REPS = 1_000_000
+_MAX_BPM = 240
+_MIN_BPM = 1
+_MAX_TAROT_INDEX = 21  # 22-card major arcana, zero-indexed.
+_MAX_INTERVALS = 1_000
+
+
+class _MetadataBase(BaseModel):
+    """Shared config for every per-mode session metadata model."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MeditationTimerMetadata(_MetadataBase):
+    """A plain countdown emits no extra data — the duration is on the row."""
+
+    mode: Literal["meditation_timer"] = "meditation_timer"
+
+
+class CountUpMetadata(_MetadataBase):
+    """An open-ended count-up has no target, hence no extra outputs."""
+
+    mode: Literal["count_up"] = "count_up"
+
+
+class MetronomeMetadata(_MetadataBase):
+    """Captures the BPM the metronome actually ran at (may differ from preset)."""
+
+    mode: Literal["metronome"] = "metronome"
+    bpm_used: int = Field(ge=_MIN_BPM, le=_MAX_BPM)
+
+
+class IntervalBellMetadata(_MetadataBase):
+    """How many of the scheduled bells the session actually struck."""
+
+    mode: Literal["interval_bell"] = "interval_bell"
+    intervals_struck: int = Field(ge=0, le=_MAX_INTERVALS)
+    total_intervals: int = Field(ge=0, le=_MAX_INTERVALS)
+
+
+class RepCounterMetadata(_MetadataBase):
+    """Total reps the user tapped through during the session."""
+
+    mode: Literal["rep_counter"] = "rep_counter"
+    rep_count: int = Field(ge=0, le=_MAX_REPS)
+
+
+class SenseGroundingMetadata(_MetadataBase):
+    """Which sense prompts the user finished (an ordered, possibly-partial run)."""
+
+    mode: Literal["sense_grounding"] = "sense_grounding"
+    senses_completed: list[Sense] = Field(default_factory=list)
+
+
+class TarotMetadata(_MetadataBase):
+    """Major-arcana card index (0..21) the user meditated on."""
+
+    mode: Literal["tarot"] = "tarot"
+    card_index: int = Field(ge=0, le=_MAX_TAROT_INDEX)
+
+
+#: Discriminated union over all per-mode session metadata payloads.
+SessionMetadata = Annotated[
+    MeditationTimerMetadata
+    | CountUpMetadata
+    | MetronomeMetadata
+    | IntervalBellMetadata
+    | RepCounterMetadata
+    | SenseGroundingMetadata
+    | TarotMetadata,
+    Field(discriminator="mode"),
+]
+
+#: Reusable validator — instantiate once, validate many JSON payloads.
+SessionMetadataAdapter: TypeAdapter[SessionMetadata] = TypeAdapter(SessionMetadata)

--- a/backend/src/schemas/practice_session_metadata.py
+++ b/backend/src/schemas/practice_session_metadata.py
@@ -10,9 +10,9 @@ post-session.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
 from schemas.practice_mode_config import Sense
 
@@ -54,6 +54,19 @@ class IntervalBellMetadata(_MetadataBase):
     mode: Literal["interval_bell"] = "interval_bell"
     intervals_struck: int = Field(ge=0, le=_MAX_INTERVALS)
     total_intervals: int = Field(ge=0, le=_MAX_INTERVALS)
+
+    @model_validator(mode="after")
+    def _check_struck_within_total(self) -> Self:
+        """Reject ``intervals_struck > total_intervals`` (PR #311 review).
+
+        Each field individually satisfies its ge/le bounds; only the
+        cross-field invariant catches the nonsense state of striking more
+        bells than were scheduled.
+        """
+        if self.intervals_struck > self.total_intervals:
+            msg = "intervals_struck cannot exceed total_intervals"
+            raise ValueError(msg)
+        return self
 
 
 class RepCounterMetadata(_MetadataBase):

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -32,6 +32,10 @@ _RESET_LOOKUP_REVISION = "d7e8f9a0b1c2"  # pragma: allowlist secret
 _PRACTICE_MODE_BASE_REVISION = "d7e8f9a0b1c2"  # pragma: allowlist secret
 _PRACTICE_MODE_REVISION = "e9f0a1b2c3d4"  # pragma: allowlist secret
 
+# ritual-04: practice-session metadata migration (mode + mode_metadata + …).
+_PRACTICE_SESSION_METADATA_BASE_REVISION = "e9f0a1b2c3d4"  # pragma: allowlist secret
+_PRACTICE_SESSION_METADATA_REVISION = "f0a1b2c3d4e5"  # pragma: allowlist secret
+
 
 def test_timestamptz_migration_exists() -> None:
     """Regression guard: the migration file must stay where Alembic finds it."""
@@ -314,3 +318,110 @@ def test_practice_mode_migration_round_trip_on_sqlite(
     row_after = _practice_row(db_url, practice_id=1)
     assert row_after["mode"] == "meditation_timer"
     assert json.loads(row_after["mode_config"])["duration_minutes"] == 12.5
+
+
+# -- ritual-04 practice-session metadata migration round-trip ---------------
+
+
+def _bootstrap_practicesession_table(sync_url: str) -> None:
+    """Pre-create a minimal ``practicesession`` table for the round-trip fixture.
+
+    Mirrors the columns the ritual-04 migration ``f0a1b2c3d4e5`` expects
+    to ALTER, without pulling in every preceding migration.  One legacy
+    row is inserted so the backfill branches can be observed.
+    """
+    bootstrap_engine = create_engine(sync_url)
+    with bootstrap_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE practicesession ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " user_practice_id INTEGER NOT NULL,"
+                " duration_minutes FLOAT NOT NULL,"
+                " timestamp DATETIME NOT NULL,"
+                " reflection VARCHAR(5000)"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO practicesession"
+                " (id, user_id, user_practice_id, duration_minutes, timestamp)"
+                " VALUES (1, 1, 1, 7.5, '2026-05-01 12:00:00')"
+            )
+        )
+    bootstrap_engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_practice_session_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before ritual-04's migration."""
+    db_path = tmp_path / "practice_session_metadata_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_practicesession_table(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _PRACTICE_SESSION_METADATA_BASE_REVISION)
+    return cfg
+
+
+def _practicesession_row(db_url: str, session_id: int) -> dict[str, Any]:
+    """Fetch a ``practicesession`` row including ritual-04 columns."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        "SELECT id, mode, mode_metadata, completed, insight"
+                        " FROM practicesession WHERE id = :id"
+                    ),
+                    {"id": session_id},
+                )
+                .mappings()
+                .first()
+            )
+            assert row is not None
+            return dict(row)
+    finally:
+        engine.dispose()
+
+
+def test_practice_session_metadata_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_practice_session_metadata: Config,
+) -> None:
+    """Round-trip ``f0a1b2c3d4e5``: upgrade backfills, downgrade drops, re-upgrade idempotent."""
+    cfg = alembic_sqlite_config_practice_session_metadata
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade applies the four new columns and backfills the seeded row.
+    command.upgrade(cfg, _PRACTICE_SESSION_METADATA_REVISION)
+    cols = _columns_of(db_url, "practicesession")
+    assert {"mode", "mode_metadata", "completed", "insight"}.issubset(cols)
+    row = _practicesession_row(db_url, session_id=1)
+    assert row["mode"] == "meditation_timer"
+    assert row["mode_metadata"] is None
+    assert bool(row["completed"]) is True
+    assert row["insight"] is None
+
+    # Phase 2: downgrade drops the new columns.
+    command.downgrade(cfg, _PRACTICE_SESSION_METADATA_BASE_REVISION)
+    cols_after = _columns_of(db_url, "practicesession")
+    assert {"mode", "mode_metadata", "completed", "insight"}.isdisjoint(cols_after)
+
+    # Phase 3: re-upgrade reproduces the backfill on the same legacy row.
+    command.upgrade(cfg, _PRACTICE_SESSION_METADATA_REVISION)
+    row_again = _practicesession_row(db_url, session_id=1)
+    assert row_again["mode"] == "meditation_timer"
+    assert bool(row_again["completed"]) is True

--- a/backend/tests/test_practice_insights.py
+++ b/backend/tests/test_practice_insights.py
@@ -178,6 +178,27 @@ def test_30d_window_excludes_old_sessions() -> None:
     assert "metronome" not in insights.per_mode_counts
 
 
+def test_30d_stats_skip_zero_duration_sessions() -> None:
+    """Quick-cancel sessions must not pollute 30d stats (PR #311 review HIGH).
+
+    The weekly bucket already ignores ``duration_minutes <= 0``; mirroring
+    the guard in the 30d window keeps the two dimensions in sync so a
+    habit of cancelling never silently inflates ``per_mode_counts`` or
+    drags the average toward zero.
+    """
+    now = _now_utc()
+    sessions = [
+        _session(timestamp=now, duration_minutes=20.0, mode="meditation_timer"),
+        _session(timestamp=now - timedelta(days=1), duration_minutes=0.0, mode="rep_counter"),
+        _session(timestamp=now - timedelta(days=2), duration_minutes=0.0, mode="metronome"),
+    ]
+    insights = build_insights(sessions, tz="UTC")
+    # Only the 20-minute session reaches the rollup.
+    assert insights.per_mode_counts == {"meditation_timer": 1}
+    assert insights.total_minutes_30d == pytest.approx(20.0)
+    assert insights.avg_duration_minutes_30d == pytest.approx(20.0)
+
+
 # -- last_insight -----------------------------------------------------------
 
 

--- a/backend/tests/test_practice_insights.py
+++ b/backend/tests/test_practice_insights.py
@@ -1,0 +1,245 @@
+"""Pure-Python tests for the practice-insights aggregator."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from domain.practice_insights import (
+    WEEKLY_HISTORY_WEEKS,
+    WEEKLY_TARGET_SESSIONS,
+    PracticeInsights,
+    build_insights,
+)
+from models.practice_session import PracticeSession
+
+
+def _session(
+    *,
+    timestamp: datetime,
+    duration_minutes: float = 10.0,
+    mode: str = "meditation_timer",
+    insight: str | None = None,
+    completed: bool = True,
+) -> PracticeSession:
+    """Build an in-memory ``PracticeSession`` row (no DB write)."""
+    return PracticeSession(
+        user_id=1,
+        user_practice_id=1,
+        duration_minutes=duration_minutes,
+        timestamp=timestamp,
+        mode=mode,
+        insight=insight,
+        completed=completed,
+    )
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+# -- weekly_counts ----------------------------------------------------------
+
+
+def test_weekly_counts_has_history_weeks_buckets() -> None:
+    """An empty input still yields the full rolling-window shape (8 zero buckets)."""
+    insights = build_insights([], tz="UTC")
+    assert len(insights.weekly_counts) == WEEKLY_HISTORY_WEEKS
+    assert all(bucket.count == 0 for bucket in insights.weekly_counts)
+
+
+def test_weekly_counts_are_oldest_first() -> None:
+    """Buckets are ordered so the chart reads left-to-right without reversing."""
+    insights = build_insights([], tz="UTC")
+    week_starts = [bucket.week_start for bucket in insights.weekly_counts]
+    assert week_starts == sorted(week_starts)
+
+
+def test_weekly_counts_bucket_current_week_sessions() -> None:
+    """Sessions logged in this week's mid-week window land in the rightmost bucket."""
+    anchor = _monday_anchor_utc()
+    sessions = [_session(timestamp=anchor + timedelta(hours=i)) for i in range(3)]
+    insights = build_insights(sessions, tz="UTC")
+    assert insights.weekly_counts[-1].count == 3
+    # Older buckets stay zero.
+    assert sum(b.count for b in insights.weekly_counts[:-1]) == 0
+
+
+def test_weekly_counts_ignore_zero_duration_sessions() -> None:
+    """A cancelled session with ``duration_minutes=0`` does not move the cadence."""
+    now = _now_utc()
+    sessions = [_session(timestamp=now, duration_minutes=0.0, completed=False) for _ in range(2)]
+    insights = build_insights(sessions, tz="UTC")
+    assert insights.weekly_counts[-1].count == 0
+
+
+def test_partial_session_with_positive_duration_counts() -> None:
+    """An aborted-but-non-empty session still counts toward weekly totals."""
+    now = _now_utc()
+    sessions = [_session(timestamp=now, duration_minutes=2.0, completed=False)]
+    insights = build_insights(sessions, tz="UTC")
+    assert insights.weekly_counts[-1].count == 1
+
+
+# -- streak_weeks ------------------------------------------------------------
+
+
+def _monday_anchor_utc() -> datetime:
+    """Return a UTC instant pinned to Monday 12:00 of the current week.
+
+    Anchoring the synthetic sessions to mid-week keeps small ``hours=i``
+    offsets safely inside the same calendar bucket, even when the test
+    runs at the boundary between Sunday and Monday.
+    """
+    now = _now_utc()
+    monday = now.date() - timedelta(days=now.weekday())
+    return datetime.combine(monday, datetime.min.time(), tzinfo=UTC) + timedelta(hours=12)
+
+
+def test_streak_weeks_boundary_at_target() -> None:
+    """Exactly ``WEEKLY_TARGET_SESSIONS`` counts; one fewer doesn't."""
+    anchor = _monday_anchor_utc()
+    # 4 sessions this week, 3 last week (breaks streak), 4 the week before.
+    this_week = [
+        _session(timestamp=anchor + timedelta(hours=i)) for i in range(WEEKLY_TARGET_SESSIONS)
+    ]
+    last_week = [
+        _session(timestamp=anchor - timedelta(days=7) + timedelta(hours=i))
+        for i in range(WEEKLY_TARGET_SESSIONS - 1)
+    ]
+    older = [
+        _session(timestamp=anchor - timedelta(days=14) + timedelta(hours=i))
+        for i in range(WEEKLY_TARGET_SESSIONS)
+    ]
+    insights = build_insights([*this_week, *last_week, *older], tz="UTC")
+    # Only the current week meets the target; the chain breaks at last week's 3.
+    assert insights.streak_weeks == 1
+
+
+def test_streak_weeks_three_in_a_row() -> None:
+    """Three consecutive on-target weeks return ``streak_weeks=3``."""
+    anchor = _monday_anchor_utc()
+    sessions: list[PracticeSession] = []
+    for week_offset in range(3):
+        sessions.extend(
+            _session(timestamp=anchor - timedelta(days=7 * week_offset) + timedelta(hours=i))
+            for i in range(WEEKLY_TARGET_SESSIONS)
+        )
+    insights = build_insights(sessions, tz="UTC")
+    assert insights.streak_weeks == 3
+
+
+def test_streak_weeks_zero_when_no_sessions() -> None:
+    assert build_insights([], tz="UTC").streak_weeks == 0
+
+
+# -- 30-day rollups ---------------------------------------------------------
+
+
+def test_total_minutes_and_avg_30d() -> None:
+    now = _now_utc()
+    sessions = [
+        _session(timestamp=now - timedelta(days=1), duration_minutes=20.0),
+        _session(timestamp=now - timedelta(days=10), duration_minutes=10.0),
+    ]
+    insights = build_insights(sessions, tz="UTC")
+    expected_total_minutes = 30.0
+    expected_avg_minutes = 15.0
+    assert insights.total_minutes_30d == pytest.approx(expected_total_minutes)
+    assert insights.avg_duration_minutes_30d == pytest.approx(expected_avg_minutes)
+
+
+def test_avg_is_none_when_no_sessions_in_30d() -> None:
+    insights = build_insights([], tz="UTC")
+    assert insights.avg_duration_minutes_30d is None
+    assert insights.total_minutes_30d == 0.0
+
+
+def test_per_mode_counts_30d() -> None:
+    now = _now_utc()
+    sessions = [
+        _session(timestamp=now, mode="meditation_timer"),
+        _session(timestamp=now - timedelta(days=2), mode="rep_counter"),
+        _session(timestamp=now - timedelta(days=5), mode="rep_counter"),
+    ]
+    insights = build_insights(sessions, tz="UTC")
+    assert insights.per_mode_counts == {"meditation_timer": 1, "rep_counter": 2}
+
+
+def test_30d_window_excludes_old_sessions() -> None:
+    """A 45-day-old session is past the rolling window and excluded everywhere."""
+    now = _now_utc()
+    old = _session(timestamp=now - timedelta(days=45), duration_minutes=60.0, mode="metronome")
+    insights = build_insights([old], tz="UTC")
+    assert insights.total_minutes_30d == 0.0
+    assert insights.avg_duration_minutes_30d is None
+    assert "metronome" not in insights.per_mode_counts
+
+
+# -- last_insight -----------------------------------------------------------
+
+
+def test_last_insight_picks_most_recent_non_null() -> None:
+    now = _now_utc()
+    sessions = [
+        _session(timestamp=now - timedelta(days=2), insight="first"),
+        _session(timestamp=now, insight="latest"),
+        _session(timestamp=now - timedelta(days=1), insight=None),
+    ]
+    assert build_insights(sessions, tz="UTC").last_insight == "latest"
+
+
+def test_last_insight_is_none_when_no_insights_logged() -> None:
+    now = _now_utc()
+    sessions = [_session(timestamp=now)]
+    assert build_insights(sessions, tz="UTC").last_insight is None
+
+
+# -- Timezone-aware bucketing ----------------------------------------------
+
+
+def test_bucket_uses_user_timezone_at_midnight_boundary() -> None:
+    """A late-evening Pacific session stays in *its* local week, not UTC's next."""
+    # 07:30 UTC on a Monday is 00:30 Pacific the *same* Monday — but the user
+    # logged at 23:30 their previous Sunday by wall clock.  We only assert the
+    # session reaches *some* bucket in both zones; the week_start values may
+    # differ across zones by design.
+    utc_instant = datetime(2026, 5, 11, 6, 30, tzinfo=UTC)
+    session_row = _session(timestamp=utc_instant)
+    insights_utc = build_insights([session_row], tz="UTC")
+    insights_pacific = build_insights([session_row], tz="America/Los_Angeles")
+    assert sum(b.count for b in insights_utc.weekly_counts) == 1
+    assert sum(b.count for b in insights_pacific.weekly_counts) == 1
+
+
+# -- Dataclass invariants ---------------------------------------------------
+
+
+def test_insights_dataclass_is_frozen() -> None:
+    """``PracticeInsights`` is immutable so callers can't mutate cached rollups."""
+    insights = build_insights([], tz="UTC")
+    with pytest.raises(FrozenInstanceError):
+        insights.streak_weeks = 99  # type: ignore[misc]
+
+
+def test_weekly_count_dataclass_is_frozen() -> None:
+    """``WeeklyCount`` buckets are immutable; mutating ``count`` raises."""
+    insights = build_insights([], tz="UTC")
+    bucket = insights.weekly_counts[0]
+    with pytest.raises(FrozenInstanceError):
+        bucket.count = 42  # type: ignore[misc]
+
+
+def test_weekly_count_week_start_is_a_monday() -> None:
+    """Every bucket key is a Monday in ISO terms (weekday() == 0)."""
+    insights = build_insights([], tz="UTC")
+    assert all(isinstance(b.week_start, date) for b in insights.weekly_counts)
+    assert all(b.week_start.weekday() == 0 for b in insights.weekly_counts)
+
+
+def test_returns_practice_insights_instance() -> None:
+    """Sanity: the public function returns the documented dataclass."""
+    result = build_insights([], tz="UTC")
+    assert isinstance(result, PracticeInsights)

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -1,0 +1,129 @@
+"""Tests for the per-mode practice **session** metadata discriminated union."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.practice_session_metadata import (
+    CountUpMetadata,
+    IntervalBellMetadata,
+    MeditationTimerMetadata,
+    MetronomeMetadata,
+    RepCounterMetadata,
+    SenseGroundingMetadata,
+    SessionMetadataAdapter,
+    TarotMetadata,
+)
+
+# -- Round-trip --------------------------------------------------------------
+
+
+def test_meditation_timer_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python({"mode": "meditation_timer"})
+    assert isinstance(payload, MeditationTimerMetadata)
+
+
+def test_count_up_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python({"mode": "count_up"})
+    assert isinstance(payload, CountUpMetadata)
+
+
+def test_metronome_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python({"mode": "metronome", "bpm_used": 72})
+    assert isinstance(payload, MetronomeMetadata)
+    assert payload.bpm_used == 72
+
+
+def test_interval_bell_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python(
+        {"mode": "interval_bell", "intervals_struck": 4, "total_intervals": 6}
+    )
+    assert isinstance(payload, IntervalBellMetadata)
+    assert payload.intervals_struck == 4
+    assert payload.total_intervals == 6
+
+
+def test_rep_counter_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python({"mode": "rep_counter", "rep_count": 108})
+    assert isinstance(payload, RepCounterMetadata)
+    assert payload.rep_count == 108
+
+
+def test_sense_grounding_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python(
+        {"mode": "sense_grounding", "senses_completed": ["sight", "touch"]}
+    )
+    assert isinstance(payload, SenseGroundingMetadata)
+    assert payload.senses_completed == ["sight", "touch"]
+
+
+def test_sense_grounding_defaults_to_empty_list() -> None:
+    payload = SessionMetadataAdapter.validate_python({"mode": "sense_grounding"})
+    assert isinstance(payload, SenseGroundingMetadata)
+    assert payload.senses_completed == []
+
+
+def test_tarot_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python({"mode": "tarot", "card_index": 5})
+    assert isinstance(payload, TarotMetadata)
+    assert payload.card_index == 5
+
+
+# -- Validators --------------------------------------------------------------
+
+
+def test_unknown_mode_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SessionMetadataAdapter.validate_python({"mode": "telepathy"})
+
+
+def test_metronome_rejects_zero_bpm() -> None:
+    with pytest.raises(ValidationError):
+        MetronomeMetadata(mode="metronome", bpm_used=0)
+
+
+def test_metronome_rejects_excessive_bpm() -> None:
+    with pytest.raises(ValidationError):
+        MetronomeMetadata(mode="metronome", bpm_used=241)
+
+
+def test_rep_counter_rejects_negative_count() -> None:
+    with pytest.raises(ValidationError):
+        RepCounterMetadata(mode="rep_counter", rep_count=-1)
+
+
+def test_tarot_rejects_out_of_range_card() -> None:
+    with pytest.raises(ValidationError):
+        TarotMetadata(mode="tarot", card_index=22)
+
+
+def test_tarot_rejects_negative_card() -> None:
+    with pytest.raises(ValidationError):
+        TarotMetadata(mode="tarot", card_index=-1)
+
+
+def test_interval_bell_rejects_negative_counts() -> None:
+    with pytest.raises(ValidationError):
+        IntervalBellMetadata(mode="interval_bell", intervals_struck=-1, total_intervals=4)
+
+
+def test_sense_grounding_rejects_unknown_sense() -> None:
+    with pytest.raises(ValidationError):
+        SessionMetadataAdapter.validate_python(
+            {"mode": "sense_grounding", "senses_completed": ["aura"]}
+        )
+
+
+def test_extra_fields_are_forbidden() -> None:
+    """``extra="forbid"`` catches typos like ``bpmUsed`` vs ``bpm_used``."""
+    with pytest.raises(ValidationError):
+        SessionMetadataAdapter.validate_python(
+            {"mode": "metronome", "bpm_used": 72, "extra": "nope"}
+        )
+
+
+def test_discriminator_dispatches_to_right_subclass() -> None:
+    """The union picks the right model purely from ``mode``."""
+    payload = SessionMetadataAdapter.validate_python({"mode": "count_up"})
+    assert type(payload) is CountUpMetadata

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -108,6 +108,23 @@ def test_interval_bell_rejects_negative_counts() -> None:
         IntervalBellMetadata(mode="interval_bell", intervals_struck=-1, total_intervals=4)
 
 
+def test_interval_bell_rejects_struck_greater_than_total() -> None:
+    """``intervals_struck`` cannot exceed ``total_intervals`` (PR #311 review HIGH).
+
+    Each field individually passes its ge/le bounds; only the cross-field
+    invariant rejects the nonsense state of "struck more bells than were
+    scheduled".
+    """
+    with pytest.raises(ValidationError):
+        IntervalBellMetadata(mode="interval_bell", intervals_struck=10, total_intervals=4)
+
+
+def test_interval_bell_accepts_equal_struck_and_total() -> None:
+    """Completing every scheduled interval is valid (boundary)."""
+    payload = IntervalBellMetadata(mode="interval_bell", intervals_struck=4, total_intervals=4)
+    assert payload.intervals_struck == payload.total_intervals == 4
+
+
 def test_sense_grounding_rejects_unknown_sense() -> None:
     with pytest.raises(ValidationError):
         SessionMetadataAdapter.validate_python(

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -440,6 +440,12 @@ async def _create_typed_user_practice(
                 "end_bell": True,
             },
         },
+        "interval_bell": {
+            "mode": "interval_bell",
+            "duration_minutes": 20,
+            "interval_minutes": 5,
+            "bell_tone": "bowl",
+        },
     }
     practice = Practice(
         stage_number=stage_number,
@@ -521,6 +527,43 @@ async def test_create_session_rejects_mismatched_mode_metadata(
 
 
 @pytest.mark.asyncio
+async def test_create_session_persists_interval_bell_metadata(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """IntervalBell metadata round-trips through POST and the cross-field invariant fires.
+
+    Closes the end-to-end coverage gap flagged in the PR #311 review: the
+    cross-field validator was schema-tested but not exercised over HTTP.
+    """
+    headers, _ = await _signup(async_client)
+    up_id, _ = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="interval_bell"
+    )
+
+    valid = _session_payload(
+        up_id,
+        mode_metadata={"mode": "interval_bell", "intervals_struck": 4, "total_intervals": 6},
+    )
+    resp = await async_client.post("/practice-sessions/", json=valid, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    expected_struck = 4
+    expected_total = 6
+    assert resp.json()["mode_metadata"] == {
+        "mode": "interval_bell",
+        "intervals_struck": expected_struck,
+        "total_intervals": expected_total,
+    }
+
+    # Cross-field invariant: striking more bells than scheduled → 422.
+    bad = _session_payload(
+        up_id,
+        mode_metadata={"mode": "interval_bell", "intervals_struck": 10, "total_intervals": 4},
+    )
+    resp_bad = await async_client.post("/practice-sessions/", json=bad, headers=headers)
+    assert resp_bad.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
 async def test_create_session_rejects_invalid_metadata_payload(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
@@ -581,6 +624,8 @@ async def test_insights_empty_user_returns_empty_rollup(async_client: AsyncClien
     assert body["last_insight"] is None
     # Cache-Control is set so a chatty UI doesn't hammer the DB.
     assert resp.headers["cache-control"] == "private, max-age=60"
+    # Vary: Authorization is defense-in-depth against a proxy that ignores ``private``.
+    assert resp.headers["vary"] == "Authorization"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -409,3 +409,219 @@ async def test_week_count_scoped_to_user(
     resp = await async_client.get("/practice-sessions/week-count", headers=bob_headers)
     assert resp.status_code == HTTPStatus.OK
     assert resp.json()["count"] == 0
+
+
+# -- ritual-04: mode-aware metadata + insights ------------------------------
+
+
+async def _create_typed_user_practice(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    headers: dict[str, str],
+    *,
+    mode: str = "rep_counter",
+    stage_number: int = 1,
+) -> tuple[int, Practice]:
+    """Seed a non-default-mode practice and return ``(user_practice_id, practice)``."""
+    mode_configs: dict[str, dict[str, object]] = {
+        "rep_counter": {
+            "mode": "rep_counter",
+            "target_reps": 108,
+            "unit_label": "breath cycles",
+        },
+        "metronome": {
+            "mode": "metronome",
+            "bpm": 72,
+            "timer": {
+                "mode": "meditation_timer",
+                "duration_minutes": 10,
+                "start_bell": True,
+                "halfway_bell": False,
+                "end_bell": True,
+            },
+        },
+    }
+    practice = Practice(
+        stage_number=stage_number,
+        name=f"{mode} practice",
+        description="Test fixture",
+        instructions="Test fixture",
+        default_duration_minutes=10,
+        approved=True,
+        mode=mode,
+        mode_config=mode_configs[mode],
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+
+    resp = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": stage_number},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"]), practice
+
+
+@pytest.mark.asyncio
+async def test_create_session_persists_mode_metadata(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Rep-counter session round-trips its ``mode_metadata`` payload."""
+    headers, _ = await _signup(async_client)
+    up_id, _practice = await _create_typed_user_practice(async_client, db_session, headers)
+
+    expected_rep_count = 42
+    payload = _session_payload(
+        up_id,
+        mode_metadata={"mode": "rep_counter", "rep_count": expected_rep_count},
+        insight="counted faster than yesterday",
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    body = resp.json()
+    assert body["mode"] == "rep_counter"
+    assert body["mode_metadata"] == {"mode": "rep_counter", "rep_count": expected_rep_count}
+    assert body["insight"] == "counted faster than yesterday"
+    assert body["completed"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_session_records_partial_completion(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``completed=false`` with positive duration counts toward weekly totals."""
+    headers, _ = await _signup(async_client)
+    up_id = await _create_user_practice(async_client, db_session, headers)
+    payload = _session_payload(up_id, completed=False)
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["completed"] is False
+
+    wk = await async_client.get("/practice-sessions/week-count", headers=headers)
+    assert wk.status_code == HTTPStatus.OK
+    assert wk.json()["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_mismatched_mode_metadata(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Sending ``rep_counter`` metadata against a meditation-timer practice → 400."""
+    headers, _ = await _signup(async_client)
+    up_id = await _create_user_practice(async_client, db_session, headers)
+    payload = _session_payload(
+        up_id,
+        mode_metadata={"mode": "rep_counter", "rep_count": 10},
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "mode_metadata_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_invalid_metadata_payload(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A malformed metadata payload (BPM out of range) is rejected at 422."""
+    headers, _ = await _signup(async_client)
+    up_id, _ = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="metronome"
+    )
+    payload = _session_payload(
+        up_id,
+        mode_metadata={"mode": "metronome", "bpm_used": 0},
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_session_without_metadata_defaults_to_meditation_timer_mode(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Existing clients (no metadata) still get the resolved practice mode echoed."""
+    headers, _ = await _signup(async_client)
+    up_id = await _create_user_practice(async_client, db_session, headers)
+    resp = await async_client.post(
+        "/practice-sessions/", json=_session_payload(up_id), headers=headers
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    body = resp.json()
+    assert body["mode"] == "meditation_timer"
+    assert body["mode_metadata"] is None
+    assert body["insight"] is None
+    assert body["completed"] is True
+
+
+# -- ritual-04: insights endpoint -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insights_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.get("/practice-sessions/insights")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_insights_empty_user_returns_empty_rollup(async_client: AsyncClient) -> None:
+    """A user with no sessions still gets the full shape (8 zero buckets)."""
+    headers, _ = await _signup(async_client)
+    resp = await async_client.get("/practice-sessions/insights", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    expected_history_weeks = 8
+    assert len(body["weekly_counts"]) == expected_history_weeks
+    assert all(b["count"] == 0 for b in body["weekly_counts"])
+    assert body["streak_weeks"] == 0
+    assert body["total_minutes_30d"] == 0.0
+    assert body["avg_duration_minutes_30d"] is None
+    assert body["per_mode_counts"] == {}
+    assert body["last_insight"] is None
+    # Cache-Control is set so a chatty UI doesn't hammer the DB.
+    assert resp.headers["cache-control"] == "private, max-age=60"
+
+
+@pytest.mark.asyncio
+async def test_insights_aggregates_recent_sessions(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A POST-driven smoke test: two rep-counter sessions land in the rollup."""
+    headers, _ = await _signup(async_client)
+    up_id, _ = await _create_typed_user_practice(async_client, db_session, headers)
+    for reps in (10, 20):
+        await async_client.post(
+            "/practice-sessions/",
+            json=_session_payload(
+                up_id,
+                mode_metadata={"mode": "rep_counter", "rep_count": reps},
+                insight=f"reps={reps}",
+            ),
+            headers=headers,
+        )
+
+    resp = await async_client.get("/practice-sessions/insights", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    expected_session_count = 2
+    assert body["per_mode_counts"] == {"rep_counter": expected_session_count}
+    assert body["weekly_counts"][-1]["count"] == expected_session_count
+    assert body["last_insight"] == "reps=20"
+
+
+@pytest.mark.asyncio
+async def test_insights_scoped_to_user(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    """Bob's insights must never see Alice's sessions."""
+    alice_headers, _ = await _signup(async_client, "alice")
+    bob_headers, _ = await _signup(async_client, "bob")
+    up_id = await _create_user_practice(async_client, db_session, alice_headers)
+    await async_client.post(
+        "/practice-sessions/", json=_session_payload(up_id), headers=alice_headers
+    )
+
+    resp = await async_client.get("/practice-sessions/insights", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["per_mode_counts"] == {}
+    assert body["last_insight"] is None


### PR DESCRIPTION
Adds mode-aware metadata to PracticeSession (mode, mode_metadata,
completed, insight) plus a GET /practice-sessions/insights rollup so
the ritual screen can show weekly cadence, streaks, and the last
takeaway without n-queries on the client.

* New ``schemas.practice_session_metadata.SessionMetadata`` discriminated
  union covers all seven engine modes; POST resolves the practice mode
  server-side and rejects mismatched metadata with 400.
* ``domain.practice_insights.build_insights`` is a pure aggregator over
  the last 60 days, returning the 8-week bar chart, on-target streak,
  30-day totals, per-mode counts, and the most recent insight.
* Backfilled migration ``f0a1b2c3d4e5`` keeps existing rows usable
  (mode='meditation_timer', completed=True).