### PR TITLE
feat(frontend-practice): 5-4-3-2-1 + tarot preset views (ritual-08)

### DIFF
--- a/frontend/src/features/Practice/data/tarot.ts
+++ b/frontend/src/features/Practice/data/tarot.ts
@@ -1,0 +1,179 @@
+/**
+ * Major arcana data + day-index resolver for the tarot meditation preset.
+ *
+ * The deck is 22 cards in the traditional Marseille / RWS order; the cycle
+ * wraps every 22 days so `cardForDayIndex` is a pure modulo lookup. The
+ * caller — `PracticeScreen` in ritual-11 — is responsible for computing
+ * `daysSinceStart` from `UserPractice.start_date` and the user's local
+ * timezone before calling this helper.
+ *
+ * Keywords and symbolism strings are deliberately short (≤ 80 chars) so the
+ * view can render them inline without truncation across phone widths. No
+ * image assets ship in this issue; the view renders the card name plus a
+ * stylised border. A follow-up asset task can layer illustrations on top
+ * once licensing for a deck has been sorted.
+ */
+
+import { TAROT_DECK_SIZE } from '../engine/types';
+
+export interface TarotCard {
+  readonly index: number;
+  readonly name: string;
+  readonly keyword: string;
+  readonly symbolism: string;
+}
+
+export const MAJOR_ARCANA: readonly TarotCard[] = [
+  {
+    index: 0,
+    name: 'The Fool',
+    keyword: 'Beginnings',
+    symbolism: 'Stepping off the cliff with open eyes and an open heart.',
+  },
+  {
+    index: 1,
+    name: 'The Magician',
+    keyword: 'Manifestation',
+    symbolism: 'Channelling will into form; tools of every element to hand.',
+  },
+  {
+    index: 2,
+    name: 'The High Priestess',
+    keyword: 'Intuition',
+    symbolism: 'The veiled gate between the seen and the felt.',
+  },
+  {
+    index: 3,
+    name: 'The Empress',
+    keyword: 'Abundance',
+    symbolism: 'Fertile garden, ripening, the body as a place to belong.',
+  },
+  {
+    index: 4,
+    name: 'The Emperor',
+    keyword: 'Structure',
+    symbolism: 'Throne of stone — order, boundary, the limits that protect.',
+  },
+  {
+    index: 5,
+    name: 'The Hierophant',
+    keyword: 'Tradition',
+    symbolism: 'The keeper of inherited keys; teacher, lineage, vow.',
+  },
+  {
+    index: 6,
+    name: 'The Lovers',
+    keyword: 'Choice',
+    symbolism: 'Two paths converge; the heart speaks before the mind.',
+  },
+  {
+    index: 7,
+    name: 'The Chariot',
+    keyword: 'Will',
+    symbolism: 'Reins held in tension — two beasts moving as one.',
+  },
+  {
+    index: 8,
+    name: 'Strength',
+    keyword: 'Gentle power',
+    symbolism: 'A woman closing the lion’s jaws with a soft hand.',
+  },
+  {
+    index: 9,
+    name: 'The Hermit',
+    keyword: 'Solitude',
+    symbolism: 'Lantern raised on the mountain path; light made for one.',
+  },
+  {
+    index: 10,
+    name: 'Wheel of Fortune',
+    keyword: 'Turning',
+    symbolism: 'Cycles within cycles; what rose will fall, what fell will rise.',
+  },
+  {
+    index: 11,
+    name: 'Justice',
+    keyword: 'Truth',
+    symbolism: 'Sword and scales — clear sight, fair weight, honest cut.',
+  },
+  {
+    index: 12,
+    name: 'The Hanged Man',
+    keyword: 'Surrender',
+    symbolism: 'Suspended upside-down; the view changes when struggle stops.',
+  },
+  {
+    index: 13,
+    name: 'Death',
+    keyword: 'Release',
+    symbolism: 'The threshold; what is finished, allowed to be finished.',
+  },
+  {
+    index: 14,
+    name: 'Temperance',
+    keyword: 'Blending',
+    symbolism: 'Water poured between two cups without spill — middle way.',
+  },
+  {
+    index: 15,
+    name: 'The Devil',
+    keyword: 'Shadow',
+    symbolism: 'Chains loose enough to slip; the bondage we agree to.',
+  },
+  {
+    index: 16,
+    name: 'The Tower',
+    keyword: 'Rupture',
+    symbolism: 'Lightning splits the false structure; rubble before renewal.',
+  },
+  {
+    index: 17,
+    name: 'The Star',
+    keyword: 'Hope',
+    symbolism: 'Naked under the night sky, pouring water on parched earth.',
+  },
+  {
+    index: 18,
+    name: 'The Moon',
+    keyword: 'Mystery',
+    symbolism: 'Tides, dreams, and the long path between the towers.',
+  },
+  {
+    index: 19,
+    name: 'The Sun',
+    keyword: 'Joy',
+    symbolism: 'Child on horseback in a garden — uncomplicated gladness.',
+  },
+  {
+    index: 20,
+    name: 'Judgement',
+    keyword: 'Awakening',
+    symbolism: 'The trumpet calls; the buried rise into their own names.',
+  },
+  {
+    index: 21,
+    name: 'The World',
+    keyword: 'Completion',
+    symbolism: 'The dance finished; the circle closes and opens again.',
+  },
+];
+
+/**
+ * Resolve a day offset (0-based; day 0 is the user's first day) to a card.
+ *
+ * The cycle wraps modulo {@link TAROT_DECK_SIZE}, so day 22 returns the
+ * Fool again. Negative offsets are not expected — callers should clamp
+ * pre-start days to 0 — but JavaScript's `%` operator already produces a
+ * non-negative result for the inputs we accept.
+ */
+export function cardForDayIndex(daysSinceStart: number): TarotCard {
+  const normalised = ((daysSinceStart % TAROT_DECK_SIZE) + TAROT_DECK_SIZE) % TAROT_DECK_SIZE;
+  const card = MAJOR_ARCANA[normalised];
+  if (!card) {
+    // Unreachable: MAJOR_ARCANA has TAROT_DECK_SIZE entries and `normalised`
+    // is in [0, TAROT_DECK_SIZE). Keep the explicit guard so the return type
+    // is `TarotCard` rather than `TarotCard | undefined`.
+    throw new Error(`tarot: no card at normalised index ${normalised}`);
+  }
+  return card;
+}

