### PR TITLE
fix(habits): count no-log days as success for subtractive habits

### DIFF
--- a/backend/src/domain/habit_stats.py
+++ b/backend/src/domain/habit_stats.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from domain.dates import to_user_date, today_in_tz
 from schemas.habit_stats import HabitStats
+from services.streaks import SubtractiveContext
 
 if TYPE_CHECKING:
     from models.goal_completion import GoalCompletion
@@ -85,11 +86,115 @@ def _completion_rate(sorted_dates: list[date], user_timezone: str) -> float:
     return len(sorted_dates) / span if span > 0 else 0.0
 
 
+def _subtractive_day_totals(
+    completions: list[GoalCompletion],
+    user_timezone: str,
+) -> dict[date, float]:
+    """Sum completion units per user-local day, including zero-sum days.
+
+    Mirrors :func:`services.streaks._bucket_day_totals` so the abstention
+    walks here line up with the streak helpers; a key with no row at all
+    is reads as 0 (perfect abstention).
+    """
+    day_totals: dict[date, float] = {}
+    for c in completions:
+        moment = c.timestamp if c.timestamp.tzinfo is not None else c.timestamp.replace(tzinfo=UTC)
+        day = to_user_date(user_timezone, moment)
+        day_totals[day] = day_totals.get(day, 0.0) + c.completed_units
+    return day_totals
+
+
+def _subtractive_current_streak(
+    day_totals: dict[date, float],
+    user_timezone: str,
+    ctx: SubtractiveContext,
+) -> int:
+    """Walk backwards from today counting abstention days, bounded by ``start_date``."""
+    today = today_in_tz(user_timezone)
+    if ctx.start_date > today:
+        return 0
+    streak = 0
+    cursor = today
+    while cursor >= ctx.start_date:
+        if day_totals.get(cursor, 0.0) > ctx.clear_threshold:
+            break
+        streak += 1
+        cursor -= timedelta(days=1)
+    return streak
+
+
+def _subtractive_longest_streak(
+    day_totals: dict[date, float],
+    user_timezone: str,
+    ctx: SubtractiveContext,
+) -> int:
+    """Longest no-transgression run across ``[start_date, today]``.
+
+    Without this the API's ``longest_streak`` for a subtractive habit
+    falls through to the additive helper, which sorts logged days --
+    producing 0 for the no-log case and a contradictory display
+    (``current=N, longest=0``) for any user mid-abstention.
+    """
+    today = today_in_tz(user_timezone)
+    if ctx.start_date > today:
+        return 0
+    longest = 0
+    run = 0
+    cursor = ctx.start_date
+    while cursor <= today:
+        if day_totals.get(cursor, 0.0) > ctx.clear_threshold:
+            run = 0
+        else:
+            run += 1
+            longest = max(longest, run)
+        cursor += timedelta(days=1)
+    return longest
+
+
+def _subtractive_stats(
+    completions: list[GoalCompletion],
+    user_timezone: str,
+    ctx: SubtractiveContext,
+) -> HabitStats:
+    """Subtractive variant of :func:`compute_habit_stats`.
+
+    Day-of-week / completion-rate / total-completions stay rooted in
+    the additive bucketing because they describe "what the user logged"
+    -- pre-existing semantics this PR explicitly leaves unchanged.
+    Only the two streak fields flip polarity, which is the visible
+    inconsistency that PR #379 review surfaced.
+    """
+    units, presence, dates = _aggregate_by_day(completions, user_timezone)
+    sorted_dates = sorted(dates)
+    day_totals = _subtractive_day_totals(completions, user_timezone)
+    return HabitStats(
+        day_labels=list(_DAY_LABELS),
+        values=units,
+        completions_by_day=presence,
+        longest_streak=_subtractive_longest_streak(day_totals, user_timezone, ctx),
+        current_streak=_subtractive_current_streak(day_totals, user_timezone, ctx),
+        total_completions=len(completions),
+        completion_rate=_completion_rate(sorted_dates, user_timezone),
+        completion_dates=[d.isoformat() for d in sorted_dates],
+    )
+
+
 def compute_habit_stats(
     completions: list[GoalCompletion],
     user_timezone: str = "UTC",
+    subtractive: SubtractiveContext | None = None,
 ) -> HabitStats:
-    """Aggregate completions into stats using the user's local calendar."""
+    """Aggregate completions into stats using the user's local calendar.
+
+    Pass ``subtractive`` for habits where success is staying *under* a
+    threshold ("abstain from sugar"): the two streak fields then walk
+    backwards/forwards across ``[start_date, today]`` counting absent
+    days as abstention wins rather than data gaps.  Without it the
+    additive path runs, preserving the legacy behavior for every
+    existing caller.
+    """
+    if subtractive is not None:
+        return _subtractive_stats(completions, user_timezone, subtractive)
     if not completions:
         return _empty_stats()
 

--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -23,7 +23,12 @@ from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from routers.auth import get_current_user
 from schemas import CheckInResult
-from services.streaks import check_milestones, compute_consecutive_streak, update_streak
+from services.streaks import (
+    SubtractiveContext,
+    check_milestones,
+    compute_consecutive_streak,
+    update_streak,
+)
 from services.users import get_user_timezone
 
 
@@ -41,6 +46,10 @@ class _CheckInJob:
     # Explicit completion time for a backfilled past day; ``None`` lets the
     # ``GoalCompletion`` model default (``datetime.now(UTC)``) stand.
     timestamp: datetime | None
+    # Subtractive-habit context for the streak computation: a no-log day
+    # on an "abstain from sugar" habit is success, not a chain break.
+    # ``None`` selects the additive code path.
+    subtractive: SubtractiveContext | None
 
 
 logger = logging.getLogger(__name__)
@@ -117,14 +126,40 @@ async def _idempotent_already_logged_response(
     goal_id: int,
     user_id: int,
     user_timezone: str,
+    subtractive: SubtractiveContext | None = None,
 ) -> CheckInResult:
     """Build the ``already_logged_today`` response shape used by both fast + race paths."""
-    streak = await compute_consecutive_streak(session, goal_id, user_id, user_timezone)
+    streak = await compute_consecutive_streak(session, goal_id, user_id, user_timezone, subtractive)
     return CheckInResult(
         streak=streak,
         milestones=[],
         reason_code="already_logged_today",
     )
+
+
+async def _subtractive_context_for_goal(
+    session: AsyncSession, habit: Habit, posted_goal: Goal
+) -> SubtractiveContext | None:
+    """Build the subtractive-streak context for the habit, else ``None``.
+
+    The check-in payload identifies a single goal (any tier), but the
+    "transgression" line the user thinks in terms of is always the
+    clear-tier sibling.  ``None`` selects the additive code path so
+    additive habits behave exactly as before.
+
+    Queries the sibling directly rather than walking ``habit.goals``
+    because the habit row is fetched with ``session.get`` (no eager
+    relationship load), and touching the lazy-loaded relationship in an
+    async context raises ``MissingGreenlet``.
+    """
+    if posted_goal.is_additive:
+        return None
+    clear_target = await session.scalar(
+        select(Goal.target).where(Goal.habit_id == habit.id, Goal.tier == "clear")
+    )
+    if clear_target is None:
+        return None
+    return SubtractiveContext(clear_threshold=clear_target, start_date=habit.start_date)
 
 
 def _held_response(current_user: int, goal_id: int, old_streak: int) -> CheckInResult:
@@ -178,7 +213,11 @@ async def _persist_and_build_response(session: AsyncSession, job: _CheckInJob) -
         session.add(completion)
         await session.flush()
         new_streak = await compute_consecutive_streak(
-            session, job.goal_id, job.user_id, job.user_timezone
+            session,
+            job.goal_id,
+            job.user_id,
+            job.user_timezone,
+            job.subtractive,
         )
         _, reason = update_streak(
             job.old_streak,
@@ -211,7 +250,11 @@ async def _try_persist_or_idempotent(session: AsyncSession, job: _CheckInJob) ->
         # raise on a clean-looking happy path.
         await session.rollback()
         return await _idempotent_already_logged_response(
-            session, job.goal_id, job.user_id, job.user_timezone
+            session,
+            job.goal_id,
+            job.user_id,
+            job.user_timezone,
+            job.subtractive,
         )
 
 
@@ -231,16 +274,21 @@ async def create_goal_completion(
     goal, habit, goal_id = await _get_owned_goal_and_habit(session, payload.goal_id, current_user)
     user_tz = await get_user_timezone(session, current_user)
     target_day = _resolve_target_day(payload.completed_on, user_tz)
+    subtractive = await _subtractive_context_for_goal(session, habit, goal)
 
     if await _already_logged_on(session, goal_id, current_user, user_tz, target_day):
-        return await _idempotent_already_logged_response(session, goal_id, current_user, user_tz)
+        return await _idempotent_already_logged_response(
+            session, goal_id, current_user, user_tz, subtractive
+        )
 
     is_scheduled = is_scheduled_on(habit.notification_days, target_day.strftime("%a"))
     # ``old_streak`` is also the held-path response value, so it has to
     # be read before the unscheduled-miss early return; the cheap
     # idempotency check above has already short-circuited duplicate
     # retries so only legitimate fresh requests pay the cost.
-    old_streak = await compute_consecutive_streak(session, goal_id, current_user, user_tz)
+    old_streak = await compute_consecutive_streak(
+        session, goal_id, current_user, user_tz, subtractive
+    )
 
     if not payload.did_complete and not is_scheduled:
         return _held_response(current_user, goal_id, old_streak)
@@ -254,5 +302,6 @@ async def create_goal_completion(
         is_scheduled=is_scheduled,
         old_streak=old_streak,
         timestamp=_completion_timestamp(payload.completed_on, user_tz),
+        subtractive=subtractive,
     )
     return await _try_persist_or_idempotent(session, job)

--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -7,11 +7,11 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, MultipleResultsFound
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import log_ownership_denied
@@ -152,20 +152,39 @@ async def _subtractive_context_for_goal(
     relationship load), and touching the lazy-loaded relationship in an
     async context raises ``MissingGreenlet``.
 
-    Uses ``scalar_one_or_none`` rather than ``scalar`` so that data
-    drift -- two ``clear``-tier goals sharing a ``habit_id`` after a
-    migration artifact or a future multi-group schema change -- raises
-    ``MultipleResultsFound`` instead of silently picking an arbitrary
-    threshold.  ``(habit_id, tier)`` has no DB-level uniqueness
-    constraint today (PR #379 review), so this guard is the only thing
-    making the assumption visible if it ever breaks.
+    Filters on ``is_additive == False`` to mirror the in-memory
+    ``_subtractive_context`` helper in ``routers/habits.py``: if a
+    mixed-polarity fixture or partial migration ever co-locates an
+    additive clear goal under the same habit, this filter rejects it
+    before it builds a wrong-shape context.
+
+    Uses ``scalar_one_or_none`` rather than ``scalar`` so duplicate
+    ``clear``-tier siblings (no DB-level ``UniqueConstraint`` on
+    ``(habit_id, tier)`` today -- PR #379 review) surface as a
+    ``MultipleResultsFound``, which is re-raised as a stable 500
+    so clients see a predictable error code instead of an opaque
+    server error.
     """
     if posted_goal.is_additive:
         return None
     result = await session.execute(
-        select(Goal.target).where(Goal.habit_id == habit.id, Goal.tier == "clear")
+        select(Goal.target).where(
+            Goal.habit_id == habit.id,
+            Goal.tier == "clear",
+            col(Goal.is_additive).is_(False),
+        )
     )
-    clear_target = result.scalar_one_or_none()
+    try:
+        clear_target = result.scalar_one_or_none()
+    except MultipleResultsFound as exc:
+        logger.exception(
+            "subtractive_check_in_duplicate_clear_goal",
+            extra={"habit_id": habit.id, "user_id": habit.user_id},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="duplicate_clear_tier_goals",
+        ) from exc
     if clear_target is None:
         return None
     return SubtractiveContext(clear_threshold=clear_target, start_date=habit.start_date)

--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -151,12 +151,21 @@ async def _subtractive_context_for_goal(
     because the habit row is fetched with ``session.get`` (no eager
     relationship load), and touching the lazy-loaded relationship in an
     async context raises ``MissingGreenlet``.
+
+    Uses ``scalar_one_or_none`` rather than ``scalar`` so that data
+    drift -- two ``clear``-tier goals sharing a ``habit_id`` after a
+    migration artifact or a future multi-group schema change -- raises
+    ``MultipleResultsFound`` instead of silently picking an arbitrary
+    threshold.  ``(habit_id, tier)`` has no DB-level uniqueness
+    constraint today (PR #379 review), so this guard is the only thing
+    making the assumption visible if it ever breaks.
     """
     if posted_goal.is_additive:
         return None
-    clear_target = await session.scalar(
+    result = await session.execute(
         select(Goal.target).where(Goal.habit_id == habit.id, Goal.tier == "clear")
     )
+    clear_target = result.scalar_one_or_none()
     if clear_target is None:
         return None
     return SubtractiveContext(clear_threshold=clear_target, start_date=habit.start_date)

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -285,4 +285,4 @@ async def get_habit_stats(
     habit = await _get_habit_with_completions(habit_id, current_user, session)
     completions = [c for goal in habit.goals for c in goal.completions if c.user_id == current_user]
     user_tz = await get_user_timezone(session, current_user)
-    return compute_habit_stats(completions, user_tz)
+    return compute_habit_stats(completions, user_tz, _subtractive_context(habit))

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -25,7 +25,7 @@ from schemas.habit import Habit as HabitSchema
 from schemas.habit import HabitCreate, HabitWithGoals
 from schemas.habit_stats import HabitStats
 from schemas.pagination import paginate_query
-from services.streaks import compute_habit_streak
+from services.streaks import SubtractiveContext, compute_habit_streak
 from services.users import get_user_timezone
 
 logger = logging.getLogger(__name__)
@@ -48,10 +48,26 @@ _DEFAULT_GOAL_TIERS: tuple[tuple[str, str, float], ...] = (
 )
 
 
+def _subtractive_context(habit: Habit) -> SubtractiveContext | None:
+    """Return the streak context for a subtractive habit, else ``None``.
+
+    ``None`` selects the additive code path in :func:`compute_habit_streak`.
+    Onboarding writes the three tiers atomically with a shared
+    ``is_additive`` value, so the first subtractive *clear*-tier goal is
+    a sufficient probe; a habit lacking that goal (older test fixtures,
+    partial migrations) falls back to additive logic to avoid
+    mis-counting against a phantom threshold.
+    """
+    clear = next((g for g in habit.goals if g.tier == "clear" and not g.is_additive), None)
+    if clear is None:
+        return None
+    return SubtractiveContext(clear_threshold=clear.target, start_date=habit.start_date)
+
+
 def _populate_streak(habit: Habit, current_user: int, user_timezone: str) -> None:
     """Set ``habit.streak`` from the goal completions loaded in memory."""
     completions = [c for g in habit.goals for c in g.completions if c.user_id == current_user]
-    habit.streak = compute_habit_streak(completions, user_timezone)
+    habit.streak = compute_habit_streak(completions, user_timezone, _subtractive_context(habit))
 
 
 def _filter_completions_to_caller(habit: Habit, current_user: int) -> None:

--- a/backend/src/services/streaks.py
+++ b/backend/src/services/streaks.py
@@ -18,6 +18,7 @@ silently coerces naive datetimes.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,11 +30,28 @@ from models.goal_completion import GoalCompletion
 from schemas.milestone import Milestone
 
 __all__ = [
+    "SubtractiveContext",
     "check_milestones",
     "compute_consecutive_streak",
     "compute_habit_streak",
     "update_streak",
 ]
+
+
+@dataclass(frozen=True)
+class SubtractiveContext:
+    """Habit-level context required to compute a subtractive streak.
+
+    Bundles the two values a subtractive-habit streak walk needs into a
+    single kwarg so streak functions stay under the project's
+    ``PLR0913`` (max-5-args) bar even after picking up the abstention
+    code path.  ``clear_threshold`` is the day's failure cutoff (sum >
+    threshold = transgression); ``start_date`` is the habit's birth so
+    the walk cannot accrue streak days before the habit existed.
+    """
+
+    clear_threshold: float
+    start_date: date
 
 
 def _to_user_date(ts: datetime | str, user_timezone: str) -> date:
@@ -107,6 +125,7 @@ async def compute_consecutive_streak(
     goal_id: int,
     user_id: int,
     user_timezone: str = "UTC",
+    subtractive: SubtractiveContext | None = None,
 ) -> int:
     """Count consecutive *days* with completed check-ins for a goal.
 
@@ -116,6 +135,13 @@ async def compute_consecutive_streak(
     boundary applies (BUG-STREAK-002); routers should pass
     :func:`services.users.get_user_timezone` so streaks tick over at the
     user's midnight rather than UTC's.
+
+    For subtractive habits, pass ``subtractive`` to flip the success
+    polarity: a day with no log = perfect abstention (success), and the
+    chain only breaks on a day where the user logged above
+    ``subtractive.clear_threshold``.  Omitting ``subtractive`` keeps
+    legacy additive behavior, so callers that don't know the habit's
+    polarity stay safe.
     """
     rows = await session.execute(
         select(GoalCompletion.timestamp, GoalCompletion.completed_units)
@@ -127,6 +153,9 @@ async def compute_consecutive_streak(
     for ts, units in rows:
         day = _to_user_date(ts, user_timezone)
         day_totals[day] = day_totals.get(day, 0.0) + units
+
+    if subtractive is not None:
+        return _compute_subtractive_streak(day_totals, user_timezone, subtractive)
 
     sorted_days = sorted(day_totals, reverse=True)
     # Mirror the frontend's recency gate so a stale chain reports 0 here
@@ -152,9 +181,64 @@ def _completed_user_dates(
     return {_to_user_date(c.timestamp, user_timezone) for c in completions if c.completed_units > 0}
 
 
+def _bucket_day_totals(
+    completions: Sequence[GoalCompletion],
+    user_timezone: str,
+) -> dict[date, float]:
+    """Sum completion units per user-local day, *without* the >0 filter.
+
+    The additive path uses :func:`_completed_user_dates` because absence
+    of a row is the failure signal there.  For subtractive habits the
+    opposite is true (no row = perfect abstention), so the bucketing
+    must keep zero-sum days addressable too.  Returns ``{day: total}``;
+    callers treat ``get(day, 0.0)`` as the canonical "did the user stay
+    under their limit" probe.
+    """
+    day_totals: dict[date, float] = {}
+    for c in completions:
+        day = _to_user_date(c.timestamp, user_timezone)
+        day_totals[day] = day_totals.get(day, 0.0) + c.completed_units
+    return day_totals
+
+
+def _compute_subtractive_streak(
+    day_totals: dict[date, float],
+    user_timezone: str,
+    ctx: SubtractiveContext,
+) -> int:
+    """Count consecutive abstention days for a subtractive habit.
+
+    Walks backwards from today.  A day counts toward the streak when
+    the user's total for that day is at most ``ctx.clear_threshold`` —
+    which is trivially true for a day that has no row at all (no log =
+    didn't slip).  The walk stops when:
+
+    * the user logged *above* the clear threshold on that day
+      (a "transgression" breaks the chain), or
+    * the cursor crosses ``ctx.start_date`` going backwards (you
+      cannot accrue streak before the habit existed).
+
+    Returns 0 when the habit's start_date is in the future relative to
+    the user's "today" — the habit hasn't begun yet, so there is no
+    abstention to count.
+    """
+    today = today_in_tz(user_timezone)
+    if ctx.start_date > today:
+        return 0
+    streak = 0
+    cursor = today
+    while cursor >= ctx.start_date:
+        if day_totals.get(cursor, 0.0) > ctx.clear_threshold:
+            break
+        streak += 1
+        cursor -= timedelta(days=1)
+    return streak
+
+
 def compute_habit_streak(
     completions: Sequence[GoalCompletion],
     user_timezone: str = "UTC",
+    subtractive: SubtractiveContext | None = None,
 ) -> int:
     """Compute current consecutive-day streak from in-memory completions.
 
@@ -164,15 +248,21 @@ def compute_habit_streak(
     show two different streak counts depending on whether it was loaded
     via the in-memory or per-goal path.
 
-    Also enforces the same recency gate the frontend
-    ``streakFromCompletions`` helper uses (BUG-FE-HABIT-207): if the most
-    recent completion is older than yesterday in the user's calendar,
-    the streak is broken and the helper returns 0.  Without the gate the
-    Habits list endpoint would advertise a non-zero "10-day streak 🔥"
-    while the stats overlay (which used the frontend helper) showed 0
-    after a missed day -- exactly the visible discrepancy this gate
-    prevents.
+    For **additive** habits (the default — ``subtractive=None``),
+    enforces the recency gate the frontend ``streakFromCompletions``
+    helper uses (BUG-FE-HABIT-207): if the most recent completion is
+    older than yesterday in the user's calendar, the streak is broken
+    and the helper returns 0.
+
+    For **subtractive** habits (e.g. "abstain from sugar") a day with
+    *no* log is the best possible outcome, so the recency gate would
+    invert the correct behavior.  Pass a :class:`SubtractiveContext`
+    bundling the sibling clear-tier goal's target and the habit's
+    ``start_date`` to walk backwards counting abstention days instead.
     """
+    if subtractive is not None:
+        day_totals = _bucket_day_totals(completions, user_timezone)
+        return _compute_subtractive_streak(day_totals, user_timezone, subtractive)
     dates = _completed_user_dates(completions, user_timezone)
     if not dates:
         return 0

--- a/backend/tests/services/test_streaks.py
+++ b/backend/tests/services/test_streaks.py
@@ -14,6 +14,7 @@ from models.habit import Habit
 from models.user import User
 from schemas.milestone import Milestone
 from services.streaks import (
+    SubtractiveContext,
     check_milestones,
     compute_consecutive_streak,
     compute_habit_streak,
@@ -363,3 +364,124 @@ async def test_compute_consecutive_streak_returns_zero_when_chain_is_stale(
     await db_session.commit()
 
     assert await compute_consecutive_streak(db_session, goal.id, user.id, "UTC") == 0
+
+
+# ── Subtractive habits: no-log days count as abstention success ────────────
+
+
+def test_compute_habit_streak_subtractive_with_no_logs_counts_from_start_date() -> None:
+    """A subtractive habit with zero logs accrues a streak day per calendar day.
+
+    User opened the app every day but never had any sugar to log; the
+    habit started 5 days ago, so the streak should be 6 (today + the
+    five days since start).  This is the exact case the bug report
+    pointed at: "It should still mark achieved if it hasn't been logged
+    at all, meaning I have abstained."
+    """
+    today = datetime.now(UTC).date()
+    ctx = SubtractiveContext(clear_threshold=5.0, start_date=today - timedelta(days=5))
+
+    assert compute_habit_streak([], "UTC", ctx) == 6
+
+
+def test_compute_habit_streak_subtractive_breaks_on_transgression() -> None:
+    """Logging above the clear threshold yesterday breaks the streak there.
+
+    Today is still success (no log = 0 sugar), but yesterday's
+    transgression (7 > clear=5) ends the chain — streak = 1.
+    """
+    yesterday = _utc_dt_n_days_ago(1)
+    completions = [GoalCompletion(goal_id=1, user_id=1, completed_units=7.0, timestamp=yesterday)]
+    today_date = datetime.now(UTC).date()
+    ctx = SubtractiveContext(clear_threshold=5.0, start_date=today_date - timedelta(days=10))
+
+    assert compute_habit_streak(completions, "UTC", ctx) == 1
+
+
+def test_compute_habit_streak_subtractive_below_threshold_keeps_streak() -> None:
+    """A small log under the clear threshold still counts as a success day."""
+    completions = [
+        GoalCompletion(
+            goal_id=1,
+            user_id=1,
+            completed_units=2.0,
+            timestamp=_utc_dt_n_days_ago(days_ago),
+        )
+        for days_ago in (0, 1, 2)
+    ]
+    today_date = datetime.now(UTC).date()
+    ctx = SubtractiveContext(clear_threshold=5.0, start_date=today_date - timedelta(days=5))
+
+    # Five days of habit existence, every day below the clear threshold ->
+    # full streak from today back to start_date (6 days inclusive).
+    assert compute_habit_streak(completions, "UTC", ctx) == 6
+
+
+def test_compute_habit_streak_subtractive_at_threshold_is_success() -> None:
+    """A log *equal* to the clear threshold is "just under" — the day still counts.
+
+    The frontend's tier resolver treats ``total <= target`` as success
+    for subtractive goals; the backend streak must agree or the tile's
+    "Achieved Today!" badge and the streak counter diverge on the edge
+    case.
+    """
+    today_dt = _utc_dt_n_days_ago(0)
+    completions = [GoalCompletion(goal_id=1, user_id=1, completed_units=5.0, timestamp=today_dt)]
+    today_date = datetime.now(UTC).date()
+    ctx = SubtractiveContext(clear_threshold=5.0, start_date=today_date)
+
+    assert compute_habit_streak(completions, "UTC", ctx) == 1
+
+
+def test_compute_habit_streak_subtractive_returns_zero_before_start_date() -> None:
+    """A habit that hasn't started yet has no streak to accrue."""
+    today_date = datetime.now(UTC).date()
+    ctx = SubtractiveContext(clear_threshold=5.0, start_date=today_date + timedelta(days=3))
+    assert compute_habit_streak([], "UTC", ctx) == 0
+
+
+@pytest.mark.asyncio
+async def test_compute_consecutive_streak_subtractive_no_logs(
+    db_session: AsyncSession,
+) -> None:
+    """DB path: a subtractive goal with no logs streaks from start_date.
+
+    Mirrors :func:`test_compute_habit_streak_subtractive_with_no_logs_counts_from_start_date`
+    so the in-memory path used by ``GET /habits`` and the per-goal DB
+    path used during check-in report the same number.
+    """
+    user = await _make_user(db_session)
+    assert user.id is not None
+    goal = await _make_goal(db_session, user.id)
+    assert goal.id is not None
+
+    today_date = datetime.now(UTC).date()
+    ctx = SubtractiveContext(clear_threshold=5.0, start_date=today_date - timedelta(days=3))
+    assert await compute_consecutive_streak(db_session, goal.id, user.id, "UTC", ctx) == 4
+
+
+@pytest.mark.asyncio
+async def test_compute_consecutive_streak_subtractive_breaks_on_transgression(
+    db_session: AsyncSession,
+) -> None:
+    """DB path: a single above-threshold log day breaks the abstention chain."""
+    user = await _make_user(db_session)
+    assert user.id is not None
+    goal = await _make_goal(db_session, user.id)
+    assert goal.id is not None
+
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal.id,
+            user_id=user.id,
+            completed_units=10.0,  # well above clear=5
+            timestamp=_utc_dt_n_days_ago(2),
+        ),
+    )
+    await db_session.commit()
+
+    today_date = datetime.now(UTC).date()
+    ctx = SubtractiveContext(clear_threshold=5.0, start_date=today_date - timedelta(days=10))
+    # Today + yesterday are abstention days (streak=2), then day -2 is a
+    # transgression that breaks the chain.
+    assert await compute_consecutive_streak(db_session, goal.id, user.id, "UTC", ctx) == 2

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -9,7 +9,6 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
@@ -799,15 +798,16 @@ async def test_subtractive_check_in_idempotent_path_preserves_subtractive_streak
 async def test_subtractive_check_in_fails_loudly_on_duplicate_clear_tier(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """A habit with two ``clear``-tier goals surfaces the data drift.
+    """A habit with two ``clear``-tier goals returns a stable 500.
 
     There is no DB-level ``UniqueConstraint`` on ``(habit_id, tier)``
     (PR #379 review).  If a migration artifact or a future multi-group
     schema change ever puts two ``clear`` goals under one habit,
     ``_subtractive_context_for_goal`` MUST refuse to silently pick one
-    -- which is exactly what the original ``scalar()`` did.  Pins the
-    new ``scalar_one_or_none()`` guard by asserting the request raises
-    instead of returning a 200 with a coin-flipped threshold.
+    -- which is exactly what the original ``scalar()`` did.  The router
+    catches ``MultipleResultsFound`` and re-raises a 500 with detail
+    ``duplicate_clear_tier_goals`` so clients see a predictable code
+    instead of an opaque server error.
     """
     headers, user_id = await _signup(async_client, "abstain_dup_clear")
     today = today_in_tz("UTC")
@@ -832,9 +832,10 @@ async def test_subtractive_check_in_fails_loudly_on_duplicate_clear_tier(
     )
     await db_session.commit()
 
-    with pytest.raises(MultipleResultsFound):
-        await async_client.post(
-            "/goal_completions/",
-            json={"goal_id": clear.id, "did_complete": True},
-            headers=headers,
-        )
+    resp = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": clear.id, "did_complete": True},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert resp.json()["detail"] == "duplicate_clear_tier_goals"

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -599,3 +599,196 @@ async def test_response_streak_matches_db_after_commit(
     assert goal.id is not None
     db_streak = await compute_consecutive_streak(db_session, goal.id, user_id, "UTC")
     assert api_streak == db_streak
+
+
+# ── Subtractive habits: no-log days count as abstention success ──────────
+
+
+# Three tiers matching the onboarding shape: low/clear/stretch with
+# decreasing target values (subtractive = "stay under the target").
+_SUBTRACTIVE_TIERS: tuple[tuple[str, float], ...] = (
+    ("low", 10.0),
+    ("clear", 5.0),
+    ("stretch", 2.0),
+)
+
+
+async def _seed_subtractive_habit(
+    db_session: AsyncSession,
+    user_id: int,
+    start_date: date,
+) -> tuple[Goal, Goal, Goal]:
+    """Create an abstain-style habit with the three-tier subtractive goal set.
+
+    Returns ``(low, clear, stretch)``.  Mirrors the shape onboarding builds
+    so the router's clear-tier lookup is exercised end-to-end — without
+    this fixture the new ``_subtractive_context_for_goal`` DB query was
+    never executed in any test, exactly the gap the PR review flagged.
+    """
+    habit = Habit(
+        name="No sugar",
+        icon="🍬",
+        start_date=start_date,
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    goals: list[Goal] = []
+    for tier, target in _SUBTRACTIVE_TIERS:
+        goal = Goal(
+            habit_id=habit.id,
+            title=f"{tier} sugar",
+            tier=tier,
+            target=target,
+            target_unit="g",
+            frequency=1.0,
+            frequency_unit="per_day",
+            is_additive=False,
+        )
+        db_session.add(goal)
+        goals.append(goal)
+    await db_session.commit()
+    for goal in goals:
+        await db_session.refresh(goal)
+    return goals[0], goals[1], goals[2]
+
+
+@pytest.mark.asyncio
+async def test_subtractive_check_in_uses_clear_tier_threshold(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """End-to-end: ``POST /goal_completions`` resolves the clear-tier sibling.
+
+    The router's ``_subtractive_context_for_goal`` issues a live
+    ``session.scalar(select(Goal.target).where(habit_id == ..., tier ==
+    'clear'))`` query.  Unit tests on the streak helpers pass a hand-built
+    context, so the wiring layer — the SELECT, the tier-string match,
+    the SubtractiveContext build — is only covered through this test.
+
+    Posts the check-in against the *stretch* tier (target=2, under
+    clear=5) so today's stored row stays in the abstention range and the
+    test cleanly demonstrates the subtractive walk: zero prior logs +
+    habit started 3 days ago = 4 days of abstention (today + 3 prior).
+
+    If the router silently fell back to additive logic the streak would
+    be 1 (today only), so the assertion specifically pins the polarity.
+    """
+    headers, user_id = await _signup(async_client, "abstain_user")
+    today = today_in_tz("UTC")
+    _low, _clear, stretch = await _seed_subtractive_habit(
+        db_session, user_id, today - timedelta(days=3)
+    )
+    assert stretch.id is not None
+
+    resp = await async_client.post(
+        "/goal_completions/",
+        # Logging at the stretch tier stores `target=2` units, below
+        # clear=5 -> today counts as a successful abstention day.
+        json={"goal_id": stretch.id, "did_complete": True},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    # 4 days = today + the three prior abstention days since start_date.
+    expected_streak = 4
+    assert resp.json()["streak"] == expected_streak
+
+
+@pytest.mark.asyncio
+async def test_subtractive_check_in_falls_back_to_additive_for_additive_habit(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Additive habits do not pick up the subtractive walk by accident.
+
+    Inverse of :func:`test_subtractive_check_in_uses_clear_tier_threshold`:
+    same scenario (habit started 3 days ago, zero prior logs, one log
+    today) on a vanilla additive habit must yield streak=1, proving the
+    polarity branch in ``_subtractive_context_for_goal`` actually
+    distinguishes additive from subtractive.
+    """
+    headers, user_id = await _signup(async_client, "additive_baseline")
+    goal = await _seed_goal(db_session, user_id)
+    assert goal.id is not None
+
+    resp = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": goal.id, "did_complete": True},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["streak"] == 1
+
+
+@pytest.mark.asyncio
+async def test_subtractive_check_in_breaks_streak_on_transgression(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A pre-existing transgression day caps the abstention chain end-to-end."""
+    headers, user_id = await _signup(async_client, "abstain_user_transgress")
+    today = today_in_tz("UTC")
+    _low, clear, _stretch = await _seed_subtractive_habit(
+        db_session, user_id, today - timedelta(days=10)
+    )
+    assert clear.id is not None
+
+    # Two days ago the user blew past the clear=5 limit; the chain should
+    # only count today + yesterday.
+    db_session.add(
+        GoalCompletion(
+            goal_id=clear.id,
+            user_id=user_id,
+            completed_units=20.0,
+            timestamp=datetime.now(UTC) - timedelta(days=2),
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": clear.id, "did_complete": True},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    expected_streak = 2
+    assert resp.json()["streak"] == expected_streak
+
+
+@pytest.mark.asyncio
+async def test_subtractive_check_in_idempotent_path_preserves_subtractive_streak(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Replays of the same-day log keep the subtractive abstention count.
+
+    Covers the ``_idempotent_already_logged_response`` branch — without
+    threading ``SubtractiveContext`` through both the happy-path and
+    idempotent-replay paths, a retry would fall back to additive logic
+    and return a smaller streak than the first call.
+    """
+    headers, user_id = await _signup(async_client, "abstain_idempotent")
+    today = today_in_tz("UTC")
+    _low, clear, _stretch = await _seed_subtractive_habit(
+        db_session, user_id, today - timedelta(days=4)
+    )
+    assert clear.id is not None
+
+    first = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": clear.id, "did_complete": True},
+        headers=headers,
+    )
+    assert first.status_code == HTTPStatus.OK
+    expected_streak = 5  # today + 4 days back since start_date.
+    assert first.json()["streak"] == expected_streak
+
+    # Same-day retry hits the already-logged-today branch; the streak
+    # must agree with the original response, not the additive fallback.
+    second = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": clear.id, "did_complete": True},
+        headers=headers,
+    )
+    assert second.status_code == HTTPStatus.OK
+    assert second.json()["reason_code"] == "already_logged_today"
+    assert second.json()["streak"] == expected_streak

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -9,6 +9,7 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
@@ -792,3 +793,48 @@ async def test_subtractive_check_in_idempotent_path_preserves_subtractive_streak
     assert second.status_code == HTTPStatus.OK
     assert second.json()["reason_code"] == "already_logged_today"
     assert second.json()["streak"] == expected_streak
+
+
+@pytest.mark.asyncio
+async def test_subtractive_check_in_fails_loudly_on_duplicate_clear_tier(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A habit with two ``clear``-tier goals surfaces the data drift.
+
+    There is no DB-level ``UniqueConstraint`` on ``(habit_id, tier)``
+    (PR #379 review).  If a migration artifact or a future multi-group
+    schema change ever puts two ``clear`` goals under one habit,
+    ``_subtractive_context_for_goal`` MUST refuse to silently pick one
+    -- which is exactly what the original ``scalar()`` did.  Pins the
+    new ``scalar_one_or_none()`` guard by asserting the request raises
+    instead of returning a 200 with a coin-flipped threshold.
+    """
+    headers, user_id = await _signup(async_client, "abstain_dup_clear")
+    today = today_in_tz("UTC")
+    _low, clear, _stretch = await _seed_subtractive_habit(
+        db_session, user_id, today - timedelta(days=3)
+    )
+    assert clear.id is not None
+
+    # Inject a second ``clear``-tier goal on the same habit.  Schema
+    # allows this today; the new guard is what catches it.
+    db_session.add(
+        Goal(
+            habit_id=clear.habit_id,
+            title="Duplicate clear sugar",
+            tier="clear",
+            target=999.0,  # absurd target so a silent pick would skew streak hugely
+            target_unit="g",
+            frequency=1.0,
+            frequency_unit="per_day",
+            is_additive=False,
+        )
+    )
+    await db_session.commit()
+
+    with pytest.raises(MultipleResultsFound):
+        await async_client.post(
+            "/goal_completions/",
+            json={"goal_id": clear.id, "did_complete": True},
+            headers=headers,
+        )

--- a/backend/tests/test_habit_stats_api.py
+++ b/backend/tests/test_habit_stats_api.py
@@ -8,9 +8,12 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
+from domain.dates import today_in_tz
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
+from models.habit import Habit
 
 # Named constants for test assertions (avoids magic-number lint warnings)
 DAYS_IN_WEEK = 7
@@ -434,3 +437,107 @@ async def test_stats_current_streak_returns_zero_for_stale_chain(
     # Longest streak is unaffected by the recency gate -- it still
     # reflects the historical 3-day run.
     assert data["longest_streak"] == 3
+
+
+# ── Subtractive habits: stats endpoint mirrors the streak polarity ───────
+
+
+_SUBTRACTIVE_TIERS_STATS: tuple[tuple[str, float], ...] = (
+    ("low", 10.0),
+    ("clear", 5.0),
+    ("stretch", 2.0),
+)
+
+
+async def _seed_subtractive_habit_for_stats(
+    db_session: AsyncSession,
+    user_id: int,
+    start_date_offset_days: int,
+) -> int:
+    """Insert an abstain-style habit with 3 subtractive tier goals; return habit_id."""
+    start = today_in_tz("UTC") - timedelta(days=start_date_offset_days)
+    habit = Habit(
+        name="No sugar",
+        icon="🍬",
+        start_date=start,
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    for tier, target in _SUBTRACTIVE_TIERS_STATS:
+        db_session.add(
+            Goal(
+                habit_id=habit.id,
+                title=f"{tier} sugar",
+                tier=tier,
+                target=target,
+                target_unit="g",
+                frequency=1.0,
+                frequency_unit="per_day",
+                is_additive=False,
+            )
+        )
+    await db_session.commit()
+    assert habit.id is not None
+    return habit.id
+
+
+@pytest.mark.asyncio
+async def test_stats_subtractive_no_logs_reports_consistent_current_and_longest(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """PR #379 review blocker: avoid contradictory "Current: N · Longest: 0".
+
+    Pre-fix, ``GET /habits/{id}/stats`` for a habit with zero logs
+    returned ``longest_streak: 0`` (additive path), while a follow-up
+    fix to ``current_streak`` made the same response report a non-zero
+    abstention count.  This test pins that both fields walk the
+    subtractive algorithm now, so the stats overlay shows internally
+    consistent numbers.
+    """
+    headers, user_id = await _signup_with_id(async_client, "abstain_stats")
+    habit_id = await _seed_subtractive_habit_for_stats(db_session, user_id, 5)
+
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    # Today + 5 prior days = 6 days of abstention, all of which form the
+    # longest run because there are no transgressions.
+    expected = 6
+    assert body["current_streak"] == expected
+    assert body["longest_streak"] == expected
+
+
+@pytest.mark.asyncio
+async def test_stats_subtractive_longest_predates_current_after_transgression(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Longest > current when a past transgression bisects the abstention chain."""
+    headers, user_id = await _signup_with_id(async_client, "abstain_stats_break")
+    habit_id = await _seed_subtractive_habit_for_stats(db_session, user_id, 14)
+    # Inject a transgression two days ago via a goal id resolved from the seeded habit.
+    clear_goal_id = await db_session.scalar(
+        select(Goal.id).where(Goal.habit_id == habit_id, Goal.tier == "clear")
+    )
+    assert clear_goal_id is not None
+    db_session.add(
+        GoalCompletion(
+            goal_id=clear_goal_id,
+            user_id=user_id,
+            completed_units=20.0,  # >> clear=5g
+            timestamp=datetime.now(UTC) - timedelta(days=2),
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/habits/{habit_id}/stats", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    # Today + yesterday since the transgression = 2-day current run.
+    assert body["current_streak"] == 2
+    # Pre-transgression window: 12 days (start_date .. day -3 inclusive).
+    expected_longest = 12
+    assert body["longest_streak"] == expected_longest

--- a/backend/tests/test_habits_api.py
+++ b/backend/tests/test_habits_api.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import timedelta
 from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from domain.dates import today_in_tz
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
+from models.habit import Habit
 
 
 def sample_payload(**overrides: object) -> dict[str, object]:
@@ -338,6 +341,85 @@ async def test_list_habits_includes_goal_completions(async_client: AsyncClient) 
     [habit] = resp.json()
     clear_goal = next(g for g in habit["goals"] if g["tier"] == "clear")
     assert len(clear_goal["completions"]) == 1
+
+
+# Three subtractive tiers (low/clear/stretch) matching the onboarding
+# shape; lifted to module scope so the helper below stays at 3 args and
+# under the project's PLR0913 limit.
+_SUBTRACTIVE_TIERS_FOR_API: tuple[tuple[str, float], ...] = (
+    ("low", 10.0),
+    ("clear", 5.0),
+    ("stretch", 2.0),
+)
+
+
+async def _signup_with_user_id(client: AsyncClient, username: str) -> tuple[dict[str, str], int]:
+    """Variant of ``_signup`` that also returns the user id for DB-direct seeding."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+@pytest.mark.asyncio
+async def test_get_habits_reports_subtractive_streak_from_start_date(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``GET /habits`` runs the subtractive streak path end-to-end.
+
+    The check-in path (``POST /goal_completions``) and the list path
+    (``GET /habits``) build the ``SubtractiveContext`` through two
+    separate helpers -- ``_subtractive_context_for_goal`` queries the
+    DB directly, while ``_populate_streak`` reads the eager-loaded
+    ``habit.goals`` relationship.  Per the PR #379 review, only the
+    former was HTTP-covered; this test closes the loop on the second
+    wiring so a regression in ``_subtractive_context`` (e.g. dropping
+    the tier filter, returning ``None`` for a valid habit) flips a red
+    test instead of silently zeroing the streak on the user's tile.
+    """
+    headers, user_id = await _signup_with_user_id(async_client, "abstain_list")
+    today = today_in_tz("UTC")
+    start = today - timedelta(days=3)
+    habit = Habit(
+        name="No sugar",
+        icon="🍬",
+        start_date=start,
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    for tier, target in _SUBTRACTIVE_TIERS_FOR_API:
+        db_session.add(
+            Goal(
+                habit_id=habit.id,
+                title=f"{tier} sugar",
+                tier=tier,
+                target=target,
+                target_unit="g",
+                frequency=1.0,
+                frequency_unit="per_day",
+                is_additive=False,
+            )
+        )
+    await db_session.commit()
+
+    resp = await async_client.get("/habits/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    [body_habit] = resp.json()
+    # 4 days = today + the three prior abstention days since start_date.
+    # If ``_subtractive_context`` regressed to the additive path the
+    # streak would be 0 (no log rows at all -> additive recency gate
+    # zeroes the chain), so this assertion specifically pins polarity.
+    assert body_habit["streak"] == 4
 
 
 @pytest.mark.asyncio

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_TIMEZONE,
   dayKeyInTZ,
   streakFromCompletions,
+  subtractiveStreakFromCompletions,
   todayInUserTZ,
 } from '../../utils/dateUtils';
 
@@ -375,12 +376,55 @@ const computeCompletionRate = (sortedDays: Date[], totalUniqueDays: number): num
 };
 
 /**
+ * Subtractive habits (e.g. "abstain from sugar") count *no-log* days as
+ * abstention successes, so the additive helper — which requires a row
+ * per counted day — is wrong for them.  Returns `null` when the habit
+ * is additive or lacks the clear-tier sibling to read the threshold
+ * from, falling back to the additive code path.
+ */
+const subtractiveStreakInputs = (
+  habit: Habit,
+  tz: string,
+): { clearThreshold: number; startDate: string } | null => {
+  const firstGoal = habit.goals[0];
+  if (!firstGoal || firstGoal.is_additive) return null;
+  const clearGoal = habit.goals.find((g) => g.tier === 'clear');
+  if (!clearGoal) return null;
+  return {
+    clearThreshold: getGoalTarget(clearGoal),
+    startDate: dayKeyInTZ(habit.start_date, tz),
+  };
+};
+
+/**
  * Wrap the centralized streak helper so this file's call sites keep their
  * existing signature.  The shared helper compares against "today" in the
  * user's TZ so a stale chain that ended a week ago no longer reports a
  * non-zero streak (BUG-FE-HABIT-207).
+ *
+ * For subtractive habits, delegates to the abstention-aware helper so a
+ * habit with no log entries still accrues streak days — the user has
+ * stayed clean since `habit.start_date`.
  */
-const computeCurrentStreak = (completions: ReadonlyArray<Completion>, tz: string): number => {
+const computeCurrentStreak = (
+  habit: Habit,
+  completions: ReadonlyArray<Completion>,
+  tz: string,
+): number => {
+  const subtractive = subtractiveStreakInputs(habit, tz);
+  if (subtractive) {
+    return subtractiveStreakFromCompletions(
+      {
+        completions: completions.map((c) => ({
+          timestamp: c.timestamp,
+          completed_units: c.completed_units,
+        })),
+        clearThreshold: subtractive.clearThreshold,
+        startDate: subtractive.startDate,
+      },
+      tz,
+    );
+  }
   return streakFromCompletions(
     completions.map((c) => c.timestamp),
     tz,
@@ -405,7 +449,15 @@ export const generateStatsForHabit = (
   tz: string = DEFAULT_TIMEZONE,
 ): HabitStatsData => {
   const completions = habit.completions;
-  if (!completions || completions.length === 0) return emptyStats();
+  if (!completions || completions.length === 0) {
+    // Subtractive habits accrue a streak even with zero rows — abstaining
+    // every day since `start_date` is the success case, not the no-data
+    // case — so emptyStats() would zero out an active abstention chain.
+    return {
+      ...emptyStats(),
+      currentStreak: computeCurrentStreak(habit, [], tz),
+    };
+  }
 
   const { unitsByDay, presenceByDay, daysWithCompletions } = aggregateByDayOfWeek(completions, tz);
 
@@ -419,7 +471,7 @@ export const generateStatsForHabit = (
     completionsByDay: presenceByDay,
     dayLabels: DAY_LABELS,
     longestStreak: computeLongestStreak(sortedDays),
-    currentStreak: computeCurrentStreak(completions, tz),
+    currentStreak: computeCurrentStreak(habit, completions, tz),
     totalCompletions: completions.length,
     completionRate: computeCompletionRate(sortedDays, daysWithCompletions.size),
     completionDates: collectCompletionDates(sortedDays),

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -381,14 +381,17 @@ const computeCompletionRate = (sortedDays: Date[], totalUniqueDays: number): num
  * per counted day — is wrong for them.  Returns `null` when the habit
  * is additive or lacks the clear-tier sibling to read the threshold
  * from, falling back to the additive code path.
+ *
+ * Probes ``tier === 'clear' && !is_additive`` together so a partial
+ * fixture (or future migration that lets per-tier ``is_additive`` drift)
+ * cannot misclassify an additive habit as subtractive.  Mirrors the
+ * backend ``_subtractive_context`` helper in ``routers/habits.py``.
  */
 const subtractiveStreakInputs = (
   habit: Habit,
   tz: string,
 ): { clearThreshold: number; startDate: string } | null => {
-  const firstGoal = habit.goals[0];
-  if (!firstGoal || firstGoal.is_additive) return null;
-  const clearGoal = habit.goals.find((g) => g.tier === 'clear');
+  const clearGoal = habit.goals.find((g) => g.tier === 'clear' && !g.is_additive);
   if (!clearGoal) return null;
   return {
     clearThreshold: getGoalTarget(clearGoal),

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_TIMEZONE,
   dayKeyInTZ,
   streakFromCompletions,
+  subtractiveLongestStreakFromCompletions,
   subtractiveStreakFromCompletions,
   todayInUserTZ,
 } from '../../utils/dateUtils';
@@ -434,6 +435,40 @@ const computeCurrentStreak = (
   );
 };
 
+/**
+ * Longest streak across the habit's life — subtractive-aware.
+ *
+ * For additive habits, defers to the existing
+ * :func:`computeLongestStreak` which counts consecutive logged days.
+ * For subtractive habits, walks ``[start_date, today]`` and tracks the
+ * longest no-transgression run; without this the stats overlay shows
+ * a contradictory "Current: 7 · Longest: 0" pair for any habit whose
+ * current streak is non-zero but has no log entries (the
+ * ``computeLongestStreak`` input is empty in that case).
+ */
+const computeLongestStreakFor = (
+  habit: Habit,
+  completions: ReadonlyArray<Completion>,
+  sortedDays: Date[],
+  tz: string,
+): number => {
+  const subtractive = subtractiveStreakInputs(habit, tz);
+  if (subtractive) {
+    return subtractiveLongestStreakFromCompletions(
+      {
+        completions: completions.map((c) => ({
+          timestamp: c.timestamp,
+          completed_units: c.completed_units,
+        })),
+        clearThreshold: subtractive.clearThreshold,
+        startDate: subtractive.startDate,
+      },
+      tz,
+    );
+  }
+  return computeLongestStreak(sortedDays);
+};
+
 const collectCompletionDates = (sortedDays: Date[]): string[] =>
   sortedDays.filter((d) => !isNaN(d.getTime())).map((d) => d.toISOString().slice(0, 10));
 
@@ -459,6 +494,7 @@ export const generateStatsForHabit = (
     return {
       ...emptyStats(),
       currentStreak: computeCurrentStreak(habit, [], tz),
+      longestStreak: computeLongestStreakFor(habit, [], [], tz),
     };
   }
 
@@ -473,7 +509,7 @@ export const generateStatsForHabit = (
     values: unitsByDay,
     completionsByDay: presenceByDay,
     dayLabels: DAY_LABELS,
-    longestStreak: computeLongestStreak(sortedDays),
+    longestStreak: computeLongestStreakFor(habit, completions, sortedDays, tz),
     currentStreak: computeCurrentStreak(habit, completions, tz),
     totalCompletions: completions.length,
     completionRate: computeCompletionRate(sortedDays, daysWithCompletions.size),

--- a/frontend/src/features/Habits/__tests__/HabitStats.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitStats.test.ts
@@ -219,6 +219,12 @@ describe('generateStatsForHabit', () => {
       const stats = generateStatsForHabit(habit, 'UTC');
       // Today + 3 prior days = 4 days of abstention.
       expect(stats.currentStreak).toBe(4);
+      // ``longestStreak`` must agree with ``currentStreak`` here -- with
+      // no transgressions across the whole habit life, the longest run
+      // is the same as the current one.  Pins the regression flagged in
+      // PR #379 review where current was non-zero while longest stayed
+      // 0 from ``emptyStats()`` -- a contradictory display.
+      expect(stats.longestStreak).toBe(4);
     } finally {
       jest.useRealTimers();
     }
@@ -240,6 +246,10 @@ describe('generateStatsForHabit', () => {
       const stats = generateStatsForHabit(habit, 'UTC');
       // Today + yesterday = 2 abstention days; the transgression breaks the chain.
       expect(stats.currentStreak).toBe(2);
+      // Longest abstention run was the 12-day stretch before the
+      // transgression (06-01 .. 06-12) -- longer than the current
+      // 2-day post-transgression run.
+      expect(stats.longestStreak).toBe(12);
     } finally {
       jest.useRealTimers();
     }

--- a/frontend/src/features/Habits/__tests__/HabitStats.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitStats.test.ts
@@ -166,6 +166,113 @@ describe('generateStatsForHabit', () => {
     expect(stats.currentStreak).toBe(0);
   });
 
+  test('subtractive habit accrues currentStreak with no log entries', () => {
+    // Bug report case: "abstain from sugar" — if the user never logs
+    // anything, every day since `start_date` is a successful abstention
+    // day and should be on the streak.
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-15T18:00:00Z'));
+    try {
+      const subtractiveGoals: Goal[] = [
+        {
+          id: 10,
+          tier: 'low',
+          title: 'low',
+          target: 10,
+          target_unit: 'g',
+          frequency: 1,
+          frequency_unit: 'per_day',
+          is_additive: false,
+        },
+        {
+          id: 11,
+          tier: 'clear',
+          title: 'clear',
+          target: 5,
+          target_unit: 'g',
+          frequency: 1,
+          frequency_unit: 'per_day',
+          is_additive: false,
+        },
+        {
+          id: 12,
+          tier: 'stretch',
+          title: 'stretch',
+          target: 2,
+          target_unit: 'g',
+          frequency: 1,
+          frequency_unit: 'per_day',
+          is_additive: false,
+        },
+      ];
+      const habit: Habit = {
+        ...baseHabit,
+        name: 'No sugar',
+        goals: subtractiveGoals,
+        // Habit started 3 days ago in UTC; no logs since.
+        start_date: new Date('2026-06-12T00:00:00Z'),
+        completions: [],
+      };
+      const stats = generateStatsForHabit(habit, 'UTC');
+      // Today + 3 prior days = 4 days of abstention.
+      expect(stats.currentStreak).toBe(4);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('subtractive habit streak breaks on a day logged above clear threshold', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-15T18:00:00Z'));
+    try {
+      const subtractiveGoals: Goal[] = [
+        {
+          id: 10,
+          tier: 'low',
+          title: 'low',
+          target: 10,
+          target_unit: 'g',
+          frequency: 1,
+          frequency_unit: 'per_day',
+          is_additive: false,
+        },
+        {
+          id: 11,
+          tier: 'clear',
+          title: 'clear',
+          target: 5,
+          target_unit: 'g',
+          frequency: 1,
+          frequency_unit: 'per_day',
+          is_additive: false,
+        },
+        {
+          id: 12,
+          tier: 'stretch',
+          title: 'stretch',
+          target: 2,
+          target_unit: 'g',
+          frequency: 1,
+          frequency_unit: 'per_day',
+          is_additive: false,
+        },
+      ];
+      const habit: Habit = {
+        ...baseHabit,
+        name: 'No sugar',
+        goals: subtractiveGoals,
+        start_date: new Date('2026-06-01T00:00:00Z'),
+        completions: [
+          // Two days ago user logged 8g > clear=5g -> transgression
+          { id: 'c-1', timestamp: new Date('2026-06-13T12:00:00Z'), completed_units: 8 },
+        ],
+      };
+      const stats = generateStatsForHabit(habit, 'UTC');
+      // Today + yesterday = 2 abstention days; the transgression breaks the chain.
+      expect(stats.currentStreak).toBe(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   test('includes completionDates as ISO date strings', () => {
     const habit: Habit = {
       ...baseHabit,

--- a/frontend/src/features/Habits/__tests__/HabitStats.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitStats.test.ts
@@ -166,44 +166,48 @@ describe('generateStatsForHabit', () => {
     expect(stats.currentStreak).toBe(0);
   });
 
+  // Shared subtractive-habit goal set for the abstention-streak tests below.
+  // Lifted out so a third subtractive test can be added without duplicating
+  // ~30 lines of fixture per case.
+  const subtractiveGoals: Goal[] = [
+    {
+      id: 10,
+      tier: 'low',
+      title: 'low',
+      target: 10,
+      target_unit: 'g',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    },
+    {
+      id: 11,
+      tier: 'clear',
+      title: 'clear',
+      target: 5,
+      target_unit: 'g',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    },
+    {
+      id: 12,
+      tier: 'stretch',
+      title: 'stretch',
+      target: 2,
+      target_unit: 'g',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    },
+  ];
+
   test('subtractive habit accrues currentStreak with no log entries', () => {
     // Bug report case: "abstain from sugar" — if the user never logs
     // anything, every day since `start_date` is a successful abstention
     // day and should be on the streak.
     jest.useFakeTimers().setSystemTime(new Date('2026-06-15T18:00:00Z'));
     try {
-      const subtractiveGoals: Goal[] = [
-        {
-          id: 10,
-          tier: 'low',
-          title: 'low',
-          target: 10,
-          target_unit: 'g',
-          frequency: 1,
-          frequency_unit: 'per_day',
-          is_additive: false,
-        },
-        {
-          id: 11,
-          tier: 'clear',
-          title: 'clear',
-          target: 5,
-          target_unit: 'g',
-          frequency: 1,
-          frequency_unit: 'per_day',
-          is_additive: false,
-        },
-        {
-          id: 12,
-          tier: 'stretch',
-          title: 'stretch',
-          target: 2,
-          target_unit: 'g',
-          frequency: 1,
-          frequency_unit: 'per_day',
-          is_additive: false,
-        },
-      ];
       const habit: Habit = {
         ...baseHabit,
         name: 'No sugar',
@@ -223,38 +227,6 @@ describe('generateStatsForHabit', () => {
   test('subtractive habit streak breaks on a day logged above clear threshold', () => {
     jest.useFakeTimers().setSystemTime(new Date('2026-06-15T18:00:00Z'));
     try {
-      const subtractiveGoals: Goal[] = [
-        {
-          id: 10,
-          tier: 'low',
-          title: 'low',
-          target: 10,
-          target_unit: 'g',
-          frequency: 1,
-          frequency_unit: 'per_day',
-          is_additive: false,
-        },
-        {
-          id: 11,
-          tier: 'clear',
-          title: 'clear',
-          target: 5,
-          target_unit: 'g',
-          frequency: 1,
-          frequency_unit: 'per_day',
-          is_additive: false,
-        },
-        {
-          id: 12,
-          tier: 'stretch',
-          title: 'stretch',
-          target: 2,
-          target_unit: 'g',
-          frequency: 1,
-          frequency_unit: 'per_day',
-          is_additive: false,
-        },
-      ];
       const habit: Habit = {
         ...baseHabit,
         name: 'No sugar',

--- a/frontend/src/utils/__tests__/dateUtils.test.ts
+++ b/frontend/src/utils/__tests__/dateUtils.test.ts
@@ -7,6 +7,7 @@ import {
   dayLabel,
   detectDeviceTimezone,
   streakFromCompletions,
+  subtractiveStreakFromCompletions,
   todayInUserTZ,
 } from '../dateUtils';
 
@@ -199,6 +200,97 @@ describe('streakFromCompletions', () => {
     expect(streakFromCompletions(completed, 'America/Los_Angeles', TODAY_PACIFIC_MORNING)).toBe(2);
     // UTC sees both timestamps on the same day -> streak 1.
     expect(streakFromCompletions(completed, 'UTC', TODAY_PACIFIC_MORNING)).toBe(1);
+  });
+});
+
+describe('subtractiveStreakFromCompletions', () => {
+  // "today" anchored at 18:00 UTC = 11 AM PDT on 2026-06-15 to keep the
+  // tz-bucket comparisons deterministic across CI clock drift.
+  const TODAY = new Date('2026-06-15T18:00:00Z');
+  const TZ = 'America/Los_Angeles';
+
+  it('counts every day since start_date when no logs exist (the bug report case)', () => {
+    // Habit started 4 days ago on 2026-06-11; the user has had nothing to
+    // log since.  That is 5 days of perfect abstention (today inclusive).
+    expect(
+      subtractiveStreakFromCompletions(
+        { completions: [], clearThreshold: 5, startDate: '2026-06-11' },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(5);
+  });
+
+  it('breaks the streak on a day where the user logged above the clear threshold', () => {
+    // Two days ago the user blew past the clear limit; today and yesterday
+    // are still abstention days, so streak = 2.
+    expect(
+      subtractiveStreakFromCompletions(
+        {
+          completions: [{ timestamp: '2026-06-13T17:00:00Z', completed_units: 10 }],
+          clearThreshold: 5,
+          startDate: '2026-06-01',
+        },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(2);
+  });
+
+  it('treats a log equal to the clear threshold as success (boundary)', () => {
+    // total == clear is "just within budget" per the frontend tier
+    // resolver; the streak must agree or the tile and stats diverge.
+    expect(
+      subtractiveStreakFromCompletions(
+        {
+          completions: [{ timestamp: '2026-06-15T17:00:00Z', completed_units: 5 }],
+          clearThreshold: 5,
+          startDate: '2026-06-15',
+        },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(1);
+  });
+
+  it('sums multiple logs in the same day before comparing to the threshold', () => {
+    // 3 + 3 = 6 > clear=5, so today is a transgression and streak = 0.
+    expect(
+      subtractiveStreakFromCompletions(
+        {
+          completions: [
+            { timestamp: '2026-06-15T15:00:00Z', completed_units: 3 },
+            { timestamp: '2026-06-15T22:00:00Z', completed_units: 3 },
+          ],
+          clearThreshold: 5,
+          startDate: '2026-06-01',
+        },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(0);
+  });
+
+  it('returns 0 when the habit has not started yet', () => {
+    expect(
+      subtractiveStreakFromCompletions(
+        { completions: [], clearThreshold: 5, startDate: '2026-06-20' },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(0);
+  });
+
+  it('caps the streak at days since start_date even with no transgressions', () => {
+    // Habit started today; one day of life means streak = 1, not "since
+    // the dawn of time".
+    expect(
+      subtractiveStreakFromCompletions(
+        { completions: [], clearThreshold: 5, startDate: '2026-06-15' },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(1);
   });
 });
 

--- a/frontend/src/utils/__tests__/dateUtils.test.ts
+++ b/frontend/src/utils/__tests__/dateUtils.test.ts
@@ -7,6 +7,7 @@ import {
   dayLabel,
   detectDeviceTimezone,
   streakFromCompletions,
+  subtractiveLongestStreakFromCompletions,
   subtractiveStreakFromCompletions,
   todayInUserTZ,
 } from '../dateUtils';
@@ -291,6 +292,73 @@ describe('subtractiveStreakFromCompletions', () => {
         TODAY,
       ),
     ).toBe(1);
+  });
+});
+
+describe('subtractiveLongestStreakFromCompletions', () => {
+  const TODAY = new Date('2026-06-15T18:00:00Z');
+  const TZ = 'America/Los_Angeles';
+
+  it('equals the abstention chain length when nothing has ever been logged', () => {
+    // Habit started 6 days ago (today + 6 prior abstention days = 7).
+    // Current = longest = 7; the bug report case where Current and
+    // Longest disagreed used to display "Current: 7 · Longest: 0".
+    expect(
+      subtractiveLongestStreakFromCompletions(
+        { completions: [], clearThreshold: 5, startDate: '2026-06-09' },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(7);
+  });
+
+  it('picks the longest run between past transgressions, even if shorter than current', () => {
+    // start_date 2026-06-01 (15-day window through 2026-06-15).
+    // Two transgressions: 2026-06-04 (8g > 5) and 2026-06-13 (8g > 5).
+    // Runs: [06-01..06-03] = 3 days, [06-05..06-12] = 8 days,
+    //       [06-14..06-15] = 2 days (current).
+    // Longest = 8, current = 2.
+    expect(
+      subtractiveLongestStreakFromCompletions(
+        {
+          completions: [
+            { timestamp: '2026-06-04T15:00:00Z', completed_units: 8 },
+            { timestamp: '2026-06-13T15:00:00Z', completed_units: 8 },
+          ],
+          clearThreshold: 5,
+          startDate: '2026-06-01',
+        },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(8);
+  });
+
+  it('returns 0 when every day in range is a transgression', () => {
+    expect(
+      subtractiveLongestStreakFromCompletions(
+        {
+          completions: [
+            { timestamp: '2026-06-14T15:00:00Z', completed_units: 99 },
+            { timestamp: '2026-06-15T15:00:00Z', completed_units: 99 },
+          ],
+          clearThreshold: 5,
+          startDate: '2026-06-14',
+        },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(0);
+  });
+
+  it('returns 0 when the habit has not started yet', () => {
+    expect(
+      subtractiveLongestStreakFromCompletions(
+        { completions: [], clearThreshold: 5, startDate: '2026-06-20' },
+        TZ,
+        TODAY,
+      ),
+    ).toBe(0);
   });
 });
 

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -197,3 +197,56 @@ export const streakFromCompletions = (
   }
   return streak;
 };
+
+export interface SubtractiveStreakInput {
+  /** Completion log entries: timestamp + units logged on that timestamp. */
+  completions: ReadonlyArray<{ timestamp: string | Date; completed_units: number }>;
+  /** The clear-tier goal's target; a day's sum > this value breaks the streak. */
+  clearThreshold: number;
+  /** Habit's start date as `YYYY-MM-DD` in the user's TZ; the walk stops here. */
+  startDate: string;
+}
+
+/**
+ * Compute the streak for a subtractive habit (e.g. "abstain from sugar").
+ *
+ * For subtractive goals, *absence* of a log is the best possible
+ * outcome — it means the user did not slip — so the additive helper's
+ * "every counted day must have a row" model produces the wrong answer.
+ * This helper walks backwards from `now` in the user's TZ:
+ *
+ *   - A day where the user's logged sum stays ≤ ``clearThreshold``
+ *     counts as a streak day (no row at all maps to sum=0 = success).
+ *   - The first day going back where the sum > ``clearThreshold`` is
+ *     a transgression and breaks the chain.
+ *   - The walk stops at ``startDate`` so the streak can never exceed
+ *     the habit's life.
+ *
+ * Mirrors backend ``services.streaks._compute_subtractive_streak``
+ * so the stats overlay and the tile-displayed ``habit.streak`` (which
+ * comes from the backend's ``compute_habit_streak``) agree.
+ */
+export const subtractiveStreakFromCompletions = (
+  input: SubtractiveStreakInput,
+  tz: string,
+  now: Date = new Date(),
+): number => {
+  const today = dayKeyInTZ(now, tz);
+  if (input.startDate > today) return 0;
+
+  const dayTotals = new Map<string, number>();
+  for (const c of input.completions) {
+    const key = dayKeyInTZ(c.timestamp, tz);
+    dayTotals.set(key, (dayTotals.get(key) ?? 0) + c.completed_units);
+  }
+
+  let streak = 0;
+  let cursor = today;
+  while (cursor >= input.startDate) {
+    const total = dayTotals.get(cursor) ?? 0;
+    if (total > input.clearThreshold) break;
+    streak += 1;
+    cursor = addDaysInTZ(cursor, -1, tz);
+  }
+  return streak;
+};

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -250,3 +250,47 @@ export const subtractiveStreakFromCompletions = (
   }
   return streak;
 };
+
+/**
+ * Longest abstention run for a subtractive habit over its whole life.
+ *
+ * Walks the full ``[startDate, today]`` window in the user's TZ and
+ * tracks the longest consecutive run of days that stayed within the
+ * clear threshold.  Use this for the stats overlay's "longest streak"
+ * field — the additive ``computeLongestStreak`` counts logged days,
+ * which is the inverse of what a subtractive habit cares about and
+ * produces a contradictory display (e.g. "Current: 30 · Longest: 0"
+ * for a 30-day perfect abstention).
+ *
+ * Returns 0 when the habit has not started yet.  Walks ``cursor`` from
+ * ``startDate`` forward to keep the run-tracking obvious; backwards
+ * would produce the same number but the read is noisier.
+ */
+export const subtractiveLongestStreakFromCompletions = (
+  input: SubtractiveStreakInput,
+  tz: string,
+  now: Date = new Date(),
+): number => {
+  const today = dayKeyInTZ(now, tz);
+  if (input.startDate > today) return 0;
+
+  const dayTotals = new Map<string, number>();
+  for (const c of input.completions) {
+    const key = dayKeyInTZ(c.timestamp, tz);
+    dayTotals.set(key, (dayTotals.get(key) ?? 0) + c.completed_units);
+  }
+
+  let longest = 0;
+  let run = 0;
+  let cursor = input.startDate;
+  while (cursor <= today) {
+    if ((dayTotals.get(cursor) ?? 0) > input.clearThreshold) {
+      run = 0;
+    } else {
+      run += 1;
+      if (run > longest) longest = run;
+    }
+    cursor = addDaysInTZ(cursor, 1, tz);
+  }
+  return longest;
+};


### PR DESCRIPTION
A subtractive habit (e.g. "abstain from sugar") with no log entries
means perfect abstention, not absence of data. The streak helpers
previously required a row per counted day, so a user who never logged
saw their streak stuck at 0 while the tile's "Achieved Today!" badge
(which uses separate frontend logic) still lit up — the two displays
disagreed.

Teach `compute_habit_streak` / `compute_consecutive_streak` /
`subtractiveStreakFromCompletions` about the polarity: walk backwards
from today counting days whose summed logs stay at or below the clear
threshold, treating a missing day as sum=0 (success), bounded by the
habit's `start_date`. Bundle the threshold + start date into a new
`SubtractiveContext` value so the streak signatures stay under the
project's max-args bar.