### PR TITLE
fix(frontend): use tile stage color for habit progress bar

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -465,14 +465,14 @@ const ProgressBar = ({
   );
 };
 
-const useHabitTileData = (habit: Habit, tz: string) => {
+const useHabitTileData = (habit: Habit, tz: string, stageColor: string) => {
   const lowGoal = habit.goals.find((g) => g.tier === 'low');
   const clearGoal = habit.goals.find((g) => g.tier === 'clear');
   const stretchGoal = habit.goals.find((g) => g.tier === 'stretch');
 
   const { currentGoal, completedAllGoals } = getGoalTier(habit, tz);
   const progressPercentage = clampPercentage(getProgressPercentage(habit, currentGoal, tz));
-  const progressBarColor = getProgressBarColor(habit, tz);
+  const progressBarColor = getProgressBarColor(habit, tz, stageColor);
   const hasCompletedGoal = completedAllGoals || progressPercentage >= 100;
 
   const {
@@ -647,6 +647,7 @@ const UnlockedTile = ({
   const { progressPercentage, progressBarColor, hasCompletedGoal, markers } = useHabitTileData(
     habit,
     tz,
+    stageColor,
   );
 
   const streakText =

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -266,9 +266,19 @@ export const getProgressPercentage = (
 /**
  * Progress-bar color for a habit: the stage color while the goal is
  * unmet, and a brighter shade of that same stage color once it is met.
+ *
+ * The tile renders its border from a position-derived color (see
+ * ``HabitsScreen.renderHabitTile``) because ``habit.stage`` defaults to
+ * an empty string on the backend. Callers that already resolved that
+ * tile color should pass it via ``stageColorOverride`` so the bar
+ * matches the border instead of collapsing to the black fallback.
  */
-export const getProgressBarColor = (habit: Habit, tz: string = DEFAULT_TIMEZONE): string => {
-  const stageColor = STAGE_COLORS[habit.stage] ?? '#000';
+export const getProgressBarColor = (
+  habit: Habit,
+  tz: string = DEFAULT_TIMEZONE,
+  stageColorOverride?: string,
+): string => {
+  const stageColor = stageColorOverride ?? STAGE_COLORS[habit.stage] ?? '#000';
   const clearGoal = habit.goals.find((g) => g.tier === 'clear');
 
   if (!clearGoal) return stageColor;

--- a/frontend/src/features/Habits/__tests__/HabitsScreen.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitsScreen.test.ts
@@ -224,6 +224,45 @@ describe('habit progress utilities', () => {
     expect(getProgressBarColor(habit)).toBe(STAGE_COLORS[habit.stage]);
   });
 
+  it('uses the explicit stageColor argument when habit.stage is empty', () => {
+    // Backend defaults habit.stage to "" (see backend/src/models/habit.py).
+    // The tile resolves its color from list position, so getProgressBarColor
+    // must honor that override instead of falling back to black.
+    const habit: Habit = {
+      id: 9,
+      stage: '',
+      name: 'Unstaged',
+      icon: '✨',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: additiveGoals,
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 1 }],
+    };
+
+    expect(getProgressBarColor(habit, undefined, STAGE_COLORS.Orange)).toBe(STAGE_COLORS.Orange);
+  });
+
+  it('brightens the explicit stageColor when the clear goal is met', () => {
+    const habit: Habit = {
+      id: 10,
+      stage: '',
+      name: 'Unstaged Achiever',
+      icon: '⭐',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: additiveGoals,
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 2 }],
+    };
+
+    expect(getProgressBarColor(habit, undefined, STAGE_COLORS.Orange)).toBe(
+      brightenColor(STAGE_COLORS.Orange!),
+    );
+  });
+
   it('clamps percentage values between 0 and 100', () => {
     expect(clampPercentage(150)).toBe(100);
     expect(clampPercentage(-20)).toBe(0);


### PR DESCRIPTION
The progress-bar fill resolved its color from STAGE_COLORS[habit.stage],
but habit.stage defaults to "" on the backend, so the lookup missed and
the '#000' fallback rendered the bar black. The tile border already
shows the correct position-derived color via the stageColor prop; thread
that resolved color through getProgressBarColor so the fill matches the
border (and brightens to brightenColor(stageColor) when the goal is met).