### PR TITLE
fix(backend): isolate startup seeders so one failure doesn't starve the rest

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -242,17 +242,25 @@ async def _seed_startup_data(session: AsyncSession) -> None:
     """Run the three idempotent seeders in dependency order.
 
     ``seed_practices`` and ``seed_content`` both read from the seeded
-    ``CourseStage`` rows, so stages must land first. Each seeder inserts
-    only the rows it would expect to find missing (matched by stable keys
-    like ``stage_number`` or ``(stage_number, name)``), so repeated calls
-    are no-ops once steady state is reached.
+    ``CourseStage`` rows, so stages must land first. Each seeder is
+    isolated in its own try/except so a failure in one (e.g. a new mode
+    landing in a CHECK constraint before the seed list catches up) does
+    not starve the later, independent seeders — without this, a single
+    ``seed_practices`` blow-up would skip ``seed_content`` and leave the
+    course catalog empty. Successes log the inserted count so a quiet
+    deploy is still verifiable from the boot log.
     """
-    # Each seeder commits its own inserts before returning, so this function
-    # does not need a trailing commit; the dependency-order contract above is
-    # what callers rely on.
-    await seed_stages(session)
-    await seed_practices(session)
-    await seed_content(session)
+    for name, seeder in (
+        ("stages", seed_stages),
+        ("practices", seed_practices),
+        ("content", seed_content),
+    ):
+        try:
+            inserted = await seeder(session)
+            logger.info("seed_complete", extra={"seeder": name, "inserted": inserted})
+        except Exception:
+            logger.exception("seed_failed", extra={"seeder": name})
+            await session.rollback()
 
 
 @asynccontextmanager

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -239,19 +239,27 @@ install_trace_id_logging()
 
 
 async def _seed_startup_data(session: AsyncSession) -> None:
-    """Run the three idempotent seeders in dependency order.
+    """Run the three idempotent seeders, with isolation and a stages prerequisite.
 
     ``seed_practices`` and ``seed_content`` both read from the seeded
