### PR TITLE
fix(course): render chapter HTML in iframe on web

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -101,13 +101,17 @@ function buildDocument(bodyHtml: string): string {
  */
 function renderBody(html: string, title: string): React.ReactElement {
   if (Platform.OS === 'web') {
-    return React.createElement('iframe', {
-      'data-testid': 'reader-iframe',
-      srcDoc: html,
-      title,
-      sandbox: 'allow-popups',
-      style: { width: '100%', height: '100%', border: 0 },
-    });
+    return (
+      <View style={styles.webview}>
+        {React.createElement('iframe', {
+          'data-testid': 'reader-iframe',
+          srcDoc: html,
+          title,
+          sandbox: 'allow-popups',
+          style: { width: '100%', height: '100%', border: 0 },
+        })}
+      </View>
+    );
   }
   return (
     <WebView
@@ -276,9 +280,10 @@ const ChapterReader = ({
         </View>
       )}
       {!loading && error !== null && <ErrorView message={error} onRetry={retry} />}
-      {!loading && error === null && body !== null && (
-        <View style={styles.webview}>{renderBody(buildDocument(body.body_html), headerTitle)}</View>
-      )}
+      {!loading &&
+        error === null &&
+        body !== null &&
+        renderBody(buildDocument(body.body_html), headerTitle)}
       {footer}
     </View>
   );

--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Linking, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Linking, Platform, Text, TouchableOpacity, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import type { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes';
 
@@ -33,8 +33,7 @@ interface ChapterReaderProps {
  * second backend round-trip just to render the same chrome on every
  * chapter.
  */
-function buildDocument(bodyHtml: string): string {
-  const styleBlock = `
+const READER_STYLE_BLOCK = `
     :root { color-scheme: light dark; }
     html, body { margin: 0; padding: 0; }
     body {
@@ -73,15 +72,53 @@ function buildDocument(bodyHtml: string): string {
       a { color: #d4b878; }
     }
   `;
+
+function buildDocument(bodyHtml: string): string {
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5" />
-  <style>${styleBlock}</style>
+  <base target="_blank" />
+  <style>${READER_STYLE_BLOCK}</style>
 </head>
 <body>${bodyHtml}</body>
 </html>`;
+}
+
+/**
+ * Render the cleaned chapter HTML.  React Native's WebView throws
+ * "WebView does not support this platform" when bundled for web, so we
+ * branch on ``Platform.OS`` and fall back to an ``<iframe srcdoc>`` —
+ * the closest web-native equivalent (isolated document, no script
+ * execution unless the sandbox allows it, links honour ``<base
+ * target="_blank">`` and open in a new tab).
+ *
+ * ``sandbox="allow-popups"`` lets external links open in a new tab
+ * while blocking scripts, forms, same-origin access, and top-level
+ * navigation — matching the ``onShouldStartLoadWithRequest`` guard
+ * we use on native.
+ */
+function renderBody(html: string, title: string): React.ReactElement {
+  if (Platform.OS === 'web') {
+    return React.createElement('iframe', {
+      'data-testid': 'reader-iframe',
+      srcDoc: html,
+      title,
+      sandbox: 'allow-popups',
+      style: { width: '100%', height: '100%', border: 0 },
+    });
+  }
+  return (
+    <WebView
+      testID="reader-webview"
+      source={{ html }}
+      originWhitelist={['*']}
+      onShouldStartLoadWithRequest={shouldLoadInWebView}
+      style={styles.webview}
+      accessibilityLabel={title}
+    />
+  );
 }
 
 interface HeaderProps {
@@ -240,14 +277,7 @@ const ChapterReader = ({
       )}
       {!loading && error !== null && <ErrorView message={error} onRetry={retry} />}
       {!loading && error === null && body !== null && (
-        <WebView
-          testID="reader-webview"
-          source={{ html: buildDocument(body.body_html) }}
-          originWhitelist={['*']}
-          onShouldStartLoadWithRequest={shouldLoadInWebView}
-          style={styles.webview}
-          accessibilityLabel={headerTitle}
-        />
+        <View style={styles.webview}>{renderBody(buildDocument(body.body_html), headerTitle)}</View>
       )}
       {footer}
     </View>

--- a/frontend/src/features/Course/__tests__/ChapterReader.web.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.web.test.tsx
@@ -1,0 +1,87 @@
+/* eslint-env jest */
+import { describe, expect, it, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import { render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { Platform } from 'react-native';
+
+jest.mock('../../../api', () => ({
+  course: {
+    contentBody: jest.fn(),
+    siteResourceBody: jest.fn(),
+  },
+}));
+
+import type * as Api from '../../../api';
+import ChapterReader from '../ChapterReader';
+
+const { course: courseApi } = jest.requireMock('../../../api') as {
+  course: {
+    contentBody: jest.MockedFunction<typeof Api.course.contentBody>;
+    siteResourceBody: jest.MockedFunction<typeof Api.course.siteResourceBody>;
+  };
+};
+
+const { contentBody: mockContentBody } = courseApi;
+
+describe('ChapterReader (web platform)', () => {
+  // Platform.OS is read inside renderBody at render time, so flipping it for
+  // this file's tests is enough; the native test file leaves it on the default
+  // ('ios') and continues to exercise the WebView branch.
+  let originalOS: typeof Platform.OS;
+
+  beforeAll(() => {
+    originalOS = Platform.OS;
+    (Platform as { OS: typeof Platform.OS }).OS = 'web';
+  });
+
+  afterAll(() => {
+    (Platform as { OS: typeof Platform.OS }).OS = originalOS;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContentBody.mockResolvedValue({
+      url: 'https://aptitude.guru/course/beige-1',
+      title: 'Chapter One',
+      body_html: '<article>chapter body</article>',
+    });
+  });
+
+  it('renders an iframe with the cleaned document and the popup sandbox', async () => {
+    // ``react-test-renderer`` strips props it does not recognise from the
+    // snapshot for unknown host elements like ``iframe``, but the underlying
+    // ``ReactTestInstance`` keeps the original props — that's what we read.
+    const { UNSAFE_root } = render(
+      <ChapterReader
+        source={{ kind: 'content', id: 1 }}
+        fallbackTitle="Loading…"
+        onBack={jest.fn()}
+      />,
+    );
+
+    const iframe = await waitFor(() =>
+      UNSAFE_root.findByType('iframe' as unknown as React.ComponentType),
+    );
+    expect(String(iframe.props.srcDoc)).toMatch(/<!doctype html>/i);
+    expect(String(iframe.props.srcDoc)).toContain('chapter body');
+    expect(iframe.props.sandbox).toBe('allow-popups');
+    expect(iframe.props.title).toBe('Chapter One');
+    // The <base target="_blank"> in buildDocument is what makes links open in
+    // a new tab on web (replaces the native onShouldStartLoadWithRequest
+    // guard).  Pin it so a future buildDocument tweak can't drop it.
+    expect(String(iframe.props.srcDoc)).toContain('<base target="_blank"');
+  });
+
+  it('does not render the native WebView on web', async () => {
+    const { queryByTestId, UNSAFE_root } = render(
+      <ChapterReader
+        source={{ kind: 'content', id: 1 }}
+        fallbackTitle="Loading…"
+        onBack={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => UNSAFE_root.findByType('iframe' as unknown as React.ComponentType));
+    expect(queryByTestId('reader-webview')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Chapter reader was rendering "React Native WebView does not support this platform" on the Expo Web build (`app.aptitude.guru`). The backend is correctly serving cleaned chapter HTML (`/course/site-resources/liminal-creep/body` returns 200) — only the UI couldn't display it because `react-native-webview` is iOS/Android only.

## Changes

- **`ChapterReader.tsx`** — `renderBody()` branches on `Platform.OS`. Web uses `<iframe srcdoc={...} sandbox="allow-popups">`, the closest web-native equivalent to WebView's isolated-document model (no script execution, no same-origin access, links can open in new tabs). Native still uses `<WebView>` with the existing `onShouldStartLoadWithRequest` guard.
- **`buildDocument()`** — injects `<base target="_blank" />` so links default to opening in a new tab. No-op on native (the navigation guard intercepts external URLs before the base attribute is honoured); essential on web (replaces the `Linking.openURL` redirect).
- **Refactor**: pulled the inline `styleBlock` template literal out to a module-level `READER_STYLE_BLOCK` constant — same content, allocated once at module load instead of per render, and keeps `buildDocument` under the 50-line ESLint cap.

## Test plan

- [x] `tsc --noEmit` green
- [x] `jest src/features/Course` — 55 tests passing on native-shim path (Platform.OS === 'ios' in jest)
- [x] Pre-commit + pre-push gates green locally
- [ ] After redeploy on `app.aptitude.guru`: tap a site-resource tile → see the cleaned HTML in an iframe, not the "WebView does not support" error

## Caveat

Jest's RN shim leaves `Platform.OS === 'ios'`, so the iframe branch isn't exercised in tests. Adding a Platform mock to test the web branch is a clean follow-up if you want belt-and-suspenders.

https://claude.ai/code/session_01GRZXVdTjpqWXw4rrAK72pa

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRZXVdTjpqWXw4rrAK72pa)_