### PR TITLE
fix(backend): close preset-seeder race that double-inserted 5-4-3-2-1

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -69,6 +69,12 @@ _SQLITE_ALWAYS_INDEXES: tuple[str, ...] = (
     # ``lower()`` / ``trim()`` in functional indexes natively.
     'CREATE UNIQUE INDEX IF NOT EXISTS "ix_habit_user_lower_name_unique_test" '
     "ON habit (user_id, lower(trim(name)))",
+    # practice presets: one preset row per (stage_number, normalized name).
+    # Closes the seeder-race duplication noted in PR fixing the
+    # 5-4-3-2-1 duplicate. Mirrors production migration ``d2e3f4a5b6c7``;
+    # user-submitted practices are exempt via the partial ``WHERE`` clause.
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practice_preset_stage_lower_name_unique_test" '
+    "ON practice (stage_number, lower(trim(name))) WHERE submitted_by_user_id IS NULL",
 )
 
 # Concurrency-only indexes: the regular ``db_session`` fixture deliberately

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -60,6 +60,7 @@ _RAW_SQL_MANAGED_INDEXES: frozenset[str] = frozenset(
         "ix_goal_completion_goal_user_timestamp",  # d4e5f6a7b8c9: composite
         "ix_user_practice_active_stage",  # f6a7b8c9d0e1: partial unique
         "ix_habit_user_lower_name_unique",  # b5c6d7e8f9a0: lower(trim(name))
+        "ix_practice_preset_stage_lower_name_unique",  # d2e3f4a5b6c7: lower(trim(name)) WHERE submitted_by_user_id IS NULL
     }
 )
 

