### PR TITLE
feat(backend): ritual cleanup — override size cap, migration round-trip, insight contract

### DIFF
--- a/backend/migrations/versions/c0d1e2f3a4b5_audit_completed_stages_gaps.py
+++ b/backend/migrations/versions/c0d1e2f3a4b5_audit_completed_stages_gaps.py
@@ -31,6 +31,11 @@ down_revision: Union[str, Sequence[str], None] = "b9c0d1e2f3a4"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+# Opt-out marker for the migration round-trip-pattern test (P1-6).
+# This migration only emits log records — there is no schema or data change
+# to reverse. The downgrade is intentionally a no-op.
+ALEMBIC_INTENTIONAL_EMPTY_DOWNGRADE = True
+
 
 _logger = logging.getLogger("alembic.runtime.migration")
 

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Self
 
@@ -21,7 +22,45 @@ PRACTICE_NAME_MAX_LENGTH = 255
 PRACTICE_DESCRIPTION_MAX_LENGTH = 2_000
 PRACTICE_INSTRUCTIONS_MAX_LENGTH = 10_000
 PRACTICE_REFLECTION_MAX_LENGTH = 5_000
+# Cross-system contract: frontend mirror lives at
+# ``frontend/src/features/Practice/components/InsightCaptureModal.tsx``
+# (``PRACTICE_INSIGHT_HARD_CAP``). The OpenAPI schema's ``maxLength`` on
+# ``PracticeSessionCreate.insight`` is what the frontend should authoritatively
+# read; the explicit cross-check is in
+# ``tests/test_openapi_insight_cap_contract.py``.
 PRACTICE_INSIGHT_MAX_LENGTH = 2_000
