### PR TITLE
docs(roadmap): add grounding-techniques feature epic and sub-issues

### DIFF
--- a/prompts/github-issues/README.md
+++ b/prompts/github-issues/README.md
@@ -196,3 +196,36 @@ Recommended execution order by priority:
 - **~65 issues** across 7 phases
 - Phases 1–5 complete, Phase 6 (Gumroad monetization) and Phase 7 (cleanup) are active
 - Phase 7 is all pure refactoring — no behavior changes, can run in parallel with Phase 6
+
+## Feature Epics (outside the numbered phases)
+
+Feature work that extends the catalog or product surface, not part of the
+refactor roadmap. Each epic owns its own sub-issues and can ship
+independently.
+
+### Generalize grounding techniques
+
+Add **Find Shapes**, **Find Colors**, **Touch Grass**, and **Mindful
+Eating** by extending the mode-discriminated practice engine with two
+new modes (`tallied_grounding`, `mindful_anchor`). Existing
+`sense_grounding` (5-4-3-2-1) is untouched.
+
+| # | Issue | Scope | Est. LoC |
+|---|-------|-------|----------|
+| — | [Epic tracker](grounding-techniques-epic.md) | — | — |
+| 01 | [Add `tallied_grounding` mode](grounding-techniques-01-tallied-mode-backend.md) | Backend | ~250 |
+| 02 | [Add `mindful_anchor` mode](grounding-techniques-02-mindful-anchor-mode-backend.md) | Backend | ~200 |
+| 03 | [Seed Find Shapes + Find Colors presets](grounding-techniques-03-presets-shapes-and-colors.md) | Backend | ~100 |
+| 04 | [Seed Touch Grass + Mindful Eating presets](grounding-techniques-04-presets-touch-grass-and-mindful-eating.md) | Backend | ~100 |
+| 05 | [Build `TalliedGroundingView`](grounding-techniques-05-tallied-view-frontend.md) | Frontend | ~250 |
+| 06 | [Build `MindfulAnchorView`](grounding-techniques-06-mindful-anchor-view-frontend.md) | Frontend | ~200 |
+
+Dependency graph:
+
+```
+01 tallied-mode-backend ──┬── 03 tallied-presets
+                          └── 05 tallied-view-frontend
+
+02 mindful-anchor-mode ───┬── 04 mindful-anchor-presets
+                          └── 06 mindful-anchor-view-frontend
+```

--- a/prompts/github-issues/README.md
+++ b/prompts/github-issues/README.md
@@ -203,6 +203,21 @@ Feature work that extends the catalog or product surface, not part of the
 refactor roadmap. Each epic owns its own sub-issues and can ship
 independently.
 
+### Customizable practices, catalog browse, and share links
+
+Two new modes (`random_interval_bell`, `card_meditation`) round out the engine to 11; users can browse a global catalog, create custom practices in any mode, assign customs to any stage, and share a practice via private link. Rider-Waite-Smith deck content ships bundled.
+
+| # | Issue | Scope | Est. LoC |
+|---|-------|-------|----------|
+| — | [Epic tracker](custom-practices-epic.md) | — | — |
+| 01 | [Add `random_interval_bell` mode](custom-practices-01-random-interval-bell-backend.md) | Backend | ~200 |
+| 02 | [Add `card_meditation` mode](custom-practices-02-card-meditation-backend.md) | Backend | ~250 |
+| 03 | [Practice share-link feature](custom-practices-03-share-link-feature.md) | Full-stack | ~400 |
+| 04 | [Ship RWS deck content + asset folder](custom-practices-04-rws-deck-content.md) | Frontend | ~200 |
+| 05 | [Build `RandomIntervalBellView` + form](custom-practices-05-random-interval-bell-frontend.md) | Frontend | ~250 |
+| 06 | [Build `CardMeditationView` + image picker](custom-practices-06-card-meditation-frontend.md) | Frontend | ~350 |
+| 07 | [Catalog browse + Create-custom flow](custom-practices-07-catalog-and-create-flow.md) | Frontend | ~450 |
+
 ### Generalize grounding techniques
 
 Add **Find Shapes**, **Find Colors**, **Touch Grass**, and **Mindful

