### PR TITLE
feat(backend): add card_meditation practice mode (#347)

### DIFF
--- a/backend/migrations/versions/a2b3c4d5e6f8_add_card_meditation_mode.py
+++ b/backend/migrations/versions/a2b3c4d5e6f8_add_card_meditation_mode.py
@@ -1,0 +1,85 @@
+"""extend ck_practice_mode_valid to include card_meditation
+
+Revision ID: a2b3c4d5e6f8
+Revises: f4a5b6c7d8e9
+Create Date: 2026-05-17 12:00:00.000000
+
+Adds ``card_meditation`` to the closed set of values accepted by the
+``practice.mode`` CHECK constraint. The new value powers deck-agnostic
+card meditation (RWS, Thoth, Marseille, oracle, user-curated photo
+decks) whose config and per-session metadata shapes live in
+:mod:`schemas.practice_mode_config.CardMeditationConfig` and
+:mod:`schemas.practice_session_metadata.CardMeditationMetadata`.
+
+Chains off ``f4a5b6c7d8e9`` (mindful_anchor) — the prior CHECK already
+lists nine modes, so the upgrade adds the tenth and the downgrade
+narrows back to the same nine. The existing ``tarot`` mode is
+preserved unchanged for backward compatibility.
+
+The migration drops and recreates ``ck_practice_mode_valid`` inside a
+``batch_alter_table`` block so SQLite (used by the round-trip test
+fixture) rebuilds the table once. The downgrade refuses to run if any
+rows already carry ``card_meditation`` — narrowing the CHECK while data
+violates it would either rewrite history or leave the DB in an
+inconsistent state, and the operator should resolve the rows first.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a2b3c4d5e6f8"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "f4a5b6c7d8e9"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_MODE_CHECK_NAME = "ck_practice_mode_valid"
+_NEW_MODE = "card_meditation"
+
+# Intentionally duplicated from ``domain.practice_modes.ALL_MODES`` — migrations
+# must not import application modules so the schema replays on a repo state
+# where the model no longer matches. The ninth mode (``mindful_anchor``)
+# was added by the down_revision migration ``f4a5b6c7d8e9``.
+_PREVIOUS_MODES = (
+    "meditation_timer",
+    "count_up",
+    "metronome",
+    "interval_bell",
+    "rep_counter",
+    "sense_grounding",
+    "tarot",
+    "tallied_grounding",
+    "mindful_anchor",
+)
+_EXTENDED_MODES = (*_PREVIOUS_MODES, _NEW_MODE)
+
+
+def _check_clause(modes: Sequence[str]) -> str:
+    quoted = ", ".join(f"'{m}'" for m in modes)
+    return f"mode IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Drop and recreate the CHECK constraint with ``card_meditation`` allowed."""
+    with op.batch_alter_table("practice") as batch_op:
+        batch_op.drop_constraint(_MODE_CHECK_NAME, type_="check")
+        batch_op.create_check_constraint(_MODE_CHECK_NAME, _check_clause(_EXTENDED_MODES))
+
+
+def downgrade() -> None:
+    """Narrow the CHECK back to the prior set; refuse if rows still use the new mode."""
+    bind = op.get_bind()
+    offenders = bind.execute(
+        sa.text("SELECT COUNT(*) FROM practice WHERE mode = :mode").bindparams(mode=_NEW_MODE)
+    ).scalar_one()
+    if offenders:
+        msg = (
+            f"Cannot downgrade: {offenders} practice row(s) carry mode='{_NEW_MODE}'. "
+            "Reassign those rows to a supported mode before downgrading."
+        )
+        raise RuntimeError(msg)
+    with op.batch_alter_table("practice") as batch_op:
+        batch_op.drop_constraint(_MODE_CHECK_NAME, type_="check")
+        batch_op.create_check_constraint(_MODE_CHECK_NAME, _check_clause(_PREVIOUS_MODES))

--- a/backend/src/domain/practice_modes.py
+++ b/backend/src/domain/practice_modes.py
@@ -24,6 +24,7 @@ class PracticeMode(StrEnum):
     TAROT = "tarot"
     TALLIED_GROUNDING = "tallied_grounding"
     MINDFUL_ANCHOR = "mindful_anchor"
+    CARD_MEDITATION = "card_meditation"
 
 
 #: Ordered tuple of wire values, suitable for CHECK constraints and docs.

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -38,6 +38,17 @@ _OPTION_DESCRIPTION_MAX = 500
 _INSTRUCTION_MAX = 500
 _MIN_DURATION_SECONDS_MAX = 3_600
 _MINDFUL_ANCHOR_OPTIONS_MAX = 20
+# Shared with ``schemas.practice_session_metadata`` so the deck slug and
+# card-name caps are encoded once. ``CardMeditationMetadata`` mirrors the
+# same bounds it sees coming back from sessions.
+CARD_DECK_ID_MAX = 64
+CARD_DECK_ID_PATTERN = r"^[a-z][a-z0-9_]*$"
+CARD_NAME_MAX = 120
+_CARD_IMAGE_ASSET_KEY_MAX = 200
+_CARD_IMAGE_URI_MAX = 500
+_CARD_SYMBOLISM_MAX = 500
+_CARD_MEDITATION_CARDS_MAX = 200
+_CARD_MEDITATION_CUSTOM_DECK_ID = "custom"
 
 Sense = Literal["sight", "touch", "hearing", "smell", "taste"]
 BellTone = Literal["bowl", "chime", "gong"]
@@ -264,6 +275,62 @@ class MindfulAnchorConfig(_ConfigBase):
         return self
 
 
+class CardMeditationCard(_ConfigBase):
+    """One card in a card-meditation deck — bundled or user-curated.
+
+    ``image_asset_key`` is an opaque handle the frontend resolves against
+    a bundled deck manifest (e.g. ``"rws/major/00_fool"``); the server
+    never dereferences it. ``image_uri`` is a client-local URI (the most
+    common case is a phone-photo ``file:///...`` path for a custom deck)
+    that the server likewise never fetches. The two are mutually
+    exclusive — a card either points at a curated asset *or* at a local
+    file, never both — and both being unset is also valid for a text-only
+    card whose meaning rides entirely on ``name`` and ``symbolism``.
+    """
+
+    name: str = Field(min_length=1, max_length=CARD_NAME_MAX)
+    image_asset_key: str | None = Field(
+        default=None, min_length=1, max_length=_CARD_IMAGE_ASSET_KEY_MAX
+    )
+    image_uri: str | None = Field(default=None, min_length=1, max_length=_CARD_IMAGE_URI_MAX)
+    symbolism: str | None = Field(default=None, max_length=_CARD_SYMBOLISM_MAX)
+
+    @model_validator(mode="after")
+    def _check_exclusive_image_fields(self) -> Self:
+        if self.image_asset_key is not None and self.image_uri is not None:
+            msg = "set at most one of image_asset_key or image_uri"
+            raise ValueError(msg)
+        return self
+
+
+class CardMeditationConfig(_ConfigBase):
+    """Deck-agnostic card meditation — bundled deck *or* user-curated cards.
+
+    ``deck_id`` is the slug the frontend uses to resolve which bundled
+    deck (``"rws"``, ``"thoth"``, …) to render; the sentinel ``"custom"``
+    signals a user-curated deck whose cards travel inline in ``cards``.
+    For bundled decks the ``cards`` field stays ``None`` because the
+    frontend already owns the canonical card list.
+    """
+
+    mode: Literal["card_meditation"] = "card_meditation"
+    deck_id: str = Field(min_length=1, max_length=CARD_DECK_ID_MAX, pattern=CARD_DECK_ID_PATTERN)
+    per_card_minutes: float = Field(default=5, ge=_DURATION_MIN_MINUTES, le=_DURATION_MAX_MINUTES)
+    shuffle: bool = True
+    reveal_after_meditation: bool = False
+    hide_timer_during_meditation: bool = True
+    cards: list[CardMeditationCard] | None = Field(
+        default=None, max_length=_CARD_MEDITATION_CARDS_MAX
+    )
+
+    @model_validator(mode="after")
+    def _check_custom_deck_carries_cards(self) -> Self:
+        if self.deck_id == _CARD_MEDITATION_CUSTOM_DECK_ID and not self.cards:
+            msg = "cards must be a non-empty list when deck_id is 'custom'"
+            raise ValueError(msg)
+        return self
+
+
 #: Discriminated union over all per-mode config payloads, keyed on ``mode``.
 ModeConfig = Annotated[
     MeditationTimerConfig
@@ -274,7 +341,8 @@ ModeConfig = Annotated[
     | SenseGroundingConfig
     | TarotConfig
     | TalliedGroundingConfig
-    | MindfulAnchorConfig,
+    | MindfulAnchorConfig
+    | CardMeditationConfig,
     Field(discriminator="mode"),
 ]
 

--- a/backend/src/schemas/practice_mode_config.py
+++ b/backend/src/schemas/practice_mode_config.py
@@ -44,11 +44,26 @@ _MINDFUL_ANCHOR_OPTIONS_MAX = 20
 CARD_DECK_ID_MAX = 64
 CARD_DECK_ID_PATTERN = r"^[a-z][a-z0-9_]*$"
 CARD_NAME_MAX = 120
+# Public so ``schemas.practice_session_metadata`` can derive its
+# ``card_drawn_index`` ceiling without the two modules silently drifting
+# (see ``test_card_meditation_metadata_ceiling_matches_config_constant``).
+CARD_MEDITATION_CARDS_MAX = 200
+# Sentinel deck id that signals a user-curated deck whose cards travel
+# inline in the config. Public so tests and callers reference one
+# canonical literal — a rename here would catch any stale string.
+CARD_MEDITATION_CUSTOM_DECK_ID = "custom"
 _CARD_IMAGE_ASSET_KEY_MAX = 200
 _CARD_IMAGE_URI_MAX = 500
 _CARD_SYMBOLISM_MAX = 500
-_CARD_MEDITATION_CARDS_MAX = 200
-_CARD_MEDITATION_CUSTOM_DECK_ID = "custom"
+# Allowlist mobile-local URI schemes for ``image_uri``. The server never
+# fetches the URI, but the value round-trips through the API to every
+# client that reads the practice, so a stored
+# ``http://attacker.com/beacon`` or ``javascript:...`` would be a stored
+# XSS/SSRF staging vector if a frontend ever renders the string as an
+# image source without re-sanitising. Restricting to the schemes mobile
+# clients actually produce (``file``, ``content``, ``ph``, ``asset``)
+# closes that vector at the schema boundary.
+_CARD_IMAGE_URI_PATTERN = r"^(file|content|ph|asset)://[^\s<>\"]+$"
 
 Sense = Literal["sight", "touch", "hearing", "smell", "taste"]
 BellTone = Literal["bowl", "chime", "gong"]
@@ -288,12 +303,36 @@ class CardMeditationCard(_ConfigBase):
     card whose meaning rides entirely on ``name`` and ``symbolism``.
     """
 
-    name: str = Field(min_length=1, max_length=CARD_NAME_MAX)
-    image_asset_key: str | None = Field(
-        default=None, min_length=1, max_length=_CARD_IMAGE_ASSET_KEY_MAX
+    name: str = Field(
+        min_length=1,
+        max_length=CARD_NAME_MAX,
+        description="Card title shown above the image / symbolism block.",
     )
-    image_uri: str | None = Field(default=None, min_length=1, max_length=_CARD_IMAGE_URI_MAX)
-    symbolism: str | None = Field(default=None, max_length=_CARD_SYMBOLISM_MAX)
+    image_asset_key: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=_CARD_IMAGE_ASSET_KEY_MAX,
+        description=(
+            "Opaque handle resolved against the bundled deck manifest "
+            "(e.g. ``rws/major/00_fool``). The server never dereferences it."
+        ),
+    )
+    image_uri: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=_CARD_IMAGE_URI_MAX,
+        pattern=_CARD_IMAGE_URI_PATTERN,
+        description=(
+            "Mobile-local URI (``file://``, ``content://``, ``ph://``, ``asset://``). "
+            "The server never fetches it and rejects network/script schemes at "
+            "the schema boundary."
+        ),
+    )
+    symbolism: str | None = Field(
+        default=None,
+        max_length=_CARD_SYMBOLISM_MAX,
+        description="Short reflection prompt rendered alongside the card image.",
+    )
 
     @model_validator(mode="after")
     def _check_exclusive_image_fields(self) -> Self:
@@ -320,13 +359,15 @@ class CardMeditationConfig(_ConfigBase):
     reveal_after_meditation: bool = False
     hide_timer_during_meditation: bool = True
     cards: list[CardMeditationCard] | None = Field(
-        default=None, max_length=_CARD_MEDITATION_CARDS_MAX
+        default=None, max_length=CARD_MEDITATION_CARDS_MAX
     )
 
     @model_validator(mode="after")
     def _check_custom_deck_carries_cards(self) -> Self:
-        if self.deck_id == _CARD_MEDITATION_CUSTOM_DECK_ID and not self.cards:
-            msg = "cards must be a non-empty list when deck_id is 'custom'"
+        if self.deck_id == CARD_MEDITATION_CUSTOM_DECK_ID and not self.cards:
+            msg = (
+                f"cards must be a non-empty list when deck_id is {CARD_MEDITATION_CUSTOM_DECK_ID!r}"
+            )
             raise ValueError(msg)
         return self
 

--- a/backend/src/schemas/practice_session_metadata.py
+++ b/backend/src/schemas/practice_session_metadata.py
@@ -15,6 +15,9 @@ from typing import Annotated, Literal, Self
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
 from schemas.practice_mode_config import (
+    CARD_DECK_ID_MAX,
+    CARD_DECK_ID_PATTERN,
+    CARD_NAME_MAX,
     OPTION_KEY_MAX,
     OPTION_KEY_PATTERN,
     TALLIED_CATEGORIES_MAX,
@@ -36,6 +39,13 @@ _MAX_INTERVALS = 1_000
 MAX_TALLIED_ROUNDS = TALLIED_ROUNDS_MAX
 MAX_TALLIED_ITEMS = TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
 _MAX_ANCHOR_DURATION_SECONDS = 4 * 60 * 60  # 4 hours; well above any plausible mindful act.
+# Index ceiling for a card_meditation deck: matches the cards-list cap on
+# :class:`schemas.practice_mode_config.CardMeditationConfig` (200 cards,
+# zero-indexed). Keeping it here as a derived bound would require
+# importing the private cap; the constant is short enough that pinning it
+# inline keeps the two modules independently readable while the
+# round-trip test below double-checks both stay in sync.
+_MAX_CARD_INDEX = 199
 
 
 class _MetadataBase(BaseModel):
@@ -143,6 +153,22 @@ class MindfulAnchorMetadata(_MetadataBase):
     met_min_duration: bool
 
 
+class CardMeditationMetadata(_MetadataBase):
+    """Which card the user drew (by name and optional index).
+
+    ``card_drawn_index`` is optional because a custom deck may shuffle on
+    the client side without echoing positions back, and a bundled deck
+    may identify the card purely by name. The name is the authoritative
+    field; the index is a convenience for analytics that want to
+    correlate sessions with deck positions.
+    """
+
+    mode: Literal["card_meditation"] = "card_meditation"
+    deck_id: str = Field(min_length=1, max_length=CARD_DECK_ID_MAX, pattern=CARD_DECK_ID_PATTERN)
+    card_drawn_name: str = Field(min_length=1, max_length=CARD_NAME_MAX)
+    card_drawn_index: int | None = Field(default=None, ge=0, le=_MAX_CARD_INDEX)
+
+
 #: Discriminated union over all per-mode session metadata payloads.
 SessionMetadata = Annotated[
     MeditationTimerMetadata
@@ -153,7 +179,8 @@ SessionMetadata = Annotated[
     | SenseGroundingMetadata
     | TarotMetadata
     | TalliedGroundingMetadata
-    | MindfulAnchorMetadata,
+    | MindfulAnchorMetadata
+    | CardMeditationMetadata,
     Field(discriminator="mode"),
 ]
 

--- a/backend/src/schemas/practice_session_metadata.py
+++ b/backend/src/schemas/practice_session_metadata.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 from schemas.practice_mode_config import (
     CARD_DECK_ID_MAX,
     CARD_DECK_ID_PATTERN,
+    CARD_MEDITATION_CARDS_MAX,
     CARD_NAME_MAX,
     OPTION_KEY_MAX,
     OPTION_KEY_PATTERN,
@@ -39,13 +40,14 @@ _MAX_INTERVALS = 1_000
 MAX_TALLIED_ROUNDS = TALLIED_ROUNDS_MAX
 MAX_TALLIED_ITEMS = TALLIED_ROUNDS_MAX * TALLIED_CATEGORIES_MAX * TALLIED_TARGET_MAX
 _MAX_ANCHOR_DURATION_SECONDS = 4 * 60 * 60  # 4 hours; well above any plausible mindful act.
-# Index ceiling for a card_meditation deck: matches the cards-list cap on
-# :class:`schemas.practice_mode_config.CardMeditationConfig` (200 cards,
-# zero-indexed). Keeping it here as a derived bound would require
-# importing the private cap; the constant is short enough that pinning it
-# inline keeps the two modules independently readable while the
-# round-trip test below double-checks both stay in sync.
-_MAX_CARD_INDEX = 199
+# Index ceiling for a card_meditation deck. Derived from the authoring-
+# side cap so a future bump to ``CARD_MEDITATION_CARDS_MAX`` cannot leave
+# the post-session index ceiling silently stale. The cross-module guard
+# in ``test_card_meditation_metadata_ceiling_matches_config_constant``
+# locks this derivation in case the constant is ever inlined. Re-exported
+# at module scope so the contract test asserts against the same name a
+# caller would import.
+MAX_CARD_INDEX = CARD_MEDITATION_CARDS_MAX - 1
 
 
 class _MetadataBase(BaseModel):
@@ -166,7 +168,7 @@ class CardMeditationMetadata(_MetadataBase):
     mode: Literal["card_meditation"] = "card_meditation"
     deck_id: str = Field(min_length=1, max_length=CARD_DECK_ID_MAX, pattern=CARD_DECK_ID_PATTERN)
     card_drawn_name: str = Field(min_length=1, max_length=CARD_NAME_MAX)
-    card_drawn_index: int | None = Field(default=None, ge=0, le=_MAX_CARD_INDEX)
+    card_drawn_index: int | None = Field(default=None, ge=0, le=MAX_CARD_INDEX)
 
 
 #: Discriminated union over all per-mode session metadata payloads.

--- a/backend/tests/domain/test_practice_modes.py
+++ b/backend/tests/domain/test_practice_modes.py
@@ -14,6 +14,7 @@ _EXPECTED_MEMBERS: tuple[str, ...] = (
     "tarot",
     "tallied_grounding",
     "mindful_anchor",
+    "card_meditation",
 )
 
 

--- a/backend/tests/domain/test_practice_resolution.py
+++ b/backend/tests/domain/test_practice_resolution.py
@@ -11,6 +11,7 @@ from domain.practice_resolution import effective_config, effective_name
 from models.practice import Practice
 from models.user_practice import UserPractice
 from schemas.practice_mode_config import (
+    CardMeditationConfig,
     CountUpConfig,
     IntervalBellConfig,
     MeditationTimerConfig,
@@ -193,3 +194,44 @@ def test_effective_config_tarot_round_trip() -> None:
     cfg = effective_config(practice, _user_practice())
     assert isinstance(cfg, TarotConfig)
     assert cfg.per_card_minutes == 5
+
+
+def test_effective_config_card_meditation_bundled_deck_round_trip() -> None:
+    """The catalog config for a bundled-deck card_meditation resolves cleanly."""
+    catalog_cfg = {
+        "mode": "card_meditation",
+        "deck_id": "rws",
+        "per_card_minutes": 7,
+        "shuffle": True,
+        "reveal_after_meditation": False,
+        "hide_timer_during_meditation": True,
+        "cards": None,
+    }
+    practice = _practice("card_meditation", catalog_cfg)
+    cfg = effective_config(practice, _user_practice())
+    assert isinstance(cfg, CardMeditationConfig)
+    assert cfg.deck_id == "rws"
+    assert cfg.per_card_minutes == 7
+    assert cfg.cards is None
+
+
+def test_effective_config_card_meditation_custom_deck_round_trip() -> None:
+    """A custom-deck catalog config carries cards through the resolver."""
+    catalog_cfg = {
+        "mode": "card_meditation",
+        "deck_id": "custom",
+        "per_card_minutes": 5,
+        "shuffle": False,
+        "reveal_after_meditation": True,
+        "hide_timer_during_meditation": True,
+        "cards": [
+            {"name": "Mountain", "image_uri": "file:///var/mobile/IMG_0123.jpg"},
+            {"name": "River", "image_uri": "file:///var/mobile/IMG_0124.jpg"},
+        ],
+    }
+    practice = _practice("card_meditation", catalog_cfg)
+    cfg = effective_config(practice, _user_practice())
+    assert isinstance(cfg, CardMeditationConfig)
+    assert cfg.shuffle is False
+    assert cfg.cards is not None
+    assert [c.name for c in cfg.cards] == ["Mountain", "River"]

--- a/backend/tests/schemas/test_practice_mode_config.py
+++ b/backend/tests/schemas/test_practice_mode_config.py
@@ -6,6 +6,8 @@ import pytest
 from pydantic import TypeAdapter, ValidationError
 
 from schemas.practice_mode_config import (
+    CARD_MEDITATION_CARDS_MAX,
+    CARD_MEDITATION_CUSTOM_DECK_ID,
     CardMeditationCard,
     CardMeditationConfig,
     CountUpConfig,
@@ -467,7 +469,7 @@ def _custom_deck_payload(**overrides: object) -> dict[str, object]:
     """Minimal valid custom-deck ``card_meditation`` config (two phone photos)."""
     payload: dict[str, object] = {
         "mode": "card_meditation",
-        "deck_id": "custom",
+        "deck_id": CARD_MEDITATION_CUSTOM_DECK_ID,
         "per_card_minutes": 5,
         "shuffle": True,
         "reveal_after_meditation": True,
@@ -559,16 +561,37 @@ def test_card_meditation_rejects_zero_per_card_minutes() -> None:
 
 
 def test_card_meditation_rejects_too_many_cards() -> None:
-    """The 200-card cap guards against bloated payloads in a single config."""
-    cards = [{"name": f"Card {i}"} for i in range(201)]
+    """The cards-list cap guards against bloated payloads in a single config."""
+    cards = [{"name": f"Card {i}"} for i in range(CARD_MEDITATION_CARDS_MAX + 1)]
     with pytest.raises(ValidationError):
         _ADAPTER.validate_python(_custom_deck_payload(cards=cards))
+
+
+def test_card_meditation_accepts_cards_at_ceiling() -> None:
+    """The exact ceiling is a valid (inclusive) boundary — pins the off-by-one.
+
+    Mirrors :func:`test_tallied_grounding_accepts_items_completed_at_ceiling`
+    so the cards-list bound is locked at the inclusive edge rather than
+    just rejecting overflow.
+    """
+    cards = [{"name": f"Card {i}"} for i in range(CARD_MEDITATION_CARDS_MAX)]
+    cfg = _ADAPTER.validate_python(_custom_deck_payload(cards=cards))
+    assert isinstance(cfg, CardMeditationConfig)
+    assert cfg.cards is not None
+    assert len(cfg.cards) == CARD_MEDITATION_CARDS_MAX
 
 
 def test_card_meditation_rejects_extra_fields() -> None:
     """``extra="forbid"`` catches typos like ``perCardMinutes`` or ``deckId``."""
     with pytest.raises(ValidationError):
         _ADAPTER.validate_python(_bundled_deck_payload(perCardMinutes=5))
+
+
+def test_card_meditation_shuffle_false_round_trip() -> None:
+    """``shuffle=False`` round-trips so curated decks can present cards in order."""
+    cfg = _ADAPTER.validate_python(_bundled_deck_payload(shuffle=False))
+    assert isinstance(cfg, CardMeditationConfig)
+    assert cfg.shuffle is False
 
 
 def test_card_meditation_does_not_disturb_tarot() -> None:
@@ -582,3 +605,46 @@ def test_card_meditation_does_not_disturb_tarot() -> None:
         }
     )
     assert type(cfg) is TarotConfig
+
+
+# -- card_meditation image_uri scheme allowlist ----------------------------
+
+
+@pytest.mark.parametrize(
+    "safe_uri",
+    [
+        "file:///var/mobile/IMG_0123.jpg",
+        "content://media/external/images/media/1234",
+        "ph://4D2D4E51-1FE2-4B7B-9F61-3C2D5E6F1A2B/L0/001",
+        "asset://photos/IMG_0125.jpg",
+    ],
+)
+def test_card_meditation_card_accepts_safe_image_uri_schemes(safe_uri: str) -> None:
+    """The four mobile-local schemes round-trip cleanly through validation."""
+    card = CardMeditationCard(name="Photo", image_uri=safe_uri)
+    assert card.image_uri == safe_uri
+
+
+@pytest.mark.parametrize(
+    "unsafe_uri",
+    [
+        "http://attacker.com/beacon",
+        "https://attacker.com/beacon",
+        "javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "ftp://example.com/x",
+        "vbscript:msgbox(1)",
+        "/var/photos/IMG.jpg",  # missing scheme
+        "file:/var/photos/IMG.jpg",  # missing double-slash
+    ],
+)
+def test_card_meditation_card_rejects_unsafe_image_uri_schemes(unsafe_uri: str) -> None:
+    """Network / script / data URIs are stored-XSS or SSRF staging vectors.
+
+    The server never fetches ``image_uri``, but the value travels back to
+    every client that reads the practice; allowing arbitrary schemes
+    would let a malicious draft poison the catalog payload. The schema
+    allowlist closes that vector at the boundary.
+    """
+    with pytest.raises(ValidationError):
+        CardMeditationCard(name="Photo", image_uri=unsafe_uri)

--- a/backend/tests/schemas/test_practice_mode_config.py
+++ b/backend/tests/schemas/test_practice_mode_config.py
@@ -6,6 +6,8 @@ import pytest
 from pydantic import TypeAdapter, ValidationError
 
 from schemas.practice_mode_config import (
+    CardMeditationCard,
+    CardMeditationConfig,
     CountUpConfig,
     IntervalBellConfig,
     MeditationTimerConfig,
@@ -441,3 +443,142 @@ def test_mindful_anchor_rejects_extra_fields() -> None:
     """``extra="forbid"`` catches typos like ``minDurationSeconds``."""
     with pytest.raises(ValidationError):
         _ADAPTER.validate_python(_mindful_anchor_payload(extra_junk="nope"))
+
+
+# -- card_meditation config -------------------------------------------------
+
+
+def _bundled_deck_payload(**overrides: object) -> dict[str, object]:
+    """Minimal valid ``card_meditation`` config pointing at a bundled deck."""
+    payload: dict[str, object] = {
+        "mode": "card_meditation",
+        "deck_id": "rws",
+        "per_card_minutes": 7,
+        "shuffle": True,
+        "reveal_after_meditation": False,
+        "hide_timer_during_meditation": True,
+        "cards": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _custom_deck_payload(**overrides: object) -> dict[str, object]:
+    """Minimal valid custom-deck ``card_meditation`` config (two phone photos)."""
+    payload: dict[str, object] = {
+        "mode": "card_meditation",
+        "deck_id": "custom",
+        "per_card_minutes": 5,
+        "shuffle": True,
+        "reveal_after_meditation": True,
+        "hide_timer_during_meditation": True,
+        "cards": [
+            {
+                "name": "Mountain",
+                "image_uri": "file:///var/.../IMG_0123.jpg",
+                "symbolism": "Stillness.",
+            },
+            {"name": "River", "image_uri": "file:///var/.../IMG_0124.jpg", "symbolism": "Flow."},
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_card_meditation_bundled_deck_round_trip() -> None:
+    """Bundled deck: ``cards`` is ``None`` because the frontend owns the canonical list."""
+    cfg = _ADAPTER.validate_python(_bundled_deck_payload())
+    assert isinstance(cfg, CardMeditationConfig)
+    assert cfg.deck_id == "rws"
+    assert cfg.per_card_minutes == 7
+    assert cfg.cards is None
+
+
+def test_card_meditation_custom_deck_round_trip() -> None:
+    """Custom deck: ``cards`` carries the user-curated list inline."""
+    cfg = _ADAPTER.validate_python(_custom_deck_payload())
+    assert isinstance(cfg, CardMeditationConfig)
+    assert cfg.deck_id == "custom"
+    assert cfg.cards is not None
+    assert [c.name for c in cfg.cards] == ["Mountain", "River"]
+
+
+def test_card_meditation_custom_deck_requires_cards() -> None:
+    """``deck_id="custom"`` with ``cards=None`` is contradictory and rejected."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(_custom_deck_payload(cards=None))
+
+
+def test_card_meditation_custom_deck_rejects_empty_cards_list() -> None:
+    """``deck_id="custom"`` with an empty list is the same contradiction in disguise."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(_custom_deck_payload(cards=[]))
+
+
+def test_card_meditation_card_rejects_both_image_fields() -> None:
+    """A card can carry a curated asset key *or* a client-local URI, never both."""
+    with pytest.raises(ValidationError):
+        CardMeditationCard(
+            name="Confusing",
+            image_asset_key="rws/major/00_fool",
+            image_uri="file:///photos/IMG.jpg",
+        )
+
+
+def test_card_meditation_card_accepts_neither_image_field() -> None:
+    """A text-only card (no images at all) is valid — its meaning rides on name + symbolism."""
+    card = CardMeditationCard(name="Stillness", symbolism="Sit with it.")
+    assert card.image_asset_key is None
+    assert card.image_uri is None
+
+
+def test_card_meditation_card_accepts_only_asset_key() -> None:
+    """A bundled-deck card carries an opaque asset key the frontend resolves."""
+    card = CardMeditationCard(name="The Fool", image_asset_key="rws/major/00_fool")
+    assert card.image_asset_key == "rws/major/00_fool"
+    assert card.image_uri is None
+
+
+def test_card_meditation_rejects_invalid_deck_id_slug() -> None:
+    """``deck_id`` must satisfy the snake-case slug regex (no uppercase, no leading digits)."""
+    for bad in ("RWS", "1deck", "deck-id", "deck id"):
+        with pytest.raises(ValidationError):
+            _ADAPTER.validate_python(_bundled_deck_payload(deck_id=bad))
+
+
+def test_card_meditation_rejects_empty_deck_id() -> None:
+    """An empty ``deck_id`` cannot resolve to any bundled deck or the custom sentinel."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(_bundled_deck_payload(deck_id=""))
+
+
+def test_card_meditation_rejects_zero_per_card_minutes() -> None:
+    """``per_card_minutes`` is a hard floor — a zero-minute card is meaningless."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(_bundled_deck_payload(per_card_minutes=0))
+
+
+def test_card_meditation_rejects_too_many_cards() -> None:
+    """The 200-card cap guards against bloated payloads in a single config."""
+    cards = [{"name": f"Card {i}"} for i in range(201)]
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(_custom_deck_payload(cards=cards))
+
+
+def test_card_meditation_rejects_extra_fields() -> None:
+    """``extra="forbid"`` catches typos like ``perCardMinutes`` or ``deckId``."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(_bundled_deck_payload(perCardMinutes=5))
+
+
+def test_card_meditation_does_not_disturb_tarot() -> None:
+    """Adding ``card_meditation`` to the union must not change ``tarot`` dispatch."""
+    cfg = _ADAPTER.validate_python(
+        {
+            "mode": "tarot",
+            "deck": "major_arcana",
+            "per_card_minutes": 5,
+            "hide_timer_during_meditation": True,
+        }
+    )
+    assert type(cfg) is TarotConfig

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -48,6 +48,12 @@ _TALLIED_GROUNDING_REVISION = "a1b2c3d4e5f7"  # pragma: allowlist secret
 _MINDFUL_ANCHOR_BASE_REVISION = "a1b2c3d4e5f7"  # pragma: allowlist secret
 _MINDFUL_ANCHOR_REVISION = "f4a5b6c7d8e9"  # pragma: allowlist secret
 
+# custom-practices-02: extend ck_practice_mode_valid to include card_meditation.
+# Chains off the mindful_anchor migration so the three custom-practice modes
+# coexist on a single linear timeline.
+_CARD_MEDITATION_BASE_REVISION = "f4a5b6c7d8e9"  # pragma: allowlist secret
+_CARD_MEDITATION_REVISION = "a2b3c4d5e6f8"  # pragma: allowlist secret
+
 
 def test_timestamptz_migration_exists() -> None:
     """Regression guard: the migration file must stay where Alembic finds it."""
@@ -564,6 +570,7 @@ _ORIGINAL_SEVEN_MODES = (
     "tarot",
 )
 _EIGHT_MODES_AFTER_TALLIED = (*_ORIGINAL_SEVEN_MODES, "tallied_grounding")
+_NINE_MODES_AFTER_MINDFUL_ANCHOR = (*_EIGHT_MODES_AFTER_TALLIED, "mindful_anchor")
 
 
 def _bootstrap_practice_with_mode_check(sync_url: str, allowed_modes: tuple[str, ...]) -> None:
@@ -779,3 +786,93 @@ def test_mindful_anchor_downgrade_refuses_with_existing_rows(
 
     with pytest.raises(RuntimeError, match="mindful_anchor"):
         command.downgrade(cfg, _MINDFUL_ANCHOR_BASE_REVISION)
+
+
+# -- custom-practices-02 card_meditation migration round-trip --------------
+
+
+@pytest.fixture
+def alembic_sqlite_config_card_meditation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before ``a2b3c4d5e6f8``.
+
+    The down_revision is the mindful_anchor migration so the pre-upgrade
+    CHECK already lists nine modes; bootstrap mirrors that state.
+    """
+    db_path = tmp_path / "card_meditation_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_practice_with_mode_check(sync_url, _NINE_MODES_AFTER_MINDFUL_ANCHOR)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _CARD_MEDITATION_BASE_REVISION)
+    return cfg
+
+
+def test_card_meditation_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_card_meditation: Config,
+) -> None:
+    """Round-trip ``a2b3c4d5e6f8``: upgrade allows ``card_meditation``; downgrade reverts.
+
+    Phase 1: upgrade lets a ``card_meditation`` row insert succeed
+    (proving the CHECK was widened). Phase 2: with that row deleted,
+    downgrade narrows the CHECK and rejects future ``card_meditation``
+    inserts. Phase 3: re-upgrade is idempotent.
+    """
+    cfg = alembic_sqlite_config_card_meditation
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade widens the CHECK.
+    command.upgrade(cfg, _CARD_MEDITATION_REVISION)
+    _insert_practice_row(db_url, mode="card_meditation", name="RWS daily card")
+    assert _count_practice_with_mode(db_url, "card_meditation") == 1
+
+    # Phase 2: clear the new-mode row, then downgrade and prove the CHECK is
+    # back in force. ``tarot`` must still insert successfully — the new
+    # mode is additive, not a replacement.
+    sync_engine = create_engine(_sync_url(db_url))
+    try:
+        with sync_engine.begin() as conn:
+            conn.execute(text("DELETE FROM practice WHERE mode = 'card_meditation'"))
+    finally:
+        sync_engine.dispose()
+    command.downgrade(cfg, _CARD_MEDITATION_BASE_REVISION)
+    with pytest.raises(IntegrityError):
+        _insert_practice_row(db_url, mode="card_meditation", name="Should fail")
+    _insert_practice_row(db_url, mode="tarot", name="Tarot still works")
+    assert _count_practice_with_mode(db_url, "tarot") == 1
+
+    # Phase 3: re-upgrade so the cycle is idempotent. The phase-1 row was
+    # deleted to enable the downgrade, so only this new row remains.
+    command.upgrade(cfg, _CARD_MEDITATION_REVISION)
+    _insert_practice_row(db_url, mode="card_meditation", name="Custom phone deck")
+    assert _count_practice_with_mode(db_url, "card_meditation") == 1
+
+
+def test_card_meditation_downgrade_refuses_with_existing_rows(
+    alembic_sqlite_config_card_meditation: Config,
+) -> None:
+    """The downgrade aborts when ``card_meditation`` rows still exist.
+
+    Mirrors the mindful_anchor guard: narrowing the CHECK while data
+    violates it would either rewrite history or leave the DB in an
+    inconsistent state. The migration refuses to run and the operator
+    clears the rows themselves.
+    """
+    cfg = alembic_sqlite_config_card_meditation
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    command.upgrade(cfg, _CARD_MEDITATION_REVISION)
+    _insert_practice_row(db_url, mode="card_meditation", name="Stick around")
+
+    with pytest.raises(RuntimeError, match="card_meditation"):
+        command.downgrade(cfg, _CARD_MEDITATION_BASE_REVISION)

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -6,11 +6,13 @@ import pytest
 from pydantic import ValidationError
 
 from schemas.practice_mode_config import (
+    CARD_MEDITATION_CARDS_MAX,
     TALLIED_CATEGORIES_MAX,
     TALLIED_ROUNDS_MAX,
     TALLIED_TARGET_MAX,
 )
 from schemas.practice_session_metadata import (
+    MAX_CARD_INDEX,
     MAX_TALLIED_ITEMS,
     MAX_TALLIED_ROUNDS,
     CardMeditationMetadata,
@@ -375,14 +377,43 @@ def test_card_meditation_metadata_rejects_negative_index() -> None:
 
 
 def test_card_meditation_metadata_rejects_index_past_cap() -> None:
-    """The 200-card cap on the config side bounds the index to 0..199."""
+    """The cards-list cap on the config side bounds the index to 0..MAX_CARD_INDEX.
+
+    Computing the reject value from the config constant keeps this test
+    in sync with any future ceiling bump — the analogue of
+    :func:`test_tallied_grounding_rejects_items_above_ceiling`.
+    """
     with pytest.raises(ValidationError):
         CardMeditationMetadata(
             mode="card_meditation",
             deck_id="rws",
             card_drawn_name="The Fool",
-            card_drawn_index=200,
+            card_drawn_index=CARD_MEDITATION_CARDS_MAX,
         )
+
+
+def test_card_meditation_metadata_accepts_index_at_ceiling() -> None:
+    """``MAX_CARD_INDEX`` itself is valid (inclusive bound, off-by-one guard)."""
+    payload = CardMeditationMetadata(
+        mode="card_meditation",
+        deck_id="rws",
+        card_drawn_name="The World",
+        card_drawn_index=MAX_CARD_INDEX,
+    )
+    assert payload.card_drawn_index == MAX_CARD_INDEX
+
+
+def test_card_meditation_metadata_ceiling_matches_config_constant() -> None:
+    """Lock ``MAX_CARD_INDEX`` to the authoring-side ``CARD_MEDITATION_CARDS_MAX``.
+
+    Mirrors :func:`test_tallied_metadata_ceilings_match_config_constants`:
+    the metadata module derives the index ceiling from the config-side
+    cap so a future bump (e.g. raising the cards-list limit) cannot
+    leave the post-session index cap silently stale. This test pins the
+    contract — it fails loudly if the derivation is ever inlined or the
+    underlying constant changes without the metadata module noticing.
+    """
+    assert MAX_CARD_INDEX == CARD_MEDITATION_CARDS_MAX - 1
 
 
 def test_card_meditation_metadata_rejects_empty_card_name() -> None:

--- a/backend/tests/test_practice_session_metadata.py
+++ b/backend/tests/test_practice_session_metadata.py
@@ -13,6 +13,7 @@ from schemas.practice_mode_config import (
 from schemas.practice_session_metadata import (
     MAX_TALLIED_ITEMS,
     MAX_TALLIED_ROUNDS,
+    CardMeditationMetadata,
     CountUpMetadata,
     IntervalBellMetadata,
     MeditationTimerMetadata,
@@ -330,3 +331,80 @@ def test_mindful_anchor_metadata_rejects_invalid_option_key_slug() -> None:
                 duration_seconds=10,
                 met_min_duration=False,
             )
+
+
+# -- card_meditation metadata ----------------------------------------------
+
+
+def test_card_meditation_metadata_round_trip() -> None:
+    payload = SessionMetadataAdapter.validate_python(
+        {
+            "mode": "card_meditation",
+            "deck_id": "rws",
+            "card_drawn_name": "The Fool",
+            "card_drawn_index": 0,
+        }
+    )
+    assert isinstance(payload, CardMeditationMetadata)
+    assert payload.deck_id == "rws"
+    assert payload.card_drawn_name == "The Fool"
+    assert payload.card_drawn_index == 0
+
+
+def test_card_meditation_metadata_index_is_optional() -> None:
+    """Custom decks may shuffle on the client without echoing positions back."""
+    payload = SessionMetadataAdapter.validate_python(
+        {
+            "mode": "card_meditation",
+            "deck_id": "custom",
+            "card_drawn_name": "Mountain",
+        }
+    )
+    assert isinstance(payload, CardMeditationMetadata)
+    assert payload.card_drawn_index is None
+
+
+def test_card_meditation_metadata_rejects_negative_index() -> None:
+    with pytest.raises(ValidationError):
+        CardMeditationMetadata(
+            mode="card_meditation",
+            deck_id="rws",
+            card_drawn_name="The Fool",
+            card_drawn_index=-1,
+        )
+
+
+def test_card_meditation_metadata_rejects_index_past_cap() -> None:
+    """The 200-card cap on the config side bounds the index to 0..199."""
+    with pytest.raises(ValidationError):
+        CardMeditationMetadata(
+            mode="card_meditation",
+            deck_id="rws",
+            card_drawn_name="The Fool",
+            card_drawn_index=200,
+        )
+
+
+def test_card_meditation_metadata_rejects_empty_card_name() -> None:
+    with pytest.raises(ValidationError):
+        CardMeditationMetadata(
+            mode="card_meditation",
+            deck_id="rws",
+            card_drawn_name="",
+        )
+
+
+def test_card_meditation_metadata_rejects_invalid_deck_slug() -> None:
+    """``deck_id`` mirrors the config-side regex (lowercase snake_case)."""
+    with pytest.raises(ValidationError):
+        CardMeditationMetadata(
+            mode="card_meditation",
+            deck_id="Bad-Deck",
+            card_drawn_name="The Fool",
+        )
+
+
+def test_card_meditation_metadata_does_not_disturb_tarot() -> None:
+    """Adding ``card_meditation`` to the union must not change ``tarot`` dispatch."""
+    payload = SessionMetadataAdapter.validate_python({"mode": "tarot", "card_index": 5})
+    assert type(payload) is TarotMetadata

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -482,6 +482,35 @@ async def _create_typed_user_practice(
             ],
             "require_option_choice": False,
         },
+        "card_meditation_bundled": {
+            "mode": "card_meditation",
+            "deck_id": "rws",
+            "per_card_minutes": 7,
+            "shuffle": True,
+            "reveal_after_meditation": False,
+            "hide_timer_during_meditation": True,
+            "cards": None,
+        },
+        "card_meditation_custom": {
+            "mode": "card_meditation",
+            "deck_id": "custom",
+            "per_card_minutes": 5,
+            "shuffle": True,
+            "reveal_after_meditation": True,
+            "hide_timer_during_meditation": True,
+            "cards": [
+                {
+                    "name": "Mountain",
+                    "image_uri": "file:///var/mobile/IMG_0123.jpg",
+                    "symbolism": "Stillness.",
+                },
+                {
+                    "name": "River",
+                    "image_uri": "file:///var/mobile/IMG_0124.jpg",
+                    "symbolism": "Flow.",
+                },
+            ],
+        },
     }
     catalog_mode = mode_configs[mode]["mode"]
     assert isinstance(catalog_mode, str)
@@ -798,6 +827,142 @@ async def test_create_session_allows_missing_chosen_key_when_optional(
     resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
     assert resp.status_code == HTTPStatus.CREATED
     assert resp.json()["mode_metadata"]["chosen_option_key"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_session_persists_card_meditation_metadata_bundled_deck(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A bundled-deck ``card_meditation`` session round-trips its metadata.
+
+    Mirrors :func:`test_create_session_persists_tallied_grounding_metadata`
+    so the new mode gets the same end-to-end coverage: schema dispatch
+    plus JSON-column round-trip over HTTP. ``card_drawn_index`` is the
+    optional field whose round-trip would otherwise be untested.
+    """
+    headers, _ = await _signup(async_client)
+    up_id, _ = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="card_meditation_bundled"
+    )
+
+    payload = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "card_meditation",
+            "deck_id": "rws",
+            "card_drawn_name": "The Fool",
+            "card_drawn_index": 0,
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    body = resp.json()
+    assert body["mode"] == "card_meditation"
+    assert body["mode_metadata"] == {
+        "mode": "card_meditation",
+        "deck_id": "rws",
+        "card_drawn_name": "The Fool",
+        "card_drawn_index": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_session_persists_card_meditation_metadata_custom_deck(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A custom-deck ``card_meditation`` session round-trips without ``card_drawn_index``.
+
+    Custom decks often shuffle on the client without echoing positions
+    back, so the optional-index path must round-trip as ``None``.
+    """
+    headers, _ = await _signup(async_client)
+    up_id, _ = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="card_meditation_custom"
+    )
+
+    payload = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "card_meditation",
+            "deck_id": "custom",
+            "card_drawn_name": "Mountain",
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    body = resp.json()
+    assert body["mode_metadata"]["card_drawn_name"] == "Mountain"
+    assert body["mode_metadata"]["card_drawn_index"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_card_meditation_metadata_on_tarot_practice(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Posting ``card_meditation`` metadata against a ``tarot`` practice → 400.
+
+    The Pydantic union deserialises the metadata cleanly, but the
+    resolved practice's mode disagrees with the metadata's
+    discriminator — exercising the ``mode_metadata_mismatch`` branch of
+    ``_validate_session_metadata`` for the new mode.
+    """
+    headers, _ = await _signup(async_client)
+    # Seed a tarot practice directly so the resolved mode is ``tarot``.
+    practice = Practice(
+        stage_number=1,
+        name="tarot practice",
+        description="Test fixture",
+        instructions="Test fixture",
+        default_duration_minutes=10,
+        approved=True,
+        mode="tarot",
+        mode_config={"mode": "tarot", "deck": "major_arcana", "per_card_minutes": 5},
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    resp_up = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 1},
+        headers=headers,
+    )
+    assert resp_up.status_code == HTTPStatus.CREATED
+    up_id = int(resp_up.json()["id"])
+
+    payload = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "card_meditation",
+            "deck_id": "rws",
+            "card_drawn_name": "The Fool",
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "mode_metadata_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_card_meditation_index_past_cap(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``card_drawn_index`` past the schema ceiling fails Pydantic validation → 422."""
+    headers, _ = await _signup(async_client)
+    up_id, _ = await _create_typed_user_practice(
+        async_client, db_session, headers, mode="card_meditation_bundled"
+    )
+
+    payload = _session_payload(
+        up_id,
+        mode_metadata={
+            "mode": "card_meditation",
+            "deck_id": "rws",
+            "card_drawn_name": "Phantom",
+            "card_drawn_index": 1_000_000,
+        },
+    )
+    resp = await async_client.post("/practice-sessions/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #347. Adds a deck-agnostic `card_meditation` practice mode that can power full-screen card meditation for any deck — bundled (RWS, Thoth, Marseille, oracle, …) or user-curated phone-photo decks. The existing `tarot` mode stays untouched for backward compatibility.

- `PracticeMode.CARD_MEDITATION` joins the closed enum and `ALL_MODES`.
- `CardMeditationCard` enforces mutually-exclusive `image_asset_key` / `image_uri` (server treats both as opaque strings — never dereferenced) and tolerates a text-only card.
- `CardMeditationConfig` requires a non-empty `cards` list when `deck_id == "custom"`; bundled decks omit `cards` and let the frontend resolve the canonical list.
- `CardMeditationMetadata` records the drawn card by name plus an optional deck index.
- Migration `a2b3c4d5e6f8` widens `ck_practice_mode_valid` and refuses to downgrade while `card_meditation` rows exist — mirrors the `mindful_anchor` migration pattern.
- Shared bound constants (`CARD_DECK_ID_MAX`, `CARD_DECK_ID_PATTERN`, `CARD_NAME_MAX`) live in `practice_mode_config` and are re-imported by `practice_session_metadata` so the config and metadata can't silently drift.

## Test plan

- [x] `pytest backend/` — 1211 passed, 94.11% coverage
- [x] `pre-commit run --all-files` — all 28 hooks green
- [x] Round-trip migration on SQLite (upgrade → insert → delete → downgrade → re-upgrade) with `tarot` still accepted after downgrade
- [x] Downgrade refuses with existing `card_meditation` rows
- [x] Bundled-deck round-trip (`cards=None`)
- [x] Custom-deck round-trip (`cards` populated)
- [x] Rejects `deck_id="custom"` with `cards=None` and `cards=[]`
- [x] Rejects a card with both `image_asset_key` and `image_uri`
- [x] Accepts a text-only card (neither image field set)
- [x] `tarot` config and metadata round-trips unchanged

https://claude.ai/code/session_019jHdLw8TKEcSvFk1FH4DQf

---
_Generated by [Claude Code](https://claude.ai/code/session_019jHdLw8TKEcSvFk1FH4DQf)_