### PR TITLE
feat(backend): add tallied_grounding practice mode (#337)

### DIFF
--- a/backend/migrations/versions/a1b2c3d4e5f7_add_tallied_grounding_mode.py
+++ b/backend/migrations/versions/a1b2c3d4e5f7_add_tallied_grounding_mode.py
@@ -48,6 +48,12 @@ _ALLOWED_MODES_AFTER_UPGRADE = (
     "tallied_grounding",
 )
 
+# These must be exactly the modes present at the down_revision
+# (``d2e3f4a5b6c7``) — every entry in ``_ALLOWED_MODES_AFTER_UPGRADE``
+# except the one this migration adds. The derivation is mechanical;
+# any future copy-paste of this module must keep that invariant or the
+# downgrade will recreate the CHECK with a different set than callers
+# expect.
 _ALLOWED_MODES_BEFORE_UPGRADE = tuple(
     m for m in _ALLOWED_MODES_AFTER_UPGRADE if m != _NEW_MODE
 )

--- a/backend/migrations/versions/a1b2c3d4e5f7_add_tallied_grounding_mode.py
+++ b/backend/migrations/versions/a1b2c3d4e5f7_add_tallied_grounding_mode.py
@@ -1,0 +1,99 @@
+"""add tallied_grounding to practice.mode CHECK constraint
+
+Revision ID: a1b2c3d4e5f7
+Revises: d2e3f4a5b6c7
+Create Date: 2026-05-16 12:00:00.000000
+
+ritual / grounding-techniques 01:
+
+The original CHECK constraint introduced by ``e9f0a1b2c3d4`` pins
+``practice.mode`` to the seven launch-time modes. Adding
+``tallied_grounding`` to :data:`domain.practice_modes.ALL_MODES` is
+necessary but not sufficient — the database-level CHECK still rejects
+inserts and updates carrying the new value. This migration drops the
+existing CHECK and recreates it listing all eight modes.
+
+``downgrade()`` refuses to run if any ``practice`` row already carries
+``mode='tallied_grounding'``: silently rewriting it would either lose
+data (set it to ``meditation_timer``) or fail the recreated CHECK
+constraint at the next insert. Operators forced to roll back must
+either delete or remap the offending rows first.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f7"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "d2e3f4a5b6c7"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_MODE_CHECK_NAME = "ck_practice_mode_valid"
+_NEW_MODE = "tallied_grounding"
+
+# Intentionally duplicated from ``domain.practice_modes.ALL_MODES`` —
+# migrations must not import application modules so the schema can be
+# replayed on a repo state where the model no longer exists.
+_ALLOWED_MODES_AFTER_UPGRADE = (
+    "meditation_timer",
+    "count_up",
+    "metronome",
+    "interval_bell",
+    "rep_counter",
+    "sense_grounding",
+    "tarot",
+    "tallied_grounding",
+)
+
+_ALLOWED_MODES_BEFORE_UPGRADE = tuple(
+    m for m in _ALLOWED_MODES_AFTER_UPGRADE if m != _NEW_MODE
+)
+
+
+def _recreate_check(allowed_modes: tuple[str, ...]) -> None:
+    """Drop the existing CHECK and recreate it pinning ``mode`` to ``allowed_modes``.
+
+    batch_alter_table groups the drop + create so SQLite (used by the
+    round-trip migration tests) can rebuild the table once instead of
+    twice. Postgres processes the two ops in-place.
+    """
+    quoted = ", ".join(f"'{m}'" for m in allowed_modes)
+    with op.batch_alter_table("practice") as batch_op:
+        batch_op.drop_constraint(_MODE_CHECK_NAME, type_="check")
+        batch_op.create_check_constraint(_MODE_CHECK_NAME, f"mode IN ({quoted})")
+
+
+def upgrade() -> None:
+    """Recreate the CHECK constraint listing ``tallied_grounding`` as a valid mode."""
+    _recreate_check(_ALLOWED_MODES_AFTER_UPGRADE)
+
+
+def downgrade() -> None:
+    """Recreate the original 7-mode CHECK, refusing if ``tallied_grounding`` rows exist.
+
+    Silently rewriting them would lose data; failing the recreated
+    constraint mid-migration would leave the schema in a half-applied
+    state. Surface the conflict so an operator decides.
+    """
+    bind = op.get_bind()
+    practice_t = sa.Table(
+        "practice",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("mode", sa.String(length=32)),
+    )
+    offending = bind.execute(
+        sa.select(sa.func.count())
+        .select_from(practice_t)
+        .where(practice_t.c.mode == _NEW_MODE)
+    ).scalar_one()
+    if offending:
+        msg = (
+            f"Cannot downgrade: {offending} practice row(s) still use "
+            f"mode={_NEW_MODE!r}. Delete or remap them before rolling back."
+        )
+        raise RuntimeError(msg)
+    _recreate_check(_ALLOWED_MODES_BEFORE_UPGRADE)

--- a/backend/src/domain/practice_modes.py
+++ b/backend/src/domain/practice_modes.py
@@ -22,6 +22,7 @@ class PracticeMode(StrEnum):
     REP_COUNTER = "rep_counter"
     SENSE_GROUNDING = "sense_grounding"
     TAROT = "tarot"
+    TALLIED_GROUNDING = "tallied_grounding"
 
 
 #: Ordered tuple of wire values, suitable for CHECK constraints and docs.

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -18,6 +18,15 @@ _DURATION_MIN_MINUTES = 0.5
 _DURATION_MAX_MINUTES = 24 * 60
 _PROMPT_LABEL_MAX = 255
 _UNIT_LABEL_MAX = 64
+_TALLIED_KEY_MAX = 64
+_TALLIED_LABEL_MAX = 255
+_TALLIED_KEY_PATTERN = r"^[a-z][a-z0-9_]*$"
+_TALLIED_TARGET_MIN = 1
+_TALLIED_TARGET_MAX = 20
+_TALLIED_ROUNDS_MIN = 1
+_TALLIED_ROUNDS_MAX = 10
+_TALLIED_CATEGORIES_MIN = 1
+_TALLIED_CATEGORIES_MAX = 12
 
 Sense = Literal["sight", "touch", "hearing", "smell", "taste"]
 BellTone = Literal["bowl", "chime", "gong"]
@@ -131,6 +140,45 @@ class SenseGroundingConfig(_ConfigBase):
     prompts: list[SensePrompt] = Field(min_length=1)
 
 
+class TalliedCategory(_ConfigBase):
+    """One category in a tallied-grounding round (e.g. "shapes", "colors")."""
+
+    key: str = Field(
+        min_length=1,
+        max_length=_TALLIED_KEY_MAX,
+        pattern=_TALLIED_KEY_PATTERN,
+    )
+    label: str = Field(min_length=1, max_length=_TALLIED_LABEL_MAX)
+    target_count: int = Field(ge=_TALLIED_TARGET_MIN, le=_TALLIED_TARGET_MAX)
+
+
+class TalliedGroundingConfig(_ConfigBase):
+    """Rounds-by-categories-by-target-count shape shared by Find Shapes / Find Colors.
+
+    Each round walks every category in order; the user tallies up to
+    ``target_count`` items per category before advancing. ``key`` is the
+    machine slug used for analytics and translation lookups; ``label`` is
+    the display string.
+    """
+
+    mode: Literal["tallied_grounding"] = "tallied_grounding"
+    rounds: int = Field(ge=_TALLIED_ROUNDS_MIN, le=_TALLIED_ROUNDS_MAX)
+    categories: list[TalliedCategory] = Field(
+        min_length=_TALLIED_CATEGORIES_MIN, max_length=_TALLIED_CATEGORIES_MAX
+    )
+
+    @model_validator(mode="after")
+    def _check_unique_category_keys(self) -> Self:
+        """Reject duplicate ``key`` values — analytics rely on uniqueness."""
+        seen: set[str] = set()
+        for category in self.categories:
+            if category.key in seen:
+                msg = f"duplicate category key: {category.key!r}"
+                raise ValueError(msg)
+            seen.add(category.key)
+        return self
+
+
 class TarotConfig(_ConfigBase):
     """Meditate on one major-arcana card per day, rotating through 22."""
 
@@ -148,7 +196,8 @@ ModeConfig = Annotated[
     | IntervalBellConfig
     | RepCounterConfig
     | SenseGroundingConfig
-    | TarotConfig,
+    | TarotConfig
+    | TalliedGroundingConfig,
     Field(discriminator="mode"),
 ]
 

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -21,12 +21,13 @@ _UNIT_LABEL_MAX = 64
 _TALLIED_KEY_MAX = 64
 _TALLIED_LABEL_MAX = 255
 _TALLIED_KEY_PATTERN = r"^[a-z][a-z0-9_]*$"
-_TALLIED_TARGET_MIN = 1
-_TALLIED_TARGET_MAX = 20
-_TALLIED_ROUNDS_MIN = 1
-_TALLIED_ROUNDS_MAX = 10
-_TALLIED_CATEGORIES_MIN = 1
-_TALLIED_CATEGORIES_MAX = 12
+# Public ceilings: imported by ``schemas.practice_session_metadata`` to
+# derive its post-session caps so the two modules cannot silently diverge
+# when these values change. Treat any new ceiling that the metadata
+# module also needs as part of the same public contract.
+TALLIED_TARGET_MAX = 20
+TALLIED_ROUNDS_MAX = 10
+TALLIED_CATEGORIES_MAX = 12
 
 Sense = Literal["sight", "touch", "hearing", "smell", "taste"]
 BellTone = Literal["bowl", "chime", "gong"]
@@ -147,9 +148,13 @@ class TalliedCategory(_ConfigBase):
         min_length=1,
         max_length=_TALLIED_KEY_MAX,
         pattern=_TALLIED_KEY_PATTERN,
+        description=(
+            "Snake-case analytics slug matching ``^[a-z][a-z0-9_]*$`` "
+            "(hyphens and uppercase are rejected)."
+        ),
     )
     label: str = Field(min_length=1, max_length=_TALLIED_LABEL_MAX)
-    target_count: int = Field(ge=_TALLIED_TARGET_MIN, le=_TALLIED_TARGET_MAX)
+    target_count: int = Field(ge=1, le=TALLIED_TARGET_MAX)
 
 
 class TalliedGroundingConfig(_ConfigBase):
@@ -162,10 +167,8 @@ class TalliedGroundingConfig(_ConfigBase):
     """
 
     mode: Literal["tallied_grounding"] = "tallied_grounding"
-    rounds: int = Field(ge=_TALLIED_ROUNDS_MIN, le=_TALLIED_ROUNDS_MAX)
-    categories: list[TalliedCategory] = Field(
-        min_length=_TALLIED_CATEGORIES_MIN, max_length=_TALLIED_CATEGORIES_MAX
-    )
+    rounds: int = Field(ge=1, le=TALLIED_ROUNDS_MAX)
+    categories: list[TalliedCategory] = Field(min_length=1, max_length=TALLIED_CATEGORIES_MAX)
 
     @model_validator(mode="after")
     def _check_unique_category_keys(self) -> Self:

--- a/backend/src/schemas/practice_session_metadata.py
+++ b/backend/src/schemas/practice_session_metadata.py
@@ -26,12 +26,13 @@ _MAX_BPM = 240
 _MIN_BPM = 1
 _MAX_TAROT_INDEX = 21  # 22-card major arcana, zero-indexed.
 _MAX_INTERVALS = 1_000
-# Derived from the authoring-side ceilings so the post-session cap can
-# never silently lag a config bump (e.g. raising the categories limit).
-# The cross-module guard in ``test_practice_session_metadata.py`` locks
-# this derivation in case the underlying constants are ever inlined.
-_MAX_TALLIED_ROUNDS = TALLIED_ROUNDS_MAX
-_MAX_TALLIED_ITEMS = TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
+# Public ceilings derived from the authoring-side ceilings so the
+# post-session cap can never silently lag a config bump (e.g. raising
+# the categories limit). The cross-module guard in
+# ``test_practice_session_metadata.py`` locks this derivation in case
+# the underlying constants are ever inlined.
+MAX_TALLIED_ROUNDS = TALLIED_ROUNDS_MAX
+MAX_TALLIED_ITEMS = TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
 
 
 class _MetadataBase(BaseModel):
@@ -110,9 +111,9 @@ class TalliedGroundingMetadata(_MetadataBase):
     """
 
     mode: Literal["tallied_grounding"] = "tallied_grounding"
-    rounds_completed: int = Field(ge=0, le=_MAX_TALLIED_ROUNDS)
-    total_rounds: int = Field(ge=1, le=_MAX_TALLIED_ROUNDS)
-    items_completed: int = Field(ge=0, le=_MAX_TALLIED_ITEMS)
+    rounds_completed: int = Field(ge=0, le=MAX_TALLIED_ROUNDS)
+    total_rounds: int = Field(ge=1, le=MAX_TALLIED_ROUNDS)
+    items_completed: int = Field(ge=0, le=MAX_TALLIED_ITEMS)
 
     @model_validator(mode="after")
     def _check_completed_within_total(self) -> Self:

--- a/backend/src/schemas/practice_session_metadata.py
+++ b/backend/src/schemas/practice_session_metadata.py
@@ -14,15 +14,24 @@ from typing import Annotated, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
-from schemas.practice_mode_config import Sense
+from schemas.practice_mode_config import (
+    TALLIED_CATEGORIES_MAX,
+    TALLIED_ROUNDS_MAX,
+    TALLIED_TARGET_MAX,
+    Sense,
+)
 
 _MAX_REPS = 1_000_000
 _MAX_BPM = 240
 _MIN_BPM = 1
 _MAX_TAROT_INDEX = 21  # 22-card major arcana, zero-indexed.
 _MAX_INTERVALS = 1_000
-_MAX_TALLIED_ROUNDS = 10
-_MAX_TALLIED_ITEMS = 2_400  # 10 rounds * 12 categories * 20 target_count ceiling.
+# Derived from the authoring-side ceilings so the post-session cap can
+# never silently lag a config bump (e.g. raising the categories limit).
+# The cross-module guard in ``test_practice_session_metadata.py`` locks
+# this derivation in case the underlying constants are ever inlined.
+_MAX_TALLIED_ROUNDS = TALLIED_ROUNDS_MAX
+_MAX_TALLIED_ITEMS = TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
 
 
 class _MetadataBase(BaseModel):

--- a/backend/src/schemas/practice_session_metadata.py
+++ b/backend/src/schemas/practice_session_metadata.py
@@ -21,6 +21,8 @@ _MAX_BPM = 240
 _MIN_BPM = 1
 _MAX_TAROT_INDEX = 21  # 22-card major arcana, zero-indexed.
 _MAX_INTERVALS = 1_000
+_MAX_TALLIED_ROUNDS = 10
+_MAX_TALLIED_ITEMS = 2_400  # 10 rounds * 12 categories * 20 target_count ceiling.
 
 
 class _MetadataBase(BaseModel):
@@ -90,6 +92,28 @@ class TarotMetadata(_MetadataBase):
     card_index: int = Field(ge=0, le=_MAX_TAROT_INDEX)
 
 
+class TalliedGroundingMetadata(_MetadataBase):
+    """How many rounds the user finished, plus the total items tallied.
+
+    The cross-field validator rejects ``rounds_completed > total_rounds``;
+    each field individually satisfies its ge/le bounds, mirroring the
+    invariant on :class:`IntervalBellMetadata`.
+    """
+
+    mode: Literal["tallied_grounding"] = "tallied_grounding"
+    rounds_completed: int = Field(ge=0, le=_MAX_TALLIED_ROUNDS)
+    total_rounds: int = Field(ge=1, le=_MAX_TALLIED_ROUNDS)
+    items_completed: int = Field(ge=0, le=_MAX_TALLIED_ITEMS)
+
+    @model_validator(mode="after")
+    def _check_completed_within_total(self) -> Self:
+        """Reject ``rounds_completed > total_rounds``."""
+        if self.rounds_completed > self.total_rounds:
+            msg = "rounds_completed cannot exceed total_rounds"
+            raise ValueError(msg)
+        return self
+
+
 #: Discriminated union over all per-mode session metadata payloads.
 SessionMetadata = Annotated[
     MeditationTimerMetadata
@@ -98,7 +122,8 @@ SessionMetadata = Annotated[
     | IntervalBellMetadata
     | RepCounterMetadata
     | SenseGroundingMetadata
-    | TarotMetadata,
+    | TarotMetadata
+    | TalliedGroundingMetadata,
     Field(discriminator="mode"),
 ]
 

--- a/backend/tests/domain/test_practice_modes.py
+++ b/backend/tests/domain/test_practice_modes.py
@@ -12,6 +12,7 @@ _EXPECTED_MEMBERS: tuple[str, ...] = (
     "rep_counter",
     "sense_grounding",
     "tarot",
+    "tallied_grounding",
 )
 
 

--- a/backend/tests/schemas/test_practice_mode_config.py
+++ b/backend/tests/schemas/test_practice_mode_config.py
@@ -14,6 +14,8 @@ from schemas.practice_mode_config import (
     ModeConfigAdapter,
     RepCounterConfig,
     SenseGroundingConfig,
+    TalliedCategory,
+    TalliedGroundingConfig,
     TarotConfig,
 )
 
@@ -116,6 +118,23 @@ def test_sense_grounding_default_prompts_round_trip() -> None:
     )
     assert isinstance(cfg, SenseGroundingConfig)
     assert [p.sense for p in cfg.prompts] == ["sight", "touch", "hearing", "smell", "taste"]
+
+
+def test_tallied_grounding_round_trip() -> None:
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "tallied_grounding",
+            "rounds": 3,
+            "categories": [
+                {"key": "shapes", "label": "Find shapes", "target_count": 5},
+                {"key": "colors", "label": "Find colors", "target_count": 4},
+            ],
+        }
+    )
+    assert isinstance(cfg, TalliedGroundingConfig)
+    assert cfg.rounds == 3
+    assert [c.key for c in cfg.categories] == ["shapes", "colors"]
+    assert cfg.categories[0].target_count == 5
 
 
 def test_tarot_round_trip() -> None:
@@ -256,6 +275,72 @@ def test_rep_counter_rejects_zero_target() -> None:
 def test_tarot_rejects_zero_per_card_minutes() -> None:
     with pytest.raises(ValidationError):
         TarotConfig(mode="tarot", deck="major_arcana", per_card_minutes=0)
+
+
+def test_tallied_grounding_rejects_duplicate_keys() -> None:
+    """The cross-field validator rejects two categories sharing the same ``key``."""
+    with pytest.raises(ValidationError):
+        TalliedGroundingConfig(
+            mode="tallied_grounding",
+            rounds=2,
+            categories=[
+                TalliedCategory(key="shapes", label="Find shapes", target_count=5),
+                TalliedCategory(key="shapes", label="Also shapes", target_count=3),
+            ],
+        )
+
+
+def test_tallied_grounding_rejects_rounds_below_one() -> None:
+    with pytest.raises(ValidationError):
+        TalliedGroundingConfig(
+            mode="tallied_grounding",
+            rounds=0,
+            categories=[TalliedCategory(key="shapes", label="Find shapes", target_count=5)],
+        )
+
+
+def test_tallied_grounding_rejects_empty_categories() -> None:
+    with pytest.raises(ValidationError):
+        TalliedGroundingConfig(mode="tallied_grounding", rounds=1, categories=[])
+
+
+def test_tallied_grounding_rejects_target_count_above_max() -> None:
+    """``target_count`` must stay within (0, 20]."""
+    with pytest.raises(ValidationError):
+        TalliedCategory(key="shapes", label="Find shapes", target_count=21)
+
+
+def test_tallied_grounding_rejects_zero_target_count() -> None:
+    with pytest.raises(ValidationError):
+        TalliedCategory(key="shapes", label="Find shapes", target_count=0)
+
+
+def test_tallied_grounding_rejects_invalid_key_slug() -> None:
+    """The ``key`` slug must match the documented identifier regex."""
+    with pytest.raises(ValidationError):
+        TalliedCategory(key="9bad", label="Bad", target_count=5)
+    with pytest.raises(ValidationError):
+        TalliedCategory(key="Spaces Bad", label="Bad", target_count=5)
+
+
+def test_tallied_grounding_rejects_rounds_above_max() -> None:
+    with pytest.raises(ValidationError):
+        TalliedGroundingConfig(
+            mode="tallied_grounding",
+            rounds=11,
+            categories=[TalliedCategory(key="shapes", label="Find shapes", target_count=5)],
+        )
+
+
+def test_tallied_grounding_rejects_too_many_categories() -> None:
+    with pytest.raises(ValidationError):
+        TalliedGroundingConfig(
+            mode="tallied_grounding",
+            rounds=1,
+            categories=[
+                TalliedCategory(key=f"k{i}", label=f"L{i}", target_count=1) for i in range(13)
+            ],
+        )
 
 
 def test_discriminator_keyed_payload_dispatches_to_right_model() -> None:

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -37,6 +37,10 @@ _PRACTICE_MODE_REVISION = "e9f0a1b2c3d4"  # pragma: allowlist secret
 _PRACTICE_SESSION_METADATA_BASE_REVISION = "e9f0a1b2c3d4"  # pragma: allowlist secret
 _PRACTICE_SESSION_METADATA_REVISION = "f0a1b2c3d4e5"  # pragma: allowlist secret
 
+# grounding-techniques 01: tallied_grounding CHECK-constraint migration.
+_TALLIED_GROUNDING_BASE_REVISION = "d2e3f4a5b6c7"  # pragma: allowlist secret
+_TALLIED_GROUNDING_REVISION = "a1b2c3d4e5f7"  # pragma: allowlist secret
+
 
 def test_timestamptz_migration_exists() -> None:
     """Regression guard: the migration file must stay where Alembic finds it."""
@@ -539,3 +543,139 @@ def test_practice_session_metadata_migration_round_trip_on_sqlite(
     row_again = _practicesession_row(db_url, session_id=1)
     assert row_again["mode"] == "meditation_timer"
     assert bool(row_again["completed"]) is True
+
+
+# -- grounding-techniques 01 tallied_grounding CHECK constraint -------------
+
+_ORIGINAL_SEVEN_MODES = (
+    "meditation_timer",
+    "count_up",
+    "metronome",
+    "interval_bell",
+    "rep_counter",
+    "sense_grounding",
+    "tarot",
+)
+
+
+def _bootstrap_practice_with_seven_mode_check(sync_url: str) -> None:
+    """Pre-create a ``practice`` table with the pre-tallied 7-mode CHECK constraint.
+
+    Mirrors the schema in place at :data:`_TALLIED_GROUNDING_BASE_REVISION`
+    just before our migration runs: ``mode`` is constrained to the
+    original seven values. Keeps the bootstrap SQLite-friendly so the
+    round-trip exercises only our new migration.
+    """
+    quoted = ", ".join(f"'{m}'" for m in _ORIGINAL_SEVEN_MODES)
+    bootstrap_engine = create_engine(sync_url)
+    with bootstrap_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE practice ("
+                " id INTEGER PRIMARY KEY,"
+                " stage_number INTEGER NOT NULL,"
+                " name VARCHAR(255) NOT NULL,"
+                " description VARCHAR(2000) NOT NULL DEFAULT '',"
+                " instructions VARCHAR(10000) NOT NULL DEFAULT '',"
+                " default_duration_minutes FLOAT NOT NULL,"
+                " submitted_by_user_id INTEGER,"
+                " approved BOOLEAN NOT NULL DEFAULT 1,"
+                " mode VARCHAR(32) NOT NULL DEFAULT 'meditation_timer',"
+                " mode_config TEXT NOT NULL DEFAULT '{}',"
+                f" CONSTRAINT ck_practice_mode_valid CHECK (mode IN ({quoted}))"
+                ")"
+            )
+        )
+    bootstrap_engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_tallied_grounding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before grounding-techniques 01's migration."""
+    db_path = tmp_path / "tallied_grounding_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_practice_with_seven_mode_check(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _TALLIED_GROUNDING_BASE_REVISION)
+    return cfg
+
+
+def _insert_practice_row(db_url: str, *, mode: str, name: str) -> None:
+    """Insert a single practice row with the given mode (raises on CHECK violation)."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO practice (stage_number, name, default_duration_minutes, mode)"
+                    " VALUES (:s, :n, :d, :m)"
+                ),
+                {"s": 1, "n": name, "d": 10.0, "m": mode},
+            )
+    finally:
+        engine.dispose()
+
+
+def _count_practice_with_mode(db_url: str, mode: str) -> int:
+    """Count practice rows carrying a particular mode value."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text("SELECT count(*) FROM practice WHERE mode = :m"),
+                {"m": mode},
+            ).first()
+            assert row is not None
+            return int(row[0])
+    finally:
+        engine.dispose()
+
+
+def test_tallied_grounding_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_tallied_grounding: Config,
+) -> None:
+    """Round-trip ``a1b2c3d4e5f7``: upgrade allows the new mode; downgrade reverts the CHECK.
+
+    Acceptance criterion #4 from issue #337: the migration runs cleanly
+    on a fresh DB and rolls back on an empty ``practice`` table.
+    """
+    cfg = alembic_sqlite_config_tallied_grounding
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade — the new CHECK should accept tallied_grounding inserts.
+    command.upgrade(cfg, _TALLIED_GROUNDING_REVISION)
+    _insert_practice_row(db_url, mode="tallied_grounding", name="Find shapes")
+    assert _count_practice_with_mode(db_url, "tallied_grounding") == 1
+
+    # Phase 2: downgrade — refuses to run while a tallied_grounding row exists.
+    with pytest.raises(Exception, match="tallied_grounding"):
+        command.downgrade(cfg, _TALLIED_GROUNDING_BASE_REVISION)
+
+    # Phase 3: clear the offending row, then downgrade cleanly.
+    sync_engine = create_engine(_sync_url(db_url))
+    try:
+        with sync_engine.begin() as conn:
+            conn.execute(text("DELETE FROM practice WHERE mode = 'tallied_grounding'"))
+    finally:
+        sync_engine.dispose()
+    command.downgrade(cfg, _TALLIED_GROUNDING_BASE_REVISION)
+
+    # Phase 4: the original CHECK is back — inserting tallied_grounding now fails.
+    with pytest.raises(Exception, match="CHECK"):
+        _insert_practice_row(db_url, mode="tallied_grounding", name="Should fail")
+
+    # Phase 5: re-upgrade — tallied_grounding inserts succeed again (idempotent cycle).
+    command.upgrade(cfg, _TALLIED_GROUNDING_REVISION)
+    _insert_practice_row(db_url, mode="tallied_grounding", name="Find colors")
+    assert _count_practice_with_mode(db_url, "tallied_grounding") == 1

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -632,12 +632,11 @@ def _count_practice_with_mode(db_url: str, mode: str) -> int:
     engine = create_engine(_sync_url(db_url))
     try:
         with engine.connect() as conn:
