### PR TITLE
feat(frontend-habits): paint tile borders by list position (Beige → Clear Light)

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -609,6 +609,7 @@ const LockedTile = ({
 
 interface UnlockedTileProps {
   habit: Habit;
+  stageColor: string;
   onOpenGoals?: () => void;
   onLongPress?: () => void;
   onIconPress?: () => void;
@@ -633,9 +634,15 @@ const buildUnlockedTileStyle = (
   backgroundColor: '#f8f8f8',
 });
 
-const UnlockedTile = ({ habit, onOpenGoals, onLongPress, onIconPress, tz }: UnlockedTileProps) => {
+const UnlockedTile = ({
+  habit,
+  stageColor,
+  onOpenGoals,
+  onLongPress,
+  onIconPress,
+  tz,
+}: UnlockedTileProps) => {
   const { scale, gridGutter, tileMinHeight, iconInline } = useTileLayout();
-  const stageColor = STAGE_COLORS[habit.stage] ?? '#000';
   const [tooltip, setTooltip] = useState<TierType | null>(null);
   const { progressPercentage, progressBarColor, hasCompletedGoal, markers } = useHabitTileData(
     habit,
@@ -686,9 +693,10 @@ export const HabitTile = ({
   onIconPress,
   onUnlockHabit,
   tz = DEFAULT_TIMEZONE,
+  stageColorOverride,
 }: HabitTileProps) => {
   const { scale, gridGutter, tileMinHeight } = useTileLayout();
-  const stageColor = STAGE_COLORS[habit.stage] ?? '#000';
+  const stageColor = stageColorOverride ?? STAGE_COLORS[habit.stage] ?? '#000';
 
   if (locked) {
     return (
@@ -706,6 +714,7 @@ export const HabitTile = ({
   return (
     <UnlockedTile
       habit={habit}
+      stageColor={stageColor}
       onOpenGoals={onOpenGoals}
       onLongPress={onLongPress}
       onIconPress={onIconPress}

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -693,16 +693,16 @@ export const HabitTile = ({
   onIconPress,
   onUnlockHabit,
   tz = DEFAULT_TIMEZONE,
-  stageColorOverride,
+  stageColor,
 }: HabitTileProps) => {
   const { scale, gridGutter, tileMinHeight } = useTileLayout();
-  const stageColor = stageColorOverride ?? STAGE_COLORS[habit.stage] ?? '#000';
+  const color = stageColor ?? STAGE_COLORS[habit.stage] ?? '#000';
 
   if (locked) {
     return (
       <LockedTile
         habit={habit}
-        stageColor={stageColor}
+        stageColor={color}
         scale={scale}
         gridGutter={gridGutter}
         tileMinHeight={tileMinHeight}
@@ -714,7 +714,7 @@ export const HabitTile = ({
   return (
     <UnlockedTile
       habit={habit}
-      stageColor={stageColor}
+      stageColor={color}
       onOpenGoals={onOpenGoals}
       onLongPress={onLongPress}
       onIconPress={onIconPress}

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -132,6 +132,13 @@ export interface HabitTileProps {
    * absent so legacy tests render without an auth context.
    */
   tz?: string;
+  /**
+   * When the list paints tiles with a position-based gradient (Beige →
+   * Clear Light), the renderer passes the resolved hex here. Falls back
+   * to ``STAGE_COLORS[habit.stage]`` when omitted so direct ``<HabitTile>``
+   * uses (e.g. tests) keep their stage-driven coloring.
+   */
+  stageColorOverride?: string;
 }
 
 export interface HabitSettingsModalProps {

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -132,13 +132,8 @@ export interface HabitTileProps {
    * absent so legacy tests render without an auth context.
    */
   tz?: string;
-  /**
-   * When the list paints tiles with a position-based gradient (Beige →
-   * Clear Light), the renderer passes the resolved hex here. Falls back
-   * to ``STAGE_COLORS[habit.stage]`` when omitted so direct ``<HabitTile>``
-   * uses (e.g. tests) keep their stage-driven coloring.
-   */
-  stageColorOverride?: string;
+  /** Border/accent color; falls back to ``STAGE_COLORS[habit.stage]`` when omitted. */
+  stageColor?: string;
 }
 
 export interface HabitSettingsModalProps {

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -8,7 +8,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { habits as habitsApi } from '../../api';
 import { useAuth } from '../../context/AuthContext';
-import { spacing } from '../../design/tokens';
+import { STAGE_COLORS, STAGE_ORDER, spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 
 import AddHabitModal from './components/AddHabitModal';
@@ -436,10 +436,16 @@ const useHabitTileRenderer = (
   const renderHabitTile = ({ item, index }: { item: Habit; index: number }) => {
     const isLocked = item.revealed === false;
     const globalIndex = pageOffset + index;
+    // Position-based palette: tiles paint Beige → Clear Light by row, and
+    // each page restarts the sequence — so a freshly added 11th habit on
+    // page 2 reads as Beige again instead of inheriting page 1's gradient.
+    const stageName = STAGE_ORDER[index % STAGE_ORDER.length] ?? 'Beige';
+    const stageColorOverride = STAGE_COLORS[stageName];
     return (
       <HabitTile
         habit={item}
         locked={isLocked}
+        stageColorOverride={stageColorOverride}
         onOpenGoals={
           isLocked
             ? undefined

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -436,16 +436,13 @@ const useHabitTileRenderer = (
   const renderHabitTile = ({ item, index }: { item: Habit; index: number }) => {
     const isLocked = item.revealed === false;
     const globalIndex = pageOffset + index;
-    // Position-based palette: tiles paint Beige → Clear Light by row, and
-    // each page restarts the sequence — so a freshly added 11th habit on
-    // page 2 reads as Beige again instead of inheriting page 1's gradient.
-    const stageName = STAGE_ORDER[index % STAGE_ORDER.length] ?? 'Beige';
-    const stageColorOverride = STAGE_COLORS[stageName];
+    // index is page-relative, so each page restarts the Beige → Clear Light gradient.
+    const stageColor = STAGE_COLORS[STAGE_ORDER[index % STAGE_ORDER.length]!]!;
     return (
       <HabitTile
         habit={item}
         locked={isLocked}
-        stageColorOverride={stageColorOverride}
+        stageColor={stageColor}
         onOpenGoals={
           isLocked
             ? undefined

--- a/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
@@ -1,0 +1,217 @@
+/* eslint-env jest */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest, describe, afterEach, it, expect } from '@jest/globals';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { STAGE_COLORS } from '../../../design/tokens';
+import type { Habit } from '../Habits.types';
+import { HabitTile } from '../HabitTile';
+
+const makeApiHabit = (id: number, overrides: Record<string, unknown> = {}) => ({
+  id,
+  name: `Habit ${id}`,
+  icon: '✨',
+  start_date: '2020-01-01',
+  energy_cost: 1,
+  energy_return: 2,
+  stage: 'Beige',
+  streak: 0,
+  goals: [
+    {
+      id: id * 100,
+      habit_id: id,
+      title: 'Clear',
+      tier: 'clear',
+      target: 1,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+  ],
+  ...overrides,
+});
+
+const buildApiHabits = (count: number) =>
+  Array.from({ length: count }, (_, i) => makeApiHabit(i + 1, { sort_order: i }));
+
+jest.mock('../../../api', () => ({
+  habits: {
+    list: jest.fn() as any,
+    create: jest.fn() as any,
+    update: jest.fn() as any,
+    delete: jest.fn() as any,
+    getStats: (jest.fn() as any).mockResolvedValue({
+      day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      values: [0, 0, 0, 0, 0, 0, 0],
+      completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+      longest_streak: 0,
+      current_streak: 0,
+      total_completions: 0,
+      completion_rate: 0,
+      completion_dates: [],
+    }),
+  },
+  goalCompletions: { create: jest.fn() as any },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: (jest.fn() as any).mockResolvedValue({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn() as any,
+  scheduleNotificationAsync: jest.fn() as any,
+  cancelScheduledNotificationAsync: jest.fn() as any,
+  getExpoPushTokenAsync: (jest.fn() as any).mockResolvedValue({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactLib = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: any }) =>
+      ReactLib.createElement(ReactLib.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/StatsModal', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+const { habits: habitsApi } = require('../../../api');
+const HabitsScreen = require('../HabitsScreen').default;
+
+const renderScreen = async (apiHabits: ReturnType<typeof buildApiHabits>) => {
+  habitsApi.list.mockResolvedValue(apiHabits);
+  jest
+    .spyOn(require('react-native'), 'useWindowDimensions')
+    .mockReturnValue({ width: 400, height: 800, scale: 1, fontScale: 1 });
+  let testRenderer: any;
+  await renderer.act(async () => {
+    testRenderer = renderer.create(React.createElement(HabitsScreen));
+  });
+  // Allow the post-load reconciliation effects to settle so notification
+  // mocks don't trigger unhandled promise rejections.
+  await renderer.act(async () => {
+    await Promise.resolve();
+  });
+  return testRenderer;
+};
+
+const uniqueTiles = (tree: any): any[] => {
+  // ``TouchableOpacity`` forwards testID through wrapper layers, producing
+  // multiple matches per tile under ``findAllByProps``. Filter to the
+  // composite root (its instance is exactly one per tile).
+  const { TouchableOpacity } = require('react-native');
+  return tree
+    .findAllByType(TouchableOpacity)
+    .filter((node: any) => node.props.testID === 'habit-tile');
+};
+
+const tileBorderAt = (tree: any, index: number): string => {
+  const tile = uniqueTiles(tree)[index];
+  const style = Array.isArray(tile.props.style)
+    ? tile.props.style.reduce((acc: any, s: any) => ({ ...acc, ...s }), {})
+    : tile.props.style;
+  return style.borderColor as string;
+};
+
+describe('HabitTile stageColor prop', () => {
+  const baseHabit: Habit = {
+    id: 1,
+    stage: 'Purple',
+    name: 'Override Test',
+    icon: '🎨',
+    streak: 0,
+    energy_cost: 1,
+    energy_return: 1,
+    start_date: new Date(2020, 0, 1),
+    goals: [
+      {
+        title: 'Clear',
+        tier: 'clear',
+        target: 1,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+    ],
+    completions: [],
+    revealed: true,
+  };
+
+  it('uses the stageColor override on the unlocked tile border', () => {
+    const component = renderer.create(
+      <HabitTile habit={baseHabit} stageColor="#abcdef" onOpenGoals={() => {}} />,
+    );
+    const tile = component.root.findByProps({ testID: 'habit-tile' });
+    expect(tile.props.style.borderColor).toBe('#abcdef');
+  });
+
+  it('uses the stageColor override on the locked tile border', () => {
+    const component = renderer.create(
+      <HabitTile habit={{ ...baseHabit, revealed: false }} locked stageColor="#123456" />,
+    );
+    const tile = component.root.findByProps({ testID: 'habit-tile' });
+    expect(tile.props.style.borderColor).toBe('#123456');
+  });
+
+  it('falls back to STAGE_COLORS[habit.stage] when stageColor is omitted', () => {
+    const component = renderer.create(<HabitTile habit={baseHabit} onOpenGoals={() => {}} />);
+    const tile = component.root.findByProps({ testID: 'habit-tile' });
+    expect(tile.props.style.borderColor).toBe(STAGE_COLORS.Purple);
+  });
+});
+
+describe('HabitsScreen position-based stage colors', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('paints the first tile Beige and the second tile Purple', async () => {
+    const testRenderer = await renderScreen(buildApiHabits(3));
+    const tree = testRenderer.root;
+    expect(tileBorderAt(tree, 0)).toBe(STAGE_COLORS.Beige);
+    expect(tileBorderAt(tree, 1)).toBe(STAGE_COLORS.Purple);
+    expect(tileBorderAt(tree, 2)).toBe(STAGE_COLORS.Red);
+  });
+
+  it('paints the tenth tile Clear Light at the end of the gradient', async () => {
+    const testRenderer = await renderScreen(buildApiHabits(10));
+    const tree = testRenderer.root;
+    expect(tileBorderAt(tree, 9)).toBe(STAGE_COLORS['Clear Light']);
+  });
+
+  it('restarts the Beige → Clear Light sequence on page 2', async () => {
+    const testRenderer = await renderScreen(buildApiHabits(12));
+    const tree = testRenderer.root;
+    expect(tileBorderAt(tree, 0)).toBe(STAGE_COLORS.Beige);
+    const nextButton = tree.findByProps({ testID: 'pagination-next' });
+    await renderer.act(async () => {
+      nextButton.props.onPress();
+    });
+    expect(tileBorderAt(tree, 0)).toBe(STAGE_COLORS.Beige);
+    expect(tileBorderAt(tree, 1)).toBe(STAGE_COLORS.Purple);
+  });
+
+  it('colors tiles by list position regardless of habit.stage', async () => {
+    // Every API habit has stage "Beige" — without position-based coloring
+    // all tiles would render Beige. The renderer must override that.
+    const testRenderer = await renderScreen(buildApiHabits(3));
+    const tree = testRenderer.root;
+    expect(tileBorderAt(tree, 0)).toBe(STAGE_COLORS.Beige);
+    expect(tileBorderAt(tree, 1)).toBe(STAGE_COLORS.Purple);
+    expect(tileBorderAt(tree, 1)).not.toBe(STAGE_COLORS.Beige);
+  });
+});


### PR DESCRIPTION
The habits list now applies the APTITUDE stage palette as a position-based
gradient: the first row is Beige, the second Purple, and so on through Clear
Light at row 10. Pagination restarts the sequence so an 11th habit on page 2
reads as Beige again.

The override flows in via a new optional ``stageColorOverride`` prop on
``HabitTile``. When omitted (e.g. in unit tests that render a single tile),
the tile keeps its previous ``STAGE_COLORS[habit.stage]`` lookup so existing
test assertions hold.