### PR TITLE
feat(practice): build CardMeditationView + image-picker configurator form

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -13,6 +13,14 @@
     "name": "frontend",
     "newArchEnabled": true,
     "orientation": "portrait",
+    "plugins": [
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "Allow Adepthood to access your photos so you can add them as meditation cards."
+        }
+      ]
+    ],
     "slug": "frontend",
     "splash": {
       "backgroundColor": "#ffffff",

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -27,6 +27,7 @@ module.exports = {
     '^expo-secure-store$': '<rootDir>/src/__mocks__/expo-secure-store.js',
     '^expo-av$': '<rootDir>/src/__mocks__/expo-av.js',
     '^expo-haptics$': '<rootDir>/src/__mocks__/expo-haptics.js',
+    '^expo-image-picker$': '<rootDir>/src/__mocks__/expo-image-picker.js',
     '^expo-keep-awake$': '<rootDir>/src/__mocks__/expo-keep-awake.js',
     '^@react-native-community/netinfo$': '<rootDir>/src/__mocks__/netinfo.js',
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "expo": "~52.0.43",
         "expo-av": "~15.0.2",
         "expo-haptics": "~14.0.1",
+        "expo-image-picker": "~16.0.6",
         "expo-keep-awake": "~14.0.3",
         "expo-notifications": "~0.29.14",
         "expo-secure-store": "^55.0.11",
@@ -9805,6 +9806,27 @@
       "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-14.0.1.tgz",
       "integrity": "sha512-V81FZ7xRUfqM6uSI6FA1KnZ+QpEKnISqafob/xEfcx1ymwhm4V3snuLWWFjmAz+XaZQTqlYa8z3QbqEXz7G63w==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.0.0.tgz",
+      "integrity": "sha512-Eg+5FHtyzv3Jjw9dHwu2pWy4xjf8fu3V0Asyy42kO+t/FbvW/vjUixpTjPtgKQLQh+2/9Nk4JjFDV6FwCnF2ZA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.0.6.tgz",
+      "integrity": "sha512-HN4xZirFjsFDIsWFb12AZh19fRzuvZjj2ll17cGr19VNRP06S/VPQU3Tdccn5vwUzQhOBlLu704CnNm278boiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.0.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "expo": "~52.0.43",
     "expo-av": "~15.0.2",
     "expo-haptics": "~14.0.1",
+    "expo-image-picker": "~16.0.6",
     "expo-keep-awake": "~14.0.3",
     "expo-notifications": "~0.29.14",
     "expo-secure-store": "^55.0.11",

--- a/frontend/src/__mocks__/expo-image-picker.js
+++ b/frontend/src/__mocks__/expo-image-picker.js
@@ -1,0 +1,9 @@
+/* global jest */
+// Jest mock for ``expo-image-picker``: the native module cannot load in
+// the test environment. Tests override these per-case with
+// ``mockResolvedValueOnce`` to drive permission/cancel/pick branches.
+
+module.exports = {
+  requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({ granted: true }),
+  launchImageLibraryAsync: jest.fn().mockResolvedValue({ canceled: true, assets: null }),
+};

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1653,6 +1653,14 @@ export interface TarotSessionMetadata {
   card_index: number;
 }
 
+export interface CardMeditationSessionMetadata {
+  mode: 'card_meditation';
+  deck_id: string;
+  card_drawn_name: string;
+  /** Canonical deck index; omitted when the draw cannot be positioned. */
+  card_drawn_index?: number;
+}
+
 export type SessionMetadata =
   | MeditationTimerSessionMetadata
   | CountUpSessionMetadata
@@ -1660,7 +1668,8 @@ export type SessionMetadata =
   | IntervalBellSessionMetadata
   | RepCounterSessionMetadata
   | SenseGroundingSessionMetadata
-  | TarotSessionMetadata;
+  | TarotSessionMetadata
+  | CardMeditationSessionMetadata;
 
 export interface PracticeSessionCreate {
   user_practice_id: number;

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -501,8 +501,10 @@ function parseDayKeyMs(key: string): number | null {
  * `unit_label`, `card_name` from `ModeSummaryMetadata`). The backend
  * validates this discriminator against the resolved practice mode and
  * returns 400 ``mode_metadata_mismatch`` otherwise.
+ *
+ * Exported for unit testing the per-mode harvest branches.
  */
-function harvestMetadata(
+export function harvestMetadata(
   config: ModeConfig,
   state: RitualState,
   cardPick: PickedCard | null,
@@ -557,8 +559,10 @@ function normalizeTarotIndex(index: number): number {
  * Presentation-layer metadata for the ritual-12 `InsightCaptureModal`
  * summary. Carries the same fields as the wire `SessionMetadata` plus
  * presentation-only extras (`unit_label`, `card_name`) the formatter needs.
+ *
+ * Exported for unit testing the per-mode harvest branches.
  */
-function harvestSummaryMetadata(
+export function harvestSummaryMetadata(
   config: ModeConfig,
   state: RitualState,
   tarotCardIndex: number,

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -38,6 +38,7 @@ import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 import { InsightCaptureModal } from '@/features/Practice/components/InsightCaptureModal';
 import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConfiguratorSheet';
+import { buildCardMeditationMetadata, pickCard } from '@/features/Practice/data/resolveCard';
 import { cardForDayIndex } from '@/features/Practice/data/tarot';
 import { scheduledCues } from '@/features/Practice/engine/cues';
 import type {
@@ -50,6 +51,7 @@ import type {
 } from '@/features/Practice/engine/types';
 import { useRitualEngine } from '@/features/Practice/engine/useRitualEngine';
 import type { ModeSummaryKind, ModeSummaryMetadata } from '@/features/Practice/insights/format';
+import CardMeditationView from '@/features/Practice/views/CardMeditationView';
 import CountUpTimerView from '@/features/Practice/views/CountUpTimerView';
 import IntervalBellView from '@/features/Practice/views/IntervalBellView';
 import MeditationTimerView from '@/features/Practice/views/MeditationTimerView';
@@ -407,6 +409,8 @@ function ModeView({ config, state, controls, tarotCardIndex }: ModeViewProps): R
           hideTimer={config.hide_timer_during_meditation ?? false}
         />
       );
+    case 'card_meditation':
+      return <CardMeditationView config={config} state={state} controls={controls} />;
   }
 }
 
@@ -491,6 +495,8 @@ function harvestMetadata(config: ModeConfig, state: RitualState): SessionMetadat
         mode: 'tarot',
         card_index: normalizeTarotIndex(state.currentStepIndex),
       };
+    case 'card_meditation':
+      return buildCardMeditationMetadata(config, pickCard(config));
   }
 }
 
@@ -556,6 +562,12 @@ function harvestSummaryMetadata(
       const idx = normalizeTarotIndex(tarotCardIndex);
       return { mode: 'tarot', card_index: idx, card_name: cardForDayIndex(idx).name };
     }
+    case 'card_meditation':
+      return {
+        mode: 'card_meditation',
+        deck_id: config.deck_id,
+        card_name: pickCard(config).card.name,
+      };
   }
 }
 

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -562,12 +562,15 @@ function harvestSummaryMetadata(
       const idx = normalizeTarotIndex(tarotCardIndex);
       return { mode: 'tarot', card_index: idx, card_name: cardForDayIndex(idx).name };
     }
-    case 'card_meditation':
-      return {
-        mode: 'card_meditation',
-        deck_id: config.deck_id,
-        card_name: pickCard(config).card.name,
-      };
+    case 'card_meditation': {
+      // Reuse the wire harvest (and its single `pickCard` draw) rather than
+      // drawing the card a second time — mirrors the `interval_bell` reuse.
+      const wire = harvestMetadata(config, state) as Extract<
+        SessionMetadata,
+        { mode: 'card_meditation' }
+      >;
+      return { mode: 'card_meditation', deck_id: wire.deck_id, card_name: wire.card_drawn_name };
+    }
   }
 }
 

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -38,6 +38,7 @@ import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 import { InsightCaptureModal } from '@/features/Practice/components/InsightCaptureModal';
 import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConfiguratorSheet';
+import type { PickedCard } from '@/features/Practice/data/resolveCard';
 import { buildCardMeditationMetadata, pickCard } from '@/features/Practice/data/resolveCard';
 import { cardForDayIndex } from '@/features/Practice/data/tarot';
 import { scheduledCues } from '@/features/Practice/engine/cues';