-            row = conn.execute(
+            count: int = conn.execute(
                 text("SELECT count(*) FROM practice WHERE mode = :m"),
                 {"m": mode},
-            ).first()
-            assert row is not None
-            return int(row[0])
+            ).scalar_one()
+            return count
     finally:
         engine.dispose()
 
@@ -662,7 +661,7 @@ def test_tallied_grounding_migration_round_trip_on_sqlite(
     # Phase 2: downgrade — refuses to run while a tallied_grounding row exists.
     # The migration's ``downgrade()`` raises a concrete ``RuntimeError`` rather
     # than any random Exception — pinning the class avoids masking unrelated
-    # failures (PR #343 review feedback).
+    # failures.
     with pytest.raises(RuntimeError, match="tallied_grounding"):
         command.downgrade(cfg, _TALLIED_GROUNDING_BASE_REVISION)
 
@@ -679,7 +678,7 @@ def test_tallied_grounding_migration_round_trip_on_sqlite(
     # ``IntegrityError`` is the precise class SQLAlchemy raises on a CHECK
     # constraint violation; using it (rather than the broad ``Exception``)
     # avoids masking unrelated failures whose message happens to mention
-    # "CHECK" (PR #343 review feedback).
+    # "CHECK".
     with pytest.raises(IntegrityError):
         _insert_practice_row(db_url, mode="tallied_grounding", name="Should fail")
 

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -19,6 +19,7 @@ import pytest
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
 
 MIGRATIONS_DIR = Path(__file__).parent.parent / "migrations" / "versions"
 
@@ -659,7 +660,10 @@ def test_tallied_grounding_migration_round_trip_on_sqlite(
     assert _count_practice_with_mode(db_url, "tallied_grounding") == 1
 
     # Phase 2: downgrade — refuses to run while a tallied_grounding row exists.
-    with pytest.raises(Exception, match="tallied_grounding"):
+    # The migration's ``downgrade()`` raises a concrete ``RuntimeError`` rather
+    # than any random Exception — pinning the class avoids masking unrelated
+    # failures (PR #343 review feedback).
+    with pytest.raises(RuntimeError, match="tallied_grounding"):
         command.downgrade(cfg, _TALLIED_GROUNDING_BASE_REVISION)
 
     # Phase 3: clear the offending row, then downgrade cleanly.
@@ -672,7 +676,11 @@ def test_tallied_grounding_migration_round_trip_on_sqlite(
     command.downgrade(cfg, _TALLIED_GROUNDING_BASE_REVISION)
 
     # Phase 4: the original CHECK is back — inserting tallied_grounding now fails.
-    with pytest.raises(Exception, match="CHECK"):
+    # ``IntegrityError`` is the precise class SQLAlchemy raises on a CHECK
+    # constraint violation; using it (rather than the broad ``Exception``)
+    # avoids masking unrelated failures whose message happens to mention
+    # "CHECK" (PR #343 review feedback).
+    with pytest.raises(IntegrityError):
         _insert_practice_row(db_url, mode="tallied_grounding", name="Should fail")
 
     # Phase 5: re-upgrade — tallied_grounding inserts succeed again (idempotent cycle).

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -13,6 +13,7 @@ from schemas.practice_session_metadata import (
     RepCounterMetadata,
     SenseGroundingMetadata,
     SessionMetadataAdapter,
+    TalliedGroundingMetadata,
     TarotMetadata,
 )
 
@@ -70,6 +71,21 @@ def test_tarot_round_trip() -> None:
     assert payload.card_index == 5
 
 
+def test_tallied_grounding_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python(
+        {
+            "mode": "tallied_grounding",
+            "rounds_completed": 2,
+            "total_rounds": 3,
+            "items_completed": 27,
+        }
+    )
+    assert isinstance(payload, TalliedGroundingMetadata)
+    assert payload.rounds_completed == 2
+    assert payload.total_rounds == 3
+    assert payload.items_completed == 27
+
+
 # -- Validators --------------------------------------------------------------
 
 
@@ -123,6 +139,59 @@ def test_interval_bell_accepts_equal_struck_and_total() -> None:
     """Completing every scheduled interval is valid (boundary)."""
     payload = IntervalBellMetadata(mode="interval_bell", intervals_struck=4, total_intervals=4)
     assert payload.intervals_struck == payload.total_intervals == 4
+
+
+def test_tallied_grounding_rejects_rounds_completed_above_total() -> None:
+    """``rounds_completed`` cannot exceed ``total_rounds`` (cross-field invariant)."""
+    with pytest.raises(ValidationError):
+        TalliedGroundingMetadata(
+            mode="tallied_grounding",
+            rounds_completed=4,
+            total_rounds=3,
+            items_completed=10,
+        )
+
+
+def test_tallied_grounding_accepts_equal_rounds() -> None:
+    """Completing every scheduled round is valid (boundary)."""
+    payload = TalliedGroundingMetadata(
+        mode="tallied_grounding",
+        rounds_completed=3,
+        total_rounds=3,
+        items_completed=15,
+    )
+    assert payload.rounds_completed == payload.total_rounds == 3
+
+
+def test_tallied_grounding_rejects_negative_items_completed() -> None:
+    with pytest.raises(ValidationError):
+        TalliedGroundingMetadata(
+            mode="tallied_grounding",
+            rounds_completed=0,
+            total_rounds=1,
+            items_completed=-1,
+        )
+
+
+def test_tallied_grounding_rejects_items_above_ceiling() -> None:
+    """``items_completed`` is capped at the 10-rounds * 12-categories * 20-target ceiling."""
+    with pytest.raises(ValidationError):
+        TalliedGroundingMetadata(
+            mode="tallied_grounding",
+            rounds_completed=10,
+            total_rounds=10,
+            items_completed=2401,
+        )
+
+
+def test_tallied_grounding_rejects_total_rounds_above_max() -> None:
+    with pytest.raises(ValidationError):
+        TalliedGroundingMetadata(
+            mode="tallied_grounding",
+            rounds_completed=0,
+            total_rounds=11,
+            items_completed=0,
+        )
 
 
 def test_sense_grounding_rejects_unknown_sense() -> None:

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -196,14 +196,16 @@ def test_tallied_grounding_accepts_items_completed_at_ceiling() -> None:
 
     Mirrors :func:`test_interval_bell_accepts_equal_struck_and_total` — the
     rejection test pins the off-by-one, this one pins the inclusive bound.
+    Computing the ceiling from the config-module constants keeps the test
+    in sync with any future ceiling bump.
     """
+    expected_items = TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
     payload = TalliedGroundingMetadata(
         mode="tallied_grounding",
-        rounds_completed=10,
-        total_rounds=10,
-        items_completed=2400,
+        rounds_completed=TALLIED_ROUNDS_MAX,
+        total_rounds=TALLIED_ROUNDS_MAX,
+        items_completed=expected_items,
     )
-    expected_items = 2400
     assert payload.items_completed == expected_items
 
 

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -11,8 +11,8 @@ from schemas.practice_mode_config import (
     TALLIED_TARGET_MAX,
 )
 from schemas.practice_session_metadata import (
-    _MAX_TALLIED_ITEMS,
-    _MAX_TALLIED_ROUNDS,
+    MAX_TALLIED_ITEMS,
+    MAX_TALLIED_ROUNDS,
     CountUpMetadata,
     IntervalBellMetadata,
     MeditationTimerMetadata,
@@ -210,14 +210,14 @@ def test_tallied_grounding_accepts_items_completed_at_ceiling() -> None:
 def test_tallied_metadata_ceilings_match_config_constants() -> None:
     """Lock the metadata ceiling to the authoring-side ceiling constants.
 
-    The metadata module derives ``_MAX_TALLIED_ROUNDS`` and
-    ``_MAX_TALLIED_ITEMS`` from the config module so a future bump (e.g.
+    The metadata module derives ``MAX_TALLIED_ROUNDS`` and
+    ``MAX_TALLIED_ITEMS`` from the config module so a future bump (e.g.
     raising the categories limit) cannot leave the post-session cap
     silently stale. This test pins the contract: it fails loudly if the
     derivation is ever inlined or the underlying constants change.
     """
-    assert _MAX_TALLIED_ROUNDS == TALLIED_ROUNDS_MAX
-    assert _MAX_TALLIED_ITEMS == TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
+    assert MAX_TALLIED_ROUNDS == TALLIED_ROUNDS_MAX
+    assert MAX_TALLIED_ITEMS == TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
 
 
 def test_tallied_grounding_rejects_total_rounds_above_max() -> None:

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from schemas.practice_mode_config import (
+    TALLIED_CATEGORIES_MAX,
+    TALLIED_ROUNDS_MAX,
+    TALLIED_TARGET_MAX,
+)
 from schemas.practice_session_metadata import (
+    _MAX_TALLIED_ITEMS,
+    _MAX_TALLIED_ROUNDS,
     CountUpMetadata,
     IntervalBellMetadata,
     MeditationTimerMetadata,
@@ -182,6 +189,35 @@ def test_tallied_grounding_rejects_items_above_ceiling() -> None:
             total_rounds=10,
             items_completed=2401,
         )
+
+
+def test_tallied_grounding_accepts_items_completed_at_ceiling() -> None:
+    """The exact ceiling (every round * every category * every target) is valid (boundary).
+
+    Mirrors :func:`test_interval_bell_accepts_equal_struck_and_total` — the
+    rejection test pins the off-by-one, this one pins the inclusive bound.
+    """
+    payload = TalliedGroundingMetadata(
+        mode="tallied_grounding",
+        rounds_completed=10,
+        total_rounds=10,
+        items_completed=2400,
+    )
+    expected_items = 2400
+    assert payload.items_completed == expected_items
+
+
+def test_tallied_metadata_ceilings_match_config_constants() -> None:
+    """Lock the metadata ceiling to the authoring-side ceiling constants.
+
+    The metadata module derives ``_MAX_TALLIED_ROUNDS`` and
+    ``_MAX_TALLIED_ITEMS`` from the config module so a future bump (e.g.
+    raising the categories limit) cannot leave the post-session cap
+    silently stale. This test pins the contract: it fails loudly if the
+    derivation is ever inlined or the underlying constants change.
+    """
+    assert _MAX_TALLIED_ROUNDS == TALLIED_ROUNDS_MAX
+    assert _MAX_TALLIED_ITEMS == TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
 
 
 def test_tallied_grounding_rejects_total_rounds_above_max() -> None:

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -451,6 +451,18 @@ async def _create_typed_user_practice(
             "interval_minutes": 5,
             "bell_tone": "bowl",
         },
+        "sense_grounding": {
+            "mode": "sense_grounding",
+            "prompts": [{"sense": "sight", "label": "Name 5 things you can see"}],
+        },
+        "tallied_grounding": {
+            "mode": "tallied_grounding",
+            "rounds": 3,
+            "categories": [
+                {"key": "shapes", "label": "Find shapes", "target_count": 5},
+                {"key": "colors", "label": "Find colors", "target_count": 4},
+            ],
+        },
     }
     practice = Practice(
         stage_number=stage_number,
@@ -583,6 +595,81 @@ async def test_create_session_rejects_invalid_metadata_payload(
     )
     resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_tallied_metadata_on_sense_grounding_practice(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Posting a ``tallied_grounding`` session to a ``sense_grounding`` practice → 400.
+
+    The Pydantic union deserialises the metadata cleanly, but the resolved
+    practice's mode disagrees with the metadata's discriminator — the same
+    contract enforced for every cross-mode mismatch.
+    """
+    headers, _ = await _signup(async_client)
+    up_id, _ = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="sense_grounding"
+    )
+    payload = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "tallied_grounding",
+            "rounds_completed": 1,
+            "total_rounds": 3,
+            "items_completed": 5,
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "mode_metadata_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_create_session_persists_tallied_grounding_metadata(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A ``tallied_grounding`` session round-trips its metadata through POST.
+
+    Mirrors :func:`test_create_session_persists_interval_bell_metadata` so
+    the new mode gets the same end-to-end coverage: schema dispatch +
+    cross-field validator firing over HTTP.
+    """
+    headers, _ = await _signup(async_client)
+    up_id, _ = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="tallied_grounding"
+    )
+
+    valid = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "tallied_grounding",
+            "rounds_completed": 2,
+            "total_rounds": 3,
+            "items_completed": 18,
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=valid, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["mode_metadata"] == {
+        "mode": "tallied_grounding",
+        "rounds_completed": 2,
+        "total_rounds": 3,
+        "items_completed": 18,
+    }
+
+    # Cross-field invariant: completing more rounds than total → 422.
+    bad = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "tallied_grounding",
+            "rounds_completed": 5,
+            "total_rounds": 3,
+            "items_completed": 18,
+        },
+    )
+    resp_bad = await async_client.post("/practice-sessions/", json=bad, headers=headers)
+    assert resp_bad.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Introduces a new ``tallied_grounding`` practice mode capturing the
``rounds × categories × target_count_per_category`` shape shared by
Find Shapes / Find Colors. The mode rounds-trips through
``Practice.mode_config``, validates at the API edge via Pydantic,
passes a new CHECK constraint on ``practice.mode``, and emits a
per-session metadata payload with a ``rounds_completed`` cross-field
invariant.

- ``domain.practice_modes``: add ``TALLIED_GROUNDING`` enum member
- ``schemas.practice_mode_config``: add ``TalliedCategory`` (slug-keyed,
  target 1..20) and ``TalliedGroundingConfig`` (rounds 1..10,
  categories 1..12) with a duplicate-key validator, wired into the
  ``ModeConfig`` discriminated union
- ``schemas.practice_session_metadata``: add ``TalliedGroundingMetadata``
  with the same cross-field invariant pattern as ``IntervalBellMetadata``
- ``migrations/a1b2c3d4e5f7``: drop ``ck_practice_mode_valid`` and
  recreate it listing the new mode; ``downgrade()`` refuses while any
  ``practice`` row still carries ``tallied_grounding``
- Tests for round-trip, validators, mode-mismatch (400), HTTP
  cross-field invariant (422), and SQLite migration round-trip