### PR TITLE
feat(frontend-habits): collapse goal editor behind pencil/checkmark toggle

### DIFF
--- a/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
@@ -59,6 +59,19 @@ const sampleHabit: Habit = {
   completions: [],
 };
 
+/**
+ * Expand the inline edit region. The modal opens collapsed by default —
+ * only the title row and the Log Units bar are mounted — so any test that
+ * pokes the goal target editor or the progress markers needs to flip the
+ * pencil to a checkmark first.
+ */
+const expandEditRegion = (testRenderer: ReturnType<typeof renderer.create>): void => {
+  const toggle = testRenderer.root.findByProps({ testID: 'goal-modal-edit-toggle' });
+  renderer.act(() => {
+    toggle.props.onPress();
+  });
+};
+
 describe('GoalModal hook order', () => {
   it('renders without crashing when habit becomes available', () => {
     const testRenderer = renderer.create(
@@ -101,6 +114,7 @@ describe('GoalModal progress', () => {
         onUpdateHabit={() => {}}
       />,
     );
+    expandEditRegion(testRenderer);
 
     expect(testRenderer.root.findByProps({ testID: 'modal-marker-stretch' })).toBeTruthy();
     const initialFill = testRenderer.root.findByProps({ testID: 'modal-progress-fill' });
@@ -137,6 +151,7 @@ describe('GoalModal tooltips', () => {
         onUpdateHabit={() => {}}
       />,
     );
+    expandEditRegion(testRenderer);
 
     const lowMarker = testRenderer.root.findByProps({ testID: 'modal-marker-low' });
     renderer.act(() => {
@@ -152,7 +167,7 @@ describe('GoalModal tooltips', () => {
 
 describe('GoalModal target editor', () => {
   // Click-to-edit chip → input → commit → chip round-trip; tests cover both modes.
-  it('renders a saved-state display for every goal tier by default', () => {
+  it('renders a saved-state display for every goal tier in edit mode', () => {
     const testRenderer = renderer.create(
       <GoalModal
         visible
@@ -163,6 +178,7 @@ describe('GoalModal target editor', () => {
         onUpdateHabit={() => {}}
       />,
     );
+    expandEditRegion(testRenderer);
 
     expect(testRenderer.root.findByProps({ testID: 'goal-target-display-low' })).toBeTruthy();
     expect(testRenderer.root.findByProps({ testID: 'goal-target-display-clear' })).toBeTruthy();
@@ -181,6 +197,7 @@ describe('GoalModal target editor', () => {
         onUpdateHabit={() => {}}
       />,
     );
+    expandEditRegion(testRenderer);
 
     const display = testRenderer.root.findByProps({ testID: 'goal-target-display-clear' });
     renderer.act(() => {
@@ -202,6 +219,7 @@ describe('GoalModal target editor', () => {
         onUpdateHabit={() => {}}
       />,
     );
+    expandEditRegion(testRenderer);
 
     renderer.act(() => {
       testRenderer.root.findByProps({ testID: 'goal-target-display-clear' }).props.onPress();
@@ -245,6 +263,7 @@ describe('GoalModal target editor', () => {
         onUpdateHabit={() => {}}
       />,
     );
+    expandEditRegion(testRenderer);
 
     renderer.act(() => {
       testRenderer.root.findByProps({ testID: 'goal-target-display-clear' }).props.onPress();
@@ -271,6 +290,7 @@ describe('GoalModal target editor', () => {
         onUpdateHabit={() => {}}
       />,
     );
+    expandEditRegion(testRenderer);
 
     renderer.act(() => {
       testRenderer.root.findByProps({ testID: 'goal-target-display-low' }).props.onPress();
@@ -295,6 +315,7 @@ describe('GoalModal target editor', () => {
         onUpdateHabit={() => {}}
       />,
     );
+    expandEditRegion(testRenderer);
 
     renderer.act(() => {
       testRenderer.root.findByProps({ testID: 'goal-target-display-clear' }).props.onPress();
@@ -345,6 +366,7 @@ describe('GoalModal backdrop close', () => {
         onUpdateHabit={() => {}}
       />,
     );
+    expandEditRegion(testRenderer);
 
     // Walking up the tree from a body element must not hit ``onPress === onClose``.
     const display = testRenderer.root.findByProps({ testID: 'goal-target-display-low' });
@@ -358,5 +380,81 @@ describe('GoalModal backdrop close', () => {
     }
 
     expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('GoalModal edit toggle', () => {
+  // The modal opens collapsed so the primary action (logging units) stays
+  // one tap away; only the pencil reveals the goal editor surface.
+  it('hides the goal editor and progress bar by default', () => {
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    expect(() => testRenderer.root.findByProps({ testID: 'goal-modal-edit-region' })).toThrow();
+    expect(() => testRenderer.root.findByProps({ testID: 'goal-target-editor' })).toThrow();
+    expect(() => testRenderer.root.findByProps({ testID: 'modal-progress-fill' })).toThrow();
+  });
+
+  it('renders Log Units controls in both collapsed and expanded states', () => {
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    // Collapsed: the Log Units controls are the deliberate primary affordance.
+    expect(testRenderer.root.findByProps({ testID: 'goal-modal-log-unit-section' })).toBeTruthy();
+
+    expandEditRegion(testRenderer);
+
+    expect(testRenderer.root.findByProps({ testID: 'goal-modal-log-unit-section' })).toBeTruthy();
+  });
+
+  it('toggles the goal editor visibility when the pencil/checkmark is pressed', () => {
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+
+    const toggle = testRenderer.root.findByProps({ testID: 'goal-modal-edit-toggle' });
+    // First press: pencil → checkmark, editor mounts.
+    expect(toggle.props.accessibilityState).toEqual({ expanded: false });
+    renderer.act(() => {
+      toggle.props.onPress();
+    });
+    expect(testRenderer.root.findByProps({ testID: 'goal-modal-edit-region' })).toBeTruthy();
+    expect(testRenderer.root.findByProps({ testID: 'goal-target-editor' })).toBeTruthy();
+    expect(
+      testRenderer.root.findByProps({ testID: 'goal-modal-edit-toggle' }).props.accessibilityState,
+    ).toEqual({ expanded: true });
+
+    // Second press: checkmark → pencil, editor unmounts.
+    renderer.act(() => {
+      testRenderer.root.findByProps({ testID: 'goal-modal-edit-toggle' }).props.onPress();
+    });
+    expect(() => testRenderer.root.findByProps({ testID: 'goal-modal-edit-region' })).toThrow();
+    expect(() => testRenderer.root.findByProps({ testID: 'goal-target-editor' })).toThrow();
+    expect(
+      testRenderer.root.findByProps({ testID: 'goal-modal-edit-toggle' }).props.accessibilityState,
+    ).toEqual({ expanded: false });
   });
 });

--- a/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
@@ -59,12 +59,6 @@ const sampleHabit: Habit = {
   completions: [],
 };
 
-/**
- * Expand the inline edit region. The modal opens collapsed by default —
- * only the title row and the Log Units bar are mounted — so any test that
- * pokes the goal target editor or the progress markers needs to flip the
- * pencil to a checkmark first.
- */
 const expandEditRegion = (testRenderer: ReturnType<typeof renderer.create>): void => {
   const toggle = testRenderer.root.findByProps({ testID: 'goal-modal-edit-toggle' });
   renderer.act(() => {
@@ -386,7 +380,7 @@ describe('GoalModal backdrop close', () => {
 describe('GoalModal edit toggle', () => {
   // The modal opens collapsed so the primary action (logging units) stays
   // one tap away; only the pencil reveals the goal editor surface.
-  it('hides the goal editor and progress bar by default', () => {
+  it('renders the header toggle and Log Units while hiding the editor by default', () => {
     const testRenderer = renderer.create(
       <GoalModal
         visible
@@ -397,6 +391,10 @@ describe('GoalModal edit toggle', () => {
         onUpdateHabit={() => {}}
       />,
     );
+
+    const toggle = testRenderer.root.findByProps({ testID: 'goal-modal-edit-toggle' });
+    expect(toggle.props.accessibilityState).toEqual({ expanded: false });
+    expect(testRenderer.root.findByProps({ testID: 'goal-modal-log-unit-section' })).toBeTruthy();
 
     expect(() => testRenderer.root.findByProps({ testID: 'goal-modal-edit-region' })).toThrow();
     expect(() => testRenderer.root.findByProps({ testID: 'goal-target-editor' })).toThrow();

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -1,3 +1,4 @@
+import { Check, Pencil } from 'lucide-react-native';
 import React, { useState, useRef, useEffect } from 'react';
 import {
   Alert,
@@ -22,7 +23,7 @@ import EmojiSelector from 'react-native-emoji-selector';
 
 import { goalGroups as goalGroupsApi, type ApiGoalGroup } from '../../../api';
 import { useAuth } from '../../../context/AuthContext';
-import { colors, SPACING, STAGE_COLORS, shadows } from '../../../design/tokens';
+import { colors, SPACING, STAGE_COLORS, shadows, touchTarget } from '../../../design/tokens';
 import { TARGET_UNITS, FREQUENCY_UNITS } from '../constants';
 import styles from '../Habits.styles';
 import type { GoalModalProps, Goal } from '../Habits.types';
@@ -329,7 +330,7 @@ interface LogUnitSectionProps {
 }
 
 const LogUnitSection = ({ logAmount, setLogAmount, onLog }: LogUnitSectionProps) => (
-  <View style={styles.actionButtons}>
+  <View style={styles.actionButtons} testID="goal-modal-log-unit-section">
     <View style={styles.logUnitContainer}>
       <TextInput
         style={styles.logUnitInput}
@@ -1005,6 +1006,30 @@ const useGoalMarkers = (
   };
 };
 
+const EDIT_TOGGLE_ICON_SIZE = 22;
+
+interface EditToggleButtonProps {
+  isEditing: boolean;
+  onToggle: () => void;
+}
+
+const EditToggleButton = ({ isEditing, onToggle }: EditToggleButtonProps) => (
+  <TouchableOpacity
+    testID="goal-modal-edit-toggle"
+    accessibilityRole="button"
+    accessibilityLabel={isEditing ? 'Save and close edit mode' : 'Edit habit goals'}
+    accessibilityState={{ expanded: isEditing }}
+    onPress={onToggle}
+    style={editToggleStyles.button}
+  >
+    {isEditing ? (
+      <Check size={EDIT_TOGGLE_ICON_SIZE} color={colors.text.secondary} />
+    ) : (
+      <Pencil size={EDIT_TOGGLE_ICON_SIZE} color={colors.text.secondary} />
+    )}
+  </TouchableOpacity>
+);
+
 interface GoalModalHeaderProps {
   habit: NonNullable<GoalModalProps['habit']>;
   goalGroup: ApiGoalGroup | null;
@@ -1012,6 +1037,8 @@ interface GoalModalHeaderProps {
   setShowEmojiSelector: (_v: boolean) => void;
   onClose: () => void;
   onUpdateHabit: GoalModalProps['onUpdateHabit'];
+  isEditing: boolean;
+  onToggleEdit: () => void;
 }
 
 const GoalModalHeader = ({
@@ -1021,10 +1048,13 @@ const GoalModalHeader = ({
   setShowEmojiSelector,
   onClose,
   onUpdateHabit,
+  isEditing,
+  onToggleEdit,
 }: GoalModalHeaderProps) => (
   <>
     <View style={styles.modalHeader}>
       <Text style={styles.modalTitle}>{habit.name}</Text>
+      <EditToggleButton isEditing={isEditing} onToggle={onToggleEdit} />
       <TouchableOpacity onPress={() => setShowEmojiSelector(true)}>
         <Text style={styles.iconLarge}>{habit.icon}</Text>
       </TouchableOpacity>
@@ -1109,6 +1139,12 @@ const GoalModalBody = ({
 }: GoalModalBodyProps) => {
   const [logAmount, setLogAmount] = useState('1');
   const [showEmojiSelector, setShowEmojiSelector] = useState(false);
+  // Inline edit mode is collapsed by default so the modal opens as a quick
+  // log-units affordance; tapping the pencil expands the goal editor for
+  // intentional changes, and the checkmark collapses it back. Per-field
+  // commits inside the editor already persist optimistically, so the
+  // checkmark only needs to flip the local view state.
+  const [isEditing, setIsEditing] = useState(false);
   const goalGroup = useGoalGroup(habit);
   const m = useGoalMarkers(habit, onUpdateGoal);
   const { userTimezone } = useAuth();
@@ -1128,9 +1164,15 @@ const GoalModalBody = ({
         setShowEmojiSelector={setShowEmojiSelector}
         onClose={onClose}
         onUpdateHabit={onUpdateHabit}
+        isEditing={isEditing}
+        onToggleEdit={() => setIsEditing((prev) => !prev)}
       />
-      <GoalProgressBar {...buildProgressBarProps(habit, m, userTimezone)} />
-      <GoalTargetEditor habit={habit} onUpdateGoal={onUpdateGoal} />
+      {isEditing && (
+        <View testID="goal-modal-edit-region">
+          <GoalProgressBar {...buildProgressBarProps(habit, m, userTimezone)} />
+          <GoalTargetEditor habit={habit} onUpdateGoal={onUpdateGoal} />
+        </View>
+      )}
       <LogUnitSection logAmount={logAmount} setLogAmount={setLogAmount} onLog={handleLogUnit} />
     </View>
   );
@@ -1182,6 +1224,16 @@ const goalGroupBadgeStyles = StyleSheet.create({
     fontSize: 12,
     color: '#555',
     fontStyle: 'italic',
+  },
+});
+
+const editToggleStyles = StyleSheet.create({
+  button: {
+    minWidth: touchTarget.minimum,
+    minHeight: touchTarget.minimum,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.xs,
   },
 });
 

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -1139,11 +1139,6 @@ const GoalModalBody = ({
 }: GoalModalBodyProps) => {
   const [logAmount, setLogAmount] = useState('1');
   const [showEmojiSelector, setShowEmojiSelector] = useState(false);
-  // Inline edit mode is collapsed by default so the modal opens as a quick
-  // log-units affordance; tapping the pencil expands the goal editor for
-  // intentional changes, and the checkmark collapses it back. Per-field
-  // commits inside the editor already persist optimistically, so the
-  // checkmark only needs to flip the local view state.
   const [isEditing, setIsEditing] = useState(false);
   const goalGroup = useGoalGroup(habit);
   const m = useGoalMarkers(habit, onUpdateGoal);

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -49,6 +49,12 @@ const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
   ...overrides,
 });
 
+/**
+ * Render the modal and immediately expand the inline edit region. The
+ * pencil/checkmark toggle defaults to collapsed, but every test below
+ * targets the goal editor surface — so opening edit mode is a fixture
+ * concern, not part of the behaviour under test.
+ */
 const renderModal = (
   habit: Habit | null = makeHabit(),
   overrides: Partial<React.ComponentProps<typeof GoalModal>> = {},
@@ -62,7 +68,10 @@ const renderModal = (
     onUpdateHabit: jest.fn(),
     ...overrides,
   };
-  return { ...render(<GoalModal {...props} />), props };
+  const utils = render(<GoalModal {...props} />);
+  const toggle = utils.queryByTestId('goal-modal-edit-toggle');
+  if (toggle) fireEvent.press(toggle);
+  return { ...utils, props };
 };
 
 describe('GoalModal goal-target editor', () => {

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -49,12 +49,6 @@ const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
   ...overrides,
 });
 
-/**
- * Render the modal and immediately expand the inline edit region. The
- * pencil/checkmark toggle defaults to collapsed, but every test below
- * targets the goal editor surface — so opening edit mode is a fixture
- * concern, not part of the behaviour under test.
- */
 const renderModal = (
   habit: Habit | null = makeHabit(),
   overrides: Partial<React.ComponentProps<typeof GoalModal>> = {},


### PR DESCRIPTION
The GoalModal opened with the inline goal editor and progress markers
expanded by default, so the primary in-modal action (logging units)
shared real estate with rarely-changed configuration. Add a header
toggle that defaults to a pencil with the editor collapsed and reveals
a checkmark plus the editable surface when expanded; per-field commits
already persist optimistically, so the checkmark just flips local view
state. Log Units stays visible in both states.