### PR TITLE
docs(roadmap): add practice-presets epic for Spiral Dynamics alternatives

### DIFF
--- a/prompts/github-issues/README.md
+++ b/prompts/github-issues/README.md
@@ -218,6 +218,30 @@ Two new modes (`random_interval_bell`, `card_meditation`) round out the engine t
 | 06 | [Build `CardMeditationView` + image picker](custom-practices-06-card-meditation-frontend.md) | Frontend | ~350 |
 | 07 | [Catalog browse + Create-custom flow](custom-practices-07-catalog-and-create-flow.md) | Frontend | ~450 |
 
+### Spiral Dynamics practice-preset catalog expansion
+
+Seed ~60 alternative presets across stages 1-8 (BEIGE through TEAL) so each
+Spiral Dynamics frequency band offers a deeper menu of practices alongside
+its canonical stage practice. Pure content: no new modes, no migrations,
+no frontend work. Each sub-issue handles one color/stage and is fully
+independent of the others.
+
+| # | Issue | Stage | New presets | Est. LoC |
+|---|-------|-------|-------------|----------|
+| — | [Epic tracker](practice-presets-epic.md) | — | — | — |
+| 01 | [Seed BEIGE alternatives](practice-presets-01-beige-grounding.md)        | 1 | 7  | ~250 |
+| 02 | [Seed PURPLE alternatives](practice-presets-02-purple-divination.md)     | 2 | 8  | ~275 |
+| 03 | [Seed RED alternatives](practice-presets-03-red-energy.md)               | 3 | 10 | ~325 |
+| 04 | [Seed BLUE alternatives](practice-presets-04-blue-heart.md)              | 4 | 10 | ~325 |
+| 05 | [Seed ORANGE alternatives](practice-presets-05-orange-activation.md)     | 5 | 8  | ~275 |
+| 06 | [Seed GREEN alternatives](practice-presets-06-green-shadow.md)           | 6 | 8  | ~275 |
+| 07 | [Seed TEAL alternatives](practice-presets-07-teal-integration.md)        | 8 | 9  | ~300 |
+
+Stages 7 (YELLOW), 9 (ULTRAVIOLET), and 10 (CLEAR LIGHT) carry no
+alternatives in the source table and are not part of this epic. All seven
+sub-issues are fully independent — they touch the same three files but at
+disjoint locations and can ship in any order or in parallel.
+
 ### Generalize grounding techniques
 
 Add **Find Shapes**, **Find Colors**, **Touch Grass**, and **Mindful

--- a/prompts/github-issues/practice-presets-01-beige-grounding.md
+++ b/prompts/github-issues/practice-presets-01-beige-grounding.md
@@ -1,0 +1,128 @@
+# practice-presets-01: Seed BEIGE (stage 1) alternative grounding presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~250
+
+## Role
+
+You are a backend engineer adding stage-1 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **seven** new BEIGE-band grounding alternatives at stage 1 so the
+catalog menu for a stage-1 user offers a body-anchored toolkit beyond
+the canonical 5-4-3-2-1 grounding. The new presets are:
+
+| Name                           | Mode                | Duration | Notes                                       |
+|--------------------------------|---------------------|----------|---------------------------------------------|
+| Crystal Charging               | `meditation_timer`  | 5 min    | Hold a chosen crystal outdoors / on earth   |
+| Tense and Release              | `meditation_timer`  | 5 min    | Halfway bell. Clench/release body scan      |
+| Contact Points                 | `meditation_timer`  | 5 min    | Notice every point body meets a surface     |
+| Box Breathing                  | `meditation_timer`  | 5 min    | Halfway bell. 4-4-4-4 pattern               |
+| Toe Wiggling                   | `meditation_timer`  | 3 min    | Feel feet and wiggle toes                   |
+| Body Scan                      | `meditation_timer`  | 5 min    | Halfway bell. Toes-to-head sweep            |
+| Progressive Muscle Relaxation  | `meditation_timer`  | 10 min   | Halfway bell. Jacobson PMR                  |
+
+## Context
+
+`backend/src/seed_practices.py:257-314` shows the four existing stage-1
+alternatives (Touch Grass, Mindful Eating, Find Shapes, Find Colors).
+The source table's *Stand Barefoot Outdoors*, *Square-Circle-Triangle x5*,
+and *Colors of the Rainbow* are intentionally skipped because they are
+duplicates of those four — see the epic's constraints section.
+
+Every preset in this issue uses `meditation_timer` mode with the
+existing `_meditation_timer(...)` helper at `seed_practices.py:49-57`.
+No new mode helpers required.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One module-level `_TUPLE` constant per preset, named after the
+     practice (e.g. `_CRYSTAL_CHARGING`, `_BOX_BREATHING`).
+   - Append each to the `PRESET_COPY` dict at the bottom of the file,
+     keyed by the exact display name used in `seed_practices.py`.
+   - Each description: 1-2 sentences, plain English, ≤ 2000 chars.
+   - Each instructions block: 3-6 sentences, second-person imperative,
+     ≤ 10000 chars. Lift from the source-table cell and elaborate
+     enough that a first-timer can complete the practice.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All seven entries land at `stage_number=1`.
+   - Use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`
+     for each `mode_config`.
+   - Keep the new entries grouped together with a brief comment
+     describing the BEIGE block, e.g.:
+     ```python
+     # Stage 1 alternatives — body-grounding / nervous-system regulation.
+     _build_preset(1, "Crystal Charging", ...),
+     ...
+     ```
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset following the
+     `test_touch_grass_preset_seeds` pattern at line 233. Verify:
+     - The row is present after `seed_practices(session)`.
+     - `mode == "meditation_timer"`.
+     - `mode_config["duration_minutes"]` matches the spec.
+     - `mode_config["halfway_bell"]` matches where applicable.
+     - `stage_number == 1`.
+   - **Do not** add a new global-invariant test — the existing
+     `test_every_preset_sits_on_a_known_stage` and
+     `test_every_preset_mode_config_is_valid` automatically cover the
+     new rows.
+   - Update the `EXPECTED_PRESET_COUNT` literal at the top of the file
+     (line ~28) by +7.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] `pytest backend/ -k preset` green.
+- [ ] `python -c "from seed_practices import PRESET_PRACTICES; \
+       print(len([p for p in PRESET_PRACTICES if p['stage_number']==1]))"`
+       returns `12` (1 canonical + 4 prior alternatives + 7 new).
+- [ ] `GET /practices?stage=1` returns 12 rows.
+- [ ] `STAGE_TO_PRESET_NAME[1]` is still `"5-4-3-2-1 grounding"`.
+- [ ] Running the seeder twice still inserts 7 net new rows the first
+      time and 0 the second.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 7 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 7 copy tuples + entries in `PRESET_COPY` |
+| `backend/tests/test_seed_practices.py` | Modify — add 7 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`. None of the seven proposed
+  names collide with existing entries; do not rename them without
+  checking the duplicate-name guard at `seed_practices.py:337-341`.
+- Do not change `_CANONICAL_PRESETS` or the existing stage-1 alternatives.
+- Keep descriptions and instructions tight; second-person imperative
+  ("Sit upright. Inhale…") matches the existing copy voice at
+  `seed_practice_copy.py:36-104`.
+
+## Example output
+
+```bash
+$ curl -s 'http://localhost:8000/practices?stage=1' | jq '.[] | .name'
+"5-4-3-2-1 grounding"
+"Touch Grass"
+"Mindful Eating"
+"Find Shapes"
+"Find Colors"
+"Crystal Charging"
+"Tense and Release"
+"Contact Points"
+"Box Breathing"
+"Toe Wiggling"
+"Body Scan"
+"Progressive Muscle Relaxation"
+```

