### PR TITLE
feat(practice): add share-link feature (generate, preview, import)

### DIFF
--- a/backend/migrations/versions/f5b6c7d8e9a0_add_practice_share_link.py
+++ b/backend/migrations/versions/f5b6c7d8e9a0_add_practice_share_link.py
@@ -1,0 +1,74 @@
+"""add practiceshare link token table
+
+Revision ID: f5b6c7d8e9a0
+Revises: a2b3c4d5e6f8
+Create Date: 2026-05-17 09:00:00.000000
+
+Adds a new ``practicesharelink`` table backing the practice share-link
+feature (issue #348).  Holds one row per outstanding share token:
+
+* ``token`` -- URL-safe base64 string minted with
+  ``secrets.token_urlsafe(32)`` (256 bits of entropy).  Unique +
+  indexed so the redeem endpoints can resolve a token in a single
+  point lookup.
+* ``practice_id`` -- FK to ``practice``.  ``ON DELETE CASCADE`` so a
+  removed practice drops its outstanding links instead of leaving
+  dangling tokens that 410 with a confusing message.
+* ``created_by_user_id`` -- FK to ``user`` with ``ON DELETE SET NULL``
+  so audit history survives a right-to-be-forgotten purge.
+* ``expires_at`` / ``max_uses`` / ``use_count`` / ``revoked_at`` --
+  the three soft-kill levers documented at
+  :mod:`models.practice_share_link`.
+
+Chains off ``a2b3c4d5e6f8`` (card_meditation) -- rebased onto that head
+during the PR #359 update so the chain stays linear after the parallel
+custom-practices-02 work merged.
+
+This is a pure additive migration -- no existing rows are touched and
+the downgrade path simply drops the table.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f5b6c7d8e9a0"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "a2b3c4d5e6f8"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE_NAME = "practicesharelink"
+_TOKEN_INDEX = "ix_practicesharelink_token"
+_PRACTICE_INDEX = "ix_practicesharelink_practice_id"
+_CREATED_BY_INDEX = "ix_practicesharelink_created_by_user_id"
+
+
+def upgrade() -> None:
+    """Create ``practicesharelink`` plus the three indexes it needs."""
+    op.create_table(
+        _TABLE_NAME,
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("token", sa.String(length=64), nullable=False),
+        sa.Column("practice_id", sa.Integer(), nullable=False),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("max_uses", sa.Integer(), nullable=True),
+        sa.Column("use_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["practice_id"], ["practice.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="SET NULL"),
+    )
+    op.create_index(_TOKEN_INDEX, _TABLE_NAME, ["token"], unique=True)
+    op.create_index(_PRACTICE_INDEX, _TABLE_NAME, ["practice_id"])
+    op.create_index(_CREATED_BY_INDEX, _TABLE_NAME, ["created_by_user_id"])
+
+
+def downgrade() -> None:
+    """Drop the table and its indexes."""
+    op.drop_index(_CREATED_BY_INDEX, table_name=_TABLE_NAME)
+    op.drop_index(_PRACTICE_INDEX, table_name=_TABLE_NAME)
+    op.drop_index(_TOKEN_INDEX, table_name=_TABLE_NAME)
+    op.drop_table(_TABLE_NAME)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -38,6 +38,7 @@ from routers.goals import router as goals_router
 from routers.habits import router as habits_router
 from routers.journal import router as journal_router
 from routers.practice_sessions import router as practice_sessions_router
+from routers.practice_share import router as practice_share_router
 from routers.practices import router as practices_router
 from routers.prompts import router as prompts_router
 from routers.stages import router as stages_router
@@ -333,6 +334,7 @@ app.include_router(auth_router)
 app.include_router(botmason_router)
 app.include_router(course_router)
 app.include_router(practices_router)
+app.include_router(practice_share_router)
 app.include_router(user_practices_router)
 app.include_router(practice_sessions_router)
 app.include_router(habits_router)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -13,6 +13,7 @@ from .login_attempt import LoginAttempt
 from .password_reset_token import PasswordResetToken
 from .practice import Practice
 from .practice_session import PracticeSession
+from .practice_share_link import PracticeShareLink
 from .prompt_response import PromptResponse
 from .revoked_token import RevokedToken
 from .stage_content import StageContent
@@ -35,6 +36,7 @@ __all__ = [
     "PasswordResetToken",
     "Practice",
     "PracticeSession",
+    "PracticeShareLink",
     "PromptResponse",
     "RevokedToken",
     "StageContent",

--- a/backend/src/models/practice_share_link.py
+++ b/backend/src/models/practice_share_link.py
@@ -45,9 +45,14 @@ class PracticeShareLink(SQLModel, table=True):
     keeps the FK as ``SET NULL`` on user deletion so audit history
     survives a right-to-be-forgotten purge.
 
-    ``use_count`` starts at zero and ``UPDATE ... SET use_count =
-    use_count + 1 WHERE ...`` increments atomically inside the import
-    transaction so the cap holds even under concurrent redemptions.
+    ``use_count`` starts at zero.  The import endpoint issues a single
+    ``UPDATE ... SET use_count = use_count + 1 WHERE id = ? AND
+    revoked_at IS NULL AND (max_uses IS NULL OR use_count < max_uses)``
+    so the read of the current count, the cap check, and the increment
+    are all one statement.  Two concurrent imports of a ``max_uses=1``
+    link therefore cannot both pass the cap -- the loser's ``rowcount``
+    is zero and the endpoint returns 410 ``share_link_exhausted``
+    instead of cloning a second copy.
     """
 
     id: int | None = Field(default=None, primary_key=True)

--- a/backend/src/models/practice_share_link.py
+++ b/backend/src/models/practice_share_link.py
@@ -1,0 +1,72 @@
+"""Share-link tokens for forwarding a custom practice to another user.
+
+A share link is a long-random URL-safe token bound to a single source
+``practice_id``.  The owner mints the token via
+``POST /practices/{practice_id}/share-link``; recipients preview the
+shape of the practice with ``GET /practices/share/{token}`` and import
+their own private copy with ``POST /practices/share/{token}/import``.
+
+The token itself is the secret -- anyone who holds it can preview and
+import.  Two enforcement levers narrow that window:
+
+* ``expires_at`` -- optional wall-clock deadline.  Past-due tokens fail
+  closed with 410 instead of 404 so the client can distinguish "you
+  typo'd" from "the sender's link has aged out".
+* ``max_uses`` / ``use_count`` -- optional redemption cap.  Each
+  successful import increments ``use_count`` inside the same
+  transaction that copies the practice so a race cannot exhaust the
+  cap by even one redemption.
+* ``revoked_at`` -- explicit revocation by the owner via
+  ``DELETE /practices/share-links/{share_link_id}``.  Set once and
+  never cleared -- a revoked link stays revoked.
+
+Imported practices are independent copies (new row with
+``approved=False`` and ``submitted_by_user_id`` set to the
+recipient) so revoking the link does not retroactively unshare what
+already landed in the recipient's catalog.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, DateTime
+from sqlmodel import Field, SQLModel
+
+
+class PracticeShareLink(SQLModel, table=True):
+    """A token row authorising one or more imports of a source practice.
+
+    ``token`` is a URL-safe base64 string minted from
+    ``secrets.token_urlsafe(32)`` -- 32 random bytes encode to a 43-char
+    string with 256 bits of entropy.  We store it plaintext (it is the
+    capability) and index it for the point lookup the redeem endpoints
+    do on every request.
+
+    ``created_by_user_id`` is the owner who minted the link.  The DB
+    keeps the FK as ``SET NULL`` on user deletion so audit history
+    survives a right-to-be-forgotten purge.
+
+    ``use_count`` starts at zero and ``UPDATE ... SET use_count =
+    use_count + 1 WHERE ...`` increments atomically inside the import
+    transaction so the cap holds even under concurrent redemptions.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    token: str = Field(unique=True, index=True, max_length=64, nullable=False)
+    practice_id: int = Field(foreign_key="practice.id", ondelete="CASCADE", index=True)
+    created_by_user_id: int | None = Field(
+        default=None, foreign_key="user.id", ondelete="SET NULL", index=True
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    expires_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    max_uses: int | None = Field(default=None)
+    use_count: int = Field(default=0, nullable=False)
+    revoked_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )

--- a/backend/src/routers/practice_share.py
+++ b/backend/src/routers/practice_share.py
@@ -28,10 +28,13 @@ from __future__ import annotations
 import logging
 import secrets
 from datetime import UTC, datetime, timedelta
-from typing import Annotated, cast
+from typing import Annotated, Any, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from slowapi.util import get_remote_address
+from sqlalchemy import or_ as sa_or
+from sqlalchemy import update as sa_update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -343,6 +346,41 @@ async def preview_share_link(
     )
 
 
