### PR TITLE
fix(habits): repair stats charts data alignment + light-theme styling

### DIFF
--- a/backend/src/domain/habit_stats.py
+++ b/backend/src/domain/habit_stats.py
@@ -32,18 +32,18 @@ def _aggregate_by_day(
     completions: list[GoalCompletion],
     user_timezone: str,
 ) -> tuple[list[float], list[int], set[date]]:
-    """Sum units per JS weekday in user-local time; returns dates as ``date`` objects."""
+    """Sum units + count events per JS weekday; returns dates as ``date`` objects."""
     units = [0.0] * _DAYS_IN_WEEK
-    presence = [0] * _DAYS_IN_WEEK
+    counts = [0] * _DAYS_IN_WEEK
     dates: set[date] = set()
     for c in completions:
         moment = c.timestamp if c.timestamp.tzinfo is not None else c.timestamp.replace(tzinfo=UTC)
         local_date = to_user_date(user_timezone, moment)
         js_idx = (local_date.weekday() + 1) % _DAYS_IN_WEEK
         units[js_idx] += c.completed_units
-        presence[js_idx] = 1
+        counts[js_idx] += 1
         dates.add(local_date)
-    return units, presence, dates
+    return units, counts, dates
 
 
 def _longest_streak(sorted_dates: list[date]) -> int:
