### PR TITLE
feat(practice): build TalliedGroundingView for Find Shapes / Find Colors (#341)

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1653,6 +1653,13 @@ export interface TarotSessionMetadata {
   card_index: number;
 }
 
+export interface TalliedGroundingSessionMetadata {
+  mode: 'tallied_grounding';
+  rounds_completed: number;
+  total_rounds: number;
+  items_completed: number;
+}
+
 export type SessionMetadata =
   | MeditationTimerSessionMetadata
   | CountUpSessionMetadata
@@ -1660,6 +1667,7 @@ export type SessionMetadata =
   | IntervalBellSessionMetadata
   | RepCounterSessionMetadata
   | SenseGroundingSessionMetadata
+  | TalliedGroundingSessionMetadata
   | TarotSessionMetadata;
 
 export interface PracticeSessionCreate {

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -3,7 +3,6 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 
 import type { FrequencyResponse, PracticeItem, UserPractice } from '../../../api';
-import type { ModeConfig } from '../engine/types';
 
 const samplePractice = (overrides: Partial<PracticeItem> = {}): PracticeItem => ({
   id: 1,
@@ -194,7 +193,7 @@ const modeFixtures: ModeFixture[] = [
           { sense: 'smell', label: 'two scents' },
           { sense: 'taste', label: 'one taste' },
         ],
-      } as ModeConfig,
+      },
     }),
     mountTestId: 'sense-grounding-view',
   },
@@ -211,7 +210,7 @@ const modeFixtures: ModeFixture[] = [
           { key: 'triangles', label: 'a triangle', target_count: 3 },
           { key: 'circles', label: 'a circle', target_count: 3 },
         ],
