### PR TITLE
fix(course): move Squarespace auth POST to /course section

### DIFF
--- a/backend/src/services/squarespace.py
+++ b/backend/src/services/squarespace.py
@@ -57,6 +57,15 @@ _DEFAULT_CACHE_TTL: Final[int] = 60 * 60  # 1 hour
 _REQUEST_TIMEOUT_SECONDS: Final[float] = 10.0
 _HTTP_ERROR_THRESHOLD: Final[int] = 400
 _USER_AGENT: Final[str] = "AdepthoodApp/1.0 (+https://adepthood.com)"
+# Squarespace section under which the site password is configured.  The
+# rest of aptitude.guru (philosophy, about, …) is publicly readable and
+# does not require — or accept — the password POST.  Posting to a URL
+# outside this section returns 403 from Squarespace's edge.
+_AUTH_PATH: Final[str] = "/course"
+# Number of response bytes we capture on the auth-failure log line.
+# Enough to read a Squarespace error message or a WAF block page without
+# bloating the log.
+_AUTH_FAILURE_BODY_PREVIEW: Final[int] = 500
 #: Selectors we strip wholesale before returning the article body.  These
 #: are intentionally Squarespace-generic — site theme changes occasionally
 #: rename block classes, but the *roles* (header, footer, nav) are stable.
@@ -233,25 +242,29 @@ class SquarespaceClient:
     async def _authenticate(self) -> None:
         """POST the site password and capture the resulting cookie.
 
-        Squarespace site-wide passwords are submitted to the same URL as
-        the page being viewed; the server then sets a ``SiteUserInfo``-
-        family cookie on the domain.  We send to the site root since the
-        cookie applies site-wide.
+        The password gate on aptitude.guru is configured on the
+        ``/course`` section, not the site root.  Posting elsewhere
+        returns 403 from Squarespace's edge — the server only accepts
+        a password POST at a URL inside the protected section.  The
+        ``SiteUserInfo``-family cookie set by a successful POST applies
+        to every subsequent request under that section.
         """
         if not self._password:
             raise SquarespaceAuthError(
                 "SQUARESPACE_SITE_PASSWORD is not configured on the backend.",
             )
+        auth_url = f"{self._base_url}{_AUTH_PATH}"
         client = await self._ensure_client()
         try:
             response = await client.post(
-                f"{self._base_url}/",
+                auth_url,
                 data={"password": self._password},
             )
         except httpx.HTTPError as exc:
             raise SquarespaceFetchError(f"Network error during auth: {exc}") from exc
 
         if response.status_code >= _HTTP_ERROR_THRESHOLD:
+            self._log_auth_failure(auth_url, response)
             raise SquarespaceAuthError(
                 f"Squarespace rejected the site password (HTTP {response.status_code}).",
             )
@@ -264,6 +277,26 @@ class SquarespaceClient:
         self._authenticated = True
         logger.info("squarespace_authenticated", extra={"base_url": self._base_url})
 
+    @staticmethod
+    def _log_auth_failure(auth_url: str, response: httpx.Response) -> None:
+        """Emit a single warning with the data we need to debug 4xx auth.
+
+        Includes the status, content-type, server header, and a short
+        body preview.  Cookies are deliberately not logged — they could
+        carry session tokens on the success path and there is no
+        diagnostic value in them on the failure path.
+        """
+        logger.warning(
+            "squarespace_auth_http_error",
+            extra={
+                "auth_url": auth_url,
+                "status": response.status_code,
+                "content_type": response.headers.get("content-type"),
+                "server": response.headers.get("server"),
+                "body_preview": response.text[:_AUTH_FAILURE_BODY_PREVIEW],
+            },
+        )
+
     async def _ensure_authenticated(self) -> None:
         """Authenticate once per process unless the cookie has been cleared."""
         if self._authenticated:
@@ -272,6 +305,18 @@ class SquarespaceClient:
             if self._authenticated:
                 return
             await self._authenticate()
+
+    @staticmethod
+    def _requires_auth(url: str) -> bool:
+        """True when ``url`` falls under the password-protected section.
+
+        Public site pages (``/about``, ``/philosophy``, …) do not need
+        — and do not accept — the site password POST, so we skip
+        authentication for them.  This also means a misconfigured
+        ``SQUARESPACE_SITE_PASSWORD`` does not break those pages.
+        """
+        path = urlparse(url).path
+        return path == _AUTH_PATH or path.startswith(f"{_AUTH_PATH}/")
 
     # ------------------------------------------------------------------ #
     # Fetch                                                               #
@@ -322,7 +367,8 @@ class SquarespaceClient:
         if cached is not None and cached.expires_at > now:
             return cached.content
 