--- a/frontend/src/features/Practice/data/tarot.ts
+++ b/frontend/src/features/Practice/data/tarot.ts
@@ -162,9 +162,10 @@ export const MAJOR_ARCANA: readonly TarotCard[] = [
  * Resolve a day offset (0-based; day 0 is the user's first day) to a card.
  *
  * The cycle wraps modulo {@link TAROT_DECK_SIZE}, so day 22 returns the
- * Fool again. Negative offsets are not expected — callers should clamp
- * pre-start days to 0 — but JavaScript's `%` operator already produces a
- * non-negative result for the inputs we accept.
+ * Fool again. Callers should pre-clamp pre-start days to 0; negative
+ * inputs are nonetheless guarded by the double-modulo expression below
+ * (JavaScript's `%` returns a negative result for negative operands, so
+ * a single `% SIZE` would leak `-1`).
  */
 export function cardForDayIndex(daysSinceStart: number): TarotCard {
   const normalised = ((daysSinceStart % TAROT_DECK_SIZE) + TAROT_DECK_SIZE) % TAROT_DECK_SIZE;

--- a/frontend/src/features/Practice/views/SenseGroundingView.tsx
+++ b/frontend/src/features/Practice/views/SenseGroundingView.tsx
@@ -42,9 +42,11 @@ interface Props {
   config: SenseGroundingConfig;
   state: RitualState;
   controls: RitualControls;
+  /** Optional Save callback; the parent typically launches the insight modal. */
+  onSave?: () => void;
 }
 
-const SenseGroundingView = ({ config, state, controls }: Props): React.JSX.Element => {
+const SenseGroundingView = ({ config, state, controls, onSave }: Props): React.JSX.Element => {
   const total = config.prompts.length;
   const currentIdx = Math.min(state.currentStepIndex, total - 1);
   const activePrompt = config.prompts[currentIdx];
@@ -54,7 +56,7 @@ const SenseGroundingView = ({ config, state, controls }: Props): React.JSX.Eleme
     <View style={styles.container} testID="sense-grounding-view">
       <SenseHeader prompt={isComplete ? null : activePrompt} />
       {isComplete ? (
-        <CompleteCard />
+        <CompleteCard onSave={onSave} />
       ) : (
         activePrompt && (
           <ActivePrompt prompt={activePrompt} canAdvance={canAdvance} onTap={controls.tap} />
@@ -84,12 +86,23 @@ const SenseHeader = ({ prompt }: { prompt: SensePrompt | null | undefined }): Re
   </View>
 );
 
-const CompleteCard = (): React.JSX.Element => (
+const CompleteCard = ({ onSave }: { onSave?: () => void }): React.JSX.Element => (
   <View style={styles.completeCard} testID="sense-grounding-complete">
     <Text style={styles.completeTitle}>Grounding complete</Text>
     <Text style={styles.completeBody}>
       You moved through all five senses. Save the session below.
     </Text>
+    <Pressable
+      style={[styles.save, !onSave && styles.saveDisabled]}
+      onPress={onSave}
+      disabled={!onSave}
+      testID="sense-grounding-save"
+      accessibilityRole="button"
+      accessibilityLabel="Save session and reflect"
+      accessibilityState={{ disabled: !onSave }}
+    >
+      <Text style={styles.saveText}>Save session</Text>
+    </Pressable>
   </View>
 );
 
@@ -180,7 +193,19 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: colors.text.secondaryAccessible,
     textAlign: 'center',
+    marginBottom: SPACING.lg,
   },
+  save: {
+    backgroundColor: colors.success,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  saveDisabled: { opacity: 0.5 },
+  saveText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
 });
 
 export default SenseGroundingView;

--- a/frontend/src/features/Practice/views/SenseGroundingView.tsx
+++ b/frontend/src/features/Practice/views/SenseGroundingView.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import type {
+  RitualControls,
+  RitualState,
+  SenseGroundingConfig,
+  SenseKind,
+  SensePrompt,
+} from '../engine/types';
+
+import RitualControlsBar from './RitualControlsBar';
+
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+/**
+ * Canonical 5-4-3-2-1 grounding counts.
+ *
+ * The classic anxiety-regulation exercise asks for five sights, four
+ * touches, three sounds, two smells, and one taste. The badge copy is
+ * derived from this mapping rather than from `config.prompts.length` so
+ * the header reads identically across slightly customised prompt sets.
+ */
+const SENSE_COUNT: Readonly<Record<SenseKind, number>> = {
+  sight: 5,
+  touch: 4,
+  hearing: 3,
+  smell: 2,
+  taste: 1,
+};
+
+/** Verb shown in the header for each sense ("5 things you can SEE"). */
+const SENSE_VERB: Readonly<Record<SenseKind, string>> = {
+  sight: 'SEE',
+  touch: 'TOUCH',
+  hearing: 'HEAR',
+  smell: 'SMELL',
+  taste: 'TASTE',
+};
+
+interface Props {
+  config: SenseGroundingConfig;
+  state: RitualState;
+  controls: RitualControls;
+}
+
+const SenseGroundingView = ({ config, state, controls }: Props): React.JSX.Element => {
+  const total = config.prompts.length;
+  const currentIdx = Math.min(state.currentStepIndex, total - 1);
+  const activePrompt = config.prompts[currentIdx];
+  const isComplete = state.status === 'complete' || state.currentStepIndex >= total;
+  const canAdvance = state.status === 'running' && !isComplete;
+  return (
+    <View style={styles.container} testID="sense-grounding-view">
+      <SenseHeader prompt={isComplete ? null : activePrompt} />
+      {isComplete ? (
+        <CompleteCard />
+      ) : (
+        activePrompt && (
+          <ActivePrompt prompt={activePrompt} canAdvance={canAdvance} onTap={controls.tap} />
+        )
+      )}
+      <RitualControlsBar status={state.status} controls={controls} startLabel="Begin grounding" />
+    </View>
+  );
+};
+
+const SenseHeader = ({ prompt }: { prompt: SensePrompt | null | undefined }): React.JSX.Element => (
+  <View
+    style={styles.header}
+    testID="sense-grounding-header"
+    accessibilityRole="header"
+    accessibilityLabel="5-4-3-2-1 grounding"
+  >
+    <Text style={styles.badge} testID="sense-grounding-badge">
+      5-4-3-2-1
+    </Text>
+    {prompt && (
+      <Text style={styles.count} testID="sense-grounding-count">
+        {`${SENSE_COUNT[prompt.sense]} things you can `}
+        <Text style={styles.countVerb}>{SENSE_VERB[prompt.sense]}</Text>
+      </Text>
+    )}
+  </View>
+);
+
+const CompleteCard = (): React.JSX.Element => (
+  <View style={styles.completeCard} testID="sense-grounding-complete">
+    <Text style={styles.completeTitle}>Grounding complete</Text>
+    <Text style={styles.completeBody}>
+      You moved through all five senses. Save the session below.
+    </Text>
+  </View>
+);
+
+interface ActivePromptProps {
+  prompt: SensePrompt;
+  canAdvance: boolean;
+  onTap: () => void;
+}
+
+const ActivePrompt = ({ prompt, canAdvance, onTap }: ActivePromptProps): React.JSX.Element => (
+  <>
+    <Text style={styles.prompt} testID="sense-grounding-prompt">
+      {prompt.label}
+    </Text>
+    <Pressable
+      style={[styles.advance, !canAdvance && styles.advanceDisabled]}
+      onPress={canAdvance ? onTap : undefined}
+      disabled={!canAdvance}
+      testID="sense-grounding-advance"
+      accessibilityRole="button"
+      accessibilityLabel={`Mark ${prompt.sense} done`}
+      accessibilityState={{ disabled: !canAdvance }}
+    >
+      <Text style={styles.advanceText}>{`Mark ${prompt.sense} done`}</Text>
+    </Pressable>
+  </>
+);
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl },
+  header: { alignItems: 'center', marginBottom: SPACING.xl },
+  badge: {
+    fontSize: 36,
+    fontWeight: '700',
+    letterSpacing: 4,
+    color: colors.text.primary,
+    marginBottom: SPACING.sm,
+  },
+  count: {
+    fontSize: 18,
+    color: colors.text.secondaryAccessible,
+  },
+  countVerb: {
+    fontWeight: '700',
+    letterSpacing: 2,
+    color: colors.text.primary,
+  },
+  prompt: {
+    fontSize: 20,
+    fontWeight: '500',
+    color: colors.text.primary,
+    textAlign: 'center',
+    marginBottom: SPACING.xxl,
+    paddingHorizontal: SPACING.lg,
+  },
+  advance: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    marginBottom: SPACING.xl,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  advanceDisabled: { opacity: 0.5 },
+  advanceText: {
+    color: colors.text.light,
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  completeCard: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.xl,
+    alignItems: 'center',
+    marginBottom: SPACING.xl,
+    maxWidth: 320,
+    ...shadows.small,
+  },
+  completeTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    color: colors.success,
+    marginBottom: SPACING.sm,
+  },
+  completeBody: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    textAlign: 'center',
+  },
+});
+
+export default SenseGroundingView;

--- a/frontend/src/features/Practice/views/TarotMeditationView.tsx
+++ b/frontend/src/features/Practice/views/TarotMeditationView.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import type { TarotCard } from '../data/tarot';
+import type { RitualControls, RitualState } from '../engine/types';
+
+import { formatTime } from './formatTime';
+import RitualControlsBar from './RitualControlsBar';
+
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+/**
+ * Day-by-day major-arcana meditation view.
+ *
+ * Important contract: this view does not read the wall clock. The parent
+ * (`PracticeScreen` in ritual-11) computes the day-of-practice from
+ * `UserPractice.start_date` in the user's local timezone and passes the
+ * resolved card down via `card`. Recomputing here would let timezone bugs
+ * land in two places — keep it pinned to the parent.
+ *
+ * The timer is intentionally hidden during the meditative window when
+ * `hideTimer` is true: the practice asks the user to sit with the card
+ * for ~5 minutes without clock-watching. Pausing brings the timer back as
+ * an "honesty over purism" escape hatch, and completion always reveals
+ * the final reading alongside the post-session Save CTA.
+ */
+interface Props {
+  state: RitualState;
+  controls: RitualControls;
+  card: TarotCard;
+  /** When true, suppress the countdown while the engine is running. */
+  hideTimer: boolean;
+  /** Optional Save callback; the parent typically launches the insight modal. */
+  onSave?: () => void;
+}
+
+const TarotMeditationView = ({
+  state,
+  controls,
+  card,
+  hideTimer,
+  onSave,
+}: Props): React.JSX.Element => {
+  const showTimer =
+    state.status === 'paused' ||
+    state.status === 'complete' ||
+    (state.status === 'running' && !hideTimer);
+  return (
+    <View style={styles.container} testID="tarot-meditation-view">
+      <TarotCardFace card={card} />
+      {showTimer && (
+        <Text style={styles.timer} testID="tarot-time-remaining">
+          {formatTime(state.remainingMs ?? 0)}
+        </Text>
+      )}
+      <TarotFooter state={state} controls={controls} hideTimer={hideTimer} onSave={onSave} />
+    </View>
+  );
+};
+
+const TarotCardFace = ({ card }: { card: TarotCard }): React.JSX.Element => (
+  <View style={styles.card} testID="tarot-card">
+    <Text style={styles.cardIndex}>{`${card.index} · MAJOR ARCANA`}</Text>
+    <Text style={styles.cardName} testID="tarot-card-name">
+      {card.name}
+    </Text>
+    <Text style={styles.cardKeyword} testID="tarot-card-keyword">
+      {card.keyword}
+    </Text>
+    <Text style={styles.cardSymbolism} testID="tarot-card-symbolism">
+      {card.symbolism}
+    </Text>
+  </View>
+);
+
+interface FooterProps {
+  state: RitualState;
+  controls: RitualControls;
+  hideTimer: boolean;
+  onSave?: () => void;
+}
+
+const TarotFooter = ({ state, controls, hideTimer, onSave }: FooterProps): React.JSX.Element => {
+  if (state.status === 'idle') {
+    return (
+      <Pressable
+        style={styles.begin}
+        onPress={controls.start}
+        testID="tarot-begin"
+        accessibilityRole="button"
+        accessibilityLabel="Begin meditation"
+      >
+        <Text style={styles.beginText}>Begin meditation</Text>
+      </Pressable>
+    );
+  }
+  if (state.status === 'running' && hideTimer) {
+    return (
+      <Pressable
+        style={styles.longCancel}
+        onLongPress={controls.cancel}
+        delayLongPress={800}
+        testID="tarot-cancel-longpress"
+        accessibilityRole="button"
+        accessibilityLabel="Long-press to cancel meditation"
+        accessibilityHint="Hold to end the sit early without revealing the timer."
+      >
+        <Text style={styles.longCancelText}>Hold to cancel</Text>
+      </Pressable>
+    );
+  }
+  if (state.status === 'paused') {
+    return <RitualControlsBar status={state.status} controls={controls} startLabel="Begin" />;
+  }
+  if (state.status === 'complete') {
+    return (
+      <View style={styles.completeRow}>
+        <Pressable
+          style={styles.save}
+          onPress={onSave}
+          disabled={!onSave}
+          testID="tarot-save"
+          accessibilityRole="button"
+          accessibilityLabel="Save session and reflect"
+        >
+          <Text style={styles.saveText}>Save session</Text>
+        </Pressable>
+      </View>
+    );
+  }
+  // status === 'running' && !hideTimer — let the parent surface the standard
+  // controls bar; the timer is already visible above.
+  return <RitualControlsBar status={state.status} controls={controls} startLabel="Begin" />;
+};
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl },
+  card: {
+    width: 260,
+    minHeight: 360,
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.xl,
+    borderWidth: 2,
+    borderColor: colors.secondary,
+    padding: SPACING.xl,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: SPACING.xl,
+    ...shadows.medium,
+  },
+  cardIndex: {
+    fontSize: 11,
+    letterSpacing: 3,
+    color: colors.text.tertiaryAccessible,
+    marginBottom: SPACING.md,
+  },
+  cardName: {
+    fontSize: 26,
+    fontWeight: '600',
+    color: colors.text.primary,
+    textAlign: 'center',
+    marginBottom: SPACING.md,
+  },
+  cardKeyword: {
+    fontSize: 14,
+    fontStyle: 'italic',
+    color: colors.text.secondaryAccessible,
+    textAlign: 'center',
+    marginBottom: SPACING.lg,
+  },
+  cardSymbolism: {
+    fontSize: 13,
+    color: colors.text.secondaryAccessible,
+    textAlign: 'center',
+    lineHeight: 18,
+    paddingHorizontal: SPACING.sm,
+  },
+  timer: {
+    fontSize: 36,
+    fontWeight: '300',
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+    marginBottom: SPACING.lg,
+  },
+  begin: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  beginText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
+  longCancel: {
+    paddingVertical: SPACING.md,
+    paddingHorizontal: SPACING.xl,
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    borderColor: colors.text.tertiaryAccessible,
+  },
+  longCancelText: {
+    color: colors.text.tertiaryAccessible,
+    fontSize: 13,
+    letterSpacing: 1,
+  },
+  completeRow: { alignItems: 'center', marginTop: SPACING.md },
+  save: {
+    backgroundColor: colors.success,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  saveText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
+});
+
+export default TarotMeditationView;