+# 8 KiB is comfortably above the largest legitimate ModeConfig
+# (sense_grounding with a 5-prompt list weighs ~400 bytes after JSON
+# encoding) while keeping a single PATCH request bounded so a malicious
+# client cannot dump megabytes into the ``mode_config_override`` JSON
+# column. The cap is enforced via the JSON-encoded byte length so a
+# payload that arrives nested-but-empty still passes; only the wire
+# size counts.
+MODE_CONFIG_OVERRIDE_MAX_BYTES = 8 * 1_024
+
+
+def _validate_override_size(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Reject override payloads larger than ``MODE_CONFIG_OVERRIDE_MAX_BYTES``.
+
+    Pydantic's discriminated union runs after this check, so the message the
+    client sees identifies the size problem explicitly rather than a noisy
+    structural-validation diff over the bloated payload.
+    """
+    if value is None:
+        return None
+    # ``ensure_ascii=False`` so multibyte characters count by their wire size,
+    # not their escaped ASCII length — a 1 KB Chinese-character payload should
+    # measure as ~3 KB, not ~10 KB (otherwise a legitimate i18n override
+    # could trip the cap).
+    size = len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
+    if size > MODE_CONFIG_OVERRIDE_MAX_BYTES:
+        msg = (
+            f"mode_config_override is too large ({size} bytes); "
+            f"must be at most {MODE_CONFIG_OVERRIDE_MAX_BYTES} bytes"
+        )
+        raise ValueError(msg)
+    return value
+
 
 MAX_DURATION_MINUTES = 24 * 60
 
@@ -220,6 +259,12 @@ class UserPracticeCustomize(BaseModel):
         max_length=PRACTICE_NAME_MAX_LENGTH,
     )
     mode_config_override: dict[str, Any] | None = None
+
+    @field_validator("mode_config_override")
+    @classmethod
+    def _cap_override_size(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Reject oversize override payloads — see ``_validate_override_size``."""
+        return _validate_override_size(value)
 
     @field_validator("custom_name")
     @classmethod

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -39,29 +39,6 @@ PRACTICE_INSIGHT_MAX_LENGTH = 2_000
 MODE_CONFIG_OVERRIDE_MAX_BYTES = 8 * 1_024
 
 
-def _validate_override_size(value: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Reject override payloads larger than ``MODE_CONFIG_OVERRIDE_MAX_BYTES``.
-
-    Pydantic's discriminated union runs after this check, so the message the
-    client sees identifies the size problem explicitly rather than a noisy
-    structural-validation diff over the bloated payload.
-    """
-    if value is None:
-        return None
-    # ``ensure_ascii=False`` so multibyte characters count by their wire size,
-    # not their escaped ASCII length — a 1 KB Chinese-character payload should
-    # measure as ~3 KB, not ~10 KB (otherwise a legitimate i18n override
-    # could trip the cap).
-    size = len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
-    if size > MODE_CONFIG_OVERRIDE_MAX_BYTES:
-        msg = (
-            f"mode_config_override is too large ({size} bytes); "
-            f"must be at most {MODE_CONFIG_OVERRIDE_MAX_BYTES} bytes"
-        )
-        raise ValueError(msg)
-    return value
-
-
 MAX_DURATION_MINUTES = 24 * 60
 
 # Server-side bounds for ``PracticeSessionCreate`` timestamps (BUG-PRACTICE-006,
@@ -263,8 +240,27 @@ class UserPracticeCustomize(BaseModel):
     @field_validator("mode_config_override")
     @classmethod
     def _cap_override_size(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
-        """Reject oversize override payloads — see ``_validate_override_size``."""
-        return _validate_override_size(value)
+        """Reject override payloads larger than ``MODE_CONFIG_OVERRIDE_MAX_BYTES``.
+
+        The discriminated union runs after this check, so the message the
+        client sees identifies the size problem explicitly rather than a
+        noisy structural-validation diff over the bloated payload.
+
+        ``ensure_ascii=False`` so multibyte characters count by their wire
+        size, not their escaped ASCII length — a 1 KB Chinese-character
+        payload measures ~3 KB on the wire, not ~10 KB (otherwise a
+        legitimate i18n override could trip the cap).
+        """
+        if value is None:
+            return None
+        size = len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
+        if size > MODE_CONFIG_OVERRIDE_MAX_BYTES:
+            msg = (
+                f"mode_config_override is too large ({size} bytes); "
+                f"must be at most {MODE_CONFIG_OVERRIDE_MAX_BYTES} bytes"
+            )
+            raise ValueError(msg)
+        return value
 
     @field_validator("custom_name")
     @classmethod

--- a/backend/tests/schemas/test_user_practice_customize.py
+++ b/backend/tests/schemas/test_user_practice_customize.py
@@ -20,8 +20,34 @@ from schemas.practice import (
 
 
 def _padded(byte_count: int) -> dict[str, object]:
-    """Construct an opaque dict whose JSON-encoded size is roughly ``byte_count``."""
+    """Construct an opaque dict whose JSON-encoded size is roughly ``byte_count``.
+
+    The constant fields (``mode``, ``duration_minutes``, ``_pad`` key + JSON
+    overhead) add ~60 bytes, so the wire size is ``byte_count + ~60`` — fine
+    for tests that just need to be safely-under or safely-over the cap.
+    Use ``_padded_to_exact_wire_size`` when an exactly-bounded payload is
+    required.
+    """
     return {"mode": "meditation_timer", "duration_minutes": 10, "_pad": "x" * byte_count}
+
+
+def _padded_to_exact_wire_size(target_bytes: int) -> dict[str, object]:
+    """Construct a payload whose JSON-encoded UTF-8 size equals ``target_bytes`` exactly.
+
+    Computes the overhead of the constant fields once, then sizes ``_pad`` to
+    fill the rest. Used by boundary tests so a one-byte change in the input
+    flips the validator's verdict.
+    """
+    skeleton: dict[str, object] = {"mode": "meditation_timer", "duration_minutes": 10, "_pad": ""}
+    overhead = len(json.dumps(skeleton, ensure_ascii=False).encode("utf-8"))
+    pad_chars = target_bytes - overhead
+    if pad_chars < 0:
+        msg = f"target_bytes={target_bytes} is below the skeleton overhead ({overhead})"
+        raise ValueError(msg)
+    skeleton["_pad"] = "x" * pad_chars
+    actual = len(json.dumps(skeleton, ensure_ascii=False).encode("utf-8"))
+    assert actual == target_bytes, f"got {actual}, expected {target_bytes}"
+    return skeleton
 
 
 def test_override_under_cap_passes() -> None:
@@ -39,6 +65,26 @@ def test_override_just_over_cap_fails_with_size_message() -> None:
 
     with pytest.raises(ValidationError) as exc:
         UserPracticeCustomize.model_validate({"mode_config_override": payload})
+    assert "too large" in str(exc.value)
+
+
+def test_override_at_exact_boundary_accepts_cap_rejects_cap_plus_one() -> None:
+    """The boundary is closed at the cap: ``== max`` passes, ``max + 1`` fails.
+
+    Uses ``_padded_to_exact_wire_size`` so a one-byte change flips the verdict
+    — proving the comparison is ``size > cap`` (not ``>=``) and that there is
+    no off-by-one on the threshold.
+    """
+    at_cap = _padded_to_exact_wire_size(MODE_CONFIG_OVERRIDE_MAX_BYTES)
+    over_cap = _padded_to_exact_wire_size(MODE_CONFIG_OVERRIDE_MAX_BYTES + 1)
+
+    # Exactly at cap: passes the size guard.
+    model = UserPracticeCustomize.model_validate({"mode_config_override": at_cap})
+    assert model.mode_config_override == at_cap
+
+    # Exactly cap + 1: rejected by the size guard with the canonical message.
+    with pytest.raises(ValidationError) as exc:
+        UserPracticeCustomize.model_validate({"mode_config_override": over_cap})
     assert "too large" in str(exc.value)
 
 

--- a/backend/tests/schemas/test_user_practice_customize.py
+++ b/backend/tests/schemas/test_user_practice_customize.py
@@ -53,6 +53,10 @@ def _padded_to_exact_wire_size(target_bytes: int) -> dict[str, object]:
 def test_override_under_cap_passes() -> None:
     """A small override is accepted by the size guard (schema layer)."""
     payload = _padded(100)
+    # ASCII-only pad — ``ensure_ascii=True`` (the json.dumps default used
+    # here) and ``ensure_ascii=False`` (used by the validator) produce
+    # identical byte counts for this payload, so the size assertion is
+    # equivalent. The dedicated CJK test below covers the divergent case.
     assert len(json.dumps(payload).encode("utf-8")) < MODE_CONFIG_OVERRIDE_MAX_BYTES
     model = UserPracticeCustomize.model_validate({"mode_config_override": payload})
     assert model.mode_config_override == payload
@@ -61,6 +65,7 @@ def test_override_under_cap_passes() -> None:
 def test_override_just_over_cap_fails_with_size_message() -> None:
     """A payload past the cap fires the size validator with an actionable message."""
     payload = _padded(MODE_CONFIG_OVERRIDE_MAX_BYTES + 100)
+    # ASCII-only pad — see note in ``test_override_under_cap_passes``.
     assert len(json.dumps(payload).encode("utf-8")) > MODE_CONFIG_OVERRIDE_MAX_BYTES
 
     with pytest.raises(ValidationError) as exc:

--- a/backend/tests/schemas/test_user_practice_customize.py
+++ b/backend/tests/schemas/test_user_practice_customize.py
@@ -1,0 +1,70 @@
+"""Schema-level tests for ``UserPracticeCustomize`` size cap.
+
+The integration test in ``tests/test_user_practice_customization.py`` covers
+the end-to-end PATCH path; this file pins the schema contract in isolation
+so a regression in the size cap can be caught without spinning up the
+full async client + DB stack.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.practice import (
+    MODE_CONFIG_OVERRIDE_MAX_BYTES,
+    UserPracticeCustomize,
+)
+
+
+def _padded(byte_count: int) -> dict[str, object]:
+    """Construct an opaque dict whose JSON-encoded size is roughly ``byte_count``."""
+    return {"mode": "meditation_timer", "duration_minutes": 10, "_pad": "x" * byte_count}
+
+
+def test_override_under_cap_passes() -> None:
+    """A small override is accepted by the size guard (schema layer)."""
+    payload = _padded(100)
+    assert len(json.dumps(payload).encode("utf-8")) < MODE_CONFIG_OVERRIDE_MAX_BYTES
+    model = UserPracticeCustomize.model_validate({"mode_config_override": payload})
+    assert model.mode_config_override == payload
+
+
+def test_override_just_over_cap_fails_with_size_message() -> None:
+    """A payload past the cap fires the size validator with an actionable message."""
+    payload = _padded(MODE_CONFIG_OVERRIDE_MAX_BYTES + 100)
+    assert len(json.dumps(payload).encode("utf-8")) > MODE_CONFIG_OVERRIDE_MAX_BYTES
+
+    with pytest.raises(ValidationError) as exc:
+        UserPracticeCustomize.model_validate({"mode_config_override": payload})
+    assert "too large" in str(exc.value)
+
+
+def test_none_override_skips_size_check() -> None:
+    """``None`` clears the override; the size guard must accept it."""
+    model = UserPracticeCustomize.model_validate({"mode_config_override": None})
+    assert model.mode_config_override is None
+
+
+def test_unicode_counted_by_utf8_byte_size_not_escaped_char_count() -> None:
+    r"""Multibyte characters count by their wire size, not by their escaped length.
+
+    Without ``ensure_ascii=False`` in the encoder, the JSON would escape every
+    non-ASCII codepoint to ``\uXXXX`` (6 ASCII bytes per char). A 2 000-char
+    Chinese payload would then measure 12 KB on the wire and trip the cap
+    erroneously. With ``ensure_ascii=False`` it measures ~6 KB (3 bytes per
+    codepoint in UTF-8) — well under the 8 KB cap, and accepted here.
+    """
+    chinese_padding = "字" * 2_000
+    payload = {"mode": "meditation_timer", "duration_minutes": 10, "_pad": chinese_padding}
+    # Verify the *wire* size is under cap so the test fails loudly if someone
+    # later switches the encoder to ensure_ascii=True.
+    assert (
+        len(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+        < MODE_CONFIG_OVERRIDE_MAX_BYTES
+    )
+
+    model = UserPracticeCustomize.model_validate({"mode_config_override": payload})
+    assert model.mode_config_override == payload

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -10,6 +10,7 @@ CI wakes up.
 
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
 from typing import Any
@@ -74,6 +75,119 @@ def test_both_directions_exist(direction: str) -> None:
             continue
         body = path.read_text()
         assert f"def {direction}" in body, f"{path.name} missing {direction}()"
+
+
+def _migration_files() -> list[Path]:
+    return sorted(p for p in MIGRATIONS_DIR.glob("*.py") if not p.name.startswith("_"))
+
+
+def _is_trivial_body(body: list[ast.stmt]) -> bool:
+    """Return True if a function body is only a docstring (or empty / pass).
+
+    A migration whose ``downgrade`` is just a docstring carries no rollback
+    logic — for a real schema migration that's the same class of bug
+    BUG-INFRA-022 caught. The exception is no-op merge migrations whose
+    ``downgrade`` is intentionally empty (the prior heads remain applied
+    after the merge); we whitelist them by filename via ``_is_no_op_merge``.
+    """
+    if not body:
+        return True
+    if len(body) == 1:
+        only = body[0]
+        if isinstance(only, ast.Pass):
+            return True
+        if (
+            isinstance(only, ast.Expr)
+            and isinstance(only.value, ast.Constant)
+            and isinstance(only.value.value, str)
+        ):
+            # Sole docstring.
+            return True
+    # A body containing a docstring + ``pass`` is still trivial.
+    return (
+        len(body) == 2
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+        and isinstance(body[1], ast.Pass)
+    )
+
+
+def _is_no_op_merge(path: Path) -> bool:
+    """Identify a no-op merge migration by Alembic's filename convention.
+
+    ``alembic merge -m '...'`` emits files named ``<rev>_merge_*.py``. Such
+    migrations exist solely to unify multiple heads and ship empty
+    ``upgrade``/``downgrade`` bodies — that's the intended contract, not a
+    placeholder gap.
+    """
+    return "_merge_" in path.name
+
+
+def _has_intentional_empty_downgrade_marker(tree: ast.Module) -> bool:
+    """Return True if the migration module declares ``ALEMBIC_INTENTIONAL_EMPTY_DOWNGRADE = True``.
+
+    Read-only audit migrations and other no-op data migrations set this
+    marker so the round-trip-pattern test recognises the empty downgrade
+    as intentional. Writing the assignment explicitly forces a deliberate
+    act when authoring such a migration.
+    """
+    for node in tree.body:
+        if not isinstance(node, ast.Assign | ast.AnnAssign):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if (
+                isinstance(target, ast.Name)
+                and target.id == "ALEMBIC_INTENTIONAL_EMPTY_DOWNGRADE"
+                and isinstance(node.value, ast.Constant)
+                and node.value.value is True
+            ):
+                return True
+    return False
+
+
+@pytest.mark.parametrize("migration", _migration_files(), ids=lambda p: p.name)
+def test_downgrade_is_non_trivial_unless_no_op_merge(migration: Path) -> None:
+    """Codifies the migration round-trip pattern flagged in the ritual-practice grooming.
+
+    Every non-merge migration must have a downgrade body that actually
+    rewinds the upgrade. A stub like ``def downgrade(): pass`` or
+    ``def downgrade(): \"\"\"TODO\"\"\"`` is rejected here, so a regression
+    that ships an unreversible migration fails at unit-test speed instead
+    of waiting for the migration-drift CI job (which only catches it via
+    Postgres round-trip and only for the branch CI happens to traverse).
+    """
+    tree = ast.parse(migration.read_text())
+    downgrade = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == "downgrade"
+        ),
+        None,
+    )
+    assert downgrade is not None, f"{migration.name}: no ``downgrade`` function defined"
+    trivial = _is_trivial_body(downgrade.body)
+    if _is_no_op_merge(migration):
+        # Merge migrations MUST be trivial; an op call here would be unexpected.
+        assert trivial, (
+            f"{migration.name}: merge migrations are expected to have an empty downgrade; "
+            "if this one really needs to roll back schema, rename it off the ``_merge_`` "
+            "convention so the contract test recognises it as a regular migration."
+        )
+        return
+    if _has_intentional_empty_downgrade_marker(tree):
+        # A read-only audit or other no-op data migration that explicitly
+        # opts out. The marker assignment is the deliberate "I meant this".
+        return
+    assert not trivial, (
+        f"{migration.name}: downgrade body is empty / docstring-only / ``pass``. "
+        "Every non-merge migration must actually reverse its upgrade — this is the "
+        "round-trip contract from BUG-INFRA-022 + ritual-practice backlog P1-6. "
+        "If this migration is genuinely a no-op (e.g. read-only data audit), add "
+        "``ALEMBIC_INTENTIONAL_EMPTY_DOWNGRADE = True`` at module level."
+    )
 
 
 @pytest.fixture

--- a/backend/tests/test_openapi_insight_cap_contract.py
+++ b/backend/tests/test_openapi_insight_cap_contract.py
@@ -1,0 +1,107 @@
+"""Cross-system contract test for the practice-insight character cap.
+
+The frontend's ``PRACTICE_INSIGHT_HARD_CAP`` constant (in
+``frontend/src/features/Practice/components/InsightCaptureModal.tsx``)
+must match the backend's ``PRACTICE_INSIGHT_MAX_LENGTH``. A drift here
+silently changes the contract from "you can save up to N characters" on
+one end to a different N on the other.
+
+The previous safeguard was a "KEEP IN SYNC" comment on both sides — easy
+to miss when bumping one. This test pins three things at once:
+
+1. The Python constant equals the documented value (2000).
+2. The Pydantic field's ``max_length`` equals the constant.
+3. The FastAPI-generated OpenAPI schema's ``maxLength`` for the
+   ``insight`` field of ``PracticeSessionCreate`` matches.
+
+Any divergence here fires before merge. The frontend has a mirror test
+(``frontend/src/features/Practice/components/__tests__/InsightCaptureModal.test.tsx``)
+that pins ``PRACTICE_INSIGHT_HARD_CAP === 2_000`` — together the two
+tests bracket the contract.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from main import app
+from schemas.practice import PRACTICE_INSIGHT_MAX_LENGTH, PracticeSessionCreate
+
+# The expected wire value. If this ever changes, BOTH constants (here and
+# the frontend mirror) must update — the change ripples through the
+# OpenAPI schema and the frontend test, surfacing the contract drift.
+_EXPECTED_INSIGHT_CAP = 2_000
+
+
+def test_python_constant_matches_expected_wire_value() -> None:
+    """Pins the source-of-truth constant. Frontend mirror reads the same value."""
+    assert PRACTICE_INSIGHT_MAX_LENGTH == _EXPECTED_INSIGHT_CAP
+
+
+def test_pydantic_field_max_length_matches_constant() -> None:
+    """The Pydantic field's ``max_length`` must derive from the constant.
+
+    Without this, a developer who bumps the constant but leaves a hardcoded
+    ``max_length=2000`` on the field would have the OpenAPI schema drift
+    out of sync with the constant.
+    """
+    field = PracticeSessionCreate.model_fields["insight"]
+    # Pydantic stores ``max_length`` as a constraint on the field's metadata.
+    constraints = [m for m in field.metadata if getattr(m, "max_length", None) is not None]
+    assert constraints, "PracticeSessionCreate.insight has no max_length constraint"
+    assert all(c.max_length == PRACTICE_INSIGHT_MAX_LENGTH for c in constraints)
+
+
+def test_openapi_schema_exposes_the_insight_cap() -> None:
+    """FastAPI's auto-generated OpenAPI schema reflects the same maxLength.
+
+    The frontend (which currently hardcodes ``PRACTICE_INSIGHT_HARD_CAP``)
+    can in principle derive its cap from this OpenAPI field by reading the
+    spec at build time — this test pins the schema shape that pipeline
+    would depend on, so the contract is enforced even before that work
+    lands.
+    """
+    schema = app.openapi()
+    create_schema = schema["components"]["schemas"]["PracticeSessionCreate"]
+    insight = create_schema["properties"]["insight"]
+    # ``insight`` is ``str | None`` — the maxLength sits inside one of the
+    # ``anyOf`` branches (the string branch); FastAPI may also hoist it to
+    # the top level depending on the Pydantic version. Accept either shape.
+    found_max = _extract_max_length(insight)
+    assert found_max == PRACTICE_INSIGHT_MAX_LENGTH, (
+        f"OpenAPI maxLength for insight is {found_max}; expected "
+        f"{PRACTICE_INSIGHT_MAX_LENGTH}. The frontend "
+        "``PRACTICE_INSIGHT_HARD_CAP`` mirror also needs to move."
+    )
+
+
+def _extract_max_length(field_schema: dict[str, object]) -> int | None:
+    """Pluck the ``maxLength`` from a possibly-nullable string schema."""
+    direct = field_schema.get("maxLength")
+    if isinstance(direct, int):
+        return direct
+    any_of = field_schema.get("anyOf")
+    if isinstance(any_of, list):
+        for branch in any_of:
+            if isinstance(branch, dict):
+                branch_max = branch.get("maxLength")
+                if isinstance(branch_max, int):
+                    return branch_max
+    return None
+
+
+@pytest.mark.parametrize("invalid_length", [_EXPECTED_INSIGHT_CAP + 1, _EXPECTED_INSIGHT_CAP * 10])
+def test_pydantic_rejects_insight_exceeding_cap(invalid_length: int) -> None:
+    """End-to-end pin: a too-long insight is rejected by the model at all sizes past cap."""
+    started = datetime.now(UTC)
+    with pytest.raises(ValidationError) as exc:
+        PracticeSessionCreate(
+            user_practice_id=1,
+            started_at=started,
+            ended_at=started + timedelta(minutes=5),
+            insight="x" * invalid_length,
+        )
+    assert "at most" in str(exc.value) or "max_length" in str(exc.value).lower()

--- a/backend/tests/test_user_practice_customization.py
+++ b/backend/tests/test_user_practice_customization.py
@@ -282,6 +282,38 @@ async def test_customize_rejects_invalid_mode_config(
 
 
 @pytest.mark.asyncio
+async def test_customize_rejects_oversize_mode_config_override(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An override payload past the size cap is rejected at the schema layer.
+
+    Mitigates payload bloat / DoS via the unbounded JSON column noted in the
+    ritual-practice backlog. The cap is generous (8 KiB after JSON encoding)
+    so any legitimate ModeConfig — even with the worst-case
+    sense_grounding prompt list — fits comfortably.
+    """
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    # ~10 KiB payload: the dict has a single oversized junk key. The Pydantic
+    # discriminated union would reject this on shape, but the size cap fires
+    # first so we get a 413/422 with a clear "too large" message rather than
+    # a noisy validation diff.
+    huge_override = {**_timer_cfg(10), "_junk": "x" * 10_000}
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"mode_config_override": huge_override},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    body = resp.json()
+    # The message must clearly identify the size cap so an operator can act.
+    flattened = repr(body).lower()
+    assert "too large" in flattened or "max_length" in flattened or "size" in flattened
+
+
+@pytest.mark.asyncio
 async def test_customize_403_on_other_user(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:

--- a/backend/tests/test_user_practice_customization.py
+++ b/backend/tests/test_user_practice_customization.py
@@ -311,9 +311,9 @@ async def test_customize_rejects_oversize_mode_config_override(
     # The message must clearly identify the SIZE guard — not a structural
     # error from the discriminated union or any other validator that happens
     # to mention "size". The literal "too large" is what
-    # ``_validate_override_size`` emits and only what that guard emits, so a
-    # regression that re-orders validators or removes the size cap fails
-    # this assertion immediately.
+    # ``UserPracticeCustomize._cap_override_size`` emits and only what that
+    # guard emits, so a regression that re-orders validators or removes the
+    # size cap fails this assertion immediately.
     flattened = repr(body).lower()
     assert "too large" in flattened
 

--- a/backend/tests/test_user_practice_customization.py
+++ b/backend/tests/test_user_practice_customization.py
@@ -308,9 +308,14 @@ async def test_customize_rejects_oversize_mode_config_override(
     )
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     body = resp.json()
-    # The message must clearly identify the size cap so an operator can act.
+    # The message must clearly identify the SIZE guard — not a structural
+    # error from the discriminated union or any other validator that happens
+    # to mention "size". The literal "too large" is what
+    # ``_validate_override_size`` emits and only what that guard emits, so a
+    # regression that re-orders validators or removes the size cap fails
+    # this assertion immediately.
     flattened = repr(body).lower()
-    assert "too large" in flattened or "max_length" in flattened or "size" in flattened
+    assert "too large" in flattened
 
 
 @pytest.mark.asyncio

--- a/frontend/src/features/Practice/__tests__/InsightCaptureModal.test.tsx
+++ b/frontend/src/features/Practice/__tests__/InsightCaptureModal.test.tsx
@@ -142,7 +142,11 @@ describe('InsightCaptureModal', () => {
     expect(onSkip).toHaveBeenCalledTimes(1);
   });
 
-  it('exposes the hard cap constant matching the backend column max_length', () => {
+  it('pins the hard cap constant to the cross-system value (2000 chars)', () => {
+    // Cross-system contract: the backend mirror is asserted in
+    // ``backend/tests/test_openapi_insight_cap_contract.py``.  Together the
+    // two tests bracket the contract — bumping the cap on one side without
+    // the other will fail the corresponding test before merge.
     expect(PRACTICE_INSIGHT_HARD_CAP).toBe(2_000);
   });
 

--- a/frontend/src/features/Practice/components/InsightCaptureModal.tsx
+++ b/frontend/src/features/Practice/components/InsightCaptureModal.tsx
@@ -41,7 +41,17 @@ import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 
 /** Soft cap — the modal nudges the user toward a single sentence past this. */
 export const PRACTICE_INSIGHT_SOFT_CAP = 200;
-/** Hard cap — matches `backend.src.schemas.practice.PRACTICE_INSIGHT_MAX_LENGTH`. */
+/**
+ * Hard cap — mirrors `backend.src.schemas.practice.PRACTICE_INSIGHT_MAX_LENGTH`.
+ *
+ * The contract is pinned end-to-end:
+ * - This value is asserted to be `2_000` in
+ *   `__tests__/InsightCaptureModal.test.tsx` (frontend mirror).
+ * - The backend constant, the Pydantic field's `max_length`, and the
+ *   FastAPI-generated OpenAPI schema's `maxLength` for the `insight`
+ *   field are all pinned in `backend/tests/test_openapi_insight_cap_contract.py`.
+ * Drift on either side fires before merge.
+ */
 export const PRACTICE_INSIGHT_HARD_CAP = 2_000;
 
 export interface InsightCaptureModalProps {


### PR DESCRIPTION
## Summary

Closes the three P1 items from `plan/2026-05-13_BACKLOG_GROOMING.md` that aren't audio-dependent. One PR, three small slices, all TDD'd.

| Plan item | Where | Approach |
| --- | --- | --- |
| **P1-5** `mode_config_override` JSON column unbounded (#312 follow-up) | `schemas/practice.py`, two new test files | `MODE_CONFIG_OVERRIDE_MAX_BYTES = 8 KiB` + field validator on `UserPracticeCustomize`. Wire size measured against UTF-8 (`ensure_ascii=False`) so i18n payloads aren't double-counted. |
| **P1-6** Migration round-trip pattern (#307 follow-up) | `tests/test_migrations.py` (parametrised), audit migration marker | Walk every migration via AST; flag any `downgrade` that's only a docstring / `pass`. Opt-out via Alembic's `_merge_` filename convention or an explicit `ALEMBIC_INTENTIONAL_EMPTY_DOWNGRADE = True` marker (added to the existing read-only audit migration). |
| **P1-7** Insight-length cap sync (#324 follow-up) | `tests/test_openapi_insight_cap_contract.py` (new), `InsightCaptureModal.tsx` mirror comment | Pin three layers at once: Python constant, Pydantic field's `max_length`, and the FastAPI-generated OpenAPI schema's `maxLength`. Frontend mirror test already pins `PRACTICE_INSIGHT_HARD_CAP === 2_000`. Drift on either side fires a test. |

## Tests

47 new test cases across 3 files (+1 frontend comment update):

- `tests/schemas/test_user_practice_customize.py` (4): under-cap acceptance, over-cap rejection with actionable message, `None` clearing, UTF-8-byte counting (CJK payload that would erroneously trip an ASCII-escaping encoder).
- `tests/test_user_practice_customization.py` (+1 integration): PATCH endpoint returns 422 with a "too large" message for an oversize override.
- `tests/test_migrations.py` (+1 parametrised over all 27 migrations + 2 helpers): every non-merge, non-marked migration has a non-trivial downgrade.
- `tests/test_openapi_insight_cap_contract.py` (5): constant value, Pydantic constraint, OpenAPI `maxLength`, end-to-end rejection at cap+1 and cap*10.

Backend suite: **1056 → 1103 passing**. Frontend Insight mirror suite green.

## Quality gates

- `pre-commit run --files ...` ✅
- Pre-push (full backend suite, 1103 passing) ✅
- No `# noqa`, `# type: ignore`, `eslint-disable`, or `any`. The one ruff-suggested `R"""` raw-docstring fix was applied at source. Hoisted module-level imports rather than allowing PLC0415 to fire.

## Out of scope

- Audio assets (`metronome-tick.wav`, bell licensing) — deferred to the dedicated `ritual-audio` PR per the plan.
- The CHANGES_REQUESTED self-audit (P1-4) and BUG-FE-PRACTICE-005 regression-test verification (P1-8) — those are review/audit work, not code changes.
- P2 polish bundle — tracked in the same plan file.

## Test plan

- [x] `cd backend && pytest tests/schemas/test_user_practice_customize.py tests/test_openapi_insight_cap_contract.py tests/test_migrations.py tests/test_user_practice_customization.py`
- [x] `cd backend && pytest` (full suite, 1103 tests)
- [x] `cd frontend && npx jest src/features/Practice/__tests__/InsightCaptureModal.test.tsx`
- [x] `pre-commit run --all-files` (gated on touched files)

https://claude.ai/code/session_01FqtfNeSbMP8fNirreyrsji

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqtfNeSbMP8fNirreyrsji)_