-        await self._ensure_authenticated()
+        if self._requires_auth(url):
+            await self._ensure_authenticated()
         content = await self._fetch_and_clean(url)
 
         self._cache[url] = _CacheEntry(

--- a/backend/src/services/squarespace.py
+++ b/backend/src/services/squarespace.py
@@ -388,10 +388,13 @@ class SquarespaceClient:
         response = await self._raw_get(url)
 
         # Session might have expired between authentication and this
-        # request; if so, log in once more and retry exactly once.
-        if response.status_code == httpx.codes.UNAUTHORIZED or self._looks_like_password_page(
-            response.text
-        ):
+        # request; if so, log in once more and retry exactly once.  Skip
+        # the re-auth for public URLs — they never had a cookie, and a
+        # 401 there is a real error, not a stale-session indicator.
+        looks_locked = response.status_code == httpx.codes.UNAUTHORIZED or (
+            self._looks_like_password_page(response.text)
+        )
+        if looks_locked and self._requires_auth(url):
             self._authenticated = False
             await self._ensure_authenticated()
             response = await self._raw_get(url)

--- a/backend/src/services/squarespace.py
+++ b/backend/src/services/squarespace.py
@@ -384,20 +384,25 @@ class SquarespaceClient:
         except httpx.HTTPError as exc:
             raise SquarespaceFetchError(f"Network error fetching {url}: {exc}") from exc
 
-    async def _fetch_and_clean(self, url: str) -> FetchedContent:
-        response = await self._raw_get(url)
+    async def _retry_if_session_expired(self, url: str, response: httpx.Response) -> httpx.Response:
+        """Re-authenticate and retry once if the response looks locked.
 
-        # Session might have expired between authentication and this
-        # request; if so, log in once more and retry exactly once.  Skip
-        # the re-auth for public URLs — they never had a cookie, and a
-        # 401 there is a real error, not a stale-session indicator.
-        looks_locked = response.status_code == httpx.codes.UNAUTHORIZED or (
+        Public URLs are exempt: they never had a cookie, and a 401 or
+        password-lookalike body there indicates a real upstream error,
+        not a stale session.
+        """
+        locked = response.status_code == httpx.codes.UNAUTHORIZED or (
             self._looks_like_password_page(response.text)
         )
-        if looks_locked and self._requires_auth(url):
-            self._authenticated = False
-            await self._ensure_authenticated()
-            response = await self._raw_get(url)
+        if not (locked and self._requires_auth(url)):
+            return response
+        self._authenticated = False
+        await self._ensure_authenticated()
+        return await self._raw_get(url)
+
+    async def _fetch_and_clean(self, url: str) -> FetchedContent:
+        response = await self._raw_get(url)
+        response = await self._retry_if_session_expired(url, response)
 
         if response.status_code >= _HTTP_ERROR_THRESHOLD:
             raise SquarespaceFetchError(

--- a/backend/tests/test_squarespace_service.py
+++ b/backend/tests/test_squarespace_service.py
@@ -64,7 +64,7 @@ async def test_fetch_authenticates_once_then_returns_clean_article() -> None:
     page_gets: list[Request] = []
 
     def handler(request: Request) -> Response:
-        if request.method == "POST" and request.url.path == "/":
+        if request.method == "POST" and request.url.path == "/course":
             auth_posts.append(request)
             return Response(200, html="<html><body>OK</body></html>")
         if request.method == "GET" and request.url.path == "/course/beige-1":
@@ -106,7 +106,7 @@ async def test_fetch_reauthenticates_when_session_expires() -> None:
     def handler(request: Request) -> Response:
         nonlocal gets
         request_log.append((request.method, request.url.path))
-        if request.method == "POST" and request.url.path == "/":
+        if request.method == "POST" and request.url.path == "/course":
             return Response(200, html="<html><body>OK</body></html>")
         if request.method == "GET" and request.url.path == "/course/beige-1":
             gets += 1
@@ -231,6 +231,98 @@ async def test_invalidate_cache_forces_refetch() -> None:
     client.invalidate_cache()
     await client.fetch(_CHAPTER_URL)
     assert gets == 3
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fetch_skips_auth_for_public_pages() -> None:
+    """Public pages outside ``/course`` are not gated and must skip auth."""
+    auth_posts: list[Request] = []
+    page_gets: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        if request.method == "POST":
+            auth_posts.append(request)
+            return Response(200, html="<html><body>OK</body></html>")
+        if request.method == "GET" and request.url.path == "/about":
+            page_gets.append(request)
+            return Response(200, html=_ARTICLE_PAGE)
+        return Response(404)
+
+    transport = MockTransport(handler)
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="open-sesame",  # pragma: allowlist secret
+        http_client_factory=_build_factory(transport),
+    )
+
+    await client.fetch(f"{_BASE_URL}/about")
+
+    assert len(auth_posts) == 0
+    assert len(page_gets) == 1
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fetch_public_page_works_when_password_unset() -> None:
+    """A missing password must not break public-page fetches."""
+    page_gets: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        if request.method == "GET" and request.url.path == "/philosophy":
+            page_gets.append(request)
+            return Response(200, html=_ARTICLE_PAGE)
+        return Response(404)
+
+    transport = MockTransport(handler)
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="",
+        http_client_factory=_build_factory(transport),
+    )
+
+    fetched = await client.fetch(f"{_BASE_URL}/philosophy")
+    assert "<article>" in fetched.body_html
+    assert len(page_gets) == 1
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_logs_response_details(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """On a 4xx auth response, the warning log carries enough to debug."""
+
+    def handler(request: Request) -> Response:
+        if request.method == "POST":
+            return Response(
+                403,
+                text="Host not in allowlist",
+                headers={"content-type": "text/plain", "server": "envoy"},
+            )
+        return Response(404)
+
+    transport = MockTransport(handler)
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="open-sesame",  # pragma: allowlist secret
+        http_client_factory=_build_factory(transport),
+    )
+
+    with (
+        caplog.at_level("WARNING", logger="services.squarespace"),
+        pytest.raises(SquarespaceAuthError),
+    ):
+        await client.fetch(_CHAPTER_URL)
+
+    record = next(r for r in caplog.records if r.message == "squarespace_auth_http_error")
+    # ``logger.warning(..., extra={...})`` merges the dict into the record's
+    # ``__dict__`` but those attributes are invisible to static analysis.
+    fields = record.__dict__
+    assert fields["status"] == 403
+    assert fields["auth_url"] == f"{_BASE_URL}/course"
+    assert "Host not in allowlist" in fields["body_preview"]
+    assert fields["content_type"] == "text/plain"
     await client.aclose()
 
 

