### PR TITLE
feat(frontend-practice): ritual configurator sheet + per-mode forms (ritual-09)

### DIFF
--- a/frontend/src/api/__tests__/userPractices-customize.test.ts
+++ b/frontend/src/api/__tests__/userPractices-customize.test.ts
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { userPractices } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+describe('userPractices.customize', () => {
+  test('sends PATCH to /user-practices/{id}/customize with the override payload', async () => {
+    const updated = {
+      id: 17,
+      user_id: 1,
+      practice_id: 9,
+      stage_number: 3,
+      start_date: '2026-05-01',
+      end_date: null,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(updated));
+
+    const result = await userPractices.customize(
+      17,
+      {
+        custom_name: 'My Sit',
+        mode_config_override: { mode: 'meditation_timer', duration_minutes: 15 },
+      },
+      'token-xyz',
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/user-practices/17/customize');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body)).toEqual({
+      custom_name: 'My Sit',
+      mode_config_override: { mode: 'meditation_timer', duration_minutes: 15 },
+    });
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer token-xyz' });
+    expect(result).toEqual(updated);
+  });
+
+  test('passes null overrides to clear server-side state', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({}));
+    await userPractices.customize(42, { custom_name: null, mode_config_override: null });
+    const [, init] = mockFetch.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({
+      custom_name: null,
+      mode_config_override: null,
+    });
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1550,11 +1550,27 @@ export interface UserPractice {
   stage_number: number;
   start_date: string;
   end_date: string | null;
+  /** ritual-03: per-user display name override; null when no override set. */
+  custom_name?: string | null;
+  /** ritual-03: per-user mode_config override (validated server-side as ModeConfig). */
+  mode_config_override?: Record<string, unknown> | null;
 }
 
 export interface UserPracticeCreate {
   practice_id: number;
   stage_number: number;
+}
+
+/**
+ * Payload for ``PATCH /user-practices/{id}/customize`` (ritual-03).
+ *
+ * Both fields are nullable so a request can clear an override by passing
+ * ``null`` explicitly: the backend treats ``null`` as "remove" and ``undefined``
+ * (field absent from JSON) as "leave alone".
+ */
+export interface UserPracticeCustomize {
+  custom_name?: string | null;
+  mode_config_override?: Record<string, unknown> | null;
 }
 
 export interface PracticeSessionCreate {
@@ -1611,6 +1627,26 @@ export const userPractices = {
   },
   list(token?: string): Promise<UserPractice[]> {
     return request<UserPractice[]>('/user-practices/', { token });
+  },
+  /**
+   * PATCH the per-user overrides (custom name + mode_config_override).
+   *
+   * Passing ``mode_config_override: null`` resets to the catalog default;
+   * passing ``undefined`` (or omitting the field) leaves the existing
+   * override untouched. The endpoint is documented in ritual-03; until
+   * that PR lands, this client method targets the agreed-upon route so
+   * the frontend can be cut over with no extra refactor.
+   */
+  customize(
+    userPracticeId: number,
+    payload: UserPracticeCustomize,
+    token?: string,
+  ): Promise<UserPractice> {
+    return request<UserPractice>(`/user-practices/${userPracticeId}/customize`, {
+      method: 'PATCH',
+      body: payload,
+      token,
+    });
   },
 };
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -16,6 +16,7 @@ import type { components, paths } from './types';
 
 import { API_BASE_URL } from '@/config';
 import type { Habit as LocalHabit } from '@/features/Habits/Habits.types';
+import type { ModeConfig } from '@/features/Practice/engine/types';
 
 // Re-export OpenAPI types for convenience
 export type EnergyPlanRequest =
@@ -1553,7 +1554,7 @@ export interface UserPractice {
   /** ritual-03: per-user display name override; null when no override set. */
   custom_name?: string | null;
   /** ritual-03: per-user mode_config override (validated server-side as ModeConfig). */
-  mode_config_override?: Record<string, unknown> | null;
+  mode_config_override?: ModeConfig | null;
 }
 
 export interface UserPracticeCreate {
@@ -1570,7 +1571,7 @@ export interface UserPracticeCreate {
  */
 export interface UserPracticeCustomize {
   custom_name?: string | null;
-  mode_config_override?: Record<string, unknown> | null;
+  mode_config_override?: ModeConfig | null;
 }
 
 export interface PracticeSessionCreate {

--- a/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
+++ b/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 
 import type { ModeConfig } from '../engine/types';
-import { validateModeConfig } from '../engine/validation';
+import { CUSTOM_NAME_MAX, validateCustomName, validateModeConfig } from '../engine/validation';
 
 import CountUpForm from './forms/CountUpForm';
 import IntervalBellForm from './forms/IntervalBellForm';
@@ -45,17 +45,9 @@ export interface RitualConfiguratorSheetProps {
  * practice mode is a separate flow (ritual-10).
  */
 const RitualConfiguratorSheet = (props: RitualConfiguratorSheetProps): React.JSX.Element => {
-  const [name, setName] = useState(props.initialName);
-  const [config, setConfig] = useState<ModeConfig>(props.initialConfig);
+  const edit = useEditState(props.initialName, props.initialConfig);
   const state = useSaveState();
-
-  const dirty = useMemo(
-    () => name !== props.initialName || !isShallowEqualConfig(config, props.initialConfig),
-    [name, config, props.initialName, props.initialConfig],
-  );
-  const errors = useMemo(() => validateModeConfig(config), [config]);
-  const canSave = dirty && errors.length === 0 && !state.submitting;
-
+  const canSave = edit.dirty && edit.errors.length === 0 && !state.submitting;
   return (
     <Modal visible={props.visible} transparent animationType="slide" onRequestClose={props.onClose}>
       <KeyboardAvoidingView
@@ -65,37 +57,70 @@ const RitualConfiguratorSheet = (props: RitualConfiguratorSheetProps): React.JSX
       >
         <View style={styles.sheet} testID="ritual-configurator-sheet">
           <ConfiguratorHeader
-            name={name}
+            name={edit.name}
             aspect={props.aspect ?? null}
-            onNameChange={setName}
+            onNameChange={edit.setName}
             onCancel={props.onClose}
-            onSave={() => state.save(props, { name, config })}
+            onSave={() => state.save(props, { name: edit.name, config: edit.config })}
             canSave={canSave}
           />
           <ScrollView style={styles.body} keyboardShouldPersistTaps="handled">
-            <ConfiguratorBody config={config} onChange={setConfig} />
-            <ErrorList errors={errors} />
+            <ConfiguratorBody config={edit.config} onChange={edit.setConfig} />
+            <ErrorList errors={edit.errors} />
             {state.apiError !== null && (
               <Text style={styles.apiError} testID="ritual-configurator-api-error">
                 {state.apiError}
               </Text>
             )}
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessibilityLabel="Reset to default"
-              onPress={() => state.reset(props)}
-              style={styles.resetButton}
-              testID="ritual-configurator-reset"
-              disabled={state.submitting}
-            >
-              <Text style={styles.resetText}>Reset to default</Text>
-            </TouchableOpacity>
+            <ResetButton disabled={state.submitting} onPress={() => state.reset(props)} />
           </ScrollView>
         </View>
       </KeyboardAvoidingView>
     </Modal>
   );
 };
+
+interface EditState {
+  name: string;
+  config: ModeConfig;
+  setName: (next: string) => void;
+  setConfig: (next: ModeConfig) => void;
+  errors: readonly string[];
+  dirty: boolean;
+}
+
+function useEditState(initialName: string, initialConfig: ModeConfig): EditState {
+  const [name, setName] = useState(initialName);
+  const [config, setConfig] = useState<ModeConfig>(initialConfig);
+  const dirty = useMemo(
+    () => name !== initialName || !deepEqualConfig(config, initialConfig),
+    [name, config, initialName, initialConfig],
+  );
+  const errors = useMemo(
+    () => [...validateCustomName(name), ...validateModeConfig(config)],
+    [name, config],
+  );
+  return { name, config, setName, setConfig, errors, dirty };
+}
+
+interface ResetButtonProps {
+  disabled: boolean;
+  onPress: () => void;
+}
+
+const ResetButton = ({ disabled, onPress }: ResetButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel="Reset to default"
+    accessibilityState={{ disabled }}
+    onPress={disabled ? undefined : onPress}
+    style={styles.resetButton}
+    testID="ritual-configurator-reset"
+    disabled={disabled}
+  >
+    <Text style={styles.resetText}>Reset to default</Text>
+  </TouchableOpacity>
+);
 
 interface HeaderProps {
   name: string;
@@ -121,6 +146,7 @@ const ConfiguratorHeader = ({
         value={name}
         onChangeText={onNameChange}
         placeholder="Practice name"
+        maxLength={CUSTOM_NAME_MAX}
         testID="ritual-configurator-name"
       />
       {aspect !== null && aspect.length > 0 && (
@@ -225,7 +251,7 @@ function useSaveState(): SaveState {
     (props: RitualConfiguratorSheetProps, values: SaveValues) =>
       run(props, {
         custom_name: values.name === props.initialName ? undefined : values.name,
-        mode_config_override: values.config as unknown as Record<string, unknown>,
+        mode_config_override: values.config,
       }),
     [run],
   );
@@ -239,7 +265,16 @@ function useSaveState(): SaveState {
   return { submitting, apiError, save, reset };
 }
 
-function isShallowEqualConfig(a: ModeConfig, b: ModeConfig): boolean {
+/**
+ * Structural equality check for ``ModeConfig`` payloads.
+ *
+ * ``JSON.stringify`` is a deep, value-based comparison (not shallow). V8
+ * preserves insertion order for string keys, and the discriminated-union
+ * configs are constructed from spread + literal patches so key order is
+ * stable in practice. If a future ``ModeConfig`` variant carries dynamic
+ * keys this will need a proper structural equality helper.
+ */
+function deepEqualConfig(a: ModeConfig, b: ModeConfig): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 

--- a/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
+++ b/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
@@ -1,0 +1,310 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import type { ModeConfig } from '../engine/types';
+import { validateModeConfig } from '../engine/validation';
+
+import CountUpForm from './forms/CountUpForm';
+import IntervalBellForm from './forms/IntervalBellForm';
+import MeditationTimerForm from './forms/MeditationTimerForm';
+import MetronomeForm from './forms/MetronomeForm';
+import RepCounterForm from './forms/RepCounterForm';
+import SenseGroundingForm from './forms/SenseGroundingForm';
+import { ErrorList } from './forms/shared';
+import TarotForm from './forms/TarotForm';
+
+import { type UserPractice, type UserPracticeCustomize, userPractices } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+export interface RitualConfiguratorSheetProps {
+  visible: boolean;
+  userPracticeId: number;
+  initialName: string;
+  aspect?: string | null;
+  initialConfig: ModeConfig;
+  /** Override the API client; used by tests so they don't hit the network. */
+  customize?: typeof userPractices.customize;
+  onClose: () => void;
+  onSaved?: (updated: UserPractice) => void;
+}
+
+/**
+ * Bottom-sheet modal for editing the active practice's name and per-mode
+ * config. The mode itself is **not** editable here -- replacing the
+ * practice mode is a separate flow (ritual-10).
+ */
+const RitualConfiguratorSheet = (props: RitualConfiguratorSheetProps): React.JSX.Element => {
+  const [name, setName] = useState(props.initialName);
+  const [config, setConfig] = useState<ModeConfig>(props.initialConfig);
+  const state = useSaveState();
+
+  const dirty = useMemo(
+    () => name !== props.initialName || !isShallowEqualConfig(config, props.initialConfig),
+    [name, config, props.initialName, props.initialConfig],
+  );
+  const errors = useMemo(() => validateModeConfig(config), [config]);
+  const canSave = dirty && errors.length === 0 && !state.submitting;
+
+  return (
+    <Modal visible={props.visible} transparent animationType="slide" onRequestClose={props.onClose}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.overlay}
+        testID="ritual-configurator-overlay"
+      >
+        <View style={styles.sheet} testID="ritual-configurator-sheet">
+          <ConfiguratorHeader
+            name={name}
+            aspect={props.aspect ?? null}
+            onNameChange={setName}
+            onCancel={props.onClose}
+            onSave={() => state.save(props, { name, config })}
+            canSave={canSave}
+          />
+          <ScrollView style={styles.body} keyboardShouldPersistTaps="handled">
+            <ConfiguratorBody config={config} onChange={setConfig} />
+            <ErrorList errors={errors} />
+            {state.apiError !== null && (
+              <Text style={styles.apiError} testID="ritual-configurator-api-error">
+                {state.apiError}
+              </Text>
+            )}
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessibilityLabel="Reset to default"
+              onPress={() => state.reset(props)}
+              style={styles.resetButton}
+              testID="ritual-configurator-reset"
+              disabled={state.submitting}
+            >
+              <Text style={styles.resetText}>Reset to default</Text>
+            </TouchableOpacity>
+          </ScrollView>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+};
+
+interface HeaderProps {
+  name: string;
+  aspect: string | null;
+  onNameChange: (next: string) => void;
+  onCancel: () => void;
+  onSave: () => void;
+  canSave: boolean;
+}
+
+const ConfiguratorHeader = ({
+  name,
+  aspect,
+  onNameChange,
+  onCancel,
+  onSave,
+  canSave,
+}: HeaderProps): React.JSX.Element => (
+  <View style={styles.header}>
+    <View style={styles.nameRow}>
+      <TextInput
+        style={styles.nameInput}
+        value={name}
+        onChangeText={onNameChange}
+        placeholder="Practice name"
+        testID="ritual-configurator-name"
+      />
+      {aspect !== null && aspect.length > 0 && (
+        <View style={styles.aspectChip} testID="ritual-configurator-aspect">
+          <Text style={styles.aspectText}>{aspect}</Text>
+        </View>
+      )}
+    </View>
+    <View style={styles.actionRow}>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Cancel"
+        onPress={onCancel}
+        style={styles.cancelButton}
+        testID="ritual-configurator-cancel"
+      >
+        <Text style={styles.cancelText}>Cancel</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Save"
+        accessibilityState={{ disabled: !canSave }}
+        onPress={canSave ? onSave : undefined}
+        style={[styles.saveButton, !canSave && styles.disabledButton]}
+        testID="ritual-configurator-save"
+      >
+        <Text style={styles.saveText}>Save</Text>
+      </TouchableOpacity>
+    </View>
+  </View>
+);
+
+interface BodyProps {
+  config: ModeConfig;
+  onChange: (next: ModeConfig) => void;
+}
+
+const ConfiguratorBody = ({ config, onChange }: BodyProps): React.JSX.Element => {
+  switch (config.mode) {
+    case 'meditation_timer':
+      return <MeditationTimerForm value={config} onChange={onChange} />;
+    case 'count_up':
+      return <CountUpForm value={config} onChange={onChange} />;
+    case 'metronome':
+      return <MetronomeForm value={config} onChange={onChange} />;
+    case 'interval_bell':
+      return <IntervalBellForm value={config} onChange={onChange} />;
+    case 'rep_counter':
+      return <RepCounterForm value={config} onChange={onChange} />;
+    case 'sense_grounding':
+      return <SenseGroundingForm value={config} onChange={onChange} />;
+    case 'tarot':
+      return <TarotForm value={config} onChange={onChange} />;
+    default:
+      return <UnknownModeNotice />;
+  }
+};
+
+const UnknownModeNotice = (): React.JSX.Element => (
+  <View testID="ritual-configurator-unknown">
+    <Text style={styles.unknownText}>
+      Configuration not yet available — long-press to replace this practice.
+    </Text>
+  </View>
+);
+
+interface SaveValues {
+  name: string;
+  config: ModeConfig;
+}
+
+interface SaveState {
+  submitting: boolean;
+  apiError: string | null;
+  save: (props: RitualConfiguratorSheetProps, values: SaveValues) => Promise<void>;
+  reset: (props: RitualConfiguratorSheetProps) => Promise<void>;
+}
+
+function useSaveState(): SaveState {
+  const [submitting, setSubmitting] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const run = useCallback(
+    async (props: RitualConfiguratorSheetProps, payload: UserPracticeCustomize): Promise<void> => {
+      setSubmitting(true);
+      setApiError(null);
+      try {
+        const client = props.customize ?? userPractices.customize;
+        const updated = await client(props.userPracticeId, payload);
+        props.onSaved?.(updated);
+        props.onClose();
+      } catch (err: unknown) {
+        setApiError(formatApiError(err, { fallback: 'Could not save practice.' }));
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [],
+  );
+
+  const save = useCallback(
+    (props: RitualConfiguratorSheetProps, values: SaveValues) =>
+      run(props, {
+        custom_name: values.name === props.initialName ? undefined : values.name,
+        mode_config_override: values.config as unknown as Record<string, unknown>,
+      }),
+    [run],
+  );
+
+  const reset = useCallback(
+    (props: RitualConfiguratorSheetProps) =>
+      run(props, { custom_name: null, mode_config_override: null }),
+    [run],
+  );
+
+  return { submitting, apiError, save, reset };
+}
+
+function isShallowEqualConfig(a: ModeConfig, b: ModeConfig): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: colors.background.primary,
+    borderTopLeftRadius: BORDER_RADIUS.xl,
+    borderTopRightRadius: BORDER_RADIUS.xl,
+    maxHeight: '90%',
+    ...shadows.large,
+  },
+  header: {
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.lg,
+    paddingBottom: SPACING.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.background.accent,
+    gap: SPACING.sm,
+  },
+  nameRow: { flexDirection: 'row', alignItems: 'center', gap: SPACING.sm },
+  nameInput: {
+    flex: 1,
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text.primary,
+    paddingVertical: SPACING.xs,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.background.accent,
+  },
+  aspectChip: {
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.lg,
+    backgroundColor: colors.background.accent,
+  },
+  aspectText: { color: colors.text.primary, fontSize: 12, fontWeight: '500' },
+  actionRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: SPACING.sm },
+  cancelButton: {
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    borderRadius: BORDER_RADIUS.md,
+  },
+  cancelText: { color: colors.text.secondaryAccessible, fontSize: 14, fontWeight: '500' },
+  saveButton: {
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.primary,
+  },
+  disabledButton: { opacity: 0.4 },
+  saveText: { color: colors.text.light, fontSize: 14, fontWeight: '600' },
+  body: { padding: SPACING.lg },
+  apiError: { color: colors.danger, fontSize: 13, marginTop: SPACING.sm },
+  resetButton: {
+    marginTop: SPACING.lg,
+    paddingVertical: SPACING.sm,
+    alignItems: 'center',
+  },
+  resetText: { color: colors.danger, fontSize: 13, fontWeight: '500' },
+  unknownText: { color: colors.text.secondaryAccessible, fontSize: 14, lineHeight: 20 },
+});
+
+export default RitualConfiguratorSheet;

--- a/frontend/src/features/Practice/configurator/__tests__/CountUpForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/CountUpForm.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { CountUpConfig } from '../../engine/types';
+import CountUpForm from '../forms/CountUpForm';
+
+const base: CountUpConfig = { mode: 'count_up' };
+
+describe('CountUpForm', () => {
+  it('renders an empty field when no soft cap is set', () => {
+    const { getByTestId } = render(<CountUpForm value={base} onChange={jest.fn()} />);
+    expect(getByTestId('count-up-soft-cap').props.value).toBe('');
+  });
+
+  it('emits a numeric soft cap on change', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<CountUpForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('count-up-soft-cap'), '15');
+    expect(onChange).toHaveBeenCalledWith({ mode: 'count_up', soft_cap_minutes: 15 });
+  });
+
+  it('clears the soft cap when the field is emptied', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <CountUpForm value={{ mode: 'count_up', soft_cap_minutes: 20 }} onChange={onChange} />,
+    );
+    fireEvent.changeText(getByTestId('count-up-soft-cap'), '');
+    expect(onChange).toHaveBeenCalledWith({ mode: 'count_up', soft_cap_minutes: null });
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/IntervalBellForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/IntervalBellForm.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { IntervalBellConfig } from '../../engine/types';
+import IntervalBellForm from '../forms/IntervalBellForm';
+
+const evenBase: IntervalBellConfig = {
+  mode: 'interval_bell',
+  duration_minutes: 20,
+  interval_minutes: 5,
+  cue_offsets_minutes: null,
+  bell_tone: 'bowl',
+};
+
+const customBase: IntervalBellConfig = {
+  ...evenBase,
+  interval_minutes: null,
+  cue_offsets_minutes: [3, 7, 12],
+};
+
+describe('IntervalBellForm', () => {
+  it('renders the even-interval branch when interval_minutes is set', () => {
+    const { getByTestId, queryByTestId } = render(
+      <IntervalBellForm value={evenBase} onChange={jest.fn()} />,
+    );
+    expect(getByTestId('interval-bell-interval').props.value).toBe('5');
+    expect(queryByTestId('interval-bell-offsets')).toBeNull();
+  });
+
+  it('updates duration when the field changes', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<IntervalBellForm value={evenBase} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('interval-bell-duration'), '30');
+    expect(onChange).toHaveBeenCalledWith({ ...evenBase, duration_minutes: 30 });
+  });
+
+  it('switches to custom offsets and back', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<IntervalBellForm value={evenBase} onChange={onChange} />);
+    fireEvent.press(getByTestId('interval-bell-custom'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...evenBase,
+      interval_minutes: null,
+      cue_offsets_minutes: [],
+    });
+    onChange.mockClear();
+    const { getByTestId: getCustomTestId } = render(
+      <IntervalBellForm value={customBase} onChange={onChange} />,
+    );
+    fireEvent.press(getCustomTestId('interval-bell-even'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...customBase,
+      interval_minutes: 5,
+      cue_offsets_minutes: null,
+    });
+  });
+
+  it('adds a custom offset', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<IntervalBellForm value={customBase} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('interval-bell-offset-draft'), '15');
+    fireEvent.press(getByTestId('interval-bell-offset-add'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...customBase,
+      cue_offsets_minutes: [3, 7, 12, 15],
+    });
+  });
+
+  it('removes a custom offset', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<IntervalBellForm value={customBase} onChange={onChange} />);
+    fireEvent.press(getByTestId('interval-bell-offset-1'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...customBase,
+      cue_offsets_minutes: [3, 12],
+    });
+  });
+
+  it('changes the bell tone', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<IntervalBellForm value={evenBase} onChange={onChange} />);
+    fireEvent.press(getByTestId('interval-bell-tone-gong'));
+    expect(onChange).toHaveBeenCalledWith({ ...evenBase, bell_tone: 'gong' });
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/MeditationTimerForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/MeditationTimerForm.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { MeditationTimerConfig } from '../../engine/types';
+import MeditationTimerForm from '../forms/MeditationTimerForm';
+
+const base: MeditationTimerConfig = {
+  mode: 'meditation_timer',
+  duration_minutes: 10,
+  start_bell: true,
+  halfway_bell: false,
+  end_bell: true,
+};
+
+describe('MeditationTimerForm', () => {
+  it('renders the current duration', () => {
+    const { getByTestId } = render(<MeditationTimerForm value={base} onChange={jest.fn()} />);
+    expect(getByTestId('meditation-timer-duration').props.value).toBe('10');
+  });
+
+  it('emits an updated duration when the field changes', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MeditationTimerForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('meditation-timer-duration'), '20');
+    expect(onChange).toHaveBeenCalledWith({ ...base, duration_minutes: 20 });
+  });
+
+  it('toggles the halfway bell', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MeditationTimerForm value={base} onChange={onChange} />);
+    fireEvent(getByTestId('meditation-timer-halfway-bell'), 'valueChange', true);
+    expect(onChange).toHaveBeenCalledWith({ ...base, halfway_bell: true });
+  });
+
+  it('uses an id prefix when embedded', () => {
+    const { getByTestId } = render(
+      <MeditationTimerForm value={base} onChange={jest.fn()} idPrefix="metronome-timer" />,
+    );
+    expect(getByTestId('metronome-timer-form')).toBeTruthy();
+    expect(getByTestId('metronome-timer-duration')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/MetronomeForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/MetronomeForm.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { MetronomeConfig } from '../../engine/types';
+import MetronomeForm from '../forms/MetronomeForm';
+
+const base: MetronomeConfig = {
+  mode: 'metronome',
+  bpm: 60,
+  timer: { mode: 'meditation_timer', duration_minutes: 10 },
+};
+
+describe('MetronomeForm', () => {
+  it('renders the BPM value', () => {
+    const { getByTestId } = render(<MetronomeForm value={base} onChange={jest.fn()} />);
+    expect(getByTestId('metronome-bpm-value').props.children).toBe(60);
+  });
+
+  it('increments BPM by ±1', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MetronomeForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('metronome-bpm-plus'));
+    expect(onChange).toHaveBeenCalledWith({ ...base, bpm: 61 });
+  });
+
+  it('increments BPM by ±5', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MetronomeForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('metronome-bpm-plus-big'));
+    expect(onChange).toHaveBeenCalledWith({ ...base, bpm: 65 });
+  });
+
+  it('clamps BPM to the [20, 240] window', () => {
+    const onChange = jest.fn();
+    const lowerBound = { ...base, bpm: 20 };
+    const { getByTestId, rerender } = render(
+      <MetronomeForm value={lowerBound} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('metronome-bpm-minus'));
+    expect(onChange).toHaveBeenLastCalledWith({ ...lowerBound, bpm: 20 });
+
+    const upperBound = { ...base, bpm: 240 };
+    rerender(<MetronomeForm value={upperBound} onChange={onChange} />);
+    fireEvent.press(getByTestId('metronome-bpm-plus'));
+    expect(onChange).toHaveBeenLastCalledWith({ ...upperBound, bpm: 240 });
+  });
+
+  it('embeds the inner meditation timer form for the surrounding window', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MetronomeForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('metronome-timer-duration'), '12');
+    expect(onChange).toHaveBeenCalledWith({
+      ...base,
+      timer: { ...base.timer, duration_minutes: 12 },
+    });
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/RepCounterForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/RepCounterForm.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { RepCounterConfig } from '../../engine/types';
+import RepCounterForm from '../forms/RepCounterForm';
+
+const base: RepCounterConfig = {
+  mode: 'rep_counter',
+  target_reps: 108,
+  unit_label: 'breaths',
+  time_cap_minutes: null,
+};
+
+describe('RepCounterForm', () => {
+  it('renders the target reps', () => {
+    const { getByTestId } = render(<RepCounterForm value={base} onChange={jest.fn()} />);
+    expect(getByTestId('rep-counter-target').props.value).toBe('108');
+  });
+
+  it('rounds non-integer target reps on change', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<RepCounterForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('rep-counter-target'), '7.6');
+    expect(onChange).toHaveBeenCalledWith({ ...base, target_reps: 8 });
+  });
+
+  it('updates the unit label', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<RepCounterForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('rep-counter-unit'), 'bows');
+    expect(onChange).toHaveBeenCalledWith({ ...base, unit_label: 'bows' });
+  });
+
+  it('updates the optional time cap', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<RepCounterForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('rep-counter-time-cap'), '30');
+    expect(onChange).toHaveBeenCalledWith({ ...base, time_cap_minutes: 30 });
+  });
+
+  it('clears the time cap when the field is emptied', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <RepCounterForm value={{ ...base, time_cap_minutes: 20 }} onChange={onChange} />,
+    );
+    fireEvent.changeText(getByTestId('rep-counter-time-cap'), '');
+    expect(onChange).toHaveBeenCalledWith({ ...base, time_cap_minutes: null });
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/RitualConfiguratorSheet.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/RitualConfiguratorSheet.test.tsx
@@ -132,6 +132,32 @@ describe('RitualConfiguratorSheet', () => {
     expect(getByTestId('ritual-configurator-unknown')).toBeTruthy();
   });
 
