### PR TITLE
feat(frontend-practice): post-session insight modal + BotMason CTA (ritual-12)

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1610,6 +1610,9 @@ export interface SenseGroundingSessionMetadata {
   // Sense union duplicated inline (the engine layer owns the named type at
   // ``features/Practice/engine/types.SenseKind``); we keep the api wire
   // surface free of feature-layer imports.
+  // KEEP IN SYNC WITH ``features/Practice/engine/types.SenseKind`` —
+  // adding a new sense requires updating both unions or the engine emits
+  // a value the wire layer can't represent (and TS won't catch it).
   senses_completed: ReadonlyArray<'sight' | 'touch' | 'hearing' | 'smell' | 'taste'>;
 }
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1574,6 +1574,59 @@ export interface UserPracticeCustomize {
   mode_config_override?: ModeConfig | null;
 }
 
+/**
+ * Per-mode session metadata mirroring the backend
+ * :class:`schemas.practice_session_metadata.SessionMetadata`
+ * discriminated union (ritual-04). The runtime payload is plain JSON;
+ * the discriminator must match the resolved practice mode or the server
+ * returns 400 ``mode_metadata_mismatch``.
+ */
+export interface MeditationTimerSessionMetadata {
+  mode: 'meditation_timer';
+}
+
+export interface CountUpSessionMetadata {
+  mode: 'count_up';
+}
+
+export interface MetronomeSessionMetadata {
+  mode: 'metronome';
+  bpm_used: number;
+}
+
+export interface IntervalBellSessionMetadata {
+  mode: 'interval_bell';
+  intervals_struck: number;
+  total_intervals: number;
+}
+
+export interface RepCounterSessionMetadata {
+  mode: 'rep_counter';
+  rep_count: number;
+}
+
+export interface SenseGroundingSessionMetadata {
+  mode: 'sense_grounding';
+  // Sense union duplicated inline (the engine layer owns the named type at
+  // ``features/Practice/engine/types.SenseKind``); we keep the api wire
+  // surface free of feature-layer imports.
+  senses_completed: ReadonlyArray<'sight' | 'touch' | 'hearing' | 'smell' | 'taste'>;
+}
+
+export interface TarotSessionMetadata {
+  mode: 'tarot';
+  card_index: number;
+}
+
+export type SessionMetadata =
+  | MeditationTimerSessionMetadata
+  | CountUpSessionMetadata
+  | MetronomeSessionMetadata
+  | IntervalBellSessionMetadata
+  | RepCounterSessionMetadata
+  | SenseGroundingSessionMetadata
+  | TarotSessionMetadata;
+
 export interface PracticeSessionCreate {
   user_practice_id: number;
   // BUG-PRACTICE-006 / BUG-FE-PRACTICE-101: clients send wall-clock ISO
@@ -1582,6 +1635,12 @@ export interface PracticeSessionCreate {
   started_at: string;
   ended_at: string;
   reflection?: string | null;
+  /** ritual-04: per-mode session metadata; discriminator must match practice mode. */
+  mode_metadata?: SessionMetadata | null;
+  /** ritual-04: ``true`` means the engine reached its terminal state. */
+  completed?: boolean;
+  /** ritual-12: short post-session insight (≤ 2,000 chars; distinct from ``reflection``). */
+  insight?: string | null;
 }
 
 export interface PracticeSessionResponse {
@@ -1591,6 +1650,11 @@ export interface PracticeSessionResponse {
   duration_minutes: number;
   timestamp: string;
   reflection: string | null;
+  /** ritual-04 fields — older sessions may have these absent on the wire. */
+  mode?: string;
+  mode_metadata?: SessionMetadata | null;
+  completed?: boolean;
+  insight?: string | null;
 }
 
 export interface WeekCountResponse {

--- a/frontend/src/features/Practice/__tests__/InsightCaptureModal.test.tsx
+++ b/frontend/src/features/Practice/__tests__/InsightCaptureModal.test.tsx
@@ -145,4 +145,41 @@ describe('InsightCaptureModal', () => {
   it('exposes the hard cap constant matching the backend column max_length', () => {
     expect(PRACTICE_INSIGHT_HARD_CAP).toBe(2_000);
   });
+
+  it('clears the draft when the modal is re-shown after dismissal (retry path)', () => {
+    // Render a controlled wrapper so we can flip ``visible`` without
+    // remounting — the bug the reviewer flagged is that the draft state
+    // survived an open → close → open cycle because the component is
+    // null-rendered (not unmounted) when ``visible`` is false.
+    function Harness({ visible }: { visible: boolean }) {
+      return (
+        <InsightCaptureModal
+          visible={visible}
+          mode="meditation_timer"
+          durationMinutes={10}
+          modeMetadata={{ mode: 'meditation_timer' }}
+          onSave={jest.fn()}
+          onSkip={jest.fn()}
+        />
+      );
+    }
+    const { getByTestId, rerender } = render(<Harness visible />);
+    fireEvent.changeText(getByTestId('insight-input'), 'stale draft from a prior session');
+    rerender(<Harness visible={false} />);
+    rerender(<Harness visible />);
+    expect(getByTestId('insight-input').props.value).toBe('');
+  });
+
+  it('keeps Save enabled when the raw input crosses the hard cap only via trailing whitespace', () => {
+    // The submitted value is ``trimmed``; evaluating the cap against
+    // ``trimmed.length`` means a user who types right up to the cap and
+    // then adds a trailing space (e.g. mid-sentence) is not blocked.
+    const onSave = jest.fn();
+    const { getByTestId, queryByTestId } = renderModal({ onSave });
+    const atCap = 'x'.repeat(PRACTICE_INSIGHT_HARD_CAP);
+    fireEvent.changeText(getByTestId('insight-input'), `${atCap}    `);
+    expect(queryByTestId('insight-hard-error')).toBeNull();
+    fireEvent.press(getByTestId('insight-save'));
+    expect(onSave).toHaveBeenCalledWith(atCap);
+  });
 });

--- a/frontend/src/features/Practice/__tests__/InsightCaptureModal.test.tsx
+++ b/frontend/src/features/Practice/__tests__/InsightCaptureModal.test.tsx
@@ -1,0 +1,148 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import {
+  InsightCaptureModal,
+  type InsightCaptureModalProps,
+  PRACTICE_INSIGHT_HARD_CAP,
+  PRACTICE_INSIGHT_SOFT_CAP,
+} from '../components/InsightCaptureModal';
+import type { ModeSummaryMetadata } from '../insights/format';
+
+type RenderOpts = Partial<InsightCaptureModalProps>;
+
+function renderModal(opts: RenderOpts = {}) {
+  const props: InsightCaptureModalProps = {
+    visible: opts.visible ?? true,
+    mode: opts.mode ?? 'meditation_timer',
+    durationMinutes: opts.durationMinutes ?? 10,
+    modeMetadata: opts.modeMetadata ?? { mode: 'meditation_timer' },
+    onSave: opts.onSave ?? jest.fn(),
+    onSkip: opts.onSkip ?? jest.fn(),
+    // Defer to the explicit undefined-vs-default distinction so a test that
+    // passes ``onJournal: undefined`` exercises the "hand-off not wired"
+    // branch instead of silently getting the spy.
+    onJournal: 'onJournal' in opts ? opts.onJournal : jest.fn(),
+  };
+  return { ...render(<InsightCaptureModal {...props} />), props };
+}
+
+describe('InsightCaptureModal', () => {
+  it('renders nothing when visible is false', () => {
+    const { queryByTestId } = renderModal({ visible: false });
+    expect(queryByTestId('insight-capture-modal')).toBeNull();
+  });
+
+  it.each<[string, ModeSummaryMetadata['mode'], ModeSummaryMetadata, number, string]>([
+    ['meditation', 'meditation_timer', { mode: 'meditation_timer' }, 10, '10:00 of stillness'],
+    ['count-up', 'count_up', { mode: 'count_up' }, 7.5, '07:30 of open practice'],
+    ['metronome', 'metronome', { mode: 'metronome', bpm_used: 60 }, 30, 'BPM 60 for 30:00'],
+    [
+      'interval-bell',
+      'interval_bell',
+      { mode: 'interval_bell', intervals_struck: 3, total_intervals: 5 },
+      15,
+      '3/5 bells over 15:00',
+    ],
+    [
+      'rep-counter',
+      'rep_counter',
+      { mode: 'rep_counter', rep_count: 108, unit_label: 'breath cycles' },
+      12 + 34 / 60,
+      '108 breath cycles in 12:34',
+    ],
+    [
+      'sense-grounding',
+      'sense_grounding',
+      { mode: 'sense_grounding', senses_completed: ['sight', 'touch', 'hearing'] },
+      4,
+      'Grounded through 3 senses',
+    ],
+    [
+      'tarot',
+      'tarot',
+      { mode: 'tarot', card_index: 0, card_name: 'The Fool' },
+      5,
+      'The Fool for 05:00',
+    ],
+  ])('renders the %s summary line', (_label, mode, modeMetadata, durationMinutes, expected) => {
+    const { getByTestId } = renderModal({ mode, modeMetadata, durationMinutes });
+    expect(getByTestId('insight-summary').props.children).toBe(expected);
+  });
+
+  it('passes the typed insight to onSave when Save is pressed', () => {
+    const onSave = jest.fn();
+    const { getByTestId } = renderModal({ onSave });
+    fireEvent.changeText(getByTestId('insight-input'), 'Felt steady.');
+    fireEvent.press(getByTestId('insight-save'));
+    expect(onSave).toHaveBeenCalledWith('Felt steady.');
+  });
+
+  it('passes the typed insight to onJournal when Save & journal is pressed', () => {
+    const onJournal = jest.fn();
+    const { getByTestId } = renderModal({ onJournal });
+    fireEvent.changeText(getByTestId('insight-input'), 'Curious about a memory.');
+    fireEvent.press(getByTestId('insight-journal'));
+    expect(onJournal).toHaveBeenCalledWith('Curious about a memory.');
+  });
+
+  it('hides the Save & journal CTA when onJournal is not wired', () => {
+    const { queryByTestId } = renderModal({ onJournal: undefined });
+    expect(queryByTestId('insight-journal')).toBeNull();
+  });
+
+  it('calls onSkip with no arguments when Skip is pressed (no insight POSTed)', () => {
+    const onSkip = jest.fn();
+    const { getByTestId } = renderModal({ onSkip });
+    // Typing then skipping must still skip — the buffered insight is discarded.
+    fireEvent.changeText(getByTestId('insight-input'), 'Will not be saved.');
+    fireEvent.press(getByTestId('insight-skip'));
+    expect(onSkip).toHaveBeenCalledWith();
+  });
+
+  it('trims whitespace-only insights to empty strings (still routed via onSave)', () => {
+    const onSave = jest.fn();
+    const { getByTestId } = renderModal({ onSave });
+    fireEvent.changeText(getByTestId('insight-input'), '   ');
+    fireEvent.press(getByTestId('insight-save'));
+    expect(onSave).toHaveBeenCalledWith('');
+  });
+
+  it('shows a soft hint once the soft cap is crossed but keeps Save enabled', () => {
+    const onSave = jest.fn();
+    const { getByTestId, queryByTestId } = renderModal({ onSave });
+    const longish = 'x'.repeat(PRACTICE_INSIGHT_SOFT_CAP + 1);
+    fireEvent.changeText(getByTestId('insight-input'), longish);
+    expect(queryByTestId('insight-soft-hint')).toBeTruthy();
+    expect(queryByTestId('insight-hard-error')).toBeNull();
+    fireEvent.press(getByTestId('insight-save'));
+    expect(onSave).toHaveBeenCalledWith(longish);
+  });
+
+  it('disables Save and surfaces a validation message beyond the hard cap', () => {
+    const onSave = jest.fn();
+    const onJournal = jest.fn();
+    const { getByTestId, queryByTestId } = renderModal({ onSave, onJournal });
+    const tooLong = 'x'.repeat(PRACTICE_INSIGHT_HARD_CAP + 1);
+    fireEvent.changeText(getByTestId('insight-input'), tooLong);
+    expect(queryByTestId('insight-hard-error')).toBeTruthy();
+    fireEvent.press(getByTestId('insight-save'));
+    fireEvent.press(getByTestId('insight-journal'));
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onJournal).not.toHaveBeenCalled();
+  });
+
+  it('still lets the user skip when the hard cap is exceeded (analytics row matters)', () => {
+    const onSkip = jest.fn();
+    const { getByTestId } = renderModal({ onSkip });
+    fireEvent.changeText(getByTestId('insight-input'), 'x'.repeat(PRACTICE_INSIGHT_HARD_CAP + 50));
+    fireEvent.press(getByTestId('insight-skip'));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes the hard cap constant matching the backend column max_length', () => {
+    expect(PRACTICE_INSIGHT_HARD_CAP).toBe(2_000);
+  });
+});

--- a/frontend/src/features/Practice/components/InsightCaptureModal.tsx
+++ b/frontend/src/features/Practice/components/InsightCaptureModal.tsx
@@ -1,0 +1,361 @@
+/**
+ * `InsightCaptureModal` — post-session prompt for a short one-line insight.
+ *
+ * Lifts out of the parent screen (ritual-11's `PracticeScreen`) every time
+ * the ritual engine emits ``complete``. Three buttons:
+ *
+ *   - **Save**: POST the session row with the typed insight attached and
+ *     dismiss.
+ *   - **Save & journal with BotMason** (when ``onJournal`` is wired): POST
+ *     then hand off to the Journal tab with ``practiceSessionId`` so
+ *     BotMason has context. Hidden when the parent does not wire the
+ *     handler (precedent: `PracticeSwitcherSheet.onSubmitOwn`).
+ *   - **Skip**: POST the session row *without* an insight. Analytics still
+ *     need the row; only the free-text field is omitted.
+ *
+ * Caps mirror the backend ``PRACTICE_INSIGHT_MAX_LENGTH`` constant
+ * (see :mod:`backend.src.schemas.practice`). Crossing the soft cap shows a
+ * gentle nudge; crossing the hard cap disables Save / Journal but keeps
+ * Skip enabled so the user can still close the prompt without losing the
+ * analytics row.
+ */
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import {
+  formatModeSummary,
+  type ModeSummaryKind,
+  type ModeSummaryMetadata,
+} from '../insights/format';
+
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+/** Soft cap — the modal nudges the user toward a single sentence past this. */
+export const PRACTICE_INSIGHT_SOFT_CAP = 200;
+/** Hard cap — matches `backend.src.schemas.practice.PRACTICE_INSIGHT_MAX_LENGTH`. */
+export const PRACTICE_INSIGHT_HARD_CAP = 2_000;
+
+export interface InsightCaptureModalProps {
+  /** Visibility flag — parent owns mount state so the engine can re-show on retry. */
+  visible: boolean;
+  /** Mode discriminator (must match ``modeMetadata.mode`` at the type level). */
+  mode: ModeSummaryKind;
+  /** Server-derived duration in minutes (fractional allowed). */
+  durationMinutes: number;
+  /** Per-mode session metadata for the summary line; see ``insights/format.ts``. */
+  modeMetadata: ModeSummaryMetadata;
+  /** Called with the trimmed insight string when Save is tapped. */
+  onSave: (_insight: string) => void;
+  /** Called with no args when Skip is tapped — the session is still POSTed by the parent. */
+  onSkip: () => void;
+  /**
+   * Optional Journal hand-off. When wired, the modal renders the
+   * "Save & journal with BotMason" CTA; when absent, the CTA is hidden so
+   * the modal can ship before the journal-link plumbing is merged.
+   */
+  onJournal?: (_insight: string) => void;
+}
+
+interface ValidationResult {
+  trimmed: string;
+  withinSoftCap: boolean;
+  withinHardCap: boolean;
+}
+
+function validate(input: string): ValidationResult {
+  const trimmed = input.trim();
+  return {
+    trimmed,
+    withinSoftCap: input.length <= PRACTICE_INSIGHT_SOFT_CAP,
+    withinHardCap: input.length <= PRACTICE_INSIGHT_HARD_CAP,
+  };
+}
+
+interface SummaryBlockProps {
+  mode: ModeSummaryKind;
+  durationMinutes: number;
+  metadata: ModeSummaryMetadata;
+}
+
+function SummaryBlock({ mode, durationMinutes, metadata }: SummaryBlockProps) {
+  // formatModeSummary narrows its `metadata` arg via the generic — the cast
+  // is needed because the props type pairs ``mode`` and ``modeMetadata`` at
+  // the modal boundary but not at the generic call-site.
+  const summary = useMemo(
+    () =>
+      formatModeSummary(
+        mode,
+        durationMinutes,
+        metadata as Extract<ModeSummaryMetadata, { mode: typeof mode }>,
+      ),
+    [mode, durationMinutes, metadata],
+  );
+  return (
+    <Text style={styles.summary} testID="insight-summary">
+      {summary}
+    </Text>
+  );
+}
+
+interface CapHintsProps {
+  withinSoftCap: boolean;
+  withinHardCap: boolean;
+}
+
+function CapHints({ withinSoftCap, withinHardCap }: CapHintsProps) {
+  if (!withinHardCap) {
+    return (
+      <Text style={styles.hardError} testID="insight-hard-error">
+        Keep your note under {PRACTICE_INSIGHT_HARD_CAP.toLocaleString()} characters to save.
+      </Text>
+    );
+  }
+  if (!withinSoftCap) {
+    return (
+      <Text style={styles.softHint} testID="insight-soft-hint">
+        One sentence is plenty — the reflection lives in your journal.
+      </Text>
+    );
+  }
+  return null;
+}
+
+interface ActionsProps {
+  saveDisabled: boolean;
+  onSavePress: () => void;
+  onSkipPress: () => void;
+  onJournalPress?: () => void;
+}
+
+function Actions({ saveDisabled, onSavePress, onSkipPress, onJournalPress }: ActionsProps) {
+  return (
+    <View style={styles.actions}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ disabled: saveDisabled }}
+        disabled={saveDisabled}
+        onPress={onSavePress}
+        style={[styles.primaryButton, saveDisabled && styles.disabled]}
+        testID="insight-save"
+      >
+        <Text style={styles.primaryText}>Save</Text>
+      </Pressable>
+      {onJournalPress && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ disabled: saveDisabled }}
+          disabled={saveDisabled}
+          onPress={onJournalPress}
+          style={[styles.secondaryButton, saveDisabled && styles.disabled]}
+          testID="insight-journal"
+        >
+          <Text style={styles.secondaryText}>Save &amp; journal with BotMason</Text>
+        </Pressable>
+      )}
+      <Pressable
+        accessibilityRole="button"
+        onPress={onSkipPress}
+        style={styles.skipButton}
+        testID="insight-skip"
+      >
+        <Text style={styles.skipText}>Skip</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+interface SheetContentProps {
+  mode: ModeSummaryKind;
+  durationMinutes: number;
+  modeMetadata: ModeSummaryMetadata;
+  draft: string;
+  setDraft: (_value: string) => void;
+  withinSoftCap: boolean;
+  withinHardCap: boolean;
+  onSavePress: () => void;
+  onSkipPress: () => void;
+  onJournalPress?: () => void;
+}
+
+function SheetContent(props: SheetContentProps) {
+  const {
+    mode,
+    durationMinutes,
+    modeMetadata,
+    draft,
+    setDraft,
+    withinSoftCap,
+    withinHardCap,
+    onSavePress,
+    onSkipPress,
+    onJournalPress,
+  } = props;
+  return (
+    <View style={styles.sheet}>
+      <Text style={styles.title}>How did it land?</Text>
+      <SummaryBlock mode={mode} durationMinutes={durationMinutes} metadata={modeMetadata} />
+      <TextInput
+        accessibilityLabel="One-line insight"
+        multiline
+        onChangeText={setDraft}
+        placeholder="One sentence is plenty…"
+        placeholderTextColor={colors.text.tertiaryAccessible}
+        style={styles.input}
+        testID="insight-input"
+        value={draft}
+      />
+      <CapHints withinSoftCap={withinSoftCap} withinHardCap={withinHardCap} />
+      <Actions
+        saveDisabled={!withinHardCap}
+        onSavePress={onSavePress}
+        onSkipPress={onSkipPress}
+        onJournalPress={onJournalPress}
+      />
+    </View>
+  );
+}
+
+export function InsightCaptureModal({
+  visible,
+  mode,
+  durationMinutes,
+  modeMetadata,
+  onSave,
+  onSkip,
+  onJournal,
+}: InsightCaptureModalProps): React.JSX.Element | null {
+  const [draft, setDraft] = useState('');
+  const { trimmed, withinSoftCap, withinHardCap } = validate(draft);
+
+  const handleSave = useCallback(() => {
+    if (!withinHardCap) return;
+    onSave(trimmed);
+  }, [onSave, trimmed, withinHardCap]);
+
+  const handleJournal = useCallback(() => {
+    if (!withinHardCap || !onJournal) return;
+    onJournal(trimmed);
+  }, [onJournal, trimmed, withinHardCap]);
+
+  if (!visible) return null;
+
+  return (
+    <Modal
+      animationType="fade"
+      onRequestClose={onSkip}
+      transparent
+      visible={visible}
+      testID="insight-capture-modal"
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.backdrop}
+      >
+        <SheetContent
+          mode={mode}
+          durationMinutes={durationMinutes}
+          modeMetadata={modeMetadata}
+          draft={draft}
+          setDraft={setDraft}
+          withinSoftCap={withinSoftCap}
+          withinHardCap={withinHardCap}
+          onSavePress={handleSave}
+          onSkipPress={onSkip}
+          onJournalPress={onJournal ? handleJournal : undefined}
+        />
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.lg,
+  },
+  sheet: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.xl,
+    padding: SPACING.xl,
+    ...shadows.large,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: colors.text.primary,
+    marginBottom: SPACING.xs,
+  },
+  summary: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    marginBottom: SPACING.md,
+  },
+  input: {
+    minHeight: 80,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md,
+    fontSize: 16,
+    color: colors.text.primary,
+    textAlignVertical: 'top',
+  },
+  softHint: {
+    color: colors.text.secondaryAccessible,
+    fontSize: 13,
+    marginTop: SPACING.sm,
+  },
+  hardError: {
+    color: colors.destructive.text,
+    fontSize: 13,
+    marginTop: SPACING.sm,
+  },
+  actions: {
+    marginTop: SPACING.lg,
+    gap: SPACING.sm,
+  },
+  primaryButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.buttonV,
+    borderRadius: BORDER_RADIUS.lg,
+    alignItems: 'center',
+  },
+  primaryText: {
+    color: colors.text.light,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    backgroundColor: colors.secondary,
+    paddingVertical: SPACING.buttonV,
+    borderRadius: BORDER_RADIUS.lg,
+    alignItems: 'center',
+  },
+  secondaryText: {
+    color: colors.text.light,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  skipButton: {
+    paddingVertical: SPACING.md,
+    alignItems: 'center',
+  },
+  skipText: {
+    color: colors.text.tertiaryAccessible,
+    fontSize: 15,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});