--- a/backend/migrations/versions/d2e3f4a5b6c7_practice_preset_unique_index.py
+++ b/backend/migrations/versions/d2e3f4a5b6c7_practice_preset_unique_index.py
@@ -1,0 +1,106 @@
+"""practice partial unique index on (stage_number, lower(trim(name))) for presets
+
+Revision ID: d2e3f4a5b6c7
+Revises: c5ed9dd1dabc
+Create Date: 2026-05-15 23:00:00.000000
+
+Closes the duplicate-preset-practice TOCTOU. ``seed_practices`` does a
+SELECT-then-INSERT match on ``(stage_number, name)`` for rows where
+``submitted_by_user_id IS NULL`` to stay idempotent, but two concurrent
+boots — for example, a rolling-restart deploy where two workers run
+``lifespan`` in parallel — can both pass the SELECT before either
+commits and insert a second copy of every preset. Symptom: every stage
+shows two "5-4-3-2-1 grounding", two "Tarot meditation", and so on.
+
+This migration:
+
+1. Repoints any ``UserPractice.practice_id`` references from the
+   duplicate rows back to the lowest-id row per
+   ``(stage_number, lower(trim(name)))`` group, so deleting the dupes
+   doesn't orphan any user selections.
+2. Deletes the duplicate ``Practice`` rows (only for presets — the
+   ``submitted_by_user_id IS NULL`` filter is what keeps user-submitted
+   practices with the same name alone).
+3. Adds a partial functional unique index so future race-inserts fail
+   at the DB layer.
+
+Modelled on PR #287's ``b5c6d7e8f9a0_habit_unique_user_lower_name``.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d2e3f4a5b6c7"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "c5ed9dd1dabc"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_UNIQUE_INDEX = "ix_practice_preset_stage_lower_name_unique"
+
+
+def upgrade() -> None:
+    """Repoint UserPractice FKs onto the keeper row, drop dupes, add the index."""
+    # 1. Reassign UserPractice.practice_id from duplicate Practice rows to
+    #    the keeper (lowest-id row per (stage_number, lower(trim(name)))
+    #    group). Without this the DELETE below would either fail on the FK
+    #    constraint or orphan a UserPractice row.
+    op.execute(
+        """
+        WITH dupes AS (
+            SELECT p.id AS dupe_id, keeper.keeper_id
+            FROM practice p
+            JOIN (
+                SELECT stage_number, lower(trim(name)) AS norm_name, min(id) AS keeper_id
+                FROM practice
+                WHERE submitted_by_user_id IS NULL
+                GROUP BY stage_number, lower(trim(name))
+                HAVING count(*) > 1
+            ) keeper
+              ON keeper.stage_number = p.stage_number
+             AND keeper.norm_name = lower(trim(p.name))
+             AND p.id != keeper.keeper_id
+            WHERE p.submitted_by_user_id IS NULL
+        )
+        UPDATE userpractice SET practice_id = dupes.keeper_id
+        FROM dupes
+        WHERE userpractice.practice_id = dupes.dupe_id
+        """
+    )
+
+    # 2. Delete the duplicate preset rows now that no FK references them.
+    op.execute(
+        """
+        DELETE FROM practice
+        WHERE id IN (
+            SELECT p.id FROM practice p
+            JOIN (
+                SELECT stage_number, lower(trim(name)) AS norm_name, min(id) AS keeper_id
+                FROM practice
+                WHERE submitted_by_user_id IS NULL
+                GROUP BY stage_number, lower(trim(name))
+                HAVING count(*) > 1
+            ) keeper
+              ON keeper.stage_number = p.stage_number
+             AND keeper.norm_name = lower(trim(p.name))
+             AND p.id != keeper.keeper_id
+            WHERE p.submitted_by_user_id IS NULL
+        )
+        """
+    )
+
+    # 3. Add the partial functional unique index. ``WHERE submitted_by_user_id
+    #    IS NULL`` scopes it to presets — user-submitted practices remain
+    #    free to share a name with a preset or with each other.
+    op.execute(
+        f'CREATE UNIQUE INDEX "{_UNIQUE_INDEX}" '
+        "ON practice (stage_number, lower(trim(name))) "
+        "WHERE submitted_by_user_id IS NULL"
+    )
+
+
+def downgrade() -> None:
+    """Drop the unique index; row deduplication is not reversed."""
+    op.execute(f'DROP INDEX IF EXISTS "{_UNIQUE_INDEX}"')

--- a/backend/src/models/practice.py
+++ b/backend/src/models/practice.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from sqlalchemy import JSON, CheckConstraint, Column
+from sqlalchemy import JSON, CheckConstraint, Column, Index, func, text
 from sqlmodel import Field, SQLModel
 
 from domain.practice_modes import ALL_MODES, PracticeMode
@@ -17,10 +17,28 @@ def _mode_check_constraint() -> CheckConstraint:
     return CheckConstraint(f"mode IN ({quoted})", name="ck_practice_mode_valid")
 
 
+def _preset_unique_index() -> Index:
+    """Partial functional unique index on ``(stage_number, lower(trim(name)))``.
+
+    Scoped to presets via ``submitted_by_user_id IS NULL`` so a user-submitted
+    practice can still share a name with the preset (or with another user
+    submission). Closes the seeder race that two-pod rolling restarts could
+    otherwise produce — see migration ``d2e3f4a5b6c7``.
+    """
+    return Index(
+        "ix_practice_preset_stage_lower_name_unique",
+        "stage_number",
+        func.lower(func.trim(text("name"))),
+        unique=True,
+        postgresql_where=text("submitted_by_user_id IS NULL"),
+        sqlite_where=text("submitted_by_user_id IS NULL"),
+    )
+
+
 class Practice(SQLModel, table=True):
     """Defines a single practice users can perform."""
 
-    __table_args__ = (_mode_check_constraint(),)
+    __table_args__ = (_mode_check_constraint(), _preset_unique_index())
 
     id: int | None = Field(default=None, primary_key=True)
     stage_number: int

--- a/backend/src/models/practice.py
+++ b/backend/src/models/practice.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from sqlalchemy import JSON, CheckConstraint, Column, Index, func, text
+from sqlalchemy import JSON, CheckConstraint, Column
 from sqlmodel import Field, SQLModel
 
 from domain.practice_modes import ALL_MODES, PracticeMode
@@ -17,28 +17,20 @@ def _mode_check_constraint() -> CheckConstraint:
     return CheckConstraint(f"mode IN ({quoted})", name="ck_practice_mode_valid")
 
 
-def _preset_unique_index() -> Index:
-    """Partial functional unique index on ``(stage_number, lower(trim(name)))``.
-
-    Scoped to presets via ``submitted_by_user_id IS NULL`` so a user-submitted
-    practice can still share a name with the preset (or with another user
-    submission). Closes the seeder race that two-pod rolling restarts could
-    otherwise produce — see migration ``d2e3f4a5b6c7``.
-    """
-    return Index(
-        "ix_practice_preset_stage_lower_name_unique",
-        "stage_number",
-        func.lower(func.trim(text("name"))),
-        unique=True,
-        postgresql_where=text("submitted_by_user_id IS NULL"),
-        sqlite_where=text("submitted_by_user_id IS NULL"),
-    )
-
-
 class Practice(SQLModel, table=True):
-    """Defines a single practice users can perform."""
+    """Defines a single practice users can perform.
 
