### PR TITLE
feat(practice): mindfulness recipe library with full tag CRUD

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -75,6 +75,17 @@ _SQLITE_ALWAYS_INDEXES: tuple[str, ...] = (
     # user-submitted practices are exempt via the partial ``WHERE`` clause.
     'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practice_preset_stage_lower_name_unique_test" '
     "ON practice (stage_number, lower(trim(name))) WHERE submitted_by_user_id IS NULL",
+    # practice tags: per-namespace slug uniqueness.  Mirrors migration
+    # ``07b8c9d0e1f2``; SQLite supports partial unique indexes natively.
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practicetag_system_slug_test" '
+    "ON practicetag (slug) WHERE owner_user_id IS NULL",
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practicetag_user_slug_test" '
+    "ON practicetag (owner_user_id, slug) WHERE owner_user_id IS NOT NULL",
+    # practice recipes: per-namespace slug uniqueness.  Same migration.
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practicerecipe_system_slug_test" '
+    "ON practicerecipe (slug) WHERE owner_user_id IS NULL",
+    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practicerecipe_user_slug_test" '
+    "ON practicerecipe (owner_user_id, slug) WHERE owner_user_id IS NOT NULL",
 )
 
 # Concurrency-only indexes: the regular ``db_session`` fixture deliberately

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -75,17 +75,6 @@ _SQLITE_ALWAYS_INDEXES: tuple[str, ...] = (
     # user-submitted practices are exempt via the partial ``WHERE`` clause.
     'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practice_preset_stage_lower_name_unique_test" '
     "ON practice (stage_number, lower(trim(name))) WHERE submitted_by_user_id IS NULL",
-    # practice tags: per-namespace slug uniqueness.  Mirrors migration
-    # ``07b8c9d0e1f2``; SQLite supports partial unique indexes natively.
-    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practicetag_system_slug_test" '
-    "ON practicetag (slug) WHERE owner_user_id IS NULL",
-    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practicetag_user_slug_test" '
-    "ON practicetag (owner_user_id, slug) WHERE owner_user_id IS NOT NULL",
-    # practice recipes: per-namespace slug uniqueness.  Same migration.
-    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practicerecipe_system_slug_test" '
-    "ON practicerecipe (slug) WHERE owner_user_id IS NULL",
-    'CREATE UNIQUE INDEX IF NOT EXISTS "ix_practicerecipe_user_slug_test" '
-    "ON practicerecipe (owner_user_id, slug) WHERE owner_user_id IS NOT NULL",
 )
 
 # Concurrency-only indexes: the regular ``db_session`` fixture deliberately

--- a/backend/migrations/versions/07b8c9d0e1f2_add_practice_recipes_and_tags.py
+++ b/backend/migrations/versions/07b8c9d0e1f2_add_practice_recipes_and_tags.py
@@ -1,7 +1,7 @@
 """add practice_tag, practice_recipe, practice_recipe_step tables
 
 Revision ID: 07b8c9d0e1f2
-Revises: f6a7b8c9d0e1
+Revises: b6c7d8e9a0b1
 Create Date: 2026-05-23 00:00:00.000000
 
 Adds a user-managed recipe library for tier-one mindfulness practices.
@@ -35,7 +35,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "07b8c9d0e1f2"  # pragma: allowlist secret
-down_revision: Union[str, Sequence[str], None] = "f6a7b8c9d0e1"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "b6c7d8e9a0b1"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/migrations/versions/07b8c9d0e1f2_add_practice_recipes_and_tags.py
+++ b/backend/migrations/versions/07b8c9d0e1f2_add_practice_recipes_and_tags.py
@@ -1,0 +1,157 @@
+"""add practice_tag, practice_recipe, practice_recipe_step tables
+
+Revision ID: 07b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-05-23 00:00:00.000000
+
+Adds a user-managed recipe library for tier-one mindfulness practices.
+
+* ``practice_tag`` - atomic labels (sight, red, square, "felt inside").
+  ``owner_user_id IS NULL`` for system tags; otherwise scoped to one user.
+
+* ``practice_recipe`` - named ordered collection of steps that materialises
+  into a ``mode_config`` payload when the user picks it.  Carries the
+  generated ``mode`` discriminator so applying a recipe to a UserPractice
+  can be rejected at the API edge when the catalog row uses a different
+  mode (the override mechanism cannot swap modes).
+
+* ``practice_recipe_step`` - per-step row (FK -> recipe).  ``tag_slug`` is
+  intentionally a copy of the originating tag's slug, NOT a foreign key:
+  it keeps system recipes self-contained when a user has not yet built
+  their own tag library, and means deleting a personal tag does not
+  silently break a recipe that referenced it.
+
+Each owner_user_id column has a partial-unique index on slug (system
+namespace and per-user namespaces are independent), and recipe steps
+are uniquely ordered within their recipe via a (recipe_id, position)
+unique index.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "07b8c9d0e1f2"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "f6a7b8c9d0e1"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the three new tables and their supporting indexes."""
+    op.create_table(
+        "practicetag",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("slug", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=False),
+        sa.Column("label", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("owner_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["owner_user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # System tags share one namespace; user tags namespace per user.  The
+    # two partial unique indexes encode that without colliding with each
+    # other: a user can claim ``sight`` even though a system tag named
+    # ``sight`` already exists.
+    op.create_index(
+        "ix_practicetag_system_slug",
+        "practicetag",
+        ["slug"],
+        unique=True,
+        postgresql_where=sa.text("owner_user_id IS NULL"),
+        sqlite_where=sa.text("owner_user_id IS NULL"),
+    )
+    op.create_index(
+        "ix_practicetag_user_slug",
+        "practicetag",
+        ["owner_user_id", "slug"],
+        unique=True,
+        postgresql_where=sa.text("owner_user_id IS NOT NULL"),
+        sqlite_where=sa.text("owner_user_id IS NOT NULL"),
+    )
+
+    op.create_table(
+        "practicerecipe",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("slug", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=False),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(length=2000), nullable=False),
+        sa.Column("owner_user_id", sa.Integer(), nullable=True),
+        sa.Column("mode", sqlmodel.sql.sqltypes.AutoString(length=32), nullable=False),
+        sa.Column("rounds", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["owner_user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "mode IN ('sense_grounding', 'tallied_grounding')",
+            name="ck_practicerecipe_mode_valid",
+        ),
+        sa.CheckConstraint("rounds >= 1 AND rounds <= 10", name="ck_practicerecipe_rounds_range"),
+    )
+    op.create_index(
+        "ix_practicerecipe_system_slug",
+        "practicerecipe",
+        ["slug"],
+        unique=True,
+        postgresql_where=sa.text("owner_user_id IS NULL"),
+        sqlite_where=sa.text("owner_user_id IS NULL"),
+    )
+    op.create_index(
+        "ix_practicerecipe_user_slug",
+        "practicerecipe",
+        ["owner_user_id", "slug"],
+        unique=True,
+        postgresql_where=sa.text("owner_user_id IS NOT NULL"),
+        sqlite_where=sa.text("owner_user_id IS NOT NULL"),
+    )
+
+    op.create_table(
+        "practicerecipestep",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("recipe_id", sa.Integer(), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("tag_slug", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=False),
+        sa.Column("tag_label", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("prompt_label", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("target_count", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["recipe_id"],
+            ["practicerecipe.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "target_count >= 1 AND target_count <= 20",
+            name="ck_practicerecipestep_target_count_range",
+        ),
+        sa.CheckConstraint("position >= 0", name="ck_practicerecipestep_position_nonneg"),
+    )
+    op.create_index(
+        "ix_practicerecipestep_recipe_position",
+        "practicerecipestep",
+        ["recipe_id", "position"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Drop the three tables in reverse FK order."""
+    op.drop_index("ix_practicerecipestep_recipe_position", table_name="practicerecipestep")
+    op.drop_table("practicerecipestep")
+    op.drop_index("ix_practicerecipe_user_slug", table_name="practicerecipe")
+    op.drop_index("ix_practicerecipe_system_slug", table_name="practicerecipe")
+    op.drop_table("practicerecipe")
+    op.drop_index("ix_practicetag_user_slug", table_name="practicetag")
+    op.drop_index("ix_practicetag_system_slug", table_name="practicetag")
+    op.drop_table("practicetag")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -37,13 +37,16 @@ from routers.goal_groups import router as goal_groups_router
 from routers.goals import router as goals_router
 from routers.habits import router as habits_router
 from routers.journal import router as journal_router
+from routers.practice_recipes import router as practice_recipes_router
 from routers.practice_sessions import router as practice_sessions_router
 from routers.practice_share import router as practice_share_router
+from routers.practice_tags import router as practice_tags_router
 from routers.practices import router as practices_router
 from routers.prompts import router as prompts_router
 from routers.stages import router as stages_router
 from routers.user_practices import router as user_practices_router
 from seed_content import seed_content
+from seed_practice_recipes import seed_practice_recipes
 from seed_practices import seed_practices
 from seed_stages import seed_stages
 
@@ -252,6 +255,7 @@ async def _seed_startup_data(session: AsyncSession) -> None:
     # what callers rely on.
     await seed_stages(session)
     await seed_practices(session)
+    await seed_practice_recipes(session)
     await seed_content(session)
 
 
@@ -335,6 +339,8 @@ app.include_router(botmason_router)
 app.include_router(course_router)
 app.include_router(practices_router)
 app.include_router(practice_share_router)
+app.include_router(practice_recipes_router)
+app.include_router(practice_tags_router)
 app.include_router(user_practices_router)
 app.include_router(practice_sessions_router)
 app.include_router(habits_router)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -12,8 +12,10 @@ from .llm_usage_log import LLMUsageLog
 from .login_attempt import LoginAttempt
 from .password_reset_token import PasswordResetToken
 from .practice import Practice
+from .practice_recipe import PracticeRecipe, PracticeRecipeStep
 from .practice_session import PracticeSession
 from .practice_share_link import PracticeShareLink
+from .practice_tag import PracticeTag
 from .prompt_response import PromptResponse
 from .revoked_token import RevokedToken
 from .stage_content import StageContent
