### PR TITLE
feat(backend): user-practice customization (ritual-03)

### DIFF
--- a/backend/migrations/versions/83b01b64cad3_user_practice_overrides.py
+++ b/backend/migrations/versions/83b01b64cad3_user_practice_overrides.py
@@ -4,8 +4,8 @@ Revision ID: 83b01b64cad3
 Revises: e9f0a1b2c3d4
 Create Date: 2026-05-11 01:00:00.000000
 
-ritual-03: lets a user rename their selected practice ("My Morning Sit")
-and override individual mode_config fields (duration, BPM, prompts, …)
+Lets a user rename their selected practice ("My Morning Sit") and
+override individual mode_config fields (duration, BPM, prompts, …)
 without mutating the shared ``Practice`` catalog row.
 
 Both columns are nullable; ``None`` means "use the catalog value". The

--- a/backend/migrations/versions/83b01b64cad3_user_practice_overrides.py
+++ b/backend/migrations/versions/83b01b64cad3_user_practice_overrides.py
@@ -1,6 +1,6 @@
 """add userpractice.custom_name + userpractice.mode_config_override
 
-Revision ID: f0a1b2c3d4e5
+Revision ID: 83b01b64cad3
 Revises: e9f0a1b2c3d4
 Create Date: 2026-05-11 01:00:00.000000
 
@@ -23,7 +23,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "f0a1b2c3d4e5"  # pragma: allowlist secret
+revision: str = "83b01b64cad3"  # pragma: allowlist secret
 down_revision: Union[str, Sequence[str], None] = "e9f0a1b2c3d4"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/migrations/versions/f0a1b2c3d4e5_user_practice_overrides.py
+++ b/backend/migrations/versions/f0a1b2c3d4e5_user_practice_overrides.py
@@ -1,0 +1,49 @@
+"""add userpractice.custom_name + userpractice.mode_config_override
+
+Revision ID: f0a1b2c3d4e5
+Revises: e9f0a1b2c3d4
+Create Date: 2026-05-11 01:00:00.000000
+
+ritual-03: lets a user rename their selected practice ("My Morning Sit")
+and override individual mode_config fields (duration, BPM, prompts, …)
+without mutating the shared ``Practice`` catalog row.
+
+Both columns are nullable; ``None`` means "use the catalog value". The
+API resolver in :mod:`domain.practice_resolution` collapses
+``(practice, user_practice)`` into ``effective_name`` and
+``effective_config`` so frontend code never has to merge by hand.
+
+The override is intentionally not allowed to change ``mode`` itself —
+mode-shifting is a replacement, not a tweak.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f0a1b2c3d4e5"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e9f0a1b2c3d4"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the two nullable columns; no backfill required."""
+    op.add_column(
+        "userpractice",
+        sa.Column("custom_name", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "userpractice",
+        sa.Column("mode_config_override", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop both columns."""
+    # Use batch_alter_table for SQLite compatibility (no inline ALTER COLUMN).
+    with op.batch_alter_table("userpractice") as batch_op:
+        batch_op.drop_column("mode_config_override")
+        batch_op.drop_column("custom_name")

--- a/backend/src/domain/practice_resolution.py
+++ b/backend/src/domain/practice_resolution.py
@@ -1,0 +1,42 @@
+"""Pure helpers that collapse ``(Practice, UserPractice)`` to effective values.
+
+Frontend code reads a single ``effective_name`` / ``effective_config`` per
+user-practice; these helpers are the single place that merges the user's
+overrides on top of the shared catalog row. Keeping them pure (no DB
+access) makes them trivially testable and lets the API endpoints reuse
+them without round-tripping through the ORM.
+"""
+
+from __future__ import annotations
+
+from models.practice import Practice
+from models.user_practice import UserPractice
+from schemas.practice_mode_config import ModeConfig, ModeConfigAdapter
+
+
+def effective_name(practice: Practice, user_practice: UserPractice | None) -> str:
+    """Return the user's custom name if set, else the catalog name."""
+    if user_practice is not None and user_practice.custom_name:
+        return user_practice.custom_name
+    return practice.name
+
+
+def effective_config(practice: Practice, user_practice: UserPractice | None) -> ModeConfig:
+    """Return the user's override if set, else the catalog ``mode_config``.
+
+    Validates the resolved payload through :class:`ModeConfigAdapter` so a
+    structurally invalid override surfaces as a domain error rather than
+    leaking into engine code. Raises ``ValueError("mode_mismatch")`` when
+    the override's ``mode`` discriminator doesn't agree with the catalog
+    mode — the override may only swap fields *within* a mode.
+    """
+    payload = (
+        user_practice.mode_config_override
+        if user_practice is not None and user_practice.mode_config_override is not None
+        else practice.mode_config
+    )
+    cfg = ModeConfigAdapter.validate_python(payload)
+    if cfg.mode != practice.mode:
+        msg = "mode_mismatch"
+        raise ValueError(msg)
+    return cfg

--- a/backend/src/models/user_practice.py
+++ b/backend/src/models/user_practice.py
@@ -1,6 +1,7 @@
 from datetime import date
+from typing import Any
 
-from sqlalchemy import Column, Date, Index
+from sqlalchemy import JSON, Column, Date, Index
 from sqlmodel import Field, SQLModel
 
 # Bound at module scope so :class:`Index`'s ``*_where`` predicates can
@@ -42,3 +43,19 @@ class UserPractice(SQLModel, table=True):
     stage_number: int
     start_date: date
     end_date: date | None = Field(default=None, sa_column=_END_DATE_COLUMN)