--- a/frontend/src/features/Practice/components/InsightCaptureModal.tsx
+++ b/frontend/src/features/Practice/components/InsightCaptureModal.tsx
@@ -19,7 +19,7 @@
  * Skip enabled so the user can still close the prompt without losing the
  * analytics row.
  */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Modal,
@@ -72,11 +72,17 @@ interface ValidationResult {
 }
 
 function validate(input: string): ValidationResult {
+  // Caps are evaluated against the trimmed value because that is what gets
+  // POSTed to ``/practice-sessions`` (and what the backend's
+  // ``PRACTICE_INSIGHT_MAX_LENGTH`` validator actually sees). Evaluating on
+  // raw ``input.length`` would block a user who, mid-sentence, lands on the
+  // cap with a trailing space — surprising UX given the trailing whitespace
+  // is dropped before the send.
   const trimmed = input.trim();
   return {
     trimmed,
-    withinSoftCap: input.length <= PRACTICE_INSIGHT_SOFT_CAP,
-    withinHardCap: input.length <= PRACTICE_INSIGHT_HARD_CAP,
+    withinSoftCap: trimmed.length <= PRACTICE_INSIGHT_SOFT_CAP,
+    withinHardCap: trimmed.length <= PRACTICE_INSIGHT_HARD_CAP,
   };
 }
 
