### PR TITLE
fix(frontend): persist archived Energy Scaffolding CTA across logins

### DIFF
--- a/frontend/src/features/Habits/__tests__/useHabits.test.ts
+++ b/frontend/src/features/Habits/__tests__/useHabits.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { renderHook, act } from '@testing-library/react-native';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
 
 import type { Goal, Habit } from '../Habits.types';
 import { useHabits } from '../hooks/useHabits';
@@ -124,10 +124,11 @@ describe('useHabits', () => {
     expect(typeof result.current.actions.emojiSelect).toBe('function');
   });
 
-  it('exposes UI flags for energy CTA and archive', () => {
+  it('exposes UI flags for energy CTA and archive', async () => {
     const { result } = renderHook(() => useHabits());
 
-    expect(result.current.ui.showEnergyCTA).toBe(true);
+    // showEnergyCTA starts hidden and is revealed after the async storage read.
+    await waitFor(() => expect(result.current.ui.showEnergyCTA).toBe(true));
     expect(result.current.ui.showArchiveMessage).toBe(false);
     expect(typeof result.current.ui.archiveEnergyCTA).toBe('function');
   });

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitUI.test.ts
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitUI.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for `useHabitUI` — focused on the Energy Scaffolding CTA lifecycle.
+ * Regression coverage: an archived CTA must stay archived across logins
+ * (it used to reappear because the flag lived only in component state).
+ */
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+jest.mock('../../../../storage/energyScaffoldingStorage', () => ({
+  loadEnergyScaffoldingArchived: jest.fn(() => Promise.resolve(false)),
+  saveEnergyScaffoldingArchived: jest.fn(() => Promise.resolve(undefined)),
+}));
+
+import {
+  loadEnergyScaffoldingArchived,
+  saveEnergyScaffoldingArchived,
+} from '../../../../storage/energyScaffoldingStorage';
+import { useHabitUI } from '../useHabitUI';
+
+const mockLoad = loadEnergyScaffoldingArchived as jest.MockedFunction<
+  typeof loadEnergyScaffoldingArchived
+>;
+const mockSave = saveEnergyScaffoldingArchived as jest.MockedFunction<
+  typeof saveEnergyScaffoldingArchived
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useHabitUI — energy scaffolding CTA', () => {
+  it('shows the CTA when nothing has been archived', async () => {
+    mockLoad.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => useHabitUI());
+    expect(result.current.showEnergyCTA).toBe(true);
+    await waitFor(() => expect(mockLoad).toHaveBeenCalled());
+    expect(result.current.showEnergyCTA).toBe(true);
+  });
+
+  it('hides the CTA on mount when it was archived in a previous session', async () => {
+    mockLoad.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useHabitUI());
+    await waitFor(() => expect(result.current.showEnergyCTA).toBe(false));
+  });
+
+  it('persists the archived flag when the CTA is archived', async () => {
+    const { result } = renderHook(() => useHabitUI());
+    await waitFor(() => expect(mockLoad).toHaveBeenCalled());
+
+    act(() => {
+      result.current.archiveEnergyCTA();
+    });
+
+    expect(result.current.showEnergyCTA).toBe(false);
+    expect(result.current.showArchiveMessage).toBe(true);
+    expect(mockSave).toHaveBeenCalledWith(true);
+  });
+
+  it('dismisses the archive message after the toast delay', async () => {
+    const { result } = renderHook(() => useHabitUI());
+    await waitFor(() => expect(mockLoad).toHaveBeenCalled());
+
+    act(() => {
+      result.current.archiveEnergyCTA();
+    });
+    expect(result.current.showArchiveMessage).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(result.current.showArchiveMessage).toBe(false);
+  });
+});

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitUI.test.ts
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitUI.test.ts
@@ -34,18 +34,20 @@ afterEach(() => {
 });
 
 describe('useHabitUI — energy scaffolding CTA', () => {
-  it('shows the CTA when nothing has been archived', async () => {
+  it('starts hidden and reveals the CTA once the load confirms it is not archived', async () => {
     mockLoad.mockResolvedValueOnce(false);
     const { result } = renderHook(() => useHabitUI());
-    expect(result.current.showEnergyCTA).toBe(true);
-    await waitFor(() => expect(mockLoad).toHaveBeenCalled());
-    expect(result.current.showEnergyCTA).toBe(true);
+    // Hidden before the async read resolves — no flash for archived users.
+    expect(result.current.showEnergyCTA).toBe(false);
+    await waitFor(() => expect(result.current.showEnergyCTA).toBe(true));
   });
 
-  it('hides the CTA on mount when it was archived in a previous session', async () => {
+  it('keeps the CTA hidden when it was archived in a previous session', async () => {
     mockLoad.mockResolvedValueOnce(true);
     const { result } = renderHook(() => useHabitUI());
-    await waitFor(() => expect(result.current.showEnergyCTA).toBe(false));
+    expect(result.current.showEnergyCTA).toBe(false);
+    await waitFor(() => expect(mockLoad).toHaveBeenCalled());
+    expect(result.current.showEnergyCTA).toBe(false);
   });
 
   it('persists the archived flag when the CTA is archived', async () => {

--- a/frontend/src/features/Habits/hooks/useHabitUI.ts
+++ b/frontend/src/features/Habits/hooks/useHabitUI.ts
@@ -37,16 +37,16 @@ export const useHabitUI = (): HabitUIState => {
   const selectedHabit = useHabitStore(selectHabitById(selectedHabitId)) ?? null;
   const [mode, setMode] = useState<HabitScreenMode>('normal');
   const [emojiHabitIndex, setEmojiHabitIndex] = useState<number | null>(null);
-  const [showEnergyCTA, setShowEnergyCTA] = useState(true);
+  // Start hidden so a previously-archived CTA never flashes before the async
+  // storage read resolves; the effect reveals it only when it isn't archived.
+  const [showEnergyCTA, setShowEnergyCTA] = useState(false);
   const [showArchiveMessage, setShowArchiveMessage] = useState(false);
 
-  // Rehydrate the archived state from device storage: a CTA the user archived
-  // in a previous session must stay archived across logins, not reappear.
   useEffect(() => {
     let cancelled = false;
     loadEnergyScaffoldingArchived()
       .then((archived) => {
-        if (!cancelled && archived) setShowEnergyCTA(false);
+        if (!cancelled) setShowEnergyCTA(!archived);
       })
       .catch((err: unknown) => {
         console.warn('[useHabitUI] failed to load energy-CTA archived state', err);

--- a/frontend/src/features/Habits/hooks/useHabitUI.ts
+++ b/frontend/src/features/Habits/hooks/useHabitUI.ts
@@ -1,5 +1,9 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+import {
+  loadEnergyScaffoldingArchived,
+  saveEnergyScaffoldingArchived,
+} from '../../../storage/energyScaffoldingStorage';
 import { selectHabitById, useHabitStore } from '../../../store/useHabitStore';
 import type { Habit, HabitScreenMode } from '../Habits.types';
 
@@ -36,6 +40,22 @@ export const useHabitUI = (): HabitUIState => {
   const [showEnergyCTA, setShowEnergyCTA] = useState(true);
   const [showArchiveMessage, setShowArchiveMessage] = useState(false);
 
+  // Rehydrate the archived state from device storage: a CTA the user archived
+  // in a previous session must stay archived across logins, not reappear.
+  useEffect(() => {
+    let cancelled = false;
+    loadEnergyScaffoldingArchived()
+      .then((archived) => {
+        if (!cancelled && archived) setShowEnergyCTA(false);
+      })
+      .catch((err: unknown) => {
+        console.warn('[useHabitUI] failed to load energy-CTA archived state', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const setSelectedHabit = useCallback((habit: Habit | null) => {
     setSelectedHabitId(habit?.id ?? null);
   }, []);
@@ -44,6 +64,9 @@ export const useHabitUI = (): HabitUIState => {
     setShowEnergyCTA(false);
     setShowArchiveMessage(true);
     setTimeout(() => setShowArchiveMessage(false), ARCHIVE_MESSAGE_DURATION_MS);
+    saveEnergyScaffoldingArchived(true).catch((err: unknown) => {
+      console.warn('[useHabitUI] failed to persist energy-CTA archived state', err);
+    });
   }, []);
 
   return {

--- a/frontend/src/storage/__tests__/energyScaffoldingStorage.test.ts
+++ b/frontend/src/storage/__tests__/energyScaffoldingStorage.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  loadEnergyScaffoldingArchived,
+  saveEnergyScaffoldingArchived,
+} from '../energyScaffoldingStorage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('energyScaffoldingStorage', () => {
+  const KEY = '@adepthood/energy_scaffolding_archived';
+
+  describe('saveEnergyScaffoldingArchived', () => {
+    test('persists the archived flag as JSON', async () => {
+      await saveEnergyScaffoldingArchived(true);
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(KEY, 'true');
+    });
+  });
+
+  describe('loadEnergyScaffoldingArchived', () => {
+    test('returns false when nothing is stored', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+      await expect(loadEnergyScaffoldingArchived()).resolves.toBe(false);
+    });
+
+    test('returns the stored boolean', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('true');
+      await expect(loadEnergyScaffoldingArchived()).resolves.toBe(true);
+    });
+
+    test('clears the key and returns false for a non-boolean value', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('"yes"');
+      await expect(loadEnergyScaffoldingArchived()).resolves.toBe(false);
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(KEY);
+    });
+
+    test('clears the key and returns false for malformed JSON', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('{not json');
+      await expect(loadEnergyScaffoldingArchived()).resolves.toBe(false);
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(KEY);
+    });
+
+    test('returns false when AsyncStorage throws', async () => {
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('boom'));
+      await expect(loadEnergyScaffoldingArchived()).resolves.toBe(false);
+    });
+  });
+});

--- a/frontend/src/storage/__tests__/energyScaffoldingStorage.test.ts
+++ b/frontend/src/storage/__tests__/energyScaffoldingStorage.test.ts
@@ -26,6 +26,11 @@ describe('energyScaffoldingStorage', () => {
       await saveEnergyScaffoldingArchived(true);
       expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(KEY, 'true');
     });
+
+    test('persists a cleared flag as JSON', async () => {
+      await saveEnergyScaffoldingArchived(false);
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(KEY, 'false');
+    });
   });
 
   describe('loadEnergyScaffoldingArchived', () => {
@@ -51,9 +56,10 @@ describe('energyScaffoldingStorage', () => {
       expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(KEY);
     });
 
-    test('returns false when AsyncStorage throws', async () => {
+    test('returns false without deleting data when AsyncStorage throws', async () => {
       mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('boom'));
       await expect(loadEnergyScaffoldingArchived()).resolves.toBe(false);
+      expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/storage/energyScaffoldingStorage.ts
+++ b/frontend/src/storage/energyScaffoldingStorage.ts
@@ -1,0 +1,42 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ARCHIVED_KEY = '@adepthood/energy_scaffolding_archived';
+
+/**
+ * BUG-FRONTEND-INFRA-011 — when AsyncStorage hands back malformed JSON we
+ * clear the poisoned key so the next launch self-heals rather than parsing
+ * the same garbage forever.
+ */
+async function resetCorruptKey(key: string, err: unknown): Promise<void> {
+  console.warn(`[storage] corrupt JSON in ${key}, clearing to self-heal`, err);
+  try {
+    await AsyncStorage.removeItem(key);
+  } catch (removeErr) {
+    console.warn(`[storage] failed to clear corrupt key ${key}`, removeErr);
+  }
+}
+
+/**
+ * Persist whether the user has archived the Energy Scaffolding CTA. Stored
+ * at device scope (not wiped on logout) so the dismissal survives the next
+ * login — re-showing an archived CTA on every login is the bug this fixes.
+ */
+export async function saveEnergyScaffoldingArchived(archived: boolean): Promise<void> {
+  await AsyncStorage.setItem(ARCHIVED_KEY, JSON.stringify(archived));
+}
+
+export async function loadEnergyScaffoldingArchived(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(ARCHIVED_KEY);
+    if (raw === null) return false;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== 'boolean') {
+      await resetCorruptKey(ARCHIVED_KEY, new Error('expected boolean'));
+      return false;
+    }
+    return parsed;
+  } catch (err: unknown) {
+    await resetCorruptKey(ARCHIVED_KEY, err);
+    return false;
+  }
+}

--- a/frontend/src/storage/energyScaffoldingStorage.ts
+++ b/frontend/src/storage/energyScaffoldingStorage.ts
@@ -2,11 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const ARCHIVED_KEY = '@adepthood/energy_scaffolding_archived';
 
-/**
- * BUG-FRONTEND-INFRA-011 — when AsyncStorage hands back malformed JSON we
- * clear the poisoned key so the next launch self-heals rather than parsing
- * the same garbage forever.
- */
+// Clears poisoned storage on bad JSON so the next launch self-heals.
 async function resetCorruptKey(key: string, err: unknown): Promise<void> {
   console.warn(`[storage] corrupt JSON in ${key}, clearing to self-heal`, err);
   try {
@@ -16,19 +12,20 @@ async function resetCorruptKey(key: string, err: unknown): Promise<void> {
   }
 }
 
-/**
- * Persist whether the user has archived the Energy Scaffolding CTA. Stored
- * at device scope (not wiped on logout) so the dismissal survives the next
- * login — re-showing an archived CTA on every login is the bug this fixes.
- */
+// Device-scoped (not wiped on logout) so the dismissal survives the next login.
 export async function saveEnergyScaffoldingArchived(archived: boolean): Promise<void> {
   await AsyncStorage.setItem(ARCHIVED_KEY, JSON.stringify(archived));
 }
 
 export async function loadEnergyScaffoldingArchived(): Promise<boolean> {
+  let raw: string | null;
   try {
-    const raw = await AsyncStorage.getItem(ARCHIVED_KEY);
-    if (raw === null) return false;
+    raw = await AsyncStorage.getItem(ARCHIVED_KEY);
+  } catch {
+    return false; // transient IO error — don't touch stored data
+  }
+  if (raw === null) return false;
+  try {
     const parsed = JSON.parse(raw) as unknown;
     if (typeof parsed !== 'boolean') {
       await resetCorruptKey(ARCHIVED_KEY, new Error('expected boolean'));


### PR DESCRIPTION
The Energy Scaffolding CTA's archived state lived only in component
state (showEnergyCTA), so it reset to visible on every login. Persist
the flag to device-scoped AsyncStorage and rehydrate it on mount so an
archived CTA stays archived.

https://claude.ai/code/session_01CbDtK2hUT8qH8zzs5kReaU