### PR TITLE
feat(backend): add mindful_anchor practice mode

### DIFF
--- a/backend/migrations/versions/f4a5b6c7d8e9_add_mindful_anchor_mode.py
+++ b/backend/migrations/versions/f4a5b6c7d8e9_add_mindful_anchor_mode.py
@@ -1,0 +1,83 @@
+"""extend ck_practice_mode_valid to include mindful_anchor
+
+Revision ID: f4a5b6c7d8e9
+Revises: a1b2c3d4e5f7
+Create Date: 2026-05-16 12:00:00.000000
+
+Adds ``mindful_anchor`` to the closed set of values accepted by the
+``practice.mode`` CHECK constraint. The new value powers single-action
+mindful presence practices (Touch Grass, Mindful Eating) whose config
+and per-session metadata shapes live in
+:mod:`schemas.practice_mode_config.MindfulAnchorConfig` and
+:mod:`schemas.practice_session_metadata.MindfulAnchorMetadata`.
+
+Chains off ``a1b2c3d4e5f7`` (tallied_grounding) — the prior CHECK
+already lists eight modes, so the upgrade adds the ninth and the
+downgrade narrows back to the same eight.
+
+The migration drops and recreates ``ck_practice_mode_valid`` inside a
+``batch_alter_table`` block so SQLite (used by the round-trip test
+fixture) rebuilds the table once. The downgrade refuses to run if any
+rows already carry ``mindful_anchor`` — narrowing the CHECK while data
+violates it would either rewrite history or leave the DB in an
+inconsistent state, and the operator should resolve the rows first.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f4a5b6c7d8e9"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "a1b2c3d4e5f7"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_MODE_CHECK_NAME = "ck_practice_mode_valid"
+_NEW_MODE = "mindful_anchor"
+
+# Intentionally duplicated from ``domain.practice_modes.ALL_MODES`` — migrations
+# must not import application modules so the schema replays on a repo state
+# where the model no longer matches. The eighth mode (``tallied_grounding``)
+# was added by the down_revision migration ``a1b2c3d4e5f7``.
+_PREVIOUS_MODES = (
+    "meditation_timer",
+    "count_up",
+    "metronome",
+    "interval_bell",
+    "rep_counter",
+    "sense_grounding",
+    "tarot",
+    "tallied_grounding",
+)
+_EXTENDED_MODES = (*_PREVIOUS_MODES, _NEW_MODE)
+
+
+def _check_clause(modes: Sequence[str]) -> str:
+    quoted = ", ".join(f"'{m}'" for m in modes)
+    return f"mode IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Drop and recreate the CHECK constraint with ``mindful_anchor`` allowed."""
+    with op.batch_alter_table("practice") as batch_op:
+        batch_op.drop_constraint(_MODE_CHECK_NAME, type_="check")
+        batch_op.create_check_constraint(_MODE_CHECK_NAME, _check_clause(_EXTENDED_MODES))
+
+
+def downgrade() -> None:
+    """Narrow the CHECK back to the prior set; refuse if rows still use the new mode."""
+    bind = op.get_bind()
+    offenders = bind.execute(
+        sa.text("SELECT COUNT(*) FROM practice WHERE mode = :mode").bindparams(mode=_NEW_MODE)
+    ).scalar_one()
+    if offenders:
+        msg = (
+            f"Cannot downgrade: {offenders} practice row(s) carry mode='{_NEW_MODE}'. "
+            "Reassign those rows to a supported mode before downgrading."
+        )
+        raise RuntimeError(msg)
+    with op.batch_alter_table("practice") as batch_op:
+        batch_op.drop_constraint(_MODE_CHECK_NAME, type_="check")
+        batch_op.create_check_constraint(_MODE_CHECK_NAME, _check_clause(_PREVIOUS_MODES))

--- a/backend/src/domain/practice_modes.py
+++ b/backend/src/domain/practice_modes.py
@@ -23,6 +23,7 @@ class PracticeMode(StrEnum):
     SENSE_GROUNDING = "sense_grounding"
     TAROT = "tarot"
     TALLIED_GROUNDING = "tallied_grounding"
+    MINDFUL_ANCHOR = "mindful_anchor"
 
 
 #: Ordered tuple of wire values, suitable for CHECK constraints and docs.

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -16,6 +16,8 @@ from sqlmodel import col, func, select
 from database import get_session
 from dependencies.ownership import require_owned_user_practice
 from domain.practice_insights import build_insights
+from domain.practice_modes import PracticeMode
+from domain.practice_resolution import effective_config
 from errors import bad_request, forbidden, not_found
 from models.practice import Practice
 from models.practice_session import PracticeSession
@@ -28,6 +30,8 @@ from schemas.practice import (
     PracticeSessionCreate,
     PracticeSessionResponse,
 )
+from schemas.practice_mode_config import MindfulAnchorConfig
+from schemas.practice_session_metadata import MindfulAnchorMetadata
 from services.users import get_user_timezone
 
 # Window for the insights SQL fetch.  Slightly larger than the 8-week rollup
