### PR TITLE
fix(frontend-habits): position-based stage display + web date picker

### DIFF
--- a/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
+++ b/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
@@ -3,6 +3,7 @@ import type { ComponentType } from 'react';
 import { Modal, Platform, Text, TouchableOpacity, View } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 
+import { parseISODate, toISODate } from '../../../components/DatePicker';
 import { STAGE_COLORS } from '../../../design/tokens';
 import { useProgramStore } from '../../../store/useProgramStore';
 import styles from '../Habits.styles';
@@ -28,46 +29,96 @@ const updateStartDates = (habits: Habit[], startDate: Date): Habit[] =>
     start_date: calculateHabitStartDate(startDate, index),
   }));
 
+/** The displayed stage in the reorder modal comes from list position so the
+ *  color reconfigures live as the user drags, matching how
+ *  ``HabitsScreen`` paints tile borders (BUG-FE-HABIT — position-based,
+ *  not the stored ``habit.stage`` field). */
+const stageAtPosition = (index: number): string =>
+  STAGE_ORDER[index % STAGE_ORDER.length] ?? 'Clear Light';
+
 interface ReorderItemProps {
   item: Habit;
+  index: number;
   drag: () => void;
   isActive: boolean;
 }
 
-const ReorderHabitItem = ({ item, drag, isActive }: ReorderItemProps) => (
-  <TouchableOpacity
-    onLongPress={drag}
-    disabled={isActive}
-    style={[
-      styles.reorderItem,
-      isActive && styles.reorderItemActive,
-      { borderLeftColor: STAGE_COLORS[item.stage] || '#ccc', borderLeftWidth: 4 },
-    ]}
-  >
-    <View style={styles.reorderItemContent}>
-      <Text style={styles.reorderItemText}>
-        {item.icon} {item.name} ({item.stage})
-      </Text>
-      <Text style={styles.reorderItemDate}>{formatDate(new Date(item.start_date))}</Text>
-    </View>
-  </TouchableOpacity>
-);
+const ReorderHabitItem = ({ item, index, drag, isActive }: ReorderItemProps) => {
+  const stage = stageAtPosition(index);
+  const color = STAGE_COLORS[stage] ?? '#ccc';
+  return (
+    <TouchableOpacity
+      onLongPress={drag}
+      disabled={isActive}
+      style={[
+        styles.reorderItem,
+        isActive && styles.reorderItemActive,
+        { borderLeftColor: color, borderLeftWidth: 4 },
+      ]}
+    >
+      <View style={styles.reorderItemContent}>
+        <Text style={styles.reorderItemText}>
+          {item.icon} {item.name} ({stage})
+        </Text>
+        <Text style={styles.reorderItemDate}>{formatDate(new Date(item.start_date))}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
 
 interface ReorderDateButtonProps {
   startDate: Date;
   onOpenPicker: () => void;
+  onSelectDate: (_date: Date) => void;
 }
 
-const ReorderDateButton = ({ startDate, onOpenPicker }: ReorderDateButtonProps) => (
+// ``react-native-modal-datetime-picker`` is a no-op on web, so on the
+// browser app we render an HTML ``<input type="date">`` overlaid on the
+// button.  Tapping the button opens the OS's native date picker.
+const WebDateButton = ({
+  startDate,
+  onSelectDate,
+}: Pick<ReorderDateButtonProps, 'startDate' | 'onSelectDate'>) => (
+  <View style={[styles.datePickerButton, { position: 'relative' }]} testID="reorder-start-date">
+    <Text style={styles.datePickerButtonText}>{formatDate(startDate)}</Text>
+    <input
+      aria-label="First habit start date"
+      data-testid="reorder-start-date-input"
+      type="date"
+      value={toISODate(startDate)}
+      onChange={(e) => {
+        if (e.target.value) onSelectDate(parseISODate(e.target.value));
+      }}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        opacity: 0,
+        cursor: 'pointer',
+        border: 0,
+        padding: 0,
+        margin: 0,
+      }}
+    />
+  </View>
+);
+
+const ReorderDateButton = ({ startDate, onOpenPicker, onSelectDate }: ReorderDateButtonProps) => (
   <View style={styles.datePickerContainer}>
     <Text style={styles.datePickerLabel}>First Habit Start Date:</Text>
-    <TouchableOpacity
-      testID="reorder-start-date"
-      style={styles.datePickerButton}
-      onPress={onOpenPicker}
-    >
-      <Text style={styles.datePickerButtonText}>{formatDate(startDate)}</Text>
-    </TouchableOpacity>
+    {Platform.OS === 'web' ? (
+      <WebDateButton startDate={startDate} onSelectDate={onSelectDate} />
+    ) : (
+      <TouchableOpacity
+        testID="reorder-start-date"
+        style={styles.datePickerButton}
+        onPress={onOpenPicker}
+      >
+        <Text style={styles.datePickerButtonText}>{formatDate(startDate)}</Text>
+      </TouchableOpacity>
+    )}
   </View>
 );
 
@@ -82,8 +133,8 @@ const ReorderList = ({ orderedHabits, onDragEnd }: ReorderListProps) => (
       style={{ flex: 1 }}
       data={orderedHabits}
       keyExtractor={(item) => (item.id ? item.id.toString() : item.name)}
-      renderItem={({ item, drag, isActive }) => (
-        <ReorderHabitItem item={item} drag={drag} isActive={isActive} />
+      renderItem={({ item, drag, isActive, getIndex }) => (
+        <ReorderHabitItem item={item} index={getIndex() ?? 0} drag={drag} isActive={isActive} />
       )}
       onDragEnd={onDragEnd}
     />
@@ -135,14 +186,17 @@ const useReorderState = ({
 
   // BUG-FE-HABIT-204: only seed the ordered list on the open transition;
   // re-firing on every startDate change clobbered manual drags.
+  // Preserve the order the parent passed in -- the API already sorts
+  // ascending by ``sort_order``, which is the order the main screen
+  // shows.  Re-sorting by ``STAGE_ORDER.indexOf(item.stage)`` here was
+  // shoving newly-added habits (whose stored ``stage`` was assigned by
+  // total count, not list position) to the bottom even though the main
+  // screen had them at the top.
   useEffect(() => {
     const justOpened = visible && !wasVisibleRef.current;
     wasVisibleRef.current = visible;
     if (!justOpened || habits.length === 0) return;
-    const sortedHabits = [...habits].sort(
-      (a, b) => STAGE_ORDER.indexOf(a.stage) - STAGE_ORDER.indexOf(b.stage),
-    );
-    setOrderedHabits(updateStartDates(sortedHabits, startDate));
+    setOrderedHabits(updateStartDates(habits, startDate));
   }, [visible, habits, startDate]);
 
   return {
@@ -171,6 +225,7 @@ interface ReorderBodyProps {
   orderedHabits: Habit[];
   startDate: Date;
   onOpenPicker: () => void;
+  onSelectDate: (_d: Date) => void;
   onDragEnd: (_a: { data: Habit[] }) => void;
   onSave: () => void;
 }
@@ -180,6 +235,7 @@ const ReorderBody = ({
   orderedHabits,
   startDate,
   onOpenPicker,
+  onSelectDate,
   onDragEnd,
   onSave,
 }: ReorderBodyProps) => (
@@ -190,7 +246,11 @@ const ReorderBody = ({
         <Text style={styles.closeButtonText}>×</Text>
       </TouchableOpacity>
     </View>
-    <ReorderDateButton startDate={startDate} onOpenPicker={onOpenPicker} />
+    <ReorderDateButton
+      startDate={startDate}
+      onOpenPicker={onOpenPicker}
+      onSelectDate={onSelectDate}
+    />
     <Text style={styles.reorderInstructions}>
       Drag habits to reorder. Habits 1-8 start 21 days apart, habits 9-10 start 42 days apart.
     </Text>
@@ -218,6 +278,7 @@ export const ReorderHabitsModal = ({
             orderedHabits={state.orderedHabits}
             startDate={state.startDate}
             onOpenPicker={() => state.setPickerVisible(true)}
+            onSelectDate={state.handleConfirmDate}
             onDragEnd={state.handleDragEnd}
             onSave={state.handleSave}
           />

--- a/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
+++ b/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
@@ -29,10 +29,7 @@ const updateStartDates = (habits: Habit[], startDate: Date): Habit[] =>
     start_date: calculateHabitStartDate(startDate, index),
   }));
 
-/** The displayed stage in the reorder modal comes from list position so the
- *  color reconfigures live as the user drags, matching how
- *  ``HabitsScreen`` paints tile borders (BUG-FE-HABIT — position-based,
- *  not the stored ``habit.stage`` field). */
+/** Stage at this position; matches HabitsScreen's index-based coloring. */
 const stageAtPosition = (index: number): string =>
   STAGE_ORDER[index % STAGE_ORDER.length] ?? 'Clear Light';
 
@@ -72,9 +69,7 @@ interface ReorderDateButtonProps {
   onSelectDate: (_date: Date) => void;
 }
 
-// ``react-native-modal-datetime-picker`` is a no-op on web, so on the
-// browser app we render an HTML ``<input type="date">`` overlaid on the
-// button.  Tapping the button opens the OS's native date picker.
+// Web fallback: react-native-modal-datetime-picker is a no-op on web.
 const WebDateButton = ({
   startDate,
   onSelectDate,
@@ -184,14 +179,7 @@ const useReorderState = ({
     if (!visible) setPickerVisible(false);
   }, [visible]);
 
-  // BUG-FE-HABIT-204: only seed the ordered list on the open transition;
-  // re-firing on every startDate change clobbered manual drags.
-  // Preserve the order the parent passed in -- the API already sorts
-  // ascending by ``sort_order``, which is the order the main screen
-  // shows.  Re-sorting by ``STAGE_ORDER.indexOf(item.stage)`` here was
-  // shoving newly-added habits (whose stored ``stage`` was assigned by
-  // total count, not list position) to the bottom even though the main
-  // screen had them at the top.
+  // Seed only on the open transition; preserve parent order (sort_order).
   useEffect(() => {
     const justOpened = visible && !wasVisibleRef.current;
     wasVisibleRef.current = visible;

--- a/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
@@ -293,18 +293,8 @@ describe('ReorderHabitsModal — save flow', () => {
 });
 
 describe('ReorderHabitsModal — stage is derived from list position, not stored field', () => {
-  // Stage label/color used to come from ``item.stage`` -- that's the
-  // value stamped by ``habitManager.addHabit`` when the user adds a
-  // habit *after* energy scaffolding (e.g. "skincare" → "Yellow").  The
-  // main HabitsScreen paints by position
-  // (``STAGE_ORDER[index % STAGE_ORDER.length]``); the reorder modal
-  // must agree, otherwise drag-to-reorder doesn't visibly recolor and
-  // the label in parens diverges from the tile color the user sees on
-  // the main screen.
-
   it('labels the parentheses by list position, ignoring item.stage', () => {
-    // Stages stored on the items deliberately disagree with the
-    // positional order so the assertion proves the source of truth.
+    // Stored stages deliberately disagree with positional order.
     const habits: Habit[] = [
       makeHabit(1, 'Yellow', 'first'),
       makeHabit(2, '', 'second'),
@@ -321,10 +311,6 @@ describe('ReorderHabitsModal — stage is derived from list position, not stored
   });
 
   it('does not re-sort by item.stage on open — uses the order the parent passed in', () => {
-    // The user's main screen shows habits ordered by ``sort_order``.
-    // Re-sorting on open by ``STAGE_ORDER.indexOf(item.stage)`` was
-    // shoving "skincare" (stored stage "Yellow") to the bottom even
-    // though the main screen had it at the top.
     const habits: Habit[] = [
       makeHabit(7, 'Yellow', 'skincare'), // stored 7th-color, but listed first
       makeHabit(1, 'Beige', 'journal'),
@@ -349,8 +335,6 @@ describe('ReorderHabitsModal — stage is derived from list position, not stored
       <ReorderHabitsModal visible habits={habits} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
     );
 
-    // Drag the third row to the top.  It must now read "(Beige)" --
-    // the colour the main screen would paint at index 0.
     const list = result.getByTestId('reorder-list');
     act(() => {
       list.props.onDragEnd({ data: [habits[2], habits[0], habits[1]] });
@@ -363,12 +347,6 @@ describe('ReorderHabitsModal — stage is derived from list position, not stored
 });
 
 describe('ReorderHabitsModal — date picker on web', () => {
-  // ``react-native-modal-datetime-picker`` is a no-op on web, so the
-  // user had no way to change the program start date from the
-  // ``app.aptitude.guru`` browser app.  The reorder modal must render
-  // an HTML ``<input type="date">`` on web so the OS-native picker
-  // opens on tap, mirroring the pattern in ``components/DatePicker``.
-
   const Platform = require('react-native').Platform as { OS: string };
   let originalOS: string;
   beforeEach(() => {
@@ -384,8 +362,6 @@ describe('ReorderHabitsModal — date picker on web', () => {
       <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
     );
 
-    // The native picker testID is replaced on web; the HTML <input>
-    // we render is what intercepts the tap on the visible button.
     const input = result.UNSAFE_root.findByProps({ type: 'date' });
     expect(input).toBeTruthy();
     expect(input.props['aria-label']).toBe('First habit start date');

--- a/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 // Regression tests for the three reorder-modal bugs: drag freeze, picker dismissal, and the iOS sibling-mount.
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 import { fireEvent, render, act, within } from '@testing-library/react-native';
 import React from 'react';
 
@@ -289,5 +289,114 @@ describe('ReorderHabitsModal — save flow', () => {
     const saved = onSave.mock.calls[0]![0] as Habit[];
     expect(saved.map((h) => h.id)).toEqual([2, 3, 1]);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ReorderHabitsModal — stage is derived from list position, not stored field', () => {
+  // Stage label/color used to come from ``item.stage`` -- that's the
+  // value stamped by ``habitManager.addHabit`` when the user adds a
+  // habit *after* energy scaffolding (e.g. "skincare" → "Yellow").  The
+  // main HabitsScreen paints by position
+  // (``STAGE_ORDER[index % STAGE_ORDER.length]``); the reorder modal
+  // must agree, otherwise drag-to-reorder doesn't visibly recolor and
+  // the label in parens diverges from the tile color the user sees on
+  // the main screen.
+
+  it('labels the parentheses by list position, ignoring item.stage', () => {
+    // Stages stored on the items deliberately disagree with the
+    // positional order so the assertion proves the source of truth.
+    const habits: Habit[] = [
+      makeHabit(1, 'Yellow', 'first'),
+      makeHabit(2, '', 'second'),
+      makeHabit(3, 'Clear Light', 'third'),
+    ];
+
+    const result = render(
+      <ReorderHabitsModal visible habits={habits} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    expect(result.queryByText('⭐ first (Beige)')).toBeTruthy();
+    expect(result.queryByText('⭐ second (Purple)')).toBeTruthy();
+    expect(result.queryByText('⭐ third (Red)')).toBeTruthy();
+  });
+
+  it('does not re-sort by item.stage on open — uses the order the parent passed in', () => {
+    // The user's main screen shows habits ordered by ``sort_order``.
+    // Re-sorting on open by ``STAGE_ORDER.indexOf(item.stage)`` was
+    // shoving "skincare" (stored stage "Yellow") to the bottom even
+    // though the main screen had it at the top.
+    const habits: Habit[] = [
+      makeHabit(7, 'Yellow', 'skincare'), // stored 7th-color, but listed first
+      makeHabit(1, 'Beige', 'journal'),
+      makeHabit(2, 'Purple', 'fitness'),
+    ];
+
+    const result = render(
+      <ReorderHabitsModal visible habits={habits} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    expect(getOrderedIds(result)).toEqual([7, 1, 2]);
+  });
+
+  it('updates stage labels live as the user drags rows into new positions', () => {
+    const habits: Habit[] = [
+      makeHabit(1, 'Beige', 'a'),
+      makeHabit(2, 'Purple', 'b'),
+      makeHabit(3, 'Red', 'c'),
+    ];
+
+    const result = render(
+      <ReorderHabitsModal visible habits={habits} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    // Drag the third row to the top.  It must now read "(Beige)" --
+    // the colour the main screen would paint at index 0.
+    const list = result.getByTestId('reorder-list');
+    act(() => {
+      list.props.onDragEnd({ data: [habits[2], habits[0], habits[1]] });
+    });
+
+    expect(result.queryByText('⭐ c (Beige)')).toBeTruthy();
+    expect(result.queryByText('⭐ a (Purple)')).toBeTruthy();
+    expect(result.queryByText('⭐ b (Red)')).toBeTruthy();
+  });
+});
+
+describe('ReorderHabitsModal — date picker on web', () => {
+  // ``react-native-modal-datetime-picker`` is a no-op on web, so the
+  // user had no way to change the program start date from the
+  // ``app.aptitude.guru`` browser app.  The reorder modal must render
+  // an HTML ``<input type="date">`` on web so the OS-native picker
+  // opens on tap, mirroring the pattern in ``components/DatePicker``.
+
+  const Platform = require('react-native').Platform as { OS: string };
+  let originalOS: string;
+  beforeEach(() => {
+    originalOS = Platform.OS;
+    Platform.OS = 'web';
+  });
+  afterEach(() => {
+    Platform.OS = originalOS;
+  });
+
+  it('renders an HTML date input on web that updates the master program anchor', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    // The native picker testID is replaced on web; the HTML <input>
+    // we render is what intercepts the tap on the visible button.
+    const input = result.UNSAFE_root.findByProps({ type: 'date' });
+    expect(input).toBeTruthy();
+    expect(input.props['aria-label']).toBe('First habit start date');
+
+    act(() => {
+      input.props.onChange({ target: { value: '2026-09-01' } });
+    });
+
+    const stored = useProgramStore.getState().programStartDate!;
+    expect(stored.getFullYear()).toBe(2026);
+    expect(stored.getMonth()).toBe(8);
+    expect(stored.getDate()).toBe(1);
   });
 });


### PR DESCRIPTION
Reorder modal now agrees with the main habits screen: the stage label in
parens and the row border color both derive from list position
(STAGE_ORDER[index]) rather than the stored habit.stage field. Habits
added after onboarding had stage stamped by total count, which made
"skincare" show "(Yellow)" and sort to the bottom even when the user had
dragged it to the top.

The modal also dropped its on-open re-sort by item.stage so the order
matches what the API returns (ascending by sort_order, the same order
the main screen shows).

On web (app.aptitude.guru), react-native-modal-datetime-picker is a
no-op, so the master program start date was unsettable. The button now
overlays an invisible <input type="date"> that triggers the browser's
native picker, mirroring components/DatePicker. Native iOS/Android path
unchanged.