--- a/backend/tests/test_squarespace_service.py
+++ b/backend/tests/test_squarespace_service.py
@@ -288,6 +288,39 @@ async def test_fetch_public_page_works_when_password_unset() -> None:
 
 
 @pytest.mark.asyncio
+async def test_public_page_401_does_not_trigger_reauth() -> None:
+    """A 401 on a public URL must surface as a fetch error, not re-auth.
+
+    ``_requires_auth`` documents the public-page contract; the
+    ``_fetch_and_clean`` retry path must honour it or a misconfigured
+    public page would attempt to authenticate with an empty password
+    and surface ``SquarespaceAuthError`` instead of the real upstream
+    failure.
+    """
+    auth_posts: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        if request.method == "POST":
+            auth_posts.append(request)
+            return Response(200, html="<html><body>OK</body></html>")
+        if request.method == "GET" and request.url.path == "/philosophy":
+            return Response(401, html="<html><body>Forbidden</body></html>")
+        return Response(404)
+
+    transport = MockTransport(handler)
+    client = SquarespaceClient(
+        base_url=_BASE_URL,
+        password="open-sesame",  # pragma: allowlist secret
+        http_client_factory=_build_factory(transport),
+    )
+
+    with pytest.raises(SquarespaceFetchError):
+        await client.fetch(f"{_BASE_URL}/philosophy")
+    assert len(auth_posts) == 0
+    await client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_auth_failure_logs_response_details(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Summary

Production was returning `503 cms_auth_failed` for every chapter and site-resource body request after PR #334 merged. Root cause: aptitude.guru's site password is configured on the `/course` section only, but our client POSTs the password to the site root (`/`), which is publicly readable and returns `403 Host not in allowlist` from Squarespace's edge. The auth cookie was never set, so every `_fetch_and_clean` call raised `SquarespaceAuthError`.

## Changes

- **`backend/src/services/squarespace.py`** — auth POST now targets `{base_url}/course`; new `_AUTH_PATH` constant and `_requires_auth(url)` predicate gate the `_ensure_authenticated()` call so public pages (`/about`, `/philosophy`) skip auth entirely. A misconfigured password no longer breaks non-paywalled resources.
- **Diagnostic logging** — on a 4xx response from the auth POST, log status, content-type, server, and a 500-byte body preview at WARNING (cookies omitted). Future outages of this class are now one log read instead of a redeploy-and-pray loop.
- **`backend/tests/test_squarespace_service.py`** — mock auth path updated to `/course`; new tests for the public-page bypass, the missing-password / public-page combination, and the diagnostic logging payload.

## Test plan

- [x] Backend suite: 1134 passed, 94% coverage
- [x] Pre-commit + pre-push gates green locally
- [ ] After merge + Railway redeploy, verify `GET /course/site-resources/about/body` returns 200 and `GET /course/content/<id>/body` for a released chapter returns 200
- [ ] If still 4xx, the new `squarespace_auth_http_error` WARNING log line will reveal whether it's a WAF block, form-shape change, or wrong password

https://claude.ai/code/session_01GRZXVdTjpqWXw4rrAK72pa

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRZXVdTjpqWXw4rrAK72pa)_