-      } as ModeConfig,
+      },
     }),
     mountTestId: 'tallied-grounding-view',
   },

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -199,6 +199,23 @@ const modeFixtures: ModeFixture[] = [
     mountTestId: 'sense-grounding-view',
   },
   {
+    label: 'tallied_grounding',
+    practice: samplePractice({
+      id: 18,
+      mode: 'tallied_grounding',
+      mode_config: {
+        mode: 'tallied_grounding',
+        rounds: 3,
+        categories: [
+          { key: 'squares', label: 'a square', target_count: 3 },
+          { key: 'triangles', label: 'a triangle', target_count: 3 },
+          { key: 'circles', label: 'a circle', target_count: 3 },
+        ],
+      } as ModeConfig,
+    }),
+    mountTestId: 'tallied-grounding-view',
+  },
+  {
     label: 'tarot',
     practice: samplePractice({
       id: 17,

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -510,7 +510,7 @@ function harvestMetadata(config: ModeConfig, state: RitualState): SessionMetadat
 function harvestTalliedGrounding(
   config: TalliedGroundingConfig,
   state: RitualState,
-): SessionMetadata {
+): Extract<SessionMetadata, { mode: 'tallied_grounding' }> {
   const perRound = totalStepsPerRound(config);
   const itemsCompleted = Math.min(state.currentStepIndex, totalSteps(config));
   return {
@@ -579,18 +579,9 @@ function harvestSummaryMetadata(
       >;
       return { mode: 'sense_grounding', senses_completed: wire.senses_completed };
     }
-    case 'tallied_grounding': {
-      const wire = harvestTalliedGrounding(config, state) as Extract<
-        SessionMetadata,
-        { mode: 'tallied_grounding' }
-      >;
-      return {
-        mode: 'tallied_grounding',
-        rounds_completed: wire.rounds_completed,
-        total_rounds: wire.total_rounds,
-        items_completed: wire.items_completed,
-      };
-    }
+    case 'tallied_grounding':
+      // Wire and summary shapes are identical — no presentation-only extras.
+      return harvestTalliedGrounding(config, state);
     case 'tarot': {
       const idx = normalizeTarotIndex(tarotCardIndex);
       return { mode: 'tarot', card_index: idx, card_name: cardForDayIndex(idx).name };

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -40,6 +40,7 @@ import { InsightCaptureModal } from '@/features/Practice/components/InsightCaptu
 import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConfiguratorSheet';
 import { cardForDayIndex } from '@/features/Practice/data/tarot';
 import { scheduledCues } from '@/features/Practice/engine/cues';
+import { totalSteps, totalStepsPerRound } from '@/features/Practice/engine/tallied';
 import type {
   IntervalBellConfig,
   ModeConfig,
@@ -47,6 +48,7 @@ import type {
   RitualControls,
   RitualState,
   SenseGroundingConfig,
+  TalliedGroundingConfig,
 } from '@/features/Practice/engine/types';
 import { useRitualEngine } from '@/features/Practice/engine/useRitualEngine';
 import type { ModeSummaryKind, ModeSummaryMetadata } from '@/features/Practice/insights/format';
@@ -56,6 +58,7 @@ import MeditationTimerView from '@/features/Practice/views/MeditationTimerView';
 import MetronomeView from '@/features/Practice/views/MetronomeView';
 import RepCounterView from '@/features/Practice/views/RepCounterView';
 import SenseGroundingView from '@/features/Practice/views/SenseGroundingView';
+import TalliedGroundingView from '@/features/Practice/views/TalliedGroundingView';
 import TarotMeditationView from '@/features/Practice/views/TarotMeditationView';
 import { useOptimisticMutation } from '@/hooks/useOptimisticMutation';
 
@@ -398,6 +401,8 @@ function ModeView({ config, state, controls, tarotCardIndex }: ModeViewProps): R
       return <RepCounterView config={config} state={state} controls={controls} />;
     case 'sense_grounding':
       return <SenseGroundingView config={config} state={state} controls={controls} />;
+    case 'tallied_grounding':
+      return <TalliedGroundingView config={config} state={state} controls={controls} />;
     case 'tarot':
       return (
         <TarotMeditationView
@@ -486,12 +491,34 @@ function harvestMetadata(config: ModeConfig, state: RitualState): SessionMetadat
       return { mode: 'rep_counter', rep_count: state.repCount };
     case 'sense_grounding':
       return harvestSenseGrounding(config, state);
+    case 'tallied_grounding':
+      return harvestTalliedGrounding(config, state);
     case 'tarot':
       return {
         mode: 'tarot',
         card_index: normalizeTarotIndex(state.currentStepIndex),
       };
   }
+}
+
+/**
+ * Tallied-grounding wire metadata. `items_completed` is the linear tap
+ * count clamped to the ritual total; `rounds_completed` is how many full
+ * rounds those taps covered. The summary metadata reuses this shape
+ * verbatim — there are no presentation-only extras.
+ */
+function harvestTalliedGrounding(
+  config: TalliedGroundingConfig,
+  state: RitualState,
+): SessionMetadata {
+  const perRound = totalStepsPerRound(config);
+  const itemsCompleted = Math.min(state.currentStepIndex, totalSteps(config));
+  return {
+    mode: 'tallied_grounding',
+    rounds_completed: perRound > 0 ? Math.floor(itemsCompleted / perRound) : 0,
+    total_rounds: config.rounds,
+    items_completed: itemsCompleted,
+  };
 }
 
 function harvestIntervalBell(config: IntervalBellConfig, state: RitualState): SessionMetadata {
@@ -551,6 +578,18 @@ function harvestSummaryMetadata(
         { mode: 'sense_grounding' }
       >;
       return { mode: 'sense_grounding', senses_completed: wire.senses_completed };
+    }
+    case 'tallied_grounding': {
+      const wire = harvestTalliedGrounding(config, state) as Extract<
+        SessionMetadata,
+        { mode: 'tallied_grounding' }
+      >;
+      return {
+        mode: 'tallied_grounding',
+        rounds_completed: wire.rounds_completed,
+        total_rounds: wire.total_rounds,
+        items_completed: wire.items_completed,
+      };
     }
     case 'tarot': {
       const idx = normalizeTarotIndex(tarotCardIndex);

--- a/frontend/src/features/Practice/engine/__tests__/reducer.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/reducer.test.ts
@@ -11,6 +11,7 @@ import type {
   ModeConfig,
   RepCounterConfig,
   SenseGroundingConfig,
+  TalliedGroundingConfig,
   TarotConfig,
 } from '../types';
 
@@ -207,6 +208,42 @@ describe('ritualReducer — sense_grounding', () => {
   });
 });
 
+describe('ritualReducer — tallied_grounding', () => {
+  const config: TalliedGroundingConfig = {
+    mode: 'tallied_grounding',
+    rounds: 2,
+    categories: [
+      { key: 'squares', label: 'a square', target_count: 2 },
+      { key: 'circles', label: 'a circle', target_count: 1 },
+    ],
+  };
+  // totalStepsPerRound = 3, totalSteps = 6.
+
+  it('TAP advances currentStepIndex and tracks fractional progress', () => {
+    const s = drive(config, [{ type: 'START', now: 0 }, { type: 'TAP' }, { type: 'TAP' }]);
+    expect(s.currentStepIndex).toBe(2);
+    expect(s.progress).toBeCloseTo(2 / 6);
+    expect(s.status).toBe('running');
+  });
+
+  it('auto-completes once every round is tallied', () => {
+    const taps = Array.from({ length: 6 }, (): EngineAction => ({ type: 'TAP' }));
+    const s = drive(config, [{ type: 'START', now: 0 }, ...taps]);
+    expect(s.currentStepIndex).toBe(6);
+    expect(s.progress).toBe(1);
+    expect(s.status).toBe('complete');
+  });
+
+  it('ADVANCE_STEP behaves like TAP', () => {
+    const s = drive(config, [
+      { type: 'START', now: 0 },
+      { type: 'ADVANCE_STEP' },
+      { type: 'ADVANCE_STEP' },
+    ]);
+    expect(s.currentStepIndex).toBe(2);
+  });
+});
+
 describe('ritualReducer — tarot', () => {
   const config: TarotConfig = { mode: 'tarot', deck: 'major_arcana', per_card_minutes: 5 };
 
@@ -254,6 +291,14 @@ const allConfigs: readonly [string, ModeConfig][] = [
   ],
   ['rep_counter', { mode: 'rep_counter', target_reps: 5, unit_label: 'reps' }],
   ['sense_grounding', { mode: 'sense_grounding', prompts: [{ sense: 'sight', label: 'a tree' }] }],
+  [
+    'tallied_grounding',
+    {
+      mode: 'tallied_grounding',
+      rounds: 2,
+      categories: [{ key: 'squares', label: 'a square', target_count: 3 }],
+    },
+  ],
   ['tarot', { mode: 'tarot', deck: 'major_arcana', per_card_minutes: 5 }],
 ];
 

--- a/frontend/src/features/Practice/engine/__tests__/tallied.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/tallied.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { decompose, totalSteps, totalStepsPerRound } from '../tallied';
+import type { TalliedGroundingConfig } from '../types';
+
+const config: TalliedGroundingConfig = {
+  mode: 'tallied_grounding',
+  rounds: 3,
+  categories: [
+    { key: 'squares', label: 'a square', target_count: 3 },
+    { key: 'triangles', label: 'a triangle', target_count: 3 },
+    { key: 'circles', label: 'a circle', target_count: 3 },
+  ],
+};
+
+describe('tallied helpers', () => {
+  it('sums target counts for a single round', () => {
+    expect(totalStepsPerRound(config)).toBe(9);
+  });
+
+  it('multiplies the per-round total by the round count', () => {
+    expect(totalSteps(config)).toBe(27);
+  });
+
+  it('decomposes the first step into round 1, first category, first item', () => {
+    expect(decompose(0, config)).toMatchObject({
+      roundIndex: 0,
+      categoryIndex: 0,
+      itemInCategory: 0,
+    });
+    expect(decompose(0, config).category.key).toBe('squares');
+  });
+
+  it('decomposes a mid-round step into the right category and item', () => {
+    expect(decompose(4, config)).toMatchObject({
+      roundIndex: 0,
+      categoryIndex: 1,
+      itemInCategory: 1,
+    });
+  });
+
+  it('rolls into the next round at the round boundary', () => {
+    expect(decompose(9, config)).toMatchObject({
+      roundIndex: 1,
+      categoryIndex: 0,
+      itemInCategory: 0,
+    });
+  });
+
+  it('clamps an overrun step index to the final item', () => {
+    expect(decompose(27, config)).toMatchObject({
+      roundIndex: 2,
+      categoryIndex: 2,
+      itemInCategory: 2,
+    });
+  });
+
+  it('clamps a negative step index to the first item', () => {
+    expect(decompose(-5, config)).toMatchObject({
+      roundIndex: 0,
+      categoryIndex: 0,
+      itemInCategory: 0,
+    });
+  });
+
+  it('throws when the config has no categories', () => {
+    const empty: TalliedGroundingConfig = { mode: 'tallied_grounding', rounds: 1, categories: [] };
+    expect(() => decompose(0, empty)).toThrow(/no categories/);
+  });
+});

--- a/frontend/src/features/Practice/engine/__tests__/validation.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/validation.test.ts
@@ -6,6 +6,7 @@ import type {
   MetronomeConfig,
   RepCounterConfig,
   SenseGroundingConfig,
+  TalliedGroundingConfig,
   TarotConfig,
 } from '../types';
 import {
@@ -15,6 +16,9 @@ import {
   DURATION_MAX_MINUTES,
   DURATION_MIN_MINUTES,
   PROMPT_LABEL_MAX,
+  TALLIED_CATEGORIES_MAX,
+  TALLIED_LABEL_MAX,
+  TALLIED_TARGET_MAX,
   UNIT_LABEL_MAX,
   validateCountUp,
   validateCustomName,
@@ -24,6 +28,7 @@ import {
   validateModeConfig,
   validateRepCounter,
   validateSenseGrounding,
+  validateTalliedGrounding,
   validateTarot,
 } from '../validation';
 
@@ -248,6 +253,94 @@ describe('validateSenseGrounding', () => {
         ],
       })[0],
     ).toMatch(/unknown sense/);
+  });
+});
+
+describe('validateTalliedGrounding', () => {
+  const base: TalliedGroundingConfig = {
+    mode: 'tallied_grounding',
+    rounds: 3,
+    categories: [
+      { key: 'squares', label: 'a square', target_count: 3 },
+      { key: 'circles', label: 'a circle', target_count: 3 },
+    ],
+  };
+
+  it('accepts a valid config', () => {
+    expect(validateTalliedGrounding(base)).toEqual([]);
+  });
+
+  it('rejects a round count below 1', () => {
+    expect(validateTalliedGrounding({ ...base, rounds: 0 })[0]).toMatch(/Rounds must be/);
+  });
+
+  it('rejects a non-integer round count', () => {
+    expect(validateTalliedGrounding({ ...base, rounds: 2.5 })[0]).toMatch(/Rounds must be/);
+  });
+
+  it('rejects an empty category list', () => {
+    expect(validateTalliedGrounding({ ...base, categories: [] })[0]).toMatch(/At least one/);
+  });
+
+  it('rejects too many categories', () => {
+    const categories = Array.from({ length: TALLIED_CATEGORIES_MAX + 1 }, (_, i) => ({
+      key: `cat_${i}`,
+      label: `item ${i}`,
+      target_count: 1,
+    }));
+    expect(validateTalliedGrounding({ ...base, categories })[0]).toMatch(/At most/);
+  });
+
+  it('rejects keys that break the slug pattern', () => {
+    expect(
+      validateTalliedGrounding({
+        ...base,
+        categories: [{ key: 'Bad-Key', label: 'a square', target_count: 3 }],
+      })[0],
+    ).toMatch(/key must match/);
+  });
+
+  it('rejects blank labels', () => {
+    expect(
+      validateTalliedGrounding({
+        ...base,
+        categories: [{ key: 'squares', label: '  ', target_count: 3 }],
+      })[0],
+    ).toMatch(/label cannot be empty/);
+  });
+
+  it('rejects oversize labels', () => {
+    expect(
+      validateTalliedGrounding({
+        ...base,
+        categories: [{ key: 'squares', label: 'x'.repeat(TALLIED_LABEL_MAX + 1), target_count: 3 }],
+      })[0],
+    ).toMatch(new RegExp(`≤ ${TALLIED_LABEL_MAX}`));
+  });
+
+  it('rejects a target count outside range', () => {
+    expect(
+      validateTalliedGrounding({
+        ...base,
+        categories: [{ key: 'squares', label: 'a square', target_count: TALLIED_TARGET_MAX + 1 }],
+      })[0],
+    ).toMatch(/target count must be/);
+  });
+
+  it('rejects duplicate category keys', () => {
+    expect(
+      validateTalliedGrounding({
+        ...base,
+        categories: [
+          { key: 'squares', label: 'a square', target_count: 3 },
+          { key: 'squares', label: 'a circle', target_count: 3 },
+        ],
+      }).some((e) => /duplicate key/.test(e)),
+    ).toBe(true);
+  });
+
+  it('dispatches through validateModeConfig', () => {
+    expect(validateModeConfig(base)).toEqual([]);
   });
 });
 

--- a/frontend/src/features/Practice/engine/cues.ts
+++ b/frontend/src/features/Practice/engine/cues.ts
@@ -18,6 +18,7 @@ export function scheduledCues(config: ModeConfig): readonly Cue[] {
     case 'count_up':
     case 'rep_counter':
     case 'sense_grounding':
+    case 'tallied_grounding':
       return [];
     case 'metronome':
       return cuesForMetronome(config);

--- a/frontend/src/features/Practice/engine/reducer.ts
+++ b/frontend/src/features/Practice/engine/reducer.ts
@@ -1,10 +1,13 @@
 import { scheduledCues } from './cues';
+import { totalSteps } from './tallied';
 import type {
   EngineAction,
   EngineState,
   ModeConfig,
   RepCounterConfig,
   SenseGroundingConfig,
+  TalliedGroundingConfig,
+  TarotConfig,
 } from './types';
 import { DEFAULT_TAROT_MINUTES, MS_PER_MINUTE, TAROT_DECK_SIZE } from './types';
 
@@ -138,12 +141,14 @@ function handleTap(state: EngineState, config: ModeConfig): EngineState {
   if (state.status !== 'running') return state;
   if (config.mode === 'rep_counter') return tapRep(state, config);
   if (config.mode === 'sense_grounding') return advanceSense(state, config);
+  if (config.mode === 'tallied_grounding') return advanceTallied(state, config);
   return state;
 }
 
 function handleAdvanceStep(state: EngineState, config: ModeConfig): EngineState {
   if (state.status !== 'running') return state;
   if (config.mode === 'sense_grounding') return advanceSense(state, config);
+  if (config.mode === 'tallied_grounding') return advanceTallied(state, config);
   if (config.mode === 'tarot') {
     return { ...state, currentStepIndex: (state.currentStepIndex + 1) % TAROT_DECK_SIZE };
   }
@@ -172,10 +177,22 @@ function advanceSense(state: EngineState, config: SenseGroundingConfig): EngineS
   };
 }
 
+function advanceTallied(state: EngineState, config: TalliedGroundingConfig): EngineState {
+  const idx = state.currentStepIndex + 1;
+  const total = totalSteps(config);
+  return {
+    ...state,
+    currentStepIndex: idx,
+    progress: total > 0 ? Math.min(1, idx / total) : 0,
+    status: idx >= total ? 'complete' : state.status,
+  };
+}
+
 export function getTotalMs(config: ModeConfig): number | null {
   switch (config.mode) {
     case 'count_up':
     case 'sense_grounding':
+    case 'tallied_grounding':
       return null;
     case 'meditation_timer':
     case 'interval_bell':
@@ -183,21 +200,41 @@ export function getTotalMs(config: ModeConfig): number | null {
     case 'metronome':
       return config.timer.duration_minutes * MS_PER_MINUTE;
     case 'tarot':
-      return (config.per_card_minutes ?? DEFAULT_TAROT_MINUTES) * MS_PER_MINUTE;
+      return tarotTotalMs(config);
     case 'rep_counter':
-      return config.time_cap_minutes != null ? config.time_cap_minutes * MS_PER_MINUTE : null;
+      return repCounterTotalMs(config);
   }
 }
 
+function tarotTotalMs(config: TarotConfig): number {
+  return (config.per_card_minutes ?? DEFAULT_TAROT_MINUTES) * MS_PER_MINUTE;
+}
+
+function repCounterTotalMs(config: RepCounterConfig): number | null {
+  return config.time_cap_minutes != null ? config.time_cap_minutes * MS_PER_MINUTE : null;
+}
+
+/** Fraction in [0, 1] of a step- or rep-counted ritual; 0 when unbounded. */
+function stepProgress(completed: number, total: number): number {
+  return total > 0 ? Math.min(1, completed / total) : 0;
+}
+
+/** Fraction in [0, 1] of a time-bounded ritual; 0 when the total is open. */
+function timeProgress(elapsedMs: number, totalMs: number | null): number {
+  return totalMs !== null && totalMs > 0 ? Math.min(1, elapsedMs / totalMs) : 0;
+}
+
 function getProgress(state: EngineState, config: ModeConfig, elapsedMs: number): number {
-  if (config.mode === 'count_up') return 0;
-  if (config.mode === 'rep_counter') {
-    return config.target_reps > 0 ? Math.min(1, state.repCount / config.target_reps) : 0;
+  switch (config.mode) {
+    case 'count_up':
+      return 0;
+    case 'rep_counter':
+      return stepProgress(state.repCount, config.target_reps);
+    case 'sense_grounding':
+      return stepProgress(state.currentStepIndex, config.prompts.length);
+    case 'tallied_grounding':
+      return stepProgress(state.currentStepIndex, totalSteps(config));
+    default:
+      return timeProgress(elapsedMs, getTotalMs(config));
   }
-  if (config.mode === 'sense_grounding') {
-    const total = config.prompts.length;
-    return total > 0 ? Math.min(1, state.currentStepIndex / total) : 0;
-  }
-  const total = getTotalMs(config);
-  return total !== null && total > 0 ? Math.min(1, elapsedMs / total) : 0;
 }

--- a/frontend/src/features/Practice/engine/tallied.ts
+++ b/frontend/src/features/Practice/engine/tallied.ts
@@ -1,0 +1,53 @@
+// Pure decomposition helpers for the `tallied_grounding` mode. The engine
+// keeps a single linear `currentStepIndex`; both the reducer (completion
+// detection, progress) and `TalliedGroundingView` (header copy) derive the
+// `(round, category, item)` position from it through this module so the
+// arithmetic lives in exactly one place.
+
+import type { TalliedCategory, TalliedGroundingConfig } from './types';
+
+/** Steps in a single round: the sum of every category's target count. */
+export function totalStepsPerRound(config: TalliedGroundingConfig): number {
+  return config.categories.reduce((sum, category) => sum + category.target_count, 0);
+}
+
+/** Total taps to finish the ritual: `rounds × totalStepsPerRound`. */
+export function totalSteps(config: TalliedGroundingConfig): number {
+  return config.rounds * totalStepsPerRound(config);
+}
+
+/**
+ * Position of a linear step within the ritual. All indices are 0-based;
+ * the view adds 1 for display.
+ */
+export interface TalliedPosition {
+  roundIndex: number;
+  category: TalliedCategory;
+  categoryIndex: number;
+  itemInCategory: number;
+}
+
+/**
+ * Map a linear `stepIndex` to its `(round, category, item)` position.
+ *
+ * `stepIndex` is clamped into `[0, totalSteps)` so the final
+ * complete-state index (`stepIndex === totalSteps`) resolves to the last
+ * item rather than overflowing. Throws when `config.categories` is empty
+ * — the backend's `min_length=1` constraint makes that an invalid config,
+ * not a state the engine can reach.
+ */
+export function decompose(stepIndex: number, config: TalliedGroundingConfig): TalliedPosition {
+  const perRound = totalStepsPerRound(config);
+  const clamped = Math.max(0, Math.min(stepIndex, totalSteps(config) - 1));
+  const roundIndex = Math.floor(clamped / perRound);
+  let cursor = clamped % perRound;
+  let categoryIndex = 0;
+  for (const category of config.categories) {
+    if (cursor < category.target_count) {
+      return { roundIndex, category, categoryIndex, itemInCategory: cursor };
+    }
+    cursor -= category.target_count;
+    categoryIndex += 1;
+  }
+  throw new Error('decompose: tallied-grounding config has no categories');
+}

--- a/frontend/src/features/Practice/engine/types.ts
+++ b/frontend/src/features/Practice/engine/types.ts
@@ -72,6 +72,30 @@ export interface TarotConfig {
   hide_timer_during_meditation?: boolean;
 }
 
+/**
+ * One category in a tallied-grounding round. `key` is the machine slug
+ * used for analytics; `label` is the display string and is expected to
+ * carry its own article (e.g. `"a square"`) so the view can render
+ * `Find {label}` directly. Mirrors the backend `TalliedCategory`.
+ */
+export interface TalliedCategory {
+  key: string;
+  label: string;
+  target_count: number;
+}
+
+/**
+ * Rounds-by-categories-by-target-count shape shared by Find Shapes and
+ * Find Colors. Total steps = `rounds × sum(category.target_count)`; the
+ * view derives `(round, category, item)` from the linear
+ * `currentStepIndex`. Mirrors the backend `TalliedGroundingConfig`.
+ */
+export interface TalliedGroundingConfig {
+  mode: 'tallied_grounding';
+  rounds: number;
+  categories: readonly TalliedCategory[];
+}
+
 export type ModeConfig =
   | MeditationTimerConfig
   | CountUpConfig
@@ -79,7 +103,20 @@ export type ModeConfig =
   | IntervalBellConfig
   | RepCounterConfig
   | SenseGroundingConfig
+  | TalliedGroundingConfig
   | TarotConfig;
+
+/**
+ * Per-session metadata emitted when a tallied-grounding ritual completes.
+ * Mirrors the backend `TalliedGroundingMetadata`; `rounds_completed` never
+ * exceeds `total_rounds`.
+ */
+export interface TalliedGroundingMetadata {
+  mode: 'tallied_grounding';
+  rounds_completed: number;
+  total_rounds: number;
+  items_completed: number;
+}
 
 export interface RitualState {
   status: EngineStatus;

--- a/frontend/src/features/Practice/engine/validation.ts
+++ b/frontend/src/features/Practice/engine/validation.ts
@@ -14,6 +14,8 @@ import type {
   SenseGroundingConfig,
   SenseKind,
   SensePrompt,
+  TalliedCategory,
+  TalliedGroundingConfig,
   TarotConfig,
 } from './types';
 
@@ -26,6 +28,17 @@ export const UNIT_LABEL_MAX = 64;
 export const TARGET_REPS_MIN = 1;
 /** Mirrors the backend ``UserPractice.custom_name`` column (ritual-03). */
 export const CUSTOM_NAME_MAX = 255;
+
+/** Tallied-grounding bounds — mirror ``practice_mode_config.py``. */
+export const TALLIED_ROUNDS_MIN = 1;
+export const TALLIED_ROUNDS_MAX = 10;
+export const TALLIED_CATEGORIES_MIN = 1;
+export const TALLIED_CATEGORIES_MAX = 12;
+export const TALLIED_TARGET_MIN = 1;
+export const TALLIED_TARGET_MAX = 20;
+export const TALLIED_KEY_MAX = 64;
+export const TALLIED_LABEL_MAX = 255;
+export const TALLIED_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
 
 export const ALLOWED_SENSES: readonly SenseKind[] = ['sight', 'touch', 'hearing', 'smell', 'taste'];
 
@@ -174,6 +187,61 @@ export function validateTarot(config: TarotConfig): string[] {
   return errors;
 }
 
+function checkTalliedCategory(category: TalliedCategory, index: number): string[] {
+  const errors: string[] = [];
+  const position = `Category ${index + 1}`;
+  if (!TALLIED_KEY_PATTERN.test(category.key) || category.key.length > TALLIED_KEY_MAX) {
+    errors.push(`${position}: key must match ^[a-z][a-z0-9_]*$ and be ≤ ${TALLIED_KEY_MAX} chars`);
+  }
+  const labelLen = category.label.trim().length;
+  if (labelLen === 0) {
+    errors.push(`${position}: label cannot be empty`);
+  }
+  if (category.label.length > TALLIED_LABEL_MAX) {
+    errors.push(`${position}: label must be ≤ ${TALLIED_LABEL_MAX} characters`);
+  }
+  if (
+    !Number.isInteger(category.target_count) ||
+    category.target_count < TALLIED_TARGET_MIN ||
+    category.target_count > TALLIED_TARGET_MAX
+  ) {
+    errors.push(
+      `${position}: target count must be a whole number between ` +
+        `${TALLIED_TARGET_MIN} and ${TALLIED_TARGET_MAX}`,
+    );
+  }
+  return errors;
+}
+
+export function validateTalliedGrounding(config: TalliedGroundingConfig): string[] {
+  const errors: string[] = [];
+  if (
+    !Number.isInteger(config.rounds) ||
+    config.rounds < TALLIED_ROUNDS_MIN ||
+    config.rounds > TALLIED_ROUNDS_MAX
+  ) {
+    errors.push(
+      `Rounds must be a whole number between ${TALLIED_ROUNDS_MIN} and ${TALLIED_ROUNDS_MAX}`,
+    );
+  }
+  if (config.categories.length < TALLIED_CATEGORIES_MIN) {
+    errors.push('At least one category is required');
+    return errors;
+  }
+  if (config.categories.length > TALLIED_CATEGORIES_MAX) {
+    errors.push(`At most ${TALLIED_CATEGORIES_MAX} categories are allowed`);
+  }
+  const seenKeys = new Set<string>();
+  config.categories.forEach((category, index) => {
+    errors.push(...checkTalliedCategory(category, index));
+    if (seenKeys.has(category.key)) {
+      errors.push(`Category ${index + 1}: duplicate key "${category.key}"`);
+    }
+    seenKeys.add(category.key);
+  });
+  return errors;
+}
+
 const VALIDATORS: {
   [K in ModeConfig['mode']]: (config: Extract<ModeConfig, { mode: K }>) => string[];
 } = {
@@ -183,6 +251,7 @@ const VALIDATORS: {
   interval_bell: validateIntervalBell,
   rep_counter: validateRepCounter,
   sense_grounding: validateSenseGrounding,
+  tallied_grounding: validateTalliedGrounding,
   tarot: validateTarot,
 };
 

--- a/frontend/src/features/Practice/insights/__tests__/format.test.ts
+++ b/frontend/src/features/Practice/insights/__tests__/format.test.ts
@@ -24,6 +24,11 @@ describe('formatModeSummary', () => {
       'Grounded through 3 senses',
     ],
     [{ mode: 'tarot', card_index: 0, card_name: 'The Fool' }, 5, 'The Fool for 05:00'],
+    [
+      { mode: 'tallied_grounding', rounds_completed: 3, total_rounds: 3, items_completed: 27 },
+      6,
+      '27 items across 3/3 rounds',
+    ],
   ])('formats %j (%s min) as %s', (metadata, durationMinutes, expected) => {
     expect(formatModeSummary(metadata.mode, durationMinutes, metadata)).toBe(expected);
   });

--- a/frontend/src/features/Practice/insights/format.ts
+++ b/frontend/src/features/Practice/insights/format.ts
@@ -55,6 +55,13 @@ export interface ModeSummaryTarot {
   readonly card_name: string;
 }
 
+export interface ModeSummaryTalliedGrounding {
+  readonly mode: 'tallied_grounding';
+  readonly rounds_completed: number;
+  readonly total_rounds: number;
+  readonly items_completed: number;
+}
+
 export type ModeSummaryMetadata =
   | ModeSummaryMeditationTimer
   | ModeSummaryCountUp
@@ -62,6 +69,7 @@ export type ModeSummaryMetadata =
   | ModeSummaryIntervalBell
   | ModeSummaryRepCounter
   | ModeSummarySenseGrounding
+  | ModeSummaryTalliedGrounding
   | ModeSummaryTarot;
 
 export type ModeSummaryKind = ModeSummaryMetadata['mode'];
@@ -105,6 +113,10 @@ export function formatModeSummary<M extends ModeSummaryKind>(
     case 'sense_grounding': {
       const m = metadata as ModeSummarySenseGrounding;
       return `Grounded through ${m.senses_completed.length} senses`;
+    }
+    case 'tallied_grounding': {
+      const m = metadata as ModeSummaryTalliedGrounding;
+      return `${m.items_completed} items across ${m.rounds_completed}/${m.total_rounds} rounds`;
     }
     case 'tarot': {
       const m = metadata as ModeSummaryTarot;

--- a/frontend/src/features/Practice/views/TalliedGroundingView.tsx
+++ b/frontend/src/features/Practice/views/TalliedGroundingView.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { decompose, totalSteps } from '../engine/tallied';
+import type { TalliedPosition } from '../engine/tallied';
+import type { RitualControls, RitualState, TalliedGroundingConfig } from '../engine/types';
+
+import RitualControlsBar from './RitualControlsBar';
+
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+/**
+ * `TalliedGroundingView` drives the Find Shapes / Find Colors ritual UX.
+ *
+ * The engine keeps a single linear `currentStepIndex`; this view derives
+ * the `(round, category, item)` position via `decompose` and never mutates
+ * the engine's state shape. Each `controls.tap()` advances one item; the
+ * final tap moves the engine to `complete` and the Complete card replaces
+ * the active prompt.
+ */
+interface Props {
+  config: TalliedGroundingConfig;
+  state: RitualState;
+  controls: RitualControls;
+  /** Optional Save callback; the parent typically launches the insight modal. */
+  onSave?: () => void;
+}
+
+const TalliedGroundingView = ({ config, state, controls, onSave }: Props): React.JSX.Element => {
+  const total = totalSteps(config);
+  const isComplete = state.status === 'complete' || state.currentStepIndex >= total;
+  const position = decompose(state.currentStepIndex, config);
+  const canAdvance = state.status === 'running' && !isComplete;
+  return (
+    <View style={styles.container} testID="tallied-grounding-view">
+      <TalliedHeader config={config} position={isComplete ? null : position} />
+      {isComplete ? (
+        <CompleteCard onSave={onSave} />
+      ) : (
+        <ActivePrompt position={position} canAdvance={canAdvance} onTap={controls.tap} />
+      )}
+      <RitualControlsBar status={state.status} controls={controls} startLabel="Begin grounding" />
+    </View>
+  );
+};
+
+interface HeaderProps {
+  config: TalliedGroundingConfig;
+  position: TalliedPosition | null;
+}
+
+const TalliedHeader = ({ config, position }: HeaderProps): React.JSX.Element => (
+  <View
+    style={styles.header}
+    testID="tallied-grounding-header"
+    accessibilityRole="header"
+    accessibilityLabel="Tallied grounding"
+  >
+    <Text style={styles.badge} testID="tallied-grounding-badge">
+      {`${config.categories.length} × ${config.rounds}`}
+    </Text>
+    {position && (
+      <Text style={styles.round} testID="tallied-grounding-round">
+        {`Round ${position.roundIndex + 1} of ${config.rounds}`}
+      </Text>
+    )}
+  </View>
+);
+
+const CompleteCard = ({ onSave }: { onSave?: () => void }): React.JSX.Element => (
+  <View style={styles.completeCard} testID="tallied-grounding-complete">
+    <Text style={styles.completeTitle}>Grounding complete</Text>
+    <Text style={styles.completeBody}>You tallied every round. Save the session below.</Text>
+    <Pressable
+      style={[styles.save, !onSave && styles.saveDisabled]}
+      onPress={onSave}
+      disabled={!onSave}
+      testID="tallied-grounding-save"
+      accessibilityRole="button"
+      accessibilityLabel="Save session and reflect"
+      accessibilityState={{ disabled: !onSave }}
+    >
+      <Text style={styles.saveText}>Save session</Text>
+    </Pressable>
+  </View>
+);
+
+interface ActivePromptProps {
+  position: TalliedPosition;
+  canAdvance: boolean;
+  onTap: () => void;
+}
+
+const ActivePrompt = ({ position, canAdvance, onTap }: ActivePromptProps): React.JSX.Element => {
+  const { category, itemInCategory } = position;
+  const promptText = `Find ${category.label} (${itemInCategory + 1} of ${category.target_count})`;
+  return (
+    <>
+      <Text style={styles.prompt} testID="tallied-grounding-prompt">
+        {promptText}
+      </Text>
+      <Pressable
+        style={[styles.advance, !canAdvance && styles.advanceDisabled]}
+        onPress={canAdvance ? onTap : undefined}
+        disabled={!canAdvance}
+        testID="tallied-grounding-advance"
+        accessibilityRole="button"
+        accessibilityLabel={`Tally ${category.label}`}
+        accessibilityState={{ disabled: !canAdvance }}
+      >
+        <Text style={styles.advanceText}>I found one</Text>
+      </Pressable>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl },
+  header: { alignItems: 'center', marginBottom: SPACING.xl },
+  badge: {
+    fontSize: 36,
+    fontWeight: '700',
+    letterSpacing: 4,
+    color: colors.text.primary,
+    marginBottom: SPACING.sm,
+  },
+  round: {
+    fontSize: 18,
+    fontWeight: '700',
+    letterSpacing: 2,
+    color: colors.text.primary,
+  },
+  prompt: {
+    fontSize: 20,
+    fontWeight: '500',
+    color: colors.text.primary,
+    textAlign: 'center',
+    marginBottom: SPACING.xxl,
+    paddingHorizontal: SPACING.lg,
+  },
+  advance: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    marginBottom: SPACING.xl,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  advanceDisabled: { opacity: 0.5 },
+  advanceText: {
+    color: colors.text.light,
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  completeCard: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.xl,
+    alignItems: 'center',
+    marginBottom: SPACING.xl,
+    maxWidth: 320,
+    ...shadows.small,
+  },
+  completeTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    color: colors.success,
+    marginBottom: SPACING.sm,
+  },
+  completeBody: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    textAlign: 'center',
+    marginBottom: SPACING.lg,
+  },
+  save: {
+    backgroundColor: colors.success,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  saveDisabled: { opacity: 0.5 },
+  saveText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
+});
+
+export default TalliedGroundingView;

--- a/frontend/src/features/Practice/views/TalliedGroundingView.tsx
+++ b/frontend/src/features/Practice/views/TalliedGroundingView.tsx
@@ -29,12 +29,13 @@ interface Props {
 const TalliedGroundingView = ({ config, state, controls, onSave }: Props): React.JSX.Element => {
   const total = totalSteps(config);
   const isComplete = state.status === 'complete' || state.currentStepIndex >= total;
-  const position = decompose(state.currentStepIndex, config);
+  // Skip the decomposition entirely once complete — the result would be unused.
+  const position = isComplete ? null : decompose(state.currentStepIndex, config);
   const canAdvance = state.status === 'running' && !isComplete;
   return (
     <View style={styles.container} testID="tallied-grounding-view">
-      <TalliedHeader config={config} position={isComplete ? null : position} />
-      {isComplete ? (
+      <TalliedHeader config={config} position={position} />
+      {position === null ? (
         <CompleteCard onSave={onSave} />
       ) : (
         <ActivePrompt position={position} canAdvance={canAdvance} onTap={controls.tap} />

--- a/frontend/src/features/Practice/views/__tests__/TalliedGroundingView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/TalliedGroundingView.test.tsx
@@ -1,0 +1,197 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { TalliedGroundingConfig } from '../../engine/types';
+import TalliedGroundingView from '../TalliedGroundingView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+// Find Shapes: 3 rounds × 3 categories × 3 items = 27 linear steps.
+const config: TalliedGroundingConfig = {
+  mode: 'tallied_grounding',
+  rounds: 3,
+  categories: [
+    { key: 'squares', label: 'a square', target_count: 3 },
+    { key: 'triangles', label: 'a triangle', target_count: 3 },
+    { key: 'circles', label: 'a circle', target_count: 3 },
+  ],
+};
+
+const TOTAL_STEPS = 27;
+
+describe('TalliedGroundingView', () => {
+  it('renders the categories-by-rounds badge', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 0 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-badge').props.children).toBe('3 × 3');
+  });
+
+  it('renders "Round 1 of 3" on the initial state', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 0 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-round').props.children).toBe('Round 1 of 3');
+  });
+
+  it('renders the first category prompt on the initial state', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 0 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-prompt').props.children).toBe('Find a square (1 of 3)');
+  });
+
+  it('decomposes a mid-round step into the right category and item', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 4 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-round').props.children).toBe('Round 1 of 3');
+    expect(getByTestId('tallied-grounding-prompt').props.children).toBe('Find a triangle (2 of 3)');
+  });
+
+  it('advances into Round 2 after a full round of nine steps', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 9 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-round').props.children).toBe('Round 2 of 3');
+    expect(getByTestId('tallied-grounding-prompt').props.children).toBe('Find a square (1 of 3)');
+  });
+
+  it('calls controls.tap when the advance button is pressed', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 2 })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('tallied-grounding-advance'));
+    expect(controls.tap).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes a per-category accessibility label on the advance button', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 3 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-advance').props.accessibilityLabel).toBe(
+      'Tally a triangle',
+    );
+  });
+
+  it('disables the advance button while paused and ignores taps', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'paused', currentStepIndex: 1 })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('tallied-grounding-advance'));
+    expect(controls.tap).not.toHaveBeenCalled();
+    expect(getByTestId('tallied-grounding-advance').props.accessibilityState).toEqual({
+      disabled: true,
+    });
+  });
+
+  it('shows the Start control while idle and forwards controls.start', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'idle', currentStepIndex: 0 })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('ritual-start'));
+    expect(controls.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the Complete card and hides the advance button when complete', () => {
+    const { getByTestId, queryByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'complete', currentStepIndex: TOTAL_STEPS })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-complete')).toBeTruthy();
+    expect(queryByTestId('tallied-grounding-advance')).toBeNull();
+    expect(queryByTestId('tallied-grounding-round')).toBeNull();
+  });
+
+  it('treats an overrun step index as complete', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: TOTAL_STEPS })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-complete')).toBeTruthy();
+  });
+
+  it('forwards onSave when the Save CTA is pressed', () => {
+    const onSave = jest.fn();
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'complete', currentStepIndex: TOTAL_STEPS })}
+        controls={fakeControls()}
+        onSave={onSave}
+      />,
+    );
+    fireEvent.press(getByTestId('tallied-grounding-save'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the Save CTA when onSave is omitted', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'complete', currentStepIndex: TOTAL_STEPS })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-save').props.accessibilityState).toEqual({
+      disabled: true,
+    });
+  });
+
+  it('sets the header accessibility role', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingView
+        config={config}
+        state={fakeState({ status: 'running', currentStepIndex: 0 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('tallied-grounding-header').props.accessibilityRole).toBe('header');
+  });
+});


### PR DESCRIPTION
Adds the `tallied_grounding` ritual mode to the frontend engine and a
`TalliedGroundingView` that drives the Find Shapes / Find Colors UX off a
`TalliedGroundingConfig`. The view derives `(round, category, item)` from
the engine's linear `currentStepIndex` via shared pure helpers in
`engine/tallied.ts`, so the engine state shape is unchanged.

- Extend the `ModeConfig` union with `TalliedGroundingConfig` and add
  `TalliedGroundingMetadata`; mirror the wire metadata in `api` and the
  summary metadata in `insights/format`.
- Teach the reducer to advance and complete tallied sessions on TAP, and
  the cue scheduler / validators about the new mode.
- Dispatch `tallied_grounding` to the new view in `ActiveRitualSession`
  and harvest `rounds_completed` / `items_completed` on completion.

https://claude.ai/code/session_01G19QPV5ChvKUx6oD7zVyMB