--- a/frontend/src/features/Practice/views/TarotMeditationView.tsx
+++ b/frontend/src/features/Practice/views/TarotMeditationView.tsx
@@ -112,26 +112,27 @@ const TarotFooter = ({ state, controls, hideTimer, onSave }: FooterProps): React
   if (state.status === 'paused') {
     return <RitualControlsBar status={state.status} controls={controls} startLabel="Begin" />;
   }
-  if (state.status === 'complete') {
-    return (
-      <View style={styles.completeRow}>
-        <Pressable
-          style={styles.save}
-          onPress={onSave}
-          disabled={!onSave}
-          testID="tarot-save"
-          accessibilityRole="button"
-          accessibilityLabel="Save session and reflect"
-        >
-          <Text style={styles.saveText}>Save session</Text>
-        </Pressable>
-      </View>
-    );
-  }
+  if (state.status === 'complete') return <TarotSaveButton onSave={onSave} />;
   // status === 'running' && !hideTimer — let the parent surface the standard
   // controls bar; the timer is already visible above.
   return <RitualControlsBar status={state.status} controls={controls} startLabel="Begin" />;
 };
+
+const TarotSaveButton = ({ onSave }: { onSave?: () => void }): React.JSX.Element => (
+  <View style={styles.completeRow}>
+    <Pressable
+      style={[styles.save, !onSave && styles.saveDisabled]}
+      onPress={onSave}
+      disabled={!onSave}
+      testID="tarot-save"
+      accessibilityRole="button"
+      accessibilityLabel="Save session and reflect"
+      accessibilityState={{ disabled: !onSave }}
+    >
+      <Text style={styles.saveText}>Save session</Text>
+    </Pressable>
+  </View>
+);
 
 const styles = StyleSheet.create({
   container: { alignItems: 'center', padding: SPACING.xl },
@@ -214,6 +215,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     ...shadows.small,
   },
+  saveDisabled: { opacity: 0.5 },
   saveText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
 });
 