+async def _atomically_claim_use_slot(session: AsyncSession, link_id: int) -> bool:
+    """Increment ``use_count`` only if the cap still allows.
+
+    The WHERE clause encodes the precondition (link not revoked and
+    ``max_uses IS NULL OR use_count < max_uses``) inside the same
+    statement that performs the increment, so two concurrent importers
+    of a ``max_uses=1`` link cannot both pass the read-side check and
+    both bump the counter (the bug flagged in PR #359 review).
+
+    Returns ``True`` when the row was updated, ``False`` when the cap
+    or revocation gate caused the UPDATE to match zero rows.  The
+    expiry check stays in the read-side :func:`_check_link_alive`
+    because ``datetime.now(UTC)`` cannot be expressed inside a portable
+    UPDATE expression and clock skew between request handlers is
+    smaller than the typical expiry granularity (days, not microseconds).
+    """
+    use_count_col = col(PracticeShareLink.use_count)
+    max_uses_col = col(PracticeShareLink.max_uses)
+    statement = (
+        sa_update(PracticeShareLink)
+        .where(
+            col(PracticeShareLink.id) == link_id,
+            col(PracticeShareLink.revoked_at).is_(None),
+            sa_or(max_uses_col.is_(None), use_count_col < max_uses_col),
+        )
+        .values(use_count=use_count_col + 1)
+    )
+    # ``AsyncSession.execute`` is typed as returning ``Result[Any]`` even for
+    # UPDATE statements; the runtime object is a ``CursorResult`` carrying
+    # the ``rowcount`` attribute the contract here depends on.  Cast keeps
+    # the type-checker honest without resorting to ``type: ignore``.
+    result = cast("CursorResult[Any]", await session.execute(statement))
+    return result.rowcount > 0
+
+
 @router.post(
     "/share/{token}/import",
     response_model=ShareLinkImportResponse,
@@ -361,10 +399,14 @@ async def import_share_link(
     owns the original row -- cloning it would just clutter their
     catalog with a duplicate.
 
-    The ``use_count`` increment happens in the same commit as the
-    clone so a crash between INSERT and UPDATE cannot leave the
-    counter behind reality (recipients get an extra import, the cap
-    misfires by one).
+    Race safety: :func:`_atomically_claim_use_slot` issues a single
+    ``UPDATE ... SET use_count = use_count + 1 WHERE ... AND
+    use_count < max_uses`` so two concurrent importers of a
+    ``max_uses=1`` link cannot both bypass the cap.  The loser sees
+    ``rowcount == 0`` and gets the same 410 ``share_link_exhausted``
+    that a sequential third importer would.  The increment and the
+    clone live in the same transaction so a crash between the two
+    rolls both back together.
     """
     link = await _load_active_link(session, token)
     if link.created_by_user_id == current_user:
@@ -374,10 +416,15 @@ async def import_share_link(
     if source is None:
         raise _gone(_DETAIL_REVOKED)
 
+    if not await _atomically_claim_use_slot(session, cast("int", link.id)):
+        # The link was exhausted (or revoked) between the read-side
+        # check and the atomic update -- treat the loser the same way
+        # the read-side check would treat a fresh request.
+        await session.rollback()
+        raise _gone(_DETAIL_EXHAUSTED)
+
     copy = _clone_practice_for_recipient(source, current_user)
     session.add(copy)
-    link.use_count += 1
-    session.add(link)
     await session.commit()
     await session.refresh(copy)
 
@@ -426,17 +473,33 @@ async def revoke_share_link(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
+_LIST_LIMIT_DEFAULT = 50
+_LIST_LIMIT_MAX = 200
+
+
 @router.get("/{practice_id}/share-links", response_model=list[ShareLinkResponse])
 async def list_share_links(
     practice_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=_LIST_LIMIT_MAX,
+            description="Maximum links to return (newest first). Defaults to 50.",
+        ),
+    ] = _LIST_LIMIT_DEFAULT,
 ) -> list[PracticeShareLink]:
     """List the share links the caller has minted for a practice.
 
     Powers the "active links with Revoke" panel in the frontend's
     ``ShareSheet``.  Visibility mirrors ``create_share_link``: the
     caller must own the source practice (preset or self-submitted).
+
+    Bounded by ``limit`` (default 50, max 200) so a long-lived practice
+    cannot produce an unbounded payload.  Rows are returned newest-first
+    so the most relevant links appear in the first page.
     """
     await _ensure_owner_or_preset(session, practice_id, current_user)
 
@@ -447,6 +510,7 @@ async def list_share_links(
             PracticeShareLink.created_by_user_id == current_user,
         )
         .order_by(col(PracticeShareLink.created_at).desc())
+        .limit(limit)
     )
     return list(result.scalars().all())
 

--- a/backend/src/routers/practice_share.py
+++ b/backend/src/routers/practice_share.py
@@ -1,0 +1,454 @@
+"""Share-link endpoints for forwarding a custom practice to another user.
+
+The flow is four routes joined by one token table
+(:class:`models.practice_share_link.PracticeShareLink`):
+
+* Owner mints a link with ``POST /practices/{practice_id}/share-link``.
+* Recipient (any signed-in user) previews with
+  ``GET /practices/share/{token}``.
+* Recipient imports with ``POST /practices/share/{token}/import`` --
+  the server clones the source practice as an ``approved=False`` row
+  whose ``submitted_by_user_id`` is the recipient, so the visibility
+  filter in :mod:`dependencies.ownership` keeps it private to them.
+* Owner revokes with ``DELETE /practices/share-links/{share_link_id}``.
+
+Tokens are opaque secrets -- anyone who holds one can preview and
+import.  The status-code split for failed redemptions is deliberate:
+
+* ``404 share_link_not_found`` -- the token does not exist.
+* ``410 share_link_expired|revoked|exhausted`` -- the token did exist
+  but has aged out, been revoked, or hit its ``max_uses`` cap.  410
+  tells the client the link itself is dead and not worth retrying.
+* ``400 cannot_import_own_practice`` -- self-import is a UX foot-gun;
+  the recipient already owns the original row.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import UTC, datetime, timedelta
+from typing import Annotated, cast
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from slowapi.util import get_remote_address
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from database import get_session
+from errors import bad_request, forbidden, not_found
+from models.practice import Practice
+from models.practice_share_link import PracticeShareLink
+from models.user import User
+from rate_limit import limiter
+from routers.auth import extract_user_id_from_authorization, get_current_user
+from schemas.practice_share import (
+    ShareLinkCreateRequest,
+    ShareLinkImportResponse,
+    ShareLinkPreviewResponse,
+    ShareLinkResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+# 32 random bytes encodes to a 43-char URL-safe base64 string with 256
+# bits of entropy -- comfortably outside any plausible online brute
+# force.  Mirrors the password-reset token width.
+_TOKEN_BYTES = 32
+# A handful of mint retries in the astronomically unlikely event of a
+# token collision (~ 2**-256 per attempt).  Caps the loop so a future
+# DB bug that always raises IntegrityError can't hang the request.
+_MAX_MINT_ATTEMPTS = 4
+
+# 410 Gone keeps the wire shape the dead-link UX prefers -- 404 would
+# imply "we couldn't find it" which gives the client nothing to act
+# on, while 410 says "this is dead, don't retry."  Each detail string
+# is a stable token the frontend branches on.
+_DETAIL_EXPIRED = "share_link_expired"
+_DETAIL_REVOKED = "share_link_revoked"
+_DETAIL_EXHAUSTED = "share_link_exhausted"
+
+# Rate limits per #348:
+# * mint -- 10/hour keyed on the JWT ``sub`` so a single user can't
+#   carpet-bomb every practice with new links;
+# * redeem -- 30/hour keyed on the remote IP so an attacker enumerating
+#   random tokens hits a wall quickly even without an account.
+_MINT_RATE_LIMIT = "10/hour"
+_REDEEM_RATE_LIMIT = "30/hour"
+
+
+def _per_user_rate_limit_key(request: Request) -> str:
+    """Rate-limit key derived from the JWT ``sub`` claim.
+
+    Mirrors :func:`routers.practices._per_user_rate_limit_key`: falling
+    back to the remote address on a malformed token means the limiter
+    never sees an empty key.
+    """
+    try:
+        return f"user:{extract_user_id_from_authorization(request.headers.get('authorization'))}"
+    except Exception:  # noqa: BLE001 — fall through to IP for any decode failure
+        return get_remote_address(request)
+
+
+router = APIRouter(prefix="/practices", tags=["practice-share"])
+
+
+def _gone(detail: str) -> HTTPException:
+    """Build a 410 HTTPException with the canonical share-link detail string."""
+    return HTTPException(status_code=status.HTTP_410_GONE, detail=detail)
+
+
+async def _ensure_owner_or_preset(
+    session: AsyncSession, practice_id: int, current_user: int
+) -> Practice:
+    """Resolve a practice for share-link operations.
+
+    Owner-or-preset (``submitted_by_user_id IS NULL`` or matches
+    caller) so the "Sharing a preset is also allowed" constraint from
+    #348 sits in one place instead of branching per route.
+    """
+    practice = await session.get(Practice, practice_id)
+    if practice is None:
+        raise not_found("practice")
+    if practice.submitted_by_user_id not in (None, current_user):
+        raise forbidden("forbidden")
+    return practice
+
+
+async def _insert_with_fresh_token(
+    session: AsyncSession, link: PracticeShareLink
+) -> PracticeShareLink:
+    """Insert ``link`` retrying on token uniqueness collisions.
+
+    Each retry mints a fresh ``secrets.token_urlsafe`` value before
+    committing, so a unique-index hit (astronomically unlikely at 256
+    bits but possible against a malicious-but-prescient attacker)
+    transparently rolls forward.  ``_MAX_MINT_ATTEMPTS`` caps the loop
+    so a future DB bug that always raises IntegrityError surfaces as a
+    500 instead of hanging the request.
+    """
+    last_exc: IntegrityError | None = None
+    for _ in range(_MAX_MINT_ATTEMPTS):
+        link.token = secrets.token_urlsafe(_TOKEN_BYTES)
+        session.add(link)
+        try:
+            await session.commit()
+        except IntegrityError as exc:
+            await session.rollback()
+            last_exc = exc
+            continue
+        await session.refresh(link)
+        return link
+    msg = "failed to mint a unique share-link token after retries"
+    raise RuntimeError(msg) from last_exc
+
+
+def _build_share_link(
+    *,
+    practice_id: int,
+    current_user: int,
+    expires_at: datetime | None,
+    max_uses: int | None,
+) -> PracticeShareLink:
+    """Construct a ``PracticeShareLink`` with a freshly minted token.
+
+    Mints the token before constructing the row so the SQLModel field
+    is never instantiated with a sentinel value -- keeps the bandit
+    ``B106 hardcoded_password`` check quiet without a noqa, and
+    closes a minor race where a partially-built row could be saved
+    before the token is set.
+    """
+    return PracticeShareLink(
+        token=secrets.token_urlsafe(_TOKEN_BYTES),
+        practice_id=practice_id,
+        created_by_user_id=current_user,
+        expires_at=expires_at,
+        max_uses=max_uses,
+    )
+
+
+def _display_name_from_email(email: str | None) -> str | None:
+    """Derive a public-facing display name from an email address.
+
+    Returns the part before ``@`` (``alice@example.com -> "alice"``) so
+    the recipient sees *something* identifying the sender without the
+    full address landing in the preview payload.  ``None`` for a
+    missing user (post-deletion) so the frontend can fall back to a
+    generic "Shared with you" copy.
+    """
+    if not email or "@" not in email:
+        return None
+    return email.split("@", 1)[0] or None
+
+
+def _is_link_expired(link: PracticeShareLink) -> bool:
+    return link.expires_at is not None and link.expires_at <= datetime.now(UTC)
+
+
+def _is_link_exhausted(link: PracticeShareLink) -> bool:
+    return link.max_uses is not None and link.use_count >= link.max_uses
+
+
+def _dead_link_detail(link: PracticeShareLink) -> str | None:
+    """Return the 410-detail string for a dead link, or ``None`` if alive.
+
+    Each soft-kill predicate is delegated to a one-liner so this function
+    stays at xenon rank A while preserving the explicit precedence
+    (revoked > expired > exhausted) the API contract documents.
+    """
+    if link.revoked_at is not None:
+        return _DETAIL_REVOKED
+    if _is_link_expired(link):
+        return _DETAIL_EXPIRED
+    if _is_link_exhausted(link):
+        return _DETAIL_EXHAUSTED
+    return None
+
+
+def _check_link_alive(link: PracticeShareLink) -> None:
+    """Raise 410 if the link is revoked, expired, or exhausted."""
+    detail = _dead_link_detail(link)
+    if detail is not None:
+        raise _gone(detail)
+
+
+async def _load_active_link(session: AsyncSession, token: str) -> PracticeShareLink:
+    """Resolve a token to a live :class:`PracticeShareLink`.
+
+    Centralises the 404 -> 410 split so each redeem endpoint stays a
+    couple of lines long.
+    """
+    result = await session.execute(
+        select(PracticeShareLink).where(PracticeShareLink.token == token)
+    )
+    link = result.scalars().first()
+    if link is None:
+        raise not_found("share_link")
+    _check_link_alive(link)
+    return link
+
+
+def _clone_practice_for_recipient(source: Practice, recipient_user_id: int) -> Practice:
+    """Build the recipient's private draft from the source row.
+
+    ``approved=False`` keeps the new row private via the visibility
+    filter in :mod:`dependencies.ownership`; ``submitted_by_user_id``
+    is the recipient so a follow-up customize / delete is authorised.
+    ``mode_config`` is shallow-copied (it's already plain JSON; a deep
+    copy would re-walk the same dict) so an in-place tweak by the
+    recipient cannot mutate the source row through the shared
+    reference.
+    """
+    return Practice(
+        stage_number=source.stage_number,
+        name=source.name,
+        description=source.description,
+        instructions=source.instructions,
+        default_duration_minutes=source.default_duration_minutes,
+        submitted_by_user_id=recipient_user_id,
+        approved=False,
+        mode=source.mode,
+        mode_config=dict(source.mode_config),
+    )
+
+
+@router.post(
+    "/{practice_id}/share-link",
+    response_model=ShareLinkResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+@limiter.limit(_MINT_RATE_LIMIT, key_func=_per_user_rate_limit_key)
+async def create_share_link(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    practice_id: int,
+    payload: ShareLinkCreateRequest,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PracticeShareLink:
+    """Mint a share-link token for a practice the caller owns.
+
+    Ownership is "I submitted this row" -- preset practices have
+    ``submitted_by_user_id IS NULL`` so anyone can share them
+    (consistent with #348's "sharing a preset is also allowed").  A
+    practice submitted by someone else 403s.
+    """
+    await _ensure_owner_or_preset(session, practice_id, current_user)
+
+    expires_at: datetime | None = None
+    if payload.expires_in_days is not None:
+        expires_at = datetime.now(UTC) + timedelta(days=payload.expires_in_days)
+
+    link = _build_share_link(
+        practice_id=practice_id,
+        current_user=current_user,
+        expires_at=expires_at,
+        max_uses=payload.max_uses,
+    )
+    minted = await _insert_with_fresh_token(session, link)
+    logger.info(
+        "practice_share_link_created",
+        extra={
+            "practice_id": practice_id,
+            "user_id": current_user,
+            "share_link_id": minted.id,
+        },
+    )
+    return minted
+
+
+@router.get("/share/{token}", response_model=ShareLinkPreviewResponse)
+@limiter.limit(_REDEEM_RATE_LIMIT)
+async def preview_share_link(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    token: str,
+    _current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ShareLinkPreviewResponse:
+    """Return the practice payload a redeem would copy.
+
+    The caller is authenticated (any signed-in user is allowed) so an
+    anonymous link harvester cannot crawl tokens without paying the
+    signup tax.  The response intentionally omits the source row's
+    ``submitted_by_user_id`` to keep the endpoint from doubling as a
+    user-id enumeration oracle.
+    """
+    link = await _load_active_link(session, token)
+    practice = await session.get(Practice, link.practice_id)
+    if practice is None:
+        # Source row was deleted after the link was minted -- treat
+        # the link as dead.  Same wire shape as ``revoked_at`` so the
+        # frontend's stale-link UX covers both.
+        raise _gone(_DETAIL_REVOKED)
+
+    display_name: str | None = None
+    if link.created_by_user_id is not None:
+        owner = await session.get(User, link.created_by_user_id)
+        if owner is not None:
+            display_name = _display_name_from_email(owner.email)
+
+    return ShareLinkPreviewResponse(
+        practice_id=cast("int", practice.id),
+        stage_number=practice.stage_number,
+        name=practice.name,
+        description=practice.description,
+        instructions=practice.instructions,
+        default_duration_minutes=practice.default_duration_minutes,
+        mode=practice.mode,
+        mode_config=practice.mode_config,
+        created_by_display_name=display_name,
+        expires_at=link.expires_at,
+        max_uses=link.max_uses,
+        use_count=link.use_count,
+    )
+
+
+@router.post(
+    "/share/{token}/import",
+    response_model=ShareLinkImportResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+@limiter.limit(_REDEEM_RATE_LIMIT)
+async def import_share_link(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    token: str,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ShareLinkImportResponse:
+    """Copy the source practice into the recipient's catalog.
+
+    Self-import is rejected with 400 because the recipient already
+    owns the original row -- cloning it would just clutter their
+    catalog with a duplicate.
+
+    The ``use_count`` increment happens in the same commit as the
+    clone so a crash between INSERT and UPDATE cannot leave the
+    counter behind reality (recipients get an extra import, the cap
+    misfires by one).
+    """
+    link = await _load_active_link(session, token)
+    if link.created_by_user_id == current_user:
+        raise bad_request("cannot_import_own_practice")
+
+    source = await session.get(Practice, link.practice_id)
+    if source is None:
+        raise _gone(_DETAIL_REVOKED)
+
+    copy = _clone_practice_for_recipient(source, current_user)
+    session.add(copy)
+    link.use_count += 1
+    session.add(link)
+    await session.commit()
+    await session.refresh(copy)
+
+    logger.info(
+        "practice_share_link_imported",
+        extra={
+            "share_link_id": link.id,
+            "source_practice_id": source.id,
+            "imported_practice_id": copy.id,
+            "user_id": current_user,
+        },
+    )
+    return ShareLinkImportResponse(
+        practice_id=cast("int", copy.id),
+        stage_number=copy.stage_number,
+        name=copy.name,
+        approved=copy.approved,
+    )
+
+
+@router.delete("/share-links/{share_link_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_share_link(
+    share_link_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> Response:
+    """Revoke an outstanding share link the caller minted.
+
+    Idempotent in the sense that calling DELETE on an already-revoked
+    link is a no-op 204 -- the row stays revoked, ``revoked_at`` is
+    not pushed forward.
+    """
+    link = await session.get(PracticeShareLink, share_link_id)
+    if link is None:
+        raise not_found("share_link")
+    if link.created_by_user_id != current_user:
+        raise forbidden("forbidden")
+    if link.revoked_at is None:
+        link.revoked_at = datetime.now(UTC)
+        session.add(link)
+        await session.commit()
+        logger.info(
+            "practice_share_link_revoked",
+            extra={"share_link_id": link.id, "user_id": current_user},
+        )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/{practice_id}/share-links", response_model=list[ShareLinkResponse])
+async def list_share_links(
+    practice_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> list[PracticeShareLink]:
+    """List the share links the caller has minted for a practice.
+
+    Powers the "active links with Revoke" panel in the frontend's
+    ``ShareSheet``.  Visibility mirrors ``create_share_link``: the
+    caller must own the source practice (preset or self-submitted).
+    """
+    await _ensure_owner_or_preset(session, practice_id, current_user)
+
+    result = await session.execute(
+        select(PracticeShareLink)
+        .where(
+            PracticeShareLink.practice_id == practice_id,
+            PracticeShareLink.created_by_user_id == current_user,
+        )
+        .order_by(col(PracticeShareLink.created_at).desc())
+    )
+    return list(result.scalars().all())
+
+
+__all__: list[str] = ["router"]

--- a/backend/src/schemas/practice_share.py
+++ b/backend/src/schemas/practice_share.py
@@ -1,0 +1,106 @@
+"""Schemas for the practice share-link feature.
+
+Wire DTOs for the four share-link endpoints:
+
+* ``POST /practices/{practice_id}/share-link`` -- :class:`ShareLinkCreateRequest`
+  in, :class:`ShareLinkResponse` out.
+* ``GET /practices/share/{token}`` -- :class:`ShareLinkPreviewResponse`.
+* ``POST /practices/share/{token}/import`` -- :class:`ShareLinkImportResponse`.
+* ``DELETE /practices/share-links/{share_link_id}`` -- 204, no body.
+
+``ShareLinkPreviewResponse`` deliberately omits the original
+``submitted_by_user_id`` so the preview cannot be turned into a
+user-id enumeration oracle.  The owner's display handle (currently the
+email's local part; populated by the router) sits in
+``created_by_display_name`` instead.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Upper bounds for the optional knobs the owner sets when minting a
+# link.  ``MAX_EXPIRY_DAYS`` caps the wall-clock window so a forgotten
+# link cannot live indefinitely; ``MAX_USES_CAP`` keeps the redemption
+# counter inside a sane band so a typo (``max_uses=1000000``) doesn't
+# masquerade as an unlimited link.  ``None`` on either field means the
+# corresponding gate is disabled.
+MAX_EXPIRY_DAYS = 365
+MAX_USES_CAP = 1_000
+
+
+class ShareLinkCreateRequest(BaseModel):
+    """Owner-supplied knobs for a new share link.
+
+    Both fields are optional: omitting ``expires_in_days`` mints a
+    never-expiring link and omitting ``max_uses`` mints an unlimited
+    one.  The router resolves ``expires_in_days`` into a concrete
+    ``expires_at`` against ``datetime.now(UTC)`` at mint time so the
+    persisted row is timezone-aware and not vulnerable to clock drift
+    on the client.
+    """
+
+    expires_in_days: int | None = Field(default=None, ge=1, le=MAX_EXPIRY_DAYS)
+    max_uses: int | None = Field(default=None, ge=1, le=MAX_USES_CAP)
+
+
+class ShareLinkResponse(BaseModel):
+    """Owner-facing view of a freshly minted (or listed) share link.
+
+    Echoes back the ``token`` so the client can paste it into a
+    share-sheet URL without an extra round trip.  ``use_count`` lets
+    the owner see how many redemptions have happened; ``revoked_at``
+    surfaces the terminal state for the active-links list rendered
+    inside ``ShareSheet``.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    token: str
+    practice_id: int
+    created_at: datetime
+    expires_at: datetime | None
+    max_uses: int | None
+    use_count: int
+    revoked_at: datetime | None
+
+
+class ShareLinkPreviewResponse(BaseModel):
+    """Recipient-facing preview returned by ``GET /practices/share/{token}``.
+
+    Mirrors the fields a normal practice GET returns minus anything
+    that would leak the owner's user id.  The frontend renders this
+    inside ``SharePreviewScreen`` with an Import button.
+    """
+
+    practice_id: int
+    stage_number: int
+    name: str
+    description: str
+    instructions: str
+    default_duration_minutes: float
+    mode: str
+    mode_config: dict[str, Any]
+    created_by_display_name: str | None = None
+    expires_at: datetime | None = None
+    max_uses: int | None = None
+    use_count: int = 0
+
+
+class ShareLinkImportResponse(BaseModel):
+    """Result of redeeming a share link into a private draft.
+
+    ``practice_id`` is the recipient's *new* copy -- the frontend
+    navigates straight to its detail screen.  ``approved`` is always
+    ``False`` so the frontend can keep the "draft / awaiting approval"
+    badge in lockstep with the catalog filter.
+    """
+
+    practice_id: int
+    stage_number: int
+    name: str
+    approved: bool

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -54,6 +54,12 @@ _MINDFUL_ANCHOR_REVISION = "f4a5b6c7d8e9"  # pragma: allowlist secret
 _CARD_MEDITATION_BASE_REVISION = "f4a5b6c7d8e9"  # pragma: allowlist secret
 _CARD_MEDITATION_REVISION = "a2b3c4d5e6f8"  # pragma: allowlist secret
 
+# custom-practices-03: practice share-link token table (issue #348).  Rebased
+# onto card_meditation's head so the chain stays linear after the parallel
+# work merged.
+_PRACTICE_SHARE_LINK_BASE_REVISION = "a2b3c4d5e6f8"  # pragma: allowlist secret
+_PRACTICE_SHARE_LINK_REVISION = "f5b6c7d8e9a0"  # pragma: allowlist secret
+
 
 def test_timestamptz_migration_exists() -> None:
     """Regression guard: the migration file must stay where Alembic finds it."""
@@ -876,3 +882,100 @@ def test_card_meditation_downgrade_refuses_with_existing_rows(
 
     with pytest.raises(RuntimeError, match="card_meditation"):
         command.downgrade(cfg, _CARD_MEDITATION_BASE_REVISION)
+
+
+# -- custom-practices-03 practice share-link table round-trip ----------------
+
+
+def _bootstrap_practice_share_link_baseline(sync_url: str) -> None:
+    """Bootstrap the minimal schema required by the share-link migration.
+
+    The migration adds ``practicesharelink`` with FKs to ``practice`` and
+    ``user``; SQLite needs both parent tables present (FK enforcement is
+    off by default, but ``op.create_table`` still validates the column
+    references).  Mirrors the bootstrap style used by the password-reset
+    and practice-mode round-trip tests so a future schema change to
+    either parent surfaces as a deliberate bump of this fixture.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE user ( id INTEGER PRIMARY KEY, email VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE practice ("
+                " id INTEGER PRIMARY KEY,"
+                " stage_number INTEGER NOT NULL,"
+                " name VARCHAR(255) NOT NULL,"
+                " description VARCHAR(2000) NOT NULL DEFAULT '',"
+                " instructions VARCHAR(10000) NOT NULL DEFAULT '',"
+                " default_duration_minutes FLOAT NOT NULL,"
+                " submitted_by_user_id INTEGER,"
+                " approved BOOLEAN NOT NULL DEFAULT 1,"
+                " mode VARCHAR(32) NOT NULL DEFAULT 'meditation_timer',"
+                " mode_config TEXT NOT NULL DEFAULT '{}'"
+                ")"
+            )
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_practice_share_link(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before ``f5b6c7d8e9a0``."""
+    db_path = tmp_path / "share_link_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_practice_share_link_baseline(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _PRACTICE_SHARE_LINK_BASE_REVISION)
+    return cfg
+
+
+def test_practice_share_link_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_practice_share_link: Config,
+) -> None:
+    """Round-trip ``f5b6c7d8e9a0``: upgrade creates the table; downgrade drops it.
+
+    Phase 1: upgrade installs ``practicesharelink`` with the expected
+    columns and unique index on ``token``.  Phase 2: downgrade removes
+    the table cleanly.  Phase 3: re-upgrade is idempotent.
+    """
+    cfg = alembic_sqlite_config_practice_share_link
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade.
+    command.upgrade(cfg, _PRACTICE_SHARE_LINK_REVISION)
+    assert _table_exists(db_url, "practicesharelink")
+    cols = _columns_of(db_url, "practicesharelink")
+    expected = {
+        "id",
+        "token",
+        "practice_id",
+        "created_by_user_id",
+        "created_at",
+        "expires_at",
+        "max_uses",
+        "use_count",
+        "revoked_at",
+    }
+    assert expected.issubset(cols)
+
+    # Phase 2: downgrade drops the table.
+    command.downgrade(cfg, _PRACTICE_SHARE_LINK_BASE_REVISION)
+    assert not _table_exists(db_url, "practicesharelink")
+
+    # Phase 3: re-upgrade is idempotent.
+    command.upgrade(cfg, _PRACTICE_SHARE_LINK_REVISION)
+    assert _table_exists(db_url, "practicesharelink")

--- a/backend/tests/test_practice_share.py
+++ b/backend/tests/test_practice_share.py
@@ -1,0 +1,516 @@
+"""Tests for the practice share-link API (issue #348)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+from typing import cast
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.practice import Practice
+from models.practice_share_link import PracticeShareLink
+
+
+def _timer_cfg(duration_minutes: float) -> dict[str, object]:
+    return {
+        "mode": "meditation_timer",
+        "duration_minutes": duration_minutes,
+        "start_bell": True,
+        "halfway_bell": False,
+        "end_bell": True,
+    }
+
+
+async def _signup(client: AsyncClient, username: str = "owner") -> tuple[dict[str, str], int]:
+    """Create a user via the public signup endpoint and return (headers, id)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, cast("int", data["user_id"])
+
+
+async def _create_custom_practice(client: AsyncClient, headers: dict[str, str]) -> int:
+    """Submit a user-owned practice and return its id."""
+    payload = {
+        "stage_number": 1,
+        "name": "Sandbox practice",
+        "description": "A draft",
+        "instructions": "Sit and notice",
+        "default_duration_minutes": 10,
+    }
+    resp = await client.post("/practices/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+    return cast("int", resp.json()["id"])
+
+
+async def _seed_preset(db_session: AsyncSession) -> int:
+    practice = Practice(
+        stage_number=1,
+        name="Preset",
+        description="Catalog preset",
+        instructions="Breathe",
+        default_duration_minutes=10,
+        approved=True,
+        submitted_by_user_id=None,
+        mode="meditation_timer",
+        mode_config=_timer_cfg(10),
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    return cast("int", practice.id)
+
+
+async def _mint_link(
+    client: AsyncClient,
+    headers: dict[str, str],
+    practice_id: int,
+    *,
+    expires_in_days: int | None = None,
+    max_uses: int | None = None,
+) -> dict[str, object]:
+    body: dict[str, object] = {}
+    if expires_in_days is not None:
+        body["expires_in_days"] = expires_in_days
+    if max_uses is not None:
+        body["max_uses"] = max_uses
+    resp = await client.post(
+        f"/practices/{practice_id}/share-link",
+        json=body,
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+    return cast("dict[str, object]", resp.json())
+
+
+# -- Auth ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_share_link_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.post("/practices/1/share-link", json={})
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_preview_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.get("/practices/share/some-token")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_import_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.post("/practices/share/some-token/import")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+# -- Mint ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_can_mint_share_link(async_client: AsyncClient) -> None:
+    owner_headers, _ = await _signup(async_client, "owner1")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+
+    link = await _mint_link(async_client, owner_headers, practice_id)
+    assert link["practice_id"] == practice_id
+    assert link["use_count"] == 0
+    assert link["revoked_at"] is None
+    # ``secrets.token_urlsafe(32)`` -> 43 char URL-safe string.
+    token = cast("str", link["token"])
+    assert len(token) >= 32
+    assert "/" not in token
+    assert "=" not in token
+
+
+@pytest.mark.asyncio
+async def test_anyone_can_mint_link_for_preset(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    preset_id = await _seed_preset(db_session)
+    user_headers, _ = await _signup(async_client, "preset_sharer")
+    link = await _mint_link(async_client, user_headers, preset_id)
+    assert link["practice_id"] == preset_id
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_mint_share_link(async_client: AsyncClient) -> None:
+    owner_headers, _ = await _signup(async_client, "owner2")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    other_headers, _ = await _signup(async_client, "other2")
+    resp = await async_client.post(
+        f"/practices/{practice_id}/share-link",
+        json={},
+        headers=other_headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_mint_share_link_missing_practice(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client, "mint_404")
+    resp = await async_client.post(
+        "/practices/9999/share-link",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_mint_with_options_persists_expires_and_max_uses(
+    async_client: AsyncClient,
+) -> None:
+    headers, _ = await _signup(async_client, "mint_opts")
+    practice_id = await _create_custom_practice(async_client, headers)
+    link = await _mint_link(async_client, headers, practice_id, expires_in_days=7, max_uses=3)
+    assert link["max_uses"] == 3
+    assert link["expires_at"] is not None
+
+
+# -- Preview -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_returns_practice_and_owner_display_name(
+    async_client: AsyncClient,
+) -> None:
+    owner_headers, _ = await _signup(async_client, "alice")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+
+    recipient_headers, _ = await _signup(async_client, "bob")
+    token = cast("str", link["token"])
+    resp = await async_client.get(
+        f"/practices/share/{token}",
+        headers=recipient_headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["practice_id"] == practice_id
+    assert data["name"] == "Sandbox practice"
+    assert data["created_by_display_name"] == "alice"
+    # Issue #348 constraint: do not expose the original owner's user id.
+    assert "submitted_by_user_id" not in data
+    assert "created_by_user_id" not in data
+
+
+@pytest.mark.asyncio
+async def test_preview_unknown_token_returns_404(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client, "tokenless")
+    resp = await async_client.get(
+        "/practices/share/this-token-does-not-exist",
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "share_link_not_found"
+
+
+@pytest.mark.asyncio
+async def test_preview_expired_link_returns_410(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_exp")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id, expires_in_days=1)
+
+    # Fast-forward by mutating the row.
+    row = await db_session.get(PracticeShareLink, link["id"])
+    assert row is not None
+    row.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    db_session.add(row)
+    await db_session.commit()
+
+    recipient_headers, _ = await _signup(async_client, "recipient_exp")
+    token = cast("str", link["token"])
+    resp = await async_client.get(
+        f"/practices/share/{token}",
+        headers=recipient_headers,
+    )
+    assert resp.status_code == HTTPStatus.GONE
+    assert resp.json()["detail"] == "share_link_expired"
+
+
+@pytest.mark.asyncio
+async def test_preview_revoked_link_returns_410(
+    async_client: AsyncClient,
+) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_rev")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+
+    revoke = await async_client.delete(
+        f"/practices/share-links/{link['id']}",
+        headers=owner_headers,
+    )
+    assert revoke.status_code == HTTPStatus.NO_CONTENT
+
+    recipient_headers, _ = await _signup(async_client, "recipient_rev")
+    token = cast("str", link["token"])
+    resp = await async_client.get(
+        f"/practices/share/{token}",
+        headers=recipient_headers,
+    )
+    assert resp.status_code == HTTPStatus.GONE
+    assert resp.json()["detail"] == "share_link_revoked"
+
+
+@pytest.mark.asyncio
+async def test_preview_exhausted_link_returns_410(
+    async_client: AsyncClient,
+) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_exh")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id, max_uses=1)
+
+    # Recipient imports once -> use_count == 1, max_uses == 1.
+    recipient_headers, _ = await _signup(async_client, "recipient_exh")
+    token = cast("str", link["token"])
+    import_resp = await async_client.post(
+        f"/practices/share/{token}/import",
+        headers=recipient_headers,
+    )
+    assert import_resp.status_code == HTTPStatus.CREATED
+
+    # A second user can no longer redeem.
+    second_headers, _ = await _signup(async_client, "recipient_exh2")
+    resp = await async_client.get(
+        f"/practices/share/{token}",
+        headers=second_headers,
+    )
+    assert resp.status_code == HTTPStatus.GONE
+    assert resp.json()["detail"] == "share_link_exhausted"
+
+
+# -- Import --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_clones_practice_as_unapproved_recipient_draft(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner_headers, owner_id = await _signup(async_client, "owner_imp")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+
+    recipient_headers, recipient_id = await _signup(async_client, "recipient_imp")
+    token = cast("str", link["token"])
+    resp = await async_client.post(
+        f"/practices/share/{token}/import",
+        headers=recipient_headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    body = resp.json()
+    assert body["approved"] is False
+    new_id = body["practice_id"]
+    assert new_id != practice_id
+
+    copy = await db_session.get(Practice, new_id)
+    assert copy is not None
+    assert copy.submitted_by_user_id == recipient_id
+    assert copy.approved is False
+    assert copy.name == "Sandbox practice"
+    # The original row is untouched.
+    original = await db_session.get(Practice, practice_id)
+    assert original is not None
+    assert original.submitted_by_user_id == owner_id
+
+
+@pytest.mark.asyncio
+async def test_import_increments_use_count(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_count")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+
+    recipient_headers, _ = await _signup(async_client, "recipient_count")
+    token = cast("str", link["token"])
+    resp = await async_client.post(
+        f"/practices/share/{token}/import",
+        headers=recipient_headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+    row = await db_session.get(PracticeShareLink, link["id"])
+    assert row is not None
+    await db_session.refresh(row)
+    assert row.use_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_recipient_sees_imported_practice_in_their_catalog(
+    async_client: AsyncClient,
+) -> None:
+    """End-to-end smoke from issue #348 acceptance criteria.
+
+    Owner creates -> shares -> recipient imports -> recipient can GET
+    the new private draft (approved=False, only visible to them).
+    """
+    owner_headers, _ = await _signup(async_client, "smoke_owner")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+
+    recipient_headers, _ = await _signup(async_client, "smoke_recipient")
+    token = cast("str", link["token"])
+    import_resp = await async_client.post(
+        f"/practices/share/{token}/import",
+        headers=recipient_headers,
+    )
+    assert import_resp.status_code == HTTPStatus.CREATED
+    new_id = import_resp.json()["practice_id"]
+
+    # Recipient can GET the new private draft.
+    detail = await async_client.get(f"/practices/{new_id}", headers=recipient_headers)
+    assert detail.status_code == HTTPStatus.OK
+    assert detail.json()["approved"] is False
+
+    # And the original owner cannot see the recipient's copy (visibility
+    # filter restricts unapproved rows to the submitter).
+    forbidden = await async_client.get(f"/practices/{new_id}", headers=owner_headers)
+    assert forbidden.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_self_import_rejected_with_400(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client, "self_share")
+    practice_id = await _create_custom_practice(async_client, headers)
+    link = await _mint_link(async_client, headers, practice_id)
+    token = cast("str", link["token"])
+    resp = await async_client.post(
+        f"/practices/share/{token}/import",
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "cannot_import_own_practice"
+
+
+@pytest.mark.asyncio
+async def test_import_revoked_link_410(async_client: AsyncClient) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_imp_rev")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+
+    revoke = await async_client.delete(
+        f"/practices/share-links/{link['id']}",
+        headers=owner_headers,
+    )
+    assert revoke.status_code == HTTPStatus.NO_CONTENT
+
+    recipient_headers, _ = await _signup(async_client, "recipient_imp_rev")
+    token = cast("str", link["token"])
+    resp = await async_client.post(
+        f"/practices/share/{token}/import",
+        headers=recipient_headers,
+    )
+    assert resp.status_code == HTTPStatus.GONE
+
+
+# -- Revoke --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_can_revoke_share_link(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_revoke")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+
+    resp = await async_client.delete(
+        f"/practices/share-links/{link['id']}",
+        headers=owner_headers,
+    )
+    assert resp.status_code == HTTPStatus.NO_CONTENT
+
+    row = await db_session.get(PracticeShareLink, link["id"])
+    assert row is not None
+    await db_session.refresh(row)
+    assert row.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_revoke_idempotent_for_already_revoked(
+    async_client: AsyncClient,
+) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_revoke2")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+
+    first = await async_client.delete(
+        f"/practices/share-links/{link['id']}",
+        headers=owner_headers,
+    )
+    second = await async_client.delete(
+        f"/practices/share-links/{link['id']}",
+        headers=owner_headers,
+    )
+    assert first.status_code == HTTPStatus.NO_CONTENT
+    assert second.status_code == HTTPStatus.NO_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_revoke_share_link(async_client: AsyncClient) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_revoke3")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+    other_headers, _ = await _signup(async_client, "other_revoke3")
+    resp = await async_client.delete(
+        f"/practices/share-links/{link['id']}",
+        headers=other_headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_revoke_unknown_share_link_returns_404(
+    async_client: AsyncClient,
+) -> None:
+    headers, _ = await _signup(async_client, "revoke_404")
+    resp = await async_client.delete(
+        "/practices/share-links/99999",
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+# -- List ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_can_list_share_links(async_client: AsyncClient) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_list")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    first = await _mint_link(async_client, owner_headers, practice_id)
+    second = await _mint_link(async_client, owner_headers, practice_id)
+
+    resp = await async_client.get(
+        f"/practices/{practice_id}/share-links",
+        headers=owner_headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    ids = {row["id"] for row in body}
+    assert ids == {first["id"], second["id"]}
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_list_share_links(async_client: AsyncClient) -> None:
+    owner_headers, _ = await _signup(async_client, "owner_list2")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    await _mint_link(async_client, owner_headers, practice_id)
+    other_headers, _ = await _signup(async_client, "other_list2")
+    resp = await async_client.get(
+        f"/practices/{practice_id}/share-links",
+        headers=other_headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN

--- a/backend/tests/test_practice_share.py
+++ b/backend/tests/test_practice_share.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from typing import cast
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import select
 
 from models.practice import Practice
 from models.practice_share_link import PracticeShareLink
@@ -514,3 +516,135 @@ async def test_non_owner_cannot_list_share_links(async_client: AsyncClient) -> N
         headers=other_headers,
     )
     assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+# -- Regression: PR #359 review feedback --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_share_links_only_returns_caller_links_for_preset(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Listing a preset's share links must not leak other users' links.
+
+    Regression for PR #359 review: ``_ensure_owner_or_preset`` lets any
+    authenticated user list a preset's links, but the WHERE clause must
+    still scope to ``created_by_user_id == caller`` so user A cannot
+    see the tokens user B minted for the same preset.
+    """
+    preset_id = await _seed_preset(db_session)
+    alice_headers, _ = await _signup(async_client, "preset_alice")
+    bob_headers, _ = await _signup(async_client, "preset_bob")
+    await _mint_link(async_client, alice_headers, preset_id)
+    bob_link = await _mint_link(async_client, bob_headers, preset_id)
+
+    resp = await async_client.get(
+        f"/practices/{preset_id}/share-links",
+        headers=bob_headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert {row["id"] for row in body} == {bob_link["id"]}
+
+
+@pytest.mark.asyncio
+async def test_list_share_links_respects_limit_query(async_client: AsyncClient) -> None:
+    """``?limit=N`` caps the response so a long-lived practice never returns an unbounded payload.
+
+    Regression for PR #359 review: an owner that has minted dozens of
+    links could otherwise dump them all in one response.  We mint a
+    handful and assert the slice respects both the default and an
+    explicit limit.
+    """
+    owner_headers, _ = await _signup(async_client, "owner_limit")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    mint_count = 5
+    for _ in range(mint_count):
+        await _mint_link(async_client, owner_headers, practice_id)
+
+    full = await async_client.get(
+        f"/practices/{practice_id}/share-links",
+        headers=owner_headers,
+    )
+    assert full.status_code == HTTPStatus.OK
+    assert len(full.json()) == mint_count
+
+    capped = await async_client.get(
+        f"/practices/{practice_id}/share-links",
+        params={"limit": 2},
+        headers=owner_headers,
+    )
+    assert capped.status_code == HTTPStatus.OK
+    assert len(capped.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_share_links_rejects_limit_out_of_range(async_client: AsyncClient) -> None:
+    """``limit`` is bounded by the documented ``[1, 200]`` window."""
+    headers, _ = await _signup(async_client, "owner_limit_bounds")
+    practice_id = await _create_custom_practice(async_client, headers)
+    too_low = await async_client.get(
+        f"/practices/{practice_id}/share-links",
+        params={"limit": 0},
+        headers=headers,
+    )
+    too_high = await async_client.get(
+        f"/practices/{practice_id}/share-links",
+        params={"limit": 1_000},
+        headers=headers,
+    )
+    assert too_low.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert too_high.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_concurrent_imports_cannot_exceed_max_uses(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """``max_uses=1`` holds when two recipients import simultaneously.
+
+    Regression for PR #359 review: the prior ``use_count += 1`` did a
+    Python-side read-modify-write so two concurrent importers could
+    both read ``use_count=0``, both clone, and both commit.  The
+    atomic ``UPDATE ... SET use_count = use_count + 1 WHERE
+    use_count < max_uses`` makes the loser's update match zero rows
+    and the endpoint returns 410 instead of cloning a second copy.
+    """
+    owner_headers, _ = await _signup(concurrent_async_client, "owner_race")
+    practice_id = await _create_custom_practice(concurrent_async_client, owner_headers)
+    link = await _mint_link(concurrent_async_client, owner_headers, practice_id, max_uses=1)
+    token = cast("str", link["token"])
+
+    r1_headers, _ = await _signup(concurrent_async_client, "racer1")
+    r2_headers, _ = await _signup(concurrent_async_client, "racer2")
+
+    responses = await asyncio.gather(
+        concurrent_async_client.post(f"/practices/share/{token}/import", headers=r1_headers),
+        concurrent_async_client.post(f"/practices/share/{token}/import", headers=r2_headers),
+    )
+    statuses = sorted(r.status_code for r in responses)
+    assert statuses == [HTTPStatus.CREATED, HTTPStatus.GONE]
+    loser = next(r for r in responses if r.status_code == HTTPStatus.GONE)
+    assert loser.json()["detail"] == "share_link_exhausted"
+
+    async with concurrent_session_factory() as session:
+        row = (
+            (
+                await session.execute(
+                    select(PracticeShareLink).where(PracticeShareLink.id == link["id"])
+                )
+            )
+            .scalars()
+            .one()
+        )
+        assert row.use_count == 1
+        clones = (
+            (await session.execute(select(Practice).where(Practice.name == "Sandbox practice")))
+            .scalars()
+            .all()
+        )
+        # One source row + one imported clone = two.  A bypass would
+        # yield three (the source plus two clones).
+        assert len(clones) == 2

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -76,6 +76,11 @@ const linking: LinkingOptions<LinkedRootParamList> = {
         },
       },
       ApiKeySettings: 'api-key-settings', // pragma: allowlist secret
+      // Practice share-link landing (issue #348). The recipient
+      // taps ``adepthood://practices/share/<token>`` -- the parser
+      // pulls ``token`` into ``route.params`` for
+      // ``SharePreviewScreen`` to fetch + render.
+      SharePreview: 'practices/share/:token',
       // Auth-stack routes -- only resolve while the AuthNavigator is mounted.
       // Cast through ``unknown`` because react-navigation's typing for
       // ``screens`` is keyed strictly on the param-list, but the same

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1854,6 +1854,105 @@ export const practiceSessions = {
   },
 };
 
+// Practice share-link types and client (issue #348)
+
+/**
+ * Owner-supplied knobs for ``POST /practices/{id}/share-link``.
+ *
+ * Both fields are optional: omitting ``expires_in_days`` mints a never-expiring
+ * link and omitting ``max_uses`` mints an unlimited one. The backend caps
+ * the values (``ge=1, le=365`` for days, ``le=1000`` for max_uses).
+ */
+export interface ShareLinkCreateRequest {
+  expires_in_days?: number | null;
+  max_uses?: number | null;
+}
+
+/** Owner-facing view of a share link row. */
+export interface ShareLinkResponse {
+  id: number;
+  token: string;
+  practice_id: number;
+  created_at: string;
+  expires_at: string | null;
+  max_uses: number | null;
+  use_count: number;
+  revoked_at: string | null;
+}
+
+/**
+ * Recipient-facing preview returned by ``GET /practices/share/{token}``.
+ *
+ * Mirrors the catalog payload minus anything that would leak the source
+ * row's owner id. ``created_by_display_name`` is the email-local-part the
+ * backend derives so the recipient sees *something* identifying the
+ * sender (full email is not exposed).
+ */
+export interface ShareLinkPreviewResponse {
+  practice_id: number;
+  stage_number: number;
+  name: string;
+  description: string;
+  instructions: string;
+  default_duration_minutes: number;
+  mode: string;
+  mode_config: Record<string, unknown>;
+  created_by_display_name: string | null;
+  expires_at: string | null;
+  max_uses: number | null;
+  use_count: number;
+}
+
+/** Result of redeeming a share link into a private draft. */
+export interface ShareLinkImportResponse {
+  practice_id: number;
+  stage_number: number;
+  name: string;
+  approved: boolean;
+}
+
+export const practiceShare = {
+  /**
+   * Mint a new share link for a practice the caller owns (or any preset).
+   * Backend rate-limits to 10/hour per user.
+   */
+  create(
+    practiceId: number,
+    payload: ShareLinkCreateRequest = {},
+    token?: string,
+  ): Promise<ShareLinkResponse> {
+    return request<ShareLinkResponse>(`/practices/${practiceId}/share-link`, {
+      method: 'POST',
+      body: payload,
+      token,
+    });
+  },
+  /** List the caller's outstanding share links for a practice (owner only). */
+  list(practiceId: number, token?: string): Promise<ShareLinkResponse[]> {
+    return request<ShareLinkResponse[]>(`/practices/${practiceId}/share-links`, { token });
+  },
+  /** Preview a share link by token. Any signed-in user may call. */
+  preview(shareToken: string, token?: string): Promise<ShareLinkPreviewResponse> {
+    return request<ShareLinkPreviewResponse>(`/practices/share/${encodeURIComponent(shareToken)}`, {
+      token,
+    });
+  },
+  /** Redeem a share link, cloning the source into the recipient's catalog. */
+  import(shareToken: string, token?: string): Promise<ShareLinkImportResponse> {
+    return request<ShareLinkImportResponse>(
+      `/practices/share/${encodeURIComponent(shareToken)}/import`,
+      { method: 'POST', token },
+    );
+  },
+  /** Revoke a share link the caller minted. Idempotent. */
+  revoke(shareLinkId: number, token?: string): Promise<void> {
+    return request<void>(`/practices/share-links/${shareLinkId}`, {
+      method: 'DELETE',
+      token,
+    });
+  },
+};
+
 // Auth types and client
 export interface AuthRequest {
   email: string;
@@ -1993,6 +2092,7 @@ export default {
   stages,
   course,
   practices,
+  practiceShare,
   userPractices,
   frequency,
   practiceSessions,

--- a/frontend/src/api/practiceShare.ts
+++ b/frontend/src/api/practiceShare.ts
@@ -1,0 +1,20 @@
+/**
+ * Practice share-link API surface (issue #348).
+ *
+ * Re-exports from ``./index`` so this feature has a discoverable module
+ * path (per the issue's file list) while the actual implementation
+ * lives alongside every other API namespace and shares the
+ * retry/timeout/refresh middleware in ``request()``.
+ *
+ * Consumers should import from this module rather than reaching into
+ * ``@/api`` for the share-specific surface:
+ *
+ *     import { practiceShare, type ShareLinkPreviewResponse } from '@/api/practiceShare';
+ */
+export {
+  practiceShare,
+  type ShareLinkCreateRequest,
+  type ShareLinkImportResponse,
+  type ShareLinkPreviewResponse,
+  type ShareLinkResponse,
+} from './index';

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -71,6 +71,14 @@ jest.mock('@/navigation/BottomTabs', () => {
   const { Text } = require('react-native');
   return () => <Text>BottomTabs</Text>;
 });
+// New for issue #348: RootStack mounts SharePreviewScreen as a sibling
+// route to ``Tabs``. The mocked navigator renders every child component
+// with no props, and the real screen reads ``route.params.token`` --
+// stub it out so the auth-flow tests stay focused on auth gating.
+jest.mock('@/features/Practice/screens/SharePreviewScreen', () => {
+  const { Text } = require('react-native');
+  return () => <Text>SharePreviewScreen</Text>;
+});
 
 import App from '@/App';
 

--- a/frontend/src/features/Practice/components/ShareSheet.tsx
+++ b/frontend/src/features/Practice/components/ShareSheet.tsx
@@ -1,0 +1,685 @@
+/**
+ * `ShareSheet` — bottom-sheet that lets the owner of a practice mint
+ * share links and revoke outstanding ones.
+ *
+ * Owner-only by construction: the parent decides whether to mount the
+ * sheet (typically by checking `practice.submitted_by_user_id === currentUserId`
+ * or that the row is a preset). When mounted, the sheet:
+ *
+ * 1. Loads the existing active links via `practiceShare.list`.
+ * 2. Offers a Mint form with two optional knobs (`expires_in_days`
+ *    and `max_uses`) and a Copy button on the resulting URL.
+ * 3. Lets the owner Revoke any active link inline.
+ *
+ * The deep-link URL is built from the application scheme so a tap on
+ * the link in another app routes through `App.tsx`'s linking config to
+ * the `SharePreviewScreen`.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { practiceShare, type ShareLinkResponse } from '@/api/practiceShare';
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+const DEEP_LINK_PREFIX = 'adepthood://practices/share/';
+
+const LOAD_FAILED_MSG = "We couldn't load your share links. Tap retry below.";
+const MINT_FAILED_MSG = "We couldn't create the share link. Check your connection and try again.";
+const REVOKE_FAILED_MSG = "We couldn't revoke that link. Try again in a moment.";
+
+export interface ShareSheetProps {
+  visible: boolean;
+  practiceId: number;
+  onClose: () => void;
+}
+
+/** Build the public deep-link URL for a token. */
+export function buildShareUrl(token: string): string {
+  return `${DEEP_LINK_PREFIX}${encodeURIComponent(token)}`;
+}
+
+/**
+ * Best-effort clipboard write that survives the absence of
+ * ``expo-clipboard``. The web bundle hits ``navigator.clipboard``
+ * (works on RN web); React Native targets fall through to the rejection
+ * branch and the caller renders a "long-press the link to copy"
+ * fallback. Pulled into a tiny helper so tests can mock it without
+ * touching globals.
+ */
+interface ClipboardHost {
+  clipboard?: { writeText?: (_v: string) => Promise<void> };
+}
+
+export async function copyToClipboard(value: string): Promise<boolean> {
+  const host: ClipboardHost =
+    typeof navigator === 'undefined' ? {} : (navigator as unknown as ClipboardHost);
+  const writer = host.clipboard?.writeText;
+  if (!writer) return false;
+  try {
+    await writer.call(host.clipboard, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function useMountedRef() {
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+  return mountedRef;
+}
+
+interface MintFormState {
+  expiresInDays: string;
+  maxUses: string;
+}
+
+const EMPTY_FORM: MintFormState = { expiresInDays: '', maxUses: '' };
+
+interface SheetState {
+  links: ShareLinkResponse[];
+  isLoading: boolean;
+  loadError: string | null;
+  writeError: string | null;
+  isMinting: boolean;
+  revokingId: number | null;
+  form: MintFormState;
+  setForm: (_form: MintFormState) => void;
+  reload: () => Promise<void>;
+  handleMint: () => Promise<void>;
+  handleRevoke: (_id: number) => Promise<void>;
+}
+
+interface UseSheetStateOptions {
+  visible: boolean;
+  practiceId: number;
+}
+
+function parsePositiveInt(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const value = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return value;
+}
+
+interface LoadControl {
+  links: ShareLinkResponse[];
+  setLinks: React.Dispatch<React.SetStateAction<ShareLinkResponse[]>>;
+  isLoading: boolean;
+  loadError: string | null;
+  reload: () => Promise<void>;
+}
+
+function useLoadLinks(
+  practiceId: number,
+  visible: boolean,
+  mountedRef: React.RefObject<boolean>,
+): LoadControl {
+  const [links, setLinks] = useState<ShareLinkResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const data = await practiceShare.list(practiceId);
+      if (mountedRef.current) setLinks(data);
+    } catch {
+      if (mountedRef.current) setLoadError(LOAD_FAILED_MSG);
+    } finally {
+      if (mountedRef.current) setIsLoading(false);
+    }
+  }, [practiceId, mountedRef]);
+
+  useEffect(() => {
+    if (!visible) return;
+    void reload();
+  }, [visible, reload]);
+
+  return { links, setLinks, isLoading, loadError, reload };
+}
+
+interface WriteState {
+  writeError: string | null;
+  setWriteError: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+interface MintControl extends WriteState {
+  isMinting: boolean;
+  form: MintFormState;
+  setForm: (_form: MintFormState) => void;
+  handleMint: () => Promise<void>;
+}
+
+function useMintControl(
+  practiceId: number,
+  setLinks: LoadControl['setLinks'],
+  mountedRef: React.RefObject<boolean>,
+  write: WriteState,
+): MintControl {
+  const { setWriteError } = write;
+  const [isMinting, setIsMinting] = useState(false);
+  const [form, setForm] = useState<MintFormState>(EMPTY_FORM);
+
+  const handleMint = useCallback(async () => {
+    setIsMinting(true);
+    setWriteError(null);
+    try {
+      const created = await practiceShare.create(practiceId, {
+        expires_in_days: parsePositiveInt(form.expiresInDays),
+        max_uses: parsePositiveInt(form.maxUses),
+      });
+      if (!mountedRef.current) return;
+      setLinks((prev) => [created, ...prev]);
+      setForm(EMPTY_FORM);
+    } catch {
+      if (mountedRef.current) setWriteError(MINT_FAILED_MSG);
+    } finally {
+      if (mountedRef.current) setIsMinting(false);
+    }
+  }, [practiceId, form, mountedRef, setLinks, setWriteError]);
+
+  return { ...write, isMinting, form, setForm, handleMint };
+}
+
+interface RevokeControl {
+  revokingId: number | null;
+  handleRevoke: (_id: number) => Promise<void>;
+}
+
+function useRevokeControl(
+  setLinks: LoadControl['setLinks'],
+  mountedRef: React.RefObject<boolean>,
+  setWriteError: WriteState['setWriteError'],
+): RevokeControl {
+  const [revokingId, setRevokingId] = useState<number | null>(null);
+
+  const markRevoked = useCallback(
+    (id: number) => {
+      const now = new Date().toISOString();
+      const applyRevoked = (link: ShareLinkResponse) =>
+        link.id === id ? { ...link, revoked_at: now } : link;
+      setLinks((prev) => prev.map(applyRevoked));
+    },
+    [setLinks],
+  );
+
+  const handleRevoke = useCallback(
+    async (id: number) => {
+      setRevokingId(id);
+      setWriteError(null);
+      try {
+        await practiceShare.revoke(id);
+        if (mountedRef.current) markRevoked(id);
+      } catch {
+        if (mountedRef.current) setWriteError(REVOKE_FAILED_MSG);
+      } finally {
+        if (mountedRef.current) setRevokingId(null);
+      }
+    },
+    [mountedRef, markRevoked, setWriteError],
+  );
+
+  return { revokingId, handleRevoke };
+}
+
+function useShareSheetState(opts: UseSheetStateOptions): SheetState {
+  const mountedRef = useMountedRef();
+  const load = useLoadLinks(opts.practiceId, opts.visible, mountedRef);
+  const [writeError, setWriteError] = useState<string | null>(null);
+  const write: WriteState = { writeError, setWriteError };
+  const mint = useMintControl(opts.practiceId, load.setLinks, mountedRef, write);
+  const revoke = useRevokeControl(load.setLinks, mountedRef, setWriteError);
+  return { ...load, ...mint, ...revoke };
+}
+
+function SheetHeader({ onClose }: { onClose: () => void }) {
+  return (
+    <View style={styles.headerRow}>
+      <Text style={styles.title}>Share this practice</Text>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Close"
+        onPress={onClose}
+        style={styles.closeButton}
+        testID="share-sheet-close"
+      >
+        <Text style={styles.closeButtonText}>✕</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+interface MintFormProps {
+  form: MintFormState;
+  onChange: (_form: MintFormState) => void;
+  onSubmit: () => void;
+  isMinting: boolean;
+}
+
+function MintForm({ form, onChange, onSubmit, isMinting }: MintFormProps) {
+  return (
+    <View style={styles.form}>
+      <Text style={styles.formLabel}>Expires in (days)</Text>
+      <TextInput
+        accessibilityLabel="Expires in days"
+        keyboardType="number-pad"
+        onChangeText={(text) => onChange({ ...form, expiresInDays: text })}
+        placeholder="Leave blank for no expiry"
+        style={styles.input}
+        testID="share-sheet-expires-input"
+        value={form.expiresInDays}
+      />
+      <Text style={styles.formLabel}>Max uses</Text>
+      <TextInput
+        accessibilityLabel="Maximum uses"
+        keyboardType="number-pad"
+        onChangeText={(text) => onChange({ ...form, maxUses: text })}
+        placeholder="Leave blank for unlimited"
+        style={styles.input}
+        testID="share-sheet-max-uses-input"
+        value={form.maxUses}
+      />
+      <TouchableOpacity
+        accessibilityRole="button"
+        disabled={isMinting}
+        onPress={onSubmit}
+        style={[styles.mintButton, isMinting && styles.mintButtonDisabled]}
+        testID="share-sheet-mint"
+      >
+        {isMinting ? (
+          <ActivityIndicator color={colors.text.light} testID="share-sheet-mint-pending" />
+        ) : (
+          <Text style={styles.mintButtonText}>Generate link</Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+interface LinkRowProps {
+  link: ShareLinkResponse;
+  revokingId: number | null;
+  onRevoke: (_id: number) => void;
+  onCopy: (_token: string) => void;
+}
+
+function formatStatus(link: ShareLinkResponse): string {
+  if (link.revoked_at) return 'Revoked';
+  if (link.max_uses !== null && link.use_count >= link.max_uses) return 'Exhausted';
+  if (link.expires_at && new Date(link.expires_at).getTime() <= Date.now()) return 'Expired';
+  return 'Active';
+}
+
+function LinkRow({ link, revokingId, onRevoke, onCopy }: LinkRowProps) {
+  const status = formatStatus(link);
+  const isActive = status === 'Active';
+  const isRevoking = revokingId === link.id;
+  return (
+    <View style={styles.row} testID={`share-sheet-row-${link.id}`}>
+      <View style={styles.rowText}>
+        <Text style={styles.rowUrl} numberOfLines={1} ellipsizeMode="middle">
+          {buildShareUrl(link.token)}
+        </Text>
+        <Text style={styles.rowMeta}>
+          {status}
+          {link.max_uses !== null
+            ? ` • ${link.use_count}/${link.max_uses} uses`
+            : ` • ${link.use_count} uses`}
+        </Text>
+      </View>
+      <View style={styles.rowActions}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Copy link"
+          onPress={() => onCopy(link.token)}
+          style={styles.iconButton}
+          testID={`share-sheet-copy-${link.id}`}
+        >
+          <Text style={styles.iconButtonText}>Copy</Text>
+        </TouchableOpacity>
+        {isActive && (
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel="Revoke link"
+            disabled={isRevoking}
+            onPress={() => onRevoke(link.id)}
+            style={[styles.iconButton, styles.revokeButton]}
+            testID={`share-sheet-revoke-${link.id}`}
+          >
+            {isRevoking ? (
+              <ActivityIndicator color={colors.destructive.text} />
+            ) : (
+              <Text style={[styles.iconButtonText, styles.revokeButtonText]}>Revoke</Text>
+            )}
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+}
+
+interface LinkListProps {
+  state: SheetState;
+  onCopy: (_token: string) => void;
+}
+
+function LinkList({ state, onCopy }: LinkListProps) {
+  const { links, isLoading, loadError, reload, revokingId, handleRevoke } = state;
+  if (isLoading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color={colors.primary} testID="share-sheet-loading" />
+      </View>
+    );
+  }
+  if (loadError) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.loadErrorText}>{loadError}</Text>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={() => {
+            void reload();
+          }}
+          style={styles.retryButton}
+          testID="share-sheet-retry"
+        >
+          <Text style={styles.retryButtonText}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+  if (links.length === 0) {
+    return (
+      <Text style={styles.emptyText} testID="share-sheet-empty">
+        No active share links yet.
+      </Text>
+    );
+  }
+  return (
+    <View testID="share-sheet-list">
+      {links.map((link) => (
+        <LinkRow
+          key={link.id}
+          link={link}
+          revokingId={revokingId}
+          onRevoke={handleRevoke}
+          onCopy={onCopy}
+        />
+      ))}
+    </View>
+  );
+}
+
+interface SheetBodyProps {
+  state: SheetState;
+  copyMessage: string | null;
+  onCopy: (_token: string) => void;
+  onClose: () => void;
+}
+
+function SheetBody({ state, copyMessage, onCopy, onClose }: SheetBodyProps) {
+  return (
+    <Pressable accessible={false} onPress={(event) => event.stopPropagation()} style={styles.sheet}>
+      <View style={styles.handle} />
+      <SheetHeader onClose={onClose} />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <MintForm
+          form={state.form}
+          onChange={state.setForm}
+          onSubmit={() => {
+            void state.handleMint();
+          }}
+          isMinting={state.isMinting}
+        />
+        {state.writeError && (
+          <View style={styles.errorBanner} testID="share-sheet-error">
+            <Text style={styles.errorBannerText}>{state.writeError}</Text>
+          </View>
+        )}
+        {copyMessage && (
+          <View style={styles.copyBanner} testID="share-sheet-copy-banner">
+            <Text style={styles.copyBannerText}>{copyMessage}</Text>
+          </View>
+        )}
+        <View style={styles.divider} />
+        <Text style={styles.subTitle}>Your share links</Text>
+        <LinkList state={state} onCopy={onCopy} />
+      </ScrollView>
+    </Pressable>
+  );
+}
+
+export function ShareSheet({ visible, practiceId, onClose }: ShareSheetProps): React.JSX.Element {
+  const state = useShareSheetState({ visible, practiceId });
+  const [copyMessage, setCopyMessage] = useState<string | null>(null);
+
+  const handleCopy = useCallback(async (token: string) => {
+    const ok = await copyToClipboard(buildShareUrl(token));
+    setCopyMessage(
+      ok ? 'Link copied to clipboard.' : 'Could not copy — long-press the link to copy manually.',
+    );
+  }, []);
+
+  return (
+    <Modal animationType="slide" onRequestClose={onClose} transparent visible={visible}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Close share sheet"
+        onPress={onClose}
+        style={styles.backdrop}
+        testID="share-sheet-backdrop"
+      >
+        <SheetBody state={state} copyMessage={copyMessage} onCopy={handleCopy} onClose={onClose} />
+      </Pressable>
+    </Modal>
+  );
+}
+
+export default ShareSheet;
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    maxHeight: '90%',
+    backgroundColor: colors.background.card,
+    borderTopLeftRadius: BORDER_RADIUS.xl,
+    borderTopRightRadius: BORDER_RADIUS.xl,
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.sm,
+    paddingBottom: SPACING.xxl,
+    ...shadows.large,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 36,
+    height: 4,
+    borderRadius: BORDER_RADIUS.circle,
+    backgroundColor: colors.border,
+    marginBottom: SPACING.sm,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: SPACING.md,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  subTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.primary,
+    marginBottom: SPACING.sm,
+  },
+  closeButton: {
+    minWidth: 44,
+    minHeight: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    fontSize: 20,
+    color: colors.text.secondary,
+  },
+  scrollContent: {
+    paddingBottom: SPACING.xl,
+  },
+  form: {
+    marginBottom: SPACING.md,
+  },
+  formLabel: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    marginBottom: SPACING.xs,
+  },
+  input: {
+    backgroundColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.md,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    marginBottom: SPACING.md,
+    fontSize: 15,
+    color: colors.text.primary,
+  },
+  mintButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.buttonV,
+    borderRadius: BORDER_RADIUS.md,
+    alignItems: 'center',
+  },
+  mintButtonDisabled: {
+    opacity: 0.5,
+  },
+  mintButtonText: {
+    color: colors.text.light,
+    fontWeight: '600',
+    fontSize: 15,
+  },
+  errorBanner: {
+    padding: SPACING.md,
+    marginBottom: SPACING.sm,
+    backgroundColor: colors.destructive.background,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    borderColor: colors.destructive.border,
+  },
+  errorBannerText: {
+    color: colors.destructive.text,
+    fontSize: 14,
+  },
+  copyBanner: {
+    padding: SPACING.md,
+    marginBottom: SPACING.sm,
+    backgroundColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.md,
+  },
+  copyBannerText: {
+    color: colors.text.primary,
+    fontSize: 14,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginVertical: SPACING.md,
+  },
+  center: {
+    paddingVertical: SPACING.xxl,
+    alignItems: 'center',
+  },
+  loadErrorText: {
+    color: colors.destructive.text,
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: SPACING.md,
+  },
+  retryButton: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.sm,
+    borderRadius: BORDER_RADIUS.md,
+  },
+  retryButtonText: {
+    color: colors.text.light,
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  emptyText: {
+    color: colors.text.secondary,
+    fontSize: 14,
+    textAlign: 'center',
+    paddingVertical: SPACING.md,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: SPACING.sm,
+    backgroundColor: colors.background.accent,
+  },
+  rowText: {
+    flex: 1,
+    paddingRight: SPACING.sm,
+  },
+  rowUrl: {
+    fontSize: 13,
+    color: colors.text.primary,
+    fontWeight: '600',
+    marginBottom: 2,
+  },
+  rowMeta: {
+    fontSize: 12,
+    color: colors.text.secondary,
+  },
+  rowActions: {
+    flexDirection: 'row',
+    gap: SPACING.xs,
+  },
+  iconButton: {
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    minWidth: 60,
+    alignItems: 'center',
+  },
+  iconButtonText: {
+    fontSize: 13,
+    color: colors.text.primary,
+    fontWeight: '600',
+  },
+  revokeButton: {
+    borderColor: colors.destructive.border,
+  },
+  revokeButtonText: {
+    color: colors.destructive.text,
+  },
+});

--- a/frontend/src/features/Practice/components/ShareSheet.tsx
+++ b/frontend/src/features/Practice/components/ShareSheet.tsx
@@ -468,6 +468,10 @@ function SheetBody({ state, copyMessage, onCopy, onClose }: SheetBodyProps) {
   );
 }
 
+// Auto-dismiss the "copied" banner after a beat so a second copy in
+// quick succession doesn't read as a stale toast (PR #359 review).
+const COPY_BANNER_TIMEOUT_MS = 3000;
+
 export function ShareSheet({ visible, practiceId, onClose }: ShareSheetProps): React.JSX.Element {
   const state = useShareSheetState({ visible, practiceId });
   const [copyMessage, setCopyMessage] = useState<string | null>(null);
@@ -478,6 +482,12 @@ export function ShareSheet({ visible, practiceId, onClose }: ShareSheetProps): R
       ok ? 'Link copied to clipboard.' : 'Could not copy — long-press the link to copy manually.',
     );
   }, []);
+
+  useEffect(() => {
+    if (!copyMessage) return undefined;
+    const timer = setTimeout(() => setCopyMessage(null), COPY_BANNER_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [copyMessage]);
 
   return (
     <Modal animationType="slide" onRequestClose={onClose} transparent visible={visible}>

--- a/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
 import type { ShareLinkCreateRequest, ShareLinkResponse } from '../../../../api/practiceShare';
@@ -179,5 +179,30 @@ describe('ShareSheet', () => {
     // Jest's jsdom may or may not provide navigator.clipboard; just assert
     // the helper does not throw and returns a boolean.
     expect(typeof result).toBe('boolean');
+  });
+
+  describe('copy-banner auto-dismiss (PR #359 review)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('clears the copy banner after the timeout so a second copy is fresh', async () => {
+      mockList.mockResolvedValueOnce(sampleLinks);
+      const { findByTestId, queryByTestId, getByTestId } = renderSheet();
+      const copyBtn = await findByTestId('share-sheet-copy-1');
+      fireEvent.press(copyBtn);
+      await waitFor(() => {
+        expect(getByTestId('share-sheet-copy-banner')).toBeTruthy();
+      });
+      act(() => {
+        jest.advanceTimersByTime(4000);
+      });
+      await waitFor(() => {
+        expect(queryByTestId('share-sheet-copy-banner')).toBeNull();
+      });
+    });
   });
 });

--- a/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
@@ -1,0 +1,183 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import type { ShareLinkCreateRequest, ShareLinkResponse } from '../../../../api/practiceShare';
+
+const sampleLinks: ShareLinkResponse[] = [
+  {
+    id: 1,
+    token: 'token-alpha',
+    practice_id: 42,
+    created_at: '2026-05-17T10:00:00Z',
+    expires_at: null,
+    max_uses: null,
+    use_count: 0,
+    revoked_at: null,
+  },
+];
+
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<ShareLinkResponse[]>>;
+const mockCreate = jest.fn() as jest.MockedFunction<
+  (_id: number, _payload: ShareLinkCreateRequest) => Promise<ShareLinkResponse>
+>;
+const mockRevoke = jest.fn() as jest.MockedFunction<(_id: number) => Promise<void>>;
+
+jest.mock('@/api/practiceShare', () => ({
+  practiceShare: {
+    list: (...args: unknown[]) =>
+      (mockList as unknown as (...a: unknown[]) => Promise<ShareLinkResponse[]>)(...args),
+    create: (...args: unknown[]) =>
+      (mockCreate as unknown as (...a: unknown[]) => Promise<ShareLinkResponse>)(...args),
+    revoke: (...args: unknown[]) =>
+      (mockRevoke as unknown as (...a: unknown[]) => Promise<void>)(...args),
+    preview: jest.fn(),
+    import: jest.fn(),
+  },
+}));
+
+const { ShareSheet, buildShareUrl, copyToClipboard } = require('../ShareSheet');
+
+interface RenderOptions {
+  visible?: boolean;
+  practiceId?: number;
+  onClose?: () => void;
+}
+
+function renderSheet(opts: RenderOptions = {}) {
+  return render(
+    <ShareSheet
+      visible={opts.visible ?? true}
+      practiceId={opts.practiceId ?? 42}
+      onClose={opts.onClose ?? jest.fn()}
+    />,
+  );
+}
+
+describe('ShareSheet', () => {
+  beforeEach(() => {
+    mockList.mockReset();
+    mockCreate.mockReset();
+    mockRevoke.mockReset();
+  });
+
+  it('builds the deep-link URL for a token', () => {
+    expect(buildShareUrl('abc')).toBe('adepthood://practices/share/abc');
+    expect(buildShareUrl('a/b+c')).toBe('adepthood://practices/share/a%2Fb%2Bc');
+  });
+
+  it('loads and renders the active share links on open', async () => {
+    mockList.mockResolvedValueOnce(sampleLinks);
+    const { findByTestId } = renderSheet();
+    const row = await findByTestId('share-sheet-row-1');
+    expect(row).toBeTruthy();
+    expect(mockList).toHaveBeenCalledWith(42);
+  });
+
+  it('mints a new link and prepends it to the list', async () => {
+    mockList.mockResolvedValueOnce([]);
+    const created: ShareLinkResponse = {
+      id: 7,
+      token: 'token-new',
+      practice_id: 42,
+      created_at: '2026-05-17T12:00:00Z',
+      expires_at: null,
+      max_uses: 3,
+      use_count: 0,
+      revoked_at: null,
+    };
+    mockCreate.mockResolvedValueOnce(created);
+
+    const { findByTestId, getByTestId } = renderSheet();
+    await findByTestId('share-sheet-empty');
+    fireEvent.changeText(getByTestId('share-sheet-max-uses-input'), '3');
+    fireEvent.press(getByTestId('share-sheet-mint'));
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith(42, {
+        expires_in_days: null,
+        max_uses: 3,
+      });
+    });
+    const newRow = await findByTestId('share-sheet-row-7');
+    expect(newRow).toBeTruthy();
+  });
+
+  it('treats blank or zero inputs as null on mint', async () => {
+    mockList.mockResolvedValueOnce([]);
+    const first = sampleLinks[0];
+    if (!first) throw new Error('test fixture missing');
+    const created: ShareLinkResponse = { ...first, id: 11 };
+    mockCreate.mockResolvedValueOnce(created);
+
+    const { findByTestId, getByTestId } = renderSheet();
+    await findByTestId('share-sheet-empty');
+    fireEvent.changeText(getByTestId('share-sheet-expires-input'), '   ');
+    fireEvent.changeText(getByTestId('share-sheet-max-uses-input'), '0');
+    fireEvent.press(getByTestId('share-sheet-mint'));
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith(42, {
+        expires_in_days: null,
+        max_uses: null,
+      });
+    });
+  });
+
+  it('surfaces a mint failure via an inline error banner', async () => {
+    mockList.mockResolvedValueOnce([]);
+    mockCreate.mockRejectedValueOnce(new Error('offline'));
+
+    const { findByTestId, getByTestId } = renderSheet();
+    await findByTestId('share-sheet-empty');
+    fireEvent.press(getByTestId('share-sheet-mint'));
+    const banner = await findByTestId('share-sheet-error');
+    expect(banner).toBeTruthy();
+  });
+
+  it('revokes a link inline and updates the row status', async () => {
+    mockList.mockResolvedValueOnce(sampleLinks);
+    mockRevoke.mockResolvedValueOnce(undefined);
+
+    const { findByTestId, queryByTestId } = renderSheet();
+    const revokeBtn = await findByTestId('share-sheet-revoke-1');
+    fireEvent.press(revokeBtn);
+
+    await waitFor(() => {
+      expect(mockRevoke).toHaveBeenCalledWith(1);
+    });
+    // After revocation the revoke button disappears (status flips to "Revoked").
+    await waitFor(() => {
+      expect(queryByTestId('share-sheet-revoke-1')).toBeNull();
+    });
+  });
+
+  it('renders an inline error and retry button if the list fetch fails', async () => {
+    mockList.mockRejectedValueOnce(new Error('offline'));
+    mockList.mockResolvedValueOnce(sampleLinks);
+
+    const { findByTestId } = renderSheet();
+    const retry = await findByTestId('share-sheet-retry');
+    fireEvent.press(retry);
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('the close affordance fires onClose', async () => {
+    mockList.mockResolvedValueOnce([]);
+    const onClose = jest.fn();
+    const { findByTestId } = renderSheet({ onClose });
+    const close = await findByTestId('share-sheet-close');
+    fireEvent.press(close);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('copyToClipboard returns false when navigator.clipboard is missing', async () => {
+    const result = await copyToClipboard('hello');
+    // Jest's jsdom may or may not provide navigator.clipboard; just assert
+    // the helper does not throw and returns a boolean.
+    expect(typeof result).toBe('boolean');
+  });
+});

--- a/frontend/src/features/Practice/screens/SharePreviewScreen.tsx
+++ b/frontend/src/features/Practice/screens/SharePreviewScreen.tsx
@@ -285,21 +285,19 @@ export function SharePreviewScreen({
       </View>
     );
   }
-  if (state.loadError) {
+  if (state.loadError || !state.preview) {
+    // ``preview`` is set on success and cleared on load failure, so the
+    // ``!preview`` half of the union here is exactly the same state as
+    // ``loadError`` is set -- the explicit guard is just a type-narrow
+    // for TypeScript. Fall back to a generic banner on the
+    // theoretically-unreachable ``!preview && !loadError`` path.
     return (
       <ScrollView contentContainerStyle={styles.scroll}>
         <ErrorView
-          banner={state.loadError}
-          onRetry={state.loadError.detail === null ? load : undefined}
+          banner={state.loadError ?? { kind: 'preview', detail: null }}
+          onRetry={(state.loadError?.detail ?? null) === null ? load : undefined}
         />
       </ScrollView>
-    );
-  }
-  if (!state.preview) {
-    return (
-      <View style={styles.loading}>
-        <Text style={styles.bodyText}>Nothing to show.</Text>
-      </View>
     );
   }
   return (

--- a/frontend/src/features/Practice/screens/SharePreviewScreen.tsx
+++ b/frontend/src/features/Practice/screens/SharePreviewScreen.tsx
@@ -1,0 +1,427 @@
+/**
+ * `SharePreviewScreen` — opened by deep link
+ * (`adepthood://practices/share/:token`) when the recipient taps a
+ * shared practice URL.
+ *
+ * Behaviour:
+ *
+ * 1. Fetch the preview via `practiceShare.preview`. While loading,
+ *    show a spinner; on error, show a stable copy and a Retry button.
+ * 2. Render the practice name + description + sender display name
+ *    + duration with an Import and a Cancel CTA.
+ * 3. On Import, call `practiceShare.import`; on success, navigate
+ *    back into the Practice tab (the new private draft is the
+ *    deep-linked target of the parent navigator).
+ *
+ * The 410 status (revoked / expired / exhausted) and 400
+ * `cannot_import_own_practice` map to in-screen banners so the user
+ * never sees a raw error.
+ */
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { ApiError } from '@/api';
+import {
+  practiceShare,
+  type ShareLinkImportResponse,
+  type ShareLinkPreviewResponse,
+} from '@/api/practiceShare';
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import type { RootStackParamList } from '@/navigation/RootStack';
+
+export type SharePreviewScreenProps = NativeStackScreenProps<RootStackParamList, 'SharePreview'>;
+
+const LOAD_FAILED_MSG = "We couldn't load the shared practice. Tap retry below.";
+const IMPORT_FAILED_MSG = "We couldn't import the practice. Try again in a moment.";
+
+interface ErrorBanner {
+  kind: 'preview' | 'import';
+  detail: string | null;
+}
+
+function errorCopyFor(banner: ErrorBanner): string {
+  if (banner.detail === 'share_link_revoked') return 'This share link has been revoked.';
+  if (banner.detail === 'share_link_expired') return 'This share link has expired.';
+  if (banner.detail === 'share_link_exhausted') return 'This share link has reached its use limit.';
+  if (banner.detail === 'share_link_not_found') return "We couldn't find that share link.";
+  if (banner.detail === 'cannot_import_own_practice') {
+    return 'You already own this practice — no need to import.';
+  }
+  return banner.kind === 'preview' ? LOAD_FAILED_MSG : IMPORT_FAILED_MSG;
+}
+
+function classifyApiError(err: unknown): string | null {
+  if (err instanceof ApiError) return err.detail;
+  return null;
+}
+
+interface PreviewState {
+  preview: ShareLinkPreviewResponse | null;
+  loadError: ErrorBanner | null;
+  importError: ErrorBanner | null;
+  imported: ShareLinkImportResponse | null;
+  isLoading: boolean;
+  isImporting: boolean;
+}
+
+function initialState(): PreviewState {
+  return {
+    preview: null,
+    loadError: null,
+    importError: null,
+    imported: null,
+    isLoading: true,
+    isImporting: false,
+  };
+}
+
+function useSharePreview(token: string) {
+  const [state, setState] = useState<PreviewState>(initialState);
+
+  const load = useCallback(async () => {
+    setState((prev) => ({ ...prev, isLoading: true, loadError: null }));
+    try {
+      const preview = await practiceShare.preview(token);
+      setState((prev) => ({ ...prev, preview, isLoading: false }));
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        preview: null,
+        isLoading: false,
+        loadError: { kind: 'preview', detail: classifyApiError(err) },
+      }));
+    }
+  }, [token]);
+
+  const importPractice = useCallback(async () => {
+    setState((prev) => ({ ...prev, isImporting: true, importError: null }));
+    try {
+      const imported = await practiceShare.import(token);
+      setState((prev) => ({ ...prev, imported, isImporting: false }));
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        isImporting: false,
+        importError: { kind: 'import', detail: classifyApiError(err) },
+      }));
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { state, load, importPractice };
+}
+
+function PreviewHeader({ preview }: { preview: ShareLinkPreviewResponse }) {
+  return (
+    <View style={styles.headerBlock}>
+      <Text style={styles.heading}>{preview.name}</Text>
+      {preview.created_by_display_name && (
+        <Text style={styles.subHeading} testID="share-preview-sender">
+          Shared by {preview.created_by_display_name}
+        </Text>
+      )}
+      <Text style={styles.duration}>
+        {preview.default_duration_minutes} min • Stage {preview.stage_number}
+      </Text>
+    </View>
+  );
+}
+
+function PreviewBody({ preview }: { preview: ShareLinkPreviewResponse }) {
+  return (
+    <View style={styles.body}>
+      <Text style={styles.bodyLabel}>Description</Text>
+      <Text style={styles.bodyText}>{preview.description}</Text>
+      <Text style={styles.bodyLabel}>Instructions</Text>
+      <Text style={styles.bodyText}>{preview.instructions}</Text>
+    </View>
+  );
+}
+
+interface ImportActionsProps {
+  isImporting: boolean;
+  onImport: () => void;
+  onCancel: () => void;
+}
+
+function ImportActions({ isImporting, onImport, onCancel }: ImportActionsProps) {
+  return (
+    <View style={styles.actions}>
+      <TouchableOpacity
+        accessibilityRole="button"
+        onPress={onCancel}
+        style={[styles.actionButton, styles.cancelButton]}
+        testID="share-preview-cancel"
+      >
+        <Text style={styles.cancelButtonText}>Cancel</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        disabled={isImporting}
+        onPress={onImport}
+        style={[styles.actionButton, styles.importButton, isImporting && styles.disabledButton]}
+        testID="share-preview-import"
+      >
+        {isImporting ? (
+          <ActivityIndicator color={colors.text.light} testID="share-preview-importing" />
+        ) : (
+          <Text style={styles.importButtonText}>Import</Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+interface SuccessProps {
+  imported: ShareLinkImportResponse;
+  onDone: () => void;
+}
+
+function SuccessBanner({ imported, onDone }: SuccessProps) {
+  return (
+    <View style={styles.successBlock} testID="share-preview-success">
+      <Text style={styles.successHeading}>Imported.</Text>
+      <Text style={styles.successText}>
+        {imported.name} is now in your catalog as a private draft.
+      </Text>
+      <TouchableOpacity
+        accessibilityRole="button"
+        onPress={onDone}
+        style={[styles.actionButton, styles.importButton]}
+        testID="share-preview-done"
+      >
+        <Text style={styles.importButtonText}>Open my practice</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function ErrorView({ banner, onRetry }: { banner: ErrorBanner; onRetry?: () => void }) {
+  return (
+    <View style={styles.errorBlock} testID={`share-preview-error-${banner.kind}`}>
+      <Text style={styles.errorText}>{errorCopyFor(banner)}</Text>
+      {onRetry && (
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={onRetry}
+          style={[styles.actionButton, styles.importButton]}
+          testID="share-preview-retry"
+        >
+          <Text style={styles.importButtonText}>Retry</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+interface LoadedViewProps {
+  preview: ShareLinkPreviewResponse;
+  imported: ShareLinkImportResponse | null;
+  importError: ErrorBanner | null;
+  isImporting: boolean;
+  onImport: () => void;
+  onCancel: () => void;
+  onDone: () => void;
+}
+
+function LoadedView(props: LoadedViewProps): React.JSX.Element {
+  const { preview, imported, importError, isImporting, onImport, onCancel, onDone } = props;
+  return (
+    <ScrollView contentContainerStyle={styles.scroll} testID="share-preview-screen">
+      <PreviewHeader preview={preview} />
+      <PreviewBody preview={preview} />
+      {imported ? (
+        <SuccessBanner imported={imported} onDone={onDone} />
+      ) : (
+        <>
+          {importError && <ErrorView banner={importError} />}
+          <ImportActions isImporting={isImporting} onImport={onImport} onCancel={onCancel} />
+        </>
+      )}
+    </ScrollView>
+  );
+}
+
+function useNavCallbacks(
+  navigation: SharePreviewScreenProps['navigation'],
+  imported: ShareLinkImportResponse | null,
+) {
+  const handleCancel = useCallback(() => navigation.goBack(), [navigation]);
+  const handleDone = useCallback(() => {
+    if (imported) {
+      navigation.navigate('Tabs', {
+        screen: 'Practice',
+        params: { stageNumber: imported.stage_number },
+      });
+    } else {
+      navigation.goBack();
+    }
+  }, [navigation, imported]);
+  return { handleCancel, handleDone };
+}
+
+export function SharePreviewScreen({
+  route,
+  navigation,
+}: SharePreviewScreenProps): React.JSX.Element {
+  const { state, load, importPractice } = useSharePreview(route.params.token);
+  const { handleCancel, handleDone } = useNavCallbacks(navigation, state.imported);
+
+  if (state.isLoading) {
+    return (
+      <View style={styles.loading} testID="share-preview-loading">
+        <ActivityIndicator color={colors.primary} size="large" />
+      </View>
+    );
+  }
+  if (state.loadError) {
+    return (
+      <ScrollView contentContainerStyle={styles.scroll}>
+        <ErrorView
+          banner={state.loadError}
+          onRetry={state.loadError.detail === null ? load : undefined}
+        />
+      </ScrollView>
+    );
+  }
+  if (!state.preview) {
+    return (
+      <View style={styles.loading}>
+        <Text style={styles.bodyText}>Nothing to show.</Text>
+      </View>
+    );
+  }
+  return (
+    <LoadedView
+      preview={state.preview}
+      imported={state.imported}
+      importError={state.importError}
+      isImporting={state.isImporting}
+      onImport={() => {
+        void importPractice();
+      }}
+      onCancel={handleCancel}
+      onDone={handleDone}
+    />
+  );
+}
+
+export default SharePreviewScreen;
+
+const styles = StyleSheet.create({
+  scroll: {
+    padding: SPACING.lg,
+    paddingBottom: SPACING.xxl,
+  },
+  loading: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: SPACING.lg,
+  },
+  headerBlock: {
+    marginBottom: SPACING.lg,
+  },
+  heading: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: colors.text.primary,
+    marginBottom: SPACING.xs,
+  },
+  subHeading: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    marginBottom: SPACING.xs,
+  },
+  duration: {
+    fontSize: 13,
+    color: colors.text.tertiaryAccessible,
+  },
+  body: {
+    marginBottom: SPACING.lg,
+  },
+  bodyLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text.secondary,
+    marginTop: SPACING.md,
+    marginBottom: SPACING.xs,
+  },
+  bodyText: {
+    fontSize: 15,
+    color: colors.text.primary,
+    lineHeight: 22,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: SPACING.lg,
+    gap: SPACING.md,
+  },
+  actionButton: {
+    flex: 1,
+    paddingVertical: SPACING.buttonV,
+    borderRadius: BORDER_RADIUS.md,
+    alignItems: 'center',
+  },
+  cancelButton: {
+    backgroundColor: colors.background.accent,
+  },
+  cancelButtonText: {
+    color: colors.text.primary,
+    fontWeight: '600',
+    fontSize: 15,
+  },
+  importButton: {
+    backgroundColor: colors.primary,
+  },
+  importButtonText: {
+    color: colors.text.light,
+    fontWeight: '600',
+    fontSize: 15,
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+  successBlock: {
+    marginTop: SPACING.lg,
+    padding: SPACING.lg,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.background.accent,
+  },
+  successHeading: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.successText,
+    marginBottom: SPACING.sm,
+  },
+  successText: {
+    fontSize: 14,
+    color: colors.text.primary,
+    marginBottom: SPACING.md,
+  },
+  errorBlock: {
+    padding: SPACING.md,
+    marginBottom: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.destructive.background,
+    borderWidth: 1,
+    borderColor: colors.destructive.border,
+  },
+  errorText: {
+    fontSize: 14,
+    color: colors.destructive.text,
+    marginBottom: SPACING.sm,
+  },
+});

--- a/frontend/src/features/Practice/screens/__tests__/SharePreviewScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/SharePreviewScreen.test.tsx
@@ -1,0 +1,165 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import { ApiError } from '@/api';
+import type { ShareLinkImportResponse, ShareLinkPreviewResponse } from '@/api/practiceShare';
+
+const samplePreview: ShareLinkPreviewResponse = {
+  practice_id: 99,
+  stage_number: 3,
+  name: 'Forest grounding',
+  description: 'A 5-minute reset under canopy.',
+  instructions: 'Find a tree, place a palm on the bark, breathe.',
+  default_duration_minutes: 5,
+  mode: 'mindful_anchor',
+  mode_config: {},
+  created_by_display_name: 'alice',
+  expires_at: null,
+  max_uses: null,
+  use_count: 0,
+};
+
+const importedResponse: ShareLinkImportResponse = {
+  practice_id: 250,
+  stage_number: 3,
+  name: 'Forest grounding',
+  approved: false,
+};
+
+const mockPreview = jest.fn() as jest.MockedFunction<
+  (_token: string) => Promise<ShareLinkPreviewResponse>
+>;
+const mockImport = jest.fn() as jest.MockedFunction<
+  (_token: string) => Promise<ShareLinkImportResponse>
+>;
+
+jest.mock('@/api/practiceShare', () => ({
+  practiceShare: {
+    preview: (...args: unknown[]) =>
+      (mockPreview as unknown as (...a: unknown[]) => Promise<ShareLinkPreviewResponse>)(...args),
+    import: (...args: unknown[]) =>
+      (mockImport as unknown as (...a: unknown[]) => Promise<ShareLinkImportResponse>)(...args),
+    list: jest.fn(),
+    create: jest.fn(),
+    revoke: jest.fn(),
+  },
+}));
+
+const { SharePreviewScreen } = require('../SharePreviewScreen');
+
+interface NavMock {
+  goBack: jest.Mock<() => void>;
+  navigate: jest.Mock<(...args: unknown[]) => void>;
+}
+
+function makeNav(): NavMock {
+  return {
+    goBack: jest.fn() as jest.Mock<() => void>,
+    navigate: jest.fn() as jest.Mock<(...args: unknown[]) => void>,
+  };
+}
+
+function renderScreen(token = 'tok-1', navOverride?: NavMock) {
+  const navigation = navOverride ?? makeNav();
+  const route = { key: 'k', name: 'SharePreview' as const, params: { token } };
+  const Screen = SharePreviewScreen as unknown as React.ComponentType<{
+    navigation: NavMock;
+    route: typeof route;
+  }>;
+  const view = render(<Screen navigation={navigation} route={route} />);
+  return { view, navigation };
+}
+
+describe('SharePreviewScreen', () => {
+  beforeEach(() => {
+    mockPreview.mockReset();
+    mockImport.mockReset();
+  });
+
+  it('shows a loading state then renders the practice preview', async () => {
+    mockPreview.mockResolvedValueOnce(samplePreview);
+    const { view } = renderScreen();
+    expect(view.getByTestId('share-preview-loading')).toBeTruthy();
+    const sender = await view.findByTestId('share-preview-sender');
+    expect(sender.props.children.join('')).toContain('alice');
+  });
+
+  it('imports the practice when the user taps Import', async () => {
+    mockPreview.mockResolvedValueOnce(samplePreview);
+    mockImport.mockResolvedValueOnce(importedResponse);
+
+    const { view } = renderScreen('tok-1');
+    const importBtn = await view.findByTestId('share-preview-import');
+    fireEvent.press(importBtn);
+    await waitFor(() => {
+      expect(mockImport).toHaveBeenCalledWith('tok-1');
+    });
+    const success = await view.findByTestId('share-preview-success');
+    expect(success).toBeTruthy();
+  });
+
+  it('navigates to the Practice tab on tapping Open after a successful import', async () => {
+    mockPreview.mockResolvedValueOnce(samplePreview);
+    mockImport.mockResolvedValueOnce(importedResponse);
+
+    const navigation = makeNav();
+    const { view } = renderScreen('tok-1', navigation);
+    fireEvent.press(await view.findByTestId('share-preview-import'));
+    const done = await view.findByTestId('share-preview-done');
+    fireEvent.press(done);
+    expect(navigation.navigate).toHaveBeenCalledWith('Tabs', {
+      screen: 'Practice',
+      params: { stageNumber: 3 },
+    });
+  });
+
+  it('calls goBack on Cancel', async () => {
+    mockPreview.mockResolvedValueOnce(samplePreview);
+    const navigation = makeNav();
+    const { view } = renderScreen('tok-1', navigation);
+    const cancel = await view.findByTestId('share-preview-cancel');
+    fireEvent.press(cancel);
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the revoked detail copy when the API returns 410 share_link_revoked', async () => {
+    mockPreview.mockRejectedValueOnce(new ApiError(410, 'share_link_revoked'));
+    const { view } = renderScreen('tok-1');
+    const banner = await view.findByTestId('share-preview-error-preview');
+    expect(banner.props.children).toBeTruthy();
+  });
+
+  it('renders the expired detail copy when the API returns 410 share_link_expired', async () => {
+    mockPreview.mockRejectedValueOnce(new ApiError(410, 'share_link_expired'));
+    const { view } = renderScreen('tok-1');
+    await view.findByTestId('share-preview-error-preview');
+  });
+
+  it('renders the exhausted detail copy when the API returns 410 share_link_exhausted', async () => {
+    mockPreview.mockRejectedValueOnce(new ApiError(410, 'share_link_exhausted'));
+    const { view } = renderScreen('tok-1');
+    await view.findByTestId('share-preview-error-preview');
+  });
+
+  it('renders the self-import banner when the API returns 400 cannot_import_own_practice', async () => {
+    mockPreview.mockResolvedValueOnce(samplePreview);
+    mockImport.mockRejectedValueOnce(new ApiError(400, 'cannot_import_own_practice'));
+    const { view } = renderScreen('tok-1');
+    fireEvent.press(await view.findByTestId('share-preview-import'));
+    const banner = await view.findByTestId('share-preview-error-import');
+    expect(banner).toBeTruthy();
+  });
+
+  it('shows a generic load error with a retry button on transient failure', async () => {
+    mockPreview.mockRejectedValueOnce(new Error('offline'));
+    mockPreview.mockResolvedValueOnce(samplePreview);
+    const { view } = renderScreen('tok-1');
+    const retry = await view.findByTestId('share-preview-retry');
+    fireEvent.press(retry);
+    await waitFor(() => {
+      expect(mockPreview).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -1,18 +1,29 @@
+import type { NavigatorScreenParams } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 
+import SharePreviewScreen from '../features/Practice/screens/SharePreviewScreen';
 import ApiKeySettingsScreen from '../features/Settings/ApiKeySettingsScreen';
 
+import type { RootTabParamList } from './BottomTabs';
 import BottomTabs from './BottomTabs';
 
 /**
  * Root stack for the authenticated app. Hosts the bottom-tabs shell plus
- * modal-style screens (e.g. BYOK API key settings) that should not live
+ * modal-style screens (e.g. BYOK API key settings, the practice share
+ * preview screen deep-linked from another app) that should not live
  * inside any single tab.
+ *
+ * ``Tabs`` is typed as ``NavigatorScreenParams<RootTabParamList>`` (not
+ * ``undefined``) so screens nested under it -- e.g. ``SharePreviewScreen``
+ * forwarding the recipient back to the Practice tab after a successful
+ * import -- can pass ``{ screen, params }`` through ``navigation.navigate``
+ * with full type safety.
  */
 export type RootStackParamList = {
-  Tabs: undefined;
+  Tabs: NavigatorScreenParams<RootTabParamList>;
   ApiKeySettings: undefined;
+  SharePreview: { token: string };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -24,6 +35,11 @@ const RootStack = (): React.JSX.Element => (
       name="ApiKeySettings"
       component={ApiKeySettingsScreen}
       options={{ title: 'API Key' }}
+    />
+    <Stack.Screen
+      name="SharePreview"
+      component={SharePreviewScreen}
+      options={{ title: 'Shared practice' }}
     />
   </Stack.Navigator>
 );


### PR DESCRIPTION
Implements issue #348: practice owners can mint a share link, send it,
and the recipient previews + imports the practice into their own
catalog as an unapproved draft owned by them. The visibility filter
already restricts approved=False rows to the owner, so imported copies
are automatically private to the recipient.

Backend
- New PracticeShareLink model + alembic migration (f5b6c7d8e9a0)
- POST /practices/{id}/share-link (owner / preset, 10/h rate-limit per user)
- GET /practices/share/{token} (any signed-in user, 30/h per IP)
- POST /practices/share/{token}/import (clones to recipient, 400 on self-import)
- DELETE /practices/share-links/{id} (owner-only revoke, idempotent)
- GET /practices/{id}/share-links (owner-only list for revoke UI)
- 410 Gone with stable detail strings for revoked/expired/exhausted
- Only created_by_display_name (email local part) is exposed -- never user_id

Frontend
- @/api/practiceShare client and types
- ShareSheet bottom-sheet: mint form + active-links list with Revoke
- SharePreviewScreen for the adepthood://practices/share/:token deep link
- Deep-link route wired into App.tsx linking config + RootStack