@@ -93,6 +94,8 @@ interface ActiveSession {
   wireMetadata: SessionMetadata;
   summaryMetadata: ModeSummaryMetadata;
   tarotCardIndex: number;
+  /** The card drawn for a `card_meditation` session; `null` for other modes. */
+  cardPick: PickedCard | null;
   completedWindow: { start: Date; end: Date } | null;
   isSaving: boolean;
   saveError: string | null;
@@ -116,6 +119,7 @@ export function ActiveRitualSession(props: ActiveRitualSessionProps): React.JSX.
         state={session.state}
         controls={session.controls}
         tarotCardIndex={session.tarotCardIndex}
+        cardPick={session.cardPick}
         saveError={session.saveError}
       />
       <RitualConfiguratorSheet
@@ -182,13 +186,14 @@ function useActiveSession(props: ActiveRitualSessionProps): ActiveSession {
   useKeepAwakeWhileRunning(state.status);
   const window = useCompletionWindow(state.status);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const cardPick = useCardPick(props.effectiveConfig);
   const wireMetadata = useMemo<SessionMetadata>(
-    () => harvestMetadata(props.effectiveConfig, state),
-    [props.effectiveConfig, state],
+    () => harvestMetadata(props.effectiveConfig, state, cardPick),
+    [props.effectiveConfig, state, cardPick],
   );
   const summaryMetadata = useMemo<ModeSummaryMetadata>(
-    () => harvestSummaryMetadata(props.effectiveConfig, state, tarotCardIndex),
-    [props.effectiveConfig, state, tarotCardIndex],
+    () => harvestSummaryMetadata(props.effectiveConfig, state, tarotCardIndex, cardPick),
+    [props.effectiveConfig, state, tarotCardIndex, cardPick],
   );
   const saveMutation = useSaveMutation({
     apply: props.onSessionApply,
@@ -214,12 +219,22 @@ function useActiveSession(props: ActiveRitualSessionProps): ActiveSession {
     wireMetadata,
     summaryMetadata,
     tarotCardIndex,
+    cardPick,
     completedWindow: window.completedWindow,
     isSaving: saveMutation.pending,
     saveError,
     submitSession,
     finishAndReset,
   };
+}
+
+/**
+ * Draw the `card_meditation` card once per session. Resolving it here (not
+ * separately in the view and the metadata harvest) guarantees the displayed
+ * card and the recorded card are always the same draw.
+ */
+function useCardPick(config: ModeConfig): PickedCard | null {
+  return useMemo(() => (config.mode === 'card_meditation' ? pickCard(config) : null), [config]);
 }
 
 function useTarotCardIndex(props: ActiveRitualSessionProps): number {
@@ -334,6 +349,7 @@ interface SessionCardProps {
   state: RitualState;
   controls: RitualControls;
   tarotCardIndex: number;
+  cardPick: PickedCard | null;
   saveError: string | null;
 }
 
@@ -369,6 +385,7 @@ function SessionCard(props: SessionCardProps): React.JSX.Element {
         state={props.state}
         controls={props.controls}
         tarotCardIndex={props.tarotCardIndex}
+        cardPick={props.cardPick}
       />
       {props.saveError !== null && (
         <Text style={styles.error} testID="active-practice-save-error">
@@ -384,9 +401,16 @@ interface ModeViewProps {
   state: RitualState;
   controls: RitualControls;
   tarotCardIndex: number;
+  cardPick: PickedCard | null;
 }
 
-function ModeView({ config, state, controls, tarotCardIndex }: ModeViewProps): React.JSX.Element {
+function ModeView({
+  config,
+  state,
+  controls,
+  tarotCardIndex,
+  cardPick,
+}: ModeViewProps): React.JSX.Element {
   switch (config.mode) {
     case 'meditation_timer':
       return <MeditationTimerView state={state} controls={controls} />;
@@ -410,7 +434,9 @@ function ModeView({ config, state, controls, tarotCardIndex }: ModeViewProps): R
         />
       );
     case 'card_meditation':
-      return <CardMeditationView config={config} state={state} controls={controls} />;
+      return (
+        <CardMeditationView config={config} state={state} controls={controls} picked={cardPick} />
+      );
   }
 }
 
@@ -476,7 +502,11 @@ function parseDayKeyMs(key: string): number | null {
  * validates this discriminator against the resolved practice mode and
  * returns 400 ``mode_metadata_mismatch`` otherwise.
  */
-function harvestMetadata(config: ModeConfig, state: RitualState): SessionMetadata {
+function harvestMetadata(
+  config: ModeConfig,
+  state: RitualState,
+  cardPick: PickedCard | null,
+): SessionMetadata {
   switch (config.mode) {
     case 'meditation_timer':
       return { mode: 'meditation_timer' };
@@ -496,7 +526,9 @@ function harvestMetadata(config: ModeConfig, state: RitualState): SessionMetadat
         card_index: normalizeTarotIndex(state.currentStepIndex),
       };
     case 'card_meditation':
-      return buildCardMeditationMetadata(config, pickCard(config));
+      // `cardPick` is resolved once in `useActiveSession`; the fallback only
+      // guards a direct call without a pre-resolved draw.
+      return buildCardMeditationMetadata(config, cardPick ?? pickCard(config));
   }
 }
 
@@ -530,6 +562,7 @@ function harvestSummaryMetadata(
   config: ModeConfig,
   state: RitualState,
   tarotCardIndex: number,
+  cardPick: PickedCard | null,
 ): ModeSummaryMetadata {
   switch (config.mode) {
     case 'meditation_timer':
@@ -563,9 +596,9 @@ function harvestSummaryMetadata(
       return { mode: 'tarot', card_index: idx, card_name: cardForDayIndex(idx).name };
     }
     case 'card_meditation': {
-      // Reuse the wire harvest (and its single `pickCard` draw) rather than
-      // drawing the card a second time — mirrors the `interval_bell` reuse.
-      const wire = harvestMetadata(config, state) as Extract<
+      // Reuse the wire harvest (and its single card draw) rather than drawing
+      // the card a second time — mirrors the `interval_bell` reuse above.
+      const wire = harvestMetadata(config, state, cardPick) as Extract<
         SessionMetadata,
         { mode: 'card_meditation' }
       >;

--- a/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.test.ts
+++ b/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { pickCard } from '../../data/resolveCard';
+import type { PickedCard } from '../../data/resolveCard';
+import type { CardMeditationConfig } from '../../engine/types';
+import { fakeState } from '../../views/__tests__/fixtures';
+import { harvestMetadata, harvestSummaryMetadata } from '../ActiveRitualSession';
+
+const config: CardMeditationConfig = { mode: 'card_meditation', deck_id: 'rws', cards: null };
+
+describe('card_meditation metadata harvest', () => {
+  it('records the same card in the wire and summary metadata', () => {
+    const cardPick = pickCard(config);
+    const wire = harvestMetadata(config, fakeState(), cardPick);
+    const summary = harvestSummaryMetadata(config, fakeState(), 0, cardPick);
+    expect(wire.mode).toBe('card_meditation');
+    expect(summary.mode).toBe('card_meditation');
+    // The card shown in the post-session summary must match the card
+    // recorded in the wire metadata — they share one threaded draw.
+    if (wire.mode === 'card_meditation' && summary.mode === 'card_meditation') {
+      expect(summary.card_name).toBe(wire.card_drawn_name);
+      expect(wire.card_drawn_name).toBe(cardPick.card.name);
+    }
+  });
+
+  it('harvests the threaded card draw rather than reshuffling', () => {
+    // An injected draw the deck would never produce: if the harvest read
+    // the threaded value it surfaces here; if it re-called pickCard it would
+    // not.
+    const injected: PickedCard = {
+      card: { name: 'Injected Card', image_asset_key: null, image_uri: null, symbolism: null },
+      index: 7,
+    };
+    const wire = harvestMetadata(config, fakeState(), injected);
+    expect(wire).toMatchObject({
+      mode: 'card_meditation',
+      card_drawn_name: 'Injected Card',
+      card_drawn_index: 7,
+    });
+  });
+});

--- a/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
+++ b/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
@@ -14,6 +14,7 @@ import {
 import type { ModeConfig } from '../engine/types';
 import { CUSTOM_NAME_MAX, validateCustomName, validateModeConfig } from '../engine/validation';
 
+import CardMeditationForm from './forms/CardMeditationForm';
 import CountUpForm from './forms/CountUpForm';
 import IntervalBellForm from './forms/IntervalBellForm';
 import MeditationTimerForm from './forms/MeditationTimerForm';
@@ -200,6 +201,8 @@ const ConfiguratorBody = ({ config, onChange }: BodyProps): React.JSX.Element =>
       return <SenseGroundingForm value={config} onChange={onChange} />;
     case 'tarot':
       return <TarotForm value={config} onChange={onChange} />;
+    case 'card_meditation':
+      return <CardMeditationForm value={config} onChange={onChange} />;
     default:
       return <UnknownModeNotice />;
   }

--- a/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
@@ -208,8 +208,14 @@ interface CardPhotoFieldProps {
 
 const CardPhotoField = ({ index, card, onUpdate }: CardPhotoFieldProps): React.JSX.Element => {
   const choosePhoto = async () => {
-    const photo = await pickCardPhoto();
-    if (photo) onUpdate(index, { image_uri: photo.uri, image_asset_key: null });
+    try {
+      const photo = await pickCardPhoto();
+      if (photo) onUpdate(index, { image_uri: photo.uri, image_asset_key: null });
+    } catch (error) {
+      // A broken native build can reject the permission/picker call; keep the
+      // form usable and leave a breadcrumb rather than crashing the editor.
+      console.warn('Card photo picker failed:', error);
+    }
   };
   return (
     <View style={styles.photoRow}>

--- a/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { resolveCardImage } from '../../data/assetResolver';
@@ -116,13 +116,30 @@ const KnownDeckSummary = ({ deck }: { deck: DeckMeta }): React.JSX.Element => {
   );
 };
 
+// Monotonic source of per-row keys. Cards have no persistable id (the
+// backend config schema is `extra="forbid"`), so row identity is tracked
+// transiently here instead of on the card object.
+let nextCardKey = 0;
+
 const CustomCardEditor = ({ value, onChange }: Props): React.JSX.Element => {
   const cards = value.cards ?? [];
+  // One stable key per row, kept in lockstep with add/remove so a non-tail
+  // removal cannot shift a surviving row onto a different key (which would
+  // let React reuse the wrong row instance).
+  const keysRef = useRef<string[] | null>(null);
+  keysRef.current ??= cards.map(() => `card-${(nextCardKey += 1)}`);
+  const keys = keysRef.current;
   const setCards = (next: readonly CardMeditationCard[]) => onChange({ ...value, cards: next });
   const updateCard = (index: number, patch: Partial<CardMeditationCard>) =>
     setCards(cards.map((card, i) => (i === index ? { ...card, ...patch } : card)));
-  const removeCard = (index: number) => setCards(cards.filter((_, i) => i !== index));
-  const addCard = () => setCards([...cards, EMPTY_CARD]);
+  const removeCard = (index: number) => {
+    keysRef.current = keys.filter((_, i) => i !== index);
+    setCards(cards.filter((_, i) => i !== index));
+  };
+  const addCard = () => {
+    keysRef.current = [...keys, `card-${(nextCardKey += 1)}`];
+    setCards([...cards, EMPTY_CARD]);
+  };
   return (
     <View testID="card-meditation-card-editor">
       <Text style={styles.sectionTitle}>Your cards</Text>
@@ -136,7 +153,7 @@ const CustomCardEditor = ({ value, onChange }: Props): React.JSX.Element => {
       )}
       {cards.map((card, index) => (
         <CardRow
-          key={index}
+          key={keys[index] ?? `card-fallback-${index}`}
           index={index}
           card={card}
           onUpdate={updateCard}
@@ -213,8 +230,8 @@ const CardPhotoField = ({ index, card, onUpdate }: CardPhotoFieldProps): React.J
       if (photo) onUpdate(index, { image_uri: photo.uri, image_asset_key: null });
     } catch (error) {
       // A broken native build can reject the permission/picker call; keep the
-      // form usable and leave a breadcrumb rather than crashing the editor.
-      console.warn('Card photo picker failed:', error);
+      // form usable and leave a dev-only breadcrumb rather than crashing.
+      if (__DEV__) console.warn('Card photo picker failed:', error);
     }
   };
   return (
@@ -264,7 +281,7 @@ const AdvancedSection = ({ value, onChange }: Props): React.JSX.Element => {
 
 const AdvancedFields = ({ value, onChange }: Props): React.JSX.Element => (
   <View testID="card-meditation-advanced-fields">
-    <LabeledRow label="Per-card minutes">
+    <LabeledRow label="Minutes with the card">
       <NumericField
         value={value.per_card_minutes ?? DEFAULT_CARD_MEDITATION_MINUTES}
         onChange={(minutes) =>

--- a/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
@@ -1,0 +1,377 @@
+import React, { useState } from 'react';
+import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { resolveCardImage } from '../../data/assetResolver';
+import type { DeckMeta } from '../../data/decks';
+import { BUNDLED_DECKS, getDeck } from '../../data/decks';
+import type { CardMeditationCard, CardMeditationConfig } from '../../engine/types';
+import {
+  CARD_MEDITATION_CARDS_MAX,
+  CARD_MEDITATION_CUSTOM_DECK_ID,
+  CARD_MEDITATION_NAME_MAX,
+  CARD_MEDITATION_SYMBOLISM_MAX,
+  DEFAULT_CARD_MEDITATION_MINUTES,
+} from '../../engine/types';
+import { pickCardPhoto } from '../../utils/pickCardPhoto';
+
+import { Chip, LabeledRow, NumericField, TextField, ToggleRow } from './shared';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+interface Props {
+  value: CardMeditationConfig;
+  onChange: (next: CardMeditationConfig) => void;
+}
+
+const PHOTO_NOTE =
+  'Photos are kept on this device. If you delete the photo, the card falls back to its name.';
+
+const EMPTY_CARD: CardMeditationCard = {
+  name: '',
+  image_asset_key: null,
+  image_uri: null,
+  symbolism: null,
+};
+
+const CardMeditationForm = ({ value, onChange }: Props): React.JSX.Element => {
+  const isCustom = value.deck_id === CARD_MEDITATION_CUSTOM_DECK_ID;
+  return (
+    <View testID="card-meditation-form">
+      <DeckPicker value={value} onChange={onChange} />
+      {isCustom ? (
+        <CustomCardEditor value={value} onChange={onChange} />
+      ) : (
+        <DeckSummary deckId={value.deck_id} />
+      )}
+      <AdvancedSection value={value} onChange={onChange} />
+    </View>
+  );
+};
+
+const DeckPicker = ({ value, onChange }: Props): React.JSX.Element => {
+  const selectDeck = (deckId: string) => {
+    if (deckId === value.deck_id) return;
+    onChange(
+      deckId === CARD_MEDITATION_CUSTOM_DECK_ID
+        ? { ...value, deck_id: deckId, cards: value.cards ?? [] }
+        : { ...value, deck_id: deckId, cards: null },
+    );
+  };
+  return (
+    <View testID="card-meditation-deck-picker">
+      <Text style={styles.sectionTitle}>Deck</Text>
+      <View style={styles.deckRow}>
+        {BUNDLED_DECKS.map((deck) => (
+          <Chip
+            key={deck.id}
+            label={deck.name}
+            active={value.deck_id === deck.id}
+            onPress={() => selectDeck(deck.id)}
+            testID={`card-meditation-deck-${deck.id}`}
+          />
+        ))}
+        <Chip
+          label="Custom"
+          active={value.deck_id === CARD_MEDITATION_CUSTOM_DECK_ID}
+          onPress={() => selectDeck(CARD_MEDITATION_CUSTOM_DECK_ID)}
+          testID={`card-meditation-deck-${CARD_MEDITATION_CUSTOM_DECK_ID}`}
+        />
+      </View>
+    </View>
+  );
+};
+
+const DeckSummary = ({ deckId }: { deckId: string }): React.JSX.Element => {
+  const deck = getDeck(deckId);
+  if (!deck) {
+    return (
+      <View testID="card-meditation-deck-summary">
+        <Text style={styles.unknownDeck}>This deck is no longer available.</Text>
+      </View>
+    );
+  }
+  return <KnownDeckSummary deck={deck} />;
+};
+
+const KnownDeckSummary = ({ deck }: { deck: DeckMeta }): React.JSX.Element => {
+  const cover = deck.cards.length > 0 ? resolveCardImage(deck.cards[0]?.asset_key ?? null) : null;
+  return (
+    <View style={styles.summary} testID="card-meditation-deck-summary">
+      {cover !== null && (
+        <Image
+          source={cover}
+          style={styles.cover}
+          resizeMode="cover"
+          testID="card-meditation-deck-cover"
+        />
+      )}
+      <View style={styles.summaryText}>
+        <Text style={styles.summaryName}>{deck.name}</Text>
+        <Text style={styles.summaryCount} testID="card-meditation-deck-count">
+          {`${deck.cards.length} cards`}
+        </Text>
+        <Text style={styles.summaryDescription}>{deck.description}</Text>
+      </View>
+    </View>
+  );
+};
+
+const CustomCardEditor = ({ value, onChange }: Props): React.JSX.Element => {
+  const cards = value.cards ?? [];
+  const setCards = (next: readonly CardMeditationCard[]) => onChange({ ...value, cards: next });
+  const updateCard = (index: number, patch: Partial<CardMeditationCard>) =>
+    setCards(cards.map((card, i) => (i === index ? { ...card, ...patch } : card)));
+  const removeCard = (index: number) => setCards(cards.filter((_, i) => i !== index));
+  const addCard = () => setCards([...cards, EMPTY_CARD]);
+  return (
+    <View testID="card-meditation-card-editor">
+      <Text style={styles.sectionTitle}>Your cards</Text>
+      <Text style={styles.photoNote} testID="card-meditation-photo-note">
+        {PHOTO_NOTE}
+      </Text>
+      {cards.length === 0 && (
+        <Text style={styles.emptyState} testID="card-meditation-empty">
+          Add at least one card to use this deck.
+        </Text>
+      )}
+      {cards.map((card, index) => (
+        <CardRow
+          key={index}
+          index={index}
+          card={card}
+          onUpdate={updateCard}
+          onRemove={removeCard}
+        />
+      ))}
+      {cards.length < CARD_MEDITATION_CARDS_MAX && (
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Add card"
+          onPress={addCard}
+          style={styles.addButton}
+          testID="card-meditation-add-card"
+        >
+          <Text style={styles.addButtonText}>+ Add card</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
+
+interface CardRowProps {
+  index: number;
+  card: CardMeditationCard;
+  onUpdate: (index: number, patch: Partial<CardMeditationCard>) => void;
+  onRemove: (index: number) => void;
+}
+
+const CardRow = ({ index, card, onUpdate, onRemove }: CardRowProps): React.JSX.Element => (
+  <View style={styles.cardRow} testID={`card-meditation-card-row-${index}`}>
+    <View style={styles.cardRowHeader}>
+      <Text style={styles.cardRowLabel}>{`Card ${index + 1}`}</Text>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={`Remove card ${index + 1}`}
+        onPress={() => onRemove(index)}
+        testID={`card-meditation-remove-card-${index}`}
+      >
+        <Text style={styles.removeText}>Remove</Text>
+      </TouchableOpacity>
+    </View>
+    <LabeledRow label="Name">
+      <TextField
+        value={card.name}
+        onChange={(name) => onUpdate(index, { name })}
+        placeholder="Card name"
+        maxLength={CARD_MEDITATION_NAME_MAX}
+        testID={`card-meditation-card-name-${index}`}
+      />
+    </LabeledRow>
+    <CardPhotoField index={index} card={card} onUpdate={onUpdate} />
+    <LabeledRow label="Symbolism">
+      <TextField
+        value={card.symbolism ?? ''}
+        onChange={(text) => onUpdate(index, { symbolism: text.length > 0 ? text : null })}
+        placeholder="Optional"
+        maxLength={CARD_MEDITATION_SYMBOLISM_MAX}
+        testID={`card-meditation-card-symbolism-${index}`}
+      />
+    </LabeledRow>
+  </View>
+);
+
+interface CardPhotoFieldProps {
+  index: number;
+  card: CardMeditationCard;
+  onUpdate: (index: number, patch: Partial<CardMeditationCard>) => void;
+}
+
+const CardPhotoField = ({ index, card, onUpdate }: CardPhotoFieldProps): React.JSX.Element => {
+  const choosePhoto = async () => {
+    const photo = await pickCardPhoto();
+    if (photo) onUpdate(index, { image_uri: photo.uri, image_asset_key: null });
+  };
+  return (
+    <View style={styles.photoRow}>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={`Choose photo for card ${index + 1}`}
+        onPress={() => {
+          void choosePhoto();
+        }}
+        style={styles.photoButton}
+        testID={`card-meditation-choose-photo-${index}`}
+      >
+        <Text style={styles.photoButtonText}>
+          {card.image_uri !== null ? 'Change photo' : 'Choose photo'}
+        </Text>
+      </TouchableOpacity>
+      {card.image_uri !== null && (
+        <Image
+          source={{ uri: card.image_uri }}
+          style={styles.photoThumb}
+          testID={`card-meditation-photo-thumb-${index}`}
+        />
+      )}
+    </View>
+  );
+};
+
+const AdvancedSection = ({ value, onChange }: Props): React.JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <View testID="card-meditation-advanced">
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Advanced settings"
+        accessibilityState={{ expanded: open }}
+        onPress={() => setOpen((prev) => !prev)}
+        style={styles.advancedToggle}
+        testID="card-meditation-advanced-toggle"
+      >
+        <Text style={styles.advancedToggleText}>{`${open ? '▾' : '▸'} Advanced`}</Text>
+      </TouchableOpacity>
+      {open && <AdvancedFields value={value} onChange={onChange} />}
+    </View>
+  );
+};
+
+const AdvancedFields = ({ value, onChange }: Props): React.JSX.Element => (
+  <View testID="card-meditation-advanced-fields">
+    <LabeledRow label="Per-card minutes">
+      <NumericField
+        value={value.per_card_minutes ?? DEFAULT_CARD_MEDITATION_MINUTES}
+        onChange={(minutes) =>
+          onChange({ ...value, per_card_minutes: minutes ?? DEFAULT_CARD_MEDITATION_MINUTES })
+        }
+        allowNull
+        testID="card-meditation-per-card"
+      />
+    </LabeledRow>
+    <ToggleRow
+      label="Shuffle the deck"
+      value={value.shuffle ?? true}
+      onChange={(shuffle) => onChange({ ...value, shuffle })}
+      testID="card-meditation-shuffle"
+    />
+    <ToggleRow
+      label="Reveal card after the sit"
+      value={value.reveal_after_meditation ?? false}
+      onChange={(reveal_after_meditation) => onChange({ ...value, reveal_after_meditation })}
+      testID="card-meditation-reveal"
+    />
+    <ToggleRow
+      label="Hide timer during sit"
+      value={value.hide_timer_during_meditation ?? true}
+      onChange={(hide_timer_during_meditation) =>
+        onChange({ ...value, hide_timer_during_meditation })
+      }
+      testID="card-meditation-hide-timer"
+    />
+  </View>
+);
+
+const COVER_SIZE = 64;
+const THUMB_SIZE = 44;
+
+const styles = StyleSheet.create({
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text.tertiary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: SPACING.md,
+    marginBottom: SPACING.sm,
+  },
+  deckRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.sm },
+  summary: {
+    flexDirection: 'row',
+    gap: SPACING.md,
+    padding: SPACING.md,
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.md,
+    marginTop: SPACING.sm,
+  },
+  summaryText: { flex: 1 },
+  summaryName: { fontSize: 15, fontWeight: '600', color: colors.text.primary },
+  summaryCount: { fontSize: 13, color: colors.text.secondaryAccessible, marginTop: 2 },
+  summaryDescription: {
+    fontSize: 13,
+    color: colors.text.secondaryAccessible,
+    marginTop: SPACING.xs,
+    lineHeight: 18,
+  },
+  cover: { width: COVER_SIZE, height: COVER_SIZE, borderRadius: BORDER_RADIUS.sm },
+  unknownDeck: { fontSize: 14, color: colors.danger, marginTop: SPACING.sm },
+  photoNote: {
+    fontSize: 12,
+    color: colors.text.secondaryAccessible,
+    fontStyle: 'italic',
+    marginBottom: SPACING.sm,
+  },
+  emptyState: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    paddingVertical: SPACING.md,
+  },
+  cardRow: {
+    padding: SPACING.md,
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: SPACING.sm,
+  },
+  cardRowHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  cardRowLabel: { fontSize: 13, fontWeight: '600', color: colors.text.primary },
+  removeText: { fontSize: 13, color: colors.danger, fontWeight: '500' },
+  photoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.sm,
+    paddingVertical: SPACING.sm,
+  },
+  photoButton: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+  },
+  photoButtonText: { fontSize: 13, fontWeight: '500', color: colors.text.primary },
+  photoThumb: { width: THUMB_SIZE, height: THUMB_SIZE, borderRadius: BORDER_RADIUS.sm },
+  addButton: {
+    paddingVertical: SPACING.sm,
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+  },
+  addButtonText: { fontSize: 14, fontWeight: '600', color: colors.text.primary },
+  advancedToggle: { paddingVertical: SPACING.md, marginTop: SPACING.sm },
+  advancedToggleText: { fontSize: 14, fontWeight: '600', color: colors.text.primary },
+});
+
+export default CardMeditationForm;

--- a/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
@@ -1,0 +1,201 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import type { CardMeditationCard, CardMeditationConfig } from '../../../engine/types';
+import { pickCardPhoto } from '../../../utils/pickCardPhoto';
+import CardMeditationForm from '../CardMeditationForm';
+
+jest.mock('../../../utils/pickCardPhoto', () => ({
+  pickCardPhoto: jest.fn(),
+}));
+
+const mockPickCardPhoto = jest.mocked(pickCardPhoto);
+
+function bundled(over: Partial<CardMeditationConfig> = {}): CardMeditationConfig {
+  return { mode: 'card_meditation', deck_id: 'rws', cards: null, ...over };
+}
+
+function custom(cards: readonly CardMeditationCard[]): CardMeditationConfig {
+  return { mode: 'card_meditation', deck_id: 'custom', cards };
+}
+
+const EMPTY_CARD: CardMeditationCard = {
+  name: '',
+  image_asset_key: null,
+  image_uri: null,
+  symbolism: null,
+};
+
+describe('CardMeditationForm — deck picker', () => {
+  it('renders the three deck options', () => {
+    const { getByTestId } = render(<CardMeditationForm value={bundled()} onChange={jest.fn()} />);
+    expect(getByTestId('card-meditation-deck-major_arcana_text')).toBeTruthy();
+    expect(getByTestId('card-meditation-deck-rws')).toBeTruthy();
+    expect(getByTestId('card-meditation-deck-custom')).toBeTruthy();
+  });
+
+  it('switches to the custom deck with an empty card list', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<CardMeditationForm value={bundled()} onChange={onChange} />);
+    fireEvent.press(getByTestId('card-meditation-deck-custom'));
+    expect(onChange).toHaveBeenCalledWith({ ...bundled(), deck_id: 'custom', cards: [] });
+  });
+
+  it('clears the custom cards when switching back to a bundled deck', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom([EMPTY_CARD])} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('card-meditation-deck-major_arcana_text'));
+    expect(onChange).toHaveBeenCalledWith({
+      mode: 'card_meditation',
+      deck_id: 'major_arcana_text',
+      cards: null,
+    });
+  });
+
+  it('does nothing when the already-selected deck is pressed', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<CardMeditationForm value={bundled()} onChange={onChange} />);
+    fireEvent.press(getByTestId('card-meditation-deck-rws'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('CardMeditationForm — bundled deck summary', () => {
+  it('shows the card count and a cover image for an image deck', () => {
+    const { getByTestId } = render(<CardMeditationForm value={bundled()} onChange={jest.fn()} />);
+    expect(getByTestId('card-meditation-deck-count').props.children).toBe('78 cards');
+    expect(getByTestId('card-meditation-deck-cover')).toBeTruthy();
+  });
+
+  it('omits the cover for the text-only deck', () => {
+    const { queryByTestId } = render(
+      <CardMeditationForm value={bundled({ deck_id: 'major_arcana_text' })} onChange={jest.fn()} />,
+    );
+    expect(queryByTestId('card-meditation-deck-cover')).toBeNull();
+  });
+
+  it('reports an unavailable deck gracefully', () => {
+    const { getByTestId } = render(
+      <CardMeditationForm value={bundled({ deck_id: 'retired_deck' })} onChange={jest.fn()} />,
+    );
+    expect(getByTestId('card-meditation-deck-summary')).toBeTruthy();
+  });
+});
+
+describe('CardMeditationForm — custom card editor', () => {
+  it('shows the empty state when a custom deck has no cards', () => {
+    const { getByTestId } = render(<CardMeditationForm value={custom([])} onChange={jest.fn()} />);
+    expect(getByTestId('card-meditation-empty')).toBeTruthy();
+    expect(getByTestId('card-meditation-photo-note')).toBeTruthy();
+  });
+
+  it('adds a card', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<CardMeditationForm value={custom([])} onChange={onChange} />);
+    fireEvent.press(getByTestId('card-meditation-add-card'));
+    expect(onChange).toHaveBeenCalledWith(custom([EMPTY_CARD]));
+  });
+
+  it('removes a card', () => {
+    const onChange = jest.fn();
+    const card: CardMeditationCard = { ...EMPTY_CARD, name: 'Keep me' };
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom([EMPTY_CARD, card])} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('card-meditation-remove-card-0'));
+    expect(onChange).toHaveBeenCalledWith(custom([card]));
+  });
+
+  it('edits a card name and symbolism', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom([EMPTY_CARD])} onChange={onChange} />,
+    );
+    fireEvent.changeText(getByTestId('card-meditation-card-name-0'), 'Sunrise');
+    expect(onChange).toHaveBeenCalledWith(custom([{ ...EMPTY_CARD, name: 'Sunrise' }]));
+    fireEvent.changeText(getByTestId('card-meditation-card-symbolism-0'), 'a new day');
+    expect(onChange).toHaveBeenCalledWith(custom([{ ...EMPTY_CARD, symbolism: 'a new day' }]));
+  });
+
+  it('clears symbolism back to null when emptied', () => {
+    const onChange = jest.fn();
+    const card: CardMeditationCard = { ...EMPTY_CARD, symbolism: 'something' };
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom([card])} onChange={onChange} />,
+    );
+    fireEvent.changeText(getByTestId('card-meditation-card-symbolism-0'), '');
+    expect(onChange).toHaveBeenCalledWith(custom([{ ...card, symbolism: null }]));
+  });
+
+  it('stores a picked photo uri on the card', async () => {
+    mockPickCardPhoto.mockResolvedValueOnce({ uri: 'file:///new.jpg' });
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom([EMPTY_CARD])} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('card-meditation-choose-photo-0'));
+    expect(mockPickCardPhoto).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(
+        custom([{ ...EMPTY_CARD, image_uri: 'file:///new.jpg', image_asset_key: null }]),
+      ),
+    );
+  });
+
+  it('leaves the card unchanged when the photo picker is dismissed', async () => {
+    mockPickCardPhoto.mockResolvedValueOnce(null);
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom([EMPTY_CARD])} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('card-meditation-choose-photo-0'));
+    await waitFor(() => expect(mockPickCardPhoto).toHaveBeenCalledTimes(1));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('renders a thumbnail for a card that already has a photo', () => {
+    const card: CardMeditationCard = { ...EMPTY_CARD, image_uri: 'file:///saved.jpg' };
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom([card])} onChange={jest.fn()} />,
+    );
+    expect(getByTestId('card-meditation-photo-thumb-0').props.source).toEqual({
+      uri: 'file:///saved.jpg',
+    });
+  });
+});
+
+describe('CardMeditationForm — advanced section', () => {
+  it('keeps the advanced fields collapsed until toggled', () => {
+    const { getByTestId, queryByTestId } = render(
+      <CardMeditationForm value={bundled()} onChange={jest.fn()} />,
+    );
+    expect(queryByTestId('card-meditation-advanced-fields')).toBeNull();
+    fireEvent.press(getByTestId('card-meditation-advanced-toggle'));
+    expect(getByTestId('card-meditation-advanced-fields')).toBeTruthy();
+  });
+
+  it('edits the per-card minutes and behaviour toggles', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<CardMeditationForm value={bundled()} onChange={onChange} />);
+    fireEvent.press(getByTestId('card-meditation-advanced-toggle'));
+    fireEvent.changeText(getByTestId('card-meditation-per-card'), '8');
+    expect(onChange).toHaveBeenCalledWith({ ...bundled(), per_card_minutes: 8 });
+    fireEvent(getByTestId('card-meditation-shuffle'), 'valueChange', false);
+    expect(onChange).toHaveBeenCalledWith({ ...bundled(), shuffle: false });
+    fireEvent(getByTestId('card-meditation-reveal'), 'valueChange', true);
+    expect(onChange).toHaveBeenCalledWith({ ...bundled(), reveal_after_meditation: true });
+    fireEvent(getByTestId('card-meditation-hide-timer'), 'valueChange', false);
+    expect(onChange).toHaveBeenCalledWith({ ...bundled(), hide_timer_during_meditation: false });
+  });
+
+  it('restores the default per-card minutes when the field is cleared', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<CardMeditationForm value={bundled()} onChange={onChange} />);
+    fireEvent.press(getByTestId('card-meditation-advanced-toggle'));
+    fireEvent.changeText(getByTestId('card-meditation-per-card'), '');
+    expect(onChange).toHaveBeenCalledWith({ ...bundled(), per_card_minutes: 5 });
+  });
+});