-    __table_args__ = (_mode_check_constraint(), _preset_unique_index())
+    A partial functional unique index on
+    ``(stage_number, lower(trim(name))) WHERE submitted_by_user_id IS NULL``
+    lives at the DB layer (migration ``d2e3f4a5b6c7``) but is intentionally
+    NOT declared in ``__table_args__``: alembic's autogenerate cannot
+    round-trip a partial functional index against a raw-SQL migration, and
+    declaring it would cause ``alembic check`` to flag false drift. The
+    constraint is exercised by the regression tests in
+    ``tests/test_seed_practices.py``.
+    """
+
+    __table_args__ = (_mode_check_constraint(),)
 
     id: int | None = Field(default=None, primary_key=True)
     stage_number: int

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import Any
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -196,6 +197,33 @@ STAGE_TO_PRESET_NAME: MappingProxyType[int, str] = MappingProxyType(
 )
 
 
+async def _existing_preset_keys(session: AsyncSession) -> set[tuple[int, str]]:
+    """Return ``(stage_number, name)`` for every preset already in the DB."""
+    result = await session.execute(
+        select(Practice.stage_number, Practice.name).where(
+            col(Practice.submitted_by_user_id).is_(None)
+        )
+    )
+    return {(row[0], row[1]) for row in result.all()}
+
+
+async def _commit_or_yield_to_race_winner(session: AsyncSession, inserted: int) -> int:
+    """Commit ``inserted`` new rows, treating a unique-index collision as a no-op.
+
+    Race-loser path: a peer process committed the same preset(s) between
+    our SELECT and our COMMIT. Roll back and return 0 — the work has
+    already been done by the peer. Migration ``d2e3f4a5b6c7`` is what
+    makes the database arbitrate; without it both peers would commit and
+    we'd ship the duplicate the index was added to prevent.
+    """
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        return 0
+    return inserted
+
+
 async def seed_practices(session: AsyncSession) -> int:
     """Insert preset practices that don't already exist by ``(stage, name)``.
 