@@ -224,6 +230,21 @@ function SheetContent(props: SheetContentProps) {
   );
 }
 
+/**
+ * Resets the draft each time the modal re-opens.
+ *
+ * ``visible: false`` null-renders rather than unmounts, so ``useState('')``
+ * would otherwise carry the previous session's text forward on the retry
+ * path. Extracted so the component body stays under the line cap.
+ */
+function useDraftState(visible: boolean) {
+  const [draft, setDraft] = useState('');
+  useEffect(() => {
+    if (visible) setDraft('');
+  }, [visible]);
+  return [draft, setDraft] as const;
+}
+
 export function InsightCaptureModal({
   visible,
   mode,
@@ -233,7 +254,7 @@ export function InsightCaptureModal({
   onSkip,
   onJournal,
 }: InsightCaptureModalProps): React.JSX.Element | null {
-  const [draft, setDraft] = useState('');
+  const [draft, setDraft] = useDraftState(visible);
   const { trimmed, withinSoftCap, withinHardCap } = validate(draft);
 
   const handleSave = useCallback(() => {

--- a/frontend/src/features/Practice/insights/__tests__/format.test.ts
+++ b/frontend/src/features/Practice/insights/__tests__/format.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { formatModeSummary, type ModeSummaryMetadata } from '../format';
+
+describe('formatModeSummary', () => {
+  it.each<[ModeSummaryMetadata, number, string]>([
+    [{ mode: 'meditation_timer' }, 10, '10:00 of stillness'],
+    [{ mode: 'meditation_timer' }, 12 + 34 / 60, '12:34 of stillness'],
+    [{ mode: 'count_up' }, 7.5, '07:30 of open practice'],
+    [{ mode: 'metronome', bpm_used: 60 }, 30, 'BPM 60 for 30:00'],
+    [
+      { mode: 'interval_bell', intervals_struck: 3, total_intervals: 5 },
+      15,
+      '3/5 bells over 15:00',
+    ],
+    [
+      { mode: 'rep_counter', rep_count: 108, unit_label: 'breath cycles' },
+      12 + 34 / 60,
+      '108 breath cycles in 12:34',
+    ],
+    [
+      { mode: 'sense_grounding', senses_completed: ['sight', 'touch', 'hearing'] },
+      4,
+      'Grounded through 3 senses',
+    ],
+    [{ mode: 'tarot', card_index: 0, card_name: 'The Fool' }, 5, 'The Fool for 05:00'],
+  ])('formats %j (%s min) as %s', (metadata, durationMinutes, expected) => {
+    expect(formatModeSummary(metadata.mode, durationMinutes, metadata)).toBe(expected);
+  });
+
+  it('clamps negative durations to 00:00', () => {
+    expect(formatModeSummary('meditation_timer', -1, { mode: 'meditation_timer' })).toBe(
+      '00:00 of stillness',
+    );
+  });
+
+  it('rounds seconds down, not up', () => {
+    // 59.999 seconds -> 00:59, not 01:00.
+    expect(formatModeSummary('count_up', 59.999 / 60, { mode: 'count_up' })).toBe(
+      '00:59 of open practice',
+    );
+  });
+
+  it('renders a singular rep with the supplied unit_label unchanged', () => {
+    expect(
+      formatModeSummary('rep_counter', 1, {
+        mode: 'rep_counter',
+        rep_count: 1,
+        unit_label: 'rep',
+      }),
+    ).toBe('1 rep in 01:00');
+  });
+
+  it('renders zero senses_completed without crashing', () => {
+    expect(
+      formatModeSummary('sense_grounding', 0.5, {
+        mode: 'sense_grounding',
+        senses_completed: [],
+      }),
+    ).toBe('Grounded through 0 senses');
+  });
+
+  it('throws on an unknown mode discriminator (defensive — the type system normally forbids this)', () => {
+    // Cast through ``unknown`` so a future refactor that drops the
+    // exhaustive switch is caught at runtime by the existing tests instead
+    // of silently producing an undefined summary string.
+    expect(() =>
+      (formatModeSummary as unknown as (m: string, d: number, meta: { mode: string }) => string)(
+        'not_a_mode',
+        1,
+        { mode: 'not_a_mode' },
+      ),
+    ).toThrow(/unhandled mode/);
+  });
+});

--- a/frontend/src/features/Practice/insights/format.ts
+++ b/frontend/src/features/Practice/insights/format.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure post-session summary formatter for the insight-capture modal.
+ *
+ * Each per-mode shape mirrors the backend's
+ * :class:`schemas.practice_session_metadata.SessionMetadata` discriminated
+ * union, with two presentation-only extras the backend doesn't store:
+ *
+ *   - ``rep_counter.unit_label`` — the user-facing noun (e.g. "breath cycles");
+ *     the backend only persists ``rep_count``.
+ *   - ``tarot.card_name`` — resolved by the parent from the card index via
+ *     :func:`features/Practice/data/tarot::cardForDayIndex`; the backend
+ *     persists ``card_index`` and re-resolves the name as needed.
+ *
+ * The caller strips these fields before POSTing to ``/practice-sessions``.
+ */
+
+import type { SenseKind } from '../engine/types';
+import { formatTime } from '../views/formatTime';
+
+const MS_PER_MINUTE = 60_000;
+
+export interface ModeSummaryMeditationTimer {
+  readonly mode: 'meditation_timer';
+}
+
+export interface ModeSummaryCountUp {
+  readonly mode: 'count_up';
+}
+
+export interface ModeSummaryMetronome {
+  readonly mode: 'metronome';
+  readonly bpm_used: number;
+}
+
+export interface ModeSummaryIntervalBell {
+  readonly mode: 'interval_bell';
+  readonly intervals_struck: number;
+  readonly total_intervals: number;
+}
+
+export interface ModeSummaryRepCounter {
+  readonly mode: 'rep_counter';
+  readonly rep_count: number;
+  readonly unit_label: string;
+}
+
+export interface ModeSummarySenseGrounding {
+  readonly mode: 'sense_grounding';
+  readonly senses_completed: readonly SenseKind[];
+}
+
+export interface ModeSummaryTarot {
+  readonly mode: 'tarot';
+  readonly card_index: number;
+  readonly card_name: string;
+}
+
+export type ModeSummaryMetadata =
+  | ModeSummaryMeditationTimer
+  | ModeSummaryCountUp
+  | ModeSummaryMetronome
+  | ModeSummaryIntervalBell
+  | ModeSummaryRepCounter
+  | ModeSummarySenseGrounding
+  | ModeSummaryTarot;
+
+export type ModeSummaryKind = ModeSummaryMetadata['mode'];
+
+function clock(durationMinutes: number): string {
+  return formatTime(Math.max(0, durationMinutes) * MS_PER_MINUTE);
+}
+
+/**
+ * Render the one-line post-session summary shown above the insight input.
+ *
+ * The ``mode`` parameter is duplicated with ``metadata.mode`` so the
+ * call-site discriminator matches the payload at compile time; the
+ * generic constraint narrows ``metadata`` to the shape that matches the
+ * literal ``mode``. Passing a mismatched pair fails type-check rather
+ * than producing a silently wrong summary.
+ */
+export function formatModeSummary<M extends ModeSummaryKind>(
+  mode: M,
+  durationMinutes: number,
+  metadata: Extract<ModeSummaryMetadata, { mode: M }>,
+): string {
+  const mmss = clock(durationMinutes);
+  switch (mode) {
+    case 'meditation_timer':
+      return `${mmss} of stillness`;
+    case 'count_up':
+      return `${mmss} of open practice`;
+    case 'metronome': {
+      const m = metadata as ModeSummaryMetronome;
+      return `BPM ${m.bpm_used} for ${mmss}`;
+    }
+    case 'interval_bell': {
+      const m = metadata as ModeSummaryIntervalBell;
+      return `${m.intervals_struck}/${m.total_intervals} bells over ${mmss}`;
+    }
+    case 'rep_counter': {
+      const m = metadata as ModeSummaryRepCounter;
+      return `${m.rep_count} ${m.unit_label} in ${mmss}`;
+    }
+    case 'sense_grounding': {
+      const m = metadata as ModeSummarySenseGrounding;
+      return `Grounded through ${m.senses_completed.length} senses`;
+    }
+    case 'tarot': {
+      const m = metadata as ModeSummaryTarot;
+      return `${m.card_name} for ${mmss}`;
+    }
+    default:
+      return assertNever(mode);
+  }
+}
+
+function assertNever(mode: never): never {
+  throw new Error(`formatModeSummary: unhandled mode ${String(mode)}`);
+}


### PR DESCRIPTION
## Summary

Implements **ritual-12** — the post-session insight capture modal that
ritual-11's `PracticeScreen` mounts on engine `complete`.

- **`InsightCaptureModal`** — visible-controlled modal with a per-mode
  summary line, a multiline `TextInput`, and three CTAs: **Save**,
  **Save & journal with BotMason**, **Skip**. The "Save & journal" CTA
  is hidden when the parent does not wire `onJournal` (precedent:
  `PracticeSwitcherSheet.onSubmitOwn`), so this PR can ship before
  ritual-11 lands. The parent screen owns the API call + nav; the modal
  is presentation-only.
- **`formatModeSummary`** — pure formatter that produces the summary
  line per the issue spec (`"108 breath cycles in 12:34"`, `"BPM 60
  for 30:00"`, `"3/5 bells over 15:00"`, …). Discriminated-union typed
  via `ModeSummaryMetadata`. Presentation-only fields (`rep_counter.
  unit_label`, `tarot.card_name`) live in the formatter input only —
  the parent strips them before posting.
- **API client extension** — `PracticeSessionCreate` and
  `PracticeSessionResponse` gain ritual-04's `mode_metadata`,
  `completed`, and `insight` fields. `SessionMetadata` is a new
  discriminated union mirroring `backend/src/schemas/
  practice_session_metadata.py`.

**Wiring deferred to ritual-11.** Per the issue's last paragraph,
PracticeScreen still uses the legacy `PracticeTimer` + summary/reflection
flow on `main`; ritual-11 is the screen-integration issue that wires the
engine and the modal together. Touching `PracticeScreen.tsx` here would
collide with that concurrent workstream. The new modal is fully
type-checked, tested, and ready to be dropped in.

## Files modified

| File | Action |
|---|---|
| `frontend/src/features/Practice/components/InsightCaptureModal.tsx` | **Create** (361 lines) |
| `frontend/src/features/Practice/insights/format.ts` | **Create** (120 lines) |
| `frontend/src/features/Practice/__tests__/InsightCaptureModal.test.tsx` | **Create** (148 lines) |
| `frontend/src/features/Practice/insights/__tests__/format.test.ts` | **Create** (75 lines) |
| `frontend/src/api/index.ts` | **Modify** — add `SessionMetadata` union and ritual-04 fields on session create/response (64 lines added) |

No existing engine/view/screen files were modified.

## LoC

Net **768 LoC added** (exceeds the issue's 300 estimate and the 700
guardrail). Breakdown:

| File | + | - | Net |
|---|---:|---:|---:|
| `components/InsightCaptureModal.tsx` | 361 | 0 | 361 |
| `__tests__/InsightCaptureModal.test.tsx` | 148 | 0 | 148 |
| `insights/format.ts` | 120 | 0 | 120 |
| `insights/__tests__/format.test.ts` | 75 | 0 | 75 |
| `api/index.ts` | 64 | 0 | 64 |
| **Total** | **768** | **0** | **768** |

The overrun is mostly StyleSheet definitions, typed discriminated
unions (ModeSummary*Metadata × 7 modes mirrored both in the formatter
and the API), and parameterized tests covering every mode + the three
cap-state branches. None of it is speculative — every type is consumed
by either the modal or the tests.

## Quality gates

- `npx tsc --noEmit` — clean
- `npm run lint` — clean (0 warnings)
- `npm test -- --no-coverage` — 1298/1298 passing
- New-file coverage: `format.ts` 100% / `InsightCaptureModal.tsx`
  93% stmt, 86% branch, 100% func, 100% line (well above the 90%
  project bar on the new surface; project-global 90% was already
  failing on `main` pre-merge — out of scope here)
- `pre-commit run --files <touched>` — all hooks pass (eslint,
  prettier, typecheck, jest, detect-secrets)

## Test plan

- [x] Modal renders the right summary per mode (parameterized over all
  7 backend modes)
- [x] "Save" calls `onSave` with the typed (trimmed) insight
- [x] "Save & journal with BotMason" calls `onJournal` with the same
  payload
- [x] "Skip" calls `onSkip()` (no insight) — even if the user typed
- [x] Hard cap at 2,000 chars enforced; validation message shown;
  Save + Journal both disabled past the cap
- [x] Soft cap at 200 chars surfaces a gentle hint but keeps Save
  enabled
- [x] Hard-cap state still lets the user Skip (analytics row matters)
- [x] `onJournal: undefined` hides the BotMason CTA entirely
- [x] `visible: false` renders nothing
- [x] `formatModeSummary` parameterized snapshot per mode + edge
  cases (negative duration, sub-second rounding, singular unit_label,
  zero-sense run, unknown-mode defensive throw)

## Out of scope

- **PracticeScreen wiring.** Deferred to ritual-11 (screen integration);
  the modal is a ready-to-drop-in component. Once ritual-11 merges, the
  parent calls something like:
  ```ts
  <InsightCaptureModal
    visible={engineState.status === 'complete'}
    mode={resolvedConfig.mode}
    durationMinutes={completedMinutes}
    modeMetadata={buildModeMetadata(engineState, config, card)}
    onSave={insight => save({ ..., insight })}
    onJournal={insight => save({ ..., insight }).then(s => nav.navigate('Journal', { practiceSessionId: s.id, ... }))}
    onSkip={() => save({ ..., insight: null })}
  />
  ```
  The Journal route (`BottomTabs.RootTabParamList.Journal`) already
  accepts `practiceSessionId` from the existing reflection flow, so no
  new nav types are needed when ritual-11 wires it.
- **`feature_flag.botmasonHandoff`.** Not needed — the journal-link nav
  type already exists on `main`.
- **Mode-metadata builder.** The pure helper that constructs the
  backend `SessionMetadata` from `EngineState + ModeConfig` belongs in
  ritual-11 alongside the engine wiring.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CWnef7z8BDUjgeuzYvB8iT)_