@@ -35,8 +37,11 @@ __all__ = [
     "LoginAttempt",
     "PasswordResetToken",
     "Practice",
+    "PracticeRecipe",
+    "PracticeRecipeStep",
     "PracticeSession",
     "PracticeShareLink",
+    "PracticeTag",
     "PromptResponse",
     "RevokedToken",
     "StageContent",

--- a/backend/src/models/practice_recipe.py
+++ b/backend/src/models/practice_recipe.py
@@ -1,0 +1,139 @@
+"""Recipes: named ordered collections of steps that materialise into a mode_config.
+
+A recipe is the user-facing unit in the tier-one customise flow.
+Examples: ``5-4-3-2-1 Grounding``, ``Find the Rainbow``, ``Four
+Elements``.  Each recipe holds an ordered list of
+:class:`PracticeRecipeStep` rows whose tag + prompt + count combine to
+produce a ``mode_config`` payload at apply time.
+
+System recipes (``owner_user_id IS NULL``) are seeded read-only; user
+recipes are full CRUD.  The "edit" flow in the client forks a user
+copy of a system recipe rather than mutating the shared row.
+
+``mode`` mirrors the practice-mode discriminator the recipe is built
+for (``sense_grounding`` for per-prompt label structures like
+5-4-3-2-1, ``tallied_grounding`` for rounds-by-categories).  Apply
+checks the catalog's ``mode`` against this field and refuses
+cross-mode swaps -- the override mechanism cannot change ``mode``
+itself.
+
+``rounds`` is stored at the recipe level (not per-step) so
+"rounds-by-categories" recipes like ``Find the Rainbow x3`` can be
+expressed without expanding every round into its own duplicated
+steps.  For ``sense_grounding`` mode the rounds value is always 1.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint, Column, DateTime, Index
+from sqlmodel import Field, SQLModel
+
+from domain.practice_modes import PracticeMode
+
+# Bounds mirrored from schemas.practice_mode_config so the DB CHECK
+# constraint and the Pydantic validator agree.  Drift between the two
+# would surface as a 500 (the DB rejecting what the schema accepted),
+# so a single named constant per bound is preferable to an enum here.
+_RECIPE_ROUNDS_MIN = 1
+_RECIPE_ROUNDS_MAX = 10
+_STEP_TARGET_COUNT_MIN = 1
+_STEP_TARGET_COUNT_MAX = 20
+# Recipes that can be applied directly into a UserPractice override:
+# the override mechanism cannot change ``mode`` so a recipe whose
+# ``mode`` does not match the catalog row is rejected at apply time.
+RECIPE_MODES: tuple[str, ...] = (
+    PracticeMode.SENSE_GROUNDING.value,
+    PracticeMode.TALLIED_GROUNDING.value,
+)
+
+
+def _recipe_mode_check() -> CheckConstraint:
+    """Pin ``mode`` to the recipe-capable subset of :data:`PracticeMode`."""
+    quoted = ", ".join(f"'{m}'" for m in RECIPE_MODES)
+    return CheckConstraint(f"mode IN ({quoted})", name="ck_practicerecipe_mode_valid")
+
+
+class PracticeRecipe(SQLModel, table=True):
+    """A reusable named template that materialises into a ``mode_config``.
+
+    The partial-unique indexes on ``slug`` live at the DB layer
+    (migration ``07b8c9d0e1f2``) for the same reason as
+    :class:`~models.practice_tag.PracticeTag`: system and per-user
+    namespaces are independent and alembic autogenerate cannot
+    round-trip the partial predicate.
+
+    ``created_at`` is timezone-aware so the picker can show "added
+    today" without timezone gymnastics on the client.
+    """
+
+    __table_args__ = (
+        _recipe_mode_check(),
+        CheckConstraint(
+            f"rounds >= {_RECIPE_ROUNDS_MIN} AND rounds <= {_RECIPE_ROUNDS_MAX}",
+            name="ck_practicerecipe_rounds_range",
+        ),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    slug: str = Field(
+        max_length=64,
+        description="Snake-case machine slug; pattern enforced by the schema layer.",
+    )
+    name: str = Field(max_length=255)
+    description: str = Field(max_length=2_000)
+    owner_user_id: int | None = Field(
+        default=None,
+        foreign_key="user.id",
+        ondelete="CASCADE",
+        description="NULL for system recipes; otherwise the owning user.",
+    )
+    mode: str = Field(
+        max_length=32,
+        description="Target practice mode this recipe materialises into.",
+    )
+    rounds: int = Field(default=1)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class PracticeRecipeStep(SQLModel, table=True):
+    """One ordered step in a :class:`PracticeRecipe`.
+
+    ``tag_slug`` and ``tag_label`` are copies of the originating
+    :class:`~models.practice_tag.PracticeTag` fields rather than a
+    foreign key: a recipe must keep working after the user deletes
+    the personal tag it was built from, and a system recipe must be
+    self-contained even when the user has no matching tag in their
+    personal library.
+
+    The ``(recipe_id, position)`` unique index lives at the DB layer
+    (migration ``07b8c9d0e1f2``) and is mirrored here so SQLite tests
+    inherit the same enforcement via ``metadata.create_all``.
+    """
+
+    __table_args__ = (
+        Index(
+            "ix_practicerecipestep_recipe_position",
+            "recipe_id",
+            "position",
+            unique=True,
+        ),
+        CheckConstraint(
+            (
+                f"target_count >= {_STEP_TARGET_COUNT_MIN} "
+                f"AND target_count <= {_STEP_TARGET_COUNT_MAX}"
+            ),
+            name="ck_practicerecipestep_target_count_range",
+        ),
+        CheckConstraint("position >= 0", name="ck_practicerecipestep_position_nonneg"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    recipe_id: int = Field(foreign_key="practicerecipe.id", ondelete="CASCADE", index=True)
+    position: int = Field(description="Zero-based ordering within the recipe.")
+    tag_slug: str = Field(max_length=64)
+    tag_label: str = Field(max_length=255)
+    prompt_label: str = Field(max_length=255)
+    target_count: int = Field(default=1)

--- a/backend/src/models/practice_recipe.py
+++ b/backend/src/models/practice_recipe.py
@@ -25,10 +25,15 @@ steps.  For ``sense_grounding`` mode the rounds value is always 1.
 
 from datetime import UTC, datetime
 
-from sqlalchemy import CheckConstraint, Column, DateTime, Index
+from sqlalchemy import CheckConstraint, Column, DateTime, Index, Integer
 from sqlmodel import Field, SQLModel
 
 from domain.practice_modes import PracticeMode
+
+# Bound at module scope so :class:`Index`'s ``*_where`` predicates can
+# resolve the column at table-creation time.  Both Postgres and SQLite
+# accept the same ``IS NULL`` form (mirrors :mod:`models.user_practice`).
+_OWNER_COLUMN = Column("owner_user_id", Integer, nullable=True)
 
 # Bounds mirrored from schemas.practice_mode_config so the DB CHECK
 # constraint and the Pydantic validator agree.  Drift between the two
@@ -71,6 +76,21 @@ class PracticeRecipe(SQLModel, table=True):
         CheckConstraint(
             f"rounds >= {_RECIPE_ROUNDS_MIN} AND rounds <= {_RECIPE_ROUNDS_MAX}",
             name="ck_practicerecipe_rounds_range",
+        ),
+        Index(
+            "ix_practicerecipe_system_slug",
+            "slug",
+            unique=True,
+            postgresql_where=_OWNER_COLUMN.is_(None),
+            sqlite_where=_OWNER_COLUMN.is_(None),
+        ),
+        Index(
+            "ix_practicerecipe_user_slug",
+            "owner_user_id",
+            "slug",
+            unique=True,
+            postgresql_where=_OWNER_COLUMN.is_not(None),
+            sqlite_where=_OWNER_COLUMN.is_not(None),
         ),
     )
 
@@ -131,7 +151,10 @@ class PracticeRecipeStep(SQLModel, table=True):
     )
 
     id: int | None = Field(default=None, primary_key=True)
-    recipe_id: int = Field(foreign_key="practicerecipe.id", ondelete="CASCADE", index=True)
+    # The composite ``(recipe_id, position)`` unique index above also acts
+    # as the lookup index for ``WHERE recipe_id = ?`` queries (its leftmost
+    # prefix), so we deliberately do NOT mark this FK with ``index=True``.
+    recipe_id: int = Field(foreign_key="practicerecipe.id", ondelete="CASCADE")
     position: int = Field(description="Zero-based ordering within the recipe.")
     tag_slug: str = Field(max_length=64)
     tag_label: str = Field(max_length=255)

--- a/backend/src/models/practice_tag.py
+++ b/backend/src/models/practice_tag.py
@@ -1,0 +1,51 @@
+"""Personal tag library entries for the practice-recipe builder.
+
+A tag is the smallest unit a recipe step is built from: ``sight``,
+``red``, ``square``, ``earth``, ``felt_inside``.  It carries a slug
+(snake-case, machine-stable) and a label (display string), nothing
+else -- visual styling lives in the client.
+
+``owner_user_id`` partitions the namespace.  ``NULL`` marks a system
+tag the seeder owns; a non-NULL value scopes the tag to one user.  The
+partial-unique indexes (migration ``07b8c9d0e1f2``) keep the two
+namespaces independent so a user can claim ``sight`` even when a
+system tag with the same slug already exists -- their personal copy
+hides nothing and overrides nothing.
+
+The recipe step layer (see :mod:`models.practice_recipe`) stores a
+copy of the tag's ``slug`` rather than a foreign key, so deleting a
+personal tag here never silently breaks a recipe that referenced it.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, DateTime
+from sqlmodel import Field, SQLModel
+
+
+class PracticeTag(SQLModel, table=True):
+    """One label in the recipe-builder's tag library.
+
+    The partial-unique indexes on ``slug`` (one for ``owner_user_id IS
+    NULL``, one for ``owner_user_id IS NOT NULL``) live at the DB
+    layer in migration ``07b8c9d0e1f2``; they are intentionally NOT
+    declared in ``__table_args__`` so ``alembic check`` does not flag
+    spurious drift against the partial predicate.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    slug: str = Field(
+        max_length=64,
+        description="Snake-case machine slug; pattern enforced by the schema layer.",
+    )
+    label: str = Field(max_length=255, description="Human-facing display string.")
+    owner_user_id: int | None = Field(
+        default=None,
+        foreign_key="user.id",
+        ondelete="CASCADE",
+        description="NULL for system tags; otherwise the owning user.",
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/src/models/practice_tag.py
+++ b/backend/src/models/practice_tag.py
@@ -19,19 +19,44 @@ personal tag here never silently breaks a recipe that referenced it.
 
 from datetime import UTC, datetime
 
-from sqlalchemy import Column, DateTime
+from sqlalchemy import Column, DateTime, Index, Integer
 from sqlmodel import Field, SQLModel
+
+# Bound at module scope so :class:`Index`'s ``*_where`` predicates can
+# resolve the column at table-creation time.  Both Postgres and SQLite
+# accept the same ``IS NULL`` form (mirrors :mod:`models.user_practice`).
+_OWNER_COLUMN = Column("owner_user_id", Integer, nullable=True)
 
 
 class PracticeTag(SQLModel, table=True):
     """One label in the recipe-builder's tag library.
 
-    The partial-unique indexes on ``slug`` (one for ``owner_user_id IS
-    NULL``, one for ``owner_user_id IS NOT NULL``) live at the DB
-    layer in migration ``07b8c9d0e1f2``; they are intentionally NOT
-    declared in ``__table_args__`` so ``alembic check`` does not flag
-    spurious drift against the partial predicate.
+    The partial-unique indexes on ``slug`` mirror migration
+    ``07b8c9d0e1f2``: one for ``owner_user_id IS NULL`` (system
+    namespace) and one for ``owner_user_id IS NOT NULL`` (per-user
+    namespace).  Declaring them here (with ``postgresql_where`` and
+    ``sqlite_where``) keeps the metadata aligned with the migration so
+    ``alembic check`` sees no drift, and lets ``metadata.create_all``
+    install the same constraints on the test SQLite DB.
     """
+
+    __table_args__ = (
+        Index(
+            "ix_practicetag_system_slug",
+            "slug",
+            unique=True,
+            postgresql_where=_OWNER_COLUMN.is_(None),
+            sqlite_where=_OWNER_COLUMN.is_(None),
+        ),
+        Index(
+            "ix_practicetag_user_slug",
+            "owner_user_id",
+            "slug",
+            unique=True,
+            postgresql_where=_OWNER_COLUMN.is_not(None),
+            sqlite_where=_OWNER_COLUMN.is_not(None),
+        ),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     slug: str = Field(

--- a/backend/src/routers/practice_recipes.py
+++ b/backend/src/routers/practice_recipes.py
@@ -1,0 +1,338 @@
+"""Practice-recipe API -- library + apply-to-user-practice endpoints.
+
+Six endpoints around :class:`models.practice_recipe.PracticeRecipe`:
+
+* ``GET /practice-recipes`` -- list system + caller-owned recipes,
+  optionally filtered by ``mode``.
+* ``POST /practice-recipes`` -- create a personal recipe.  The client's
+  "fork a system recipe to edit it" flow calls this with the system
+  recipe's payload after picking a new slug.
+* ``GET /practice-recipes/{recipe_id}`` -- read one recipe and its steps.
+* ``PATCH /practice-recipes/{recipe_id}`` -- replace name + description +
+  rounds + steps wholesale.  Slug and mode are immutable.
+* ``DELETE /practice-recipes/{recipe_id}`` -- delete a personal recipe.
+* ``POST /practice-recipes/{recipe_id}/apply-to/{user_practice_id}`` --
+  materialise the recipe and copy it into
+  ``UserPractice.mode_config_override``.  Re-uses the same catalog-mode
+  check the customise endpoint runs so the override invariant ("mode
+  may not change") cannot be bypassed via the recipe path.
+
+System recipes (``owner_user_id IS NULL``) are read-only.  Mutation
+attempts return ``403 cannot_modify_system_recipe``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query, status
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, or_, select
+
+from database import get_session
+from dependencies.ownership import require_owned_user_practice
+from domain.practice_resolution import effective_config, effective_name
+from errors import bad_request, conflict, forbidden, not_found
+from models.practice import Practice
+from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
+from models.user_practice import UserPractice
+from routers.auth import get_current_user
+from schemas.practice import UserPracticeDetail
+from schemas.practice_mode_config import ModeConfigAdapter
+from schemas.practice_recipe import (
+    PracticeRecipeCreate,
+    PracticeRecipeOut,
+    PracticeRecipeStepOut,
+    PracticeRecipeUpdate,
+    materialise_mode_config,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/practice-recipes", tags=["practice-recipes"])
+
+
+async def _load_steps(recipe_id: int, session: AsyncSession) -> list[PracticeRecipeStep]:
+    """Fetch a recipe's steps in display order."""
+    result = await session.execute(
+        select(PracticeRecipeStep)
+        .where(PracticeRecipeStep.recipe_id == recipe_id)
+        .order_by(col(PracticeRecipeStep.position))
+    )
+    return list(result.scalars().all())
+
+
+def _to_out(recipe: PracticeRecipe, steps: list[PracticeRecipeStep]) -> PracticeRecipeOut:
+    """Build the wire DTO for a recipe + its already-loaded steps."""
+    return PracticeRecipeOut(
+        id=recipe.id or 0,
+        slug=recipe.slug,
+        name=recipe.name,
+        description=recipe.description,
+        owner_user_id=recipe.owner_user_id,
+        mode=recipe.mode,
+        rounds=recipe.rounds,
+        created_at=recipe.created_at,
+        steps=[PracticeRecipeStepOut.model_validate(s, from_attributes=True) for s in steps],
+    )
+
+
+async def _load_visible_recipe(
+    recipe_id: int, user_id: int, session: AsyncSession
+) -> PracticeRecipe:
+    """Fetch a recipe the caller is allowed to see, else raise 404."""
+    result = await session.execute(
+        select(PracticeRecipe).where(
+            PracticeRecipe.id == recipe_id,
+            or_(
+                col(PracticeRecipe.owner_user_id).is_(None),
+                PracticeRecipe.owner_user_id == user_id,
+            ),
+        )
+    )
+    recipe = result.scalar_one_or_none()
+    if recipe is None:
+        raise not_found("practice_recipe")
+    return recipe
+
+
+def _require_personal(recipe: PracticeRecipe) -> None:
+    """Reject mutation of a system recipe with a stable 403 detail."""
+    if recipe.owner_user_id is None:
+        raise forbidden("cannot_modify_system_recipe")
+
+
+def _build_step_rows(recipe_id: int, payload_steps: list[Any]) -> list[PracticeRecipeStep]:
+    """Materialise per-step input rows with positional ordering."""
+    return [
+        PracticeRecipeStep(
+            recipe_id=recipe_id,
+            position=index,
+            tag_slug=step.tag_slug,
+            tag_label=step.tag_label,
+            prompt_label=step.prompt_label,
+            target_count=step.target_count,
+        )
+        for index, step in enumerate(payload_steps)
+    ]
+
+
+@router.get("/", response_model=list[PracticeRecipeOut])
+async def list_practice_recipes(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    mode: Annotated[str | None, Query(description="Filter by recipe mode.")] = None,
+) -> list[PracticeRecipeOut]:
+    """List every recipe visible to the caller, optionally filtered by mode."""
+    query = select(PracticeRecipe).where(
+        or_(
+            col(PracticeRecipe.owner_user_id).is_(None),
+            PracticeRecipe.owner_user_id == user_id,
+        )
+    )
+    if mode is not None:
+        query = query.where(PracticeRecipe.mode == mode)
+    query = query.order_by(col(PracticeRecipe.owner_user_id).nulls_first(), PracticeRecipe.name)
+    result = await session.execute(query)
+    recipes = list(result.scalars().all())
+    out: list[PracticeRecipeOut] = []
+    for recipe in recipes:
+        recipe_id = recipe.id
+        if recipe_id is None:
+            continue
+        steps = await _load_steps(recipe_id, session)
+        out.append(_to_out(recipe, steps))
+    return out
+
+
+@router.post("/", response_model=PracticeRecipeOut, status_code=status.HTTP_201_CREATED)
+async def create_practice_recipe(
+    payload: PracticeRecipeCreate,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PracticeRecipeOut:
+    """Create a personal recipe owned by the caller."""
+    recipe = PracticeRecipe(
+        slug=payload.slug,
+        name=payload.name,
+        description=payload.description,
+        owner_user_id=user_id,
+        mode=payload.mode,
+        rounds=payload.rounds,
+    )
+    session.add(recipe)
+    try:
+        await session.flush()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise conflict("recipe_slug_taken") from exc
+    recipe_id = recipe.id
+    if recipe_id is None:  # pragma: no cover - flush always populates the PK
+        await session.rollback()
+        raise bad_request("recipe_persist_failed")
+    steps = _build_step_rows(recipe_id, list(payload.steps))
+    session.add_all(steps)
+    await session.commit()
+    await session.refresh(recipe)
+    logger.info(
+        "practice_recipe_created",
+        extra={"recipe_id": recipe.id, "user_id": user_id, "slug": recipe.slug},
+    )
+    return _to_out(recipe, steps)
+
+
+@router.get("/{recipe_id}", response_model=PracticeRecipeOut)
+async def get_practice_recipe(
+    recipe_id: int,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PracticeRecipeOut:
+    """Read one recipe + its steps."""
+    recipe = await _load_visible_recipe(recipe_id, user_id, session)
+    steps = await _load_steps(recipe_id, session)
+    return _to_out(recipe, steps)
+
+
+@router.patch("/{recipe_id}", response_model=PracticeRecipeOut)
+async def update_practice_recipe(
+    recipe_id: int,
+    payload: PracticeRecipeUpdate,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PracticeRecipeOut:
+    """Replace name + description + rounds + steps wholesale.
+
+    Slug and mode are immutable -- a slug rename would break any
+    UserPractice that captured the recipe by id, and a mode swap would
+    invalidate the step tag mappings.  Steps are wholesale-replaced
+    rather than diffed: simpler, and the client always sends the full
+    list anyway.
+    """
+    recipe = await _load_visible_recipe(recipe_id, user_id, session)
+    _require_personal(recipe)
+    # Replay the mode-aware invariants ``PracticeRecipeCreate`` enforces
+    # so PATCH cannot land an inconsistent state (e.g. rounds != 1 for
+    # a sense_grounding recipe).  Re-validate via the create schema --
+    # cheaper than duplicating the rules.
+    try:
+        PracticeRecipeCreate(
+            slug=recipe.slug,
+            name=payload.name,
+            description=payload.description,
+            mode=recipe.mode,
+            rounds=payload.rounds,
+            steps=payload.steps,
+        )
+    except ValidationError as exc:
+        raise bad_request("recipe_invariant_violated") from exc
+
+    recipe.name = payload.name
+    recipe.description = payload.description
+    recipe.rounds = payload.rounds
+    session.add(recipe)
+    # Wipe + replace steps in one transaction.
+    existing = await _load_steps(recipe_id, session)
+    for old in existing:
+        await session.delete(old)
+    await session.flush()
+    new_steps = _build_step_rows(recipe_id, list(payload.steps))
+    session.add_all(new_steps)
+    await session.commit()
+    await session.refresh(recipe)
+    return _to_out(recipe, new_steps)
+
+
+@router.delete("/{recipe_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_practice_recipe(
+    recipe_id: int,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> None:
+    """Delete a personal recipe.
+
+    Cascade on ``PracticeRecipeStep.recipe_id`` removes the step rows;
+    UserPractice rows are unaffected (the recipe only ever populated
+    their override JSON, never pointed at the recipe by FK).
+    """
+    recipe = await _load_visible_recipe(recipe_id, user_id, session)
+    _require_personal(recipe)
+    await session.delete(recipe)
+    await session.commit()
+    logger.info("practice_recipe_deleted", extra={"recipe_id": recipe_id, "user_id": user_id})
+
+
+def _validate_materialised_against_catalog(
+    materialised: dict[str, Any], practice: Practice
+) -> None:
+    """Run the materialised config through the same gate the customise route uses.
+
+    Shared with ``user_practices.customize_user_practice`` in spirit:
+    both paths land in ``UserPractice.mode_config_override`` and both
+    must (a) parse cleanly under ``ModeConfigAdapter`` and (b) match
+    the catalog ``mode``.
+    """
+    try:
+        cfg = ModeConfigAdapter.validate_python(materialised)
+    except ValidationError as exc:
+        raise bad_request("recipe_invalid_for_mode") from exc
+    if cfg.mode != practice.mode:
+        raise bad_request("mode_mismatch")
+
+
+@router.post(
+    "/{recipe_id}/apply-to/{user_practice_id}",
+    response_model=UserPracticeDetail,
+)
+async def apply_recipe_to_user_practice(
+    recipe_id: int,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
+) -> dict[str, Any]:
+    """Materialise a recipe and store it as the UserPractice's override.
+
+    Re-uses ``require_owned_user_practice`` (the same dependency the
+    customise endpoint uses) so the ownership rule for overrides is
+    enforced in exactly one place.  Mode mismatch returns ``400
+    mode_mismatch`` to mirror the customise endpoint's error shape.
+    """
+    recipe = await _load_visible_recipe(recipe_id, user_id, session)
+    steps = await _load_steps(recipe_id, session)
+    recipe_out = _to_out(recipe, steps)
+    materialised = materialise_mode_config(recipe_out)
+
+    practice_result = await session.execute(
+        select(Practice).where(Practice.id == user_practice.practice_id)
+    )
+    practice = practice_result.scalar_one_or_none()
+    if practice is None:
+        raise not_found("practice")
+    _validate_materialised_against_catalog(materialised, practice)
+
+    user_practice.mode_config_override = materialised
+    session.add(user_practice)
+    await session.commit()
+    await session.refresh(user_practice)
+    logger.info(
+        "practice_recipe_applied",
+        extra={
+            "recipe_id": recipe_id,
+            "user_practice_id": user_practice.id,
+            "user_id": user_id,
+        },
+    )
+    return {
+        "id": user_practice.id,
+        "practice_id": user_practice.practice_id,
+        "stage_number": user_practice.stage_number,
+        "start_date": user_practice.start_date,
+        "end_date": user_practice.end_date,
+        "custom_name": user_practice.custom_name,
+        "mode_config_override": user_practice.mode_config_override,
+        "effective_name": effective_name(practice, user_practice),
+        "effective_config": effective_config(practice, user_practice).model_dump(),
+        "sessions": [],
+    }

--- a/backend/src/routers/practice_recipes.py
+++ b/backend/src/routers/practice_recipes.py
@@ -24,12 +24,13 @@ attempts return ``403 cannot_modify_system_recipe``.
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, Query, status
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.selectable import Select
 from sqlmodel import col, or_, select
 
 from database import get_session
@@ -38,6 +39,7 @@ from domain.practice_resolution import effective_config, effective_name
 from errors import bad_request, conflict, forbidden, not_found
 from models.practice import Practice
 from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
+from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
 from schemas.practice import UserPracticeDetail
@@ -56,13 +58,41 @@ router = APIRouter(prefix="/practice-recipes", tags=["practice-recipes"])
 
 
 async def _load_steps(recipe_id: int, session: AsyncSession) -> list[PracticeRecipeStep]:
-    """Fetch a recipe's steps in display order."""
+    """Fetch one recipe's steps in display order.
+
+    Used by single-recipe endpoints (GET / PATCH / apply); the list
+    endpoint uses :func:`_load_steps_for_recipes` instead to avoid an
+    N+1 query as the recipe library grows.
+    """
     result = await session.execute(
         select(PracticeRecipeStep)
         .where(PracticeRecipeStep.recipe_id == recipe_id)
         .order_by(col(PracticeRecipeStep.position))
     )
     return list(result.scalars().all())
+
+
+async def _load_steps_for_recipes(
+    recipe_ids: list[int], session: AsyncSession
+) -> dict[int, list[PracticeRecipeStep]]:
+    """Fetch steps for many recipes in a single query, grouped by recipe id.
+
+    Returns a ``defaultdict``-style mapping so callers can index by
+    recipe id without a key-existence check; recipes with no steps
+    return an empty list.  Ordering inside each list mirrors
+    :func:`_load_steps` (position ascending).
+    """
+    if not recipe_ids:
+        return {}
+    result = await session.execute(
+        select(PracticeRecipeStep)
+        .where(col(PracticeRecipeStep.recipe_id).in_(recipe_ids))
+        .order_by(col(PracticeRecipeStep.recipe_id), col(PracticeRecipeStep.position))
+    )
+    grouped: dict[int, list[PracticeRecipeStep]] = {rid: [] for rid in recipe_ids}
+    for step in result.scalars():
+        grouped[step.recipe_id].append(step)
+    return grouped
 
 
 def _to_out(recipe: PracticeRecipe, steps: list[PracticeRecipeStep]) -> PracticeRecipeOut:
@@ -120,13 +150,13 @@ def _build_step_rows(recipe_id: int, payload_steps: list[Any]) -> list[PracticeR
     ]
 
 
-@router.get("/", response_model=list[PracticeRecipeOut])
-async def list_practice_recipes(
-    user_id: Annotated[int, Depends(get_current_user)],
-    session: Annotated[AsyncSession, Depends(get_session)],
-    mode: Annotated[str | None, Query(description="Filter by recipe mode.")] = None,
-) -> list[PracticeRecipeOut]:
-    """List every recipe visible to the caller, optionally filtered by mode."""
+def _build_recipe_list_query(user_id: int, mode: str | None) -> Select[tuple[PracticeRecipe]]:
+    """Build the `WHERE`-clause query for visible recipes, optionally mode-filtered.
+
+    Extracted so :func:`list_practice_recipes` stays at xenon rank A;
+    the visibility + mode + ordering branches add up to enough
+    complexity that inlining them pushes the endpoint to rank B.
+    """
     query = select(PracticeRecipe).where(
         or_(
             col(PracticeRecipe.owner_user_id).is_(None),
@@ -135,17 +165,38 @@ async def list_practice_recipes(
     )
     if mode is not None:
         query = query.where(PracticeRecipe.mode == mode)
-    query = query.order_by(col(PracticeRecipe.owner_user_id).nulls_first(), PracticeRecipe.name)
-    result = await session.execute(query)
-    recipes = list(result.scalars().all())
-    out: list[PracticeRecipeOut] = []
-    for recipe in recipes:
-        recipe_id = recipe.id
-        if recipe_id is None:
-            continue
-        steps = await _load_steps(recipe_id, session)
-        out.append(_to_out(recipe, steps))
-    return out
+    return query.order_by(col(PracticeRecipe.owner_user_id).nulls_first(), PracticeRecipe.name)
+
+
+async def _hydrate_recipes_with_steps(
+    recipes: list[PracticeRecipe], session: AsyncSession
+) -> list[PracticeRecipeOut]:
+    """Attach each recipe's step list via a single batched lookup.
+
+    ``recipe.id`` is typed ``int | None`` because the SQLModel base
+    permits unflushed rows, but rows loaded from a SELECT always
+    carry their PK -- the ``cast`` reflects that invariant without
+    re-filtering and keeps this helper at xenon rank A.
+    """
+    ids = [cast("int", r.id) for r in recipes]
+    steps_by_recipe = await _load_steps_for_recipes(ids, session)
+    return [_to_out(r, steps_by_recipe.get(cast("int", r.id), [])) for r in recipes]
+
+
+@router.get("/", response_model=list[PracticeRecipeOut])
+async def list_practice_recipes(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    mode: Annotated[str | None, Query(description="Filter by recipe mode.")] = None,
+) -> list[PracticeRecipeOut]:
+    """List every recipe visible to the caller, optionally filtered by mode.
+
+    Batches the step lookup into a single ``WHERE recipe_id IN (...)``
+    query so the picker, which fires this endpoint every time the
+    sheet opens, scales with library size instead of N+1.
+    """
+    result = await session.execute(_build_recipe_list_query(user_id, mode))
+    return await _hydrate_recipes_with_steps(list(result.scalars().all()), session)
 
 
 @router.post("/", response_model=PracticeRecipeOut, status_code=status.HTTP_201_CREATED)
@@ -210,6 +261,13 @@ async def update_practice_recipe(
     invalidate the step tag mappings.  Steps are wholesale-replaced
     rather than diffed: simpler, and the client always sends the full
     list anyway.
+
+    Concurrency: this endpoint is last-write-wins on the entire step
+    list.  Two clients editing the same recipe in parallel will see
+    the second writer's payload overwrite the first's; optimistic
+    locking is intentionally not added because recipes are personal
+    (single-user) and the conflict surface is therefore vanishingly
+    small.
     """
     recipe = await _load_visible_recipe(recipe_id, user_id, session)
     _require_personal(recipe)
@@ -316,6 +374,16 @@ async def apply_recipe_to_user_practice(
     session.add(user_practice)
     await session.commit()
     await session.refresh(user_practice)
+    # Load real session history so the response matches what GET
+    # ``/user-practices/{id}`` and ``customize_user_practice`` return.
+    # Returning ``sessions: []`` here would clobber any frontend store
+    # that merges the response back into local state.
+    sessions_result = await session.execute(
+        select(PracticeSession)
+        .where(PracticeSession.user_practice_id == user_practice.id)
+        .order_by(col(PracticeSession.timestamp).desc())
+    )
+    sessions = list(sessions_result.scalars().all())
     logger.info(
         "practice_recipe_applied",
         extra={
@@ -334,5 +402,5 @@ async def apply_recipe_to_user_practice(
         "mode_config_override": user_practice.mode_config_override,
         "effective_name": effective_name(practice, user_practice),
         "effective_config": effective_config(practice, user_practice).model_dump(),
-        "sessions": [],
+        "sessions": sessions,
     }

--- a/backend/src/routers/practice_tags.py
+++ b/backend/src/routers/practice_tags.py
@@ -1,0 +1,153 @@
+"""Practice-tag API -- personal tag library backing the recipe builder.
+
+Five endpoints around :class:`models.practice_tag.PracticeTag`:
+
+* ``GET /practice-tags`` -- visible to the caller (system + own).
+* ``POST /practice-tags`` -- create a personal tag.
+* ``GET /practice-tags/{tag_id}`` -- read one.
+* ``PATCH /practice-tags/{tag_id}`` -- rename a personal tag (label only;
+  slug is immutable so recipe steps that copied it stay valid).
+* ``DELETE /practice-tags/{tag_id}`` -- delete a personal tag.
+
+The visibility rule for read endpoints is identical to recipes: the
+caller sees every system row plus every row whose ``owner_user_id``
+matches their JWT subject.  Mutation routes additionally check that
+``owner_user_id`` is set to the caller -- attempts to mutate a system
+tag return ``403 cannot_modify_system_tag`` rather than 404 so the
+client can render an informative message.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, or_, select
+
+from database import get_session
+from errors import conflict, forbidden, not_found
+from models.practice_tag import PracticeTag
+from routers.auth import get_current_user
+from schemas.practice_tag import PracticeTagCreate, PracticeTagOut, PracticeTagUpdate
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/practice-tags", tags=["practice-tags"])
+
+
+async def _load_visible_tag(tag_id: int, user_id: int, session: AsyncSession) -> PracticeTag:
+    """Fetch a tag the caller is allowed to see, else raise 404."""
+    result = await session.execute(
+        select(PracticeTag).where(
+            PracticeTag.id == tag_id,
+            or_(
+                col(PracticeTag.owner_user_id).is_(None),
+                PracticeTag.owner_user_id == user_id,
+            ),
+        )
+    )
+    tag = result.scalar_one_or_none()
+    if tag is None:
+        raise not_found("practice_tag")
+    return tag
+
+
+def _require_personal(tag: PracticeTag) -> None:
+    """Reject mutation of a system tag with a stable 403 detail."""
+    if tag.owner_user_id is None:
+        raise forbidden("cannot_modify_system_tag")
+
+
+@router.get("/", response_model=list[PracticeTagOut])
+async def list_practice_tags(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> list[PracticeTag]:
+    """List every tag the caller can see (system + own), label-sorted."""
+    result = await session.execute(
+        select(PracticeTag)
+        .where(
+            or_(
+                col(PracticeTag.owner_user_id).is_(None),
+                PracticeTag.owner_user_id == user_id,
+            )
+        )
+        .order_by(col(PracticeTag.owner_user_id).nulls_first(), PracticeTag.label)
+    )
+    return list(result.scalars().all())
+
+
+@router.post("/", response_model=PracticeTagOut, status_code=status.HTTP_201_CREATED)
+async def create_practice_tag(
+    payload: PracticeTagCreate,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PracticeTag:
+    """Create a personal tag owned by the caller.
+
+    Slug uniqueness is per-user (the partial index in migration
+    ``07b8c9d0e1f2``).  A collision returns ``409 tag_slug_taken``
+    rather than the bare 500 the IntegrityError would otherwise
+    bubble up to.
+    """
+    tag = PracticeTag(slug=payload.slug, label=payload.label, owner_user_id=user_id)
+    session.add(tag)
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise conflict("tag_slug_taken") from exc
+    await session.refresh(tag)
+    logger.info(
+        "practice_tag_created",
+        extra={"tag_id": tag.id, "user_id": user_id, "slug": tag.slug},
+    )
+    return tag
+
+
+@router.get("/{tag_id}", response_model=PracticeTagOut)
+async def get_practice_tag(
+    tag_id: int,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PracticeTag:
+    """Read one tag visible to the caller."""
+    return await _load_visible_tag(tag_id, user_id, session)
+
+
+@router.patch("/{tag_id}", response_model=PracticeTagOut)
+async def update_practice_tag(
+    tag_id: int,
+    payload: PracticeTagUpdate,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PracticeTag:
+    """Rename a personal tag.  Slug is immutable; only ``label`` changes."""
+    tag = await _load_visible_tag(tag_id, user_id, session)
+    _require_personal(tag)
+    tag.label = payload.label
+    session.add(tag)
+    await session.commit()
+    await session.refresh(tag)
+    return tag
+
+
+@router.delete("/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_practice_tag(
+    tag_id: int,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> None:
+    """Delete a personal tag.
+
+    Recipes that copied the slug stay intact -- recipe steps carry
+    ``tag_slug`` by value, not by FK.
+    """
+    tag = await _load_visible_tag(tag_id, user_id, session)
+    _require_personal(tag)
+    await session.delete(tag)
+    await session.commit()
+    logger.info("practice_tag_deleted", extra={"tag_id": tag_id, "user_id": user_id})

--- a/backend/src/schemas/practice_recipe.py
+++ b/backend/src/schemas/practice_recipe.py
@@ -1,0 +1,219 @@
+"""Wire DTOs for the recipe library + apply endpoints.
+
+Six routes around :class:`models.practice_recipe.PracticeRecipe`:
+
+* ``GET /practice-recipes`` -- list system + caller's personal recipes,
+  optionally filtered by mode.
+* ``POST /practice-recipes`` -- create a personal recipe (optionally
+  forked from a system one client-side; the server treats both paths
+  identically).
+* ``GET /practice-recipes/{recipe_id}`` -- read one with its steps.
+* ``PATCH /practice-recipes/{recipe_id}`` -- replace name / description
+  / rounds / steps in a single call.  Steps are wholesale-replaced (not
+  diffed) -- much simpler than reconciling positional moves and the
+  client always sends the full list anyway.
+* ``DELETE /practice-recipes/{recipe_id}`` -- delete a personal recipe.
+* ``POST /practice-recipes/{recipe_id}/apply-to/{user_practice_id}`` --
+  materialise the recipe into ``UserPractice.mode_config_override``.
+
+System recipes (``owner_user_id IS NULL``) are read-only and the
+router rejects mutation with ``403 cannot_modify_system_recipe``.  The
+client's "edit a system recipe" flow forks a personal copy via POST
+before opening the editor.
+
+The ``materialise_mode_config`` helper turns a recipe into the
+``mode_config`` JSON the existing override mechanism expects.  Keeping
+that conversion at the schema layer (not the router) means the seed
+script can call it too -- the test suite asserts the seeded system
+recipes round-trip through ``ModeConfigAdapter`` cleanly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Any, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from domain.practice_modes import PracticeMode
+from models.practice_recipe import RECIPE_MODES
+from schemas.practice_mode_config import (
+    TALLIED_CATEGORIES_MAX,
+    TALLIED_ROUNDS_MAX,
+    TALLIED_TARGET_MAX,
+)
+from schemas.practice_tag import TAG_LABEL_MAX, TAG_SLUG_MAX, TAG_SLUG_PATTERN
+
+# Bounds mirror schemas.practice_mode_config so a recipe that validates
+# here always serialises into a mode_config that validates against
+# ``ModeConfigAdapter`` downstream.
+_RECIPE_SLUG_MAX = 64
+_RECIPE_SLUG_PATTERN = r"^[a-z][a-z0-9_]*$"
+_RECIPE_NAME_MAX = 255
+_RECIPE_DESCRIPTION_MAX = 2_000
+_PROMPT_LABEL_MAX = 255
+_STEPS_MIN = 1
+_STEPS_MAX = TALLIED_CATEGORIES_MAX
+_ROUNDS_MIN = 1
+_ROUNDS_MAX = TALLIED_ROUNDS_MAX
+_TARGET_COUNT_MIN = 1
+_TARGET_COUNT_MAX = TALLIED_TARGET_MAX
+# ``sense_grounding`` mode has no concept of rounds-by-categories: the
+# user walks the prompt list once.  Recipes built for that mode are
+# pinned to a single round to keep the materialised payload valid.
+SENSE_GROUNDING_ROUNDS = 1
+
+RecipeMode = Annotated[str, Field(pattern="|".join(RECIPE_MODES))]
+
+
+class PracticeRecipeStepOut(BaseModel):
+    """One step row in a recipe read response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    position: int
+    tag_slug: str
+    tag_label: str
+    prompt_label: str
+    target_count: int
+
+
+class PracticeRecipeOut(BaseModel):
+    """List / read response for one recipe row."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    slug: str
+    name: str
+    description: str
+    owner_user_id: int | None
+    mode: str
+    rounds: int
+    created_at: datetime
+    steps: list[PracticeRecipeStepOut] = Field(default_factory=list)
+
+
+class PracticeRecipeStepInput(BaseModel):
+    """One step row in a create / update request body.
+
+    ``position`` is intentionally absent -- the router assigns
+    positions from the list index so the client never has to keep two
+    representations of order in sync.
+    """
+
+    tag_slug: str = Field(min_length=1, max_length=TAG_SLUG_MAX, pattern=TAG_SLUG_PATTERN)
+    tag_label: str = Field(min_length=1, max_length=TAG_LABEL_MAX)
+    prompt_label: str = Field(min_length=1, max_length=_PROMPT_LABEL_MAX)
+    target_count: int = Field(ge=_TARGET_COUNT_MIN, le=_TARGET_COUNT_MAX)
+
+
+def _check_steps_invariants(steps: list[PracticeRecipeStepInput], mode: str) -> None:
+    """Reject duplicate slugs within one recipe; analytics keys must be unique.
+
+    Extracted as a free function so the create + update validators stay
+    at xenon rank A and share one rule rather than drifting.
+    """
+    if mode == PracticeMode.TALLIED_GROUNDING.value:
+        seen: set[str] = set()
+        for step in steps:
+            if step.tag_slug in seen:
+                msg = f"duplicate tag_slug within recipe: {step.tag_slug!r}"
+                raise ValueError(msg)
+            seen.add(step.tag_slug)
+
+
+def _check_rounds_for_mode(rounds: int, mode: str) -> None:
+    """Sense-grounding recipes are walked once; pin rounds to 1 for that mode."""
+    if mode == PracticeMode.SENSE_GROUNDING.value and rounds != SENSE_GROUNDING_ROUNDS:
+        msg = f"sense_grounding recipes require rounds == {SENSE_GROUNDING_ROUNDS}"
+        raise ValueError(msg)
+
+
+class PracticeRecipeCreate(BaseModel):
+    """Body accepted by ``POST /practice-recipes``.
+
+    The router stamps ``owner_user_id`` from the JWT subject.  Clients
+    cannot create a system recipe.
+    """
+
+    slug: str = Field(min_length=1, max_length=_RECIPE_SLUG_MAX, pattern=_RECIPE_SLUG_PATTERN)
+    name: str = Field(min_length=1, max_length=_RECIPE_NAME_MAX)
+    description: str = Field(min_length=0, max_length=_RECIPE_DESCRIPTION_MAX, default="")
+    mode: RecipeMode
+    rounds: int = Field(ge=_ROUNDS_MIN, le=_ROUNDS_MAX, default=SENSE_GROUNDING_ROUNDS)
+    steps: list[PracticeRecipeStepInput] = Field(min_length=_STEPS_MIN, max_length=_STEPS_MAX)
+
+    @model_validator(mode="after")
+    def _check_invariants(self) -> Self:
+        _check_rounds_for_mode(self.rounds, self.mode)
+        _check_steps_invariants(self.steps, self.mode)
+        return self
+
+
+class PracticeRecipeUpdate(BaseModel):
+    """Body accepted by ``PATCH /practice-recipes/{recipe_id}``.
+
+    Replaces the editable fields wholesale.  ``slug`` and ``mode`` are
+    immutable post-create -- renaming the slug would break any
+    UserPractice that captured the recipe by id, and switching mode
+    would invalidate every step's tag mapping.
+    """
+
+    name: str = Field(min_length=1, max_length=_RECIPE_NAME_MAX)
+    description: str = Field(min_length=0, max_length=_RECIPE_DESCRIPTION_MAX, default="")
+    rounds: int = Field(ge=_ROUNDS_MIN, le=_ROUNDS_MAX, default=SENSE_GROUNDING_ROUNDS)
+    steps: list[PracticeRecipeStepInput] = Field(min_length=_STEPS_MIN, max_length=_STEPS_MAX)
+
+
+def _materialise_sense_grounding(steps: list[PracticeRecipeStepOut]) -> dict[str, Any]:
+    """Build a ``sense_grounding`` ``mode_config`` from a recipe's steps.
+
+    Each step contributes ``target_count`` consecutive prompts with the
+    same label so a 5-4-3-2-1 step ("sight, count=5, label='Name 5
+    things you can see'") produces one prompt -- the count is encoded
+    in the label.  Repetition only happens for tallied recipes.
+    """
+    return {
+        "mode": PracticeMode.SENSE_GROUNDING.value,
+        "prompts": [{"sense": step.tag_slug, "label": step.prompt_label} for step in steps],
+    }
+
+
+def _materialise_tallied_grounding(
+    steps: list[PracticeRecipeStepOut], rounds: int
+) -> dict[str, Any]:
+    """Build a ``tallied_grounding`` ``mode_config`` from a recipe's steps."""
+    return {
+        "mode": PracticeMode.TALLIED_GROUNDING.value,
+        "rounds": rounds,
+        "categories": [
+            {
+                "key": step.tag_slug,
+                "label": step.tag_label,
+                "target_count": step.target_count,
+            }
+            for step in steps
+        ],
+    }
+
+
+def materialise_mode_config(recipe: PracticeRecipeOut) -> dict[str, Any]:
+    """Turn a recipe into the ``mode_config`` JSON the override mechanism expects.
+
+    Dispatch on ``recipe.mode``.  The result is intended to be passed
+    straight to :class:`schemas.practice.UserPracticeCustomize` as the
+    ``mode_config_override`` field, where the existing validator runs
+    it through :data:`schemas.practice_mode_config.ModeConfigAdapter`
+    against the catalog mode.
+    """
+    if recipe.mode == PracticeMode.SENSE_GROUNDING.value:
+        return _materialise_sense_grounding(recipe.steps)
+    if recipe.mode == PracticeMode.TALLIED_GROUNDING.value:
+        return _materialise_tallied_grounding(recipe.steps, recipe.rounds)
+    # Unreachable: ``mode`` is constrained by RECIPE_MODES at the
+    # schema and DB layers.  Defensive raise keeps mypy happy and
+    # surfaces a clear error if a new mode is added to RECIPE_MODES
+    # without updating this dispatcher.
+    msg = f"unsupported recipe mode: {recipe.mode!r}"
+    raise ValueError(msg)

--- a/backend/src/schemas/practice_tag.py
+++ b/backend/src/schemas/practice_tag.py
@@ -1,0 +1,61 @@
+"""Wire DTOs for the personal-tag library endpoints.
+
+Five routes around :class:`models.practice_tag.PracticeTag`:
+
+* ``GET /practice-tags`` -- list system tags + the caller's personal tags.
+* ``POST /practice-tags`` -- create a personal tag.
+* ``GET /practice-tags/{tag_id}`` -- read one (system or personal).
+* ``PATCH /practice-tags/{tag_id}`` -- rename a personal tag.
+* ``DELETE /practice-tags/{tag_id}`` -- delete a personal tag.
+
+System tags (``owner_user_id IS NULL``) are read-only and the router
+rejects mutation attempts with ``403 cannot_modify_system_tag``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Mirror ``schemas.practice_mode_config._TALLIED_KEY_*`` so the recipe
+# step layer (which copies a tag's slug by value) cannot accept a slug
+# the tag layer rejected.  Drift would surface as a 500 at apply
+# time; the shared constants keep validation symmetric.
+TAG_SLUG_MAX = 64
+TAG_SLUG_PATTERN = r"^[a-z][a-z0-9_]*$"
+TAG_LABEL_MAX = 255
+
+
+class PracticeTagOut(BaseModel):
+    """List / read response for one tag row."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    slug: str
+    label: str
+    owner_user_id: int | None
+    created_at: datetime
+
+
+class PracticeTagCreate(BaseModel):
+    """Body accepted by ``POST /practice-tags``.
+
+    The router always sets ``owner_user_id`` from the JWT subject, so
+    the body never carries it.  Clients cannot create a system tag.
+    """
+
+    slug: str = Field(min_length=1, max_length=TAG_SLUG_MAX, pattern=TAG_SLUG_PATTERN)
+    label: str = Field(min_length=1, max_length=TAG_LABEL_MAX)
+
+
+class PracticeTagUpdate(BaseModel):
+    """Body accepted by ``PATCH /practice-tags/{tag_id}``.
+
+    ``slug`` is immutable post-create: recipe steps copy the slug by
+    value at build time and a rename here would leave them pointing at
+    a stale machine identifier.  Only the display ``label`` is patchable.
+    """
+
+    label: str = Field(min_length=1, max_length=TAG_LABEL_MAX)

--- a/backend/src/seed_practice_recipes.py
+++ b/backend/src/seed_practice_recipes.py
@@ -1,0 +1,413 @@
+"""Seed system :class:`PracticeTag` + :class:`PracticeRecipe` rows.
+
+Mirrors :mod:`seed_practices` -- defines the preset list, validates
+each materialised ``mode_config`` payload at import time so a typo
+crashes the seeder (not the runtime), and inserts only what is missing
+on a per-call basis.
+
+System recipes are owner_user_id IS NULL so they share one namespace
+and are read-only via the API.  Tags are seeded alongside so the
+recipe-editor's tag picker has a useful starting library even before
+the user creates any of their own.
+
+The five recipes mirror the mindfulness practices a user might pick
+for their tier-one habit:
+
+* ``5-4-3-2-1 Grounding`` -- the canonical five-senses descending count.
+* ``Find the Rainbow`` -- seven colors x N rounds.
+* ``Find Shapes`` -- square / circle / triangle x N rounds.
+* ``Four Elements`` -- Buddhist body scan: earth, water, fire, air.
+* ``Embodied Mindfulness`` -- pressure-direction body awareness x N rounds.
+
+The match key is ``(slug,)`` scoped to ``owner_user_id IS NULL`` so a
+user-created recipe with the same slug under a different owner does
+not block a system preset from being inserted.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.practice_modes import PracticeMode
+from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
+from models.practice_tag import PracticeTag
+from schemas.practice_mode_config import ModeConfigAdapter
+from schemas.practice_recipe import (
+    PracticeRecipeOut,
+    PracticeRecipeStepOut,
+    materialise_mode_config,
+)
+
+# Default repeat counts for rounds-by-categories recipes.  Three is the
+# defacto "enough to settle, not so many you check out" round count the
+# user described in the original spec.
+_DEFAULT_ROUNDS = 3
+# The "Four Elements" recipe is walked once at three observations per
+# element -- four elements x three observations matches the rhythm of
+# the Buddhist body scan it's based on.
+_FOUR_ELEMENTS_PER_ELEMENT = 3
+
+
+def _system_tag(slug: str, label: str) -> dict[str, str]:
+    """Build one system-tag definition (owner_user_id stays NULL at insert)."""
+    return {"slug": slug, "label": label}
+
+
+#: Tag library seeded alongside the recipes.  These are the building
+#: blocks every recipe step references; the recipe steps copy the slug
+#: + label by value, so removing a tag here later does not break the
+#: already-seeded recipes (but does remove it from the picker).
+SYSTEM_TAGS: tuple[dict[str, str], ...] = (
+    # 5-4-3-2-1
+    _system_tag("sight", "Sight"),
+    _system_tag("touch", "Touch"),
+    _system_tag("hearing", "Hearing"),
+    _system_tag("smell", "Smell"),
+    _system_tag("taste", "Taste"),
+    # Find the Rainbow
+    _system_tag("red", "Red"),
+    _system_tag("orange", "Orange"),
+    _system_tag("yellow", "Yellow"),
+    _system_tag("green", "Green"),
+    _system_tag("blue", "Blue"),
+    _system_tag("indigo", "Indigo"),
+    _system_tag("violet", "Violet"),
+    # Find Shapes
+    _system_tag("square", "Square"),
+    _system_tag("circle", "Circle"),
+    _system_tag("triangle", "Triangle"),
+    # Four Elements
+    _system_tag("earth", "Earth"),
+    _system_tag("water", "Water"),
+    _system_tag("fire", "Fire"),
+    _system_tag("air", "Air"),
+    # Embodied
+    _system_tag("pressing_on_me", "Pressing on me"),
+    _system_tag("i_press_on", "I press on"),
+    _system_tag("felt_inside", "Felt inside"),
+)
+
+
+def _step(
+    tag_slug: str, tag_label: str, prompt_label: str, target_count: int = 1
+) -> dict[str, Any]:
+    """Build one recipe-step definition."""
+    return {
+        "tag_slug": tag_slug,
+        "tag_label": tag_label,
+        "prompt_label": prompt_label,
+        "target_count": target_count,
+    }
+
+
+def _build_recipe(meta: dict[str, Any], steps: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compose one system recipe definition.
+
+    ``meta`` carries the per-recipe header fields (slug, name,
+    description, mode, rounds); ``steps`` is the ordered list of step
+    definitions.  Owner is always ``None`` here -- only the seeder
+    inserts system recipes.
+    """
+    return {**meta, "owner_user_id": None, "steps": steps}
+
+
+def _five_four_three_two_one_steps() -> list[dict[str, Any]]:
+    """5-4-3-2-1 canonical step list, one prompt per sense."""
+    return [
+        _step("sight", "Sight", "Name 5 things you can see", target_count=5),
+        _step("touch", "Touch", "Name 4 things you can touch", target_count=4),
+        _step("hearing", "Hearing", "Name 3 things you can hear", target_count=3),
+        _step("smell", "Smell", "Name 2 things you can smell", target_count=2),
+        _step("taste", "Taste", "Name 1 thing you can taste", target_count=1),
+    ]
+
+
+def _find_rainbow_steps() -> list[dict[str, Any]]:
+    """Seven rainbow colors; one observation per color per round."""
+    return [
+        _step("red", "Red", "Find something red"),
+        _step("orange", "Orange", "Find something orange"),
+        _step("yellow", "Yellow", "Find something yellow"),
+        _step("green", "Green", "Find something green"),
+        _step("blue", "Blue", "Find something blue"),
+        _step("indigo", "Indigo", "Find something indigo"),
+        _step("violet", "Violet", "Find something violet"),
+    ]
+
+
+def _find_shapes_steps() -> list[dict[str, Any]]:
+    """Three basic shapes; one observation per shape per round."""
+    return [
+        _step("square", "Square", "Find a square"),
+        _step("circle", "Circle", "Find a circle"),
+        _step("triangle", "Triangle", "Find a triangle"),
+    ]
+
+
+def _four_elements_steps() -> list[dict[str, Any]]:
+    """Buddhist body-element scan: earth, water, fire, air."""
+    return [
+        _step(
+            "earth",
+            "Earth",
+            "Notice the earth element: solidity, weight, density",
+            target_count=_FOUR_ELEMENTS_PER_ELEMENT,
+        ),
+        _step(
+            "water",
+            "Water",
+            "Notice the water element: fluidity, cohesion, moisture",
+            target_count=_FOUR_ELEMENTS_PER_ELEMENT,
+        ),
+        _step(
+            "fire",
+            "Fire",
+            "Notice the fire element: warmth, heat, temperature",
+            target_count=_FOUR_ELEMENTS_PER_ELEMENT,
+        ),
+        _step(
+            "air",
+            "Air",
+            "Notice the air element: movement, breath, vibration",
+            target_count=_FOUR_ELEMENTS_PER_ELEMENT,
+        ),
+    ]
+
+
+def _embodied_mindfulness_steps() -> list[dict[str, Any]]:
+    """Pressure-direction body awareness: three observations per direction."""
+    return [
+        _step(
+            "pressing_on_me",
+            "Pressing on me",
+            "Notice something pressing on your body",
+        ),
+        _step(
+            "i_press_on",
+            "I press on",
+            "Notice something your body is pressing on",
+        ),
+        _step(
+            "felt_inside",
+            "Felt inside",
+            "Notice a sensation inside your body",
+        ),
+    ]
+
+
+#: All system recipes seeded into the recipe library.  Tuple (not list)
+#: so callers cannot mutate the seed plan after import.
+SYSTEM_RECIPES: tuple[dict[str, Any], ...] = (
+    _build_recipe(
+        {
+            "slug": "five_four_three_two_one",
+            "name": "5-4-3-2-1 Grounding",
+            "description": (
+                "Walk the five senses in descending count.  Anchor attention "
+                "by naming five sights, four textures, three sounds, two "
+                "smells, one taste."
+            ),
+            "mode": PracticeMode.SENSE_GROUNDING.value,
+            "rounds": 1,
+        },
+        _five_four_three_two_one_steps(),
+    ),
+    _build_recipe(
+        {
+            "slug": "find_the_rainbow",
+            "name": "Find the Rainbow",
+            "description": (
+                "Hunt the seven rainbow colors around you.  Repeat for "
+                "several rounds to deepen the noticing."
+            ),
+            "mode": PracticeMode.TALLIED_GROUNDING.value,
+            "rounds": _DEFAULT_ROUNDS,
+        },
+        _find_rainbow_steps(),
+    ),
+    _build_recipe(
+        {
+            "slug": "find_shapes",
+            "name": "Find Shapes",
+            "description": (
+                "Spot the three primitive shapes -- square, circle, triangle "
+                "-- in the room you're sitting in.  Repeat for several rounds."
+            ),
+            "mode": PracticeMode.TALLIED_GROUNDING.value,
+            "rounds": _DEFAULT_ROUNDS,
+        },
+        _find_shapes_steps(),
+    ),
+    _build_recipe(
+        {
+            "slug": "four_elements",
+            "name": "Four Elements",
+            "description": (
+                "Buddhist embodied mindfulness: notice earth, water, fire, "
+                "and air sensations in your body.  Three observations per "
+                "element."
+            ),
+            "mode": PracticeMode.TALLIED_GROUNDING.value,
+            "rounds": 1,
+        },
+        _four_elements_steps(),
+    ),
+    _build_recipe(
+        {
+            "slug": "embodied_mindfulness",
+            "name": "Embodied Mindfulness",
+            "description": (
+                "Three pressures, three counter-pressures, three felt-inside "
+                "sensations.  Repeat to settle into the body."
+            ),
+            "mode": PracticeMode.TALLIED_GROUNDING.value,
+            "rounds": _DEFAULT_ROUNDS,
+        },
+        _embodied_mindfulness_steps(),
+    ),
+)
+
+
+def _validate_recipe_materialises(definition: dict[str, Any]) -> None:
+    """Build the recipe out shape and round-trip it through ``ModeConfigAdapter``.
+
+    Catches typos in seeded recipes at import time -- a step whose tag
+    slug fails the schema pattern, or a recipe whose materialised
+    payload does not parse as the declared mode, fails the import
+    instead of poisoning the DB on first startup.
+    """
+    step_outs = [
+        PracticeRecipeStepOut(
+            position=i,
+            tag_slug=step["tag_slug"],
+            tag_label=step["tag_label"],
+            prompt_label=step["prompt_label"],
+            target_count=step["target_count"],
+        )
+        for i, step in enumerate(definition["steps"])
+    ]
+    out = PracticeRecipeOut(
+        id=0,
+        slug=definition["slug"],
+        name=definition["name"],
+        description=definition["description"],
+        owner_user_id=None,
+        mode=definition["mode"],
+        rounds=definition["rounds"],
+        created_at=datetime.now(UTC),
+        steps=step_outs,
+    )
+    materialised = materialise_mode_config(out)
+    ModeConfigAdapter.validate_python(materialised)
+
+
+for _definition in SYSTEM_RECIPES:
+    _validate_recipe_materialises(_definition)
+
+# Reject duplicate slugs in the seed plan -- a collision would block
+# every later seeder run on the partial-unique index.
+_recipe_slugs = [r["slug"] for r in SYSTEM_RECIPES]
+if len(set(_recipe_slugs)) != len(_recipe_slugs):
+    _dupes = sorted(s for s in _recipe_slugs if _recipe_slugs.count(s) > 1)
+    msg = f"Duplicate system recipe slug: {_dupes}"
+    raise ValueError(msg)
+_tag_slugs = [t["slug"] for t in SYSTEM_TAGS]
+if len(set(_tag_slugs)) != len(_tag_slugs):
+    _tag_dupes = sorted(s for s in _tag_slugs if _tag_slugs.count(s) > 1)
+    msg = f"Duplicate system tag slug: {_tag_dupes}"
+    raise ValueError(msg)
+
+
+async def _existing_system_tag_slugs(session: AsyncSession) -> set[str]:
+    """Return slugs of system tags already in the DB."""
+    result = await session.execute(
+        select(PracticeTag.slug).where(col(PracticeTag.owner_user_id).is_(None))
+    )
+    return {row[0] for row in result.all()}
+
+
+async def _existing_system_recipe_slugs(session: AsyncSession) -> set[str]:
+    """Return slugs of system recipes already in the DB."""
+    result = await session.execute(
+        select(PracticeRecipe.slug).where(col(PracticeRecipe.owner_user_id).is_(None))
+    )
+    return {row[0] for row in result.all()}
+
+
+async def _seed_system_tags(session: AsyncSession) -> int:
+    """Insert system tags not yet present.  Returns inserted row count."""
+    existing = await _existing_system_tag_slugs(session)
+    inserted = 0
+    for definition in SYSTEM_TAGS:
+        if definition["slug"] in existing:
+            continue
+        session.add(PracticeTag(slug=definition["slug"], label=definition["label"]))
+        inserted += 1
+    return inserted
+
+
+async def _insert_recipe_with_steps(session: AsyncSession, definition: dict[str, Any]) -> None:
+    """Insert one recipe + its steps, flushing to obtain the recipe PK."""
+    recipe = PracticeRecipe(
+        slug=definition["slug"],
+        name=definition["name"],
+        description=definition["description"],
+        owner_user_id=None,
+        mode=definition["mode"],
+        rounds=definition["rounds"],
+    )
+    session.add(recipe)
+    await session.flush()
+    recipe_id = recipe.id
+    if recipe_id is None:  # pragma: no cover - flush always populates the PK
+        msg = "recipe insert failed to populate primary key"
+        raise RuntimeError(msg)
+    for index, step in enumerate(definition["steps"]):
+        session.add(
+            PracticeRecipeStep(
+                recipe_id=recipe_id,
+                position=index,
+                tag_slug=step["tag_slug"],
+                tag_label=step["tag_label"],
+                prompt_label=step["prompt_label"],
+                target_count=step["target_count"],
+            )
+        )
+
+
+async def _seed_system_recipes(session: AsyncSession) -> int:
+    """Insert system recipes not yet present.  Returns inserted row count."""
+    existing = await _existing_system_recipe_slugs(session)
+    inserted = 0
+    for definition in SYSTEM_RECIPES:
+        if definition["slug"] in existing:
+            continue
+        await _insert_recipe_with_steps(session, definition)
+        inserted += 1
+    return inserted
+
+
+async def seed_practice_recipes(session: AsyncSession) -> int:
+    """Insert system tags + recipes that don't already exist.
+
+    Returns the total rows inserted (tags + recipes).  Idempotent:
+    re-running on a populated DB returns 0.  An :class:`IntegrityError`
+    from a peer process winning the race is converted to a no-op so
+    concurrent worker startup does not crash.
+    """
+    tags_inserted = await _seed_system_tags(session)
+    recipes_inserted = await _seed_system_recipes(session)
+    total = tags_inserted + recipes_inserted
+    if not total:
+        return 0
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        return 0
+    return total

--- a/backend/tests/test_practice_recipes_api.py
+++ b/backend/tests/test_practice_recipes_api.py
@@ -1,0 +1,435 @@
+"""Tests for /practice-recipes CRUD + apply endpoints."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.practice import Practice
+from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
+from models.stage_progress import StageProgress
+
+
+async def _signup(client: AsyncClient, username: str = "owner") -> tuple[dict[str, str], int]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+def _sense_grounding_steps() -> list[dict[str, Any]]:
+    return [
+        {
+            "tag_slug": "sight",
+            "tag_label": "Sight",
+            "prompt_label": "Name 5 things you can see",
+            "target_count": 5,
+        },
+        {
+            "tag_slug": "touch",
+            "tag_label": "Touch",
+            "prompt_label": "Name 4 things you can touch",
+            "target_count": 4,
+        },
+    ]
+
+
+def _tallied_steps() -> list[dict[str, Any]]:
+    return [
+        {"tag_slug": "red", "tag_label": "Red", "prompt_label": "Find red", "target_count": 1},
+        {"tag_slug": "blue", "tag_label": "Blue", "prompt_label": "Find blue", "target_count": 1},
+    ]
+
+
+def _sense_recipe_body(slug: str = "my_sense") -> dict[str, Any]:
+    return {
+        "slug": slug,
+        "name": "My Sense Recipe",
+        "description": "",
+        "mode": "sense_grounding",
+        "rounds": 1,
+        "steps": _sense_grounding_steps(),
+    }
+
+
+def _tallied_recipe_body(slug: str = "my_tallied", rounds: int = 2) -> dict[str, Any]:
+    return {
+        "slug": slug,
+        "name": "My Tallied Recipe",
+        "description": "",
+        "mode": "tallied_grounding",
+        "rounds": rounds,
+        "steps": _tallied_steps(),
+    }
+
+
+async def _seed_system_recipe(db_session: AsyncSession, slug: str = "system_one") -> PracticeRecipe:
+    recipe = PracticeRecipe(
+        slug=slug,
+        name="System Recipe",
+        description="",
+        owner_user_id=None,
+        mode="tallied_grounding",
+        rounds=1,
+    )
+    db_session.add(recipe)
+    await db_session.commit()
+    await db_session.refresh(recipe)
+    assert recipe.id is not None
+    db_session.add(
+        PracticeRecipeStep(
+            recipe_id=recipe.id,
+            position=0,
+            tag_slug="red",
+            tag_label="Red",
+            prompt_label="Find red",
+            target_count=1,
+        )
+    )
+    await db_session.commit()
+    return recipe
+
+
+# -- Create -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_sense_recipe_201(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    resp = await async_client.post("/practice-recipes/", json=_sense_recipe_body(), headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+    body = resp.json()
+    assert body["slug"] == "my_sense"
+    assert body["mode"] == "sense_grounding"
+    assert body["owner_user_id"] is not None
+    assert len(body["steps"]) == 2
+    assert body["steps"][0]["position"] == 0
+    assert body["steps"][1]["position"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_tallied_recipe_201(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    resp = await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body(rounds=3), headers=headers
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+    body = resp.json()
+    assert body["rounds"] == 3
+    assert body["mode"] == "tallied_grounding"
+
+
+@pytest.mark.asyncio
+async def test_create_sense_with_rounds_gt_1_rejected(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    payload = _sense_recipe_body()
+    payload["rounds"] = 2
+    resp = await async_client.post("/practice-recipes/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_tallied_duplicate_slug_within_recipe_rejected(
+    async_client: AsyncClient,
+) -> None:
+    headers, _ = await _signup(async_client)
+    payload = _tallied_recipe_body()
+    payload["steps"] = [
+        {"tag_slug": "red", "tag_label": "R", "prompt_label": "x", "target_count": 1},
+        {"tag_slug": "red", "tag_label": "R", "prompt_label": "y", "target_count": 1},
+    ]
+    resp = await async_client.post("/practice-recipes/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_user_slug_409(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    await async_client.post("/practice-recipes/", json=_sense_recipe_body("dup"), headers=headers)
+    resp = await async_client.post(
+        "/practice-recipes/", json=_sense_recipe_body("dup"), headers=headers
+    )
+    assert resp.status_code == HTTPStatus.CONFLICT
+    assert resp.json()["detail"] == "recipe_slug_taken"
+
+
+@pytest.mark.asyncio
+async def test_create_unknown_mode_422(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    payload = _sense_recipe_body()
+    payload["mode"] = "meditation_timer"
+    resp = await async_client.post("/practice-recipes/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# -- List + read ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_returns_system_and_own(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _seed_system_recipe(db_session, slug="seed_one")
+    headers, _ = await _signup(async_client)
+    await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body("user_one"), headers=headers
+    )
+    resp = await async_client.get("/practice-recipes/", headers=headers)
+    slugs = {r["slug"] for r in resp.json()}
+    assert {"seed_one", "user_one"} <= slugs
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_mode(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    await async_client.post(
+        "/practice-recipes/", json=_sense_recipe_body("only_sense"), headers=headers
+    )
+    await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body("only_tallied"), headers=headers
+    )
+    resp = await async_client.get("/practice-recipes/?mode=sense_grounding", headers=headers)
+    slugs = {r["slug"] for r in resp.json()}
+    assert "only_sense" in slugs
+    assert "only_tallied" not in slugs
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_other_users(async_client: AsyncClient) -> None:
+    headers_alice, _ = await _signup(async_client, "alice")
+    headers_bob, _ = await _signup(async_client, "bob")
+    await async_client.post(
+        "/practice-recipes/", json=_sense_recipe_body("alice_secret"), headers=headers_alice
+    )
+    resp = await async_client.get("/practice-recipes/", headers=headers_bob)
+    slugs = {r["slug"] for r in resp.json()}
+    assert "alice_secret" not in slugs
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_includes_steps(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    recipe = await _seed_system_recipe(db_session)
+    headers, _ = await _signup(async_client)
+    resp = await async_client.get(f"/practice-recipes/{recipe.id}", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert len(body["steps"]) == 1
+    assert body["steps"][0]["tag_slug"] == "red"
+
+
+# -- Update -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_personal_recipe(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    create = await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body(), headers=headers
+    )
+    recipe_id = create.json()["id"]
+    new_steps = [
+        {"tag_slug": "green", "tag_label": "Green", "prompt_label": "g", "target_count": 1},
+    ]
+    resp = await async_client.patch(
+        f"/practice-recipes/{recipe_id}",
+        json={
+            "name": "Renamed",
+            "description": "new desc",
+            "rounds": 5,
+            "steps": new_steps,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+    assert body["name"] == "Renamed"
+    assert body["rounds"] == 5
+    assert len(body["steps"]) == 1
+    assert body["steps"][0]["tag_slug"] == "green"
+
+
+@pytest.mark.asyncio
+async def test_update_system_recipe_403(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    recipe = await _seed_system_recipe(db_session)
+    headers, _ = await _signup(async_client)
+    resp = await async_client.patch(
+        f"/practice-recipes/{recipe.id}",
+        json={
+            "name": "x",
+            "description": "",
+            "rounds": 1,
+            "steps": _tallied_steps(),
+        },
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "cannot_modify_system_recipe"
+
+
+# -- Delete -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_personal_recipe(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+    create = await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body("doomed"), headers=headers
+    )
+    recipe_id = create.json()["id"]
+    resp = await async_client.delete(f"/practice-recipes/{recipe_id}", headers=headers)
+    assert resp.status_code == HTTPStatus.NO_CONTENT
+    get_resp = await async_client.get(f"/practice-recipes/{recipe_id}", headers=headers)
+    assert get_resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_delete_system_recipe_403(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    recipe = await _seed_system_recipe(db_session)
+    headers, _ = await _signup(async_client)
+    resp = await async_client.delete(f"/practice-recipes/{recipe.id}", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+# -- Apply ------------------------------------------------------------------
+
+
+async def _seed_catalog_practice(
+    db_session: AsyncSession, mode: str, mode_config: dict[str, Any]
+) -> Practice:
+    practice = Practice(
+        stage_number=1,
+        name=f"Catalog {mode}",
+        description="x",
+        instructions="x",
+        default_duration_minutes=5,
+        approved=True,
+        mode=mode,
+        mode_config=mode_config,
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    return practice
+
+
+async def _setup_user_practice(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    headers: dict[str, str],
+    user_id: int,
+    practice: Practice,
+) -> int:
+    db_session.add(StageProgress(user_id=user_id, current_stage=practice.stage_number))
+    await db_session.commit()
+    resp = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": practice.stage_number},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+    return int(resp.json()["id"])
+
+
+@pytest.mark.asyncio
+async def test_apply_recipe_to_matching_mode(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    catalog = await _seed_catalog_practice(
+        db_session,
+        mode="tallied_grounding",
+        mode_config={
+            "mode": "tallied_grounding",
+            "rounds": 1,
+            "categories": [{"key": "red", "label": "Red", "target_count": 1}],
+        },
+    )
+    up_id = await _setup_user_practice(async_client, db_session, headers, user_id, catalog)
+    create_recipe = await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body("apply_me", rounds=3), headers=headers
+    )
+    recipe_id = create_recipe.json()["id"]
+
+    resp = await async_client.post(
+        f"/practice-recipes/{recipe_id}/apply-to/{up_id}", headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    eff_cfg = resp.json()["effective_config"]
+    assert eff_cfg["mode"] == "tallied_grounding"
+    assert eff_cfg["rounds"] == 3
+    assert {c["key"] for c in eff_cfg["categories"]} == {"red", "blue"}
+
+
+@pytest.mark.asyncio
+async def test_apply_mode_mismatch_400(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    headers, user_id = await _signup(async_client)
+    catalog = await _seed_catalog_practice(
+        db_session,
+        mode="sense_grounding",
+        mode_config={
+            "mode": "sense_grounding",
+            "prompts": [{"sense": "sight", "label": "x"}],
+        },
+    )
+    up_id = await _setup_user_practice(async_client, db_session, headers, user_id, catalog)
+    create_recipe = await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body(), headers=headers
+    )
+    recipe_id = create_recipe.json()["id"]
+
+    resp = await async_client.post(
+        f"/practice-recipes/{recipe_id}/apply-to/{up_id}", headers=headers
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "mode_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_apply_other_users_practice_forbidden(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers_alice, alice_id = await _signup(async_client, "alice")
+    headers_bob, _ = await _signup(async_client, "bob")
+    catalog = await _seed_catalog_practice(
+        db_session,
+        mode="tallied_grounding",
+        mode_config={
+            "mode": "tallied_grounding",
+            "rounds": 1,
+            "categories": [{"key": "red", "label": "Red", "target_count": 1}],
+        },
+    )
+    alice_up = await _setup_user_practice(
+        async_client, db_session, headers_alice, alice_id, catalog
+    )
+    create_recipe = await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body("bobs"), headers=headers_bob
+    )
+    recipe_id = create_recipe.json()["id"]
+
+    resp = await async_client.post(
+        f"/practice-recipes/{recipe_id}/apply-to/{alice_up}", headers=headers_bob
+    )
+    assert resp.status_code in {HTTPStatus.NOT_FOUND, HTTPStatus.FORBIDDEN}
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_rejected(async_client: AsyncClient) -> None:
+    resp = await async_client.get("/practice-recipes/")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED

--- a/backend/tests/test_practice_recipes_api.py
+++ b/backend/tests/test_practice_recipes_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import Any
 
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.practice import Practice
 from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
+from models.practice_session import PracticeSession
 from models.stage_progress import StageProgress
 
 
@@ -427,6 +429,101 @@ async def test_apply_other_users_practice_forbidden(
         f"/practice-recipes/{recipe_id}/apply-to/{alice_up}", headers=headers_bob
     )
     assert resp.status_code in {HTTPStatus.NOT_FOUND, HTTPStatus.FORBIDDEN}
+
+
+@pytest.mark.asyncio
+async def test_apply_preserves_existing_sessions(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Regression: the apply response must include real session history.
+
+    Returning ``sessions: []`` would clobber any frontend store that
+    merges the response back into local state.  Mirrors the contract
+    `customize_user_practice` returns.
+    """
+    headers, user_id = await _signup(async_client)
+    catalog = await _seed_catalog_practice(
+        db_session,
+        mode="tallied_grounding",
+        mode_config={
+            "mode": "tallied_grounding",
+            "rounds": 1,
+            "categories": [{"key": "red", "label": "Red", "target_count": 1}],
+        },
+    )
+    up_id = await _setup_user_practice(async_client, db_session, headers, user_id, catalog)
+    # Plant a session row directly so we can assert it round-trips.
+    db_session.add(
+        PracticeSession(
+            user_id=user_id,
+            user_practice_id=up_id,
+            duration_minutes=4.5,
+            timestamp=datetime.now(UTC),
+        )
+    )
+    await db_session.commit()
+    create_recipe = await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body("apply_sessions"), headers=headers
+    )
+    recipe_id = create_recipe.json()["id"]
+
+    resp = await async_client.post(
+        f"/practice-recipes/{recipe_id}/apply-to/{up_id}", headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    sessions = resp.json()["sessions"]
+    assert len(sessions) == 1
+    assert sessions[0]["duration_minutes"] == 4.5
+
+
+@pytest.mark.asyncio
+async def test_list_batches_step_lookup(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """List endpoint must scale: step lookups are batched, not N+1.
+
+    We seed several recipes and assert that the response carries the
+    steps each one was built with.  The shape check alone would not
+    catch an N+1; this test exists alongside a code review of
+    ``_load_steps_for_recipes`` to keep the batched path discoverable.
+    """
+    headers, _ = await _signup(async_client)
+    # Two system recipes via direct DB insert + two user recipes via the API.
+    for slug in ("sys_one", "sys_two"):
+        recipe = PracticeRecipe(
+            slug=slug,
+            name=slug,
+            description="",
+            owner_user_id=None,
+            mode="tallied_grounding",
+            rounds=1,
+        )
+        db_session.add(recipe)
+        await db_session.commit()
+        await db_session.refresh(recipe)
+        assert recipe.id is not None
+        db_session.add(
+            PracticeRecipeStep(
+                recipe_id=recipe.id,
+                position=0,
+                tag_slug="red",
+                tag_label="Red",
+                prompt_label="x",
+                target_count=1,
+            )
+        )
+    await db_session.commit()
+    for slug in ("u_one", "u_two"):
+        await async_client.post(
+            "/practice-recipes/", json=_tallied_recipe_body(slug), headers=headers
+        )
+
+    resp = await async_client.get("/practice-recipes/", headers=headers)
+    rows = resp.json()
+    by_slug = {r["slug"]: r for r in rows}
+    for slug in ("sys_one", "sys_two", "u_one", "u_two"):
+        assert slug in by_slug, f"missing {slug}"
+        assert len(by_slug[slug]["steps"]) >= 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_practice_tags_api.py
+++ b/backend/tests/test_practice_tags_api.py
@@ -1,0 +1,195 @@
+"""Tests for /practice-tags CRUD endpoints."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.practice_tag import PracticeTag
+
+
+async def _signup(client: AsyncClient, username: str = "owner") -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _seed_system_tag(
+    db_session: AsyncSession, slug: str = "sight", label: str = "Sight"
+) -> PracticeTag:
+    tag = PracticeTag(slug=slug, label=label, owner_user_id=None)
+    db_session.add(tag)
+    await db_session.commit()
+    await db_session.refresh(tag)
+    return tag
+
+
+@pytest.mark.asyncio
+async def test_list_returns_system_and_own_tags(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _seed_system_tag(db_session, slug="sight", label="Sight")
+    headers = await _signup(async_client)
+    create = await async_client.post(
+        "/practice-tags/",
+        json={"slug": "my_custom", "label": "Custom"},
+        headers=headers,
+    )
+    assert create.status_code == HTTPStatus.CREATED, create.text
+
+    resp = await async_client.get("/practice-tags/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    slugs = {row["slug"] for row in body}
+    assert {"sight", "my_custom"} <= slugs
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_other_users_tags(async_client: AsyncClient) -> None:
+    headers_alice = await _signup(async_client, "alice")
+    headers_bob = await _signup(async_client, "bob")
+    await async_client.post(
+        "/practice-tags/",
+        json={"slug": "alice_only", "label": "Alice's tag"},
+        headers=headers_alice,
+    )
+    resp = await async_client.get("/practice-tags/", headers=headers_bob)
+    slugs = {row["slug"] for row in resp.json()}
+    assert "alice_only" not in slugs
+
+
+@pytest.mark.asyncio
+async def test_create_personal_tag_201(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/practice-tags/",
+        json={"slug": "my_tag", "label": "My Tag"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+    body = resp.json()
+    assert body["slug"] == "my_tag"
+    assert body["label"] == "My Tag"
+    assert body["owner_user_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_slug(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/practice-tags/",
+        json={"slug": "BadSlug", "label": "x"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_user_slug_409(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    await async_client.post("/practice-tags/", json={"slug": "dup", "label": "A"}, headers=headers)
+    resp = await async_client.post(
+        "/practice-tags/", json={"slug": "dup", "label": "B"}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.CONFLICT
+    assert resp.json()["detail"] == "tag_slug_taken"
+
+
+@pytest.mark.asyncio
+async def test_user_can_create_same_slug_as_system(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """System and user namespaces are independent (partial unique indexes)."""
+    await _seed_system_tag(db_session, slug="sight", label="Sight")
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/practice-tags/",
+        json={"slug": "sight", "label": "My Sight"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_visible_tag_200(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    tag = await _seed_system_tag(db_session)
+    headers = await _signup(async_client)
+    resp = await async_client.get(f"/practice-tags/{tag.id}", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["slug"] == "sight"
+
+
+@pytest.mark.asyncio
+async def test_get_invisible_tag_404(async_client: AsyncClient) -> None:
+    headers_alice = await _signup(async_client, "alice")
+    headers_bob = await _signup(async_client, "bob")
+    create = await async_client.post(
+        "/practice-tags/",
+        json={"slug": "alice_secret", "label": "secret"},
+        headers=headers_alice,
+    )
+    tag_id = create.json()["id"]
+    resp = await async_client.get(f"/practice-tags/{tag_id}", headers=headers_bob)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_update_renames_personal_tag(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    create = await async_client.post(
+        "/practice-tags/", json={"slug": "to_rename", "label": "Old"}, headers=headers
+    )
+    tag_id = create.json()["id"]
+    resp = await async_client.patch(
+        f"/practice-tags/{tag_id}", json={"label": "New"}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["label"] == "New"
+    assert resp.json()["slug"] == "to_rename"
+
+
+@pytest.mark.asyncio
+async def test_update_system_tag_403(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    tag = await _seed_system_tag(db_session)
+    headers = await _signup(async_client)
+    resp = await async_client.patch(
+        f"/practice-tags/{tag.id}", json={"label": "New"}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "cannot_modify_system_tag"
+
+
+@pytest.mark.asyncio
+async def test_delete_personal_tag_204(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client)
+    create = await async_client.post(
+        "/practice-tags/", json={"slug": "doomed", "label": "x"}, headers=headers
+    )
+    tag_id = create.json()["id"]
+    resp = await async_client.delete(f"/practice-tags/{tag_id}", headers=headers)
+    assert resp.status_code == HTTPStatus.NO_CONTENT
+    get_resp = await async_client.get(f"/practice-tags/{tag_id}", headers=headers)
+    assert get_resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_delete_system_tag_403(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    tag = await _seed_system_tag(db_session)
+    headers = await _signup(async_client)
+    resp = await async_client.delete(f"/practice-tags/{tag.id}", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_rejected(async_client: AsyncClient) -> None:
+    resp = await async_client.get("/practice-tags/")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED

--- a/backend/tests/test_seed_practice_recipes.py
+++ b/backend/tests/test_seed_practice_recipes.py
@@ -1,0 +1,119 @@
+"""Tests for the system-recipe + system-tag seeder."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
+from models.practice_tag import PracticeTag
+from schemas.practice_mode_config import ModeConfigAdapter
+from schemas.practice_recipe import (
+    PracticeRecipeOut,
+    PracticeRecipeStepOut,
+    materialise_mode_config,
+)
+from seed_practice_recipes import (
+    SYSTEM_RECIPES,
+    SYSTEM_TAGS,
+    seed_practice_recipes,
+)
+
+
+@pytest.mark.asyncio
+async def test_seed_inserts_all_recipes_and_tags(db_session: AsyncSession) -> None:
+    inserted = await seed_practice_recipes(db_session)
+    assert inserted == len(SYSTEM_RECIPES) + len(SYSTEM_TAGS)
+
+    tag_count = (
+        await db_session.execute(
+            select(PracticeTag).where(col(PracticeTag.owner_user_id).is_(None))
+        )
+    ).all()
+    assert len(tag_count) == len(SYSTEM_TAGS)
+
+    recipe_count = (
+        await db_session.execute(
+            select(PracticeRecipe).where(col(PracticeRecipe.owner_user_id).is_(None))
+        )
+    ).all()
+    assert len(recipe_count) == len(SYSTEM_RECIPES)
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(db_session: AsyncSession) -> None:
+    first = await seed_practice_recipes(db_session)
+    assert first > 0
+    second = await seed_practice_recipes(db_session)
+    assert second == 0
+
+
+@pytest.mark.asyncio
+async def test_seeded_recipes_materialise_to_valid_mode_config(
+    db_session: AsyncSession,
+) -> None:
+    """Every system recipe must round-trip through ModeConfigAdapter cleanly."""
+    await seed_practice_recipes(db_session)
+    recipes = (
+        (
+            await db_session.execute(
+                select(PracticeRecipe).where(col(PracticeRecipe.owner_user_id).is_(None))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for recipe in recipes:
+        assert recipe.id is not None
+        steps = (
+            (
+                await db_session.execute(
+                    select(PracticeRecipeStep)
+                    .where(PracticeRecipeStep.recipe_id == recipe.id)
+                    .order_by(col(PracticeRecipeStep.position))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        recipe_out = PracticeRecipeOut(
+            id=recipe.id,
+            slug=recipe.slug,
+            name=recipe.name,
+            description=recipe.description,
+            owner_user_id=None,
+            mode=recipe.mode,
+            rounds=recipe.rounds,
+            created_at=recipe.created_at,
+            steps=[PracticeRecipeStepOut.model_validate(s, from_attributes=True) for s in steps],
+        )
+        materialised = materialise_mode_config(recipe_out)
+        # Round-trip the materialised payload through the discriminated union.
+        validated = ModeConfigAdapter.validate_python(materialised)
+        assert validated.mode == recipe.mode
+
+
+@pytest.mark.asyncio
+async def test_canonical_five_four_three_two_one_seeded(db_session: AsyncSession) -> None:
+    """The 5-4-3-2-1 recipe is the linchpin of the tier-one habit; assert shape."""
+    await seed_practice_recipes(db_session)
+    result = await db_session.execute(
+        select(PracticeRecipe).where(PracticeRecipe.slug == "five_four_three_two_one")
+    )
+    recipe = result.scalar_one()
+    assert recipe.mode == "sense_grounding"
+    assert recipe.rounds == 1
+    steps = (
+        (
+            await db_session.execute(
+                select(PracticeRecipeStep)
+                .where(PracticeRecipeStep.recipe_id == recipe.id)
+                .order_by(col(PracticeRecipeStep.position))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [s.tag_slug for s in steps] == ["sight", "touch", "hearing", "smell", "taste"]
+    assert [s.target_count for s in steps] == [5, 4, 3, 2, 1]

--- a/frontend/src/api/__tests__/practiceRecipes-api.test.ts
+++ b/frontend/src/api/__tests__/practiceRecipes-api.test.ts
@@ -1,0 +1,177 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { practiceRecipes, practiceTags } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+const recipeFixture = {
+  id: 7,
+  slug: 'find_the_rainbow',
+  name: 'Find the Rainbow',
+  description: '',
+  owner_user_id: null,
+  mode: 'tallied_grounding',
+  rounds: 3,
+  created_at: '2026-05-23T00:00:00Z',
+  steps: [
+    {
+      position: 0,
+      tag_slug: 'red',
+      tag_label: 'Red',
+      prompt_label: 'Find red',
+      target_count: 1,
+    },
+  ],
+};
+
+describe('practiceRecipes.list', () => {
+  test('GETs /practice-recipes/ without mode by default', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse([recipeFixture]));
+    const out = await practiceRecipes.list();
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-recipes/');
+    expect(init.method).toBeUndefined();
+    expect(out).toEqual([recipeFixture]);
+  });
+
+  test('appends ?mode= when provided', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse([recipeFixture]));
+    await practiceRecipes.list('tallied_grounding');
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-recipes/?mode=tallied_grounding');
+  });
+
+  test('rejects payload with missing fields', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse([{ slug: 'incomplete' }]));
+    await expect(practiceRecipes.list()).rejects.toThrow('Invalid practice-recipes response');
+  });
+});
+
+describe('practiceRecipes.create', () => {
+  test('POSTs the payload and parses the response', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(recipeFixture, 201));
+    const out = await practiceRecipes.create({
+      slug: 'my_recipe',
+      name: 'My Recipe',
+      mode: 'tallied_grounding',
+      rounds: 3,
+      steps: [
+        {
+          tag_slug: 'red',
+          tag_label: 'Red',
+          prompt_label: 'Find red',
+          target_count: 1,
+        },
+      ],
+    });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-recipes/');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body).slug).toBe('my_recipe');
+    expect(out).toEqual(recipeFixture);
+  });
+});
+
+describe('practiceRecipes.update', () => {
+  test('PATCHes the recipe id', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(recipeFixture));
+    await practiceRecipes.update(7, {
+      name: 'Renamed',
+      rounds: 2,
+      steps: [{ tag_slug: 'red', tag_label: 'Red', prompt_label: 'x', target_count: 1 }],
+    });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-recipes/7');
+    expect(init.method).toBe('PATCH');
+  });
+});
+
+describe('practiceRecipes.remove', () => {
+  test('DELETEs the recipe id', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(null, 204));
+    await practiceRecipes.remove(11);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-recipes/11');
+    expect(init.method).toBe('DELETE');
+  });
+});
+
+describe('practiceRecipes.apply', () => {
+  test('POSTs apply-to/{user_practice_id}', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({
+        id: 99,
+        user_id: 1,
+        practice_id: 5,
+        stage_number: 1,
+        start_date: '2026-05-01',
+        end_date: null,
+      }),
+    );
+    await practiceRecipes.apply(7, 99);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-recipes/7/apply-to/99');
+    expect(init.method).toBe('POST');
+  });
+});
+
+describe('practiceTags', () => {
+  const tagFixture = {
+    id: 3,
+    slug: 'red',
+    label: 'Red',
+    owner_user_id: null,
+    created_at: '2026-05-23T00:00:00Z',
+  };
+
+  test('list parses the array', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse([tagFixture]));
+    const out = await practiceTags.list();
+    expect(out).toEqual([tagFixture]);
+  });
+
+  test('create POSTs and parses', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(tagFixture, 201));
+    const out = await practiceTags.create({ slug: 'red', label: 'Red' });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-tags/');
+    expect(init.method).toBe('POST');
+    expect(out).toEqual(tagFixture);
+  });
+
+  test('update PATCHes the tag id', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(tagFixture));
+    await practiceTags.update(3, { label: 'Crimson' });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-tags/3');
+    expect(init.method).toBe('PATCH');
+  });
+
+  test('remove DELETEs the tag id', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(null, 204));
+    await practiceTags.remove(3);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-tags/3');
+    expect(init.method).toBe('DELETE');
+  });
+
+  test('list rejects invalid payload', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse([{ slug: 'no-id' }]));
+    await expect(practiceTags.list()).rejects.toThrow('Invalid practice-tags response');
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1803,6 +1803,226 @@ export const userPractices = {
 };
 
 /**
+ * Mirrors the backend `PracticeTagOut` schema (migration `07b8c9d0e1f2`).
+ *
+ * `owner_user_id === null` marks a system tag (read-only); a non-null
+ * value scopes the tag to one user. The personal namespace is
+ * independent of the system one — a user can claim a slug a system
+ * tag already uses.
+ */
+export interface PracticeTag {
+  id: number;
+  slug: string;
+  label: string;
+  owner_user_id: number | null;
+  created_at: string;
+}
+
+export interface PracticeTagCreate {
+  slug: string;
+  label: string;
+}
+
+export interface PracticeTagUpdate {
+  label: string;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function validatePracticeTag(data: unknown): data is PracticeTag {
+  if (!isObject(data)) return false;
+  return (
+    typeof data.id === 'number' &&
+    typeof data.slug === 'string' &&
+    typeof data.label === 'string' &&
+    (data.owner_user_id === null || typeof data.owner_user_id === 'number') &&
+    typeof data.created_at === 'string'
+  );
+}
+
+export const practiceTags = {
+  async list(token?: string): Promise<PracticeTag[]> {
+    const data = await request<unknown>('/practice-tags/', { token });
+    if (!Array.isArray(data) || !data.every(validatePracticeTag)) {
+      throw new Error('Invalid practice-tags response');
+    }
+    return data;
+  },
+  async create(payload: PracticeTagCreate, token?: string): Promise<PracticeTag> {
+    const data = await request<unknown>('/practice-tags/', {
+      method: 'POST',
+      body: payload,
+      token,
+    });
+    if (!validatePracticeTag(data)) throw new Error('Invalid practice-tag response');
+    return data;
+  },
+  async update(tagId: number, payload: PracticeTagUpdate, token?: string): Promise<PracticeTag> {
+    const data = await request<unknown>(`/practice-tags/${tagId}`, {
+      method: 'PATCH',
+      body: payload,
+      token,
+    });
+    if (!validatePracticeTag(data)) throw new Error('Invalid practice-tag response');
+    return data;
+  },
+  remove(tagId: number, token?: string): Promise<void> {
+    return request<void>(`/practice-tags/${tagId}`, { method: 'DELETE', token });
+  },
+};
+
+/**
+ * Mirrors the backend `PracticeRecipeOut` schema. A recipe is a named
+ * ordered collection of steps that materialises into a `mode_config`
+ * payload on apply. `mode` is one of the recipe-capable modes
+ * (`sense_grounding` or `tallied_grounding`).
+ */
+export type RecipeMode = 'sense_grounding' | 'tallied_grounding';
+
+export interface PracticeRecipeStep {
+  position: number;
+  tag_slug: string;
+  tag_label: string;
+  prompt_label: string;
+  target_count: number;
+}
+
+export interface PracticeRecipe {
+  id: number;
+  slug: string;
+  name: string;
+  description: string;
+  owner_user_id: number | null;
+  mode: RecipeMode;
+  rounds: number;
+  created_at: string;
+  steps: PracticeRecipeStep[];
+}
+
+export interface PracticeRecipeStepInput {
+  tag_slug: string;
+  tag_label: string;
+  prompt_label: string;
+  target_count: number;
+}
+
+export interface PracticeRecipeCreate {
+  slug: string;
+  name: string;
+  description?: string;
+  mode: RecipeMode;
+  rounds: number;
+  steps: PracticeRecipeStepInput[];
+}
+
+export interface PracticeRecipeUpdate {
+  name: string;
+  description?: string;
+  rounds: number;
+  steps: PracticeRecipeStepInput[];
+}
+
+function validatePracticeRecipeStep(data: unknown): data is PracticeRecipeStep {
+  if (!isObject(data)) return false;
+  return (
+    typeof data.position === 'number' &&
+    typeof data.tag_slug === 'string' &&
+    typeof data.tag_label === 'string' &&
+    typeof data.prompt_label === 'string' &&
+    typeof data.target_count === 'number'
+  );
+}
+
+function hasRecipeOwnerShape(data: Record<string, unknown>): boolean {
+  return data.owner_user_id === null || typeof data.owner_user_id === 'number';
+}
+
+function hasRecipeModeShape(data: Record<string, unknown>): boolean {
+  return data.mode === 'sense_grounding' || data.mode === 'tallied_grounding';
+}
+
+function hasRecipeStringFields(data: Record<string, unknown>): boolean {
+  return (
+    typeof data.slug === 'string' &&
+    typeof data.name === 'string' &&
+    typeof data.description === 'string' &&
+    typeof data.created_at === 'string'
+  );
+}
+
+function hasRecipeStepsArray(data: Record<string, unknown>): boolean {
+  return Array.isArray(data.steps) && data.steps.every(validatePracticeRecipeStep);
+}
+
+function validatePracticeRecipe(data: unknown): data is PracticeRecipe {
+  if (!isObject(data)) return false;
+  return (
+    typeof data.id === 'number' &&
+    typeof data.rounds === 'number' &&
+    hasRecipeStringFields(data) &&
+    hasRecipeOwnerShape(data) &&
+    hasRecipeModeShape(data) &&
+    hasRecipeStepsArray(data)
+  );
+}
+
+const INVALID_RECIPE_RESPONSE = 'Invalid practice-recipe response';
+
+export const practiceRecipes = {
+  async list(mode?: RecipeMode, token?: string): Promise<PracticeRecipe[]> {
+    const qs = mode ? `?mode=${encodeURIComponent(mode)}` : '';
+    const data = await request<unknown>(`/practice-recipes/${qs}`, { token });
+    if (!Array.isArray(data) || !data.every(validatePracticeRecipe)) {
+      throw new Error('Invalid practice-recipes response');
+    }
+    return data;
+  },
+  async get(recipeId: number, token?: string): Promise<PracticeRecipe> {
+    const data = await request<unknown>(`/practice-recipes/${recipeId}`, { token });
+    if (!validatePracticeRecipe(data)) throw new Error(INVALID_RECIPE_RESPONSE);
+    return data;
+  },
+  async create(payload: PracticeRecipeCreate, token?: string): Promise<PracticeRecipe> {
+    const data = await request<unknown>('/practice-recipes/', {
+      method: 'POST',
+      body: payload,
+      token,
+    });
+    if (!validatePracticeRecipe(data)) throw new Error(INVALID_RECIPE_RESPONSE);
+    return data;
+  },
+  async update(
+    recipeId: number,
+    payload: PracticeRecipeUpdate,
+    token?: string,
+  ): Promise<PracticeRecipe> {
+    const data = await request<unknown>(`/practice-recipes/${recipeId}`, {
+      method: 'PATCH',
+      body: payload,
+      token,
+    });
+    if (!validatePracticeRecipe(data)) throw new Error(INVALID_RECIPE_RESPONSE);
+    return data;
+  },
+  remove(recipeId: number, token?: string): Promise<void> {
+    return request<void>(`/practice-recipes/${recipeId}`, { method: 'DELETE', token });
+  },
+  /**
+   * Materialise the recipe into the target UserPractice's
+   * `mode_config_override`. The backend re-validates against the catalog
+   * mode and rejects cross-mode swaps with `400 mode_mismatch`.
+   */
+  apply(recipeId: number, userPracticeId: number, token?: string): Promise<UserPractice> {
+    return request<UserPractice>(`/practice-recipes/${recipeId}/apply-to/${userPracticeId}`, {
+      method: 'POST',
+      token,
+    });
+  },
+};
+
+/**
  * Server-assembled frequency banner payload. Mirrors the
  * `FrequencyResponse` schema introduced in ritual-05
  * (`backend/src/routers/user_practices.py::GET /user-practices/current/frequency`).
@@ -2123,6 +2343,8 @@ export default {
   course,
   practices,
   practiceShare,
+  practiceRecipes,
+  practiceTags,
   userPractices,
   frequency,
   practiceSessions,

--- a/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
+++ b/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
@@ -13,6 +13,7 @@ import {
 
 import type { ModeConfig } from '../engine/types';
 import { CUSTOM_NAME_MAX, validateCustomName, validateModeConfig } from '../engine/validation';
+import RecipePickerModal from '../recipes/RecipePickerModal';
 
 import CardMeditationForm from './forms/CardMeditationForm';
 import CountUpForm from './forms/CountUpForm';
@@ -28,6 +29,9 @@ import TarotForm from './forms/TarotForm';
 import { type UserPractice, type UserPracticeCustomize, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+/** Modes that have a recipe library backing them; see backend `RECIPE_MODES`. */
+const RECIPE_LIBRARY_MODES = new Set(['sense_grounding', 'tallied_grounding']);
 
 export interface RitualConfiguratorSheetProps {
   visible: boolean;
@@ -49,38 +53,95 @@ export interface RitualConfiguratorSheetProps {
 const RitualConfiguratorSheet = (props: RitualConfiguratorSheetProps): React.JSX.Element => {
   const edit = useEditState(props.initialName, props.initialConfig);
   const state = useSaveState();
+  const [pickerVisible, setPickerVisible] = useState(false);
   const canSave = edit.dirty && edit.errors.length === 0 && !state.submitting;
+  const recipeLibraryAvailable = RECIPE_LIBRARY_MODES.has(edit.config.mode);
   return (
     <Modal visible={props.visible} transparent animationType="slide" onRequestClose={props.onClose}>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        style={styles.overlay}
-        testID="ritual-configurator-overlay"
-      >
-        <View style={styles.sheet} testID="ritual-configurator-sheet">
-          <ConfiguratorHeader
-            name={edit.name}
-            aspect={props.aspect ?? null}
-            onNameChange={edit.setName}
-            onCancel={props.onClose}
-            onSave={() => state.save(props, { name: edit.name, config: edit.config })}
-            canSave={canSave}
-          />
-          <ScrollView style={styles.body} keyboardShouldPersistTaps="handled">
-            <ConfiguratorBody config={edit.config} onChange={edit.setConfig} />
-            <ErrorList errors={edit.errors} />
-            {state.apiError !== null && (
-              <Text style={styles.apiError} testID="ritual-configurator-api-error">
-                {state.apiError}
-              </Text>
-            )}
-            <ResetButton disabled={state.submitting} onPress={() => state.reset(props)} />
-          </ScrollView>
-        </View>
-      </KeyboardAvoidingView>
+      <ConfiguratorSheetBody
+        edit={edit}
+        state={state}
+        canSave={canSave}
+        aspect={props.aspect ?? null}
+        recipeLibraryAvailable={recipeLibraryAvailable}
+        onOpenRecipePicker={() => setPickerVisible(true)}
+        onSave={() => state.save(props, { name: edit.name, config: edit.config })}
+        onCancel={props.onClose}
+        onReset={() => state.reset(props)}
+      />
+      {recipeLibraryAvailable && (
+        <RecipePickerModal
+          visible={pickerVisible}
+          mode={edit.config.mode as 'sense_grounding' | 'tallied_grounding'}
+          userPracticeId={props.userPracticeId}
+          onClose={() => setPickerVisible(false)}
+          onApplied={(updated) => {
+            props.onSaved?.(updated);
+            props.onClose();
+          }}
+        />
+      )}
     </Modal>
   );
 };
+
+interface ConfiguratorSheetBodyProps {
+  edit: EditState;
+  state: SaveState;
+  canSave: boolean;
+  aspect: string | null;
+  recipeLibraryAvailable: boolean;
+  onOpenRecipePicker: () => void;
+  onSave: () => void;
+  onCancel: () => void;
+  onReset: () => void;
+}
+
+const ConfiguratorSheetBody = (props: ConfiguratorSheetBodyProps): React.JSX.Element => (
+  <KeyboardAvoidingView
+    behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    style={styles.overlay}
+    testID="ritual-configurator-overlay"
+  >
+    <View style={styles.sheet} testID="ritual-configurator-sheet">
+      <ConfiguratorHeader
+        name={props.edit.name}
+        aspect={props.aspect}
+        onNameChange={props.edit.setName}
+        onCancel={props.onCancel}
+        onSave={props.onSave}
+        canSave={props.canSave}
+      />
+      <ScrollView style={styles.body} keyboardShouldPersistTaps="handled">
+        {props.recipeLibraryAvailable && <RecipeLibraryButton onPress={props.onOpenRecipePicker} />}
+        <ConfiguratorBody config={props.edit.config} onChange={props.edit.setConfig} />
+        <ErrorList errors={props.edit.errors} />
+        {props.state.apiError !== null && (
+          <Text style={styles.apiError} testID="ritual-configurator-api-error">
+            {props.state.apiError}
+          </Text>
+        )}
+        <ResetButton disabled={props.state.submitting} onPress={props.onReset} />
+      </ScrollView>
+    </View>
+  </KeyboardAvoidingView>
+);
+
+interface RecipeLibraryButtonProps {
+  onPress: () => void;
+}
+
+const RecipeLibraryButton = ({ onPress }: RecipeLibraryButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel="Browse recipe library"
+    onPress={onPress}
+    style={styles.recipeLibraryButton}
+    testID="ritual-configurator-recipe-library"
+  >
+    <Text style={styles.recipeLibraryText}>Browse recipe library →</Text>
+  </TouchableOpacity>
+);
 
 interface EditState {
   name: string;
@@ -346,6 +407,17 @@ const styles = StyleSheet.create({
   },
   resetText: { color: colors.danger, fontSize: 13, fontWeight: '500' },
   unknownText: { color: colors.text.secondaryAccessible, fontSize: 14, lineHeight: 20 },
+  recipeLibraryButton: {
+    marginBottom: SPACING.md,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.background.card,
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    alignItems: 'center',
+  },
+  recipeLibraryText: { color: colors.text.primary, fontSize: 14, fontWeight: '600' },
 });
 
 export default RitualConfiguratorSheet;

--- a/frontend/src/features/Practice/recipes/RecipeEditorModal.tsx
+++ b/frontend/src/features/Practice/recipes/RecipeEditorModal.tsx
@@ -1,0 +1,804 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import TagPicker from './TagPicker';
+import type { DraftStep, RecipeDraft } from './types';
+import { nameToSlug, newStepUid } from './types';
+
+import type {
+  PracticeRecipe,
+  PracticeRecipeCreate,
+  PracticeRecipeStepInput,
+  PracticeRecipeUpdate,
+  PracticeTag,
+  PracticeTagCreate,
+  RecipeMode,
+} from '@/api';
+import { practiceRecipes, practiceTags } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+export interface RecipeEditorModalProps {
+  visible: boolean;
+  mode: RecipeMode;
+  initialDraft: RecipeDraft;
+  /** ``null`` opens the editor in create mode; non-null opens in edit mode. */
+  recipeId: number | null;
+  onClose: () => void;
+  onSaved: (saved: PracticeRecipe) => void;
+  /** Test injection seams. */
+  create?: typeof practiceRecipes.create;
+  update?: typeof practiceRecipes.update;
+  listTags?: typeof practiceTags.list;
+  createTag?: typeof practiceTags.create;
+}
+
+const NAME_MAX = 255;
+const DESCRIPTION_MAX = 2_000;
+const PROMPT_MAX = 255;
+const ROUNDS_MAX = 10;
+const TARGET_COUNT_MAX = 20;
+const STEPS_MAX = 12;
+
+const RecipeEditorModal = (props: RecipeEditorModalProps): React.JSX.Element => {
+  const deps = resolveDeps(props);
+  const draftState = useDraftState(props.initialDraft);
+  const tagLibrary = useTagLibrary(props.visible, deps.listTags);
+  const saveState = useSaveState();
+
+  const errors = useMemo(
+    () => validateDraft(draftState.draft, props.mode),
+    [draftState.draft, props.mode],
+  );
+  const canSave = errors.length === 0 && !saveState.busy;
+
+  const onSave = useCallback(async (): Promise<void> => {
+    const saved = await saveState.save({
+      recipeId: props.recipeId,
+      mode: props.mode,
+      draft: draftState.draft,
+      create: deps.create,
+      update: deps.update,
+    });
+    if (saved !== null) props.onSaved(saved);
+  }, [saveState, props, draftState.draft, deps]);
+
+  const onCreateTag = useCallback(
+    async (payload: PracticeTagCreate) => {
+      const created = await deps.createTag(payload);
+      tagLibrary.add(created);
+      return created;
+    },
+    [deps, tagLibrary],
+  );
+
+  return (
+    <Modal visible={props.visible} transparent animationType="slide" onRequestClose={props.onClose}>
+      <EditorSheetContent
+        recipeId={props.recipeId}
+        mode={props.mode}
+        canSave={canSave}
+        saveError={saveState.error}
+        draftState={draftState}
+        tagLibrary={tagLibrary.tags}
+        errors={errors}
+        onSave={onSave}
+        onCancel={props.onClose}
+        onCreateTag={onCreateTag}
+      />
+    </Modal>
+  );
+};
+
+interface ResolvedDeps {
+  create: typeof practiceRecipes.create;
+  update: typeof practiceRecipes.update;
+  listTags: typeof practiceTags.list;
+  createTag: typeof practiceTags.create;
+}
+
+function resolveDeps(props: RecipeEditorModalProps): ResolvedDeps {
+  return {
+    create: props.create ?? practiceRecipes.create,
+    update: props.update ?? practiceRecipes.update,
+    listTags: props.listTags ?? practiceTags.list,
+    createTag: props.createTag ?? practiceTags.create,
+  };
+}
+
+interface EditorSheetContentProps {
+  recipeId: number | null;
+  mode: RecipeMode;
+  canSave: boolean;
+  saveError: string | null;
+  draftState: DraftState;
+  tagLibrary: PracticeTag[];
+  errors: string[];
+  onSave: () => void;
+  onCancel: () => void;
+  onCreateTag: (payload: PracticeTagCreate) => Promise<PracticeTag>;
+}
+
+const EditorSheetContent = (props: EditorSheetContentProps): React.JSX.Element => (
+  <KeyboardAvoidingView
+    behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    style={styles.overlay}
+    testID="recipe-editor-overlay"
+  >
+    <View style={styles.sheet} testID="recipe-editor-sheet">
+      <EditorHeader
+        title={props.recipeId === null ? 'New recipe' : 'Edit recipe'}
+        canSave={props.canSave}
+        onCancel={props.onCancel}
+        onSave={props.onSave}
+      />
+      {props.saveError !== null && (
+        <Text style={styles.apiError} testID="recipe-editor-api-error">
+          {props.saveError}
+        </Text>
+      )}
+      <ScrollView
+        style={styles.body}
+        keyboardShouldPersistTaps="handled"
+        testID="recipe-editor-scroll"
+      >
+        <EditorFields
+          draftState={props.draftState}
+          mode={props.mode}
+          tagLibrary={props.tagLibrary}
+          onCreateTag={props.onCreateTag}
+        />
+        {props.errors.length > 0 && <ValidationErrors errors={props.errors} />}
+      </ScrollView>
+    </View>
+  </KeyboardAvoidingView>
+);
+
+interface EditorFieldsProps {
+  draftState: DraftState;
+  mode: RecipeMode;
+  tagLibrary: PracticeTag[];
+  onCreateTag: (payload: PracticeTagCreate) => Promise<PracticeTag>;
+}
+
+const EditorFields = (props: EditorFieldsProps): React.JSX.Element => (
+  <>
+    <NameField
+      value={props.draftState.draft.name}
+      onChange={(name) => props.draftState.update({ name })}
+    />
+    <DescriptionField
+      value={props.draftState.draft.description}
+      onChange={(description) => props.draftState.update({ description })}
+    />
+    {props.mode === 'tallied_grounding' && (
+      <RoundsField
+        value={props.draftState.draft.rounds}
+        onChange={(rounds) => props.draftState.update({ rounds })}
+      />
+    )}
+    <StepEditor
+      steps={props.draftState.draft.steps}
+      mode={props.mode}
+      tagLibrary={props.tagLibrary}
+      onCreateTag={props.onCreateTag}
+      onChangeStep={props.draftState.updateStep}
+      onMoveStep={props.draftState.moveStep}
+      onRemoveStep={props.draftState.removeStep}
+      onAppendStep={props.draftState.appendStep}
+    />
+  </>
+);
+
+const ValidationErrors = ({ errors }: { errors: string[] }): React.JSX.Element => (
+  <View style={styles.errors} testID="recipe-editor-errors">
+    {errors.map((msg) => (
+      <Text key={msg} style={styles.errorText}>
+        • {msg}
+      </Text>
+    ))}
+  </View>
+);
+
+interface DraftState {
+  draft: RecipeDraft;
+  update: (patch: Partial<RecipeDraft>) => void;
+  updateStep: (uid: string, patch: Partial<DraftStep>) => void;
+  moveStep: (uid: string, direction: -1 | 1) => void;
+  removeStep: (uid: string) => void;
+  appendStep: () => void;
+}
+
+function applyPatch(prev: RecipeDraft, patch: Partial<RecipeDraft>): RecipeDraft {
+  return { ...prev, ...patch };
+}
+
+function applyStepPatch(prev: RecipeDraft, uid: string, patch: Partial<DraftStep>): RecipeDraft {
+  return {
+    ...prev,
+    steps: prev.steps.map((s) => (s.uid === uid ? { ...s, ...patch } : s)),
+  };
+}
+
+function applyStepSwap(prev: RecipeDraft, uid: string, direction: -1 | 1): RecipeDraft {
+  const index = prev.steps.findIndex((s) => s.uid === uid);
+  const target = index + direction;
+  if (index === -1 || target < 0 || target >= prev.steps.length) return prev;
+  const next = prev.steps.slice();
+  const tmp = next[index];
+  const swap = next[target];
+  if (tmp === undefined || swap === undefined) return prev;
+  next[index] = swap;
+  next[target] = tmp;
+  return { ...prev, steps: next };
+}
+
+function applyStepRemove(prev: RecipeDraft, uid: string): RecipeDraft {
+  return { ...prev, steps: prev.steps.filter((s) => s.uid !== uid) };
+}
+
+function blankStep(): DraftStep {
+  return {
+    uid: newStepUid(),
+    tag_slug: '',
+    tag_label: '',
+    prompt_label: '',
+    target_count: 1,
+  };
+}
+
+function applyStepAppend(prev: RecipeDraft): RecipeDraft {
+  return { ...prev, steps: [...prev.steps, blankStep()] };
+}
+
+function useDraftState(initial: RecipeDraft): DraftState {
+  const [draft, setDraft] = useState<RecipeDraft>(initial);
+  const update = useCallback(
+    (patch: Partial<RecipeDraft>) => setDraft((prev) => applyPatch(prev, patch)),
+    [],
+  );
+  const updateStep = useCallback(
+    (uid: string, patch: Partial<DraftStep>) =>
+      setDraft((prev) => applyStepPatch(prev, uid, patch)),
+    [],
+  );
+  const moveStep = useCallback(
+    (uid: string, direction: -1 | 1) => setDraft((prev) => applyStepSwap(prev, uid, direction)),
+    [],
+  );
+  const removeStep = useCallback(
+    (uid: string) => setDraft((prev) => applyStepRemove(prev, uid)),
+    [],
+  );
+  const appendStep = useCallback(() => setDraft(applyStepAppend), []);
+  return { draft, update, updateStep, moveStep, removeStep, appendStep };
+}
+
+interface TagLibraryState {
+  tags: PracticeTag[];
+  add: (tag: PracticeTag) => void;
+}
+
+function useTagLibrary(visible: boolean, list: typeof practiceTags.list): TagLibraryState {
+  const [tags, setTags] = useState<PracticeTag[]>([]);
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const loaded = await list();
+        if (!cancelled) setTags(loaded);
+      } catch {
+        // Tag library is best-effort; the user can still type a custom
+        // slug + label by hand if loading fails.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, list]);
+  const add = useCallback((tag: PracticeTag) => setTags((prev) => [...prev, tag]), []);
+  return { tags, add };
+}
+
+interface SaveArgs {
+  recipeId: number | null;
+  mode: RecipeMode;
+  draft: RecipeDraft;
+  create: typeof practiceRecipes.create;
+  update: typeof practiceRecipes.update;
+}
+
+interface SaveState {
+  busy: boolean;
+  error: string | null;
+  save: (args: SaveArgs) => Promise<PracticeRecipe | null>;
+}
+
+function useSaveState(): SaveState {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const save = useCallback(async (args: SaveArgs): Promise<PracticeRecipe | null> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const steps: PracticeRecipeStepInput[] = args.draft.steps.map((step) => ({
+        tag_slug: step.tag_slug,
+        tag_label: step.tag_label,
+        prompt_label: step.prompt_label,
+        target_count: step.target_count,
+      }));
+      if (args.recipeId === null) {
+        const payload: PracticeRecipeCreate = {
+          slug: args.draft.slug.length > 0 ? args.draft.slug : nameToSlug(args.draft.name),
+          name: args.draft.name,
+          description: args.draft.description,
+          mode: args.mode,
+          rounds: args.draft.rounds,
+          steps,
+        };
+        return await args.create(payload);
+      }
+      const updatePayload: PracticeRecipeUpdate = {
+        name: args.draft.name,
+        description: args.draft.description,
+        rounds: args.draft.rounds,
+        steps,
+      };
+      return await args.update(args.recipeId, updatePayload);
+    } catch (err: unknown) {
+      setError(formatApiError(err, { fallback: 'Could not save recipe.' }));
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+  return { busy, error, save };
+}
+
+function validateDraft(draft: RecipeDraft, mode: RecipeMode): string[] {
+  const errors: string[] = [];
+  if (draft.name.trim().length === 0) errors.push('Recipe needs a name.');
+  if (draft.name.length > NAME_MAX) errors.push(`Name must be ${NAME_MAX} characters or fewer.`);
+  if (draft.description.length > DESCRIPTION_MAX) {
+    errors.push(`Description must be ${DESCRIPTION_MAX} characters or fewer.`);
+  }
+  if (draft.steps.length === 0) errors.push('Add at least one step.');
+  if (draft.steps.length > STEPS_MAX) errors.push(`Recipes are limited to ${STEPS_MAX} steps.`);
+  if (mode === 'sense_grounding' && draft.rounds !== 1) {
+    errors.push('Sense-grounding recipes use exactly one round.');
+  }
+  if (draft.rounds < 1 || draft.rounds > ROUNDS_MAX) {
+    errors.push(`Rounds must be between 1 and ${ROUNDS_MAX}.`);
+  }
+  const seenSlugs = new Set<string>();
+  draft.steps.forEach((step, idx) => {
+    if (step.tag_slug.length === 0) errors.push(`Step ${idx + 1} needs a tag.`);
+    if (step.prompt_label.trim().length === 0) errors.push(`Step ${idx + 1} needs a prompt.`);
+    if (step.prompt_label.length > PROMPT_MAX) {
+      errors.push(`Step ${idx + 1} prompt is too long.`);
+    }
+    if (step.target_count < 1 || step.target_count > TARGET_COUNT_MAX) {
+      errors.push(`Step ${idx + 1} count must be 1-${TARGET_COUNT_MAX}.`);
+    }
+    if (mode === 'tallied_grounding') {
+      if (seenSlugs.has(step.tag_slug)) {
+        errors.push(`Step ${idx + 1} repeats tag "${step.tag_slug}"; use a different tag.`);
+      }
+      seenSlugs.add(step.tag_slug);
+    }
+  });
+  return errors;
+}
+
+interface EditorHeaderProps {
+  title: string;
+  canSave: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+const EditorHeader = ({
+  title,
+  canSave,
+  onCancel,
+  onSave,
+}: EditorHeaderProps): React.JSX.Element => (
+  <View style={styles.header}>
+    <Text style={styles.title}>{title}</Text>
+    <View style={styles.headerActions}>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Cancel"
+        onPress={onCancel}
+        style={styles.cancelButton}
+        testID="recipe-editor-cancel"
+      >
+        <Text style={styles.cancelText}>Cancel</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Save"
+        accessibilityState={{ disabled: !canSave }}
+        onPress={canSave ? onSave : undefined}
+        style={[styles.saveButton, !canSave && styles.disabled]}
+        testID="recipe-editor-save"
+      >
+        <Text style={styles.saveText}>Save</Text>
+      </TouchableOpacity>
+    </View>
+  </View>
+);
+
+const NameField = ({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}): React.JSX.Element => (
+  <View style={styles.field}>
+    <Text style={styles.label}>Name</Text>
+    <TextInput
+      value={value}
+      onChangeText={onChange}
+      style={styles.input}
+      placeholder="My grounding practice"
+      maxLength={NAME_MAX}
+      testID="recipe-editor-name"
+    />
+  </View>
+);
+
+const DescriptionField = ({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}): React.JSX.Element => (
+  <View style={styles.field}>
+    <Text style={styles.label}>Description</Text>
+    <TextInput
+      value={value}
+      onChangeText={onChange}
+      style={[styles.input, styles.descriptionInput]}
+      placeholder="Optional note about when to use this recipe"
+      multiline
+      maxLength={DESCRIPTION_MAX}
+      testID="recipe-editor-description"
+    />
+  </View>
+);
+
+const RoundsField = ({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (next: number) => void;
+}): React.JSX.Element => (
+  <View style={styles.field}>
+    <Text style={styles.label}>Rounds</Text>
+    <View style={styles.stepperRow}>
+      <RoundsButton
+        label="-"
+        onPress={() => onChange(Math.max(1, value - 1))}
+        testID="recipe-editor-rounds-minus"
+      />
+      <Text style={styles.stepperValue} testID="recipe-editor-rounds-value">
+        {value}
+      </Text>
+      <RoundsButton
+        label="+"
+        onPress={() => onChange(Math.min(ROUNDS_MAX, value + 1))}
+        testID="recipe-editor-rounds-plus"
+      />
+    </View>
+  </View>
+);
+
+const RoundsButton = ({
+  label,
+  onPress,
+  testID,
+}: {
+  label: string;
+  onPress: () => void;
+  testID: string;
+}): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={label}
+    onPress={onPress}
+    style={styles.stepperButton}
+    testID={testID}
+  >
+    <Text style={styles.stepperButtonText}>{label}</Text>
+  </TouchableOpacity>
+);
+
+interface StepEditorProps {
+  steps: DraftStep[];
+  mode: RecipeMode;
+  tagLibrary: PracticeTag[];
+  onCreateTag: (payload: PracticeTagCreate) => Promise<PracticeTag>;
+  onChangeStep: (uid: string, patch: Partial<DraftStep>) => void;
+  onMoveStep: (uid: string, direction: -1 | 1) => void;
+  onRemoveStep: (uid: string) => void;
+  onAppendStep: () => void;
+}
+
+const StepEditor = (props: StepEditorProps): React.JSX.Element => (
+  <View testID="recipe-editor-steps">
+    <Text style={styles.label}>Steps</Text>
+    {props.steps.map((step, index) => (
+      <StepCard
+        key={step.uid}
+        step={step}
+        index={index}
+        last={index === props.steps.length - 1}
+        mode={props.mode}
+        tagLibrary={props.tagLibrary}
+        onCreateTag={props.onCreateTag}
+        onChange={(patch) => props.onChangeStep(step.uid, patch)}
+        onMove={(dir) => props.onMoveStep(step.uid, dir)}
+        onRemove={() => props.onRemoveStep(step.uid)}
+      />
+    ))}
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel="Add step"
+      onPress={props.onAppendStep}
+      style={styles.addButton}
+      testID="recipe-editor-add-step"
+    >
+      <Text style={styles.addButtonText}>+ Add step</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+interface StepCardProps {
+  step: DraftStep;
+  index: number;
+  last: boolean;
+  mode: RecipeMode;
+  tagLibrary: PracticeTag[];
+  onCreateTag: (payload: PracticeTagCreate) => Promise<PracticeTag>;
+  onChange: (patch: Partial<DraftStep>) => void;
+  onMove: (direction: -1 | 1) => void;
+  onRemove: () => void;
+}
+
+const StepCard = (props: StepCardProps): React.JSX.Element => (
+  <View style={styles.stepCard} testID={`recipe-editor-step-${props.index}`}>
+    <TagPicker
+      stepIndex={props.index}
+      selectedSlug={props.step.tag_slug}
+      tagLibrary={props.tagLibrary}
+      onSelect={(tag) => props.onChange({ tag_slug: tag.slug, tag_label: tag.label })}
+      onCreateTag={async (payload) => {
+        const created = await props.onCreateTag(payload);
+        props.onChange({ tag_slug: created.slug, tag_label: created.label });
+      }}
+    />
+    <TextInput
+      value={props.step.prompt_label}
+      onChangeText={(text) => props.onChange({ prompt_label: text })}
+      style={styles.input}
+      placeholder="What should the user notice?"
+      maxLength={PROMPT_MAX}
+      testID={`recipe-editor-step-${props.index}-prompt`}
+    />
+    {props.mode === 'tallied_grounding' && (
+      <StepCountRow
+        index={props.index}
+        value={props.step.target_count}
+        onChange={(target_count) => props.onChange({ target_count })}
+      />
+    )}
+    <StepActionsRow
+      index={props.index}
+      isFirst={props.index === 0}
+      isLast={props.last}
+      onMove={props.onMove}
+      onRemove={props.onRemove}
+    />
+  </View>
+);
+
+interface StepCountRowProps {
+  index: number;
+  value: number;
+  onChange: (next: number) => void;
+}
+
+const StepCountRow = ({ index, value, onChange }: StepCountRowProps): React.JSX.Element => (
+  <View style={styles.countRow}>
+    <Text style={styles.label}>Count</Text>
+    <View style={styles.stepperRow}>
+      <RoundsButton
+        label="-"
+        onPress={() => onChange(Math.max(1, value - 1))}
+        testID={`recipe-editor-step-${index}-count-minus`}
+      />
+      <Text style={styles.stepperValue} testID={`recipe-editor-step-${index}-count-value`}>
+        {value}
+      </Text>
+      <RoundsButton
+        label="+"
+        onPress={() => onChange(Math.min(TARGET_COUNT_MAX, value + 1))}
+        testID={`recipe-editor-step-${index}-count-plus`}
+      />
+    </View>
+  </View>
+);
+
+interface StepActionsRowProps {
+  index: number;
+  isFirst: boolean;
+  isLast: boolean;
+  onMove: (direction: -1 | 1) => void;
+  onRemove: () => void;
+}
+
+const StepActionsRow = (props: StepActionsRowProps): React.JSX.Element => (
+  <View style={styles.actionsRow}>
+    <SmallButton
+      label="↑"
+      disabled={props.isFirst}
+      onPress={() => props.onMove(-1)}
+      testID={`recipe-editor-step-${props.index}-up`}
+    />
+    <SmallButton
+      label="↓"
+      disabled={props.isLast}
+      onPress={() => props.onMove(1)}
+      testID={`recipe-editor-step-${props.index}-down`}
+    />
+    <SmallButton
+      label="Remove"
+      disabled={false}
+      onPress={props.onRemove}
+      testID={`recipe-editor-step-${props.index}-remove`}
+    />
+  </View>
+);
+
+interface SmallButtonProps {
+  label: string;
+  disabled: boolean;
+  onPress: () => void;
+  testID: string;
+}
+
+const SmallButton = ({ label, disabled, onPress, testID }: SmallButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={label}
+    accessibilityState={{ disabled }}
+    onPress={disabled ? undefined : onPress}
+    style={[styles.smallButton, disabled && styles.disabled]}
+    testID={testID}
+  >
+    <Text style={styles.smallButtonText}>{label}</Text>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: colors.mystical.overlay, justifyContent: 'flex-end' },
+  sheet: {
+    backgroundColor: colors.background.primary,
+    borderTopLeftRadius: BORDER_RADIUS.xl,
+    borderTopRightRadius: BORDER_RADIUS.xl,
+    maxHeight: '95%',
+    ...shadows.large,
+  },
+  header: {
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.lg,
+    paddingBottom: SPACING.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.background.accent,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: { fontSize: 18, fontWeight: '600', color: colors.text.primary },
+  headerActions: { flexDirection: 'row', gap: SPACING.sm },
+  cancelButton: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+  },
+  cancelText: { color: colors.text.secondaryAccessible, fontWeight: '500' },
+  saveButton: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.primary,
+  },
+  saveText: { color: colors.text.light, fontWeight: '600' },
+  disabled: { opacity: 0.4 },
+  body: { padding: SPACING.lg },
+  apiError: { color: colors.danger, paddingHorizontal: SPACING.lg, paddingTop: SPACING.sm },
+  field: { marginBottom: SPACING.md },
+  label: { color: colors.text.primary, fontSize: 14, fontWeight: '500', marginBottom: SPACING.xs },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    color: colors.text.primary,
+    fontSize: 14,
+  },
+  descriptionInput: { minHeight: 60, textAlignVertical: 'top' },
+  stepperRow: { flexDirection: 'row', alignItems: 'center', gap: SPACING.sm },
+  stepperButton: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+    minWidth: 40,
+    alignItems: 'center',
+  },
+  stepperButtonText: { color: colors.text.primary, fontSize: 16, fontWeight: '600' },
+  stepperValue: {
+    minWidth: 32,
+    textAlign: 'center',
+    fontSize: 16,
+    color: colors.text.primary,
+    fontVariant: ['tabular-nums'],
+  },
+  stepCard: {
+    padding: SPACING.sm,
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: SPACING.sm,
+    gap: SPACING.xs,
+  },
+  countRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  actionsRow: { flexDirection: 'row', gap: SPACING.xs, marginTop: SPACING.xs },
+  smallButton: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+    minHeight: 32,
+  },
+  smallButtonText: { color: colors.text.primary, fontSize: 13, fontWeight: '500' },
+  addButton: {
+    paddingVertical: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+    alignItems: 'center',
+    marginTop: SPACING.sm,
+  },
+  addButtonText: { color: colors.text.primary, fontWeight: '600', fontSize: 14 },
+  errors: {
+    backgroundColor: colors.background.card,
+    borderLeftColor: colors.danger,
+    borderLeftWidth: 3,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    marginTop: SPACING.md,
+  },
+  errorText: { color: colors.danger, fontSize: 13, marginVertical: 2 },
+});
+
+export default RecipeEditorModal;

--- a/frontend/src/features/Practice/recipes/RecipePickerModal.tsx
+++ b/frontend/src/features/Practice/recipes/RecipePickerModal.tsx
@@ -1,0 +1,612 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import RecipeEditorModal from './RecipeEditorModal';
+import type { RecipeDraft } from './types';
+import { newStepUid } from './types';
+
+import type { PracticeRecipe, RecipeMode, UserPractice } from '@/api';
+import { practiceRecipes } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+
+export interface RecipePickerModalProps {
+  visible: boolean;
+  /** Constrain the list to recipes compatible with the active practice's mode. */
+  mode: RecipeMode;
+  /** The active UserPractice this picker applies a recipe to. */
+  userPracticeId: number;
+  onClose: () => void;
+  /** Called after a recipe is applied; the parent typically forwards to its
+   *  configurator's `onSaved` so the customise UI refreshes too. */
+  onApplied?: (updated: UserPractice) => void;
+  /** Injection seams for tests. */
+  list?: typeof practiceRecipes.list;
+  apply?: typeof practiceRecipes.apply;
+  remove?: typeof practiceRecipes.remove;
+}
+
+type EditorState =
+  | { kind: 'closed' }
+  | { kind: 'new'; draft: RecipeDraft }
+  | { kind: 'edit'; recipeId: number; draft: RecipeDraft };
+
+/**
+ * Library picker for recipes the user can apply to their active tier-one
+ * UserPractice.  Lists system + personal recipes filtered by mode.
+ *
+ * System recipes are read-only; personal recipes have Edit + Delete
+ * buttons.  "Edit a system recipe" forks a personal copy via the
+ * editor's create path -- the original stays untouched.
+ */
+const RecipePickerModal = (props: RecipePickerModalProps): React.JSX.Element => {
+  const deps = resolvePickerDeps(props);
+  const fetch = useFetchState(props.mode, deps.list);
+  const action = useActionState();
+  const [editor, setEditor] = useState<EditorState>({ kind: 'closed' });
+  const refresh = fetch.refresh;
+
+  useEffect(() => {
+    if (props.visible) void refresh();
+  }, [props.visible, refresh]);
+
+  const handlers = useRecipeHandlers({
+    apply: deps.apply,
+    remove: deps.remove,
+    userPracticeId: props.userPracticeId,
+    action,
+    refresh,
+    onApplied: props.onApplied,
+    onClose: props.onClose,
+  });
+  const editorHandlers = useEditorHandlers(props.mode, setEditor);
+
+  return (
+    <Modal visible={props.visible} transparent animationType="slide" onRequestClose={props.onClose}>
+      <PickerSheet
+        action={action}
+        fetch={fetch}
+        onClose={props.onClose}
+        onApply={handlers.onApply}
+        onDelete={handlers.onDelete}
+        onOpenNew={editorHandlers.openNew}
+        onOpenEdit={editorHandlers.openEdit}
+        onOpenFork={editorHandlers.openFork}
+      />
+      {editor.kind !== 'closed' && (
+        <RecipeEditorModal
+          visible
+          mode={props.mode}
+          initialDraft={editor.draft}
+          recipeId={editor.kind === 'edit' ? editor.recipeId : null}
+          onClose={() => setEditor({ kind: 'closed' })}
+          onSaved={() => {
+            setEditor({ kind: 'closed' });
+            void refresh();
+          }}
+        />
+      )}
+    </Modal>
+  );
+};
+
+interface EditorHandlers {
+  openNew: () => void;
+  openEdit: (recipe: PracticeRecipe) => void;
+  openFork: (recipe: PracticeRecipe) => void;
+}
+
+function useEditorHandlers(
+  mode: RecipeMode,
+  setEditor: React.Dispatch<React.SetStateAction<EditorState>>,
+): EditorHandlers {
+  const openNew = useCallback(
+    () => setEditor({ kind: 'new', draft: newRecipeDraft(mode) }),
+    [mode, setEditor],
+  );
+  const openEdit = useCallback(
+    (recipe: PracticeRecipe) =>
+      setEditor({ kind: 'edit', recipeId: recipe.id, draft: recipeToDraft(recipe) }),
+    [setEditor],
+  );
+  const openFork = useCallback(
+    (recipe: PracticeRecipe) =>
+      setEditor({
+        kind: 'new',
+        draft: { ...recipeToDraft(recipe), slug: '', name: `${recipe.name} copy` },
+      }),
+    [setEditor],
+  );
+  return { openNew, openEdit, openFork };
+}
+
+interface PickerDeps {
+  list: typeof practiceRecipes.list;
+  apply: typeof practiceRecipes.apply;
+  remove: typeof practiceRecipes.remove;
+}
+
+function resolvePickerDeps(props: RecipePickerModalProps): PickerDeps {
+  return {
+    list: props.list ?? practiceRecipes.list,
+    apply: props.apply ?? practiceRecipes.apply,
+    remove: props.remove ?? practiceRecipes.remove,
+  };
+}
+
+interface RecipeHandlerArgs {
+  apply: typeof practiceRecipes.apply;
+  remove: typeof practiceRecipes.remove;
+  userPracticeId: number;
+  action: ActionState;
+  refresh: () => Promise<void>;
+  onApplied?: (updated: UserPractice) => void;
+  onClose: () => void;
+}
+
+interface RecipeHandlers {
+  onApply: (recipe: PracticeRecipe) => Promise<void>;
+  onDelete: (recipe: PracticeRecipe) => Promise<void>;
+}
+
+function useRecipeHandlers(args: RecipeHandlerArgs): RecipeHandlers {
+  const { apply, remove, userPracticeId, action, refresh, onApplied, onClose } = args;
+  const onApply = useCallback(
+    async (recipe: PracticeRecipe): Promise<void> => {
+      const updated = await action.run(() => apply(recipe.id, userPracticeId));
+      if (updated !== null) {
+        onApplied?.(updated);
+        onClose();
+      }
+    },
+    [action, apply, userPracticeId, onApplied, onClose],
+  );
+  const onDelete = useCallback(
+    async (recipe: PracticeRecipe): Promise<void> => {
+      const ok = await action.run(async () => {
+        await remove(recipe.id);
+        return true as const;
+      });
+      if (ok !== null) void refresh();
+    },
+    [action, remove, refresh],
+  );
+  return { onApply, onDelete };
+}
+
+interface PickerSheetProps {
+  action: ActionState;
+  fetch: FetchState;
+  onClose: () => void;
+  onApply: (recipe: PracticeRecipe) => Promise<void>;
+  onDelete: (recipe: PracticeRecipe) => Promise<void>;
+  onOpenNew: () => void;
+  onOpenEdit: (recipe: PracticeRecipe) => void;
+  onOpenFork: (recipe: PracticeRecipe) => void;
+}
+
+const PickerSheet = (props: PickerSheetProps): React.JSX.Element => (
+  <View style={styles.overlay} testID="recipe-picker-overlay">
+    <View style={styles.sheet} testID="recipe-picker-sheet">
+      <PickerHeader onClose={props.onClose} onNew={props.onOpenNew} />
+      {props.action.error !== null && (
+        <Text style={styles.apiError} testID="recipe-picker-api-error">
+          {props.action.error}
+        </Text>
+      )}
+      <RecipeList
+        fetch={props.fetch}
+        disableActions={props.action.busy}
+        onApply={props.onApply}
+        onEdit={props.onOpenEdit}
+        onFork={props.onOpenFork}
+        onDelete={props.onDelete}
+      />
+    </View>
+  </View>
+);
+
+interface FetchState {
+  recipes: PracticeRecipe[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+function useFetchState(mode: RecipeMode, list: typeof practiceRecipes.list): FetchState {
+  const [recipes, setRecipes] = useState<PracticeRecipe[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await list(mode);
+      setRecipes(next);
+    } catch (err: unknown) {
+      setError(formatApiError(err, { fallback: 'Could not load recipes.' }));
+    } finally {
+      setLoading(false);
+    }
+  }, [mode, list]);
+  return { recipes, loading, error, refresh };
+}
+
+interface ActionState {
+  busy: boolean;
+  error: string | null;
+  run: <T>(task: () => Promise<T>) => Promise<T | null>;
+}
+
+function useActionState(): ActionState {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const run = useCallback(async <T,>(task: () => Promise<T>): Promise<T | null> => {
+    setBusy(true);
+    setError(null);
+    try {
+      return await task();
+    } catch (err: unknown) {
+      setError(formatApiError(err, { fallback: 'Action failed.' }));
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+  return { busy, error, run };
+}
+
+interface PickerHeaderProps {
+  onClose: () => void;
+  onNew: () => void;
+}
+
+const PickerHeader = ({ onClose, onNew }: PickerHeaderProps): React.JSX.Element => (
+  <View style={styles.header}>
+    <Text style={styles.title}>Recipe library</Text>
+    <View style={styles.headerActions}>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Create new recipe"
+        onPress={onNew}
+        style={styles.newButton}
+        testID="recipe-picker-new"
+      >
+        <Text style={styles.newButtonText}>+ New</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Close"
+        onPress={onClose}
+        style={styles.closeButton}
+        testID="recipe-picker-close"
+      >
+        <Text style={styles.closeText}>Close</Text>
+      </TouchableOpacity>
+    </View>
+  </View>
+);
+
+interface RecipeListProps {
+  fetch: FetchState;
+  disableActions: boolean;
+  onApply: (recipe: PracticeRecipe) => Promise<void>;
+  onEdit: (recipe: PracticeRecipe) => void;
+  onFork: (recipe: PracticeRecipe) => void;
+  onDelete: (recipe: PracticeRecipe) => Promise<void>;
+}
+
+const RecipeList = (props: RecipeListProps): React.JSX.Element => {
+  if (props.fetch.loading && props.fetch.recipes.length === 0) {
+    return (
+      <View style={styles.center} testID="recipe-picker-loading">
+        <ActivityIndicator />
+      </View>
+    );
+  }
+  if (props.fetch.error !== null && props.fetch.recipes.length === 0) {
+    return (
+      <Text style={styles.apiError} testID="recipe-picker-list-error">
+        {props.fetch.error}
+      </Text>
+    );
+  }
+  if (props.fetch.recipes.length === 0) {
+    return (
+      <Text style={styles.emptyText} testID="recipe-picker-empty">
+        No recipes available. Tap + New to create one.
+      </Text>
+    );
+  }
+  return (
+    <ScrollView style={styles.body} testID="recipe-picker-list">
+      {props.fetch.recipes.map((recipe) => (
+        <RecipeRow
+          key={recipe.id}
+          recipe={recipe}
+          disableActions={props.disableActions}
+          onApply={() => props.onApply(recipe)}
+          onEdit={() => props.onEdit(recipe)}
+          onFork={() => props.onFork(recipe)}
+          onDelete={() => props.onDelete(recipe)}
+        />
+      ))}
+    </ScrollView>
+  );
+};
+
+interface RecipeRowProps {
+  recipe: PracticeRecipe;
+  disableActions: boolean;
+  onApply: () => void;
+  onEdit: () => void;
+  onFork: () => void;
+  onDelete: () => void;
+}
+
+const RecipeRow = (props: RecipeRowProps): React.JSX.Element => {
+  const isSystem = props.recipe.owner_user_id === null;
+  const stepSummary = useMemo(() => describeSteps(props.recipe), [props.recipe]);
+  return (
+    <View style={styles.card} testID={`recipe-row-${props.recipe.id}`}>
+      <RecipeRowHeader recipe={props.recipe} isSystem={isSystem} summary={stepSummary} />
+      <View style={styles.rowActions}>
+        <RowButton
+          label="Use this"
+          variant="primary"
+          disabled={props.disableActions}
+          onPress={props.onApply}
+          testID={`recipe-row-${props.recipe.id}-apply`}
+        />
+        <RecipeRowMutationButtons
+          recipeId={props.recipe.id}
+          isSystem={isSystem}
+          disableActions={props.disableActions}
+          onEdit={props.onEdit}
+          onFork={props.onFork}
+          onDelete={props.onDelete}
+        />
+      </View>
+    </View>
+  );
+};
+
+interface RecipeRowHeaderProps {
+  recipe: PracticeRecipe;
+  isSystem: boolean;
+  summary: string;
+}
+
+const RecipeRowHeader = (props: RecipeRowHeaderProps): React.JSX.Element => (
+  <>
+    <View style={styles.cardHead}>
+      <Text style={styles.recipeName}>{props.recipe.name}</Text>
+      {props.isSystem && (
+        <View style={styles.systemBadge}>
+          <Text style={styles.systemBadgeText}>System</Text>
+        </View>
+      )}
+    </View>
+    {props.recipe.description.length > 0 && (
+      <Text style={styles.description}>{props.recipe.description}</Text>
+    )}
+    <Text style={styles.summary}>{props.summary}</Text>
+  </>
+);
+
+interface RecipeRowMutationButtonsProps {
+  recipeId: number;
+  isSystem: boolean;
+  disableActions: boolean;
+  onEdit: () => void;
+  onFork: () => void;
+  onDelete: () => void;
+}
+
+const RecipeRowMutationButtons = (props: RecipeRowMutationButtonsProps): React.JSX.Element => {
+  if (props.isSystem) {
+    return (
+      <RowButton
+        label="Edit a copy"
+        disabled={props.disableActions}
+        onPress={props.onFork}
+        testID={`recipe-row-${props.recipeId}-fork`}
+      />
+    );
+  }
+  return (
+    <>
+      <RowButton
+        label="Edit"
+        disabled={props.disableActions}
+        onPress={props.onEdit}
+        testID={`recipe-row-${props.recipeId}-edit`}
+      />
+      <RowButton
+        label="Delete"
+        variant="danger"
+        disabled={props.disableActions}
+        onPress={props.onDelete}
+        testID={`recipe-row-${props.recipeId}-delete`}
+      />
+    </>
+  );
+};
+
+interface RowButtonProps {
+  label: string;
+  variant?: 'primary' | 'danger' | 'default';
+  disabled: boolean;
+  onPress: () => void;
+  testID: string;
+}
+
+const RowButton = ({
+  label,
+  variant = 'default',
+  disabled,
+  onPress,
+  testID,
+}: RowButtonProps): React.JSX.Element => {
+  const variantStyle =
+    variant === 'primary'
+      ? styles.primaryButton
+      : variant === 'danger'
+        ? styles.dangerButton
+        : styles.defaultButton;
+  const variantText =
+    variant === 'primary' || variant === 'danger' ? styles.lightText : styles.defaultText;
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled }}
+      onPress={disabled ? undefined : onPress}
+      style={[styles.smallButton, variantStyle, disabled && styles.disabled]}
+      testID={testID}
+    >
+      <Text style={[styles.smallButtonText, variantText]}>{label}</Text>
+    </TouchableOpacity>
+  );
+};
+
+function describeSteps(recipe: PracticeRecipe): string {
+  const totalSteps = recipe.steps.reduce((acc, step) => acc + step.target_count, 0);
+  const stepWord = totalSteps === 1 ? 'observation' : 'observations';
+  if (recipe.rounds > 1) {
+    return `${recipe.rounds} rounds, ${totalSteps} ${stepWord} per round`;
+  }
+  return `${totalSteps} ${stepWord}`;
+}
+
+function newRecipeDraft(mode: RecipeMode): RecipeDraft {
+  return {
+    slug: '',
+    name: '',
+    description: '',
+    mode,
+    rounds: 1,
+    steps: [
+      {
+        uid: newStepUid(),
+        tag_slug: '',
+        tag_label: '',
+        prompt_label: '',
+        target_count: 1,
+      },
+    ],
+  };
+}
+
+function recipeToDraft(recipe: PracticeRecipe): RecipeDraft {
+  return {
+    slug: recipe.slug,
+    name: recipe.name,
+    description: recipe.description,
+    mode: recipe.mode,
+    rounds: recipe.rounds,
+    steps: recipe.steps.map((step) => ({
+      uid: newStepUid(),
+      tag_slug: step.tag_slug,
+      tag_label: step.tag_label,
+      prompt_label: step.prompt_label,
+      target_count: step.target_count,
+    })),
+  };
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: colors.background.primary,
+    borderTopLeftRadius: BORDER_RADIUS.xl,
+    borderTopRightRadius: BORDER_RADIUS.xl,
+    maxHeight: '90%',
+    ...shadows.large,
+  },
+  header: {
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.lg,
+    paddingBottom: SPACING.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.background.accent,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: { fontSize: 18, fontWeight: '600', color: colors.text.primary },
+  headerActions: { flexDirection: 'row', gap: SPACING.sm },
+  newButton: {
+    backgroundColor: colors.primary,
+    borderRadius: BORDER_RADIUS.md,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+  },
+  newButtonText: { color: colors.text.light, fontWeight: '600' },
+  closeButton: {
+    borderRadius: BORDER_RADIUS.md,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+  },
+  closeText: { color: colors.text.secondaryAccessible, fontWeight: '500' },
+  body: { padding: SPACING.lg },
+  center: { padding: SPACING.xl, alignItems: 'center' },
+  emptyText: {
+    color: colors.text.secondaryAccessible,
+    padding: SPACING.lg,
+    textAlign: 'center',
+  },
+  apiError: {
+    color: colors.danger,
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.sm,
+  },
+  card: {
+    backgroundColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md,
+    marginBottom: SPACING.sm,
+    gap: SPACING.xs,
+  },
+  cardHead: { flexDirection: 'row', alignItems: 'center', gap: SPACING.sm },
+  recipeName: { fontSize: 16, fontWeight: '600', color: colors.text.primary, flexShrink: 1 },
+  systemBadge: {
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: 2,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.accent,
+  },
+  systemBadgeText: { fontSize: 11, color: colors.text.secondaryAccessible, fontWeight: '500' },
+  description: { color: colors.text.secondaryAccessible, fontSize: 13, lineHeight: 18 },
+  summary: { color: colors.text.secondaryAccessible, fontSize: 12, fontStyle: 'italic' },
+  rowActions: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs, marginTop: SPACING.xs },
+  smallButton: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    minHeight: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  defaultButton: { backgroundColor: colors.background.accent },
+  primaryButton: { backgroundColor: colors.primary },
+  dangerButton: { backgroundColor: colors.danger },
+  defaultText: { color: colors.text.primary, fontSize: 13, fontWeight: '500' },
+  lightText: { color: colors.text.light, fontSize: 13, fontWeight: '600' },
+  smallButtonText: {},
+  disabled: { opacity: 0.4 },
+});
+
+export default RecipePickerModal;

--- a/frontend/src/features/Practice/recipes/TagPicker.tsx
+++ b/frontend/src/features/Practice/recipes/TagPicker.tsx
@@ -1,0 +1,253 @@
+import React, { useMemo, useState } from 'react';
+import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+import { nameToSlug } from './types';
+
+import type { PracticeTag, PracticeTagCreate } from '@/api';
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+export interface TagPickerProps {
+  stepIndex: number;
+  selectedSlug: string;
+  tagLibrary: PracticeTag[];
+  onSelect: (tag: PracticeTag) => void;
+  /** Resolves once the tag is persisted; the caller usually patches
+   *  the step's tag_slug + tag_label inside this callback. */
+  onCreateTag: (payload: PracticeTagCreate) => Promise<void>;
+}
+
+/**
+ * Two-state widget under a recipe step's tag chip row.
+ *
+ * Default state: render every tag in ``tagLibrary`` as a selectable
+ * chip plus a "+ New tag" affordance.  When the user taps "+ New tag"
+ * the inline create form takes over with two inputs (label + slug)
+ * and a Create button that mints a fresh tag and selects it.
+ *
+ * Slug auto-fills from the label via ``nameToSlug`` so the user
+ * never has to think about snake-casing -- they only see it if they
+ * want to override the derived value.
+ */
+const TagPicker = (props: TagPickerProps): React.JSX.Element => {
+  const [creating, setCreating] = useState(false);
+  const sortedTags = useMemo(() => sortTagsForPicker(props.tagLibrary), [props.tagLibrary]);
+  return (
+    <View style={styles.container} testID={`tag-picker-${props.stepIndex}`}>
+      <View style={styles.chipRow}>
+        {sortedTags.map((tag) => (
+          <TagChip
+            key={`${tag.owner_user_id ?? 'sys'}-${tag.id}`}
+            tag={tag}
+            active={tag.slug === props.selectedSlug}
+            onPress={() => props.onSelect(tag)}
+            testID={`tag-picker-${props.stepIndex}-chip-${tag.slug}`}
+          />
+        ))}
+        {!creating && (
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel="Create new tag"
+            onPress={() => setCreating(true)}
+            style={[styles.chip, styles.newTagChip]}
+            testID={`tag-picker-${props.stepIndex}-new`}
+          >
+            <Text style={styles.newTagText}>+ New tag</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+      {creating && (
+        <InlineTagCreator
+          stepIndex={props.stepIndex}
+          onCreate={async (payload) => {
+            await props.onCreateTag(payload);
+            setCreating(false);
+          }}
+          onCancel={() => setCreating(false)}
+        />
+      )}
+    </View>
+  );
+};
+
+interface TagChipProps {
+  tag: PracticeTag;
+  active: boolean;
+  onPress: () => void;
+  testID: string;
+}
+
+const TagChip = ({ tag, active, onPress, testID }: TagChipProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={tag.label}
+    accessibilityState={{ selected: active }}
+    onPress={onPress}
+    style={[styles.chip, active && styles.chipActive]}
+    testID={testID}
+  >
+    <Text style={[styles.chipText, active && styles.chipTextActive]}>{tag.label}</Text>
+  </TouchableOpacity>
+);
+
+interface InlineTagCreatorProps {
+  stepIndex: number;
+  onCreate: (payload: PracticeTagCreate) => Promise<void>;
+  onCancel: () => void;
+}
+
+interface CreatorFormState {
+  label: string;
+  setLabel: (next: string) => void;
+  slug: string;
+  setSlug: (next: string) => void;
+  error: string | null;
+  busy: boolean;
+  derivedSlug: string;
+  canCreate: boolean;
+  submit: () => Promise<void>;
+}
+
+function useCreatorFormState(
+  onCreate: (payload: PracticeTagCreate) => Promise<void>,
+): CreatorFormState {
+  const [label, setLabel] = useState('');
+  const [slug, setSlug] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const derivedSlug = slug.length > 0 ? slug : nameToSlug(label);
+  const canCreate = label.trim().length > 0 && derivedSlug.length > 0 && !busy;
+  const submit = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      await onCreate({ slug: derivedSlug, label: label.trim() });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Could not create tag.');
+    } finally {
+      setBusy(false);
+    }
+  };
+  return { label, setLabel, slug, setSlug, error, busy, derivedSlug, canCreate, submit };
+}
+
+const InlineTagCreator = (props: InlineTagCreatorProps): React.JSX.Element => {
+  const form = useCreatorFormState(props.onCreate);
+  return (
+    <View style={styles.creator} testID={`tag-picker-${props.stepIndex}-creator`}>
+      <TextInput
+        value={form.label}
+        onChangeText={form.setLabel}
+        style={styles.input}
+        placeholder="Tag label (what users see)"
+        maxLength={255}
+        testID={`tag-picker-${props.stepIndex}-creator-label`}
+      />
+      <TextInput
+        value={form.slug.length > 0 ? form.slug : form.derivedSlug}
+        onChangeText={form.setSlug}
+        style={styles.input}
+        placeholder="slug_in_snake_case"
+        maxLength={64}
+        autoCapitalize="none"
+        autoCorrect={false}
+        testID={`tag-picker-${props.stepIndex}-creator-slug`}
+      />
+      {form.error !== null && (
+        <Text style={styles.error} testID={`tag-picker-${props.stepIndex}-creator-error`}>
+          {form.error}
+        </Text>
+      )}
+      <CreatorActions
+        stepIndex={props.stepIndex}
+        canCreate={form.canCreate}
+        onCancel={props.onCancel}
+        onConfirm={form.submit}
+      />
+    </View>
+  );
+};
+
+interface CreatorActionsProps {
+  stepIndex: number;
+  canCreate: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const CreatorActions = (props: CreatorActionsProps): React.JSX.Element => (
+  <View style={styles.creatorActions}>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel="Cancel new tag"
+      onPress={props.onCancel}
+      style={[styles.chip, styles.cancelChip]}
+      testID={`tag-picker-${props.stepIndex}-creator-cancel`}
+    >
+      <Text style={styles.chipText}>Cancel</Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel="Create tag"
+      accessibilityState={{ disabled: !props.canCreate }}
+      onPress={props.canCreate ? props.onConfirm : undefined}
+      style={[styles.chip, styles.confirmChip, !props.canCreate && styles.disabled]}
+      testID={`tag-picker-${props.stepIndex}-creator-confirm`}
+    >
+      <Text style={styles.confirmText}>Create</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+function sortTagsForPicker(tags: PracticeTag[]): PracticeTag[] {
+  // System tags first, then personal, alphabetised within each group so
+  // the chip row stays predictable as the library grows.
+  return [...tags].sort((a, b) => {
+    const aSys = a.owner_user_id === null ? 0 : 1;
+    const bSys = b.owner_user_id === null ? 0 : 1;
+    if (aSys !== bSys) return aSys - bSys;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+const styles = StyleSheet.create({
+  container: { gap: SPACING.xs },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
+  chip: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.xl,
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    backgroundColor: colors.background.card,
+  },
+  chipActive: { backgroundColor: colors.primary, borderColor: colors.primary },
+  chipText: { color: colors.text.secondaryAccessible, fontSize: 13, fontWeight: '500' },
+  chipTextActive: { color: colors.text.light },
+  newTagChip: { borderStyle: 'dashed' },
+  newTagText: { color: colors.text.primary, fontSize: 13, fontWeight: '500' },
+  creator: {
+    marginTop: SPACING.xs,
+    padding: SPACING.sm,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.background.accent,
+    gap: SPACING.xs,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    color: colors.text.primary,
+    fontSize: 13,
+    backgroundColor: colors.background.primary,
+  },
+  creatorActions: { flexDirection: 'row', gap: SPACING.xs, justifyContent: 'flex-end' },
+  cancelChip: { backgroundColor: colors.background.card },
+  confirmChip: { backgroundColor: colors.primary, borderColor: colors.primary },
+  confirmText: { color: colors.text.light, fontSize: 13, fontWeight: '600' },
+  disabled: { opacity: 0.4 },
+  error: { color: colors.danger, fontSize: 12 },
+});
+
+export default TagPicker;

--- a/frontend/src/features/Practice/recipes/__tests__/RecipeEditorModal.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/RecipeEditorModal.test.tsx
@@ -1,0 +1,161 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import RecipeEditorModal from '../RecipeEditorModal';
+import type { RecipeDraft } from '../types';
+import { newStepUid } from '../types';
+
+import type { PracticeRecipe, PracticeTag } from '@/api';
+
+function makeDraft(overrides: Partial<RecipeDraft> = {}): RecipeDraft {
+  return {
+    slug: '',
+    name: '',
+    description: '',
+    mode: 'tallied_grounding',
+    rounds: 1,
+    steps: [
+      {
+        uid: newStepUid(),
+        tag_slug: '',
+        tag_label: '',
+        prompt_label: '',
+        target_count: 1,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const tagLibrary: PracticeTag[] = [
+  { id: 1, slug: 'red', label: 'Red', owner_user_id: null, created_at: '2026-01-01T00:00:00Z' },
+  { id: 2, slug: 'blue', label: 'Blue', owner_user_id: null, created_at: '2026-01-01T00:00:00Z' },
+];
+
+const savedFixture: PracticeRecipe = {
+  id: 42,
+  slug: 'new_one',
+  name: 'New one',
+  description: '',
+  owner_user_id: 7,
+  mode: 'tallied_grounding',
+  rounds: 1,
+  created_at: '2026-05-23T00:00:00Z',
+  steps: [],
+};
+
+function mountEditor(overrides: Partial<React.ComponentProps<typeof RecipeEditorModal>> = {}) {
+  const create = jest.fn(async (_payload: unknown) => savedFixture);
+  const update = jest.fn(async (_recipeId: number, _payload: unknown) => savedFixture);
+  const listTags = jest.fn(async () => tagLibrary);
+  const createTag = jest.fn(async (payload: { slug: string; label: string }) => ({
+    id: 99,
+    slug: payload.slug,
+    label: payload.label,
+    owner_user_id: 7,
+    created_at: '2026-05-23T00:00:00Z',
+  }));
+  const onClose = jest.fn();
+  const onSaved = jest.fn();
+  const draft = makeDraft({
+    name: 'My Recipe',
+    steps: [
+      {
+        uid: newStepUid(),
+        tag_slug: 'red',
+        tag_label: 'Red',
+        prompt_label: 'Find red',
+        target_count: 1,
+      },
+    ],
+  });
+  const utils = render(
+    <RecipeEditorModal
+      visible
+      mode="tallied_grounding"
+      initialDraft={draft}
+      recipeId={null}
+      onClose={onClose}
+      onSaved={onSaved}
+      create={create as never}
+      update={update as never}
+      listTags={listTags as never}
+      createTag={createTag as never}
+      {...overrides}
+    />,
+  );
+  return { ...utils, create, update, listTags, createTag, onClose, onSaved };
+}
+
+describe('RecipeEditorModal', () => {
+  it('renders with the initial draft populated', async () => {
+    const utils = mountEditor();
+    await waitFor(() => expect(utils.listTags).toHaveBeenCalled());
+    expect(utils.getByTestId('recipe-editor-name').props.value).toBe('My Recipe');
+    expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy();
+  });
+
+  it('blocks save until name + tag are set', () => {
+    const utils = mountEditor({ initialDraft: makeDraft() });
+    const save = utils.getByTestId('recipe-editor-save');
+    expect(save.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('calls create with the assembled payload', async () => {
+    const utils = mountEditor();
+    await waitFor(() => expect(utils.listTags).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('recipe-editor-save'));
+    });
+    await waitFor(() => expect(utils.create).toHaveBeenCalled());
+    const firstCall = utils.create.mock.calls[0];
+    if (firstCall === undefined) throw new Error('create was not called');
+    const callArgs = firstCall[0] as Record<string, unknown>;
+    expect(callArgs.name).toBe('My Recipe');
+    expect(callArgs.mode).toBe('tallied_grounding');
+    expect(callArgs.slug).toBe('my_recipe');
+    expect(Array.isArray(callArgs.steps)).toBe(true);
+    expect(utils.onSaved).toHaveBeenCalledWith(savedFixture);
+  });
+
+  it('calls update when editing an existing recipe', async () => {
+    const utils = mountEditor({ recipeId: 17 });
+    await waitFor(() => expect(utils.listTags).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('recipe-editor-save'));
+    });
+    await waitFor(() => expect(utils.update).toHaveBeenCalledWith(17, expect.any(Object)));
+    expect(utils.create).not.toHaveBeenCalled();
+  });
+
+  it('appends, moves, and removes steps', async () => {
+    const utils = mountEditor();
+    await waitFor(() => expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('recipe-editor-add-step'));
+    expect(utils.getByTestId('recipe-editor-step-1')).toBeTruthy();
+    fireEvent.press(utils.getByTestId('recipe-editor-step-1-up'));
+    fireEvent.press(utils.getByTestId('recipe-editor-step-0-remove'));
+    expect(utils.queryByTestId('recipe-editor-step-1')).toBeNull();
+  });
+
+  it('rejects duplicate tag slugs in tallied mode', async () => {
+    const utils = mountEditor();
+    await waitFor(() => expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('recipe-editor-add-step'));
+    // Select 'red' on both steps via the tag picker chip
+    await waitFor(() => expect(utils.getByTestId('tag-picker-0-chip-red')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('tag-picker-1-chip-red'));
+    // Need a prompt for step 1 to clear the prompt error
+    fireEvent.changeText(utils.getByTestId('recipe-editor-step-1-prompt'), 'Find red again');
+    await waitFor(() => expect(utils.getByTestId('recipe-editor-errors')).toBeTruthy());
+  });
+
+  it('hides the rounds field for sense_grounding', async () => {
+    const utils = mountEditor({
+      mode: 'sense_grounding',
+      initialDraft: makeDraft({ mode: 'sense_grounding', name: 'x' }),
+    });
+    expect(utils.queryByTestId('recipe-editor-rounds-value')).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/recipes/__tests__/RecipePickerModal.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/RecipePickerModal.test.tsx
@@ -1,0 +1,139 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import RecipePickerModal from '../RecipePickerModal';
+
+import type { PracticeRecipe, UserPractice } from '@/api';
+
+const systemRecipe: PracticeRecipe = {
+  id: 1,
+  slug: 'five_four_three_two_one',
+  name: '5-4-3-2-1 Grounding',
+  description: 'Walk the five senses.',
+  owner_user_id: null,
+  mode: 'sense_grounding',
+  rounds: 1,
+  created_at: '2026-05-23T00:00:00Z',
+  steps: [
+    {
+      position: 0,
+      tag_slug: 'sight',
+      tag_label: 'Sight',
+      prompt_label: 'Name 5 things you can see',
+      target_count: 5,
+    },
+  ],
+};
+
+const userRecipe: PracticeRecipe = {
+  id: 2,
+  slug: 'my_custom',
+  name: 'My Custom',
+  description: '',
+  owner_user_id: 99,
+  mode: 'sense_grounding',
+  rounds: 1,
+  created_at: '2026-05-23T00:00:00Z',
+  steps: [
+    {
+      position: 0,
+      tag_slug: 'sight',
+      tag_label: 'Sight',
+      prompt_label: 'My prompt',
+      target_count: 1,
+    },
+  ],
+};
+
+const userPracticeFixture: UserPractice = {
+  id: 17,
+  user_id: 1,
+  practice_id: 5,
+  stage_number: 1,
+  start_date: '2026-05-01',
+  end_date: null,
+  effective_name: 'Updated',
+};
+
+function mountPicker(overrides: Partial<React.ComponentProps<typeof RecipePickerModal>> = {}) {
+  const list = jest.fn(async (_mode?: string) => [systemRecipe, userRecipe]);
+  const apply = jest.fn(async (_recipeId: number, _upId: number) => userPracticeFixture);
+  const remove = jest.fn(async (_recipeId: number) => undefined);
+  const onClose = jest.fn();
+  const onApplied = jest.fn();
+  const utils = render(
+    <RecipePickerModal
+      visible
+      mode="sense_grounding"
+      userPracticeId={17}
+      onClose={onClose}
+      onApplied={onApplied}
+      list={list as never}
+      apply={apply as never}
+      remove={remove as never}
+      {...overrides}
+    />,
+  );
+  return { ...utils, list, apply, remove, onClose, onApplied };
+}
+
+describe('RecipePickerModal', () => {
+  it('loads and renders system + user recipes', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.list).toHaveBeenCalledWith('sense_grounding'));
+    await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());
+    expect(utils.getByTestId('recipe-row-2')).toBeTruthy();
+  });
+
+  it('shows a System badge on read-only recipes', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());
+    expect(utils.queryByText('System')).toBeTruthy();
+  });
+
+  it('renders "Edit a copy" on system rows and "Edit" on user rows', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());
+    expect(utils.getByTestId('recipe-row-1-fork')).toBeTruthy();
+    expect(utils.queryByTestId('recipe-row-1-edit')).toBeNull();
+    expect(utils.getByTestId('recipe-row-2-edit')).toBeTruthy();
+    expect(utils.queryByTestId('recipe-row-2-fork')).toBeNull();
+  });
+
+  it('applies a recipe and closes the picker', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('recipe-row-1-apply'));
+    });
+    await waitFor(() => expect(utils.apply).toHaveBeenCalledWith(1, 17));
+    expect(utils.onApplied).toHaveBeenCalledWith(userPracticeFixture);
+    expect(utils.onClose).toHaveBeenCalled();
+  });
+
+  it('deletes a personal recipe and refreshes the list', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.getByTestId('recipe-row-2')).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('recipe-row-2-delete'));
+    });
+    await waitFor(() => expect(utils.remove).toHaveBeenCalledWith(2));
+    // initial load + refresh after delete
+    await waitFor(() => expect(utils.list).toHaveBeenCalledTimes(2));
+  });
+
+  it('surfaces a load error in the empty state', async () => {
+    const list = jest.fn(async () => {
+      throw new Error('network down');
+    });
+    const utils = mountPicker({ list: list as never });
+    await waitFor(() => expect(utils.getByTestId('recipe-picker-list-error')).toBeTruthy());
+  });
+
+  it('renders an empty-state message when there are no recipes', async () => {
+    const list = jest.fn(async () => []);
+    const utils = mountPicker({ list: list as never });
+    await waitFor(() => expect(utils.getByTestId('recipe-picker-empty')).toBeTruthy());
+  });
+});