+    custom_name: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Per-user display name; falls back to Practice.name when null.",
+    )
+    # ``mode`` itself is intentionally not overridable — a user who wants a
+    # different mode should select a different preset / submit a new
+    # practice. The override only swaps fields *within* the catalog mode.
+    mode_config_override: dict[str, Any] | None = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+        description=(
+            "Per-user override of Practice.mode_config. Validated against "
+            "the catalog mode at the API edge by domain.practice_resolution."
+        ),
+    )

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -120,6 +120,56 @@ async def create_user_practice(
     return user_practice
 
 
+def _list_row_payload(item: UserPractice, practice: Practice | None) -> dict[str, Any]:
+    """Build the response dict for one row in the list endpoint.
+
+    Falls back to ``effective_*: None`` when the catalog row is missing
+    (a user-practice can outlive its catalog parent during soft-deletes
+    where the FK isn't enforced) so the list endpoint never crashes on
+    that edge case.
+    """
+    payload: dict[str, Any] = {
+        **_user_practice_payload(item),
+        "effective_name": None,
+        "effective_config": None,
+    }
+    if practice is not None:
+        payload["effective_name"] = effective_name(practice, item)
+        payload["effective_config"] = effective_config(practice, item).model_dump()
+    return payload
+
+
+async def _load_catalog_map(session: AsyncSession, practice_ids: set[int]) -> dict[int, Practice]:
+    """One batched ``SELECT … WHERE id IN (…)`` over the catalog.
+
+    Avoids the N+1 the per-row resolver would incur in the list path.
+    """
+    if not practice_ids:
+        return {}
+    rows = (
+        (await session.execute(select(Practice).where(col(Practice.id).in_(practice_ids))))
+        .scalars()
+        .all()
+    )
+    return {p.id: p for p in rows if p.id is not None}
+
+
+async def _build_list_response(
+    session: AsyncSession, items: list[UserPractice]
+) -> list[UserPracticeResponse]:
+    """Resolve ``effective_name`` / ``effective_config`` for each item.
+
+    ritual-03 review B1: GET /user-practices/ used to return null for both
+    fields, contradicting the documented "merged view in every response"
+    contract. Catalog rows are batched via :func:`_load_catalog_map`.
+    """
+    catalog = await _load_catalog_map(session, {item.practice_id for item in items})
+    return [
+        UserPracticeResponse.model_validate(_list_row_payload(item, catalog.get(item.practice_id)))
+        for item in items
+    ]
+
+
 @router.get("/", response_model=None)
 async def list_user_practices(
     current_user: Annotated[int, Depends(get_current_user)],
@@ -134,7 +184,7 @@ async def list_user_practices(
     """
     query = select(UserPractice).where(UserPractice.user_id == current_user)
     items, total = await paginate_query(session, query, pagination)
-    serialized = [UserPracticeResponse.model_validate(u, from_attributes=True) for u in items]
+    serialized = await _build_list_response(session, list(items))
     if pagination.paginate:
         return build_page(serialized, total, pagination)
     return serialized
@@ -145,9 +195,12 @@ async def _resolve_effective_fields(
 ) -> tuple[str, dict[str, Any]]:
     """Look up the catalog Practice and return (effective_name, effective_config_dict).
 
-    ritual-03: shared between GET, PATCH, and POST so every response shape
-    carries the same merged view. ``effective_config`` is dumped to a
-    dict for JSON serialization through the discriminated-union schema.
+    ritual-03: used by the GET-one endpoint. The PATCH path holds its
+    own ``practice`` reference from pre-flight validation and calls the
+    resolvers directly to avoid a redundant DB round-trip; the list
+    endpoint batches catalog lookups via ``_build_list_response``.
+    ``effective_config`` is dumped to a dict for JSON serialization
+    through the discriminated-union schema.
     """
     practice = await _resolve_practice(session, user_practice.practice_id)
     name = effective_name(practice, user_practice)

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -120,13 +120,37 @@ async def create_user_practice(
     return user_practice
 
 
+def _safe_resolve_config(item: UserPractice, practice: Practice) -> dict[str, Any] | None:
+    """Resolve ``effective_config`` defensively for read paths.
+
+    Pre-flight validation at the PATCH edge prevents corrupt overrides
+    from being written through the normal API, but a row can arrive via
+    direct DB tooling, an admin script, or a catalog mode being edited
+    after users stored overrides for it. Returning ``None`` with a
+    warning lets the rest of the user's list still render instead of
+    blowing up the whole page with a 500.
+    """
+    try:
+        return effective_config(practice, item).model_dump()
+    except (ValueError, ValidationError):
+        logger.warning(
+            "corrupt_mode_config_override",
+            extra={
+                "user_practice_id": item.id,
+                "practice_id": practice.id,
+                "mode": practice.mode,
+            },
+        )
+        return None
+
+
 def _list_row_payload(item: UserPractice, practice: Practice | None) -> dict[str, Any]:
     """Build the response dict for one row in the list endpoint.
 
     Falls back to ``effective_*: None`` when the catalog row is missing
     (a user-practice can outlive its catalog parent during soft-deletes
-    where the FK isn't enforced) so the list endpoint never crashes on
-    that edge case.
+    where the FK isn't enforced) or when the stored override is
+    corrupt — see :func:`_safe_resolve_config`.
     """
     payload: dict[str, Any] = {
         **_user_practice_payload(item),
@@ -135,7 +159,7 @@ def _list_row_payload(item: UserPractice, practice: Practice | None) -> dict[str
     }
     if practice is not None:
         payload["effective_name"] = effective_name(practice, item)
-        payload["effective_config"] = effective_config(practice, item).model_dump()
+        payload["effective_config"] = _safe_resolve_config(item, practice)
     return payload
 
 
@@ -159,9 +183,10 @@ async def _build_list_response(
 ) -> list[UserPracticeResponse]:
     """Resolve ``effective_name`` / ``effective_config`` for each item.
 
-    ritual-03 review B1: GET /user-practices/ used to return null for both
-    fields, contradicting the documented "merged view in every response"
-    contract. Catalog rows are batched via :func:`_load_catalog_map`.
+    Catalog rows are batched via :func:`_load_catalog_map`; corrupt
+    overrides fall through to ``effective_config: None`` via
+    :func:`_safe_resolve_config` so a single bad row never crashes
+    the whole page.
     """
     catalog = await _load_catalog_map(session, {item.practice_id for item in items})
     return [
@@ -192,20 +217,19 @@ async def list_user_practices(
 
 async def _resolve_effective_fields(
     session: AsyncSession, user_practice: UserPractice
-) -> tuple[str, dict[str, Any]]:
+) -> tuple[str, dict[str, Any] | None]:
     """Look up the catalog Practice and return (effective_name, effective_config_dict).
 
-    ritual-03: used by the GET-one endpoint. The PATCH path holds its
-    own ``practice`` reference from pre-flight validation and calls the
-    resolvers directly to avoid a redundant DB round-trip; the list
-    endpoint batches catalog lookups via ``_build_list_response``.
-    ``effective_config`` is dumped to a dict for JSON serialization
-    through the discriminated-union schema.
+    Used by the GET-one endpoint. PATCH holds its own ``practice``
+    reference from pre-flight validation and calls the resolvers
+    directly to avoid a redundant DB round-trip; the list endpoint
+    batches catalog lookups via :func:`_load_catalog_map`. The config
+    is resolved via :func:`_safe_resolve_config` so a corrupt stored
+    override falls through to ``None`` rather than crashing the GET.
     """
     practice = await _resolve_practice(session, user_practice.practice_id)
     name = effective_name(practice, user_practice)
-    cfg = effective_config(practice, user_practice)
-    return name, cfg.model_dump()
+    return name, _safe_resolve_config(user_practice, practice)
 
 
 def _user_practice_payload(user_practice: UserPractice) -> dict[str, Any]:
@@ -278,7 +302,7 @@ async def customize_user_practice(
     session: Annotated[AsyncSession, Depends(get_session)],
     user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
 ) -> dict[str, Any]:
-    """Per-user override of name + mode_config (ritual-03).
+    """Per-user override of name + mode_config.
 
     Both fields are nullable; passing ``None`` clears the override and
     falls back to the catalog value. Mode-shifting is rejected with

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -13,6 +14,7 @@ from sqlmodel import col, select
 from database import get_session
 from dependencies.ownership import require_owned_user_practice
 from domain.dates import today_in_tz
+from domain.practice_resolution import effective_config, effective_name
 from domain.stage_progress import get_user_progress, is_stage_unlocked
 from errors import bad_request, conflict, forbidden, not_found
 from models.practice import Practice
@@ -23,9 +25,11 @@ from schemas import Page, PaginationParams, build_page
 from schemas.pagination import paginate_query
 from schemas.practice import (
     UserPracticeCreate,
+    UserPracticeCustomize,
     UserPracticeDetail,
     UserPracticeResponse,
 )
+from schemas.practice_mode_config import ModeConfigAdapter
 from services.users import get_user_timezone
 
 logger = logging.getLogger(__name__)
@@ -136,6 +140,34 @@ async def list_user_practices(
     return serialized
 
 
+async def _resolve_effective_fields(
+    session: AsyncSession, user_practice: UserPractice
+) -> tuple[str, dict[str, Any]]:
+    """Look up the catalog Practice and return (effective_name, effective_config_dict).
+
+    ritual-03: shared between GET, PATCH, and POST so every response shape
+    carries the same merged view. ``effective_config`` is dumped to a
+    dict for JSON serialization through the discriminated-union schema.
+    """
+    practice = await _resolve_practice(session, user_practice.practice_id)
+    name = effective_name(practice, user_practice)
+    cfg = effective_config(practice, user_practice)
+    return name, cfg.model_dump()
+
+
+def _user_practice_payload(user_practice: UserPractice) -> dict[str, Any]:
+    """Serialize the user-practice row's stored columns (no resolution yet)."""
+    return {
+        "id": user_practice.id,
+        "practice_id": user_practice.practice_id,
+        "stage_number": user_practice.stage_number,
+        "start_date": user_practice.start_date,
+        "end_date": user_practice.end_date,
+        "custom_name": user_practice.custom_name,
+        "mode_config_override": user_practice.mode_config_override,
+    }
+
+
 @router.get("/{user_practice_id}", response_model=UserPracticeDetail)
 async def get_user_practice(
     session: Annotated[AsyncSession, Depends(get_session)],
@@ -151,12 +183,88 @@ async def get_user_practice(
         .order_by(col(PracticeSession.timestamp).desc())
     )
     sessions = list(sessions_result.scalars().all())
+    name, cfg = await _resolve_effective_fields(session, user_practice)
 
     return {
-        "id": user_practice.id,
-        "practice_id": user_practice.practice_id,
-        "stage_number": user_practice.stage_number,
-        "start_date": user_practice.start_date,
-        "end_date": user_practice.end_date,
+        **_user_practice_payload(user_practice),
+        "effective_name": name,
+        "effective_config": cfg,
+        "sessions": sessions,
+    }
+
+
+def _validate_override_against_catalog(override: dict[str, Any] | None, practice: Practice) -> None:
+    """Pre-flight validation: reject malformed or mode-mismatched overrides.
+
+    Raises ``HTTPException`` directly so the endpoint short-circuits
+    *before* persisting; without this guard, a bad override would land in
+    the DB and the post-write resolver would 500. Pydantic's
+    ``ValidationError`` is caught here and re-raised as a 422 with
+    structured error details so the client can show field-level messages.
+    Mode mismatch is mapped to a domain-meaningful 400.
+    """
+    if override is None:
+        return
+    try:
+        cfg = ModeConfigAdapter.validate_python(override)
+    except ValidationError as exc:
+        # Preserve Pydantic's structured per-field errors so the client
+        # can render field-level messages — ``unprocessable()`` only
+        # accepts a string detail.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=exc.errors(),
+        ) from exc
+    if cfg.mode != practice.mode:
+        raise bad_request("mode_mismatch")
+
+
+@router.patch("/{user_practice_id}/customize", response_model=UserPracticeDetail)
+async def customize_user_practice(
+    payload: UserPracticeCustomize,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
+) -> dict[str, Any]:
+    """Per-user override of name + mode_config (ritual-03).
+
+    Both fields are nullable; passing ``None`` clears the override and
+    falls back to the catalog value. Mode-shifting is rejected with
+    400 ``mode_mismatch`` because mode changes are conceptually a
+    practice replacement, not a tweak.
+    """
+    practice = await _resolve_practice(session, user_practice.practice_id)
+    fields_set = payload.model_fields_set
+
+    if "mode_config_override" in fields_set:
+        _validate_override_against_catalog(payload.mode_config_override, practice)
+        user_practice.mode_config_override = payload.mode_config_override
+    if "custom_name" in fields_set:
+        user_practice.custom_name = payload.custom_name
+
+    session.add(user_practice)
+    await session.commit()
+    await session.refresh(user_practice)
+
+    name = effective_name(practice, user_practice)
+    cfg = effective_config(practice, user_practice).model_dump()
+
+    sessions_result = await session.execute(
+        select(PracticeSession)
+        .where(PracticeSession.user_practice_id == user_practice.id)
+        .order_by(col(PracticeSession.timestamp).desc())
+    )
+    sessions = list(sessions_result.scalars().all())
+    logger.info(
+        "user_practice_customized",
+        extra={
+            "user_practice_id": user_practice.id,
+            "user_id": user_practice.user_id,
+            "fields_changed": sorted(fields_set),
+        },
+    )
+    return {
+        **_user_practice_payload(user_practice),
+        "effective_name": name,
+        "effective_config": cfg,
         "sessions": sessions,
     }

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from domain.constants import TOTAL_STAGES as MAX_STAGE_NUMBER
 from domain.practice_modes import PracticeMode
@@ -212,8 +212,30 @@ class UserPracticeCustomize(BaseModel):
     :func:`domain.practice_resolution.effective_config` for the guard.
     """
 
-    custom_name: str | None = Field(default=None, max_length=PRACTICE_NAME_MAX_LENGTH)
+    custom_name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=PRACTICE_NAME_MAX_LENGTH,
+    )
     mode_config_override: dict[str, Any] | None = None
+
+    @field_validator("custom_name")
+    @classmethod
+    def _strip_and_reject_whitespace(cls, value: str | None) -> str | None:
+        """Trim surrounding whitespace and reject "" / "   " custom names.
+
+        Without this an empty / whitespace-only string would persist, then
+        ``effective_name``'s falsy check would silently fall back to the
+        catalog name — producing a contradictory response that says
+        ``custom_name = "   "`` alongside ``effective_name = "<catalog>"``.
+        """
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            msg = "custom_name cannot be empty or whitespace-only"
+            raise ValueError(msg)
+        return stripped
 
 
 # -- PracticeSession --------------------------------------------------------

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -156,6 +156,11 @@ class UserPracticeResponse(OwnedResourcePublic):
     returned to its owner -- cross-user fetches raise 403 in the router
     -- so echoing the surrogate key adds no information and aids
     enumeration.
+
+    ``effective_name`` and ``effective_config`` (ritual-03) collapse the
+    catalog row + the user's optional overrides into a single payload so
+    frontend code never has to merge by hand. Both are populated by the
+    router from :mod:`domain.practice_resolution`.
     """
 
     id: int
@@ -163,6 +168,10 @@ class UserPracticeResponse(OwnedResourcePublic):
     stage_number: int
     start_date: date
     end_date: date | None = None
+    custom_name: str | None = None
+    mode_config_override: dict[str, Any] | None = None
+    effective_name: str | None = None
+    effective_config: ModeConfig | None = None
 
 
 class PracticeSessionSummary(BaseModel):
@@ -186,7 +195,25 @@ class UserPracticeDetail(OwnedResourcePublic):
     stage_number: int
     start_date: date
     end_date: date | None = None
+    custom_name: str | None = None
+    mode_config_override: dict[str, Any] | None = None
+    effective_name: str | None = None
+    effective_config: ModeConfig | None = None
     sessions: list[PracticeSessionSummary]
+
+
+class UserPracticeCustomize(BaseModel):
+    """PATCH body for ``/user-practices/{id}/customize`` (ritual-03).
+
+    Both fields are nullable: passing ``None`` clears the override and
+    falls back to the catalog value. Omitting a field leaves the existing
+    value untouched (resolved at the router via ``model_fields_set``).
+    The ``mode`` cannot be changed here — see
+    :func:`domain.practice_resolution.effective_config` for the guard.
+    """
+
+    custom_name: str | None = Field(default=None, max_length=PRACTICE_NAME_MAX_LENGTH)
+    mode_config_override: dict[str, Any] | None = None
 
 
 # -- PracticeSession --------------------------------------------------------

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -157,10 +157,10 @@ class UserPracticeResponse(OwnedResourcePublic):
     -- so echoing the surrogate key adds no information and aids
     enumeration.
 
-    ``effective_name`` and ``effective_config`` (ritual-03) collapse the
-    catalog row + the user's optional overrides into a single payload so
-    frontend code never has to merge by hand. Both are populated by the
-    router from :mod:`domain.practice_resolution`.
+    ``effective_name`` and ``effective_config`` collapse the catalog row
+    plus the user's optional overrides into a single payload so frontend
+    code never has to merge by hand. Both are populated by the router
+    from :mod:`domain.practice_resolution`.
     """
 
     id: int
@@ -203,7 +203,7 @@ class UserPracticeDetail(OwnedResourcePublic):
 
 
 class UserPracticeCustomize(BaseModel):
-    """PATCH body for ``/user-practices/{id}/customize`` (ritual-03).
+    """PATCH body for ``/user-practices/{id}/customize``.
 
     Both fields are nullable: passing ``None`` clears the override and
     falls back to the catalog value. Omitting a field leaves the existing

--- a/backend/tests/domain/test_practice_resolution.py
+++ b/backend/tests/domain/test_practice_resolution.py
@@ -1,0 +1,195 @@
+"""Tests for the user-practice customization resolver."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date
+
+import pytest
+
+from domain.practice_resolution import effective_config, effective_name
+from models.practice import Practice
+from models.user_practice import UserPractice
+from schemas.practice_mode_config import (
+    CountUpConfig,
+    IntervalBellConfig,
+    MeditationTimerConfig,
+    MetronomeConfig,
+    RepCounterConfig,
+    SenseGroundingConfig,
+    TarotConfig,
+)
+
+
+def _practice(mode: str, mode_config: Mapping[str, object], **overrides: object) -> Practice:
+    """Build a catalog Practice with the requested mode/config."""
+    base: dict[str, object] = {
+        "id": 1,
+        "stage_number": 1,
+        "name": "Catalog name",
+        "description": "x",
+        "instructions": "x",
+        "default_duration_minutes": 10,
+        "submitted_by_user_id": None,
+        "approved": True,
+        "mode": mode,
+        "mode_config": dict(mode_config),
+    }
+    base.update(overrides)
+    return Practice(**base)
+
+
+def _user_practice(
+    practice_id: int = 1,
+    *,
+    custom_name: str | None = None,
+    mode_config_override: dict[str, object] | None = None,
+) -> UserPractice:
+    return UserPractice(
+        id=42,
+        user_id=7,
+        practice_id=practice_id,
+        stage_number=1,
+        start_date=date(2026, 1, 1),
+        end_date=None,
+        custom_name=custom_name,
+        mode_config_override=mode_config_override,
+    )
+
+
+# -- effective_name ---------------------------------------------------------
+
+
+def test_effective_name_falls_back_to_catalog_when_no_override() -> None:
+    practice = _practice("count_up", {"mode": "count_up"})
+    assert effective_name(practice, _user_practice()) == "Catalog name"
+
+
+def test_effective_name_uses_user_custom_name_when_set() -> None:
+    practice = _practice("count_up", {"mode": "count_up"})
+    user_practice = _user_practice(custom_name="My Morning Sit")
+    assert effective_name(practice, user_practice) == "My Morning Sit"
+
+
+def test_effective_name_handles_missing_user_practice() -> None:
+    practice = _practice("count_up", {"mode": "count_up"})
+    assert effective_name(practice, None) == "Catalog name"
+
+
+# -- effective_config -------------------------------------------------------
+
+
+def test_effective_config_returns_catalog_when_no_override() -> None:
+    catalog_cfg = {"mode": "count_up", "soft_cap_minutes": None}
+    practice = _practice("count_up", catalog_cfg)
+    cfg = effective_config(practice, _user_practice())
+    assert isinstance(cfg, CountUpConfig)
+    assert cfg.soft_cap_minutes is None
+
+
+def test_effective_config_uses_override_when_set() -> None:
+    catalog_cfg = {
+        "mode": "meditation_timer",
+        "duration_minutes": 10,
+        "start_bell": True,
+        "halfway_bell": False,
+        "end_bell": True,
+    }
+    practice = _practice("meditation_timer", catalog_cfg)
+    override = {**catalog_cfg, "duration_minutes": 25, "halfway_bell": True}
+    user_practice = _user_practice(mode_config_override=override)
+    cfg = effective_config(practice, user_practice)
+    assert isinstance(cfg, MeditationTimerConfig)
+    assert cfg.duration_minutes == 25
+    assert cfg.halfway_bell is True
+
+
+def test_effective_config_handles_missing_user_practice() -> None:
+    catalog_cfg = {"mode": "count_up", "soft_cap_minutes": 30}
+    practice = _practice("count_up", catalog_cfg)
+    cfg = effective_config(practice, None)
+    assert isinstance(cfg, CountUpConfig)
+    assert cfg.soft_cap_minutes == 30
+
+
+def test_effective_config_rejects_override_with_mismatched_mode() -> None:
+    catalog_cfg = {"mode": "count_up", "soft_cap_minutes": None}
+    practice = _practice("count_up", catalog_cfg)
+    bad_override = {
+        "mode": "meditation_timer",
+        "duration_minutes": 10,
+    }
+    user_practice = _user_practice(mode_config_override=bad_override)
+    with pytest.raises(ValueError, match="mode_mismatch"):
+        effective_config(practice, user_practice)
+
+
+# -- Per-mode round-trip coverage -------------------------------------------
+
+
+def test_effective_config_metronome_override_round_trip() -> None:
+    catalog_cfg = {
+        "mode": "metronome",
+        "bpm": 60,
+        "timer": {"mode": "meditation_timer", "duration_minutes": 30},
+    }
+    practice = _practice("metronome", catalog_cfg)
+    override = {
+        "mode": "metronome",
+        "bpm": 90,
+        "timer": {"mode": "meditation_timer", "duration_minutes": 20, "halfway_bell": True},
+    }
+    cfg = effective_config(practice, _user_practice(mode_config_override=override))
+    assert isinstance(cfg, MetronomeConfig)
+    assert cfg.bpm == 90
+    assert cfg.timer.duration_minutes == 20
+
+
+def test_effective_config_interval_bell_override_round_trip() -> None:
+    catalog_cfg = {
+        "mode": "interval_bell",
+        "duration_minutes": 30,
+        "interval_minutes": 5,
+        "bell_tone": "bowl",
+    }
+    practice = _practice("interval_bell", catalog_cfg)
+    override = {**catalog_cfg, "interval_minutes": None, "cue_offsets_minutes": [5, 10, 20]}
+    cfg = effective_config(practice, _user_practice(mode_config_override=override))
+    assert isinstance(cfg, IntervalBellConfig)
+    assert cfg.cue_offsets_minutes == [5, 10, 20]
+
+
+def test_effective_config_rep_counter_round_trip() -> None:
+    catalog_cfg = {
+        "mode": "rep_counter",
+        "target_reps": 108,
+        "unit_label": "breaths",
+    }
+    practice = _practice("rep_counter", catalog_cfg)
+    override = {**catalog_cfg, "target_reps": 54, "unit_label": "prostrations"}
+    cfg = effective_config(practice, _user_practice(mode_config_override=override))
+    assert isinstance(cfg, RepCounterConfig)
+    assert cfg.target_reps == 54
+    assert cfg.unit_label == "prostrations"
+
+
+def test_effective_config_sense_grounding_round_trip() -> None:
+    catalog_cfg = {
+        "mode": "sense_grounding",
+        "prompts": [
+            {"sense": "sight", "label": "5 things"},
+            {"sense": "touch", "label": "4 things"},
+        ],
+    }
+    practice = _practice("sense_grounding", catalog_cfg)
+    cfg = effective_config(practice, _user_practice())
+    assert isinstance(cfg, SenseGroundingConfig)
+    assert len(cfg.prompts) == 2
+
+
+def test_effective_config_tarot_round_trip() -> None:
+    catalog_cfg = {"mode": "tarot", "deck": "major_arcana", "per_card_minutes": 5}
+    practice = _practice("tarot", catalog_cfg)
+    cfg = effective_config(practice, _user_practice())
+    assert isinstance(cfg, TarotConfig)
+    assert cfg.per_card_minutes == 5

--- a/backend/tests/test_user_practice_customization.py
+++ b/backend/tests/test_user_practice_customization.py
@@ -150,6 +150,81 @@ async def test_customize_clears_override_with_explicit_null(
 
 
 @pytest.mark.asyncio
+async def test_customize_partial_patch_preserves_other_field(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A PATCH that touches only one field must not clobber the other.
+
+    ``model_fields_set`` is what makes this work — without it Pydantic
+    would deserialize an omitted field as ``None`` and the router would
+    happily overwrite the existing override.
+    """
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    # 1. Set both fields together.
+    both = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": "Original", "mode_config_override": _timer_cfg(33)},
+        headers=headers,
+    )
+    assert both.status_code == HTTPStatus.OK
+
+    # 2. PATCH only custom_name → mode_config_override must survive.
+    only_name = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": "Renamed"},
+        headers=headers,
+    )
+    assert only_name.status_code == HTTPStatus.OK
+    body = only_name.json()
+    assert body["custom_name"] == "Renamed"
+    assert body["mode_config_override"]["duration_minutes"] == 33
+
+    # 3. PATCH only mode_config_override → custom_name must survive.
+    only_cfg = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"mode_config_override": _timer_cfg(44)},
+        headers=headers,
+    )
+    assert only_cfg.status_code == HTTPStatus.OK
+    body = only_cfg.json()
+    assert body["custom_name"] == "Renamed"
+    assert body["mode_config_override"]["duration_minutes"] == 44
+
+
+@pytest.mark.asyncio
+async def test_customize_empty_body_is_idempotent_no_op(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``PATCH {}`` returns 200 without changing anything.
+
+    Pins the documented partial-PATCH contract — no fields set means no
+    writes. A future regression that clobbered fields on an empty body
+    would fail this test.
+    """
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": "Sticky", "mode_config_override": _timer_cfg(25)},
+        headers=headers,
+    )
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["custom_name"] == "Sticky"
+    assert body["mode_config_override"]["duration_minutes"] == 25
+
+
+@pytest.mark.asyncio
 async def test_customize_does_not_mutate_catalog_practice(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
@@ -250,11 +325,12 @@ async def test_customize_rejects_blank_custom_name(
     db_session: AsyncSession,
     blank: str,
 ) -> None:
-    """Empty / whitespace-only custom_name must 422 (review H2).
+    """Empty / whitespace-only custom_name must 422.
 
     Without this guard the value would persist, then ``effective_name``'s
-    falsy check would silently fall back to the catalog name — producing a
-    contradictory response shape that the reviewer flagged.
+    falsy check would silently fall back to the catalog name — yielding a
+    contradictory response (``custom_name=""`` alongside ``effective_name=
+    "<catalog>"``).
     """
     headers, user_id = await _signup(async_client)
     practice = await _seed_practice(db_session)
@@ -292,17 +368,73 @@ async def test_customize_strips_surrounding_whitespace_on_custom_name(
     assert resp.json()["effective_name"] == "My Sit"
 
 
-# -- List endpoint coverage (review B1) -------------------------------------
+# -- List endpoint coverage -------------------------------------------------
+
+
+async def _force_corrupt_override(db_session: AsyncSession, user_practice_id: int) -> None:
+    """Plant a mode-mismatched override directly via the ORM.
+
+    Pre-flight validation at the PATCH edge prevents this through the
+    API, but corrupt rows can arrive via direct DB tooling or a catalog
+    mode being edited after users stored overrides. The read paths must
+    tolerate them.
+    """
+    persisted = await db_session.get(UserPractice, user_practice_id)
+    assert persisted is not None
+    persisted.mode_config_override = {"mode": "count_up"}  # catalog mode is meditation_timer
+    db_session.add(persisted)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_falls_back_when_override_is_corrupt(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A row with a corrupt stored override returns 200 with effective_config=null.
+
+    Regression: a single bad row used to crash the entire user's list
+    with a 500 because ``effective_config()`` propagated its
+    ``ValueError``. The read path now logs a warning and falls through.
+    """
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+    await _force_corrupt_override(db_session, up_id)
+
+    resp = await async_client.get("/user-practices/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["effective_config"] is None
+    # ``effective_name`` is unaffected — the corrupt field is only the config.
+    assert items[0]["effective_name"] == practice.name
+
+
+@pytest.mark.asyncio
+async def test_get_one_falls_back_when_override_is_corrupt(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Detail endpoint mirrors the list endpoint's safe-resolution behavior."""
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+    await _force_corrupt_override(db_session, up_id)
+
+    resp = await async_client.get(f"/user-practices/{up_id}", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["effective_config"] is None
+    assert body["effective_name"] == practice.name
 
 
 @pytest.mark.asyncio
 async def test_list_user_practices_populates_effective_fields(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """List endpoint populates effective_* on every row (review B1).
+    """List endpoint populates effective_* on every row.
 
     Mirrors the GET-one shape so frontend code never has to merge by
-    hand. Pins the contract that the reviewer flagged as silently broken.
+    hand. Pins the cross-endpoint consistency contract.
     """
     headers, user_id = await _signup(async_client)
     practice = await _seed_practice(db_session)

--- a/backend/tests/test_user_practice_customization.py
+++ b/backend/tests/test_user_practice_customization.py
@@ -1,0 +1,243 @@
+"""Tests for the PATCH /user-practices/{id}/customize endpoint."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.practice import Practice
+from models.stage_progress import StageProgress
+from models.user_practice import UserPractice
+
+
+async def _signup(client: AsyncClient, username: str = "owner") -> tuple[dict[str, str], int]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+def _timer_cfg(duration_minutes: float = 10) -> dict[str, object]:
+    return {
+        "mode": "meditation_timer",
+        "duration_minutes": duration_minutes,
+        "start_bell": True,
+        "halfway_bell": False,
+        "end_bell": True,
+    }
+
+
+async def _seed_practice(db_session: AsyncSession, **overrides: object) -> Practice:
+    fields: dict[str, object] = {
+        "stage_number": 1,
+        "name": "Catalog meditation",
+        "description": "x",
+        "instructions": "x",
+        "default_duration_minutes": 10,
+        "approved": True,
+        "mode": "meditation_timer",
+        "mode_config": _timer_cfg(10),
+    }
+    fields.update(overrides)
+    practice = Practice(**fields)
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    return practice
+
+
+async def _create_user_practice(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    headers: dict[str, str],
+    user_id: int,
+    practice: Practice,
+) -> int:
+    """Select a practice and return the resulting user_practice_id."""
+    db_session.add(StageProgress(user_id=user_id, current_stage=practice.stage_number))
+    await db_session.commit()
+    resp = await client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": practice.stage_number},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+    return int(resp.json()["id"])
+
+
+# -- Happy paths ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_customize_sets_custom_name(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": "My Morning Sit"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+    assert body["effective_name"] == "My Morning Sit"
+
+    # GET reflects the change.
+    refetch = await async_client.get(f"/user-practices/{up_id}", headers=headers)
+    assert refetch.json()["effective_name"] == "My Morning Sit"
+
+
+@pytest.mark.asyncio
+async def test_customize_sets_mode_config_override(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    override = {**_timer_cfg(25), "halfway_bell": True}
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"mode_config_override": override},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    eff_cfg = resp.json()["effective_config"]
+    assert eff_cfg["duration_minutes"] == 25
+    assert eff_cfg["halfway_bell"] is True
+
+
+@pytest.mark.asyncio
+async def test_customize_clears_override_with_explicit_null(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    # Set an override first.
+    await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"mode_config_override": {**_timer_cfg(25)}},
+        headers=headers,
+    )
+    # Then clear it.
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"mode_config_override": None},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    assert resp.json()["effective_config"]["duration_minutes"] == 10  # catalog default
+
+    # And the underlying override column is null.
+    persisted = await db_session.get(UserPractice, up_id)
+    assert persisted is not None
+    await db_session.refresh(persisted)
+    assert persisted.mode_config_override is None
+
+
+@pytest.mark.asyncio
+async def test_customize_does_not_mutate_catalog_practice(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Customization must never touch the shared :class:`Practice` row."""
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    catalog_name_before = practice.name
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": "Renamed", "mode_config_override": _timer_cfg(60)},
+        headers=headers,
+    )
+    await db_session.refresh(practice)
+    assert practice.name == catalog_name_before
+    assert practice.mode_config["duration_minutes"] == 10  # unchanged
+
+
+# -- Error paths ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_customize_rejects_mode_mismatch(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"mode_config_override": {"mode": "count_up"}},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert "mode_mismatch" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_customize_rejects_invalid_mode_config(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    bad = {**_timer_cfg(10), "duration_minutes": 0.0}  # below 0.5 minimum
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"mode_config_override": bad},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_customize_403_on_other_user(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner_headers, owner_id = await _signup(async_client, username="owner")
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, owner_headers, owner_id, practice)
+
+    intruder_headers, _ = await _signup(async_client, username="intruder")
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": "stolen"},
+        headers=intruder_headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_customize_404_on_missing_id(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    resp = await async_client.patch(
+        "/user-practices/9999/customize",
+        json={"custom_name": "ghost"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_customize_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.patch(
+        "/user-practices/1/customize",
+        json={"custom_name": "x"},
+    )
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED

--- a/backend/tests/test_user_practice_customization.py
+++ b/backend/tests/test_user_practice_customization.py
@@ -241,3 +241,84 @@ async def test_customize_requires_auth(async_client: AsyncClient) -> None:
         json={"custom_name": "x"},
     )
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+async def test_customize_rejects_blank_custom_name(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    blank: str,
+) -> None:
+    """Empty / whitespace-only custom_name must 422 (review H2).
+
+    Without this guard the value would persist, then ``effective_name``'s
+    falsy check would silently fall back to the catalog name — producing a
+    contradictory response shape that the reviewer flagged.
+    """
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": blank},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_customize_strips_surrounding_whitespace_on_custom_name(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Surrounding whitespace on a non-blank custom_name is stripped.
+
+    Keeps ``effective_name`` well-formed for display while preserving
+    the user's intent (the leading/trailing spaces are noise).
+    """
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": "  My Sit  "},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["custom_name"] == "My Sit"
+    assert resp.json()["effective_name"] == "My Sit"
+
+
+# -- List endpoint coverage (review B1) -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_user_practices_populates_effective_fields(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """List endpoint populates effective_* on every row (review B1).
+
+    Mirrors the GET-one shape so frontend code never has to merge by
+    hand. Pins the contract that the reviewer flagged as silently broken.
+    """
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+    await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": "List Test"},
+        headers=headers,
+    )
+
+    resp = await async_client.get("/user-practices/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()
+    assert len(items) == 1
+    item = items[0]
+    assert item["effective_name"] == "List Test"
+    assert item["effective_config"] is not None
+    assert item["effective_config"]["mode"] == "meditation_timer"
+    assert item["effective_config"]["duration_minutes"] == 10

--- a/backend/tests/test_user_practices_api.py
+++ b/backend/tests/test_user_practices_api.py
@@ -50,6 +50,14 @@ async def _seed_practice(db_session: AsyncSession, **overrides: object) -> Pract
         "instructions": "Close your eyes and breathe",
         "default_duration_minutes": 10,
         "approved": True,
+        "mode": "meditation_timer",
+        "mode_config": {
+            "mode": "meditation_timer",
+            "duration_minutes": 10,
+            "start_bell": True,
+            "halfway_bell": False,
+            "end_bell": True,
+        },
     }
     defaults.update(overrides)
     practice = Practice(**defaults)
@@ -355,6 +363,14 @@ async def test_concurrent_picks_for_same_stage_yield_one_open_row(
             instructions="y",
             default_duration_minutes=5,
             approved=True,
+            mode="meditation_timer",
+            mode_config={
+                "mode": "meditation_timer",
+                "duration_minutes": 5,
+                "start_bell": True,
+                "halfway_bell": False,
+                "end_bell": True,
+            },
         )
         session.add(practice)
         await session.commit()


### PR DESCRIPTION
## Summary

ritual-03: per-user customization of name + `mode_config` for a `UserPractice`,
without mutating the shared catalog row. Mode-shifting is rejected — the
override may only swap fields *within* the catalog mode.

## What landed

**Model.** `UserPractice` gains nullable `custom_name` (str ≤ 255) and
`mode_config_override` (JSON). Both default to NULL, meaning "use the catalog
value".

**Migration `83b01b64cad3`.** Additive nullable columns; SQLite-safe
`batch_alter_table` downgrade. Verified locally against real Postgres:
`upgrade head → downgrade -1 → upgrade head → check` returns
"No new upgrade operations detected".

**Resolver (`domain.practice_resolution`).** Pure functions:
- `effective_name(practice, user_practice) -> str` — custom name or catalog
- `effective_config(practice, user_practice) -> ModeConfig` — override or
  catalog, validated through the discriminated union. Raises
  `ValueError("mode_mismatch")` if the override's `mode` disagrees with the
  catalog mode.

**Endpoint.** `PATCH /user-practices/{id}/customize`:
- Optional `custom_name` / `mode_config_override` (both nullable; explicit
  `null` clears the override)
- `model_fields_set` is consulted so a request that only includes
  `custom_name` doesn't clobber an existing `mode_config_override`
- Empty body `{}` is an idempotent no-op (200 with no writes)
- Pre-flight validation so a bad override never lands in the DB:
  - Structural failure → **422** with Pydantic's per-field error list
  - Mode mismatch → **400 `mode_mismatch`**
- Inherits `403` / `404` / `401` from the existing
  `require_owned_user_practice` dependency

**Defensive read paths.** `_safe_resolve_config` wraps `effective_config()`
in the list and GET-one paths so a corrupt stored override (planted via
direct DB tooling or a catalog mode edited after users stored overrides)
falls through to `effective_config: null` with a logged warning instead of
crashing the user's entire list with a 500.

**Response shapes.** `UserPracticeResponse` and `UserPracticeDetail` now echo
`custom_name`, `mode_config_override`, `effective_name`, and `effective_config`
so the client gets the merged view in one payload (no client-side merging).

## Tests

| File | Coverage |
|------|---|
| `tests/domain/test_practice_resolution.py` | 12 pure-function tests: name/config fallback, override-wins, missing user-practice handling, mode-mismatch rejection, per-mode round-trip (meditation_timer, count_up, metronome, interval_bell, rep_counter, sense_grounding, tarot) |
| `tests/test_user_practice_customization.py` | endpoint tests: custom_name round-trip, override round-trip, null clears override, partial-PATCH non-regression, empty body is idempotent, list endpoint populates `effective_*`, list / GET-one fall back gracefully on a corrupt stored override, catalog Practice never mutated, mode-mismatch → 400, invalid range → 422, blank `custom_name` → 422 (parametrized), cross-user → 403, missing id → 404, unauth → 401 |
| `tests/test_user_practices_api.py` | fixture update — seeded `Practice` rows supply valid `mode_config` (post-ritual-01 the resolver requires it) |

Full focused suite passes. Pre-push gate green: xenon A on every block, full
backend suite + 90% coverage gate passed.

## Out of scope / follow-ups

- Frontend wiring (ritual-09 will consume this PATCH endpoint).
- `mode` itself is intentionally not editable here — mode-shifting is a
  practice replacement (existing flow via `POST /user-practices/`).

https://claude.ai/code/session_015RtJLZGkcgdHms5z1qfPkw

---
_Generated by [Claude Code](https://claude.ai/code/session_015RtJLZGkcgdHms5z1qfPkw)_