@@ -93,13 +93,13 @@ def compute_habit_stats(
     if not completions:
         return _empty_stats()
 
-    units, presence, dates = _aggregate_by_day(completions, user_timezone)
+    units, counts, dates = _aggregate_by_day(completions, user_timezone)
     sorted_dates = sorted(dates)
 
     return HabitStats(
         day_labels=list(_DAY_LABELS),
         values=units,
-        completions_by_day=presence,
+        completions_by_day=counts,
         longest_streak=_longest_streak(sorted_dates),
         current_streak=_current_streak(sorted_dates, user_timezone),
         total_completions=len(completions),

--- a/backend/tests/test_habit_stats_api.py
+++ b/backend/tests/test_habit_stats_api.py
@@ -16,6 +16,8 @@ from models.goal_completion import GoalCompletion
 DAYS_IN_WEEK = 7
 EXPECTED_MONDAY_UNITS = 3.0  # 2.0 + 1.0 from two completions
 EXPECTED_WEDNESDAY_UNITS = 3.0
+EXPECTED_MONDAY_COMPLETIONS = 2  # two completions logged Monday
+EXPECTED_WEDNESDAY_COMPLETIONS = 1
 EXPECTED_COMPLETIONS_3_ENTRIES = 3
 EXPECTED_LONGEST_STREAK_3 = 3
 EXPECTED_COMPLETIONS_5_ENTRIES = 5
@@ -198,10 +200,10 @@ async def test_stats_aggregates_completions_by_day_of_week(
     # Monday=index 1, Wednesday=index 3
     assert data["values"][1] == EXPECTED_MONDAY_UNITS  # 2+1
     assert data["values"][3] == EXPECTED_WEDNESDAY_UNITS
-    # completions_by_day: 1 if any completion that weekday, else 0
-    assert data["completions_by_day"][1] == 1
+    # completions_by_day counts completion events per weekday (Sun..Sat).
+    assert data["completions_by_day"][1] == EXPECTED_MONDAY_COMPLETIONS
     assert data["completions_by_day"][2] == 0
-    assert data["completions_by_day"][3] == 1
+    assert data["completions_by_day"][3] == EXPECTED_WEDNESDAY_COMPLETIONS
 
 
 @pytest.mark.asyncio

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -304,29 +304,14 @@ export const darkColors = {
   border: '#2f2f2f',
 } as const;
 
-/**
- * Chart styling for ``react-native-chart-kit``. The library expects
- * functions (not static colors) because it bakes the caller-supplied
- * opacity into stroke / fill / label paints. Keep the surface light to
- * match the surrounding card and the rest of the Habits UI -- the
- * dark-green palette the library ships with reads as a foreign panel
- * when dropped into a white modal.
- *
- * ``axisLabel`` is sourced from ``colors.text.secondaryAccessible`` so
- * tick labels clear WCAG AA on the chart's white background. The chart
- * lives inside a ``card`` surface (not ``primary``), so the slight
- * extra contrast vs. plain ``secondary`` keeps the labels readable
- * without bleeding into the title.
- */
-export const CHART_AXIS_LABEL_COLOR = '#555555'; // colors.text.secondaryAccessible
+/** WCAG-AA on the white modal card: #555 = 7.22:1 on #ffffff (AAA normal). */
+export const CHART_AXIS_LABEL_COLOR = '#555555';
 
 export const CHART_STYLE = {
-  /** Background gradient -- transparent so the modal's white card shows through. */
   backgroundGradientFrom: '#ffffff',
   backgroundGradientFromOpacity: 0,
   backgroundGradientTo: '#ffffff',
   backgroundGradientToOpacity: 0,
-  /** Grid + axis-line color is a low-opacity dark; labels use secondaryAccessible. */
   axisLineOpacity: 0.15,
 } as const;
 

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -304,6 +304,32 @@ export const darkColors = {
   border: '#2f2f2f',
 } as const;
 
+/**
+ * Chart styling for ``react-native-chart-kit``. The library expects
+ * functions (not static colors) because it bakes the caller-supplied
+ * opacity into stroke / fill / label paints. Keep the surface light to
+ * match the surrounding card and the rest of the Habits UI -- the
+ * dark-green palette the library ships with reads as a foreign panel
+ * when dropped into a white modal.
+ *
+ * ``axisLabel`` is sourced from ``colors.text.secondaryAccessible`` so
+ * tick labels clear WCAG AA on the chart's white background. The chart
+ * lives inside a ``card`` surface (not ``primary``), so the slight
+ * extra contrast vs. plain ``secondary`` keeps the labels readable
+ * without bleeding into the title.
+ */
+export const CHART_AXIS_LABEL_COLOR = '#555555'; // colors.text.secondaryAccessible
+
+export const CHART_STYLE = {
+  /** Background gradient -- transparent so the modal's white card shows through. */
+  backgroundGradientFrom: '#ffffff',
+  backgroundGradientFromOpacity: 0,
+  backgroundGradientTo: '#ffffff',
+  backgroundGradientToOpacity: 0,
+  /** Grid + axis-line color is a low-opacity dark; labels use secondaryAccessible. */
+  axisLineOpacity: 0.15,
+} as const;
+
 export const breakpoints = { xs: 0, sm: 360, md: 600, lg: 900, xl: 1200 } as const;
 
 export const elevation = {

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -292,7 +292,6 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const DAYS_IN_WEEK = 7;
 
 const emptyStats = (): HabitStatsData => ({
-  dates: DAY_LABELS,
   values: new Array(DAYS_IN_WEEK).fill(0) as number[],
   completionsByDay: new Array(DAYS_IN_WEEK).fill(0) as number[],
   dayLabels: DAY_LABELS,
@@ -404,7 +403,6 @@ export const generateStatsForHabit = (
     .sort((a, b) => a.getTime() - b.getTime());
 
   return {
-    dates: DAY_LABELS,
     values: unitsByDay,
     completionsByDay: countsByDay,
     dayLabels: DAY_LABELS,
@@ -420,7 +418,6 @@ export const generateStatsForHabit = (
  * Convert an API habit stats response (snake_case) to local HabitStatsData (camelCase).
  */
 export const toLocalHabitStats = (api: ApiHabitStats): HabitStatsData => ({
-  dates: api.day_labels,
   values: api.values,
   completionsByDay: api.completions_by_day,
   dayLabels: api.day_labels,

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -323,7 +323,7 @@ const utcDayKey = (d: Date): string => dayKeyInTZ(d, DEFAULT_TIMEZONE);
  */
 const aggregateByDayOfWeek = (completions: Completion[], tz: string) => {
   const unitsByDay = new Array(DAYS_IN_WEEK).fill(0) as number[];
-  const presenceByDay = new Array(DAYS_IN_WEEK).fill(0) as number[];
+  const countsByDay = new Array(DAYS_IN_WEEK).fill(0) as number[];
   const daysWithCompletions = new Set<string>();
 
   for (const c of completions) {
@@ -332,11 +332,11 @@ const aggregateByDayOfWeek = (completions: Completion[], tz: string) => {
     const localDate = new Date(`${localDayKey}T12:00:00Z`);
     const dayIdx = localDate.getUTCDay() % DAYS_IN_WEEK;
     unitsByDay[dayIdx] = unitsByDay[dayIdx]! + c.completed_units;
-    presenceByDay[dayIdx] = 1;
+    countsByDay[dayIdx] = countsByDay[dayIdx]! + 1;
     daysWithCompletions.add(localDayKey);
   }
 
-  return { unitsByDay, presenceByDay, daysWithCompletions };
+  return { unitsByDay, countsByDay, daysWithCompletions };
 };
 
 const computeLongestStreak = (sortedDays: Date[]): number => {
@@ -397,7 +397,7 @@ export const generateStatsForHabit = (
   const completions = habit.completions;
   if (!completions || completions.length === 0) return emptyStats();
 
-  const { unitsByDay, presenceByDay, daysWithCompletions } = aggregateByDayOfWeek(completions, tz);
+  const { unitsByDay, countsByDay, daysWithCompletions } = aggregateByDayOfWeek(completions, tz);
 
   const sortedDays = Array.from(daysWithCompletions)
     .map((s) => new Date(s + 'T00:00:00Z'))
@@ -406,7 +406,7 @@ export const generateStatsForHabit = (
   return {
     dates: DAY_LABELS,
     values: unitsByDay,
-    completionsByDay: presenceByDay,
+    completionsByDay: countsByDay,
     dayLabels: DAY_LABELS,
     longestStreak: computeLongestStreak(sortedDays),
     currentStreak: computeCurrentStreak(completions, tz),

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -75,7 +75,6 @@ export interface Completion {
 }
 
 export interface HabitStatsData {
-  dates: string[];
   values: number[];
   completionsByDay: number[];
   dayLabels: string[];

--- a/frontend/src/features/Habits/__tests__/HabitStats.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitStats.test.ts
@@ -110,20 +110,21 @@ describe('generateStatsForHabit', () => {
     expect(stats.completionRate).toBeCloseTo(2 / 3, 1);
   });
 
-  test('completionsByDay is 1/0 per day of week', () => {
+  test('completionsByDay counts completion events per day of week', () => {
     const habit: Habit = {
       ...baseHabit,
       completions: [
-        // Monday
+        // Monday — two completions same day
         { id: 'c-1', timestamp: new Date('2024-01-01T08:00:00'), completed_units: 2 },
-        // Wednesday
-        { id: 'c-2', timestamp: new Date('2024-01-03T08:00:00'), completed_units: 3 },
+        { id: 'c-2', timestamp: new Date('2024-01-01T18:00:00'), completed_units: 1 },
+        // Wednesday — single completion
+        { id: 'c-3', timestamp: new Date('2024-01-03T08:00:00'), completed_units: 3 },
       ],
     };
     const stats = generateStatsForHabit(habit);
-    expect(stats.completionsByDay[1]).toBe(1); // Monday
-    expect(stats.completionsByDay[2]).toBe(0); // Tuesday
-    expect(stats.completionsByDay[3]).toBe(1); // Wednesday
+    expect(stats.completionsByDay[1]).toBe(2); // Monday: two events
+    expect(stats.completionsByDay[2]).toBe(0); // Tuesday: none
+    expect(stats.completionsByDay[3]).toBe(1); // Wednesday: one event
   });
 
   test('includes currentStreak counting from today backwards (BUG-FE-HABIT-207)', () => {

--- a/frontend/src/features/Habits/__tests__/HabitStats.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitStats.test.ts
@@ -197,7 +197,6 @@ describe('toLocalHabitStats', () => {
     };
     const local = toLocalHabitStats(api);
     expect(local.dayLabels).toEqual(api.day_labels);
-    expect(local.dates).toEqual(api.day_labels);
     expect(local.values).toEqual(api.values);
     expect(local.completionsByDay).toEqual(api.completions_by_day);
     expect(local.longestStreak).toBe(3);

--- a/frontend/src/features/Habits/components/StatsModal.tsx
+++ b/frontend/src/features/Habits/components/StatsModal.tsx
@@ -12,15 +12,13 @@ import { generateStatsForHabit, toLocalHabitStats } from '../HabitUtils';
 const FALLBACK_CHART_COLOR = 'rgba(134, 65, 244, 1)';
 const FALLBACK_CALENDAR_COLOR = '#50cebb';
 
-// Chart sits inside ``statsModalContent`` (90% of window) with
-// ``SPACING.lg`` padding on both sides plus ``statsContainer``'s
-// ``SPACING.md`` inner padding -- subtract the full chrome so the
-// chart never overruns its card. Cap at 480 so on tablets / web the
-// chart stays a readable size rather than stretching edge-to-edge.
 const MODAL_WIDTH_FRACTION = 0.9;
 const MAX_CHART_WIDTH = 480;
+// Mirrors statsModalContent (SPACING.lg) + statsContainer (SPACING.md) padding
+// in Habits.styles.ts -- keep in sync if those rules change.
 const CHART_CHROME = SPACING.lg * 2 + SPACING.md * 2;
 const CHART_HEIGHT = 220;
+const MIN_LABEL_OPACITY = 0.6;
 
 const useChartWidth = (): number => {
   const { width } = useWindowDimensions();
@@ -29,31 +27,48 @@ const useChartWidth = (): number => {
 
 const getStageColor = (stage: string, fallback: string): string => STAGE_COLORS[stage] || fallback;
 
-const buildChartConfig = (chartColor: string) => ({
-  ...CHART_STYLE,
-  decimalPlaces: 0,
-  color: (opacity = 1) => {
-    const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(chartColor);
-    if (!match) return chartColor;
-    const r = Number.parseInt(match[1]!, 16);
-    const g = Number.parseInt(match[2]!, 16);
-    const b = Number.parseInt(match[3]!, 16);
-    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
-  },
-  labelColor: (opacity = 1) => {
-    const op = Math.max(opacity, 0.6);
-    return `rgba(85, 85, 85, ${op})`;
-  },
-  propsForBackgroundLines: {
-    stroke: CHART_AXIS_LABEL_COLOR,
-    strokeOpacity: CHART_STYLE.axisLineOpacity,
-    strokeDasharray: '4 6',
-  },
-  propsForLabels: { fontSize: 11 },
-  barPercentage: 0.6,
-  strokeWidth: 2,
-  useShadowColorFromDataset: false,
-});
+const HEX_TRIPLET = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i;
+
+const parseHexRgb = (hex: string): [number, number, number] | null => {
+  const match = HEX_TRIPLET.exec(hex);
+  if (!match) return null;
+  return [
+    Number.parseInt(match[1]!, 16),
+    Number.parseInt(match[2]!, 16),
+    Number.parseInt(match[3]!, 16),
+  ];
+};
+
+const AXIS_LABEL_RGB = parseHexRgb(CHART_AXIS_LABEL_COLOR);
+const axisLabelColor = (opacity: number): string => {
+  const op = Math.max(opacity, MIN_LABEL_OPACITY);
+  if (!AXIS_LABEL_RGB) return CHART_AXIS_LABEL_COLOR;
+  const [r, g, b] = AXIS_LABEL_RGB;
+  return `rgba(${r}, ${g}, ${b}, ${op})`;
+};
+
+const buildChartConfig = (chartColor: string) => {
+  const rgb = parseHexRgb(chartColor);
+  const colorFn = rgb
+    ? (opacity = 1) => `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${opacity})`
+    : () => chartColor;
+
+  return {
+    ...CHART_STYLE,
+    decimalPlaces: 0,
+    color: colorFn,
+    labelColor: axisLabelColor,
+    propsForBackgroundLines: {
+      stroke: CHART_AXIS_LABEL_COLOR,
+      strokeOpacity: CHART_STYLE.axisLineOpacity,
+      strokeDasharray: '4 6',
+    },
+    propsForLabels: { fontSize: 11 },
+    barPercentage: 0.6,
+    strokeWidth: 2,
+    useShadowColorFromDataset: false,
+  };
+};
 
 const buildMarkedDates = (
   completionDates: string[],

--- a/frontend/src/features/Habits/components/StatsModal.tsx
+++ b/frontend/src/features/Habits/components/StatsModal.tsx
@@ -1,30 +1,59 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Dimensions, TouchableOpacity, Modal, ScrollView } from 'react-native';
+import { View, Text, useWindowDimensions, TouchableOpacity, Modal, ScrollView } from 'react-native';
 import { Calendar } from 'react-native-calendars';
 import { LineChart, BarChart } from 'react-native-chart-kit';
 
 import { habits as habitsApi } from '../../../api';
-import type { ApiHabitStats } from '../../../api';
-import { STAGE_COLORS } from '../../../design/tokens';
+import { CHART_AXIS_LABEL_COLOR, CHART_STYLE, SPACING, STAGE_COLORS } from '../../../design/tokens';
 import styles from '../Habits.styles';
 import type { HabitStatsData, StatsModalProps } from '../Habits.types';
-import { generateStatsForHabit } from '../HabitUtils';
+import { generateStatsForHabit, toLocalHabitStats } from '../HabitUtils';
 
-const CHART_CONFIG = {
-  backgroundGradientFrom: '#1E2923',
-  backgroundGradientTo: '#08130D',
-  color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
-  strokeWidth: 2,
-  barPercentage: 0.7,
-  useShadowColorFromDataset: false,
-};
-
-const CHART_WIDTH = Dimensions.get('window').width - 40;
-const CHART_HEIGHT = 220;
 const FALLBACK_CHART_COLOR = 'rgba(134, 65, 244, 1)';
 const FALLBACK_CALENDAR_COLOR = '#50cebb';
 
+// Chart sits inside ``statsModalContent`` (90% of window) with
+// ``SPACING.lg`` padding on both sides plus ``statsContainer``'s
+// ``SPACING.md`` inner padding -- subtract the full chrome so the
+// chart never overruns its card. Cap at 480 so on tablets / web the
+// chart stays a readable size rather than stretching edge-to-edge.
+const MODAL_WIDTH_FRACTION = 0.9;
+const MAX_CHART_WIDTH = 480;
+const CHART_CHROME = SPACING.lg * 2 + SPACING.md * 2;
+const CHART_HEIGHT = 220;
+
+const useChartWidth = (): number => {
+  const { width } = useWindowDimensions();
+  return Math.min(width * MODAL_WIDTH_FRACTION - CHART_CHROME, MAX_CHART_WIDTH);
+};
+
 const getStageColor = (stage: string, fallback: string): string => STAGE_COLORS[stage] || fallback;
+
+const buildChartConfig = (chartColor: string) => ({
+  ...CHART_STYLE,
+  decimalPlaces: 0,
+  color: (opacity = 1) => {
+    const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(chartColor);
+    if (!match) return chartColor;
+    const r = Number.parseInt(match[1]!, 16);
+    const g = Number.parseInt(match[2]!, 16);
+    const b = Number.parseInt(match[3]!, 16);
+    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+  },
+  labelColor: (opacity = 1) => {
+    const op = Math.max(opacity, 0.6);
+    return `rgba(85, 85, 85, ${op})`;
+  },
+  propsForBackgroundLines: {
+    stroke: CHART_AXIS_LABEL_COLOR,
+    strokeOpacity: CHART_STYLE.axisLineOpacity,
+    strokeDasharray: '4 6',
+  },
+  propsForLabels: { fontSize: 11 },
+  barPercentage: 0.6,
+  strokeWidth: 2,
+  useShadowColorFromDataset: false,
+});
 
 const buildMarkedDates = (
   completionDates: string[],
@@ -58,9 +87,9 @@ const TAB_LABELS: Record<string, string> = {
 };
 
 const buildLineData = (stats: HabitStatsData, color: string) => ({
-  labels: stats.dates.slice(-7),
-  datasets: [{ data: stats.values.slice(-7), color: () => color, strokeWidth: 2 }],
-  legend: ['Daily Progress'],
+  labels: stats.dayLabels,
+  datasets: [{ data: stats.values, color: () => color, strokeWidth: 2 }],
+  legend: ['Units logged'],
 });
 
 const buildBarData = (stats: HabitStatsData, color: string) => ({
@@ -140,23 +169,6 @@ const StatsModalHeader = ({
   </View>
 );
 
-/**
- * Convert an API stats response to the local HabitStatsData shape.
- */
-function apiStatsToLocal(api: ApiHabitStats): HabitStatsData {
-  return {
-    dates: api.completion_dates,
-    values: api.values,
-    completionsByDay: api.completions_by_day,
-    dayLabels: api.day_labels,
-    longestStreak: api.longest_streak,
-    currentStreak: api.current_streak,
-    totalCompletions: api.total_completions,
-    completionRate: api.completion_rate,
-    completionDates: api.completion_dates,
-  };
-}
-
 interface StatsContentProps {
   habit: NonNullable<StatsModalProps['habit']>;
   stats: HabitStatsData;
@@ -169,6 +181,8 @@ interface StatsContentProps {
 const StatsContent = (props: StatsContentProps) => {
   const { habit, stats, selectedTab, onSelectTab, onClose, loading } = props;
   const chartColor = getStageColor(habit.stage, FALLBACK_CHART_COLOR);
+  const chartWidth = useChartWidth();
+  const chartConfig = buildChartConfig(chartColor);
 
   return (
     <View style={[styles.statsModalContent, { borderTopColor: STAGE_COLORS[habit.stage] }]}>
@@ -182,13 +196,14 @@ const StatsContent = (props: StatsContentProps) => {
         )}
         {selectedTab === 'calendar' && <CalendarTab habit={habit} stats={stats} />}
         {selectedTab === 'progress' && (
-          <ChartTab title="Progress (Last 7 Days)">
+          <ChartTab title="Units by Weekday">
             <LineChart
               data={buildLineData(stats, chartColor)}
-              width={CHART_WIDTH}
+              width={chartWidth}
               height={CHART_HEIGHT}
-              chartConfig={CHART_CONFIG}
+              chartConfig={chartConfig}
               bezier
+              fromZero
               style={styles.chart}
             />
           </ChartTab>
@@ -197,13 +212,14 @@ const StatsContent = (props: StatsContentProps) => {
           <ChartTab title="Completions by Day of Week">
             <BarChart
               data={buildBarData(stats, chartColor)}
-              width={CHART_WIDTH}
+              width={chartWidth}
               height={CHART_HEIGHT}
-              chartConfig={CHART_CONFIG}
+              chartConfig={chartConfig}
               yAxisLabel=""
               yAxisSuffix=""
               style={styles.chart}
               fromZero
+              showValuesOnTopOfBars
             />
           </ChartTab>
         )}
@@ -228,7 +244,7 @@ export const StatsModal = ({ visible, habit, stats: localStats, onClose }: Stats
     habitsApi
       .getStats(habit.id)
       .then((response) => {
-        if (!cancelled) setApiStats(apiStatsToLocal(response));
+        if (!cancelled) setApiStats(toLocalHabitStats(response));
       })
       .catch(() => {
         if (!cancelled) setApiStats(null);

--- a/frontend/src/features/Habits/components/__tests__/StatsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/StatsModal.test.tsx
@@ -23,7 +23,7 @@ jest.mock('../../../../api', () => ({
 // Mock HabitUtils to avoid indirect dependency issues
 jest.mock('../../HabitUtils', () => ({
   generateStatsForHabit: jest.fn(() => ({
-    dates: [],
+    dates: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     values: [0, 0, 0, 0, 0, 0, 0],
     completionsByDay: [0, 0, 0, 0, 0, 0, 0],
     dayLabels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
@@ -32,6 +32,17 @@ jest.mock('../../HabitUtils', () => ({
     totalCompletions: 0,
     completionRate: 0,
     completionDates: [],
+  })),
+  toLocalHabitStats: jest.fn((api: Record<string, unknown>) => ({
+    dates: api.day_labels,
+    values: api.values,
+    completionsByDay: api.completions_by_day,
+    dayLabels: api.day_labels,
+    longestStreak: api.longest_streak,
+    currentStreak: api.current_streak,
+    totalCompletions: api.total_completions,
+    completionRate: api.completion_rate,
+    completionDates: api.completion_dates,
   })),
 }));
 
@@ -56,7 +67,7 @@ const baseHabit: Habit = {
 };
 
 const localStats: HabitStatsData = {
-  dates: [],
+  dates: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
   values: [0, 0, 0, 0, 0, 0, 0],
   completionsByDay: [0, 0, 0, 0, 0, 0, 0],
   dayLabels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
@@ -70,7 +81,7 @@ const localStats: HabitStatsData = {
 const apiResponse = {
   day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
   values: [1, 3, 2, 2, 3, 2, 2],
-  completions_by_day: [1, 1, 1, 1, 1, 1, 1],
+  completions_by_day: [1, 2, 1, 2, 3, 1, 5],
   longest_streak: 7,
   current_streak: 3,
   total_completions: 15,
@@ -177,7 +188,7 @@ describe('StatsModal', () => {
 
     // Switch to progress tab
     fireEvent.press(getByText('Progress'));
-    expect(getByText('Progress (Last 7 Days)')).toBeTruthy();
+    expect(getByText('Units by Weekday')).toBeTruthy();
 
     // Switch to by-day tab
     fireEvent.press(getByText('By Day'));

--- a/frontend/src/features/Habits/components/__tests__/StatsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/StatsModal.test.tsx
@@ -23,7 +23,6 @@ jest.mock('../../../../api', () => ({
 // Mock HabitUtils to avoid indirect dependency issues
 jest.mock('../../HabitUtils', () => ({
   generateStatsForHabit: jest.fn(() => ({
-    dates: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     values: [0, 0, 0, 0, 0, 0, 0],
     completionsByDay: [0, 0, 0, 0, 0, 0, 0],
     dayLabels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
@@ -34,7 +33,6 @@ jest.mock('../../HabitUtils', () => ({
     completionDates: [],
   })),
   toLocalHabitStats: jest.fn((api: Record<string, unknown>) => ({
-    dates: api.day_labels,
     values: api.values,
     completionsByDay: api.completions_by_day,
     dayLabels: api.day_labels,
@@ -67,7 +65,6 @@ const baseHabit: Habit = {
 };
 
 const localStats: HabitStatsData = {
-  dates: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
   values: [0, 0, 0, 0, 0, 0, 0],
   completionsByDay: [0, 0, 0, 0, 0, 0, 0],
   dayLabels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],


### PR DESCRIPTION
The Stats modal had two bugs that made the Progress chart unreadable
and dishonest:

- ``apiStatsToLocal`` mapped ``dates: api.completion_dates`` while
  ``values`` stayed weekday-indexed.  Labels (sparse unique dates) and
  data points (Sun..Sat weekday totals) lined up by accident only --
  the "Last 7 Days" title was never true.  Removed the duplicate
  converter and routed both code paths through ``toLocalHabitStats``,
  which uses ``day_labels`` for X.  Retitled to "Units by Weekday".
- The bar chart's Y-axis topped out at 1.0 forever because the
  backend returned a 0/1 presence array.  Switched
  ``compute_habit_stats`` (and the frontend fallback
  ``generateStatsForHabit``) to count completion events per weekday,
  so the chart finally shows real tallies.

Aesthetic pass:
- Replaced the hardcoded dark-green chart palette with token-driven
  light styling that sits on the modal's white card.  Added
  ``CHART_STYLE`` / ``CHART_AXIS_LABEL_COLOR`` to ``design/tokens``
  with WCAG-AA label color (``#555555`` = 7.22:1 on white).
- Sized charts off ``useWindowDimensions`` minus modal+padding
  chrome, capped at 480px, so the chart no longer overruns the card
  on phones and stays readable on tablets/web.
- ``decimalPlaces: 0`` kills the meaningless ``16.25 / 32.50``
  fractional ticks; ``showValuesOnTopOfBars`` makes integer counts
  legible without overlapping labels.

Updated the StatsModal/HabitStats/test_habit_stats_api tests to
assert the new count semantic.