### PR TITLE
feat(practice): practice catalog browse screen + create-custom wizard

### DIFF
--- a/backend/src/routers/practices.py
+++ b/backend/src/routers/practices.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any, cast
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from slowapi.util import get_remote_address
+from sqlalchemy import or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -51,19 +52,34 @@ router = APIRouter(prefix="/practices", tags=["practices"])
 @router.get("/", response_model=None)
 async def list_practices(
     stage_number: int,
-    _current_user: Annotated[int, Depends(get_current_user)],
+    current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
     pagination: Annotated[PaginationParams, Depends()],
+    *,
+    include_mine: Annotated[bool, Query(description="Include the caller's own drafts.")] = False,
 ) -> Page[PracticeResponse] | list[PracticeResponse]:
     """List approved practices for a given stage.
 
     BUG-INFRA-012: returns ``Page[PracticeResponse]`` when ``?paginate=true``
     is set; otherwise the legacy bare list is returned for one release while
     the frontend migrates to the envelope.
+
+    ``include_mine`` (custom-practices-07): when ``True``, also include
+    unapproved drafts whose ``submitted_by_user_id`` matches the
+    authenticated user. The default ``False`` preserves the existing
+    "approved only" listing semantics so existing clients see no change;
+    the catalog screen opts in so a user's own drafts appear under
+    "My drafts" without leaking other users' submissions.
     """
+    approved_clause = col(Practice.approved).is_(True)
+    visibility = (
+        or_(approved_clause, col(Practice.submitted_by_user_id) == current_user)
+        if include_mine
+        else approved_clause
+    )
     query = select(Practice).where(
         Practice.stage_number == stage_number,
-        col(Practice.approved).is_(True),
+        visibility,
     )
     items, total = await paginate_query(session, query, pagination)
     serialized = [PracticeResponse.model_validate(p, from_attributes=True) for p in items]

