### PR TITLE
feat(habits): add additive/subtractive direction toggle to goal editor

### DIFF
--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -650,6 +650,84 @@ const GoalUnitEditor = ({ goals, habitId, onUpdateGoal }: GoalUnitEditorProps) =
   );
 };
 
+const DIRECTION_OPTIONS = [
+  { value: true, label: 'Add up', testID: 'goal-direction-additive' },
+  { value: false, label: 'Cut back', testID: 'goal-direction-subtractive' },
+] as const;
+
+interface GoalDirectionRowProps {
+  isAdditive: boolean;
+  onChange: (_v: boolean) => void;
+}
+
+/**
+ * Toggle between additive ("Add up": progress fills as you log) and
+ * subtractive ("Cut back": bar starts full and each log eats into it).
+ * Rendered as a radio-style chip pair so VoiceOver/TalkBack announce
+ * selection the same way the unit + frequency chips do.
+ */
+const GoalDirectionRow = ({ isAdditive, onChange }: GoalDirectionRowProps) => (
+  <View style={goalEditorStyles.row} testID="goal-direction-row">
+    <Text style={goalEditorStyles.fieldLabel}>Type</Text>
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={goalEditorStyles.chipRow}
+      testID="goal-direction-chips"
+    >
+      {DIRECTION_OPTIONS.map((opt) => {
+        const selected = opt.value === isAdditive;
+        return (
+          <TouchableOpacity
+            key={opt.testID}
+            testID={opt.testID}
+            onPress={() => onChange(opt.value)}
+            style={[goalEditorStyles.chip, selected && goalEditorStyles.chipSelected]}
+            accessibilityRole="radio"
+            accessibilityLabel={opt.label}
+            accessibilityState={{ checked: selected }}
+          >
+            <Text
+              style={[goalEditorStyles.chipText, selected && goalEditorStyles.chipTextSelected]}
+            >
+              {opt.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </ScrollView>
+  </View>
+);
+
+/**
+ * Flip a habit between additive and subtractive direction.
+ *
+ * Re-orders the existing tier targets so monotonicity matches the new
+ * direction (additive: low<clear<stretch; subtractive: low>clear>stretch),
+ * then fan-outs one PUT per tier in ascending **new-target** order. That
+ * ordering keeps the clamp in ``normalizeGoalTiers`` a no-op for every PUT
+ * — without it, the half-flipped intermediate states would re-clamp targets
+ * and the largest tier (e.g. ``low`` in subtractive) would land at the
+ * smallest value of the previous direction.
+ *
+ * Tier-to-new-target mapping inverts when the direction flips:
+ *   additive    → smallest new target goes to ``low`` (easiest tier).
+ *   subtractive → smallest new target goes to ``stretch`` (strictest cap).
+ */
+const buildDirectionChangePayloads = (goals: readonly Goal[], newIsAdditive: boolean): Goal[] => {
+  const ascendingTargets = goals.map((g) => g.target).sort((a, b) => a - b);
+  const tiersByAscendingNewTarget = newIsAdditive
+    ? (['low', 'clear', 'stretch'] as const)
+    : (['stretch', 'clear', 'low'] as const);
+  return tiersByAscendingNewTarget
+    .map((tier, i) => {
+      const goal = goals.find((g) => g.tier === tier);
+      if (!goal) return null;
+      return { ...goal, is_additive: newIsAdditive, target: ascendingTargets[i]! };
+    })
+    .filter((g): g is Goal => g !== null);
+};
+
 interface GoalTargetEditorProps {
   habit: NonNullable<GoalModalProps['habit']>;
   onUpdateGoal: GoalModalProps['onUpdateGoal'];
@@ -674,9 +752,18 @@ const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
   const [head, ...tail] = orderedGoals;
   if (head === undefined) return null;
   const nonEmptyGoals: NonEmptyGoals = [head, ...tail];
+
+  const handleDirectionChange = (newIsAdditive: boolean) => {
+    if (nonEmptyGoals.every((g) => g.is_additive === newIsAdditive)) return;
+    for (const payload of buildDirectionChangePayloads(nonEmptyGoals, newIsAdditive)) {
+      onUpdateGoal(habitId, payload);
+    }
+  };
+
   return (
     <View style={goalEditorStyles.container} testID="goal-target-editor">
       <Text style={goalEditorStyles.sectionTitle}>Goals</Text>
+      <GoalDirectionRow isAdditive={head.is_additive} onChange={handleDirectionChange} />
       {nonEmptyGoals.map((goal) => (
         <GoalTargetRow
           key={goal.id ?? goal.tier}

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -660,12 +660,6 @@ interface GoalDirectionRowProps {
   onChange: (_v: boolean) => void;
 }
 
-/**
- * Toggle between additive ("Add up": progress fills as you log) and
- * subtractive ("Cut back": bar starts full and each log eats into it).
- * Rendered as a radio-style chip pair so VoiceOver/TalkBack announce
- * selection the same way the unit + frequency chips do.
- */
 const GoalDirectionRow = ({ isAdditive, onChange }: GoalDirectionRowProps) => (
   <View style={goalEditorStyles.row} testID="goal-direction-row">
     <Text style={goalEditorStyles.fieldLabel}>Type</Text>
@@ -679,7 +673,7 @@ const GoalDirectionRow = ({ isAdditive, onChange }: GoalDirectionRowProps) => (
         const selected = opt.value === isAdditive;
         return (
           <TouchableOpacity
-            key={opt.testID}
+            key={opt.label}
             testID={opt.testID}
             onPress={() => onChange(opt.value)}
             style={[goalEditorStyles.chip, selected && goalEditorStyles.chipSelected]}
@@ -699,21 +693,7 @@ const GoalDirectionRow = ({ isAdditive, onChange }: GoalDirectionRowProps) => (
   </View>
 );
 
-/**
- * Flip a habit between additive and subtractive direction.
- *
- * Re-orders the existing tier targets so monotonicity matches the new
- * direction (additive: low<clear<stretch; subtractive: low>clear>stretch),
- * then fan-outs one PUT per tier in ascending **new-target** order. That
- * ordering keeps the clamp in ``normalizeGoalTiers`` a no-op for every PUT
- * — without it, the half-flipped intermediate states would re-clamp targets
- * and the largest tier (e.g. ``low`` in subtractive) would land at the
- * smallest value of the previous direction.
- *
- * Tier-to-new-target mapping inverts when the direction flips:
- *   additive    → smallest new target goes to ``low`` (easiest tier).
- *   subtractive → smallest new target goes to ``stretch`` (strictest cap).
- */
+// Emit PUTs in ascending new-target order so each normalizeGoalTiers clamp is a no-op.
 const buildDirectionChangePayloads = (goals: readonly Goal[], newIsAdditive: boolean): Goal[] => {
   const ascendingTargets = goals.map((g) => g.target).sort((a, b) => a - b);
   const tiersByAscendingNewTarget = newIsAdditive

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -198,6 +198,103 @@ describe('GoalModal unit + frequency editor', () => {
   });
 });
 
+describe('GoalModal direction toggle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders an Add up / Cut back chip pair reflecting the habit direction', () => {
+    const { getByTestId } = renderModal();
+    const additive = getByTestId('goal-direction-additive');
+    const subtractive = getByTestId('goal-direction-subtractive');
+    expect(additive.props.accessibilityRole).toBe('radio');
+    expect(additive.props.accessibilityState).toEqual({ checked: true });
+    expect(subtractive.props.accessibilityState).toEqual({ checked: false });
+  });
+
+  it('marks the subtractive chip checked when the habit is subtractive', () => {
+    const subtractiveHabit = makeHabit({
+      goals: [
+        makeGoal('low', { target: 25, is_additive: false }),
+        makeGoal('clear', { target: 6, is_additive: false }),
+        makeGoal('stretch', { target: 0, is_additive: false }),
+      ],
+    });
+    const { getByTestId } = renderModal(subtractiveHabit);
+    expect(getByTestId('goal-direction-additive').props.accessibilityState).toEqual({
+      checked: false,
+    });
+    expect(getByTestId('goal-direction-subtractive').props.accessibilityState).toEqual({
+      checked: true,
+    });
+  });
+
+  it('flips all three tiers when switching from additive to subtractive and inverts target order', () => {
+    // Habit starts additive with low=1, clear=2, stretch=3. Switching to
+    // subtractive ("Cut back") should send PUTs for all three tiers with
+    // is_additive=false and the targets inverted so ``low`` (the most
+    // lenient limit) gets the largest target and ``stretch`` (the strictest
+    // cap) gets the smallest. PUTs fan out in ascending-new-target order so
+    // each clamp in ``normalizeGoalTiers`` is a no-op.
+    const { getByTestId, props } = renderModal();
+    fireEvent.press(getByTestId('goal-direction-subtractive'));
+
+    expect(props.onUpdateGoal).toHaveBeenCalledTimes(3);
+    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
+      1,
+      42,
+      expect.objectContaining({ tier: 'stretch', target: 1, is_additive: false }),
+    );
+    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
+      2,
+      42,
+      expect.objectContaining({ tier: 'clear', target: 2, is_additive: false }),
+    );
+    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
+      3,
+      42,
+      expect.objectContaining({ tier: 'low', target: 3, is_additive: false }),
+    );
+  });
+
+  it('flips back to additive and restores ascending target order', () => {
+    const subtractiveHabit = makeHabit({
+      goals: [
+        makeGoal('low', { target: 25, is_additive: false }),
+        makeGoal('clear', { target: 6, is_additive: false }),
+        makeGoal('stretch', { target: 0, is_additive: false }),
+      ],
+    });
+    const { getByTestId, props } = renderModal(subtractiveHabit);
+    fireEvent.press(getByTestId('goal-direction-additive'));
+
+    expect(props.onUpdateGoal).toHaveBeenCalledTimes(3);
+    // Smallest new target first so each PUT's clamp is a no-op against the
+    // already-additive suffix. For additive, ``low`` takes the smallest.
+    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
+      1,
+      42,
+      expect.objectContaining({ tier: 'low', target: 0, is_additive: true }),
+    );
+    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
+      2,
+      42,
+      expect.objectContaining({ tier: 'clear', target: 6, is_additive: true }),
+    );
+    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
+      3,
+      42,
+      expect.objectContaining({ tier: 'stretch', target: 25, is_additive: true }),
+    );
+  });
+
+  it('does nothing when the user taps the chip already selected', () => {
+    const { getByTestId, props } = renderModal();
+    fireEvent.press(getByTestId('goal-direction-additive'));
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
+  });
+});
+
 describe('GoalModal editor visibility guards', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -359,6 +359,33 @@ describe('habitManager', () => {
       );
     });
 
+    it('propagates is_additive to sibling tiers so a direction flip lands atomically', () => {
+      // Updating ``low`` alone with ``is_additive=false`` must also flip
+      // clear + stretch locally — otherwise ``normalizeGoalTiers`` would key
+      // off ``low.is_additive`` and run the wrong clamp on subsequent fan-out
+      // PUTs, leaving the store in a half-additive / half-subtractive state.
+      useHabitStore.setState({ habits: [makeHabit()] });
+
+      const flippedLow: Goal = {
+        id: 1,
+        title: 'Low',
+        tier: 'low',
+        target: 1,
+        target_unit: 'units',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      };
+
+      habitManager.updateGoal(1, flippedLow);
+
+      const { goals } = useHabitStore.getState().habits[0]!;
+      for (const tier of ['low', 'clear', 'stretch'] as const) {
+        const goal = goals.find((g) => g.tier === tier)!;
+        expect(goal.is_additive).toBe(false);
+      }
+    });
+
     it('skips the network call for synthetic goals with no id', async () => {
       useHabitStore.setState({ habits: [makeHabit()] });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -120,12 +120,23 @@ const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.list>>): Ha
     sort_order: h.sort_order ?? null,
   }));
 
+// ``is_additive`` is propagated alongside unit/frequency because it is a
+// habit-level property stored per-goal: flipping the direction on one tier
+// without the others leaves the store in an inconsistent half-additive,
+// half-subtractive state that ``normalizeGoalTiers`` can't clamp correctly
+// (the clamp keys off ``low.is_additive``).
 const normalizeGoalUnits = (goals: Goal[], updatedGoal: Goal): void => {
-  const { target_unit: unit, frequency: freq, frequency_unit: freqUnit } = updatedGoal;
+  const {
+    target_unit: unit,
+    frequency: freq,
+    frequency_unit: freqUnit,
+    is_additive: additive,
+  } = updatedGoal;
   for (const g of goals) {
     g.target_unit = unit;
     g.frequency = freq;
     g.frequency_unit = freqUnit;
+    g.is_additive = additive;
   }
 };
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -120,11 +120,7 @@ const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.list>>): Ha
     sort_order: h.sort_order ?? null,
   }));
 
