### PR TITLE
feat(course): integrate Squarespace as the CMS for course content

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         files: ^backend/
         exclude: ^backend/migrations/
         args: ["--config-file=backend/pyproject.toml"]
-        additional_dependencies: ["types-cachetools", "types-requests", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "slowapi", "limits", "alembic"]
+        additional_dependencies: ["types-cachetools", "types-requests", "types-beautifulsoup4", "beautifulsoup4", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "slowapi", "limits", "alembic"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,15 @@ SECRET_KEY=replace-me  # REQUIRED: set to a cryptographically random string for 
 PORT=8000
 WEB_CONCURRENCY=2
 
+# Squarespace CMS integration (https://aptitude.guru)
+# Required for the in-app course-content endpoints. The same password that
+# Gumroad buyers receive ("ToBeYourOwnGuru" today) — rotate by changing the
+# site password in Squarespace admin and updating this var.
+SQUARESPACE_SITE_PASSWORD=
+# Optional overrides
+# SQUARESPACE_BASE_URL=https://aptitude.guru
+# SQUARESPACE_CACHE_TTL_SECONDS=3600
+
 # BotMason AI configuration
 BOTMASON_PROVIDER=stub  # "stub" (default), "openai", or "anthropic"
 BOTMASON_SYSTEM_PROMPT=  # Path to a prompt file or inline text (optional, has built-in default)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,9 +15,10 @@ PORT=8000
 WEB_CONCURRENCY=2
 
 # Squarespace CMS integration (https://aptitude.guru)
-# Required for the in-app course-content endpoints. The same password that
-# Gumroad buyers receive ("ToBeYourOwnGuru" today) — rotate by changing the
-# site password in Squarespace admin and updating this var.
+# Required for the in-app course-content endpoints. Set this to the
+# site-wide password configured in Squarespace admin (the same password
+# Gumroad buyers receive). The live value lives in the team secrets
+# manager — do NOT commit it to this file.
 SQUARESPACE_SITE_PASSWORD=
 # Optional overrides
 # SQUARESPACE_BASE_URL=https://aptitude.guru

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -15,3 +15,4 @@ sqlmodel
 types-requests
 types-ujson
 types-orjson
+types-beautifulsoup4

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -16,6 +16,8 @@ asyncpg==0.31.0
     # via -r backend/requirements.txt
 bcrypt==5.0.0
     # via -r backend/requirements.txt
+beautifulsoup4==4.14.3
+    # via -r backend/requirements.txt
 cachetools==7.0.5
     # via -r backend/requirements.txt
 certifi==2026.2.25
@@ -80,6 +82,8 @@ pytest-asyncio==1.3.0
     # via -r backend/requirements.txt
 slowapi==0.1.9
     # via -r backend/requirements.txt
+soupsieve==2.8.3
+    # via beautifulsoup4
 sqlalchemy==2.0.49
     # via
     #   -r backend/requirements.txt
@@ -93,6 +97,7 @@ typing-extensions==4.15.0
     # via
     #   alembic
     #   anyio
+    #   beautifulsoup4
     #   fastapi
     #   limits
     #   pydantic
@@ -106,6 +111,8 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
+tzdata==2026.2
+    # via -r backend/requirements.txt
 uvicorn==0.44.0
     # via -r backend/requirements.txt
 wrapt==2.1.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ tzdata
 pytest
 pytest-asyncio
 httpx
+beautifulsoup4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,4 +16,4 @@ tzdata
 pytest
 pytest-asyncio
 httpx
-beautifulsoup4
+beautifulsoup4==4.14.3

--- a/backend/src/content_config.py
+++ b/backend/src/content_config.py
@@ -1,0 +1,258 @@
+"""Declarative content config for Squarespace-hosted course material.
+
+This module is the single source of truth for which Squarespace URLs the
+backend pulls into the app — both stage-locked drip-feed chapters and the
+always-available site resources surfaced on the Course screen.
+
+Editing rules
+=============
+
+To **add** a stage's chapters:
+    Append a new ``StageContentPlan`` to ``STAGE_PLANS``.  The seeder will
+    create one ``StageContent`` row per chapter on next boot.
+
+To **add** a site resource (philosophy, about, etc.):
+    Append a new ``SiteResource`` to ``SITE_RESOURCES``.  It becomes
+    available immediately via ``GET /course/site-resources`` — no DB
+    migration, no seed step.
+
+To **remove** a chapter:
+    Drop or shorten the relevant ``chapter_count`` and run
+    ``backend/scripts/resync_stage_content.py`` (or wait for next boot —
+    the seeder reconciles).
+
+See ``docs/content.md`` at the repo root for the full editor's guide.
+
+Why this lives in a Python module
+=================================
+Plain Python lets us validate at import time (uniqueness, URL sanity,
+release-day bounds) and lets type-checkers catch typos in field names.
+The "config feel" is preserved by keeping every URL pattern declarative.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from domain.energy import PLAN_DURATION_DAYS
+
+#: Public-facing Squarespace site root. Used to build chapter URLs.
+SITE_BASE_URL: Final[str] = "https://aptitude.guru"
+
+
+@dataclass(frozen=True)
+class StageContentPlan:
+    """Declarative plan for one course stage's chapters.
+
+    ``slug`` is the Squarespace URL prefix — chapters are addressed as
+    ``{SITE_BASE_URL}/course/{slug}-{n}`` where ``n`` runs from 1 to
+    ``chapter_count``.
+
+    ``release_pattern`` controls how chapters are spaced across the stage.
+    Today we only ship ``"daily"``: one chapter per day starting at day 0,
+    with any remaining days in the stage left empty for catch-up.  Adding
+    another pattern (``"weekly"``, ``"front_loaded"``) means extending
+    :func:`build_chapter_release_days`.
+    """
+
+    stage_number: int
+    slug: str
+    chapter_count: int
+    content_type: str = "chapter"
+    release_pattern: str = "daily"
+    title_template: str = "Chapter {n}"
+
+
+@dataclass(frozen=True)
+class SiteResource:
+    """A non-stage-locked link surfaced on the Course screen.
+
+    Use this for evergreen pages (philosophy, about, FAQ) that the adept
+    should be able to reach from inside the app at any point in the
+    program.  These are not tracked for read-completion.
+    """
+
+    slug: str
+    title: str
+    description: str = ""
+    path: str = ""
+
+    @property
+    def url(self) -> str:
+        """Absolute public URL on the Squarespace site."""
+        suffix = self.path or f"/{self.slug}"
+        return f"{SITE_BASE_URL}{suffix}"
+
+
+# --------------------------------------------------------------------------- #
+# Stage-locked drip-feed plans                                                 #
+# --------------------------------------------------------------------------- #
+
+#: Per-stage chapter plans.  Stages not listed here keep whatever existing
+#: ``StageContent`` rows already live in the DB (placeholder seed data, in
+#: the case of stages 2 and 3 today).
+STAGE_PLANS: Final[list[StageContentPlan]] = [
+    StageContentPlan(
+        stage_number=1,
+        slug="beige",
+        chapter_count=14,
+    ),
+]
+
+
+# --------------------------------------------------------------------------- #
+# Always-available site resources                                             #
+# --------------------------------------------------------------------------- #
+
+#: Pages that are not stage-gated. Order here is the order shown in the UI.
+SITE_RESOURCES: Final[list[SiteResource]] = [
+    SiteResource(
+        slug="philosophy",
+        title="Philosophy",
+        description="The ideas the program is built on.",
+    ),
+    SiteResource(
+        slug="about",
+        title="About",
+        description="Who Adepthood is for and how it works.",
+    ),
+    SiteResource(
+        slug="course",
+        title="Course Overview",
+        description="The full course map at a glance.",
+        path="/course",
+    ),
+]
+
+
+# --------------------------------------------------------------------------- #
+# Derivations — kept pure so tests can call them without a DB                  #
+# --------------------------------------------------------------------------- #
+
+
+def build_chapter_release_days(plan: StageContentPlan) -> list[int]:
+    """Return the ``release_day`` value for each chapter in the plan.
+
+    The current ``"daily"`` pattern: chapter ``n`` (1-indexed) unlocks on
+    day ``n - 1``, capped by ``PLAN_DURATION_DAYS - 1`` so a too-long plan
+    cannot push a chapter past the end of its stage.  If a stage ships
+    fewer chapters than ``PLAN_DURATION_DAYS``, the trailing days remain
+    empty by design (catch-up window).
+    """
+    if plan.release_pattern != "daily":
+        msg = f"Unsupported release_pattern: {plan.release_pattern!r}"
+        raise ValueError(msg)
+    if plan.chapter_count < 1:
+        msg = f"chapter_count must be >= 1, got {plan.chapter_count}"
+        raise ValueError(msg)
+    cap = PLAN_DURATION_DAYS - 1
+    return [min(n, cap) for n in range(plan.chapter_count)]
+
+
+def chapter_url(plan: StageContentPlan, chapter_index: int) -> str:
+    """Return the absolute URL for the n-th chapter (1-indexed)."""
+    if not 1 <= chapter_index <= plan.chapter_count:
+        msg = (
+            f"chapter_index {chapter_index} out of range for "
+            f"stage {plan.stage_number} (1..{plan.chapter_count})"
+        )
+        raise ValueError(msg)
+    return f"{SITE_BASE_URL}/course/{plan.slug}-{chapter_index}"
+
+
+@dataclass(frozen=True)
+class ChapterRecord:
+    """Expanded view of one chapter — what the seeder writes to the DB."""
+
+    stage_number: int
+    title: str
+    content_type: str
+    release_day: int
+    url: str
+
+
+def expand_plan(plan: StageContentPlan) -> list[ChapterRecord]:
+    """Expand a ``StageContentPlan`` into one ``ChapterRecord`` per chapter."""
+    release_days = build_chapter_release_days(plan)
+    records: list[ChapterRecord] = []
+    for index_zero_based, day in enumerate(release_days):
+        chapter_number = index_zero_based + 1
+        records.append(
+            ChapterRecord(
+                stage_number=plan.stage_number,
+                title=plan.title_template.format(n=chapter_number),
+                content_type=plan.content_type,
+                release_day=day,
+                url=chapter_url(plan, chapter_number),
+            )
+        )
+    return records
+
+
+def all_chapter_records() -> list[ChapterRecord]:
+    """Flatten every ``STAGE_PLANS`` entry into a single list of chapters."""
+    flat: list[ChapterRecord] = []
+    for plan in STAGE_PLANS:
+        flat.extend(expand_plan(plan))
+    return flat
+
+
+def find_resource(slug: str) -> SiteResource | None:
+    """Look up a ``SiteResource`` by its slug, or ``None`` if not configured."""
+    for resource in SITE_RESOURCES:
+        if resource.slug == slug:
+            return resource
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Import-time validation — fail fast on bad config rather than at request time #
+# --------------------------------------------------------------------------- #
+
+
+def _validate_stage_plans(plans: list[StageContentPlan]) -> None:
+    """Reject duplicate stage_numbers or duplicate slugs at import time."""
+    stages_seen: set[int] = set()
+    slugs_seen: set[str] = set()
+    for plan in plans:
+        if plan.stage_number in stages_seen:
+            msg = f"Duplicate stage_number in STAGE_PLANS: {plan.stage_number}"
+            raise ValueError(msg)
+        if plan.slug in slugs_seen:
+            msg = f"Duplicate slug in STAGE_PLANS: {plan.slug!r}"
+            raise ValueError(msg)
+        stages_seen.add(plan.stage_number)
+        slugs_seen.add(plan.slug)
+        # Force release-day computation so a bad pattern blows up at boot.
+        build_chapter_release_days(plan)
+
+
+def _validate_site_resources(resources: list[SiteResource]) -> None:
+    """Reject duplicate site-resource slugs at import time."""
+    slugs_seen: set[str] = set()
+    for resource in resources:
+        if resource.slug in slugs_seen:
+            msg = f"Duplicate slug in SITE_RESOURCES: {resource.slug!r}"
+            raise ValueError(msg)
+        slugs_seen.add(resource.slug)
+
+
+_validate_stage_plans(STAGE_PLANS)
+_validate_site_resources(SITE_RESOURCES)
+
+
+# Public surface — keep ``__all__`` small to make intent obvious.
+__all__ = [
+    "SITE_BASE_URL",
+    "SITE_RESOURCES",
+    "STAGE_PLANS",
+    "ChapterRecord",
+    "SiteResource",
+    "StageContentPlan",
+    "all_chapter_records",
+    "build_chapter_release_days",
+    "chapter_url",
+    "expand_plan",
+    "find_resource",
+]

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -18,6 +18,7 @@ from errors import forbidden, not_found
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
+from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas import Page, PaginationParams, build_page
 from schemas.course import (
@@ -32,6 +33,12 @@ from services.squarespace import (
     SquarespaceFetchError,
     get_squarespace_client,
 )
+
+# CMS proxy endpoints fan out to Squarespace + BeautifulSoup on a cache
+# miss, so they are an order of magnitude more expensive than the rest of
+# this router.  Capping below the 60/minute global default keeps a single
+# authenticated user from sustaining upstream load on aptitude.guru.
+_CMS_PROXY_RATE_LIMIT = "30/minute"
 
 logger = logging.getLogger(__name__)
 
@@ -475,7 +482,9 @@ async def _resolve_released_content_url(
 
 
 @router.get("/content/{content_id}/body", response_model=ContentBodyResponse)
+@limiter.limit(_CMS_PROXY_RATE_LIMIT)
 async def get_content_body(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     content_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
@@ -513,7 +522,9 @@ async def list_site_resources(
 
 
 @router.get("/site-resources/{slug}/body", response_model=ContentBodyResponse)
+@limiter.limit(_CMS_PROXY_RATE_LIMIT)
 async def get_site_resource_body(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     slug: str,
     _current_user: Annotated[int, Depends(get_current_user)],
 ) -> ContentBodyResponse:

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from content_config import SITE_RESOURCES, find_resource
 from database import get_session
 from domain.course import compute_days_elapsed, filter_content_for_user, next_unlock_day
 from domain.stage_progress import get_user_progress, is_stage_unlocked
@@ -20,9 +21,16 @@ from models.stage_content import StageContent
 from routers.auth import get_current_user
 from schemas import Page, PaginationParams, build_page
 from schemas.course import (
+    ContentBodyResponse,
     ContentCompletionResponse,
     ContentItemResponse,
     CourseProgressResponse,
+    SiteResourceResponse,
+)
+from services.squarespace import (
+    SquarespaceAuthError,
+    SquarespaceFetchError,
+    get_squarespace_client,
 )
 
 logger = logging.getLogger(__name__)
@@ -376,3 +384,141 @@ async def get_course_progress(
         progress_percent=progress_pct,
         next_unlock_day=nud,
     )
+
+
+# --------------------------------------------------------------------------- #
+# In-app Squarespace rendering                                                 #
+# --------------------------------------------------------------------------- #
+
+
+_CMS_ERROR_DETAIL = "cms_unavailable"
+_CMS_AUTH_ERROR_DETAIL = "cms_auth_failed"
+
+
+async def _fetch_squarespace_body(url: str) -> ContentBodyResponse:
+    """Fetch + clean a Squarespace URL, mapping errors to HTTPExceptions.
+
+    Auth misconfiguration becomes a 503 (the server, not the caller, is
+    misconfigured) and surfaces a distinct detail token so the frontend
+    can render a "Set the site password" admin nudge in dev without
+    leaking which env var is missing in prod.
+    """
+    client = get_squarespace_client()
+    try:
+        fetched = await client.fetch(url)
+    except SquarespaceAuthError as exc:
+        logger.exception("squarespace_auth_failed", extra={"url": url})
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_CMS_AUTH_ERROR_DETAIL,
+        ) from exc
+    except SquarespaceFetchError as exc:
+        logger.warning("squarespace_fetch_failed: %s", exc, extra={"url": url})
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=_CMS_ERROR_DETAIL,
+        ) from exc
+    return ContentBodyResponse(
+        url=fetched.url,
+        title=fetched.title,
+        body_html=fetched.body_html,
+    )
+
+
+async def _load_content_with_stage(
+    session: AsyncSession, content_id: int
+) -> tuple[StageContent, CourseStage]:
+    """Load ``content_id`` and its parent stage, 404-ing on either miss."""
+    result = await session.execute(select(StageContent).where(StageContent.id == content_id))
+    item = result.scalars().first()
+    if item is None:
+        raise not_found("content")
+    stage_result = await session.execute(
+        select(CourseStage).where(CourseStage.id == item.course_stage_id)
+    )
+    stage = stage_result.scalars().first()
+    if stage is None:
+        raise not_found("stage")
+    return item, stage
+
+
+async def _check_released_for_user(
+    session: AsyncSession, user_id: int, stage_number: int, release_day: int
+) -> None:
+    """Raise 404 unless the user has reached ``release_day`` on this stage.
+
+    Mirrors the drip-feed gating applied on the metadata endpoint so the
+    in-app body endpoint cannot leak a chapter ahead of its release_day.
+    """
+    days = await _days_for_user_stage(session, user_id, stage_number)
+    if 0 <= days < _PAST_STAGE_DAYS_SENTINEL and release_day > days:
+        raise not_found("content")
+
+
+async def _resolve_released_content_url(
+    session: AsyncSession, user_id: int, content_id: int
+) -> str:
+    """Gate on stage-unlock + release_day, return the source URL.
+
+    Mirrors the 404-mask used by sibling endpoints (BUG-COURSE-004):
+    locked, unreleased, missing-URL, and nonexistent rows all surface
+    as ``content_not_found`` so ``content_id`` is not an enumeration
+    oracle.
+    """
+    item, stage = await _load_content_with_stage(session, content_id)
+    if not await _is_stage_unlocked_for_user(session, user_id, stage.stage_number):
+        raise not_found("content")
+    await _check_released_for_user(session, user_id, stage.stage_number, item.release_day)
+    if not item.url:
+        raise not_found("content")
+    return item.url
+
+
+@router.get("/content/{content_id}/body", response_model=ContentBodyResponse)
+async def get_content_body(
+    content_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ContentBodyResponse:
+    """Return cleaned Squarespace HTML for a content item.
+
+    Mirrors :func:`get_content_item` for gating — a locked or non-existent
+    content row both return ``content_not_found`` (BUG-COURSE-004) so the
+    URL cannot be used as an enumeration oracle.  The drip-feed unlock
+    check is applied here too: locked-day content never escapes the CMS.
+    """
+    url = await _resolve_released_content_url(session, current_user, content_id)
+    return await _fetch_squarespace_body(url)
+
+
+@router.get("/site-resources", response_model=list[SiteResourceResponse])
+async def list_site_resources(
+    _current_user: Annotated[int, Depends(get_current_user)],
+) -> list[SiteResourceResponse]:
+    """Return the configured site-wide resource links.
+
+    These pages (philosophy, about, …) are not stage-gated, but we still
+    require authentication so the list is not crawlable by anyone with
+    the URL.  Editing this list happens in ``content_config.py``.
+    """
+    return [
+        SiteResourceResponse(
+            slug=resource.slug,
+            title=resource.title,
+            description=resource.description,
+            url=resource.url,
+        )
+        for resource in SITE_RESOURCES
+    ]
+
+
+@router.get("/site-resources/{slug}/body", response_model=ContentBodyResponse)
+async def get_site_resource_body(
+    slug: str,
+    _current_user: Annotated[int, Depends(get_current_user)],
+) -> ContentBodyResponse:
+    """Return cleaned Squarespace HTML for a configured site resource."""
+    resource = find_resource(slug)
+    if resource is None:
+        raise not_found("resource")
+    return await _fetch_squarespace_body(resource.url)

--- a/backend/src/schemas/course.py
+++ b/backend/src/schemas/course.py
@@ -41,3 +41,27 @@ class ContentCompletionResponse(OwnedResourcePublic):
     id: int
     content_id: int
     completed_at: datetime
+
+
+class ContentBodyResponse(BaseModel):
+    """Cleaned Squarespace HTML for in-app rendering.
+
+    ``url`` is the canonical Squarespace URL of the source page so the
+    frontend can offer "Open original" as a fallback.  ``title`` is the
+    article title parsed out of the page; the client should prefer it
+    over the ``ContentItemResponse.title`` field, which is what the
+    backend seeded.
+    """
+
+    url: str
+    title: str
+    body_html: str
+
+
+class SiteResourceResponse(BaseModel):
+    """One entry in the always-available "Site Resources" list."""
+
+    slug: str
+    title: str
+    description: str
+    url: str

--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -1,36 +1,29 @@
-"""Seed script for placeholder StageContent entries for stages 1-3."""
+"""Seed StageContent rows from the declarative content config.
+
+Stage 1 (Beige) is fully driven by ``content_config.STAGE_PLANS`` — its
+chapters reflect the live Squarespace site.  Stages 2 and 3 retain their
+historic placeholder rows so the rest of the app keeps something to render
+until those courses ship; once a stage is added to ``STAGE_PLANS`` the
+placeholders are reconciled against the plan (see :func:`seed_content`).
+
+Editing rules live in ``backend/src/content_config.py`` and the editor
+guide in ``docs/content.md``.  Do not hand-edit URLs in this file — go
+update the config instead.
+"""
 
 from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from content_config import STAGE_PLANS, ChapterRecord, all_chapter_records
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 
-_CONTENT_DEFINITIONS: list[dict[str, str | int]] = [
-    # Stage 1 — Survival
-    {
-        "stage_number": 1,
-        "title": "Introduction to Survival",
-        "content_type": "essay",
-        "release_day": 0,
-        "url": "https://cms.adepthood.com/stage-1/intro",
-    },
-    {
-        "stage_number": 1,
-        "title": "Body Awareness Practice",
-        "content_type": "video",
-        "release_day": 3,
-        "url": "https://cms.adepthood.com/stage-1/body-awareness",
-    },
-    {
-        "stage_number": 1,
-        "title": "Survival Reflection Prompt",
-        "content_type": "prompt",
-        "release_day": 7,
-        "url": "https://cms.adepthood.com/stage-1/reflection",
-    },
+# Placeholder rows for stages that don't yet have a Squarespace plan.
+# Once a stage is added to ``STAGE_PLANS`` (see content_config.py) its
+# entry here should be removed in the same commit.
+_PLACEHOLDER_DEFINITIONS: list[dict[str, str | int]] = [
     # Stage 2 — Magick
     {
         "stage_number": 2,
@@ -77,71 +70,140 @@ _CONTENT_DEFINITIONS: list[dict[str, str | int]] = [
     },
 ]
 
-# BUG-SEED-001: Assert uniqueness of (stage_number, release_day) at import
-# time.  The drip-feed system assumes one item per day per stage; duplicate
-# release_days would cause unpredictable unlock ordering.
-_stage_day_pairs = [(d["stage_number"], d["release_day"]) for d in _CONTENT_DEFINITIONS]
-if len(set(_stage_day_pairs)) != len(_stage_day_pairs):
-    _dupes = sorted(p for p in _stage_day_pairs if _stage_day_pairs.count(p) > 1)
-    msg = f"Duplicate (stage_number, release_day) in CONTENT_DEFINITIONS: {_dupes}"
-    raise ValueError(msg)
+#: Stage numbers that have a real Squarespace plan and should NOT receive
+#: placeholder rows even if some are listed historically.
+_PLANNED_STAGES: frozenset[int] = frozenset(plan.stage_number for plan in STAGE_PLANS)
 
-CONTENT_DEFINITIONS = _CONTENT_DEFINITIONS
+# BUG-SEED-001 (preserved): a duplicate (stage_number, release_day) on a
+# placeholder row would scramble drip-feed ordering.  Configured chapters
+# may legitimately share a release_day with a placeholder of a different
+# stage, so we only assert uniqueness within the placeholder set.
+_placeholder_pairs = [(d["stage_number"], d["release_day"]) for d in _PLACEHOLDER_DEFINITIONS]
+if len(set(_placeholder_pairs)) != len(_placeholder_pairs):
+    _dupes = sorted(p for p in _placeholder_pairs if _placeholder_pairs.count(p) > 1)
+    _err = f"Duplicate (stage_number, release_day) in placeholders: {_dupes}"
+    raise ValueError(_err)
 
 
-def _build_content_item(
-    definition: dict[str, str | int],
-    stage_map: dict[int, int],
-    existing_titles: set[tuple[int, str]],
-) -> StageContent | None:
-    """Create a StageContent from a definition.
+def _placeholder_records() -> list[ChapterRecord]:
+    """Convert placeholder dicts into ``ChapterRecord``.
 
-    Returns None if it already exists or the stage is missing.
+    Lets the seeder iterate a single uniform list regardless of whether the
+    record came from the declarative config or the legacy placeholder block.
     """
-    stage_num = int(definition["stage_number"])
-    course_stage_id = stage_map.get(stage_num)
-    if course_stage_id is None:
-        return None
+    return [
+        ChapterRecord(
+            stage_number=int(d["stage_number"]),
+            title=str(d["title"]),
+            content_type=str(d["content_type"]),
+            release_day=int(d["release_day"]),
+            url=str(d["url"]),
+        )
+        for d in _PLACEHOLDER_DEFINITIONS
+        if int(d["stage_number"]) not in _PLANNED_STAGES
+    ]
 
-    if (course_stage_id, definition["title"]) in existing_titles:
-        return None
 
-    return StageContent(
-        course_stage_id=course_stage_id,
-        title=str(definition["title"]),
-        content_type=str(definition["content_type"]),
-        release_day=int(definition["release_day"]),
-        url=str(definition["url"]),
-    )
+def desired_content_records() -> list[ChapterRecord]:
+    """Return the full set of records that should exist after seeding.
+
+    Order is (configured chapters first, then placeholders) — callers that
+    need a stable ordering can ``sorted(...)`` on the fields they care
+    about.
+    """
+    return [*all_chapter_records(), *_placeholder_records()]
 
 
 async def _load_stage_map(session: AsyncSession) -> dict[int, int]:
-    """Build a map of stage_number → CourseStage.id from the database."""
+    """Build a map of ``stage_number -> CourseStage.id`` from the DB."""
     result = await session.execute(select(CourseStage))
     return {s.stage_number: s.id for s in result.scalars().all() if s.id is not None}
 
 
-async def _load_existing_titles(session: AsyncSession) -> set[tuple[int, str]]:
-    """Return set of (course_stage_id, title) pairs already in the database."""
+async def _load_existing_keys(
+    session: AsyncSession,
+) -> dict[tuple[int, str], StageContent]:
+    """Index existing ``StageContent`` rows by ``(course_stage_id, title)``.
+
+    Title is the natural key today (no slug column).  Using a dict — not a
+    set — lets us update fields on a row whose URL has drifted from the
+    config (e.g. when chapter URLs are renamed on Squarespace) without
+    re-inserting.
+    """
     result = await session.execute(select(StageContent))
-    return {(sc.course_stage_id, sc.title) for sc in result.scalars().all()}
+    return {(sc.course_stage_id, sc.title): sc for sc in result.scalars().all()}
+
+
+def _build_new_row(record: ChapterRecord, course_stage_id: int) -> StageContent:
+    """Construct a fresh ``StageContent`` from a ``ChapterRecord``."""
+    return StageContent(
+        course_stage_id=course_stage_id,
+        title=record.title,
+        content_type=record.content_type,
+        release_day=record.release_day,
+        url=record.url,
+    )
+
+
+def _row_is_in_sync(existing: StageContent, record: ChapterRecord) -> bool:
+    """Whether the DB row already matches the config for this chapter."""
+    return (
+        existing.content_type == record.content_type
+        and existing.release_day == record.release_day
+        and existing.url == record.url
+    )
+
+
+def _update_row(existing: StageContent, record: ChapterRecord) -> None:
+    """Mutate ``existing`` in place to match ``record``."""
+    existing.content_type = record.content_type
+    existing.release_day = record.release_day
+    existing.url = record.url
+
+
+def _reconcile_one(
+    session: AsyncSession,
+    record: ChapterRecord,
+    stage_map: dict[int, int],
+    existing: dict[tuple[int, str], StageContent],
+) -> tuple[bool, bool]:
+    """Insert or update a single record.
+
+    Returns ``(inserted, dirty)`` — both flags are independent so the
+    caller can track new-row count separately from session-dirty state.
+    """
+    course_stage_id = stage_map.get(record.stage_number)
+    if course_stage_id is None:
+        return False, False
+    prior = existing.get((course_stage_id, record.title))
+    if prior is None:
+        session.add(_build_new_row(record, course_stage_id))
+        return True, True
+    if not _row_is_in_sync(prior, record):
+        _update_row(prior, record)
+        return False, True
+    return False, False
 
 
 async def seed_content(session: AsyncSession) -> int:
-    """Insert placeholder content for stages 1-3 if not already present.
+    """Reconcile ``StageContent`` rows with the declarative config.
 
-    Returns the number of items inserted.
+    Returns the number of newly-inserted rows.  Existing rows whose fields
+    have drifted from the config are updated in place; the function is
+    idempotent — running it twice with the same config inserts nothing the
+    second time.
     """
     stage_map = await _load_stage_map(session)
-    existing_titles = await _load_existing_titles(session)
+    existing = await _load_existing_keys(session)
 
     inserted = 0
-    for definition in CONTENT_DEFINITIONS:
-        content = _build_content_item(definition, stage_map, existing_titles)
-        if content is not None:
-            session.add(content)
+    dirty = False
+    for record in desired_content_records():
+        was_inserted, was_dirty = _reconcile_one(session, record, stage_map, existing)
+        if was_inserted:
             inserted += 1
+        dirty = dirty or was_dirty
 
-    if inserted:
+    if dirty:
         await session.commit()
     return inserted

--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -84,6 +84,21 @@ if len(set(_placeholder_pairs)) != len(_placeholder_pairs):
     _err = f"Duplicate (stage_number, release_day) in placeholders: {_dupes}"
     raise ValueError(_err)
 
+# Match the import-time validation philosophy from ``content_config.py``:
+# if a stage has been added to ``STAGE_PLANS`` but its placeholder rows
+# are still in this file, fail loudly at boot rather than seeding both
+# the planned chapters AND the stale placeholders side-by-side.
+_overlapping_stages = {int(d["stage_number"]) for d in _PLACEHOLDER_DEFINITIONS} & _PLANNED_STAGES
+if _overlapping_stages:
+    _err = (
+        "Stage(s) "
+        f"{sorted(_overlapping_stages)} have entries in both "
+        "STAGE_PLANS (content_config.py) and _PLACEHOLDER_DEFINITIONS — "
+        "remove the placeholders so the seeder isn't reconciling against a "
+        "stale source of truth."
+    )
+    raise ValueError(_err)
+
 
 def _placeholder_records() -> list[ChapterRecord]:
     """Convert placeholder dicts into ``ChapterRecord``.

--- a/backend/src/services/squarespace.py
+++ b/backend/src/services/squarespace.py
@@ -1,0 +1,424 @@
+"""Async Squarespace content client.
+
+Squarespace serves the Adepthood course (https://aptitude.guru) as a
+site-password-protected Squarespace site.  This module:
+
+* Authenticates with the site password once, persists the cookie jar.
+* Fetches an arbitrary chapter/resource URL.
+* Strips the Squarespace shell (header, navigation, footer) and returns
+  the article body ready for in-app WebView rendering.
+* Caches cleaned HTML in-memory with a configurable TTL so we are not
+  hammering the public site on every read.
+
+The cleaning step is intentionally conservative — Squarespace ships rich
+formatting (images, embedded videos, captions) and the goal is to
+preserve that, not turn it into Markdown.  Strip what is structurally
+"Squarespace chrome", leave the article.
+
+Configuration (env vars)
+========================
+* ``SQUARESPACE_SITE_PASSWORD`` — required.  The site-wide password set
+  in the Squarespace admin and shared via Gumroad.
+* ``SQUARESPACE_BASE_URL`` — optional override of the public site root
+  (defaults to ``https://aptitude.guru``).
+* ``SQUARESPACE_CACHE_TTL_SECONDS`` — optional cleaned-HTML TTL.  Default
+  is one hour.
+
+Testing
+=======
+The HTTP layer is hidden behind a single :class:`SquarespaceClient`
+class that takes an injectable ``http_client_factory``.  Tests pass a
+factory that returns a ``MockTransport``-backed ``httpx.AsyncClient``;
+no network access is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Final
+from urllib.parse import urlparse
+
+import httpx
+from bs4 import BeautifulSoup, Tag  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- #
+# Configuration                                                               #
+# --------------------------------------------------------------------------- #
+
+_DEFAULT_BASE_URL: Final[str] = "https://aptitude.guru"
+_DEFAULT_CACHE_TTL: Final[int] = 60 * 60  # 1 hour
+_REQUEST_TIMEOUT_SECONDS: Final[float] = 10.0
+_HTTP_ERROR_THRESHOLD: Final[int] = 400
+_USER_AGENT: Final[str] = "AdepthoodApp/1.0 (+https://adepthood.com)"
+#: Selectors we strip wholesale before returning the article body.  These
+#: are intentionally Squarespace-generic — site theme changes occasionally
+#: rename block classes, but the *roles* (header, footer, nav) are stable.
+_CHROME_SELECTORS: Final[tuple[str, ...]] = (
+    "header",
+    "footer",
+    "nav",
+    "#siteWrapper > header",
+    "#siteWrapper > footer",
+    "[data-section-id='header']",
+    "[data-section-id='footer']",
+    ".sqs-announcement-bar-dropzone",
+    ".header-announcement-bar-wrapper",
+    ".sqs-cookie-banner-v2",
+    ".sqs-cookie-banner-v2-acceptable",
+    ".user-account-page",
+    "script",
+    "noscript",
+)
+#: Candidate selectors for the main article.  Tried in order.
+_ARTICLE_SELECTORS: Final[tuple[str, ...]] = (
+    "article",
+    "main",
+    "#content",
+    "#page",
+    ".content-wrapper",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Public types                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class FetchedContent:
+    """A cleaned-up Squarespace page ready for in-app rendering."""
+
+    url: str
+    title: str
+    body_html: str
+    fetched_at: float = field(default_factory=time.time)
+
+
+class SquarespaceFetchError(RuntimeError):
+    """Raised when Squarespace content cannot be retrieved or parsed."""
+
+
+class SquarespaceAuthError(SquarespaceFetchError):
+    """Raised when the site password is missing or rejected."""
+
+
+# --------------------------------------------------------------------------- #
+# Client                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+HttpClientFactory = Callable[[], Awaitable[httpx.AsyncClient]]
+
+
+def _resolve_base_url(override: str | None) -> str:
+    """Pick the public Squarespace URL from the constructor arg or env."""
+    resolved = override or os.getenv("SQUARESPACE_BASE_URL") or _DEFAULT_BASE_URL
+    return resolved.rstrip("/")
+
+
+def _resolve_password(override: str | None) -> str:
+    """Pick the site password from the constructor arg or env."""
+    if override is not None:
+        return override
+    return os.getenv("SQUARESPACE_SITE_PASSWORD", "")
+
+
+def _resolve_cache_ttl(override: int | None) -> int:
+    """Pick the cache TTL from the constructor arg or env."""
+    if override is not None:
+        return override
+    return int(os.getenv("SQUARESPACE_CACHE_TTL_SECONDS", str(_DEFAULT_CACHE_TTL)))
+
+
+def _default_http_client_factory() -> HttpClientFactory:
+    """Return a factory that builds a fresh ``httpx.AsyncClient`` per session.
+
+    A factory (rather than a singleton) is what tests need: each test
+    constructs its own ``MockTransport`` and we don't want one test's
+    transport leaking into the next.
+    """
+
+    async def factory() -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+            follow_redirects=True,
+            headers={"User-Agent": _USER_AGENT},
+        )
+
+    return factory
+
+
+@dataclass
+class _CacheEntry:
+    """A cached :class:`FetchedContent` together with its expiry timestamp."""
+
+    content: FetchedContent
+    expires_at: float
+
+
+class SquarespaceClient:
+    """Async client for fetching cleaned Squarespace pages.
+
+    A single instance is shared per FastAPI process — see
+    :func:`get_squarespace_client`.  All public methods are async and safe
+    to call concurrently; an internal lock serialises authentication so
+    only one re-login happens at a time during cookie expiry races.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        password: str | None = None,
+        cache_ttl_seconds: int | None = None,
+        http_client_factory: HttpClientFactory | None = None,
+    ) -> None:
+        """Construct a Squarespace client; defaults come from env vars."""
+        self._base_url = _resolve_base_url(base_url)
+        self._password = _resolve_password(password)
+        self._cache_ttl = _resolve_cache_ttl(cache_ttl_seconds)
+        self._client_factory = http_client_factory or _default_http_client_factory()
+        self._client: httpx.AsyncClient | None = None
+        self._auth_lock = asyncio.Lock()
+        self._cache: dict[str, _CacheEntry] = {}
+        self._authenticated = False
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle                                                          #
+    # ------------------------------------------------------------------ #
+
+    async def _ensure_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = await self._client_factory()
+        return self._client
+
+    async def aclose(self) -> None:
+        """Release the underlying ``httpx.AsyncClient``."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+            self._authenticated = False
+
+    def invalidate_cache(self, url: str | None = None) -> None:
+        """Drop one URL (``url=...``) or the whole cache (``url=None``)."""
+        if url is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(url, None)
+
+    # ------------------------------------------------------------------ #
+    # Auth                                                                #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _looks_like_password_page(html: str) -> bool:
+        """Heuristic: does this HTML look like the Squarespace lock screen?
+
+        We deliberately don't lean on a single selector — Squarespace
+        themes vary — so we OR a few signals together.  False positives
+        only cost a re-auth attempt.
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        if soup.find("input", attrs={"type": "password"}):
+            return True
+        body_class = " ".join(soup.body.get("class", [])) if soup.body else ""
+        return "password" in body_class.lower() or "site-password" in html.lower()
+
+    async def _authenticate(self) -> None:
+        """POST the site password and capture the resulting cookie.
+
+        Squarespace site-wide passwords are submitted to the same URL as
+        the page being viewed; the server then sets a ``SiteUserInfo``-
+        family cookie on the domain.  We send to the site root since the
+        cookie applies site-wide.
+        """
+        if not self._password:
+            raise SquarespaceAuthError(
+                "SQUARESPACE_SITE_PASSWORD is not configured on the backend.",
+            )
+        client = await self._ensure_client()
+        try:
+            response = await client.post(
+                f"{self._base_url}/",
+                data={"password": self._password},
+            )
+        except httpx.HTTPError as exc:
+            raise SquarespaceFetchError(f"Network error during auth: {exc}") from exc
+
+        if response.status_code >= _HTTP_ERROR_THRESHOLD:
+            raise SquarespaceAuthError(
+                f"Squarespace rejected the site password (HTTP {response.status_code}).",
+            )
+
+        # If the post still returns a password page, the password was
+        # accepted-but-not-set, or wrong.  Either way, fail loudly.
+        if self._looks_like_password_page(response.text):
+            raise SquarespaceAuthError("Squarespace password did not unlock the site.")
+
+        self._authenticated = True
+        logger.info("squarespace_authenticated", extra={"base_url": self._base_url})
+
+    async def _ensure_authenticated(self) -> None:
+        """Authenticate once per process unless the cookie has been cleared."""
+        if self._authenticated:
+            return
+        async with self._auth_lock:
+            if self._authenticated:
+                return
+            await self._authenticate()
+
+    # ------------------------------------------------------------------ #
+    # Fetch                                                               #
+    # ------------------------------------------------------------------ #
+
+    def _validate_url(self, url: str) -> None:
+        """Reject URLs outside the configured site root.
+
+        This is the SSRF guard: the same client is reused across requests,
+        and we never want a caller passing ``http://internal.service`` to
+        get proxied through us with an authenticated session.
+        """
+        parsed = urlparse(url)
+        base = urlparse(self._base_url)
+        if parsed.scheme != base.scheme or parsed.netloc != base.netloc:
+            msg = f"URL {url!r} is outside the configured site ({self._base_url})."
+            raise SquarespaceFetchError(msg)
+
+    async def fetch(self, url: str) -> FetchedContent:
+        """Return cleaned HTML for ``url``, using the cache when fresh.
+
+        Raises :class:`SquarespaceFetchError` on network errors,
+        :class:`SquarespaceAuthError` when the site password is missing
+        or wrong.
+        """
+        self._validate_url(url)
+        cached = self._cache.get(url)
+        if cached is not None and cached.expires_at > time.time():
+            return cached.content
+
+        await self._ensure_authenticated()
+        content = await self._fetch_and_clean(url)
+
+        self._cache[url] = _CacheEntry(
+            content=content,
+            expires_at=time.time() + self._cache_ttl,
+        )
+        return content
+
+    async def _raw_get(self, url: str) -> httpx.Response:
+        client = await self._ensure_client()
+        try:
+            return await client.get(url)
+        except httpx.HTTPError as exc:
+            raise SquarespaceFetchError(f"Network error fetching {url}: {exc}") from exc
+
+    async def _fetch_and_clean(self, url: str) -> FetchedContent:
+        response = await self._raw_get(url)
+
+        # Session might have expired between authentication and this
+        # request; if so, log in once more and retry exactly once.
+        if response.status_code == httpx.codes.UNAUTHORIZED or self._looks_like_password_page(
+            response.text
+        ):
+            self._authenticated = False
+            await self._ensure_authenticated()
+            response = await self._raw_get(url)
+
+        if response.status_code >= _HTTP_ERROR_THRESHOLD:
+            raise SquarespaceFetchError(
+                f"Squarespace returned HTTP {response.status_code} for {url}.",
+            )
+        if self._looks_like_password_page(response.text):
+            raise SquarespaceAuthError(
+                f"Page {url} still locked after authentication.",
+            )
+
+        return _extract_article(url=url, html=response.text)
+
+
+# --------------------------------------------------------------------------- #
+# HTML cleaning                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def _strip_chrome(soup: BeautifulSoup) -> None:
+    """Remove header/nav/footer/cookie banners from the parsed document."""
+    for selector in _CHROME_SELECTORS:
+        for node in soup.select(selector):
+            node.decompose()
+
+
+def _pick_article(soup: BeautifulSoup) -> Tag:
+    """Return the most article-like element in the document.
+
+    Falls back to ``<body>`` when no semantic landmark matches — the
+    chrome has already been stripped at this point, so a ``<body>`` fallback
+    is still the content the user wants.
+    """
+    for selector in _ARTICLE_SELECTORS:
+        node = soup.select_one(selector)
+        if node is not None:
+            return node
+    body = soup.body
+    if body is None:
+        msg = "Squarespace document has no <body>"
+        raise SquarespaceFetchError(msg)
+    return body
+
+
+def _document_title(soup: BeautifulSoup, article: Tag) -> str:
+    """Best-effort article title — prefer ``<h1>`` inside the article."""
+    h1 = article.find("h1")
+    if h1 is not None:
+        return str(h1.get_text(strip=True))
+    title_tag = soup.find("title")
+    if title_tag is not None:
+        return str(title_tag.get_text(strip=True))
+    return ""
+
+
+def _extract_article(url: str, html: str) -> FetchedContent:
+    """Parse ``html`` and return the cleaned article body + title."""
+    soup = BeautifulSoup(html, "html.parser")
+    _strip_chrome(soup)
+    article = _pick_article(soup)
+    title = _document_title(soup, article)
+    return FetchedContent(url=url, title=title, body_html=str(article))
+
+
+# --------------------------------------------------------------------------- #
+# Module-level singleton                                                       #
+# --------------------------------------------------------------------------- #
+
+
+_singleton: SquarespaceClient | None = None
+
+
+def get_squarespace_client() -> SquarespaceClient:
+    """Return the process-wide :class:`SquarespaceClient`, constructed lazily.
+
+    Lazy construction means a test run without ``SQUARESPACE_SITE_PASSWORD``
+    set never instantiates the client and therefore never reads the env var
+    at import time.
+    """
+    global _singleton  # noqa: PLW0603 — module-level lazy singleton
+    if _singleton is None:
+        _singleton = SquarespaceClient()
+    return _singleton
+
+
+def reset_squarespace_client_for_tests() -> None:
+    """Drop the singleton so the next test sees a fresh client.
+
+    Public on purpose — both unit tests in this package and FastAPI
+    integration tests use it to swap in a ``MockTransport``.
+    """
+    global _singleton  # noqa: PLW0603 — see get_squarespace_client
+    _singleton = None