--- a/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
@@ -109,6 +109,21 @@ describe('CardMeditationForm — custom card editor', () => {
     expect(onChange).toHaveBeenCalledWith(custom([card]));
   });
 
+  it('shows the surviving card values in their rows after card 0 is removed', () => {
+    const alpha: CardMeditationCard = { ...EMPTY_CARD, name: 'Alpha' };
+    const beta: CardMeditationCard = { ...EMPTY_CARD, name: 'Beta' };
+    const onChange = jest.fn();
+    const { getByTestId, queryByTestId, rerender } = render(
+      <CardMeditationForm value={custom([alpha, beta])} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('card-meditation-remove-card-0'));
+    // The rows are fully controlled, so re-rendering with the filtered list
+    // pulls each row's value straight from props — no stale index-key state.
+    rerender(<CardMeditationForm value={custom([beta])} onChange={onChange} />);
+    expect(getByTestId('card-meditation-card-name-0').props.value).toBe('Beta');
+    expect(queryByTestId('card-meditation-card-name-1')).toBeNull();
+  });
+
   it('edits a card name and symbolism', () => {
     const onChange = jest.fn();
     const { getByTestId } = render(
@@ -154,6 +169,19 @@ describe('CardMeditationForm — custom card editor', () => {
     fireEvent.press(getByTestId('card-meditation-choose-photo-0'));
     await waitFor(() => expect(mockPickCardPhoto).toHaveBeenCalledTimes(1));
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('survives a photo-picker failure without crashing or updating the card', async () => {
+    mockPickCardPhoto.mockRejectedValueOnce(new Error('native module unavailable'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom([EMPTY_CARD])} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('card-meditation-choose-photo-0'));
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    expect(onChange).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it('renders a thumbnail for a card that already has a photo', () => {

--- a/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
@@ -78,10 +78,11 @@ describe('CardMeditationForm — bundled deck summary', () => {
   });
 
   it('reports an unavailable deck gracefully', () => {
-    const { getByTestId } = render(
+    const { getByTestId, getByText } = render(
       <CardMeditationForm value={bundled({ deck_id: 'retired_deck' })} onChange={jest.fn()} />,
     );
     expect(getByTestId('card-meditation-deck-summary')).toBeTruthy();
+    expect(getByText('This deck is no longer available.')).toBeTruthy();
   });
 });
 

--- a/frontend/src/features/Practice/data/__tests__/resolveCard.test.ts
+++ b/frontend/src/features/Practice/data/__tests__/resolveCard.test.ts
@@ -1,4 +1,3 @@
-/* eslint-env jest */
 import { describe, expect, it } from '@jest/globals';
 
 import type { CardMeditationCard, CardMeditationConfig } from '../../engine/types';

--- a/frontend/src/features/Practice/data/__tests__/resolveCard.test.ts
+++ b/frontend/src/features/Practice/data/__tests__/resolveCard.test.ts
@@ -1,0 +1,118 @@
+/* eslint-env jest */
+import { describe, expect, it } from '@jest/globals';
+
+import type { CardMeditationCard, CardMeditationConfig } from '../../engine/types';
+import { getDeck } from '../decks';
+import { buildCardMeditationMetadata, pickCard, resolveDeckCards } from '../resolveCard';
+
+const CUSTOM_CARDS: readonly CardMeditationCard[] = [
+  { name: 'First', image_asset_key: null, image_uri: 'file:///1.jpg', symbolism: 'one' },
+  { name: 'Second', image_asset_key: null, image_uri: 'file:///2.jpg', symbolism: null },
+  { name: 'Third', image_asset_key: null, image_uri: null, symbolism: 'three' },
+];
+
+function customConfig(over: Partial<CardMeditationConfig> = {}): CardMeditationConfig {
+  return { mode: 'card_meditation', deck_id: 'custom', cards: CUSTOM_CARDS, ...over };
+}
+
+function bundledConfig(over: Partial<CardMeditationConfig> = {}): CardMeditationConfig {
+  return { mode: 'card_meditation', deck_id: 'rws', cards: null, ...over };
+}
+
+describe('resolveDeckCards', () => {
+  it('returns the inline cards for a custom deck', () => {
+    expect(resolveDeckCards(customConfig())).toBe(CUSTOM_CARDS);
+  });
+
+  it('returns an empty list for a custom deck with no cards', () => {
+    expect(resolveDeckCards(customConfig({ cards: null }))).toEqual([]);
+  });
+
+  it('maps a bundled deck manifest to card-meditation cards', () => {
+    const resolved = resolveDeckCards(bundledConfig());
+    const deck = getDeck('rws');
+    expect(deck).toBeDefined();
+    expect(resolved).toHaveLength(deck?.cards.length ?? 0);
+    expect(resolved[0]?.name).toBe(deck?.cards[0]?.name);
+    expect(resolved[0]?.image_asset_key).toBe(deck?.cards[0]?.asset_key);
+    expect(resolved[0]?.image_uri).toBeNull();
+  });
+
+  it('returns an empty list for an unknown bundled deck', () => {
+    expect(resolveDeckCards(bundledConfig({ deck_id: 'nonexistent' }))).toEqual([]);
+  });
+});
+
+describe('pickCard', () => {
+  it('is deterministic for a given seed', () => {
+    const config = customConfig();
+    const first = pickCard(config, { random: () => 0.5 });
+    const second = pickCard(config, { random: () => 0.5 });
+    expect(first).toEqual(second);
+    expect(first.card.name).toBe('Second');
+    expect(first.index).toBe(1);
+  });
+
+  it('draws different cards for different seeds', () => {
+    const config = customConfig();
+    expect(pickCard(config, { random: () => 0 }).card.name).toBe('First');
+    expect(pickCard(config, { random: () => 0.99 }).card.name).toBe('Third');
+  });
+
+  it('clamps the draw when the RNG yields its 1.0 edge', () => {
+    const picked = pickCard(customConfig(), { random: () => 1 });
+    expect(picked.index).toBe(CUSTOM_CARDS.length - 1);
+  });
+
+  it('draws the first card when shuffle is off', () => {
+    const picked = pickCard(customConfig({ shuffle: false }), { random: () => 0.9 });
+    expect(picked.index).toBe(0);
+    expect(picked.card.name).toBe('First');
+  });
+
+  it('draws from the inline cards override for a custom deck', () => {
+    const picked = pickCard(customConfig({ shuffle: false }));
+    expect(CUSTOM_CARDS).toContainEqual(picked.card);
+  });
+
+  it('draws from the bundled deck when the override is null', () => {
+    const picked = pickCard(bundledConfig({ shuffle: false }));
+    const deck = getDeck('rws');
+    expect(picked.card.name).toBe(deck?.cards[0]?.name);
+    expect(picked.index).toBe(0);
+  });
+
+  it('caches the draw per config object so re-renders never reshuffle', () => {
+    const config = bundledConfig();
+    expect(pickCard(config)).toBe(pickCard(config));
+  });
+
+  it('falls back to a text-only card for an unknown deck', () => {
+    const picked = pickCard(bundledConfig({ deck_id: 'gone' }));
+    expect(picked.index).toBeNull();
+    expect(picked.card.image_asset_key).toBeNull();
+    expect(picked.card.image_uri).toBeNull();
+  });
+});
+
+describe('buildCardMeditationMetadata', () => {
+  it('records the drawn card name, deck id, and index', () => {
+    const config = customConfig();
+    const metadata = buildCardMeditationMetadata(config, { card: CUSTOM_CARDS[1]!, index: 1 });
+    expect(metadata).toEqual({
+      mode: 'card_meditation',
+      deck_id: 'custom',
+      card_drawn_name: 'Second',
+      card_drawn_index: 1,
+    });
+  });
+
+  it('omits the index when the draw cannot be positioned', () => {
+    const metadata = buildCardMeditationMetadata(bundledConfig({ deck_id: 'gone' }), {
+      card: { name: 'Card', image_asset_key: null, image_uri: null, symbolism: null },
+      index: null,
+    });
+    expect(metadata.card_drawn_index).toBeUndefined();
+    expect(metadata.card_drawn_name).toBe('Card');
+  });
+});

--- a/frontend/src/features/Practice/data/resolveCard.ts
+++ b/frontend/src/features/Practice/data/resolveCard.ts
@@ -1,0 +1,105 @@
+// Resolves a `CardMeditationConfig` to the single card drawn for a session.
+
+import type { CardMeditationCard, CardMeditationConfig } from '../engine/types';
+import { CARD_MEDITATION_CUSTOM_DECK_ID } from '../engine/types';
+
+import type { CardMeta } from './decks';
+import { getDeck } from './decks';
+
+import type { CardMeditationSessionMetadata } from '@/api';
+
+/** The card drawn for a session plus its canonical (pre-shuffle) deck index. */
+export interface PickedCard {
+  readonly card: CardMeditationCard;
+  /** Zero-based index in the canonical deck order; `null` when the deck is empty/unknown. */
+  readonly index: number | null;
+}
+
+/** Injectable RNG for deterministic tests; production callers omit it. */
+export interface PickCardDeps {
+  readonly random?: () => number;
+}
+
+/** Graceful fallback when a config points at an unknown or empty deck. */
+const FALLBACK_CARD: CardMeditationCard = {
+  name: 'Card',
+  image_asset_key: null,
+  image_uri: null,
+  symbolism: null,
+};
+
+function metaToCard(meta: CardMeta): CardMeditationCard {
+  return {
+    name: meta.name,
+    image_asset_key: meta.asset_key,
+    image_uri: null,
+    symbolism: meta.symbolism,
+  };
+}
+
+/**
+ * The canonical, pre-shuffle card list for a config: the inline `cards`
+ * for a custom deck, or the bundled deck's manifest otherwise. An unknown
+ * `deck_id` yields an empty list rather than throwing.
+ */
+export function resolveDeckCards(config: CardMeditationConfig): readonly CardMeditationCard[] {
+  if (config.deck_id === CARD_MEDITATION_CUSTOM_DECK_ID) {
+    return config.cards ?? [];
+  }
+  const deck = getDeck(config.deck_id);
+  return deck ? deck.cards.map(metaToCard) : [];
+}
+
+// A session draws its card once; a WeakMap keyed on the config object keeps
+// the draw idempotent across re-renders (the same config reference always
+// resolves to the same card) without leaking between sessions — a
+// configurator save produces a fresh config object and thus a fresh draw.
+const pickCache = new WeakMap<CardMeditationConfig, PickedCard>();
+
+/**
+ * Draw a single card for a session.
+ *
+ * `shuffle` (default on) draws a uniformly random card; with `shuffle`
+ * off the first card of the deck is drawn. The result is cached per
+ * config object so re-renders never reshuffle. Passing an explicit
+ * `random` bypasses the cache, which keeps shuffle deterministic in tests.
+ */
+export function pickCard(config: CardMeditationConfig, deps: PickCardDeps = {}): PickedCard {
+  const cached = pickCache.get(config);
+  if (cached !== undefined && deps.random === undefined) {
+    return cached;
+  }
+  const cards = resolveDeckCards(config);
+  const picked = drawCard(config, cards, deps.random ?? Math.random);
+  if (deps.random === undefined) {
+    pickCache.set(config, picked);
+  }
+  return picked;
+}
+
+function drawCard(
+  config: CardMeditationConfig,
+  cards: readonly CardMeditationCard[],
+  random: () => number,
+): PickedCard {
+  if (cards.length === 0) {
+    return { card: FALLBACK_CARD, index: null };
+  }
+  const shuffle = config.shuffle ?? true;
+  // `random()` is in [0, 1); the `min` guards the theoretical 1.0 edge.
+  const index = shuffle ? Math.min(cards.length - 1, Math.floor(random() * cards.length)) : 0;
+  return { card: cards[index]!, index };
+}
+
+/** Build the wire metadata recording which card the session drew. */
+export function buildCardMeditationMetadata(
+  config: CardMeditationConfig,
+  picked: PickedCard,
+): CardMeditationSessionMetadata {
+  const metadata: CardMeditationSessionMetadata = {
+    mode: 'card_meditation',
+    deck_id: config.deck_id,
+    card_drawn_name: picked.card.name,
+  };
+  return picked.index === null ? metadata : { ...metadata, card_drawn_index: picked.index };
+}

--- a/frontend/src/features/Practice/engine/__tests__/cues.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/cues.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import { scheduledCues } from '../cues';
 import type {
+  CardMeditationConfig,
   IntervalBellConfig,
   MeditationTimerConfig,
   MetronomeConfig,
@@ -126,6 +127,18 @@ describe('scheduledCues — tarot', () => {
   it.each<[string, TarotConfig]>([
     ['explicit per_card_minutes', { mode: 'tarot', deck: 'major_arcana', per_card_minutes: 5 }],
     ['default per_card_minutes', { mode: 'tarot', deck: 'major_arcana' }],
+  ])('emits a single end cue (%s)', (_label, config) => {
+    expect(scheduledCues(config)).toEqual([{ atMs: 5 * MIN, kind: 'end_bell' }]);
+  });
+});
+
+describe('scheduledCues — card_meditation', () => {
+  it.each<[string, CardMeditationConfig]>([
+    [
+      'explicit per_card_minutes',
+      { mode: 'card_meditation', deck_id: 'rws', cards: null, per_card_minutes: 5 },
+    ],
+    ['default per_card_minutes', { mode: 'card_meditation', deck_id: 'rws', cards: null }],
   ])('emits a single end cue (%s)', (_label, config) => {
     expect(scheduledCues(config)).toEqual([{ atMs: 5 * MIN, kind: 'end_bell' }]);
   });

--- a/frontend/src/features/Practice/engine/__tests__/reducer.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/reducer.test.ts
@@ -241,6 +241,31 @@ describe('ritualReducer — tarot', () => {
   });
 });
 
+describe('ritualReducer — card_meditation', () => {
+  it('completes after per_card_minutes elapse', () => {
+    const config: ModeConfig = {
+      mode: 'card_meditation',
+      deck_id: 'rws',
+      cards: null,
+      per_card_minutes: 3,
+    };
+    let s = drive(config, [{ type: 'START', now: 0 }]);
+    expect(s.status).toBe('running');
+    s = ritualReducer(s, { type: 'TICK', now: 3 * MIN }, config);
+    expect(s.status).toBe('complete');
+    expect(s.cuesStruck).toBe(1);
+  });
+
+  it('defaults per_card_minutes to 5 when omitted', () => {
+    const config: ModeConfig = { mode: 'card_meditation', deck_id: 'rws', cards: null };
+    const s = drive(config, [
+      { type: 'START', now: 0 },
+      { type: 'TICK', now: 5 * MIN },
+    ]);
+    expect(s.status).toBe('complete');
+  });
+});
+
 const allConfigs: readonly [string, ModeConfig][] = [
   ['meditation_timer', { mode: 'meditation_timer', duration_minutes: 10 }],
   ['count_up', { mode: 'count_up' }],
@@ -255,6 +280,10 @@ const allConfigs: readonly [string, ModeConfig][] = [
   ['rep_counter', { mode: 'rep_counter', target_reps: 5, unit_label: 'reps' }],
   ['sense_grounding', { mode: 'sense_grounding', prompts: [{ sense: 'sight', label: 'a tree' }] }],
   ['tarot', { mode: 'tarot', deck: 'major_arcana', per_card_minutes: 5 }],
+  [
+    'card_meditation',
+    { mode: 'card_meditation', deck_id: 'rws', cards: null, per_card_minutes: 5 },
+  ],
 ];
 
 describe.each(allConfigs)('lifecycle — %s', (_mode, config) => {

--- a/frontend/src/features/Practice/engine/__tests__/validation.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/validation.test.ts
@@ -321,6 +321,28 @@ describe('validateCardMeditation', () => {
     expect(validateCardMeditation(config)[0]).toMatch(/name cannot be empty/i);
   });
 
+  it('rejects a custom card whose photo uri uses a network scheme', () => {
+    const config: CardMeditationConfig = {
+      mode: 'card_meditation',
+      deck_id: 'custom',
+      cards: [
+        { name: 'Web', image_asset_key: null, image_uri: 'https://x/y.png', symbolism: null },
+      ],
+    };
+    expect(validateCardMeditation(config)[0]).toMatch(/web link/i);
+  });
+
+  it('accepts a custom card with a device-file photo uri', () => {
+    const config: CardMeditationConfig = {
+      mode: 'card_meditation',
+      deck_id: 'custom',
+      cards: [
+        { name: 'Photo', image_asset_key: null, image_uri: 'file:///p.jpg', symbolism: null },
+      ],
+    };
+    expect(validateCardMeditation(config)).toEqual([]);
+  });
+
   it('rejects a custom card that sets two image sources', () => {
     const config: CardMeditationConfig = {
       mode: 'card_meditation',

--- a/frontend/src/features/Practice/engine/__tests__/validation.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import type {
+  CardMeditationConfig,
   IntervalBellConfig,
   MeditationTimerConfig,
   MetronomeConfig,
@@ -8,6 +9,7 @@ import type {
   SenseGroundingConfig,
   TarotConfig,
 } from '../types';
+import { CARD_MEDITATION_CARDS_MAX, CARD_MEDITATION_NAME_MAX } from '../types';
 import {
   BPM_MAX,
   BPM_MIN,
@@ -23,6 +25,7 @@ import {
   validateMetronome,
   validateModeConfig,
   validateRepCounter,
+  validateCardMeditation,
   validateSenseGrounding,
   validateTarot,
 } from '../validation';
@@ -274,6 +277,88 @@ describe('validateTarot', () => {
   });
 });
 
+describe('validateCardMeditation', () => {
+  const bundled: CardMeditationConfig = {
+    mode: 'card_meditation',
+    deck_id: 'rws',
+    cards: null,
+    per_card_minutes: 5,
+  };
+
+  it('accepts a valid bundled-deck config', () => {
+    expect(validateCardMeditation(bundled)).toEqual([]);
+  });
+
+  it('rejects per-card minutes outside range', () => {
+    expect(validateCardMeditation({ ...bundled, per_card_minutes: 0 })).toHaveLength(1);
+  });
+
+  it('rejects an invalid deck id', () => {
+    expect(validateCardMeditation({ ...bundled, deck_id: 'Bad Deck' })[0]).toMatch(/deck id/i);
+  });
+
+  it('rejects a custom deck with no cards', () => {
+    const empty: CardMeditationConfig = { mode: 'card_meditation', deck_id: 'custom', cards: [] };
+    expect(validateCardMeditation(empty)[0]).toMatch(/at least one card/i);
+    expect(validateCardMeditation({ ...empty, cards: null })[0]).toMatch(/at least one card/i);
+  });
+
+  it('accepts a custom deck with a valid card', () => {
+    const config: CardMeditationConfig = {
+      mode: 'card_meditation',
+      deck_id: 'custom',
+      cards: [{ name: 'Sunrise', image_asset_key: null, image_uri: null, symbolism: null }],
+    };
+    expect(validateCardMeditation(config)).toEqual([]);
+  });
+
+  it('rejects a custom card with an empty name', () => {
+    const config: CardMeditationConfig = {
+      mode: 'card_meditation',
+      deck_id: 'custom',
+      cards: [{ name: '  ', image_asset_key: null, image_uri: null, symbolism: null }],
+    };
+    expect(validateCardMeditation(config)[0]).toMatch(/name cannot be empty/i);
+  });
+
+  it('rejects a custom card that sets two image sources', () => {
+    const config: CardMeditationConfig = {
+      mode: 'card_meditation',
+      deck_id: 'custom',
+      cards: [
+        { name: 'Both', image_asset_key: 'rws/the_fool', image_uri: 'file:///x', symbolism: null },
+      ],
+    };
+    expect(validateCardMeditation(config)[0]).toMatch(/at most one image/i);
+  });
+
+  it('rejects a custom card with an oversize name', () => {
+    const config: CardMeditationConfig = {
+      mode: 'card_meditation',
+      deck_id: 'custom',
+      cards: [
+        {
+          name: 'x'.repeat(CARD_MEDITATION_NAME_MAX + 1),
+          image_asset_key: null,
+          image_uri: null,
+          symbolism: null,
+        },
+      ],
+    };
+    expect(validateCardMeditation(config).some((e) => /≤/.test(e))).toBe(true);
+  });
+
+  it('rejects a custom deck above the card cap', () => {
+    const card = { name: 'c', image_asset_key: null, image_uri: null, symbolism: null };
+    const config: CardMeditationConfig = {
+      mode: 'card_meditation',
+      deck_id: 'custom',
+      cards: Array.from({ length: CARD_MEDITATION_CARDS_MAX + 1 }, () => card),
+    };
+    expect(validateCardMeditation(config).some((e) => /at most/.test(e))).toBe(true);
+  });
+});
+
 describe('validateCustomName', () => {
   it('accepts a normal name', () => {
     expect(validateCustomName('My Morning Sit')).toEqual([]);
@@ -333,6 +418,13 @@ describe('validateModeConfig dispatch', () => {
         mode: 'tarot',
         deck: 'major_arcana',
         per_card_minutes: 5,
+      }),
+    ).toEqual([]);
+    expect(
+      validateModeConfig({
+        mode: 'card_meditation',
+        deck_id: 'rws',
+        cards: null,
       }),
     ).toEqual([]);
   });

--- a/frontend/src/features/Practice/engine/cues.ts
+++ b/frontend/src/features/Practice/engine/cues.ts
@@ -1,4 +1,5 @@
 import type {
+  CardMeditationConfig,
   Cue,
   IntervalBellConfig,
   MeditationTimerConfig,
@@ -6,7 +7,7 @@ import type {
   ModeConfig,
   TarotConfig,
 } from './types';
-import { DEFAULT_TAROT_MINUTES, MS_PER_MINUTE } from './types';
+import { DEFAULT_CARD_MEDITATION_MINUTES, DEFAULT_TAROT_MINUTES, MS_PER_MINUTE } from './types';
 
 // Defensive: at bpm=240 over the max session this would otherwise blow up.
 const MAX_METRONOME_TICKS = 10_000;
@@ -25,6 +26,8 @@ export function scheduledCues(config: ModeConfig): readonly Cue[] {
       return cuesForIntervalBell(config);
     case 'tarot':
       return cuesForTarot(config);
+    case 'card_meditation':
+      return cuesForCardMeditation(config);
   }
 }
 
@@ -72,6 +75,11 @@ function computeIntervalOffsets(config: IntervalBellConfig, totalMs: number): re
 
 function cuesForTarot(config: TarotConfig): readonly Cue[] {
   const totalMs = (config.per_card_minutes ?? DEFAULT_TAROT_MINUTES) * MS_PER_MINUTE;
+  return [{ atMs: totalMs, kind: 'end_bell' }];
+}
+
+function cuesForCardMeditation(config: CardMeditationConfig): readonly Cue[] {
+  const totalMs = (config.per_card_minutes ?? DEFAULT_CARD_MEDITATION_MINUTES) * MS_PER_MINUTE;
   return [{ atMs: totalMs, kind: 'end_bell' }];
 }
 

--- a/frontend/src/features/Practice/engine/reducer.ts
+++ b/frontend/src/features/Practice/engine/reducer.ts
@@ -6,7 +6,12 @@ import type {
   RepCounterConfig,
   SenseGroundingConfig,
 } from './types';
-import { DEFAULT_TAROT_MINUTES, MS_PER_MINUTE, TAROT_DECK_SIZE } from './types';
+import {
+  DEFAULT_CARD_MEDITATION_MINUTES,
+  DEFAULT_TAROT_MINUTES,
+  MS_PER_MINUTE,
+  TAROT_DECK_SIZE,
+} from './types';
 
 export function initialState(config: ModeConfig, startCardIndex = 0): EngineState {
   return {
@@ -183,10 +188,17 @@ export function getTotalMs(config: ModeConfig): number | null {
     case 'metronome':
       return config.timer.duration_minutes * MS_PER_MINUTE;
     case 'tarot':
-      return (config.per_card_minutes ?? DEFAULT_TAROT_MINUTES) * MS_PER_MINUTE;
+      return perCardTotalMs(config.per_card_minutes, DEFAULT_TAROT_MINUTES);
+    case 'card_meditation':
+      return perCardTotalMs(config.per_card_minutes, DEFAULT_CARD_MEDITATION_MINUTES);
     case 'rep_counter':
       return config.time_cap_minutes != null ? config.time_cap_minutes * MS_PER_MINUTE : null;
   }
+}
+
+/** Resolve a per-card sit length (with its mode default) to milliseconds. */
+function perCardTotalMs(minutes: number | undefined, fallback: number): number {
+  return (minutes ?? fallback) * MS_PER_MINUTE;
 }
 
 function getProgress(state: EngineState, config: ModeConfig, elapsedMs: number): number {

--- a/frontend/src/features/Practice/engine/types.ts
+++ b/frontend/src/features/Practice/engine/types.ts
@@ -72,6 +72,41 @@ export interface TarotConfig {
   hide_timer_during_meditation?: boolean;
 }
 
+/**
+ * One card in a `card_meditation` deck — bundled or user-curated.
+ *
+ * Mirrors the backend `CardMeditationCard`. `image_asset_key` and
+ * `image_uri` are mutually exclusive: a card points at a bundled asset
+ * *or* at a device-local file, never both. Both unset is valid for a
+ * text-only card whose meaning rides on `name` and `symbolism`.
+ */
+export interface CardMeditationCard {
+  name: string;
+  /** Opaque handle resolved against a bundled deck manifest; null for device/text cards. */
+  image_asset_key: string | null;
+  /** Device-local URI (`file://`, `content://`, …); null for bundled/text cards. */
+  image_uri: string | null;
+  symbolism: string | null;
+}
+
+/**
+ * Deck-agnostic card meditation — a bundled deck *or* user-curated cards.
+ *
+ * Mirrors the backend `CardMeditationConfig`. `deck_id` resolves a
+ * bundled deck; the sentinel {@link CARD_MEDITATION_CUSTOM_DECK_ID}
+ * signals a user-curated deck whose cards travel inline in `cards`.
+ */
+export interface CardMeditationConfig {
+  mode: 'card_meditation';
+  deck_id: string;
+  per_card_minutes?: number;
+  shuffle?: boolean;
+  reveal_after_meditation?: boolean;
+  /** View-layer only: suppress the countdown ring during the sit. No engine effect. */
+  hide_timer_during_meditation?: boolean;
+  cards?: readonly CardMeditationCard[] | null;
+}
+
 export type ModeConfig =
   | MeditationTimerConfig
   | CountUpConfig
@@ -79,7 +114,8 @@ export type ModeConfig =
   | IntervalBellConfig
   | RepCounterConfig
   | SenseGroundingConfig
-  | TarotConfig;
+  | TarotConfig
+  | CardMeditationConfig;
 
 export interface RitualState {
   status: EngineStatus;
@@ -145,3 +181,16 @@ export const MS_PER_MINUTE = 60_000;
 export const DEFAULT_TAROT_MINUTES = 5;
 /** 22 cards in a major arcana deck; tarot's cycle wraps modulo this. */
 export const TAROT_DECK_SIZE = 22;
+
+/** Default per-card sit length for `card_meditation`; mirrors the backend default. */
+export const DEFAULT_CARD_MEDITATION_MINUTES = 5;
+/** Sentinel `deck_id` for a user-curated deck whose cards travel inline in the config. */
+export const CARD_MEDITATION_CUSTOM_DECK_ID = 'custom';
+/** Upper bound on a custom deck's card count; mirrors the backend `CARD_MEDITATION_CARDS_MAX`. */
+export const CARD_MEDITATION_CARDS_MAX = 200;
+/** Maximum card-name length; mirrors the backend `CARD_NAME_MAX`. */
+export const CARD_MEDITATION_NAME_MAX = 120;
+/** Maximum card-symbolism length; mirrors the backend `_CARD_SYMBOLISM_MAX`. */
+export const CARD_MEDITATION_SYMBOLISM_MAX = 500;
+/** Deck-id slug pattern; mirrors the backend `CARD_DECK_ID_PATTERN`. */
+export const CARD_DECK_ID_PATTERN = /^[a-z][a-z0-9_]*$/;

--- a/frontend/src/features/Practice/engine/types.ts
+++ b/frontend/src/features/Practice/engine/types.ts
@@ -194,3 +194,9 @@ export const CARD_MEDITATION_NAME_MAX = 120;
 export const CARD_MEDITATION_SYMBOLISM_MAX = 500;
 /** Deck-id slug pattern; mirrors the backend `CARD_DECK_ID_PATTERN`. */
 export const CARD_DECK_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
+/**
+ * Allowed schemes for a card's `image_uri`; mirrors the backend
+ * `_CARD_IMAGE_URI_PATTERN`. Network/script schemes are rejected so a
+ * stored URI can never trigger a fetch when rendered as an image source.
+ */
+export const CARD_IMAGE_URI_PATTERN = /^(file|content|ph|asset):\/\/[^\s<>"]+$/;

--- a/frontend/src/features/Practice/engine/validation.ts
+++ b/frontend/src/features/Practice/engine/validation.ts
@@ -5,6 +5,8 @@
 // list means the payload is acceptable.
 
 import type {
+  CardMeditationCard,
+  CardMeditationConfig,
   CountUpConfig,
   IntervalBellConfig,
   MeditationTimerConfig,
@@ -15,6 +17,13 @@ import type {
   SenseKind,
   SensePrompt,
   TarotConfig,
+} from './types';
+import {
+  CARD_DECK_ID_PATTERN,
+  CARD_MEDITATION_CARDS_MAX,
+  CARD_MEDITATION_CUSTOM_DECK_ID,
+  CARD_MEDITATION_NAME_MAX,
+  CARD_MEDITATION_SYMBOLISM_MAX,
 } from './types';
 
 export const BPM_MIN = 20;
@@ -174,6 +183,48 @@ export function validateTarot(config: TarotConfig): string[] {
   return errors;
 }
 
+function checkCard(card: CardMeditationCard, index: number): string[] {
+  const errors: string[] = [];
+  const position = `Card ${index + 1}`;
+  if (card.name.trim().length === 0) {
+    errors.push(`${position}: name cannot be empty`);
+  }
+  if (card.name.length > CARD_MEDITATION_NAME_MAX) {
+    errors.push(`${position}: name must be ≤ ${CARD_MEDITATION_NAME_MAX} characters`);
+  }
+  if (card.image_asset_key !== null && card.image_uri !== null) {
+    errors.push(`${position}: set at most one image source`);
+  }
+  if (card.symbolism !== null && card.symbolism.length > CARD_MEDITATION_SYMBOLISM_MAX) {
+    errors.push(`${position}: symbolism must be ≤ ${CARD_MEDITATION_SYMBOLISM_MAX} characters`);
+  }
+  return errors;
+}
+
+export function validateCardMeditation(config: CardMeditationConfig): string[] {
+  const errors: string[] = [];
+  if (config.per_card_minutes !== undefined) {
+    pushIfOutOfDurationRange(errors, 'Per-card minutes', config.per_card_minutes);
+  }
+  if (!CARD_DECK_ID_PATTERN.test(config.deck_id)) {
+    errors.push('Deck id is invalid');
+  }
+  if (config.deck_id === CARD_MEDITATION_CUSTOM_DECK_ID) {
+    const cards = config.cards ?? [];
+    if (cards.length === 0) {
+      errors.push('Add at least one card to use a custom deck');
+      return errors;
+    }
+    if (cards.length > CARD_MEDITATION_CARDS_MAX) {
+      errors.push(`A custom deck can hold at most ${CARD_MEDITATION_CARDS_MAX} cards`);
+    }
+    cards.forEach((card, index) => {
+      errors.push(...checkCard(card, index));
+    });
+  }
+  return errors;
+}
+
 const VALIDATORS: {
   [K in ModeConfig['mode']]: (config: Extract<ModeConfig, { mode: K }>) => string[];
 } = {
@@ -184,6 +235,7 @@ const VALIDATORS: {
   rep_counter: validateRepCounter,
   sense_grounding: validateSenseGrounding,
   tarot: validateTarot,
+  card_meditation: validateCardMeditation,
 };
 
 /**

--- a/frontend/src/features/Practice/engine/validation.ts
+++ b/frontend/src/features/Practice/engine/validation.ts
@@ -20,6 +20,7 @@ import type {
 } from './types';
 import {
   CARD_DECK_ID_PATTERN,
+  CARD_IMAGE_URI_PATTERN,
   CARD_MEDITATION_CARDS_MAX,
   CARD_MEDITATION_CUSTOM_DECK_ID,
   CARD_MEDITATION_NAME_MAX,
@@ -194,6 +195,9 @@ function checkCard(card: CardMeditationCard, index: number): string[] {
   }
   if (card.image_asset_key !== null && card.image_uri !== null) {
     errors.push(`${position}: set at most one image source`);
+  }
+  if (card.image_uri !== null && !CARD_IMAGE_URI_PATTERN.test(card.image_uri)) {
+    errors.push(`${position}: photo must be a device file, not a web link`);
   }
   if (card.symbolism !== null && card.symbolism.length > CARD_MEDITATION_SYMBOLISM_MAX) {
     errors.push(`${position}: symbolism must be ≤ ${CARD_MEDITATION_SYMBOLISM_MAX} characters`);

--- a/frontend/src/features/Practice/insights/__tests__/format.test.ts
+++ b/frontend/src/features/Practice/insights/__tests__/format.test.ts
@@ -24,6 +24,7 @@ describe('formatModeSummary', () => {
       'Grounded through 3 senses',
     ],
     [{ mode: 'tarot', card_index: 0, card_name: 'The Fool' }, 5, 'The Fool for 05:00'],
+    [{ mode: 'card_meditation', deck_id: 'rws', card_name: 'The Star' }, 5, 'The Star for 05:00'],
   ])('formats %j (%s min) as %s', (metadata, durationMinutes, expected) => {
     expect(formatModeSummary(metadata.mode, durationMinutes, metadata)).toBe(expected);
   });

--- a/frontend/src/features/Practice/insights/format.ts
+++ b/frontend/src/features/Practice/insights/format.ts
@@ -55,6 +55,12 @@ export interface ModeSummaryTarot {
   readonly card_name: string;
 }
 
+export interface ModeSummaryCardMeditation {
+  readonly mode: 'card_meditation';
+  readonly deck_id: string;
+  readonly card_name: string;
+}
+
 export type ModeSummaryMetadata =
   | ModeSummaryMeditationTimer
   | ModeSummaryCountUp
@@ -62,7 +68,8 @@ export type ModeSummaryMetadata =
   | ModeSummaryIntervalBell
   | ModeSummaryRepCounter
   | ModeSummarySenseGrounding
-  | ModeSummaryTarot;
+  | ModeSummaryTarot
+  | ModeSummaryCardMeditation;
 
 export type ModeSummaryKind = ModeSummaryMetadata['mode'];
 
@@ -108,6 +115,10 @@ export function formatModeSummary<M extends ModeSummaryKind>(
     }
     case 'tarot': {
       const m = metadata as ModeSummaryTarot;
+      return `${m.card_name} for ${mmss}`;
+    }
+    case 'card_meditation': {
+      const m = metadata as ModeSummaryCardMeditation;
       return `${m.card_name} for ${mmss}`;
     }
     default:

--- a/frontend/src/features/Practice/utils/__tests__/pickCardPhoto.test.ts
+++ b/frontend/src/features/Practice/utils/__tests__/pickCardPhoto.test.ts
@@ -1,4 +1,3 @@
-/* eslint-env jest */
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import * as ImagePicker from 'expo-image-picker';
 

--- a/frontend/src/features/Practice/utils/__tests__/pickCardPhoto.test.ts
+++ b/frontend/src/features/Practice/utils/__tests__/pickCardPhoto.test.ts
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as ImagePicker from 'expo-image-picker';
+
+import { pickCardPhoto } from '../pickCardPhoto';
+
+const requestPermission = jest.mocked(ImagePicker.requestMediaLibraryPermissionsAsync);
+const launchLibrary = jest.mocked(ImagePicker.launchImageLibraryAsync);
+
+function asset(uri: string): ImagePicker.ImagePickerAsset {
+  return { uri, width: 1, height: 1 } as ImagePicker.ImagePickerAsset;
+}
+
+describe('pickCardPhoto', () => {
+  beforeEach(() => {
+    requestPermission.mockResolvedValue({ granted: true } as ImagePicker.PermissionResponse);
+    launchLibrary.mockResolvedValue({ canceled: true, assets: null });
+  });
+
+  it('returns null when media-library permission is denied', async () => {
+    requestPermission.mockResolvedValueOnce({ granted: false } as ImagePicker.PermissionResponse);
+    expect(await pickCardPhoto()).toBeNull();
+    expect(launchLibrary).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the picker is cancelled', async () => {
+    launchLibrary.mockResolvedValueOnce({ canceled: true, assets: null });
+    expect(await pickCardPhoto()).toBeNull();
+  });
+
+  it('returns the chosen photo uri on a successful pick', async () => {
+    launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [asset('file:///pick.jpg')] });
+    expect(await pickCardPhoto()).toEqual({ uri: 'file:///pick.jpg' });
+  });
+
+  it('returns null when a successful pick yields no asset', async () => {
+    launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [] });
+    expect(await pickCardPhoto()).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/utils/pickCardPhoto.ts
+++ b/frontend/src/features/Practice/utils/pickCardPhoto.ts
@@ -8,6 +8,10 @@ export interface PickedPhoto {
   readonly uri: string;
 }
 
+// Slight compression: the full-resolution original can be several MB and the
+// URI is stored inline in the practice config. 0.8 is visually lossless here.
+const IMAGE_QUALITY = 0.8;
+
 /**
  * Open the media library and return the chosen photo.
  *
@@ -23,7 +27,7 @@ export async function pickCardPhoto(): Promise<PickedPhoto | null> {
   }
   const result = await ImagePicker.launchImageLibraryAsync({
     mediaTypes: ['images'],
-    quality: 1,
+    quality: IMAGE_QUALITY,
   });
   if (result.canceled) {
     return null;

--- a/frontend/src/features/Practice/utils/pickCardPhoto.ts
+++ b/frontend/src/features/Practice/utils/pickCardPhoto.ts
@@ -1,0 +1,33 @@
+// Wraps `expo-image-picker` so the configurator imports a single function.
+
+import * as ImagePicker from 'expo-image-picker';
+
+/** A photo the user picked from their device's media library. */
+export interface PickedPhoto {
+  /** Device-local URI (`file://`, `content://`, `ph://`, `asset://`). */
+  readonly uri: string;
+}
+
+/**
+ * Open the media library and return the chosen photo.
+ *
+ * Requests media-library permission on first use. Returns `null` when the
+ * user denies permission or cancels the picker — callers treat both as a
+ * no-op rather than an error. V1 does not upload the photo: the returned
+ * `uri` is a device path stored as-is in the practice config.
+ */
+export async function pickCardPhoto(): Promise<PickedPhoto | null> {
+  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (!permission.granted) {
+    return null;
+  }
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images'],
+    quality: 1,
+  });
+  if (result.canceled) {
+    return null;
+  }
+  const asset = result.assets[0];
+  return asset ? { uri: asset.uri } : null;
+}

--- a/frontend/src/features/Practice/views/CardMeditationView.tsx
+++ b/frontend/src/features/Practice/views/CardMeditationView.tsx
@@ -26,18 +26,18 @@ import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
  *
  * The timer is hidden while running when `hide_timer_during_meditation`
  * is set; pausing brings it back as an honesty-over-purism escape hatch.
+ * Saving is handled by the parent's post-completion insight modal — the
+ * complete state here just surfaces the standard controls bar.
  */
 interface Props {
   config: CardMeditationConfig;
   state: RitualState;
   controls: RitualControls;
-  /** Optional Save callback; the parent typically launches the insight modal. */
-  onSave?: () => void;
 }
 
 const PLACEHOLDER_COPY = 'Sit. The card will be revealed when the timer ends.';
 
-const CardMeditationView = ({ config, state, controls, onSave }: Props): React.JSX.Element => {
+const CardMeditationView = ({ config, state, controls }: Props): React.JSX.Element => {
   const [picked] = useState<PickedCard>(() => pickCard(config));
   const reveal = config.reveal_after_meditation ?? false;
   const hideTimer = config.hide_timer_during_meditation ?? true;
@@ -54,7 +54,7 @@ const CardMeditationView = ({ config, state, controls, onSave }: Props): React.J
           {formatTime(state.remainingMs ?? 0)}
         </Text>
       )}
-      <CardFooter state={state} controls={controls} hideTimer={hideTimer} onSave={onSave} />
+      <CardFooter state={state} controls={controls} hideTimer={hideTimer} />
     </View>
   );
 };
@@ -110,10 +110,9 @@ interface FooterProps {
   state: RitualState;
   controls: RitualControls;
   hideTimer: boolean;
-  onSave?: () => void;
 }
 
-const CardFooter = ({ state, controls, hideTimer, onSave }: FooterProps): React.JSX.Element => {
+const CardFooter = ({ state, controls, hideTimer }: FooterProps): React.JSX.Element => {
   if (state.status === 'idle') {
     return (
       <Pressable
@@ -142,26 +141,10 @@ const CardFooter = ({ state, controls, hideTimer, onSave }: FooterProps): React.
       </Pressable>
     );
   }
-  if (state.status === 'complete') return <SaveButton onSave={onSave} />;
-  // running (timer visible) or paused — surface the standard controls bar.
+  // running (timer visible), paused, or complete — surface the standard
+  // controls bar; the parent opens the insight modal on completion.
   return <RitualControlsBar status={state.status} controls={controls} startLabel="Begin" />;
 };
-
-const SaveButton = ({ onSave }: { onSave?: () => void }): React.JSX.Element => (
-  <View style={styles.completeRow}>
-    <Pressable
-      style={[styles.save, !onSave && styles.saveDisabled]}
-      onPress={onSave}
-      disabled={!onSave}
-      testID="card-meditation-save"
-      accessibilityRole="button"
-      accessibilityLabel="Save session and reflect"
-      accessibilityState={{ disabled: !onSave }}
-    >
-      <Text style={styles.saveText}>Save session</Text>
-    </Pressable>
-  </View>
-);
 
 const CARD_WIDTH = 280;
 const CARD_MIN_HEIGHT = 380;
@@ -240,18 +223,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     letterSpacing: 1,
   },
-  completeRow: { alignItems: 'center', marginTop: SPACING.md },
-  save: {
-    backgroundColor: colors.success,
-    paddingVertical: SPACING.buttonV,
-    paddingHorizontal: SPACING.xxl,
-    borderRadius: BORDER_RADIUS.lg,
-    minWidth: 220,
-    alignItems: 'center',
-    ...shadows.small,
-  },
-  saveDisabled: { opacity: 0.5 },
-  saveText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
 });
 
 export default CardMeditationView;

--- a/frontend/src/features/Practice/views/CardMeditationView.tsx
+++ b/frontend/src/features/Practice/views/CardMeditationView.tsx
@@ -1,0 +1,257 @@
+import React, { useState } from 'react';
+import type { ImageSourcePropType } from 'react-native';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { resolveCardImage } from '../data/assetResolver';
+import type { PickedCard } from '../data/resolveCard';
+import { pickCard } from '../data/resolveCard';
+import type { CardMeditationCard, CardMeditationConfig } from '../engine/types';
+import type { RitualControls, RitualState } from '../engine/types';
+
+import { formatTime } from './formatTime';
+import RitualControlsBar from './RitualControlsBar';
+
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+/**
+ * Single-card meditation view for the `card_meditation` mode.
+ *
+ * The card is drawn once at mount (`pickCard`) and held in local state so
+ * a re-render never reshuffles. Two flows:
+ *
+ *   - **Reveal** (`reveal_after_meditation`): the card is hidden behind a
+ *     placeholder while the engine runs and is revealed at completion, so
+ *     the card meets the user unprimed.
+ *   - **Immediate**: the card image fills the frame from the start.
+ *
+ * The timer is hidden while running when `hide_timer_during_meditation`
+ * is set; pausing brings it back as an honesty-over-purism escape hatch.
+ */
+interface Props {
+  config: CardMeditationConfig;
+  state: RitualState;
+  controls: RitualControls;
+  /** Optional Save callback; the parent typically launches the insight modal. */
+  onSave?: () => void;
+}
+
+const PLACEHOLDER_COPY = 'Sit. The card will be revealed when the timer ends.';
+
+const CardMeditationView = ({ config, state, controls, onSave }: Props): React.JSX.Element => {
+  const [picked] = useState<PickedCard>(() => pickCard(config));
+  const reveal = config.reveal_after_meditation ?? false;
+  const hideTimer = config.hide_timer_during_meditation ?? true;
+  const showCard = !reveal || state.status === 'complete';
+  const showTimer =
+    state.status === 'paused' ||
+    state.status === 'complete' ||
+    (state.status === 'running' && !hideTimer);
+  return (
+    <View style={styles.container} testID="card-meditation-view">
+      {showCard ? <CardFace card={picked.card} /> : <RevealPlaceholder />}
+      {showTimer && (
+        <Text style={styles.timer} testID="card-meditation-time-remaining">
+          {formatTime(state.remainingMs ?? 0)}
+        </Text>
+      )}
+      <CardFooter state={state} controls={controls} hideTimer={hideTimer} onSave={onSave} />
+    </View>
+  );
+};
+
+const RevealPlaceholder = (): React.JSX.Element => (
+  <View style={styles.card} testID="card-meditation-placeholder">
+    <Text style={styles.placeholderText}>{PLACEHOLDER_COPY}</Text>
+  </View>
+);
+
+const CardFace = ({ card }: { card: CardMeditationCard }): React.JSX.Element => {
+  // A device-local `image_uri` may no longer resolve (the user deleted the
+  // photo); `uriError` flips the card to its text rendering instead of
+  // crashing on a broken source.
+  const [uriError, setUriError] = useState(false);
+  const useUri = card.image_uri !== null && !uriError;
+  const assetSource = card.image_asset_key !== null ? resolveCardImage(card.image_asset_key) : null;
+  const imageSource: ImageSourcePropType | null = useUri
+    ? { uri: card.image_uri ?? undefined }
+    : assetSource;
+  const altText = card.symbolism !== null && card.symbolism.length > 0 ? card.symbolism : card.name;
+  return (
+    <View
+      style={styles.card}
+      testID="card-meditation-card"
+      accessibilityLabel={`Card: ${card.name}`}
+    >
+      {imageSource !== null && (
+        <Image
+          source={imageSource}
+          style={styles.cardImage}
+          resizeMode="contain"
+          testID="card-meditation-card-image"
+          accessibilityLabel={altText}
+          onError={() => {
+            if (useUri) setUriError(true);
+          }}
+        />
+      )}
+      <Text style={styles.cardName} testID="card-meditation-card-name">
+        {card.name}
+      </Text>
+      {card.symbolism !== null && card.symbolism.length > 0 && (
+        <Text style={styles.cardSymbolism} testID="card-meditation-card-symbolism">
+          {card.symbolism}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+interface FooterProps {
+  state: RitualState;
+  controls: RitualControls;
+  hideTimer: boolean;
+  onSave?: () => void;
+}
+
+const CardFooter = ({ state, controls, hideTimer, onSave }: FooterProps): React.JSX.Element => {
+  if (state.status === 'idle') {
+    return (
+      <Pressable
+        style={styles.begin}
+        onPress={controls.start}
+        testID="card-meditation-begin"
+        accessibilityRole="button"
+        accessibilityLabel="Begin meditation"
+      >
+        <Text style={styles.beginText}>Begin meditation</Text>
+      </Pressable>
+    );
+  }
+  if (state.status === 'running' && hideTimer) {
+    return (
+      <Pressable
+        style={styles.longCancel}
+        onLongPress={controls.cancel}
+        delayLongPress={800}
+        testID="card-meditation-cancel-longpress"
+        accessibilityRole="button"
+        accessibilityLabel="Long-press to cancel meditation"
+        accessibilityHint="Hold to end the sit early without revealing the timer."
+      >
+        <Text style={styles.longCancelText}>Hold to cancel</Text>
+      </Pressable>
+    );
+  }
+  if (state.status === 'complete') return <SaveButton onSave={onSave} />;
+  // running (timer visible) or paused — surface the standard controls bar.
+  return <RitualControlsBar status={state.status} controls={controls} startLabel="Begin" />;
+};
+
+const SaveButton = ({ onSave }: { onSave?: () => void }): React.JSX.Element => (
+  <View style={styles.completeRow}>
+    <Pressable
+      style={[styles.save, !onSave && styles.saveDisabled]}
+      onPress={onSave}
+      disabled={!onSave}
+      testID="card-meditation-save"
+      accessibilityRole="button"
+      accessibilityLabel="Save session and reflect"
+      accessibilityState={{ disabled: !onSave }}
+    >
+      <Text style={styles.saveText}>Save session</Text>
+    </Pressable>
+  </View>
+);
+
+const CARD_WIDTH = 280;
+const CARD_MIN_HEIGHT = 380;
+const CARD_IMAGE_HEIGHT = 280;
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', padding: SPACING.xl },
+  card: {
+    width: CARD_WIDTH,
+    minHeight: CARD_MIN_HEIGHT,
+    // Generous dark frame: lowers visual noise and lets the artwork settle.
+    backgroundColor: colors.primary,
+    borderRadius: BORDER_RADIUS.xl,
+    borderWidth: 8,
+    borderColor: colors.primary,
+    padding: SPACING.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: SPACING.xl,
+    ...shadows.medium,
+  },
+  cardImage: {
+    width: CARD_WIDTH - SPACING.lg * 2,
+    height: CARD_IMAGE_HEIGHT,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: SPACING.md,
+  },
+  cardName: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: colors.text.light,
+    textAlign: 'center',
+    marginBottom: SPACING.sm,
+  },
+  cardSymbolism: {
+    fontSize: 13,
+    color: colors.text.light,
+    textAlign: 'center',
+    lineHeight: 18,
+    paddingHorizontal: SPACING.sm,
+    opacity: 0.85,
+  },
+  placeholderText: {
+    fontSize: 16,
+    color: colors.text.light,
+    textAlign: 'center',
+    lineHeight: 24,
+    paddingHorizontal: SPACING.lg,
+  },
+  timer: {
+    fontSize: 36,
+    fontWeight: '300',
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+    marginBottom: SPACING.lg,
+  },
+  begin: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  beginText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
+  longCancel: {
+    paddingVertical: SPACING.md,
+    paddingHorizontal: SPACING.xl,
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    borderColor: colors.text.tertiaryAccessible,
+  },
+  longCancelText: {
+    color: colors.text.tertiaryAccessible,
+    fontSize: 13,
+    letterSpacing: 1,
+  },
+  completeRow: { alignItems: 'center', marginTop: SPACING.md },
+  save: {
+    backgroundColor: colors.success,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xxl,
+    borderRadius: BORDER_RADIUS.lg,
+    minWidth: 220,
+    alignItems: 'center',
+    ...shadows.small,
+  },
+  saveDisabled: { opacity: 0.5 },
+  saveText: { color: colors.text.light, fontSize: 18, fontWeight: '600' },
+});
+
+export default CardMeditationView;

--- a/frontend/src/features/Practice/views/CardMeditationView.tsx
+++ b/frontend/src/features/Practice/views/CardMeditationView.tsx
@@ -33,12 +33,23 @@ interface Props {
   config: CardMeditationConfig;
   state: RitualState;
   controls: RitualControls;
+  /**
+   * The drawn card, resolved once by the parent so the view and the
+   * harvested session metadata never describe different cards. `null` /
+   * omitted only in isolation tests, where the view draws its own card.
+   */
+  picked?: PickedCard | null;
 }
 
 const PLACEHOLDER_COPY = 'Sit. The card will be revealed when the timer ends.';
 
-const CardMeditationView = ({ config, state, controls }: Props): React.JSX.Element => {
-  const [picked] = useState<PickedCard>(() => pickCard(config));
+const CardMeditationView = ({
+  config,
+  state,
+  controls,
+  picked: pickedProp,
+}: Props): React.JSX.Element => {
+  const [picked] = useState<PickedCard>(() => pickedProp ?? pickCard(config));
   const reveal = config.reveal_after_meditation ?? false;
   const hideTimer = config.hide_timer_during_meditation ?? true;
   const showCard = !reveal || state.status === 'complete';
@@ -67,14 +78,13 @@ const RevealPlaceholder = (): React.JSX.Element => (
 
 const CardFace = ({ card }: { card: CardMeditationCard }): React.JSX.Element => {
   // A device-local `image_uri` may no longer resolve (the user deleted the
-  // photo); `uriError` flips the card to its text rendering instead of
-  // crashing on a broken source.
+  // photo); `uriError` then drops to the bundled asset or text rendering
+  // instead of crashing on a broken source.
   const [uriError, setUriError] = useState(false);
-  const useUri = card.image_uri !== null && !uriError;
+  const deviceSource: ImageSourcePropType | null =
+    card.image_uri !== null && !uriError ? { uri: card.image_uri } : null;
   const assetSource = card.image_asset_key !== null ? resolveCardImage(card.image_asset_key) : null;
-  const imageSource: ImageSourcePropType | null = useUri
-    ? { uri: card.image_uri ?? undefined }
-    : assetSource;
+  const imageSource: ImageSourcePropType | null = deviceSource ?? assetSource;
   const altText = card.symbolism !== null && card.symbolism.length > 0 ? card.symbolism : card.name;
   return (
     <View
@@ -90,7 +100,7 @@ const CardFace = ({ card }: { card: CardMeditationCard }): React.JSX.Element => 
           testID="card-meditation-card-image"
           accessibilityLabel={altText}
           onError={() => {
-            if (useUri) setUriError(true);
+            if (deviceSource !== null) setUriError(true);
           }}
         />
       )}
@@ -149,16 +159,17 @@ const CardFooter = ({ state, controls, hideTimer }: FooterProps): React.JSX.Elem
 const CARD_WIDTH = 280;
 const CARD_MIN_HEIGHT = 380;
 const CARD_IMAGE_HEIGHT = 280;
+/** Generous dark frame around the artwork — lowers visual noise during the sit. */
+const CARD_BORDER_WIDTH = 8;
 
 const styles = StyleSheet.create({
   container: { alignItems: 'center', padding: SPACING.xl },
   card: {
     width: CARD_WIDTH,
     minHeight: CARD_MIN_HEIGHT,
-    // Generous dark frame: lowers visual noise and lets the artwork settle.
     backgroundColor: colors.primary,
     borderRadius: BORDER_RADIUS.xl,
-    borderWidth: 8,
+    borderWidth: CARD_BORDER_WIDTH,
     borderColor: colors.primary,
     padding: SPACING.lg,
     alignItems: 'center',

--- a/frontend/src/features/Practice/views/__tests__/CardMeditationView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/CardMeditationView.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
+import type { PickedCard } from '../../data/resolveCard';
 import type { CardMeditationCard, CardMeditationConfig } from '../../engine/types';
 import CardMeditationView from '../CardMeditationView';
 
@@ -36,6 +37,22 @@ describe('CardMeditationView', () => {
     );
     expect(getByTestId('card-meditation-card-image')).toBeTruthy();
     expect(getByTestId('card-meditation-card-name').props.children).toBeTruthy();
+  });
+
+  it('renders the card supplied by the parent via the picked prop', () => {
+    const picked: PickedCard = {
+      card: { name: 'Parent Card', image_asset_key: null, image_uri: null, symbolism: null },
+      index: 3,
+    };
+    const { getByTestId } = render(
+      <CardMeditationView
+        config={config()}
+        state={fakeState()}
+        controls={fakeControls()}
+        picked={picked}
+      />,
+    );
+    expect(getByTestId('card-meditation-card-name').props.children).toBe('Parent Card');
   });
 
   it('renders a custom card from its device image_uri', () => {

--- a/frontend/src/features/Practice/views/__tests__/CardMeditationView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/CardMeditationView.test.tsx
@@ -1,0 +1,233 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { CardMeditationCard, CardMeditationConfig } from '../../engine/types';
+import CardMeditationView from '../CardMeditationView';
+
+import { fakeControls, fakeState } from './fixtures';
+
+function config(over: Partial<CardMeditationConfig> = {}): CardMeditationConfig {
+  return { mode: 'card_meditation', deck_id: 'rws', cards: null, shuffle: false, ...over };
+}
+
+function customConfig(card: CardMeditationCard): CardMeditationConfig {
+  return config({ deck_id: 'custom', cards: [card], shuffle: false });
+}
+
+const PHOTO_CARD: CardMeditationCard = {
+  name: 'Photo Card',
+  image_asset_key: null,
+  image_uri: 'file:///photo.jpg',
+  symbolism: 'a remembered place',
+};
+
+const TEXT_CARD: CardMeditationCard = {
+  name: 'Text Card',
+  image_asset_key: null,
+  image_uri: null,
+  symbolism: 'meaning without a picture',
+};
+
+describe('CardMeditationView', () => {
+  it('renders a bundled deck card with its image', () => {
+    const { getByTestId } = render(
+      <CardMeditationView config={config()} state={fakeState()} controls={fakeControls()} />,
+    );
+    expect(getByTestId('card-meditation-card-image')).toBeTruthy();
+    expect(getByTestId('card-meditation-card-name').props.children).toBeTruthy();
+  });
+
+  it('renders a custom card from its device image_uri', () => {
+    const { getByTestId } = render(
+      <CardMeditationView
+        config={customConfig(PHOTO_CARD)}
+        state={fakeState()}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('card-meditation-card-image').props.source).toEqual({
+      uri: 'file:///photo.jpg',
+    });
+    expect(getByTestId('card-meditation-card-name').props.children).toBe('Photo Card');
+  });
+
+  it('falls back to text when both image fields are missing', () => {
+    const { getByTestId, queryByTestId } = render(
+      <CardMeditationView
+        config={customConfig(TEXT_CARD)}
+        state={fakeState()}
+        controls={fakeControls()}
+      />,
+    );
+    expect(queryByTestId('card-meditation-card-image')).toBeNull();
+    expect(getByTestId('card-meditation-card-name').props.children).toBe('Text Card');
+    expect(getByTestId('card-meditation-card-symbolism').props.children).toBe(
+      'meaning without a picture',
+    );
+  });
+
+  it('falls back to text when a device image_uri no longer resolves', () => {
+    const { getByTestId, queryByTestId } = render(
+      <CardMeditationView
+        config={customConfig(PHOTO_CARD)}
+        state={fakeState()}
+        controls={fakeControls()}
+      />,
+    );
+    fireEvent(getByTestId('card-meditation-card-image'), 'error');
+    expect(queryByTestId('card-meditation-card-image')).toBeNull();
+    expect(getByTestId('card-meditation-card-name').props.children).toBe('Photo Card');
+  });
+
+  it('hides the card behind a placeholder while running in the reveal flow', () => {
+    const { getByTestId, queryByTestId } = render(
+      <CardMeditationView
+        config={config({ reveal_after_meditation: true })}
+        state={fakeState({ status: 'running' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('card-meditation-placeholder')).toBeTruthy();
+    expect(queryByTestId('card-meditation-card')).toBeNull();
+  });
+
+  it('reveals the card at completion in the reveal flow', () => {
+    const { getByTestId, queryByTestId } = render(
+      <CardMeditationView
+        config={config({ reveal_after_meditation: true })}
+        state={fakeState({ status: 'complete', remainingMs: 0 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(queryByTestId('card-meditation-placeholder')).toBeNull();
+    expect(getByTestId('card-meditation-card')).toBeTruthy();
+  });
+
+  it('shows the card from the start in the immediate flow', () => {
+    const { getByTestId, queryByTestId } = render(
+      <CardMeditationView
+        config={config({ reveal_after_meditation: false })}
+        state={fakeState({ status: 'running' })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('card-meditation-card')).toBeTruthy();
+    expect(queryByTestId('card-meditation-placeholder')).toBeNull();
+  });
+
+  it('starts the engine from the idle Begin button', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(
+      <CardMeditationView
+        config={config()}
+        state={fakeState({ status: 'idle' })}
+        controls={controls}
+      />,
+    );
+    fireEvent.press(getByTestId('card-meditation-begin'));
+    expect(controls.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an image card without symbolism', () => {
+    const imageOnly: CardMeditationCard = {
+      name: 'Untitled',
+      image_asset_key: null,
+      image_uri: 'file:///bare.jpg',
+      symbolism: null,
+    };
+    const { getByTestId, queryByTestId } = render(
+      <CardMeditationView
+        config={customConfig(imageOnly)}
+        state={fakeState()}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('card-meditation-card-image').props.accessibilityLabel).toBe('Untitled');
+    expect(queryByTestId('card-meditation-card-symbolism')).toBeNull();
+  });
+
+  it('keeps a bundled image visible if its image element reports an error', () => {
+    const { getByTestId } = render(
+      <CardMeditationView config={config()} state={fakeState()} controls={fakeControls()} />,
+    );
+    fireEvent(getByTestId('card-meditation-card-image'), 'error');
+    expect(getByTestId('card-meditation-card-image')).toBeTruthy();
+  });
+
+  it('renders a 00:00 timer when no remaining time is supplied', () => {
+    const { getByTestId } = render(
+      <CardMeditationView
+        config={config()}
+        state={fakeState({ status: 'complete', remainingMs: null })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('card-meditation-time-remaining').props.children).toBe('00:00');
+  });
+
+  it('hides the timer while running when hide_timer_during_meditation is set', () => {
+    const controls = fakeControls();
+    const { getByTestId, queryByTestId } = render(
+      <CardMeditationView
+        config={config({ hide_timer_during_meditation: true })}
+        state={fakeState({ status: 'running', remainingMs: 120_000 })}
+        controls={controls}
+      />,
+    );
+    expect(queryByTestId('card-meditation-time-remaining')).toBeNull();
+    fireEvent(getByTestId('card-meditation-cancel-longpress'), 'longPress');
+    expect(controls.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the timer and controls bar while running when the timer is not hidden', () => {
+    const { getByTestId } = render(
+      <CardMeditationView
+        config={config({ hide_timer_during_meditation: false })}
+        state={fakeState({ status: 'running', remainingMs: 90_000 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('card-meditation-time-remaining').props.children).toBe('01:30');
+    expect(getByTestId('ritual-controls-bar')).toBeTruthy();
+  });
+
+  it('shows the timer and controls bar when paused', () => {
+    const { getByTestId } = render(
+      <CardMeditationView
+        config={config()}
+        state={fakeState({ status: 'paused', remainingMs: 60_000 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('card-meditation-time-remaining').props.children).toBe('01:00');
+    expect(getByTestId('ritual-controls-bar')).toBeTruthy();
+  });
+
+  it('saves the session from the complete-state Save button', () => {
+    const onSave = jest.fn();
+    const { getByTestId } = render(
+      <CardMeditationView
+        config={config()}
+        state={fakeState({ status: 'complete', remainingMs: 0 })}
+        controls={fakeControls()}
+        onSave={onSave}
+      />,
+    );
+    fireEvent.press(getByTestId('card-meditation-save'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the Save button when no onSave handler is supplied', () => {
+    const { getByTestId } = render(
+      <CardMeditationView
+        config={config()}
+        state={fakeState({ status: 'complete', remainingMs: 0 })}
+        controls={fakeControls()}
+      />,
+    );
+    expect(getByTestId('card-meditation-save').props.accessibilityState).toEqual({
+      disabled: true,
+    });
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/CardMeditationView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/CardMeditationView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
@@ -204,21 +204,7 @@ describe('CardMeditationView', () => {
     expect(getByTestId('ritual-controls-bar')).toBeTruthy();
   });
 
-  it('saves the session from the complete-state Save button', () => {
-    const onSave = jest.fn();
-    const { getByTestId } = render(
-      <CardMeditationView
-        config={config()}
-        state={fakeState({ status: 'complete', remainingMs: 0 })}
-        controls={fakeControls()}
-        onSave={onSave}
-      />,
-    );
-    fireEvent.press(getByTestId('card-meditation-save'));
-    expect(onSave).toHaveBeenCalledTimes(1);
-  });
-
-  it('disables the Save button when no onSave handler is supplied', () => {
+  it('surfaces the standard controls bar on completion', () => {
     const { getByTestId } = render(
       <CardMeditationView
         config={config()}
@@ -226,8 +212,7 @@ describe('CardMeditationView', () => {
         controls={fakeControls()}
       />,
     );
-    expect(getByTestId('card-meditation-save').props.accessibilityState).toEqual({
-      disabled: true,
-    });
+    expect(getByTestId('ritual-controls-bar')).toBeTruthy();
+    expect(getByTestId('ritual-complete-label')).toBeTruthy();
   });
 });


### PR DESCRIPTION
Add the session UI and configurator form for the card_meditation
practice mode. CardMeditationView draws one card at mount and supports
a reveal flow (card hidden during the sit) and an immediate flow, with
graceful text fallback when an image source is missing or a device
photo no longer resolves. CardMeditationForm picks between the bundled
RWS / major-arcana-text decks and a custom deck of user-picked photos
via expo-image-picker, with advanced behaviour settings collapsed.

Closes #351

https://claude.ai/code/session_01TgF2Ved3xiKfqTx3zxmWpm