--- a/frontend/src/features/Practice/recipes/__tests__/TagPicker.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/TagPicker.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import TagPicker from '../TagPicker';
+
+import type { PracticeTag } from '@/api';
+
+const library: PracticeTag[] = [
+  { id: 1, slug: 'red', label: 'Red', owner_user_id: null, created_at: '2026-01-01T00:00:00Z' },
+  { id: 2, slug: 'blue', label: 'Blue', owner_user_id: null, created_at: '2026-01-01T00:00:00Z' },
+];
+
+describe('TagPicker', () => {
+  it('renders one chip per tag in the library', () => {
+    const utils = render(
+      <TagPicker
+        stepIndex={0}
+        selectedSlug=""
+        tagLibrary={library}
+        onSelect={jest.fn()}
+        onCreateTag={jest.fn(async () => undefined)}
+      />,
+    );
+    expect(utils.getByTestId('tag-picker-0-chip-red')).toBeTruthy();
+    expect(utils.getByTestId('tag-picker-0-chip-blue')).toBeTruthy();
+  });
+
+  it('reflects active selection on the chosen chip', () => {
+    const utils = render(
+      <TagPicker
+        stepIndex={0}
+        selectedSlug="red"
+        tagLibrary={library}
+        onSelect={jest.fn()}
+        onCreateTag={jest.fn(async () => undefined)}
+      />,
+    );
+    expect(utils.getByTestId('tag-picker-0-chip-red').props.accessibilityState.selected).toBe(true);
+  });
+
+  it('selects a tag when its chip is pressed', () => {
+    const onSelect = jest.fn();
+    const utils = render(
+      <TagPicker
+        stepIndex={0}
+        selectedSlug=""
+        tagLibrary={library}
+        onSelect={onSelect}
+        onCreateTag={jest.fn(async () => undefined)}
+      />,
+    );
+    fireEvent.press(utils.getByTestId('tag-picker-0-chip-blue'));
+    expect(onSelect).toHaveBeenCalledWith(library[1]);
+  });
+
+  it('shows the inline creator and submits a new tag', async () => {
+    const onCreateTag = jest.fn(async (_payload: { slug: string; label: string }) => undefined);
+    const utils = render(
+      <TagPicker
+        stepIndex={0}
+        selectedSlug=""
+        tagLibrary={library}
+        onSelect={jest.fn()}
+        onCreateTag={onCreateTag}
+      />,
+    );
+    fireEvent.press(utils.getByTestId('tag-picker-0-new'));
+    expect(utils.getByTestId('tag-picker-0-creator')).toBeTruthy();
+    fireEvent.changeText(utils.getByTestId('tag-picker-0-creator-label'), 'Crimson Star');
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('tag-picker-0-creator-confirm'));
+    });
+    await waitFor(() => expect(onCreateTag).toHaveBeenCalled());
+    const firstCall = onCreateTag.mock.calls[0];
+    if (firstCall === undefined) throw new Error('onCreateTag was not called');
+    const callArgs = firstCall[0] as { slug: string; label: string };
+    expect(callArgs.slug).toBe('crimson_star');
+    expect(callArgs.label).toBe('Crimson Star');
+  });
+
+  it('cancels the inline creator', () => {
+    const utils = render(
+      <TagPicker
+        stepIndex={0}
+        selectedSlug=""
+        tagLibrary={library}
+        onSelect={jest.fn()}
+        onCreateTag={jest.fn(async () => undefined)}
+      />,
+    );
+    fireEvent.press(utils.getByTestId('tag-picker-0-new'));
+    fireEvent.press(utils.getByTestId('tag-picker-0-creator-cancel'));
+    expect(utils.queryByTestId('tag-picker-0-creator')).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/recipes/__tests__/types.test.ts
+++ b/frontend/src/features/Practice/recipes/__tests__/types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { nameToSlug, newStepUid } from '../types';
+
+describe('nameToSlug', () => {
+  it('snake-cases a simple name', () => {
+    expect(nameToSlug('Find the Rainbow')).toBe('find_the_rainbow');
+  });
+
+  it('collapses runs of non-alpha to a single underscore', () => {
+    expect(nameToSlug('5-4-3-2-1 grounding')).toBe('r_5_4_3_2_1_grounding');
+  });
+
+  it('prefixes leading digits so the result matches /^[a-z]/', () => {
+    expect(nameToSlug('123 test')).toBe('r_123_test');
+  });
+
+  it('returns "untitled" for empty input', () => {
+    expect(nameToSlug('')).toBe('untitled');
+    expect(nameToSlug('!!!')).toBe('untitled');
+  });
+
+  it('trims leading and trailing underscores', () => {
+    expect(nameToSlug('---hello---')).toBe('hello');
+  });
+});
+
+describe('newStepUid', () => {
+  it('returns a unique value each call', () => {
+    const uids = new Set([newStepUid(), newStepUid(), newStepUid()]);
+    expect(uids.size).toBe(3);
+  });
+});

--- a/frontend/src/features/Practice/recipes/types.ts
+++ b/frontend/src/features/Practice/recipes/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared types for the recipe picker + editor.
+ *
+ * The wire shapes themselves live in `@/api`; the editor's working
+ * shape is a draft step (no `position` field -- the editor's array
+ * index defines order at save time, the same convention the backend
+ * uses for `PracticeRecipeStepInput`).
+ */
+
+export type RecipeMode = 'sense_grounding' | 'tallied_grounding';
+
+export interface DraftStep {
+  /** Stable client-side id so React's key prop survives reordering. */
+  uid: string;
+  tag_slug: string;
+  tag_label: string;
+  prompt_label: string;
+  target_count: number;
+}
+
+export interface RecipeDraft {
+  /** Empty string while creating a new recipe; populated on edit. */
+  slug: string;
+  name: string;
+  description: string;
+  mode: RecipeMode;
+  rounds: number;
+  steps: DraftStep[];
+}
+
+/**
+ * Lower-cap snake-case conversion used when minting a slug from a
+ * recipe name on create.  Mirrors the backend pattern
+ * `^[a-z][a-z0-9_]*$`; characters outside [a-z0-9] collapse to `_`,
+ * leading non-alpha is prefixed with `r_`, empty result becomes
+ * `untitled`.
+ */
+export function nameToSlug(name: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (cleaned.length === 0) return 'untitled';
+  if (!/^[a-z]/.test(cleaned)) return `r_${cleaned}`;
+  return cleaned;
+}
+
+let _uidCounter = 0;
+export function newStepUid(): string {
+  _uidCounter += 1;
+  return `step_${Date.now()}_${_uidCounter}`;
+}


### PR DESCRIPTION
Adds a user-managed recipe library backing the tier-one practice
customise flow.  A recipe is a named ordered collection of steps
that materialises into a `mode_config` payload when applied to a
UserPractice; tags are the atomic chip labels recipes are built from.

Seeded system recipes:
- 5-4-3-2-1 Grounding (sense_grounding, 5 senses)
- Find the Rainbow (tallied, 7 colors x 3 rounds)
- Find Shapes (tallied, square/circle/triangle x 3 rounds)
- Four Elements (tallied, earth/water/fire/air, Buddhist body scan)
- Embodied Mindfulness (tallied, pressure directions x 3 rounds)

Backend (3 new tables, 11 new endpoints):
- `practicetag` + `practicerecipe` + `practicerecipestep` migration with
  partial-unique slug indexes per (system | user) namespace.
- Full CRUD on `/practice-tags` and `/practice-recipes`; system rows are
  read-only and forking a system recipe creates a user-owned copy.
- `POST /practice-recipes/{id}/apply-to/{user_practice_id}` materialises
  the recipe and writes it into `UserPractice.mode_config_override`,
  re-using the existing catalog-mode check so cross-mode swaps still
  return 400 mode_mismatch.
- 35 new tests covering CRUD, 403/409/422 paths, ownership, and
  seed round-trip through ModeConfigAdapter.

Frontend (recipes/ subdirectory):
- `RecipePickerModal` lists system + user recipes filtered by mode,
  with Use this / Edit / Edit a copy / Delete actions.
- `RecipeEditorModal` for create + edit; reuses the existing prompt-
  row editor pattern and includes a `TagPicker` that inlines tag
  creation alongside the chip row.
- "Browse recipe library" button added to `RitualConfiguratorSheet`
  for any recipe-capable mode (sense_grounding, tallied_grounding).
- 37 new tests across picker, editor, tag picker, slug derivation, and
  API client.

The override mechanism is unchanged: applying a recipe lands in
`UserPractice.mode_config_override` exactly as the customise endpoint
would, so the existing resolution layer (`domain.practice_resolution`)
serves the recipe-applied config without modification.

https://claude.ai/code/session_01A3vu73LmDCjpxjYMJuZypW