### PR TITLE
fix(habits): make mobile energy inputs editable

### DIFF
--- a/frontend/src/features/Habits/components/AddHabitModal.tsx
+++ b/frontend/src/features/Habits/components/AddHabitModal.tsx
@@ -7,27 +7,15 @@ import styles from '../Habits.styles';
 import type { AddHabitInput } from '../Habits.types';
 import { calculateNetEnergy } from '../HabitUtils';
 
+import { EnergyTextInput } from './EnergyTextInput';
+
 interface AddHabitModalProps {
   visible: boolean;
   onClose: () => void;
   onAdd: (_input: AddHabitInput) => void | Promise<void>;
 }
 
-/**
- * Energy bounds match `HabitSettingsModal` so a habit created here can be
- * tuned to the same negative-cost / negative-return range an existing habit
- * supports — a previous version capped at 0 and produced an inconsistency.
- */
-const ENERGY_MIN = -10;
-const ENERGY_MAX = 10;
 const DEFAULT_ENERGY = 5;
-
-const parseEnergy = (text: string): number | null => {
-  const value = parseInt(text, 10);
-  if (Number.isNaN(value)) return null;
-  if (value < ENERGY_MIN || value > ENERGY_MAX) return null;
-  return value;
-};
 
 const randomDefaultIcon = (): string =>
   DEFAULT_ICONS[Math.floor(Math.random() * DEFAULT_ICONS.length)] ?? '⭐';