--- a/prompts/github-issues/practice-presets-02-purple-divination.md
+++ b/prompts/github-issues/practice-presets-02-purple-divination.md
@@ -1,0 +1,95 @@
+# practice-presets-02: Seed PURPLE (stage 2) alternative divination / symbol presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~275
+
+## Role
+
+You are a backend engineer adding stage-2 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **eight** new PURPLE-band divination / symbolic alternatives at
+stage 2 so the catalog menu offers a richer set of intuitive practices
+beyond the canonical daily Tarot draw. The new presets are:
+
+| Name                  | Mode               | Duration | Halfway bell | Source row                                             |
+|-----------------------|--------------------|----------|--------------|--------------------------------------------------------|
+| Traffic Lights        | `meditation_timer` | 5 min    | No           | "Traffic lights" — visualize and decode color signals  |
+| I Ching Toss          | `meditation_timer` | 10 min   | Yes          | "I Ching coin toss with meditative journaling"         |
+| Bibliomancy           | `meditation_timer` | 5 min    | No           | "Bibliomancy: random passage reading and reflection"   |
+| Synchronicity Sweep   | `meditation_timer` | 5 min    | No           | "Tracking Synchronicity"                               |
+| Trataka Candle Gazing | `meditation_timer` | 10 min   | Yes          | "Candle gazing (Trataka) while inviting intuitive imagery" |
+| Dream Recollection    | `meditation_timer` | 10 min   | Yes          | "Dream recollection and symbol mapping"                |
+| Archetypal Mantra     | `meditation_timer` | 10 min   | Yes          | "Repetitive mantra with archetypal resonance"          |
+| Totem Meditation      | `meditation_timer` | 5 min    | No           | "Meditating on a personal totem or object"             |
+
+## Context
+
+Stage 2's canonical preset is `Tarot meditation` (mode `tarot`). These
+alternatives all use the simpler `meditation_timer` engine with
+descriptive instructions so they pose zero migration / schema risk — the
+intuitive content is in the copy, not the mode.
+
+See `backend/src/seed_practices.py:179-189` for the canonical entry and
+`seed_practice_copy.py:26-33` for the voice / length of the canonical
+copy.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, named `_TRAFFIC_LIGHTS`, `_I_CHING_TOSS`,
+     `_BIBLIOMANCY`, `_SYNCHRONICITY_SWEEP`, `_TRATAKA`,
+     `_DREAM_RECOLLECTION`, `_ARCHETYPAL_MANTRA`, `_TOTEM_MEDITATION`.
+   - Each description: 1-2 sentences capturing the practice's flavour.
+   - Each instructions block: 3-6 sentences, second-person imperative,
+     covering setup, focus, and completion. For divination practices,
+     name the *posture* explicitly (e.g. "Sit with the coins in your
+     palm before the first toss") so a beginner can perform the
+     practice without further context.
+   - Append entries to `PRESET_COPY` keyed by display name.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All eight at `stage_number=2`.
+   - All use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Group under a brief comment, e.g.
+     `# Stage 2 alternatives — divination / symbolic intuition.`
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset, mirroring
+     `test_touch_grass_preset_seeds`. Verify the row's
+     `stage_number`, `mode`, `mode_config.duration_minutes`, and
+     `mode_config.halfway_bell` (where set).
+   - Bump `EXPECTED_PRESET_COUNT` by +8.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All eight rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[2]` is still `"Tarot meditation"`.
+- [ ] `GET /practices?stage=2` returns 9 rows (canonical + 8 new).
+- [ ] Re-running the seeder is a no-op (idempotent).
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 8 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 8 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 8 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Tarot meditation` entry or its config.
+- Do not introduce new modes. The intuitive flavour of these practices
+  belongs in the copy, not the engine. If you believe a row really
+  wants `tarot` or `metronome`, surface the choice in the PR description
+  before opening the PR.
+- Match the existing copy voice — declarative, present-tense, no
+  hedging, no marketing language.

--- a/prompts/github-issues/practice-presets-03-red-energy.md
+++ b/prompts/github-issues/practice-presets-03-red-energy.md
@@ -1,0 +1,94 @@
+# practice-presets-03: Seed RED (stage 3) alternative energy / power presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~325
+
+## Role
+
+You are a backend engineer adding stage-3 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **ten** new RED-band energy / power-building alternatives at
+stage 3 so the catalog menu offers a wider toolkit beyond canonical
+belly breathing. The new presets are:
+
+| Name                       | Mode               | Duration | Halfway bell | Source row                                                       |
+|----------------------------|--------------------|----------|--------------|------------------------------------------------------------------|
+| Hand Energy Sensing        | `meditation_timer` | 5 min    | No           | "Raise energy by rubbing hands together…"                        |
+| Windhorse Breathwork       | `meditation_timer` | 10 min   | Yes          | "'Windhorse' breathwork (stoking inner fire)"                    |
+| Water Charging             | `meditation_timer` | 5 min    | No           | "Charging Water using Damien Echols's techniques"                |
+| Mini TED Talk              | `meditation_timer` | 10 min   | No           | "Mini-TED Talk: describe something you understand well…"         |
+| Power Posture              | `meditation_timer` | 10 min   | No           | "Power posture meditation with steady breath"                    |
+| Mountain Pose Sit          | `meditation_timer` | 10 min   | No           | "Seated mountain pose visualization ('I cannot be moved')"       |
+| Fire Gazing                | `meditation_timer` | 10 min   | Yes          | "Fire gazing while anchoring into the solar plexus"              |
+| Warrior Stillness          | `meditation_timer` | 10 min   | No           | "Holding one physical posture (e.g., warrior pose) in stillness" |
+| Red Sphere Visualization   | `meditation_timer` | 10 min   | Yes          | "Visualizing a red sphere of light pulsing in your gut"          |
+| Love to Past Selves        | `meditation_timer` | 15 min   | Yes          | "Sending love to different ages of your past self"               |
+
+## Context
+
+Stage 3's canonical preset is `Belly breathing`
+(`meditation_timer`, 10 min). The new alternatives mostly follow the
+same 10-minute timer with a halfway bell for the longer / more
+demanding ones. `Love to Past Selves` is a 15-minute sit because the
+practice steps through multiple ages.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug (e.g.
+     `_HAND_ENERGY_SENSING`, `_MINI_TED_TALK`, `_RED_SPHERE_VISUALIZATION`).
+   - Each instructions block must include setup (posture, where to
+     focus attention), the practice itself, and a closing cue
+     ("until the bell," "for the rest of the timer").
+   - For `Mini TED Talk` specifically: spell out that the user should
+     speak aloud or sub-vocalize for the full duration, picking a topic
+     of genuine expertise.
+   - For `Water Charging`: brief framing of the Damien Echols technique
+     (sigil + intention into a held glass of water) without invoking
+     real ritual gear.
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All ten at `stage_number=3`.
+   - All use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Group under a `# Stage 3 alternatives — energy / power.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset, mirroring
+     `test_touch_grass_preset_seeds`. Verify the row's
+     `stage_number`, `mode`, and the `mode_config.duration_minutes` /
+     `mode_config.halfway_bell` flags.
+   - Bump `EXPECTED_PRESET_COUNT` by +10.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All ten rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[3]` is still `"Belly breathing"`.
+- [ ] `GET /practices?stage=3` returns 11 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 10 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 10 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 10 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Belly breathing` entry.
+- Do not introduce new modes; energy-raising flavour belongs in copy.
+- Keep instructions safe: no breath-retention practice longer than the
+  canonical Wim Hof preset, no advice that contradicts general medical
+  guidance. The `Windhorse Breathwork` and `Fire Gazing` instructions
+  should explicitly tell the user to ease off if they feel lightheaded.

--- a/prompts/github-issues/practice-presets-04-blue-heart.md
+++ b/prompts/github-issues/practice-presets-04-blue-heart.md
@@ -1,0 +1,90 @@
+# practice-presets-04: Seed BLUE (stage 4) alternative heart / lovingkindness presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~325
+
+## Role
+
+You are a backend engineer adding stage-4 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **ten** new BLUE-band heart / lovingkindness alternatives at
+stage 4 so the catalog menu carries a deep menu of relational practices
+beyond canonical Metta. The new presets are:
+
+| Name                    | Mode               | Duration | Halfway bell | Source row                                                   |
+|-------------------------|--------------------|----------|--------------|--------------------------------------------------------------|
+| Tonglen                 | `meditation_timer` | 15 min   | Yes          | "Tonglen: breathing in pain, breathing out compassion"       |
+| I Am Love Through       | `meditation_timer` | 15 min   | Yes          | "Selig's 'I am Love through so and so'"                      |
+| Heart Centered Breath   | `meditation_timer` | 15 min   | Yes          | "Heart-centered breath (inhale into heart, exhale out)"      |
+| Animist Gratitude       | `meditation_timer` | 10 min   | No           | "Animist Gratitude: Speaking thanks aloud for local beings"  |
+| Hug Visualization       | `meditation_timer` | 10 min   | No           | "Guided visualization of hugging someone you miss"           |
+| Relational Gratitude    | `meditation_timer` | 15 min   | Yes          | "Gratitude meditation focused on relationships"              |
+| Blessing Strangers      | `meditation_timer` | 10 min   | No           | "Mentally blessing strangers while people-watching"          |
+| Heart Imagery           | `meditation_timer` | 15 min   | Yes          | "Meditating on heart imagery (green rose, spiral, chalice)"  |
+| Just Like Me            | `meditation_timer` | 15 min   | Yes          | "Repeating the phrase: 'Just like me, this being seeks happiness'" |
+| Ancestral Connection    | `meditation_timer` | 15 min   | Yes          | "Establishing ancestral connection via gratitude or lovingkindness" |
+
+## Context
+
+Stage 4's canonical preset is `Metta` (`meditation_timer`, 15 min,
+halfway bell). The new alternatives keep the 15-minute heart-sit default
+for full-arc practices and drop to 10 minutes for the lighter
+"in-the-world" practices (`Animist Gratitude`, `Hug Visualization`,
+`Blessing Strangers`).
+
+`Blessing Strangers` is intended to be done in public (a café, a park);
+the instructions must make this explicit and tell the user they can do
+it with eyes open.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug.
+   - Each instructions block: 3-6 sentences. For phrase-based practices
+     (`Just Like Me`, `I Am Love Through`), quote the exact phrase the
+     user is meant to repeat so the preset is self-contained.
+   - For `Tonglen`: keep the breath-direction language unambiguous
+     ("inhale the discomfort of [target]; exhale ease toward them").
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All ten at `stage_number=4`.
+   - All use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Group under a `# Stage 4 alternatives — heart / lovingkindness.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset, mirroring
+     `test_touch_grass_preset_seeds`.
+   - Bump `EXPECTED_PRESET_COUNT` by +10.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All ten rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[4]` is still `"Metta"`.
+- [ ] `GET /practices?stage=4` returns 11 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 10 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 10 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 10 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Metta` entry.
+- Do not introduce new modes.
+- Heart practices benefit from a halfway bell as an "open the circle"
+  cue; default to `halfway_bell=True` for any 15-minute sit and
+  `halfway_bell=False` for 10-minute / in-the-world variants.

--- a/prompts/github-issues/practice-presets-05-orange-activation.md
+++ b/prompts/github-issues/practice-presets-05-orange-activation.md
@@ -1,0 +1,90 @@
+# practice-presets-05: Seed ORANGE (stage 5) alternative activation / manifestation presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~275
+
+## Role
+
+You are a backend engineer adding stage-5 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **eight** new ORANGE-band activation / manifestation alternatives
+at stage 5 so the catalog menu carries a wider menu of high-energy
+practices beyond canonical Wim Hof. The new presets are:
+
+| Name                              | Mode               | Duration | Halfway bell | Source row                                                       |
+|-----------------------------------|--------------------|----------|--------------|------------------------------------------------------------------|
+| Kapalabhati Skull Shining         | `meditation_timer` | 15 min   | Yes          | "Skull Shining (Kapalabhati) to boost focus and alertness"       |
+| Middle Pillar                     | `meditation_timer` | 20 min   | Yes          | "'Middle Pillar' Golden Dawn exercise (energy body building)"    |
+| Sigil Dhyana                      | `meditation_timer` | 20 min   | Yes          | "Chaos Magick's style meditation of Dhyana on Sigils…"           |
+| Reality Selection Visualization   | `meditation_timer` | 20 min   | Yes          | "Neville Goddard style hypnagogic visualization…"                |
+| Single Instrument Listening       | `meditation_timer` | 20 min   | No           | "Listen to energizing music, focusing on one instrument"         |
+| Chanting or Kirtan                | `meditation_timer` | 20 min   | No           | "Chanting or Kirtan"                                             |
+| Breath of Fire + Silence          | `meditation_timer` | 20 min   | Yes          | "Breath of Fire followed by a period of silence"                 |
+| Lion's Breath                     | `meditation_timer` | 10 min   | No           | "Lion's Breath"                                                  |
+
+## Context
+
+Stage 5's canonical preset is `Wim Hof method` (`meditation_timer`,
+20 min). The new alternatives mostly hold to a 20-minute sit so the
+heart-rate / energy-spike profile is consistent with the stage's
+intent. `Lion's Breath` is a shorter 10-minute session because the
+practice itself is cathartic and quick.
+
+`Breath of Fire + Silence` uses a halfway bell to mark the transition
+from active breathwork to silent integration.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug.
+   - For breath-intensive practices (`Kapalabhati`, `Breath of Fire`,
+     `Lion's Breath`): include an explicit safety note — "ease off if
+     you feel lightheaded; rest in normal breathing until it passes" —
+     consistent with the canonical Wim Hof copy at
+     `seed_practice_copy.py:56-61`.
+   - For `Middle Pillar` and `Sigil Dhyana`: brief framing without
+     requiring real ritual gear; the practice should be feasible from
+     a seat with eyes closed.
+   - For `Single Instrument Listening`: tell the user to queue a song
+     before starting and stay with the one instrument until the bell.
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All eight at `stage_number=5`.
+   - All use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Group under a `# Stage 5 alternatives — activation / manifestation.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset.
+   - Bump `EXPECTED_PRESET_COUNT` by +8.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All eight rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[5]` is still `"Wim Hof method"`.
+- [ ] `GET /practices?stage=5` returns 9 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 8 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 8 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 8 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Wim Hof method` entry.
+- Do not introduce new modes.
+- Every breathwork preset must carry an explicit safety note in its
+  instructions.

--- a/prompts/github-issues/practice-presets-06-green-shadow.md
+++ b/prompts/github-issues/practice-presets-06-green-shadow.md
@@ -1,0 +1,111 @@
+# practice-presets-06: Seed GREEN (stage 6) alternative shadow-work presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~275
+
+## Role
+
+You are a backend engineer adding stage-6 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **eight** new GREEN-band shadow-work alternatives at stage 6 so
+the catalog menu carries a deeper toolkit beyond canonical "Coal to
+Gold" Shadow Work. The new presets are:
+
+| Name                            | Mode               | Duration | Halfway bell | Source row                                                       |
+|---------------------------------|--------------------|----------|--------------|------------------------------------------------------------------|
+| Chair Work                      | `meditation_timer` | 30 min   | Yes          | "Chair work (self vs. shadow) alternating every 5 min"           |
+| Wording Through It              | `meditation_timer` | 30 min   | Yes          | "Wording Through it" — speak the shadow content aloud            |
+| Wilber 3-2-1                    | `meditation_timer` | 30 min   | Yes          | "Wilber's '3-2-1' Practice"                                      |
+| Emotion Transmutation           | `meditation_timer` | 30 min   | Yes          | "Tibetan Buddhist emotion transmutation"                         |
+| Pain Body Meditation            | `meditation_timer` | 30 min   | Yes          | "Meditating on the Pain Body a la Eckhart Tolle"                 |
+| Letter to the Repressed Self    | `count_up`         | —        | —            | "Stream of consciousness quick-write of a letter to your most repressed self" |
+| Shadow Drawing                  | `count_up`         | —        | —            | "Drawing your shadow self and holding eye contact with it"       |
+| REACH Inward                    | `meditation_timer` | 30 min   | Yes          | "REACH directed inward (From Rise Above)"                        |
+
+## Context
+
+Stage 6's canonical preset is `Shadow work` (`metronome`, 30 min). The
+new alternatives mostly hold to a 30-minute sit consistent with the
+stage. **Two** of the alternatives are open-ended creative practices —
+`Letter to the Repressed Self` and `Shadow Drawing` — and use
+`count_up` mode so the user can take as long as the practice asks for.
+
+The `count_up` mode is already exercised by the canonical
+`Dog Walkin' Shamanism` preset
+(`seed_practices.py:230-236`). Use the same shape:
+```python
+mode="count_up",
+mode_config={"mode": "count_up", "soft_cap_minutes": None},
+default_duration_minutes=_COUNT_UP_NOMINAL_DURATION_MINUTES,
+```
+The `_COUNT_UP_NOMINAL_DURATION_MINUTES` constant is already defined
+at `seed_practices.py:46` — reuse it; do not introduce a per-issue
+duplicate.
+
+For `Chair Work`: the source row says "alternating every 5 min."
+Encode the cadence in the instructions ("every five minutes, swap
+chairs"), not in the engine. A `metronome` or `interval_bell`
+implementation might be a nicer fit later, but is out of scope for
+this content-only issue.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug.
+   - For `Chair Work`: explain the two-chair / inner-critic technique
+     and tell the user to physically switch seats every five minutes.
+   - For `Wilber 3-2-1`: name the three steps (face it / talk to it /
+     be it) so a first-timer can perform the practice without a
+     reference.
+   - For `Pain Body Meditation`: include the Tolle framing — observe
+     the pain body as a distinct presence rather than identifying
+     with it.
+   - For the two `count_up` practices: tell the user they can stop
+     when the practice feels complete and mark the session done.
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - Six entries use `_meditation_timer(30, halfway_bell=True)`.
+   - Two entries (`Letter to the Repressed Self`, `Shadow Drawing`)
+     use the `count_up` shape above.
+   - Group under a `# Stage 6 alternatives — shadow work.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset. For the `count_up` presets,
+     verify `mode == "count_up"` and `mode_config["soft_cap_minutes"]
+     is None` (matching the canonical Dog Walkin' Shamanism test).
+   - Bump `EXPECTED_PRESET_COUNT` by +8.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All eight rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[6]` is still `"Shadow work"`.
+- [ ] `GET /practices?stage=6` returns 9 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 8 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 8 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 8 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Shadow work` entry.
+- Do not introduce new modes; the two `count_up` presets reuse the
+  already-validated shape from Dog Walkin' Shamanism.
+- Shadow-work copy should warn that strong emotion is possible and
+  invite the user to pause / journal rather than push through — match
+  the careful voice of the canonical entry at
+  `seed_practice_copy.py:64-70`.

--- a/prompts/github-issues/practice-presets-07-teal-integration.md
+++ b/prompts/github-issues/practice-presets-07-teal-integration.md
@@ -1,0 +1,109 @@
+# practice-presets-07: Seed TEAL (stage 8) alternative integration / shamanic presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~300
+
+## Role
+
+You are a backend engineer adding stage-8 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **nine** new TEAL-band integration / shamanic alternatives at
+stage 8 so the catalog menu carries a deeper toolkit beyond canonical
+Dog Walkin' Shamanism. The new presets are:
+
+| Name                          | Mode               | Duration | Halfway bell | Source row                                                       |
+|-------------------------------|--------------------|----------|--------------|------------------------------------------------------------------|
+| Clairaudient Listening        | `meditation_timer` | 20 min   | Yes          | "Clairaudient Practice: Sitting and listening to the 'still small voice' inside" |
+| Channeling Writing            | `count_up`         | —        | —            | "Channeling writing: ask 'What would you have me know?'"         |
+| Active Imagination Dialogue   | `meditation_timer` | 30 min   | Yes          | "Jung's 'Active Imagination' dialogue with a part of self"       |
+| Aura Scanning                 | `meditation_timer` | 15 min   | No           | "Subtle energy scanning of your own aura"                        |
+| Sangha Field Tuning           | `meditation_timer` | 15 min   | No           | "Tuning into a collective prayer field or sangha field"          |
+| Freedom Log                   | `count_up`         | —        | —            | "Freedom Log: Re-patterning practice"                            |
+| Hierarchical Re-Feeling       | `count_up`         | —        | —            | "Hierarchical 'Re-Feeling' Journal"                              |
+| Reflective Tarot Draw         | `meditation_timer` | 5 min    | No           | "Tarot Draw: 'What was the lesson of today / this event / that relationship'" |
+| Sacred Pause                  | `meditation_timer` | 5 min    | No           | "Tara Brach's 'Sacred Pause' from Radical Acceptance"            |
+
+## Context
+
+Stage 8's canonical preset is `Dog Walkin' Shamanism` (`count_up`).
+The TEAL band includes a mix of contemplative sits, open-ended
+journaling, and short single-act practices.
+
+**Three** of the new presets are `count_up` (Channeling Writing,
+Freedom Log, Hierarchical Re-Feeling) — open-ended journaling
+practices that complete when the user feels done. Reuse the existing
+shape and the `_COUNT_UP_NOMINAL_DURATION_MINUTES` constant
+(`seed_practices.py:46`).
+
+`Reflective Tarot Draw` deliberately uses `meditation_timer` (not
+`tarot` mode) because there is no full Major-Arcana progression here —
+just a single card prompted by a reflective question. Treating it as
+a 5-minute timed sit keeps the engine choice the user-facing
+distinction (canonical 22-day Tarot meditation at stage 2 → `tarot`;
+reflective single-card pull at stage 8 → `meditation_timer`).
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug.
+   - For `Channeling Writing`: instruct the user to write the exact
+     prompt at the top of the page and then transcribe whatever
+     arises without editing.
+   - For `Active Imagination Dialogue`: name the Jung framing — invite
+     a figure or aspect to appear, address it directly, record what
+     it says.
+   - For `Freedom Log` and `Hierarchical Re-Feeling`: brief description
+     of the re-patterning intent; tell the user to journal until the
+     practice feels complete.
+   - For `Reflective Tarot Draw`: tell the user to shuffle, draw one
+     card, and sit with the question "what was the lesson of today /
+     this event / this relationship" for the full 5-minute timer.
+   - For `Sacred Pause`: lift directly from Tara Brach's framing —
+     stop, take a breath, notice what is here without trying to fix it.
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - Six entries use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Three entries (`Channeling Writing`, `Freedom Log`,
+     `Hierarchical Re-Feeling`) use the `count_up` shape.
+   - Group under a `# Stage 8 alternatives — integration / shamanic.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset. For the `count_up` presets, verify
+     `mode == "count_up"` and `mode_config["soft_cap_minutes"] is None`.
+   - Bump `EXPECTED_PRESET_COUNT` by +9.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All nine rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[8]` is still `"Dog Walkin' Shamanism"`.
+- [ ] `GET /practices?stage=8` returns 10 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 9 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 9 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 9 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Dog Walkin' Shamanism` entry.
+- Do not introduce new modes. `Reflective Tarot Draw` does *not* use
+  `tarot` mode — the engine would require a deck slug; this preset is
+  a single-card timed sit instead.
+- Keep instructions self-contained — TEAL practices often assume
+  background a beginner won't have. Give just enough framing that a
+  user encountering Active Imagination or Tonglen-style channeling
+  for the first time can complete the session.

--- a/prompts/github-issues/practice-presets-epic.md
+++ b/prompts/github-issues/practice-presets-epic.md
@@ -1,0 +1,147 @@
+# Epic: Spiral Dynamics practice-preset catalog expansion
+
+**Labels:** `epic`, `backend`, `feature`, `practice`, `seeding`
+**Scope:** Backend (preset rows + copy + tests). No new modes, no migrations,
+no frontend changes.
+**Estimated total LoC:** ~1,900 across 7 sub-issues.
+
+## Role
+
+You are a backend engineer extending the seeded practice catalog with
+alternative presets that share each stage with the canonical practice.
+You follow the established seed-preset pattern (`seed_practices.py` +
+`seed_practice_copy.py`) and validate every payload at import time via
+`ModeConfigAdapter`.
+
+## Goal
+
+Add **~60 alternative presets** across stages 1-8 so each Spiral Dynamics
+frequency band offers users a deep menu of practices they can swap in for
+the canonical stage practice. Source content is the practitioner-authored
+"alternative practices per frequency" table — one column per color, each
+row a discrete practice with its own instructions.
+
+After this epic ships, the catalog browse screen shows the canonical
+preset *plus* this color's alternatives whenever the user opens the
+practice catalog at a given stage.
+
+## Context
+
+The catalog is mode-discriminated and already supports multiple
+alternative presets per stage — see the stage-1 alternatives Touch Grass,
+Mindful Eating, Find Shapes, Find Colors in
+`backend/src/seed_practices.py:257-314`. The seeder is idempotent on
+`(stage_number, name)` and a partial unique index at the DB layer
+arbitrates races (migration `d2e3f4a5b6c7`). Adding a preset is a
+content-only change:
+
+1. Add `(description, instructions)` to `PRESET_COPY` in `seed_practice_copy.py`.
+2. Append a `_build_preset(...)` entry to `_ALTERNATIVE_PRESETS` in
+   `seed_practices.py` with a validated `mode_config`.
+3. Add catalog assertion tests in `tests/test_seed_practices.py`
+   (mode, key fields, idempotency).
+
+No new `PracticeMode` enum values are needed — every preset in the source
+table maps to an existing mode (`meditation_timer`, `count_up`, or
+`mindful_anchor`). No migrations are needed. No frontend changes are
+needed: the catalog screen, frequency banner, and `UserPractice`
+customization flow already iterate over whatever presets exist.
+
+## Stage-to-color mapping
+
+| Stage | Color       | Canonical (already seeded)          | Alternatives in source table |
+|-------|-------------|-------------------------------------|------------------------------|
+| 1     | BEIGE       | `5-4-3-2-1 grounding`               | 10 (3 already seeded as Touch Grass / Find Shapes / Find Colors) |
+| 2     | PURPLE      | `Tarot meditation`                  | 8 |
+| 3     | RED         | `Belly breathing`                   | 10 |
+| 4     | BLUE        | `Metta`                             | 10 |
+| 5     | ORANGE      | `Wim Hof method`                    | 8 |
+| 6     | GREEN       | `Shadow work`                       | 8 |
+| 7     | YELLOW      | `Blissy meditation`                 | 0 (source row is "see Blissy instructions") |
+| 8     | TEAL        | `Dog Walkin' Shamanism`             | 9 |
+| 9     | ULTRAVIOLET | `Concentration practice`            | 0 (no alternatives in source) |
+| 10    | CLEAR LIGHT | `Insight practice`                  | 0 (no alternatives in source) |
+
+YELLOW, ULTRAVIOLET, and CLEAR LIGHT have no alternatives in the source
+table and are not part of this epic.
+
+## Sub-issues
+
+| # | Title | Stage | New presets | LoC |
+|---|-------|-------|-------------|-----|
+| 01 | [Seed BEIGE alternatives](practice-presets-01-beige-grounding.md)        | 1 | 7 | ~250 |
+| 02 | [Seed PURPLE alternatives](practice-presets-02-purple-divination.md)     | 2 | 8 | ~275 |
+| 03 | [Seed RED alternatives](practice-presets-03-red-energy.md)               | 3 | 10 | ~325 |
+| 04 | [Seed BLUE alternatives](practice-presets-04-blue-heart.md)              | 4 | 10 | ~325 |
+| 05 | [Seed ORANGE alternatives](practice-presets-05-orange-activation.md)     | 5 | 8 | ~275 |
+| 06 | [Seed GREEN alternatives](practice-presets-06-green-shadow.md)           | 6 | 8 | ~275 |
+| 07 | [Seed TEAL alternatives](practice-presets-07-teal-integration.md)        | 8 | 9 | ~300 |
+
+All seven sub-issues are **fully independent** — they touch the same
+three files but at disjoint locations (different stage_number rows,
+different `PRESET_COPY` keys, different test functions). Conflicts on
+merge are limited to import-ordering / list-append friction that resolves
+trivially. They can ship in any order or in parallel.
+
+## Acceptance Criteria (epic-level)
+
+- [ ] ~60 new alternative presets seeded across 7 stages.
+- [ ] `STAGE_TO_PRESET_NAME` (canonical pointer) is unchanged after each PR.
+- [ ] `pytest backend/` green, coverage thresholds unchanged.
+- [ ] `pre-commit run --all-files` green on every sub-issue PR.
+- [ ] `python -m seed_practices` on a fresh DB inserts every new preset
+      exactly once and is idempotent on re-run.
+- [ ] `GET /practices?stage=N` returns each new preset alongside the
+      stage's canonical and any prior alternatives.
+
+## Constraints
+
+- **Do not** alter `_CANONICAL_PRESETS`. Only `_ALTERNATIVE_PRESETS` and
+  `PRESET_COPY` change.
+- **Do not** introduce new `PracticeMode` values, schemas, or Alembic
+  migrations. Every preset uses one of: `meditation_timer`, `count_up`,
+  `mindful_anchor`.
+- **Preset names must be unique** across the entire catalog (the
+  import-time guard at `seed_practices.py:337-341` enforces this). Pick
+  short, clear, capitalized names; do not reuse a name already in
+  `PRESET_COPY`.
+- **Skip source rows that duplicate an already-seeded preset.** For
+  stage 1 specifically:
+  - *Stand Barefoot Outdoors* ≈ existing `Touch Grass` — skip.
+  - *Square - Circle - Triangle x5* ≈ existing `Find Shapes` — skip.
+  - *Colors of the Rainbow* ≈ existing `Find Colors` — skip.
+- Each preset's `mode_config` must round-trip through
+  `ModeConfigAdapter.validate_python()` — the seeder does this at import
+  time so a typo crashes the seeder, not production startup.
+- Keep descriptions ≤ 2000 chars, instructions ≤ 10000 chars (matches
+  the `Practice` column caps).
+- Use the existing duration ladder for each stage as a default
+  (stage 1 ≈ 3-5 min, stage 3 ≈ 10 min, stage 4 ≈ 15 min, stages 5-6 ≈
+  20-30 min, stage 8 = `count_up` for open-ended).
+
+## Mode selection guidance
+
+| Source-row shape                                          | Mode             |
+|-----------------------------------------------------------|------------------|
+| Timed sit / breath / visualization with start/end bell    | `meditation_timer` |
+| Long sit benefiting from a mid-bell                       | `meditation_timer` with `halfway_bell=True` |
+| Open-ended journaling / drawing / walking                 | `count_up` |
+| Single-act presence with a chooser (e.g. Touch Grass)     | `mindful_anchor` |
+
+No source row in this epic requires `tarot`, `metronome`, `interval_bell`,
+`rep_counter`, `tallied_grounding`, `card_meditation`, or
+`random_interval_bell`. If a sub-issue author thinks a row really wants
+one of those, surface the choice in the PR description instead of
+silently switching — the bar for adding a different-mode alternative is
+higher than just "it might work."
+
+## References
+
+- `backend/src/models/practice.py:20-58` — `Practice` model
+- `backend/src/domain/practice_modes.py:15-28` — `PracticeMode` enum (closed)
+- `backend/src/seed_practices.py:166-314` — canonical + alternative preset list
+- `backend/src/seed_practices.py:316-358` — import-time validation + dedup guards
+- `backend/src/seed_practice_copy.py` — `PRESET_COPY` table
+- `backend/tests/test_seed_practices.py:233-313` — preset assertion test pattern
+- `backend/tests/test_seed_practices.py:339-356` — global preset invariants
+- `prompts/github-issues/grounding-techniques-03-presets-shapes-and-colors.md` — closest precedent


### PR DESCRIPTION
Decomposes the practitioner-authored "alternative practices per
frequency" table into an epic of 7 sub-issues, one per stage with
new alternative content (BEIGE 1, PURPLE 2, RED 3, BLUE 4, ORANGE 5,
GREEN 6, TEAL 8). Stages 7/9/10 carry no alternatives in the source
table and are out of scope.

The epic is pure content (~60 new presets across the existing modes:
meditation_timer, count_up, mindful_anchor) so no new PracticeMode
values, schemas, or Alembic migrations are needed. Each sub-issue
appends rows to _ALTERNATIVE_PRESETS in seed_practices.py, copy
tuples to PRESET_COPY in seed_practice_copy.py, and assertion tests
to test_seed_practices.py — and is fully independent of the others.