### PR TITLE
feat(backend): seed Touch Grass + Mindful Eating presets (#340)

### DIFF
--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -1,10 +1,12 @@
-"""Long-form ``description`` and ``instructions`` text for the 10 stage presets.
+"""Long-form ``description`` and ``instructions`` text for the catalog presets.
 
 Split from :mod:`seed_practices` so the seeder logic stays small and the
 product-editable copy lives in a flat, diff-friendly data module.
 
-Each entry maps a stage number to a ``(description, instructions)`` tuple.
-Lengths stay under the ``Practice`` model's column caps
+Each entry maps a preset *name* to a ``(description, instructions)`` tuple.
+Keying by name (rather than stage number) lets a single stage carry more
+than one preset — e.g. the stage-1 grounding alternatives. Lengths stay
+under the ``Practice`` model's column caps
 (description ≤ 2000 chars, instructions ≤ 10000 chars).
 """
 
@@ -102,15 +104,41 @@ _S10 = (
 )
 
 
-PRESET_COPY: dict[int, tuple[str, str]] = {
-    1: _S1,
-    2: _S2,
-    3: _S3,
-    4: _S4,
-    5: _S5,
-    6: _S6,
-    7: _S7,
-    8: _S8,
-    9: _S9,
-    10: _S10,
+#: Stage 1 alternative — Touch Grass (mindful_anchor mode).
+_TOUCH_GRASS = (
+    "A single-action grounding practice: stand barefoot on a natural "
+    "surface and let its texture and temperature draw you into the "
+    "present moment.",
+    "Find a patch of grass, soil, sand, or stone where you can safely "
+    "stand barefoot. Take off your shoes. Plant both feet and let your "
+    "weight settle. Notice the texture, the temperature, and the pressure "
+    "where your soles meet the earth. There is nothing to accomplish — "
+    "stay until you feel settled, then mark the practice complete.",
+)
+
+#: Stage 1 alternative — Mindful Eating (mindful_anchor mode).
+_MINDFUL_EATING = (
+    "A single-action mindful-presence practice: eat one small portion of "
+    "a grounding food slowly, giving full attention to every sense.",
+    "Choose one small portion of a grounding food and sit down with it. "
+    "Before the first bite, take in its colour, shape, and aroma. Eat "
+    "slowly: attend to texture, temperature, and flavour, and pause "
+    "between bites to let each one finish. When the portion is gone, sit "
+    "with the aftertaste for a moment before marking the practice complete.",
+)
+
+
+PRESET_COPY: dict[str, tuple[str, str]] = {
+    "5-4-3-2-1 grounding": _S1,
+    "Tarot meditation": _S2,
+    "Belly breathing": _S3,
+    "Metta": _S4,
+    "Wim Hof method": _S5,
+    "Shadow work": _S6,
+    "Blissy meditation": _S7,
+    "Dog Walkin' Shamanism": _S8,
+    "Concentration practice": _S9,
+    "Insight practice": _S10,
+    "Touch Grass": _TOUCH_GRASS,
+    "Mindful Eating": _MINDFUL_EATING,
 }

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -1,8 +1,14 @@
-"""Seed script for the 10 stage-aligned default :class:`Practice` rows.
+"""Seed script for the default :class:`Practice` catalog rows.
 
-Mirrors :mod:`seed_stages` — defines the canonical preset list, validates
-each ``mode_config`` payload at import time so a typo crashes the seeder
-(not the runtime), and inserts only what is missing on a per-call basis.
+Mirrors :mod:`seed_stages` — defines the preset list, validates each
+``mode_config`` payload at import time so a typo crashes the seeder (not
+the runtime), and inserts only what is missing on a per-call basis.
+
+Each :class:`~models.course_stage.CourseStage` has exactly one *canonical*
+preset (see :data:`CANONICAL_PRESET_PRACTICES`). A stage may additionally
+carry *alternative* presets — extra catalog entries a user can pick
+instead — without those alternatives shadowing the canonical pointer in
+:data:`STAGE_TO_PRESET_NAME`.
 
 The match key is ``(stage_number, name)`` so a user-submitted practice with
 the same display name on a different stage does not block a preset from
@@ -62,6 +68,47 @@ def _sense_grounding_prompts() -> list[dict[str, str]]:
     ]
 
 
+def _touch_grass_options() -> list[dict[str, str]]:
+    """Natural surfaces a user can stand barefoot on for the Touch Grass preset."""
+    return [
+        {"key": "grass", "label": "Grass", "description": "A lawn, a park, a meadow."},
+        {"key": "soil", "label": "Soil", "description": "Garden bed, forest floor, planter."},
+        {"key": "sand", "label": "Sand", "description": "A beach or a sandbox."},
+        {"key": "stone", "label": "Stone", "description": "Bare rock, a flagstone path."},
+    ]
+
+
+def _mindful_eating_options() -> list[dict[str, str]]:
+    """Grounding foods a user can choose for the Mindful Eating preset."""
+    return [
+        {
+            "key": "nuts_seeds",
+            "label": "Nuts or seeds",
+            "description": "Almonds, walnuts, pumpkin seeds.",
+        },
+        {
+            "key": "root_vegetable",
+            "label": "Root vegetable",
+            "description": "Carrot, beet, sweet potato.",
+        },
+        {
+            "key": "whole_grain",
+            "label": "Whole-grain bread",
+            "description": "Dense, hearty, a slow chew.",
+        },
+        {
+            "key": "dark_chocolate",
+            "label": "Dark chocolate",
+            "description": "A single square, savored.",
+        },
+        {
+            "key": "fresh_fruit",
+            "label": "Fresh fruit",
+            "description": "Apple, pear, berries.",
+        },
+    ]
+
+
 def _build_preset(
     stage_number: int,
     name: str,
@@ -71,7 +118,7 @@ def _build_preset(
     default_duration_minutes: float,
 ) -> dict[str, Any]:
     """Compose one preset row, drawing description / instructions from copy."""
-    description, instructions = PRESET_COPY[stage_number]
+    description, instructions = PRESET_COPY[name]
     return {
         "stage_number": stage_number,
         "name": name,
@@ -85,7 +132,9 @@ def _build_preset(
     }
 
 
-_PRESET_PRACTICES: list[dict[str, Any]] = [
+#: The one canonical preset per stage. :data:`STAGE_TO_PRESET_NAME` and the
+#: frequency-banner endpoint resolve against exactly this list.
+_CANONICAL_PRESETS: list[dict[str, Any]] = [
     _build_preset(
         1,
         "5-4-3-2-1 grounding",
@@ -170,6 +219,49 @@ _PRESET_PRACTICES: list[dict[str, Any]] = [
     ),
 ]
 
+#: Per-stage alternative presets — extra catalog entries a user may pick
+#: instead of the stage's canonical practice. Deliberately excluded from
+#: :data:`STAGE_TO_PRESET_NAME` so the frequency banner keeps pointing at
+#: the one canonical preset per stage.
+_ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
+    _build_preset(
+        1,
+        "Touch Grass",
+        mode="mindful_anchor",
+        mode_config={
+            "mode": "mindful_anchor",
+            "instruction": (
+                "Stand barefoot on the earth. Notice the texture, "
+                "temperature, and pressure under your feet. "
+                "Stay until you feel settled."
+            ),
+            "min_duration_seconds": 120,
+            "options": _touch_grass_options(),
+            "require_option_choice": True,
+        },
+        default_duration_minutes=3,
+    ),
+    _build_preset(
+        1,
+        "Mindful Eating",
+        mode="mindful_anchor",
+        mode_config={
+            "mode": "mindful_anchor",
+            "instruction": (
+                "Eat one small portion slowly. Notice texture, "
+                "temperature, aroma, and flavor with each bite. "
+                "Pause between bites."
+            ),
+            "min_duration_seconds": 180,
+            "options": _mindful_eating_options(),
+            "require_option_choice": True,
+        },
+        default_duration_minutes=5,
+    ),
+]
+
+_PRESET_PRACTICES: list[dict[str, Any]] = [*_CANONICAL_PRESETS, *_ALTERNATIVE_PRESETS]
+
 
 # Validate every preset's mode_config at import time — a typo here crashes
 # the seeder (a deliberate, immediate failure) rather than poisoning the DB
@@ -177,23 +269,30 @@ _PRESET_PRACTICES: list[dict[str, Any]] = [
 for _preset in _PRESET_PRACTICES:
     ModeConfigAdapter.validate_python(_preset["mode_config"])
 
-# Reject duplicate stage_numbers at import time, mirroring seed_stages.py.
-_stage_numbers = [p["stage_number"] for p in _PRESET_PRACTICES]
+# Reject duplicate canonical stage_numbers at import time, mirroring
+# seed_stages.py. Alternatives intentionally share a stage with their
+# canonical sibling, so the check is scoped to the canonical list.
+_stage_numbers = [p["stage_number"] for p in _CANONICAL_PRESETS]
 if len(set(_stage_numbers)) != len(_stage_numbers):
     _dupes = sorted(n for n in _stage_numbers if _stage_numbers.count(n) > 1)
-    msg = f"Duplicate stage_number in PRESET_PRACTICES: {_dupes}"
+    msg = f"Duplicate stage_number among canonical presets: {_dupes}"
     raise ValueError(msg)
 
-#: Immutable view of the preset definitions. Tuple (not list) so callers
-#: can't accidentally ``.append()`` or ``.clear()`` and silently de-sync
-#: :data:`STAGE_TO_PRESET_NAME`.
+#: Immutable view of every preset definition (canonical + alternatives).
+#: Tuple (not list) so callers can't accidentally ``.append()`` or
+#: ``.clear()`` and silently de-sync :data:`STAGE_TO_PRESET_NAME`.
 PRESET_PRACTICES: tuple[dict[str, Any], ...] = tuple(_PRESET_PRACTICES)
+
+#: The one canonical preset per stage. :data:`STAGE_TO_PRESET_NAME` and the
+#: frequency-banner endpoint resolve against exactly this subset; per-stage
+#: alternatives in :data:`PRESET_PRACTICES` are excluded.
+CANONICAL_PRESET_PRACTICES: tuple[dict[str, Any], ...] = tuple(_CANONICAL_PRESETS)
 
 #: Read-only lookup consumed by ritual-05's frequency-banner endpoint.
 #: ``MappingProxyType`` forbids mutation so the table can't drift from
-#: :data:`PRESET_PRACTICES` after import.
+#: :data:`CANONICAL_PRESET_PRACTICES` after import.
 STAGE_TO_PRESET_NAME: MappingProxyType[int, str] = MappingProxyType(
-    {p["stage_number"]: p["name"] for p in PRESET_PRACTICES}
+    {p["stage_number"]: p["name"] for p in CANONICAL_PRESET_PRACTICES}
 )
 
 

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -117,7 +117,11 @@ def _build_preset(
     mode_config: dict[str, Any],
     default_duration_minutes: float,
 ) -> dict[str, Any]:
-    """Compose one preset row, drawing description / instructions from copy."""
+    """Compose one preset row.
+
+    ``name`` must be a key in :data:`PRESET_COPY`; its
+    ``(description, instructions)`` tuple supplies the long-form copy.
+    """
     description, instructions = PRESET_COPY[name]
     return {
         "stage_number": stage_number,
@@ -276,6 +280,15 @@ _stage_numbers = [p["stage_number"] for p in _CANONICAL_PRESETS]
 if len(set(_stage_numbers)) != len(_stage_numbers):
     _dupes = sorted(n for n in _stage_numbers if _stage_numbers.count(n) > 1)
     msg = f"Duplicate stage_number among canonical presets: {_dupes}"
+    raise ValueError(msg)
+
+# Reject duplicate preset names at import time. ``name`` is the PRESET_COPY
+# lookup key, so a collision would silently shadow one preset's copy; it
+# also defeats the partial unique index for two presets sharing a stage.
+_preset_names = [p["name"] for p in _PRESET_PRACTICES]
+if len(set(_preset_names)) != len(_preset_names):
+    _name_dupes = sorted(n for n in _preset_names if _preset_names.count(n) > 1)
+    msg = f"Duplicate preset name in PRESET_PRACTICES: {_name_dupes}"
     raise ValueError(msg)
 
 #: Immutable view of every preset definition (canonical + alternatives).

--- a/backend/tests/test_lifespan_seeding.py
+++ b/backend/tests/test_lifespan_seeding.py
@@ -26,6 +26,12 @@ from main import _seed_startup_data, app, lifespan
 from models.course_stage import CourseStage
 from models.practice import Practice
 from models.stage_content import StageContent
+from seed_practices import PRESET_PRACTICES
+
+#: Total preset rows the practice seeder inserts — sourced from
+#: ``PRESET_PRACTICES`` so adding a catalog preset doesn't silently drift
+#: this test's expectation.
+_EXPECTED_PRACTICE_COUNT = len(PRESET_PRACTICES)
 
 
 @asynccontextmanager
@@ -55,7 +61,7 @@ async def test_seed_startup_data_inserts_stages_practices_and_content(
     contents = (await db_session.execute(select(StageContent))).scalars().all()
 
     assert len(stages) == 10
-    assert len(practices) == 10
+    assert len(practices) == _EXPECTED_PRACTICE_COUNT
     # ``seed_content`` seeds the chapters configured for the beige stage
     # (14 today) plus the 6 placeholder rows that still cover stages 2
     # and 3.  Asserting the count means a regression that drops the
@@ -77,7 +83,7 @@ async def test_seed_startup_data_is_idempotent(
     practices = (await db_session.execute(select(Practice))).scalars().all()
 
     assert len(stages) == 10
-    assert len(practices) == 10
+    assert len(practices) == _EXPECTED_PRACTICE_COUNT
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -12,17 +12,22 @@ from sqlmodel import select
 from models.practice import Practice
 from schemas.practice_mode_config import (
     MetronomeConfig,
+    MindfulAnchorConfig,
     ModeConfigAdapter,
     SenseGroundingConfig,
 )
 from seed_practices import (
+    CANONICAL_PRESET_PRACTICES,
     PRESET_PRACTICES,
     STAGE_TO_PRESET_NAME,
     seed_practices,
 )
 from seed_stages import STAGE_DEFINITIONS
 
-_EXPECTED_PRESET_COUNT = 10
+#: Total catalog presets the seeder inserts — one canonical preset per
+#: stage (10) plus the stage-1 grounding alternatives (Touch Grass,
+#: Mindful Eating).
+_EXPECTED_PRESET_COUNT = 12
 #: Stage number outside the canonical 1..10 range. Used by the
 #: name-collision test to plant a user submission that the seeder must
 #: ignore — the bare ``Practice`` model has no FK or range check on
@@ -42,7 +47,7 @@ _SENSE_ORDER: tuple[tuple[str, int], ...] = (
 
 @pytest.mark.asyncio
 async def test_seed_practices_inserts_all(db_session: AsyncSession) -> None:
-    """Empty DB → all 10 presets are inserted; the function returns 10."""
+    """Empty DB → every preset is inserted; the function returns the count."""
     inserted = await seed_practices(db_session)
     assert inserted == _EXPECTED_PRESET_COUNT
 
@@ -216,18 +221,90 @@ async def test_seed_practices_does_not_collide_with_user_named_practice(
     assert inserted == _EXPECTED_PRESET_COUNT
 
 
+async def _seed_and_fetch(db_session: AsyncSession, name: str) -> Practice:
+    """Run the seeder, then return the single ``Practice`` row named ``name``."""
+    await seed_practices(db_session)
+    result = await db_session.execute(select(Practice).where(Practice.name == name))
+    return result.scalars().one()
+
+
+@pytest.mark.asyncio
+async def test_touch_grass_preset_seeds(db_session: AsyncSession) -> None:
+    """Touch Grass seeds as a stage-1 mindful_anchor preset with 4 anchor options."""
+    row = await _seed_and_fetch(db_session, "Touch Grass")
+
+    assert row.stage_number == 1
+    assert row.mode == "mindful_anchor"
+    assert row.description
+    assert row.instructions
+
+    cfg = MindfulAnchorConfig.model_validate(row.mode_config)
+    assert [opt.key for opt in cfg.options] == ["grass", "soil", "sand", "stone"]
+    assert cfg.require_option_choice is True
+    assert cfg.min_duration_seconds == 120
+    assert all(opt.description for opt in cfg.options)
+
+
+@pytest.mark.asyncio
+async def test_mindful_eating_preset_seeds(db_session: AsyncSession) -> None:
+    """Mindful Eating seeds as a mindful_anchor preset with 5 options and a 180s floor."""
+    row = await _seed_and_fetch(db_session, "Mindful Eating")
+
+    assert row.stage_number == 1
+    assert row.mode == "mindful_anchor"
+
+    cfg = MindfulAnchorConfig.model_validate(row.mode_config)
+    assert [opt.key for opt in cfg.options] == [
+        "nuts_seeds",
+        "root_vegetable",
+        "whole_grain",
+        "dark_chocolate",
+        "fresh_fruit",
+    ]
+    assert cfg.instruction.strip() != ""
+    assert cfg.min_duration_seconds == 180
+    assert cfg.require_option_choice is True
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> None:
+    """Re-running the seeder leaves exactly one row for each mindful_anchor preset."""
+    first = await seed_practices(db_session)
+    second = await seed_practices(db_session)
+    assert first == _EXPECTED_PRESET_COUNT
+    assert second == 0
+
+    for name in ("Touch Grass", "Mindful Eating"):
+        result = await db_session.execute(select(Practice).where(Practice.name == name))
+        assert len(result.scalars().all()) == 1
+
+
 # -- Preset data validation -------------------------------------------------
 
 
-def test_preset_practices_count_matches_stage_total() -> None:
-    """One preset per CourseStage row, exactly."""
-    assert len(PRESET_PRACTICES) == len(STAGE_DEFINITIONS) == _EXPECTED_PRESET_COUNT
+def test_canonical_presets_match_stage_total() -> None:
+    """Exactly one canonical preset per CourseStage row.
+
+    The full :data:`PRESET_PRACTICES` list is larger than the stage count
+    because a stage may carry alternative presets alongside its canonical
+    one; the canonical subset stays 1:1 with the stages.
+    """
+    assert len(CANONICAL_PRESET_PRACTICES) == len(STAGE_DEFINITIONS)
+    assert len(PRESET_PRACTICES) == _EXPECTED_PRESET_COUNT
+    assert len(PRESET_PRACTICES) > len(CANONICAL_PRESET_PRACTICES)
 
 
-def test_preset_practices_cover_each_stage_once() -> None:
-    """Stage numbers 1..10 appear exactly once across the preset list."""
-    seen = sorted(p["stage_number"] for p in PRESET_PRACTICES)
-    assert seen == list(range(1, _EXPECTED_PRESET_COUNT + 1))
+def test_canonical_presets_cover_each_stage_once() -> None:
+    """Stage numbers 1..10 appear exactly once across the canonical presets."""
+    seen = sorted(p["stage_number"] for p in CANONICAL_PRESET_PRACTICES)
+    assert seen == list(range(1, len(STAGE_DEFINITIONS) + 1))
+
+
+def test_every_preset_sits_on_a_known_stage() -> None:
+    """Every preset — canonical or alternative — lands on a defined stage."""
+    valid_stages = set(range(1, len(STAGE_DEFINITIONS) + 1))
+    for preset in PRESET_PRACTICES:
+        assert preset["stage_number"] in valid_stages
 
 
 def test_every_preset_mode_config_is_valid() -> None:
@@ -286,7 +363,21 @@ def test_shadow_work_preset_uses_exact_metronome_config() -> None:
     assert cfg.timer.halfway_bell is True
 
 
-def test_stage_to_preset_name_map_matches_preset_list() -> None:
-    """``STAGE_TO_PRESET_NAME`` is the source of truth ritual-05 imports."""
-    expected = {p["stage_number"]: p["name"] for p in PRESET_PRACTICES}
+def test_stage_to_preset_name_map_matches_canonical_presets() -> None:
+    """``STAGE_TO_PRESET_NAME`` is the canonical-preset table ritual-05 imports."""
+    expected = {p["stage_number"]: p["name"] for p in CANONICAL_PRESET_PRACTICES}
     assert expected == STAGE_TO_PRESET_NAME
+
+
+def test_alternative_presets_never_shadow_the_canonical_pointer() -> None:
+    """Touch Grass / Mindful Eating sit on stage 1 but never become its canonical preset.
+
+    They are seeded into the catalog (so the chooser can offer them) yet
+    excluded from ``STAGE_TO_PRESET_NAME`` so the frequency-banner endpoint
+    keeps resolving stage 1 to the canonical 5-4-3-2-1 grounding preset.
+    """
+    alternative_names = {"Touch Grass", "Mindful Eating"}
+    all_names = {p["name"] for p in PRESET_PRACTICES}
+    assert alternative_names <= all_names
+    assert alternative_names.isdisjoint(STAGE_TO_PRESET_NAME.values())
+    assert STAGE_TO_PRESET_NAME[1] == "5-4-3-2-1 grounding"

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -24,10 +24,10 @@ from seed_practices import (
 )
 from seed_stages import STAGE_DEFINITIONS
 
-#: Total catalog presets the seeder inserts — one canonical preset per
-#: stage (10) plus the stage-1 grounding alternatives (Touch Grass,
-#: Mindful Eating).
-_EXPECTED_PRESET_COUNT = 12
+#: Total catalog presets the seeder inserts. Derived from the source list
+#: so adding a preset never silently drifts these expectations — mirrors
+#: the dynamic count in ``test_lifespan_seeding.py``.
+_EXPECTED_PRESET_COUNT = len(PRESET_PRACTICES)
 #: Stage number outside the canonical 1..10 range. Used by the
 #: name-collision test to plant a user submission that the seeder must
 #: ignore — the bare ``Practice`` model has no FK or range check on
@@ -290,7 +290,6 @@ def test_canonical_presets_match_stage_total() -> None:
     one; the canonical subset stays 1:1 with the stages.
     """
     assert len(CANONICAL_PRESET_PRACTICES) == len(STAGE_DEFINITIONS)
-    assert len(PRESET_PRACTICES) == _EXPECTED_PRESET_COUNT
     assert len(PRESET_PRACTICES) > len(CANONICAL_PRESET_PRACTICES)
 
 
@@ -378,6 +377,8 @@ def test_alternative_presets_never_shadow_the_canonical_pointer() -> None:
     """
     alternative_names = {"Touch Grass", "Mindful Eating"}
     all_names = {p["name"] for p in PRESET_PRACTICES}
+    canonical_names = {p["name"] for p in CANONICAL_PRESET_PRACTICES}
     assert alternative_names <= all_names
+    assert alternative_names.isdisjoint(canonical_names)
     assert alternative_names.isdisjoint(STAGE_TO_PRESET_NAME.values())
     assert STAGE_TO_PRESET_NAME[1] == "5-4-3-2-1 grounding"


### PR DESCRIPTION
Add two mindful_anchor catalog presets as stage-1 grounding
alternatives. Re-key PRESET_COPY by preset name so a stage can carry
more than one preset, and split presets into a canonical-per-stage
list (which STAGE_TO_PRESET_NAME and the frequency banner resolve
against) and per-stage alternatives.

https://claude.ai/code/session_01JSweY17USF9hmgScoMGMWs