+  it('disables Save and Reset while the API call is in flight', async () => {
+    let resolveCustomize: ((value: UserPractice) => void) | undefined;
+    const customize = jest.fn(
+      () =>
+        new Promise<UserPractice>((resolve) => {
+          resolveCustomize = resolve;
+        }),
+    );
+    const { getByTestId } = renderSheet({ customize });
+    fireEvent.changeText(getByTestId('ritual-configurator-name'), 'My Sit');
+    fireEvent.press(getByTestId('ritual-configurator-save'));
+    expect(getByTestId('ritual-configurator-save').props.accessibilityState?.disabled).toBe(true);
+    expect(getByTestId('ritual-configurator-reset').props.accessibilityState?.disabled).toBe(true);
+    await act(async () => {
+      resolveCustomize?.(updated);
+      await flushPromises();
+    });
+  });
+
+  it('blocks save when the name is cleared and shows an inline error', () => {
+    const { getByTestId, queryByTestId } = renderSheet();
+    fireEvent.changeText(getByTestId('ritual-configurator-name'), '');
+    expect(queryByTestId('configurator-errors')).toBeTruthy();
+    expect(getByTestId('ritual-configurator-save').props.accessibilityState?.disabled).toBe(true);
+  });
+
   it('cancels without calling the API', () => {
     const { getByTestId, customize, onClose } = renderSheet();
     fireEvent.press(getByTestId('ritual-configurator-cancel'));

--- a/frontend/src/features/Practice/configurator/__tests__/RitualConfiguratorSheet.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/RitualConfiguratorSheet.test.tsx
@@ -1,0 +1,190 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { ModeConfig } from '../../engine/types';
+import RitualConfiguratorSheet from '../RitualConfiguratorSheet';
+
+import { ApiError, type UserPractice } from '@/api';
+
+const updated: UserPractice = {
+  id: 17,
+  user_id: 1,
+  practice_id: 9,
+  stage_number: 3,
+  start_date: '2026-05-01',
+  end_date: null,
+  custom_name: 'My Sit',
+  mode_config_override: null,
+};
+
+const flushPromises = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+function renderSheet(
+  overrides: Partial<React.ComponentProps<typeof RitualConfiguratorSheet>> = {},
+) {
+  const customize = jest.fn(async () => updated);
+  const onClose = jest.fn();
+  const onSaved = jest.fn();
+  const baseConfig: ModeConfig = { mode: 'meditation_timer', duration_minutes: 10 };
+  const utils = render(
+    <RitualConfiguratorSheet
+      visible
+      userPracticeId={17}
+      initialName="Morning Sit"
+      aspect="Body"
+      initialConfig={baseConfig}
+      customize={customize}
+      onClose={onClose}
+      onSaved={onSaved}
+      {...overrides}
+    />,
+  );
+  return { ...utils, customize, onClose, onSaved };
+}
+
+describe('RitualConfiguratorSheet', () => {
+  it('renders the meditation timer form by default', () => {
+    const { getByTestId } = renderSheet();
+    expect(getByTestId('meditation-timer-form')).toBeTruthy();
+    expect(getByTestId('ritual-configurator-aspect')).toBeTruthy();
+  });
+
+  it('disables save until the form is dirty', () => {
+    const { getByTestId } = renderSheet();
+    const save = getByTestId('ritual-configurator-save');
+    expect(save.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('builds the customize payload from the edited fields on save', async () => {
+    const { getByTestId, customize, onClose, onSaved } = renderSheet();
+    fireEvent.changeText(getByTestId('ritual-configurator-name'), 'My Morning Sit');
+    fireEvent.changeText(getByTestId('meditation-timer-duration'), '15');
+    await act(async () => {
+      fireEvent.press(getByTestId('ritual-configurator-save'));
+      await flushPromises();
+    });
+    expect(customize).toHaveBeenCalledWith(17, {
+      custom_name: 'My Morning Sit',
+      mode_config_override: {
+        mode: 'meditation_timer',
+        duration_minutes: 15,
+      },
+    });
+    expect(onSaved).toHaveBeenCalledWith(updated);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the custom_name when only the config changed', async () => {
+    const { getByTestId, customize } = renderSheet();
+    fireEvent.changeText(getByTestId('meditation-timer-duration'), '12');
+    await act(async () => {
+      fireEvent.press(getByTestId('ritual-configurator-save'));
+      await flushPromises();
+    });
+    expect(customize).toHaveBeenCalledWith(17, {
+      custom_name: undefined,
+      mode_config_override: { mode: 'meditation_timer', duration_minutes: 12 },
+    });
+  });
+
+  it('shows validation errors and blocks save when out of range', () => {
+    const { getByTestId, queryByTestId } = renderSheet();
+    fireEvent.changeText(getByTestId('meditation-timer-duration'), '0');
+    expect(queryByTestId('configurator-errors')).toBeTruthy();
+    expect(getByTestId('ritual-configurator-save').props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('sends nulls for both fields when the user resets to default', async () => {
+    const { getByTestId, customize, onSaved, onClose } = renderSheet();
+    await act(async () => {
+      fireEvent.press(getByTestId('ritual-configurator-reset'));
+      await flushPromises();
+    });
+    expect(customize).toHaveBeenCalledWith(17, {
+      custom_name: null,
+      mode_config_override: null,
+    });
+    expect(onSaved).toHaveBeenCalledWith(updated);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the API error message and keeps the sheet open on failure', async () => {
+    const customize = jest.fn(async () => {
+      throw new ApiError(500, 'internal');
+    });
+    const onClose = jest.fn();
+    const { getByTestId } = renderSheet({ customize, onClose });
+    fireEvent.changeText(getByTestId('ritual-configurator-name'), 'My Sit');
+    await act(async () => {
+      fireEvent.press(getByTestId('ritual-configurator-save'));
+      await flushPromises();
+    });
+    expect(getByTestId('ritual-configurator-api-error').props.children).toBe(
+      'Could not save practice.',
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renders the unknown-mode notice for unsupported modes', () => {
+    const unknownConfig = { mode: 'mystery' } as unknown as ModeConfig;
+    const { getByTestId } = renderSheet({ initialConfig: unknownConfig });
+    expect(getByTestId('ritual-configurator-unknown')).toBeTruthy();
+  });
+
+  it('cancels without calling the API', () => {
+    const { getByTestId, customize, onClose } = renderSheet();
+    fireEvent.press(getByTestId('ritual-configurator-cancel'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(customize).not.toHaveBeenCalled();
+  });
+
+  it('renders each supported mode form by discriminator', () => {
+    const cases: { config: ModeConfig; testID: string }[] = [
+      { config: { mode: 'count_up', soft_cap_minutes: null }, testID: 'count-up-form' },
+      {
+        config: {
+          mode: 'metronome',
+          bpm: 60,
+          timer: { mode: 'meditation_timer', duration_minutes: 10 },
+        },
+        testID: 'metronome-form',
+      },
+      {
+        config: {
+          mode: 'interval_bell',
+          duration_minutes: 20,
+          interval_minutes: 5,
+          cue_offsets_minutes: null,
+          bell_tone: 'bowl',
+        },
+        testID: 'interval-bell-form',
+      },
+      {
+        config: { mode: 'rep_counter', target_reps: 10, unit_label: 'reps' },
+        testID: 'rep-counter-form',
+      },
+      {
+        config: {
+          mode: 'sense_grounding',
+          prompts: [{ sense: 'sight', label: 'See' }],
+        },
+        testID: 'sense-grounding-form',
+      },
+      {
+        config: {
+          mode: 'tarot',
+          deck: 'major_arcana',
+          per_card_minutes: 5,
+          hide_timer_during_meditation: true,
+        },
+        testID: 'tarot-form',
+      },
+    ];
+    cases.forEach(({ config, testID }) => {
+      const { getByTestId, unmount } = renderSheet({ initialConfig: config });
+      expect(getByTestId(testID)).toBeTruthy();
+      unmount();
+    });
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/SenseGroundingForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/SenseGroundingForm.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { SenseGroundingConfig } from '../../engine/types';
+import SenseGroundingForm from '../forms/SenseGroundingForm';
+
+const base: SenseGroundingConfig = {
+  mode: 'sense_grounding',
+  prompts: [
+    { sense: 'sight', label: '5 things you can see' },
+    { sense: 'hearing', label: '4 things you can hear' },
+    { sense: 'touch', label: '3 things you can feel' },
+  ],
+};
+
+describe('SenseGroundingForm', () => {
+  it('renders one row per prompt', () => {
+    const { getByTestId } = render(<SenseGroundingForm value={base} onChange={jest.fn()} />);
+    expect(getByTestId('sense-prompt-0')).toBeTruthy();
+    expect(getByTestId('sense-prompt-1')).toBeTruthy();
+    expect(getByTestId('sense-prompt-2')).toBeTruthy();
+  });
+
+  it('edits a prompt label', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<SenseGroundingForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('sense-prompt-0-label'), 'Five colours');
+    expect(onChange).toHaveBeenCalledWith({
+      mode: 'sense_grounding',
+      prompts: [{ sense: 'sight', label: 'Five colours' }, base.prompts[1], base.prompts[2]],
+    });
+  });
+
+  it('changes the sense for a prompt', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<SenseGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('sense-prompt-0-smell'));
+    expect(onChange).toHaveBeenCalledWith({
+      mode: 'sense_grounding',
+      prompts: [
+        { sense: 'smell', label: '5 things you can see' },
+        base.prompts[1],
+        base.prompts[2],
+      ],
+    });
+  });
+
+  it('reorders prompts via the up/down arrows', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<SenseGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('sense-prompt-1-up'));
+    expect(onChange).toHaveBeenCalledWith({
+      mode: 'sense_grounding',
+      prompts: [base.prompts[1], base.prompts[0], base.prompts[2]],
+    });
+  });
+
+  it('removes a prompt', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<SenseGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('sense-prompt-1-remove'));
+    expect(onChange).toHaveBeenCalledWith({
+      mode: 'sense_grounding',
+      prompts: [base.prompts[0], base.prompts[2]],
+    });
+  });
+
+  it('adds a new blank prompt', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<SenseGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('sense-grounding-add'));
+    expect(onChange).toHaveBeenCalledWith({
+      mode: 'sense_grounding',
+      prompts: [...base.prompts, { sense: 'sight', label: '' }],
+    });
+  });
+
+  it('disables the up arrow for the first row and the down arrow for the last', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<SenseGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('sense-prompt-0-up'));
+    fireEvent.press(getByTestId('sense-prompt-2-down'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/TarotForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/TarotForm.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { TarotConfig } from '../../engine/types';
+import TarotForm from '../forms/TarotForm';
+
+const base: TarotConfig = {
+  mode: 'tarot',
+  deck: 'major_arcana',
+  per_card_minutes: 5,
+  hide_timer_during_meditation: true,
+};
+
+describe('TarotForm', () => {
+  it('renders the per-card minutes', () => {
+    const { getByTestId } = render(<TarotForm value={base} onChange={jest.fn()} />);
+    expect(getByTestId('tarot-per-card').props.value).toBe('5');
+  });
+
+  it('updates per-card minutes', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TarotForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('tarot-per-card'), '7');
+    expect(onChange).toHaveBeenCalledWith({ ...base, per_card_minutes: 7 });
+  });
+
+  it('toggles hide_timer_during_meditation', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TarotForm value={base} onChange={onChange} />);
+    fireEvent(getByTestId('tarot-hide-timer'), 'valueChange', false);
+    expect(onChange).toHaveBeenCalledWith({ ...base, hide_timer_during_meditation: false });
+  });
+
+  it('falls back to the default when per-card minutes is cleared', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TarotForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('tarot-per-card'), '');
+    expect(onChange).toHaveBeenCalledWith({ ...base, per_card_minutes: 5 });
+  });
+});

--- a/frontend/src/features/Practice/configurator/forms/CountUpForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/CountUpForm.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import type { CountUpConfig } from '../../engine/types';
+
+import { LabeledRow, NumericField } from './shared';
+
+interface Props {
+  value: CountUpConfig;
+  onChange: (next: CountUpConfig) => void;
+}
+
+const CountUpForm = ({ value, onChange }: Props): React.JSX.Element => (
+  <View testID="count-up-form">
+    <LabeledRow label="Soft cap (minutes, optional)">
+      <NumericField
+        value={value.soft_cap_minutes ?? null}
+        onChange={(soft_cap_minutes) => onChange({ ...value, soft_cap_minutes })}
+        placeholder="—"
+        allowNull
+        testID="count-up-soft-cap"
+      />
+    </LabeledRow>
+  </View>
+);
+
+export default CountUpForm;

--- a/frontend/src/features/Practice/configurator/forms/IntervalBellForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/IntervalBellForm.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import type { IntervalBellConfig, IntervalBellTone } from '../../engine/types';
+
+import { Chip, LabeledRow, NumericField } from './shared';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+const TONES: readonly IntervalBellTone[] = ['bowl', 'chime', 'gong'];
+
+interface Props {
+  value: IntervalBellConfig;
+  onChange: (next: IntervalBellConfig) => void;
+}
+
+type SpacingKind = 'even' | 'custom';
+
+const detectKind = (value: IntervalBellConfig): SpacingKind =>
+  value.cue_offsets_minutes !== undefined && value.cue_offsets_minutes !== null ? 'custom' : 'even';
+
+const IntervalBellForm = ({ value, onChange }: Props): React.JSX.Element => {
+  const kind = detectKind(value);
+  return (
+    <View testID="interval-bell-form">
+      <DurationRow value={value} onChange={onChange} />
+      <SpacingRow kind={kind} value={value} onChange={onChange} />
+      {kind === 'even' ? (
+        <EvenIntervalControls value={value} onChange={onChange} />
+      ) : (
+        <CustomOffsetControls value={value} onChange={onChange} />
+      )}
+      <BellToneRow value={value} onChange={onChange} />
+    </View>
+  );
+};
+
+const DurationRow = ({ value, onChange }: Props): React.JSX.Element => (
+  <LabeledRow label="Duration (minutes)">
+    <NumericField
+      value={value.duration_minutes}
+      onChange={(next) => onChange({ ...value, duration_minutes: next ?? 0 })}
+      testID="interval-bell-duration"
+    />
+  </LabeledRow>
+);
+
+interface SpacingRowProps extends Props {
+  kind: SpacingKind;
+}
+
+const SpacingRow = ({ kind, value, onChange }: SpacingRowProps): React.JSX.Element => {
+  const switchKind = (next: SpacingKind) => {
+    if (next === kind) return;
+    if (next === 'even') {
+      onChange({ ...value, interval_minutes: 5, cue_offsets_minutes: null });
+    } else {
+      onChange({ ...value, interval_minutes: null, cue_offsets_minutes: [] });
+    }
+  };
+  return (
+    <LabeledRow label="Spacing">
+      <View style={localStyles.kindRow}>
+        <Chip
+          label="Even"
+          active={kind === 'even'}
+          onPress={() => switchKind('even')}
+          testID="interval-bell-even"
+        />
+        <Chip
+          label="Custom"
+          active={kind === 'custom'}
+          onPress={() => switchKind('custom')}
+          testID="interval-bell-custom"
+        />
+      </View>
+    </LabeledRow>
+  );
+};
+
+const BellToneRow = ({ value, onChange }: Props): React.JSX.Element => (
+  <LabeledRow label="Bell tone">
+    <View style={localStyles.kindRow}>
+      {TONES.map((tone) => (
+        <Chip
+          key={tone}
+          label={tone}
+          active={value.bell_tone === tone}
+          onPress={() => onChange({ ...value, bell_tone: tone })}
+          testID={`interval-bell-tone-${tone}`}
+        />
+      ))}
+    </View>
+  </LabeledRow>
+);
+
+const EvenIntervalControls = ({ value, onChange }: Props): React.JSX.Element => (
+  <LabeledRow label="Interval (minutes)">
+    <NumericField
+      value={value.interval_minutes ?? null}
+      onChange={(interval_minutes) => onChange({ ...value, interval_minutes })}
+      placeholder="5"
+      allowNull
+      testID="interval-bell-interval"
+    />
+  </LabeledRow>
+);
+
+const CustomOffsetControls = ({ value, onChange }: Props): React.JSX.Element => {
+  const offsets = value.cue_offsets_minutes ?? [];
+  const removeAt = (index: number) => {
+    const next = offsets.filter((_, i) => i !== index);
+    onChange({ ...value, cue_offsets_minutes: next });
+  };
+  const append = (raw: number | null) => {
+    if (raw === null || !Number.isFinite(raw)) return;
+    onChange({ ...value, cue_offsets_minutes: [...offsets, raw] });
+  };
+  return (
+    <View testID="interval-bell-offsets">
+      <Text style={localStyles.subLabel}>Cue offsets (minutes from start)</Text>
+      <View style={localStyles.chipWrap}>
+        {offsets.map((offset, index) => (
+          <TouchableOpacity
+            key={`${offset}-${index}`}
+            accessibilityRole="button"
+            accessibilityLabel={`Remove offset ${offset}`}
+            onPress={() => removeAt(index)}
+            style={localStyles.offsetChip}
+            testID={`interval-bell-offset-${index}`}
+          >
+            <Text style={localStyles.offsetChipText}>{offset} ✕</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <AddOffsetRow onAdd={append} />
+    </View>
+  );
+};
+
+const AddOffsetRow = ({ onAdd }: { onAdd: (raw: number | null) => void }): React.JSX.Element => {
+  const [draft, setDraft] = React.useState<number | null>(null);
+  return (
+    <View style={localStyles.addRow}>
+      <NumericField
+        value={draft}
+        onChange={setDraft}
+        placeholder="e.g. 5"
+        allowNull
+        testID="interval-bell-offset-draft"
+      />
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Add offset"
+        onPress={() => {
+          onAdd(draft);
+          setDraft(null);
+        }}
+        style={localStyles.addButton}
+        testID="interval-bell-offset-add"
+      >
+        <Text style={localStyles.addButtonText}>Add</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  kindRow: { flexDirection: 'row', gap: SPACING.xs, flexWrap: 'wrap' },
+  subLabel: { color: colors.text.secondaryAccessible, fontSize: 13, marginTop: SPACING.sm },
+  chipWrap: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs, marginVertical: SPACING.sm },
+  offsetChip: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.lg,
+    backgroundColor: colors.background.accent,
+  },
+  offsetChipText: { color: colors.text.primary, fontSize: 13 },
+  addRow: { flexDirection: 'row', alignItems: 'center', gap: SPACING.sm },
+  addButton: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.primary,
+  },
+  addButtonText: { color: colors.text.light, fontWeight: '600', fontSize: 13 },
+});
+
+export default IntervalBellForm;

--- a/frontend/src/features/Practice/configurator/forms/MeditationTimerForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/MeditationTimerForm.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import type { MeditationTimerConfig } from '../../engine/types';
+
+import { LabeledRow, NumericField, ToggleRow } from './shared';
+
+interface Props {
+  value: MeditationTimerConfig;
+  onChange: (next: MeditationTimerConfig) => void;
+  /** Optional override so the field's testIDs are unique when embedded. */
+  idPrefix?: string;
+}
+
+const MeditationTimerForm = ({
+  value,
+  onChange,
+  idPrefix = 'meditation-timer',
+}: Props): React.JSX.Element => {
+  const update = (patch: Partial<MeditationTimerConfig>) => onChange({ ...value, ...patch });
+  return (
+    <View testID={`${idPrefix}-form`}>
+      <LabeledRow label="Duration (minutes)">
+        <NumericField
+          value={value.duration_minutes}
+          onChange={(next) => update({ duration_minutes: next ?? 0 })}
+          testID={`${idPrefix}-duration`}
+        />
+      </LabeledRow>
+      <ToggleRow
+        label="Start bell"
+        value={value.start_bell ?? true}
+        onChange={(start_bell) => update({ start_bell })}
+        testID={`${idPrefix}-start-bell`}
+      />
+      <ToggleRow
+        label="Halfway bell"
+        value={value.halfway_bell ?? false}
+        onChange={(halfway_bell) => update({ halfway_bell })}
+        testID={`${idPrefix}-halfway-bell`}
+      />
+      <ToggleRow
+        label="End bell"
+        value={value.end_bell ?? true}
+        onChange={(end_bell) => update({ end_bell })}
+        testID={`${idPrefix}-end-bell`}
+      />
+    </View>
+  );
+};
+
+export default MeditationTimerForm;

--- a/frontend/src/features/Practice/configurator/forms/MetronomeForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/MetronomeForm.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import type { MeditationTimerConfig, MetronomeConfig } from '../../engine/types';
+import { BPM_MAX, BPM_MIN } from '../../engine/validation';
+
+import MeditationTimerForm from './MeditationTimerForm';
+import { LabeledRow, NumberStepper } from './shared';
+
+interface Props {
+  value: MetronomeConfig;
+  onChange: (next: MetronomeConfig) => void;
+}
+
+const MetronomeForm = ({ value, onChange }: Props): React.JSX.Element => {
+  const setBpm = (bpm: number) => onChange({ ...value, bpm });
+  const setTimer = (timer: MeditationTimerConfig) => onChange({ ...value, timer });
+  return (
+    <View testID="metronome-form">
+      <LabeledRow label="BPM" testID="metronome-bpm-row">
+        <NumberStepper
+          value={value.bpm}
+          onChange={setBpm}
+          step={1}
+          bigStep={5}
+          min={BPM_MIN}
+          max={BPM_MAX}
+          testID="metronome-bpm"
+        />
+      </LabeledRow>
+      <MeditationTimerForm value={value.timer} onChange={setTimer} idPrefix="metronome-timer" />
+    </View>
+  );
+};
+
+export default MetronomeForm;

--- a/frontend/src/features/Practice/configurator/forms/RepCounterForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/RepCounterForm.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import type { RepCounterConfig } from '../../engine/types';
+import { UNIT_LABEL_MAX } from '../../engine/validation';
+
+import { LabeledRow, NumericField, TextField } from './shared';
+
+interface Props {
+  value: RepCounterConfig;
+  onChange: (next: RepCounterConfig) => void;
+}
+
+const RepCounterForm = ({ value, onChange }: Props): React.JSX.Element => {
+  const update = (patch: Partial<RepCounterConfig>) => onChange({ ...value, ...patch });
+  return (
+    <View testID="rep-counter-form">
+      <LabeledRow label="Target reps">
+        <NumericField
+          value={value.target_reps}
+          onChange={(next) => update({ target_reps: Math.round(next ?? 0) })}
+          testID="rep-counter-target"
+        />
+      </LabeledRow>
+      <LabeledRow label="Unit label">
+        <TextField
+          value={value.unit_label}
+          onChange={(unit_label) => update({ unit_label })}
+          placeholder="reps"
+          maxLength={UNIT_LABEL_MAX}
+          testID="rep-counter-unit"
+        />
+      </LabeledRow>
+      <LabeledRow label="Time cap (minutes, optional)">
+        <NumericField
+          value={value.time_cap_minutes ?? null}
+          onChange={(time_cap_minutes) => update({ time_cap_minutes })}
+          placeholder="—"
+          allowNull
+          testID="rep-counter-time-cap"
+        />
+      </LabeledRow>
+    </View>
+  );
+};
+
+export default RepCounterForm;

--- a/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import type { SenseGroundingConfig, SenseKind, SensePrompt } from '../../engine/types';
+import { ALLOWED_SENSES, PROMPT_LABEL_MAX } from '../../engine/validation';
+
+import { Chip, TextField } from './shared';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+interface Props {
+  value: SenseGroundingConfig;
+  onChange: (next: SenseGroundingConfig) => void;
+}
+
+const SenseGroundingForm = ({ value, onChange }: Props): React.JSX.Element => {
+  const setPrompt = (index: number, patch: Partial<SensePrompt>) => {
+    const next = value.prompts.map((prompt, i) => (i === index ? { ...prompt, ...patch } : prompt));
+    onChange({ ...value, prompts: next });
+  };
+  const move = (index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    const current = value.prompts[index];
+    const swapWith = value.prompts[target];
+    if (current === undefined || swapWith === undefined) return;
+    const next = value.prompts.slice();
+    next[index] = swapWith;
+    next[target] = current;
+    onChange({ ...value, prompts: next });
+  };
+  const remove = (index: number) => {
+    onChange({ ...value, prompts: value.prompts.filter((_, i) => i !== index) });
+  };
+  const append = () =>
+    onChange({ ...value, prompts: [...value.prompts, { sense: 'sight', label: '' }] });
+  return (
+    <View testID="sense-grounding-form">
+      {value.prompts.map((prompt, index) => (
+        <PromptRow
+          key={index}
+          prompt={prompt}
+          index={index}
+          last={index === value.prompts.length - 1}
+          onChange={(patch) => setPrompt(index, patch)}
+          onMove={(direction) => move(index, direction)}
+          onRemove={() => remove(index)}
+        />
+      ))}
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Add prompt"
+        onPress={append}
+        style={localStyles.addButton}
+        testID="sense-grounding-add"
+      >
+        <Text style={localStyles.addButtonText}>+ Add prompt</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+interface PromptRowProps {
+  prompt: SensePrompt;
+  index: number;
+  last: boolean;
+  onChange: (patch: Partial<SensePrompt>) => void;
+  onMove: (direction: -1 | 1) => void;
+  onRemove: () => void;
+}
+
+const PromptRow = ({
+  prompt,
+  index,
+  last,
+  onChange,
+  onMove,
+  onRemove,
+}: PromptRowProps): React.JSX.Element => (
+  <View style={localStyles.promptCard} testID={`sense-prompt-${index}`}>
+    <View style={localStyles.senseRow}>
+      {ALLOWED_SENSES.map((sense) => (
+        <Chip
+          key={sense}
+          label={sense}
+          active={prompt.sense === sense}
+          onPress={() => onChange({ sense: sense satisfies SenseKind })}
+          testID={`sense-prompt-${index}-${sense}`}
+        />
+      ))}
+    </View>
+    <TextField
+      value={prompt.label}
+      onChange={(label) => onChange({ label })}
+      placeholder="What do you notice?"
+      maxLength={PROMPT_LABEL_MAX}
+      testID={`sense-prompt-${index}-label`}
+    />
+    <View style={localStyles.actionsRow}>
+      <SmallButton
+        label="↑"
+        onPress={() => onMove(-1)}
+        disabled={index === 0}
+        testID={`sense-prompt-${index}-up`}
+      />
+      <SmallButton
+        label="↓"
+        onPress={() => onMove(1)}
+        disabled={last}
+        testID={`sense-prompt-${index}-down`}
+      />
+      <SmallButton label="Remove" onPress={onRemove} testID={`sense-prompt-${index}-remove`} />
+    </View>
+  </View>
+);
+
+interface SmallButtonProps {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  testID: string;
+}
+
+const SmallButton = ({
+  label,
+  onPress,
+  disabled = false,
+  testID,
+}: SmallButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={label}
+    accessibilityState={{ disabled }}
+    onPress={disabled ? undefined : onPress}
+    style={[localStyles.smallButton, disabled && localStyles.disabled]}
+    testID={testID}
+  >
+    <Text style={localStyles.smallButtonText}>{label}</Text>
+  </TouchableOpacity>
+);
+
+const localStyles = StyleSheet.create({
+  promptCard: {
+    padding: SPACING.sm,
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: SPACING.sm,
+    gap: SPACING.xs,
+  },
+  senseRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
+  actionsRow: { flexDirection: 'row', gap: SPACING.xs, marginTop: SPACING.xs },
+  smallButton: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+    minHeight: 32,
+  },
+  smallButtonText: { color: colors.text.primary, fontSize: 13, fontWeight: '500' },
+  disabled: { opacity: 0.4 },
+  addButton: {
+    paddingVertical: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+    alignItems: 'center',
+    marginTop: SPACING.sm,
+  },
+  addButtonText: { color: colors.text.primary, fontWeight: '600', fontSize: 14 },
+});
+
+export default SenseGroundingForm;

--- a/frontend/src/features/Practice/configurator/forms/TarotForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/TarotForm.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import type { TarotConfig } from '../../engine/types';
+import { DEFAULT_TAROT_MINUTES } from '../../engine/types';
+
+import { LabeledRow, NumericField, ToggleRow } from './shared';
+
+interface Props {
+  value: TarotConfig;
+  onChange: (next: TarotConfig) => void;
+}
+
+const TarotForm = ({ value, onChange }: Props): React.JSX.Element => {
+  const setMinutes = (per_card_minutes: number | null) =>
+    onChange({ ...value, per_card_minutes: per_card_minutes ?? DEFAULT_TAROT_MINUTES });
+  return (
+    <View testID="tarot-form">
+      <LabeledRow label="Per-card minutes">
+        <NumericField
+          value={value.per_card_minutes ?? DEFAULT_TAROT_MINUTES}
+          onChange={setMinutes}
+          allowNull
+          testID="tarot-per-card"
+        />
+      </LabeledRow>
+      <ToggleRow
+        label="Hide timer during sit"
+        value={value.hide_timer_during_meditation ?? true}
+        onChange={(hide_timer_during_meditation) =>
+          onChange({ ...value, hide_timer_during_meditation })
+        }
+        testID="tarot-hide-timer"
+      />
+    </View>
+  );
+};
+
+export default TarotForm;

--- a/frontend/src/features/Practice/configurator/forms/shared.tsx
+++ b/frontend/src/features/Practice/configurator/forms/shared.tsx
@@ -1,0 +1,282 @@
+import React from 'react';
+import { StyleSheet, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+interface LabeledRowProps {
+  label: string;
+  testID?: string;
+  children: React.ReactNode;
+}
+
+export const LabeledRow = ({ label, testID, children }: LabeledRowProps): React.JSX.Element => (
+  <View style={formStyles.row} testID={testID}>
+    <Text style={formStyles.label}>{label}</Text>
+    <View style={formStyles.control}>{children}</View>
+  </View>
+);
+
+interface NumberStepperProps {
+  value: number;
+  onChange: (next: number) => void;
+  step: number;
+  bigStep?: number;
+  min: number;
+  max: number;
+  testID: string;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+export const NumberStepper = ({
+  value,
+  onChange,
+  step,
+  bigStep,
+  min,
+  max,
+  testID,
+}: NumberStepperProps): React.JSX.Element => {
+  const adjust = (delta: number) => onChange(clamp(value + delta, min, max));
+  return (
+    <View style={formStyles.stepperRow} testID={testID}>
+      {bigStep !== undefined && (
+        <StepperButton
+          label={`-${bigStep}`}
+          onPress={() => adjust(-bigStep)}
+          testID={`${testID}-minus-big`}
+        />
+      )}
+      <StepperButton label={`-${step}`} onPress={() => adjust(-step)} testID={`${testID}-minus`} />
+      <Text style={formStyles.stepperValue} testID={`${testID}-value`}>
+        {value}
+      </Text>
+      <StepperButton label={`+${step}`} onPress={() => adjust(step)} testID={`${testID}-plus`} />
+      {bigStep !== undefined && (
+        <StepperButton
+          label={`+${bigStep}`}
+          onPress={() => adjust(bigStep)}
+          testID={`${testID}-plus-big`}
+        />
+      )}
+    </View>
+  );
+};
+
+interface StepperButtonProps {
+  label: string;
+  onPress: () => void;
+  testID: string;
+}
+
+const StepperButton = ({ label, onPress, testID }: StepperButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={label}
+    onPress={onPress}
+    style={formStyles.stepperButton}
+    testID={testID}
+  >
+    <Text style={formStyles.stepperButtonText}>{label}</Text>
+  </TouchableOpacity>
+);
+
+interface NumericFieldProps {
+  value: number | null;
+  onChange: (next: number | null) => void;
+  placeholder?: string;
+  allowNull?: boolean;
+  testID: string;
+}
+
+export const NumericField = ({
+  value,
+  onChange,
+  placeholder,
+  allowNull = false,
+  testID,
+}: NumericFieldProps): React.JSX.Element => (
+  <TextInput
+    style={formStyles.input}
+    value={value === null ? '' : String(value)}
+    onChangeText={(text) => {
+      if (text.trim() === '') {
+        onChange(allowNull ? null : 0);
+        return;
+      }
+      const parsed = Number(text);
+      if (Number.isFinite(parsed)) onChange(parsed);
+    }}
+    keyboardType="numeric"
+    placeholder={placeholder}
+    testID={testID}
+  />
+);
+
+interface ToggleRowProps {
+  label: string;
+  value: boolean;
+  onChange: (next: boolean) => void;
+  testID: string;
+}
+
+export const ToggleRow = ({
+  label,
+  value,
+  onChange,
+  testID,
+}: ToggleRowProps): React.JSX.Element => (
+  <View style={formStyles.row} testID={`${testID}-row`}>
+    <Text style={formStyles.label}>{label}</Text>
+    <Switch value={value} onValueChange={onChange} testID={testID} />
+  </View>
+);
+
+interface TextFieldProps {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  testID: string;
+  maxLength?: number;
+}
+
+export const TextField = ({
+  value,
+  onChange,
+  placeholder,
+  testID,
+  maxLength,
+}: TextFieldProps): React.JSX.Element => (
+  <TextInput
+    style={formStyles.input}
+    value={value}
+    onChangeText={onChange}
+    placeholder={placeholder}
+    maxLength={maxLength}
+    testID={testID}
+  />
+);
+
+interface ChipProps {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  testID: string;
+}
+
+export const Chip = ({ label, active, onPress, testID }: ChipProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={label}
+    onPress={onPress}
+    style={[formStyles.chip, active && formStyles.chipActive]}
+    testID={testID}
+  >
+    <Text style={[formStyles.chipText, active && formStyles.chipTextActive]}>{label}</Text>
+  </TouchableOpacity>
+);
+
+export const ErrorList = ({ errors }: { errors: readonly string[] }): React.JSX.Element | null => {
+  if (errors.length === 0) return null;
+  return (
+    <View testID="configurator-errors" style={formStyles.errors}>
+      {errors.map((message) => (
+        <Text key={message} style={formStyles.errorText}>
+          • {message}
+        </Text>
+      ))}
+    </View>
+  );
+};
+
+const formStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: SPACING.sm,
+    gap: SPACING.md,
+  },
+  label: {
+    color: colors.text.primary,
+    fontSize: 14,
+    fontWeight: '500',
+    flexShrink: 1,
+  },
+  control: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.sm,
+  },
+  stepperRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.xs,
+  },
+  stepperValue: {
+    minWidth: 48,
+    textAlign: 'center',
+    fontSize: 16,
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+  },
+  stepperButton: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+    minWidth: 36,
+    alignItems: 'center',
+  },
+  stepperButtonText: {
+    color: colors.text.primary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  input: {
+    minWidth: 80,
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    color: colors.text.primary,
+    fontSize: 14,
+  },
+  chip: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.xl,
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    backgroundColor: colors.background.card,
+  },
+  chipActive: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  chipText: {
+    color: colors.text.secondaryAccessible,
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  chipTextActive: {
+    color: colors.text.light,
+  },
+  errors: {
+    backgroundColor: colors.background.card,
+    borderLeftColor: colors.danger,
+    borderLeftWidth: 3,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    marginTop: SPACING.sm,
+  },
+  errorText: {
+    color: colors.danger,
+    fontSize: 13,
+    marginVertical: 2,
+  },
+});
+
+export { formStyles };

--- a/frontend/src/features/Practice/engine/__tests__/validation.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/validation.test.ts
@@ -11,11 +11,13 @@ import type {
 import {
   BPM_MAX,
   BPM_MIN,
+  CUSTOM_NAME_MAX,
   DURATION_MAX_MINUTES,
   DURATION_MIN_MINUTES,
   PROMPT_LABEL_MAX,
   UNIT_LABEL_MAX,
   validateCountUp,
+  validateCustomName,
   validateIntervalBell,
   validateMeditationTimer,
   validateMetronome,
@@ -119,18 +121,18 @@ describe('validateIntervalBell', () => {
     expect(validateIntervalBell({ ...evenBase, interval_minutes: 20 })[0]).toMatch(/less than/);
   });
 
-  it('rejects setting both interval and offsets', () => {
-    expect(validateIntervalBell({ ...evenBase, cue_offsets_minutes: [5] })[0]).toMatch(/either/);
+  it('rejects setting both interval and offsets with a "not both" message', () => {
+    expect(validateIntervalBell({ ...evenBase, cue_offsets_minutes: [5] })[0]).toMatch(/not both/i);
   });
 
-  it('rejects setting neither interval nor offsets', () => {
+  it('rejects setting neither interval nor offsets with a "select one" message', () => {
     expect(
       validateIntervalBell({
         ...evenBase,
         interval_minutes: null,
         cue_offsets_minutes: null,
       })[0],
-    ).toMatch(/either/);
+    ).toMatch(/select/i);
   });
 
   it('accepts custom offsets within duration', () => {
@@ -269,6 +271,27 @@ describe('validateTarot', () => {
   it('omits per_card_minutes check when undefined', () => {
     const partial: TarotConfig = { mode: 'tarot', deck: 'major_arcana' };
     expect(validateTarot(partial)).toEqual([]);
+  });
+});
+
+describe('validateCustomName', () => {
+  it('accepts a normal name', () => {
+    expect(validateCustomName('My Morning Sit')).toEqual([]);
+  });
+
+  it('rejects an empty/whitespace-only name', () => {
+    expect(validateCustomName('')[0]).toMatch(/empty/i);
+    expect(validateCustomName('   ')[0]).toMatch(/empty/i);
+  });
+
+  it('rejects oversize names', () => {
+    expect(validateCustomName('x'.repeat(CUSTOM_NAME_MAX + 1))[0]).toMatch(
+      new RegExp(`≤ ${CUSTOM_NAME_MAX}`),
+    );
+  });
+
+  it('accepts a name at the exact length boundary', () => {
+    expect(validateCustomName('x'.repeat(CUSTOM_NAME_MAX))).toEqual([]);
   });
 });
 

--- a/frontend/src/features/Practice/engine/__tests__/validation.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/validation.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type {
+  IntervalBellConfig,
+  MeditationTimerConfig,
+  MetronomeConfig,
+  RepCounterConfig,
+  SenseGroundingConfig,
+  TarotConfig,
+} from '../types';
+import {
+  BPM_MAX,
+  BPM_MIN,
+  DURATION_MAX_MINUTES,
+  DURATION_MIN_MINUTES,
+  PROMPT_LABEL_MAX,
+  UNIT_LABEL_MAX,
+  validateCountUp,
+  validateIntervalBell,
+  validateMeditationTimer,
+  validateMetronome,
+  validateModeConfig,
+  validateRepCounter,
+  validateSenseGrounding,
+  validateTarot,
+} from '../validation';
+
+describe('validateMeditationTimer', () => {
+  const base: MeditationTimerConfig = {
+    mode: 'meditation_timer',
+    duration_minutes: 10,
+  };
+
+  it('accepts a valid duration', () => {
+    expect(validateMeditationTimer(base)).toEqual([]);
+  });
+
+  it('rejects durations below 0.5', () => {
+    expect(validateMeditationTimer({ ...base, duration_minutes: 0 })).toHaveLength(1);
+    expect(validateMeditationTimer({ ...base, duration_minutes: 0.4 })[0]).toMatch(/Duration/);
+  });
+
+  it('rejects durations above 24h', () => {
+    expect(
+      validateMeditationTimer({ ...base, duration_minutes: DURATION_MAX_MINUTES + 1 }),
+    ).toHaveLength(1);
+  });
+
+  it('rejects non-finite durations', () => {
+    expect(validateMeditationTimer({ ...base, duration_minutes: Number.NaN })).toHaveLength(1);
+  });
+
+  it('accepts the exact 0.5 boundary', () => {
+    expect(validateMeditationTimer({ ...base, duration_minutes: DURATION_MIN_MINUTES })).toEqual(
+      [],
+    );
+  });
+});
+
+describe('validateCountUp', () => {
+  it('accepts null soft cap', () => {
+    expect(validateCountUp({ mode: 'count_up', soft_cap_minutes: null })).toEqual([]);
+  });
+
+  it('accepts omitted soft cap', () => {
+    expect(validateCountUp({ mode: 'count_up' })).toEqual([]);
+  });
+
+  it('rejects negative soft cap', () => {
+    expect(validateCountUp({ mode: 'count_up', soft_cap_minutes: -1 })).toHaveLength(1);
+  });
+});
+
+describe('validateMetronome', () => {
+  const base: MetronomeConfig = {
+    mode: 'metronome',
+    bpm: 60,
+    timer: { mode: 'meditation_timer', duration_minutes: 10 },
+  };
+
+  it('accepts a valid metronome', () => {
+    expect(validateMetronome(base)).toEqual([]);
+  });
+
+  it('rejects BPM below the floor', () => {
+    expect(validateMetronome({ ...base, bpm: BPM_MIN - 1 })[0]).toMatch(/BPM/);
+  });
+
+  it('rejects BPM above the ceiling', () => {
+    expect(validateMetronome({ ...base, bpm: BPM_MAX + 1 })[0]).toMatch(/BPM/);
+  });
+
+  it('rejects non-integer BPM', () => {
+    const errors = validateMetronome({ ...base, bpm: 60.5 });
+    expect(errors.some((e) => e.includes('whole'))).toBe(true);
+  });
+
+  it('aggregates inner-timer errors', () => {
+    expect(
+      validateMetronome({ ...base, timer: { mode: 'meditation_timer', duration_minutes: 0 } }),
+    ).toHaveLength(1);
+  });
+});
+
+describe('validateIntervalBell', () => {
+  const evenBase: IntervalBellConfig = {
+    mode: 'interval_bell',
+    duration_minutes: 20,
+    interval_minutes: 5,
+    cue_offsets_minutes: null,
+    bell_tone: 'bowl',
+  };
+
+  it('accepts even-interval config', () => {
+    expect(validateIntervalBell(evenBase)).toEqual([]);
+  });
+
+  it('rejects interval ≥ duration', () => {
+    expect(validateIntervalBell({ ...evenBase, interval_minutes: 20 })[0]).toMatch(/less than/);
+  });
+
+  it('rejects setting both interval and offsets', () => {
+    expect(validateIntervalBell({ ...evenBase, cue_offsets_minutes: [5] })[0]).toMatch(/either/);
+  });
+
+  it('rejects setting neither interval nor offsets', () => {
+    expect(
+      validateIntervalBell({
+        ...evenBase,
+        interval_minutes: null,
+        cue_offsets_minutes: null,
+      })[0],
+    ).toMatch(/either/);
+  });
+
+  it('accepts custom offsets within duration', () => {
+    expect(
+      validateIntervalBell({
+        ...evenBase,
+        interval_minutes: null,
+        cue_offsets_minutes: [3, 7, 12],
+      }),
+    ).toEqual([]);
+  });
+
+  it('rejects offsets outside (0, duration]', () => {
+    expect(
+      validateIntervalBell({
+        ...evenBase,
+        interval_minutes: null,
+        cue_offsets_minutes: [0, 30],
+      })[0],
+    ).toMatch(/within/);
+  });
+
+  it('rejects empty offset list', () => {
+    expect(
+      validateIntervalBell({
+        ...evenBase,
+        interval_minutes: null,
+        cue_offsets_minutes: [],
+      })[0],
+    ).toMatch(/At least one/);
+  });
+
+  it('rejects unknown bell tone', () => {
+    const errors = validateIntervalBell({
+      ...evenBase,
+      bell_tone: 'kazoo' as IntervalBellConfig['bell_tone'],
+    });
+    expect(errors.some((e) => e.includes('Unknown bell tone'))).toBe(true);
+  });
+});
+
+describe('validateRepCounter', () => {
+  const base: RepCounterConfig = {
+    mode: 'rep_counter',
+    target_reps: 108,
+    unit_label: 'breaths',
+    time_cap_minutes: null,
+  };
+
+  it('accepts a valid rep counter', () => {
+    expect(validateRepCounter(base)).toEqual([]);
+  });
+
+  it('rejects zero reps', () => {
+    expect(validateRepCounter({ ...base, target_reps: 0 })[0]).toMatch(/Target reps/);
+  });
+
+  it('rejects fractional reps', () => {
+    expect(validateRepCounter({ ...base, target_reps: 1.5 })[0]).toMatch(/whole/);
+  });
+
+  it('rejects blank unit label', () => {
+    expect(validateRepCounter({ ...base, unit_label: '   ' })[0]).toMatch(/Unit label/);
+  });
+
+  it('rejects oversize unit label', () => {
+    expect(validateRepCounter({ ...base, unit_label: 'a'.repeat(UNIT_LABEL_MAX + 1) })[0]).toMatch(
+      new RegExp(`≤ ${UNIT_LABEL_MAX}`),
+    );
+  });
+
+  it('validates the optional time cap', () => {
+    expect(validateRepCounter({ ...base, time_cap_minutes: -1 })).toHaveLength(1);
+    expect(validateRepCounter({ ...base, time_cap_minutes: 30 })).toEqual([]);
+  });
+});
+
+describe('validateSenseGrounding', () => {
+  const base: SenseGroundingConfig = {
+    mode: 'sense_grounding',
+    prompts: [{ sense: 'sight', label: 'Notice 5 colours' }],
+  };
+
+  it('accepts a valid sequence', () => {
+    expect(validateSenseGrounding(base)).toEqual([]);
+  });
+
+  it('rejects empty prompts', () => {
+    expect(validateSenseGrounding({ ...base, prompts: [] })[0]).toMatch(/At least one/);
+  });
+
+  it('rejects blank labels', () => {
+    expect(
+      validateSenseGrounding({ ...base, prompts: [{ sense: 'sight', label: '  ' }] })[0],
+    ).toMatch(/empty/);
+  });
+
+  it('rejects oversize labels', () => {
+    expect(
+      validateSenseGrounding({
+        ...base,
+        prompts: [{ sense: 'sight', label: 'x'.repeat(PROMPT_LABEL_MAX + 1) }],
+      })[0],
+    ).toMatch(new RegExp(`≤ ${PROMPT_LABEL_MAX}`));
+  });
+
+  it('rejects unknown sense literals', () => {
+    expect(
+      validateSenseGrounding({
+        ...base,
+        prompts: [
+          { sense: 'aura' as SenseGroundingConfig['prompts'][number]['sense'], label: 'x' },
+        ],
+      })[0],
+    ).toMatch(/unknown sense/);
+  });
+});
+
+describe('validateTarot', () => {
+  const base: TarotConfig = {
+    mode: 'tarot',
+    deck: 'major_arcana',
+    per_card_minutes: 5,
+    hide_timer_during_meditation: true,
+  };
+
+  it('accepts a valid tarot config', () => {
+    expect(validateTarot(base)).toEqual([]);
+  });
+
+  it('rejects per-card minutes outside range', () => {
+    expect(validateTarot({ ...base, per_card_minutes: 0 })).toHaveLength(1);
+    expect(validateTarot({ ...base, per_card_minutes: DURATION_MAX_MINUTES + 1 })).toHaveLength(1);
+  });
+
+  it('omits per_card_minutes check when undefined', () => {
+    const partial: TarotConfig = { mode: 'tarot', deck: 'major_arcana' };
+    expect(validateTarot(partial)).toEqual([]);
+  });
+});
+
+describe('validateModeConfig dispatch', () => {
+  it('routes by discriminator for each mode', () => {
+    expect(validateModeConfig({ mode: 'meditation_timer', duration_minutes: 10 })).toEqual([]);
+    expect(validateModeConfig({ mode: 'count_up' })).toEqual([]);
+    expect(
+      validateModeConfig({
+        mode: 'metronome',
+        bpm: 60,
+        timer: { mode: 'meditation_timer', duration_minutes: 10 },
+      }),
+    ).toEqual([]);
+    expect(
+      validateModeConfig({
+        mode: 'interval_bell',
+        duration_minutes: 20,
+        interval_minutes: 5,
+        cue_offsets_minutes: null,
+        bell_tone: 'bowl',
+      }),
+    ).toEqual([]);
+    expect(
+      validateModeConfig({
+        mode: 'rep_counter',
+        target_reps: 10,
+        unit_label: 'reps',
+      }),
+    ).toEqual([]);
+    expect(
+      validateModeConfig({
+        mode: 'sense_grounding',
+        prompts: [{ sense: 'taste', label: '1 thing' }],
+      }),
+    ).toEqual([]);
+    expect(
+      validateModeConfig({
+        mode: 'tarot',
+        deck: 'major_arcana',
+        per_card_minutes: 5,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/features/Practice/engine/validation.ts
+++ b/frontend/src/features/Practice/engine/validation.ts
@@ -24,6 +24,8 @@ export const DURATION_MAX_MINUTES = 24 * 60;
 export const PROMPT_LABEL_MAX = 255;
 export const UNIT_LABEL_MAX = 64;
 export const TARGET_REPS_MIN = 1;
+/** Mirrors the backend ``UserPractice.custom_name`` column (ritual-03). */
+export const CUSTOM_NAME_MAX = 255;
 
 export const ALLOWED_SENSES: readonly SenseKind[] = ['sight', 'touch', 'hearing', 'smell', 'taste'];
 
@@ -90,25 +92,33 @@ function checkIntervalSpacing(interval: number, duration: number): string[] {
   return [];
 }
 
+function checkBellTone(tone: IntervalBellConfig['bell_tone']): string[] {
+  return ALLOWED_BELL_TONES.includes(tone) ? [] : ['Unknown bell tone'];
+}
+
 export function validateIntervalBell(config: IntervalBellConfig): string[] {
   const errors: string[] = [];
   pushIfOutOfDurationRange(errors, 'Duration', config.duration_minutes);
-  const hasInterval = config.interval_minutes !== undefined && config.interval_minutes !== null;
-  const hasOffsets =
-    config.cue_offsets_minutes !== undefined && config.cue_offsets_minutes !== null;
-  if (hasInterval === hasOffsets) {
+  const interval = config.interval_minutes ?? null;
+  const offsets = config.cue_offsets_minutes ?? null;
+  // The two spacing strategies are mutually exclusive (mirrors the Pydantic
+  // model_validator in ``backend/src/schemas/practice_mode_config.py``).
+  // Split the two violation classes so the surfaced error tells the user
+  // which side of the constraint they tripped.
+  if (interval === null && offsets === null) {
+    errors.push('Select a spacing method: even intervals or custom offsets');
+    return errors;
+  }
+  if (interval !== null && offsets !== null) {
     errors.push('Choose either even intervals or custom offsets, not both');
     return errors;
   }
-  if (hasInterval && config.interval_minutes !== null && config.interval_minutes !== undefined) {
-    errors.push(...checkIntervalSpacing(config.interval_minutes, config.duration_minutes));
+  if (interval !== null) {
+    errors.push(...checkIntervalSpacing(interval, config.duration_minutes));
+  } else if (offsets !== null) {
+    errors.push(...checkOffsetList(offsets, config.duration_minutes));
   }
-  if (hasOffsets && config.cue_offsets_minutes) {
-    errors.push(...checkOffsetList(config.cue_offsets_minutes, config.duration_minutes));
-  }
-  if (!ALLOWED_BELL_TONES.includes(config.bell_tone)) {
-    errors.push('Unknown bell tone');
-  }
+  errors.push(...checkBellTone(config.bell_tone));
   return errors;
 }
 
@@ -175,6 +185,22 @@ const VALIDATORS: {
   sense_grounding: validateSenseGrounding,
   tarot: validateTarot,
 };
+
+/**
+ * Validate the user-supplied ``custom_name`` override.  Trimmed length must
+ * be non-empty; raw length is capped at :data:`CUSTOM_NAME_MAX` to match the
+ * ``UserPractice.custom_name`` column added in ritual-03.
+ */
+export function validateCustomName(name: string): string[] {
+  const errors: string[] = [];
+  if (name.trim().length === 0) {
+    errors.push('Name cannot be empty');
+  }
+  if (name.length > CUSTOM_NAME_MAX) {
+    errors.push(`Name must be ≤ ${CUSTOM_NAME_MAX} characters`);
+  }
+  return errors;
+}
 
 export function validateModeConfig(config: ModeConfig): string[] {
   // The mapped-type ``VALIDATORS`` table guarantees every mode has a

--- a/frontend/src/features/Practice/engine/validation.ts
+++ b/frontend/src/features/Practice/engine/validation.ts
@@ -1,0 +1,189 @@
+// Mirrors the backend Pydantic constraints from
+// ``backend/src/schemas/practice_mode_config.py`` so the configurator UI
+// can short-circuit save attempts that would round-trip to a 422.  Each
+// per-mode validator returns a list of human-readable errors; an empty
+// list means the payload is acceptable.
+
+import type {
+  CountUpConfig,
+  IntervalBellConfig,
+  MeditationTimerConfig,
+  MetronomeConfig,
+  ModeConfig,
+  RepCounterConfig,
+  SenseGroundingConfig,
+  SenseKind,
+  SensePrompt,
+  TarotConfig,
+} from './types';
+
+export const BPM_MIN = 20;
+export const BPM_MAX = 240;
+export const DURATION_MIN_MINUTES = 0.5;
+export const DURATION_MAX_MINUTES = 24 * 60;
+export const PROMPT_LABEL_MAX = 255;
+export const UNIT_LABEL_MAX = 64;
+export const TARGET_REPS_MIN = 1;
+
+export const ALLOWED_SENSES: readonly SenseKind[] = ['sight', 'touch', 'hearing', 'smell', 'taste'];
+
+export const ALLOWED_BELL_TONES = ['bowl', 'chime', 'gong'] as const;
+
+function pushIfOutOfDurationRange(
+  errors: string[],
+  field: string,
+  value: number,
+  min: number = DURATION_MIN_MINUTES,
+): void {
+  if (!Number.isFinite(value) || value < min || value > DURATION_MAX_MINUTES) {
+    errors.push(`${field} must be between ${min} and ${DURATION_MAX_MINUTES} minutes`);
+  }
+}
+
+export function validateMeditationTimer(config: MeditationTimerConfig): string[] {
+  const errors: string[] = [];
+  pushIfOutOfDurationRange(errors, 'Duration', config.duration_minutes);
+  return errors;
+}
+
+export function validateCountUp(config: CountUpConfig): string[] {
+  const errors: string[] = [];
+  if (config.soft_cap_minutes !== undefined && config.soft_cap_minutes !== null) {
+    pushIfOutOfDurationRange(errors, 'Soft cap', config.soft_cap_minutes);
+  }
+  return errors;
+}
+
+export function validateMetronome(config: MetronomeConfig): string[] {
+  const errors: string[] = [];
+  if (!Number.isFinite(config.bpm) || config.bpm < BPM_MIN || config.bpm > BPM_MAX) {
+    errors.push(`BPM must be between ${BPM_MIN} and ${BPM_MAX}`);
+  }
+  if (!Number.isInteger(config.bpm)) {
+    errors.push('BPM must be a whole number');
+  }
+  errors.push(...validateMeditationTimer(config.timer));
+  return errors;
+}
+
+function checkOffsetList(offsets: readonly number[], duration: number): string[] {
+  const errors: string[] = [];
+  if (offsets.length === 0) {
+    errors.push('At least one cue offset is required');
+  }
+  for (const offset of offsets) {
+    if (!Number.isFinite(offset) || offset <= 0 || offset > duration) {
+      errors.push('Cue offsets must fall within (0, duration]');
+      break;
+    }
+  }
+  return errors;
+}
+
+function checkIntervalSpacing(interval: number, duration: number): string[] {
+  if (!Number.isFinite(interval) || interval < DURATION_MIN_MINUTES) {
+    return [`Interval must be at least ${DURATION_MIN_MINUTES} minute(s)`];
+  }
+  if (interval >= duration) {
+    return ['Interval must be less than total duration'];
+  }
+  return [];
+}
+
+export function validateIntervalBell(config: IntervalBellConfig): string[] {
+  const errors: string[] = [];
+  pushIfOutOfDurationRange(errors, 'Duration', config.duration_minutes);
+  const hasInterval = config.interval_minutes !== undefined && config.interval_minutes !== null;
+  const hasOffsets =
+    config.cue_offsets_minutes !== undefined && config.cue_offsets_minutes !== null;
+  if (hasInterval === hasOffsets) {
+    errors.push('Choose either even intervals or custom offsets, not both');
+    return errors;
+  }
+  if (hasInterval && config.interval_minutes !== null && config.interval_minutes !== undefined) {
+    errors.push(...checkIntervalSpacing(config.interval_minutes, config.duration_minutes));
+  }
+  if (hasOffsets && config.cue_offsets_minutes) {
+    errors.push(...checkOffsetList(config.cue_offsets_minutes, config.duration_minutes));
+  }
+  if (!ALLOWED_BELL_TONES.includes(config.bell_tone)) {
+    errors.push('Unknown bell tone');
+  }
+  return errors;
+}
+
+export function validateRepCounter(config: RepCounterConfig): string[] {
+  const errors: string[] = [];
+  if (!Number.isInteger(config.target_reps) || config.target_reps < TARGET_REPS_MIN) {
+    errors.push(`Target reps must be a whole number ≥ ${TARGET_REPS_MIN}`);
+  }
+  if (config.unit_label.trim().length === 0) {
+    errors.push('Unit label cannot be empty');
+  }
+  if (config.unit_label.length > UNIT_LABEL_MAX) {
+    errors.push(`Unit label must be ≤ ${UNIT_LABEL_MAX} characters`);
+  }
+  if (config.time_cap_minutes !== undefined && config.time_cap_minutes !== null) {
+    pushIfOutOfDurationRange(errors, 'Time cap', config.time_cap_minutes);
+  }
+  return errors;
+}
+
+function checkPrompt(prompt: SensePrompt, index: number): string[] {
+  const errors: string[] = [];
+  if (!ALLOWED_SENSES.includes(prompt.sense)) {
+    errors.push(`Prompt ${index + 1}: unknown sense`);
+  }
+  const labelLen = prompt.label.trim().length;
+  if (labelLen === 0) {
+    errors.push(`Prompt ${index + 1}: label cannot be empty`);
+  }
+  if (prompt.label.length > PROMPT_LABEL_MAX) {
+    errors.push(`Prompt ${index + 1}: label must be ≤ ${PROMPT_LABEL_MAX} characters`);
+  }
+  return errors;
+}
+
+export function validateSenseGrounding(config: SenseGroundingConfig): string[] {
+  const errors: string[] = [];
+  if (config.prompts.length === 0) {
+    errors.push('At least one sense prompt is required');
+    return errors;
+  }
+  config.prompts.forEach((prompt, index) => {
+    errors.push(...checkPrompt(prompt, index));
+  });
+  return errors;
+}
+
+export function validateTarot(config: TarotConfig): string[] {
+  const errors: string[] = [];
+  if (config.per_card_minutes !== undefined) {
+    pushIfOutOfDurationRange(errors, 'Per-card minutes', config.per_card_minutes);
+  }
+  return errors;
+}
+
+const VALIDATORS: {
+  [K in ModeConfig['mode']]: (config: Extract<ModeConfig, { mode: K }>) => string[];
+} = {
+  meditation_timer: validateMeditationTimer,
+  count_up: validateCountUp,
+  metronome: validateMetronome,
+  interval_bell: validateIntervalBell,
+  rep_counter: validateRepCounter,
+  sense_grounding: validateSenseGrounding,
+  tarot: validateTarot,
+};
+
+export function validateModeConfig(config: ModeConfig): string[] {
+  // The mapped-type ``VALIDATORS`` table guarantees every mode has a
+  // validator. The double cast narrows the union per-mode without an
+  // ``as`` chain at every call site. Unknown discriminators (e.g. a
+  // newer server-side mode the client doesn't yet recognise) skip
+  // validation here -- the configurator renders an "unsupported mode"
+  // notice instead of attempting to edit.
+  type AnyValidator = (config: ModeConfig) => string[];
+  const validator = VALIDATORS[config.mode] as AnyValidator | undefined;
+  return validator ? validator(config) : [];
+}


### PR DESCRIPTION
## Summary

Implements **ritual-09** — the bottom-sheet UI that lets a user "build their
own ritual": rename the practice, change durations, edit metronome BPM,
add/remove interval bells, and rewrite sense-grounding prompts. Saves go
through `PATCH /user-practices/{id}/customize` (ritual-03 contract; client
is a typed mock until that PR lands, no waiting cross-stream).

- New `RitualConfiguratorSheet` modal with editable name, aspect chip,
  Cancel / Save / Reset-to-default, validation gate, API-error surface.
- Seven per-mode forms covering every `ModeConfig` discriminator from
  ritual-01: `meditation_timer`, `count_up`, `metronome`, `interval_bell`,
  `rep_counter`, `sense_grounding`, `tarot`. Unknown modes render an
  "unsupported — long-press to replace" notice so 09 doesn't crash if the
  server adds a mode the client hasn't shipped yet.
- New `engine/validation.ts` mirroring the Pydantic constraints in
  `backend/src/schemas/practice_mode_config.py` (BPM 20–240, duration
  0.5–1440 min, BPM integer, interval &lt; duration, mutually-exclusive
  interval-vs-offsets, sense-prompt label length, unit_label ≤ 64, etc.).
  Reused by the configurator and exposed so other surfaces can prevalidate.
- API client gains `userPractices.customize(id, payload)` (PATCH); passing
  `mode_config_override: null` clears the override per the ritual-03 spec.

## Files

| File | Action | Notes |
|------|--------|-------|
| `frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx` | new | sheet shell, save/reset flow |
| `frontend/src/features/Practice/configurator/forms/*.tsx` | new | 7 mode forms + `shared.tsx` primitives |
| `frontend/src/features/Practice/engine/validation.ts` | new | TS mirror of Pydantic rules |
| `frontend/src/api/index.ts` | modified | `UserPracticeCustomize` type + `userPractices.customize` |
| `frontend/src/features/Practice/configurator/__tests__/*.test.tsx` | new | per-form + sheet tests |
| `frontend/src/features/Practice/engine/__tests__/validation.test.ts` | new | 36 cases across 7 modes |
| `frontend/src/api/__tests__/userPractices-customize.test.ts` | new | PATCH wire format |

## LoC

The issue estimated ~600 LoC; this PR lands ~2,300 LoC net (precedent set
by #309 / #310). Declared per the runbook:

| File group | LoC |
|---|---|
| `RitualConfiguratorSheet.tsx` | 320 |
| `forms/shared.tsx` | 274 |
| `forms/*Form.tsx` (7 files) | 535 |
| `engine/validation.ts` | 195 |
| `api/index.ts` delta | 36 |
| **Production subtotal** | **1,360** |
| `engine/__tests__/validation.test.ts` | 320 |
| `configurator/__tests__/*.test.tsx` (7 files) | 587 |
| `api/__tests__/userPractices-customize.test.ts` | 60 |
| **Test subtotal** | **967** |
| **Total** | **2,327** |

Did not split into 09a/09b because the seven forms share `shared.tsx` /
validation, and the sheet already implements the unknown-mode escape hatch
the split-plan required. Happy to split if the reviewer prefers.

## Quality gates

- `npx tsc --noEmit` — clean
- `npm run lint` (ESLint `--max-warnings=0`) — clean
- `npm test` — 1,158 tests pass (82 new); per-file coverage on the new
  module:
  - `engine/validation.ts`: 100% lines / 97.67% branches
  - `configurator/RitualConfiguratorSheet.tsx`: 100% lines / 90% branches
  - `configurator/forms/`: 96% lines / 83% branches
- Pre-commit: all 28 hooks green (eslint, prettier, typecheck, jest,
  detect-secrets, …).
- Pre-push: same plus full backend pipeline (skipped — no backend files).

## Test plan

- [ ] Configurator opens with the current name + effective config preloaded.
- [ ] Save stays disabled until a field actually changes.
- [ ] Out-of-range fields surface inline errors and disable Save.
- [ ] Save sends only the changed fields (`custom_name` omitted when name
      untouched, `mode_config_override` always sent when config dirty).
- [ ] Reset-to-default posts `{ custom_name: null, mode_config_override: null }`.
- [ ] API failure renders the formatted error and keeps the sheet open.
- [ ] Unknown server-side modes show the long-press-to-replace notice.

## Out of scope (deferred to later issues)

- PracticeScreen wiring (ritual-11 — explicitly out per the prompt's
  guardrails).
- Frequency banner / replace-this-practice flow (ritual-10).
- Backend `PATCH /user-practices/{id}/customize` endpoint (ritual-03).
  This PR depends on it conceptually but does not wait on it: the API
  method targets the agreed URL so cutover is a no-op once ritual-03
  merges.

Do not merge — awaiting human or Claude-reviewer verdict.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEavw1YbfpwrrmQhgdC7qQ)_