### PR TITLE
fix(frontend-journal): un-mirror empty-state heading inside inverted FlatList

### DIFF
--- a/frontend/src/features/Journal/Journal.styles.ts
+++ b/frontend/src/features/Journal/Journal.styles.ts
@@ -228,6 +228,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: SPACING.xl,
+    // The parent FlatList is `inverted`, which applies scaleY(-1) to its
+    // contents — including ListEmptyComponent. Counter-flip here so the
+    // heading reads top-to-bottom, left-to-right.
+    transform: [{ scaleY: -1 }],
   },
   emptyIcon: {
     fontSize: 48,


### PR DESCRIPTION
The inverted FlatList applies scaleY(-1) to its contents, including
ListEmptyComponent, which flipped the empty-state heading upside-down.
Counter-flip the empty container so "Your Journal Awaits" reads
top-to-bottom, left-to-right.

https://claude.ai/code/session_01WWmS9j1dA4n4cd83EkuHcA