@@ -204,13 +232,7 @@ async def seed_practices(session: AsyncSession) -> int:
     ``submitted_by_user_id IS NULL`` so user submissions can't shadow a
     preset by colliding on ``(stage_number, name)``.
     """
-    result = await session.execute(
-        select(Practice.stage_number, Practice.name).where(
-            col(Practice.submitted_by_user_id).is_(None)
-        )
-    )
-    existing: set[tuple[int, str]] = {(row[0], row[1]) for row in result.all()}
-
+    existing = await _existing_preset_keys(session)
     inserted = 0
     for definition in PRESET_PRACTICES:
         key = (definition["stage_number"], definition["name"])
@@ -218,7 +240,6 @@ async def seed_practices(session: AsyncSession) -> int:
             continue
         session.add(Practice(**definition))
         inserted += 1
-
-    if inserted:
-        await session.commit()
-    return inserted
+    if not inserted:
+        return 0
+    return await _commit_or_yield_to_race_winner(session, inserted)

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -118,9 +120,10 @@ async def test_preset_unique_index_allows_user_submission_with_same_name(
     db_session.add(preset)
     await db_session.commit()
 
-    # Carry a synthetic user id — the bare ``Practice`` model has no FK back
-    # to ``user``, so any non-null integer suffices to fall outside the
-    # partial index's predicate.
+    # Carry a synthetic user id. The model declares a FK to ``user.id`` but
+    # SQLite's FK enforcement is off by default in tests; the relevant
+    # contract here is that any non-null value falls outside the partial
+    # index's ``WHERE submitted_by_user_id IS NULL`` predicate.
     user_submission = Practice(
         **{**PRESET_PRACTICES[0], "submitted_by_user_id": 12_345, "approved": False}
     )
@@ -129,29 +132,55 @@ async def test_preset_unique_index_allows_user_submission_with_same_name(
 
 
 @pytest.mark.asyncio
-async def test_seed_practices_swallows_race_loser_integrity_error(
+async def test_seed_practices_skips_already_seeded_preset(
     db_session: AsyncSession,
 ) -> None:
-    """A peer process committing the preset between our SELECT and COMMIT is benign.
+    """A pre-seeded preset is skipped by the existence-check pre-pass.
 
-    The seeder catches ``IntegrityError``, rolls back, and returns 0 — the
-    work has already been done by the peer. This is the production-race
-    behaviour: rolling restart triggers two concurrent ``lifespan`` runs,
-    one of them wins the insert, the other one's commit raises, both end
-    up with the same correct state.
+    This is the idempotency path the seeder is designed around: if any
+    preset is already in the DB, the SELECT in ``_existing_preset_keys``
+    finds it, ``seed_practices`` doesn't try to insert it, and only the
+    missing rows land.
     """
-    # Simulate the peer's insert landing first by seeding the row directly.
     db_session.add(Practice(**PRESET_PRACTICES[0]))
     await db_session.commit()
 
-    # Now stage a fresh Practice with the same key and call the seeder —
-    # the seeder's pre-check (SELECT existing keys) ought to skip it. We
-    # verify that even if it somehow tries (e.g. someone refactors the
-    # existence check away), the IntegrityError handler returns 0 rather
-    # than crashing startup.
     inserted = await seed_practices(db_session)
-    # The remaining 9 presets are still inserted; only the dupe is skipped.
     assert inserted == _EXPECTED_PRESET_COUNT - 1
+
+
+@pytest.mark.asyncio
+async def test_seed_practices_race_loser_returns_zero(
+    db_session: AsyncSession,
+) -> None:
+    """The actual race-loser path: SELECT misses, COMMIT loses the race.
+
+    Reproduces the production scenario by patching ``_existing_preset_keys``
+    to return an empty set — the seeder then stages every preset for insert,
+    but the row(s) the "race-winner" peer already committed make the unique
+    index fire on commit. ``_commit_or_yield_to_race_winner`` catches the
+    ``IntegrityError``, rolls back, and returns 0.
+
+    This is the only test that actually exercises the ``except IntegrityError``
+    branch — the previous ``test_seed_practices_skips_already_seeded_preset``
+    short-circuits before reaching it via the pre-pass.
+    """
+    # Simulate the race-winner peer's commit landing first.
+    for definition in PRESET_PRACTICES:
+        db_session.add(Practice(**definition))
+    await db_session.commit()
+
+    # Patch the existence check to claim the table is empty so the seeder
+    # actually attempts every insert — the DB unique index is the only
+    # arbiter, just like the production race.
+    with patch("seed_practices._existing_preset_keys", new=AsyncMock(return_value=set())):
+        result = await seed_practices(db_session)
+
+    assert result == 0
+    # The original 10 rows are still the only ones in the DB — no duplicate
+    # leaked past the rollback.
+    rows = (await db_session.execute(select(Practice))).scalars().all()
+    assert len(rows) == _EXPECTED_PRESET_COUNT
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -57,6 +58,100 @@ async def test_seed_practices_idempotent(db_session: AsyncSession) -> None:
 
     rows = (await db_session.execute(select(Practice))).scalars().all()
     assert len(rows) == _EXPECTED_PRESET_COUNT