@@ -72,6 +76,26 @@ async def _resolve_user_practice_for_session(
     return user_practice
 
 
+def _enforce_mindful_anchor_invariants(
+    practice: Practice,
+    user_practice: UserPractice,
+    metadata: MindfulAnchorMetadata,
+) -> None:
+    """Reject a ``mindful_anchor`` session whose metadata violates the catalog config.
+
+    The metadata schema cannot see the catalog config (the discriminated
+    union has no back-reference), so the cross-field invariant
+    ``require_option_choice=True ⇒ chosen_option_key is not None`` is
+    enforced here. Extracted from :func:`_resolve_practice_with_mode` to
+    keep that helper at xenon rank A.
+    """
+    cfg = effective_config(practice, user_practice)
+    if not isinstance(cfg, MindfulAnchorConfig):
+        return
+    if cfg.require_option_choice and metadata.chosen_option_key is None:
+        raise bad_request("chosen_option_key_required")
+
+
 async def _resolve_practice_with_mode(
     session: AsyncSession,
     user_practice: UserPractice,
@@ -95,6 +119,10 @@ async def _resolve_practice_with_mode(
         raise not_found("practice")
     if payload.mode_metadata is not None and payload.mode_metadata.mode != practice.mode:
         raise bad_request("mode_metadata_mismatch")
+    if practice.mode == PracticeMode.MINDFUL_ANCHOR.value and isinstance(
+        payload.mode_metadata, MindfulAnchorMetadata
+    ):
+        _enforce_mindful_anchor_invariants(practice, user_practice, payload.mode_metadata)
     return practice
 
 

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -75,6 +75,29 @@ async def _resolve_user_practice_for_session(
     return user_practice
 
 
+def _require_chosen_option_key_when_required(
+    cfg: MindfulAnchorConfig, metadata: MindfulAnchorMetadata
+) -> None:
+    """Reject sessions that omit ``chosen_option_key`` against a required-choice config."""
+    if cfg.require_option_choice and metadata.chosen_option_key is None:
+        raise bad_request("chosen_option_key_required")
+
+
+def _require_chosen_option_key_in_catalog(
+    cfg: MindfulAnchorConfig, metadata: MindfulAnchorMetadata
+) -> None:
+    """Reject a ``chosen_option_key`` the catalog never declared.
+
+    Without this, a client could persist phantom keys (``"mud"`` against
+    a catalog of ``["grass", "stone"]``) that pollute analytics rollups
+    grouping on the field.
+    """
+    if metadata.chosen_option_key is None:
+        return
+    if metadata.chosen_option_key not in {opt.key for opt in cfg.options}:
+        raise bad_request("chosen_option_key_not_in_catalog")
+
+
 def _enforce_mindful_anchor_invariants(
     practice: Practice,
     user_practice: UserPractice,
@@ -83,16 +106,15 @@ def _enforce_mindful_anchor_invariants(
     """Reject a ``mindful_anchor`` session whose metadata violates the catalog config.
 
     The metadata schema cannot see the catalog config (the discriminated
-    union has no back-reference), so the cross-field invariant
-    ``require_option_choice=True ⇒ chosen_option_key is not None`` is
-    enforced here. Extracted from :func:`_validate_session_metadata` to
-    keep the validation pipeline at xenon rank A.
+    union has no back-reference), so the cross-field invariants are
+    enforced here via :func:`_require_chosen_option_key_when_required`
+    and :func:`_require_chosen_option_key_in_catalog`.
     """
     cfg = effective_config(practice, user_practice)
     if not isinstance(cfg, MindfulAnchorConfig):
         return
-    if cfg.require_option_choice and metadata.chosen_option_key is None:
-        raise bad_request("chosen_option_key_required")
+    _require_chosen_option_key_when_required(cfg, metadata)
+    _require_chosen_option_key_in_catalog(cfg, metadata)
 
 
 def _validate_session_metadata(

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -16,7 +16,6 @@ from sqlmodel import col, func, select
 from database import get_session
 from dependencies.ownership import require_owned_user_practice
 from domain.practice_insights import build_insights
-from domain.practice_modes import PracticeMode
 from domain.practice_resolution import effective_config
 from errors import bad_request, forbidden, not_found
 from models.practice import Practice
@@ -86,8 +85,8 @@ def _enforce_mindful_anchor_invariants(
     The metadata schema cannot see the catalog config (the discriminated
     union has no back-reference), so the cross-field invariant
     ``require_option_choice=True ⇒ chosen_option_key is not None`` is
-    enforced here. Extracted from :func:`_resolve_practice_with_mode` to
-    keep that helper at xenon rank A.
+    enforced here. Extracted from :func:`_validate_session_metadata` to
+    keep the validation pipeline at xenon rank A.
     """
     cfg = effective_config(practice, user_practice)
     if not isinstance(cfg, MindfulAnchorConfig):
@@ -96,17 +95,42 @@ def _enforce_mindful_anchor_invariants(
         raise bad_request("chosen_option_key_required")
 
 
+def _validate_session_metadata(
+    practice: Practice,
+    user_practice: UserPractice,
+    payload: PracticeSessionCreate,
+) -> None:
+    """Run every metadata-vs-catalog check before the session is persisted.
+
+    Two rules currently live here:
+
+    - ``mode_metadata.mode`` must match the resolved practice mode
+      (else 400 ``mode_metadata_mismatch``).
+    - For ``mindful_anchor`` practices, ``chosen_option_key`` must be
+      set whenever ``require_option_choice=True``
+      (delegated to :func:`_enforce_mindful_anchor_invariants`).
+
+    Extracted from :func:`_resolve_practice_with_mode` so the lookup
+    stays at xenon rank A.
+    """
+    if payload.mode_metadata is None:
+        return
+    if payload.mode_metadata.mode != practice.mode:
+        raise bad_request("mode_metadata_mismatch")
+    if isinstance(payload.mode_metadata, MindfulAnchorMetadata):
+        _enforce_mindful_anchor_invariants(practice, user_practice, payload.mode_metadata)
+
+
 async def _resolve_practice_with_mode(
     session: AsyncSession,
     user_practice: UserPractice,
     payload: PracticeSessionCreate,
 ) -> Practice:
-    """Load the catalog practice and validate the metadata discriminator.
+    """Load the catalog practice and validate the request metadata.
 
-    A 400 ``mode_metadata_mismatch`` is returned when the request's
-    ``mode_metadata`` references a mode that disagrees with the resolved
-    practice — distinct from a 422 schema failure: the union deserialized
-    cleanly; the caller just targeted the wrong practice.
+    The actual cross-field checks live in
+    :func:`_validate_session_metadata`; this wrapper just resolves the
+    catalog row and delegates so it stays trivially simple.
     """
     practice = (
         (await session.execute(select(Practice).where(Practice.id == user_practice.practice_id)))
@@ -117,12 +141,7 @@ async def _resolve_practice_with_mode(
         # Defensive: a UserPractice row whose practice was deleted is a
         # data-integrity issue.  Surface as 404 so the client retries.
         raise not_found("practice")
-    if payload.mode_metadata is not None and payload.mode_metadata.mode != practice.mode:
-        raise bad_request("mode_metadata_mismatch")
-    if practice.mode == PracticeMode.MINDFUL_ANCHOR.value and isinstance(
-        payload.mode_metadata, MindfulAnchorMetadata
-    ):
-        _enforce_mindful_anchor_invariants(practice, user_practice, payload.mode_metadata)
+    _validate_session_metadata(practice, user_practice, payload)
     return practice
 
 

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -212,6 +212,29 @@ class MindfulAnchorOption(_ConfigBase):
     description: str | None = Field(default=None, max_length=_OPTION_DESCRIPTION_MAX)
 
 
+def _reject_duplicate_option_keys(options: list[MindfulAnchorOption]) -> None:
+    """Reject any options list containing duplicate ``key`` slugs.
+
+    Extracted from :class:`MindfulAnchorConfig` so the validator method
+    stays at xenon rank A — the duplicate-key check is independent of
+    the "require_option_choice ⇒ options non-empty" rule and reads more
+    clearly on its own.
+    """
+    keys = [opt.key for opt in options]
+    if len(keys) != len(set(keys)):
+        msg = "options must not contain duplicate keys"
+        raise ValueError(msg)
+
+
+def _reject_empty_options_when_choice_required(
+    options: list[MindfulAnchorOption], *, require_option_choice: bool
+) -> None:
+    """Reject the contradictory ``require_option_choice=True`` + empty list state."""
+    if require_option_choice and not options:
+        msg = "options must be non-empty when require_option_choice is True"
+        raise ValueError(msg)
+
+
 class MindfulAnchorConfig(_ConfigBase):
     """Single mindful act with an optional chooser and a soft duration floor.
 
@@ -231,13 +254,10 @@ class MindfulAnchorConfig(_ConfigBase):
 
     @model_validator(mode="after")
     def _check_options_invariants(self) -> Self:
-        keys = [opt.key for opt in self.options]
-        if len(keys) != len(set(keys)):
-            msg = "options must not contain duplicate keys"
-            raise ValueError(msg)
-        if self.require_option_choice and not self.options:
-            msg = "options must be non-empty when require_option_choice is True"
-            raise ValueError(msg)
+        _reject_duplicate_option_keys(self.options)
+        _reject_empty_options_when_choice_required(
+            self.options, require_option_choice=self.require_option_choice
+        )
         return self
 
 

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -28,10 +28,13 @@ _TALLIED_KEY_PATTERN = r"^[a-z][a-z0-9_]*$"
 TALLIED_TARGET_MAX = 20
 TALLIED_ROUNDS_MAX = 10
 TALLIED_CATEGORIES_MAX = 12
-_OPTION_KEY_MAX = 64
+# Shared with ``schemas.practice_session_metadata`` so the option-key bound
+# is encoded once: ``MindfulAnchorMetadata.chosen_option_key`` mirrors the
+# values the catalog config emits.
+OPTION_KEY_MAX = 64
+OPTION_KEY_PATTERN = r"^[a-z][a-z0-9_]*$"
 _OPTION_LABEL_MAX = 255
 _OPTION_DESCRIPTION_MAX = 500
-_OPTION_KEY_PATTERN = r"^[a-z][a-z0-9_]*$"
 _INSTRUCTION_MAX = 500
 _MIN_DURATION_SECONDS_MAX = 3_600
 _MINDFUL_ANCHOR_OPTIONS_MAX = 20
@@ -207,7 +210,7 @@ class MindfulAnchorOption(_ConfigBase):
     alongside the label.
     """
 
-    key: str = Field(min_length=1, max_length=_OPTION_KEY_MAX, pattern=_OPTION_KEY_PATTERN)
+    key: str = Field(min_length=1, max_length=OPTION_KEY_MAX, pattern=OPTION_KEY_PATTERN)
     label: str = Field(min_length=1, max_length=_OPTION_LABEL_MAX)
     description: str | None = Field(default=None, max_length=_OPTION_DESCRIPTION_MAX)
 

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -28,6 +28,13 @@ _TALLIED_KEY_PATTERN = r"^[a-z][a-z0-9_]*$"
 TALLIED_TARGET_MAX = 20
 TALLIED_ROUNDS_MAX = 10
 TALLIED_CATEGORIES_MAX = 12
+_OPTION_KEY_MAX = 64
+_OPTION_LABEL_MAX = 255
+_OPTION_DESCRIPTION_MAX = 500
+_OPTION_KEY_PATTERN = r"^[a-z][a-z0-9_]*$"
+_INSTRUCTION_MAX = 500
+_MIN_DURATION_SECONDS_MAX = 3_600
+_MINDFUL_ANCHOR_OPTIONS_MAX = 20
 
 Sense = Literal["sight", "touch", "hearing", "smell", "taste"]
 BellTone = Literal["bowl", "chime", "gong"]
@@ -191,6 +198,49 @@ class TarotConfig(_ConfigBase):
     hide_timer_during_meditation: bool = True
 
 
+class MindfulAnchorOption(_ConfigBase):
+    """One pickable anchor for a single-action mindful practice.
+
+    ``key`` is a stable machine identifier (used by session metadata to
+    record which option the user chose); ``label`` is the human-facing
+    string the UI renders; ``description`` is an optional hint shown
+    alongside the label.
+    """
+
+    key: str = Field(min_length=1, max_length=_OPTION_KEY_MAX, pattern=_OPTION_KEY_PATTERN)
+    label: str = Field(min_length=1, max_length=_OPTION_LABEL_MAX)
+    description: str | None = Field(default=None, max_length=_OPTION_DESCRIPTION_MAX)
+
+
+class MindfulAnchorConfig(_ConfigBase):
+    """Single mindful act with an optional chooser and a soft duration floor.
+
+    Covers practices like Touch Grass or Mindful Eating — one instruction,
+    one "mark complete" action, an optional list of anchors to pick from,
+    and a soft minimum the client can nudge against without the server
+    rejecting shorter sessions.
+    """
+
+    mode: Literal["mindful_anchor"] = "mindful_anchor"
+    instruction: str = Field(min_length=1, max_length=_INSTRUCTION_MAX)
+    min_duration_seconds: int = Field(ge=0, le=_MIN_DURATION_SECONDS_MAX)
+    options: list[MindfulAnchorOption] = Field(
+        default_factory=list, max_length=_MINDFUL_ANCHOR_OPTIONS_MAX
+    )
+    require_option_choice: bool = False
+
+    @model_validator(mode="after")
+    def _check_options_invariants(self) -> Self:
+        keys = [opt.key for opt in self.options]
+        if len(keys) != len(set(keys)):
+            msg = "options must not contain duplicate keys"
+            raise ValueError(msg)
+        if self.require_option_choice and not self.options:
+            msg = "options must be non-empty when require_option_choice is True"
+            raise ValueError(msg)
+        return self
+
+
 #: Discriminated union over all per-mode config payloads, keyed on ``mode``.
 ModeConfig = Annotated[
     MeditationTimerConfig
@@ -200,7 +250,8 @@ ModeConfig = Annotated[
     | RepCounterConfig
     | SenseGroundingConfig
     | TarotConfig
-    | TalliedGroundingConfig,
+    | TalliedGroundingConfig
+    | MindfulAnchorConfig,
     Field(discriminator="mode"),
 ]
 

--- a/backend/src/schemas/practice_session_metadata.py
+++ b/backend/src/schemas/practice_session_metadata.py
@@ -33,6 +33,8 @@ _MAX_INTERVALS = 1_000
 # the underlying constants are ever inlined.
 MAX_TALLIED_ROUNDS = TALLIED_ROUNDS_MAX
 MAX_TALLIED_ITEMS = TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
+_MAX_ANCHOR_DURATION_SECONDS = 4 * 60 * 60  # 4 hours; well above any plausible mindful act.
+_MAX_OPTION_KEY = 64
 
 
 class _MetadataBase(BaseModel):
@@ -124,6 +126,20 @@ class TalliedGroundingMetadata(_MetadataBase):
         return self
 
 
+class MindfulAnchorMetadata(_MetadataBase):
+    """What the user picked (if anything) and how long the mindful act lasted.
+
+    ``met_min_duration`` is emitted by the client so the analytics rollup
+    can distinguish "long enough" from "abandoned early" without re-running
+    the soft-floor comparison against the catalog config at every query.
+    """
+
+    mode: Literal["mindful_anchor"] = "mindful_anchor"
+    chosen_option_key: str | None = Field(default=None, max_length=_MAX_OPTION_KEY)
+    duration_seconds: int = Field(ge=0, le=_MAX_ANCHOR_DURATION_SECONDS)
+    met_min_duration: bool
+
+
 #: Discriminated union over all per-mode session metadata payloads.
 SessionMetadata = Annotated[
     MeditationTimerMetadata
@@ -133,7 +149,8 @@ SessionMetadata = Annotated[
     | RepCounterMetadata
     | SenseGroundingMetadata
     | TarotMetadata
-    | TalliedGroundingMetadata,
+    | TalliedGroundingMetadata
+    | MindfulAnchorMetadata,
     Field(discriminator="mode"),
 ]
 

--- a/backend/src/schemas/practice_session_metadata.py
+++ b/backend/src/schemas/practice_session_metadata.py
@@ -15,6 +15,8 @@ from typing import Annotated, Literal, Self
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
 from schemas.practice_mode_config import (
+    OPTION_KEY_MAX,
+    OPTION_KEY_PATTERN,
     TALLIED_CATEGORIES_MAX,
     TALLIED_ROUNDS_MAX,
     TALLIED_TARGET_MAX,
@@ -34,7 +36,6 @@ _MAX_INTERVALS = 1_000
 MAX_TALLIED_ROUNDS = TALLIED_ROUNDS_MAX
 MAX_TALLIED_ITEMS = TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
 _MAX_ANCHOR_DURATION_SECONDS = 4 * 60 * 60  # 4 hours; well above any plausible mindful act.
-_MAX_OPTION_KEY = 64
 
 
 class _MetadataBase(BaseModel):
@@ -135,7 +136,9 @@ class MindfulAnchorMetadata(_MetadataBase):
     """
 
     mode: Literal["mindful_anchor"] = "mindful_anchor"
-    chosen_option_key: str | None = Field(default=None, max_length=_MAX_OPTION_KEY)
+    chosen_option_key: str | None = Field(
+        default=None, max_length=OPTION_KEY_MAX, pattern=OPTION_KEY_PATTERN
+    )
     duration_seconds: int = Field(ge=0, le=_MAX_ANCHOR_DURATION_SECONDS)
     met_min_duration: bool
 

--- a/backend/tests/domain/test_practice_modes.py
+++ b/backend/tests/domain/test_practice_modes.py
@@ -13,6 +13,7 @@ _EXPECTED_MEMBERS: tuple[str, ...] = (
     "sense_grounding",
     "tarot",
     "tallied_grounding",
+    "mindful_anchor",
 )
 
 

--- a/backend/tests/schemas/test_practice_mode_config.py
+++ b/backend/tests/schemas/test_practice_mode_config.py
@@ -10,6 +10,8 @@ from schemas.practice_mode_config import (
     IntervalBellConfig,
     MeditationTimerConfig,
     MetronomeConfig,
+    MindfulAnchorConfig,
+    MindfulAnchorOption,
     ModeConfig,
     ModeConfigAdapter,
     RepCounterConfig,
@@ -148,6 +150,28 @@ def test_tarot_round_trip() -> None:
     )
     assert isinstance(cfg, TarotConfig)
     assert cfg.deck == "major_arcana"
+
+
+def test_mindful_anchor_config_round_trip() -> None:
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "mindful_anchor",
+            "instruction": "Stand barefoot on a natural surface and breathe slowly.",
+            "min_duration_seconds": 60,
+            "options": [
+                {"key": "grass", "label": "Grass", "description": "Cool, springy blades."},
+                {"key": "soil", "label": "Soil", "description": None},
+                {"key": "stone", "label": "Stone"},
+            ],
+            "require_option_choice": True,
+        }
+    )
+    assert isinstance(cfg, MindfulAnchorConfig)
+    assert cfg.instruction.startswith("Stand barefoot")
+    assert cfg.min_duration_seconds == 60
+    assert [o.key for o in cfg.options] == ["grass", "soil", "stone"]
+    assert cfg.options[2].description is None
+    assert cfg.require_option_choice is True
 
 
 # -- Validators --------------------------------------------------------------
@@ -347,3 +371,73 @@ def test_discriminator_keyed_payload_dispatches_to_right_model() -> None:
     """The union adapter picks the right subclass purely from ``mode``."""
     cfg = _ADAPTER.validate_python({"mode": "count_up"})
     assert type(cfg) is CountUpConfig
+
+
+# -- Mindful-anchor validators ----------------------------------------------
+
+
+def _mindful_anchor_payload(**overrides: object) -> dict[str, object]:
+    """Minimal valid ``mindful_anchor`` config payload for negative-path tests."""
+    payload: dict[str, object] = {
+        "mode": "mindful_anchor",
+        "instruction": "Mark when you have settled.",
+        "min_duration_seconds": 0,
+        "options": [],
+        "require_option_choice": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_mindful_anchor_rejects_duplicate_option_keys() -> None:
+    """Duplicate ``key`` slugs are nonsense — the chooser can't disambiguate."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(
+            _mindful_anchor_payload(
+                options=[
+                    {"key": "grass", "label": "Grass"},
+                    {"key": "grass", "label": "Cool grass"},
+                ],
+            )
+        )
+
+
+def test_mindful_anchor_requires_options_when_choice_required() -> None:
+    """``require_option_choice=True`` with an empty option list is contradictory."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(
+            _mindful_anchor_payload(options=[], require_option_choice=True),
+        )
+
+
+def test_mindful_anchor_allows_no_options_when_choice_not_required() -> None:
+    """An empty option list is fine when the chooser is optional."""
+    cfg = _ADAPTER.validate_python(
+        _mindful_anchor_payload(options=[], require_option_choice=False),
+    )
+    assert isinstance(cfg, MindfulAnchorConfig)
+    assert cfg.options == []
+
+
+def test_mindful_anchor_option_rejects_invalid_key_slug() -> None:
+    """Option keys must match the documented slug regex (lowercase, snake-style)."""
+    with pytest.raises(ValidationError):
+        MindfulAnchorOption(key="Grass", label="Grass")
+
+
+def test_mindful_anchor_rejects_empty_instruction() -> None:
+    """An empty instruction string would leave the user with no prompt."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(_mindful_anchor_payload(instruction=""))
+
+
+def test_mindful_anchor_rejects_negative_duration_floor() -> None:
+    """``min_duration_seconds`` is a soft floor but must still be non-negative."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(_mindful_anchor_payload(min_duration_seconds=-1))
+
+
+def test_mindful_anchor_rejects_extra_fields() -> None:
+    """``extra="forbid"`` catches typos like ``minDurationSeconds``."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(_mindful_anchor_payload(extra_junk="nope"))

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-import sqlalchemy as sa
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, inspect, text

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import sqlalchemy as sa
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, inspect, text
@@ -41,6 +42,12 @@ _PRACTICE_SESSION_METADATA_REVISION = "f0a1b2c3d4e5"  # pragma: allowlist secret
 # grounding-techniques 01: tallied_grounding CHECK-constraint migration.
 _TALLIED_GROUNDING_BASE_REVISION = "d2e3f4a5b6c7"  # pragma: allowlist secret
 _TALLIED_GROUNDING_REVISION = "a1b2c3d4e5f7"  # pragma: allowlist secret
+
+# grounding-techniques-02: extend ck_practice_mode_valid to include mindful_anchor.
+# Chains off the tallied_grounding migration so the two new modes coexist on
+# a single linear timeline.
+_MINDFUL_ANCHOR_BASE_REVISION = "a1b2c3d4e5f7"  # pragma: allowlist secret
+_MINDFUL_ANCHOR_REVISION = "f4a5b6c7d8e9"  # pragma: allowlist secret
 
 
 def test_timestamptz_migration_exists() -> None:
@@ -557,17 +564,18 @@ _ORIGINAL_SEVEN_MODES = (
     "sense_grounding",
     "tarot",
 )
+_EIGHT_MODES_AFTER_TALLIED = (*_ORIGINAL_SEVEN_MODES, "tallied_grounding")
 
 
-def _bootstrap_practice_with_seven_mode_check(sync_url: str) -> None:
-    """Pre-create a ``practice`` table with the pre-tallied 7-mode CHECK constraint.
+def _bootstrap_practice_with_mode_check(sync_url: str, allowed_modes: tuple[str, ...]) -> None:
+    """Pre-create a ``practice`` table whose CHECK pins ``mode`` to ``allowed_modes``.
 
-    Mirrors the schema in place at :data:`_TALLIED_GROUNDING_BASE_REVISION`
-    just before our migration runs: ``mode`` is constrained to the
-    original seven values. Keeps the bootstrap SQLite-friendly so the
-    round-trip exercises only our new migration.
+    Mirrors the schema in place at whichever revision the test stamps to,
+    just before that revision's migration runs. Keeping the bootstrap
+    SQLite-friendly (no FKs, no extra CHECKs) means the round-trip
+    exercises only the migration under test.
     """
-    quoted = ", ".join(f"'{m}'" for m in _ORIGINAL_SEVEN_MODES)
+    quoted = ", ".join(f"'{m}'" for m in allowed_modes)
     bootstrap_engine = create_engine(sync_url)
     with bootstrap_engine.begin() as conn:
         conn.execute(
@@ -601,7 +609,7 @@ def alembic_sqlite_config_tallied_grounding(
     async_url = f"sqlite+aiosqlite:///{db_path}"
     monkeypatch.setenv("DATABASE_URL", async_url)
 
-    _bootstrap_practice_with_seven_mode_check(sync_url)
+    _bootstrap_practice_with_mode_check(sync_url, _ORIGINAL_SEVEN_MODES)
 
     cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
     cfg.config_file_name = None
@@ -686,3 +694,89 @@ def test_tallied_grounding_migration_round_trip_on_sqlite(
     command.upgrade(cfg, _TALLIED_GROUNDING_REVISION)
     _insert_practice_row(db_url, mode="tallied_grounding", name="Find colors")
     assert _count_practice_with_mode(db_url, "tallied_grounding") == 1
+
+
+# -- grounding-techniques-02 mindful_anchor migration round-trip ------------
+
+
+@pytest.fixture
+def alembic_sqlite_config_mindful_anchor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before ``f4a5b6c7d8e9``.
+
+    The down_revision is the tallied_grounding migration so the
+    pre-upgrade CHECK already lists eight modes; bootstrap mirrors that
+    state.
+    """
+    db_path = tmp_path / "mindful_anchor_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_practice_with_mode_check(sync_url, _EIGHT_MODES_AFTER_TALLIED)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _MINDFUL_ANCHOR_BASE_REVISION)
+    return cfg
+
+
+def test_mindful_anchor_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_mindful_anchor: Config,
+) -> None:
+    """Round-trip ``f4a5b6c7d8e9``: upgrade allows ``mindful_anchor``; downgrade reverts.
+
+    Phase 1: upgrade lets a ``mindful_anchor`` row insert succeed
+    (proving the CHECK was widened). Phase 2: with that row deleted,
+    downgrade narrows the CHECK and rejects future ``mindful_anchor``
+    inserts. Phase 3: re-upgrade is idempotent.
+    """
+    cfg = alembic_sqlite_config_mindful_anchor
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade widens the CHECK.
+    command.upgrade(cfg, _MINDFUL_ANCHOR_REVISION)
+    _insert_practice_row(db_url, mode="mindful_anchor", name="Touch grass")
+    assert _count_practice_with_mode(db_url, "mindful_anchor") == 1
+
+    # Phase 2: clear the new-mode row, then downgrade and prove the CHECK is
+    # back in force.
+    sync_engine = create_engine(_sync_url(db_url))
+    try:
+        with sync_engine.begin() as conn:
+            conn.execute(text("DELETE FROM practice WHERE mode = 'mindful_anchor'"))
+    finally:
+        sync_engine.dispose()
+    command.downgrade(cfg, _MINDFUL_ANCHOR_BASE_REVISION)
+    with pytest.raises(IntegrityError):
+        _insert_practice_row(db_url, mode="mindful_anchor", name="Should fail")
+
+    # Phase 3: re-upgrade so the cycle is idempotent.
+    command.upgrade(cfg, _MINDFUL_ANCHOR_REVISION)
+    _insert_practice_row(db_url, mode="mindful_anchor", name="Mindful eating")
+    assert _count_practice_with_mode(db_url, "mindful_anchor") == 1
+
+
+def test_mindful_anchor_downgrade_refuses_with_existing_rows(
+    alembic_sqlite_config_mindful_anchor: Config,
+) -> None:
+    """The downgrade aborts when ``mindful_anchor`` rows still exist.
+
+    Narrowing the CHECK while data violates it would either rewrite
+    history or leave the DB in an inconsistent state. The migration
+    refuses to run and the operator clears the rows themselves.
+    """
+    cfg = alembic_sqlite_config_mindful_anchor
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    command.upgrade(cfg, _MINDFUL_ANCHOR_REVISION)
+    _insert_practice_row(db_url, mode="mindful_anchor", name="Stick around")
+
+    with pytest.raises(RuntimeError, match="mindful_anchor"):
+        command.downgrade(cfg, _MINDFUL_ANCHOR_BASE_REVISION)

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -313,3 +313,20 @@ def test_mindful_anchor_metadata_rejects_overlong_option_key() -> None:
             duration_seconds=10,
             met_min_duration=False,
         )
+
+
+def test_mindful_anchor_metadata_rejects_invalid_option_key_slug() -> None:
+    """``chosen_option_key`` mirrors option keys and must satisfy the slug regex.
+
+    Length alone is not enough: a 64-char string can still contain
+    uppercase, spaces, leading digits, or hyphens, none of which would
+    ever match a valid catalog option key.
+    """
+    for invalid in ("Grass", "has spaces", "1leading_digit", "trailing-dash"):
+        with pytest.raises(ValidationError):
+            MindfulAnchorMetadata(
+                mode="mindful_anchor",
+                chosen_option_key=invalid,
+                duration_seconds=10,
+                met_min_duration=False,
+            )

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -17,6 +17,7 @@ from schemas.practice_session_metadata import (
     IntervalBellMetadata,
     MeditationTimerMetadata,
     MetronomeMetadata,
+    MindfulAnchorMetadata,
     RepCounterMetadata,
     SenseGroundingMetadata,
     SessionMetadataAdapter,
@@ -91,6 +92,35 @@ def test_tallied_grounding_round_trip() -> None:
     assert payload.rounds_completed == 2
     assert payload.total_rounds == 3
     assert payload.items_completed == 27
+
+
+def test_mindful_anchor_metadata_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python(
+        {
+            "mode": "mindful_anchor",
+            "chosen_option_key": "grass",
+            "duration_seconds": 120,
+            "met_min_duration": True,
+        }
+    )
+    assert isinstance(payload, MindfulAnchorMetadata)
+    assert payload.chosen_option_key == "grass"
+    assert payload.duration_seconds == 120
+    assert payload.met_min_duration is True
+
+
+def test_mindful_anchor_metadata_with_no_option_chosen() -> None:
+    """Optional chooser: a session may complete without picking from the list."""
+    payload = SessionMetadataAdapter.validate_python(
+        {
+            "mode": "mindful_anchor",
+            "duration_seconds": 30,
+            "met_min_duration": False,
+        }
+    )
+    assert isinstance(payload, MindfulAnchorMetadata)
+    assert payload.chosen_option_key is None
+    assert payload.met_min_duration is False
 
 
 # -- Validators --------------------------------------------------------------
@@ -251,3 +281,35 @@ def test_discriminator_dispatches_to_right_subclass() -> None:
     """The union picks the right model purely from ``mode``."""
     payload = SessionMetadataAdapter.validate_python({"mode": "count_up"})
     assert type(payload) is CountUpMetadata
+
+
+# -- Mindful-anchor metadata validators -------------------------------------
+
+
+def test_mindful_anchor_metadata_rejects_negative_duration() -> None:
+    with pytest.raises(ValidationError):
+        MindfulAnchorMetadata(
+            mode="mindful_anchor",
+            duration_seconds=-1,
+            met_min_duration=False,
+        )
+
+
+def test_mindful_anchor_metadata_rejects_duration_past_cap() -> None:
+    """Four-hour cap guards against bogus client clocks."""
+    with pytest.raises(ValidationError):
+        MindfulAnchorMetadata(
+            mode="mindful_anchor",
+            duration_seconds=14_401,
+            met_min_duration=False,
+        )
+
+
+def test_mindful_anchor_metadata_rejects_overlong_option_key() -> None:
+    with pytest.raises(ValidationError):
+        MindfulAnchorMetadata(
+            mode="mindful_anchor",
+            chosen_option_key="x" * 65,
+            duration_seconds=10,
+            met_min_duration=False,
+        )

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -748,6 +748,36 @@ async def test_create_session_accepts_chosen_key_when_required(
 
 
 @pytest.mark.asyncio
+async def test_create_session_rejects_chosen_key_not_in_catalog(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A submitted ``chosen_option_key`` must exist in the catalog's option list.
+
+    Without this check, a client can persist phantom keys like
+    ``"mud"`` against a catalog of ``["grass", "stone"]``; analytics
+    rollups that ``GROUP BY chosen_option_key`` would then surface
+    fabricated categories.
+    """
+    headers, _ = await _signup(async_client)
+    up_id, _practice = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="mindful_anchor_required"
+    )
+
+    payload = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "mindful_anchor",
+            "chosen_option_key": "mud",
+            "duration_seconds": 45,
+            "met_min_duration": True,
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "chosen_option_key_not_in_catalog"
+
+
+@pytest.mark.asyncio
 async def test_create_session_allows_missing_chosen_key_when_optional(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -463,7 +463,28 @@ async def _create_typed_user_practice(
                 {"key": "colors", "label": "Find colors", "target_count": 4},
             ],
         },
+        "mindful_anchor_required": {
+            "mode": "mindful_anchor",
+            "instruction": "Pick a surface and stand there until you feel settled.",
+            "min_duration_seconds": 30,
+            "options": [
+                {"key": "grass", "label": "Grass"},
+                {"key": "stone", "label": "Stone"},
+            ],
+            "require_option_choice": True,
+        },
+        "mindful_anchor_optional": {
+            "mode": "mindful_anchor",
+            "instruction": "Pick a surface (optional) and stand there until you feel settled.",
+            "min_duration_seconds": 0,
+            "options": [
+                {"key": "grass", "label": "Grass"},
+            ],
+            "require_option_choice": False,
+        },
     }
+    catalog_mode = mode_configs[mode]["mode"]
+    assert isinstance(catalog_mode, str)
     practice = Practice(
         stage_number=stage_number,
         name=f"{mode} practice",
@@ -471,7 +492,7 @@ async def _create_typed_user_practice(
         instructions="Test fixture",
         default_duration_minutes=10,
         approved=True,
-        mode=mode,
+        mode=catalog_mode,
         mode_config=mode_configs[mode],
     )
     db_session.add(practice)
@@ -670,6 +691,83 @@ async def test_create_session_persists_tallied_grounding_metadata(
     )
     resp_bad = await async_client.post("/practice-sessions/", json=bad, headers=headers)
     assert resp_bad.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_missing_chosen_key_when_required(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``require_option_choice=True`` ⇒ ``chosen_option_key`` must be set.
+
+    The metadata schema alone can't see the catalog config, so the
+    server enforces this cross-field invariant at the router layer when
+    creating a session.
+    """
+    headers, _ = await _signup(async_client)
+    up_id, _practice = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="mindful_anchor_required"
+    )
+
+    payload = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "mindful_anchor",
+            "duration_seconds": 45,
+            "met_min_duration": True,
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "chosen_option_key_required"
+
+
+@pytest.mark.asyncio
+async def test_create_session_accepts_chosen_key_when_required(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A ``mindful_anchor`` session with the chosen key set round-trips cleanly."""
+    headers, _ = await _signup(async_client)
+    up_id, _practice = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="mindful_anchor_required"
+    )
+
+    payload = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "mindful_anchor",
+            "chosen_option_key": "grass",
+            "duration_seconds": 45,
+            "met_min_duration": True,
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    body = resp.json()
+    assert body["mode"] == "mindful_anchor"
+    assert body["mode_metadata"]["chosen_option_key"] == "grass"
+
+
+@pytest.mark.asyncio
+async def test_create_session_allows_missing_chosen_key_when_optional(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """When ``require_option_choice=False`` the chooser is optional."""
+    headers, _ = await _signup(async_client)
+    up_id, _practice = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="mindful_anchor_optional"
+    )
+
+    payload = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "mindful_anchor",
+            "duration_seconds": 10,
+            "met_min_duration": False,
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["mode_metadata"]["chosen_option_key"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Introduce a new practice mode for single-action mindful presence
practices (Touch Grass, Mindful Eating). Adds MindfulAnchorConfig
to the mode-config union (instruction, soft duration floor, optional
chooser of anchor options) and MindfulAnchorMetadata to the
session-metadata union (chosen key, observed duration, soft-floor
flag), plus an Alembic migration that extends ck_practice_mode_valid
to accept the new value. Downgrade refuses if any rows still carry
mindful_anchor so the CHECK can never narrow under live data.

Closes #338