--- a/backend/tests/test_practices_api.py
+++ b/backend/tests/test_practices_api.py
@@ -138,6 +138,78 @@ async def test_list_practices_excludes_unapproved(
 
 
 @pytest.mark.asyncio
+async def test_list_practices_include_mine_returns_own_drafts(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """custom-practices-07: ``?include_mine=true`` adds the caller's drafts."""
+    # Sign up two distinct users; only the caller's drafts should appear.
+    _other_headers, other_user_id = await _signup(async_client, username="other")
+    headers, user_id = await _signup(async_client, username="me")
+    assert user_id != other_user_id
+    own_draft = Practice(
+        stage_number=1,
+        name="My private draft",
+        description="",
+        instructions="",
+        default_duration_minutes=5,
+        submitted_by_user_id=user_id,
+        approved=False,
+        mode="meditation_timer",
+        mode_config=_timer_cfg(5),
+    )
+    other_draft = Practice(
+        stage_number=1,
+        name="Other user's draft",
+        description="",
+        instructions="",
+        default_duration_minutes=5,
+        submitted_by_user_id=other_user_id,
+        approved=False,
+        mode="meditation_timer",
+        mode_config=_timer_cfg(5),
+    )
+    db_session.add(own_draft)
+    db_session.add(other_draft)
+    await db_session.commit()
+
+    resp = await async_client.get(
+        "/practices/",
+        params={"stage_number": 1, "include_mine": "true"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    names = {p["name"] for p in resp.json()}
+    assert "My private draft" in names
+    assert "Other user's draft" not in names
+
+
+@pytest.mark.asyncio
+async def test_list_practices_default_still_excludes_own_drafts(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Without ``include_mine`` the legacy approved-only behaviour holds."""
+    headers, user_id = await _signup(async_client)
+    db_session.add(
+        Practice(
+            stage_number=1,
+            name="My private draft",
+            description="",
+            instructions="",
+            default_duration_minutes=5,
+            submitted_by_user_id=user_id,
+            approved=False,
+            mode="meditation_timer",
+            mode_config=_timer_cfg(5),
+        ),
+    )
+    await db_session.commit()
+
+    resp = await async_client.get("/practices/", params={"stage_number": 1}, headers=headers)
+    names = {p["name"] for p in resp.json()}
+    assert "My private draft" not in names
+
+
+@pytest.mark.asyncio
 async def test_list_practices_empty_stage(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1759,17 +1759,61 @@ function validatePracticeItem(item: unknown): item is PracticeItem {
   );
 }
 
+/**
+ * Payload for ``POST /practices/`` (custom-practices-07).
+ *
+ * Mirrors the backend ``PracticeCreate`` schema: ``mode`` and ``mode_config``
+ * are optional only for the legacy ``meditation_timer`` default — every
+ * other mode requires both to be set, and the server returns 422 if they
+ * disagree.
+ */
+export interface PracticeCreatePayload {
+  stage_number: number;
+  name: string;
+  description: string;
+  instructions: string;
+  default_duration_minutes: number;
+  mode?: string;
+  mode_config?: ModeConfig;
+}
+
 export const practices = {
-  async list(stageNumber: number, token?: string): Promise<PracticeItem[]> {
-    const data = await request<PracticeItem[]>(`/practices/?stage_number=${stageNumber}`, {
-      token,
-    });
+  /**
+   * List approved practices for a stage.
+   *
+   * ``includeMine`` opts in to the backend's ``?include_mine=true`` flag
+   * (custom-practices-07), which also returns the authenticated user's
+   * own unapproved drafts so the catalog can render a "My drafts"
+   * section. The default ``false`` preserves the legacy approved-only
+   * behaviour for existing callers (PracticeSwitcherSheet, useActivePractice).
+   *
+   * The numeric overload retains the historic ``practices.list(stage)``
+   * signature so older call sites keep working without a churn pass.
+   */
+  async list(
+    options: { stageNumber: number; includeMine?: boolean } | number,
+    token?: string,
+  ): Promise<PracticeItem[]> {
+    const params = typeof options === 'number' ? { stageNumber: options } : options;
+    const query = new URLSearchParams();
+    query.set('stage_number', String(params.stageNumber));
+    if (params.includeMine === true) query.set('include_mine', 'true');
+    const data = await request<PracticeItem[]>(`/practices/?${query.toString()}`, { token });
     return data.filter(validatePracticeItem);
   },
   async get(practiceId: number, token?: string): Promise<PracticeItem> {
     const data = await request<PracticeItem>(`/practices/${practiceId}`, { token });
     if (!validatePracticeItem(data)) throw new Error('Invalid practice response');
     return data;
+  },
+  /**
+   * Submit a new user-created practice (custom-practices-07).
+   *
+   * Drafts land with ``approved=false``; the catalog filters them into
+   * the "My drafts" section for the submitter alone.
+   */
+  create(payload: PracticeCreatePayload, token?: string): Promise<PracticeItem> {
+    return request<PracticeItem>('/practices/', { method: 'POST', body: payload, token });
   },
 };
 

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -79,6 +79,20 @@ jest.mock('@/features/Practice/screens/SharePreviewScreen', () => {
   const { Text } = require('react-native');
   return () => <Text>SharePreviewScreen</Text>;
 });
+// custom-practices-07: RootStack mounts the practice detail screen and
+// the create-practice wizard as siblings to ``Tabs``. Both read
+// ``route.params``, which the navigator stub above does not provide --
+// stub them out so this suite stays focused on auth gating.
+jest.mock('@/features/Practice/screens/PracticeDetailScreen', () => {
+  const { Text } = require('react-native');
+  const Stub = () => <Text>PracticeDetailScreen</Text>;
+  return { PracticeDetailScreen: Stub, default: Stub };
+});
+jest.mock('@/features/Practice/screens/CreatePracticeWizard', () => {
+  const { Text } = require('react-native');
+  const Stub = () => <Text>CreatePracticeWizard</Text>;
+  return { CreatePracticeWizard: Stub, default: Stub };
+});
 
 import App from '@/App';
 

--- a/frontend/src/features/Practice/components/ModePicker.tsx
+++ b/frontend/src/features/Practice/components/ModePicker.tsx
@@ -1,0 +1,282 @@
+/**
+ * ``ModePicker`` — categorized chooser for the Create Practice wizard.
+ *
+ * 11 practice modes is bloat as a flat list, so the picker groups them
+ * into five intent-oriented categories (Timers / Bells / Grounding /
+ * Reflection / Movement). Each row is radio-like so the screen reader
+ * announces selection state correctly.
+ *
+ * Pure data → UI: ``onSelect`` is the only output. The wizard owns the
+ * choice and routes to the matching mode form on selection.
+ */
+
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import type { ModeConfig } from '../engine/types';
+
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+/**
+ * Discriminator union for every mode shown in the picker. ``mindful_anchor``
+ * has no frontend type yet (the runtime engine + form land in a follow-up),
+ * so it is added inline here so the picker still surfaces it under
+ * Grounding — selecting it routes to a "Coming soon" notice in the wizard.
+ */
+export type PickableMode = ModeConfig['mode'] | 'mindful_anchor';
+
+const NEW_MODES = new Set<PickableMode>([
+  'tallied_grounding',
+  'mindful_anchor',
+  'random_interval_bell',
+  'card_meditation',
+]);
+
+interface ModeEntry {
+  mode: PickableMode;
+  label: string;
+  icon: string;
+  description: string;
+}
+
+interface ModeCategory {
+  key: string;
+  title: string;
+  blurb: string;
+  modes: readonly ModeEntry[];
+}
+
+export const MODE_CATEGORIES: readonly ModeCategory[] = [
+  {
+    key: 'timers',
+    title: 'Timers',
+    blurb: 'Bounded or open-ended sits.',
+    modes: [
+      {
+        mode: 'meditation_timer',
+        label: 'Meditation timer',
+        icon: '⏳',
+        description: 'A bounded sit with optional bells.',
+      },
+      {
+        mode: 'count_up',
+        label: 'Count up',
+        icon: '⏱',
+        description: 'Open-ended; you decide when to stop.',
+      },
+    ],
+  },
+  {
+    key: 'bells',
+    title: 'Bells',
+    blurb: 'Rhythmic cues across the session.',
+    modes: [
+      {
+        mode: 'metronome',
+        label: 'Metronome',
+        icon: '🥁',
+        description: 'Steady BPM tick over a timed window.',
+      },
+      {
+        mode: 'interval_bell',
+        label: 'Interval bell',
+        icon: '🔔',
+        description: 'Evenly spaced bells or custom offsets.',
+      },
+      {
+        mode: 'random_interval_bell',
+        label: 'Random interval bell',
+        icon: '🔀',
+        description: 'Mindfulness bells at unpredictable gaps.',
+      },
+    ],
+  },
+  {
+    key: 'grounding',
+    title: 'Grounding',
+    blurb: 'Bring attention back into the body.',
+    modes: [
+      {
+        mode: 'sense_grounding',
+        label: 'Sense grounding',
+        icon: '🌿',
+        description: 'Walk through prompts across the five senses.',
+      },
+      {
+        mode: 'tallied_grounding',
+        label: 'Tallied grounding',
+        icon: '🔢',
+        description: 'Rounds of find-N-of-each: shapes, colors, sounds.',
+      },
+      {
+        mode: 'mindful_anchor',
+        label: 'Mindful anchor',
+        icon: '🌱',
+        description: 'Pick one anchor — touch grass, mindful eating, a sip.',
+      },
+    ],
+  },
+  {
+    key: 'reflection',
+    title: 'Reflection',
+    blurb: 'Symbol-driven contemplation.',
+    modes: [
+      {
+        mode: 'tarot',
+        label: 'Tarot',
+        icon: '🃏',
+        description: 'Draw a card from the major arcana and sit with it.',
+      },
+      {
+        mode: 'card_meditation',
+        label: 'Card meditation',
+        icon: '🎴',
+        description: 'Bundled or custom deck — phone photos work.',
+      },
+    ],
+  },
+  {
+    key: 'movement',
+    title: 'Movement',
+    blurb: 'Count discrete reps or rounds.',
+    modes: [
+      {
+        mode: 'rep_counter',
+        label: 'Rep counter',
+        icon: '💪',
+        description: 'Tap to log each rep against a target.',
+      },
+    ],
+  },
+];
+
+export interface ModePickerProps {
+  /** Currently focused mode; rendered as the selected radio. */
+  selectedMode?: PickableMode | null;
+  /** Called when a mode is tapped. The wizard advances on the next render. */
+  onSelect: (mode: PickableMode) => void;
+}
+
+/**
+ * Render the five mode categories as cards. Each mode row is a radio
+ * button — TalkBack/VoiceOver announce ``selected`` correctly so users
+ * relying on screen readers can navigate the categorized list.
+ */
+const ModePicker = ({ selectedMode = null, onSelect }: ModePickerProps): React.JSX.Element => (
+  <View
+    accessibilityRole="radiogroup"
+    accessibilityLabel="Choose a practice mode"
+    testID="mode-picker"
+  >
+    {MODE_CATEGORIES.map((category) => (
+      <CategoryCard
+        key={category.key}
+        category={category}
+        selectedMode={selectedMode}
+        onSelect={onSelect}
+      />
+    ))}
+  </View>
+);
+
+interface CategoryCardProps {
+  category: ModeCategory;
+  selectedMode: PickableMode | null;
+  onSelect: (mode: PickableMode) => void;
+}
+
+const CategoryCard = ({
+  category,
+  selectedMode,
+  onSelect,
+}: CategoryCardProps): React.JSX.Element => (
+  <View style={styles.card} testID={`mode-picker-category-${category.key}`}>
+    <Text style={styles.categoryTitle}>{category.title}</Text>
+    <Text style={styles.categoryBlurb}>{category.blurb}</Text>
+    {category.modes.map((entry) => (
+      <ModeRow
+        key={entry.mode}
+        entry={entry}
+        selected={entry.mode === selectedMode}
+        onSelect={onSelect}
+      />
+    ))}
+  </View>
+);
+
+interface ModeRowProps {
+  entry: ModeEntry;
+  selected: boolean;
+  onSelect: (mode: PickableMode) => void;
+}
+
+const ModeRow = ({ entry, selected, onSelect }: ModeRowProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="radio"
+    accessibilityLabel={entry.label}
+    accessibilityHint={entry.description}
+    accessibilityState={{ selected }}
+    onPress={() => onSelect(entry.mode)}
+    style={[styles.row, selected && styles.rowSelected]}
+    testID={`mode-picker-mode-${entry.mode}`}
+  >
+    <Text style={styles.rowIcon} accessibilityElementsHidden>
+      {entry.icon}
+    </Text>
+    <View style={styles.rowText}>
+      <View style={styles.rowLabelLine}>
+        <Text style={styles.rowLabel}>{entry.label}</Text>
+        {NEW_MODES.has(entry.mode) && (
+          <View style={styles.newBadge} testID={`mode-picker-new-${entry.mode}`}>
+            <Text style={styles.newBadgeText}>New</Text>
+          </View>
+        )}
+      </View>
+      <Text style={styles.rowDescription}>{entry.description}</Text>
+    </View>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.md,
+    marginBottom: SPACING.md,
+    ...shadows.small,
+  },
+  categoryTitle: { fontSize: 16, fontWeight: '700', color: colors.text.primary },
+  categoryBlurb: {
+    fontSize: 13,
+    color: colors.text.secondaryAccessible,
+    marginTop: SPACING.xs,
+    marginBottom: SPACING.sm,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.md,
+    gap: SPACING.sm,
+  },
+  rowSelected: { backgroundColor: colors.background.accent },
+  rowIcon: { fontSize: 22, width: 28, textAlign: 'center' },
+  rowText: { flex: 1 },
+  rowLabelLine: { flexDirection: 'row', alignItems: 'center', gap: SPACING.xs },
+  rowLabel: { fontSize: 15, fontWeight: '600', color: colors.text.primary },
+  rowDescription: {
+    fontSize: 12,
+    color: colors.text.secondaryAccessible,
+    marginTop: 2,
+  },
+  newBadge: {
+    backgroundColor: colors.success,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: 2,
+    borderRadius: BORDER_RADIUS.sm,
+  },
+  newBadgeText: { color: colors.text.light, fontSize: 10, fontWeight: '700' },
+});
+
+export default ModePicker;

--- a/frontend/src/features/Practice/components/__tests__/ModePicker.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ModePicker.test.tsx
@@ -1,0 +1,96 @@
+/* eslint-env jest */
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import ModePicker, { MODE_CATEGORIES, type PickableMode } from '../ModePicker';
+
+const NEW_MODES: readonly PickableMode[] = [
+  'tallied_grounding',
+  'mindful_anchor',
+  'random_interval_bell',
+  'card_meditation',
+];
+
+describe('ModePicker — categories', () => {
+  it('renders all five intent categories', () => {
+    const { getByTestId } = render(<ModePicker onSelect={jest.fn()} />);
+    expect(getByTestId('mode-picker-category-timers')).toBeTruthy();
+    expect(getByTestId('mode-picker-category-bells')).toBeTruthy();
+    expect(getByTestId('mode-picker-category-grounding')).toBeTruthy();
+    expect(getByTestId('mode-picker-category-reflection')).toBeTruthy();
+    expect(getByTestId('mode-picker-category-movement')).toBeTruthy();
+  });
+
+  it('places every mode under exactly one category', () => {
+    const seen = new Set<string>();
+    for (const category of MODE_CATEGORIES) {
+      for (const entry of category.modes) {
+        expect(seen.has(entry.mode)).toBe(false);
+        seen.add(entry.mode);
+      }
+    }
+    expect(seen.size).toBe(11);
+  });
+
+  it('renders all eleven mode rows across the categories', () => {
+    const { getByTestId } = render(<ModePicker onSelect={jest.fn()} />);
+    for (const category of MODE_CATEGORIES) {
+      for (const entry of category.modes) {
+        expect(getByTestId(`mode-picker-mode-${entry.mode}`)).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe('ModePicker — selection', () => {
+  it('calls onSelect with the tapped mode value', () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = render(<ModePicker onSelect={onSelect} />);
+    fireEvent.press(getByTestId('mode-picker-mode-random_interval_bell'));
+    expect(onSelect).toHaveBeenCalledWith('random_interval_bell');
+  });
+
+  it('marks the currently selected mode with the radio-selected state', () => {
+    const { getByTestId } = render(
+      <ModePicker selectedMode="card_meditation" onSelect={jest.fn()} />,
+    );
+    const selected = getByTestId('mode-picker-mode-card_meditation');
+    expect(selected.props.accessibilityState).toEqual(expect.objectContaining({ selected: true }));
+    const other = getByTestId('mode-picker-mode-meditation_timer');
+    expect(other.props.accessibilityState).toEqual(expect.objectContaining({ selected: false }));
+  });
+
+  it('exposes the picker as a radio group for assistive tech', () => {
+    const { getByTestId } = render(<ModePicker onSelect={jest.fn()} />);
+    const group = getByTestId('mode-picker');
+    expect(group.props.accessibilityRole).toBe('radiogroup');
+    const row = getByTestId('mode-picker-mode-meditation_timer');
+    expect(row.props.accessibilityRole).toBe('radio');
+  });
+});
+
+describe('ModePicker — New badge', () => {
+  it('shows the New tag on tallied_grounding, mindful_anchor, random_interval_bell, card_meditation', () => {
+    const { getByTestId } = render(<ModePicker onSelect={jest.fn()} />);
+    for (const mode of NEW_MODES) {
+      expect(getByTestId(`mode-picker-new-${mode}`)).toBeTruthy();
+    }
+  });
+
+  it('does not tag legacy modes as New', () => {
+    const { queryByTestId } = render(<ModePicker onSelect={jest.fn()} />);
+    const legacy: readonly PickableMode[] = [
+      'meditation_timer',
+      'count_up',
+      'metronome',
+      'interval_bell',
+      'rep_counter',
+      'sense_grounding',
+      'tarot',
+    ];
+    for (const mode of legacy) {
+      expect(queryByTestId(`mode-picker-new-${mode}`)).toBeNull();
+    }
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/defaults.test.ts
+++ b/frontend/src/features/Practice/configurator/__tests__/defaults.test.ts
@@ -1,0 +1,80 @@
+/* eslint-env jest */
+import { describe, expect, it } from '@jest/globals';
+
+import type { ModeConfig } from '../../engine/types';
+import { validateModeConfig } from '../../engine/validation';
+import { defaultConfigFor, suggestedDurationFor } from '../defaults';
+
+const ALL_MODES: ReadonlyArray<ModeConfig['mode']> = [
+  'meditation_timer',
+  'count_up',
+  'metronome',
+  'interval_bell',
+  'random_interval_bell',
+  'rep_counter',
+  'sense_grounding',
+  'tallied_grounding',
+  'tarot',
+  'card_meditation',
+];
+
+describe('defaultConfigFor', () => {
+  it.each(ALL_MODES)('returns a server-valid default for %s', (mode) => {
+    const config = defaultConfigFor(mode);
+    expect(config.mode).toBe(mode);
+    expect(validateModeConfig(config)).toEqual([]);
+  });
+
+  it('returns fresh objects each call so the wizard can mutate safely', () => {
+    const a = defaultConfigFor('meditation_timer');
+    const b = defaultConfigFor('meditation_timer');
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('suggestedDurationFor', () => {
+  it('uses duration_minutes for duration-bearing modes', () => {
+    expect(suggestedDurationFor(defaultConfigFor('meditation_timer'))).toBeGreaterThan(0);
+    expect(suggestedDurationFor(defaultConfigFor('interval_bell'))).toBeGreaterThan(0);
+    expect(suggestedDurationFor(defaultConfigFor('random_interval_bell'))).toBeGreaterThan(0);
+  });
+
+  it('uses the embedded timer duration for metronome', () => {
+    expect(suggestedDurationFor(defaultConfigFor('metronome'))).toBeGreaterThan(0);
+  });
+
+  it('uses per_card_minutes for card-based modes', () => {
+    const tarot: ModeConfig = {
+      mode: 'tarot',
+      deck: 'major_arcana',
+      per_card_minutes: 7,
+    };
+    expect(suggestedDurationFor(tarot)).toBe(7);
+    const card: ModeConfig = {
+      mode: 'card_meditation',
+      deck_id: 'rws',
+      per_card_minutes: 6,
+    };
+    expect(suggestedDurationFor(card)).toBe(6);
+  });
+
+  it('falls back to a non-zero default for open-ended modes', () => {
+    expect(suggestedDurationFor(defaultConfigFor('count_up'))).toBeGreaterThan(0);
+    expect(suggestedDurationFor(defaultConfigFor('rep_counter'))).toBeGreaterThan(0);
+    expect(suggestedDurationFor(defaultConfigFor('sense_grounding'))).toBeGreaterThan(0);
+    expect(suggestedDurationFor(defaultConfigFor('tallied_grounding'))).toBeGreaterThan(0);
+  });
+
+  it('falls back to a default when per_card_minutes is omitted', () => {
+    expect(
+      suggestedDurationFor({ mode: 'tarot', deck: 'major_arcana' } satisfies ModeConfig),
+    ).toBeGreaterThan(0);
+    expect(
+      suggestedDurationFor({
+        mode: 'card_meditation',
+        deck_id: 'rws',
+      } satisfies ModeConfig),
+    ).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/features/Practice/configurator/defaults.ts
+++ b/frontend/src/features/Practice/configurator/defaults.ts
@@ -1,0 +1,140 @@
+/**
+ * Smart defaults for every supported ``ModeConfig`` discriminator
+ * (custom-practices-07).
+ *
+ * The Create Practice wizard pre-fills these so a user can land on the
+ * configurator step, accept the defaults, name the practice, and submit
+ * a server-valid payload without touching a single field. Each default
+ * sits inside its mode's validation window (see
+ * ``features/Practice/engine/validation``) so a wizard submission cannot
+ * round-trip to a 422.
+ */
+
+import type {
+  CardMeditationConfig,
+  CountUpConfig,
+  IntervalBellConfig,
+  MeditationTimerConfig,
+  MetronomeConfig,
+  ModeConfig,
+  RandomIntervalBellConfig,
+  RepCounterConfig,
+  SenseGroundingConfig,
+  TalliedGroundingConfig,
+  TarotConfig,
+} from '../engine/types';
+
+const DEFAULT_DURATION_MINUTES = 10;
+const DEFAULT_METRONOME_BPM = 60;
+const DEFAULT_INTERVAL_BELL_INTERVAL = 5;
+const DEFAULT_RANDOM_BELL_MIN_SECONDS = 30;
+const DEFAULT_RANDOM_BELL_MAX_SECONDS = 180;
+const DEFAULT_REP_TARGET = 10;
+const DEFAULT_TALLIED_ROUNDS = 3;
+const DEFAULT_TALLIED_TARGET = 3;
+
+const DEFAULT_SENSE_PROMPTS: SenseGroundingConfig['prompts'] = [
+  { sense: 'sight', label: 'something blue' },
+  { sense: 'touch', label: 'a smooth texture' },
+  { sense: 'hearing', label: 'a faraway sound' },
+];
+
+const DEFAULT_TALLIED_CATEGORIES: TalliedGroundingConfig['categories'] = [
+  { key: 'circle', label: 'a circle', target_count: DEFAULT_TALLIED_TARGET },
+  { key: 'square', label: 'a square', target_count: DEFAULT_TALLIED_TARGET },
+  { key: 'triangle', label: 'a triangle', target_count: DEFAULT_TALLIED_TARGET },
+];
+
+const DEFAULTS: { [K in ModeConfig['mode']]: () => Extract<ModeConfig, { mode: K }> } = {
+  meditation_timer: (): MeditationTimerConfig => ({
+    mode: 'meditation_timer',
+    duration_minutes: DEFAULT_DURATION_MINUTES,
+    start_bell: true,
+    halfway_bell: false,
+    end_bell: true,
+  }),
+  count_up: (): CountUpConfig => ({ mode: 'count_up' }),
+  metronome: (): MetronomeConfig => ({
+    mode: 'metronome',
+    bpm: DEFAULT_METRONOME_BPM,
+    timer: {
+      mode: 'meditation_timer',
+      duration_minutes: DEFAULT_DURATION_MINUTES,
+      start_bell: true,
+      end_bell: true,
+    },
+  }),
+  interval_bell: (): IntervalBellConfig => ({
+    mode: 'interval_bell',
+    duration_minutes: DEFAULT_DURATION_MINUTES * 2,
+    interval_minutes: DEFAULT_INTERVAL_BELL_INTERVAL,
+    bell_tone: 'bowl',
+  }),
+  random_interval_bell: (): RandomIntervalBellConfig => ({
+    mode: 'random_interval_bell',
+    duration_minutes: DEFAULT_DURATION_MINUTES * 2,
+    min_interval_seconds: DEFAULT_RANDOM_BELL_MIN_SECONDS,
+    max_interval_seconds: DEFAULT_RANDOM_BELL_MAX_SECONDS,
+    bell_tone: 'bowl',
+  }),
+  rep_counter: (): RepCounterConfig => ({
+    mode: 'rep_counter',
+    target_reps: DEFAULT_REP_TARGET,
+    unit_label: 'reps',
+  }),
+  sense_grounding: (): SenseGroundingConfig => ({
+    mode: 'sense_grounding',
+    prompts: DEFAULT_SENSE_PROMPTS,
+  }),
+  tallied_grounding: (): TalliedGroundingConfig => ({
+    mode: 'tallied_grounding',
+    rounds: DEFAULT_TALLIED_ROUNDS,
+    categories: DEFAULT_TALLIED_CATEGORIES,
+  }),
+  tarot: (): TarotConfig => ({ mode: 'tarot', deck: 'major_arcana' }),
+  card_meditation: (): CardMeditationConfig => ({
+    mode: 'card_meditation',
+    deck_id: 'rws',
+  }),
+};
+
+/**
+ * Build a server-valid default ``ModeConfig`` for the requested mode.
+ *
+ * Returned values are fresh objects on every call so the wizard's edit
+ * state can mutate them with ``setConfig`` without disturbing the
+ * shared defaults table.
+ */
+export function defaultConfigFor<M extends ModeConfig['mode']>(
+  mode: M,
+): Extract<ModeConfig, { mode: M }> {
+  return DEFAULTS[mode]();
+}
+
+const DURATION_HINTS: {
+  [K in ModeConfig['mode']]: (config: Extract<ModeConfig, { mode: K }>) => number;
+} = {
+  meditation_timer: (c) => c.duration_minutes,
+  interval_bell: (c) => c.duration_minutes,
+  random_interval_bell: (c) => c.duration_minutes,
+  metronome: (c) => c.timer.duration_minutes,
+  tarot: (c) => c.per_card_minutes ?? DEFAULT_DURATION_MINUTES / 2,
+  card_meditation: (c) => c.per_card_minutes ?? DEFAULT_DURATION_MINUTES / 2,
+  count_up: () => DEFAULT_DURATION_MINUTES,
+  rep_counter: () => DEFAULT_DURATION_MINUTES,
+  sense_grounding: () => DEFAULT_DURATION_MINUTES,
+  tallied_grounding: () => DEFAULT_DURATION_MINUTES,
+};
+
+/**
+ * Heuristic duration in minutes for the metadata step's auto-suggest.
+ *
+ * Modes without an inherent duration (``count_up``, ``rep_counter``,
+ * ``sense_grounding``, ``tallied_grounding``) fall back to a single
+ * shared default so the field is never blank.
+ */
+export function suggestedDurationFor(config: ModeConfig): number {
+  type AnyHint = (config: ModeConfig) => number;
+  const hint = DURATION_HINTS[config.mode] as AnyHint;
+  return Math.max(1, Math.round(hint(config)));
+}

--- a/frontend/src/features/Practice/constants.ts
+++ b/frontend/src/features/Practice/constants.ts
@@ -1,0 +1,23 @@
+/**
+ * Stage-number constants shared by the practice catalog, detail, and wizard
+ * screens (custom-practices-07).
+ *
+ * The 36-week APTITUDE program has exactly ten stages (Beige → Coral); the
+ * backend ``schemas.practice.PracticeCreate`` mirrors the same range via
+ * ``Field(ge=1, le=MAX_STAGE_NUMBER)``. Centralising the bounds here means
+ * a future stage-count change is a one-line edit instead of a three-file
+ * grep.
+ *
+ * ``FALLBACK_STAGE`` is the value sent for ``stage_number`` when the user
+ * picks "Skip" in the create wizard. The backend's ``PracticeCreate`` schema
+ * still requires a non-null stage_number on the practice row (catalog rows
+ * are stage-scoped), so we mint the draft under stage 1; the caller skips
+ * the follow-up ``POST /user-practices`` so the draft is *stored* but not
+ * *active* anywhere. A future schema relaxation could let drafts carry a
+ * null stage; until then this constant is the single, named place that
+ * encodes the workaround.
+ */
+
+export const MIN_STAGE = 1;
+export const MAX_STAGE = 10;
+export const FALLBACK_STAGE = 1;

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -1,0 +1,802 @@
+/**
+ * ``CreatePracticeWizard`` — guided author flow for a new custom practice.
+ *
+ * Funnels the user through four lightweight steps so the 11-mode catalog
+ * never collapses into a single mega-form (custom-practices-07 UX
+ * guard-rail #4):
+ *
+ *   0. Entry — start from a preset (recommended) or from scratch.
+ *   1. Mode picker — categorized cards.
+ *   2. Configurator — renders the existing per-mode form.
+ *   3. Metadata + assignment — name, description, instructions,
+ *      default_duration_minutes, optional stage_number.
+ *
+ * On submit the wizard POSTs ``/practices/`` and, when the user pinned a
+ * stage, follows with ``POST /user-practices/`` so the new draft is
+ * already active for that stage. Successful submissions navigate to
+ * ``PracticeDetail`` for the brand-new row.
+ */
+
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { defaultConfigFor, suggestedDurationFor } from '../configurator/defaults';
+import CardMeditationForm from '../configurator/forms/CardMeditationForm';
+import CountUpForm from '../configurator/forms/CountUpForm';
+import IntervalBellForm from '../configurator/forms/IntervalBellForm';
+import MeditationTimerForm from '../configurator/forms/MeditationTimerForm';
+import MetronomeForm from '../configurator/forms/MetronomeForm';
+import RandomIntervalBellForm from '../configurator/forms/RandomIntervalBellForm';
+import RepCounterForm from '../configurator/forms/RepCounterForm';
+import SenseGroundingForm from '../configurator/forms/SenseGroundingForm';
+import { ErrorList } from '../configurator/forms/shared';
+import TarotForm from '../configurator/forms/TarotForm';
+import type { ModeConfig } from '../engine/types';
+import { validateModeConfig } from '../engine/validation';
+
+import { practices, userPractices } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import ModePicker, { type PickableMode } from '@/features/Practice/components/ModePicker';
+import type { RootStackParamList } from '@/navigation/RootStack';
+
+export type CreatePracticeWizardProps = NativeStackScreenProps<
+  RootStackParamList,
+  'CreatePractice'
+>;
+
+export const PRACTICE_NAME_MAX = 120;
+export const PRACTICE_DESCRIPTION_MAX = 1_000;
+export const PRACTICE_INSTRUCTIONS_MAX = 2_000;
+const PRACTICE_NAME_MIN = 1;
+const MIN_STAGE = 1;
+const MAX_STAGE = 10;
+
+type WizardStep = 'entry' | 'mode' | 'configure' | 'metadata';
+
+interface WizardState {
+  step: WizardStep;
+  mode: PickableMode | null;
+  config: ModeConfig | null;
+  name: string;
+  description: string;
+  instructions: string;
+  duration: number;
+  stageNumber: number | null;
+}
+
+const EMPTY_STATE: WizardState = {
+  step: 'entry',
+  mode: null,
+  config: null,
+  name: '',
+  description: '',
+  instructions: '',
+  duration: 0,
+  stageNumber: null,
+};
+
+function initialState(initial: InitialPrefill | undefined): WizardState {
+  if (initial === undefined) return EMPTY_STATE;
+  return {
+    ...EMPTY_STATE,
+    step: 'configure',
+    mode: initial.config.mode,
+    config: initial.config,
+    name: initial.name ?? '',
+    description: initial.description ?? '',
+    instructions: initial.instructions ?? '',
+    duration: initial.duration ?? 0,
+    stageNumber: initial.stageNumber ?? null,
+  };
+}
+
+interface InitialPrefill {
+  config: ModeConfig;
+  name?: string;
+  description?: string;
+  instructions?: string;
+  duration?: number;
+  stageNumber?: number | null;
+}
+
+const STEP_TITLES: Record<WizardStep, string> = {
+  entry: 'How would you like to start?',
+  mode: 'Pick a mode',
+  configure: 'Configure',
+  metadata: 'Name and save',
+};
+
+const STEP_ORDER: readonly WizardStep[] = ['entry', 'mode', 'configure', 'metadata'];
+
+/**
+ * Top-level screen — owns wizard state and renders the active step.
+ *
+ * Routes that opened the wizard from a preset row pass
+ * ``route.params.prefill``; the wizard then jumps past the entry step
+ * with the chosen mode and config pre-populated.
+ */
+export function CreatePracticeWizard(props: CreatePracticeWizardProps): React.JSX.Element {
+  const [state, setState] = useState<WizardState>(() => initialState(props.route.params?.prefill));
+  const submit = useSubmitController(props, state);
+  const goTo = (next: WizardStep) => setState((prev) => ({ ...prev, step: next }));
+  const setMode = (mode: PickableMode) => setState((prev) => transitionMode(prev, mode));
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      style={styles.screen}
+      testID="create-practice-wizard"
+    >
+      <StepIndicator step={state.step} />
+      <ScrollView contentContainerStyle={styles.body} keyboardShouldPersistTaps="handled">
+        <StepView
+          state={state}
+          setState={setState}
+          goTo={goTo}
+          setMode={setMode}
+          submit={submit}
+          onCancel={() => props.navigation.goBack()}
+        />
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+function transitionMode(prev: WizardState, mode: PickableMode): WizardState {
+  if (!isSupportedMode(mode)) {
+    return { ...prev, mode, config: null, step: 'configure' };
+  }
+  const config = defaultConfigFor(mode);
+  return {
+    ...prev,
+    mode,
+    config,
+    duration: prev.duration === 0 ? suggestedDurationFor(config) : prev.duration,
+    step: 'configure',
+  };
+}
+
+function isSupportedMode(mode: PickableMode): mode is ModeConfig['mode'] {
+  return mode !== 'mindful_anchor';
+}
+
+interface StepViewProps {
+  state: WizardState;
+  setState: React.Dispatch<React.SetStateAction<WizardState>>;
+  goTo: (step: WizardStep) => void;
+  setMode: (mode: PickableMode) => void;
+  submit: SubmitController;
+  onCancel: () => void;
+}
+
+const StepView = (props: StepViewProps): React.JSX.Element => {
+  switch (props.state.step) {
+    case 'entry':
+      return <EntryStep onPickPreset={props.onCancel} onStartScratch={() => props.goTo('mode')} />;
+    case 'mode':
+      return (
+        <ModeStep
+          mode={props.state.mode}
+          onSelect={props.setMode}
+          onBack={() => props.goTo('entry')}
+        />
+      );
+    case 'configure':
+      return (
+        <ConfigureStep
+          mode={props.state.mode}
+          config={props.state.config}
+          onChange={(config) =>
+            props.setState((prev) => ({
+              ...prev,
+              config,
+              duration: prev.duration === 0 ? suggestedDurationFor(config) : prev.duration,
+            }))
+          }
+          onBack={() => props.goTo('mode')}
+          onNext={() => props.goTo('metadata')}
+        />
+      );
+    case 'metadata':
+      return (
+        <MetadataStep
+          state={props.state}
+          setState={props.setState}
+          submit={props.submit}
+          onBack={() => props.goTo('configure')}
+        />
+      );
+  }
+};
+
+interface StepIndicatorProps {
+  step: WizardStep;
+}
+
+const StepIndicator = ({ step }: StepIndicatorProps): React.JSX.Element => {
+  const index = STEP_ORDER.indexOf(step);
+  const label = `Step ${index + 1} of ${STEP_ORDER.length}: ${STEP_TITLES[step]}`;
+  return (
+    <View
+      accessibilityRole="header"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel={label}
+      style={styles.indicator}
+      testID="create-practice-step-indicator"
+    >
+      <Text style={styles.indicatorStep}>
+        {index + 1} / {STEP_ORDER.length}
+      </Text>
+      <Text style={styles.indicatorTitle}>{STEP_TITLES[step]}</Text>
+    </View>
+  );
+};
+
+interface EntryStepProps {
+  onPickPreset: () => void;
+  onStartScratch: () => void;
+}
+
+const EntryStep = ({ onPickPreset, onStartScratch }: EntryStepProps): React.JSX.Element => (
+  <View testID="create-practice-step-entry">
+    <Text style={styles.bodyLead}>
+      Most adepts find it fastest to copy a preset and tweak it. Start from scratch when no preset
+      is close to what you have in mind.
+    </Text>
+    <PrimaryCard
+      title="Start from a preset"
+      subtitle="Browse the catalog and customize a copy."
+      testID="create-practice-from-preset"
+      onPress={onPickPreset}
+    />
+    <SecondaryCard
+      title="Start from scratch"
+      subtitle="Pick a mode, configure it, name it."
+      testID="create-practice-from-scratch"
+      onPress={onStartScratch}
+    />
+  </View>
+);
+
+interface ModeStepProps {
+  mode: PickableMode | null;
+  onSelect: (mode: PickableMode) => void;
+  onBack: () => void;
+}
+
+const ModeStep = ({ mode, onSelect, onBack }: ModeStepProps): React.JSX.Element => (
+  <View testID="create-practice-step-mode">
+    <Text style={styles.bodyLead}>11 modes, grouped by intent. Tap one to configure it.</Text>
+    <ModePicker selectedMode={mode} onSelect={onSelect} />
+    <BackButton onPress={onBack} />
+  </View>
+);
+
+interface ConfigureStepProps {
+  mode: PickableMode | null;
+  config: ModeConfig | null;
+  onChange: (config: ModeConfig) => void;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+const ConfigureStep = (props: ConfigureStepProps): React.JSX.Element => {
+  const { mode, config } = props;
+  if (mode === null) {
+    return <NoticeView testID="create-practice-configure-empty" message="Pick a mode first." />;
+  }
+  if (config === null || !isSupportedMode(mode)) {
+    return (
+      <View testID="create-practice-step-configure">
+        <NoticeView
+          testID="create-practice-configure-unsupported"
+          message="This mode isn't configurable in the wizard yet. Pick a different mode or wait for the next app update."
+        />
+        <BackButton onPress={props.onBack} />
+      </View>
+    );
+  }
+  const errors = validateModeConfig(config);
+  const canProceed = errors.length === 0;
+  return (
+    <View testID="create-practice-step-configure">
+      <Text style={styles.bodyLead}>
+        Smart defaults are already filled in. Tweak anything that doesn&apos;t fit, or jump ahead to
+        naming.
+      </Text>
+      <ConfiguratorBody config={config} onChange={props.onChange} />
+      <ErrorList errors={errors} />
+      <NavRow
+        onBack={props.onBack}
+        onNext={props.onNext}
+        nextLabel="Next: name + save"
+        nextDisabled={!canProceed}
+        nextTestID="create-practice-configure-next"
+      />
+    </View>
+  );
+};
+
+interface ConfiguratorBodyProps {
+  config: ModeConfig;
+  onChange: (next: ModeConfig) => void;
+}
+
+type FormComponent<M extends ModeConfig['mode']> = React.ComponentType<{
+  value: Extract<ModeConfig, { mode: M }>;
+  onChange: (next: Extract<ModeConfig, { mode: M }>) => void;
+}>;
+
+type FormTable = { [K in ModeConfig['mode']]: FormComponent<K> | null };
+
+const MODE_FORMS: FormTable = {
+  meditation_timer: MeditationTimerForm,
+  count_up: CountUpForm,
+  metronome: MetronomeForm,
+  interval_bell: IntervalBellForm,
+  random_interval_bell: RandomIntervalBellForm,
+  rep_counter: RepCounterForm,
+  sense_grounding: SenseGroundingForm,
+  tarot: TarotForm,
+  card_meditation: CardMeditationForm,
+  // ``tallied_grounding`` ships a runtime engine + view but no configurator
+  // form yet — the wizard saves the smart defaults verbatim until the
+  // dedicated form lands in a follow-up.
+  tallied_grounding: null,
+};
+
+const ConfiguratorBody = ({ config, onChange }: ConfiguratorBodyProps): React.JSX.Element => {
+  type AnyForm = React.ComponentType<{
+    value: ModeConfig;
+    onChange: (next: ModeConfig) => void;
+  }>;
+  const Form = MODE_FORMS[config.mode] as AnyForm | null;
+  if (Form === null) {
+    return (
+      <NoticeView
+        testID="create-practice-configure-tallied"
+        message="Tallied grounding will ship with a configurator soon. The defaults below will be saved as-is."
+      />
+    );
+  }
+  return <Form value={config} onChange={onChange} />;
+};
+
+interface MetadataStepProps {
+  state: WizardState;
+  setState: React.Dispatch<React.SetStateAction<WizardState>>;
+  submit: SubmitController;
+  onBack: () => void;
+}
+
+const MetadataStep = (props: MetadataStepProps): React.JSX.Element => {
+  const errors = metadataErrors(props.state);
+  const canSubmit = errors.length === 0 && !props.submit.busy;
+  return (
+    <View testID="create-practice-step-metadata">
+      <NameField state={props.state} setState={props.setState} />
+      <DescriptionField state={props.state} setState={props.setState} />
+      <InstructionsField state={props.state} setState={props.setState} />
+      <DurationField state={props.state} setState={props.setState} />
+      <StageField state={props.state} setState={props.setState} />
+      <ErrorList errors={errors} />
+      {props.submit.apiError !== null && (
+        <Text style={styles.apiError} testID="create-practice-api-error">
+          {props.submit.apiError}
+        </Text>
+      )}
+      <NavRow
+        onBack={props.onBack}
+        onNext={() => props.submit.run()}
+        nextLabel={props.submit.busy ? 'Saving…' : 'Save practice'}
+        nextDisabled={!canSubmit}
+        nextTestID="create-practice-submit"
+      />
+    </View>
+  );
+};
+
+interface MetadataFieldProps {
+  state: WizardState;
+  setState: React.Dispatch<React.SetStateAction<WizardState>>;
+}
+
+const NameField = ({ state, setState }: MetadataFieldProps): React.JSX.Element => (
+  <FieldLabel label="Name">
+    <TextInput
+      accessibilityLabel="Practice name"
+      value={state.name}
+      onChangeText={(name) => setState((prev) => ({ ...prev, name }))}
+      placeholder="e.g. Awareness bells"
+      maxLength={PRACTICE_NAME_MAX}
+      style={styles.input}
+      testID="create-practice-name"
+    />
+  </FieldLabel>
+);
+
+const DescriptionField = ({ state, setState }: MetadataFieldProps): React.JSX.Element => (
+  <FieldLabel label="Description (optional)">
+    <TextInput
+      accessibilityLabel="Practice description"
+      value={state.description}
+      onChangeText={(description) => setState((prev) => ({ ...prev, description }))}
+      placeholder="One-liner you'll see in the catalog."
+      maxLength={PRACTICE_DESCRIPTION_MAX}
+      multiline
+      style={[styles.input, styles.inputMultiline]}
+      testID="create-practice-description"
+    />
+  </FieldLabel>
+);
+
+const InstructionsField = ({ state, setState }: MetadataFieldProps): React.JSX.Element => (
+  <FieldLabel label="Instructions (optional)">
+    <TextInput
+      accessibilityLabel="Practice instructions"
+      value={state.instructions}
+      onChangeText={(instructions) => setState((prev) => ({ ...prev, instructions }))}
+      placeholder="How to do this practice."
+      maxLength={PRACTICE_INSTRUCTIONS_MAX}
+      multiline
+      style={[styles.input, styles.inputMultiline]}
+      testID="create-practice-instructions"
+    />
+  </FieldLabel>
+);
+
+const DurationField = ({ state, setState }: MetadataFieldProps): React.JSX.Element => (
+  <FieldLabel label="Default duration (minutes)">
+    <TextInput
+      accessibilityLabel="Default duration in minutes"
+      value={state.duration === 0 ? '' : String(state.duration)}
+      onChangeText={(raw) => setState((prev) => ({ ...prev, duration: parseDuration(raw) }))}
+      keyboardType="number-pad"
+      placeholder={state.config ? String(suggestedDurationFor(state.config)) : '10'}
+      style={styles.input}
+      testID="create-practice-duration"
+    />
+  </FieldLabel>
+);
+
+function parseDuration(raw: string): number {
+  if (raw.length === 0) return 0;
+  const trimmed = raw.replace(/[^0-9]/g, '');
+  if (trimmed.length === 0) return 0;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+const StageField = ({ state, setState }: MetadataFieldProps): React.JSX.Element => {
+  const stages = Array.from({ length: MAX_STAGE - MIN_STAGE + 1 }, (_, i) => MIN_STAGE + i);
+  return (
+    <View style={styles.field} testID="create-practice-stage-field">
+      <Text style={styles.fieldLabel}>Assign to a stage (optional)</Text>
+      <Text style={styles.fieldHelp}>
+        Pick a stage to make this your active practice for it right after saving.
+      </Text>
+      <View style={styles.stageRow}>
+        <StageChip
+          label="Skip"
+          selected={state.stageNumber === null}
+          onPress={() => setState((prev) => ({ ...prev, stageNumber: null }))}
+          testID="create-practice-stage-skip"
+        />
+        {stages.map((n) => (
+          <StageChip
+            key={n}
+            label={String(n)}
+            selected={state.stageNumber === n}
+            onPress={() => setState((prev) => ({ ...prev, stageNumber: n }))}
+            testID={`create-practice-stage-${n}`}
+          />
+        ))}
+      </View>
+    </View>
+  );
+};
+
+interface StageChipProps {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+  testID: string;
+}
+
+const StageChip = ({ label, selected, onPress, testID }: StageChipProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="radio"
+    accessibilityLabel={`Stage ${label}`}
+    accessibilityState={{ selected }}
+    onPress={onPress}
+    style={[styles.stageChip, selected && styles.stageChipSelected]}
+    testID={testID}
+  >
+    <Text style={[styles.stageChipText, selected && styles.stageChipTextSelected]}>{label}</Text>
+  </TouchableOpacity>
+);
+
+interface FieldLabelProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+const FieldLabel = ({ label, children }: FieldLabelProps): React.JSX.Element => (
+  <View style={styles.field}>
+    <Text style={styles.fieldLabel}>{label}</Text>
+    {children}
+  </View>
+);
+
+interface PrimaryCardProps {
+  title: string;
+  subtitle: string;
+  testID: string;
+  onPress: () => void;
+}
+
+const PrimaryCard = ({ title, subtitle, testID, onPress }: PrimaryCardProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={title}
+    onPress={onPress}
+    style={[styles.entryCard, styles.entryCardPrimary]}
+    testID={testID}
+  >
+    <Text style={[styles.entryCardTitle, styles.entryCardTitleLight]}>{title}</Text>
+    <Text style={[styles.entryCardSubtitle, styles.entryCardSubtitleLight]}>{subtitle}</Text>
+  </TouchableOpacity>
+);
+
+const SecondaryCard = ({
+  title,
+  subtitle,
+  testID,
+  onPress,
+}: PrimaryCardProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={title}
+    onPress={onPress}
+    style={styles.entryCard}
+    testID={testID}
+  >
+    <Text style={styles.entryCardTitle}>{title}</Text>
+    <Text style={styles.entryCardSubtitle}>{subtitle}</Text>
+  </TouchableOpacity>
+);
+
+interface BackButtonProps {
+  onPress: () => void;
+}
+
+const BackButton = ({ onPress }: BackButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel="Back"
+    onPress={onPress}
+    style={styles.backButton}
+    testID="create-practice-back"
+  >
+    <Text style={styles.backButtonText}>← Back</Text>
+  </TouchableOpacity>
+);
+
+interface NavRowProps {
+  onBack: () => void;
+  onNext: () => void;
+  nextLabel: string;
+  nextDisabled?: boolean;
+  nextTestID: string;
+}
+
+const NavRow = ({
+  onBack,
+  onNext,
+  nextLabel,
+  nextDisabled = false,
+  nextTestID,
+}: NavRowProps): React.JSX.Element => (
+  <View style={styles.navRow}>
+    <BackButton onPress={onBack} />
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={nextLabel}
+      accessibilityState={{ disabled: nextDisabled }}
+      onPress={nextDisabled ? undefined : onNext}
+      style={[styles.primaryButton, nextDisabled && styles.disabledButton]}
+      testID={nextTestID}
+    >
+      <Text style={styles.primaryButtonText}>{nextLabel}</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+interface NoticeProps {
+  message: string;
+  testID: string;
+}
+
+const NoticeView = ({ message, testID }: NoticeProps): React.JSX.Element => (
+  <View style={styles.notice} testID={testID}>
+    <Text style={styles.noticeText}>{message}</Text>
+  </View>
+);
+
+interface SubmitController {
+  busy: boolean;
+  apiError: string | null;
+  run: () => Promise<void>;
+}
+
+function useSubmitController(
+  props: CreatePracticeWizardProps,
+  state: WizardState,
+): SubmitController {
+  const [busy, setBusy] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const run = async () => {
+    if (state.config === null) return;
+    setBusy(true);
+    setApiError(null);
+    try {
+      const created = await practices.create({
+        stage_number: state.stageNumber ?? 1,
+        name: state.name.trim(),
+        description: state.description.trim(),
+        instructions: state.instructions.trim(),
+        default_duration_minutes: state.duration,
+        mode: state.config.mode,
+        mode_config: state.config,
+      });
+      if (state.stageNumber !== null) {
+        await userPractices.create({
+          practice_id: created.id,
+          stage_number: state.stageNumber,
+        });
+      }
+      props.navigation.replace('PracticeDetail', { practiceId: created.id });
+    } catch (err) {
+      setApiError(formatApiError(err, { fallback: 'Could not save practice.' }));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return { busy, apiError, run };
+}
+
+function metadataErrors(state: WizardState): string[] {
+  const errors: string[] = [];
+  if (state.name.trim().length < PRACTICE_NAME_MIN) {
+    errors.push('Name is required.');
+  }
+  if (state.name.length > PRACTICE_NAME_MAX) {
+    errors.push(`Name must be ≤ ${PRACTICE_NAME_MAX} characters.`);
+  }
+  if (state.description.length > PRACTICE_DESCRIPTION_MAX) {
+    errors.push(`Description must be ≤ ${PRACTICE_DESCRIPTION_MAX} characters.`);
+  }
+  if (state.instructions.length > PRACTICE_INSTRUCTIONS_MAX) {
+    errors.push(`Instructions must be ≤ ${PRACTICE_INSTRUCTIONS_MAX} characters.`);
+  }
+  if (!Number.isFinite(state.duration) || state.duration <= 0) {
+    errors.push('Duration must be greater than 0.');
+  }
+  return errors;
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: colors.background.primary },
+  body: { padding: SPACING.md, paddingBottom: SPACING.xl },
+  indicator: {
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.background.card,
+  },
+  indicatorStep: {
+    fontSize: 12,
+    color: colors.text.secondaryAccessible,
+    fontWeight: '600',
+  },
+  indicatorTitle: { fontSize: 16, color: colors.text.primary, marginTop: 2 },
+  bodyLead: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    marginBottom: SPACING.md,
+  },
+  entryCard: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.lg,
+    marginBottom: SPACING.md,
+    ...shadows.small,
+  },
+  entryCardPrimary: { backgroundColor: colors.primary },
+  entryCardTitle: { fontSize: 16, fontWeight: '700', color: colors.text.primary },
+  entryCardTitleLight: { color: colors.text.light },
+  entryCardSubtitle: {
+    fontSize: 13,
+    color: colors.text.secondaryAccessible,
+    marginTop: SPACING.xs,
+  },
+  entryCardSubtitleLight: { color: colors.text.light, opacity: 0.85 },
+  field: { marginBottom: SPACING.md },
+  fieldLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text.primary,
+    marginBottom: SPACING.xs,
+  },
+  fieldHelp: {
+    fontSize: 12,
+    color: colors.text.secondaryAccessible,
+    marginBottom: SPACING.xs,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.sm,
+    fontSize: 14,
+    color: colors.text.primary,
+    backgroundColor: colors.background.card,
+  },
+  inputMultiline: { minHeight: 64, textAlignVertical: 'top' },
+  stageRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
+  stageChip: {
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.background.card,
+  },
+  stageChipSelected: { backgroundColor: colors.primary, borderColor: colors.primary },
+  stageChipText: { color: colors.text.primary, fontSize: 13, fontWeight: '600' },
+  stageChipTextSelected: { color: colors.text.light },
+  notice: {
+    backgroundColor: colors.background.accent,
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: SPACING.md,
+  },
+  noticeText: { color: colors.text.primary, fontSize: 13 },
+  navRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: SPACING.md,
+  },
+  backButton: { paddingVertical: SPACING.sm, paddingHorizontal: SPACING.md },
+  backButtonText: { color: colors.primary, fontSize: 14, fontWeight: '600' },
+  primaryButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    borderRadius: BORDER_RADIUS.sm,
+  },
+  primaryButtonText: { color: colors.text.light, fontWeight: '700', fontSize: 14 },
+  disabledButton: { opacity: 0.5 },
+  apiError: {
+    color: colors.destructive.text,
+    marginTop: SPACING.sm,
+    fontSize: 13,
+  },
+});
+
+export default CreatePracticeWizard;

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -48,6 +48,7 @@ import { practices, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 import ModePicker, { type PickableMode } from '@/features/Practice/components/ModePicker';
+import { FALLBACK_STAGE, MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 export type CreatePracticeWizardProps = NativeStackScreenProps<
@@ -59,8 +60,6 @@ export const PRACTICE_NAME_MAX = 120;
 export const PRACTICE_DESCRIPTION_MAX = 1_000;
 export const PRACTICE_INSTRUCTIONS_MAX = 2_000;
 const PRACTICE_NAME_MIN = 1;
-const MIN_STAGE = 1;
-const MAX_STAGE = 10;
 
 type WizardStep = 'entry' | 'mode' | 'configure' | 'metadata';
 
@@ -651,8 +650,14 @@ function useSubmitController(
     setBusy(true);
     setApiError(null);
     try {
+      // ``stage_number`` is required on ``POST /practices/`` (catalog rows
+      // are stage-scoped), so a "Skip stage" choice mints the draft under
+      // FALLBACK_STAGE and skips the follow-up ``POST /user-practices``.
+      // The draft is then stored but not active for any stage; the user
+      // can assign it later from the detail screen. See
+      // ``features/Practice/constants.ts`` for the rationale.
       const created = await practices.create({
-        stage_number: state.stageNumber ?? 1,
+        stage_number: state.stageNumber ?? FALLBACK_STAGE,
         name: state.name.trim(),
         description: state.description.trim(),
         instructions: state.instructions.trim(),

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -34,10 +34,8 @@ import { type PracticeItem, practices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 import { MODE_CATEGORIES, type PickableMode } from '@/features/Practice/components/ModePicker';
+import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
 import type { RootStackParamList } from '@/navigation/RootStack';
-
-const MIN_STAGE = 1;
-const MAX_STAGE = 10;
 
 type Section = 'presets' | 'drafts' | 'imported';
 
@@ -64,23 +62,27 @@ interface CatalogState {
  * user's current stage when this screen is the catalog tab.
  */
 export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Element {
+  // Destructure each prop the callbacks below depend on so the
+  // ``useCallback`` dependency arrays are stable refs instead of the
+  // ``props`` object (which is a new reference on every render and
+  // would silently invalidate every memoization).
+  const { initialStage, loadPractices, navigateToDetail, navigateToCreate } = props;
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const [stageNumber, setStageNumber] = useState(props.initialStage ?? MIN_STAGE);
+  const [stageNumber, setStageNumber] = useState(initialStage ?? MIN_STAGE);
   const [modeCategory, setModeCategory] = useState<string | null>(null);
   const [query, setQuery] = useState('');
-  const [state, reload] = useCatalog(stageNumber, props);
+  const [state, reload] = useCatalog(stageNumber, loadPractices);
 
   const onDetail = useCallback(
     (id: number) =>
-      props.navigateToDetail
-        ? props.navigateToDetail(id)
+      navigateToDetail
+        ? navigateToDetail(id)
         : navigation.navigate('PracticeDetail', { practiceId: id }),
-    [navigation, props],
+    [navigation, navigateToDetail],
   );
   const onCreate = useCallback(
-    () =>
-      props.navigateToCreate ? props.navigateToCreate() : navigation.navigate('CreatePractice'),
-    [navigation, props],
+    () => (navigateToCreate ? navigateToCreate() : navigation.navigate('CreatePractice')),
+    [navigation, navigateToCreate],
   );
 
   return (
@@ -102,7 +104,10 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
   );
 }
 
-function useCatalog(stageNumber: number, props: CatalogProps): [CatalogState, () => void] {
+function useCatalog(
+  stageNumber: number,
+  loadPractices: CatalogProps['loadPractices'],
+): [CatalogState, () => void] {
   const [state, setState] = useState<CatalogState>({
     practices: [],
     loading: true,
@@ -111,8 +116,8 @@ function useCatalog(stageNumber: number, props: CatalogProps): [CatalogState, ()
 
   const runReload = useCallback(async () => {
     try {
-      const list = props.loadPractices
-        ? await props.loadPractices(stageNumber)
+      const list = loadPractices
+        ? await loadPractices(stageNumber)
         : await practices.list({ stageNumber, includeMine: true });
       setState({ practices: list, loading: false, error: null });
     } catch (err) {
@@ -122,7 +127,7 @@ function useCatalog(stageNumber: number, props: CatalogProps): [CatalogState, ()
         error: formatApiError(err, { fallback: 'Could not load the catalog.' }),
       }));
     }
-  }, [stageNumber, props]);
+  }, [stageNumber, loadPractices]);
 
   const reload = useCallback(() => {
     setState((prev) => ({ ...prev, loading: true, error: null }));

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -1,0 +1,501 @@
+/**
+ * ``PracticeCatalogScreen`` — top-level browse surface for every visible
+ * practice (presets + the user's drafts + imported drafts).
+ *
+ * Apply ALL custom-practices-07 UX guard-rails:
+ *
+ *   1. Mode category filter chips — never a flat 11-mode list.
+ *   2. ``+ Create`` is the primary CTA and recommends starting from a
+ *      preset; the wizard handles that recommendation in step 0.
+ *   3. Per-stage filter — defaults to the user's current stage.
+ *   4. Sections (Presets / My drafts / Imported) so the catalog can
+ *      grow without collapsing into one giant scroll.
+ *   5. Search by name + description.
+ *
+ * The backend's ``GET /practices/`` requires ``stage_number``, so the
+ * catalog pages one stage at a time and the stage chip is the primary
+ * navigation rather than an optional filter.
+ */
+
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { type PracticeItem, practices } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import { MODE_CATEGORIES, type PickableMode } from '@/features/Practice/components/ModePicker';
+import type { RootStackParamList } from '@/navigation/RootStack';
+
+const MIN_STAGE = 1;
+const MAX_STAGE = 10;
+
+type Section = 'presets' | 'drafts' | 'imported';
+
+interface CatalogProps {
+  /** Stage to seed the chip filter with; defaults to ``1``. */
+  initialStage?: number;
+  /** Override for tests so the catalog doesn't poke the live API. */
+  loadPractices?: (stageNumber: number) => Promise<PracticeItem[]>;
+  /** Override for tests; otherwise wires through ``RootStack`` navigator. */
+  navigateToDetail?: (practiceId: number) => void;
+  /** Override for tests; otherwise opens ``CreatePractice``. */
+  navigateToCreate?: () => void;
+}
+
+interface CatalogState {
+  practices: PracticeItem[];
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Top-level catalog. Defaults to stage 1 so the screen renders something
+ * before the user picks a chip; pass ``initialStage`` to align with the
+ * user's current stage when this screen is the catalog tab.
+ */
+export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Element {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const [stageNumber, setStageNumber] = useState(props.initialStage ?? MIN_STAGE);
+  const [modeCategory, setModeCategory] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [state, reload] = useCatalog(stageNumber, props);
+
+  const onDetail = useCallback(
+    (id: number) =>
+      props.navigateToDetail
+        ? props.navigateToDetail(id)
+        : navigation.navigate('PracticeDetail', { practiceId: id }),
+    [navigation, props],
+  );
+  const onCreate = useCallback(
+    () =>
+      props.navigateToCreate ? props.navigateToCreate() : navigation.navigate('CreatePractice'),
+    [navigation, props],
+  );
+
+  return (
+    <View style={styles.screen}>
+      <ScrollView contentContainerStyle={styles.body} testID="practice-catalog-screen">
+        <Header onCreate={onCreate} />
+        <SearchBar value={query} onChange={setQuery} />
+        <StageChips selected={stageNumber} onSelect={setStageNumber} />
+        <ModeChips selected={modeCategory} onSelect={setModeCategory} />
+        <CatalogBody
+          state={state}
+          query={query}
+          modeCategory={modeCategory}
+          onDetail={onDetail}
+          onRetry={reload}
+        />
+      </ScrollView>
+    </View>
+  );
+}
+
+function useCatalog(stageNumber: number, props: CatalogProps): [CatalogState, () => void] {
+  const [state, setState] = useState<CatalogState>({
+    practices: [],
+    loading: true,
+    error: null,
+  });
+
+  const runReload = useCallback(async () => {
+    try {
+      const list = props.loadPractices
+        ? await props.loadPractices(stageNumber)
+        : await practices.list({ stageNumber, includeMine: true });
+      setState({ practices: list, loading: false, error: null });
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: formatApiError(err, { fallback: 'Could not load the catalog.' }),
+      }));
+    }
+  }, [stageNumber, props]);
+
+  const reload = useCallback(() => {
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    void runReload();
+  }, [runReload]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  return [state, reload];
+}
+
+interface HeaderProps {
+  onCreate: () => void;
+}
+
+const Header = ({ onCreate }: HeaderProps): React.JSX.Element => (
+  <View style={styles.header}>
+    <View>
+      <Text style={styles.heading}>Practice catalog</Text>
+      <Text style={styles.subheading}>Browse every practice, or author your own.</Text>
+    </View>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel="Create a new practice"
+      onPress={onCreate}
+      style={styles.createButton}
+      testID="practice-catalog-create"
+    >
+      <Text style={styles.createButtonText}>+ Create</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+interface SearchBarProps {
+  value: string;
+  onChange: (next: string) => void;
+}
+
+const SearchBar = ({ value, onChange }: SearchBarProps): React.JSX.Element => (
+  <TextInput
+    accessibilityLabel="Search practices by name or description"
+    style={styles.search}
+    placeholder="Search by name or description"
+    placeholderTextColor={colors.text.tertiaryAccessible}
+    value={value}
+    onChangeText={onChange}
+    testID="practice-catalog-search"
+  />
+);
+
+interface StageChipsProps {
+  selected: number;
+  onSelect: (stage: number) => void;
+}
+
+const StageChips = ({ selected, onSelect }: StageChipsProps): React.JSX.Element => {
+  const stages = Array.from({ length: MAX_STAGE - MIN_STAGE + 1 }, (_, i) => MIN_STAGE + i);
+  return (
+    <View style={styles.chipRow} testID="practice-catalog-stage-chips">
+      {stages.map((n) => (
+        <FilterChip
+          key={n}
+          label={`Stage ${n}`}
+          selected={selected === n}
+          onPress={() => onSelect(n)}
+          testID={`practice-catalog-stage-${n}`}
+        />
+      ))}
+    </View>
+  );
+};
+
+interface ModeChipsProps {
+  selected: string | null;
+  onSelect: (category: string | null) => void;
+}
+
+const ModeChips = ({ selected, onSelect }: ModeChipsProps): React.JSX.Element => (
+  <View style={styles.chipRow} testID="practice-catalog-mode-chips">
+    <FilterChip
+      label="All"
+      selected={selected === null}
+      onPress={() => onSelect(null)}
+      testID="practice-catalog-mode-all"
+    />
+    {MODE_CATEGORIES.map((category) => (
+      <FilterChip
+        key={category.key}
+        label={category.title}
+        selected={selected === category.key}
+        onPress={() => onSelect(category.key)}
+        testID={`practice-catalog-mode-${category.key}`}
+      />
+    ))}
+  </View>
+);
+
+interface FilterChipProps {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+  testID: string;
+}
+
+const FilterChip = ({ label, selected, onPress, testID }: FilterChipProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={label}
+    accessibilityState={{ selected }}
+    onPress={onPress}
+    style={[styles.chip, selected && styles.chipSelected]}
+    testID={testID}
+  >
+    <Text style={[styles.chipText, selected && styles.chipTextSelected]}>{label}</Text>
+  </TouchableOpacity>
+);
+
+interface CatalogBodyProps {
+  state: CatalogState;
+  query: string;
+  modeCategory: string | null;
+  onDetail: (id: number) => void;
+  onRetry: () => void;
+}
+
+const CatalogBody = (props: CatalogBodyProps): React.JSX.Element => {
+  if (props.state.loading) {
+    return (
+      <View style={styles.loadingBlock} testID="practice-catalog-loading">
+        <ActivityIndicator color={colors.primary} />
+      </View>
+    );
+  }
+  if (props.state.error !== null) {
+    return (
+      <View style={styles.errorBlock} testID="practice-catalog-error">
+        <Text style={styles.errorText}>{props.state.error}</Text>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Retry"
+          onPress={props.onRetry}
+          style={styles.retryButton}
+          testID="practice-catalog-retry"
+        >
+          <Text style={styles.retryButtonText}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+  const filtered = applyFilters(props.state.practices, props.query, props.modeCategory);
+  const sections = bucketSections(filtered);
+  return (
+    <View testID="practice-catalog-sections">
+      <SectionView
+        title="Presets"
+        section="presets"
+        items={sections.presets}
+        onDetail={props.onDetail}
+      />
+      <SectionView
+        title="My drafts"
+        section="drafts"
+        items={sections.drafts}
+        onDetail={props.onDetail}
+      />
+      <SectionView
+        title="Imported"
+        section="imported"
+        items={sections.imported}
+        onDetail={props.onDetail}
+      />
+    </View>
+  );
+};
+
+interface SectionViewProps {
+  title: string;
+  section: Section;
+  items: readonly PracticeItem[];
+  onDetail: (id: number) => void;
+}
+
+const SectionView = ({ title, section, items, onDetail }: SectionViewProps): React.JSX.Element => (
+  <View style={styles.section} testID={`practice-catalog-section-${section}`}>
+    <Text style={styles.sectionTitle}>{title}</Text>
+    {items.length === 0 ? (
+      <Text style={styles.emptyText} testID={`practice-catalog-section-${section}-empty`}>
+        Nothing here yet.
+      </Text>
+    ) : (
+      items.map((p) => <PracticeRow key={p.id} practice={p} onPress={() => onDetail(p.id)} />)
+    )}
+  </View>
+);
+
+interface PracticeRowProps {
+  practice: PracticeItem;
+  onPress: () => void;
+}
+
+const PracticeRow = ({ practice, onPress }: PracticeRowProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={practice.name}
+    onPress={onPress}
+    style={styles.row}
+    testID={`practice-catalog-row-${practice.id}`}
+  >
+    <Text style={styles.rowName}>{practice.name}</Text>
+    <View style={styles.rowMeta}>
+      <View style={styles.rowBadge}>
+        <Text style={styles.rowBadgeText}>{practice.mode ?? 'meditation_timer'}</Text>
+      </View>
+      <View style={styles.rowBadge}>
+        <Text style={styles.rowBadgeText}>Stage {practice.stage_number}</Text>
+      </View>
+      <Text style={styles.rowDuration}>{Math.round(practice.default_duration_minutes)} min</Text>
+    </View>
+  </TouchableOpacity>
+);
+
+function applyFilters(
+  items: readonly PracticeItem[],
+  query: string,
+  modeCategory: string | null,
+): readonly PracticeItem[] {
+  const needle = query.trim().toLowerCase();
+  const modes = modeCategory === null ? null : modesInCategory(modeCategory);
+  return items.filter((item) => {
+    if (needle.length > 0) {
+      const haystack = `${item.name} ${item.description}`.toLowerCase();
+      if (!haystack.includes(needle)) return false;
+    }
+    if (modes !== null) {
+      const mode = (item.mode ?? 'meditation_timer') as PickableMode;
+      if (!modes.has(mode)) return false;
+    }
+    return true;
+  });
+}
+
+function modesInCategory(categoryKey: string): Set<PickableMode> {
+  const category = MODE_CATEGORIES.find((c) => c.key === categoryKey);
+  return new Set(category?.modes.map((m) => m.mode) ?? []);
+}
+
+interface SectionBuckets {
+  presets: readonly PracticeItem[];
+  drafts: readonly PracticeItem[];
+  imported: readonly PracticeItem[];
+}
+
+/**
+ * Bucket the catalog rows into the three sections the screen renders.
+ *
+ * ``approved=True`` rows are presets — the curated catalog. Unapproved
+ * rows are the user's own drafts (the backend only surfaces unapproved
+ * rows when the caller is the submitter; see
+ * ``GET /practices/?include_mine=true``). The "Imported" section lands
+ * empty today: distinguishing imported drafts requires a Practice column
+ * that custom-practices-03 will add when share-link recipients can
+ * receive a copy under their own user id.
+ */
+function bucketSections(items: readonly PracticeItem[]): SectionBuckets {
+  const presets: PracticeItem[] = [];
+  const drafts: PracticeItem[] = [];
+  const imported: readonly PracticeItem[] = [];
+  for (const item of items) {
+    if (item.approved) {
+      presets.push(item);
+    } else {
+      drafts.push(item);
+    }
+  }
+  return { presets, drafts, imported };
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: colors.background.primary },
+  body: { padding: SPACING.md, paddingBottom: SPACING.xl },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: SPACING.md,
+  },
+  heading: { fontSize: 22, fontWeight: '700', color: colors.text.primary },
+  subheading: {
+    fontSize: 13,
+    color: colors.text.secondaryAccessible,
+    marginTop: 2,
+  },
+  createButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.sm,
+  },
+  createButtonText: { color: colors.text.light, fontWeight: '700', fontSize: 13 },
+  search: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.sm,
+    fontSize: 14,
+    color: colors.text.primary,
+    backgroundColor: colors.background.card,
+    marginBottom: SPACING.sm,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: SPACING.xs,
+    marginBottom: SPACING.sm,
+  },
+  chip: {
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.background.card,
+  },
+  chipSelected: { backgroundColor: colors.primary, borderColor: colors.primary },
+  chipText: { fontSize: 12, color: colors.text.primary, fontWeight: '600' },
+  chipTextSelected: { color: colors.text.light },
+  loadingBlock: { padding: SPACING.lg, alignItems: 'center' },
+  errorBlock: { padding: SPACING.lg, alignItems: 'center', gap: SPACING.sm },
+  errorText: { color: colors.destructive.text, fontSize: 13 },
+  retryButton: {
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  retryButtonText: { color: colors.text.primary, fontWeight: '600' },
+  section: { marginTop: SPACING.md },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.text.secondaryAccessible,
+    textTransform: 'uppercase',
+    marginBottom: SPACING.sm,
+  },
+  emptyText: { color: colors.text.tertiaryAccessible, fontSize: 13 },
+  row: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.md,
+    marginBottom: SPACING.sm,
+    ...shadows.small,
+  },
+  rowName: { fontSize: 15, fontWeight: '700', color: colors.text.primary },
+  rowMeta: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: SPACING.xs,
+    marginTop: SPACING.xs,
+  },
+  rowBadge: {
+    backgroundColor: colors.background.accent,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: 2,
+    borderRadius: BORDER_RADIUS.sm,
+  },
+  rowBadgeText: { fontSize: 11, color: colors.text.primary, fontWeight: '600' },
+  rowDuration: { fontSize: 12, color: colors.text.secondaryAccessible },
+});
+
+export default PracticeCatalogScreen;

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -24,15 +24,13 @@ import type { ModeConfig } from '../engine/types';
 import { type PracticeItem, practices, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 export type PracticeDetailScreenProps = NativeStackScreenProps<
   RootStackParamList,
   'PracticeDetail'
 >;
-
-const MIN_STAGE = 1;
-const MAX_STAGE = 10;
 
 interface ScreenState {
   practice: PracticeItem | null;

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -1,0 +1,524 @@
+/**
+ * ``PracticeDetailScreen`` — read-only summary of a single practice with
+ * the actions a user can take from the catalog.
+ *
+ * Reachable from the catalog (preset / draft / imported rows) and from the
+ * wizard after a successful create. The summary intentionally renders the
+ * mode + config as plain bullet points; deep customization stays in the
+ * configurator sheet (per-user override) and the wizard (full copy).
+ */
+
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import type { ModeConfig } from '../engine/types';
+
+import { type PracticeItem, practices, userPractices } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import type { RootStackParamList } from '@/navigation/RootStack';
+
+export type PracticeDetailScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'PracticeDetail'
+>;
+
+const MIN_STAGE = 1;
+const MAX_STAGE = 10;
+
+interface ScreenState {
+  practice: PracticeItem | null;
+  loadError: string | null;
+  actionError: string | null;
+  assigning: boolean;
+  loading: boolean;
+  pickerOpen: boolean;
+  assignedStage: number | null;
+}
+
+function initialState(): ScreenState {
+  return {
+    practice: null,
+    loadError: null,
+    actionError: null,
+    assigning: false,
+    loading: true,
+    pickerOpen: false,
+    assignedStage: null,
+  };
+}
+
+/**
+ * Top-level screen — fetches a single practice and exposes the action row.
+ *
+ * "Use for stage" opens a 1-10 stage picker that writes via
+ * ``userPractices.create``; "Customize a copy" replays the wizard with
+ * this practice's mode_config pre-filled.
+ */
+export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JSX.Element {
+  const { practiceId } = props.route.params;
+  const state = usePracticeDetail(practiceId);
+  if (state.loading) {
+    return (
+      <View style={styles.loading} testID="practice-detail-loading">
+        <ActivityIndicator color={colors.primary} size="large" />
+      </View>
+    );
+  }
+  if (state.loadError !== null || state.practice === null) {
+    return (
+      <ErrorView message={state.loadError ?? 'Could not load practice.'} onRetry={state.reload} />
+    );
+  }
+  return (
+    <ScrollView contentContainerStyle={styles.body} testID="practice-detail-screen">
+      <DetailHeader practice={state.practice} />
+      <DetailBody practice={state.practice} />
+      {state.actionError !== null && (
+        <Text style={styles.errorText} testID="practice-detail-action-error">
+          {state.actionError}
+        </Text>
+      )}
+      {state.assignedStage !== null && (
+        <View style={styles.banner} testID="practice-detail-assigned-banner">
+          <Text style={styles.bannerText}>Set as your stage {state.assignedStage} practice.</Text>
+        </View>
+      )}
+      <ActionRow
+        practice={state.practice}
+        onUseForStage={state.openPicker}
+        onCustomizeCopy={() => navigateToCopy(props, state.practice!)}
+      />
+      {state.pickerOpen && (
+        <StagePicker
+          assigning={state.assigning}
+          onPick={state.assign}
+          onClose={state.closePicker}
+        />
+      )}
+    </ScrollView>
+  );
+}
+
+interface PracticeDetailHook {
+  practice: PracticeItem | null;
+  loadError: string | null;
+  actionError: string | null;
+  assigning: boolean;
+  loading: boolean;
+  pickerOpen: boolean;
+  assignedStage: number | null;
+  reload: () => void;
+  openPicker: () => void;
+  closePicker: () => void;
+  assign: (stageNumber: number) => Promise<void>;
+}
+
+function usePracticeDetail(practiceId: number): PracticeDetailHook {
+  const [state, setState] = useState<ScreenState>(initialState);
+
+  const runReload = useCallback(async () => {
+    try {
+      const practice = await practices.get(practiceId);
+      setState((prev) => ({ ...prev, practice, loading: false }));
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        loadError: formatApiError(err, { fallback: 'Could not load practice.' }),
+      }));
+    }
+  }, [practiceId]);
+
+  const reload = useCallback(() => {
+    setState((prev) => ({ ...prev, loading: true, loadError: null }));
+    void runReload();
+  }, [runReload]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const openPicker = useCallback(
+    () => setState((prev) => ({ ...prev, pickerOpen: true, actionError: null })),
+    [],
+  );
+  const closePicker = useCallback(() => setState((prev) => ({ ...prev, pickerOpen: false })), []);
+
+  const assign = useCallback(
+    async (stageNumber: number) => {
+      setState((prev) => ({ ...prev, assigning: true, actionError: null }));
+      try {
+        await userPractices.create({ practice_id: practiceId, stage_number: stageNumber });
+        setState((prev) => ({
+          ...prev,
+          assigning: false,
+          pickerOpen: false,
+          assignedStage: stageNumber,
+        }));
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          assigning: false,
+          actionError: formatApiError(err, { fallback: 'Could not assign practice.' }),
+        }));
+      }
+    },
+    [practiceId],
+  );
+
+  return { ...state, reload, openPicker, closePicker, assign };
+}
+
+function navigateToCopy(props: PracticeDetailScreenProps, practice: PracticeItem) {
+  if (practice.mode_config === undefined) return;
+  props.navigation.navigate('CreatePractice', {
+    prefill: {
+      config: practice.mode_config,
+      name: `${practice.name} (copy)`,
+      description: practice.description,
+      instructions: practice.instructions,
+      duration: Math.round(practice.default_duration_minutes),
+      stageNumber: practice.stage_number,
+    },
+  });
+}
+
+interface DetailHeaderProps {
+  practice: PracticeItem;
+}
+
+const DetailHeader = ({ practice }: DetailHeaderProps): React.JSX.Element => (
+  <View style={styles.headerBlock}>
+    <Text style={styles.heading} testID="practice-detail-name">
+      {practice.name}
+    </Text>
+    <View style={styles.metaRow}>
+      <BadgeChip label={practice.mode ?? 'meditation_timer'} testID="practice-detail-mode-badge" />
+      <BadgeChip label={`Stage ${practice.stage_number}`} testID="practice-detail-stage-badge" />
+      <BadgeChip
+        label={`${Math.round(practice.default_duration_minutes)} min`}
+        testID="practice-detail-duration-badge"
+      />
+    </View>
+  </View>
+);
+
+interface DetailBodyProps {
+  practice: PracticeItem;
+}
+
+const DetailBody = ({ practice }: DetailBodyProps): React.JSX.Element => (
+  <View style={styles.bodyBlock}>
+    {practice.description.length > 0 && (
+      <BodySection label="Description" testID="practice-detail-description">
+        {practice.description}
+      </BodySection>
+    )}
+    {practice.instructions.length > 0 && (
+      <BodySection label="Instructions" testID="practice-detail-instructions">
+        {practice.instructions}
+      </BodySection>
+    )}
+    {practice.mode_config && <ConfigSummary config={practice.mode_config} />}
+  </View>
+);
+
+interface BodySectionProps {
+  label: string;
+  testID: string;
+  children: string;
+}
+
+const BodySection = ({ label, testID, children }: BodySectionProps): React.JSX.Element => (
+  <View style={styles.section}>
+    <Text style={styles.sectionLabel}>{label}</Text>
+    <Text style={styles.sectionText} testID={testID}>
+      {children}
+    </Text>
+  </View>
+);
+
+interface ConfigSummaryProps {
+  config: ModeConfig;
+}
+
+const ConfigSummary = ({ config }: ConfigSummaryProps): React.JSX.Element => (
+  <View style={styles.section} testID="practice-detail-config-summary">
+    <Text style={styles.sectionLabel}>Configuration</Text>
+    {summarizeConfig(config).map((line, index) => (
+      <Text key={index} style={styles.bullet}>
+        • {line}
+      </Text>
+    ))}
+  </View>
+);
+
+const SUMMARIZERS: {
+  [K in ModeConfig['mode']]: (config: Extract<ModeConfig, { mode: K }>) => readonly string[];
+} = {
+  meditation_timer: (c) => [`Duration: ${c.duration_minutes} min`],
+  count_up: (c) => (c.soft_cap_minutes ? [`Soft cap: ${c.soft_cap_minutes} min`] : ['Open-ended']),
+  metronome: (c) => [`BPM: ${c.bpm}`, `Duration: ${c.timer.duration_minutes} min`],
+  interval_bell: (c) => [
+    `Duration: ${c.duration_minutes} min`,
+    `Spacing: ${
+      c.cue_offsets_minutes
+        ? `${c.cue_offsets_minutes.length} custom cues`
+        : `every ${c.interval_minutes ?? 5} min`
+    }`,
+    `Tone: ${c.bell_tone}`,
+  ],
+  random_interval_bell: (c) => [
+    `Duration: ${c.duration_minutes} min`,
+    `Interval: ${c.min_interval_seconds}-${c.max_interval_seconds}s`,
+    `Tone: ${c.bell_tone}`,
+  ],
+  rep_counter: (c) => [`Target: ${c.target_reps} ${c.unit_label}`],
+  sense_grounding: (c) => [`${c.prompts.length} prompts across the senses`],
+  tallied_grounding: (c) => [`${c.rounds} rounds`, `${c.categories.length} categories`],
+  tarot: () => ['Major arcana — one card per sit'],
+  card_meditation: (c) => [`Deck: ${c.deck_id}`],
+};
+
+/**
+ * Mode-agnostic config bullets the detail screen renders verbatim.
+ *
+ * The full per-mode summary helpers live in the runtime views; here we
+ * keep the bullets short so the read-only surface stays legible — users
+ * who want to tweak a value go through "Customize a copy".
+ */
+function summarizeConfig(config: ModeConfig): readonly string[] {
+  type AnyHint = (c: ModeConfig) => readonly string[];
+  const summarize = SUMMARIZERS[config.mode] as AnyHint;
+  return summarize(config);
+}
+
+interface ActionRowProps {
+  practice: PracticeItem;
+  onUseForStage: () => void;
+  onCustomizeCopy: () => void;
+}
+
+const ActionRow = ({
+  practice,
+  onUseForStage,
+  onCustomizeCopy,
+}: ActionRowProps): React.JSX.Element => (
+  // ``Edit`` / ``Delete`` are owner-only per the issue spec, but the
+  // ``GET /practices/{id}`` response intentionally drops the submitter id
+  // (BUG-PRACTICE-001) so the screen cannot tell ownership reliably.
+  // "Customize a copy" covers the in-app equivalent until the backend
+  // adds an owner hint.
+  <View style={styles.actionRow}>
+    <ActionButton
+      label="Use for stage…"
+      onPress={onUseForStage}
+      testID="practice-detail-use-for-stage"
+      primary
+    />
+    <ActionButton
+      label="Customize a copy"
+      onPress={onCustomizeCopy}
+      testID="practice-detail-customize-copy"
+      disabled={practice.mode_config === undefined}
+    />
+  </View>
+);
+
+interface ActionButtonProps {
+  label: string;
+  onPress: () => void;
+  testID: string;
+  primary?: boolean;
+  disabled?: boolean;
+}
+
+const ActionButton = ({
+  label,
+  onPress,
+  testID,
+  primary = false,
+  disabled = false,
+}: ActionButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={label}
+    accessibilityState={{ disabled }}
+    onPress={disabled ? undefined : onPress}
+    style={[
+      styles.actionButton,
+      primary && styles.actionButtonPrimary,
+      disabled && styles.disabledButton,
+    ]}
+    testID={testID}
+  >
+    <Text style={[styles.actionButtonText, primary && styles.actionButtonTextPrimary]}>
+      {label}
+    </Text>
+  </TouchableOpacity>
+);
+
+interface StagePickerProps {
+  assigning: boolean;
+  onPick: (stageNumber: number) => void;
+  onClose: () => void;
+}
+
+const StagePicker = ({ assigning, onPick, onClose }: StagePickerProps): React.JSX.Element => {
+  const stages = Array.from({ length: MAX_STAGE - MIN_STAGE + 1 }, (_, i) => MIN_STAGE + i);
+  return (
+    <View style={styles.pickerCard} testID="practice-detail-stage-picker">
+      <Text style={styles.pickerHeading}>Pick a stage</Text>
+      <View style={styles.pickerRow}>
+        {stages.map((n) => (
+          <TouchableOpacity
+            key={n}
+            accessibilityRole="button"
+            accessibilityLabel={`Stage ${n}`}
+            accessibilityState={{ disabled: assigning }}
+            onPress={assigning ? undefined : () => onPick(n)}
+            style={[styles.stageBox, assigning && styles.disabledButton]}
+            testID={`practice-detail-stage-pick-${n}`}
+          >
+            <Text style={styles.stageBoxText}>{n}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Cancel"
+        onPress={onClose}
+        style={styles.pickerCancel}
+        testID="practice-detail-stage-pick-cancel"
+      >
+        <Text style={styles.pickerCancelText}>Cancel</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+interface BadgeChipProps {
+  label: string;
+  testID: string;
+}
+
+const BadgeChip = ({ label, testID }: BadgeChipProps): React.JSX.Element => (
+  <View style={styles.badge} testID={testID}>
+    <Text style={styles.badgeText}>{label}</Text>
+  </View>
+);
+
+interface ErrorViewProps {
+  message: string;
+  onRetry: () => void;
+}
+
+const ErrorView = ({ message, onRetry }: ErrorViewProps): React.JSX.Element => (
+  <View style={styles.errorBlock} testID="practice-detail-error">
+    <Text style={styles.errorText}>{message}</Text>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel="Retry"
+      onPress={onRetry}
+      style={styles.actionButton}
+      testID="practice-detail-retry"
+    >
+      <Text style={styles.actionButtonText}>Retry</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  loading: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  body: { padding: SPACING.md, paddingBottom: SPACING.xl },
+  headerBlock: { marginBottom: SPACING.md },
+  heading: { fontSize: 22, fontWeight: '700', color: colors.text.primary },
+  metaRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: SPACING.xs,
+    marginTop: SPACING.xs,
+  },
+  badge: {
+    backgroundColor: colors.background.accent,
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+  },
+  badgeText: { color: colors.text.primary, fontSize: 12, fontWeight: '600' },
+  bodyBlock: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.md,
+    marginBottom: SPACING.md,
+    ...shadows.small,
+  },
+  section: { marginBottom: SPACING.sm },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.text.secondaryAccessible,
+    textTransform: 'uppercase',
+    marginBottom: SPACING.xs,
+  },
+  sectionText: { fontSize: 14, color: colors.text.primary, lineHeight: 20 },
+  bullet: { fontSize: 13, color: colors.text.primary, marginVertical: 1 },
+  actionRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.sm },
+  actionButton: {
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  actionButtonPrimary: { backgroundColor: colors.primary, borderColor: colors.primary },
+  actionButtonText: { color: colors.text.primary, fontWeight: '600', fontSize: 13 },
+  actionButtonTextPrimary: { color: colors.text.light },
+  disabledButton: { opacity: 0.5 },
+  pickerCard: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.md,
+    marginTop: SPACING.md,
+    ...shadows.small,
+  },
+  pickerHeading: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.text.primary,
+    marginBottom: SPACING.sm,
+  },
+  pickerRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
+  stageBox: {
+    minWidth: 36,
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+    alignItems: 'center',
+  },
+  stageBoxText: { color: colors.text.primary, fontWeight: '700' },
+  pickerCancel: { marginTop: SPACING.sm, alignSelf: 'flex-end' },
+  pickerCancelText: { color: colors.primary, fontWeight: '600', fontSize: 13 },
+  banner: {
+    backgroundColor: colors.background.accent,
+    padding: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    marginBottom: SPACING.sm,
+  },
+  bannerText: { color: colors.successText, fontSize: 13, fontWeight: '600' },
+  errorBlock: { padding: SPACING.lg, alignItems: 'center', gap: SPACING.md },
+  errorText: { color: colors.destructive.text, fontSize: 13, marginBottom: SPACING.sm },
+});
+
+export default PracticeDetailScreen;

--- a/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
@@ -226,6 +226,11 @@ describe('CreatePracticeWizard — metadata + submit', () => {
 
     expect(mockPracticesCreate).toHaveBeenCalledTimes(1);
     expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+    // Skip-stage mints the draft under FALLBACK_STAGE (=1); the catalog row
+    // exists but is not active anywhere (no user-practice row). Asserting
+    // the wire value closes the contract gap flagged in the PR review.
+    const payload = mockPracticesCreate.mock.calls[0]?.[0];
+    expect(payload?.stage_number).toBe(1);
   });
 
   it('surfaces an API error when the create call fails', async () => {

--- a/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
@@ -1,0 +1,363 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { PracticeItem, UserPractice } from '@/api';
+import type { ModeConfig } from '@/features/Practice/engine/types';
+
+const createdPractice: PracticeItem = {
+  id: 501,
+  stage_number: 4,
+  name: 'Awareness bells',
+  description: '',
+  instructions: '',
+  default_duration_minutes: 20,
+  submitted_by_user_id: 9,
+  approved: false,
+  mode: 'random_interval_bell',
+  mode_config: {
+    mode: 'random_interval_bell',
+    duration_minutes: 20,
+    min_interval_seconds: 30,
+    max_interval_seconds: 180,
+    bell_tone: 'bowl',
+  },
+};
+
+const createdUserPractice: UserPractice = {
+  id: 4242,
+  user_id: 9,
+  practice_id: 501,
+  stage_number: 4,
+  start_date: '2026-05-23',
+  end_date: null,
+};
+
+const mockPracticesCreate = jest.fn() as jest.MockedFunction<
+  (payload: Record<string, unknown>) => Promise<PracticeItem>
+>;
+const mockUserPracticesCreate = jest.fn() as jest.MockedFunction<
+  (payload: { practice_id: number; stage_number: number }) => Promise<UserPractice>
+>;
+
+jest.mock('@/api', () => ({
+  practices: {
+    create: (...args: unknown[]) =>
+      (mockPracticesCreate as unknown as (...a: unknown[]) => Promise<PracticeItem>)(...args),
+  },
+  userPractices: {
+    create: (...args: unknown[]) =>
+      (mockUserPracticesCreate as unknown as (...a: unknown[]) => Promise<UserPractice>)(...args),
+  },
+}));
+
+const { CreatePracticeWizard } = require('../CreatePracticeWizard');
+
+interface NavMock {
+  goBack: jest.Mock<() => void>;
+  replace: jest.Mock<(...args: unknown[]) => void>;
+  navigate: jest.Mock<(...args: unknown[]) => void>;
+}
+
+function makeNav(): NavMock {
+  return {
+    goBack: jest.fn() as jest.Mock<() => void>,
+    replace: jest.fn() as jest.Mock<(...args: unknown[]) => void>,
+    navigate: jest.fn() as jest.Mock<(...args: unknown[]) => void>,
+  };
+}
+
+interface RenderOptions {
+  prefill?: {
+    config: ModeConfig;
+    name?: string;
+    description?: string;
+    instructions?: string;
+    duration?: number;
+    stageNumber?: number | null;
+  };
+}
+
+function renderScreen(options: RenderOptions = {}, navOverride?: NavMock) {
+  const navigation = navOverride ?? makeNav();
+  const route = {
+    key: 'k',
+    name: 'CreatePractice' as const,
+    params: options.prefill ? { prefill: options.prefill } : undefined,
+  };
+  const Screen = CreatePracticeWizard as unknown as React.ComponentType<{
+    navigation: NavMock;
+    route: typeof route;
+  }>;
+  const view = render(<Screen navigation={navigation} route={route} />);
+  return { view, navigation };
+}
+
+const flushPromises = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('CreatePracticeWizard — step navigation', () => {
+  beforeEach(() => {
+    mockPracticesCreate.mockReset();
+    mockUserPracticesCreate.mockReset();
+  });
+
+  it('opens on the entry step with two start options', () => {
+    const { view } = renderScreen();
+    expect(view.getByTestId('create-practice-step-entry')).toBeTruthy();
+    expect(view.getByTestId('create-practice-from-preset')).toBeTruthy();
+    expect(view.getByTestId('create-practice-from-scratch')).toBeTruthy();
+  });
+
+  it('start-from-scratch advances to the mode picker', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    expect(view.getByTestId('create-practice-step-mode')).toBeTruthy();
+    expect(view.getByTestId('mode-picker')).toBeTruthy();
+  });
+
+  it('start-from-preset routes the user back to the catalog via goBack', () => {
+    const nav = makeNav();
+    const { view } = renderScreen({}, nav);
+    fireEvent.press(view.getByTestId('create-practice-from-preset'));
+    expect(nav.goBack).toHaveBeenCalled();
+  });
+
+  it('back from the mode picker returns to the entry step', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('create-practice-back'));
+    expect(view.getByTestId('create-practice-step-entry')).toBeTruthy();
+  });
+});
+
+describe('CreatePracticeWizard — mode → configure dispatch', () => {
+  it('routes random_interval_bell to its form with smart defaults', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-random_interval_bell'));
+    expect(view.getByTestId('create-practice-step-configure')).toBeTruthy();
+    expect(view.getByTestId('random-interval-bell-form')).toBeTruthy();
+    expect(view.getByTestId('random-interval-bell-duration').props.value).toBe('20');
+  });
+
+  it('routes meditation_timer to its own form', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    expect(view.getByTestId('meditation-timer-form')).toBeTruthy();
+  });
+
+  it('shows a coming-soon notice for mindful_anchor', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-mindful_anchor'));
+    expect(view.getByTestId('create-practice-configure-unsupported')).toBeTruthy();
+  });
+
+  it('renders a defaults-only notice for tallied_grounding', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-tallied_grounding'));
+    expect(view.getByTestId('create-practice-configure-tallied')).toBeTruthy();
+  });
+});
+
+describe('CreatePracticeWizard — metadata + submit', () => {
+  beforeEach(() => {
+    mockPracticesCreate.mockReset();
+    mockUserPracticesCreate.mockReset();
+  });
+
+  it('disables submit until a name is entered', async () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    const submit = view.getByTestId('create-practice-submit');
+    expect(submit.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('submits practice + user-practice when a stage is selected', async () => {
+    mockPracticesCreate.mockResolvedValueOnce(createdPractice);
+    mockUserPracticesCreate.mockResolvedValueOnce(createdUserPractice);
+    const nav = makeNav();
+    const { view } = renderScreen({}, nav);
+
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-random_interval_bell'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    fireEvent.changeText(view.getByTestId('create-practice-name'), 'Awareness bells');
+    fireEvent.press(view.getByTestId('create-practice-stage-4'));
+
+    await act(async () => {
+      fireEvent.press(view.getByTestId('create-practice-submit'));
+      await flushPromises();
+    });
+
+    expect(mockPracticesCreate).toHaveBeenCalledTimes(1);
+    const payload = mockPracticesCreate.mock.calls[0]?.[0];
+    expect(payload?.name).toBe('Awareness bells');
+    expect(payload?.stage_number).toBe(4);
+    expect(payload?.mode).toBe('random_interval_bell');
+    expect(payload?.mode_config).toEqual(
+      expect.objectContaining({ mode: 'random_interval_bell', duration_minutes: 20 }),
+    );
+    expect(mockUserPracticesCreate).toHaveBeenCalledWith({
+      practice_id: 501,
+      stage_number: 4,
+    });
+    expect(nav.replace).toHaveBeenCalledWith('PracticeDetail', { practiceId: 501 });
+  });
+
+  it('skips the user-practice call when the stage is left as "Skip"', async () => {
+    mockPracticesCreate.mockResolvedValueOnce(createdPractice);
+    const { view } = renderScreen();
+
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    fireEvent.changeText(view.getByTestId('create-practice-name'), 'Quiet sit');
+
+    await act(async () => {
+      fireEvent.press(view.getByTestId('create-practice-submit'));
+      await flushPromises();
+    });
+
+    expect(mockPracticesCreate).toHaveBeenCalledTimes(1);
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an API error when the create call fails', async () => {
+    mockPracticesCreate.mockRejectedValueOnce(new Error('boom'));
+    const { view } = renderScreen();
+
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    fireEvent.changeText(view.getByTestId('create-practice-name'), 'Quiet sit');
+
+    await act(async () => {
+      fireEvent.press(view.getByTestId('create-practice-submit'));
+      await flushPromises();
+    });
+
+    expect(view.getByTestId('create-practice-api-error')).toBeTruthy();
+  });
+});
+
+describe('CreatePracticeWizard — prefill mode', () => {
+  it('opens directly on the configurator when a prefill arrives', () => {
+    const { view } = renderScreen({
+      prefill: {
+        config: {
+          mode: 'random_interval_bell',
+          duration_minutes: 25,
+          min_interval_seconds: 30,
+          max_interval_seconds: 90,
+          bell_tone: 'chime',
+        },
+        name: 'Copy of awareness bells',
+        duration: 25,
+      },
+    });
+    expect(view.getByTestId('create-practice-step-configure')).toBeTruthy();
+    expect(view.getByTestId('random-interval-bell-duration').props.value).toBe('25');
+  });
+});
+
+describe('CreatePracticeWizard — configurator dispatch (smoke)', () => {
+  it.each([
+    ['count_up', 'count-up-form'],
+    ['metronome', 'metronome-form'],
+    ['interval_bell', 'interval-bell-form'],
+    ['rep_counter', 'rep-counter-form'],
+    ['sense_grounding', 'sense-grounding-form'],
+    ['tarot', 'tarot-form'],
+    ['card_meditation', 'card-meditation-form'],
+  ])('routes %s to its existing form (%s)', (mode, formTestId) => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId(`mode-picker-mode-${mode}`));
+    expect(view.getByTestId(formTestId)).toBeTruthy();
+  });
+});
+
+describe('CreatePracticeWizard — metadata fields + nav', () => {
+  it('updates description and instructions independently', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    fireEvent.changeText(view.getByTestId('create-practice-description'), 'A short sit.');
+    fireEvent.changeText(view.getByTestId('create-practice-instructions'), 'Sit.');
+    expect(view.getByTestId('create-practice-description').props.value).toBe('A short sit.');
+    expect(view.getByTestId('create-practice-instructions').props.value).toBe('Sit.');
+  });
+
+  it('strips non-numeric characters when parsing duration', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    fireEvent.changeText(view.getByTestId('create-practice-duration'), 'abc');
+    expect(view.getByTestId('create-practice-duration').props.value).toBe('');
+    fireEvent.changeText(view.getByTestId('create-practice-duration'), '12a');
+    expect(view.getByTestId('create-practice-duration').props.value).toBe('12');
+  });
+
+  it('lets the user step back from metadata to the configurator', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    fireEvent.press(view.getByTestId('create-practice-back'));
+    expect(view.getByTestId('create-practice-step-configure')).toBeTruthy();
+  });
+
+  it('lets the user override the auto-suggested duration', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    // Smart default was filled in from the mode default — user can still tweak.
+    fireEvent.changeText(view.getByTestId('create-practice-duration'), '45');
+    expect(view.getByTestId('create-practice-duration').props.value).toBe('45');
+  });
+
+  it('threads config edits from the form back into the wizard state', async () => {
+    mockPracticesCreate.mockResolvedValueOnce(createdPractice);
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    fireEvent.changeText(view.getByTestId('meditation-timer-duration'), '17');
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    fireEvent.changeText(view.getByTestId('create-practice-name'), 'Tweaked sit');
+    await act(async () => {
+      fireEvent.press(view.getByTestId('create-practice-submit'));
+      await flushPromises();
+    });
+    const payload = mockPracticesCreate.mock.calls[0]?.[0];
+    expect(payload?.mode_config).toEqual(
+      expect.objectContaining({ mode: 'meditation_timer', duration_minutes: 17 }),
+    );
+  });
+
+  it('selecting Skip clears any previously chosen stage', () => {
+    const { view } = renderScreen();
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-meditation_timer'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    fireEvent.press(view.getByTestId('create-practice-stage-5'));
+    expect(view.getByTestId('create-practice-stage-5').props.accessibilityState?.selected).toBe(
+      true,
+    );
+    fireEvent.press(view.getByTestId('create-practice-stage-skip'));
+    expect(view.getByTestId('create-practice-stage-skip').props.accessibilityState?.selected).toBe(
+      true,
+    );
+    expect(view.getByTestId('create-practice-stage-5').props.accessibilityState?.selected).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -1,0 +1,229 @@
+/* eslint-env jest */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { PracticeItem } from '@/api';
+
+const presetA: PracticeItem = {
+  id: 1,
+  stage_number: 1,
+  name: 'Concentration on the breath',
+  description: 'Anchor in the breath cycle.',
+  instructions: '',
+  default_duration_minutes: 10,
+  submitted_by_user_id: null,
+  approved: true,
+  mode: 'meditation_timer',
+  mode_config: { mode: 'meditation_timer', duration_minutes: 10 },
+};
+
+const presetB: PracticeItem = {
+  id: 2,
+  stage_number: 1,
+  name: 'Awareness bells preset',
+  description: 'A random-bell session.',
+  instructions: '',
+  default_duration_minutes: 20,
+  submitted_by_user_id: null,
+  approved: true,
+  mode: 'random_interval_bell',
+  mode_config: {
+    mode: 'random_interval_bell',
+    duration_minutes: 20,
+    min_interval_seconds: 30,
+    max_interval_seconds: 180,
+    bell_tone: 'bowl',
+  },
+};
+
+const myDraft: PracticeItem = {
+  id: 9,
+  stage_number: 1,
+  name: 'My private bells',
+  description: 'Customized random bell.',
+  instructions: '',
+  default_duration_minutes: 15,
+  submitted_by_user_id: 42,
+  approved: false,
+  mode: 'random_interval_bell',
+  mode_config: {
+    mode: 'random_interval_bell',
+    duration_minutes: 15,
+    min_interval_seconds: 20,
+    max_interval_seconds: 60,
+    bell_tone: 'chime',
+  },
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => mockNavigation,
+}));
+
+const mockNavigation = { navigate: jest.fn() as jest.Mock<(...args: unknown[]) => void> };
+
+const mockPracticesList = jest.fn() as jest.MockedFunction<
+  (opts: { stageNumber: number; includeMine?: boolean }) => Promise<PracticeItem[]>
+>;
+
+jest.mock('@/api', () => ({
+  practices: {
+    list: (...args: unknown[]) =>
+      (mockPracticesList as unknown as (...a: unknown[]) => Promise<PracticeItem[]>)(...args),
+  },
+}));
+
+const { PracticeCatalogScreen } = require('../PracticeCatalogScreen');
+
+function renderScreen(overrides: Partial<React.ComponentProps<typeof PracticeCatalogScreen>> = {}) {
+  const loadPractices = jest.fn(async () => [presetA, presetB, myDraft]) as jest.MockedFunction<
+    (_stage: number) => Promise<PracticeItem[]>
+  >;
+  const navigateToDetail = jest.fn();
+  const navigateToCreate = jest.fn();
+  const view = render(
+    <PracticeCatalogScreen
+      initialStage={1}
+      loadPractices={loadPractices}
+      navigateToDetail={navigateToDetail}
+      navigateToCreate={navigateToCreate}
+      {...overrides}
+    />,
+  );
+  return { view, loadPractices, navigateToDetail, navigateToCreate };
+}
+
+const flushPromises = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+async function waitForLoad() {
+  await act(async () => {
+    await flushPromises();
+  });
+}
+
+describe('PracticeCatalogScreen — sections', () => {
+  it('buckets approved practices under Presets and unapproved under My drafts', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    const presets = view.getByTestId('practice-catalog-section-presets');
+    const drafts = view.getByTestId('practice-catalog-section-drafts');
+    expect(presets).toBeTruthy();
+    expect(drafts).toBeTruthy();
+    expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
+    expect(view.getByTestId('practice-catalog-row-9')).toBeTruthy();
+  });
+
+  it('renders an empty Imported section because no share-token signal exists yet', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.getByTestId('practice-catalog-section-imported-empty')).toBeTruthy();
+  });
+
+  it('shows a + Create button that fires the navigate callback', async () => {
+    const { view, navigateToCreate } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-create'));
+    expect(navigateToCreate).toHaveBeenCalled();
+  });
+
+  it('opens the detail screen when a row is tapped', async () => {
+    const { view, navigateToDetail } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-row-2'));
+    expect(navigateToDetail).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('PracticeCatalogScreen — filters', () => {
+  it('filters by name with the search bar', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    fireEvent.changeText(view.getByTestId('practice-catalog-search'), 'awareness');
+    expect(view.queryByTestId('practice-catalog-row-1')).toBeNull();
+    expect(view.getByTestId('practice-catalog-row-2')).toBeTruthy();
+  });
+
+  it('filters by mode category chip', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-mode-bells'));
+    expect(view.queryByTestId('practice-catalog-row-1')).toBeNull();
+    expect(view.getByTestId('practice-catalog-row-2')).toBeTruthy();
+  });
+
+  it('clears the mode category filter when All is tapped', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-mode-bells'));
+    expect(view.queryByTestId('practice-catalog-row-1')).toBeNull();
+    fireEvent.press(view.getByTestId('practice-catalog-mode-all'));
+    expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
+    expect(view.getByTestId('practice-catalog-row-2')).toBeTruthy();
+  });
+
+  it('refetches with the new stage when the stage chip changes', async () => {
+    const { view, loadPractices } = renderScreen();
+    await waitForLoad();
+    loadPractices.mockClear();
+    loadPractices.mockResolvedValueOnce([]);
+    fireEvent.press(view.getByTestId('practice-catalog-stage-4'));
+    await waitForLoad();
+    expect(loadPractices).toHaveBeenCalledWith(4);
+  });
+});
+
+describe('PracticeCatalogScreen — error state', () => {
+  it('renders the error block + retry button when loading fails', async () => {
+    const loadPractices = jest.fn(async () => {
+      throw new Error('nope');
+    }) as jest.MockedFunction<(_stage: number) => Promise<PracticeItem[]>>;
+    const { view } = renderScreen({ loadPractices });
+    await waitForLoad();
+    expect(view.getByTestId('practice-catalog-error')).toBeTruthy();
+    loadPractices.mockResolvedValueOnce([presetA]);
+    fireEvent.press(view.getByTestId('practice-catalog-retry'));
+    await waitForLoad();
+    expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
+  });
+});
+
+describe('PracticeCatalogScreen — defaults wiring', () => {
+  beforeEach(() => {
+    mockPracticesList.mockReset();
+    mockNavigation.navigate.mockReset();
+  });
+
+  it('calls practices.list with includeMine when no override is provided', async () => {
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    render(<PracticeCatalogScreen initialStage={3} />);
+    await waitForLoad();
+    expect(mockPracticesList).toHaveBeenCalledWith({ stageNumber: 3, includeMine: true });
+  });
+
+  it('navigates to PracticeDetail when a row is tapped without an override', async () => {
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    const view = render(<PracticeCatalogScreen initialStage={1} />);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-row-1'));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('PracticeDetail', { practiceId: 1 });
+  });
+
+  it('navigates to CreatePractice when + Create is tapped without an override', async () => {
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    const view = render(<PracticeCatalogScreen initialStage={1} />);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-create'));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('CreatePractice');
+  });
+
+  it('falls back to meditation_timer when a row has no mode field set', async () => {
+    const legacy: PracticeItem = { ...presetA, mode: undefined, mode_config: undefined };
+    mockPracticesList.mockResolvedValueOnce([legacy]);
+    const view = render(<PracticeCatalogScreen initialStage={1} />);
+    await waitForLoad();
+    expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
+    // Filtering by Timers should keep this row visible — the fallback maps it to meditation_timer.
+    fireEvent.press(view.getByTestId('practice-catalog-mode-timers'));
+    expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -1,0 +1,260 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { PracticeItem, UserPractice } from '@/api';
+
+const samplePractice: PracticeItem = {
+  id: 77,
+  stage_number: 4,
+  name: 'Forest grounding',
+  description: 'A 5-minute reset under canopy.',
+  instructions: 'Find a tree, place a palm on the bark, breathe.',
+  default_duration_minutes: 5,
+  submitted_by_user_id: null,
+  approved: true,
+  mode: 'random_interval_bell',
+  mode_config: {
+    mode: 'random_interval_bell',
+    duration_minutes: 5,
+    min_interval_seconds: 10,
+    max_interval_seconds: 30,
+    bell_tone: 'bowl',
+  },
+};
+
+const assignedUserPractice: UserPractice = {
+  id: 1,
+  user_id: 9,
+  practice_id: 77,
+  stage_number: 4,
+  start_date: '2026-05-23',
+  end_date: null,
+};
+
+const mockPracticesGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<PracticeItem>>;
+const mockUserPracticesCreate = jest.fn() as jest.MockedFunction<
+  (payload: { practice_id: number; stage_number: number }) => Promise<UserPractice>
+>;
+
+jest.mock('@/api', () => ({
+  practices: {
+    get: (...args: unknown[]) =>
+      (mockPracticesGet as unknown as (...a: unknown[]) => Promise<PracticeItem>)(...args),
+  },
+  userPractices: {
+    create: (...args: unknown[]) =>
+      (mockUserPracticesCreate as unknown as (...a: unknown[]) => Promise<UserPractice>)(...args),
+  },
+}));
+
+const { PracticeDetailScreen } = require('../PracticeDetailScreen');
+
+interface NavMock {
+  goBack: jest.Mock<() => void>;
+  replace: jest.Mock<(...args: unknown[]) => void>;
+  navigate: jest.Mock<(...args: unknown[]) => void>;
+}
+
+function makeNav(): NavMock {
+  return {
+    goBack: jest.fn() as jest.Mock<() => void>,
+    replace: jest.fn() as jest.Mock<(...args: unknown[]) => void>,
+    navigate: jest.fn() as jest.Mock<(...args: unknown[]) => void>,
+  };
+}
+
+function renderScreen(practiceId = 77, navOverride?: NavMock) {
+  const navigation = navOverride ?? makeNav();
+  const route = {
+    key: 'k',
+    name: 'PracticeDetail' as const,
+    params: { practiceId },
+  };
+  const Screen = PracticeDetailScreen as unknown as React.ComponentType<{
+    navigation: NavMock;
+    route: typeof route;
+  }>;
+  const view = render(<Screen navigation={navigation} route={route} />);
+  return { view, navigation };
+}
+
+const flushPromises = () => new Promise<void>((resolve) => setImmediate(resolve));
+async function waitForLoad() {
+  await act(async () => {
+    await flushPromises();
+  });
+}
+
+describe('PracticeDetailScreen — read-only summary', () => {
+  beforeEach(() => {
+    mockPracticesGet.mockReset();
+    mockUserPracticesCreate.mockReset();
+  });
+
+  it('renders the practice name, mode badge, stage badge, and description', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.getByTestId('practice-detail-name').props.children).toBe('Forest grounding');
+    expect(view.getByTestId('practice-detail-description')).toBeTruthy();
+    expect(view.getByTestId('practice-detail-instructions')).toBeTruthy();
+    expect(view.getByTestId('practice-detail-mode-badge')).toBeTruthy();
+    expect(view.getByTestId('practice-detail-stage-badge')).toBeTruthy();
+  });
+
+  it('renders a per-mode config summary block', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.getByTestId('practice-detail-config-summary')).toBeTruthy();
+  });
+
+  it('surfaces a load error with retry', async () => {
+    mockPracticesGet.mockRejectedValueOnce(new Error('boom'));
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.getByTestId('practice-detail-error')).toBeTruthy();
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    fireEvent.press(view.getByTestId('practice-detail-retry'));
+    await waitForLoad();
+    expect(view.getByTestId('practice-detail-screen')).toBeTruthy();
+  });
+});
+
+describe('PracticeDetailScreen — Use for stage', () => {
+  beforeEach(() => {
+    mockPracticesGet.mockReset();
+    mockUserPracticesCreate.mockReset();
+  });
+
+  it('opens the stage picker and writes via userPractices.create on pick', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
+    const { view } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-use-for-stage'));
+    expect(view.getByTestId('practice-detail-stage-picker')).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(view.getByTestId('practice-detail-stage-pick-4'));
+      await flushPromises();
+    });
+    expect(mockUserPracticesCreate).toHaveBeenCalledWith({
+      practice_id: 77,
+      stage_number: 4,
+    });
+    expect(view.getByTestId('practice-detail-assigned-banner')).toBeTruthy();
+  });
+
+  it('surfaces an action error if assignment fails', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    mockUserPracticesCreate.mockRejectedValueOnce(new Error('nope'));
+    const { view } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-use-for-stage'));
+    await act(async () => {
+      fireEvent.press(view.getByTestId('practice-detail-stage-pick-2'));
+      await flushPromises();
+    });
+    expect(view.getByTestId('practice-detail-action-error')).toBeTruthy();
+  });
+});
+
+describe('PracticeDetailScreen — Customize a copy', () => {
+  it('navigates to CreatePractice with this practice prefilled', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const nav = makeNav();
+    const { view } = renderScreen(77, nav);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-customize-copy'));
+    expect(nav.navigate).toHaveBeenCalledWith(
+      'CreatePractice',
+      expect.objectContaining({
+        prefill: expect.objectContaining({
+          config: samplePractice.mode_config,
+          name: 'Forest grounding (copy)',
+          duration: 5,
+          stageNumber: 4,
+        }),
+      }),
+    );
+  });
+
+  it('is disabled and silent when the practice has no mode_config', async () => {
+    const noConfig: PracticeItem = { ...samplePractice, mode_config: undefined };
+    mockPracticesGet.mockResolvedValueOnce(noConfig);
+    const nav = makeNav();
+    const { view } = renderScreen(77, nav);
+    await waitForLoad();
+    const button = view.getByTestId('practice-detail-customize-copy');
+    expect(button.props.accessibilityState?.disabled).toBe(true);
+    fireEvent.press(button);
+    expect(nav.navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('PracticeDetailScreen — stage picker cancel', () => {
+  it('closes the stage picker without writing when Cancel is tapped', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const { view } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-use-for-stage'));
+    expect(view.getByTestId('practice-detail-stage-picker')).toBeTruthy();
+    fireEvent.press(view.getByTestId('practice-detail-stage-pick-cancel'));
+    expect(view.queryByTestId('practice-detail-stage-picker')).toBeNull();
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('PracticeDetailScreen — config summary variants', () => {
+  it.each([
+    [{ mode: 'meditation_timer', duration_minutes: 10 } as const],
+    [{ mode: 'count_up' } as const],
+    [{ mode: 'count_up', soft_cap_minutes: 20 } as const],
+    [
+      {
+        mode: 'metronome',
+        bpm: 60,
+        timer: { mode: 'meditation_timer', duration_minutes: 10 },
+      } as const,
+    ],
+    [
+      {
+        mode: 'interval_bell',
+        duration_minutes: 20,
+        interval_minutes: 5,
+        bell_tone: 'bowl',
+      } as const,
+    ],
+    [
+      {
+        mode: 'interval_bell',
+        duration_minutes: 20,
+        cue_offsets_minutes: [2, 7, 15],
+        bell_tone: 'bowl',
+      } as const,
+    ],
+    [{ mode: 'rep_counter', target_reps: 12, unit_label: 'reps' } as const],
+    [
+      {
+        mode: 'sense_grounding',
+        prompts: [{ sense: 'sight', label: 'blue' }],
+      } as const,
+    ],
+    [
+      {
+        mode: 'tallied_grounding',
+        rounds: 2,
+        categories: [{ key: 'c', label: 'a circle', target_count: 3 }],
+      } as const,
+    ],
+    [{ mode: 'tarot', deck: 'major_arcana' } as const],
+    [{ mode: 'card_meditation', deck_id: 'rws' } as const],
+  ])('summarises %p', async (config) => {
+    mockPracticesGet.mockResolvedValueOnce({ ...samplePractice, mode_config: config });
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.getByTestId('practice-detail-config-summary')).toBeTruthy();
+  });
+});

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -7,6 +7,7 @@ import {
   BookOpen,
   Compass,
   Flower2,
+  LayoutGrid,
   NotebookPen,
   Sprout,
   type LucideIcon,
@@ -22,6 +23,7 @@ import HabitsScreen from '../features/Habits/HabitsScreen';
 import JournalScreen from '../features/Journal/JournalScreen';
 import MapScreen from '../features/Map/MapScreen';
 import PracticeScreen from '../features/Practice/PracticeScreen';
+import { PracticeCatalogScreen } from '../features/Practice/screens/PracticeCatalogScreen';
 
 import type { RootStackParamList } from './RootStack';
 
@@ -30,6 +32,7 @@ import { useAuth } from '@/context/AuthContext';
 export type RootTabParamList = {
   Habits: undefined;
   Practice: { stageNumber?: number } | undefined;
+  Catalog: undefined;
   Course: { stageNumber?: number } | undefined;
   Journal:
     | {
@@ -66,6 +69,7 @@ function withBoundary<P extends object>(
 
 const HabitsTab = withBoundary('Habits', HabitsScreen);
 const PracticeTab = withBoundary('Practice', PracticeScreen);
+const CatalogTab = withBoundary('Catalog', PracticeCatalogScreen);
 const CourseTab = withBoundary('Course', CourseScreen);
 const JournalTab = withBoundary('Journal', JournalScreen);
 const MapTab = withBoundary('Map', MapScreen);
@@ -87,6 +91,7 @@ const TAB_CONFIGS: ReadonlyArray<{
 }> = [
   { name: 'Habits', component: HabitsTab, icon: Sprout },
   { name: 'Practice', component: PracticeTab, icon: Flower2 },
+  { name: 'Catalog', component: CatalogTab, icon: LayoutGrid },
   { name: 'Course', component: CourseTab, icon: BookOpen },
   { name: 'Journal', component: JournalTab, icon: NotebookPen },
   { name: 'Map', component: MapTab, icon: Compass },

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -2,11 +2,15 @@ import type { NavigatorScreenParams } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 
+import { CreatePracticeWizard } from '../features/Practice/screens/CreatePracticeWizard';
+import { PracticeDetailScreen } from '../features/Practice/screens/PracticeDetailScreen';
 import SharePreviewScreen from '../features/Practice/screens/SharePreviewScreen';
 import ApiKeySettingsScreen from '../features/Settings/ApiKeySettingsScreen';
 
 import type { RootTabParamList } from './BottomTabs';
 import BottomTabs from './BottomTabs';
+
+import type { ModeConfig } from '@/features/Practice/engine/types';
 
 /**
  * Root stack for the authenticated app. Hosts the bottom-tabs shell plus
@@ -20,10 +24,21 @@ import BottomTabs from './BottomTabs';
  * import -- can pass ``{ screen, params }`` through ``navigation.navigate``
  * with full type safety.
  */
+export interface CreatePracticePrefill {
+  config: ModeConfig;
+  name?: string;
+  description?: string;
+  instructions?: string;
+  duration?: number;
+  stageNumber?: number | null;
+}
+
 export type RootStackParamList = {
   Tabs: NavigatorScreenParams<RootTabParamList>;
   ApiKeySettings: undefined;
   SharePreview: { token: string };
+  PracticeDetail: { practiceId: number };
+  CreatePractice: { prefill?: CreatePracticePrefill } | undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -40,6 +55,16 @@ const RootStack = (): React.JSX.Element => (
       name="SharePreview"
       component={SharePreviewScreen}
       options={{ title: 'Shared practice' }}
+    />
+    <Stack.Screen
+      name="PracticeDetail"
+      component={PracticeDetailScreen}
+      options={{ title: 'Practice' }}
+    />
+    <Stack.Screen
+      name="CreatePractice"
+      component={CreatePracticeWizard}
+      options={{ title: 'New practice' }}
     />
   </Stack.Navigator>
 );


### PR DESCRIPTION
Closes #352. Adds the global Practice catalog and the four-step
create-custom flow that funnels into it, applying every UX guard-rail
from the issue to keep 11 modes from collapsing into bloat.

Frontend:
- ``PracticeCatalogScreen`` — top-level browse surface with search,
  stage chips, mode-category chips, and Presets / My drafts / Imported
  sections. Reachable via a new ``Catalog`` bottom-tab.
- ``PracticeDetailScreen`` — read-only summary with mode-aware bullets
  plus "Use for stage…" and "Customize a copy" actions.
- ``CreatePracticeWizard`` — entry → mode → configure → metadata.
  Reuses every existing per-mode form via a dispatch table; falls back
  to a "configurator coming soon" notice for tallied_grounding and
  mindful_anchor while preserving smart-default submission.
- ``ModePicker`` — categorized cards (Timers/Bells/Grounding/
  Reflection/Movement), radio-like rows, "New" tag on the four most
  recent modes.
- ``defaults.ts`` — smart, server-valid defaults for every mode plus
  a duration auto-suggester for the metadata step.
- Wires ``PracticeDetail`` and ``CreatePractice`` into ``RootStack``.

Backend:
- ``GET /practices/?include_mine=true`` (custom-practices-07) folds
  the caller's own unapproved drafts into the catalog listing so the
  "My drafts" section is populated without leaking other users' rows.

Tests: 1667 passing (catalog filters + sections, wizard step nav and
submit, detail use-for-stage + customize-copy, mode picker radio +
"New" tag, defaults validity, backend include_mine isolation).