### PR TITLE
fix(frontend): reorder date picker visibility + master program anchor

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@
 import type { LinkingOptions, NavigatorScreenParams } from '@react-navigation/native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   ActivityIndicator,
   Appearance,
@@ -34,6 +34,8 @@ import SignupScreen from './features/Auth/SignupScreen';
 import type { RootTabParamList } from './navigation/BottomTabs';
 import type { RootStackParamList } from './navigation/RootStack';
 import RootStack from './navigation/RootStack';
+import { loadProgramStartDate } from './storage/programStorage';
+import { useProgramStore } from './store/useProgramStore';
 
 type AuthStackParamList = {
   Login: undefined;
@@ -181,6 +183,39 @@ function ThemedStatusBar(): React.JSX.Element {
   return <StatusBar barStyle={scheme === 'dark' ? 'light-content' : 'dark-content'} />;
 }
 
+/**
+ * Hydrate the program-anchor master date from AsyncStorage on cold start
+ * so the very first render of the Map / Practice / Course / Journal
+ * banner uses the correct date-derived stage and week.  Skipping this
+ * effect would briefly flash the server's count-based fallback before
+ * the user's anchor loads -- a noticeable UI glitch on slow devices.
+ */
+function useProgramAnchorHydration(): void {
+  const hydrate = useProgramStore((s) => s.hydrateProgramStartDate);
+  useEffect(() => {
+    let cancelled = false;
+    void loadProgramStartDate().then((date) => {
+      if (!cancelled) hydrate(date);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [hydrate]);
+}
+
+function AppShell(): React.JSX.Element {
+  useProgramAnchorHydration();
+  return (
+    <NavigationContainer linking={linking}>
+      <SafeAreaView style={styles.safeArea}>
+        <ThemedStatusBar />
+        <OfflineBanner />
+        <RootNavigator />
+      </SafeAreaView>
+    </NavigationContainer>
+  );
+}
+
 export default function App(): React.JSX.Element {
   if (CONFIG_ERROR) {
     return <ConfigErrorScreen message={CONFIG_ERROR} />;
@@ -192,13 +227,7 @@ export default function App(): React.JSX.Element {
           <AuthProvider>
             <ApiKeyProvider>
               <ToastProvider>
-                <NavigationContainer linking={linking}>
-                  <SafeAreaView style={styles.safeArea}>
-                    <ThemedStatusBar />
-                    <OfflineBanner />
-                    <RootNavigator />
-                  </SafeAreaView>
-                </NavigationContainer>
+                <AppShell />
               </ToastProvider>
             </ApiKeyProvider>
           </AuthProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@
 import type { LinkingOptions, NavigatorScreenParams } from '@react-navigation/native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   ActivityIndicator,
   Appearance,
@@ -34,8 +34,7 @@ import SignupScreen from './features/Auth/SignupScreen';
 import type { RootTabParamList } from './navigation/BottomTabs';
 import type { RootStackParamList } from './navigation/RootStack';
 import RootStack from './navigation/RootStack';
-import { loadProgramStartDate } from './storage/programStorage';
-import { useProgramStore } from './store/useProgramStore';
+import { useHydrateProgramStore } from './store/useProgramStore';
 
 type AuthStackParamList = {
   Login: undefined;
@@ -183,28 +182,8 @@ function ThemedStatusBar(): React.JSX.Element {
   return <StatusBar barStyle={scheme === 'dark' ? 'light-content' : 'dark-content'} />;
 }
 
-/**
- * Hydrate the program-anchor master date from AsyncStorage on cold start
- * so the very first render of the Map / Practice / Course / Journal
- * banner uses the correct date-derived stage and week.  Skipping this
- * effect would briefly flash the server's count-based fallback before
- * the user's anchor loads -- a noticeable UI glitch on slow devices.
- */
-function useProgramAnchorHydration(): void {
-  const hydrate = useProgramStore((s) => s.hydrateProgramStartDate);
-  useEffect(() => {
-    let cancelled = false;
-    void loadProgramStartDate().then((date) => {
-      if (!cancelled) hydrate(date);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [hydrate]);
-}
-
 function AppShell(): React.JSX.Element {
-  useProgramAnchorHydration();
+  useHydrateProgramStore();
   return (
     <NavigationContainer linking={linking}>
       <SafeAreaView style={styles.safeArea}>

--- a/frontend/src/constants/program.ts
+++ b/frontend/src/constants/program.ts
@@ -1,0 +1,2 @@
+// Days per APTITUDE stage: 8x21-day stages + 2x42-day stages = 36 weeks total.
+export const STAGE_DURATIONS_DAYS = [21, 21, 21, 21, 21, 21, 21, 21, 42, 42] as const;

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../api';
 import { STAGE_COLORS, colors } from '../../design/tokens';
 import { useAppNavigation, useAppRoute } from '../../navigation/hooks';
+import { useProgramStore, programStage } from '../../store/useProgramStore';
 import { deriveCurrentStage } from '../Map/services/stageService';
 
 import ContentCard from './ContentCard';
@@ -25,6 +26,7 @@ const DEFAULT_STAGE_NUMBER = 1;
 function useStagesLoader() {
   const route = useAppRoute<'Course'>();
   const routeStageNumber = route.params?.stageNumber ?? null;
+  const programAnchor = useProgramStore((s) => s.programStartDate);
 
   const [allStages, setAllStages] = useState<Stage[]>([]);
   const [selectedStage, setSelectedStage] = useState(routeStageNumber ?? DEFAULT_STAGE_NUMBER);
@@ -36,12 +38,14 @@ function useStagesLoader() {
       try {
         const stagesList = await stagesApi.list();
         setAllStages(stagesList);
-        // Derive current stage from server-owned progression
-        // (completed_count + 1), not from "max unlocked" — the latter lifts
-        // the selector to stage N when only `is_unlocked` is ahead,
-        // visually rewarding any skip-ahead attempt.
         if (routeStageNumber === null) {
-          setSelectedStage(deriveCurrentStage(stagesList));
+          // Master date wins when the user has picked an anchor; otherwise
+          // fall back to the server-owned, count-based progression
+          // (``completed_count + 1``) — "max unlocked" would visually
+          // reward skip-ahead attempts whenever ``is_unlocked`` ran
+          // ahead of completion.
+          const dateDerived = programStage(programAnchor);
+          setSelectedStage(dateDerived ?? deriveCurrentStage(stagesList));
         }
       } catch (err) {
         console.error('Failed to load stages:', err);
@@ -50,7 +54,7 @@ function useStagesLoader() {
       }
     };
     void init();
-  }, [routeStageNumber]);
+  }, [routeStageNumber, programAnchor]);
 
   return { allStages, selectedStage, setSelectedStage, loading };
 }

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import type { ApiHabitStats } from '../../api';
+import { STAGE_DURATIONS_DAYS } from '../../constants/program';
 import { colors, STAGE_COLORS, STAGE_ORDER, VICTORY_COLOR } from '../../design/tokens';
 import {
   DEFAULT_TIMEZONE,
@@ -12,17 +13,10 @@ import {
 import type { Goal, Habit, Completion, HabitStatsData } from './Habits.types';
 
 export { STAGE_ORDER };
+// Re-export so existing call sites stay valid; canonical definition lives in src/constants/program.ts.
+export { STAGE_DURATIONS_DAYS };
 
-/** Milliseconds in one calendar day, used for date-difference arithmetic. */
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
-
-/**
- * Number of days per APTITUDE stage. The 36-week program has 10 stages:
- * stages 1–8 are 21-day cycles (3 weeks each, totaling 24 weeks) and
- * stages 9–10 are 42-day cycles (6 weeks each, totaling 12 weeks).
- * Grand total: 24 + 12 = 36 weeks.
- */
-export const STAGE_DURATIONS_DAYS = [21, 21, 21, 21, 21, 21, 21, 21, 42, 42] as const;
 
 /**
  * Calculate the start date for a habit based on its order in the onboarding

--- a/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
+++ b/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
@@ -4,6 +4,7 @@ import { Modal, Platform, Text, TouchableOpacity, View } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 
 import { STAGE_COLORS } from '../../../design/tokens';
+import { useProgramStore } from '../../../store/useProgramStore';
 import styles from '../Habits.styles';
 import type { Habit, ReorderHabitsModalProps } from '../Habits.types';
 import { STAGE_ORDER, calculateHabitStartDate } from '../HabitUtils';
@@ -58,21 +59,12 @@ const ReorderHabitItem = ({ item, drag, isActive }: ReorderItemProps) => (
   </TouchableOpacity>
 );
 
-interface ReorderDatePickerProps {
+interface ReorderDateButtonProps {
   startDate: Date;
-  pickerVisible: boolean;
   onOpenPicker: () => void;
-  onConfirm: (_date: Date) => void;
-  onCancel: () => void;
 }
 
-const ReorderDatePicker = ({
-  startDate,
-  pickerVisible,
-  onOpenPicker,
-  onConfirm,
-  onCancel,
-}: ReorderDatePickerProps) => (
+const ReorderDateButton = ({ startDate, onOpenPicker }: ReorderDateButtonProps) => (
   <View style={styles.datePickerContainer}>
     <Text style={styles.datePickerLabel}>First Habit Start Date:</Text>
     <TouchableOpacity
@@ -82,13 +74,6 @@ const ReorderDatePicker = ({
     >
       <Text style={styles.datePickerButtonText}>{formatDate(startDate)}</Text>
     </TouchableOpacity>
-    <DateTimePickerModal
-      isVisible={pickerVisible}
-      mode="date"
-      date={startDate}
-      onConfirm={onConfirm}
-      onCancel={onCancel}
-    />
   </View>
 );
 
@@ -111,13 +96,6 @@ const ReorderList = ({ orderedHabits, onDragEnd }: ReorderListProps) => (
   </View>
 );
 
-interface ReorderBodyProps {
-  habits: Habit[];
-  visible: boolean;
-  onClose: () => void;
-  onSaveOrder: (_habits: Habit[]) => void;
-}
-
 interface ReorderState {
   orderedHabits: Habit[];
   startDate: Date;
@@ -129,16 +107,38 @@ interface ReorderState {
   handleSave: () => void;
 }
 
+interface ReorderBodyProps {
+  habits: Habit[];
+  visible: boolean;
+  onClose: () => void;
+  onSaveOrder: (_habits: Habit[]) => void;
+}
+
 const useReorderState = ({
   habits,
   visible,
   onClose,
   onSaveOrder,
 }: ReorderBodyProps): ReorderState => {
+  // Seed from the program-wide master date so the picker reflects the
+  // user's existing anchor on re-open.  ``programStartDate`` is the
+  // single source of truth for "when does the program start" (drives
+  // BotMason week, active practice, course unlock, current map stage);
+  // updating it here propagates to every consumer.
+  const programStartDate = useProgramStore((s) => s.programStartDate);
+  const setProgramStartDate = useProgramStore((s) => s.setProgramStartDate);
+
   const [orderedHabits, setOrderedHabits] = useState<Habit[]>([]);
-  const [startDate, setStartDate] = useState(new Date());
+  const [startDate, setStartDate] = useState<Date>(() => programStartDate ?? new Date());
   const [pickerVisible, setPickerVisible] = useState(false);
   const wasVisibleRef = useRef(false);
+
+  // Keep the modal's local startDate aligned with the store while the
+  // modal is closed, so re-opening reflects an out-of-band change (e.g.
+  // future onboarding flow that also writes the program anchor).
+  useEffect(() => {
+    if (!visible && programStartDate) setStartDate(programStartDate);
+  }, [visible, programStartDate]);
 
   // BUG-FE-HABIT-204: initialise the ordering only on the open transition;
   // the previous implementation re-fired on every ``startDate`` change and
@@ -166,6 +166,9 @@ const useReorderState = ({
       setPickerVisible(false);
       setStartDate(selectedDate);
       setOrderedHabits((prev) => updateStartDates(prev, selectedDate));
+      // Master-date write-through: every consumer that derives week/stage
+      // from ``programStartDate`` re-renders on the next paint.
+      setProgramStartDate(selectedDate);
     },
     handleCancelDate: () => setPickerVisible(false),
     handleSave: () => {
@@ -175,45 +178,73 @@ const useReorderState = ({
   };
 };
 
-const ReorderBody = (props: ReorderBodyProps) => {
-  const s = useReorderState(props);
-  return (
-    <View style={styles.reorderModalContent}>
-      <View style={styles.modalHeader}>
-        <Text style={styles.modalTitle}>Reorder Habits</Text>
-        <TouchableOpacity onPress={props.onClose} style={styles.closeButton}>
-          <Text style={styles.closeButtonText}>×</Text>
-        </TouchableOpacity>
-      </View>
-      <ReorderDatePicker
-        startDate={s.startDate}
-        pickerVisible={s.pickerVisible}
-        onOpenPicker={() => s.setPickerVisible(true)}
-        onConfirm={s.handleConfirmDate}
-        onCancel={s.handleCancelDate}
-      />
-      <Text style={styles.reorderInstructions}>
-        Drag habits to reorder. Habits 1-8 start 21 days apart, habits 9-10 start 42 days apart.
-      </Text>
-      <ReorderList orderedHabits={s.orderedHabits} onDragEnd={s.handleDragEnd} />
-      <TouchableOpacity style={styles.saveOrderButton} onPress={s.handleSave}>
-        <Text style={styles.saveOrderButtonText}>Save Order</Text>
+const ReorderBody = (props: ReorderBodyProps & ReorderState) => (
+  <View style={styles.reorderModalContent}>
+    <View style={styles.modalHeader}>
+      <Text style={styles.modalTitle}>Reorder Habits</Text>
+      <TouchableOpacity onPress={props.onClose} style={styles.closeButton}>
+        <Text style={styles.closeButtonText}>×</Text>
       </TouchableOpacity>
     </View>
-  );
-};
+    <ReorderDateButton
+      startDate={props.startDate}
+      onOpenPicker={() => props.setPickerVisible(true)}
+    />
+    <Text style={styles.reorderInstructions}>
+      Drag habits to reorder. Habits 1-8 start 21 days apart, habits 9-10 start 42 days apart.
+    </Text>
+    <ReorderList orderedHabits={props.orderedHabits} onDragEnd={props.handleDragEnd} />
+    <TouchableOpacity style={styles.saveOrderButton} onPress={props.handleSave}>
+      <Text style={styles.saveOrderButtonText}>Save Order</Text>
+    </TouchableOpacity>
+  </View>
+);
 
+/**
+ * Mounting the ``DateTimePickerModal`` as a *sibling* of the outer RN
+ * ``<Modal>`` -- not as a descendant -- is the load-bearing structural
+ * choice that makes the picker actually appear on iOS during habit
+ * edit mode.  React Native's ``<Modal>`` on iOS uses a native
+ * ``UIViewController`` presentation; any modal mounted inside an
+ * already-presented modal animates *underneath* the parent and is
+ * invisible to the user (this is the bug the previous fix in PR #299
+ * left behind).  By rendering the picker outside the parent modal,
+ * ``react-native-modal-datetime-picker``'s own
+ * ``presentationStyle: overFullScreen`` modal stacks above everything
+ * else and is reachable.
+ */
 export const ReorderHabitsModal = ({
   visible,
   habits,
   onClose,
   onSaveOrder,
-}: ReorderHabitsModalProps) => (
-  <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-    <View style={styles.modalOverlay}>
-      <ReorderBody habits={habits} visible={visible} onClose={onClose} onSaveOrder={onSaveOrder} />
-    </View>
-  </Modal>
-);
+}: ReorderHabitsModalProps) => {
+  const state = useReorderState({ habits, visible, onClose, onSaveOrder });
+  return (
+    <>
+      <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+        <View style={styles.modalOverlay}>
+          <ReorderBody
+            habits={habits}
+            visible={visible}
+            onClose={onClose}
+            onSaveOrder={onSaveOrder}
+            {...state}
+          />
+        </View>
+      </Modal>
+      <DateTimePickerModal
+        isVisible={visible && state.pickerVisible}
+        mode="date"
+        date={state.startDate}
+        // Intentionally NO ``minimumDate`` -- the program anchor MUST
+        // accept past dates so a user who already started the journey
+        // can backdate their start to land on the right week today.
+        onConfirm={state.handleConfirmDate}
+        onCancel={state.handleCancelDate}
+      />
+    </>
+  );
+};
 
 export default ReorderHabitsModal;

--- a/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
+++ b/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
@@ -9,13 +9,7 @@ import styles from '../Habits.styles';
 import type { Habit, ReorderHabitsModalProps } from '../Habits.types';
 import { STAGE_ORDER, calculateHabitStartDate } from '../HabitUtils';
 
-// ``react-native-modal-datetime-picker`` ships as ES modules and isn't in the
-// jest ``transformIgnorePatterns`` allowlist. Mirror the lazy-require pattern
-// from ``src/components/DatePicker.tsx`` so screen tests that transitively
-// import this modal don't blow up at module-load time, while production still
-// gets the real picker with confirm/cancel affordances (fixes the iOS
-// app-seize bug where the previous ``<Modal><DateTimePicker/></Modal>`` had
-// no way to be dismissed).
+// Lazy require so jest (which doesn't transform this ES-module package) can load this file.
 let DateTimePickerModal: ComponentType<Record<string, unknown>> = () => null;
 if (Platform.OS !== 'web') {
   try {
@@ -107,7 +101,7 @@ interface ReorderState {
   handleSave: () => void;
 }
 
-interface ReorderBodyProps {
+interface ReorderHookInput {
   habits: Habit[];
   visible: boolean;
   onClose: () => void;
@@ -119,12 +113,7 @@ const useReorderState = ({
   visible,
   onClose,
   onSaveOrder,
-}: ReorderBodyProps): ReorderState => {
-  // Seed from the program-wide master date so the picker reflects the
-  // user's existing anchor on re-open.  ``programStartDate`` is the
-  // single source of truth for "when does the program start" (drives
-  // BotMason week, active practice, course unlock, current map stage);
-  // updating it here propagates to every consumer.
+}: ReorderHookInput): ReorderState => {
   const programStartDate = useProgramStore((s) => s.programStartDate);
   const setProgramStartDate = useProgramStore((s) => s.setProgramStartDate);
 
@@ -133,19 +122,19 @@ const useReorderState = ({
   const [pickerVisible, setPickerVisible] = useState(false);
   const wasVisibleRef = useRef(false);
 
-  // Keep the modal's local startDate aligned with the store while the
-  // modal is closed, so re-opening reflects an out-of-band change (e.g.
-  // future onboarding flow that also writes the program anchor).
   useEffect(() => {
     if (!visible && programStartDate) setStartDate(programStartDate);
   }, [visible, programStartDate]);
 
-  // BUG-FE-HABIT-204: initialise the ordering only on the open transition;
-  // the previous implementation re-fired on every ``startDate`` change and
-  // clobbered the user's drag.  Date-picker changes go through
-  // ``handleConfirmDate`` below, which calls ``updateStartDates`` directly,
-  // so the start-date propagation handled by PR #302's dedicated effect is
-  // already covered here without a second effect.
+  // Reset the picker flag when the parent modal closes so that an
+  // ``onRequestClose`` dismissal (Android back button) doesn't leave
+  // ``pickerVisible=true`` and spring the picker open on re-render.
+  useEffect(() => {
+    if (!visible) setPickerVisible(false);
+  }, [visible]);
+
+  // BUG-FE-HABIT-204: only seed the ordered list on the open transition;
+  // re-firing on every startDate change clobbered manual drags.
   useEffect(() => {
     const justOpened = visible && !wasVisibleRef.current;
     wasVisibleRef.current = visible;
@@ -166,8 +155,7 @@ const useReorderState = ({
       setPickerVisible(false);
       setStartDate(selectedDate);
       setOrderedHabits((prev) => updateStartDates(prev, selectedDate));
-      // Master-date write-through: every consumer that derives week/stage
-      // from ``programStartDate`` re-renders on the next paint.
+      // Master-date write-through: every consumer that derives week/stage updates.
       setProgramStartDate(selectedDate);
     },
     handleCancelDate: () => setPickerVisible(false),
@@ -178,41 +166,42 @@ const useReorderState = ({
   };
 };
 
-const ReorderBody = (props: ReorderBodyProps & ReorderState) => (
+interface ReorderBodyProps {
+  onClose: () => void;
+  orderedHabits: Habit[];
+  startDate: Date;
+  onOpenPicker: () => void;
+  onDragEnd: (_a: { data: Habit[] }) => void;
+  onSave: () => void;
+}
+
+const ReorderBody = ({
+  onClose,
+  orderedHabits,
+  startDate,
+  onOpenPicker,
+  onDragEnd,
+  onSave,
+}: ReorderBodyProps) => (
   <View style={styles.reorderModalContent}>
     <View style={styles.modalHeader}>
       <Text style={styles.modalTitle}>Reorder Habits</Text>
-      <TouchableOpacity onPress={props.onClose} style={styles.closeButton}>
+      <TouchableOpacity onPress={onClose} style={styles.closeButton}>
         <Text style={styles.closeButtonText}>×</Text>
       </TouchableOpacity>
     </View>
-    <ReorderDateButton
-      startDate={props.startDate}
-      onOpenPicker={() => props.setPickerVisible(true)}
-    />
+    <ReorderDateButton startDate={startDate} onOpenPicker={onOpenPicker} />
     <Text style={styles.reorderInstructions}>
       Drag habits to reorder. Habits 1-8 start 21 days apart, habits 9-10 start 42 days apart.
     </Text>
-    <ReorderList orderedHabits={props.orderedHabits} onDragEnd={props.handleDragEnd} />
-    <TouchableOpacity style={styles.saveOrderButton} onPress={props.handleSave}>
+    <ReorderList orderedHabits={orderedHabits} onDragEnd={onDragEnd} />
+    <TouchableOpacity style={styles.saveOrderButton} onPress={onSave}>
       <Text style={styles.saveOrderButtonText}>Save Order</Text>
     </TouchableOpacity>
   </View>
 );
 
-/**
- * Mounting the ``DateTimePickerModal`` as a *sibling* of the outer RN
- * ``<Modal>`` -- not as a descendant -- is the load-bearing structural
- * choice that makes the picker actually appear on iOS during habit
- * edit mode.  React Native's ``<Modal>`` on iOS uses a native
- * ``UIViewController`` presentation; any modal mounted inside an
- * already-presented modal animates *underneath* the parent and is
- * invisible to the user (this is the bug the previous fix in PR #299
- * left behind).  By rendering the picker outside the parent modal,
- * ``react-native-modal-datetime-picker``'s own
- * ``presentationStyle: overFullScreen`` modal stacks above everything
- * else and is reachable.
- */
+// Mount the picker as a SIBLING of the parent <Modal>: iOS animates nested UIViewController modals underneath the parent, hiding them.
 export const ReorderHabitsModal = ({
   visible,
   habits,
@@ -223,13 +212,14 @@ export const ReorderHabitsModal = ({
   return (
     <>
       <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-        <View style={styles.modalOverlay}>
+        <View testID="reorder-modal-overlay" style={styles.modalOverlay}>
           <ReorderBody
-            habits={habits}
-            visible={visible}
             onClose={onClose}
-            onSaveOrder={onSaveOrder}
-            {...state}
+            orderedHabits={state.orderedHabits}
+            startDate={state.startDate}
+            onOpenPicker={() => state.setPickerVisible(true)}
+            onDragEnd={state.handleDragEnd}
+            onSave={state.handleSave}
           />
         </View>
       </Modal>
@@ -237,9 +227,7 @@ export const ReorderHabitsModal = ({
         isVisible={visible && state.pickerVisible}
         mode="date"
         date={state.startDate}
-        // Intentionally NO ``minimumDate`` -- the program anchor MUST
-        // accept past dates so a user who already started the journey
-        // can backdate their start to land on the right week today.
+        // No ``minimumDate``: the master anchor must accept past dates.
         onConfirm={state.handleConfirmDate}
         onCancel={state.handleCancelDate}
       />

--- a/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /**
- * Regression tests for ``ReorderHabitsModal`` covering two bugs reported
+ * Regression tests for ``ReorderHabitsModal`` covering three bugs reported
  * on the habits screen:
  *
  *  1. The order would snap back to the stage-default after the user
@@ -11,16 +11,28 @@
  *  2. Tapping the start-date button opened a date picker wrapped in a
  *     bare ``<Modal>`` with no dismissal affordance. On iOS the picker
  *     stayed on screen with no way to back out and the whole app froze.
- *     The fix swaps in the shared ``<DatePicker>`` component (which
- *     already wraps ``react-native-modal-datetime-picker`` with proper
- *     confirm/cancel handling) and is exercised here through its
- *     accessibility label.
+ *     PR #299 added confirm/cancel affordances via
+ *     ``react-native-modal-datetime-picker``.
+ *  3. After PR #299 the picker *still* did not appear on iOS during
+ *     habit edit mode because it was rendered as a descendant of the
+ *     parent ``<Modal>``; nested ``UIViewController`` presentations
+ *     animate underneath each other on iOS.  The picker is now
+ *     mounted as a SIBLING of the parent modal.  These tests assert the
+ *     sibling structure, that past dates are accepted, and that
+ *     confirming a date propagates to the shared program-anchor store.
  */
-import { describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 import { fireEvent, render, act } from '@testing-library/react-native';
 import React from 'react';
 
+import { useProgramStore } from '../../../../store/useProgramStore';
 import type { Habit } from '../../Habits.types';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
 
 jest.mock('react-native-draggable-flatlist', () => {
   const ReactLib = require('react');
@@ -42,27 +54,44 @@ jest.mock('react-native-draggable-flatlist', () => {
 
 jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
 
+// Capture the most recent props passed to the picker so structural / prop
+// tests can introspect them without relying on rendered output.
+const lastModalDatePickerProps: { current: Record<string, unknown> | null } = { current: null };
+
 jest.mock('react-native-modal-datetime-picker', () => {
   const ReactLib = require('react');
-  const { Text, TouchableOpacity } = require('react-native');
+  const { Text, TouchableOpacity, View } = require('react-native');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const ModalDatePickerMock = ({ isVisible, onConfirm, onCancel }: any) =>
-    isVisible
+  const ModalDatePickerMock = (props: any) => {
+    lastModalDatePickerProps.current = props;
+    return props.isVisible
       ? ReactLib.createElement(
-          ReactLib.Fragment,
-          null,
+          View,
+          { testID: 'modal-datetime-picker-root' },
           ReactLib.createElement(
             TouchableOpacity,
-            { testID: 'modal-datetime-confirm', onPress: () => onConfirm(new Date('2026-06-01')) },
+            {
+              testID: 'modal-datetime-confirm',
+              onPress: () => props.onConfirm(new Date(2026, 5, 1)),
+            },
             ReactLib.createElement(Text, null, 'Confirm'),
           ),
           ReactLib.createElement(
             TouchableOpacity,
-            { testID: 'modal-datetime-cancel', onPress: onCancel },
+            { testID: 'modal-datetime-cancel', onPress: props.onCancel },
             ReactLib.createElement(Text, null, 'Cancel'),
+          ),
+          ReactLib.createElement(
+            TouchableOpacity,
+            {
+              testID: 'modal-datetime-confirm-past',
+              onPress: () => props.onConfirm(new Date(2020, 0, 1)),
+            },
+            ReactLib.createElement(Text, null, 'Confirm past'),
           ),
         )
       : null;
+  };
   return { __esModule: true, default: ModalDatePickerMock };
 });
 
@@ -91,6 +120,11 @@ const getOrderedIds = (list: ReturnType<typeof render>): number[] => {
   return data.map((h) => h.id);
 };
 
+beforeEach(() => {
+  lastModalDatePickerProps.current = null;
+  act(() => useProgramStore.getState().hydrateProgramStartDate(null));
+});
+
 describe('ReorderHabitsModal — drag persistence (BUG: re-sort freezes)', () => {
   it('preserves the dragged order across multiple consecutive drags', () => {
     const result = render(
@@ -99,20 +133,17 @@ describe('ReorderHabitsModal — drag persistence (BUG: re-sort freezes)', () =>
 
     const list = result.getByTestId('reorder-list');
 
-    // First drag: move habit 3 (Red) to the front.
     act(() => {
       list.props.onDragEnd({ data: [HABITS[2], HABITS[0], HABITS[1]] });
     });
     expect(getOrderedIds(result)).toEqual([3, 1, 2]);
 
-    // Second drag: move habit 2 (Purple) to the front of the current order.
     const afterFirst = result.getByTestId('reorder-list').props.data as Habit[];
     act(() => {
       list.props.onDragEnd({ data: [afterFirst[2], afterFirst[0], afterFirst[1]] });
     });
     expect(getOrderedIds(result)).toEqual([2, 3, 1]);
 
-    // Third drag: swap the first two.
     const afterSecond = result.getByTestId('reorder-list').props.data as Habit[];
     act(() => {
       list.props.onDragEnd({ data: [afterSecond[1], afterSecond[0], afterSecond[2]] });
@@ -131,17 +162,84 @@ describe('ReorderHabitsModal — drag persistence (BUG: re-sort freezes)', () =>
     });
     expect(getOrderedIds(result)).toEqual([3, 1, 2]);
 
-    // Open the date picker and confirm a new date.
     fireEvent.press(result.getByTestId('reorder-start-date'));
     fireEvent.press(result.getByTestId('modal-datetime-confirm'));
 
-    // The user's manual order must survive the date change.
     expect(getOrderedIds(result)).toEqual([3, 1, 2]);
   });
 });
 
-describe('ReorderHabitsModal — date picker dismissal (BUG: app seizes)', () => {
-  it('mounts the date picker only after the user opens it and dismisses cleanly on cancel', () => {
+describe('ReorderHabitsModal — date picker visibility (BUG: picker invisible in edit mode)', () => {
+  it('mounts the picker as a sibling of the parent Modal, not a descendant', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    fireEvent.press(result.getByTestId('reorder-start-date'));
+
+    // The picker must be reachable from the test renderer's root, and
+    // must NOT be a descendant of the modal overlay -- if it were, iOS
+    // would animate it underneath the parent and the user would tap an
+    // invisible target.
+    const reorderList = result.getByTestId('reorder-list');
+    const pickerRoot = result.getByTestId('modal-datetime-picker-root');
+
+    const isDescendantOf = (
+      node: { children?: ReadonlyArray<unknown> } | null,
+      target: object,
+    ): boolean => {
+      if (!node || !Array.isArray(node.children)) return false;
+      for (const child of node.children) {
+        if (child === target) return true;
+        if (
+          typeof child === 'object' &&
+          child !== null &&
+          isDescendantOf(child as { children?: ReadonlyArray<unknown> }, target)
+        ) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    // Find a common modal-overlay ancestor by walking up from reorderList.
+    // The test verifies the picker is NOT inside that ancestor subtree.
+    let modalSubtreeRoot: unknown = reorderList;
+    for (let depth = 0; depth < 6 && modalSubtreeRoot; depth += 1) {
+      modalSubtreeRoot = (modalSubtreeRoot as { parent?: unknown }).parent ?? null;
+    }
+    expect(
+      isDescendantOf(modalSubtreeRoot as { children?: ReadonlyArray<unknown> }, pickerRoot),
+    ).toBe(false);
+  });
+
+  it('does not pass a minimumDate so past dates are selectable', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    fireEvent.press(result.getByTestId('reorder-start-date'));
+
+    const props = lastModalDatePickerProps.current!;
+    expect(props).not.toBeNull();
+    expect(props.minimumDate).toBeUndefined();
+  });
+
+  it('accepts a confirmed past date and updates the master program start date', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    fireEvent.press(result.getByTestId('reorder-start-date'));
+    fireEvent.press(result.getByTestId('modal-datetime-confirm-past'));
+
+    const stored = useProgramStore.getState().programStartDate!;
+    expect(stored.getFullYear()).toBe(2020);
+    expect(stored.getMonth()).toBe(0);
+    expect(stored.getDate()).toBe(1);
+  });
+
+  it('mounts the picker only after the user opens it and dismisses cleanly on cancel', () => {
     const result = render(
       <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
     );
@@ -153,11 +251,10 @@ describe('ReorderHabitsModal — date picker dismissal (BUG: app seizes)', () =>
 
     fireEvent.press(result.getByTestId('modal-datetime-cancel'));
     expect(result.queryByTestId('modal-datetime-confirm')).toBeNull();
-    // Order is unchanged after cancel.
     expect(getOrderedIds(result)).toEqual([1, 2, 3]);
   });
 
-  it('persists the chosen date and recomputes start_date offsets', () => {
+  it('persists the chosen date, recomputes start_date offsets, and writes the master anchor', () => {
     const result = render(
       <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
     );
@@ -166,10 +263,27 @@ describe('ReorderHabitsModal — date picker dismissal (BUG: app seizes)', () =>
     fireEvent.press(result.getByTestId('modal-datetime-confirm'));
 
     const data = result.getByTestId('reorder-list').props.data as Habit[];
-    // First habit should anchor to the confirmed date (2026-06-01 in mock).
     expect(new Date(data[0]!.start_date).toISOString().slice(0, 10)).toBe('2026-06-01');
-    // Second habit is 21 days later.
     expect(new Date(data[1]!.start_date).toISOString().slice(0, 10)).toBe('2026-06-22');
+
+    const stored = useProgramStore.getState().programStartDate!;
+    expect(stored.getFullYear()).toBe(2026);
+    expect(stored.getMonth()).toBe(5);
+    expect(stored.getDate()).toBe(1);
+  });
+});
+
+describe('ReorderHabitsModal — program-anchor wiring', () => {
+  it('seeds the start date from the existing program anchor on open', () => {
+    act(() => useProgramStore.getState().hydrateProgramStartDate(new Date(2024, 2, 15)));
+
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    // First habit's start_date must match the anchor (March 15, 2024).
+    const data = result.getByTestId('reorder-list').props.data as Habit[];
+    expect(new Date(data[0]!.start_date).toISOString().slice(0, 10)).toBe('2024-03-15');
   });
 });
 

--- a/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
@@ -1,28 +1,7 @@
 /* eslint-env jest */
-/**
- * Regression tests for ``ReorderHabitsModal`` covering three bugs reported
- * on the habits screen:
- *
- *  1. The order would snap back to the stage-default after the user
- *     dragged a habit and then picked a new start date (or any other
- *     state change that re-fired the initialisation effect). To users
- *     the manual reorder appeared to "freeze" because their drags had
- *     no visible effect once they touched anything else.
- *  2. Tapping the start-date button opened a date picker wrapped in a
- *     bare ``<Modal>`` with no dismissal affordance. On iOS the picker
- *     stayed on screen with no way to back out and the whole app froze.
- *     PR #299 added confirm/cancel affordances via
- *     ``react-native-modal-datetime-picker``.
- *  3. After PR #299 the picker *still* did not appear on iOS during
- *     habit edit mode because it was rendered as a descendant of the
- *     parent ``<Modal>``; nested ``UIViewController`` presentations
- *     animate underneath each other on iOS.  The picker is now
- *     mounted as a SIBLING of the parent modal.  These tests assert the
- *     sibling structure, that past dates are accepted, and that
- *     confirming a date propagates to the shared program-anchor store.
- */
+// Regression tests for the three reorder-modal bugs: drag freeze, picker dismissal, and the iOS sibling-mount.
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
-import { fireEvent, render, act } from '@testing-library/react-native';
+import { fireEvent, render, act, within } from '@testing-library/react-native';
 import React from 'react';
 
 import { useProgramStore } from '../../../../store/useProgramStore';
@@ -54,8 +33,7 @@ jest.mock('react-native-draggable-flatlist', () => {
 
 jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
 
-// Capture the most recent props passed to the picker so structural / prop
-// tests can introspect them without relying on rendered output.
+// Captured picker props so structural / prop tests can introspect them.
 const lastModalDatePickerProps: { current: Record<string, unknown> | null } = { current: null };
 
 jest.mock('react-native-modal-datetime-picker', () => {
@@ -177,40 +155,14 @@ describe('ReorderHabitsModal — date picker visibility (BUG: picker invisible i
 
     fireEvent.press(result.getByTestId('reorder-start-date'));
 
-    // The picker must be reachable from the test renderer's root, and
-    // must NOT be a descendant of the modal overlay -- if it were, iOS
-    // would animate it underneath the parent and the user would tap an
-    // invisible target.
-    const reorderList = result.getByTestId('reorder-list');
-    const pickerRoot = result.getByTestId('modal-datetime-picker-root');
-
-    const isDescendantOf = (
-      node: { children?: ReadonlyArray<unknown> } | null,
-      target: object,
-    ): boolean => {
-      if (!node || !Array.isArray(node.children)) return false;
-      for (const child of node.children) {
-        if (child === target) return true;
-        if (
-          typeof child === 'object' &&
-          child !== null &&
-          isDescendantOf(child as { children?: ReadonlyArray<unknown> }, target)
-        ) {
-          return true;
-        }
-      }
-      return false;
-    };
-
-    // Find a common modal-overlay ancestor by walking up from reorderList.
-    // The test verifies the picker is NOT inside that ancestor subtree.
-    let modalSubtreeRoot: unknown = reorderList;
-    for (let depth = 0; depth < 6 && modalSubtreeRoot; depth += 1) {
-      modalSubtreeRoot = (modalSubtreeRoot as { parent?: unknown }).parent ?? null;
-    }
-    expect(
-      isDescendantOf(modalSubtreeRoot as { children?: ReadonlyArray<unknown> }, pickerRoot),
-    ).toBe(false);
+    // Anchor the assertion to the modal overlay's testID; nesting the
+    // picker inside this subtree is exactly the iOS bug we're guarding
+    // against.  ``within(...).queryByTestId`` returns null when the
+    // descendant isn't present, which is the passing condition.
+    const overlay = result.getByTestId('reorder-modal-overlay');
+    expect(within(overlay).queryByTestId('modal-datetime-picker-root')).toBeNull();
+    // Sanity-check the picker actually mounted somewhere reachable.
+    expect(result.getByTestId('modal-datetime-picker-root')).toBeTruthy();
   });
 
   it('does not pass a minimumDate so past dates are selectable', () => {
@@ -270,6 +222,37 @@ describe('ReorderHabitsModal — date picker visibility (BUG: picker invisible i
     expect(stored.getFullYear()).toBe(2026);
     expect(stored.getMonth()).toBe(5);
     expect(stored.getDate()).toBe(1);
+  });
+
+  it('clears pickerVisible when the parent modal closes (e.g. Android back button)', () => {
+    // Reviewer #2 blocker: ``onRequestClose`` (Android back) bypasses
+    // both ``handleCancelDate`` and ``handleConfirmDate``, so without an
+    // explicit reset the picker would spring back open on re-render
+    // even though the user never tapped the start-date button.
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    fireEvent.press(result.getByTestId('reorder-start-date'));
+    expect(result.getByTestId('modal-datetime-cancel')).toBeTruthy();
+
+    // Parent modal closes via the system back button -- no handler runs
+    // inside the picker's own confirm/cancel paths.
+    result.rerender(
+      <ReorderHabitsModal
+        visible={false}
+        habits={HABITS}
+        onClose={jest.fn()}
+        onSaveOrder={jest.fn()}
+      />,
+    );
+
+    // Re-open the parent modal.  The picker must NOT re-mount on its
+    // own; only an explicit start-date tap should bring it back.
+    result.rerender(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+    expect(result.queryByTestId('modal-datetime-cancel')).toBeNull();
   });
 });
 

--- a/frontend/src/features/Journal/WeeklyPromptBanner.tsx
+++ b/frontend/src/features/Journal/WeeklyPromptBanner.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 
 import type { PromptDetail } from '../../api';
+import { useDerivedCurrentWeek } from '../../store/useProgramProgression';
 
 import styles from './Journal.styles';
 
@@ -11,9 +12,15 @@ interface WeeklyPromptBannerProps {
 }
 
 const WeeklyPromptBanner = ({ prompt, onRespond }: WeeklyPromptBannerProps): React.JSX.Element => {
+  // When the user has set a master program start date, the banner shows
+  // the week derived from ``today - programStartDate`` so BotMason
+  // surfaces "Week 2" exactly when the anchor says it should.  With no
+  // anchor we fall back to the server's count-based ``prompt.week_number``.
+  const displayWeek = useDerivedCurrentWeek(prompt.week_number);
+
   return (
     <View style={styles.promptBanner} testID="weekly-prompt-banner">
-      <Text style={styles.promptLabel}>Week {prompt.week_number} Reflection</Text>
+      <Text style={styles.promptLabel}>Week {displayWeek} Reflection</Text>
       <Text style={styles.promptQuestion}>{prompt.question}</Text>
       <TouchableOpacity
         testID="prompt-respond-button"

--- a/frontend/src/features/Journal/__tests__/WeeklyPromptBanner.test.tsx
+++ b/frontend/src/features/Journal/__tests__/WeeklyPromptBanner.test.tsx
@@ -1,10 +1,21 @@
 /* eslint-env jest */
-import { describe, it, expect, jest } from '@jest/globals';
-import { render, fireEvent } from '@testing-library/react-native';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import React from 'react';
 
 import type { PromptDetail } from '../../../api';
+import { useProgramStore } from '../../../store/useProgramStore';
 import WeeklyPromptBanner from '../WeeklyPromptBanner';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+beforeEach(() => {
+  act(() => useProgramStore.getState().hydrateProgramStartDate(null));
+});
 
 const samplePrompt: PromptDetail = {
   week_number: 3,
@@ -37,5 +48,20 @@ describe('WeeklyPromptBanner', () => {
     );
     fireEvent.press(getByTestId('prompt-respond-button'));
     expect(onRespond).toHaveBeenCalledTimes(1);
+  });
+
+  it('overrides the displayed week with the master program anchor when set', () => {
+    // Anchor 14 days ago -> week 3 by the date-driven rule, regardless of
+    // what the server-supplied ``prompt.week_number`` says.
+    const today = new Date();
+    const anchor = new Date(today);
+    anchor.setDate(anchor.getDate() - 14);
+    act(() => useProgramStore.getState().hydrateProgramStartDate(anchor));
+
+    const promptOnWeek1: PromptDetail = { ...samplePrompt, week_number: 1 };
+    const { getByText } = render(
+      <WeeklyPromptBanner prompt={promptOnWeek1} onRespond={jest.fn()} />,
+    );
+    expect(getByText('Week 3 Reflection')).toBeTruthy();
   });
 });

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -19,6 +19,7 @@ import type { HabitHistoryItem, PracticeHistoryItem, StageHistoryResponse } from
 import { stages as stagesApi } from '../../api';
 import { MAP_BACKGROUND_URI } from '../../constants/images';
 import { useAppNavigation } from '../../navigation/hooks';
+import { useDerivedCurrentStage } from '../../store/useProgramProgression';
 import {
   selectCurrentStage,
   selectStages,
@@ -441,7 +442,11 @@ const MapScreen = (): React.JSX.Element => {
   const stages = useStageStore(selectStages);
   const loading = useStageStore(selectStagesLoading);
   const error = useStageStore(selectStagesError);
-  const currentStage = useStageStore(selectCurrentStage);
+  const storeCurrentStage = useStageStore(selectCurrentStage);
+  // Prefer the date-driven stage when the master anchor is set; the
+  // server's count-based ``currentStage`` is the fallback for users who
+  // haven't picked an anchor yet.
+  const currentStage = useDerivedCurrentStage(storeCurrentStage);
   const [activeStage, setActiveStage] = useState<StageData | null>(null);
   const navigatingRef = useRef(false);
 

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -27,6 +27,7 @@ import { colors, SPACING, BORDER_RADIUS, shadows } from '@/design/tokens';
 import { stageService } from '@/features/Map/services/stageService';
 import { useOptimisticMutation } from '@/hooks/useOptimisticMutation';
 import { useAppNavigation, useAppRoute } from '@/navigation/hooks';
+import { useDerivedCurrentStage } from '@/store/useProgramProgression';
 import { selectCurrentStage, useStageStore } from '@/store/useStageStore';
 
 type ScreenView = 'selection' | 'timer' | 'summary' | 'reflection';
@@ -587,6 +588,12 @@ const PracticeScreen = (): React.JSX.Element => {
   // a stage-1 practice.
   const storeCurrentStage = useStageStore(selectCurrentStage);
   const storeStages = useStageStore((s) => s.stages);
+  // Master date wiring: when the user has set a program start date,
+  // derive the active stage from ``today - programStartDate`` so the
+  // practice screen tracks the real elapsed time rather than the
+  // server's count-based current stage.  Falls back to the store value
+  // when no anchor is set.
+  const derivedCurrentStage = useDerivedCurrentStage(storeCurrentStage);
 
   useEffect(() => {
     if (storeStages.length === 0) {
@@ -594,7 +601,7 @@ const PracticeScreen = (): React.JSX.Element => {
     }
   }, [storeStages.length]);
 
-  const stageNumber = route.params?.stageNumber ?? storeCurrentStage;
+  const stageNumber = route.params?.stageNumber ?? derivedCurrentStage;
   const loader = usePracticeLoader(stageNumber);
   const session = useSessionFlow(
     loader.activeUserPractice,

--- a/frontend/src/storage/__tests__/programStorage.test.ts
+++ b/frontend/src/storage/__tests__/programStorage.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  clearProgramStartDate,
+  loadProgramStartDate,
+  saveProgramStartDate,
+} from '../programStorage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('programStorage', () => {
+  const KEY = '@adepthood/program_start_date';
+
+  describe('saveProgramStartDate', () => {
+    test('serialises the date to an ISO YYYY-MM-DD string', async () => {
+      await saveProgramStartDate(new Date(2026, 4, 12)); // 2026-05-12 local
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(KEY, '2026-05-12');
+    });
+
+    test('uses the local calendar day, not UTC', async () => {
+      // 11pm local on the 12th — naively calling toISOString() would
+      // bucket this into the 13th in many timezones.
+      const date = new Date(2026, 4, 12, 23, 30);
+      await saveProgramStartDate(date);
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(KEY, '2026-05-12');
+    });
+  });
+
+  describe('loadProgramStartDate', () => {
+    test('returns null when nothing is stored', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+      await expect(loadProgramStartDate()).resolves.toBeNull();
+    });
+
+    test('parses a stored ISO date back to a local Date', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('2026-05-12');
+      const date = await loadProgramStartDate();
+      expect(date).toBeInstanceOf(Date);
+      expect(date?.getFullYear()).toBe(2026);
+      expect(date?.getMonth()).toBe(4);
+      expect(date?.getDate()).toBe(12);
+    });
+
+    test('returns null for a malformed value rather than throwing', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('not-a-date');
+      await expect(loadProgramStartDate()).resolves.toBeNull();
+    });
+
+    test('returns null when AsyncStorage throws', async () => {
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('boom'));
+      await expect(loadProgramStartDate()).resolves.toBeNull();
+    });
+  });
+
+  describe('clearProgramStartDate', () => {
+    test('removes the stored date', async () => {
+      await clearProgramStartDate();
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(KEY);
+    });
+  });
+});

--- a/frontend/src/storage/programStorage.ts
+++ b/frontend/src/storage/programStorage.ts
@@ -1,16 +1,4 @@
-/**
- * Program start date persistence.
- *
- * The program start date is the master anchor for the 36-week APTITUDE
- * journey: BotMason's weekly prompt, the active practice, the unlocked
- * course content, and the highlighted map stage all derive from
- * ``today - programStartDate``.  It is stored in AsyncStorage as an
- * ISO-8601 date string (``YYYY-MM-DD``) so that the calendar day is
- * preserved across timezone changes.  ``null`` means the user has not
- * picked a start date yet -- consumers must then fall back to their
- * server-derived progression signal.
- */
-
+// Stores the program anchor as YYYY-MM-DD (local calendar day) so TZ shifts can't roll the date.
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const PROGRAM_START_DATE_KEY = '@adepthood/program_start_date';

--- a/frontend/src/storage/programStorage.ts
+++ b/frontend/src/storage/programStorage.ts
@@ -1,0 +1,54 @@
+/**
+ * Program start date persistence.
+ *
+ * The program start date is the master anchor for the 36-week APTITUDE
+ * journey: BotMason's weekly prompt, the active practice, the unlocked
+ * course content, and the highlighted map stage all derive from
+ * ``today - programStartDate``.  It is stored in AsyncStorage as an
+ * ISO-8601 date string (``YYYY-MM-DD``) so that the calendar day is
+ * preserved across timezone changes.  ``null`` means the user has not
+ * picked a start date yet -- consumers must then fall back to their
+ * server-derived progression signal.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const PROGRAM_START_DATE_KEY = '@adepthood/program_start_date';
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const toISODate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const parseISODate = (iso: string): Date | null => {
+  if (!ISO_DATE_RE.test(iso)) return null;
+  const [yStr, mStr, dStr] = iso.split('-');
+  const year = Number(yStr);
+  const month = Number(mStr);
+  const day = Number(dStr);
+  const date = new Date(year, month - 1, day);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+export async function saveProgramStartDate(date: Date): Promise<void> {
+  await AsyncStorage.setItem(PROGRAM_START_DATE_KEY, toISODate(date));
+}
+
+export async function loadProgramStartDate(): Promise<Date | null> {
+  try {
+    const raw = await AsyncStorage.getItem(PROGRAM_START_DATE_KEY);
+    if (raw === null) return null;
+    return parseISODate(raw);
+  } catch (err) {
+    console.warn('[programStorage] failed to load program start date', err);
+    return null;
+  }
+}
+
+export async function clearProgramStartDate(): Promise<void> {
+  await AsyncStorage.removeItem(PROGRAM_START_DATE_KEY);
+}

--- a/frontend/src/store/__tests__/useProgramProgression.test.tsx
+++ b/frontend/src/store/__tests__/useProgramProgression.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { act, render } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import { useDerivedCurrentStage, useDerivedCurrentWeek } from '../useProgramProgression';
+import { useProgramStore } from '../useProgramStore';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const Probe = ({
+  today,
+  fallbackStage,
+  fallbackWeek,
+}: {
+  today: Date;
+  fallbackStage: number;
+  fallbackWeek: number;
+}) => {
+  const stage = useDerivedCurrentStage(fallbackStage, today);
+  const week = useDerivedCurrentWeek(fallbackWeek, today);
+  return (
+    <>
+      <Text testID="stage">{stage}</Text>
+      <Text testID="week">{week}</Text>
+    </>
+  );
+};
+
+beforeEach(() => {
+  act(() => useProgramStore.getState().hydrateProgramStartDate(null));
+});
+
+describe('useDerivedCurrentStage / useDerivedCurrentWeek', () => {
+  it('returns the fallback when no anchor is set', () => {
+    const result = render(
+      <Probe today={new Date(2026, 4, 12)} fallbackStage={3} fallbackWeek={9} />,
+    );
+    expect(result.getByTestId('stage').props.children).toBe(3);
+    expect(result.getByTestId('week').props.children).toBe(9);
+  });
+
+  it('returns date-derived stage/week when the anchor is set', () => {
+    act(() => useProgramStore.getState().setProgramStartDate(new Date(2026, 0, 1)));
+    // Day 22 → Stage 2 (21-day stage 1 elapsed), Week 4.
+    const result = render(
+      <Probe today={new Date(2026, 0, 23)} fallbackStage={1} fallbackWeek={1} />,
+    );
+    expect(result.getByTestId('stage').props.children).toBe(2);
+    expect(result.getByTestId('week').props.children).toBe(4);
+  });
+
+  it('reacts when the anchor changes', () => {
+    const Wrapped = () => <Probe today={new Date(2026, 5, 1)} fallbackStage={1} fallbackWeek={1} />;
+    const result = render(<Wrapped />);
+    expect(result.getByTestId('stage').props.children).toBe(1);
+
+    act(() => useProgramStore.getState().setProgramStartDate(new Date(2026, 0, 1)));
+    // June 1, 2026 - Jan 1, 2026 = ~151 days → Stage 8.
+    expect(result.getByTestId('stage').props.children).toBe(8);
+  });
+});

--- a/frontend/src/store/__tests__/useProgramStore.test.ts
+++ b/frontend/src/store/__tests__/useProgramStore.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { act } from '@testing-library/react-native';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const mockAsyncStorage = jest.requireMock('@react-native-async-storage/async-storage') as {
+  setItem: jest.Mock;
+  getItem: jest.Mock;
+  removeItem: jest.Mock;
+};
+
+describe('useProgramStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { useProgramStore } = require('../useProgramStore');
+    act(() => {
+      useProgramStore.getState().hydrateProgramStartDate(null);
+    });
+  });
+
+  it('starts with no program start date', () => {
+    const { useProgramStore } = require('../useProgramStore');
+    expect(useProgramStore.getState().programStartDate).toBeNull();
+  });
+
+  it('setProgramStartDate normalises to midnight local time', () => {
+    const { useProgramStore } = require('../useProgramStore');
+    const evening = new Date(2026, 4, 12, 23, 45);
+    act(() => useProgramStore.getState().setProgramStartDate(evening));
+
+    const stored = useProgramStore.getState().programStartDate!;
+    expect(stored.getFullYear()).toBe(2026);
+    expect(stored.getMonth()).toBe(4);
+    expect(stored.getDate()).toBe(12);
+    expect(stored.getHours()).toBe(0);
+    expect(stored.getMinutes()).toBe(0);
+  });
+
+  it('setProgramStartDate persists to AsyncStorage', async () => {
+    const { useProgramStore } = require('../useProgramStore');
+    act(() => useProgramStore.getState().setProgramStartDate(new Date(2026, 0, 1)));
+    // Persistence is fire-and-forget; flush microtasks before asserting.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+      '@adepthood/program_start_date',
+      '2026-01-01',
+    );
+  });
+
+  it('setProgramStartDate(null) clears persisted storage', async () => {
+    const { useProgramStore } = require('../useProgramStore');
+    act(() => useProgramStore.getState().setProgramStartDate(null));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/program_start_date');
+  });
+
+  it('accepts past dates without throwing', () => {
+    const { useProgramStore } = require('../useProgramStore');
+    const past = new Date(2020, 0, 1);
+    act(() => useProgramStore.getState().setProgramStartDate(past));
+    expect(useProgramStore.getState().programStartDate?.getFullYear()).toBe(2020);
+  });
+
+  it('hydrateProgramStartDate sets the value without writing storage', async () => {
+    const { useProgramStore } = require('../useProgramStore');
+    act(() => useProgramStore.getState().hydrateProgramStartDate(new Date(2026, 5, 1)));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockAsyncStorage.setItem).not.toHaveBeenCalled();
+    expect(useProgramStore.getState().programStartDate?.getMonth()).toBe(5);
+  });
+
+  it('reset() clears the anchor and removes persisted storage', async () => {
+    const { useProgramStore } = require('../useProgramStore');
+    act(() => useProgramStore.getState().setProgramStartDate(new Date(2026, 0, 1)));
+    mockAsyncStorage.removeItem.mockClear();
+
+    act(() => useProgramStore.getState().reset());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(useProgramStore.getState().programStartDate).toBeNull();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/program_start_date');
+  });
+
+  it('reset runs when resetAllStores is called', () => {
+    const { useProgramStore } = require('../useProgramStore');
+    const { resetAllStores } = require('../registry');
+    act(() => useProgramStore.getState().setProgramStartDate(new Date(2026, 0, 1)));
+    act(() => resetAllStores());
+    expect(useProgramStore.getState().programStartDate).toBeNull();
+  });
+});
+
+describe('programDayOffset / programWeek / programStage', () => {
+  const { programDayOffset, programWeek, programStage } = require('../useProgramStore');
+
+  it('returns null for every derived value when no anchor is set', () => {
+    expect(programDayOffset(null)).toBeNull();
+    expect(programWeek(null)).toBeNull();
+    expect(programStage(null)).toBeNull();
+  });
+
+  it('returns 0 offset / week 1 / stage 1 on the anchor day', () => {
+    const anchor = new Date(2026, 4, 12);
+    expect(programDayOffset(anchor, anchor)).toBe(0);
+    expect(programWeek(anchor, anchor)).toBe(1);
+    expect(programStage(anchor, anchor)).toBe(1);
+  });
+
+  it('clamps a future anchor to week 1 / stage 1 (pre-program)', () => {
+    const anchor = new Date(2026, 4, 20);
+    const today = new Date(2026, 4, 12);
+    expect(programDayOffset(anchor, today)).toBe(-8);
+    expect(programWeek(anchor, today)).toBe(1);
+    expect(programStage(anchor, today)).toBe(1);
+  });
+
+  it('advances week and stage as days elapse', () => {
+    const anchor = new Date(2026, 0, 1);
+
+    // Day 7 -> Week 2, still Stage 1 (21-day stage).
+    expect(programWeek(anchor, new Date(2026, 0, 8))).toBe(2);
+    expect(programStage(anchor, new Date(2026, 0, 8))).toBe(1);
+
+    // Day 21 -> Week 4, Stage 2.
+    expect(programWeek(anchor, new Date(2026, 0, 22))).toBe(4);
+    expect(programStage(anchor, new Date(2026, 0, 22))).toBe(2);
+
+    // Day 168 -> end of Stage 8, Stage 9 begins (24 weeks in).
+    const dayInMs = 24 * 60 * 60 * 1000;
+    expect(programStage(anchor, new Date(anchor.getTime() + 168 * dayInMs))).toBe(9);
+
+    // Day 210 -> Stage 10 begins (30 weeks in).
+    expect(programStage(anchor, new Date(anchor.getTime() + 210 * dayInMs))).toBe(10);
+  });
+
+  it('clamps a long-past anchor to week 36 / stage 10', () => {
+    const anchor = new Date(2020, 0, 1);
+    const today = new Date(2026, 4, 12);
+    expect(programWeek(anchor, today)).toBe(36);
+    expect(programStage(anchor, today)).toBe(10);
+  });
+});

--- a/frontend/src/store/useProgramProgression.ts
+++ b/frontend/src/store/useProgramProgression.ts
@@ -1,32 +1,11 @@
-/**
- * React hooks for date-driven program progression.
- *
- * These wrap ``useProgramStore`` so consumers can ask for the current
- * stage or current week as a single render-friendly value, with a
- * ``fallback`` to use when the user has not yet picked a master anchor.
- *
- * Splitting these out of ``useProgramStore`` keeps the store file a pure
- * state container (the project's convention) and gives feature code a
- * stable entry point that can be unit-tested in isolation from the
- * date-arithmetic helpers.
- */
-
+// React hooks layered on useProgramStore so consumers get a single render-friendly value plus a server-derived fallback.
 import { useProgramStore, programStage, programWeek } from './useProgramStore';
 
-/**
- * Return the date-derived current stage (1-10), or ``fallback`` when no
- * program anchor is set.  ``today`` defaults to ``new Date()`` -- pass
- * an explicit value in tests to avoid clock dependence.
- */
 export const useDerivedCurrentStage = (fallback: number, today: Date = new Date()): number => {
   const anchor = useProgramStore((s) => s.programStartDate);
   return programStage(anchor, today) ?? fallback;
 };
 
-/**
- * Return the date-derived current week (1-36), or ``fallback`` when no
- * program anchor is set.
- */
 export const useDerivedCurrentWeek = (fallback: number, today: Date = new Date()): number => {
   const anchor = useProgramStore((s) => s.programStartDate);
   return programWeek(anchor, today) ?? fallback;

--- a/frontend/src/store/useProgramProgression.ts
+++ b/frontend/src/store/useProgramProgression.ts
@@ -1,0 +1,33 @@
+/**
+ * React hooks for date-driven program progression.
+ *
+ * These wrap ``useProgramStore`` so consumers can ask for the current
+ * stage or current week as a single render-friendly value, with a
+ * ``fallback`` to use when the user has not yet picked a master anchor.
+ *
+ * Splitting these out of ``useProgramStore`` keeps the store file a pure
+ * state container (the project's convention) and gives feature code a
+ * stable entry point that can be unit-tested in isolation from the
+ * date-arithmetic helpers.
+ */
+
+import { useProgramStore, programStage, programWeek } from './useProgramStore';
+
+/**
+ * Return the date-derived current stage (1-10), or ``fallback`` when no
+ * program anchor is set.  ``today`` defaults to ``new Date()`` -- pass
+ * an explicit value in tests to avoid clock dependence.
+ */
+export const useDerivedCurrentStage = (fallback: number, today: Date = new Date()): number => {
+  const anchor = useProgramStore((s) => s.programStartDate);
+  return programStage(anchor, today) ?? fallback;
+};
+
+/**
+ * Return the date-derived current week (1-36), or ``fallback`` when no
+ * program anchor is set.
+ */
+export const useDerivedCurrentWeek = (fallback: number, today: Date = new Date()): number => {
+  const anchor = useProgramStore((s) => s.programStartDate);
+  return programWeek(anchor, today) ?? fallback;
+};

--- a/frontend/src/store/useProgramStore.ts
+++ b/frontend/src/store/useProgramStore.ts
@@ -1,29 +1,13 @@
-/**
- * Program store -- the master clock for the 36-week APTITUDE journey.
- *
- * ``programStartDate`` is the user-chosen anchor (set via the
- * ReorderHabitsModal start-date picker, or the onboarding flow).  Once
- * set, it drives:
- *
- *   * the current week BotMason shows in the weekly prompt banner;
- *   * the practice that the Practice screen pre-selects;
- *   * which course content is unlocked / next on the Course screen;
- *   * the highlighted stage on the Map.
- *
- * Past dates are allowed (the user may have started the program before
- * installing the app and want today to land on Week 5, etc.).  Future
- * dates clamp every consumer to Stage 1 / Week 1 (pre-program state) so
- * the UI never advances ahead of the anchor.
- *
- * The store is a dumb in-memory container; persistence to AsyncStorage
- * lives in ``src/storage/programStorage.ts`` and is invoked from the
- * actions below so write-through is automatic.
- */
-
+// Master clock for the 36-week journey: drives BotMason week, active practice, course unlock, and map stage.
+import { useEffect } from 'react';
 import { create } from 'zustand';
 
-import { STAGE_DURATIONS_DAYS } from '../features/Habits/HabitUtils';
-import { clearProgramStartDate, saveProgramStartDate } from '../storage/programStorage';
+import { STAGE_DURATIONS_DAYS } from '../constants/program';
+import {
+  clearProgramStartDate,
+  loadProgramStartDate,
+  saveProgramStartDate,
+} from '../storage/programStorage';
 
 import { registerStoreReset } from './registry';
 
@@ -31,25 +15,15 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24;
 const DAYS_PER_WEEK = 7;
 const STAGE_COUNT = STAGE_DURATIONS_DAYS.length;
 const TOTAL_PROGRAM_DAYS = STAGE_DURATIONS_DAYS.reduce((sum, d) => sum + d, 0);
-const TOTAL_PROGRAM_WEEKS = TOTAL_PROGRAM_DAYS / DAYS_PER_WEEK;
+// Integer-pinned so a future non-7-multiple change to STAGE_DURATIONS_DAYS can't silently leak fractional weeks.
+const TOTAL_PROGRAM_WEEKS = Math.floor(TOTAL_PROGRAM_DAYS / DAYS_PER_WEEK);
 
 export interface ProgramStoreState {
-  /**
-   * The user-chosen master anchor date (local calendar day), or ``null``
-   * when the user hasn't set one yet.  Stored as a ``Date`` for ergonomic
-   * arithmetic; serialised as ``YYYY-MM-DD`` in AsyncStorage.
-   */
   programStartDate: Date | null;
-
-  /** Set the anchor; persists to AsyncStorage. ``null`` clears the anchor. */
   setProgramStartDate: (_date: Date | null) => void;
-  /**
-   * Synchronously seed the store after hydrating from storage on app
-   * start.  Skips the persistence write -- the value already lives on
-   * disk -- so we don't churn AsyncStorage on every boot.
-   */
+  // Seed from storage on boot without re-writing it.
   hydrateProgramStartDate: (_date: Date | null) => void;
-  /** BUG-FE-STATE-001: wipe state on logout. Also clears persisted storage. */
+  // BUG-FE-STATE-001: wipe on logout. Also clears persisted storage.
   reset: () => void;
 }
 
@@ -92,24 +66,10 @@ registerStoreReset(() => {
   useProgramStore.getState().reset();
 });
 
-// ---------------------------------------------------------------------------
-// Selectors and derived helpers.
-//
-// The selectors below are pure functions of ``programStartDate`` plus the
-// caller-supplied ``today`` (defaulting to ``new Date()``).  Threading
-// ``today`` as an argument keeps the helpers deterministic for tests and
-// lets a future "time travel" debug toggle override the clock without
-// patching ``Date``.
-// ---------------------------------------------------------------------------
-
 export const selectProgramStartDate = (state: ProgramStoreState): Date | null =>
   state.programStartDate;
 
-/**
- * Whole calendar-day offset between ``today`` and the anchor.  Negative
- * when the anchor is still in the future; clamped to ``>= 0`` by every
- * consumer below so a future anchor never advances the UI past Week 1.
- */
+// Whole calendar-day offset; negative when the anchor is still in the future.
 export const programDayOffset = (anchor: Date | null, today: Date = new Date()): number | null => {
   if (anchor === null) return null;
   const a = normalize(anchor).getTime();
@@ -117,11 +77,7 @@ export const programDayOffset = (anchor: Date | null, today: Date = new Date()):
   return Math.floor((t - a) / MS_PER_DAY);
 };
 
-/**
- * Current program week (1-36) given the anchor.  Returns ``null`` when
- * no anchor is set.  Clamps below to 1 (anchor in the future) and above
- * to 36 (program already complete).
- */
+// Current program week (1-36), or null when no anchor. Future anchors clamp to 1; finished programs clamp to 36.
 export const programWeek = (anchor: Date | null, today: Date = new Date()): number | null => {
   const offset = programDayOffset(anchor, today);
   if (offset === null) return null;
@@ -131,11 +87,7 @@ export const programWeek = (anchor: Date | null, today: Date = new Date()): numb
   return week;
 };
 
-/**
- * Current stage number (1-10) given the anchor.  Walks
- * ``STAGE_DURATIONS_DAYS`` so the 21-day / 42-day split is honoured.
- * Returns ``null`` when no anchor is set.
- */
+// Current stage (1-10) walking STAGE_DURATIONS_DAYS so the 21/42-day split is honoured.
 export const programStage = (anchor: Date | null, today: Date = new Date()): number | null => {
   const offset = programDayOffset(anchor, today);
   if (offset === null) return null;
@@ -148,3 +100,17 @@ export const programStage = (anchor: Date | null, today: Date = new Date()): num
   }
   return STAGE_COUNT;
 };
+
+// Hydrate the anchor from AsyncStorage on cold start so the first paint uses the real value, not the server fallback.
+export function useHydrateProgramStore(): void {
+  const hydrate = useProgramStore((s) => s.hydrateProgramStartDate);
+  useEffect(() => {
+    let cancelled = false;
+    void loadProgramStartDate().then((date) => {
+      if (!cancelled) hydrate(date);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [hydrate]);
+}

--- a/frontend/src/store/useProgramStore.ts
+++ b/frontend/src/store/useProgramStore.ts
@@ -1,0 +1,150 @@
+/**
+ * Program store -- the master clock for the 36-week APTITUDE journey.
+ *
+ * ``programStartDate`` is the user-chosen anchor (set via the
+ * ReorderHabitsModal start-date picker, or the onboarding flow).  Once
+ * set, it drives:
+ *
+ *   * the current week BotMason shows in the weekly prompt banner;
+ *   * the practice that the Practice screen pre-selects;
+ *   * which course content is unlocked / next on the Course screen;
+ *   * the highlighted stage on the Map.
+ *
+ * Past dates are allowed (the user may have started the program before
+ * installing the app and want today to land on Week 5, etc.).  Future
+ * dates clamp every consumer to Stage 1 / Week 1 (pre-program state) so
+ * the UI never advances ahead of the anchor.
+ *
+ * The store is a dumb in-memory container; persistence to AsyncStorage
+ * lives in ``src/storage/programStorage.ts`` and is invoked from the
+ * actions below so write-through is automatic.
+ */
+
+import { create } from 'zustand';
+
+import { STAGE_DURATIONS_DAYS } from '../features/Habits/HabitUtils';
+import { clearProgramStartDate, saveProgramStartDate } from '../storage/programStorage';
+
+import { registerStoreReset } from './registry';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const DAYS_PER_WEEK = 7;
+const STAGE_COUNT = STAGE_DURATIONS_DAYS.length;
+const TOTAL_PROGRAM_DAYS = STAGE_DURATIONS_DAYS.reduce((sum, d) => sum + d, 0);
+const TOTAL_PROGRAM_WEEKS = TOTAL_PROGRAM_DAYS / DAYS_PER_WEEK;
+
+export interface ProgramStoreState {
+  /**
+   * The user-chosen master anchor date (local calendar day), or ``null``
+   * when the user hasn't set one yet.  Stored as a ``Date`` for ergonomic
+   * arithmetic; serialised as ``YYYY-MM-DD`` in AsyncStorage.
+   */
+  programStartDate: Date | null;
+
+  /** Set the anchor; persists to AsyncStorage. ``null`` clears the anchor. */
+  setProgramStartDate: (_date: Date | null) => void;
+  /**
+   * Synchronously seed the store after hydrating from storage on app
+   * start.  Skips the persistence write -- the value already lives on
+   * disk -- so we don't churn AsyncStorage on every boot.
+   */
+  hydrateProgramStartDate: (_date: Date | null) => void;
+  /** BUG-FE-STATE-001: wipe state on logout. Also clears persisted storage. */
+  reset: () => void;
+}
+
+const INITIAL_STATE = {
+  programStartDate: null as Date | null,
+};
+
+const normalize = (date: Date): Date => {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+const persistAsync = (date: Date | null): void => {
+  const op = date === null ? clearProgramStartDate() : saveProgramStartDate(date);
+  op.catch((err) => {
+    console.warn('[useProgramStore] failed to persist program start date', err);
+  });
+};
+
+export const useProgramStore = create<ProgramStoreState>((set) => ({
+  ...INITIAL_STATE,
+
+  setProgramStartDate: (date) => {
+    const normalized = date === null ? null : normalize(date);
+    set({ programStartDate: normalized });
+    persistAsync(normalized);
+  },
+  hydrateProgramStartDate: (date) => {
+    const normalized = date === null ? null : normalize(date);
+    set({ programStartDate: normalized });
+  },
+  reset: () => {
+    set({ ...INITIAL_STATE });
+    persistAsync(null);
+  },
+}));
+
+registerStoreReset(() => {
+  useProgramStore.getState().reset();
+});
+
+// ---------------------------------------------------------------------------
+// Selectors and derived helpers.
+//
+// The selectors below are pure functions of ``programStartDate`` plus the
+// caller-supplied ``today`` (defaulting to ``new Date()``).  Threading
+// ``today`` as an argument keeps the helpers deterministic for tests and
+// lets a future "time travel" debug toggle override the clock without
+// patching ``Date``.
+// ---------------------------------------------------------------------------
+
+export const selectProgramStartDate = (state: ProgramStoreState): Date | null =>
+  state.programStartDate;
+
+/**
+ * Whole calendar-day offset between ``today`` and the anchor.  Negative
+ * when the anchor is still in the future; clamped to ``>= 0`` by every
+ * consumer below so a future anchor never advances the UI past Week 1.
+ */
+export const programDayOffset = (anchor: Date | null, today: Date = new Date()): number | null => {
+  if (anchor === null) return null;
+  const a = normalize(anchor).getTime();
+  const t = normalize(today).getTime();
+  return Math.floor((t - a) / MS_PER_DAY);
+};
+
+/**
+ * Current program week (1-36) given the anchor.  Returns ``null`` when
+ * no anchor is set.  Clamps below to 1 (anchor in the future) and above
+ * to 36 (program already complete).
+ */
+export const programWeek = (anchor: Date | null, today: Date = new Date()): number | null => {
+  const offset = programDayOffset(anchor, today);
+  if (offset === null) return null;
+  if (offset < 0) return 1;
+  const week = Math.floor(offset / DAYS_PER_WEEK) + 1;
+  if (week > TOTAL_PROGRAM_WEEKS) return TOTAL_PROGRAM_WEEKS;
+  return week;
+};
+
+/**
+ * Current stage number (1-10) given the anchor.  Walks
+ * ``STAGE_DURATIONS_DAYS`` so the 21-day / 42-day split is honoured.
+ * Returns ``null`` when no anchor is set.
+ */
+export const programStage = (anchor: Date | null, today: Date = new Date()): number | null => {
+  const offset = programDayOffset(anchor, today);
+  if (offset === null) return null;
+  if (offset < 0) return 1;
+  let remaining = offset;
+  for (let i = 0; i < STAGE_COUNT; i += 1) {
+    const duration = STAGE_DURATIONS_DAYS[i]!;
+    if (remaining < duration) return i + 1;
+    remaining -= duration;
+  }
+  return STAGE_COUNT;
+};


### PR DESCRIPTION
The reorder-habits modal's date picker was rendered as a descendant of
the parent React Native <Modal>. On iOS, a nested UIViewController
modal presentation animates underneath the parent and is invisible to
the user, so tapping the start-date button in edit mode appeared to do
nothing. The picker is now mounted as a SIBLING of the parent modal so
react-native-modal-datetime-picker's own overFullScreen layer stacks
above everything.

The picker also no longer constrains minimumDate, so the user can back-
date their start (e.g. land today on Week 5 of the 36-week program).

The selected date now writes through to a new useProgramStore — the
master clock for the journey. BotMason's weekly prompt banner, the
Practice screen's active stage, the Course screen's selected stage,
and the Map screen's current stage all derive their value from
today - programStartDate (with the existing server-derived progression
as fallback when the user has not picked an anchor yet). The anchor is
persisted to AsyncStorage and hydrated on app boot so the choice
survives across sessions.