### PR TITLE
feat(practice): build MindfulAnchorView for Touch Grass / Mindful Eating

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1680,6 +1680,19 @@ export interface TalliedGroundingSessionMetadata {
   items_completed: number;
 }
 
+/**
+ * Mirrors the engine ``MindfulAnchorMetadata`` shape
+ * (``features/Practice/engine/types``). ``met_min_duration`` is emitted by
+ * the client so the analytics rollup can tell "long enough" from
+ * "abandoned early" without re-running the soft-floor comparison.
+ */
+export interface MindfulAnchorSessionMetadata {
+  mode: 'mindful_anchor';
+  chosen_option_key: string | null;
+  duration_seconds: number;
+  met_min_duration: boolean;
+}
+
 export type SessionMetadata =
   | MeditationTimerSessionMetadata
   | CountUpSessionMetadata
@@ -1690,7 +1703,8 @@ export type SessionMetadata =
   | SenseGroundingSessionMetadata
   | TalliedGroundingSessionMetadata
   | TarotSessionMetadata
-  | CardMeditationSessionMetadata;
+  | CardMeditationSessionMetadata
+  | MindfulAnchorSessionMetadata;
 
 export interface PracticeSessionCreate {
   user_practice_id: number;

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -46,6 +46,7 @@ import { totalSteps, totalStepsPerRound } from '@/features/Practice/engine/talli
 import type {
   CardMeditationConfig,
   IntervalBellConfig,
+  MindfulAnchorMetadata,
   ModeConfig,
   RandomIntervalBellMetadata,
   RepCounterConfig,
@@ -62,6 +63,7 @@ import CountUpTimerView from '@/features/Practice/views/CountUpTimerView';
 import IntervalBellView from '@/features/Practice/views/IntervalBellView';
 import MeditationTimerView from '@/features/Practice/views/MeditationTimerView';
 import MetronomeView from '@/features/Practice/views/MetronomeView';
+import MindfulAnchorView from '@/features/Practice/views/MindfulAnchorView';
 import RandomIntervalBellView from '@/features/Practice/views/RandomIntervalBellView';
 import RepCounterView from '@/features/Practice/views/RepCounterView';
 import SenseGroundingView from '@/features/Practice/views/SenseGroundingView';
@@ -103,6 +105,8 @@ interface ActiveSession {
   tarotCardIndex: number;
   /** The card drawn for a `card_meditation` session; `null` for other modes. */
   cardPick: PickedCard | null;
+  /** `mindful_anchor` view hands its save payload up through this. */
+  onMindfulAnchorComplete: (_metadata: MindfulAnchorMetadata) => void;
   completedWindow: { start: Date; end: Date } | null;
   isSaving: boolean;
   saveError: string | null;
@@ -129,6 +133,7 @@ export function ActiveRitualSession(props: ActiveRitualSessionProps): React.JSX.
         controls={session.controls}
         tarotCardIndex={session.tarotCardIndex}
         cardPick={session.cardPick}
+        onMindfulAnchorComplete={session.onMindfulAnchorComplete}
         saveError={session.saveError}
         onRandomBellMetadata={session.onRandomBellMetadata}
       />
@@ -193,9 +198,16 @@ interface HarvestedMetadata {
   wireMetadata: SessionMetadata;
   summaryMetadata: ModeSummaryMetadata;
   onRandomBellMetadata: (metadata: RandomIntervalBellMetadata) => void;
+  onMindfulAnchorComplete: (metadata: MindfulAnchorMetadata) => void;
+  /** Clears the lifted mindful-anchor payload after a save completes. */
+  resetMindfulAnchor: () => void;
 }
 
-/** Harvest wire+summary metadata; `random_interval_bell` view lifts its schedule via the setter. */
+/**
+ * Harvest wire+summary metadata. The `random_interval_bell` view lifts its
+ * live schedule via the setter; the `mindful_anchor` view lifts its full
+ * save payload (chosen option + duration + soft-floor flag) the same way.
+ */
 function useHarvestedMetadata(
   config: ModeConfig,
   state: RitualState,
@@ -205,15 +217,23 @@ function useHarvestedMetadata(
   const [randomBellMetadata, setRandomBellMetadata] = useState<RandomIntervalBellMetadata | null>(
     null,
   );
+  const [mindfulAnchorMeta, setMindfulAnchorMeta] = useState<MindfulAnchorMetadata | null>(null);
   const wireMetadata = useMemo<SessionMetadata>(
-    () => harvestMetadata(config, state, cardPick, randomBellMetadata),
-    [config, state, cardPick, randomBellMetadata],
+    () => harvestMetadata(config, state, cardPick, randomBellMetadata, mindfulAnchorMeta),
+    [config, state, cardPick, randomBellMetadata, mindfulAnchorMeta],
   );
   const summaryMetadata = useMemo<ModeSummaryMetadata>(
     () => harvestSummaryMetadata(config, state, tarotCardIndex, cardPick, randomBellMetadata),
     [config, state, tarotCardIndex, cardPick, randomBellMetadata],
   );
-  return { wireMetadata, summaryMetadata, onRandomBellMetadata: setRandomBellMetadata };
+  const resetMindfulAnchor = useCallback(() => setMindfulAnchorMeta(null), []);
+  return {
+    wireMetadata,
+    summaryMetadata,
+    onRandomBellMetadata: setRandomBellMetadata,
+    onMindfulAnchorComplete: setMindfulAnchorMeta,
+    resetMindfulAnchor,
+  };
 }
 
 function useActiveSession(props: ActiveRitualSessionProps): ActiveSession {
@@ -224,12 +244,13 @@ function useActiveSession(props: ActiveRitualSessionProps): ActiveSession {
   const window = useCompletionWindow(state.status);
   const [saveError, setSaveError] = useState<string | null>(null);
   const cardPick = useCardPick(props.effectiveConfig);
-  const { wireMetadata, summaryMetadata, onRandomBellMetadata } = useHarvestedMetadata(
-    props.effectiveConfig,
-    state,
-    tarotCardIndex,
-    cardPick,
-  );
+  const {
+    wireMetadata,
+    summaryMetadata,
+    onRandomBellMetadata,
+    onMindfulAnchorComplete,
+    resetMindfulAnchor,
+  } = useHarvestedMetadata(props.effectiveConfig, state, tarotCardIndex, cardPick);
   const saveMutation = useSaveMutation({
     apply: props.onSessionApply,
     rollback: props.onSessionRollback,
@@ -239,8 +260,9 @@ function useActiveSession(props: ActiveRitualSessionProps): ActiveSession {
   const finishAndReset = useCallback(() => {
     window.reset();
     setSaveError(null);
+    resetMindfulAnchor();
     controls.cancel();
-  }, [window, controls]);
+  }, [window, controls, resetMindfulAnchor]);
   const submitSession = useSubmitSession({
     userPracticeId: props.userPractice.id,
     completedWindow: window.completedWindow,
@@ -255,6 +277,7 @@ function useActiveSession(props: ActiveRitualSessionProps): ActiveSession {
     summaryMetadata,
     tarotCardIndex,
     cardPick,
+    onMindfulAnchorComplete,
     completedWindow: window.completedWindow,
     isSaving: saveMutation.pending,
     saveError,
@@ -386,6 +409,7 @@ interface SessionCardProps {
   controls: RitualControls;
   tarotCardIndex: number;
   cardPick: PickedCard | null;
+  onMindfulAnchorComplete: (_metadata: MindfulAnchorMetadata) => void;
   saveError: string | null;
   onRandomBellMetadata: (metadata: RandomIntervalBellMetadata) => void;
 }
@@ -424,6 +448,7 @@ function SessionCard(props: SessionCardProps): React.JSX.Element {
         tarotCardIndex={props.tarotCardIndex}
         cardPick={props.cardPick}
         onRandomBellMetadata={props.onRandomBellMetadata}
+        onMindfulAnchorComplete={props.onMindfulAnchorComplete}
       />
       {props.saveError !== null && (
         <Text style={styles.error} testID="active-practice-save-error">
@@ -441,6 +466,7 @@ interface ModeViewProps {
   tarotCardIndex: number;
   cardPick: PickedCard | null;
   onRandomBellMetadata: (metadata: RandomIntervalBellMetadata) => void;
+  onMindfulAnchorComplete: (_metadata: MindfulAnchorMetadata) => void;
 }
 
 function ModeView(props: ModeViewProps): React.JSX.Element {
@@ -463,6 +489,7 @@ function ModeView(props: ModeViewProps): React.JSX.Element {
       controls={controls}
       tarotCardIndex={props.tarotCardIndex}
       cardPick={props.cardPick}
+      onMindfulAnchorComplete={props.onMindfulAnchorComplete}
     />
   );
 }
@@ -473,6 +500,7 @@ interface EngineModeViewProps {
   controls: RitualControls;
   tarotCardIndex: number;
   cardPick: PickedCard | null;
+  onMindfulAnchorComplete: (_metadata: MindfulAnchorMetadata) => void;
 }
 
 function EngineModeView({
@@ -481,7 +509,49 @@ function EngineModeView({
   controls,
   tarotCardIndex,
   cardPick,
+  onMindfulAnchorComplete,
 }: EngineModeViewProps): React.JSX.Element {
+  if (config.mode === 'tarot' || config.mode === 'card_meditation') {
+    return (
+      <CardModeView
+        config={config}
+        state={state}
+        controls={controls}
+        tarotCardIndex={tarotCardIndex}
+        cardPick={cardPick}
+      />
+    );
+  }
+  if (config.mode === 'mindful_anchor') {
+    return (
+      <MindfulAnchorView
+        config={config}
+        state={state}
+        controls={controls}
+        onComplete={onMindfulAnchorComplete}
+      />
+    );
+  }
+  return <BasicEngineModeView config={config} state={state} controls={controls} />;
+}
+
+type BasicEngineModeConfig = Exclude<
+  EngineModeViewProps['config'],
+  { mode: 'tarot' | 'card_meditation' | 'mindful_anchor' }
+>;
+
+interface BasicEngineModeViewProps {
+  config: BasicEngineModeConfig;
+  state: RitualState;
+  controls: RitualControls;
+}
+
+/** Plain dispatch for the engine modes that take only `(config, state, controls)`. */
+function BasicEngineModeView({
+  config,
+  state,
+  controls,
+}: BasicEngineModeViewProps): React.JSX.Element {
   switch (config.mode) {
     case 'meditation_timer':
       return <MeditationTimerView state={state} controls={controls} />;
@@ -497,17 +567,6 @@ function EngineModeView({
       return <SenseGroundingView config={config} state={state} controls={controls} />;
     case 'tallied_grounding':
       return <TalliedGroundingView config={config} state={state} controls={controls} />;
-    case 'tarot':
-    case 'card_meditation':
-      return (
-        <CardModeView
-          config={config}
-          state={state}
-          controls={controls}
-          tarotCardIndex={tarotCardIndex}
-          cardPick={cardPick}
-        />
-      );
   }
 }
 
@@ -609,6 +668,7 @@ export function harvestMetadata(
   state: RitualState,
   cardPick: PickedCard | null,
   randomBellMetadata: RandomIntervalBellMetadata | null = null,
+  mindfulAnchorMeta: MindfulAnchorMetadata | null = null,
 ): SessionMetadata {
   // `random_interval_bell` schedule is view-owned, so harvest from the lifted metadata.
   if (config.mode === 'random_interval_bell') {
@@ -616,37 +676,67 @@ export function harvestMetadata(
       randomBellMetadata ?? { mode: 'random_interval_bell', bells_struck: 0, interval_seconds: [] }
     );
   }
-  return harvestEngineMetadata(config, state, cardPick);
+  return harvestEngineMetadata(config, state, cardPick, mindfulAnchorMeta);
 }
 
+type EngineMetadataConfig = Exclude<ModeConfig, { mode: 'random_interval_bell' }>;
+
+/**
+ * Pre-save fallback for the `mindful_anchor` harvest. `wireMetadata` is
+ * recomputed on every render but only consumed once the engine reaches
+ * `complete` — by which point the view has run its `onComplete` callback
+ * and populated `mindfulAnchorMeta`. This object satisfies the return
+ * type for the pre-save renders whose result is never read.
+ */
+const MINDFUL_ANCHOR_PRESAVE_FALLBACK: Extract<SessionMetadata, { mode: 'mindful_anchor' }> = {
+  mode: 'mindful_anchor',
+  chosen_option_key: null,
+  duration_seconds: 0,
+  met_min_duration: false,
+};
+
+/** Per-mode wire-metadata harvesters; the mapped type enforces exhaustive coverage. */
+const ENGINE_METADATA_HARVESTERS: {
+  [K in EngineMetadataConfig['mode']]: (
+    config: Extract<EngineMetadataConfig, { mode: K }>,
+    state: RitualState,
+    cardPick: PickedCard | null,
+    mindfulAnchorMeta: MindfulAnchorMetadata | null,
+  ) => SessionMetadata;
+} = {
+  meditation_timer: () => ({ mode: 'meditation_timer' }),
+  count_up: () => ({ mode: 'count_up' }),
+  metronome: (config) => ({ mode: 'metronome', bpm_used: config.bpm }),
+  interval_bell: harvestIntervalBell,
+  rep_counter: (_config, state) => ({ mode: 'rep_counter', rep_count: state.repCount }),
+  sense_grounding: harvestSenseGrounding,
+  tallied_grounding: harvestTalliedGrounding,
+  tarot: (_config, state) => ({
+    mode: 'tarot',
+    card_index: normalizeTarotIndex(state.currentStepIndex),
+  }),
+  card_meditation: (config, _state, cardPick) => cardMeditationWireMetadata(config, cardPick),
+  mindful_anchor: (_config, _state, _cardPick, meta) => meta ?? MINDFUL_ANCHOR_PRESAVE_FALLBACK,
+};
+
 function harvestEngineMetadata(
-  config: Exclude<ModeConfig, { mode: 'random_interval_bell' }>,
+  config: EngineMetadataConfig,
   state: RitualState,
   cardPick: PickedCard | null,
+  mindfulAnchorMeta: MindfulAnchorMetadata | null,
 ): SessionMetadata {
-  switch (config.mode) {
-    case 'meditation_timer':
-      return { mode: 'meditation_timer' };
-    case 'count_up':
-      return { mode: 'count_up' };
-    case 'metronome':
-      return { mode: 'metronome', bpm_used: config.bpm };
-    case 'interval_bell':
-      return harvestIntervalBell(config, state);
-    case 'rep_counter':
-      return { mode: 'rep_counter', rep_count: state.repCount };
-    case 'sense_grounding':
-      return harvestSenseGrounding(config, state);
-    case 'tallied_grounding':
-      return harvestTalliedGrounding(config, state);
-    case 'tarot':
-      return {
-        mode: 'tarot',
-        card_index: normalizeTarotIndex(state.currentStepIndex),
-      };
-    case 'card_meditation':
-      return cardMeditationWireMetadata(config, cardPick);
-  }
+  type AnyHarvester = (
+    config: EngineMetadataConfig,
+    state: RitualState,
+    cardPick: PickedCard | null,
+    mindfulAnchorMeta: MindfulAnchorMetadata | null,
+  ) => SessionMetadata;
+  return (ENGINE_METADATA_HARVESTERS[config.mode] as AnyHarvester)(
+    config,
+    state,
+    cardPick,
+    mindfulAnchorMeta,
+  );
 }
 
 /**
@@ -722,56 +812,91 @@ export function harvestSummaryMetadata(
   return harvestEngineSummary(config, state, tarotCardIndex, cardPick);
 }
 
+function summarizeIntervalBell(
+  config: IntervalBellConfig,
+  state: RitualState,
+): ModeSummaryMetadata {
+  const wire = harvestIntervalBell(config, state) as Extract<
+    SessionMetadata,
+    { mode: 'interval_bell' }
+  >;
+  return {
+    mode: 'interval_bell',
+    intervals_struck: wire.intervals_struck,
+    total_intervals: wire.total_intervals,
+  };
+}
+
+function summarizeSenseGrounding(
+  config: SenseGroundingConfig,
+  state: RitualState,
+): ModeSummaryMetadata {
+  const wire = harvestSenseGrounding(config, state) as Extract<
+    SessionMetadata,
+    { mode: 'sense_grounding' }
+  >;
+  return { mode: 'sense_grounding', senses_completed: wire.senses_completed };
+}
+
+function summarizeTarot(_state: RitualState, tarotCardIndex: number): ModeSummaryMetadata {
+  const idx = normalizeTarotIndex(tarotCardIndex);
+  return { mode: 'tarot', card_index: idx, card_name: cardForDayIndex(idx).name };
+}
+
+function summarizeCardMeditation(
+  config: CardMeditationConfig,
+  state: RitualState,
+  cardPick: PickedCard | null,
+): ModeSummaryMetadata {
+  // Reuse the wire harvest (and its single card draw) rather than drawing
+  // the card a second time — mirrors the `interval_bell` reuse above.
+  const wire = harvestMetadata(config, state, cardPick) as Extract<
+    SessionMetadata,
+    { mode: 'card_meditation' }
+  >;
+  return { mode: 'card_meditation', deck_id: wire.deck_id, card_name: wire.card_drawn_name };
+}
+
+/** Per-mode summary-metadata harvesters; the mapped type enforces exhaustive coverage. */
+const ENGINE_SUMMARY_HARVESTERS: {
+  [K in EngineMetadataConfig['mode']]: (
+    config: Extract<EngineMetadataConfig, { mode: K }>,
+    state: RitualState,
+    tarotCardIndex: number,
+    cardPick: PickedCard | null,
+  ) => ModeSummaryMetadata;
+} = {
+  meditation_timer: () => ({ mode: 'meditation_timer' }),
+  count_up: () => ({ mode: 'count_up' }),
+  metronome: (config) => ({ mode: 'metronome', bpm_used: config.bpm }),
+  interval_bell: (config, state) => summarizeIntervalBell(config, state),
+  rep_counter: repCounterSummary,
+  sense_grounding: (config, state) => summarizeSenseGrounding(config, state),
+  tallied_grounding: harvestTalliedGrounding,
+  tarot: (_config, state, tarotCardIndex) => summarizeTarot(state, tarotCardIndex),
+  card_meditation: (config, state, _tarotCardIndex, cardPick) =>
+    summarizeCardMeditation(config, state, cardPick),
+  mindful_anchor: () => ({ mode: 'mindful_anchor' }),
+};
+
 function harvestEngineSummary(
-  config: Exclude<ModeConfig, { mode: 'random_interval_bell' }>,
+  config: EngineMetadataConfig,
   state: RitualState,
   tarotCardIndex: number,
   cardPick: PickedCard | null,
 ): ModeSummaryMetadata {
-  switch (config.mode) {
-    case 'meditation_timer':
-      return { mode: 'meditation_timer' };
-    case 'count_up':
-      return { mode: 'count_up' };
-    case 'metronome':
-      return { mode: 'metronome', bpm_used: config.bpm };
-    case 'interval_bell': {
-      const wire = harvestIntervalBell(config, state) as Extract<
-        SessionMetadata,
-        { mode: 'interval_bell' }
-      >;
-      return {
-        mode: 'interval_bell',
-        intervals_struck: wire.intervals_struck,
-        total_intervals: wire.total_intervals,
-      };
-    }
-    case 'rep_counter':
-      return repCounterSummary(config, state);
-    case 'sense_grounding': {
-      const wire = harvestSenseGrounding(config, state) as Extract<
-        SessionMetadata,
-        { mode: 'sense_grounding' }
-      >;
-      return { mode: 'sense_grounding', senses_completed: wire.senses_completed };
-    }
-    case 'tallied_grounding':
-      // Wire and summary shapes are identical — no presentation-only extras.
-      return harvestTalliedGrounding(config, state);
-    case 'tarot': {
-      const idx = normalizeTarotIndex(tarotCardIndex);
-      return { mode: 'tarot', card_index: idx, card_name: cardForDayIndex(idx).name };
-    }
-    case 'card_meditation': {
-      // Reuse the wire harvest (and its single card draw) rather than drawing
-      // the card a second time — mirrors the `interval_bell` reuse above.
-      const wire = harvestMetadata(config, state, cardPick) as Extract<
-        SessionMetadata,
-        { mode: 'card_meditation' }
-      >;
-      return { mode: 'card_meditation', deck_id: wire.deck_id, card_name: wire.card_drawn_name };
-    }
-  }
+  type AnyHarvester = (
+    config: EngineMetadataConfig,
+    state: RitualState,
+    tarotCardIndex: number,
+    cardPick: PickedCard | null,
+  ) => ModeSummaryMetadata;
+  return (ENGINE_SUMMARY_HARVESTERS[config.mode] as AnyHarvester)(
+    config,
+    state,
+    tarotCardIndex,
+    cardPick,
+  );
 }
 
 function repCounterSummary(config: RepCounterConfig, state: RitualState): ModeSummaryMetadata {

--- a/frontend/src/features/Practice/configurator/defaults.ts
+++ b/frontend/src/features/Practice/configurator/defaults.ts
@@ -16,6 +16,7 @@ import type {
   IntervalBellConfig,
   MeditationTimerConfig,
   MetronomeConfig,
+  MindfulAnchorConfig,
   ModeConfig,
   RandomIntervalBellConfig,
   RepCounterConfig,
@@ -32,6 +33,8 @@ const DEFAULT_RANDOM_BELL_MAX_SECONDS = 180;
 const DEFAULT_REP_TARGET = 10;
 const DEFAULT_TALLIED_ROUNDS = 3;
 const DEFAULT_TALLIED_TARGET = 3;
+const DEFAULT_MINDFUL_ANCHOR_MIN_SECONDS = 120;
+const SECONDS_PER_MINUTE = 60;
 
 const DEFAULT_SENSE_PROMPTS: SenseGroundingConfig['prompts'] = [
   { sense: 'sight', label: 'something blue' },
@@ -96,6 +99,13 @@ const DEFAULTS: { [K in ModeConfig['mode']]: () => Extract<ModeConfig, { mode: K
     mode: 'card_meditation',
     deck_id: 'rws',
   }),
+  mindful_anchor: (): MindfulAnchorConfig => ({
+    mode: 'mindful_anchor',
+    instruction: "Take a slow, mindful moment with what's in front of you.",
+    min_duration_seconds: DEFAULT_MINDFUL_ANCHOR_MIN_SECONDS,
+    options: [],
+    require_option_choice: false,
+  }),
 };
 
 /**
@@ -124,6 +134,7 @@ const DURATION_HINTS: {
   rep_counter: () => DEFAULT_DURATION_MINUTES,
   sense_grounding: () => DEFAULT_DURATION_MINUTES,
   tallied_grounding: () => DEFAULT_DURATION_MINUTES,
+  mindful_anchor: (c) => c.min_duration_seconds / SECONDS_PER_MINUTE,
 };
 
 /**

--- a/frontend/src/features/Practice/engine/__tests__/validation.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/validation.test.ts
@@ -5,6 +5,7 @@ import type {
   IntervalBellConfig,
   MeditationTimerConfig,
   MetronomeConfig,
+  MindfulAnchorConfig,
   RepCounterConfig,
   SenseGroundingConfig,
   TalliedGroundingConfig,
@@ -17,6 +18,11 @@ import {
   CUSTOM_NAME_MAX,
   DURATION_MAX_MINUTES,
   DURATION_MIN_MINUTES,
+  INSTRUCTION_MAX,
+  MIN_DURATION_SECONDS_MAX,
+  MINDFUL_ANCHOR_OPTIONS_MAX,
+  OPTION_DESCRIPTION_MAX,
+  OPTION_LABEL_MAX,
   PROMPT_LABEL_MAX,
   TALLIED_CATEGORIES_MAX,
   TALLIED_LABEL_MAX,
@@ -27,6 +33,7 @@ import {
   validateIntervalBell,
   validateMeditationTimer,
   validateMetronome,
+  validateMindfulAnchor,
   validateModeConfig,
   validateRepCounter,
   validateCardMeditation,
@@ -471,6 +478,99 @@ describe('validateCardMeditation', () => {
       cards: Array.from({ length: CARD_MEDITATION_CARDS_MAX + 1 }, () => card),
     };
     expect(validateCardMeditation(config).some((e) => /at most/.test(e))).toBe(true);
+  });
+});
+
+describe('validateMindfulAnchor', () => {
+  const base: MindfulAnchorConfig = {
+    mode: 'mindful_anchor',
+    instruction: 'Rest a bare palm on the grass.',
+    min_duration_seconds: 120,
+    options: [
+      { key: 'grass', label: 'Grass', description: 'A lawn or a verge.' },
+      { key: 'soil', label: 'Soil' },
+    ],
+    require_option_choice: true,
+  };
+
+  it('accepts a valid config', () => {
+    expect(validateMindfulAnchor(base)).toEqual([]);
+  });
+
+  it('accepts a config with no options when no choice is required', () => {
+    expect(
+      validateMindfulAnchor({
+        ...base,
+        options: [],
+        require_option_choice: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it('rejects an empty instruction', () => {
+    expect(validateMindfulAnchor({ ...base, instruction: '   ' })[0]).toMatch(/empty/i);
+  });
+
+  it('rejects an oversize instruction', () => {
+    expect(
+      validateMindfulAnchor({ ...base, instruction: 'x'.repeat(INSTRUCTION_MAX + 1) }),
+    ).toEqual([`Instruction must be ≤ ${INSTRUCTION_MAX} characters`]);
+  });
+
+  it('rejects a non-integer or out-of-range minimum duration', () => {
+    expect(validateMindfulAnchor({ ...base, min_duration_seconds: 12.5 })).toHaveLength(1);
+    expect(validateMindfulAnchor({ ...base, min_duration_seconds: -1 })).toHaveLength(1);
+    expect(
+      validateMindfulAnchor({ ...base, min_duration_seconds: MIN_DURATION_SECONDS_MAX + 1 }),
+    ).toHaveLength(1);
+  });
+
+  it('rejects too many options', () => {
+    const options = Array.from({ length: MINDFUL_ANCHOR_OPTIONS_MAX + 1 }, (_unused, index) => ({
+      key: `opt_${index}`,
+      label: `Option ${index}`,
+    }));
+    expect(validateMindfulAnchor({ ...base, options })[0]).toMatch(
+      new RegExp(`At most ${MINDFUL_ANCHOR_OPTIONS_MAX}`),
+    );
+  });
+
+  it('rejects malformed option keys, labels, and descriptions', () => {
+    const errors = validateMindfulAnchor({
+      ...base,
+      options: [
+        { key: 'Bad Key', label: 'ok' },
+        { key: 'blank', label: '   ' },
+        { key: 'long', label: 'x'.repeat(OPTION_LABEL_MAX + 1) },
+        { key: 'desc', label: 'ok', description: 'x'.repeat(OPTION_DESCRIPTION_MAX + 1) },
+      ],
+    });
+    expect(errors.some((e) => /Option 1: key/.test(e))).toBe(true);
+    expect(errors.some((e) => /Option 2: label cannot be empty/.test(e))).toBe(true);
+    expect(errors.some((e) => /Option 3: label must be/.test(e))).toBe(true);
+    expect(errors.some((e) => /Option 4: description must be/.test(e))).toBe(true);
+  });
+
+  it('rejects duplicate option keys', () => {
+    expect(
+      validateMindfulAnchor({
+        ...base,
+        options: [
+          { key: 'grass', label: 'Grass' },
+          { key: 'grass', label: 'More grass' },
+        ],
+      }),
+    ).toContain('Option keys must be unique');
+  });
+
+  it('rejects requiring a choice with no options', () => {
+    expect(validateMindfulAnchor({ ...base, options: [], require_option_choice: true })).toContain(
+      'Add at least one option when a choice is required',
+    );
+  });
+
+  it('is reachable through validateModeConfig dispatch', () => {
+    expect(validateModeConfig(base)).toEqual([]);
   });
 });
 

--- a/frontend/src/features/Practice/engine/cues.ts
+++ b/frontend/src/features/Practice/engine/cues.ts
@@ -29,6 +29,7 @@ const CUE_BUILDERS: {
   tallied_grounding: noCues,
   tarot: cuesForTarot,
   card_meditation: cuesForCardMeditation,
+  mindful_anchor: noCues,
 };
 
 export function scheduledCues(config: ModeConfig): readonly Cue[] {

--- a/frontend/src/features/Practice/engine/reducer.ts
+++ b/frontend/src/features/Practice/engine/reducer.ts
@@ -220,6 +220,7 @@ const TOTAL_MS_BUILDERS: {
   tarot: tarotTotalMs,
   card_meditation: cardMeditationTotalMs,
   rep_counter: repCounterTotalMs,
+  mindful_anchor: unboundedTotalMs,
 };
 
 export function getTotalMs(config: ModeConfig): number | null {

--- a/frontend/src/features/Practice/engine/types.ts
+++ b/frontend/src/features/Practice/engine/types.ts
@@ -144,6 +144,25 @@ export interface TalliedGroundingConfig {
   categories: readonly TalliedCategory[];
 }
 
+/** One pickable anchor for a single-action mindful practice (Touch Grass, etc.). */
+export interface MindfulAnchorOption {
+  /** Stable machine identifier recorded in session metadata. */
+  key: string;
+  /** Human-facing label rendered in the chooser. */
+  label: string;
+  /** Optional hint shown alongside the label. */
+  description?: string;
+}
+
+export interface MindfulAnchorConfig {
+  mode: 'mindful_anchor';
+  instruction: string;
+  /** Soft floor (seconds) the view nudges against; never a hard lock. */
+  min_duration_seconds: number;
+  options: readonly MindfulAnchorOption[];
+  require_option_choice: boolean;
+}
+
 export type ModeConfig =
   | MeditationTimerConfig
   | CountUpConfig
@@ -154,7 +173,8 @@ export type ModeConfig =
   | SenseGroundingConfig
   | TalliedGroundingConfig
   | TarotConfig
-  | CardMeditationConfig;
+  | CardMeditationConfig
+  | MindfulAnchorConfig;
 
 /** Random-bell session metadata; `interval_seconds[i]` is the gap before struck bell `i`. */
 export interface RandomIntervalBellMetadata {
@@ -173,6 +193,16 @@ export interface TalliedGroundingMetadata {
   rounds_completed: number;
   total_rounds: number;
   items_completed: number;
+}
+
+/** Per-session payload emitted by `MindfulAnchorView` on save. */
+export interface MindfulAnchorMetadata {
+  mode: 'mindful_anchor';
+  /** `key` of the chosen option, or `null` when none was offered/picked. */
+  chosen_option_key: string | null;
+  duration_seconds: number;
+  /** Whether `duration_seconds` cleared the config's soft floor. */
+  met_min_duration: boolean;
 }
 
 export interface RitualState {

--- a/frontend/src/features/Practice/engine/validation.ts
+++ b/frontend/src/features/Practice/engine/validation.ts
@@ -11,6 +11,8 @@ import type {
   IntervalBellConfig,
   MeditationTimerConfig,
   MetronomeConfig,
+  MindfulAnchorConfig,
+  MindfulAnchorOption,
   ModeConfig,
   RandomIntervalBellConfig,
   RepCounterConfig,
@@ -55,6 +57,15 @@ export const TALLIED_TARGET_MAX = 20;
 export const TALLIED_KEY_MAX = 64;
 export const TALLIED_LABEL_MAX = 255;
 export const TALLIED_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+// Mirror ``backend/src/schemas/practice_mode_config.py`` mindful-anchor caps.
+export const INSTRUCTION_MAX = 500;
+export const MIN_DURATION_SECONDS_MAX = 3_600;
+export const MINDFUL_ANCHOR_OPTIONS_MAX = 20;
+export const OPTION_KEY_MAX = 64;
+export const OPTION_LABEL_MAX = 255;
+export const OPTION_DESCRIPTION_MAX = 500;
+export const OPTION_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
 
 export const ALLOWED_SENSES: readonly SenseKind[] = ['sight', 'touch', 'hearing', 'smell', 'taste'];
 
@@ -246,6 +257,57 @@ export function validateSenseGrounding(config: SenseGroundingConfig): string[] {
   return errors;
 }
 
+function checkAnchorOption(option: MindfulAnchorOption, index: number): string[] {
+  const errors: string[] = [];
+  const label = `Option ${index + 1}`;
+  if (!OPTION_KEY_PATTERN.test(option.key) || option.key.length > OPTION_KEY_MAX) {
+    errors.push(`${label}: key must be a slug (lowercase, ≤ ${OPTION_KEY_MAX} chars)`);
+  }
+  if (option.label.trim().length === 0) {
+    errors.push(`${label}: label cannot be empty`);
+  }
+  if (option.label.length > OPTION_LABEL_MAX) {
+    errors.push(`${label}: label must be ≤ ${OPTION_LABEL_MAX} characters`);
+  }
+  if (option.description !== undefined && option.description.length > OPTION_DESCRIPTION_MAX) {
+    errors.push(`${label}: description must be ≤ ${OPTION_DESCRIPTION_MAX} characters`);
+  }
+  return errors;
+}
+
+export function validateMindfulAnchor(config: MindfulAnchorConfig): string[] {
+  const errors: string[] = [];
+  if (config.instruction.trim().length === 0) {
+    errors.push('Instruction cannot be empty');
+  }
+  if (config.instruction.length > INSTRUCTION_MAX) {
+    errors.push(`Instruction must be ≤ ${INSTRUCTION_MAX} characters`);
+  }
+  if (
+    !Number.isInteger(config.min_duration_seconds) ||
+    config.min_duration_seconds < 0 ||
+    config.min_duration_seconds > MIN_DURATION_SECONDS_MAX
+  ) {
+    errors.push(
+      `Minimum duration must be a whole number of seconds (0–${MIN_DURATION_SECONDS_MAX})`,
+    );
+  }
+  if (config.options.length > MINDFUL_ANCHOR_OPTIONS_MAX) {
+    errors.push(`At most ${MINDFUL_ANCHOR_OPTIONS_MAX} options are allowed`);
+  }
+  config.options.forEach((option, index) => {
+    errors.push(...checkAnchorOption(option, index));
+  });
+  const keys = config.options.map((option) => option.key);
+  if (new Set(keys).size !== keys.length) {
+    errors.push('Option keys must be unique');
+  }
+  if (config.require_option_choice && config.options.length === 0) {
+    errors.push('Add at least one option when a choice is required');
+  }
+  return errors;
+}
+
 export function validateTarot(config: TarotConfig): string[] {
   const errors: string[] = [];
   if (config.per_card_minutes !== undefined) {
@@ -367,6 +429,7 @@ const VALIDATORS: {
   tallied_grounding: validateTalliedGrounding,
   tarot: validateTarot,
   card_meditation: validateCardMeditation,
+  mindful_anchor: validateMindfulAnchor,
 };
 
 /**

--- a/frontend/src/features/Practice/insights/__tests__/format.test.ts
+++ b/frontend/src/features/Practice/insights/__tests__/format.test.ts
@@ -31,6 +31,7 @@ describe('formatModeSummary', () => {
       6,
       '27 items across 3/3 rounds',
     ],
+    [{ mode: 'mindful_anchor' }, 2 + 25 / 60, '02:25 of mindful presence'],
   ])('formats %j (%s min) as %s', (metadata, durationMinutes, expected) => {
     expect(formatModeSummary(metadata.mode, durationMinutes, metadata)).toBe(expected);
   });

--- a/frontend/src/features/Practice/insights/format.ts
+++ b/frontend/src/features/Practice/insights/format.ts
@@ -73,6 +73,10 @@ export interface ModeSummaryTalliedGrounding {
   readonly items_completed: number;
 }
 
+export interface ModeSummaryMindfulAnchor {
+  readonly mode: 'mindful_anchor';
+}
+
 export type ModeSummaryMetadata =
   | ModeSummaryMeditationTimer
   | ModeSummaryCountUp
@@ -83,7 +87,8 @@ export type ModeSummaryMetadata =
   | ModeSummarySenseGrounding
   | ModeSummaryTalliedGrounding
   | ModeSummaryTarot
-  | ModeSummaryCardMeditation;
+  | ModeSummaryCardMeditation
+  | ModeSummaryMindfulAnchor;
 
 export type ModeSummaryKind = ModeSummaryMetadata['mode'];
 
@@ -116,6 +121,7 @@ const SUMMARY_FORMATTERS: {
     `${metadata.rounds_completed}/${metadata.total_rounds} rounds`,
   tarot: cardSummary,
   card_meditation: cardSummary,
+  mindful_anchor: (_metadata, mmss) => `${mmss} of mindful presence`,
 };
 
 /**

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -352,6 +352,9 @@ const MODE_FORMS: FormTable = {
   // form yet — the wizard saves the smart defaults verbatim until the
   // dedicated form lands in a follow-up.
   tallied_grounding: null,
+  // ``mindful_anchor`` ships a runtime engine + view but no configurator
+  // form yet — same deferral pattern as ``tallied_grounding``.
+  mindful_anchor: null,
 };
 
 const ConfiguratorBody = ({ config, onChange }: ConfiguratorBodyProps): React.JSX.Element => {

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -285,6 +285,10 @@ const SUMMARIZERS: {
   tallied_grounding: (c) => [`${c.rounds} rounds`, `${c.categories.length} categories`],
   tarot: () => ['Major arcana — one card per sit'],
   card_meditation: (c) => [`Deck: ${c.deck_id}`],
+  mindful_anchor: (c) => {
+    const choice = c.options.length === 0 ? 'no chooser' : `${c.options.length} options`;
+    return [`Soft minimum: ${c.min_duration_seconds}s`, choice];
+  },
 };
 
 /**

--- a/frontend/src/features/Practice/views/MindfulAnchorView.tsx
+++ b/frontend/src/features/Practice/views/MindfulAnchorView.tsx
@@ -1,0 +1,397 @@
+/**
+ * `MindfulAnchorView` — single-action ritual UX for Touch Grass / Mindful
+ * Eating and similar `mindful_anchor` practices.
+ *
+ * Unlike the step-based modes there is no `currentStepIndex`: the flow is
+ * "Begin → Save", which maps onto the engine `status` transitions
+ * `idle → running → complete`. The view owns its option selection and a
+ * 1-Hz local elapsed counter (display only — it never mutates engine
+ * state); on save it emits a `MindfulAnchorMetadata` payload upward.
+ *
+ * The `min_duration_seconds` floor is a *soft* gate: saving below it pops a
+ * confirmation rather than blocking, so a user with a real reason to cut
+ * the session short can still record it.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import type {
+  MindfulAnchorConfig,
+  MindfulAnchorMetadata,
+  MindfulAnchorOption,
+  RitualControls,
+  RitualState,
+} from '../engine/types';
+
+import { formatTime } from './formatTime';
+import RitualControlsBar from './RitualControlsBar';
+
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+const MS_PER_SECOND = 1000;
+
+interface Props {
+  config: MindfulAnchorConfig;
+  state: RitualState;
+  controls: RitualControls;
+  /** Receives the session payload the instant the user confirms Save. */
+  onComplete?: (_metadata: MindfulAnchorMetadata) => void;
+}
+
+interface AnchorState {
+  selectedOptionKey: string | null;
+  setSelectedOptionKey: (_key: string) => void;
+  elapsedSeconds: number;
+  confirmVisible: boolean;
+  hideConfirm: () => void;
+  commit: () => void;
+  handleSave: () => void;
+}
+
+/**
+ * Owns the view-local session state: the chosen option, a 1-Hz elapsed
+ * counter (display + gate only — it never touches the engine), and the
+ * soft-gate confirmation visibility.
+ */
+function useAnchorState(
+  config: MindfulAnchorConfig,
+  controls: RitualControls,
+  status: RitualState['status'],
+  onComplete: Props['onComplete'],
+): AnchorState {
+  const [selectedOptionKey, setSelectedOptionKey] = useState<string | null>(null);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [confirmVisible, setConfirmVisible] = useState(false);
+
+  const tick = useCallback(() => setElapsedSeconds((seconds) => seconds + 1), []);
+
+  useEffect(() => {
+    if (status !== 'running') return undefined;
+    const handle = setInterval(tick, MS_PER_SECOND);
+    return () => clearInterval(handle);
+  }, [status, tick]);
+
+  // A return to `idle` means cancel (or a fresh session): wipe local state.
+  useEffect(() => {
+    if (status !== 'idle') return;
+    setSelectedOptionKey(null);
+    setElapsedSeconds(0);
+    setConfirmVisible(false);
+  }, [status]);
+
+  const commit = useCallback(() => {
+    setConfirmVisible(false);
+    onComplete?.({
+      mode: 'mindful_anchor',
+      chosen_option_key: selectedOptionKey,
+      duration_seconds: elapsedSeconds,
+      met_min_duration: elapsedSeconds >= config.min_duration_seconds,
+    });
+    controls.complete();
+  }, [config.min_duration_seconds, controls, elapsedSeconds, onComplete, selectedOptionKey]);
+
+  const handleSave = useCallback(() => {
+    if (elapsedSeconds >= config.min_duration_seconds) commit();
+    else setConfirmVisible(true);
+  }, [commit, config.min_duration_seconds, elapsedSeconds]);
+
+  const hideConfirm = useCallback(() => setConfirmVisible(false), []);
+
+  return {
+    selectedOptionKey,
+    setSelectedOptionKey,
+    elapsedSeconds,
+    confirmVisible,
+    hideConfirm,
+    commit,
+    handleSave,
+  };
+}
+
+const MindfulAnchorView = ({ config, state, controls, onComplete }: Props): React.JSX.Element => {
+  const { status } = state;
+  const anchor = useAnchorState(config, controls, status, onComplete);
+  const beginDisabled = config.require_option_choice && anchor.selectedOptionKey === null;
+  return (
+    <View style={styles.container} testID="mindful-anchor-view">
+      <InstructionCard instruction={config.instruction} />
+      {status === 'idle' && config.options.length > 0 && (
+        <OptionChooser
+          options={config.options}
+          selectedKey={anchor.selectedOptionKey}
+          onSelect={anchor.setSelectedOptionKey}
+        />
+      )}
+      {status === 'running' && <ElapsedDisplay seconds={anchor.elapsedSeconds} />}
+      {status === 'idle' ? (
+        <BeginButton disabled={beginDisabled} onPress={controls.start} />
+      ) : (
+        <RitualControlsBar status={status} controls={controls} startLabel="Begin" />
+      )}
+      {status === 'running' && <SaveButton onPress={anchor.handleSave} />}
+      <ConfirmDialog
+        visible={anchor.confirmVisible}
+        seconds={anchor.elapsedSeconds}
+        onCancel={anchor.hideConfirm}
+        onConfirm={anchor.commit}
+      />
+    </View>
+  );
+};
+
+const InstructionCard = ({ instruction }: { instruction: string }): React.JSX.Element => (
+  <View style={styles.instructionCard} testID="mindful-anchor-instruction">
+    <Text style={styles.instructionText}>{instruction}</Text>
+  </View>
+);
+
+interface OptionChooserProps {
+  options: readonly MindfulAnchorOption[];
+  selectedKey: string | null;
+  onSelect: (_key: string) => void;
+}
+
+const OptionChooser = ({
+  options,
+  selectedKey,
+  onSelect,
+}: OptionChooserProps): React.JSX.Element => (
+  <View
+    style={styles.chooser}
+    testID="mindful-anchor-options"
+    accessibilityRole="radiogroup"
+    accessibilityLabel="Choose an anchor"
+  >
+    {options.map((option) => (
+      <OptionRow
+        key={option.key}
+        option={option}
+        selected={option.key === selectedKey}
+        onSelect={onSelect}
+      />
+    ))}
+  </View>
+);
+
+interface OptionRowProps {
+  option: MindfulAnchorOption;
+  selected: boolean;
+  onSelect: (_key: string) => void;
+}
+
+const OptionRow = ({ option, selected, onSelect }: OptionRowProps): React.JSX.Element => (
+  <Pressable
+    style={[styles.option, selected && styles.optionSelected]}
+    onPress={() => onSelect(option.key)}
+    testID={`mindful-anchor-option-${option.key}`}
+    accessibilityRole="radio"
+    accessibilityLabel={option.label}
+    accessibilityState={{ selected }}
+  >
+    <Text style={styles.optionLabel}>{option.label}</Text>
+    {option.description && <Text style={styles.optionDescription}>{option.description}</Text>}
+  </Pressable>
+);
+
+const ElapsedDisplay = ({ seconds }: { seconds: number }): React.JSX.Element => (
+  <View
+    style={styles.elapsedBlock}
+    testID="mindful-anchor-elapsed"
+    accessibilityLiveRegion="polite"
+  >
+    <Text style={styles.elapsedTime} testID="mindful-anchor-elapsed-time">
+      {formatTime(seconds * MS_PER_SECOND)}
+    </Text>
+    <Text style={styles.elapsedLabel}>elapsed</Text>
+  </View>
+);
+
+interface BeginButtonProps {
+  disabled: boolean;
+  onPress: () => void;
+}
+
+const BeginButton = ({ disabled, onPress }: BeginButtonProps): React.JSX.Element => (
+  <Pressable
+    style={[styles.begin, disabled && styles.disabled]}
+    onPress={disabled ? undefined : onPress}
+    disabled={disabled}
+    testID="mindful-anchor-begin"
+    accessibilityRole="button"
+    accessibilityLabel="Begin"
+    accessibilityState={{ disabled }}
+  >
+    <Text style={styles.beginText}>Begin</Text>
+  </Pressable>
+);
+
+const SaveButton = ({ onPress }: { onPress: () => void }): React.JSX.Element => (
+  <Pressable
+    style={styles.save}
+    onPress={onPress}
+    testID="mindful-anchor-save"
+    accessibilityRole="button"
+    accessibilityLabel="Save session"
+  >
+    <Text style={styles.saveText}>Save session</Text>
+  </Pressable>
+);
+
+interface ConfirmDialogProps {
+  visible: boolean;
+  seconds: number;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const ConfirmDialog = ({
+  visible,
+  seconds,
+  onCancel,
+  onConfirm,
+}: ConfirmDialogProps): React.JSX.Element | null => {
+  // Null-render while hidden (matching `InsightCaptureModal`) so the
+  // confirm content is absent from the tree, not merely visually hidden.
+  if (!visible) return null;
+  const spent = `${seconds} ${seconds === 1 ? 'second' : 'seconds'}`;
+  return (
+    <Modal
+      visible
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+      testID="mindful-anchor-confirm"
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.dialog}>
+          <Text style={styles.dialogTitle}>Take another moment?</Text>
+          <Text style={styles.dialogBody} testID="mindful-anchor-confirm-message">
+            {`It looks like you only spent ${spent} here. Take another moment, or save anyway?`}
+          </Text>
+          <Pressable
+            style={styles.dialogPrimary}
+            onPress={onCancel}
+            testID="mindful-anchor-confirm-cancel"
+            accessibilityRole="button"
+            accessibilityLabel="Keep going"
+          >
+            <Text style={styles.dialogPrimaryText}>Keep going</Text>
+          </Pressable>
+          <Pressable
+            style={styles.dialogSecondary}
+            onPress={onConfirm}
+            testID="mindful-anchor-confirm-save"
+            accessibilityRole="button"
+            accessibilityLabel="Save anyway"
+          >
+            <Text style={styles.dialogSecondaryText}>Save anyway</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl },
+  instructionCard: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.xl,
+    marginBottom: SPACING.xl,
+    maxWidth: 340,
+    ...shadows.small,
+  },
+  instructionText: {
+    fontSize: 20,
+    fontWeight: '500',
+    color: colors.text.primary,
+    textAlign: 'center',
+    lineHeight: 28,
+  },
+  chooser: { alignSelf: 'stretch', gap: SPACING.sm, marginBottom: SPACING.xl },
+  option: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.md,
+  },
+  optionSelected: {
+    borderColor: colors.primary,
+    backgroundColor: colors.background.accent,
+  },
+  optionLabel: { fontSize: 16, fontWeight: '600', color: colors.text.primary },
+  optionDescription: {
+    fontSize: 13,
+    color: colors.text.secondaryAccessible,
+    marginTop: SPACING.xs,
+  },
+  elapsedBlock: { alignItems: 'center', marginBottom: SPACING.xl },
+  elapsedTime: {
+    fontSize: 56,
+    fontWeight: '200',
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+  },
+  elapsedLabel: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    marginTop: SPACING.xs,
+    textTransform: 'uppercase',
+    letterSpacing: 2,
+  },
+  begin: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    marginBottom: SPACING.xl,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  beginText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
+  save: {
+    backgroundColor: colors.success,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    marginTop: SPACING.lg,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  saveText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
+  disabled: { opacity: 0.5 },
+  backdrop: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.lg,
+  },
+  dialog: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.xl,
+    padding: SPACING.xl,
+    gap: SPACING.sm,
+    ...shadows.large,
+  },
+  dialogTitle: { fontSize: 20, fontWeight: '700', color: colors.text.primary },
+  dialogBody: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    marginBottom: SPACING.sm,
+    lineHeight: 20,
+  },
+  dialogPrimary: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.buttonV,
+    borderRadius: BORDER_RADIUS.lg,
+    alignItems: 'center',
+  },
+  dialogPrimaryText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
+  dialogSecondary: { paddingVertical: SPACING.md, alignItems: 'center' },
+  dialogSecondaryText: { color: colors.text.tertiaryAccessible, fontSize: 15 },
+});
+
+export default MindfulAnchorView;

--- a/frontend/src/features/Practice/views/MindfulAnchorView.tsx
+++ b/frontend/src/features/Practice/views/MindfulAnchorView.tsx
@@ -29,13 +29,19 @@ import RitualControlsBar from './RitualControlsBar';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 
 const MS_PER_SECOND = 1000;
+/** Caps the instruction card so long copy stays readable on wide screens. */
+const INSTRUCTION_CARD_MAX_WIDTH = 340;
 
 interface Props {
   config: MindfulAnchorConfig;
   state: RitualState;
   controls: RitualControls;
-  /** Receives the session payload the instant the user confirms Save. */
-  onComplete?: (_metadata: MindfulAnchorMetadata) => void;
+  /**
+   * Receives the session payload the instant the user confirms Save.
+   * Required: `ActiveRitualSession` always wires this so the dispatcher
+   * can harvest `MindfulAnchorMetadata`.
+   */
+  onComplete: (_metadata: MindfulAnchorMetadata) => void;
 }
 
 interface AnchorState {
@@ -79,9 +85,13 @@ function useAnchorState(
     setConfirmVisible(false);
   }, [status]);
 
+  // `elapsedSeconds` is in the dep array, so `commit` always re-binds to the
+  // latest tick — including the seconds that pass while the soft-gate confirm
+  // dialog sits open. The saved `duration_seconds` reflects the moment the
+  // user actually confirms, not the moment they first tapped Save.
   const commit = useCallback(() => {
     setConfirmVisible(false);
-    onComplete?.({
+    onComplete({
       mode: 'mindful_anchor',
       chosen_option_key: selectedOptionKey,
       duration_seconds: elapsedSeconds,
@@ -299,7 +309,7 @@ const styles = StyleSheet.create({
     borderRadius: BORDER_RADIUS.lg,
     padding: SPACING.xl,
     marginBottom: SPACING.xl,
-    maxWidth: 340,
+    maxWidth: INSTRUCTION_CARD_MAX_WIDTH,
     ...shadows.small,
   },
   instructionText: {

--- a/frontend/src/features/Practice/views/__tests__/MindfulAnchorView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/MindfulAnchorView.test.tsx
@@ -41,6 +41,7 @@ describe('MindfulAnchorView', () => {
         config={optionConfig}
         state={fakeState({ status: 'idle' })}
         controls={fakeControls()}
+        onComplete={jest.fn()}
       />,
     );
     expect(getByTestId('mindful-anchor-instruction')).toHaveTextContent(optionConfig.instruction);
@@ -52,6 +53,7 @@ describe('MindfulAnchorView', () => {
         config={optionConfig}
         state={fakeState({ status: 'idle' })}
         controls={fakeControls()}
+        onComplete={jest.fn()}
       />,
     );
     expect(getByTestId('mindful-anchor-options')).toBeTruthy();
@@ -65,6 +67,7 @@ describe('MindfulAnchorView', () => {
         config={bareConfig}
         state={fakeState({ status: 'idle' })}
         controls={fakeControls()}
+        onComplete={jest.fn()}
       />,
     );
     expect(queryByTestId('mindful-anchor-options')).toBeNull();
@@ -76,6 +79,7 @@ describe('MindfulAnchorView', () => {
         config={optionConfig}
         state={fakeState({ status: 'running' })}
         controls={fakeControls()}
+        onComplete={jest.fn()}
       />,
     );
     expect(queryByTestId('mindful-anchor-options')).toBeNull();
@@ -88,6 +92,7 @@ describe('MindfulAnchorView', () => {
         config={optionConfig}
         state={fakeState({ status: 'idle' })}
         controls={controls}
+        onComplete={jest.fn()}
       />,
     );
     const begin = getByTestId('mindful-anchor-begin');
@@ -103,6 +108,7 @@ describe('MindfulAnchorView', () => {
         config={optionConfig}
         state={fakeState({ status: 'idle' })}
         controls={controls}
+        onComplete={jest.fn()}
       />,
     );
     fireEvent.press(getByTestId('mindful-anchor-option-grass'));
@@ -122,6 +128,7 @@ describe('MindfulAnchorView', () => {
         config={bareConfig}
         state={fakeState({ status: 'idle' })}
         controls={controls}
+        onComplete={jest.fn()}
       />,
     );
     const begin = getByTestId('mindful-anchor-begin');
@@ -136,6 +143,7 @@ describe('MindfulAnchorView', () => {
         config={bareConfig}
         state={fakeState({ status: 'idle' })}
         controls={fakeControls()}
+        onComplete={jest.fn()}
       />,
     );
     expect(queryByTestId('mindful-anchor-elapsed')).toBeNull();
@@ -144,6 +152,7 @@ describe('MindfulAnchorView', () => {
         config={bareConfig}
         state={fakeState({ status: 'running' })}
         controls={fakeControls()}
+        onComplete={jest.fn()}
       />,
     );
     expect(queryByTestId('mindful-anchor-elapsed')).toBeTruthy();
@@ -155,6 +164,7 @@ describe('MindfulAnchorView', () => {
         config={bareConfig}
         state={fakeState({ status: 'running' })}
         controls={fakeControls()}
+        onComplete={jest.fn()}
       />,
     );
     const elapsed = getByTestId('mindful-anchor-elapsed');
@@ -206,6 +216,7 @@ describe('MindfulAnchorView', () => {
         config={optionConfig}
         state={fakeState({ status: 'running' })}
         controls={fakeControls()}
+        onComplete={jest.fn()}
       />,
     );
     act(() => {
@@ -350,6 +361,7 @@ describe('MindfulAnchorView', () => {
         config={bareConfig}
         state={fakeState({ status: 'running' })}
         controls={controls}
+        onComplete={jest.fn()}
       />,
     );
     fireEvent.press(getByTestId('ritual-pause'));
@@ -359,6 +371,7 @@ describe('MindfulAnchorView', () => {
         config={bareConfig}
         state={fakeState({ status: 'complete' })}
         controls={controls}
+        onComplete={jest.fn()}
       />,
     );
     expect(getByTestId('ritual-complete-label')).toBeTruthy();
@@ -366,20 +379,27 @@ describe('MindfulAnchorView', () => {
     expect(queryByTestId('mindful-anchor-elapsed')).toBeNull();
   });
 
-  it('completes cleanly when no onComplete handler is wired', () => {
+  it('saves immediately without a dialog when min_duration_seconds is zero', () => {
+    const onComplete = jest.fn();
     const controls = fakeControls();
-    const { getByTestId } = render(
+    const zeroConfig: MindfulAnchorConfig = { ...bareConfig, min_duration_seconds: 0 };
+    const { getByTestId, queryByTestId } = render(
       <MindfulAnchorView
-        config={bareConfig}
+        config={zeroConfig}
         state={fakeState({ status: 'running' })}
         controls={controls}
+        onComplete={onComplete}
       />,
     );
-    act(() => {
-      jest.advanceTimersByTime(5000);
-    });
     fireEvent.press(getByTestId('mindful-anchor-save'));
+    expect(queryByTestId('mindful-anchor-confirm')).toBeNull();
     expect(controls.complete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({
+      mode: 'mindful_anchor',
+      chosen_option_key: null,
+      duration_seconds: 0,
+      met_min_duration: true,
+    });
   });
 
   it('matches the option-chooser snapshot', () => {
@@ -388,6 +408,7 @@ describe('MindfulAnchorView', () => {
         config={optionConfig}
         state={fakeState({ status: 'idle' })}
         controls={fakeControls()}
+        onComplete={jest.fn()}
       />,
     );
     expect(toJSON()).toMatchSnapshot();

--- a/frontend/src/features/Practice/views/__tests__/MindfulAnchorView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/MindfulAnchorView.test.tsx
@@ -1,0 +1,395 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { MindfulAnchorConfig } from '../../engine/types';
+import MindfulAnchorView from '../MindfulAnchorView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+const optionConfig: MindfulAnchorConfig = {
+  mode: 'mindful_anchor',
+  instruction: 'Step outside and rest a bare palm on the grass.',
+  min_duration_seconds: 120,
+  options: [
+    { key: 'grass', label: 'Grass', description: 'A lawn, a field, a verge.' },
+    { key: 'soil', label: 'Soil' },
+  ],
+  require_option_choice: true,
+};
+
+const bareConfig: MindfulAnchorConfig = {
+  mode: 'mindful_anchor',
+  instruction: 'Take one slow, deliberate bite and notice every texture.',
+  min_duration_seconds: 3,
+  options: [],
+  require_option_choice: false,
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('MindfulAnchorView', () => {
+  it('renders the instruction text', () => {
+    const { getByTestId } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('mindful-anchor-instruction')).toHaveTextContent(optionConfig.instruction);
+  });
+
+  it('renders the option chooser when options are configured and idle', () => {
+    const { getByTestId } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('mindful-anchor-options')).toBeTruthy();
+    expect(getByTestId('mindful-anchor-option-grass')).toBeTruthy();
+    expect(getByTestId('mindful-anchor-option-soil')).toBeTruthy();
+  });
+
+  it('hides the option chooser when no options are configured', () => {
+    const { queryByTestId } = render(
+      <MindfulAnchorView
+        config={bareConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(queryByTestId('mindful-anchor-options')).toBeNull();
+  });
+
+  it('hides the option chooser once the session is running', () => {
+    const { queryByTestId } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'running' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(queryByTestId('mindful-anchor-options')).toBeNull();
+  });
+
+  it('disables Begin while a required choice is unmade', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={controls}
+      />,
+    );
+    const begin = getByTestId('mindful-anchor-begin');
+    expect(begin.props.accessibilityState).toEqual({ disabled: true });
+    fireEvent.press(begin);
+    expect(controls.start).not.toHaveBeenCalled();
+  });
+
+  it('enables Begin after an option is tapped', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('mindful-anchor-option-grass'));
+    const begin = getByTestId('mindful-anchor-begin');
+    expect(begin.props.accessibilityState).toEqual({ disabled: false });
+    expect(getByTestId('mindful-anchor-option-grass').props.accessibilityState).toEqual({
+      selected: true,
+    });
+    fireEvent.press(begin);
+    expect(controls.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('enables Begin immediately when no choice is required', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <MindfulAnchorView
+        config={bareConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={controls}
+      />,
+    );
+    const begin = getByTestId('mindful-anchor-begin');
+    expect(begin.props.accessibilityState).toEqual({ disabled: false });
+    fireEvent.press(begin);
+    expect(controls.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the elapsed-time display only while running', () => {
+    const { queryByTestId, rerender } = render(
+      <MindfulAnchorView
+        config={bareConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(queryByTestId('mindful-anchor-elapsed')).toBeNull();
+    rerender(
+      <MindfulAnchorView
+        config={bareConfig}
+        state={fakeState({ status: 'running' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(queryByTestId('mindful-anchor-elapsed')).toBeTruthy();
+  });
+
+  it('ticks the elapsed counter once per second and announces it politely', () => {
+    const { getByTestId } = render(
+      <MindfulAnchorView
+        config={bareConfig}
+        state={fakeState({ status: 'running' })}
+        controls={fakeControls()}
+      />,
+    );
+    const elapsed = getByTestId('mindful-anchor-elapsed');
+    expect(elapsed.props.accessibilityLiveRegion).toBe('polite');
+    expect(getByTestId('mindful-anchor-elapsed-time').props.children).toBe('00:00');
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(getByTestId('mindful-anchor-elapsed-time').props.children).toBe('00:03');
+  });
+
+  it('pops the soft confirm dialog when saving below the minimum duration', () => {
+    const onComplete = jest.fn();
+    const controls = fakeControls();
+    const { getByTestId, queryByTestId } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+        onComplete={onComplete}
+      />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    fireEvent.press(getByTestId('mindful-anchor-save'));
+    expect(getByTestId('mindful-anchor-confirm')).toBeTruthy();
+    expect(getByTestId('mindful-anchor-confirm-message')).toHaveTextContent(
+      /only spent 5 seconds here/,
+    );
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(controls.complete).not.toHaveBeenCalled();
+
+    fireEvent.press(getByTestId('mindful-anchor-confirm-save'));
+    expect(queryByTestId('mindful-anchor-confirm')).toBeNull();
+    expect(controls.complete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({
+      mode: 'mindful_anchor',
+      chosen_option_key: null,
+      duration_seconds: 5,
+      met_min_duration: false,
+    });
+  });
+
+  it('uses the singular noun when only one second elapsed', () => {
+    const { getByTestId } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'running' })}
+        controls={fakeControls()}
+      />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    fireEvent.press(getByTestId('mindful-anchor-save'));
+    expect(getByTestId('mindful-anchor-confirm-message')).toHaveTextContent(
+      /only spent 1 second here/,
+    );
+  });
+
+  it('returns to the running session when the confirm dialog is dismissed', () => {
+    const onComplete = jest.fn();
+    const controls = fakeControls();
+    const { getByTestId, queryByTestId } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+        onComplete={onComplete}
+      />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    fireEvent.press(getByTestId('mindful-anchor-save'));
+    fireEvent.press(getByTestId('mindful-anchor-confirm-cancel'));
+    expect(queryByTestId('mindful-anchor-confirm')).toBeNull();
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(controls.complete).not.toHaveBeenCalled();
+  });
+
+  it('saves directly without a dialog once the minimum duration is met', () => {
+    const onComplete = jest.fn();
+    const controls = fakeControls();
+    const { getByTestId, queryByTestId } = render(
+      <MindfulAnchorView
+        config={bareConfig}
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+        onComplete={onComplete}
+      />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    fireEvent.press(getByTestId('mindful-anchor-save'));
+    expect(queryByTestId('mindful-anchor-confirm')).toBeNull();
+    expect(controls.complete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({
+      mode: 'mindful_anchor',
+      chosen_option_key: null,
+      duration_seconds: 5,
+      met_min_duration: true,
+    });
+  });
+
+  it('carries the chosen option key into the saved metadata', () => {
+    const onComplete = jest.fn();
+    const controls = fakeControls();
+    const { getByTestId, rerender } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={controls}
+        onComplete={onComplete}
+      />,
+    );
+    fireEvent.press(getByTestId('mindful-anchor-option-soil'));
+    rerender(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+        onComplete={onComplete}
+      />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(125000);
+    });
+    fireEvent.press(getByTestId('mindful-anchor-save'));
+    expect(onComplete).toHaveBeenCalledWith({
+      mode: 'mindful_anchor',
+      chosen_option_key: 'soil',
+      duration_seconds: 125,
+      met_min_duration: true,
+    });
+  });
+
+  it('clears local state when the engine returns to idle', () => {
+    const controls = fakeControls();
+    const { getByTestId, queryByTestId, rerender } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={controls}
+        onComplete={jest.fn()}
+      />,
+    );
+    fireEvent.press(getByTestId('mindful-anchor-option-grass'));
+    rerender(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+        onComplete={jest.fn()}
+      />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    rerender(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={controls}
+        onComplete={jest.fn()}
+      />,
+    );
+    expect(getByTestId('mindful-anchor-option-grass').props.accessibilityState).toEqual({
+      selected: false,
+    });
+    expect(getByTestId('mindful-anchor-begin').props.accessibilityState).toEqual({
+      disabled: true,
+    });
+    rerender(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+        onComplete={jest.fn()}
+      />,
+    );
+    expect(getByTestId('mindful-anchor-elapsed-time').props.children).toBe('00:00');
+    expect(queryByTestId('mindful-anchor-confirm')).toBeNull();
+  });
+
+  it('reuses RitualControlsBar for the non-idle engine states', () => {
+    const controls = fakeControls();
+    const { getByTestId, queryByTestId, rerender } = render(
+      <MindfulAnchorView
+        config={bareConfig}
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('ritual-pause'));
+    expect(controls.pause).toHaveBeenCalledTimes(1);
+    rerender(
+      <MindfulAnchorView
+        config={bareConfig}
+        state={fakeState({ status: 'complete' })}
+        controls={controls}
+      />,
+    );
+    expect(getByTestId('ritual-complete-label')).toBeTruthy();
+    expect(queryByTestId('mindful-anchor-save')).toBeNull();
+    expect(queryByTestId('mindful-anchor-elapsed')).toBeNull();
+  });
+
+  it('completes cleanly when no onComplete handler is wired', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <MindfulAnchorView
+        config={bareConfig}
+        state={fakeState({ status: 'running' })}
+        controls={controls}
+      />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    fireEvent.press(getByTestId('mindful-anchor-save'));
+    expect(controls.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('matches the option-chooser snapshot', () => {
+    const { toJSON } = render(
+      <MindfulAnchorView
+        config={optionConfig}
+        state={fakeState({ status: 'idle' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/__snapshots__/MindfulAnchorView.test.tsx.snap
+++ b/frontend/src/features/Practice/views/__tests__/__snapshots__/MindfulAnchorView.test.tsx.snap
@@ -1,0 +1,256 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MindfulAnchorView matches the option-chooser snapshot 1`] = `
+<View
+  style={
+    {
+      "alignItems": "center",
+      "padding": 20,
+    }
+  }
+  testID="mindful-anchor-view"
+>
+  <View
+    style={
+      {
+        "backgroundColor": "#ffffff",
+        "borderRadius": 12,
+        "elevation": 2,
+        "marginBottom": 20,
+        "maxWidth": 340,
+        "padding": 20,
+        "shadowColor": "#000000",
+        "shadowOffset": {
+          "height": 1,
+          "width": 0,
+        },
+        "shadowOpacity": 0.1,
+        "shadowRadius": 2,
+      }
+    }
+    testID="mindful-anchor-instruction"
+  >
+    <Text
+      style={
+        {
+          "color": "#333333",
+          "fontSize": 20,
+          "fontWeight": "500",
+          "lineHeight": 28,
+          "textAlign": "center",
+        }
+      }
+    >
+      Step outside and rest a bare palm on the grass.
+    </Text>
+  </View>
+  <View
+    accessibilityLabel="Choose an anchor"
+    accessibilityRole="radiogroup"
+    style={
+      {
+        "alignSelf": "stretch",
+        "gap": 8,
+        "marginBottom": 20,
+      }
+    }
+    testID="mindful-anchor-options"
+  >
+    <View
+      accessibilityLabel="Grass"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "borderColor": "#ddd",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "padding": 12,
+          },
+          false,
+        ]
+      }
+      testID="mindful-anchor-option-grass"
+    >
+      <Text
+        style={
+          {
+            "color": "#333333",
+            "fontSize": 16,
+            "fontWeight": "600",
+          }
+        }
+      >
+        Grass
+      </Text>
+      <Text
+        style={
+          {
+            "color": "#555555",
+            "fontSize": 13,
+            "marginTop": 4,
+          }
+        }
+      >
+        A lawn, a field, a verge.
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Soil"
+      accessibilityRole="radio"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": false,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "borderColor": "#ddd",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "padding": 12,
+          },
+          false,
+        ]
+      }
+      testID="mindful-anchor-option-soil"
+    >
+      <Text
+        style={
+          {
+            "color": "#333333",
+            "fontSize": 16,
+            "fontWeight": "600",
+          }
+        }
+      >
+        Soil
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityLabel="Begin"
+    accessibilityRole="button"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "alignItems": "center",
+          "backgroundColor": "#1a1910",
+          "borderRadius": 12,
+          "elevation": 2,
+          "marginBottom": 20,
+          "minWidth": 220,
+          "paddingHorizontal": 30,
+          "paddingVertical": 14,
+          "shadowColor": "#000000",
+          "shadowOffset": {
+            "height": 1,
+            "width": 0,
+          },
+          "shadowOpacity": 0.1,
+          "shadowRadius": 2,
+        },
+        {
+          "opacity": 0.5,
+        },
+      ]
+    }
+    testID="mindful-anchor-begin"
+  >
+    <Text
+      style={
+        {
+          "color": "#ffffff",
+          "fontSize": 18,
+          "fontWeight": "600",
+        }
+      }
+    >
+      Begin
+    </Text>
+  </View>
+</View>
+`;


### PR DESCRIPTION
Adds the `mindful_anchor` ritual mode to the frontend engine and a new
`MindfulAnchorView` driving the Begin -> Save flow off a
`MindfulAnchorConfig`. The view shows the instruction, an optional
option chooser gated before Begin, a 1-Hz local elapsed counter, and a
soft duration gate that confirms rather than blocks an early save.
`ActiveRitualSession` dispatches the new mode and harvests the emitted
`MindfulAnchorMetadata`.

Closes #342

https://claude.ai/code/session_01B3aVqtNCorFPc7yDNXT3to