-    ``CourseStage`` rows, so stages must land first. Each seeder is
-    isolated in its own try/except so a failure in one (e.g. a new mode
-    landing in a CHECK constraint before the seed list catches up) does
-    not starve the later, independent seeders — without this, a single
-    ``seed_practices`` blow-up would skip ``seed_content`` and leave the
-    course catalog empty. Successes log the inserted count so a quiet
-    deploy is still verifiable from the boot log.
+    ``CourseStage`` rows, so a ``seed_stages`` failure must short-circuit
+    — otherwise the dependents run against an empty stages table and log
+    a misleading ``seed_complete inserted=0``. ``seed_practices`` and
+    ``seed_content`` are independent of each other, so each is isolated
+    in its own try/except: a failure in one (e.g. a new mode landing in
+    a CHECK constraint before the seed list catches up) must not starve
+    the other. Successes log the inserted count so a quiet deploy is
+    still verifiable from the boot log.
     """
+    try:
+        inserted = await seed_stages(session)
+        logger.info("seed_complete", extra={"seeder": "stages", "inserted": inserted})
+    except Exception:
+        logger.exception("seed_failed", extra={"seeder": "stages"})
+        await session.rollback()
+        return
+
     for name, seeder in (
-        ("stages", seed_stages),
         ("practices", seed_practices),
         ("content", seed_content),
     ):

--- a/backend/tests/test_lifespan_seeding.py
+++ b/backend/tests/test_lifespan_seeding.py
@@ -33,6 +33,14 @@ from seed_practices import PRESET_PRACTICES
 #: this test's expectation.
 _EXPECTED_PRACTICE_COUNT = len(PRESET_PRACTICES)
 
+#: ``seed_content`` keeps placeholder rows for stages 2 and 3 (three each)
+#: until those stages get a real ``STAGE_PLANS`` entry.  Asserting on
+#: ``STAGE_PLANS.chapter_count + _PLACEHOLDER_CONTENT_ROWS`` means a
+#: regression that drops the content seeder fails this test, not just a
+#: ``/course`` smoke check; adjust this when ``_PLACEHOLDER_DEFINITIONS``
+#: in ``seed_content.py`` changes.
+_PLACEHOLDER_CONTENT_ROWS = 6
+
 
 @asynccontextmanager
 async def _isolated_factory_patch() -> AsyncGenerator[None, None]:
@@ -62,12 +70,7 @@ async def test_seed_startup_data_inserts_stages_practices_and_content(
 
     assert len(stages) == 10
     assert len(practices) == _EXPECTED_PRACTICE_COUNT
-    # ``seed_content`` seeds the chapters configured for the beige stage
-    # (14 today) plus the 6 placeholder rows that still cover stages 2
-    # and 3.  Asserting the count means a regression that drops the
-    # content seeder from the lifespan fails this test, not just a
-    # /course smoke check.  Adjust this when ``content_config`` changes.
-    expected_content_count = sum(p.chapter_count for p in STAGE_PLANS) + 6
+    expected_content_count = sum(p.chapter_count for p in STAGE_PLANS) + _PLACEHOLDER_CONTENT_ROWS
     assert len(contents) == expected_content_count
 
 
@@ -155,12 +158,50 @@ async def test_seed_startup_data_continues_after_per_seeder_failure(
 
     stages = (await db_session.execute(select(CourseStage))).scalars().all()
     contents = (await db_session.execute(select(StageContent))).scalars().all()
-    expected_content_count = sum(p.chapter_count for p in STAGE_PLANS) + 6
+    expected_content_count = sum(p.chapter_count for p in STAGE_PLANS) + _PLACEHOLDER_CONTENT_ROWS
     assert len(stages) == 10
     assert len(contents) == expected_content_count
 
     failure_logs = [r for r in caplog.records if "seed_failed" in r.getMessage()]
     assert failure_logs, "expected a logged failure for the practices seeder"
+    assert any(getattr(r, "seeder", None) == "practices" for r in failure_logs), (
+        "expected the seed_failed log record to carry extra={'seeder': 'practices'}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_seed_startup_data_skips_dependents_when_stages_fails(
+    db_session: AsyncSession,
+) -> None:
+    """``seed_practices`` and ``seed_content`` both read from ``CourseStage`` rows.
+
+    If ``seed_stages`` fails, running the dependent seeders against an
+    empty stages table would quietly insert nothing and log a misleading
+    ``seed_complete inserted=0`` — masking the real failure.  The seeder
+    must short-circuit instead.
+    """
+    calls: list[str] = []
+
+    async def _boom(_session: AsyncSession) -> int:
+        msg = "stages table missing"
+        raise RuntimeError(msg)
+
+    async def _track_practices(_session: AsyncSession) -> int:
+        calls.append("practices")
+        return 0
+
+    async def _track_content(_session: AsyncSession) -> int:
+        calls.append("content")
+        return 0
+
+    with (
+        patch("main.seed_stages", new=_boom),
+        patch("main.seed_practices", new=_track_practices),
+        patch("main.seed_content", new=_track_content),
+    ):
+        await _seed_startup_data(db_session)
+
+    assert calls == [], f"dependent seeders must not run when stages fails: {calls}"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_lifespan_seeding.py
+++ b/backend/tests/test_lifespan_seeding.py
@@ -133,6 +133,37 @@ async def test_lifespan_logs_and_continues_when_seeder_raises(
 
 
 @pytest.mark.asyncio
+async def test_seed_startup_data_continues_after_per_seeder_failure(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failing seeder must not starve the later, independent seeders.
+
+    Without isolation a ``seed_practices`` blow-up (e.g. a new mode lands
+    in a CHECK constraint before the seed list catches up) would skip
+    ``seed_content`` and leave stage 1 with zero chapter rows — exactly
+    the production symptom that motivated the per-seeder try/except.
+    """
+
+    async def _boom(_session: AsyncSession) -> int:
+        msg = "practice CHECK constraint mismatch"
+        raise RuntimeError(msg)
+
+    caplog.set_level(logging.WARNING, logger="main")
+    with patch("main.seed_practices", new=_boom):
+        await _seed_startup_data(db_session)
+
+    stages = (await db_session.execute(select(CourseStage))).scalars().all()
+    contents = (await db_session.execute(select(StageContent))).scalars().all()
+    expected_content_count = sum(p.chapter_count for p in STAGE_PLANS) + 6
+    assert len(stages) == 10
+    assert len(contents) == expected_content_count
+
+    failure_logs = [r for r in caplog.records if "seed_failed" in r.getMessage()]
+    assert failure_logs, "expected a logged failure for the practices seeder"
+
+
+@pytest.mark.asyncio
 async def test_seed_startup_data_runs_stages_before_practices(
     db_session: AsyncSession,
 ) -> None:


### PR DESCRIPTION
## Summary

`GET /course/stages/1/content` is returning `[]` in production (verified via Railway log: `txBytes: 2`), so the in-app reader shows **"No Content Yet"** for Stage 1 even though `content_config.STAGE_PLANS` declares 14 chapters.

**Root cause:** `_seed_startup_data` ran the three seeders sequentially under a single outer try-block in `lifespan`. If `seed_practices` raises (e.g. a new mode landing in a CHECK constraint before the seed list catches up to it), `seed_content` is **skipped entirely** — leaving stage 1 with zero `StageContent` rows on the next boot.

## Changes

- **`main._seed_startup_data`** — each seeder now runs in its own try/except. A failure logs `seed_failed` (with seeder name + traceback) and rolls back the dirty session state; the remaining independent seeders proceed. Successes log `seed_complete` with the inserted count so a quiet boot is verifiable from the Railway log.

## Test plan

- [x] `tests/test_lifespan_seeding.py::test_seed_startup_data_continues_after_per_seeder_failure` — patches `seed_practices` to raise; asserts both `seed_stages` and `seed_content` still populated the DB and a `seed_failed` warning was logged
- [x] All 7 existing lifespan-seeding tests still pass (ordering, idempotency, env opt-out, outer-lifespan log)
- [x] Full backend suite green (coverage 94%); pre-commit + pre-push gates pass
- [ ] After Railway redeploys: tail logs for `seed_failed` (identifies which seeder, if any, is the culprit) and `seed_complete extra={"seeder": "content", "inserted": 14}` — when the latter appears, Stage 1 chapters will populate and the app will render them

https://claude.ai/code/session_01GRZXVdTjpqWXw4rrAK72pa

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRZXVdTjpqWXw4rrAK72pa)_