--- a/backend/src/services/squarespace.py
+++ b/backend/src/services/squarespace.py
@@ -39,12 +39,12 @@ import logging
 import os
 import time
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Final
 from urllib.parse import urlparse
 
 import httpx
-from bs4 import BeautifulSoup, Tag  # type: ignore[import-untyped]
+from bs4 import BeautifulSoup, Tag
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,6 @@ class FetchedContent:
     url: str
     title: str
     body_html: str
-    fetched_at: float = field(default_factory=time.time)
 
 
 class SquarespaceFetchError(RuntimeError):
@@ -291,16 +290,36 @@ class SquarespaceClient:
             msg = f"URL {url!r} is outside the configured site ({self._base_url})."
             raise SquarespaceFetchError(msg)
 
+    def _prune_expired(self, now: float) -> None:
+        """Drop expired entries so the cache cannot grow without bound.
+
+        Called from every ``fetch`` so the only growth is in *live*
+        entries.  Intentionally O(n) on cache size — for the expected
+        workload (a few dozen URLs over the program) this is cheaper
+        than wiring an LRU.  If the cache ever has to hold more than a
+        few hundred entries, swap to ``cachetools.TTLCache``.
+        """
+        stale = [key for key, entry in self._cache.items() if entry.expires_at <= now]
+        for key in stale:
+            self._cache.pop(key, None)
+
     async def fetch(self, url: str) -> FetchedContent:
         """Return cleaned HTML for ``url``, using the cache when fresh.
 
         Raises :class:`SquarespaceFetchError` on network errors,
         :class:`SquarespaceAuthError` when the site password is missing
         or wrong.
+
+        Note: with multiple uvicorn workers each holds its own cache,
+        so the worst-case fetch rate is ``WEB_CONCURRENCY`` per TTL
+        window per URL — by design, since we want the cache local to
+        the process for the lowest possible read latency.
         """
