### PR TITLE
feat(backend): seed Find Shapes + Find Colors grounding presets (#339)

### DIFF
--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -127,6 +127,26 @@ _MINDFUL_EATING = (
     "with the aftertaste for a moment before marking the practice complete.",
 )
 
+#: Stage 1 alternative — Find Shapes (tallied_grounding mode).
+_FIND_SHAPES = (
+    "A grounding technique that anchors you in the present by hunting "
+    "your surroundings for everyday geometric shapes.",
+    "Look around wherever you are. Each round, find three squares, then "
+    "three triangles, then three circles — pointing to or naming each "
+    "one as you spot it. Finish all three shapes before starting the "
+    "next round. Three rounds in all.",
+)
+
+#: Stage 1 alternative — Find Colors (tallied_grounding mode).
+_FIND_COLORS = (
+    "A grounding technique that anchors you in the present by sweeping "
+    "your surroundings for each colour of the rainbow.",
+    "Look around wherever you are. Each round, find one thing for every "
+    "colour of the rainbow in order — red, orange, yellow, green, blue, "
+    "indigo, violet — naming each as you spot it. Finish the full "
+    "spectrum before starting the next round. Three rounds in all.",
+)
+
 
 PRESET_COPY: dict[str, tuple[str, str]] = {
     "5-4-3-2-1 grounding": _S1,
@@ -141,4 +161,6 @@ PRESET_COPY: dict[str, tuple[str, str]] = {
     "Insight practice": _S10,
     "Touch Grass": _TOUCH_GRASS,
     "Mindful Eating": _MINDFUL_EATING,
+    "Find Shapes": _FIND_SHAPES,
+    "Find Colors": _FIND_COLORS,
 }

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -109,6 +109,33 @@ def _mindful_eating_options() -> list[dict[str, str]]:
     ]
 
 
+#: Round count shared by the stage-1 tallied-grounding alternatives: the
+#: user walks every category three times before the practice completes.
+_GROUNDING_ROUNDS = 3
+
+#: Rainbow colours, in spectrum order, for the Find Colors alternative.
+#: Each name is also its analytics ``key`` — all match the snake-case
+#: ``TalliedCategory.key`` pattern (lowercase letters only).
+_RAINBOW_COLORS = ("red", "orange", "yellow", "green", "blue", "indigo", "violet")
+
+
+def _find_shapes_categories() -> list[dict[str, Any]]:
+    """Three geometric-shape categories, three tallies of each per round."""
+    return [
+        {"key": "squares", "label": "a square", "target_count": 3},
+        {"key": "triangles", "label": "a triangle", "target_count": 3},
+        {"key": "circles", "label": "a circle", "target_count": 3},
+    ]
+
+
+def _find_colors_categories() -> list[dict[str, Any]]:
+    """Seven rainbow-colour categories, one tally of each per round."""
+    return [
+        {"key": color, "label": f"something {color}", "target_count": 1}
+        for color in _RAINBOW_COLORS
+    ]
+
+
 def _build_preset(
     stage_number: int,
     name: str,
@@ -259,6 +286,28 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
             "min_duration_seconds": 180,
             "options": _mindful_eating_options(),
             "require_option_choice": True,
+        },
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        1,
+        "Find Shapes",
+        mode="tallied_grounding",
+        mode_config={
+            "mode": "tallied_grounding",
+            "rounds": _GROUNDING_ROUNDS,
+            "categories": _find_shapes_categories(),
+        },
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        1,
+        "Find Colors",
+        mode="tallied_grounding",
+        mode_config={
+            "mode": "tallied_grounding",
+            "rounds": _GROUNDING_ROUNDS,
+            "categories": _find_colors_categories(),
         },
         default_duration_minutes=5,
     ),

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -274,6 +274,8 @@ async def test_find_shapes_preset_seeds(db_session: AsyncSession) -> None:
 
     assert row.stage_number == 1
     assert row.mode == "tallied_grounding"
+    assert row.description
+    assert row.instructions
 
     cfg = TalliedGroundingConfig.model_validate(row.mode_config)
     assert cfg.rounds == 3
@@ -289,6 +291,8 @@ async def test_find_colors_preset_seeds(db_session: AsyncSession) -> None:
 
     assert row.stage_number == 1
     assert row.mode == "tallied_grounding"