-// ``is_additive`` is propagated alongside unit/frequency because it is a
-// habit-level property stored per-goal: flipping the direction on one tier
-// without the others leaves the store in an inconsistent half-additive,
-// half-subtractive state that ``normalizeGoalTiers`` can't clamp correctly
-// (the clamp keys off ``low.is_additive``).
+// is_additive is propagated so single-tier flips can't leave the store half-additive (normalizeGoalTiers keys off low.is_additive).
 const normalizeGoalUnits = (goals: Goal[], updatedGoal: Goal): void => {
   const {
     target_unit: unit,


### PR DESCRIPTION
## Summary
- Adds an "Add up / Cut back" chip pair to the inline goal editor in `GoalModal` so users can flip a habit between additive (do more) and subtractive (stay under a limit). The data model and progress math already supported `is_additive` end-to-end; this closes the UI gap that left users unable to create a "No sugar"-style habit from scratch.
- Flipping fans out one `PUT /goals/{id}` per tier with the new `is_additive` and the existing targets re-ordered for the new direction (`low` gets the largest target for subtractive — most lenient cap — and the smallest for additive). PUTs go out in ascending-new-target order so each clamp in `normalizeGoalTiers` is a no-op.
- Extends `normalizeGoalUnits` to also propagate `is_additive` alongside unit/frequency so a single tier's PUT lands the direction flip atomically in the local store, preventing half-flipped clamp drift on subsequent fan-out PUTs.
- "Begins the day full" works automatically: when `completions=[]`, `getSubtractiveProgressPct` returns 100 for any `totalProgress ≤ stretchTarget`. Bar starts full and each log subtracts.

## Test plan
- [x] `npx jest` — all 843 frontend tests pass (4 new in `GoalModal.test.tsx`, 1 new in `habitManager.test.ts`).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `pre-commit run --files` on the four touched files — every applicable gate passes.
- [ ] Manual smoke on a real habit: create habit → open GoalModal → tap "Cut back" → confirm low/clear/stretch markers invert, targets swap, and logging a unit reduces the bar.

https://claude.ai/code/session_01N49whJCR4xJyfSbyQqwDG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01N49whJCR4xJyfSbyQqwDG1)_