+
+
+@pytest.mark.asyncio
+async def test_preset_unique_index_rejects_duplicate_seed_insert(
+    db_session: AsyncSession,
+) -> None:
+    """The partial unique index closes the seeder race.
+
+    Without the index, two concurrent ``lifespan`` runs can each pass the
+    existence SELECT before either commits, double-inserting every preset.
+    This test simulates the race by attempting two raw INSERTs of the same
+    preset row and verifies the DB rejects the second with ``IntegrityError``.
+    """
+    first = Practice(**PRESET_PRACTICES[0])
+    db_session.add(first)
+    await db_session.commit()
+
+    # Same (stage_number, name) with submitted_by_user_id IS NULL — must fail.
+    dupe = Practice(**PRESET_PRACTICES[0])
+    db_session.add(dupe)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_preset_unique_index_is_case_and_whitespace_insensitive(
+    db_session: AsyncSession,
+) -> None:
+    """``lower(trim(name))`` collapses "5-4-3-2-1 grounding" / "  5-4-3-2-1 Grounding"."""
+    first = Practice(**PRESET_PRACTICES[0])
+    db_session.add(first)
+    await db_session.commit()
+
+    raw_name = PRESET_PRACTICES[0]["name"]
+    skewed = Practice(
+        **{
+            **PRESET_PRACTICES[0],
+            "name": f"  {raw_name.upper()}  ",
+        }
+    )
+    db_session.add(skewed)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_preset_unique_index_allows_user_submission_with_same_name(
+    db_session: AsyncSession,
+) -> None:
+    """The partial ``WHERE submitted_by_user_id IS NULL`` clause exempts user submissions.
+
+    A user submitting their own practice with the same display name as a
+    preset is a legitimate scenario the index must NOT reject.
+    """
+    preset = Practice(**PRESET_PRACTICES[0])
+    db_session.add(preset)
+    await db_session.commit()
+
+    # Carry a synthetic user id — the bare ``Practice`` model has no FK back
+    # to ``user``, so any non-null integer suffices to fall outside the
+    # partial index's predicate.
+    user_submission = Practice(
+        **{**PRESET_PRACTICES[0], "submitted_by_user_id": 12_345, "approved": False}
+    )
+    db_session.add(user_submission)
+    await db_session.commit()  # MUST NOT raise
+
+
+@pytest.mark.asyncio
+async def test_seed_practices_swallows_race_loser_integrity_error(
+    db_session: AsyncSession,
+) -> None:
+    """A peer process committing the preset between our SELECT and COMMIT is benign.
+
+    The seeder catches ``IntegrityError``, rolls back, and returns 0 — the
+    work has already been done by the peer. This is the production-race
+    behaviour: rolling restart triggers two concurrent ``lifespan`` runs,
+    one of them wins the insert, the other one's commit raises, both end
+    up with the same correct state.
+    """
+    # Simulate the peer's insert landing first by seeding the row directly.
+    db_session.add(Practice(**PRESET_PRACTICES[0]))
+    await db_session.commit()
+
+    # Now stage a fresh Practice with the same key and call the seeder —
+    # the seeder's pre-check (SELECT existing keys) ought to skip it. We
+    # verify that even if it somehow tries (e.g. someone refactors the
+    # existence check away), the IntegrityError handler returns 0 rather
+    # than crashing startup.
+    inserted = await seed_practices(db_session)
+    # The remaining 9 presets are still inserted; only the dupe is skipped.
+    assert inserted == _EXPECTED_PRESET_COUNT - 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

User report: every stage shows two copies of its preset practice (5-4-3-2-1 visible twice).

**Root cause:** `seed_practices` does a SELECT-then-INSERT match on `(stage_number, name)` to stay idempotent, but the catalog table had no DB-level uniqueness on that pair. Two concurrent `lifespan` boots — a rolling-restart deploy with overlap, or a dev who ran the seeder script while `uvicorn --reload` was also restarting — could both pass the SELECT before either committed and insert all ten presets twice.

**Fix:** mirrors PR #287 / migration `b5c6d7e8f9a0` (same problem for `habit`):