+    assert row.description
+    assert row.instructions
 
     cfg = TalliedGroundingConfig.model_validate(row.mode_config)
     assert cfg.rounds == 3

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -15,6 +15,7 @@ from schemas.practice_mode_config import (
     MindfulAnchorConfig,
     ModeConfigAdapter,
     SenseGroundingConfig,
+    TalliedGroundingConfig,
 )
 from seed_practices import (
     CANONICAL_PRESET_PRACTICES,
@@ -267,14 +268,52 @@ async def test_mindful_eating_preset_seeds(db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
+async def test_find_shapes_preset_seeds(db_session: AsyncSession) -> None:
+    """Find Shapes seeds at stage 1 as a three-round, three-shape tally."""
+    row = await _seed_and_fetch(db_session, "Find Shapes")
+
+    assert row.stage_number == 1
+    assert row.mode == "tallied_grounding"
+
+    cfg = TalliedGroundingConfig.model_validate(row.mode_config)
+    assert cfg.rounds == 3
+    assert [c.key for c in cfg.categories] == ["squares", "triangles", "circles"]
+    assert len(cfg.categories) == 3
+    assert all(c.target_count == 3 for c in cfg.categories)
+
+
+@pytest.mark.asyncio
+async def test_find_colors_preset_seeds(db_session: AsyncSession) -> None:
+    """Find Colors seeds at stage 1 with one tally per rainbow colour."""
+    row = await _seed_and_fetch(db_session, "Find Colors")
+
+    assert row.stage_number == 1
+    assert row.mode == "tallied_grounding"
+
+    cfg = TalliedGroundingConfig.model_validate(row.mode_config)
+    assert cfg.rounds == 3
+    assert [c.key for c in cfg.categories] == [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "indigo",
+        "violet",
+    ]
+    assert len(cfg.categories) == 7
+    assert all(c.target_count == 1 for c in cfg.categories)
+
+
+@pytest.mark.asyncio
 async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> None:
-    """Re-running the seeder leaves exactly one row for each mindful_anchor preset."""
+    """Re-running the seeder leaves exactly one row for each alternative preset."""
     first = await seed_practices(db_session)
     second = await seed_practices(db_session)
     assert first == _EXPECTED_PRESET_COUNT
     assert second == 0
 
-    for name in ("Touch Grass", "Mindful Eating"):
+    for name in ("Touch Grass", "Mindful Eating", "Find Shapes", "Find Colors"):
         result = await db_session.execute(select(Practice).where(Practice.name == name))
         assert len(result.scalars().all()) == 1
 
@@ -369,13 +408,13 @@ def test_stage_to_preset_name_map_matches_canonical_presets() -> None:
 
 
 def test_alternative_presets_never_shadow_the_canonical_pointer() -> None:
-    """Touch Grass / Mindful Eating sit on stage 1 but never become its canonical preset.
+    """Stage-1 alternatives sit on the catalog but never become its canonical preset.
 
     They are seeded into the catalog (so the chooser can offer them) yet
     excluded from ``STAGE_TO_PRESET_NAME`` so the frequency-banner endpoint
     keeps resolving stage 1 to the canonical 5-4-3-2-1 grounding preset.
     """
-    alternative_names = {"Touch Grass", "Mindful Eating"}
+    alternative_names = {"Touch Grass", "Mindful Eating", "Find Shapes", "Find Colors"}
     all_names = {p["name"] for p in PRESET_PRACTICES}
     canonical_names = {p["name"] for p in CANONICAL_PRESET_PRACTICES}
     assert alternative_names <= all_names


### PR DESCRIPTION
Add two `tallied_grounding` presets to the practice catalog at stage 1:
**Find Shapes** (3 rounds × 3 geometric shapes) and **Find Colors**
(3 rounds × 7 rainbow colors). They sit beside the canonical 5-4-3-2-1
grounding preset as alternatives for users who don't resonate with it,
and feed the `TalliedGroundingView` shipped in #341.

Slots into the existing canonical/alternative seeder split landed in
#371: the new rows register with `PRESET_COPY` by name and append to
`_ALTERNATIVE_PRESETS`, so `STAGE_TO_PRESET_NAME` keeps pointing at
5-4-3-2-1 grounding for the frequency-banner endpoint.

https://claude.ai/code/session_014wusYTTobQ7TMeMxupLJHM