--- a/prompts/github-issues/custom-practices-01-random-interval-bell-backend.md
+++ b/prompts/github-issues/custom-practices-01-random-interval-bell-backend.md
@@ -1,0 +1,76 @@
+# custom-practices-01: Add `random_interval_bell` practice mode (backend)
+
+**Labels:** `enhancement`, `ritual-practice`, `backend`
+**Epic:** [Customizable practices](custom-practices-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~200
+
+## Role
+
+You are a FastAPI / SQLModel engineer extending Adepthood's discriminated-union practice mode catalog with a non-deterministic timer variant. You follow the same pattern used by `interval_bell` and `tallied_grounding`.
+
+## Goal
+
+Add a `random_interval_bell` mode: a meditation timer that rings a bell at random offsets between configurable min/max bounds. Used for awareness practices where the unpredictability of the bell prompts re-anchoring attention.
+
+## Context
+
+`interval_bell` today supports evenly-spaced (`interval_minutes`) or explicit (`cue_offsets_minutes`) cue schedules (`backend/src/schemas/practice_mode_config.py:81-107`). Both are deterministic. The new mode introduces a third style — random within bounds — with its own validation rules. We add it as a separate mode rather than overloading `interval_bell` because the metadata shape differs (we record the actual struck offsets per session, not just a count).
+
+## Tasks
+
+1. **Extend `PracticeMode` enum** (`backend/src/domain/practice_modes.py`): add `RANDOM_INTERVAL_BELL = "random_interval_bell"`.
+
+2. **Add `RandomIntervalBellConfig` to `practice_mode_config.py`**:
+   - `mode: Literal["random_interval_bell"] = "random_interval_bell"`
+   - `duration_minutes: float = Field(ge=_DURATION_MIN_MINUTES, le=_DURATION_MAX_MINUTES)`
+   - `min_interval_seconds: int = Field(ge=5, le=3600)`
+   - `max_interval_seconds: int = Field(ge=10, le=3600)`
+   - `bell_tone: BellTone = "bowl"`
+   - `max_bells: int | None = Field(default=None, ge=1, le=1000)` — optional cap on total bells
+   - `start_bell: bool = True`
+   - `end_bell: bool = True`
+   - `@model_validator(mode="after")` enforcing:
+     - `max_interval_seconds >= min_interval_seconds`
+     - `min_interval_seconds <= duration_minutes * 60` (at least one bell can fit)
+   - Add to the `ModeConfig` discriminated union.
+
+3. **Add `RandomIntervalBellMetadata` to `practice_session_metadata.py`**:
+   - `mode: Literal["random_interval_bell"] = "random_interval_bell"`
+   - `bells_struck: int = Field(ge=0, le=1000)`
+   - `interval_seconds: list[int] = Field(default_factory=list, max_length=1000)` — recorded offsets between consecutive bells, useful for "what was my actual rhythm" reflection
+   - Add to the `SessionMetadata` union.
+
+4. **Alembic migration** — `backend/migrations/versions/<rev>_add_random_interval_bell_mode.py`:
+   - `upgrade()`: drop `ck_practice_mode_value`, recreate including `"random_interval_bell"`.
+   - `downgrade()`: refuse if any rows carry the new mode.
+
+5. **Tests**:
+   - `test_practice_mode_config.py`: round-trip, rejects `max < min`, rejects `min > duration*60`, default tone is `bowl`.
+   - `test_practice_session_metadata.py`: round-trip, accepts empty `interval_seconds`, accepts large lists up to `max_length`.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/` green
+- [ ] `pre-commit run --all-files` green
+- [ ] Coverage thresholds unchanged
+- [ ] Migration runs cleanly on fresh DB and rolls back on empty `practice` table
+- [ ] `ALL_MODES` contains `random_interval_bell`
+- [ ] No changes to existing `interval_bell` behavior or tests
+
+## Files
+
+| File | Action |
+|------|--------|
+| `backend/src/domain/practice_modes.py` | Modify |
+| `backend/src/schemas/practice_mode_config.py` | Modify |
+| `backend/src/schemas/practice_session_metadata.py` | Modify |
+| `backend/migrations/versions/<rev>_add_random_interval_bell_mode.py` | **Create** |
+| `backend/tests/test_practice_mode_config.py` | Modify |
+| `backend/tests/test_practice_session_metadata.py` | Modify |
+
+## Constraints
+
+- Do not change `interval_bell` config or metadata
+- Keep `extra="forbid"` on the new model
+- The client generates the random schedule; server only records what happened

--- a/prompts/github-issues/custom-practices-02-card-meditation-backend.md
+++ b/prompts/github-issues/custom-practices-02-card-meditation-backend.md
@@ -1,0 +1,115 @@
+# custom-practices-02: Add `card_meditation` practice mode (backend)
+
+**Labels:** `enhancement`, `ritual-practice`, `backend`
+**Epic:** [Customizable practices](custom-practices-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~250
+
+## Role
+
+You are a FastAPI / SQLModel engineer adding a new, deck-agnostic card-meditation mode that generalizes the existing `tarot` mode without removing it.
+
+## Goal
+
+Add a `card_meditation` mode that powers full-screen card meditation for any deck — bundled (RWS, Major Arcana text) or user-curated (a list of `{name, image_uri}` entries). The existing `tarot` mode stays for backward compatibility.
+
+## Context
+
+`tarot` today (`backend/src/schemas/practice_mode_config.py:134-141`) is hardcoded to the 22-card major arcana with text-only display. The user wants to display **images** (curated decks shipped by the app, plus optional photos picked from the user's device), to support **multiple decks** (RWS, Thoth, Marseille, oracle cards), and to let users **author custom card sets**. This mode is the structural home for all of that.
+
+Frontend has the existing major-arcana data at `frontend/src/features/Practice/data/tarot.ts`. The RWS bundle is delivered in sub-issue 04.
+
+## Tasks
+
+1. **Extend `PracticeMode` enum**: add `CARD_MEDITATION = "card_meditation"`.
+
+2. **Add `CardMeditationCard` and `CardMeditationConfig` to `practice_mode_config.py`**:
+   - `CardMeditationCard(_ConfigBase)`:
+     - `name: str = Field(min_length=1, max_length=120)`
+     - `image_asset_key: str | None = Field(default=None, max_length=200)` — references a bundled asset (e.g. `"rws/the_fool"`) or null for text-only
+     - `image_uri: str | None = Field(default=None, max_length=500)` — remote URL or device path; **client-only**, server never resolves
+     - `symbolism: str | None = Field(default=None, max_length=500)` — optional reading
+     - `@model_validator`: reject if both `image_asset_key` and `image_uri` are set
+   - `CardMeditationConfig(_ConfigBase)`:
+     - `mode: Literal["card_meditation"] = "card_meditation"`
+     - `deck_id: str = Field(min_length=1, max_length=64, pattern=r"^[a-z][a-z0-9_]*$")` — examples: `rws`, `major_arcana_text`, `custom`
+     - `per_card_minutes: float = Field(default=5, ge=_DURATION_MIN_MINUTES, le=_DURATION_MAX_MINUTES)`
+     - `shuffle: bool = True`
+     - `reveal_after_meditation: bool = False` — if True, the timer runs **first** with the card hidden, then the card is revealed
+     - `hide_timer_during_meditation: bool = True`
+     - `cards: list[CardMeditationCard] | None = Field(default=None, max_length=200)` — null means "use the bundled deck named by `deck_id`"; non-null overrides
+   - `@model_validator`: if `deck_id == "custom"`, `cards` must be non-null and non-empty.
+   - Add to the `ModeConfig` discriminated union.
+
+3. **Add `CardMeditationMetadata` to `practice_session_metadata.py`**:
+   - `mode: Literal["card_meditation"] = "card_meditation"`
+   - `deck_id: str = Field(min_length=1, max_length=64)`
+   - `card_drawn_name: str = Field(min_length=1, max_length=120)`
+   - `card_drawn_index: int | None = Field(default=None, ge=0, le=999)` — optional, useful for reproducing shuffles
+   - Add to the `SessionMetadata` union.
+
+4. **Alembic migration** — add `card_meditation` to `ck_practice_mode_value`.
+
+5. **Tests**:
+   - `test_practice_mode_config.py`:
+     - Round-trip with bundled deck (no `cards`)
+     - Round-trip with custom deck (`cards` populated)
+     - Rejects `deck_id="custom"` with `cards=None`
+     - Rejects a card with both `image_asset_key` and `image_uri` set
+     - Accepts a card with neither (text-only display)
+   - `test_practice_session_metadata.py`: round-trip, accepts null `card_drawn_index`.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/` green
+- [ ] `pre-commit run --all-files` green
+- [ ] Migration runs cleanly on fresh DB and rolls back on empty `practice` table
+- [ ] `ALL_MODES` contains `card_meditation`
+- [ ] `tarot` mode tests and behavior unchanged
+
+## Files
+
+| File | Action |
+|------|--------|
+| `backend/src/domain/practice_modes.py` | Modify |
+| `backend/src/schemas/practice_mode_config.py` | Modify |
+| `backend/src/schemas/practice_session_metadata.py` | Modify |
+| `backend/migrations/versions/<rev>_add_card_meditation_mode.py` | **Create** |
+| `backend/tests/test_practice_mode_config.py` | Modify |
+| `backend/tests/test_practice_session_metadata.py` | Modify |
+
+## Constraints
+
+- Do not modify or deprecate `tarot` — both modes coexist
+- Server never fetches `image_uri` content; it's just a string the client uses
+- `image_asset_key` is opaque to the server; frontend resolves it against the deck manifest
+- Keep `extra="forbid"`
+
+## Example payloads
+
+```json
+// Custom deck shipped with the app
+{
+  "mode": "card_meditation",
+  "deck_id": "rws",
+  "per_card_minutes": 7,
+  "shuffle": true,
+  "reveal_after_meditation": false,
+  "hide_timer_during_meditation": true,
+  "cards": null
+}
+
+// User-authored deck of phone photos
+{
+  "mode": "card_meditation",
+  "deck_id": "custom",
+  "per_card_minutes": 5,
+  "shuffle": true,
+  "reveal_after_meditation": true,
+  "hide_timer_during_meditation": true,
+  "cards": [
+    {"name": "Mountain", "image_uri": "file:///var/.../IMG_0123.jpg", "symbolism": "Stillness."},
+    {"name": "River",    "image_uri": "file:///var/.../IMG_0124.jpg", "symbolism": "Flow."}
+  ]
+}
+```

--- a/prompts/github-issues/custom-practices-03-share-link-feature.md
+++ b/prompts/github-issues/custom-practices-03-share-link-feature.md
@@ -1,0 +1,114 @@
+# custom-practices-03: Practice share-link feature
+
+**Labels:** `enhancement`, `ritual-practice`, `backend`, `frontend`
+**Epic:** [Customizable practices](custom-practices-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~400
+
+## Role
+
+You are a full-stack engineer building a private-share mechanism: one user generates a token for a practice they own; another user opens a link with that token and imports a copy into their own catalog.
+
+## Goal
+
+A user with a custom practice can tap **Share**, generate a one-time-or-multi-use link, and send it. The recipient opens the link, sees a preview of the practice (name, mode, config summary), and taps **Import** to copy the practice into their own catalog as an unapproved draft owned by them.
+
+## Context
+
+The infrastructure for "copy a practice owned by user A into user B's catalog" doesn't exist today, but the building blocks do:
+- `POST /practices` already creates `approved=False, submitted_by_user_id=<self>` rows (`backend/src/routers/practices.py:88-129`).
+- The visibility filter (`backend/src/dependencies/ownership.py:155-168`) already restricts `approved=False` rows to the owner — so an imported copy is automatically private to the recipient.
+
+What's missing: a token table, generate/redeem endpoints, and the share/import UI.
+
+## Tasks — Backend
+
+1. **New model `PracticeShareLink`** at `backend/src/models/practice_share_link.py`:
+   - `id: int` PK
+   - `token: str = Field(index=True, unique=True, max_length=64)` — URL-safe base64
+   - `practice_id: int = Field(foreign_key="practice.id", index=True)`
+   - `created_by_user_id: int = Field(foreign_key="user.id", index=True)`
+   - `created_at: datetime`
+   - `expires_at: datetime | None` — null = never expires
+   - `max_uses: int | None = Field(default=None, ge=1, le=1000)` — null = unlimited
+   - `use_count: int = Field(default=0, ge=0)`
+   - `revoked_at: datetime | None`
+
+2. **Alembic migration** for the new table.
+
+3. **Schemas** at `backend/src/schemas/practice_share.py`:
+   - `ShareLinkCreateRequest` (`expires_in_days: int | None`, `max_uses: int | None`)
+   - `ShareLinkResponse` (`token, share_url, expires_at, max_uses, use_count`)
+   - `ShareLinkPreviewResponse` (`practice_name, mode, default_duration_minutes, description, created_by_display_name, expires_at, remaining_uses`)
+   - `ShareLinkImportResponse` (`imported_practice_id`)
+
+4. **Router** at `backend/src/routers/practice_share.py`:
+   - `POST /practices/{practice_id}/share-link` (auth: owner of practice) → generate token, return `ShareLinkResponse`
+   - `GET /practices/share/{token}` (auth: any logged-in user) → return `ShareLinkPreviewResponse`. Validates not revoked, not expired, under `max_uses`.
+   - `POST /practices/share/{token}/import` (auth: any logged-in user) → copy practice as `approved=False, submitted_by_user_id=<self>`, increment `use_count`, return `ShareLinkImportResponse`. Recipient cannot import their own share (returns 400).
+   - `DELETE /practices/share-links/{share_link_id}` (auth: owner) → set `revoked_at = now`
+
+5. **Rate-limiting**: 10 share-link creates / hour / user, 30 redemptions / hour / IP.
+
+6. **Tests** at `backend/tests/test_practice_share.py`:
+   - Owner can generate a link
+   - Non-owner cannot generate a link
+   - Recipient can preview and import
+   - Imported practice belongs to recipient, is `approved=False`
+   - Expired link returns 410
+   - `max_uses` exhausted returns 410
+   - Revoked link returns 410
+   - Self-import returns 400
+   - Generated tokens are unique under contention
+
+## Tasks — Frontend
+
+7. **API client** at `frontend/src/api/practiceShare.ts` mirroring the four endpoints.
+
+8. **Share UI**:
+   - `ShareSheet` component opened from the practice detail screen for any practice the user owns
+   - Form fields: `expires_in_days` (default 30, options 1/7/30/never), `max_uses` (default unlimited, options 1/5/10/unlimited)
+   - On submit, displays the share URL with a Copy button
+   - Lists existing active links for the practice with Revoke buttons
+
+9. **Import flow**:
+   - Deep-link handler registers `adepthood://practices/share/:token` (and equivalent universal link)
+   - `SharePreviewScreen` shows the preview response, with **Import to my catalog** + **Cancel**
+   - On import, navigates to the new practice's detail screen in the catalog
+
+10. **Tests**:
+    - `ShareSheet.test.tsx`: form renders, Copy button copies the URL, Revoke calls DELETE
+    - `SharePreviewScreen.test.tsx`: renders preview fields, Import calls POST, expired link shows the error state
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/` green
+- [ ] `npm test` green
+- [ ] Manual smoke: user A creates a practice → generates a share link → opens it as user B → previews → imports → finds the practice in their own catalog at `approved=False`
+- [ ] Expired and revoked links fail closed with 410
+- [ ] Self-import is rejected
+
+## Files
+
+| File | Action |
+|------|--------|
+| `backend/src/models/practice_share_link.py` | **Create** |
+| `backend/src/schemas/practice_share.py` | **Create** |
+| `backend/src/routers/practice_share.py` | **Create** |
+| `backend/src/main.py` | Modify (mount router) |
+| `backend/migrations/versions/<rev>_add_practice_share_link.py` | **Create** |
+| `backend/tests/test_practice_share.py` | **Create** |
+| `frontend/src/api/practiceShare.ts` | **Create** |
+| `frontend/src/features/Practice/components/ShareSheet.tsx` | **Create** |
+| `frontend/src/features/Practice/screens/SharePreviewScreen.tsx` | **Create** |
+| `frontend/src/navigation/` (deep-link config) | Modify |
+| `frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx` | **Create** |
+| `frontend/src/features/Practice/screens/__tests__/SharePreviewScreen.test.tsx` | **Create** |
+
+## Constraints
+
+- Tokens are 32 random bytes URL-safe base64 (`secrets.token_urlsafe(32)`)
+- The server never auto-approves an imported practice; `approved=False` keeps it private to the recipient via the existing visibility filter
+- Do not expose the original owner's user_id — only `created_by_display_name`
+- The recipient's imported copy is independent — revoking the original share link does not affect already-imported copies
+- Sharing a preset (`submitted_by_user_id=null`) is also allowed; the import still creates a private draft owned by the recipient

--- a/prompts/github-issues/custom-practices-04-rws-deck-content.md
+++ b/prompts/github-issues/custom-practices-04-rws-deck-content.md
@@ -1,0 +1,84 @@
+# custom-practices-04: Ship Rider-Waite-Smith deck content + asset folder
+
+**Labels:** `enhancement`, `ritual-practice`, `frontend`, `content`
+**Epic:** [Customizable practices](custom-practices-epic.md)
+**Depends on:** [custom-practices-02](custom-practices-02-card-meditation-backend.md) for the `card_meditation` mode reference
+**Estimated LoC:** ~200
+
+## Role
+
+You are a frontend engineer + content curator establishing the deck content module and the asset-folder convention for bundled card decks. The dev (Geoffe-Ga) owns the RWS card images and will drop them into the folder you scaffold.
+
+## Goal
+
+Ship a frontend data module that lists all 78 Rider-Waite-Smith cards with name, keyword, symbolism, and an asset key. Scaffold the matching asset folder with a README that tells the dev exactly where to drop the image files. The bundled deck is consumed by `CardMeditationView` (sub-issue 06).
+
+## Context
+
+The existing major arcana data at `frontend/src/features/Practice/data/tarot.ts` is text-only — no images. This task adds a parallel module for the RWS deck with image references, organized so we can add more decks (Thoth, Marseille, oracle) later without re-engineering.
+
+Card-meditation backend reads only `deck_id` and `image_asset_key` strings — the frontend resolves them against a deck manifest. Keeping the asset layout flat and predictable means the dev can drop images in without code changes.
+
+## Tasks
+
+1. **Create deck content module** `frontend/src/features/Practice/data/decks/rws.ts`:
+   - Export `RWS_CARDS: readonly CardMeta[]` with all 78 cards
+   - Each entry: `{ asset_key: string; name: string; arcana: "major" | "minor"; suit?: "wands" | "cups" | "swords" | "pentacles"; rank?: string; keyword: string; symbolism: string }`
+   - `asset_key` format: `rws/<slug>` where slug uses `snake_case` (e.g. `the_fool`, `ace_of_cups`, `knight_of_swords`)
+   - Cards: 22 major + 14 per suit × 4 suits
+
+2. **Create deck manifest** `frontend/src/features/Practice/data/decks/index.ts`:
+   - Export `BUNDLED_DECKS: readonly DeckMeta[]` where each entry is `{ id: string; name: string; description: string; cards: readonly CardMeta[]; cover_asset_key: string }`
+   - For v1: include the existing 22-card text deck (id `major_arcana_text`) and the new RWS deck (id `rws`)
+   - Helper `getDeck(id: string): DeckMeta | undefined`
+
+3. **Asset resolver** `frontend/src/features/Practice/data/assetResolver.ts`:
+   - Function `resolveCardImage(asset_key: string | null): ImageSourcePropType | null`
+   - For v1 implementation: a hardcoded `require()` map keyed by `asset_key`. Metro's bundler requires static `require()` calls; dynamic strings won't resolve. Generate the map by enumerating the 78 RWS cards. Until the dev drops images in, every require points at a single placeholder file `assets/cards/_placeholder.png` so the build doesn't break.
+
+4. **Scaffold asset folder** `frontend/assets/cards/`:
+   - `frontend/assets/cards/_placeholder.png` — 800×1200 transparent or watermarked placeholder so the bundler has something to resolve
+   - `frontend/assets/cards/rws/.gitkeep`
+   - `frontend/assets/cards/README.md` — **Dev-facing instructions** covering:
+     - Exact filenames expected (`the_fool.jpg`, `ace_of_cups.jpg`, etc. — full list of 78)
+     - Recommended dimensions: 800×1200 px, JPEG quality 85, 100–250 KB per card
+     - Where to drop them: `frontend/assets/cards/rws/`
+     - Licensing reminder: RWS is public domain in the US; the dev must verify use in target jurisdictions
+     - How to add a future deck: create `frontend/assets/cards/<deck_id>/`, add a content module `frontend/src/features/Practice/data/decks/<deck_id>.ts`, register in `BUNDLED_DECKS`
+     - Future plan: S3 + CDN once more than two decks ship (cost vs. bundle size); the resolver will switch to an HTTP fetch with offline cache
+
+5. **Tests** at `frontend/src/features/Practice/data/decks/__tests__/rws.test.ts`:
+   - 78 cards total
+   - 22 major + 14 × 4 minor arcana
+   - All `asset_key` values are unique
+   - All slugs match `^[a-z][a-z0-9_]*$`
+   - `resolveCardImage` returns the placeholder for every defined card (until real images land)
+   - `getDeck("rws")` returns the deck; `getDeck("nonexistent")` returns undefined
+
+## Acceptance Criteria
+
+- [ ] `npm test` green
+- [ ] `npx tsc --noEmit` passes
+- [ ] `frontend/assets/cards/README.md` exists and tells the dev exactly where to drop images and what to name them
+- [ ] `BUNDLED_DECKS` includes `major_arcana_text` and `rws`
+- [ ] Bundle builds with the placeholder image in place (no missing-require errors)
+
+## Files
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/data/decks/rws.ts` | **Create** |
+| `frontend/src/features/Practice/data/decks/index.ts` | **Create** |
+| `frontend/src/features/Practice/data/assetResolver.ts` | **Create** |
+| `frontend/src/features/Practice/data/decks/__tests__/rws.test.ts` | **Create** |
+| `frontend/assets/cards/_placeholder.png` | **Create** |
+| `frontend/assets/cards/rws/.gitkeep` | **Create** |
+| `frontend/assets/cards/README.md` | **Create** |
+
+## Constraints
+
+- Card data is read-only at runtime; the modules export `as const` / `readonly` everywhere
+- Don't commit the actual RWS images in this PR — they ship from the dev's local in a follow-up content drop. The placeholder makes the bundler happy in the meantime.
+- Resolver uses static `require()` only — Metro can't bundle dynamic paths
+- Keep slugs deterministic so the dev can name files mechanically
+- Plan an S3/CDN migration as a follow-up issue once a second deck (Thoth) ships

--- a/prompts/github-issues/custom-practices-05-random-interval-bell-frontend.md
+++ b/prompts/github-issues/custom-practices-05-random-interval-bell-frontend.md
@@ -1,0 +1,85 @@
+# custom-practices-05: Build `RandomIntervalBellView` + configurator form
+
+**Labels:** `enhancement`, `ritual-practice`, `frontend`
+**Epic:** [Customizable practices](custom-practices-epic.md)
+**Depends on:** [custom-practices-01](custom-practices-01-random-interval-bell-backend.md)
+**Estimated LoC:** ~250
+
+## Role
+
+You are a React Native engineer extending the ritual session engine with a new view for a non-deterministic timer, plus the configurator form so users can author the mode.
+
+## Goal
+
+Build `RandomIntervalBellView` (the session UI) and `RandomIntervalBellForm` (the configurator form). The view runs a meditation timer that schedules bells at random offsets within the configured bounds. The form lets a user set `min_interval_seconds`, `max_interval_seconds`, `duration_minutes`, `max_bells`, and `bell_tone`.
+
+## Context
+
+Reference view: `frontend/src/features/Practice/views/IntervalBellView.tsx` (existing deterministic version). Reference form: `frontend/src/features/Practice/configurator/forms/IntervalBellForm.tsx`. Reference for soft-progressive disclosure: any existing form's "Advanced" toggle pattern.
+
+Engine state has `status: idle | running | paused | complete` and a `startedAt` timestamp; the view derives elapsed seconds via a local interval and schedules its own random bells off that clock.
+
+## Tasks
+
+1. **Add frontend types** to `frontend/src/features/Practice/engine/types.ts`:
+   - `RandomIntervalBellConfig`: matches the backend Pydantic shape (see sub-issue 01)
+   - `RandomIntervalBellMetadata`
+   - Extend the `RitualConfig` and `RitualMetadata` unions
+
+2. **Build the view** at `frontend/src/features/Practice/views/RandomIntervalBellView.tsx`:
+   - Props: `{ config: RandomIntervalBellConfig; state: RitualState; controls: RitualControls; onSave?: () => void }`
+   - Schedule generation: when `status` transitions `idle → running`, pre-compute a random schedule of `[t1, t2, …]` offsets (seconds from start) such that consecutive deltas are uniform in `[min_interval_seconds, max_interval_seconds]` and the cumulative sum stays under `duration_minutes * 60`. Stop generating after `max_bells` if set.
+   - Trigger a bell tone (reuse the existing bell-playback util used by `IntervalBellView`) at each scheduled offset
+   - Display: current elapsed time, current/total bells count, "Next bell in ~Xs" hint (but **only if** the user has not enabled a hide-hints toggle), and `RitualControlsBar`
+   - On completion (timer elapsed or user stops), emit `RandomIntervalBellMetadata`:
+     ```ts
+     {
+       mode: "random_interval_bell",
+       bells_struck: scheduledSoFar.length,
+       interval_seconds: deltasArray,
+     }
+     ```
+
+3. **Build the form** at `frontend/src/features/Practice/configurator/forms/RandomIntervalBellForm.tsx`:
+   - Follows the existing form pattern (validates against the Pydantic shape via zod or whatever the existing forms use)
+   - Core fields (always visible): `duration_minutes`, `min_interval_seconds`, `max_interval_seconds`, `bell_tone`
+   - Advanced (collapsible): `max_bells`, `start_bell`, `end_bell`
+   - Sensible defaults: 20 min duration, 30 s min / 180 s max, bowl tone, no `max_bells` cap, start + end bells on
+   - Client-side validation matches backend: `max >= min`, `min ≤ duration * 60`
+
+4. **Wire the dispatcher** in `ActiveRitualSession.tsx` for `mode === "random_interval_bell"`.
+
+5. **Wire the configurator** in `RitualConfiguratorSheet.tsx` to route `mode === "random_interval_bell"` to the new form.
+
+6. **Tests**:
+   - `__tests__/RandomIntervalBellView.test.tsx`: renders timer, schedules bells inside the interval bounds (use fake timers + a seeded RNG mock), emits correct metadata on completion
+   - `__tests__/RandomIntervalBellForm.test.tsx`: renders core fields, "Advanced" toggle reveals additional fields, validation rejects `max < min`
+
+## Acceptance Criteria
+
+- [ ] `npm test` green, including new test files
+- [ ] `npx tsc --noEmit` passes
+- [ ] `ActiveRitualSession` dispatches `random_interval_bell` to the new view
+- [ ] `RitualConfiguratorSheet` routes the mode to the new form
+- [ ] Manual smoke: start a session with `min=10s, max=20s, duration=2min` → hear several bells at variable intervals → save → session row carries `mode_metadata.mode = "random_interval_bell"` with a populated `interval_seconds` list
+- [ ] No regression on `IntervalBellView` / `IntervalBellForm`
+
+## Files
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/engine/types.ts` | Modify |
+| `frontend/src/features/Practice/views/RandomIntervalBellView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/__tests__/RandomIntervalBellView.test.tsx` | **Create** |
+| `frontend/src/features/Practice/configurator/forms/RandomIntervalBellForm.tsx` | **Create** |
+| `frontend/src/features/Practice/configurator/forms/__tests__/RandomIntervalBellForm.test.tsx` | **Create** |
+| `frontend/src/features/Practice/components/ActiveRitualSession.tsx` | Modify |
+| `frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx` | Modify |
+
+## Constraints
+
+- Reuse the existing bell-playback util; do not fork audio handling
+- Mode dispatch happens in `ActiveRitualSession.tsx` only
+- Progressive disclosure for the form ("Advanced" toggle) — this prevents bloat as the mode count grows
+- Match `@/design/tokens` styling
+- RNG: seed-aware in tests (via injected `random()` fn), `Math.random` at runtime is fine

--- a/prompts/github-issues/custom-practices-06-card-meditation-frontend.md
+++ b/prompts/github-issues/custom-practices-06-card-meditation-frontend.md
@@ -1,0 +1,113 @@
+# custom-practices-06: Build `CardMeditationView` + image picker form
+
+**Labels:** `enhancement`, `ritual-practice`, `frontend`
+**Epic:** [Customizable practices](custom-practices-epic.md)
+**Depends on:** [custom-practices-02](custom-practices-02-card-meditation-backend.md), [custom-practices-04](custom-practices-04-rws-deck-content.md)
+**Estimated LoC:** ~350
+
+## Role
+
+You are a React Native engineer building the session UI and the configurator form for the new `card_meditation` mode. You integrate `expo-image-picker` so users can attach photos from their phone to a custom card list.
+
+## Goal
+
+Build `CardMeditationView` (full-screen card image + name + timer) and `CardMeditationForm` (deck picker → optional custom card list editor with image picker → per-card duration). The view supports three card sources: a bundled deck (e.g. `rws`), the existing major arcana text deck (`major_arcana_text`), and a fully custom deck of user-picked photos (`deck_id: "custom"`).
+
+## Context
+
+Reference view: `frontend/src/features/Practice/views/TarotMeditationView.tsx` — text-only card display with hidden timer. Reference form: `frontend/src/features/Practice/configurator/forms/TarotForm.tsx`. Bundled decks ship from sub-issue 04 (`frontend/src/features/Practice/data/decks/`). `expo-image-picker` is already a project dependency (verify in `frontend/package.json`; if not, add it).
+
+## Tasks
+
+1. **Frontend types** in `frontend/src/features/Practice/engine/types.ts`:
+   - `CardMeditationCard`: `{ name: string; image_asset_key: string | null; image_uri: string | null; symbolism: string | null }`
+   - `CardMeditationConfig`: matches backend (sub-issue 02)
+   - `CardMeditationMetadata`
+   - Extend `RitualConfig` and `RitualMetadata` unions
+
+2. **Card resolution helper** at `frontend/src/features/Practice/data/resolveCard.ts`:
+   - `pickCard(config: CardMeditationConfig): CardMeditationCard` — applies `shuffle` to either `config.cards` or the bundled deck's card list, returns one
+   - Idempotent within a session: cache the picked card on first render so a re-render doesn't reshuffle
+
+3. **Build the view** at `frontend/src/features/Practice/views/CardMeditationView.tsx`:
+   - Props: `{ config: CardMeditationConfig; state: RitualState; controls: RitualControls; onSave?: () => void }`
+   - On mount, pick a card (via `pickCard`); store in local state
+   - Layout:
+     - **Reveal flow** (when `reveal_after_meditation = true`):
+       - `status === "running"`: hide the card, show a centered placeholder ("Sit. The card will be revealed when the timer ends.") + timer (or hidden timer per `hide_timer_during_meditation`)
+       - `status === "complete"`: reveal the card image full-screen + name + symbolism
+     - **Immediate flow** (when `reveal_after_meditation = false`):
+       - Show the card image full-screen + name from the start
+       - Hide the timer if `hide_timer_during_meditation = true` until complete
+   - Image source resolution:
+     - `card.image_asset_key` → `resolveCardImage(asset_key)` (from sub-issue 04)
+     - `card.image_uri` → `{ uri: card.image_uri }` directly (device path or remote URL)
+     - Neither → render the card name + symbolism in the existing tarot-style stylized frame as a fallback
+   - On save, emit `CardMeditationMetadata` with the picked card's name, deck_id, and (if available) its index in the deck.
+
+4. **Build the form** at `frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx`:
+   - Section 1 — Deck:
+     - Radio: `Major Arcana (text)` / `Rider-Waite-Smith` / `Custom` (driven by `BUNDLED_DECKS` for the first two)
+   - Section 2 — When `deck_id !== "custom"`:
+     - Display deck summary (cover image thumbnail + card count + description)
+   - Section 2 — When `deck_id === "custom"`:
+     - Repeating card editor: each row has `name` text input, `Choose photo` button (opens `expo-image-picker`), `symbolism` text input (optional, collapsed by default)
+     - Add Card / Remove Card buttons; max 200 cards
+     - Empty state: "Add at least one card to use this deck."
+   - Section 3 — Behavior (Advanced toggle, collapsed by default):
+     - `per_card_minutes` (number, default 5)
+     - `shuffle` (toggle, default on)
+     - `reveal_after_meditation` (toggle, default off)
+     - `hide_timer_during_meditation` (toggle, default on)
+   - Client-side validation mirrors backend (e.g. custom requires non-empty `cards`)
+
+5. **Image picker integration**:
+   - Wrap `expo-image-picker` in a helper `frontend/src/features/Practice/utils/pickCardPhoto.ts` so the form imports a single function
+   - Request media-library permission on first use
+   - Return `{ uri: string }` for the resulting asset
+   - V1 does not persist the image to backend storage — the `uri` is stored as-is in `mode_config_override`. Add an inline note in the form: "Photos are kept on this device. If you delete the photo, the card falls back to its name."
+
+6. **Wire dispatcher** in `ActiveRitualSession.tsx` for `mode === "card_meditation"`.
+
+7. **Wire configurator** in `RitualConfiguratorSheet.tsx` for `mode === "card_meditation"`.
+
+8. **Tests**:
+   - `__tests__/CardMeditationView.test.tsx`: renders bundled deck card with image, renders custom-deck card with `image_uri`, falls back to text when both image sources are missing, hides card during reveal flow, emits metadata on save
+   - `__tests__/CardMeditationForm.test.tsx`: renders three deck options, switching to Custom reveals the card-list editor, "Choose photo" calls the picker helper, validation rejects empty custom deck
+   - `__tests__/resolveCard.test.ts`: shuffle is deterministic with seed, picks from `cards` override, picks from bundled deck when override is null
+
+## Acceptance Criteria
+
+- [ ] `npm test` green
+- [ ] `npx tsc --noEmit` passes
+- [ ] `ActiveRitualSession` dispatches `card_meditation` to the new view
+- [ ] `RitualConfiguratorSheet` routes the mode to the new form
+- [ ] Manual smoke: start a session with `deck_id="rws"` → placeholder card image displays full-screen → timer counts → save → session row has `mode_metadata.mode = "card_meditation"` with `deck_id` and `card_drawn_name`
+- [ ] Manual smoke (custom): create a custom practice with `deck_id="custom"`, attach 2 phone photos via picker → save → start session → photo displays full-screen
+- [ ] `TarotMeditationView` behavior unchanged
+
+## Files
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/engine/types.ts` | Modify |
+| `frontend/src/features/Practice/views/CardMeditationView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/__tests__/CardMeditationView.test.tsx` | **Create** |
+| `frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx` | **Create** |
+| `frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx` | **Create** |
+| `frontend/src/features/Practice/data/resolveCard.ts` | **Create** |
+| `frontend/src/features/Practice/data/__tests__/resolveCard.test.ts` | **Create** |
+| `frontend/src/features/Practice/utils/pickCardPhoto.ts` | **Create** |
+| `frontend/src/features/Practice/components/ActiveRitualSession.tsx` | Modify |
+| `frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx` | Modify |
+| `frontend/package.json` | Possibly modify (add `expo-image-picker` if absent) |
+
+## Constraints
+
+- V1 does not upload images to backend storage — `image_uri` is a device path stored in JSON
+- If a stored device path no longer resolves (user deleted the photo), fall back gracefully to text display; do not crash
+- The picked card for a session is fixed at mount; don't reshuffle on re-render
+- Mode dispatch in `ActiveRitualSession.tsx` only
+- Progressive disclosure for the form (Advanced section collapsed) — prevents bloat
+- Match `@/design/tokens`; the card image fills the screen with a generous black/dark border to reduce visual noise during meditation
+- Accessibility: card name announced via `accessibilityLabel`, image has descriptive alt text from `symbolism`

--- a/prompts/github-issues/custom-practices-07-catalog-and-create-flow.md
+++ b/prompts/github-issues/custom-practices-07-catalog-and-create-flow.md
@@ -1,0 +1,110 @@
+# custom-practices-07: Practice catalog browse screen + Create-custom flow
+
+**Labels:** `enhancement`, `ritual-practice`, `frontend`
+**Epic:** [Customizable practices](custom-practices-epic.md)
+**Depends on:** custom-practices-05 (random interval bell), custom-practices-06 (card meditation). All existing mode forms should be in place.
+**Estimated LoC:** ~450
+
+## Role
+
+You are a React Native engineer building the highest-leverage UX of the epic: the global Practice catalog and the create-custom flow that funnels into it. You apply the epic-level UX guard-rails to prevent bloat with 11 modes.
+
+## Goal
+
+Add a top-level **Practice catalog** screen where users browse all visible practices (presets + their own drafts + imported drafts), filter by stage and mode, and tap **+ Create** to author a new custom practice. The create flow guides them through: pick mode → configure → name + (optional) stage assignment → save.
+
+## Context
+
+Today, the only way to pick a practice for a stage is the per-stage `PracticeSelector`. There's no global catalog and no way to create a new practice through the app (the `POST /practices` API exists but has no UI). After this issue:
+- The catalog is reachable from a new top-level nav entry (Bottom tab or drawer item)
+- The create flow reuses **every existing per-mode form** under `frontend/src/features/Practice/configurator/forms/` (do not rebuild any of these)
+- Stage assignment uses the existing `POST /user-practices` API
+
+## UX Guard-rails (apply ALL of these)
+
+The epic-level constraint: **11 modes is bloat unless mitigated.** This screen must:
+
+1. **Categorize modes** in the picker, not a flat list:
+   - **Timers:** `meditation_timer`, `count_up`
+   - **Bells:** `metronome`, `interval_bell`, `random_interval_bell`
+   - **Grounding:** `sense_grounding`, `tallied_grounding`, `mindful_anchor`
+   - **Reflection:** `tarot`, `card_meditation`
+   - **Movement:** `rep_counter`
+   - Each category renders as a card with an icon, one-line description, and the modes inside.
+2. **Start from a preset** is the recommended path. The create flow opens with two cards: **Start from a preset** (browse the catalog, pick one, "Customize a copy") and **Start from scratch** (mode picker).
+3. **Progressive disclosure** on each mode form (already applied in 05 + 06; ensure all existing forms also have an Advanced toggle — if any don't, add one with sensible defaults).
+4. **One screen per phase**: Catalog → Detail → Create wizard (3 steps). No mega-form.
+5. **Smart defaults** on every mode form so a user can submit immediately after pick.
+
+## Tasks
+
+1. **Catalog screen** at `frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx`:
+   - Top: search bar (matches name + description), filter chips (stage, mode category)
+   - Sections (collapsible):
+     - **Presets** — `submitted_by_user_id IS NULL` (group by stage)
+     - **My drafts** — practices I submitted
+     - **Imported** — drafts I received via share link (distinguished by a metadata field; add `imported_from_token: str | None` on `Practice` in a tiny extension PR or store a hint on the create call)
+   - Each row: name, mode badge, stage chip, "duration · default 5 min" subtitle
+   - Tap a row → `PracticeDetailScreen`
+   - FAB / header button: **+ Create**
+
+2. **Practice detail screen** at `frontend/src/features/Practice/screens/PracticeDetailScreen.tsx`:
+   - Read-only summary: name, description, instructions, mode, mode_config (rendered via the appropriate per-mode summary helper)
+   - Actions: **Use for stage…** (opens a stage picker, calls `POST /user-practices`), **Customize a copy** (opens the create flow with this practice's mode_config pre-filled), **Share** (sub-issue 03), **Edit** (only if I own it), **Delete** (only if I own it and it's unapproved)
+
+3. **Create-custom wizard** at `frontend/src/features/Practice/screens/CreatePracticeWizard.tsx`:
+   - **Step 0** — Entry choice: **Start from a preset** (jumps to catalog with a "select to customize" CTA) or **Start from scratch** (mode category picker)
+   - **Step 1** — Mode picker: categorized cards (per Guard-rails #1), tap a mode → step 2
+   - **Step 2** — Configurator: renders the existing form for the chosen mode (route via the same dispatch table the configurator uses). Validates with smart defaults already filled.
+   - **Step 3** — Metadata + assignment: name (required, 1..120), description (optional, ≤1000), instructions (optional, ≤2000), default_duration_minutes (auto-suggested from config), stage_number (optional radio: leave for later / assign to stage N for any unlocked stage)
+   - Submit: `POST /practices`. If stage was selected, also `POST /user-practices` to make it active for that stage. On success, navigate to the new practice's detail screen.
+
+4. **Mode picker component** at `frontend/src/features/Practice/components/ModePicker.tsx`:
+   - Pure data → UI, no state. Takes `onSelect(mode: PracticeMode)`. Renders the 5 categories with their modes as tappable rows.
+   - Each mode entry has: icon (Ionicons or similar), label, one-line description, optional "New" tag for `tallied_grounding`, `mindful_anchor`, `random_interval_bell`, `card_meditation`
+
+5. **Navigation wiring**:
+   - Add Practice catalog as a top-level bottom-tab entry (or drawer item — match the existing nav style)
+   - Adjust `frontend/src/navigation/` accordingly
+
+6. **API client extension** at `frontend/src/api/practices.ts`:
+   - Ensure `practices.list({ stage?, mode?, owner? })` supports the filters the catalog needs. Add to the existing client if not present.
+   - Confirm `userPractices.create({ practice_id, stage_number })` is wired
+
+7. **Tests**:
+   - `PracticeCatalogScreen.test.tsx`: renders Presets/My drafts/Imported sections, search filters by name, stage chip filters by stage_number
+   - `PracticeDetailScreen.test.tsx`: renders mode-config summary, "Use for stage" opens picker, "Customize a copy" opens wizard with pre-filled config
+   - `CreatePracticeWizard.test.tsx`: step navigation, mode picker routes to correct form, submit calls `practices.create` and (if stage chosen) `userPractices.create`
+   - `ModePicker.test.tsx`: renders all 5 categories, tapping a mode calls `onSelect` with the right value, "New" tag appears on the four new modes
+
+## Acceptance Criteria
+
+- [ ] `npm test` green
+- [ ] `npx tsc --noEmit` passes
+- [ ] Catalog is reachable from a top-level nav entry
+- [ ] Manual smoke: tap **+ Create** → pick **Bells → Random Interval Bell** → adjust min/max → name "Awareness bells" → assign to my current stage → start session immediately
+- [ ] Manual smoke: tap a preset → **Customize a copy** → modify → save → appears under My drafts
+- [ ] Existing per-stage `PracticeSelector` and `PracticeSwitcherSheet` flows still work unchanged
+
+## Files
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx` | **Create** |
+| `frontend/src/features/Practice/screens/PracticeDetailScreen.tsx` | **Create** |
+| `frontend/src/features/Practice/screens/CreatePracticeWizard.tsx` | **Create** |
+| `frontend/src/features/Practice/components/ModePicker.tsx` | **Create** |
+| `frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx` | **Create** |
+| `frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx` | **Create** |
+| `frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx` | **Create** |
+| `frontend/src/features/Practice/components/__tests__/ModePicker.test.tsx` | **Create** |
+| `frontend/src/navigation/` (root nav) | Modify |
+| `frontend/src/api/practices.ts` | Possibly modify |
+
+## Constraints
+
+- **Reuse every existing form** under `frontend/src/features/Practice/configurator/forms/`. Do not duplicate any form logic. If an existing form lacks progressive disclosure, add an "Advanced" toggle to it in this PR (small per-form change, ≤20 LoC each)
+- Stage assignment uses `POST /user-practices`, not a new endpoint
+- Apply ALL UX guard-rails listed above. A reviewer should be able to point at the screen and see each guard-rail in action
+- Imported practices have no special API today; if you need to distinguish them, add `imported_from_share_token: str | None` to `Practice` in a small extension within this PR (or thread it from `practice_share.py` in sub-issue 03 — coordinate during review)
+- Accessibility: every form field has `accessibilityLabel`; the wizard's step indicator is announced; mode picker rows are radio-like (`accessibilityRole="radio"`)

--- a/prompts/github-issues/custom-practices-epic.md
+++ b/prompts/github-issues/custom-practices-epic.md
@@ -1,0 +1,116 @@
+# Epic: Customizable practices, catalog browse, and share links
+
+**Labels:** `enhancement`, `ritual-practice`, `backend`, `frontend`
+**Scope:** Two new modes + asset bundle + create/browse UX + share-link feature
+**Estimated total LoC:** ~2,000
+
+## Role
+
+You are a full-stack engineer extending Adepthood's existing customizable practice infrastructure. You build on top of what already exists — you do not duplicate it.
+
+## Goal
+
+Let users create custom practices in any of the supported modes, browse a global catalog, assign a custom practice to any stage, and share a practice with another user via a one-link import flow. Two new modes round out the engine: `random_interval_bell` and `card_meditation` (a deck-agnostic generalization of the existing `tarot` mode, with optional images).
+
+After this epic, a user can:
+- Open a global **Practice catalog** and browse presets, their own drafts, and imported practices
+- Tap **+ Create** to assemble a custom practice in any of the 11 modes, with progressive-disclosure form UX
+- **Use a custom for any stage** (active selection scoped per-stage as today)
+- **Share a custom** by generating a link; another user opens the link and imports a copy into their own catalog
+- **Meditate on a card** from a curated deck (Rider-Waite-Smith ships with the feature) or pick a photo from their phone
+
+## Context — what already exists
+
+The audit (2026-05-16) confirmed most of the infrastructure is already in place. **Do not rebuild any of this.**
+
+| Capability | Status | Files |
+|---|---|---|
+| `Practice` table with `submitted_by_user_id` + `approved` | ✓ | `backend/src/models/practice.py:20-58` |
+| `POST /practices` user-submission endpoint, rate-limited 5/min | ✓ | `backend/src/routers/practices.py:88-129` |
+| Visibility filter (approved OR own draft) | ✓ | `backend/src/dependencies/ownership.py:155-168` |
+| `UserPractice` with `stage_number` + `mode_config_override` | ✓ | `backend/src/models/user_practice.py:30-61` |
+| `POST /user-practices` + active-resolution per stage | ✓ | `backend/src/routers/user_practices.py:80-130, 276-296` |
+| `RitualConfiguratorSheet` with per-mode forms (all 7+2 modes) | ✓ | `frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx` |
+| Existing tarot mode with 22-card text data | ✓ | `frontend/src/features/Practice/data/tarot.ts` |
+| `useActivePractice(stageNumber)` hook | ✓ | `frontend/src/features/Practice/hooks/useActivePractice.ts:156-191` |
+
+## Context — what's missing
+
+| Gap | Sub-issue |
+|---|---|
+| `random_interval_bell` mode (only deterministic intervals exist today) | 01 + 05 |
+| Deck-agnostic `card_meditation` mode with per-card image references | 02 + 06 |
+| Rider-Waite-Smith 78-card content module + image asset folder | 04 |
+| Practice share-link table + token generate / redeem / import endpoints | 03 |
+| Global catalog browse screen (today the picker is per-stage only) | 07 |
+| Create-custom flow accessible outside the per-stage picker | 07 |
+| Share-link UI + deep-link handler | 03 |
+
+## Output format
+
+Seven sub-issues, each shippable independently. Backend modes ship first; the catalog + create flow lands after the modes (so the mode picker is complete). Share-link is independent of both.
+
+Dependency graph:
+
+```
+01 random-interval-bell-backend ── 05 random-interval-bell-frontend
+02 card-meditation-backend     ──┬ 04 rws-deck-content
+                                 └ 06 card-meditation-frontend
+03 share-link-feature            (independent)
+                                                          ┌── (uses every mode form, so lands last)
+05, 06, 04, plus existing modes ─────────────────────────┴── 07 catalog-and-create-flow
+```
+
+## Sub-issues
+
+| # | Title | Scope | LoC |
+|---|-------|-------|-----|
+| 01 | [Add `random_interval_bell` mode](custom-practices-01-random-interval-bell-backend.md) | Backend | ~200 |
+| 02 | [Generalize `tarot` into `card_meditation` mode](custom-practices-02-card-meditation-backend.md) | Backend | ~250 |
+| 03 | [Practice share-link feature](custom-practices-03-share-link-feature.md) | Full-stack | ~400 |
+| 04 | [Ship Rider-Waite-Smith deck content + asset folder](custom-practices-04-rws-deck-content.md) | Frontend | ~200 |
+| 05 | [Build `RandomIntervalBellView` + configurator form](custom-practices-05-random-interval-bell-frontend.md) | Frontend | ~250 |
+| 06 | [Build `CardMeditationView` + image picker form](custom-practices-06-card-meditation-frontend.md) | Frontend | ~350 |
+| 07 | [Catalog browse screen + Create-custom flow](custom-practices-07-catalog-and-create-flow.md) | Frontend | ~450 |
+
+## UX guard-rails — preventing bloat
+
+With 11 modes after this epic, the create flow is the bloat risk. The Create-custom screen (issue 07) **must** apply these:
+
+- **Categorize modes:** `Timers` (meditation_timer, count_up), `Bells` (metronome, interval_bell, random_interval_bell), `Grounding` (sense_grounding, tallied_grounding, mindful_anchor), `Reflection` (card_meditation, tarot), `Movement` (rep_counter). Render as grouped cards, not a flat list.
+- **Progressive disclosure:** every mode form opens with 2–3 core fields and an "Advanced" toggle for the rest.
+- **Start-from-template:** the create flow's first action is "Start from a preset" — pick a preset, then customize. Empty-from-scratch is the secondary path.
+- **One screen per phase:** Pick mode → configure → name + (optional) stage assign. No mega-form.
+- **Smart defaults:** every field has a sensible default so the user can submit immediately after picking a mode.
+
+## Acceptance Criteria (epic-level)
+
+- [ ] User can open the catalog from a top-level nav entry
+- [ ] User can create a custom practice in any of the 11 modes from the catalog
+- [ ] User can assign any practice (preset, own draft, or imported) to any stage
+- [ ] User can generate a share link for a practice and another user can import a copy
+- [ ] `tarot` mode behavior is unchanged (`card_meditation` is additive, not a replacement)
+- [ ] `pre-commit run --all-files` green on every sub-issue PR
+- [ ] Coverage thresholds unchanged
+
+## Constraints
+
+- Build on existing endpoints (`POST /practices`, `POST /user-practices`, `PATCH /user-practices/{id}/customize`, `RitualConfiguratorSheet`) — do not duplicate.
+- Keep all new `*Config` / `*Metadata` models as `_ConfigBase` / `_MetadataBase` discriminated subclasses with `extra="forbid"`.
+- Each new mode value requires an Alembic migration that drops + recreates `ck_practice_mode_value`.
+- For v1, **device-photo card meditation is not persisted** — the user keeps the image on their phone; if they delete it, the card display falls back to the card name + symbolism text. Curated deck images (RWS) ship bundled and always render.
+- Share links do **not** auto-approve drafts. Imported practices land as `approved=False, submitted_by_user_id=<importer>`, scoped to that user via the existing visibility filter.
+- No admin approval UI in this epic. (Sharing is private + link-based; the `approved` column stays for future community-submission work.)
+
+## References
+
+- `backend/src/domain/practice_modes.py:15-28` — `PracticeMode` enum
+- `backend/src/schemas/practice_mode_config.py` — discriminated config union
+- `backend/src/schemas/practice_session_metadata.py` — discriminated metadata union
+- `backend/src/routers/practices.py:88-129` — user-submission endpoint
+- `backend/src/routers/user_practices.py` — UserPractice CRUD + active-resolution
+- `backend/src/dependencies/ownership.py:155-168` — visibility filter
+- `frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx` — existing configurator
+- `frontend/src/features/Practice/configurator/forms/` — existing per-mode forms
+- `frontend/src/features/Practice/data/tarot.ts` — existing 22-card data
+- Sibling epic: [Generalize grounding techniques](grounding-techniques-epic.md) (#336)

--- a/prompts/github-issues/grounding-techniques-01-tallied-mode-backend.md
+++ b/prompts/github-issues/grounding-techniques-01-tallied-mode-backend.md
@@ -1,0 +1,131 @@
+# grounding-techniques-01: Add `tallied_grounding` practice mode (backend)
+
+**Labels:** `backend`, `feature`, `practice`
+**Epic:** [Generalize grounding techniques](grounding-techniques-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~250
+
+## Role
+
+You are a FastAPI / SQLModel engineer extending a discriminated-union
+practice mode catalog. Your changes preserve all existing modes and
+introduce one new mode value, validated end-to-end.
+
+## Goal
+
+Introduce a new `tallied_grounding` practice mode that captures the
+"rounds × categories × target_count_per_category" shape shared by the
+**Find Shapes** and **Find Colors** techniques. The mode must:
+
+- Round-trip through `Practice.mode_config` JSON storage
+- Validate at the API edge via Pydantic
+- Pass the `practice.mode` `CHECK` constraint
+- Emit a per-session metadata payload that records progress
+
+## Context
+
+Today the only step-based grounding mode is `sense_grounding`. Find
+Shapes ("3 squares, 3 triangles, 3 circles, repeat 3×") and Find Colors
+("one of each rainbow color, repeat 3×") are conceptually the same
+shape:
+
+```
+rounds × [
+  { key: "squares",   label: "a square",   target_count: 3 },
+  { key: "triangles", label: "a triangle", target_count: 3 },
+  { key: "circles",   label: "a circle",   target_count: 3 },
+]
+```
+
+Existing migration that establishes the `mode` CHECK constraint:
+`backend/migrations/versions/e9f0a1b2c3d4_practice_mode_and_mode_config.py`.
+Adding a new value to `ALL_MODES` is necessary but not sufficient —
+the constraint itself must be dropped and recreated in a new migration.
+
+## Tasks
+
+1. **Extend `PracticeMode` enum**
+   - In `backend/src/domain/practice_modes.py`, add
+     `TALLIED_GROUNDING = "tallied_grounding"`. This automatically
+     extends `ALL_MODES`.
+
+2. **Add `TalliedGroundingConfig` to `practice_mode_config.py`**
+   - Define `TalliedCategory(_ConfigBase)` with fields:
+     - `key: str` (slug, `min_length=1, max_length=64`, regex
+       `^[a-z][a-z0-9_]*$`)
+     - `label: str` (`min_length=1, max_length=255`)
+     - `target_count: int` (`ge=1, le=20`)
+   - Define `TalliedGroundingConfig(_ConfigBase)`:
+     - `mode: Literal["tallied_grounding"] = "tallied_grounding"`
+     - `rounds: int = Field(ge=1, le=10)`
+     - `categories: list[TalliedCategory] = Field(min_length=1, max_length=12)`
+     - `@model_validator(mode="after")` rejecting duplicate `key` across
+       categories.
+   - Add `TalliedGroundingConfig` to the `ModeConfig` `Annotated[... |
+     ... ]` union.
+
+3. **Add `TalliedGroundingMetadata` to `practice_session_metadata.py`**
+   - Fields:
+     - `mode: Literal["tallied_grounding"] = "tallied_grounding"`
+     - `rounds_completed: int = Field(ge=0, le=10)`
+     - `total_rounds: int = Field(ge=1, le=10)`
+     - `items_completed: int = Field(ge=0, le=2400)` (cap = 10 rounds ×
+       12 categories × 20 items)
+   - `@model_validator(mode="after")` rejecting
+     `rounds_completed > total_rounds`.
+   - Add to the `SessionMetadata` union.
+
+4. **Alembic migration for the CHECK constraint**
+   - Create
+     `backend/migrations/versions/<rev>_add_tallied_grounding_mode.py`
+   - `upgrade()`: `op.drop_constraint("ck_practice_mode_value", ...)`
+     then `op.create_check_constraint(...)` listing the new
+     `ALL_MODES` tuple.
+   - `downgrade()`: reverse — drop, then recreate without
+     `tallied_grounding`. Treat existing `tallied_grounding` rows as a
+     downgrade error: refuse to downgrade if any rows still carry the
+     mode (mirror prior migration style).
+
+5. **Tests**
+   - `backend/tests/test_practice_mode_config.py`:
+     - `test_tallied_grounding_config_round_trip()` — JSON → model → JSON
+       preserves all fields
+     - `test_tallied_grounding_rejects_duplicate_keys()`
+     - `test_tallied_grounding_rejects_rounds_below_1()`
+     - `test_tallied_grounding_rejects_empty_categories()`
+   - `backend/tests/test_practice_session_metadata.py`:
+     - `test_tallied_grounding_metadata_round_trip()`
+     - `test_tallied_grounding_metadata_rejects_overcount()`
+   - `backend/tests/test_practice_session_routes.py` (or wherever the
+     mode-mismatch check lives): add a test that posting a
+     `tallied_grounding` session to a `sense_grounding` practice
+     returns 400.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/` green
+- [ ] `pre-commit run --all-files` green
+- [ ] Coverage thresholds unchanged (90% line / 80% branch / 85% docstring)
+- [ ] Migration runs cleanly on a fresh DB and rolls back without error
+      on an empty `practice` table
+- [ ] `ALL_MODES` now contains `tallied_grounding`
+- [ ] No changes to `sense_grounding` tests or behavior
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/domain/practice_modes.py` | Modify (add enum value) |
+| `backend/src/schemas/practice_mode_config.py` | Modify (add config) |
+| `backend/src/schemas/practice_session_metadata.py` | Modify (add metadata) |
+| `backend/migrations/versions/<rev>_add_tallied_grounding_mode.py` | **Create** |
+| `backend/tests/test_practice_mode_config.py` | Modify |
+| `backend/tests/test_practice_session_metadata.py` | Modify |
+
+## Constraints
+
+- No changes to the `Practice` or `PracticeSession` table shapes —
+  everything fits in the existing JSON columns.
+- Keep `extra="forbid"` on every new `_ConfigBase` / `_MetadataBase`
+  subclass — silently accepting unknown fields is how schemas drift.
+- Do **not** modify `SenseGroundingConfig` or its tests.

--- a/prompts/github-issues/grounding-techniques-02-mindful-anchor-mode-backend.md
+++ b/prompts/github-issues/grounding-techniques-02-mindful-anchor-mode-backend.md
@@ -1,0 +1,121 @@
+# grounding-techniques-02: Add `mindful_anchor` practice mode (backend)
+
+**Labels:** `backend`, `feature`, `practice`
+**Epic:** [Generalize grounding techniques](grounding-techniques-epic.md)
+**Depends on:** none (parallel with 01)
+**Estimated LoC:** ~200
+
+## Role
+
+You are a FastAPI / SQLModel engineer extending a discriminated-union
+practice mode catalog. Your changes preserve all existing modes and
+introduce one new mode value, validated end-to-end.
+
+## Goal
+
+Introduce a new `mindful_anchor` practice mode that captures the
+"single mindful act with optional chooser + soft duration floor" shape
+shared by the **Touch Grass** and **Mindful Eating** techniques. The
+mode must:
+
+- Round-trip through `Practice.mode_config` JSON storage
+- Validate at the API edge via Pydantic
+- Pass the `practice.mode` `CHECK` constraint
+- Emit a per-session metadata payload that records what the user chose
+  and how long they spent
+
+## Context
+
+Both techniques are *single-action* mindful presence practices, not
+step-based:
+
+- **Touch Grass:** stand barefoot on grass / soil / sand / stone, take
+  your time, mark complete.
+- **Mindful Eating:** eat a small portion of a grounding food (root
+  vegetable, dark chocolate, nuts, etc.) slowly and attentively.
+
+Both share:
+
+- A short instruction string
+- A list of options the user picks from (surfaces / foods)
+- A "take your time" expectation (no hard timer, soft minimum)
+- A single "mark complete" action
+
+## Tasks
+
+1. **Extend `PracticeMode` enum**
+   - In `backend/src/domain/practice_modes.py`, add
+     `MINDFUL_ANCHOR = "mindful_anchor"`.
+
+2. **Add `MindfulAnchorConfig` to `practice_mode_config.py`**
+   - Define `MindfulAnchorOption(_ConfigBase)` with:
+     - `key: str` (`min_length=1, max_length=64`, regex
+       `^[a-z][a-z0-9_]*$`)
+     - `label: str` (`min_length=1, max_length=255`)
+     - `description: str | None = Field(default=None, max_length=500)`
+   - Define `MindfulAnchorConfig(_ConfigBase)`:
+     - `mode: Literal["mindful_anchor"] = "mindful_anchor"`
+     - `instruction: str = Field(min_length=1, max_length=500)`
+     - `min_duration_seconds: int = Field(ge=0, le=3600)` (soft floor, 0
+       means "no nudge")
+     - `options: list[MindfulAnchorOption] = Field(default_factory=list,
+       max_length=20)`
+     - `require_option_choice: bool = False`
+   - `@model_validator(mode="after")` rejecting duplicate option keys.
+   - If `require_option_choice` is True, `options` must be non-empty.
+   - Add `MindfulAnchorConfig` to the `ModeConfig` union.
+
+3. **Add `MindfulAnchorMetadata` to `practice_session_metadata.py`**
+   - Fields:
+     - `mode: Literal["mindful_anchor"] = "mindful_anchor"`
+     - `chosen_option_key: str | None = Field(default=None, max_length=64)`
+     - `duration_seconds: int = Field(ge=0, le=14400)` (4-hour cap)
+     - `met_min_duration: bool` (server-derivable but emit from client
+       for transparency)
+   - Add to the `SessionMetadata` union.
+
+4. **Alembic migration for the CHECK constraint**
+   - Create
+     `backend/migrations/versions/<rev>_add_mindful_anchor_mode.py`
+   - Same pattern as 01 — drop & recreate `ck_practice_mode_value`.
+   - `downgrade()` refuses if any rows carry `mindful_anchor`.
+
+5. **Tests**
+   - `backend/tests/test_practice_mode_config.py`:
+     - `test_mindful_anchor_config_round_trip()`
+     - `test_mindful_anchor_rejects_duplicate_option_keys()`
+     - `test_mindful_anchor_requires_options_when_choice_required()`
+     - `test_mindful_anchor_allows_no_options_when_choice_not_required()`
+   - `backend/tests/test_practice_session_metadata.py`:
+     - `test_mindful_anchor_metadata_round_trip()`
+     - `test_mindful_anchor_metadata_with_no_option_chosen()` (when
+       `require_option_choice=False`)
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/` green
+- [ ] `pre-commit run --all-files` green
+- [ ] Coverage thresholds unchanged
+- [ ] Migration runs cleanly on a fresh DB and rolls back without error
+- [ ] `ALL_MODES` now contains `mindful_anchor`
+- [ ] No changes to existing mode behavior
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/domain/practice_modes.py` | Modify |
+| `backend/src/schemas/practice_mode_config.py` | Modify |
+| `backend/src/schemas/practice_session_metadata.py` | Modify |
+| `backend/migrations/versions/<rev>_add_mindful_anchor_mode.py` | **Create** |
+| `backend/tests/test_practice_mode_config.py` | Modify |
+| `backend/tests/test_practice_session_metadata.py` | Modify |
+
+## Constraints
+
+- `min_duration_seconds` is a **soft** floor. Server accepts sessions
+  shorter than it; the field exists so the client can nudge the user.
+- Do not introduce a server-side timer dependency. The duration is
+  derived from `(ended_at - started_at)` on the session row; the
+  metadata field records what the client observed.
+- Keep `extra="forbid"`.

--- a/prompts/github-issues/grounding-techniques-03-presets-shapes-and-colors.md
+++ b/prompts/github-issues/grounding-techniques-03-presets-shapes-and-colors.md
@@ -1,0 +1,120 @@
+# grounding-techniques-03: Seed Find Shapes + Find Colors presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Generalize grounding techniques](grounding-techniques-epic.md)
+**Depends on:** [grounding-techniques-01](grounding-techniques-01-tallied-mode-backend.md)
+**Estimated LoC:** ~100
+
+## Role
+
+You are a backend engineer adding catalog content. You follow the
+existing seed-preset pattern in `backend/src/seed_practices.py` and
+validate every payload at import time via `ModeConfigAdapter`.
+
+## Goal
+
+Add two `tallied_grounding` presets to the practice catalog so users
+can pick them from the catalog at the appropriate stages:
+
+- **Find Shapes** — 3 rounds × [3 squares, 3 triangles, 3 circles]
+- **Find Colors** — 3 rounds × one of each rainbow color (7 colors)
+
+## Context
+
+`backend/src/seed_practices.py:88-98` shows how the 5-4-3-2-1 preset is
+seeded today: `_build_preset(stage_number, name, mode=..., mode_config=...,
+default_duration_minutes=...)`. The list `_PRESET_PRACTICES` is iterated
+at seed time; each `mode_config` is validated through
+`ModeConfigAdapter.validate_python()` so a typo crashes the seeder, not
+the runtime.
+
+Stage placement is at the team's discretion — recommend:
+
+- **Find Shapes:** stage 1 (alternative grounding for users who don't
+  resonate with 5-4-3-2-1; same stage as the canonical sense grounding)
+- **Find Colors:** stage 1 (same rationale)
+
+Both alternatives let stage 1 still have one canonical preset
+(`5-4-3-2-1 grounding`) used by the frequency-banner endpoint; verify
+in `STAGE_TO_PRESET_NAME` that the canonical pointer is unchanged.
+
+## Tasks
+
+1. **Add prompt builders to `seed_practices.py`**
+   - `_find_shapes_categories()` returns:
+     ```python
+     [
+         {"key": "squares",   "label": "a square",   "target_count": 3},
+         {"key": "triangles", "label": "a triangle", "target_count": 3},
+         {"key": "circles",   "label": "a circle",   "target_count": 3},
+     ]
+     ```
+   - `_find_colors_categories()` returns the 7 rainbow colors, each with
+     `target_count=1`, labels: "something red", "something orange", …,
+     "something violet".
+
+2. **Append preset rows to `_PRESET_PRACTICES`**
+   - "Find Shapes" preset at stage 1:
+     ```python
+     mode="tallied_grounding",
+     mode_config={
+         "mode": "tallied_grounding",
+         "rounds": 3,
+         "categories": _find_shapes_categories(),
+     },
+     default_duration_minutes=5,
+     ```
+   - "Find Colors" preset at stage 1, same shape with 7 categories.
+
+3. **Add preset copy to `seed_practice_copy.py`** (if a stage-1 entry
+   isn't already reused, or if the existing key collides).
+   - Each preset needs `(description, instructions)`. If the stage-1
+     entry is keyed by stage number only, add a per-preset override
+     mechanism — but the existing system keys copy by stage. If only one
+     copy entry per stage is supported, **extend the keying** to
+     `(stage_number, name)` for these new entries; otherwise reuse the
+     stage copy and accept identical descriptions. Surface the choice
+     in the PR description.
+
+4. **Tests**
+   - `backend/tests/test_seed_practices.py`:
+     - `test_find_shapes_preset_seeds()` — preset row inserts, mode is
+       `tallied_grounding`, categories list length is 3, rounds is 3
+     - `test_find_colors_preset_seeds()` — categories list length is 7,
+       rounds is 3
+     - `test_seed_is_idempotent_with_new_presets()` — running the seeder
+       twice does not double-insert
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/` green
+- [ ] Running `python -m seed_practices` on a fresh DB inserts both
+      presets
+- [ ] Running it a second time inserts nothing new
+- [ ] Catalog `GET /practices` returns both presets at stage 1
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify |
+| `backend/src/seed_practice_copy.py` | Possibly modify |
+| `backend/tests/test_seed_practices.py` | Modify |
+
+## Constraints
+
+- Do not change the existing `5-4-3-2-1 grounding` preset.
+- Validate every preset's `mode_config` via `ModeConfigAdapter.validate_python()`.
+- Choose labels that read naturally in a prompt ("Find a square" not
+  "squares").
+
+## Example output
+
+```
+$ curl /practices?stage=1
+[
+  {"name": "5-4-3-2-1 grounding", "mode": "sense_grounding", ...},
+  {"name": "Find Shapes",         "mode": "tallied_grounding", ...},
+  {"name": "Find Colors",         "mode": "tallied_grounding", ...}
+]
+```

--- a/prompts/github-issues/grounding-techniques-04-presets-touch-grass-and-mindful-eating.md
+++ b/prompts/github-issues/grounding-techniques-04-presets-touch-grass-and-mindful-eating.md
@@ -1,0 +1,122 @@
+# grounding-techniques-04: Seed Touch Grass + Mindful Eating presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Generalize grounding techniques](grounding-techniques-epic.md)
+**Depends on:** [grounding-techniques-02](grounding-techniques-02-mindful-anchor-mode-backend.md)
+**Estimated LoC:** ~100
+
+## Role
+
+You are a backend engineer adding catalog content. You follow the
+existing seed-preset pattern and validate every payload at import time.
+
+## Goal
+
+Add two `mindful_anchor` presets to the practice catalog:
+
+- **Touch Grass** — stand barefoot on a natural surface
+- **Mindful Eating** — slowly eat one small portion of a grounding food
+
+## Context
+
+These are single-action mindful presence practices. They differ from
+the step-based grounding presets: the user picks one option (or none),
+takes their time, and marks complete. The view should surface elapsed
+time and gently nudge if the user marks complete before
+`min_duration_seconds`.
+
+Recommended stage placement is at the team's discretion; default to
+stage 1 alongside the other grounding alternatives.
+
+## Tasks
+
+1. **Add option builders to `seed_practices.py`**
+   - `_touch_grass_options()`:
+     ```python
+     [
+         {"key": "grass", "label": "Grass",
+          "description": "A lawn, a park, a meadow."},
+         {"key": "soil", "label": "Soil",
+          "description": "Garden bed, forest floor, planter."},
+         {"key": "sand", "label": "Sand",
+          "description": "A beach or a sandbox."},
+         {"key": "stone", "label": "Stone",
+          "description": "Bare rock, a flagstone path."},
+     ]
+     ```
+   - `_mindful_eating_options()`:
+     ```python
+     [
+         {"key": "nuts_seeds",     "label": "Nuts or seeds",
+          "description": "Almonds, walnuts, pumpkin seeds."},
+         {"key": "root_vegetable", "label": "Root vegetable",
+          "description": "Carrot, beet, sweet potato."},
+         {"key": "whole_grain",    "label": "Whole-grain bread",
+          "description": "Dense, hearty, a slow chew."},
+         {"key": "dark_chocolate", "label": "Dark chocolate",
+          "description": "A single square, savored."},
+         {"key": "fresh_fruit",    "label": "Fresh fruit",
+          "description": "Apple, pear, berries."},
+     ]
+     ```
+
+2. **Append preset rows to `_PRESET_PRACTICES`**
+   - **Touch Grass** preset:
+     ```python
+     mode="mindful_anchor",
+     mode_config={
+         "mode": "mindful_anchor",
+         "instruction": "Stand barefoot on the earth. Notice the texture, "
+                        "temperature, and pressure under your feet. "
+                        "Stay until you feel settled.",
+         "min_duration_seconds": 120,
+         "options": _touch_grass_options(),
+         "require_option_choice": True,
+     },
+     default_duration_minutes=3,
+     ```
+   - **Mindful Eating** preset:
+     ```python
+     mode="mindful_anchor",
+     mode_config={
+         "mode": "mindful_anchor",
+         "instruction": "Eat one small portion slowly. Notice texture, "
+                        "temperature, aroma, and flavor with each bite. "
+                        "Pause between bites.",
+         "min_duration_seconds": 180,
+         "options": _mindful_eating_options(),
+         "require_option_choice": True,
+     },
+     default_duration_minutes=5,
+     ```
+
+3. **Tests**
+   - `backend/tests/test_seed_practices.py`:
+     - `test_touch_grass_preset_seeds()` — preset row inserts, mode is
+       `mindful_anchor`, 4 options, `require_option_choice=True`
+     - `test_mindful_eating_preset_seeds()` — 5 options, instruction
+       non-empty, `min_duration_seconds=180`
+     - `test_seed_is_idempotent_with_new_presets()` (extended)
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/` green
+- [ ] Running `python -m seed_practices` on a fresh DB inserts both presets
+- [ ] Running it a second time inserts nothing new
+- [ ] Catalog returns both presets with the configured options
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify |
+| `backend/src/seed_practice_copy.py` | Possibly modify |
+| `backend/tests/test_seed_practices.py` | Modify |
+
+## Constraints
+
+- Validate every preset's `mode_config` via `ModeConfigAdapter`.
+- Option keys are slugs (`^[a-z][a-z0-9_]*$`); labels are display text.
+- Keep descriptions concrete and sensory — they appear in the chooser UI.
+- `min_duration_seconds` is a soft nudge, not a lock. The view will
+  encourage but not enforce.

--- a/prompts/github-issues/grounding-techniques-05-tallied-view-frontend.md
+++ b/prompts/github-issues/grounding-techniques-05-tallied-view-frontend.md
@@ -1,0 +1,145 @@
+# grounding-techniques-05: Build `TalliedGroundingView` (frontend)
+
+**Labels:** `frontend`, `feature`, `practice`
+**Epic:** [Generalize grounding techniques](grounding-techniques-epic.md)
+**Depends on:** [grounding-techniques-01](grounding-techniques-01-tallied-mode-backend.md)
+**Estimated LoC:** ~250
+
+## Role
+
+You are a React Native engineer extending Adepthood's ritual session
+engine. You add a new view component, wire it into the engine
+dispatcher, and ship a comprehensive test file.
+
+## Goal
+
+Build `TalliedGroundingView` to drive the **Find Shapes** and **Find
+Colors** ritual UX off a `TalliedGroundingConfig`. The view should:
+
+- Show "Round R of N — Find a {label} ({count} of {target})"
+- Advance one tap at a time through `rounds × categories × target_count`
+- Show a Complete card on the final tap and surface `onSave`
+- Emit `TalliedGroundingMetadata` to the parent on completion
+
+## Context
+
+The reference view is
+`frontend/src/features/Practice/views/SenseGroundingView.tsx`. It uses:
+
+- `RitualState`, `RitualControls`, and the discriminated config type
+  from `frontend/src/features/Practice/engine/types.ts`
+- `controls.tap()` to advance steps
+- A `CompleteCard` rendered when `state.status === 'complete' ||
+  state.currentStepIndex >= total`
+
+The dispatcher lives at
+`frontend/src/features/Practice/components/ActiveRitualSession.tsx` —
+it picks a view based on `effectiveConfig.mode` and threads
+state/controls/onSave through.
+
+Today the engine state is step-indexed (`currentStepIndex`). For
+tallied grounding, total steps = `rounds × sum(category.target_count)`.
+The view derives the current `(round, category, item_in_category)` from
+the linear `currentStepIndex` without changing the engine's state shape.
+
+## Tasks
+
+1. **Add types to `frontend/src/features/Practice/engine/types.ts`**
+   - `TalliedCategory`: `{ key: string; label: string; target_count: number }`
+   - `TalliedGroundingConfig`: `{ mode: 'tallied_grounding'; rounds:
+     number; categories: readonly TalliedCategory[] }`
+   - Extend the `RitualConfig` union to include `TalliedGroundingConfig`.
+   - Mirror in any `RitualMetadata`-style discriminated union:
+     `TalliedGroundingMetadata`: `{ mode: 'tallied_grounding';
+     rounds_completed: number; total_rounds: number; items_completed:
+     number }`.
+
+2. **Build `frontend/src/features/Practice/views/TalliedGroundingView.tsx`**
+   - Props: `{ config: TalliedGroundingConfig; state: RitualState;
+     controls: RitualControls; onSave?: () => void }`
+   - Helpers:
+     - `totalStepsPerRound(config) = sum(c.target_count for c in
+       categories)`
+     - `totalSteps(config) = config.rounds * totalStepsPerRound(config)`
+     - `decompose(stepIndex, config) → { roundIndex, category,
+       itemInCategory }` (1-based for display, 0-based internally)
+   - Header reads: e.g. `Round 2 of 3` + `Find a square (1 of 3)`.
+     Pull badge text from a `BADGE_BY_MODE` map for now — for tallied
+     grounding the badge is dynamic, e.g. computed from the categories
+     ("3×3×3" or "Rainbow"). Keep it simple: derive a short badge from
+     `config.categories.length` and `config.rounds`.
+   - Render the same `Begin grounding` / `Pause` / `Reset` controls
+     bar (`RitualControlsBar`) — reuse, don't duplicate.
+   - On the final tap, transition to the complete card (same pattern as
+     `SenseGroundingView`).
+
+3. **Wire dispatcher**
+   - In
+     `frontend/src/features/Practice/components/ActiveRitualSession.tsx`,
+     add a case for `mode === 'tallied_grounding'` that renders
+     `TalliedGroundingView` and translates engine state into
+     `TalliedGroundingMetadata` on completion. Use the same pattern as
+     the existing `sense_grounding` branch.
+
+4. **API client types**
+   - Update `frontend/src/api/` types if practice config / metadata is
+     mirrored there. Match the backend Pydantic shapes precisely.
+
+5. **Tests** — `frontend/src/features/Practice/views/__tests__/TalliedGroundingView.test.tsx`
+   - Renders header "Round 1 of 3" on initial state
+   - Renders the first category's label on initial state
+   - Tapping `tap()` 9 times (for 3×3 Find Shapes config) advances
+     into Round 2
+   - Tapping through all steps shows the Complete card
+   - Pressing Save fires `onSave`
+   - Snapshot for the complete card (optional)
+
+## Acceptance Criteria
+
+- [ ] `npm run lint` clean
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm test` green; new tests are isolated and don't leak fixtures
+- [ ] `ActiveRitualSession` dispatches `tallied_grounding` to
+      `TalliedGroundingView`
+- [ ] Manual smoke: start a Find Shapes session in dev → tap through →
+      save → session row appears with `mode_metadata.mode =
+      "tallied_grounding"`
+- [ ] No changes to `SenseGroundingView` behavior or tests
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/engine/types.ts` | Modify |
+| `frontend/src/features/Practice/views/TalliedGroundingView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/__tests__/TalliedGroundingView.test.tsx` | **Create** |
+| `frontend/src/features/Practice/components/ActiveRitualSession.tsx` | Modify |
+| `frontend/src/api/` (types module) | Possibly modify |
+
+## Constraints
+
+- Do not alter the engine's state shape — derive `(round, category,
+  item)` from `currentStepIndex`. The engine remains mode-agnostic.
+- Reuse `RitualControlsBar` and existing complete-card patterns; don't
+  fork them.
+- Mode dispatch happens in **one** place
+  (`ActiveRitualSession.tsx`). Do not introduce additional branching on
+  mode anywhere else.
+- Match design tokens (`@/design/tokens`) used by `SenseGroundingView`.
+
+## Example state decomposition
+
+```
+config = { rounds: 3, categories: [
+  { key: "squares",   target_count: 3 },
+  { key: "triangles", target_count: 3 },
+  { key: "circles",   target_count: 3 },
+]}
+totalStepsPerRound = 9
+totalSteps = 27
+
+currentStepIndex = 0  → Round 1, "squares",   item 1 of 3
+currentStepIndex = 4  → Round 1, "triangles", item 2 of 3
+currentStepIndex = 9  → Round 2, "squares",   item 1 of 3
+currentStepIndex = 27 → complete
+```

--- a/prompts/github-issues/grounding-techniques-06-mindful-anchor-view-frontend.md
+++ b/prompts/github-issues/grounding-techniques-06-mindful-anchor-view-frontend.md
@@ -1,0 +1,146 @@
+# grounding-techniques-06: Build `MindfulAnchorView` (frontend)
+
+**Labels:** `frontend`, `feature`, `practice`
+**Epic:** [Generalize grounding techniques](grounding-techniques-epic.md)
+**Depends on:** [grounding-techniques-02](grounding-techniques-02-mindful-anchor-mode-backend.md)
+**Estimated LoC:** ~200
+
+## Role
+
+You are a React Native engineer extending Adepthood's ritual session
+engine. You add a new view component, wire it into the engine
+dispatcher, and ship a comprehensive test file.
+
+## Goal
+
+Build `MindfulAnchorView` to drive the **Touch Grass** and **Mindful
+Eating** ritual UX off a `MindfulAnchorConfig`. The view should:
+
+- Show the instruction prominently
+- (If options are configured) show an option chooser before "Begin"
+- Once running, show a live elapsed-time counter
+- Gate the Save button on `met_min_duration`, but with a soft nudge,
+  not a hard lock (user can save anyway after a confirmation)
+- Emit `MindfulAnchorMetadata` to the parent on save
+
+## Context
+
+Reference view: `SenseGroundingView.tsx`. Reference dispatcher:
+`ActiveRitualSession.tsx`. Reference engine state:
+`engine/types.ts` (`RitualState`, `RitualControls`).
+
+`mindful_anchor` differs from the existing step-based modes — it has
+no `currentStepIndex` semantic. The "Begin" → "Mark complete" flow
+maps cleanly to engine `status` transitions: `idle → running →
+complete`. The view doesn't call `controls.tap()` — it calls
+`controls.complete()` (or whatever the engine's "finish now" action
+is — confirm name when reading the engine).
+
+## Tasks
+
+1. **Add types to `frontend/src/features/Practice/engine/types.ts`**
+   - `MindfulAnchorOption`: `{ key: string; label: string; description?:
+     string }`
+   - `MindfulAnchorConfig`: `{ mode: 'mindful_anchor'; instruction:
+     string; min_duration_seconds: number; options: readonly
+     MindfulAnchorOption[]; require_option_choice: boolean }`
+   - Extend the `RitualConfig` union.
+   - `MindfulAnchorMetadata`: `{ mode: 'mindful_anchor';
+     chosen_option_key: string | null; duration_seconds: number;
+     met_min_duration: boolean }`
+
+2. **Build `frontend/src/features/Practice/views/MindfulAnchorView.tsx`**
+   - Sections:
+     - Instruction card (always visible)
+     - Option chooser (visible while `status === 'idle'` if
+       `options.length > 0`)
+     - Elapsed-time display (visible while `status === 'running'`)
+       — re-renders once per second using a local `useEffect` interval;
+       does **not** mutate engine state.
+     - `RitualControlsBar` (reused)
+     - Save button (visible when `status === 'complete'`)
+   - Soft duration gate:
+     - If `met_min_duration === false` when the user taps Save, show
+       a confirm dialog: "It looks like you only spent X seconds. Take
+       another moment, or save anyway?" — Cancel returns to the running
+       state; Save anyway proceeds.
+   - Local state:
+     - `selectedOptionKey: string | null`
+     - `elapsedSeconds: number` (derived from `state.startedAt`)
+   - If `require_option_choice === true`, the Begin button is disabled
+     until an option is selected.
+
+3. **Wire dispatcher**
+   - In `ActiveRitualSession.tsx`, add the
+     `mode === 'mindful_anchor'` case. Translate state on save into
+     `MindfulAnchorMetadata`:
+     ```
+     {
+       mode: 'mindful_anchor',
+       chosen_option_key: selectedOptionKey,
+       duration_seconds: elapsedSeconds,
+       met_min_duration: elapsedSeconds >= config.min_duration_seconds,
+     }
+     ```
+
+4. **API client types**
+   - Update `frontend/src/api/` types if practice config / metadata is
+     mirrored there.
+
+5. **Tests** — `frontend/src/features/Practice/views/__tests__/MindfulAnchorView.test.tsx`
+   - Renders instruction text
+   - Renders option chooser when options are present
+   - Disables Begin when `require_option_choice && !selectedOption`
+   - Tapping an option enables Begin
+   - After Begin, elapsed time display appears
+   - Save below `min_duration_seconds` shows the confirm dialog
+   - Save after `min_duration_seconds` fires `onSave` directly
+   - Snapshot of the chooser
+
+## Acceptance Criteria
+
+- [ ] `npm run lint` clean
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm test` green
+- [ ] `ActiveRitualSession` dispatches `mindful_anchor` to the new view
+- [ ] Manual smoke: start a Touch Grass session → pick "Grass" → Begin
+      → wait 5s → Save → confirm dialog appears → "Save anyway" →
+      session row appears with `mode_metadata.mode = "mindful_anchor"`
+- [ ] Manual smoke: same flow, wait ≥120s before Save → no confirm
+      dialog, save proceeds directly
+- [ ] No changes to existing view behavior
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Practice/engine/types.ts` | Modify |
+| `frontend/src/features/Practice/views/MindfulAnchorView.tsx` | **Create** |
+| `frontend/src/features/Practice/views/__tests__/MindfulAnchorView.test.tsx` | **Create** |
+| `frontend/src/features/Practice/components/ActiveRitualSession.tsx` | Modify |
+| `frontend/src/api/` (types module) | Possibly modify |
+
+## Constraints
+
+- Soft duration gate only — never hard-lock the save. Users with
+  legitimate reasons to cut short must be able to record their session.
+- Use a 1-Hz interval for the elapsed-time display; clear it on
+  unmount and on status change to avoid leaks.
+- Mode dispatch in `ActiveRitualSession.tsx` only.
+- Match design tokens (`@/design/tokens`) used by `SenseGroundingView`.
+- Accessibility: the option chooser uses `accessibilityRole="radio"`,
+  the elapsed time is announced as a polite live region, the save
+  confirm dialog is keyboard-dismissible.
+
+## Example: Touch Grass session shape
+
+```json
+{
+  "mode_metadata": {
+    "mode": "mindful_anchor",
+    "chosen_option_key": "grass",
+    "duration_seconds": 145,
+    "met_min_duration": true
+  }
+}
+```

--- a/prompts/github-issues/grounding-techniques-epic.md
+++ b/prompts/github-issues/grounding-techniques-epic.md
@@ -1,0 +1,114 @@
+# Epic: Generalize grounding techniques (Find Shapes, Find Colors, Touch Grass, Mindful Eating)
+
+**Labels:** `epic`, `backend`, `frontend`, `feature`
+**Scope:** Backend (2 new practice modes + presets) + Frontend (2 new ritual views)
+**Estimated total LoC:** ~1,100
+
+## Role
+
+You are a full-stack engineer extending Adepthood's mode-discriminated
+practice engine. You preserve existing contracts (`sense_grounding` is
+not refactored), and add new modes by following the established
+discriminated-union pattern.
+
+## Goal
+
+Add four new grounding techniques to the practice catalog by generalizing
+the data models and UX flows that today drive the 5-4-3-2-1 sense-grounding
+ritual. After this epic ships, users can complete: **Find Shapes**, **Find
+Colors**, **Touch Grass**, and **Mindful Eating** — all stage-aligned, all
+session-logged, all using the same `Practice` / `PracticeSession` tables.
+
+## Context
+
+The practice engine is already mode-discriminated (see
+`backend/src/domain/practice_modes.py:15-28`,
+`backend/src/schemas/practice_mode_config.py:144-156`,
+`backend/src/schemas/practice_session_metadata.py:94-106`). Each mode adds:
+
+1. A value to `PracticeMode` (StrEnum) + a `CHECK` constraint migration
+2. A `*Config` model in `practice_mode_config.py` (authoring input)
+3. A `*Metadata` model in `practice_session_metadata.py` (runtime output)
+4. Entries in the two `Annotated[... Field(discriminator="mode")]` unions
+5. A frontend view component in `frontend/src/features/Practice/views/`
+6. A dispatcher case in
+   `frontend/src/features/Practice/components/ActiveRitualSession.tsx`
+7. Engine type entries in `frontend/src/features/Practice/engine/types.ts`
+8. (Optional) Preset rows in `backend/src/seed_practices.py`
+
+Today the only "step-based" grounding mode is `sense_grounding`, with
+**hard-coded** 5-4-3-2-1 counts in
+`frontend/src/features/Practice/views/SenseGroundingView.tsx:24-30`.
+The four new techniques cluster into two patterns:
+
+| Technique         | Pattern                                                       | New mode             |
+|-------------------|---------------------------------------------------------------|----------------------|
+| Find Shapes       | 3 rounds × [squares×3, triangles×3, circles×3]                | `tallied_grounding`  |
+| Find Colors       | 3 rounds × [red×1, orange×1, …, violet×1] (7 colors)          | `tallied_grounding`  |
+| Touch Grass       | One mindful act on a chosen surface (grass/soil/sand/stone)   | `mindful_anchor`     |
+| Mindful Eating    | One mindful act on a chosen grounding food                    | `mindful_anchor`     |
+
+We deliberately introduce **two** new modes rather than four, because
+shapes/colors share a "rounds × categories × target_count" data shape,
+and touch-grass/eating share a "single mindful act with chooser + soft
+duration floor" data shape. `sense_grounding` is left untouched so this
+epic carries zero migration risk to existing seeded data.
+
+## Output Format
+
+Six sub-issues, each shippable independently. Backend modes ship first
+(unblock presets and views). Presets and views can land in parallel once
+the mode lands. The dependency graph:
+
+```
+01 tallied-mode-backend ──┬── 03 tallied-presets
+                          └── 05 tallied-view-frontend
+
+02 mindful-anchor-mode ───┬── 04 mindful-anchor-presets
+                          └── 06 mindful-anchor-view-frontend
+```
+
+## Sub-issues
+
+| # | Title                                                          | Scope    | LoC |
+|---|----------------------------------------------------------------|----------|-----|
+| 01 | [Add `tallied_grounding` mode](grounding-techniques-01-tallied-mode-backend.md) | Backend  | ~250 |
+| 02 | [Add `mindful_anchor` mode](grounding-techniques-02-mindful-anchor-mode-backend.md) | Backend  | ~200 |
+| 03 | [Seed Find Shapes + Find Colors presets](grounding-techniques-03-presets-shapes-and-colors.md) | Backend  | ~100 |
+| 04 | [Seed Touch Grass + Mindful Eating presets](grounding-techniques-04-presets-touch-grass-and-mindful-eating.md) | Backend  | ~100 |
+| 05 | [Build `TalliedGroundingView`](grounding-techniques-05-tallied-view-frontend.md) | Frontend | ~250 |
+| 06 | [Build `MindfulAnchorView`](grounding-techniques-06-mindful-anchor-view-frontend.md) | Frontend | ~200 |
+
+## Acceptance Criteria (epic-level)
+
+- [ ] All four techniques are seeded presets, browsable in the catalog
+- [ ] Each completes end-to-end: start → step through → save → session row written
+- [ ] `sense_grounding` behavior is unchanged (regression tests still green)
+- [ ] `pre-commit run --all-files` green on every sub-issue PR
+- [ ] Coverage thresholds (90% line, 80% branch, 85% docstring) unchanged
+
+## Constraints
+
+- Do **not** refactor `sense_grounding` into `tallied_grounding`. They
+  stay parallel. A future migration epic can fold them if desired.
+- Each `*Config` and `*Metadata` model must be a discriminated `_ConfigBase`
+  / `_MetadataBase` subclass with `mode: Literal["..."]` and `extra="forbid"`.
+- Each new mode value requires an Alembic migration that drops + recreates
+  the `practice.mode` CHECK constraint with the expanded `ALL_MODES` tuple.
+- Frontend views dispatch off `effectiveConfig.mode` in `ActiveRitualSession`.
+  Do not introduce any other mode-branching site.
+- Soft duration gating on `mindful_anchor` (encourage, don't enforce) —
+  surface elapsed time and a gentle nudge if `duration_seconds <
+  min_duration_seconds`, but allow save anyway.
+
+## References
+
+- `backend/src/models/practice.py:20-58` — `Practice` table with `mode` / `mode_config`
+- `backend/src/models/practice_session.py:14-61` — `PracticeSession` with `mode_metadata`
+- `backend/src/domain/practice_modes.py:15-28` — `PracticeMode` enum
+- `backend/src/schemas/practice_mode_config.py` — discriminated config union
+- `backend/src/schemas/practice_session_metadata.py` — discriminated metadata union
+- `backend/src/seed_practices.py:54-98` — preset seeding pattern
+- `frontend/src/features/Practice/engine/types.ts:55-65` — frontend mode types
+- `frontend/src/features/Practice/views/SenseGroundingView.tsx` — reference view
+- `frontend/src/features/Practice/components/ActiveRitualSession.tsx:26-100` — dispatcher


### PR DESCRIPTION
Plan an epic (1 tracker + 6 sub-issues) to add four new grounding
techniques — Find Shapes, Find Colors, Touch Grass, Mindful Eating — by
extending the mode-discriminated practice engine with two new modes
(`tallied_grounding`, `mindful_anchor`) instead of four. `sense_grounding`
is left untouched.