| File | Change |
| --- | --- |
| `backend/migrations/versions/d2e3f4a5b6c7_*.py` | Repoint any `UserPractice.practice_id` off duplicate rows onto the lowest-id (keeper) row per `(stage_number, lower(trim(name)))` group, `DELETE` the dupes, then create a partial functional unique index on `(stage_number, lower(trim(name))) WHERE submitted_by_user_id IS NULL`. Partial so user-submitted practices keep their freedom to share a name with a preset or with each other. |
| `backend/src/models/practice.py` | Document in the model docstring that the index is intentionally NOT declared in `__table_args__` (alembic's autogenerate can't round-trip a partial functional index against a raw-SQL migration; declaring it would cause `alembic check` to flag false drift). The migration is the source of truth. |
| `backend/migrations/env.py` | Add the new index name to the existing `_RAW_SQL_MANAGED_INDEXES` allow-list so `alembic check` skips it during drift comparison — same pattern the other raw-SQL functional indexes use. |
| `backend/src/seed_practices.py` | Catch `IntegrityError` on commit — under the race, the slow path now arbitrates at the DB instead of either side losing data. Race-loser returns 0 and the peer's insert stands. Extracted `_existing_preset_keys` and `_commit_or_yield_to_race_winner` helpers so the public function stays at xenon rank A. |
| `backend/conftest.py` | Mirror the partial unique index on the SQLite test DB so the regression tests run cheaply. |
| `backend/tests/test_seed_practices.py` | 5 new tests pin the contract — dupes rejected by the index, case/whitespace normalisation, user submissions exempt, the already-seeded skip path, and (critically, after review feedback) a real race-loser test that patches `_existing_preset_keys` to actually exercise the `except IntegrityError` branch. |

## Tests

- `test_preset_unique_index_rejects_duplicate_seed_insert` — DB rejects a second insert of the same `(stage_number, name)` preset.
- `test_preset_unique_index_is_case_and_whitespace_insensitive` — `"  5-4-3-2-1 GROUNDING  "` and `"5-4-3-2-1 grounding"` collide.
- `test_preset_unique_index_allows_user_submission_with_same_name` — `submitted_by_user_id IS NOT NULL` is exempt from the partial index.
- `test_seed_practices_skips_already_seeded_preset` — idempotency: pre-pass finds the row, seeder skips it.
- **`test_seed_practices_race_loser_returns_zero`** — patches the existence-check to return empty, lets the seeder stage every preset against a fully-populated DB, verifies the DB unique index fires, the handler catches `IntegrityError`, rolls back, returns 0. Branch coverage on `seed_practices.py` lands at 94%.

Full backend suite: **1110 passing** (+5 new vs. base). Migration round-trip pattern test (P1-6) picks up the new migration automatically via the AST walk.

## Quality gates

- `pre-commit run --files ...` ✅
- Pre-push (full backend suite + xenon A-grade + radon MI + branch coverage) ✅
- No suppressions; complexity flag resolved by extracting helpers, not `# noqa: C901`. Drift flag resolved by `_RAW_SQL_MANAGED_INDEXES` allow-list (project precedent), not by suppressing autogenerate.

## Test plan

- [x] `pytest tests/test_seed_practices.py tests/test_migrations.py`
- [x] Full backend suite (1110 passing)
- [x] `xenon --max-absolute B --max-modules B --max-average A backend/src/seed_practices.py`
- [x] Forward-then-back migration on Postgres via `migration-drift` CI job (both branches of the merge head)

## Review history

- Initial CI failures: `migration-drift` flagged `alembic check` drift on the new index. Fix: removed the model-level `Index` declaration that confused autogenerate, then added the index name to `migrations/env.py`'s `_RAW_SQL_MANAGED_INDEXES` allow-list (project's existing escape hatch for raw-SQL functional indexes).
- Three reviewers converged on the same blocker: `test_seed_practices_swallows_race_loser_integrity_error` didn't exercise the `except IntegrityError` branch. Split into two truthfully-named tests; the new race-loser test patches `_existing_preset_keys` so the seeder actually hits the DB unique index and the exception handler runs end-to-end.

## Note on the wider "add a new practice" problem

User flagged a separate concern about "no reachable flow for adding a new practice." That diagnosis + roadmap is filed as issue #331 — out of scope for this PR.

https://claude.ai/code/session_01FqtfNeSbMP8fNirreyrsji