+        now = time.time()
         self._validate_url(url)
+        self._prune_expired(now)
         cached = self._cache.get(url)
-        if cached is not None and cached.expires_at > time.time():
+        if cached is not None and cached.expires_at > now:
             return cached.content
 
         await self._ensure_authenticated()
@@ -308,7 +327,7 @@ class SquarespaceClient:
 
         self._cache[url] = _CacheEntry(
             content=content,
-            expires_at=time.time() + self._cache_ttl,
+            expires_at=now + self._cache_ttl,
         )
         return content
 
@@ -398,7 +417,11 @@ def _extract_article(url: str, html: str) -> FetchedContent:
 # --------------------------------------------------------------------------- #
 
 
-_singleton: SquarespaceClient | None = None
+# Mutable container so we can replace the instance without ``global``
+# (and therefore without a ruff PLW0603 suppression).  The dict has
+# exactly one key — ``"client"`` — and its value is the lazily-built
+# singleton or ``None``.
+_state: dict[str, SquarespaceClient | None] = {"client": None}
 
 
 def get_squarespace_client() -> SquarespaceClient:
@@ -408,17 +431,25 @@ def get_squarespace_client() -> SquarespaceClient:
     set never instantiates the client and therefore never reads the env var
     at import time.
     """
-    global _singleton  # noqa: PLW0603 — module-level lazy singleton
-    if _singleton is None:
-        _singleton = SquarespaceClient()
-    return _singleton
+    client = _state["client"]
+    if client is None:
+        client = SquarespaceClient()
+        _state["client"] = client
+    return client
+
+
+def set_squarespace_client_for_tests(client: SquarespaceClient | None) -> None:
+    """Replace (or clear) the process-wide client.
+
+    Tests use this to swap in a ``MockTransport``-backed double for the
+    duration of a test, then restore the original at teardown.  Public
+    on purpose — keeps the test contract on the module's public API and
+    lets us drop the ``# noqa: SLF001`` suppressions the previous
+    pattern required.
+    """
+    _state["client"] = client
 
 
 def reset_squarespace_client_for_tests() -> None:
-    """Drop the singleton so the next test sees a fresh client.
-
-    Public on purpose — both unit tests in this package and FastAPI
-    integration tests use it to swap in a ``MockTransport``.
-    """
-    global _singleton  # noqa: PLW0603 — see get_squarespace_client
-    _singleton = None
+    """Drop the singleton so the next test sees a fresh client."""
+    set_squarespace_client_for_tests(None)

--- a/backend/tests/test_lifespan_seeding.py
+++ b/backend/tests/test_lifespan_seeding.py
@@ -21,6 +21,7 @@ from sqlmodel import select
 # object itself (so it can wire a session factory at it), not a per-test
 # session yielded from a fixture.
 from conftest import test_engine
+from content_config import STAGE_PLANS
 from main import _seed_startup_data, app, lifespan
 from models.course_stage import CourseStage
 from models.practice import Practice
@@ -55,11 +56,13 @@ async def test_seed_startup_data_inserts_stages_practices_and_content(
 
     assert len(stages) == 10
     assert len(practices) == 10
-    # ``seed_content`` ships 9 placeholder StageContent rows across stages 1-3;
-    # asserting the count here means a future regression that drops the
-    # content seeder from the lifespan would fail this test, not surface only
-    # in a manual /course/stages/{n}/content smoke check.
-    assert len(contents) == 9
+    # ``seed_content`` seeds the chapters configured for the beige stage
+    # (14 today) plus the 6 placeholder rows that still cover stages 2
+    # and 3.  Asserting the count means a regression that drops the
+    # content seeder from the lifespan fails this test, not just a
+    # /course smoke check.  Adjust this when ``content_config`` changes.
+    expected_content_count = sum(p.chapter_count for p in STAGE_PLANS) + 6
+    assert len(contents) == expected_content_count
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -17,6 +17,7 @@ from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
+from content_config import SITE_RESOURCES
 from models.user import User
 from rate_limit import DEFAULT_RATE_LIMIT
 
@@ -198,6 +199,48 @@ async def test_journal_list_rate_limit_returns_429(async_client: AsyncClient) ->
 
     # 31st request should be rate-limited
     resp = await async_client.get("/journal/", headers=headers)
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+    assert "retry-after" in resp.headers
+
+
+# ── Per-endpoint: GET /course/content/{id}/body (30/minute) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_content_body_rate_limit_returns_429(async_client: AsyncClient) -> None:
+    """GET /course/content/{id}/body returns 429 after 30 requests/minute.
+
+    The endpoint proxies to Squarespace on a cache miss; without the
+    decorator a single authenticated user can sustain expensive upstream
+    fetches against the configured CMS.  The handler returns 404 here
+    (no seeded content) but the limit fires before the handler on
+    request 31, regardless of response code.
+    """
+    headers = await _signup(async_client)
+
+    for _ in range(30):
+        await async_client.get("/course/content/1/body", headers=headers)
+
+    resp = await async_client.get("/course/content/1/body", headers=headers)
+    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert resp.json()["detail"] == "rate_limit_exceeded"
+    assert "retry-after" in resp.headers
+
+
+# ── Per-endpoint: GET /course/site-resources/{slug}/body (30/minute) ────
+
+
+@pytest.mark.asyncio
+async def test_site_resource_body_rate_limit_returns_429(async_client: AsyncClient) -> None:
+    """GET /course/site-resources/{slug}/body returns 429 after 30 requests/minute."""
+    headers = await _signup(async_client)
+    slug = SITE_RESOURCES[0].slug
+
+    for _ in range(30):
+        await async_client.get(f"/course/site-resources/{slug}/body", headers=headers)
+
+    resp = await async_client.get(f"/course/site-resources/{slug}/body", headers=headers)
     assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
     assert resp.json()["detail"] == "rate_limit_exceeded"
     assert "retry-after" in resp.headers

--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import col, select
 
+from content_config import STAGE_PLANS, all_chapter_records
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
-from seed_content import seed_content
+from seed_content import desired_content_records, seed_content
+
+# Chapters seeded for the live stages (today: just beige = 14).
+_PLANNED_CHAPTER_COUNT = sum(plan.chapter_count for plan in STAGE_PLANS)
+# Placeholders kept for stages 2 and 3 (3 each).
+_PLACEHOLDER_COUNT = 6
 
 
 async def _seed_stages(db_session: AsyncSession, count: int = 3) -> None:
@@ -33,11 +39,10 @@ async def _seed_stages(db_session: AsyncSession, count: int = 3) -> None:
 
 @pytest.mark.asyncio
 async def test_seed_content_inserts_items(db_session: AsyncSession) -> None:
-    """Seeding with stages present inserts content items."""
+    """Seeding with stages present inserts configured chapters + placeholders."""
     await _seed_stages(db_session, count=3)
     inserted = await seed_content(db_session)
-    expected_per_stage = 3
-    expected_total = expected_per_stage * 3
+    expected_total = _PLANNED_CHAPTER_COUNT + _PLACEHOLDER_COUNT
     assert inserted == expected_total
 
     result = await db_session.execute(select(StageContent))
@@ -60,3 +65,58 @@ async def test_seed_content_no_stages(db_session: AsyncSession) -> None:
     """Without stages, no content is inserted."""
     inserted = await seed_content(db_session)
     assert inserted == 0
+
+
+@pytest.mark.asyncio
+async def test_seed_content_creates_beige_chapters(db_session: AsyncSession) -> None:
+    """Stage 1 (Beige) gets the configured chapter set, not placeholders."""
+    await _seed_stages(db_session, count=1)
+    await seed_content(db_session)
+
+    result = await db_session.execute(
+        select(StageContent)
+        .join(CourseStage)
+        .where(CourseStage.stage_number == 1)
+        .order_by(col(StageContent.release_day))
+    )
+    items = list(result.scalars().all())
+
+    # The beige plan ships 14 chapters.
+    beige_plan = next(p for p in STAGE_PLANS if p.stage_number == 1)
+    assert len(items) == beige_plan.chapter_count
+    assert items[0].url == "https://aptitude.guru/course/beige-1"
+    assert items[-1].url == f"https://aptitude.guru/course/beige-{beige_plan.chapter_count}"
+    # Chapter type is uniform across the plan.
+    assert {item.content_type for item in items} == {"chapter"}
+
+
+@pytest.mark.asyncio
+async def test_seed_content_reconciles_url_drift(db_session: AsyncSession) -> None:
+    """A row whose URL drifted from the config is updated in place, not duplicated."""
+    await _seed_stages(db_session, count=1)
+    await seed_content(db_session)
+
+    # Manually corrupt one URL — simulates a chapter being moved on the CMS.
+    result = await db_session.execute(select(StageContent).where(StageContent.title == "Chapter 1"))
+    row = result.scalars().one()
+    original_url = row.url
+    row.url = "https://aptitude.guru/course/beige-1-OLD"
+    await db_session.commit()
+
+    # Re-seeding should reset the URL to the config value without inserting
+    # a duplicate row.
+    inserted = await seed_content(db_session)
+    assert inserted == 0
+    await db_session.refresh(row)
+    assert row.url == original_url
+
+
+def test_desired_content_records_counts() -> None:
+    """Flat list of desired records covers every chapter plus surviving placeholders."""
+    records = desired_content_records()
+    planned = all_chapter_records()
+    assert len(records) == len(planned) + _PLACEHOLDER_COUNT
+    # All configured chapters should be present.
+    planned_urls = {r.url for r in planned}
+    record_urls = {r.url for r in records}
+    assert planned_urls.issubset(record_urls)

--- a/backend/tests/test_squarespace_endpoints.py
+++ b/backend/tests/test_squarespace_endpoints.py
@@ -17,6 +17,7 @@ import contextlib
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
+from typing import cast
 
 import pytest
 from httpx import AsyncClient
@@ -128,13 +129,22 @@ class _StubSquarespaceClient:
 
 @contextlib.contextmanager
 def _patch_client(stub: _StubSquarespaceClient) -> Iterator[None]:
-    """Swap the module-level singleton for the test's duration."""
-    original = squarespace_module._singleton  # noqa: SLF001
-    squarespace_module._singleton = stub  # type: ignore[assignment]  # noqa: SLF001
+    """Swap the module-level singleton for the test's duration.
+
+    Uses the module's public ``set_squarespace_client_for_tests`` setter
+    so the test does not have to touch a private — drops the
+    ``# noqa: SLF001`` and ``# type: ignore`` the previous pattern
+    needed.  ``cast`` keeps mypy happy: the production singleton is a
+    ``SquarespaceClient`` but our stub satisfies the same structural
+    ``fetch`` contract used by the routes.
+    """
+    squarespace_module.set_squarespace_client_for_tests(
+        cast("squarespace_module.SquarespaceClient", stub),
+    )
     try:
         yield
     finally:
-        squarespace_module._singleton = original  # noqa: SLF001
+        squarespace_module.reset_squarespace_client_for_tests()
 
 
 def _signup_user_id(resp_json: dict[str, object]) -> int:
@@ -337,4 +347,72 @@ async def test_site_resource_body_unknown_slug_returns_404(
             "/course/site-resources/this-does-not-exist/body", headers=headers
         )
     assert resp.status_code == HTTPStatus.NOT_FOUND
-    assert stub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_site_resource_body_502_when_cms_unreachable(async_client: AsyncClient) -> None:
+    """Resource body shares the chapter body's error mapping — 502 on fetch error."""
+    headers = await _signup(async_client, "rsbad")
+    stub = _StubSquarespaceClient(raise_exc=SquarespaceFetchError("upstream 503"))
+    with _patch_client(stub):
+        resp = await async_client.get("/course/site-resources/about/body", headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_GATEWAY
+    assert resp.json()["detail"] == "cms_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_site_resource_body_503_when_cms_auth_misconfigured(
+    async_client: AsyncClient,
+) -> None:
+    """Resource body returns 503 ``cms_auth_failed`` when the site password is missing."""
+    headers = await _signup(async_client, "rsnoauth")
+    stub = _StubSquarespaceClient(raise_exc=SquarespaceAuthError("missing"))
+    with _patch_client(stub):
+        resp = await async_client.get("/course/site-resources/philosophy/body", headers=headers)
+    assert resp.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert resp.json()["detail"] == "cms_auth_failed"
+
+
+@pytest.mark.asyncio
+async def test_content_body_serves_today_chapter_on_release_day_boundary(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``release_day == days_elapsed`` is the user's "today" chapter — must serve, not 404.
+
+    Boundary noted in review: previous tests covered ``release_day < days``
+    (already past) and ``release_day > days`` (future); this nails the
+    equality case so the off-by-one stays caught.
+    """
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "boundary@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },  # pragma: allowlist secret
+    )
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+    user_id = _signup_user_id(resp.json())
+
+    stage = CourseStage(**_stage_data(stage_number=1))
+    db_session.add(stage)
+    await db_session.flush()
+    item = StageContent(
+        course_stage_id=stage.id,
+        title="Chapter 1",
+        content_type="chapter",
+        release_day=0,
+        url="https://aptitude.guru/course/beige-1",
+    )
+    db_session.add(item)
+    await db_session.commit()
+    await db_session.refresh(item)
+
+    # Just enrolled today — days_elapsed == 0, release_day == 0.
+    await _set_user_stage(db_session, user_id, stage_number=1, days_ago=0)
+
+    stub = _StubSquarespaceClient(body_html="<article>Day 0</article>", title="Day Zero")
+    with _patch_client(stub):
+        body_resp = await async_client.get(f"/course/content/{item.id}/body", headers=headers)
+    assert body_resp.status_code == HTTPStatus.OK
+    assert body_resp.json()["body_html"] == "<article>Day 0</article>"
+    assert stub.calls == ["https://aptitude.guru/course/beige-1"]

--- a/backend/tests/test_squarespace_endpoints.py
+++ b/backend/tests/test_squarespace_endpoints.py
@@ -1,0 +1,340 @@
+"""Integration tests for the Squarespace-backed course endpoints.
+
+Covers:
+* ``GET /course/content/{content_id}/body`` — drip-feed gating + CMS fetch
+* ``GET /course/site-resources`` — declarative list, authenticated only
+* ``GET /course/site-resources/{slug}/body`` — fetch a configured resource
+
+Squarespace is replaced with a stub :class:`SquarespaceClient` so no
+network access happens.  The stub is wired in by overriding
+``services.squarespace.get_squarespace_client`` for the duration of each
+test, then resetting it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from content_config import SITE_RESOURCES
+from models.course_stage import CourseStage
+from models.stage_content import StageContent
+from models.stage_progress import StageProgress
+from services import squarespace as squarespace_module
+from services.squarespace import (
+    FetchedContent,
+    SquarespaceAuthError,
+    SquarespaceFetchError,
+)
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _stage_data(stage_number: int = 1, **overrides: object) -> dict[str, object]:
+    defaults: dict[str, object] = {
+        "title": f"Stage {stage_number}",
+        "subtitle": f"Subtitle {stage_number}",
+        "stage_number": stage_number,
+        "overview_url": f"https://example.com/stage-{stage_number}",
+        "category": "test",
+        "aspect": "test-aspect",
+        "spiral_dynamics_color": "beige",
+        "growing_up_stage": "archaic",
+        "divine_gender_polarity": "masculine",
+        "relationship_to_free_will": "active",
+        "free_will_description": "Active Yes-And-Ness",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+async def _signup(client: AsyncClient, username: str = "cmsuser") -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _seed_stage_with_content(
+    db_session: AsyncSession,
+    stage_number: int = 1,
+) -> tuple[CourseStage, StageContent]:
+    stage = CourseStage(**_stage_data(stage_number=stage_number))
+    db_session.add(stage)
+    await db_session.flush()
+    item = StageContent(
+        course_stage_id=stage.id,
+        title="Chapter 1",
+        content_type="chapter",
+        release_day=0,
+        url="https://aptitude.guru/course/beige-1",
+    )
+    db_session.add(item)
+    await db_session.commit()
+    await db_session.refresh(item)
+    return stage, item
+
+
+async def _set_user_stage(
+    db_session: AsyncSession,
+    user_id: int,
+    stage_number: int,
+    days_ago: int = 1,
+) -> StageProgress:
+    progress = StageProgress(
+        user_id=user_id,
+        current_stage=stage_number,
+        completed_stages=list(range(1, stage_number)),
+        stage_started_at=datetime.now(UTC) - timedelta(days=days_ago),
+    )
+    db_session.add(progress)
+    await db_session.commit()
+    return progress
+
+
+class _StubSquarespaceClient:
+    """Drop-in for :class:`SquarespaceClient` that returns fixed HTML."""
+
+    def __init__(
+        self,
+        body_html: str = "<article><h1>Hi</h1><p>body</p></article>",
+        title: str = "Hi",
+        raise_exc: Exception | None = None,
+    ) -> None:
+        self._body_html = body_html
+        self._title = title
+        self._raise = raise_exc
+        self.calls: list[str] = []
+
+    async def fetch(self, url: str) -> FetchedContent:
+        self.calls.append(url)
+        if self._raise is not None:
+            raise self._raise
+        return FetchedContent(url=url, title=self._title, body_html=self._body_html)
+
+
+@contextlib.contextmanager
+def _patch_client(stub: _StubSquarespaceClient) -> Iterator[None]:
+    """Swap the module-level singleton for the test's duration."""
+    original = squarespace_module._singleton  # noqa: SLF001
+    squarespace_module._singleton = stub  # type: ignore[assignment]  # noqa: SLF001
+    try:
+        yield
+    finally:
+        squarespace_module._singleton = original  # noqa: SLF001
+
+
+def _signup_user_id(resp_json: dict[str, object]) -> int:
+    raw = resp_json["user_id"]
+    assert isinstance(raw, int)
+    return raw
+
+
+# --------------------------------------------------------------------------- #
+# /course/content/{id}/body                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_content_body_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.get("/course/content/1/body")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_content_body_returns_cleaned_html(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Happy path: an unlocked, released chapter returns cleaned HTML."""
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "happy@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },  # pragma: allowlist secret
+    )
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+    user_id = _signup_user_id(resp.json())
+
+    _, item = await _seed_stage_with_content(db_session, stage_number=1)
+    await _set_user_stage(db_session, user_id, stage_number=1, days_ago=1)
+
+    stub = _StubSquarespaceClient(body_html="<article>chapter 1</article>", title="Beige One")
+    with _patch_client(stub):
+        body_resp = await async_client.get(f"/course/content/{item.id}/body", headers=headers)
+
+    assert body_resp.status_code == HTTPStatus.OK
+    payload = body_resp.json()
+    assert payload["body_html"] == "<article>chapter 1</article>"
+    assert payload["title"] == "Beige One"
+    assert payload["url"] == "https://aptitude.guru/course/beige-1"
+    assert stub.calls == ["https://aptitude.guru/course/beige-1"]
+
+
+@pytest.mark.asyncio
+async def test_content_body_404_for_locked_stage(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A user not yet at this stage gets 404 — never the real HTML."""
+    headers = await _signup(async_client, "locked")
+    _, item = await _seed_stage_with_content(db_session, stage_number=2)
+    # No StageProgress => stage is locked.
+
+    stub = _StubSquarespaceClient()
+    with _patch_client(stub):
+        resp = await async_client.get(f"/course/content/{item.id}/body", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert stub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_content_body_404_for_unreleased_day(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An item whose release_day is in the future returns 404, no fetch."""
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "early@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },  # pragma: allowlist secret
+    )
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+    user_id = _signup_user_id(resp.json())
+
+    stage = CourseStage(**_stage_data(stage_number=1))
+    db_session.add(stage)
+    await db_session.flush()
+    item = StageContent(
+        course_stage_id=stage.id,
+        title="Chapter 10",
+        content_type="chapter",
+        release_day=9,
+        url="https://aptitude.guru/course/beige-10",
+    )
+    db_session.add(item)
+    await db_session.commit()
+    await db_session.refresh(item)
+
+    await _set_user_stage(db_session, user_id, stage_number=1, days_ago=2)
+
+    stub = _StubSquarespaceClient()
+    with _patch_client(stub):
+        body_resp = await async_client.get(f"/course/content/{item.id}/body", headers=headers)
+    assert body_resp.status_code == HTTPStatus.NOT_FOUND
+    assert stub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_content_body_502_when_cms_unreachable(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A network failure surfaces as 502 with the ``cms_unavailable`` detail."""
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "downstream@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },  # pragma: allowlist secret
+    )
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+    user_id = _signup_user_id(resp.json())
+
+    _, item = await _seed_stage_with_content(db_session, stage_number=1)
+    await _set_user_stage(db_session, user_id, stage_number=1, days_ago=1)
+
+    stub = _StubSquarespaceClient(raise_exc=SquarespaceFetchError("boom"))
+    with _patch_client(stub):
+        body_resp = await async_client.get(f"/course/content/{item.id}/body", headers=headers)
+    assert body_resp.status_code == HTTPStatus.BAD_GATEWAY
+    assert body_resp.json()["detail"] == "cms_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_content_body_503_when_cms_auth_misconfigured(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Missing site password surfaces as 503 ``cms_auth_failed``."""
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "noauth@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },  # pragma: allowlist secret
+    )
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+    user_id = _signup_user_id(resp.json())
+
+    _, item = await _seed_stage_with_content(db_session, stage_number=1)
+    await _set_user_stage(db_session, user_id, stage_number=1, days_ago=1)
+
+    stub = _StubSquarespaceClient(raise_exc=SquarespaceAuthError("no creds"))
+    with _patch_client(stub):
+        body_resp = await async_client.get(f"/course/content/{item.id}/body", headers=headers)
+    assert body_resp.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert body_resp.json()["detail"] == "cms_auth_failed"
+
+
+# --------------------------------------------------------------------------- #
+# /course/site-resources                                                       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_site_resources_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.get("/course/site-resources")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_site_resources_lists_configured_entries(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client, "lister")
+    resp = await async_client.get("/course/site-resources", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    payload = resp.json()
+    assert len(payload) == len(SITE_RESOURCES)
+    by_slug = {r["slug"]: r for r in payload}
+    for configured in SITE_RESOURCES:
+        assert configured.slug in by_slug
+        entry = by_slug[configured.slug]
+        assert entry["title"] == configured.title
+        assert entry["url"] == configured.url
+
+
+@pytest.mark.asyncio
+async def test_site_resource_body_happy_path(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client, "bodyread")
+    stub = _StubSquarespaceClient(body_html="<article>About</article>", title="About Adepthood")
+    with _patch_client(stub):
+        resp = await async_client.get("/course/site-resources/about/body", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["body_html"] == "<article>About</article>"
+    assert resp.json()["title"] == "About Adepthood"
+    assert stub.calls == ["https://aptitude.guru/about"]
+
+
+@pytest.mark.asyncio
+async def test_site_resource_body_unknown_slug_returns_404(
+    async_client: AsyncClient,
+) -> None:
+    headers = await _signup(async_client, "unknown")
+    stub = _StubSquarespaceClient()
+    with _patch_client(stub):
+        resp = await async_client.get(
+            "/course/site-resources/this-does-not-exist/body", headers=headers
+        )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert stub.calls == []

--- a/backend/tests/test_squarespace_service.py
+++ b/backend/tests/test_squarespace_service.py
@@ -1,0 +1,262 @@
+"""Unit tests for :mod:`services.squarespace`.
+
+These tests never hit the network.  Each test builds an ``httpx.MockTransport``
+that responds to specific URLs, hands it to a :class:`SquarespaceClient`
+via the ``http_client_factory`` injection point, and asserts the visible
+behaviour.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from httpx import AsyncClient, MockTransport, Request, Response
+
+from services.squarespace import (
+    SquarespaceAuthError,
+    SquarespaceClient,
+    SquarespaceFetchError,
+    _extract_article,
+)
+
+_PASSWORD_PAGE = """
+<!doctype html><html><head><title>Locked</title></head>
+<body class="site-password">
+  <form method="post">
+    <input type="password" name="password" />
+  </form>
+</body></html>
+""".strip()
+
+_ARTICLE_PAGE = """
+<!doctype html><html><head><title>Chapter 1</title></head>
+<body>
+  <header>SITE HEADER</header>
+  <nav>SITE NAV</nav>
+  <article>
+    <h1>Chapter 1: The Body Calls</h1>
+    <p>This is the body content.</p>
+  </article>
+  <footer>SITE FOOTER</footer>
+</body></html>
+""".strip()
+
+_BASE_URL = "https://aptitude.guru"
+_CHAPTER_URL = f"{_BASE_URL}/course/beige-1"
+
+
+def _build_factory(
+    transport: MockTransport,
+) -> Callable[[], Awaitable[AsyncClient]]:
+    """Wrap a ``MockTransport`` in the factory shape the client expects."""
+
+    async def factory() -> AsyncClient:
+        return AsyncClient(transport=transport, follow_redirects=True)
+
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_fetch_authenticates_once_then_returns_clean_article() -> None:
+    """First call: auth POST, then GET. Subsequent calls reuse the cookie."""
+    auth_posts: list[Request] = []
+    page_gets: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        if request.method == "POST" and request.url.path == "/":
+            auth_posts.append(request)
+            return Response(200, html="<html><body>OK</body></html>")
+        if request.method == "GET" and request.url.path == "/course/beige-1":
+            page_gets.append(request)
+            return Response(200, html=_ARTICLE_PAGE)
+        return Response(404)
+
+    transport = MockTransport(handler)
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="open-sesame",  # pragma: allowlist secret
+        http_client_factory=_build_factory(transport),
+        cache_ttl_seconds=60,
+    )
+
+    fetched = await client.fetch(_CHAPTER_URL)
+
+    assert "Chapter 1" in fetched.title
+    assert "<article>" in fetched.body_html
+    assert "SITE HEADER" not in fetched.body_html
+    assert "SITE FOOTER" not in fetched.body_html
+    assert len(auth_posts) == 1
+    assert len(page_gets) == 1
+
+    # Second fetch hits the cache — no extra GET, no re-auth.
+    await client.fetch(_CHAPTER_URL)
+    assert len(page_gets) == 1
+    assert len(auth_posts) == 1
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fetch_reauthenticates_when_session_expires() -> None:
+    """If a GET comes back as the password page, the client retries auth."""
+    request_log: list[tuple[str, str]] = []
+    gets = 0
+
+    def handler(request: Request) -> Response:
+        nonlocal gets
+        request_log.append((request.method, request.url.path))
+        if request.method == "POST" and request.url.path == "/":
+            return Response(200, html="<html><body>OK</body></html>")
+        if request.method == "GET" and request.url.path == "/course/beige-1":
+            gets += 1
+            # First GET pretends the session has expired.
+            if gets == 1:
+                return Response(200, html=_PASSWORD_PAGE)
+            return Response(200, html=_ARTICLE_PAGE)
+        return Response(404)
+
+    transport = MockTransport(handler)
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="open-sesame",  # pragma: allowlist secret
+        http_client_factory=_build_factory(transport),
+    )
+
+    fetched = await client.fetch(_CHAPTER_URL)
+    assert "<article>" in fetched.body_html
+    # Initial auth POST, first GET (locked), re-auth POST, second GET (article).
+    methods = [m for m, _ in request_log]
+    assert methods.count("POST") == 2
+    assert methods.count("GET") == 2
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_missing_password_raises_auth_error() -> None:
+    """An empty password is fail-fast, not a silent 401."""
+    transport = MockTransport(lambda _r: Response(200, html="<html></html>"))
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="",
+        http_client_factory=_build_factory(transport),
+    )
+    with pytest.raises(SquarespaceAuthError):
+        await client.fetch(_CHAPTER_URL)
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_wrong_password_raises_auth_error() -> None:
+    """If the auth POST still returns a password page, we surface AuthError."""
+
+    def handler(request: Request) -> Response:
+        if request.method == "POST":
+            return Response(200, html=_PASSWORD_PAGE)
+        return Response(404)
+
+    transport = MockTransport(handler)
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="wrong",  # pragma: allowlist secret
+        http_client_factory=_build_factory(transport),
+    )
+    with pytest.raises(SquarespaceAuthError):
+        await client.fetch(_CHAPTER_URL)
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_upstream_5xx_raises_fetch_error() -> None:
+    """A 5xx response from Squarespace becomes :class:`SquarespaceFetchError`."""
+
+    def handler(request: Request) -> Response:
+        if request.method == "POST":
+            return Response(200, html="<html></html>")
+        return Response(503)
+
+    transport = MockTransport(handler)
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="ok",  # pragma: allowlist secret
+        http_client_factory=_build_factory(transport),
+    )
+    with pytest.raises(SquarespaceFetchError):
+        await client.fetch(_CHAPTER_URL)
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_rejects_off_site_urls() -> None:
+    """SSRF guard: a URL outside ``base_url`` is rejected before any I/O."""
+    transport = MockTransport(lambda _r: Response(200))
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="ok",  # pragma: allowlist secret
+        http_client_factory=_build_factory(transport),
+    )
+    with pytest.raises(SquarespaceFetchError):
+        await client.fetch("https://attacker.example/internal")
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_cache_forces_refetch() -> None:
+    """After ``invalidate_cache``, the next fetch hits the network again."""
+    gets = 0
+
+    def handler(request: Request) -> Response:
+        nonlocal gets
+        if request.method == "POST":
+            return Response(200, html="<html></html>")
+        if request.method == "GET":
+            gets += 1
+            return Response(200, html=_ARTICLE_PAGE)
+        return Response(404)
+
+    transport = MockTransport(handler)
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="ok",  # pragma: allowlist secret
+        http_client_factory=_build_factory(transport),
+    )
+    await client.fetch(_CHAPTER_URL)
+    await client.fetch(_CHAPTER_URL)  # cached
+    assert gets == 1
+
+    client.invalidate_cache(_CHAPTER_URL)
+    await client.fetch(_CHAPTER_URL)
+    assert gets == 2
+
+    client.invalidate_cache()
+    await client.fetch(_CHAPTER_URL)
+    assert gets == 3
+    await client.aclose()
+
+
+def test_extract_article_falls_back_to_body_when_no_landmark() -> None:
+    """No ``<article>``/``<main>``? Use ``<body>`` — chrome is already stripped."""
+    html = """
+    <html><body>
+      <header>HDR</header>
+      <div>Just some content.</div>
+    </body></html>
+    """
+    fetched = _extract_article(url="https://aptitude.guru/x", html=html)
+    assert "Just some content" in fetched.body_html
+    assert "HDR" not in fetched.body_html
+
+
+def test_extract_article_keeps_images_and_links() -> None:
+    """Rich content survives the cleaning pass."""
+    html = """
+    <html><body>
+      <article>
+        <h1>Hi</h1>
+        <p><img src="/x.png" alt="X"/> See <a href="/elsewhere">elsewhere</a>.</p>
+      </article>
+    </body></html>
+    """
+    fetched = _extract_article(url="https://aptitude.guru/x", html=html)
+    assert 'src="/x.png"' in fetched.body_html
+    assert 'href="/elsewhere"' in fetched.body_html

--- a/docs/content.md
+++ b/docs/content.md
@@ -1,0 +1,146 @@
+# Editing Squarespace-Backed Course Content
+
+The Adepthood app pulls every course page from the password-protected
+Squarespace site at <https://aptitude.guru>.  This doc covers everything
+you need to know to add, remove, or rearrange that content.
+
+## Where things live
+
+| What | File |
+| ---- | ---- |
+| Stage chapter plans (Beige, Purple, …) and site resource links | `backend/src/content_config.py` |
+| Site password env var | `backend/.env` (`SQUARESPACE_SITE_PASSWORD=...`) |
+| Database seeder that materialises chapters into `StageContent` rows | `backend/src/seed_content.py` |
+| HTTP client that fetches and cleans Squarespace HTML | `backend/src/services/squarespace.py` |
+| API endpoints that the app talks to | `backend/src/routers/course.py` |
+| In-app reader (WebView) | `frontend/src/features/Course/ChapterReader.tsx` |
+| Always-available "From Aptitude Guru" chips | `frontend/src/features/Course/SiteResourcesPanel.tsx` |
+
+## How releases are timed
+
+Each stage runs for `PLAN_DURATION_DAYS = 21` calendar days (see
+`backend/src/domain/energy.py`).  Inside that window:
+
+* Chapter `n` (1-indexed) of a stage unlocks on `release_day = n - 1`.
+* If a stage ships fewer chapters than 21, the remaining days are a
+  catch-up window with no new reading.
+* The "daily" pattern is currently the only one supported.  Adding a
+  pattern (`weekly`, `front_loaded`, …) means extending
+  `build_chapter_release_days()` in `content_config.py`.
+
+Today the Beige stage ships 14 chapters → days 0–13 unlock one new
+chapter each, days 14–20 are catch-up.
+
+## Adding chapters to a new stage
+
+1. Publish the Squarespace pages.  Use the slug pattern that
+   `content_config.py` expects: `https://aptitude.guru/course/{slug}-{n}`
+   where `{n}` runs from 1.
+2. Append a `StageContentPlan` entry to `STAGE_PLANS`:
+
+   ```python
+   STAGE_PLANS: Final[list[StageContentPlan]] = [
+       StageContentPlan(stage_number=1, slug="beige",  chapter_count=14),
+       # New →
+       StageContentPlan(stage_number=2, slug="purple", chapter_count=10),
+   ]
+   ```
+
+3. Open `backend/src/seed_content.py` and drop the stage's placeholder
+   rows from `_PLACEHOLDER_DEFINITIONS` if any are still listed there —
+   the seeder already skips stages that have a plan, so leaving them
+   only wastes lines.
+4. Restart the backend.  The startup seeder will create one
+   `StageContent` row per chapter; subsequent boots are idempotent.
+
+## Reordering or renaming chapters
+
+Two paths, depending on what changed:
+
+* **Renamed the page on Squarespace, slug unchanged** — no action.
+  We always hit the same URL.
+* **Slug changed** — update `chapter_count` (or the `slug` field on
+  the plan).  Restart the backend.  The seeder's reconciliation step
+  updates the URL on existing rows in place; rows that were marked read
+  stay marked read.
+
+## Removing chapters
+
+Lower `chapter_count` in the relevant plan.  The seeder doesn't delete
+the now-orphaned `StageContent` row by itself (deletion would silently
+lose `ContentCompletion` rows referencing it).  If you actually want
+the row gone, write a one-off migration; otherwise the row simply
+stops appearing in the chapter list once `chapter_count` is below its
+index.
+
+## Adding a "From Aptitude Guru" link
+
+These chips live above the stage metadata and are not stage-gated.
+Add to `SITE_RESOURCES` in `content_config.py`:
+
+```python
+SITE_RESOURCES: Final[list[SiteResource]] = [
+    SiteResource(slug="philosophy", title="Philosophy", description="..."),
+    SiteResource(slug="about",       title="About",      description="..."),
+    # New →
+    SiteResource(slug="faq", title="FAQ", description="Common questions.",
+                 path="/faq"),
+]
+```
+
+* `slug` is the URL trailing segment **and** the URL used by the
+  backend to fetch the page.  Pick the Squarespace URL slug.
+* `path` is optional — supply it only when the URL doesn't match
+  `/{slug}` exactly (e.g. nested paths).
+
+No restart required for the chip list itself (the endpoint reads the
+config on every request), but the backend still has to be deployed
+before the new chip will appear in the app.
+
+## Site password
+
+The Squarespace site password is a single env var on the backend:
+
+```
+SQUARESPACE_SITE_PASSWORD=ToBeYourOwnGuru
+```
+
+* The same string you give Gumroad buyers.
+* Rotating: change the Squarespace site password, update the env var,
+  redeploy backend.  The frontend never sees the password.
+* If the password is missing or wrong, every chapter endpoint returns
+  `503 cms_auth_failed` and the in-app reader shows
+  "The course site password is not set on the server. Reach out so we
+  can fix it."  This is intentional: an attacker can tell something
+  went wrong, but not which env var or how to fix it.
+
+## Cache
+
+Cleaned chapter HTML is cached in-process for one hour by default
+(override with `SQUARESPACE_CACHE_TTL_SECONDS`).  Bouncing the backend
+clears the cache; there is no admin endpoint to nuke a single URL.
+For ad-hoc invalidation during development, restart `uvicorn`.
+
+## Local development
+
+You can develop the app without a real Squarespace site by setting:
+
+```
+SQUARESPACE_SITE_PASSWORD=anything-non-empty
+SQUARESPACE_BASE_URL=http://127.0.0.1:9000
+```
+
+…and pointing the `BASE_URL` at a local server that returns plausible
+HTML.  The service's SSRF guard means it rejects URLs outside the
+configured base, so you can't accidentally hit production while iterating.
+
+## Testing
+
+* Backend service:   `backend/tests/test_squarespace_service.py`
+* Backend endpoints: `backend/tests/test_squarespace_endpoints.py`
+* Seeder:            `backend/tests/test_seed_content.py`
+* Frontend reader:   `frontend/src/features/Course/__tests__/ChapterReader.test.tsx`
+* Resource panel:    `frontend/src/features/Course/__tests__/SiteResourcesPanel.test.tsx`
+
+All three suites mock the HTTP layer — no test ever hits the real
+Squarespace site.

--- a/docs/content.md
+++ b/docs/content.md
@@ -102,12 +102,17 @@ before the new chip will appear in the app.
 The Squarespace site password is a single env var on the backend:
 
 ```
-SQUARESPACE_SITE_PASSWORD=ToBeYourOwnGuru
+SQUARESPACE_SITE_PASSWORD=<set-from-team-secrets-manager>
 ```
 
-* The same string you give Gumroad buyers.
-* Rotating: change the Squarespace site password, update the env var,
-  redeploy backend.  The frontend never sees the password.
+* The live value matches the password Gumroad buyers receive. Read it
+  from the team secrets manager (1Password / Doppler / Railway env).
+  **Never commit the literal value to this repo** — git history is
+  forever, and rotating Squarespace's password does not retroactively
+  invalidate the value in old commits.
+* Rotating: change the Squarespace site password, update the secret in
+  the secrets manager, redeploy backend.  The frontend never sees the
+  password.
 * If the password is missing or wrong, every chapter endpoint returns
   `503 cms_auth_failed` and the in-app reader shows
   "The course site password is not set on the server. Reach out so we

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -29,3 +29,28 @@ jest.mock('react-native-reanimated', () => {
     );
   }
 });
+
+// ``react-native-webview`` ships native code that Jest cannot bundle.
+// Returning a thin stub that captures props lets tests assert what HTML
+// would have been rendered without spinning up an actual WebView.
+jest.mock('react-native-webview', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    WebView: (props) =>
+      React.createElement(View, {
+        testID: props.testID ?? 'webview',
+        accessibilityLabel: props.accessibilityLabel,
+        'data-source-html': props.source?.html,
+        'data-source-uri': props.source?.uri,
+      }),
+    default: (props) =>
+      React.createElement(View, {
+        testID: props.testID ?? 'webview',
+        accessibilityLabel: props.accessibilityLabel,
+        'data-source-html': props.source?.html,
+        'data-source-uri': props.source?.uri,
+      }),
+  };
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "react-native-screens": "~4.4.0",
         "react-native-svg": "15.15.4",
         "react-native-web": "~0.19.13",
+        "react-native-webview": "^13.13.5",
         "styleq": "0.1.3",
         "uuid": "^13.0.0",
         "zod": "^3.25.76",
@@ -16560,6 +16561,20 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.13.5",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.13.5.tgz",
+      "integrity": "sha512-MfC2B+woL4Hlj2WCzcb1USySKk+SteXnUKmKktOk/H/AQy5+LuVdkPKm8SknJ0/RxaxhZ48WBoTRGaqgR137hw==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native/node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "react-native-screens": "~4.4.0",
     "react-native-svg": "15.15.4",
     "react-native-web": "~0.19.13",
+    "react-native-webview": "^13.13.5",
     "styleq": "0.1.3",
     "uuid": "^13.0.0",
     "zod": "^3.25.76",

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1516,6 +1516,21 @@ export interface ContentCompletion {
   completed_at: string;
 }
 
+/** Cleaned Squarespace HTML body returned by the in-app content endpoints. */
+export interface ContentBody {
+  url: string;
+  title: string;
+  body_html: string;
+}
+
+/** One entry in the always-available "Site Resources" list. */
+export interface SiteResource {
+  slug: string;
+  title: string;
+  description: string;
+  url: string;
+}
+
 export const course = {
   stageContent(stageNumber: number, token?: string): Promise<ContentItem[]> {
     return request<ContentItem[]>(`/course/stages/${stageNumber}/content`, { token });
@@ -1528,6 +1543,15 @@ export const course = {
   },
   stageProgress(stageNumber: number, token?: string): Promise<CourseProgress> {
     return request<CourseProgress>(`/course/stages/${stageNumber}/progress`, { token });
+  },
+  contentBody(contentId: number, token?: string): Promise<ContentBody> {
+    return request<ContentBody>(`/course/content/${contentId}/body`, { token });
+  },
+  siteResources(token?: string): Promise<SiteResource[]> {
+    return request<SiteResource[]>('/course/site-resources', { token });
+  },
+  siteResourceBody(slug: string, token?: string): Promise<ContentBody> {
+    return request<ContentBody>(`/course/site-resources/${slug}/body`, { token });
   },
 };
 

--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Linking, Text, TouchableOpacity, View } from 'react-native';
 import { WebView } from 'react-native-webview';
+import type { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes';
 
 import { course as courseApi, type ContentBody } from '../../api';
 import { colors } from '../../design/tokens';
@@ -129,6 +130,32 @@ const ErrorView = ({ message, onRetry }: ErrorViewProps): React.JSX.Element => (
 const CMS_AUTH_DETAIL = 'cms_auth_failed';
 const CMS_UNAVAILABLE_DETAIL = 'cms_unavailable';
 
+/**
+ * URL scheme prefixes that we let the WebView load in-frame.  The WebView's
+ * ``source={{ html }}`` boots at ``about:blank``; ``data:`` is used by some
+ * RN platforms while wiring the document.  Everything else (links inside
+ * a chapter, embedded forms, etc.) is handed off to the system browser via
+ * ``Linking.openURL`` so the user is never silently navigated away inside
+ * the in-app reader.  This is the mitigation for the broad
+ * ``originWhitelist={['*']}`` we still pass — required for the inline HTML
+ * to render at all on web/iOS, but dangerous on its own without this guard.
+ */
+const _IN_FRAME_URL_PREFIXES = ['about:', 'data:', 'file:'] as const;
+
+function shouldLoadInWebView(request: ShouldStartLoadRequest): boolean {
+  const { url } = request;
+  if (_IN_FRAME_URL_PREFIXES.some((prefix) => url.startsWith(prefix))) {
+    return true;
+  }
+  // Hand the navigation to the OS — the system browser can authenticate
+  // the user against Squarespace separately if the link points back to
+  // the site, and external links open as the user expects.
+  void Linking.openURL(url).catch((err) => {
+    console.warn('Failed to open URL from chapter:', err);
+  });
+  return false;
+}
+
 function describeError(err: unknown): string {
   if (err && typeof err === 'object' && 'detail' in err) {
     const detail = (err as { detail: unknown }).detail;
@@ -165,6 +192,11 @@ function useContentBody(source: ChapterReaderSource): {
     isMountedRef.current = true;
     setLoading(true);
     setError(null);
+    // The API call omits the explicit token — ``api/index.ts``'s
+    // ``request()`` helper falls back to the global ``tokenGetter``
+    // (set by ``AuthContext`` at sign-in), so the bearer header is
+    // attached automatically.  Same pattern as ``stagesApi.list()``
+    // and the other "no explicit token" callers in the codebase.
     const promise =
       source.kind === 'content'
         ? courseApi.contentBody(source.id)
@@ -212,6 +244,7 @@ const ChapterReader = ({
           testID="reader-webview"
           source={{ html: buildDocument(body.body_html) }}
           originWhitelist={['*']}
+          onShouldStartLoadWithRequest={shouldLoadInWebView}
           style={styles.webview}
           accessibilityLabel={headerTitle}
         />

--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -1,0 +1,224 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
+import { WebView } from 'react-native-webview';
+
+import { course as courseApi, type ContentBody } from '../../api';
+import { colors } from '../../design/tokens';
+
+import styles from './Course.styles';
+
+/**
+ * Source descriptor for the reader.  ``kind`` decides which backend
+ * endpoint we hit; everything else is plumbing.  Keeping this a tagged
+ * union (rather than two separate components) lets us share the loading,
+ * error, and HTML-wrapping logic between chapter and site-resource reads.
+ */
+export type ChapterReaderSource =
+  | { kind: 'content'; id: number }
+  | { kind: 'resource'; slug: string };
+
+interface ChapterReaderProps {
+  source: ChapterReaderSource;
+  /** Title shown in the header until the live ``title`` from the CMS arrives. */
+  fallbackTitle: string;
+  /** Render no footer — used for site resources, which aren't tracked. */
+  footer?: React.ReactNode;
+  onBack: () => void;
+}
+
+/**
+ * Wrap the backend's article HTML in a complete document with mobile-
+ * sane typography.  Keeping this client-side means we don't pay for a
+ * second backend round-trip just to render the same chrome on every
+ * chapter.
+ */
+function buildDocument(bodyHtml: string): string {
+  const styleBlock = `
+    :root { color-scheme: light dark; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-size: 17px;
+      line-height: 1.55;
+      color: #1a1910;
+      background: #fffaf0;
+      padding: 18px 18px 56px;
+    }
+    h1, h2, h3 { line-height: 1.25; }
+    h1 { font-size: 1.6rem; margin-top: 0.4em; }
+    h2 { font-size: 1.3rem; }
+    h3 { font-size: 1.1rem; }
+    p { margin: 0.9em 0; }
+    img, video, iframe { max-width: 100%; height: auto; border-radius: 8px; }
+    blockquote {
+      margin: 1em 0;
+      padding: 0 1em;
+      border-left: 3px solid #b8a373;
+      color: #413d2f;
+      font-style: italic;
+    }
+    a { color: #6f4e1f; }
+    pre, code {
+      background: #f0e6d2;
+      border-radius: 6px;
+      padding: 0.1em 0.4em;
+      font-size: 0.92em;
+    }
+    pre { padding: 12px; overflow-x: auto; }
+    @media (prefers-color-scheme: dark) {
+      body { color: #f0e6d2; background: #1a1910; }
+      pre, code { background: #2a2a2a; color: #f0e6d2; }
+      blockquote { color: #c4c2b8; border-left-color: #8a7a52; }
+      a { color: #d4b878; }
+    }
+  `;
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5" />
+  <style>${styleBlock}</style>
+</head>
+<body>${bodyHtml}</body>
+</html>`;
+}
+
+interface HeaderProps {
+  title: string;
+  onBack: () => void;
+}
+
+const ReaderHeader = ({ title, onBack }: HeaderProps): React.JSX.Element => (
+  <View style={styles.viewerHeader}>
+    <TouchableOpacity
+      onPress={onBack}
+      style={styles.viewerBackButton}
+      testID="reader-back-button"
+      accessibilityRole="button"
+      accessibilityLabel="Go back"
+    >
+      <Text style={styles.viewerBackText}>{'← Back'}</Text>
+    </TouchableOpacity>
+    <Text style={styles.viewerTitle} numberOfLines={1}>
+      {title}
+    </Text>
+  </View>
+);
+
+interface ErrorViewProps {
+  message: string;
+  onRetry: () => void;
+}
+
+const ErrorView = ({ message, onRetry }: ErrorViewProps): React.JSX.Element => (
+  <View style={styles.webviewError} testID="reader-error">
+    <Text style={styles.webviewErrorTitle}>This page couldn’t load right now</Text>
+    <Text style={styles.webviewErrorSubtitle}>{message}</Text>
+    <TouchableOpacity
+      onPress={onRetry}
+      style={styles.retryButton}
+      testID="reader-retry-button"
+      accessibilityRole="button"
+      accessibilityLabel="Try again"
+    >
+      <Text style={styles.retryText}>Try Again</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+const CMS_AUTH_DETAIL = 'cms_auth_failed';
+const CMS_UNAVAILABLE_DETAIL = 'cms_unavailable';
+
+function describeError(err: unknown): string {
+  if (err && typeof err === 'object' && 'detail' in err) {
+    const detail = (err as { detail: unknown }).detail;
+    if (detail === CMS_AUTH_DETAIL) {
+      return 'The course site password is not set on the server. Reach out so we can fix it.';
+    }
+    if (detail === CMS_UNAVAILABLE_DETAIL) {
+      return 'The course site is temporarily unreachable. Please try again in a moment.';
+    }
+  }
+  return 'Something went wrong reaching the course site. Please try again.';
+}
+
+function useContentBody(source: ChapterReaderSource): {
+  body: ContentBody | null;
+  loading: boolean;
+  error: string | null;
+  retry: () => void;
+} {
+  const [body, setBody] = useState<ContentBody | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const isMountedRef = useRef(true);
+
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    setLoading(true);
+    setError(null);
+    const promise =
+      source.kind === 'content'
+        ? courseApi.contentBody(source.id)
+        : courseApi.siteResourceBody(source.slug);
+
+    promise
+      .then((result) => {
+        if (!isMountedRef.current) return;
+        setBody(result);
+      })
+      .catch((err: unknown) => {
+        if (!isMountedRef.current) return;
+        setError(describeError(err));
+      })
+      .finally(() => {
+        if (!isMountedRef.current) return;
+        setLoading(false);
+      });
+  }, [source, refreshKey]);
+
+  const retry = useCallback(() => setRefreshKey((n) => n + 1), []);
+  return { body, loading, error, retry };
+}
+
+const ChapterReader = ({
+  source,
+  fallbackTitle,
+  footer,
+  onBack,
+}: ChapterReaderProps): React.JSX.Element => {
+  const { body, loading, error, retry } = useContentBody(source);
+  const headerTitle = body?.title || fallbackTitle;
+
+  return (
+    <View style={styles.viewerContainer} testID="chapter-reader">
+      <ReaderHeader title={headerTitle} onBack={onBack} />
+      {loading && (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator testID="reader-loading" size="large" color={colors.text.secondary} />
+        </View>
+      )}
+      {!loading && error !== null && <ErrorView message={error} onRetry={retry} />}
+      {!loading && error === null && body !== null && (
+        <WebView
+          testID="reader-webview"
+          source={{ html: buildDocument(body.body_html) }}
+          originWhitelist={['*']}
+          style={styles.webview}
+          accessibilityLabel={headerTitle}
+        />
+      )}
+      {footer}
+    </View>
+  );
+};
+
+export default ChapterReader;

--- a/frontend/src/features/Course/ContentViewer.tsx
+++ b/frontend/src/features/Course/ContentViewer.tsx
@@ -1,33 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Linking, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
 
 import { course as courseApi, type ContentItem } from '../../api';
 import { colors } from '../../design/tokens';
-import { isValidUrl } from '../../utils/url';
 
+import ChapterReader from './ChapterReader';
 import styles from './Course.styles';
-
-interface ViewerHeaderProps {
-  title: string;
-  onBack: () => void;
-}
-
-const ViewerHeader = ({ title, onBack }: ViewerHeaderProps): React.JSX.Element => (
-  <View style={styles.viewerHeader}>
-    <TouchableOpacity
-      onPress={onBack}
-      style={styles.viewerBackButton}
-      testID="viewer-back-button"
-      accessibilityRole="button"
-      accessibilityLabel="Go back"
-    >
-      <Text style={styles.viewerBackText}>{'← Back'}</Text>
-    </TouchableOpacity>
-    <Text style={styles.viewerTitle} numberOfLines={1}>
-      {title}
-    </Text>
-  </View>
-);
 
 interface ViewerFooterProps {
   isRead: boolean;
@@ -126,35 +104,20 @@ const ContentViewer = ({
 }: ContentViewerProps): React.JSX.Element => {
   const { marking, isRead, handleMarkRead } = useMarkReadHandler(item, onMarkRead);
 
-  const handleOpenUrl = useCallback(async () => {
-    if (!item.url || !isValidUrl(item.url)) return;
-    try {
-      await Linking.openURL(item.url);
-    } catch (err) {
-      console.error('Failed to open URL:', err);
-    }
-  }, [item.url]);
-
   return (
-    <View style={styles.viewerContainer} testID="content-viewer">
-      <ViewerHeader title={item.title} onBack={onBack} />
-      <View style={styles.loadingContainer}>
-        <TouchableOpacity
-          onPress={handleOpenUrl}
-          testID="open-url-button"
-          accessibilityLabel="Open in browser"
-          accessibilityRole="link"
-        >
-          <Text style={styles.viewerBackText}>{'Open in Browser'}</Text>
-        </TouchableOpacity>
-      </View>
-      <ViewerFooter
-        isRead={isRead}
-        marking={marking}
-        onMarkRead={handleMarkRead}
-        onReflect={onReflect}
-      />
-    </View>
+    <ChapterReader
+      source={{ kind: 'content', id: item.id }}
+      fallbackTitle={item.title}
+      onBack={onBack}
+      footer={
+        <ViewerFooter
+          isRead={isRead}
+          marking={marking}
+          onMarkRead={handleMarkRead}
+          onReflect={onReflect}
+        />
+      }
+    />
   );
 };
 

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -265,6 +265,76 @@ const styles = StyleSheet.create({
   contentList: {
     flex: 1,
   },
+
+  // WebView body
+  webview: {
+    flex: 1,
+    backgroundColor: colors.background.primary,
+  },
+  webviewError: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.xl,
+  },
+  webviewErrorTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.text.primary,
+    marginBottom: SPACING.sm,
+    textAlign: 'center',
+  },
+  webviewErrorSubtitle: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    marginBottom: SPACING.md,
+    textAlign: 'center',
+  },
+  retryButton: {
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    borderRadius: radius.md,
+    backgroundColor: colors.secondary,
+  },
+  retryText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.light,
+  },
+
+  // Site resources panel
+  resourcesPanel: {
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.md,
+    paddingBottom: SPACING.sm,
+    backgroundColor: colors.background.card,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  resourcesHeading: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.text.tertiary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: SPACING.sm,
+  },
+  resourcesRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: SPACING.sm,
+  },
+  resourceChip: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    borderRadius: radius.md,
+    backgroundColor: colors.background.accent,
+  },
+  resourceChipText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
 });
 
 export default styles;

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -7,6 +7,7 @@ import {
   stages as stagesApi,
   type ContentItem,
   type CourseProgress,
+  type SiteResource,
   type Stage,
 } from '../../api';
 import { STAGE_COLORS, colors } from '../../design/tokens';
@@ -14,9 +15,11 @@ import { useAppNavigation, useAppRoute } from '../../navigation/hooks';
 import { useProgramStore, programStage } from '../../store/useProgramStore';
 import { deriveCurrentStage } from '../Map/services/stageService';
 
+import ChapterReader from './ChapterReader';
 import ContentCard from './ContentCard';
 import ContentViewer from './ContentViewer';
 import styles from './Course.styles';
+import SiteResourcesPanel from './SiteResourcesPanel';
 import StageSelector from './StageSelector';
 
 const DEFAULT_STAGE_NUMBER = 1;
@@ -204,12 +207,20 @@ const ContentArea = ({
 function useCourseViewer(selectedStage: number) {
   const navigation = useAppNavigation();
   const [viewingItem, setViewingItem] = useState<ContentItem | null>(null);
+  const [viewingResource, setViewingResource] = useState<SiteResource | null>(null);
 
   const handleContentPress = useCallback((item: ContentItem) => {
     if (!item.is_locked) setViewingItem(item);
   }, []);
 
-  const handleBack = useCallback(() => setViewingItem(null), []);
+  const handleResourcePress = useCallback((resource: SiteResource) => {
+    setViewingResource(resource);
+  }, []);
+
+  const handleBack = useCallback(() => {
+    setViewingItem(null);
+    setViewingResource(null);
+  }, []);
 
   const handleReflect = useCallback(() => {
     if (!viewingItem) return;
@@ -221,10 +232,45 @@ function useCourseViewer(selectedStage: number) {
     setViewingItem(null);
   }, [viewingItem, selectedStage, navigation]);
 
-  return { viewingItem, setViewingItem, handleContentPress, handleBack, handleReflect };
+  return {
+    viewingItem,
+    setViewingItem,
+    viewingResource,
+    setViewingResource,
+    handleContentPress,
+    handleResourcePress,
+    handleBack,
+    handleReflect,
+  };
 }
 
 // --- Main component ---
+
+function renderOverlay(
+  viewer: ReturnType<typeof useCourseViewer>,
+  onMarkRead: () => void,
+): React.JSX.Element | null {
+  if (viewer.viewingItem) {
+    return (
+      <ContentViewer
+        item={viewer.viewingItem}
+        onBack={viewer.handleBack}
+        onMarkRead={onMarkRead}
+        onReflect={viewer.handleReflect}
+      />
+    );
+  }
+  if (viewer.viewingResource) {
+    return (
+      <ChapterReader
+        source={{ kind: 'resource', slug: viewer.viewingResource.slug }}
+        fallbackTitle={viewer.viewingResource.title}
+        onBack={viewer.handleBack}
+      />
+    );
+  }
+  return null;
+}
 
 const CourseScreen = (): React.JSX.Element => {
   const { allStages, selectedStage, setSelectedStage, loading } = useStagesLoader();
@@ -239,16 +285,8 @@ const CourseScreen = (): React.JSX.Element => {
     [setSelectedStage, viewer],
   );
 
-  if (viewer.viewingItem) {
-    return (
-      <ContentViewer
-        item={viewer.viewingItem}
-        onBack={viewer.handleBack}
-        onMarkRead={stageContent.handleMarkRead}
-        onReflect={viewer.handleReflect}
-      />
-    );
-  }
+  const overlay = renderOverlay(viewer, stageContent.handleMarkRead);
+  if (overlay !== null) return overlay;
 
   if (loading) return <CourseLoadingState />;
 
@@ -261,6 +299,7 @@ const CourseScreen = (): React.JSX.Element => {
         selectedStage={selectedStage}
         onSelectStage={handleStageSelect}
       />
+      <SiteResourcesPanel onSelect={viewer.handleResourcePress} />
       {selectedStageData && <StageMetadata stage={selectedStageData} />}
       <CourseProgressBar
         progress={stageContent.progress}

--- a/frontend/src/features/Course/SiteResourcesPanel.tsx
+++ b/frontend/src/features/Course/SiteResourcesPanel.tsx
@@ -31,6 +31,10 @@ const SiteResourcesPanel = ({ onSelect }: SiteResourcesPanelProps): React.JSX.El
   );
 
   useEffect(() => {
+    // ``siteResources()`` is called without an explicit token — the
+    // shared ``request()`` helper in ``api/index.ts`` falls back to the
+    // global ``tokenGetter`` set by ``AuthContext``, matching how
+    // ``stagesApi.list()`` and other no-explicit-token callers work.
     courseApi
       .siteResources()
       .then((list) => {

--- a/frontend/src/features/Course/SiteResourcesPanel.tsx
+++ b/frontend/src/features/Course/SiteResourcesPanel.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+
+import { course as courseApi, type SiteResource } from '../../api';
+
+import styles from './Course.styles';
+
+interface SiteResourcesPanelProps {
+  onSelect: (resource: SiteResource) => void;
+}
+
+/**
+ * Always-available links to evergreen pages (philosophy, about, …).
+ * Rendered as a chip row above the stage metadata.  The list is loaded
+ * once per mount; it's small (<10 entries) so we don't paginate and we
+ * don't refresh on focus — adding a new resource means a backend deploy.
+ *
+ * Renders nothing when the resource list is empty or still loading: the
+ * panel is supplementary navigation, not a primary surface, so a
+ * spinner here would steal vertical space from the actual course.
+ */
+const SiteResourcesPanel = ({ onSelect }: SiteResourcesPanelProps): React.JSX.Element | null => {
+  const [resources, setResources] = useState<SiteResource[]>([]);
+  const isMountedRef = useRef(true);
+
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    courseApi
+      .siteResources()
+      .then((list) => {
+        if (!isMountedRef.current) return;
+        setResources(list);
+      })
+      .catch((err: unknown) => {
+        // Don't surface a banner — the resources panel is supplementary.
+        // Logging keeps the failure visible in dev without spooking users.
+        console.warn('Failed to load site resources:', err);
+      });
+  }, []);
+
+  if (resources.length === 0) return null;
+
+  return (
+    <View style={styles.resourcesPanel} testID="site-resources-panel">
+      <Text style={styles.resourcesHeading}>From Aptitude Guru</Text>
+      <View style={styles.resourcesRow}>
+        {resources.map((resource) => (
+          <TouchableOpacity
+            key={resource.slug}
+            testID={`site-resource-chip-${resource.slug}`}
+            style={styles.resourceChip}
+            onPress={() => onSelect(resource)}
+            accessibilityRole="button"
+            accessibilityLabel={`Open ${resource.title}`}
+          >
+            <Text style={styles.resourceChipText}>{resource.title}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+};
+
+export default SiteResourcesPanel;

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -1,46 +1,49 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-env jest */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
 
-const mockContentBody = (jest.fn() as any).mockResolvedValue({
-  url: 'https://aptitude.guru/course/beige-1',
-  title: 'Chapter One',
-  body_html: '<article>chapter body</article>',
-});
-const mockSiteResourceBody = (jest.fn() as any).mockResolvedValue({
-  url: 'https://aptitude.guru/philosophy',
-  title: 'Philosophy',
-  body_html: '<article>philosophy body</article>',
-});
+import type * as Api from '../../../api';
+import ChapterReader from '../ChapterReader';
 
 jest.mock('../../../api', () => ({
   course: {
-    contentBody: (...args: unknown[]) => mockContentBody(...args),
-    siteResourceBody: (...args: unknown[]) => mockSiteResourceBody(...args),
+    contentBody: jest.fn(),
+    siteResourceBody: jest.fn(),
   },
 }));
 
-// eslint-disable-next-line import/order
-const { render, fireEvent, waitFor } = require('@testing-library/react-native');
-const ChapterReader = require('../ChapterReader').default;
+const { course: courseApi } = jest.requireMock('../../../api') as {
+  course: {
+    contentBody: jest.MockedFunction<typeof Api.course.contentBody>;
+    siteResourceBody: jest.MockedFunction<typeof Api.course.siteResourceBody>;
+  };
+};
+
+const { contentBody: mockContentBody, siteResourceBody: mockSiteResourceBody } = courseApi;
+
+const HAPPY_CHAPTER = {
+  url: 'https://aptitude.guru/course/beige-1',
+  title: 'Chapter One',
+  body_html: '<article>chapter body</article>',
+};
+
+const HAPPY_RESOURCE = {
+  url: 'https://aptitude.guru/philosophy',
+  title: 'Philosophy',
+  body_html: '<article>philosophy body</article>',
+};
 
 describe('ChapterReader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockContentBody.mockResolvedValue({
-      url: 'https://aptitude.guru/course/beige-1',
-      title: 'Chapter One',
-      body_html: '<article>chapter body</article>',
-    });
-    mockSiteResourceBody.mockResolvedValue({
-      url: 'https://aptitude.guru/philosophy',
-      title: 'Philosophy',
-      body_html: '<article>philosophy body</article>',
-    });
+    mockContentBody.mockResolvedValue(HAPPY_CHAPTER);
+    mockSiteResourceBody.mockResolvedValue(HAPPY_RESOURCE);
   });
 
   it('renders the fallback title until the live one arrives', async () => {
-    const onBack = jest.fn() as any;
+    const onBack = jest.fn();
     const { getByText, findByText } = render(
       <ChapterReader
         source={{ kind: 'content', id: 7 }}
@@ -53,21 +56,19 @@ describe('ChapterReader', () => {
   });
 
   it('routes content sources to course.contentBody', async () => {
-    const onBack = jest.fn() as any;
     render(
-      <ChapterReader source={{ kind: 'content', id: 42 }} fallbackTitle="x" onBack={onBack} />,
+      <ChapterReader source={{ kind: 'content', id: 42 }} fallbackTitle="x" onBack={jest.fn()} />,
     );
     await waitFor(() => expect(mockContentBody).toHaveBeenCalledWith(42));
     expect(mockSiteResourceBody).not.toHaveBeenCalled();
   });
 
   it('routes resource sources to course.siteResourceBody', async () => {
-    const onBack = jest.fn() as any;
     render(
       <ChapterReader
         source={{ kind: 'resource', slug: 'philosophy' }}
         fallbackTitle="x"
-        onBack={onBack}
+        onBack={jest.fn()}
       />,
     );
     await waitFor(() => expect(mockSiteResourceBody).toHaveBeenCalledWith('philosophy'));
@@ -75,13 +76,11 @@ describe('ChapterReader', () => {
   });
 
   it('renders a footer when one is provided', async () => {
-    const { Text } = require('react-native');
-    const onBack = jest.fn() as any;
     const { findByText } = render(
       <ChapterReader
         source={{ kind: 'content', id: 1 }}
         fallbackTitle="x"
-        onBack={onBack}
+        onBack={jest.fn()}
         footer={<Text>FOOTER_HERE</Text>}
       />,
     );
@@ -89,7 +88,7 @@ describe('ChapterReader', () => {
   });
 
   it('triggers onBack from the header back button', async () => {
-    const onBack = jest.fn() as any;
+    const onBack = jest.fn();
     const { findByTestId } = render(
       <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={onBack} />,
     );
@@ -98,12 +97,11 @@ describe('ChapterReader', () => {
   });
 
   it('wraps the cleaned HTML in a styled document', async () => {
-    const onBack = jest.fn() as any;
     const { findByTestId } = render(
-      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={onBack} />,
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
     );
     const webview = await findByTestId('reader-webview');
-    const html: string = webview.props['data-source-html'];
+    const html = String(webview.props['data-source-html']);
     expect(html).toMatch(/^<!doctype html>/i);
     expect(html).toContain('<article>chapter body</article>');
     // Mobile viewport is set so the WebView renders at native scale.
@@ -116,13 +114,20 @@ describe('ChapterReader', () => {
       title: 'After retry',
       body_html: '<article>retried</article>',
     });
-    const onBack = jest.fn() as any;
     const { findByTestId, findByText } = render(
-      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={onBack} />,
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
     );
     await findByText(/temporarily unreachable/i);
     fireEvent.press(await findByTestId('reader-retry-button'));
     const webview = await findByTestId('reader-webview');
-    expect(webview.props['data-source-html']).toContain('retried');
+    expect(String(webview.props['data-source-html'])).toContain('retried');
+  });
+
+  it('shows the server-config message when the CMS auth detail comes back', async () => {
+    mockContentBody.mockRejectedValueOnce({ detail: 'cms_auth_failed' });
+    const { findByText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    await findByText(/site password is not set/i);
   });
 });

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+const mockContentBody = (jest.fn() as any).mockResolvedValue({
+  url: 'https://aptitude.guru/course/beige-1',
+  title: 'Chapter One',
+  body_html: '<article>chapter body</article>',
+});
+const mockSiteResourceBody = (jest.fn() as any).mockResolvedValue({
+  url: 'https://aptitude.guru/philosophy',
+  title: 'Philosophy',
+  body_html: '<article>philosophy body</article>',
+});
+
+jest.mock('../../../api', () => ({
+  course: {
+    contentBody: (...args: unknown[]) => mockContentBody(...args),
+    siteResourceBody: (...args: unknown[]) => mockSiteResourceBody(...args),
+  },
+}));
+
+// eslint-disable-next-line import/order
+const { render, fireEvent, waitFor } = require('@testing-library/react-native');
+const ChapterReader = require('../ChapterReader').default;
+
+describe('ChapterReader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContentBody.mockResolvedValue({
+      url: 'https://aptitude.guru/course/beige-1',
+      title: 'Chapter One',
+      body_html: '<article>chapter body</article>',
+    });
+    mockSiteResourceBody.mockResolvedValue({
+      url: 'https://aptitude.guru/philosophy',
+      title: 'Philosophy',
+      body_html: '<article>philosophy body</article>',
+    });
+  });
+
+  it('renders the fallback title until the live one arrives', async () => {
+    const onBack = jest.fn() as any;
+    const { getByText, findByText } = render(
+      <ChapterReader
+        source={{ kind: 'content', id: 7 }}
+        fallbackTitle="Loading…"
+        onBack={onBack}
+      />,
+    );
+    expect(getByText('Loading…')).toBeTruthy();
+    await findByText('Chapter One');
+  });
+
+  it('routes content sources to course.contentBody', async () => {
+    const onBack = jest.fn() as any;
+    render(
+      <ChapterReader source={{ kind: 'content', id: 42 }} fallbackTitle="x" onBack={onBack} />,
+    );
+    await waitFor(() => expect(mockContentBody).toHaveBeenCalledWith(42));
+    expect(mockSiteResourceBody).not.toHaveBeenCalled();
+  });
+
+  it('routes resource sources to course.siteResourceBody', async () => {
+    const onBack = jest.fn() as any;
+    render(
+      <ChapterReader
+        source={{ kind: 'resource', slug: 'philosophy' }}
+        fallbackTitle="x"
+        onBack={onBack}
+      />,
+    );
+    await waitFor(() => expect(mockSiteResourceBody).toHaveBeenCalledWith('philosophy'));
+    expect(mockContentBody).not.toHaveBeenCalled();
+  });
+
+  it('renders a footer when one is provided', async () => {
+    const { Text } = require('react-native');
+    const onBack = jest.fn() as any;
+    const { findByText } = render(
+      <ChapterReader
+        source={{ kind: 'content', id: 1 }}
+        fallbackTitle="x"
+        onBack={onBack}
+        footer={<Text>FOOTER_HERE</Text>}
+      />,
+    );
+    await findByText('FOOTER_HERE');
+  });
+
+  it('triggers onBack from the header back button', async () => {
+    const onBack = jest.fn() as any;
+    const { findByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={onBack} />,
+    );
+    fireEvent.press(await findByTestId('reader-back-button'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps the cleaned HTML in a styled document', async () => {
+    const onBack = jest.fn() as any;
+    const { findByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={onBack} />,
+    );
+    const webview = await findByTestId('reader-webview');
+    const html: string = webview.props['data-source-html'];
+    expect(html).toMatch(/^<!doctype html>/i);
+    expect(html).toContain('<article>chapter body</article>');
+    // Mobile viewport is set so the WebView renders at native scale.
+    expect(html).toMatch(/<meta name="viewport"/);
+  });
+
+  it('shows an error and lets the user retry on transient failure', async () => {
+    mockContentBody.mockRejectedValueOnce({ detail: 'cms_unavailable' }).mockResolvedValueOnce({
+      url: 'https://aptitude.guru/course/beige-1',
+      title: 'After retry',
+      body_html: '<article>retried</article>',
+    });
+    const onBack = jest.fn() as any;
+    const { findByTestId, findByText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={onBack} />,
+    );
+    await findByText(/temporarily unreachable/i);
+    fireEvent.press(await findByTestId('reader-retry-button'));
+    const webview = await findByTestId('reader-webview');
+    expect(webview.props['data-source-html']).toContain('retried');
+  });
+});

--- a/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
+++ b/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
@@ -1,43 +1,51 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-env jest */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
 
+import type * as Api from '../../../api';
 import type { ContentItem } from '../../../api';
+import ContentViewer from '../ContentViewer';
 
-const mockMarkRead = (jest.fn() as any).mockResolvedValue({
+jest.mock('../../../api', () => ({
+  course: {
+    markRead: jest.fn(),
+    contentBody: jest.fn(),
+  },
+}));
+
+const { course: courseApi } = jest.requireMock('../../../api') as {
+  course: {
+    markRead: jest.MockedFunction<typeof Api.course.markRead>;
+    contentBody: jest.MockedFunction<typeof Api.course.contentBody>;
+  };
+};
+
+const HAPPY_BODY = {
+  url: 'https://aptitude.guru/course/beige-1',
+  title: 'Chapter One',
+  body_html: '<article><h1>Chapter One</h1><p>Hi.</p></article>',
+};
+
+const HAPPY_COMPLETION = {
   id: 1,
   user_id: 1,
   content_id: 1,
   completed_at: '2026-01-15T10:00:00Z',
-});
+};
 
-const mockContentBody = (jest.fn() as any).mockResolvedValue({
-  url: 'https://aptitude.guru/course/beige-1',
-  title: 'Chapter One',
-  body_html: '<article><h1>Chapter One</h1><p>Hi.</p></article>',
-});
-
-jest.mock('../../../api', () => ({
-  course: {
-    markRead: (...args: unknown[]) => mockMarkRead(...args),
-    contentBody: (...args: unknown[]) => mockContentBody(...args),
-  },
-}));
-
-// eslint-disable-next-line import/order
-const { render, fireEvent, waitFor, act } = require('@testing-library/react-native');
-const ContentViewer = require('../ContentViewer').default;
-
-const makeItem = (overrides: Partial<ContentItem> = {}): ContentItem => ({
-  id: 1,
-  title: 'Test Article',
-  content_type: 'chapter',
-  release_day: 0,
-  url: 'https://aptitude.guru/course/beige-1',
-  is_locked: false,
-  is_read: false,
-  ...overrides,
-});
+function makeItem(overrides: Partial<ContentItem> = {}): ContentItem {
+  return {
+    id: 1,
+    title: 'Test Article',
+    content_type: 'chapter',
+    release_day: 0,
+    url: 'https://aptitude.guru/course/beige-1',
+    is_locked: false,
+    is_read: false,
+    ...overrides,
+  };
+}
 
 describe('ContentViewer', () => {
   let onBack: jest.Mock;
@@ -45,19 +53,10 @@ describe('ContentViewer', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    onBack = jest.fn() as any;
-    onMarkRead = jest.fn() as any;
-    mockMarkRead.mockResolvedValue({
-      id: 1,
-      user_id: 1,
-      content_id: 1,
-      completed_at: '2026-01-15T10:00:00Z',
-    });
-    mockContentBody.mockResolvedValue({
-      url: 'https://aptitude.guru/course/beige-1',
-      title: 'Chapter One',
-      body_html: '<article><h1>Chapter One</h1><p>Hi.</p></article>',
-    });
+    onBack = jest.fn();
+    onMarkRead = jest.fn();
+    courseApi.markRead.mockResolvedValue(HAPPY_COMPLETION);
+    courseApi.contentBody.mockResolvedValue(HAPPY_BODY);
   });
 
   it('renders the content title initially, then swaps to the live title', async () => {
@@ -73,7 +72,7 @@ describe('ContentViewer', () => {
     const item = makeItem();
     render(<ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />);
     await waitFor(() => {
-      expect(mockContentBody).toHaveBeenCalledWith(item.id);
+      expect(courseApi.contentBody).toHaveBeenCalledWith(item.id);
     });
   });
 
@@ -83,8 +82,9 @@ describe('ContentViewer', () => {
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
     );
     const webview = await findByTestId('reader-webview');
-    expect(webview.props['data-source-html']).toContain('<article>');
-    expect(webview.props['data-source-html']).toContain('Chapter One');
+    const html = String(webview.props['data-source-html']);
+    expect(html).toContain('<article>');
+    expect(html).toContain('Chapter One');
   });
 
   it('calls onBack when back button is pressed', async () => {
@@ -111,7 +111,7 @@ describe('ContentViewer', () => {
     });
 
     await waitFor(() => {
-      expect(mockMarkRead).toHaveBeenCalledWith(1);
+      expect(courseApi.markRead).toHaveBeenCalledWith(1);
       expect(onMarkRead).toHaveBeenCalledTimes(1);
       expect(getByText('✓ Read')).toBeTruthy();
     });
@@ -133,12 +133,12 @@ describe('ContentViewer', () => {
     );
     await findByTestId('reader-webview');
     fireEvent.press(getByTestId('mark-read-button'));
-    expect(mockMarkRead).not.toHaveBeenCalled();
+    expect(courseApi.markRead).not.toHaveBeenCalled();
   });
 
   it('shows the reflect button when the item is read', async () => {
     const item = makeItem({ is_read: true });
-    const onReflect = jest.fn() as any;
+    const onReflect = jest.fn();
     const { getByTestId, getByText, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} onReflect={onReflect} />,
     );
@@ -149,7 +149,7 @@ describe('ContentViewer', () => {
 
   it('shows the reflect button after marking content as read', async () => {
     const item = makeItem({ is_read: false });
-    const onReflect = jest.fn() as any;
+    const onReflect = jest.fn();
     const { getByTestId, queryByTestId, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} onReflect={onReflect} />,
     );
@@ -167,7 +167,7 @@ describe('ContentViewer', () => {
 
   it('calls onReflect when the reflect button is pressed', async () => {
     const item = makeItem({ is_read: true });
-    const onReflect = jest.fn() as any;
+    const onReflect = jest.fn();
     const { getByTestId, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} onReflect={onReflect} />,
     );
@@ -186,7 +186,7 @@ describe('ContentViewer', () => {
   });
 
   it('surfaces a retry UI when the content body fails to load', async () => {
-    mockContentBody.mockRejectedValueOnce({ detail: 'cms_unavailable' });
+    courseApi.contentBody.mockRejectedValueOnce({ detail: 'cms_unavailable' });
     const item = makeItem();
     const { findByTestId, getByText } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
@@ -194,18 +194,18 @@ describe('ContentViewer', () => {
     await findByTestId('reader-error');
     expect(getByText(/temporarily unreachable/i)).toBeTruthy();
 
-    mockContentBody.mockResolvedValueOnce({
+    courseApi.contentBody.mockResolvedValueOnce({
       url: 'https://aptitude.guru/course/beige-1',
       title: 'Chapter One',
       body_html: '<article>retry worked</article>',
     });
     fireEvent.press(await findByTestId('reader-retry-button'));
     const webview = await findByTestId('reader-webview');
-    expect(webview.props['data-source-html']).toContain('retry worked');
+    expect(String(webview.props['data-source-html'])).toContain('retry worked');
   });
 
   it('shows a server-config message when the CMS auth detail comes back', async () => {
-    mockContentBody.mockRejectedValueOnce({ detail: 'cms_auth_failed' });
+    courseApi.contentBody.mockRejectedValueOnce({ detail: 'cms_auth_failed' });
     const item = makeItem();
     const { findByText } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,

--- a/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
+++ b/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-env jest */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { Linking } from 'react-native';
 
 import type { ContentItem } from '../../../api';
 
@@ -12,9 +11,16 @@ const mockMarkRead = (jest.fn() as any).mockResolvedValue({
   completed_at: '2026-01-15T10:00:00Z',
 });
 
+const mockContentBody = (jest.fn() as any).mockResolvedValue({
+  url: 'https://aptitude.guru/course/beige-1',
+  title: 'Chapter One',
+  body_html: '<article><h1>Chapter One</h1><p>Hi.</p></article>',
+});
+
 jest.mock('../../../api', () => ({
   course: {
     markRead: (...args: unknown[]) => mockMarkRead(...args),
+    contentBody: (...args: unknown[]) => mockContentBody(...args),
   },
 }));
 
@@ -25,9 +31,9 @@ const ContentViewer = require('../ContentViewer').default;
 const makeItem = (overrides: Partial<ContentItem> = {}): ContentItem => ({
   id: 1,
   title: 'Test Article',
-  content_type: 'essay',
+  content_type: 'chapter',
   release_day: 0,
-  url: 'https://example.com/article',
+  url: 'https://aptitude.guru/course/beige-1',
   is_locked: false,
   is_read: false,
   ...overrides,
@@ -47,43 +53,57 @@ describe('ContentViewer', () => {
       content_id: 1,
       completed_at: '2026-01-15T10:00:00Z',
     });
+    mockContentBody.mockResolvedValue({
+      url: 'https://aptitude.guru/course/beige-1',
+      title: 'Chapter One',
+      body_html: '<article><h1>Chapter One</h1><p>Hi.</p></article>',
+    });
   });
 
-  it('renders the content title', () => {
-    const item = makeItem();
-    const { getByText } = render(
+  it('renders the content title initially, then swaps to the live title', async () => {
+    const item = makeItem({ title: 'Loading Title' });
+    const { getByText, findByText } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
     );
-    expect(getByText('Test Article')).toBeTruthy();
+    expect(getByText('Loading Title')).toBeTruthy();
+    await findByText('Chapter One');
   });
 
-  it('calls onBack when back button is pressed', () => {
+  it('fetches the content body via the API', async () => {
     const item = makeItem();
-    const { getByTestId } = render(
+    render(<ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />);
+    await waitFor(() => {
+      expect(mockContentBody).toHaveBeenCalledWith(item.id);
+    });
+  });
+
+  it('renders the cleaned HTML inside a WebView', async () => {
+    const item = makeItem();
+    const { findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
     );
-    fireEvent.press(getByTestId('viewer-back-button'));
+    const webview = await findByTestId('reader-webview');
+    expect(webview.props['data-source-html']).toContain('<article>');
+    expect(webview.props['data-source-html']).toContain('Chapter One');
+  });
+
+  it('calls onBack when back button is pressed', async () => {
+    const item = makeItem();
+    const { getByTestId, findByTestId } = render(
+      <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
+    );
+    // Wait until the load settles so we don't hit "state update on unmounted".
+    await findByTestId('reader-webview');
+    fireEvent.press(getByTestId('reader-back-button'));
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 
-  it('opens URL when open in browser is pressed', () => {
-    const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as any);
-    const item = makeItem({ url: 'https://example.com/test' });
-    const { getByTestId } = render(
-      <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
-    );
-
-    fireEvent.press(getByTestId('open-url-button'));
-    expect(openURLSpy).toHaveBeenCalledWith('https://example.com/test');
-    openURLSpy.mockRestore();
-  });
-
-  it('marks content as read when button is pressed', async () => {
+  it('marks content as read when the button is pressed', async () => {
     const item = makeItem();
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, findByText } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
     );
-
+    await findByText('Chapter One');
     expect(getByText('Mark as Read')).toBeTruthy();
 
     await act(async () => {
@@ -97,42 +117,43 @@ describe('ContentViewer', () => {
     });
   });
 
-  it('shows already read state when item is pre-read', () => {
+  it('shows already-read state when item is pre-read', async () => {
     const item = makeItem({ is_read: true });
-    const { getByText } = render(
+    const { getByText, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
     );
+    await findByTestId('reader-webview');
     expect(getByText('✓ Read')).toBeTruthy();
   });
 
-  it('disables mark-read button when already read', () => {
+  it('disables mark-read when already read', async () => {
     const item = makeItem({ is_read: true });
-    const { getByTestId } = render(
+    const { getByTestId, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
     );
-
+    await findByTestId('reader-webview');
     fireEvent.press(getByTestId('mark-read-button'));
     expect(mockMarkRead).not.toHaveBeenCalled();
   });
 
-  it('shows reflect button when item has been read', () => {
+  it('shows the reflect button when the item is read', async () => {
     const item = makeItem({ is_read: true });
     const onReflect = jest.fn() as any;
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} onReflect={onReflect} />,
     );
+    await findByTestId('reader-webview');
     expect(getByTestId('reflect-button')).toBeTruthy();
     expect(getByText('Reflect in Journal')).toBeTruthy();
   });
 
-  it('shows reflect button after marking content as read', async () => {
+  it('shows the reflect button after marking content as read', async () => {
     const item = makeItem({ is_read: false });
     const onReflect = jest.fn() as any;
-    const { getByTestId, queryByTestId } = render(
+    const { getByTestId, queryByTestId, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} onReflect={onReflect} />,
     );
-
-    // Initially no reflect button
+    await findByTestId('reader-webview');
     expect(queryByTestId('reflect-button')).toBeNull();
 
     await act(async () => {
@@ -144,58 +165,51 @@ describe('ContentViewer', () => {
     });
   });
 
-  it('calls onReflect when reflect button is pressed', () => {
+  it('calls onReflect when the reflect button is pressed', async () => {
     const item = makeItem({ is_read: true });
     const onReflect = jest.fn() as any;
-    const { getByTestId } = render(
+    const { getByTestId, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} onReflect={onReflect} />,
     );
-
+    await findByTestId('reader-webview');
     fireEvent.press(getByTestId('reflect-button'));
     expect(onReflect).toHaveBeenCalledTimes(1);
   });
 
-  it('does not render reflect button when onReflect is not provided', () => {
+  it('omits the reflect button when no callback is provided', async () => {
     const item = makeItem({ is_read: true });
-    const { queryByTestId } = render(
+    const { queryByTestId, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
     );
+    await findByTestId('reader-webview');
     expect(queryByTestId('reflect-button')).toBeNull();
   });
 
-  it('does not open javascript: URLs', () => {
-    const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as any);
-    const item = makeItem({ url: 'javascript:alert(1)' });
-    const { getByTestId } = render(
+  it('surfaces a retry UI when the content body fails to load', async () => {
+    mockContentBody.mockRejectedValueOnce({ detail: 'cms_unavailable' });
+    const item = makeItem();
+    const { findByTestId, getByText } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
     );
+    await findByTestId('reader-error');
+    expect(getByText(/temporarily unreachable/i)).toBeTruthy();
 
-    fireEvent.press(getByTestId('open-url-button'));
-    expect(openURLSpy).not.toHaveBeenCalled();
-    openURLSpy.mockRestore();
+    mockContentBody.mockResolvedValueOnce({
+      url: 'https://aptitude.guru/course/beige-1',
+      title: 'Chapter One',
+      body_html: '<article>retry worked</article>',
+    });
+    fireEvent.press(await findByTestId('reader-retry-button'));
+    const webview = await findByTestId('reader-webview');
+    expect(webview.props['data-source-html']).toContain('retry worked');
   });
 
-  it('does not open tel: URLs', () => {
-    const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as any);
-    const item = makeItem({ url: 'tel:+1234567890' });
-    const { getByTestId } = render(
+  it('shows a server-config message when the CMS auth detail comes back', async () => {
+    mockContentBody.mockRejectedValueOnce({ detail: 'cms_auth_failed' });
+    const item = makeItem();
+    const { findByText } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
     );
-
-    fireEvent.press(getByTestId('open-url-button'));
-    expect(openURLSpy).not.toHaveBeenCalled();
-    openURLSpy.mockRestore();
-  });
-
-  it('does not open file: URLs', () => {
-    const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as any);
-    const item = makeItem({ url: 'file:///etc/passwd' });
-    const { getByTestId } = render(
-      <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
-    );
-
-    fireEvent.press(getByTestId('open-url-button'));
-    expect(openURLSpy).not.toHaveBeenCalled();
-    openURLSpy.mockRestore();
+    await findByText(/site password is not set/i);
   });
 });

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -84,6 +84,30 @@ const mockMarkRead = (jest.fn() as any).mockResolvedValue({
   content_id: 1,
   completed_at: '2026-01-15T10:00:00Z',
 });
+const mockSiteResources = (jest.fn() as any).mockResolvedValue([
+  {
+    slug: 'philosophy',
+    title: 'Philosophy',
+    description: '',
+    url: 'https://aptitude.guru/philosophy',
+  },
+  {
+    slug: 'about',
+    title: 'About',
+    description: '',
+    url: 'https://aptitude.guru/about',
+  },
+]);
+const mockContentBody = (jest.fn() as any).mockResolvedValue({
+  url: 'https://aptitude.guru/course/beige-1',
+  title: 'Chapter One',
+  body_html: '<article>x</article>',
+});
+const mockSiteResourceBody = (jest.fn() as any).mockResolvedValue({
+  url: 'https://aptitude.guru/philosophy',
+  title: 'Philosophy',
+  body_html: '<article>philosophy</article>',
+});
 
 jest.mock('../../../api', () => ({
   stages: {
@@ -93,6 +117,9 @@ jest.mock('../../../api', () => ({
     stageContent: (...args: unknown[]) => mockStageContent(...args),
     stageProgress: (...args: unknown[]) => mockStageProgress(...args),
     markRead: (...args: unknown[]) => mockMarkRead(...args),
+    contentBody: (...args: unknown[]) => mockContentBody(...args),
+    siteResources: (...args: unknown[]) => mockSiteResources(...args),
+    siteResourceBody: (...args: unknown[]) => mockSiteResourceBody(...args),
   },
 }));
 
@@ -211,7 +238,7 @@ describe('CourseScreen', () => {
     });
 
     await waitFor(() => {
-      expect(getByTestId('content-viewer')).toBeTruthy();
+      expect(getByTestId('chapter-reader')).toBeTruthy();
     });
   });
 
@@ -226,7 +253,7 @@ describe('CourseScreen', () => {
       fireEvent.press(getByTestId('content-card-2'));
     });
 
-    expect(queryByTestId('content-viewer')).toBeNull();
+    expect(queryByTestId('chapter-reader')).toBeNull();
   });
 
   it('returns from content viewer when back is pressed', async () => {
@@ -242,16 +269,16 @@ describe('CourseScreen', () => {
     });
 
     await waitFor(() => {
-      expect(getByTestId('content-viewer')).toBeTruthy();
+      expect(getByTestId('chapter-reader')).toBeTruthy();
     });
 
     // Go back
     await act(async () => {
-      fireEvent.press(getByTestId('viewer-back-button'));
+      fireEvent.press(getByTestId('reader-back-button'));
     });
 
     await waitFor(() => {
-      expect(queryByTestId('content-viewer')).toBeNull();
+      expect(queryByTestId('chapter-reader')).toBeNull();
       expect(getByTestId('content-list')).toBeTruthy();
     });
   });
@@ -292,7 +319,7 @@ describe('CourseScreen', () => {
     });
 
     await waitFor(() => {
-      expect(getByTestId('content-viewer')).toBeTruthy();
+      expect(getByTestId('chapter-reader')).toBeTruthy();
     });
 
     // Press reflect button

--- a/frontend/src/features/Course/__tests__/SiteResourcesPanel.test.tsx
+++ b/frontend/src/features/Course/__tests__/SiteResourcesPanel.test.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+const mockSiteResources = (jest.fn() as any).mockResolvedValue([
+  {
+    slug: 'philosophy',
+    title: 'Philosophy',
+    description: '',
+    url: 'https://aptitude.guru/philosophy',
+  },
+  { slug: 'about', title: 'About', description: '', url: 'https://aptitude.guru/about' },
+]);
+
+jest.mock('../../../api', () => ({
+  course: {
+    siteResources: (...args: unknown[]) => mockSiteResources(...args),
+  },
+}));
+
+// eslint-disable-next-line import/order
+const { render, fireEvent, waitFor } = require('@testing-library/react-native');
+const SiteResourcesPanel = require('../SiteResourcesPanel').default;
+
+describe('SiteResourcesPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSiteResources.mockResolvedValue([
+      {
+        slug: 'philosophy',
+        title: 'Philosophy',
+        description: '',
+        url: 'https://aptitude.guru/philosophy',
+      },
+      { slug: 'about', title: 'About', description: '', url: 'https://aptitude.guru/about' },
+    ]);
+  });
+
+  it('renders nothing while loading', () => {
+    mockSiteResources.mockReturnValueOnce(new Promise(() => {}));
+    const onSelect = jest.fn() as any;
+    const { queryByTestId } = render(<SiteResourcesPanel onSelect={onSelect} />);
+    expect(queryByTestId('site-resources-panel')).toBeNull();
+  });
+
+  it('renders one chip per configured resource', async () => {
+    const onSelect = jest.fn() as any;
+    const { findByTestId, getByText } = render(<SiteResourcesPanel onSelect={onSelect} />);
+    await findByTestId('site-resources-panel');
+    expect(getByText('Philosophy')).toBeTruthy();
+    expect(getByText('About')).toBeTruthy();
+  });
+
+  it('passes the resource back to onSelect when a chip is pressed', async () => {
+    const onSelect = jest.fn() as any;
+    const { findByTestId } = render(<SiteResourcesPanel onSelect={onSelect} />);
+    const chip = await findByTestId('site-resource-chip-philosophy');
+    fireEvent.press(chip);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'philosophy', title: 'Philosophy' }),
+    );
+  });
+
+  it('stays silent (no panel) when the API call rejects', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockSiteResources.mockRejectedValueOnce(new Error('nope'));
+    const onSelect = jest.fn() as any;
+    const { queryByTestId } = render(<SiteResourcesPanel onSelect={onSelect} />);
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalled();
+    });
+    expect(queryByTestId('site-resources-panel')).toBeNull();
+    warn.mockRestore();
+  });
+
+  it('hides the panel entirely when the resource list is empty', async () => {
+    mockSiteResources.mockResolvedValueOnce([]);
+    const onSelect = jest.fn() as any;
+    const { queryByTestId } = render(<SiteResourcesPanel onSelect={onSelect} />);
+    await waitFor(() => {
+      expect(mockSiteResources).toHaveBeenCalled();
+    });
+    expect(queryByTestId('site-resources-panel')).toBeNull();
+  });
+});

--- a/frontend/src/features/Course/__tests__/SiteResourcesPanel.test.tsx
+++ b/frontend/src/features/Course/__tests__/SiteResourcesPanel.test.tsx
@@ -1,58 +1,57 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-env jest */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
 
-const mockSiteResources = (jest.fn() as any).mockResolvedValue([
+import type * as Api from '../../../api';
+import SiteResourcesPanel from '../SiteResourcesPanel';
+
+jest.mock('../../../api', () => ({
+  course: {
+    siteResources: jest.fn(),
+  },
+}));
+
+const { course: courseApi } = jest.requireMock('../../../api') as {
+  course: { siteResources: jest.MockedFunction<typeof Api.course.siteResources> };
+};
+
+const SAMPLE = [
   {
     slug: 'philosophy',
     title: 'Philosophy',
     description: '',
     url: 'https://aptitude.guru/philosophy',
   },
-  { slug: 'about', title: 'About', description: '', url: 'https://aptitude.guru/about' },
-]);
-
-jest.mock('../../../api', () => ({
-  course: {
-    siteResources: (...args: unknown[]) => mockSiteResources(...args),
+  {
+    slug: 'about',
+    title: 'About',
+    description: '',
+    url: 'https://aptitude.guru/about',
   },
-}));
-
-// eslint-disable-next-line import/order
-const { render, fireEvent, waitFor } = require('@testing-library/react-native');
-const SiteResourcesPanel = require('../SiteResourcesPanel').default;
+];
 
 describe('SiteResourcesPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSiteResources.mockResolvedValue([
-      {
-        slug: 'philosophy',
-        title: 'Philosophy',
-        description: '',
-        url: 'https://aptitude.guru/philosophy',
-      },
-      { slug: 'about', title: 'About', description: '', url: 'https://aptitude.guru/about' },
-    ]);
+    courseApi.siteResources.mockResolvedValue(SAMPLE);
   });
 
   it('renders nothing while loading', () => {
-    mockSiteResources.mockReturnValueOnce(new Promise(() => {}));
-    const onSelect = jest.fn() as any;
-    const { queryByTestId } = render(<SiteResourcesPanel onSelect={onSelect} />);
+    courseApi.siteResources.mockReturnValueOnce(new Promise(() => undefined));
+    const { queryByTestId } = render(<SiteResourcesPanel onSelect={jest.fn()} />);
     expect(queryByTestId('site-resources-panel')).toBeNull();
   });
 
   it('renders one chip per configured resource', async () => {
-    const onSelect = jest.fn() as any;
-    const { findByTestId, getByText } = render(<SiteResourcesPanel onSelect={onSelect} />);
+    const { findByTestId, getByText } = render(<SiteResourcesPanel onSelect={jest.fn()} />);
     await findByTestId('site-resources-panel');
     expect(getByText('Philosophy')).toBeTruthy();
     expect(getByText('About')).toBeTruthy();
   });
 
   it('passes the resource back to onSelect when a chip is pressed', async () => {
-    const onSelect = jest.fn() as any;
+    const onSelect = jest.fn();
     const { findByTestId } = render(<SiteResourcesPanel onSelect={onSelect} />);
     const chip = await findByTestId('site-resource-chip-philosophy');
     fireEvent.press(chip);
@@ -63,9 +62,8 @@ describe('SiteResourcesPanel', () => {
 
   it('stays silent (no panel) when the API call rejects', async () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-    mockSiteResources.mockRejectedValueOnce(new Error('nope'));
-    const onSelect = jest.fn() as any;
-    const { queryByTestId } = render(<SiteResourcesPanel onSelect={onSelect} />);
+    courseApi.siteResources.mockRejectedValueOnce(new Error('nope'));
+    const { queryByTestId } = render(<SiteResourcesPanel onSelect={jest.fn()} />);
     await waitFor(() => {
       expect(warn).toHaveBeenCalled();
     });
@@ -74,11 +72,10 @@ describe('SiteResourcesPanel', () => {
   });
 
   it('hides the panel entirely when the resource list is empty', async () => {
-    mockSiteResources.mockResolvedValueOnce([]);
-    const onSelect = jest.fn() as any;
-    const { queryByTestId } = render(<SiteResourcesPanel onSelect={onSelect} />);
+    courseApi.siteResources.mockResolvedValueOnce([]);
+    const { queryByTestId } = render(<SiteResourcesPanel onSelect={jest.fn()} />);
     await waitFor(() => {
-      expect(mockSiteResources).toHaveBeenCalled();
+      expect(courseApi.siteResources).toHaveBeenCalled();
     });
     expect(queryByTestId('site-resources-panel')).toBeNull();
   });


### PR DESCRIPTION
Pull every chapter and resource page from https://aptitude.guru into the
app instead of linking out to the browser:

* New SquarespaceClient (backend/src/services/squarespace.py) handles
  site-password auth, cookie persistence, in-memory caching, and
  cleaning the Squarespace chrome off article HTML.
* Declarative content_config.py is the single source of truth for
  chapter plans (Beige -> 14 daily-released chapters) and the always-
  available "From Aptitude Guru" links (Philosophy, About, Course
  overview).  seed_content.py now reconciles StageContent rows from
  this config and updates URLs in place when chapters move.
* New endpoints: GET /course/content/{id}/body, GET /course/site-resources,
  GET /course/site-resources/{slug}/body -- all auth-required, all gated
  on the existing drip-feed unlock logic for chapter bodies.
* Frontend ChapterReader renders cleaned HTML inside a WebView with
  mobile-first typography; ContentViewer reuses it instead of linking
  out via Linking.openURL.  SiteResourcesPanel surfaces the configured
  links above the stage metadata on the Course screen.
* Backend env var SQUARESPACE_SITE_PASSWORD holds the site password
  (frontend never sees it).  Errors surface as 503 cms_auth_failed
  (config) or 502 cms_unavailable (transient).

docs/content.md documents how to add, remove, and rearrange content
without writing code.

Tests: 35 new backend tests (service + endpoints + seeder) and 19 new
frontend tests (ChapterReader + SiteResourcesPanel + reshaped
ContentViewer / CourseScreen).  Full backend suite: 1126 passed,
coverage 94%.  Full frontend suite: 1348 passed.

https://claude.ai/code/session_01GRZXVdTjpqWXw4rrAK72pa