--- a/frontend/src/features/Practice/views/__tests__/SenseGroundingView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/SenseGroundingView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
@@ -84,7 +84,7 @@ describe('SenseGroundingView', () => {
     expect(controls.start).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the completion card with a Save CTA when status is complete', () => {
+  it('renders the completion card and hides the advance button when complete', () => {
     const { getByTestId, queryByTestId } = render(
       <SenseGroundingView
         config={config}
@@ -97,6 +97,56 @@ describe('SenseGroundingView', () => {
     );
     expect(getByTestId('sense-grounding-complete')).toBeTruthy();
     expect(queryByTestId('sense-grounding-advance')).toBeNull();
+  });
+
+  it('renders a Save CTA in the complete card and forwards onSave when pressed', () => {
+    const onSave = jest.fn();
+    const { getByTestId } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({
+          status: 'complete',
+          currentStepIndex: config.prompts.length,
+        })}
+        controls={fakeControls()}
+        onSave={onSave}
+      />,
+    );
+    fireEvent.press(getByTestId('sense-grounding-save'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the Save CTA when onSave is omitted', () => {
+    const { getByTestId } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({
+          status: 'complete',
+          currentStepIndex: config.prompts.length,
+        })}
+        controls={fakeControls()}
+      />,
+    );
+    const save = getByTestId('sense-grounding-save');
+    expect(save.props.accessibilityState).toEqual({ disabled: true });
+  });
+
+  it('disables the advance button when paused and ignores taps', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({ status: 'paused', currentStepIndex: 1 })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('sense-grounding-advance'));
+    expect(controls.tap).not.toHaveBeenCalled();
+    expect(getByTestId('sense-grounding-advance').props.accessibilityState).toEqual({
+      disabled: true,
+    });
+    expect(getByTestId('ritual-resume')).toBeTruthy();
+    expect(getByTestId('ritual-cancel')).toBeTruthy();
   });
 
   it('sets the header accessibility role', () => {

--- a/frontend/src/features/Practice/views/__tests__/SenseGroundingView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/SenseGroundingView.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { SenseGroundingConfig } from '../../engine/types';
+import SenseGroundingView from '../SenseGroundingView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+const config: SenseGroundingConfig = {
+  mode: 'sense_grounding',
+  prompts: [
+    { sense: 'sight', label: 'Five things you can see right now' },
+    { sense: 'touch', label: 'Four things you can feel' },
+    { sense: 'hearing', label: 'Three things you can hear' },
+    { sense: 'smell', label: 'Two things you can smell' },
+    { sense: 'taste', label: 'One thing you can taste' },
+  ],
+};
+
+describe('SenseGroundingView', () => {
+  it('renders the 5-4-3-2-1 badge and the current sense count', () => {
+    const { getByTestId, getByText } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 0 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('sense-grounding-badge').props.children).toBe('5-4-3-2-1');
+    expect(getByText('SEE')).toBeTruthy();
+    expect(getByText(/5 things you can/)).toBeTruthy();
+  });
+
+  it('shows the active prompt label for the current step', () => {
+    const { getByTestId } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 2 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('sense-grounding-prompt').props.children).toBe('Three things you can hear');
+  });
+
+  it('labels the primary button "Mark <sense> done" per step', () => {
+    const senses = ['sight', 'touch', 'hearing', 'smell', 'taste'] as const;
+    for (const [idx, sense] of senses.entries()) {
+      const { getByText, unmount } = render(
+        <SenseGroundingView
+          config={config}
+          state={fakeState({ status: 'running', currentStepIndex: idx })}
+          controls={fakeControls()}
+        />,
+      );
+      expect(getByText(`Mark ${sense} done`)).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it('calls controls.tap when the advance button is pressed', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 1 })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('sense-grounding-advance'));
+    expect(controls.tap).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the Start control while idle and forwards controls.start', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({ status: 'idle', currentStepIndex: 0 })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('ritual-start'));
+    expect(controls.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the completion card with a Save CTA when status is complete', () => {
+    const { getByTestId, queryByTestId } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({
+          status: 'complete',
+          currentStepIndex: config.prompts.length,
+        })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('sense-grounding-complete')).toBeTruthy();
+    expect(queryByTestId('sense-grounding-advance')).toBeNull();
+  });
+
+  it('sets the header accessibility role', () => {
+    const { getByTestId } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 0 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('sense-grounding-header').props.accessibilityRole).toBe('header');
+  });
+
+  it('exposes an accessibility label that updates with the current sense', () => {
+    const { getByTestId, rerender } = render(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 0 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('sense-grounding-advance').props.accessibilityLabel).toBe('Mark sight done');
+    rerender(
+      <SenseGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 3 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('sense-grounding-advance').props.accessibilityLabel).toBe('Mark smell done');
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/TarotMeditationView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/TarotMeditationView.test.tsx
@@ -114,6 +114,23 @@ describe('TarotMeditationView', () => {
     expect(onSave).toHaveBeenCalledTimes(1);
   });
 
+  it('disables the Save CTA and dims it when onSave is omitted', () => {
+    const { getByTestId } = render(
+      <TarotMeditationView
+        state={fakeState({ status: 'complete', remainingMs: 0 })}
+        controls={fakeControls()}
+        card={FOOL}
+        hideTimer
+      />,
+    );
+    const save = getByTestId('tarot-save');
+    expect(save.props.accessibilityState).toEqual({ disabled: true });
+    const flattened = Array.isArray(save.props.style)
+      ? Object.assign({}, ...save.props.style.filter(Boolean))
+      : save.props.style;
+    expect(flattened.opacity).toBe(0.5);
+  });
+
   it('renders the card name and keyword in every status', () => {
     const statuses = ['idle', 'running', 'paused', 'complete'] as const;
     for (const status of statuses) {

--- a/frontend/src/features/Practice/views/__tests__/TarotMeditationView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/TarotMeditationView.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import { MAJOR_ARCANA } from '../../data/tarot';
+import TarotMeditationView from '../TarotMeditationView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+const FOOL = MAJOR_ARCANA[0]!;
+
+describe('TarotMeditationView', () => {
+  it('renders the card name, keyword, and a Begin button while idle', () => {
+    const controls = fakeControls();
+    const { getByTestId, getByText } = render(
+      <TarotMeditationView
+        state={fakeState({ status: 'idle' })}
+        controls={controls}
+        card={FOOL}
+        hideTimer
+      />,
+    );
+    expect(getByTestId('tarot-card-name').props.children).toBe(FOOL.name);
+    expect(getByText(FOOL.keyword)).toBeTruthy();
+    fireEvent.press(getByTestId('tarot-begin'));
+    expect(controls.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the timer and controls bar while running with hideTimer=true', () => {
+    const { queryByTestId, getByTestId, getByText } = render(
+      <TarotMeditationView
+        state={fakeState({ status: 'running', remainingMs: 270_000 })}
+        controls={fakeControls()}
+        card={FOOL}
+        hideTimer
+      />,
+    );
+    expect(queryByTestId('tarot-time-remaining')).toBeNull();
+    expect(queryByTestId('ritual-controls-bar')).toBeNull();
+    // Card content stays visible.
+    expect(getByTestId('tarot-card-name').props.children).toBe(FOOL.name);
+    expect(getByText(FOOL.keyword)).toBeTruthy();
+    // Long-press cancel exists as the only exit.
+    expect(getByTestId('tarot-cancel-longpress')).toBeTruthy();
+  });
+
+  it('shows the timer while running when hideTimer=false (escape hatch off)', () => {
+    const { getByTestId } = render(
+      <TarotMeditationView
+        state={fakeState({ status: 'running', remainingMs: 90_000 })}
+        controls={fakeControls()}
+        card={FOOL}
+        hideTimer={false}
+      />,
+    );
+    expect(getByTestId('tarot-time-remaining').props.children).toBe('01:30');
+  });
+
+  it('never renders mm:ss text while running with hideTimer=true', () => {
+    const { queryByText } = render(
+      <TarotMeditationView
+        state={fakeState({ status: 'running', remainingMs: 305_000 })}
+        controls={fakeControls()}
+        card={FOOL}
+        hideTimer
+      />,
+    );
+    // Match any mm:ss substring; the card metadata never uses ":" so this
+    // catches an accidental leak of the timer string.
+    expect(queryByText(/\d{2}:\d{2}/)).toBeNull();
+  });
+
+  it('cancels the session when the long-press affordance fires', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <TarotMeditationView
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+        card={FOOL}
+        hideTimer
+      />,
+    );
+    fireEvent(getByTestId('tarot-cancel-longpress'), 'longPress');
+    expect(controls.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the timer and standard controls when paused', () => {
+    const { getByTestId } = render(
+      <TarotMeditationView
+        state={fakeState({ status: 'paused', remainingMs: 180_000 })}
+        controls={fakeControls()}
+        card={FOOL}
+        hideTimer
+      />,
+    );
+    expect(getByTestId('tarot-time-remaining').props.children).toBe('03:00');
+    expect(getByTestId('ritual-controls-bar')).toBeTruthy();
+    expect(getByTestId('ritual-resume')).toBeTruthy();
+  });
+
+  it('reveals the timer reading and a Save CTA when complete', () => {
+    const onSave = jest.fn();
+    const { getByTestId } = render(
+      <TarotMeditationView
+        state={fakeState({ status: 'complete', elapsedMs: 300_000, remainingMs: 0 })}
+        controls={fakeControls()}
+        card={FOOL}
+        hideTimer
+        onSave={onSave}
+      />,
+    );
+    expect(getByTestId('tarot-time-remaining').props.children).toBe('00:00');
+    fireEvent.press(getByTestId('tarot-save'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the card name and keyword in every status', () => {
+    const statuses = ['idle', 'running', 'paused', 'complete'] as const;
+    for (const status of statuses) {
+      const { getByTestId, getByText, unmount } = render(
+        <TarotMeditationView
+          state={fakeState({ status, remainingMs: 60_000 })}
+          controls={fakeControls()}
+          card={FOOL}
+          hideTimer
+        />,
+      );
+      expect(getByTestId('tarot-card-name').props.children).toBe(FOOL.name);
+      expect(getByText(FOOL.keyword)).toBeTruthy();
+      unmount();
+    }
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/tarot.test.ts
+++ b/frontend/src/features/Practice/views/__tests__/tarot.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { MAJOR_ARCANA, cardForDayIndex } from '../../data/tarot';
+import { TAROT_DECK_SIZE } from '../../engine/types';
+
+const TRADITIONAL_NAMES = [
+  'The Fool',
+  'The Magician',
+  'The High Priestess',
+  'The Empress',
+  'The Emperor',
+  'The Hierophant',
+  'The Lovers',
+  'The Chariot',
+  'Strength',
+  'The Hermit',
+  'Wheel of Fortune',
+  'Justice',
+  'The Hanged Man',
+  'Death',
+  'Temperance',
+  'The Devil',
+  'The Tower',
+  'The Star',
+  'The Moon',
+  'The Sun',
+  'Judgement',
+  'The World',
+] as const;
+
+describe('MAJOR_ARCANA', () => {
+  it('contains exactly 22 cards', () => {
+    expect(MAJOR_ARCANA).toHaveLength(TAROT_DECK_SIZE);
+  });
+
+  it('has unique, contiguous indices 0..21', () => {
+    const indices = MAJOR_ARCANA.map((c) => c.index);
+    expect(indices).toEqual(Array.from({ length: TAROT_DECK_SIZE }, (_, i) => i));
+  });
+
+  it('lists the names in traditional order', () => {
+    expect(MAJOR_ARCANA.map((c) => c.name)).toEqual(TRADITIONAL_NAMES);
+  });
+
+  it('keeps keywords and symbolism under 80 characters', () => {
+    for (const card of MAJOR_ARCANA) {
+      expect(card.keyword.length).toBeLessThanOrEqual(80);
+      expect(card.symbolism.length).toBeLessThanOrEqual(80);
+      expect(card.keyword.length).toBeGreaterThan(0);
+      expect(card.symbolism.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('cardForDayIndex', () => {
+  it('returns The Fool on day 0', () => {
+    expect(cardForDayIndex(0).name).toBe('The Fool');
+  });
+
+  it('returns The World on day 21', () => {
+    expect(cardForDayIndex(21).name).toBe('The World');
+  });
+
+  it('wraps back to The Fool on day 22', () => {
+    expect(cardForDayIndex(22).name).toBe('The Fool');
+  });
+
+  it('agrees with MAJOR_ARCANA[100 % 22] for large day offsets', () => {
+    const expected = MAJOR_ARCANA[100 % TAROT_DECK_SIZE];
+    expect(cardForDayIndex(100)).toEqual(expected);
+  });
+
+  it('handles negative inputs by normalising into the deck range', () => {
+    // Defensive: callers should clamp at 0, but we should still return a
+    // valid card rather than `undefined` if a clock bug produces -1.
+    expect(cardForDayIndex(-1)).toEqual(MAJOR_ARCANA[TAROT_DECK_SIZE - 1]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the two preset-specific Practice views called out in
[ritual-08](prompts/github-issues/ritual-practice/ritual-08-preset-views.md).
Neither preset fits the generic timer / metronome / counter mould, so they
each get their own layout while still consuming the existing
`useRitualEngine` (sense_grounding / tarot modes from ritual-06).

- **5-4-3-2-1 grounding** — large `5-4-3-2-1` badge, per-sense count
  ("5 things you can **SEE**"), prompt copy, and a "Mark *sight* done"
  button wired to `controls.tap()`. The reducer auto-completes after the
  fifth step; the view then shows a "Grounding complete" card. Header is
  `accessibilityRole="header"`; the advance button's `accessibilityLabel`
  updates per step.
- **Tarot meditation** — card face (index, name, keyword, symbolism) with
  the timer **hidden during the sit** when `hideTimer=true`. The only
  exit from the meditative window is a long-press cancel. Pause and
  complete both reveal the timer ("honesty over purism") and complete
  surfaces the Save CTA used by the post-session insight flow
  (ritual-12). Day-index → card is computed by the parent (ritual-11);
  the view never reads from a clock.

### Files

| File | LoC | Notes |
|---|---:|---|
| `frontend/src/features/Practice/data/tarot.ts` | 179 | `MAJOR_ARCANA` (22 cards) + pure `cardForDayIndex` |
| `frontend/src/features/Practice/views/SenseGroundingView.tsx` | 186 | Header + active-prompt + complete-card subcomponents |
| `frontend/src/features/Practice/views/TarotMeditationView.tsx` | 220 | Card face + per-status footer |
| `frontend/src/features/Practice/views/__tests__/tarot.test.ts` | 78 | Length, indices, traditional order, wrap, negative-day defense |
| `frontend/src/features/Practice/views/__tests__/SenseGroundingView.test.tsx` | 131 | Badge / count / prompt / advance / accessibility / complete |
| `frontend/src/features/Practice/views/__tests__/TarotMeditationView.test.tsx` | 133 | Idle / running±hideTimer / paused / complete / long-press cancel |
| **Total** | **927** | |

### LoC budget

Issue estimate was ~500; the actual is **927 net new** LoC (~+227 over
the soft 700-line declaration threshold from #309 / #310). Drivers:

- `data/tarot.ts` ships the 22-card table inline with per-card
  `symbolism` copy. The "If you blow the budget" suggestion in the issue
  was to move this to `tarot.json` via `resolveJsonModule`; I left it as
  a `.ts` literal so the data lives next to the `TarotCard` type and the
  `cardForDayIndex` helper. Happy to split it if the reviewer prefers.
- `TarotMeditationView.tsx` is taller than the engine-driven views
  because it has four distinct per-`status` layouts (idle / running with
  hidden timer / paused / complete) plus the card face. Each branch is a
  small subcomponent to keep complexity ≤ 10 and per-function lines ≤ 50.
- View tests are more verbose because the components branch on `status`;
  every branch has a covering test.

### Quality gates

From `frontend/`:

- `npx tsc --noEmit` — clean
- `npm run lint` — clean (`--max-warnings=0`)
- `npm test` — 1101/1101 pass, 117 suites
- `pre-commit run` (locally, via the project venv) — all hooks green
  (eslint, prettier, typecheck, jest, detect-secrets)

TDD followed for all three modules: data / sense / tarot tests written
first, watched the import fail, then implemented to green.

### Test plan

- [x] `cardForDayIndex(0)` → The Fool, `(21)` → The World, `(22)` wraps
  back to The Fool, `(100)` matches `MAJOR_ARCANA[100 % 22]`.
- [x] `MAJOR_ARCANA` has length 22, indices 0..21 unique, names in
  traditional order, every `keyword`/`symbolism` non-empty and ≤ 80
  chars.
- [x] SenseGroundingView renders the right `"Mark <sense> done"` label
  for each of the five steps; tap fires `controls.tap`; header carries
  `accessibilityRole="header"` and the advance button's
  `accessibilityLabel` tracks the active sense.
- [x] SenseGroundingView shows the completion card and suppresses the
  advance button at `status='complete'`.
- [x] TarotMeditationView never emits `mm:ss` text while
  `status='running'` and `hideTimer=true`.
- [x] TarotMeditationView shows controls + timer when paused, and the
  timer reading + Save CTA when complete.
- [x] Long-press on `tarot-cancel-longpress` fires `controls.cancel`.

### Out of scope (other ritual-XX issues)

- `PracticeScreen` integration / day-index plumbing → **ritual-11**.
  The view receives `card` and `hideTimer` from its parent; this PR
  documents that contract in the component docstring so future callers
  don't recompute the date inside the view.
- Post-session reflection modal / BotMason entry from `tarot-save` →
  **ritual-12** (the `onSave` callback is opt-in here).
- Image / illustration assets for the major arcana — deferred to a
  future asset task once licensing is sorted; we render name + keyword
  + symbolism inside a stylised border for now.
- No backend touched. No engine, adapter, or existing view files were
  modified — collision-safe with the parallel ritual-09 / ritual-10
  branches.

https://claude.ai/code/session_01NhYx4ZgtVEUBnwpM1oBayM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhYx4ZgtVEUBnwpM1oBayM)_