@@ -115,25 +103,17 @@ const EnergyRow = ({
       <Text style={styles.energyHeaderText}>Net</Text>
     </View>
     <View style={styles.energyRow}>
-      <TextInput
+      <EnergyTextInput
         testID="add-habit-cost"
         style={styles.energyInput}
-        value={energyCost.toString()}
-        onChangeText={(text) => {
-          const value = parseEnergy(text);
-          if (value !== null) setEnergyCost(value);
-        }}
-        keyboardType="numeric"
+        value={energyCost}
+        onCommit={setEnergyCost}
       />
-      <TextInput
+      <EnergyTextInput
         testID="add-habit-return"
         style={styles.energyInput}
-        value={energyReturn.toString()}
-        onChangeText={(text) => {
-          const value = parseEnergy(text);
-          if (value !== null) setEnergyReturn(value);
-        }}
-        keyboardType="numeric"
+        value={energyReturn}
+        onCommit={setEnergyReturn}
       />
       <Text style={styles.netEnergyValue}>{calculateNetEnergy(energyCost, energyReturn)}</Text>
     </View>

--- a/frontend/src/features/Habits/components/EnergyTextInput.tsx
+++ b/frontend/src/features/Habits/components/EnergyTextInput.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { TextInput, type StyleProp, type TextStyle } from 'react-native';
+
+import { parseEnergyValue } from './parseEnergyValue';
+
+interface EnergyTextInputProps {
+  value: number;
+  onCommit: (_value: number) => void;
+  style?: StyleProp<TextStyle>;
+  testID?: string;
+}
+
+/**
+ * Controlled-but-tolerant numeric input for the cost / return fields.
+ *
+ * The previous wiring fed the parsed integer straight back into the
+ * ``TextInput`` ``value`` prop, so any keystroke that produced an
+ * intermediate string (``""`` after a backspace, a lone ``"-"`` while
+ * typing ``"-5"``, or ``"58"`` mid-edit toward ``"8"``) failed parsing,
+ * left the numeric state untouched, and snapped the input back to its
+ * prior value. On mobile this looked like the field was uneditable.
+ *
+ * The buffer here holds whatever the user has typed; the parsed integer
+ * only escapes to ``onCommit`` when the buffer is a valid integer in
+ * range. ``onBlur`` rolls the buffer back to the last committed value
+ * so an invalid mid-edit doesn't strand a stale string on screen.
+ */
+export const EnergyTextInput = ({ value, onCommit, style, testID }: EnergyTextInputProps) => {
+  const [text, setText] = useState<string>(value.toString());
+
+  useEffect(() => {
+    setText(value.toString());
+  }, [value]);
+
+  const handleChangeText = (next: string) => {
+    setText(next);
+    const parsed = parseEnergyValue(next);
+    if (parsed !== null) onCommit(parsed);
+  };
+
+  const handleBlur = () => {
+    if (parseEnergyValue(text) === null) {
+      setText(value.toString());
+    }
+  };
+
+  return (
+    <TextInput
+      testID={testID}
+      style={style}
+      value={text}
+      onChangeText={handleChangeText}
+      onBlur={handleBlur}
+      keyboardType="numbers-and-punctuation"
+    />
+  );
+};
+
+export default EnergyTextInput;

--- a/frontend/src/features/Habits/components/EnergyTextInput.tsx
+++ b/frontend/src/features/Habits/components/EnergyTextInput.tsx
@@ -10,24 +10,14 @@ interface EnergyTextInputProps {
   testID?: string;
 }
 
-/**
- * Controlled-but-tolerant numeric input for the cost / return fields.
- *
- * The previous wiring fed the parsed integer straight back into the
- * ``TextInput`` ``value`` prop, so any keystroke that produced an
- * intermediate string (``""`` after a backspace, a lone ``"-"`` while
- * typing ``"-5"``, or ``"58"`` mid-edit toward ``"8"``) failed parsing,
- * left the numeric state untouched, and snapped the input back to its
- * prior value. On mobile this looked like the field was uneditable.
- *
- * The buffer here holds whatever the user has typed; the parsed integer
- * only escapes to ``onCommit`` when the buffer is a valid integer in
- * range. ``onBlur`` rolls the buffer back to the last committed value
- * so an invalid mid-edit doesn't strand a stale string on screen.
- */
+// Local string buffer so mid-edit states ('', '-', '58') aren't snapped
+// back to the last committed integer on every keystroke.
 export const EnergyTextInput = ({ value, onCommit, style, testID }: EnergyTextInputProps) => {
   const [text, setText] = useState<string>(value.toString());
 
+  // External value changes (e.g. modal reset, opening for a different habit)
+  // override the buffer. Don't drive ``value`` from a timer or auto-save loop
+  // while the user is typing — it will stomp their in-progress edit.
   useEffect(() => {
     setText(value.toString());
   }, [value]);
@@ -55,5 +45,3 @@ export const EnergyTextInput = ({ value, onCommit, style, testID }: EnergyTextIn
     />
   );
 };
-
-export default EnergyTextInput;

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -19,9 +19,7 @@ import type { Habit, HabitSettingsModalProps } from '../Habits.types';
 import { calculateNetEnergy } from '../HabitUtils';
 
 import ConfirmDialog from './ConfirmDialog';
-// BUG-FE-HABIT-201: parser lives in its own module so unit tests can
-// import without the RN component tree (see ``parseEnergyValue.ts``).
-import { parseEnergyValue } from './parseEnergyValue';
+import { EnergyTextInput } from './EnergyTextInput';
 
 const cycleFrequency = (current: string | undefined): 'daily' | 'weekly' | 'custom' => {
   if (current === 'daily') return 'weekly';
@@ -43,23 +41,15 @@ const EnergySettings = ({ habit, netEnergy, onChange }: EnergySettingsProps) => 
       <Text style={styles.energyHeaderText}>Net</Text>
     </View>
     <View style={styles.energyRow}>
-      <TextInput
+      <EnergyTextInput
         style={styles.energyInput}
-        value={habit.energy_cost.toString()}
-        onChangeText={(text) => {
-          const value = parseEnergyValue(text);
-          if (value !== null) onChange('energy_cost', value);
-        }}
-        keyboardType="numeric"
+        value={habit.energy_cost}
+        onCommit={(value) => onChange('energy_cost', value)}
       />
-      <TextInput
+      <EnergyTextInput
         style={styles.energyInput}
-        value={habit.energy_return.toString()}
-        onChangeText={(text) => {
-          const value = parseEnergyValue(text);
-          if (value !== null) onChange('energy_return', value);
-        }}
-        keyboardType="numeric"
+        value={habit.energy_return}
+        onCommit={(value) => onChange('energy_return', value)}
       />
       <Text style={styles.netEnergyValue}>{netEnergy}</Text>
     </View>

--- a/frontend/src/features/Habits/components/__tests__/AddHabitModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/AddHabitModal.test.tsx
@@ -38,17 +38,32 @@ describe('AddHabitModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects out-of-range energy inputs and keeps the previous value', () => {
-    const { getByTestId } = render(<AddHabitModal visible onClose={jest.fn()} onAdd={noopAdd} />);
+  it('lets the user type freely and only commits valid energy values', async () => {
+    const onAdd = jest.fn(() => Promise.resolve());
+    const { getByTestId } = render(<AddHabitModal visible onClose={jest.fn()} onAdd={onAdd} />);
     const cost = getByTestId('add-habit-cost');
-    fireEvent.changeText(cost, '5');
-    expect(cost.props.value).toBe('5');
-    fireEvent.changeText(cost, '99');
-    expect(cost.props.value).toBe('5');
+    // Mid-edit states must surface in the field so the user can actually
+    // edit on mobile — the prior implementation snapped the value back to
+    // the last committed integer and made the input feel uneditable.
+    fireEvent.changeText(cost, '');
+    expect(cost.props.value).toBe('');
+    fireEvent.changeText(cost, '-');
+    expect(cost.props.value).toBe('-');
     fireEvent.changeText(cost, '-3');
     expect(cost.props.value).toBe('-3');
+    // Out-of-range stays visible mid-edit but does not commit.
     fireEvent.changeText(cost, '-99');
+    expect(cost.props.value).toBe('-99');
+    // Blur with an invalid buffer rolls back to the last committed value.
+    fireEvent(cost, 'blur');
     expect(cost.props.value).toBe('-3');
+
+    fireEvent.changeText(getByTestId('add-habit-name'), 'Walk');
+    await act(async () => {
+      fireEvent.press(getByTestId('add-habit-save'));
+      await flushPromises();
+    });
+    expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({ energy_cost: -3 }));
   });
 
   it('closes the modal even when onAdd rejects', async () => {

--- a/frontend/src/features/Habits/components/__tests__/EnergyTextInput.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/EnergyTextInput.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React, { useState } from 'react';
+
+import { EnergyTextInput } from '../EnergyTextInput';
+
+const Harness = ({ initial, onCommit }: { initial: number; onCommit?: (_n: number) => void }) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <EnergyTextInput
+      testID="energy-input"
+      value={value}
+      onCommit={(next) => {
+        setValue(next);
+        onCommit?.(next);
+      }}
+    />
+  );
+};
+
+describe('EnergyTextInput', () => {
+  it('renders the initial value as a string', () => {
+    const { getByTestId } = render(<Harness initial={5} />);
+    expect(getByTestId('energy-input').props.value).toBe('5');
+  });
+
+  it('exposes mid-edit states (empty, lone minus) without dropping keystrokes', () => {
+    const onCommit = jest.fn();
+    const { getByTestId } = render(<Harness initial={5} onCommit={onCommit} />);
+    const input = getByTestId('energy-input');
+    fireEvent.changeText(input, '');
+    expect(input.props.value).toBe('');
+    fireEvent.changeText(input, '-');
+    expect(input.props.value).toBe('-');
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('commits valid integers in the [-10, 10] window', () => {
+    const onCommit = jest.fn();
+    const { getByTestId } = render(<Harness initial={5} onCommit={onCommit} />);
+    const input = getByTestId('energy-input');
+    fireEvent.changeText(input, '-3');
+    expect(onCommit).toHaveBeenLastCalledWith(-3);
+    fireEvent.changeText(input, '10');
+    expect(onCommit).toHaveBeenLastCalledWith(10);
+    fireEvent.changeText(input, '0');
+    expect(onCommit).toHaveBeenLastCalledWith(0);
+  });
+
+  it('keeps invalid text visible but does not commit it', () => {
+    const onCommit = jest.fn();
+    const { getByTestId } = render(<Harness initial={5} onCommit={onCommit} />);
+    const input = getByTestId('energy-input');
+    fireEvent.changeText(input, '99');
+    expect(input.props.value).toBe('99');
+    expect(onCommit).not.toHaveBeenCalled();
+    fireEvent.changeText(input, 'foo');
+    expect(input.props.value).toBe('foo');
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('reverts the buffer on blur when the text is invalid', () => {
+    const { getByTestId } = render(<Harness initial={5} />);
+    const input = getByTestId('energy-input');
+    fireEvent.changeText(input, '99');
+    expect(input.props.value).toBe('99');
+    fireEvent(input, 'blur');
+    expect(input.props.value).toBe('5');
+  });
+
+  it('does not revert the buffer on blur when the text parses cleanly', () => {
+    const { getByTestId } = render(<Harness initial={5} />);
+    const input = getByTestId('energy-input');
+    fireEvent.changeText(input, '7');
+    fireEvent(input, 'blur');
+    expect(input.props.value).toBe('7');
+  });
+
+  it('syncs the buffer when the external value changes', () => {
+    const Wrapper = ({ value }: { value: number }) => (
+      <EnergyTextInput testID="energy-input" value={value} onCommit={() => undefined} />
+    );
+    const { getByTestId, rerender } = render(<Wrapper value={5} />);
+    expect(getByTestId('energy-input').props.value).toBe('5');
+    rerender(<Wrapper value={-2} />);
+    expect(getByTestId('energy-input').props.value).toBe('-2');
+  });
+});


### PR DESCRIPTION
The cost / return TextInputs were controlled with the parsed integer and
only updated state when the buffer parsed cleanly. Every intermediate
keystroke ("" after a backspace, lone "-" while typing "-5", "58" while
changing 5 to 8) failed parsing, left state untouched, and snapped the
field back — so on mobile the inputs felt frozen. ``keyboardType="numeric"``
also hid the minus key on iOS, blocking negative values entirely.

Extract a shared ``EnergyTextInput`` that holds a local string buffer,
commits only on a valid parse, and rolls the buffer back on blur if it's
still invalid. Switch the keyboard to ``numbers-and-punctuation`` so the
minus key is reachable. Wire both ``AddHabitModal`` and
``HabitSettingsModal`` through the new component.

https://claude.ai/code/session_01Ybo8cerbgdVNSFCj87FVcR