### PR TITLE
feat(backend): seed 10 stage-aligned preset practices (ritual-02)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -152,17 +152,22 @@ jobs:
           # "alembic downgrade -1" is ambiguous when the head is a merge
           # migration (down_revision is a tuple of two prior heads), so we
           # resolve the previous revision explicitly via the script
-          # directory.  Falls back to "-1" for linear chains.
+          # directory.  Falls back to "-1" for linear chains and for the
+          # transient multi-head state (where get_current_head returns
+          # None) so the error message stays clear.
           prev=$(python -c "
           from alembic.config import Config
           from alembic.script import ScriptDirectory
           sd = ScriptDirectory.from_config(Config('alembic.ini'))
           head = sd.get_current_head()
-          rev = sd.get_revision(head)
-          parent = rev.down_revision
-          if isinstance(parent, tuple):
-              parent = parent[0]
-          print(parent or '-1')
+          if head is None:
+              print('-1')
+          else:
+              rev = sd.get_revision(head)
+              parent = rev.down_revision
+              if isinstance(parent, tuple):
+                  parent = parent[0]
+              print(parent or '-1')
           ")
           alembic downgrade "$prev"
           alembic upgrade head

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -149,7 +149,22 @@ jobs:
         working-directory: backend
         run: |
           alembic upgrade head
-          alembic downgrade -1
+          # "alembic downgrade -1" is ambiguous when the head is a merge
+          # migration (down_revision is a tuple of two prior heads), so we
+          # resolve the previous revision explicitly via the script
+          # directory.  Falls back to "-1" for linear chains.
+          prev=$(python -c "
+          from alembic.config import Config
+          from alembic.script import ScriptDirectory
+          sd = ScriptDirectory.from_config(Config('alembic.ini'))
+          head = sd.get_current_head()
+          rev = sd.get_revision(head)
+          parent = rev.down_revision
+          if isinstance(parent, tuple):
+              parent = parent[0]
+          print(parent or '-1')
+          ")
+          alembic downgrade "$prev"
           alembic upgrade head
 
       - name: Detect migration drift (models vs. migrations)

--- a/backend/migrations/versions/c5ed9dd1dabc_merge_ritual_03_and_ritual_04_heads.py
+++ b/backend/migrations/versions/c5ed9dd1dabc_merge_ritual_03_and_ritual_04_heads.py
@@ -1,7 +1,7 @@
 """merge ritual-03 and ritual-04 migration heads
 
 Revision ID: c5ed9dd1dabc
-Revises: 83b01b64cad3, f0a1b2c3d4e5
+Revises: 83b01b64cad3, b1c2d3e4f5a6
 Create Date: 2026-05-11 18:55:00.000000
 
 ritual-03 (``83b01b64cad3``: user-practice overrides) and ritual-04
@@ -12,20 +12,29 @@ forked into two heads, breaking ``alembic upgrade head`` with
 "Multiple head revisions are present" — surfaced by the
 ``migration-drift`` CI job on the next PR.
 
+After this PR's initial fix, PR #316 ("12B wave 2") added two
+follow-on migrations (``a0b1c2d3e4f5`` journal soft-delete and
+``b1c2d3e4f5a6`` chat-spend idempotency) chained off ``f0a1b2c3d4e5``,
+re-forking the graph relative to this merge. ``down_revision`` is
+therefore pinned to the *current* heads of both branches:
+``83b01b64cad3`` (ritual-03, never built on) and ``b1c2d3e4f5a6``
+(end of the ritual-04 → soft-delete → chat-spend chain). Future
+migrations chain off this revision; an even later sibling on the
+ritual-03 branch would re-fork and warrant another merge.
+
 This is a no-op merge migration (``upgrade``/``downgrade`` are empty)
 whose sole purpose is to give the chain a single head by declaring
-both prior heads as its ancestors. Future migrations chain off this
-revision.
+both prior heads as its ancestors.
 """
 
 from typing import Sequence, Union
 
 # revision identifiers, used by Alembic.
 revision: str = "c5ed9dd1dabc"  # pragma: allowlist secret
-# Tuple of both prior heads; alembic stitches them together at this point.
+# Tuple of both current heads; alembic stitches them together at this point.
 down_revision: Union[str, Sequence[str], None] = (
     "83b01b64cad3",  # pragma: allowlist secret — ritual-03 head
-    "f0a1b2c3d4e5",  # pragma: allowlist secret — ritual-04 head
+    "b1c2d3e4f5a6",  # pragma: allowlist secret — chat-spend (end of ritual-04 chain)
 )
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -36,4 +45,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Reverses to the forked state — both ritual-03 and ritual-04 remain applied."""
+    """Reverses to the forked state — the prior heads remain applied."""

--- a/backend/migrations/versions/c5ed9dd1dabc_merge_ritual_03_and_ritual_04_heads.py
+++ b/backend/migrations/versions/c5ed9dd1dabc_merge_ritual_03_and_ritual_04_heads.py
@@ -1,0 +1,41 @@
+"""merge ritual-03 and ritual-04 migration heads
+
+Revision ID: c5ed9dd1dabc
+Revises: 83b01b64cad3, f0a1b2c3d4e5
+Create Date: 2026-05-11 18:55:00.000000
+
+ritual-03 (``83b01b64cad3``: user-practice overrides) and ritual-04
+(``f0a1b2c3d4e5``: practice-session metadata) were developed in parallel
+and both used ``e9f0a1b2c3d4`` (ritual-01) as their ``down_revision``.
+When both merged into ``main`` independently, the migration graph
+forked into two heads, breaking ``alembic upgrade head`` with
+"Multiple head revisions are present" — surfaced by the
+``migration-drift`` CI job on the next PR.
+
+This is a no-op merge migration (``upgrade``/``downgrade`` are empty)
+whose sole purpose is to give the chain a single head by declaring
+both prior heads as its ancestors. Future migrations chain off this
+revision.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op  # noqa: F401 — required for alembic to recognise the file
+
+# revision identifiers, used by Alembic.
+revision: str = "c5ed9dd1dabc"  # pragma: allowlist secret
+# Tuple of both prior heads; alembic stitches them together at this point.
+down_revision: Union[str, Sequence[str], None] = (
+    "83b01b64cad3",  # pragma: allowlist secret — ritual-03 head
+    "f0a1b2c3d4e5",  # pragma: allowlist secret — ritual-04 head
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """No schema change; this migration only unifies the two prior heads."""
+
+
+def downgrade() -> None:
+    """Reverses to the forked state — both ritual-03 and ritual-04 remain applied."""

--- a/backend/migrations/versions/c5ed9dd1dabc_merge_ritual_03_and_ritual_04_heads.py
+++ b/backend/migrations/versions/c5ed9dd1dabc_merge_ritual_03_and_ritual_04_heads.py
@@ -20,8 +20,6 @@ revision.
 
 from typing import Sequence, Union
 
-from alembic import op  # noqa: F401 — required for alembic to recognise the file
-
 # revision identifiers, used by Alembic.
 revision: str = "c5ed9dd1dabc"  # pragma: allowlist secret
 # Tuple of both prior heads; alembic stitches them together at this point.

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -3,7 +3,7 @@ import os
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, DateTime
+from sqlalchemy import Column, DateTime, Index
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
@@ -48,6 +48,11 @@ class JournalEntry(SQLModel, table=True):
     rows older than the retention window (not implemented here — follow-up
     GitHub issue).
     """
+
+    # ``ix_journalentry_deleted_at`` is created by migration ``a0b1c2d3e4f5``
+    # (BUG-JOURNAL-007).  Declared here so the model and the migration agree
+    # — ``alembic check`` otherwise reports the index as drift and fails CI.
+    __table_args__ = (Index("ix_journalentry_deleted_at", "deleted_at"),)
 
     id: int | None = Field(default=None, primary_key=True)
     timestamp: datetime = Field(

--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -1,0 +1,116 @@
+"""Long-form ``description`` and ``instructions`` text for the 10 stage presets.
+
+Split from :mod:`seed_practices` so the seeder logic stays small and the
+product-editable copy lives in a flat, diff-friendly data module.
+
+Each entry maps a stage number to a ``(description, instructions)`` tuple.
+Lengths stay under the ``Practice`` model's column caps
+(description ≤ 2000 chars, instructions ≤ 10000 chars).
+"""
+
+from __future__ import annotations
+
+#: Stage 1 — 5-4-3-2-1 sensory grounding (sense_grounding mode).
+_S1 = (
+    "A grounding technique that anchors you in the present by inventorying "
+    "what each sense is reporting right now.",
+    "Sit or stand. For each sense in order, name the listed number of "
+    "specific things you can perceive — out loud or in your head. Move on "
+    "to the next sense only when you've completed the current one. "
+    "Five things you can see, four you can touch, three you can hear, "
+    "two you can smell, one you can taste.",
+)
+
+#: Stage 2 — Tarot meditation on the major arcana (tarot mode).
+_S2 = (
+    "Sit with one card of the Major Arcana per day for five minutes, "
+    "progressing from The Fool to The World over 22 days.",
+    "Find a quiet seat. Bring the card to mind (or place it before you) "
+    "and let the image speak. Do not analyse — observe what arises in "
+    "body, feeling, and thought. The timer is hidden during the meditation "
+    "so you can rest in the image; it reappears at the bell.",
+)
+
+#: Stage 3 — Belly breathing (meditation_timer).
+_S3 = (
+    "Ten minutes of diaphragmatic breathing to settle the nervous system.",
+    "Sit upright with one hand on the belly. Inhale slowly through the "
+    "nose, feeling the hand rise as the diaphragm drops. Exhale through "
+    "pursed lips, twice as long as the inhale if comfortable. Continue "
+    "until the closing bell.",
+)
+
+#: Stage 4 — Metta / loving-kindness (meditation_timer).
+_S4 = (
+    "Fifteen minutes of loving-kindness practice across widening circles.",
+    "Begin with yourself. Silently offer the four phrases — may I be safe, "
+    "may I be happy, may I be healthy, may I live with ease. When the "
+    "halfway bell sounds, widen to someone you love, then to a neutral "
+    "person, then to someone difficult, then to all beings.",
+)
+
+#: Stage 5 — Wim Hof method (meditation_timer).
+_S5 = (
+    "Twenty minutes of cyclic hyperventilation with retention rounds, followed by quiet rest.",
+    "Take 30-40 deep, full breaths in through the nose or mouth, exhaling "
+    "passively. After the final exhale, hold without breath until the "
+    "natural urge returns; then inhale fully and hold for 15 seconds. "
+    "Repeat three rounds, then rest in the stillness that follows.",
+)
+
+#: Stage 6 — Shadow work with metronome (metronome mode).
+_S6 = (
+    "Thirty minutes of shadow-confronting reflection paced by a metronome.",
+    "Set an intention to meet a part of yourself you usually turn away "
+    "from. Let the metronome's tick keep you from drifting into "
+    "rumination — each click is a return to bare attention. When the "
+    "halfway bell sounds, ask what this part wants you to know.",
+)
+
+#: Stage 7 — Blissy meditation (meditation_timer).
+_S7 = (
+    "Forty-five minutes resting in the field of subtle pleasure.",
+    "Sit comfortably. Locate any background sensation of contentment, "
+    "ease, or pleasantness — however faint. Rest attention there, letting "
+    "the feeling broaden by being noticed rather than chased.",
+)
+
+#: Stage 8 — Dog Walkin' Shamanism (count_up).
+_S8 = (
+    "An open-ended walking practice: take the dog (or yourself) out, "
+    "and let the world's signs speak.",
+    "Walk without a destination. Notice what catches your attention — a "
+    "bird, a license plate, a colour, a phrase overheard. Treat each as a "
+    "message worth holding lightly. End when you feel complete; the timer "
+    "counts up to honour the open container.",
+)
+
+#: Stage 9 — Concentration practice (meditation_timer).
+_S9 = (
+    "Forty-five minutes single-pointed attention on one object.",
+    "Choose a single object — breath at the nostrils, a kasina, or a "
+    "phrase. When you notice the mind has wandered, return without "
+    "comment. The halfway bell is your invitation to refresh the choice.",
+)
+
+#: Stage 10 — Insight practice (meditation_timer).
+_S10 = (
+    "Forty-five minutes of open awareness, watching the three characteristics arise and pass.",
+    "Begin grounded in the body. Open the field to whatever is present — "
+    "sensation, sound, thought — and notice how each arises, persists, "
+    "and dissolves. The work is not to control but to see clearly.",
+)
+
+
+PRESET_COPY: dict[int, tuple[str, str]] = {
+    1: _S1,
+    2: _S2,
+    3: _S3,
+    4: _S4,
+    5: _S5,
+    6: _S6,
+    7: _S7,
+    8: _S8,
+    9: _S9,
+    10: _S10,
+}

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -24,6 +24,13 @@ from models.practice import Practice
 from schemas.practice_mode_config import ModeConfigAdapter
 from seed_practice_copy import PRESET_COPY
 
+#: Nominal ``default_duration_minutes`` for the Dog Walkin' Shamanism
+#: preset, which uses ``count_up`` mode and has no real target. The
+#: catalog UI hides the duration tile for ``count_up``; this value is a
+#: non-null fallback so existing list endpoints don't need to
+#: special-case the field.
+_COUNT_UP_NOMINAL_DURATION_MINUTES = 20
+
 
 def _meditation_timer(duration_minutes: float, *, halfway_bell: bool = False) -> dict[str, Any]:
     """Build a meditation_timer ``mode_config`` payload."""
@@ -137,8 +144,7 @@ _PRESET_PRACTICES: list[dict[str, Any]] = [
         "Dog Walkin' Shamanism",
         mode="count_up",
         mode_config={"mode": "count_up", "soft_cap_minutes": None},
-        # Count-up has no target; carry a nominal default for the tile.
-        default_duration_minutes=20,
+        default_duration_minutes=_COUNT_UP_NOMINAL_DURATION_MINUTES,
     ),
     _build_preset(
         9,

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -1,0 +1,198 @@
+"""Seed script for the 10 stage-aligned default :class:`Practice` rows.
+
+Mirrors :mod:`seed_stages` — defines the canonical preset list, validates
+each ``mode_config`` payload at import time so a typo crashes the seeder
+(not the runtime), and inserts only what is missing on a per-call basis.
+
+The match key is ``(stage_number, name)`` so a user-submitted practice with
+the same display name on a different stage does not block a preset from
+being inserted.
+
+``STAGE_TO_PRESET_NAME`` is exported for the frequency-banner endpoint
+(ritual-05) which needs to look up "what's the canonical practice for the
+user's current stage" without re-encoding the table here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models.practice import Practice
+from schemas.practice_mode_config import ModeConfigAdapter
+from seed_practice_copy import PRESET_COPY
+
+
+def _meditation_timer(duration_minutes: float, *, halfway_bell: bool = False) -> dict[str, Any]:
+    """Build a meditation_timer ``mode_config`` payload."""
+    return {
+        "mode": "meditation_timer",
+        "duration_minutes": duration_minutes,
+        "start_bell": True,
+        "halfway_bell": halfway_bell,
+        "end_bell": True,
+    }
+
+
+def _sense_grounding_prompts() -> list[dict[str, str]]:
+    """5-4-3-2-1 prompts in the order the technique prescribes."""
+    return [
+        {"sense": "sight", "label": "Name 5 things you can see"},
+        {"sense": "touch", "label": "Name 4 things you can touch"},
+        {"sense": "hearing", "label": "Name 3 things you can hear"},
+        {"sense": "smell", "label": "Name 2 things you can smell"},
+        {"sense": "taste", "label": "Name 1 thing you can taste"},
+    ]
+
+
+def _build_preset(
+    stage_number: int,
+    name: str,
+    *,
+    mode: str,
+    mode_config: dict[str, Any],
+    default_duration_minutes: float,
+) -> dict[str, Any]:
+    """Compose one preset row, drawing description / instructions from copy."""
+    description, instructions = PRESET_COPY[stage_number]
+    return {
+        "stage_number": stage_number,
+        "name": name,
+        "description": description,
+        "instructions": instructions,
+        "default_duration_minutes": default_duration_minutes,
+        "submitted_by_user_id": None,
+        "approved": True,
+        "mode": mode,
+        "mode_config": mode_config,
+    }
+
+
+_PRESET_PRACTICES: list[dict[str, Any]] = [
+    _build_preset(
+        1,
+        "5-4-3-2-1 grounding",
+        mode="sense_grounding",
+        mode_config={"mode": "sense_grounding", "prompts": _sense_grounding_prompts()},
+        # Sense-grounding has no clock; carry a small nominal value so the
+        # tile shows something sensible until the catalog UI hides it for
+        # this mode.
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        2,
+        "Tarot meditation",
+        mode="tarot",
+        mode_config={
+            "mode": "tarot",
+            "deck": "major_arcana",
+            "per_card_minutes": 5,
+            "hide_timer_during_meditation": True,
+        },
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        3,
+        "Belly breathing",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        4,
+        "Metta",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        5,
+        "Wim Hof method",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(20),
+        default_duration_minutes=20,
+    ),
+    _build_preset(
+        6,
+        "Shadow work",
+        mode="metronome",
+        mode_config={
+            "mode": "metronome",
+            "bpm": 60,
+            "timer": _meditation_timer(30, halfway_bell=True),
+        },
+        default_duration_minutes=30,
+    ),
+    _build_preset(
+        7,
+        "Blissy meditation",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(45),
+        default_duration_minutes=45,
+    ),
+    _build_preset(
+        8,
+        "Dog Walkin' Shamanism",
+        mode="count_up",
+        mode_config={"mode": "count_up", "soft_cap_minutes": None},
+        # Count-up has no target; carry a nominal default for the tile.
+        default_duration_minutes=20,
+    ),
+    _build_preset(
+        9,
+        "Concentration practice",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(45, halfway_bell=True),
+        default_duration_minutes=45,
+    ),
+    _build_preset(
+        10,
+        "Insight practice",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(45),
+        default_duration_minutes=45,
+    ),
+]
+
+
+# Validate every preset's mode_config at import time — a typo here crashes
+# the seeder (a deliberate, immediate failure) rather than poisoning the DB
+# on first startup.
+for _preset in _PRESET_PRACTICES:
+    ModeConfigAdapter.validate_python(_preset["mode_config"])
+
+# Reject duplicate stage_numbers at import time, mirroring seed_stages.py.
+_stage_numbers = [p["stage_number"] for p in _PRESET_PRACTICES]
+if len(set(_stage_numbers)) != len(_stage_numbers):
+    _dupes = sorted(n for n in _stage_numbers if _stage_numbers.count(n) > 1)
+    msg = f"Duplicate stage_number in PRESET_PRACTICES: {_dupes}"
+    raise ValueError(msg)
+
+PRESET_PRACTICES = _PRESET_PRACTICES
+
+#: Lookup table consumed by ritual-05's frequency-banner endpoint.
+STAGE_TO_PRESET_NAME: dict[int, str] = {p["stage_number"]: p["name"] for p in PRESET_PRACTICES}
+
+
+async def seed_practices(session: AsyncSession) -> int:
+    """Insert preset practices that don't already exist by ``(stage, name)``.
+
+    Returns the number of rows inserted. Idempotent: re-running on a
+    populated DB returns 0.
+    """
+    result = await session.execute(select(Practice.stage_number, Practice.name))
+    existing: set[tuple[int, str]] = {(row[0], row[1]) for row in result.all()}
+
+    inserted = 0
+    for definition in PRESET_PRACTICES:
+        key = (definition["stage_number"], definition["name"])
+        if key in existing:
+            continue
+        session.add(Practice(**definition))
+        inserted += 1
+
+    if inserted:
+        await session.commit()
+    return inserted

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -11,14 +11,21 @@ being inserted.
 ``STAGE_TO_PRESET_NAME`` is exported for the frequency-banner endpoint
 (ritual-05) which needs to look up "what's the canonical practice for the
 user's current stage" without re-encoding the table here.
+
+Call :func:`seed_stages.seed_stages` before this seeder so a ``CourseStage``
+row exists for each preset's ``stage_number``. There's no FK from
+``Practice.stage_number`` to ``CourseStage.stage_number`` so the seeder
+won't crash without it, but downstream readers (e.g. the frequency-banner
+endpoint) assume both tables are populated.
 """
 
 from __future__ import annotations
 
+from types import MappingProxyType
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import col, select
 
 from models.practice import Practice
 from schemas.practice_mode_config import ModeConfigAdapter
@@ -176,19 +183,32 @@ if len(set(_stage_numbers)) != len(_stage_numbers):
     msg = f"Duplicate stage_number in PRESET_PRACTICES: {_dupes}"
     raise ValueError(msg)
 
-PRESET_PRACTICES = _PRESET_PRACTICES
+#: Immutable view of the preset definitions. Tuple (not list) so callers
+#: can't accidentally ``.append()`` or ``.clear()`` and silently de-sync
+#: :data:`STAGE_TO_PRESET_NAME`.
+PRESET_PRACTICES: tuple[dict[str, Any], ...] = tuple(_PRESET_PRACTICES)
 
-#: Lookup table consumed by ritual-05's frequency-banner endpoint.
-STAGE_TO_PRESET_NAME: dict[int, str] = {p["stage_number"]: p["name"] for p in PRESET_PRACTICES}
+#: Read-only lookup consumed by ritual-05's frequency-banner endpoint.
+#: ``MappingProxyType`` forbids mutation so the table can't drift from
+#: :data:`PRESET_PRACTICES` after import.
+STAGE_TO_PRESET_NAME: MappingProxyType[int, str] = MappingProxyType(
+    {p["stage_number"]: p["name"] for p in PRESET_PRACTICES}
+)
 
 
 async def seed_practices(session: AsyncSession) -> int:
     """Insert preset practices that don't already exist by ``(stage, name)``.
 
     Returns the number of rows inserted. Idempotent: re-running on a
-    populated DB returns 0.
+    populated DB returns 0. The existence query filters on
+    ``submitted_by_user_id IS NULL`` so user submissions can't shadow a
+    preset by colliding on ``(stage_number, name)``.
     """
-    result = await session.execute(select(Practice.stage_number, Practice.name))
+    result = await session.execute(
+        select(Practice.stage_number, Practice.name).where(
+            col(Practice.submitted_by_user_id).is_(None)
+        )
+    )
     existing: set[tuple[int, str]] = {(row[0], row[1]) for row in result.all()}
 
     inserted = 0

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -1,0 +1,146 @@
+"""Tests for the practice preset seeder."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models.practice import Practice
+from schemas.practice_mode_config import (
+    MetronomeConfig,
+    ModeConfigAdapter,
+    SenseGroundingConfig,
+)
+from seed_practices import (
+    PRESET_PRACTICES,
+    STAGE_TO_PRESET_NAME,
+    seed_practices,
+)
+from seed_stages import STAGE_DEFINITIONS
+
+_EXPECTED_PRESET_COUNT = 10
+_SENSE_ORDER: tuple[tuple[str, int], ...] = (
+    ("sight", 5),
+    ("touch", 4),
+    ("hearing", 3),
+    ("smell", 2),
+    ("taste", 1),
+)
+
+
+# -- Seeder behaviour -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seed_practices_inserts_all(db_session: AsyncSession) -> None:
+    """Empty DB → all 10 presets are inserted; the function returns 10."""
+    inserted = await seed_practices(db_session)
+    assert inserted == _EXPECTED_PRESET_COUNT
+
+    rows = (await db_session.execute(select(Practice))).scalars().all()
+    assert len(rows) == _EXPECTED_PRESET_COUNT
+
+
+@pytest.mark.asyncio
+async def test_seed_practices_idempotent(db_session: AsyncSession) -> None:
+    """Re-running on a populated DB inserts nothing and returns 0."""
+    first = await seed_practices(db_session)
+    second = await seed_practices(db_session)
+    assert first == _EXPECTED_PRESET_COUNT
+    assert second == 0
+
+    rows = (await db_session.execute(select(Practice))).scalars().all()
+    assert len(rows) == _EXPECTED_PRESET_COUNT
+
+
+@pytest.mark.asyncio
+async def test_seed_practices_does_not_collide_with_user_named_practice(
+    db_session: AsyncSession,
+) -> None:
+    """User row with a colliding name on a different stage doesn't block seeder.
+
+    The seeder's match key is ``(stage_number, name)``, not ``name`` alone,
+    so a user-submitted practice on stage 999 with the same display name
+    as the stage 1 preset must not suppress the stage 1 insert.
+    """
+    fake = Practice(
+        stage_number=999,  # outside the canonical 1..10 range
+        name=PRESET_PRACTICES[0]["name"],
+        description="user submission",
+        instructions="user instructions",
+        default_duration_minutes=5,
+        approved=True,
+        mode="meditation_timer",
+        mode_config={
+            "mode": "meditation_timer",
+            "duration_minutes": 5,
+            "start_bell": True,
+            "halfway_bell": False,
+            "end_bell": True,
+        },
+    )
+    db_session.add(fake)
+    await db_session.commit()
+
+    inserted = await seed_practices(db_session)
+    assert inserted == _EXPECTED_PRESET_COUNT
+
+
+# -- Preset data validation -------------------------------------------------
+
+
+def test_preset_practices_count_matches_stage_total() -> None:
+    """One preset per CourseStage row, exactly."""
+    assert len(PRESET_PRACTICES) == len(STAGE_DEFINITIONS) == _EXPECTED_PRESET_COUNT
+
+
+def test_preset_practices_cover_each_stage_once() -> None:
+    """Stage numbers 1..10 appear exactly once across the preset list."""
+    seen = sorted(p["stage_number"] for p in PRESET_PRACTICES)
+    assert seen == list(range(1, _EXPECTED_PRESET_COUNT + 1))
+
+
+def test_every_preset_mode_config_is_valid() -> None:
+    """Each preset round-trips through the ModeConfig discriminated union."""
+    for preset in PRESET_PRACTICES:
+        cfg_payload = {**preset["mode_config"]}
+        cfg = ModeConfigAdapter.validate_python(cfg_payload)
+        assert cfg.mode == preset["mode"], (
+            f"stage {preset['stage_number']}: parent mode {preset['mode']} "
+            f"!= mode_config.mode {cfg.mode}"
+        )
+
+
+def test_every_preset_is_approved_and_unsubmitted() -> None:
+    """Presets are catalog rows, not user submissions."""
+    for preset in PRESET_PRACTICES:
+        assert preset["approved"] is True
+        assert preset["submitted_by_user_id"] is None
+
+
+# -- Per-mode spec checks ---------------------------------------------------
+
+
+def test_sense_grounding_preset_has_5_4_3_2_1_prompts() -> None:
+    """Stage 1's preset implements the 5-4-3-2-1 grounding technique."""
+    preset = next(p for p in PRESET_PRACTICES if p["stage_number"] == 1)
+    cfg = SenseGroundingConfig.model_validate(preset["mode_config"])
+    senses = [(p.sense, int(p.label.split()[1])) for p in cfg.prompts]
+    assert senses == list(_SENSE_ORDER), (
+        f"Expected 5-sight → 4-touch → 3-hearing → 2-smell → 1-taste; got {senses}"
+    )
+
+
+def test_shadow_work_preset_uses_valid_metronome_config() -> None:
+    """Stage 6's preset is the metronome practice with a 30-minute window."""
+    preset = next(p for p in PRESET_PRACTICES if p["stage_number"] == 6)
+    cfg = MetronomeConfig.model_validate(preset["mode_config"])
+    assert 20 <= cfg.bpm <= 240
+    assert cfg.timer.duration_minutes > 0
+
+
+def test_stage_to_preset_name_map_matches_preset_list() -> None:
+    """``STAGE_TO_PRESET_NAME`` is the source of truth ritual-05 imports."""
+    expected = {p["stage_number"]: p["name"] for p in PRESET_PRACTICES}
+    assert expected == STAGE_TO_PRESET_NAME

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -123,13 +123,23 @@ def test_every_preset_is_approved_and_unsubmitted() -> None:
 
 
 def test_sense_grounding_preset_has_5_4_3_2_1_prompts() -> None:
-    """Stage 1's preset implements the 5-4-3-2-1 grounding technique."""
+    """Stage 1's preset implements the 5-4-3-2-1 grounding technique.
+
+    Checks the sense order and the per-sense count independently so a
+    label-copy change (e.g. "Name 5 …" → "Identify five …") fails on a
+    clear assertion rather than a silent ``ValueError`` from ``int()``.
+    """
     preset = next(p for p in PRESET_PRACTICES if p["stage_number"] == 1)
     cfg = SenseGroundingConfig.model_validate(preset["mode_config"])
-    senses = [(p.sense, int(p.label.split()[1])) for p in cfg.prompts]
-    assert senses == list(_SENSE_ORDER), (
-        f"Expected 5-sight → 4-touch → 3-hearing → 2-smell → 1-taste; got {senses}"
-    )
+
+    expected_senses = [sense for sense, _ in _SENSE_ORDER]
+    expected_counts = [count for _, count in _SENSE_ORDER]
+    assert [p.sense for p in cfg.prompts] == expected_senses
+    # Counts are still parsed from the label so a copy change that drops
+    # the count (e.g. "Things you can see") fails loudly; the assertion
+    # above protects the sense order even if the label parse fails.
+    actual_counts = [int(p.label.split()[1]) for p in cfg.prompts]
+    assert actual_counts == expected_counts
 
 
 def test_shadow_work_preset_uses_valid_metronome_config() -> None:

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -20,6 +20,11 @@ from seed_practices import (
 from seed_stages import STAGE_DEFINITIONS
 
 _EXPECTED_PRESET_COUNT = 10
+#: Stage number outside the canonical 1..10 range. Used by the
+#: name-collision test to plant a user submission that the seeder must
+#: ignore — the bare ``Practice`` model has no FK or range check on
+#: ``stage_number``, so any out-of-range integer works.
+_OUT_OF_RANGE_STAGE = 999
 _SENSE_ORDER: tuple[tuple[str, int], ...] = (
     ("sight", 5),
     ("touch", 4),
@@ -65,7 +70,7 @@ async def test_seed_practices_does_not_collide_with_user_named_practice(
     as the stage 1 preset must not suppress the stage 1 insert.
     """
     fake = Practice(
-        stage_number=999,  # outside the canonical 1..10 range
+        stage_number=_OUT_OF_RANGE_STAGE,
         name=PRESET_PRACTICES[0]["name"],
         description="user submission",
         instructions="user instructions",

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -125,29 +125,36 @@ def test_every_preset_is_approved_and_unsubmitted() -> None:
 def test_sense_grounding_preset_has_5_4_3_2_1_prompts() -> None:
     """Stage 1's preset implements the 5-4-3-2-1 grounding technique.
 
-    Checks the sense order and the per-sense count independently so a
-    label-copy change (e.g. "Name 5 …" → "Identify five …") fails on a
-    clear assertion rather than a silent ``ValueError`` from ``int()``.
+    Asserts the sense order from ``_SENSE_ORDER`` and that each label
+    contains the expected count token. Pure substring check (no
+    ``int()`` parse) so a wording drift fails on a clear assertion
+    rather than a silent ``ValueError``.
     """
     preset = next(p for p in PRESET_PRACTICES if p["stage_number"] == 1)
     cfg = SenseGroundingConfig.model_validate(preset["mode_config"])
 
-    expected_senses = [sense for sense, _ in _SENSE_ORDER]
-    expected_counts = [count for _, count in _SENSE_ORDER]
-    assert [p.sense for p in cfg.prompts] == expected_senses
-    # Counts are still parsed from the label so a copy change that drops
-    # the count (e.g. "Things you can see") fails loudly; the assertion
-    # above protects the sense order even if the label parse fails.
-    actual_counts = [int(p.label.split()[1]) for p in cfg.prompts]
-    assert actual_counts == expected_counts
+    assert [p.sense for p in cfg.prompts] == [sense for sense, _ in _SENSE_ORDER]
+    for prompt, (_, expected_count) in zip(cfg.prompts, _SENSE_ORDER, strict=True):
+        # Match " <count> " (surrounded by whitespace) so "10" wouldn't
+        # accidentally satisfy a check for "1".
+        assert f" {expected_count} " in f" {prompt.label} ", (
+            f"prompt {prompt.label!r} is missing the expected count {expected_count}"
+        )
 
 
-def test_shadow_work_preset_uses_valid_metronome_config() -> None:
-    """Stage 6's preset is the metronome practice with a 30-minute window."""
+def test_shadow_work_preset_uses_exact_metronome_config() -> None:
+    """Stage 6's preset pins the metronome BPM, duration, and halfway bell.
+
+    Exact-value assertions (not range checks) so a mutation that bumps
+    BPM 60→200 or duration 30→1 fails loudly — the schema-range checks
+    in ``test_every_preset_mode_config_is_valid`` already cover the
+    "within bounds" property.
+    """
     preset = next(p for p in PRESET_PRACTICES if p["stage_number"] == 6)
     cfg = MetronomeConfig.model_validate(preset["mode_config"])
-    assert 20 <= cfg.bpm <= 240
-    assert cfg.timer.duration_minutes > 0
+    assert cfg.bpm == 60
+    assert cfg.timer.duration_minutes == 30
+    assert cfg.timer.halfway_bell is True
 
 
 def test_stage_to_preset_name_map_matches_preset_list() -> None:


### PR DESCRIPTION
## Summary

ritual-02: seeds the 10 stage-aligned default `Practice` rows that the
Practice screen surfaces. Idempotent; matches on `(stage_number, name)`
so a user-submitted practice with a colliding display name on a
different stage never blocks a preset from being inserted.

## What landed

**`backend/src/seed_practices.py`** — `PRESET_PRACTICES` list (one per
`CourseStage`), `seed_practices(session)` async helper that mirrors
`seed_stages`, and `STAGE_TO_PRESET_NAME` lookup that ritual-05 (the
frequency-banner endpoint) will consume.

**`backend/src/seed_practice_copy.py`** — long-form
`description`/`instructions` text per stage, split out so the seeder
logic stays small and product-editable copy stays diff-friendly.

**Stage map** (matches the ritual-practice epic README):

| Stage | Preset | Mode | Default duration |
|-------|--------|------|-----------------|
| 1 | 5-4-3-2-1 grounding | `sense_grounding` | 5 prompts |
| 2 | Tarot meditation | `tarot` | 5 min/card |
| 3 | Belly breathing | `meditation_timer` | 10 min |
| 4 | Metta | `meditation_timer` | 15 min |
| 5 | Wim Hof method | `meditation_timer` | 20 min |
| 6 | Shadow work | `metronome` (60 BPM) | 30 min |
| 7 | Blissy meditation | `meditation_timer` | 45 min |
| 8 | Dog Walkin' Shamanism | `count_up` | open-ended |
| 9 | Concentration practice | `meditation_timer` | 45 min |
| 10 | Insight practice | `meditation_timer` | 45 min |

**Import-time guards.** Every preset's `mode_config` is validated
through `ModeConfigAdapter` at module load — a typo crashes the seeder
immediately rather than poisoning the DB on first startup.

## Tests (10 new)

- `seed_practices` inserts all 10 presets on an empty DB and returns 10
- Re-running on a populated DB inserts 0 (idempotent)
- A user-submitted practice on stage 999 with the same display name as
  the stage-1 preset doesn't block the seeder
- Preset count matches `CourseStage` row count
- Every stage 1..10 appears exactly once
- Every preset's `mode_config` round-trips through `ModeConfig`
- Every preset is `approved=True` and has no `submitted_by_user_id`
- Sense-grounding preset has prompts in 5-4-3-2-1 order
- Metronome preset's BPM ∈ [20, 240] and embedded timer duration > 0
- `STAGE_TO_PRESET_NAME` matches `PRESET_PRACTICES`

## Auto-wiring

The seeder is **not** auto-invoked at startup — same pattern as the
existing `seed_stages` and `seed_content`, both of which are defined
but called manually by tests/admin tooling. If we want fresh-DB
auto-seeding it can land as a small follow-up.

## Out of scope

- ritual-05 imports `STAGE_TO_PRESET_NAME` (already exported here);
  that PR will wire the frequency-banner endpoint to the lookup.

https://claude.ai/code/session_015RtJLZGkcgdHms5z1qfPkw

---
_Generated by [Claude Code](https://claude.ai/code/session_015RtJLZGkcgdHms5z1qfPkw)_