### PR TITLE
feat(backend): seed 60 Spiral Dynamics alternative practice presets (BEIGE-TEAL)

### DIFF
--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -807,6 +807,119 @@ _REACH_INWARD = (
 )
 
 
+# -- Stage 8 TEAL alternatives — integration / shamanic ---------------------
+
+
+#: Stage 8 alternative — Clairaudient Listening (meditation_timer mode).
+_CLAIRAUDIENT_LISTENING = (
+    "Twenty minutes of silent listening for the 'still small voice' "
+    "that speaks underneath ordinary thought.",
+    "Sit upright in a quiet room with the eyes closed. Settle the "
+    "breath until the mind grows quieter. Listen — not for sound, but "
+    "for the subtler voice that surfaces between thoughts. When a "
+    "phrase arrives, hold it gently without analysing. After the "
+    "halfway bell, ask one question silently and listen for whatever "
+    "answers. Stay with the listening until the closing bell.",
+)
+
+#: Stage 8 alternative — Channeling Writing (count_up mode).
+_CHANNELING_WRITING = (
+    "An open-ended channeling-writing practice: write the question "
+    "'What would you have me know?' and transcribe whatever arises.",
+    "Sit with a notebook and pen in a quiet space. At the top of the "
+    "page, write the question 'What would you have me know?' Then "
+    "write whatever comes — without editing, without judging the "
+    "voice or the content. If the page goes blank, write the "
+    "question again and continue. The timer counts up so you can "
+    "take as long as the writing asks for. Mark the session complete "
+    "when the practice feels finished.",
+)
+
+#: Stage 8 alternative — Active Imagination Dialogue (meditation_timer mode).
+_ACTIVE_IMAGINATION = (
+    "Thirty minutes of Jung's Active Imagination — inviting an inner "
+    "figure to appear and dialoguing with it as a distinct other.",
+    "Sit upright with the eyes closed. Invite a figure, animal, or "
+    "aspect of self to appear in mind's eye and let it take its own "
+    "shape. Greet it directly: 'who are you, and what have you come "
+    "to show me?' Listen to its reply without editing. After the "
+    "halfway bell, ask one more question and let the answer settle "
+    "in the body. Thank the figure before the closing bell.",
+)
+
+#: Stage 8 alternative — Aura Scanning (meditation_timer mode).
+_AURA_SCANNING = (
+    "Fifteen minutes of subtle-energy scanning of your own auric "
+    "field — sweeping attention through the layers around the body.",
+    "Sit upright with the eyes closed. Place attention a few inches "
+    "off the skin and slowly sweep up the body from feet to crown, "
+    "noticing any sensation of warmth, density, tingling, or colour. "
+    "Step the attention outward in turn — a hand's width, an arm's "
+    "length, a body's length — scanning each layer the same way. "
+    "Return through the layers in reverse until the closing bell.",
+)
+
+#: Stage 8 alternative — Sangha Field Tuning (meditation_timer mode).
+_SANGHA_FIELD_TUNING = (
+    "Fifteen minutes of tuning into the collective prayer field of a "
+    "community you belong to — sangha, congregation, lineage, scene.",
+    "Sit upright with the eyes closed. Bring to mind a community you "
+    "belong to — a meditation sangha, a faith congregation, a lineage "
+    "of teachers, a creative scene. Sense the felt presence of every "
+    "member holding the same intention you hold. Let your attention "
+    "rest in the shared field rather than in your own seat. Offer "
+    "and receive from the field equally until the closing bell.",
+)
+
+#: Stage 8 alternative — Freedom Log (count_up mode).
+_FREEDOM_LOG = (
+    "An open-ended re-patterning journal practice: list the conditions "
+    "currently constraining you, then re-write each as a freedom.",
+    "Sit with a notebook and pen. Down the left side of a page, list "
+    "the conditions you feel constrained by — habits, obligations, "
+    "fears, identities. On the right side, write each one's freedom "
+    "form — the unconstrained version of the same impulse. The timer "
+    "counts up so you can take as long as the practice asks for. "
+    "Mark the session complete when both columns feel finished.",
+)
+
+#: Stage 8 alternative — Hierarchical Re-Feeling (count_up mode).
+_HIERARCHICAL_RE_FEELING = (
+    "An open-ended journal practice: feel through a recent event "
+    "again at successively deeper levels of meaning.",
+    "Sit with a notebook and pen. Choose a recent event that still "
+    "carries charge. Write it once as fact (what happened). Write it "
+    "again as feeling (what it was like inside). Write it again as "
+    "meaning (what it was about). Write it again as initiation (what "
+    "it was preparing you for). The timer counts up so you can take "
+    "as long as the practice asks for. Mark the session complete "
+    "when ready.",
+)
+
+#: Stage 8 alternative — Reflective Tarot Draw (meditation_timer mode).
+_REFLECTIVE_TAROT_DRAW = (
+    "Five minutes of single-card reflection: draw one tarot card and "
+    "sit with the question 'what was the lesson?'",
+    "Shuffle a tarot deck and draw a single card. Place it in front "
+    "of you face-up. Sit upright and ask silently: 'what was the "
+    "lesson of today, of this event, of this relationship?' Look at "
+    "the image and let an answer arrive without forcing meaning onto "
+    "the suit or number. Rest with the card until the bell.",
+)
+
+#: Stage 8 alternative — Sacred Pause (meditation_timer mode).
+_SACRED_PAUSE = (
+    "Five minutes of Tara Brach's Sacred Pause — stopping completely "
+    "in the middle of life to meet whatever is here.",
+    "Sit upright wherever you are, even mid-activity. Take three slow "
+    "breaths and let the impulse to fix, plan, or move dissolve. "
+    "Notice without naming what is most alive in body, feeling, and "
+    "thought right now. Do nothing about it. When the bell sounds, "
+    "re-enter the day from the same posture but with the pause still "
+    "open underneath it.",
+)
+
+
 PRESET_COPY: dict[str, tuple[str, str]] = {
     "5-4-3-2-1 grounding": _S1,
     "Tarot meditation": _S2,
@@ -873,4 +986,13 @@ PRESET_COPY: dict[str, tuple[str, str]] = {
     "Letter to the Repressed Self": _LETTER_TO_REPRESSED_SELF,
     "Shadow Drawing": _SHADOW_DRAWING,
     "REACH Inward": _REACH_INWARD,
+    "Clairaudient Listening": _CLAIRAUDIENT_LISTENING,
+    "Channeling Writing": _CHANNELING_WRITING,
+    "Active Imagination Dialogue": _ACTIVE_IMAGINATION,
+    "Aura Scanning": _AURA_SCANNING,
+    "Sangha Field Tuning": _SANGHA_FIELD_TUNING,
+    "Freedom Log": _FREEDOM_LOG,
+    "Hierarchical Re-Feeling": _HIERARCHICAL_RE_FEELING,
+    "Reflective Tarot Draw": _REFLECTIVE_TAROT_DRAW,
+    "Sacred Pause": _SACRED_PAUSE,
 }

--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -588,6 +588,114 @@ _ANCESTRAL_CONNECTION = (
 )
 
 
+# -- Stage 5 ORANGE alternatives — activation / manifestation -----------------
+
+
+#: Stage 5 alternative — Kapalabhati Skull Shining (meditation_timer mode).
+_KAPALABHATI = (
+    "Fifteen minutes of rapid, forceful nasal exhalations — the "
+    "'skull-shining' breath that clears mental fog and sharpens "
+    "alertness.",
+    "Sit upright with the spine tall. Take a normal inhale, then "
+    "make a series of short sharp exhalations through the nose, "
+    "letting the inhales happen passively between them — about two "
+    "exhales per second. Aim for thirty per round, then breathe "
+    "normally for a minute. Ease off and breathe normally if you "
+    "feel lightheaded; resume only when it passes. After the "
+    "halfway bell, do two final rounds and rest in the bright "
+    "stillness until the closing bell.",
+)
+
+#: Stage 5 alternative — Middle Pillar (meditation_timer mode).
+_MIDDLE_PILLAR = (
+    "Twenty minutes of the Golden Dawn 'Middle Pillar' visualization, "
+    "building the energy body along the central axis.",
+    "Sit upright with the eyes closed and feet flat on the floor. "
+    "Visualize a sphere of white light at the crown, then vibrate "
+    "Eheieh silently as it brightens. Draw the light down to a sphere "
+    "at the throat (Yahweh Elohim), the heart (Yahweh Eloah Va-Daath), "
+    "the solar plexus (Shaddai El Chai), and the feet (Adonai Ha-Aretz). "
+    "After the halfway bell, circulate the light from the feet up the "
+    "spine and down the front until the closing bell.",
+)
+
+#: Stage 5 alternative — Sigil Dhyana (meditation_timer mode).
+_SIGIL_DHYANA = (
+    "Twenty minutes of single-pointed meditation on a personal sigil — "
+    "the Chaos-Magick technique of charging a designed glyph by holding "
+    "it in awareness.",
+    "Before starting, draw a simple sigil from a statement of intent "
+    "(cross out repeated letters, weave the rest into a glyph). Sit "
+    "upright with the sigil on a card in front of you. Hold the sigil "
+    "in soft gaze until it begins to flicker or float, then close the "
+    "eyes and keep it in mind's eye. After the halfway bell, let go "
+    "of the sigil and the intent both, resting in empty awareness until "
+    "the closing bell.",
+)
+
+#: Stage 5 alternative — Reality Selection Visualization (meditation_timer mode).
+_REALITY_SELECTION = (
+    "Twenty minutes of Neville Goddard's hypnagogic visualization — "
+    "rehearsing the felt reality of an already-accomplished wish.",
+    "Lie down comfortably with the eyes closed. Choose one scene that "
+    "would imply your wish is already fulfilled — a handshake, a "
+    "thank-you, a quiet moment after. Build the scene with all senses "
+    "and loop it until it feels habitual. After the halfway bell, "
+    "let the scene play on the edge of sleep without forcing wakefulness. "
+    "Return to clear focus by the closing bell.",
+)
+
+#: Stage 5 alternative — Single Instrument Listening (meditation_timer mode).
+_SINGLE_INSTRUMENT_LISTENING = (
+    "Twenty minutes of immersive listening to energizing music while "
+    "tracking a single instrument all the way through.",
+    "Before starting, queue an energizing track or playlist of about "
+    "twenty minutes and pick one instrument — a bassline, a particular "
+    "horn, a hi-hat. Sit upright with the eyes closed and follow only "
+    "that instrument through every passage, even when other lines "
+    "dominate. When attention drifts to another instrument, return "
+    "without comment. Stay with the chosen line until the bell.",
+)
+
+#: Stage 5 alternative — Chanting or Kirtan (meditation_timer mode).
+_CHANTING_OR_KIRTAN = (
+    "Twenty minutes of devotional chanting — repeating a single mantra "
+    "or kirtan call aloud to ride the breath into a unified state.",
+    "Choose one short mantra or kirtan call you know — Om Namah "
+    "Shivaya, Hare Krishna, a Gregorian Kyrie. Sit or stand upright. "
+    "Chant it aloud on each exhale at a tempo you can sustain, "
+    "letting the inhales fall in naturally. Let the volume and pitch "
+    "find their own shape over time. Continue without breaks until "
+    "the bell.",
+)
+
+#: Stage 5 alternative — Breath of Fire + Silence (meditation_timer mode).
+_BREATH_OF_FIRE_SILENCE = (
+    "Twenty minutes of the Kundalini Yoga Breath of Fire followed by "
+    "an equal period of silent integration.",
+    "Sit upright with the spine tall. Take rapid, equal-length inhales "
+    "and exhales through the nose, powered by sharp pumps of the "
+    "navel point — roughly two breaths per second. Ease off and "
+    "breathe normally if you feel lightheaded; resume only when it "
+    "passes. At the halfway bell, stop the breath of fire entirely "
+    "and rest in pure silence, letting the residual energy circulate "
+    "until the closing bell.",
+)
+
+#: Stage 5 alternative — Lion's Breath (meditation_timer mode).
+_LIONS_BREATH = (
+    "Ten minutes of Simhasana — the cathartic 'lion's breath' that "
+    "vents tension through wide eyes, an out-thrust tongue, and a "
+    "loud exhale.",
+    "Sit on the heels or in a chair. Inhale deeply through the nose. "
+    "On the exhale, open the eyes wide, stretch the tongue down "
+    "toward the chin, and exhale audibly with a 'haaa' sound. Pause, "
+    "breathe normally, then repeat — three to five lion's breaths per "
+    "minute. Ease off and breathe normally if you feel lightheaded; "
+    "resume only when it passes. Continue until the bell.",
+)
+
+
 PRESET_COPY: dict[str, tuple[str, str]] = {
     "5-4-3-2-1 grounding": _S1,
     "Tarot meditation": _S2,
@@ -638,4 +746,12 @@ PRESET_COPY: dict[str, tuple[str, str]] = {
     "Heart Imagery": _HEART_IMAGERY,
     "Just Like Me": _JUST_LIKE_ME,
     "Ancestral Connection": _ANCESTRAL_CONNECTION,
+    "Kapalabhati Skull Shining": _KAPALABHATI,
+    "Middle Pillar": _MIDDLE_PILLAR,
+    "Sigil Dhyana": _SIGIL_DHYANA,
+    "Reality Selection Visualization": _REALITY_SELECTION,
+    "Single Instrument Listening": _SINGLE_INSTRUMENT_LISTENING,
+    "Chanting or Kirtan": _CHANTING_OR_KIRTAN,
+    "Breath of Fire + Silence": _BREATH_OF_FIRE_SILENCE,
+    "Lion's Breath": _LIONS_BREATH,
 }

--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -148,6 +148,97 @@ _FIND_COLORS = (
 )
 
 
+# -- Stage 1 BEIGE alternatives — body-grounding / nervous-system regulation -
+
+
+#: Stage 1 alternative — Crystal Charging (meditation_timer mode).
+_CRYSTAL_CHARGING = (
+    "Five minutes of standing outdoors holding a stone or crystal, letting "
+    "the contact between your palms, the object, and the earth bring you "
+    "back to the moment.",
+    "Choose any stone, crystal, or smooth pebble you can hold in one "
+    "cupped palm. Step outside and stand barefoot on grass, soil, sand, "
+    "or stone. Close your fingers gently around the object and notice "
+    "its weight, temperature, and texture. Let your attention travel "
+    "between the object in your hand and the ground under your feet. "
+    "When the bell sounds, lower the stone and open your hands.",
+)
+
+#: Stage 1 alternative — Tense and Release (meditation_timer mode).
+_TENSE_AND_RELEASE = (
+    "A clench-and-release body scan that drains residual tension by "
+    "tightening each muscle group on purpose, then letting it go.",
+    "Sit or lie comfortably. Beginning at the feet, tense the muscles "
+    "there for a slow count of five, then release on the exhale and "
+    "notice the change. Move up the body in turn — calves, thighs, "
+    "glutes, belly, chest, hands, arms, shoulders, face. When the "
+    "halfway bell sounds, you should be reaching the upper body. "
+    "Finish at the crown and rest in the residual softness until the "
+    "closing bell.",
+)
+
+#: Stage 1 alternative — Contact Points (meditation_timer mode).
+_CONTACT_POINTS = (
+    "A five-minute somatic inventory of every point where your body "
+    "meets a surface, from soles to seat to skin against fabric.",
+    "Sit or lie in any comfortable position. Without moving, scan "
+    "slowly for each place your body touches something — chair, floor, "
+    "clothing, the air on your skin. Name each contact silently as you "
+    "find it: 'seat of pants,' 'left heel,' 'right palm.' When you "
+    "reach the end of the inventory, start again. Stay with the survey "
+    "until the closing bell.",
+)
+
+#: Stage 1 alternative — Box Breathing (meditation_timer mode).
+_BOX_BREATHING = (
+    "Five minutes of square-shaped breathing — inhale, hold, exhale, "
+    "hold — to steady the breath and the nervous system.",
+    "Sit upright with your hands resting on your thighs. Inhale through "
+    "the nose for a slow count of four. Hold the breath for four. "
+    "Exhale through the nose for four. Hold the empty lungs for four. "
+    "Continue the pattern, easing back to a softer count if the holds "
+    "feel forced. The halfway bell marks the midpoint.",
+)
+
+#: Stage 1 alternative — Toe Wiggling (meditation_timer mode).
+_TOE_WIGGLING = (
+    "A three-minute foot-attention practice: feel the weight of each "
+    "foot, then wake them up by slowly wiggling each toe in turn.",
+    "Take off your shoes if you can. Sit or stand with both feet flat "
+    "on the floor. Bring attention to the sole of the left foot — the "
+    "heel, the arch, the ball, each toe. Wiggle each toe slowly, one "
+    "at a time, then all together. Repeat on the right foot. When the "
+    "bell sounds, plant both feet and notice the difference.",
+)
+
+#: Stage 1 alternative — Body Scan (meditation_timer mode).
+_BODY_SCAN = (
+    "A five-minute top-down sweep of attention through the body, "
+    "noticing whatever is present at each region without trying to "
+    "change it.",
+    "Sit or lie comfortably and close the eyes. Begin at the toes and "
+    "move attention slowly upward — feet, ankles, calves, knees, "
+    "thighs, hips, belly, chest, hands, arms, shoulders, neck, face, "
+    "crown. At each region, pause for a breath and notice whatever "
+    "sensation is present without trying to change it. The halfway "
+    "bell marks the belly; finish at the crown by the closing bell.",
+)
+
+#: Stage 1 alternative — Progressive Muscle Relaxation (meditation_timer mode).
+_PROGRESSIVE_MUSCLE_RELAXATION = (
+    "Ten minutes of Jacobson's progressive muscle relaxation — "
+    "sequentially tensing and releasing every major muscle group to "
+    "invite deep rest.",
+    "Lie down if you can. Beginning with the feet, tense the muscles "
+    "there hard for five seconds, then release sharply on the exhale "
+    "and rest for ten before moving on. Work through the entire body "
+    "— calves, thighs, glutes, belly, chest, arms, hands, shoulders, "
+    "neck, jaw, face. The halfway bell signals you should be reaching "
+    "the torso. End with a whole-body tense-and-release before the "
+    "closing bell.",
+)
+
+
 PRESET_COPY: dict[str, tuple[str, str]] = {
     "5-4-3-2-1 grounding": _S1,
     "Tarot meditation": _S2,
@@ -163,4 +254,11 @@ PRESET_COPY: dict[str, tuple[str, str]] = {
     "Mindful Eating": _MINDFUL_EATING,
     "Find Shapes": _FIND_SHAPES,
     "Find Colors": _FIND_COLORS,
+    "Crystal Charging": _CRYSTAL_CHARGING,
+    "Tense and Release": _TENSE_AND_RELEASE,
+    "Contact Points": _CONTACT_POINTS,
+    "Box Breathing": _BOX_BREATHING,
+    "Toe Wiggling": _TOE_WIGGLING,
+    "Body Scan": _BODY_SCAN,
+    "Progressive Muscle Relaxation": _PROGRESSIVE_MUSCLE_RELAXATION,
 }

--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -696,6 +696,117 @@ _LIONS_BREATH = (
 )
 
 
+# -- Stage 6 GREEN alternatives — shadow work --------------------------------
+
+
+#: Stage 6 alternative — Chair Work (meditation_timer mode).
+_CHAIR_WORK = (
+    "Thirty minutes of two-chair dialogue between self and shadow, "
+    "swapping seats every five minutes to give each side a full voice.",
+    "Place two chairs facing each other. Sit in the first as your "
+    "everyday self and address the empty chair as if your shadow "
+    "occupied it. Speak aloud what you want it to know. After five "
+    "minutes, switch chairs and respond as the shadow without "
+    "softening or editing. Continue alternating every five minutes. "
+    "If strong emotion arises, pause to breathe and journal rather "
+    "than push through. The halfway bell marks the midpoint.",
+)
+
+#: Stage 6 alternative — Wording Through It (meditation_timer mode).
+_WORDING_THROUGH_IT = (
+    "Thirty minutes of speaking the shadow content out loud — naming "
+    "what would otherwise stay swallowed.",
+    "Sit alone in a private space. Bring to mind a feeling, memory, "
+    "or pattern you usually hold back. Speak it aloud in plain words, "
+    "one sentence at a time, with pauses between. Do not edit, do "
+    "not perform. If strong emotion arises, pause to breathe and "
+    "journal rather than push through. The halfway bell is your cue "
+    "to widen what you're willing to name.",
+)
+
+#: Stage 6 alternative — Wilber 3-2-1 (meditation_timer mode).
+_WILBER_321 = (
+    "Thirty minutes of Ken Wilber's 3-2-1 shadow practice: face it, talk to it, be it.",
+    "Choose a person or pattern that triggers a strong reaction. "
+    "Face it — describe the triggering presence in third person ('he,' "
+    "'she,' 'it'). Talk to it — address it directly as 'you' and tell "
+    "it what you most need it to hear. Be it — speak as the figure in "
+    "first person 'I,' from inside its perspective. The halfway bell "
+    "is your cue to cycle the three voices again. Pause to breathe "
+    "and journal if strong emotion arises.",
+)
+
+#: Stage 6 alternative — Emotion Transmutation (meditation_timer mode).
+_EMOTION_TRANSMUTATION = (
+    "Thirty minutes of the Tibetan Buddhist practice of meeting a "
+    "difficult emotion directly and transmuting it into its wisdom "
+    "counterpart.",
+    "Sit upright with the eyes closed. Invite a difficult emotion in "
+    "fully — anger, fear, jealousy, grief — and locate where it lives "
+    "in the body. Breathe into the felt sensation without storyline "
+    "and let it intensify rather than push it away. As it ripens, "
+    "notice the wisdom it carries: anger's clarity, fear's "
+    "discernment, jealousy's longing. The halfway bell is your cue "
+    "to rest in the transmuted aspect. Pause and journal if strong "
+    "emotion arises.",
+)
+
+#: Stage 6 alternative — Pain Body Meditation (meditation_timer mode).
+_PAIN_BODY_MEDITATION = (
+    "Thirty minutes of observing the 'pain body' as Eckhart Tolle "
+    "describes it — a distinct presence of accumulated emotional pain "
+    "you can witness rather than identify with.",
+    "Sit upright with the eyes closed. Notice any background mood of "
+    "heaviness, irritability, or sorrow as if it belonged to a "
+    "separate presence sitting beside you. Speak silently to it: 'I "
+    "see you, but you are not me.' Stay watchful without arguing, "
+    "fixing, or feeding the story. The halfway bell is your cue to "
+    "check whether you have slipped back into identification. Pause "
+    "and journal if strong emotion arises.",
+)
+
+#: Stage 6 alternative — Letter to the Repressed Self (count_up mode).
+_LETTER_TO_REPRESSED_SELF = (
+    "An open-ended stream-of-consciousness letter to the part of you "
+    "you most often disown — written without editing.",
+    "Sit somewhere private with a notebook and pen. Address the "
+    "letter to whichever part of yourself you tend to silence — the "
+    "rageful one, the lazy one, the desirous one. Write without "
+    "stopping or rereading until the practice feels complete. The "
+    "timer counts up so you can take as long as the writing asks for. "
+    "Pause to breathe rather than push through if strong emotion "
+    "arises. When you are done, mark the session complete.",
+)
+
+#: Stage 6 alternative — Shadow Drawing (count_up mode).
+_SHADOW_DRAWING = (
+    "An open-ended drawing practice: render the shadow self on paper, "
+    "then sit holding eye contact with what you've drawn.",
+    "Sit at a table with paper and any mark-making tool. Without "
+    "planning, let your hand draw the shadow self — figure, abstract "
+    "shape, scribble, colour. When the drawing feels finished, set "
+    "down the tool and hold steady eye contact with the figure on the "
+    "page. Notice what arises in the body. The timer counts up so you "
+    "can take as long as the practice asks for. Pause to breathe if "
+    "strong emotion arises. Mark the session complete when ready.",
+)
+
+#: Stage 6 alternative — REACH Inward (meditation_timer mode).
+_REACH_INWARD = (
+    "Thirty minutes of the REACH forgiveness practice (Recall, "
+    "Empathize, Altruistic gift, Commit, Hold) — directed inward "
+    "toward yourself.",
+    "Sit upright with the eyes closed. Recall a specific way you "
+    "have hurt yourself or fallen short. Empathize with the part of "
+    "you that acted that way — what fear or need was beneath it? "
+    "Offer that part the altruistic gift of being seen without "
+    "judgement. Commit silently to remembering this seeing. Hold the "
+    "commitment when self-criticism returns. The halfway bell is "
+    "your cue to begin a second cycle. Pause and journal if strong "
+    "emotion arises.",
+)
+
+
 PRESET_COPY: dict[str, tuple[str, str]] = {
     "5-4-3-2-1 grounding": _S1,
     "Tarot meditation": _S2,
@@ -754,4 +865,12 @@ PRESET_COPY: dict[str, tuple[str, str]] = {
     "Chanting or Kirtan": _CHANTING_OR_KIRTAN,
     "Breath of Fire + Silence": _BREATH_OF_FIRE_SILENCE,
     "Lion's Breath": _LIONS_BREATH,
+    "Chair Work": _CHAIR_WORK,
+    "Wording Through It": _WORDING_THROUGH_IT,
+    "Wilber 3-2-1": _WILBER_321,
+    "Emotion Transmutation": _EMOTION_TRANSMUTATION,
+    "Pain Body Meditation": _PAIN_BODY_MEDITATION,
+    "Letter to the Repressed Self": _LETTER_TO_REPRESSED_SELF,
+    "Shadow Drawing": _SHADOW_DRAWING,
+    "REACH Inward": _REACH_INWARD,
 }

--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -336,6 +336,133 @@ _TOTEM_MEDITATION = (
 )
 
 
+# -- Stage 3 RED alternatives — energy / power -------------------------------
+
+
+#: Stage 3 alternative — Hand Energy Sensing (meditation_timer mode).
+_HAND_ENERGY_SENSING = (
+    "Five minutes of generating warmth between your palms and tracking "
+    "the field that arises between them.",
+    "Sit upright with your hands free. Rub your palms together briskly "
+    "for thirty seconds until they feel hot. Slowly draw them apart to "
+    "a few inches and notice the sensation between them — pressure, "
+    "tingling, warmth, weight. Play with the gap, moving the hands "
+    "closer and further, and rest your attention on whatever you feel "
+    "between them until the bell.",
+)
+
+#: Stage 3 alternative — Windhorse Breathwork (meditation_timer mode).
+_WINDHORSE_BREATHWORK = (
+    "Ten minutes of vigorous, rhythmic breathing from the Tibetan Bön "
+    "tradition to stoke the inner fire (lung-ta).",
+    "Sit upright on a cushion or chair. Take deep, full breaths through "
+    "the nose, pressing the diaphragm out on the inhale and drawing it "
+    "in on the exhale, at roughly one breath every two seconds. Imagine "
+    "each inhale stoking a small flame at your navel. Ease off and "
+    "breathe normally if you feel lightheaded or dizzy. After the "
+    "halfway bell, return to natural breath and rest in the heat "
+    "you have generated until the closing bell.",
+)
+
+#: Stage 3 alternative — Water Charging (meditation_timer mode).
+_WATER_CHARGING = (
+    "Five minutes of focused intention into a glass of water — adapted "
+    "from Damien Echols's magickal water-charging technique.",
+    "Pour a glass of water and hold it in both hands at chest level. "
+    "Sit upright and close your eyes. Bring a single intention to mind "
+    "— health, focus, courage. Imagine the intention flowing from your "
+    "heart down your arms, through your palms, and into the water as "
+    "a faint coloured light. Continue until the bell, then drink the "
+    "water in slow sips.",
+)
+
+#: Stage 3 alternative — Mini TED Talk (meditation_timer mode).
+_MINI_TED_TALK = (
+    "Ten minutes of speaking aloud, uninterrupted, on something you "
+    "genuinely know well — to anchor your authority in your own voice.",
+    "Stand or sit upright in a private space. Choose one topic you "
+    "have real expertise on — a craft, a book, a story you have told "
+    "before. Speak aloud or sub-vocalize as if presenting to a small "
+    "room, in continuous sentences without notes. If you trail off, "
+    "restart from any point that brings the energy back. Keep speaking "
+    "until the bell.",
+)
+
+#: Stage 3 alternative — Power Posture (meditation_timer mode).
+_POWER_POSTURE = (
+    "Ten minutes of holding an expansive posture — chest open, feet "
+    "planted — paired with steady breath.",
+    "Stand or sit with feet planted shoulder-width apart. Lift the "
+    "crown, drop the shoulders, open the chest, and let the hands "
+    "rest at the hips or on the thighs. Breathe in slowly through the "
+    "nose, out slowly through the nose, with each breath reinforcing "
+    "the posture. Hold the shape — not rigidly, but consciously — "
+    "until the closing bell.",
+)
+
+#: Stage 3 alternative — Mountain Pose Sit (meditation_timer mode).
+_MOUNTAIN_POSE_SIT = (
+    "Ten minutes of seated mountain-pose visualization — embodying "
+    "the immovable as a felt sense in the body.",
+    "Sit cross-legged or in a chair with both feet flat. Imagine "
+    "yourself as a mountain: broad at the base, weighted, unmoved by "
+    "any weather. Silently repeat 'I cannot be moved' on each exhale. "
+    "When thoughts or restlessness arise, let them pass across you "
+    "like clouds rather than push them away. Stay with the mountain "
+    "until the bell.",
+)
+
+#: Stage 3 alternative — Fire Gazing (meditation_timer mode).
+_FIRE_GAZING = (
+    "Ten minutes of soft gaze into a candle flame or hearth fire, "
+    "anchoring attention down into the solar plexus.",
+    "Light a candle or sit safely in front of a fire at eye level. "
+    "Rest your gaze on the flame without straining, blinking only "
+    "when needed. Drop attention from the eyes down into the solar "
+    "plexus, as if the warmth above were also burning there. If your "
+    "eyes water or you feel lightheaded, close them and stay with the "
+    "heat in the belly. The halfway bell is your cue to soften the "
+    "gaze.",
+)
+
+#: Stage 3 alternative — Warrior Stillness (meditation_timer mode).
+_WARRIOR_STILLNESS = (
+    "Ten minutes of holding a single warrior-style posture — without "
+    "movement, without escape — to meet the discomfort that arises.",
+    "Choose one posture you can hold for several minutes — warrior I "
+    "or II, horse stance, low squat, plank. Take the shape with as "
+    "much precision as you can manage. Breathe slowly through the nose "
+    "and meet whatever sensations arise — burn, tremor, fatigue — "
+    "without shifting out. If the posture becomes unsafe, lower out of "
+    "it and resume the same posture from a gentler angle until the bell.",
+)
+
+#: Stage 3 alternative — Red Sphere Visualization (meditation_timer mode).
+_RED_SPHERE_VISUALIZATION = (
+    "Ten minutes of visualizing a pulsing red sphere of light at the "
+    "gut to gather and concentrate vital energy.",
+    "Sit upright with the eyes closed. Place attention at the centre "
+    "of the belly, two finger-widths below the navel. Picture a small "
+    "sphere of warm red light pulsing there with each breath — brighter "
+    "on the inhale, steadier on the exhale. The halfway bell is your "
+    "cue to let the sphere widen until it fills the whole abdomen. "
+    "Hold the image until the closing bell.",
+)
+
+#: Stage 3 alternative — Love to Past Selves (meditation_timer mode).
+_LOVE_TO_PAST_SELVES = (
+    "Fifteen minutes of directing lovingkindness toward yourself at "
+    "progressively younger ages — a self-reparenting practice.",
+    "Sit comfortably with the eyes closed. Begin with your present "
+    "self — silently offer 'may you be safe, may you feel held, may "
+    "you know you are loved.' Then step backward in time: yourself "
+    "at twenty-five, fifteen, ten, five, two, in the womb. Offer the "
+    "same phrases at each age, lingering as long as feels right. "
+    "After the halfway bell, take a few breaths and re-emerge into "
+    "the present, offering the phrases one last time.",
+)
+
+
 PRESET_COPY: dict[str, tuple[str, str]] = {
     "5-4-3-2-1 grounding": _S1,
     "Tarot meditation": _S2,
@@ -366,4 +493,14 @@ PRESET_COPY: dict[str, tuple[str, str]] = {
     "Dream Recollection": _DREAM_RECOLLECTION,
     "Archetypal Mantra": _ARCHETYPAL_MANTRA,
     "Totem Meditation": _TOTEM_MEDITATION,
+    "Hand Energy Sensing": _HAND_ENERGY_SENSING,
+    "Windhorse Breathwork": _WINDHORSE_BREATHWORK,
+    "Water Charging": _WATER_CHARGING,
+    "Mini TED Talk": _MINI_TED_TALK,
+    "Power Posture": _POWER_POSTURE,
+    "Mountain Pose Sit": _MOUNTAIN_POSE_SIT,
+    "Fire Gazing": _FIRE_GAZING,
+    "Warrior Stillness": _WARRIOR_STILLNESS,
+    "Red Sphere Visualization": _RED_SPHERE_VISUALIZATION,
+    "Love to Past Selves": _LOVE_TO_PAST_SELVES,
 }

--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -463,6 +463,131 @@ _LOVE_TO_PAST_SELVES = (
 )
 
 
+# -- Stage 4 BLUE alternatives — heart / lovingkindness ----------------------
+
+
+#: Stage 4 alternative — Tonglen (meditation_timer mode).
+_TONGLEN = (
+    "Fifteen minutes of the Tibetan giving-and-taking practice: inhale "
+    "another being's pain, exhale ease and warmth toward them.",
+    "Sit upright with the eyes closed. Bring to mind someone who is "
+    "suffering. On each inhale, draw the discomfort of that being into "
+    "your heart as warm dark smoke; on each exhale, send cool clear "
+    "light of ease back toward them. After the halfway bell, widen "
+    "the circle to all beings carrying the same kind of pain. Continue "
+    "the breath rhythm until the closing bell.",
+)
+
+#: Stage 4 alternative — I Am Love Through (meditation_timer mode).
+_I_AM_LOVE_THROUGH = (
+    "Fifteen minutes of Selig's transmission phrase: 'I am Love "
+    "through [name]' — letting love move through you toward a chosen "
+    "other.",
+    "Sit upright and close the eyes. Bring to mind one person you "
+    "care for. Silently repeat the phrase 'I am Love through "
+    "[their name]' on each exhale, letting the word Love be a felt "
+    "current that moves out from your heart toward them. After the "
+    "halfway bell, choose a second person and continue. Stay with "
+    "the transmission until the closing bell.",
+)
+
+#: Stage 4 alternative — Heart Centered Breath (meditation_timer mode).
+_HEART_CENTERED_BREATH = (
+    "Fifteen minutes of breathing as if the breath itself moved through "
+    "the centre of the chest rather than the nose.",
+    "Sit upright with one or both hands resting on the centre of the "
+    "chest. Imagine that you inhale through the heart and exhale "
+    "through the heart, with the nose merely passing the air along. "
+    "Let the breath grow slow and full. After the halfway bell, "
+    "soften the hands and let the heart breathe on its own until the "
+    "closing bell.",
+)
+
+#: Stage 4 alternative — Animist Gratitude (meditation_timer mode).
+_ANIMIST_GRATITUDE = (
+    "Ten minutes of speaking thanks aloud to the local beings — "
+    "trees, birds, weather, land — that share your place.",
+    "Step outside or sit near a window with the eyes open. Choose "
+    "one local being at a time — a tree, a particular bird, the wind, "
+    "the soil under your feet. Speak a sentence of thanks aloud, "
+    "naming what you're grateful for. Move to the next being only "
+    "when the first feels acknowledged. Continue addressing local "
+    "beings until the bell.",
+)
+
+#: Stage 4 alternative — Hug Visualization (meditation_timer mode).
+_HUG_VISUALIZATION = (
+    "Ten minutes of vividly imagining a long, warm embrace with someone you miss.",
+    "Sit comfortably with the eyes closed. Bring to mind one person "
+    "you miss — living or gone. Picture them stepping in close and "
+    "the two of you wrapping into a long, full-body embrace. Notice "
+    "the weight, the temperature, the smell, the silence. Stay in the "
+    "hug as long as it lasts, then begin again. Continue until the "
+    "bell.",
+)
+
+#: Stage 4 alternative — Relational Gratitude (meditation_timer mode).
+_RELATIONAL_GRATITUDE = (
+    "Fifteen minutes of gratitude practice focused on the people in "
+    "your life — naming specifically what each one gives you.",
+    "Sit upright with the eyes closed. Bring to mind one person in "
+    "your life and name silently what they specifically give you — "
+    "humour, patience, presence, a particular kindness. Linger on "
+    "the feeling of receiving it before moving to the next person. "
+    "After the halfway bell, widen the circle to include those who "
+    "have given less knowingly. Continue until the closing bell.",
+)
+
+#: Stage 4 alternative — Blessing Strangers (meditation_timer mode).
+_BLESSING_STRANGERS = (
+    "Ten minutes of silently blessing strangers while people-watching "
+    "in a public space — done with the eyes open.",
+    "Sit in a café, on a park bench, or in any public space with "
+    "people moving past. Keep your eyes open and soft. As each "
+    "stranger crosses your gaze, silently offer one phrase to them "
+    "— 'may you be well,' 'may you be free of pain,' 'may you be "
+    "loved.' Move on as soon as the phrase is given. Continue blessing "
+    "passers-by until the bell.",
+)
+
+#: Stage 4 alternative — Heart Imagery (meditation_timer mode).
+_HEART_IMAGERY = (
+    "Fifteen minutes of meditation on a symbolic heart image — a "
+    "green rose, a spiral, a chalice — letting the image speak.",
+    "Sit upright with the eyes closed. Choose one heart-symbol that "
+    "calls to you — a green rose, a spiral of light, a golden chalice. "
+    "Place the image at the centre of your chest and watch it without "
+    "trying to fix or interpret it. Notice colour, motion, sound, "
+    "scent that arises with it. After the halfway bell, let the image "
+    "soften and broaden. Stay with it until the closing bell.",
+)
+
+#: Stage 4 alternative — Just Like Me (meditation_timer mode).
+_JUST_LIKE_ME = (
+    "Fifteen minutes of repeating the phrase 'just like me, this being "
+    "seeks happiness' toward a widening circle of others.",
+    "Sit upright with the eyes closed. Bring to mind one specific "
+    "being — easy, neutral, then difficult. For each, silently offer "
+    "'just like me, this being seeks happiness; just like me, this "
+    "being wants to be free from suffering.' Let the recognition land "
+    "as a felt sense rather than a thought. After the halfway bell, "
+    "widen to all beings everywhere. Continue until the closing bell.",
+)
+
+#: Stage 4 alternative — Ancestral Connection (meditation_timer mode).
+_ANCESTRAL_CONNECTION = (
+    "Fifteen minutes of reaching backward through the lineage with "
+    "gratitude or lovingkindness toward those who came before.",
+    "Sit upright with the eyes closed. Place attention behind you, "
+    "as if a long line of ancestors stood at your back. Silently "
+    "thank them by name where you know them, and by relation where "
+    "you don't — grandmothers, grandfathers, the unnamed. Offer "
+    "lovingkindness in their direction. After the halfway bell, let "
+    "their presence settle into your back and shoulders, and rest "
+    "in the felt support until the closing bell.",
+)
+
+
 PRESET_COPY: dict[str, tuple[str, str]] = {
     "5-4-3-2-1 grounding": _S1,
     "Tarot meditation": _S2,
@@ -503,4 +628,14 @@ PRESET_COPY: dict[str, tuple[str, str]] = {
     "Warrior Stillness": _WARRIOR_STILLNESS,
     "Red Sphere Visualization": _RED_SPHERE_VISUALIZATION,
     "Love to Past Selves": _LOVE_TO_PAST_SELVES,
+    "Tonglen": _TONGLEN,
+    "I Am Love Through": _I_AM_LOVE_THROUGH,
+    "Heart Centered Breath": _HEART_CENTERED_BREATH,
+    "Animist Gratitude": _ANIMIST_GRATITUDE,
+    "Hug Visualization": _HUG_VISUALIZATION,
+    "Relational Gratitude": _RELATIONAL_GRATITUDE,
+    "Blessing Strangers": _BLESSING_STRANGERS,
+    "Heart Imagery": _HEART_IMAGERY,
+    "Just Like Me": _JUST_LIKE_ME,
+    "Ancestral Connection": _ANCESTRAL_CONNECTION,
 }

--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -239,6 +239,103 @@ _PROGRESSIVE_MUSCLE_RELAXATION = (
 )
 
 
+# -- Stage 2 PURPLE alternatives — divination / symbolic intuition -----------
+
+
+#: Stage 2 alternative — Traffic Lights (meditation_timer mode).
+_TRAFFIC_LIGHTS = (
+    "A divinatory micro-practice: read your environment as if every "
+    "traffic light were giving you a yes, no, or wait.",
+    "Sit somewhere with a window onto a road, or close your eyes and "
+    "visualise an intersection. Hold a single question. As each light "
+    "turns — red for no, green for yes, yellow for not yet — read the "
+    "colour as a response. Watch a sequence of three to five lights "
+    "and let the pattern speak. Stay with the question until the bell.",
+)
+
+#: Stage 2 alternative — I Ching Toss (meditation_timer mode).
+_I_CHING_TOSS = (
+    "Ten minutes of toss-and-reflect divination using three coins and a meditative journal.",
+    "Sit upright with three coins cupped in your palms and a notebook "
+    "within reach. Bring a single question to mind. Cast the coins six "
+    "times, recording the heads-or-tails sum each round to build a "
+    "hexagram from the bottom line up. Look up the resulting hexagram "
+    "and let the line readings reach you slowly. The halfway bell is "
+    "your cue to put the book down and journal what the hexagram is "
+    "asking of you.",
+)
+
+#: Stage 2 alternative — Bibliomancy (meditation_timer mode).
+_BIBLIOMANCY = (
+    "Open a book at random and read the first passage that lands as "
+    "a reply to whatever question you bring.",
+    "Pick any book of weight — poetry, scripture, a beloved novel — "
+    "and rest it on your lap. Sit upright, settle the breath, and "
+    "hold a single question in mind. Open the book at random and let "
+    "your gaze fall on a passage without searching. Read it once "
+    "slowly, then sit with the passage's resonance until the bell.",
+)
+
+#: Stage 2 alternative — Synchronicity Sweep (meditation_timer mode).
+_SYNCHRONICITY_SWEEP = (
+    "A five-minute meditative review of the day's coincidences — "
+    "names, numbers, repeated images — to see what pattern is emerging.",
+    "Sit upright and close the eyes. Sweep back through the day and "
+    "gather every coincidence you noticed: a phrase heard twice, a "
+    "number that kept appearing, a face that reminded you of someone. "
+    "Hold each in turn without forcing meaning, then ask what the "
+    "cluster is pointing toward. Stay with the inquiry until the bell.",
+)
+
+#: Stage 2 alternative — Trataka Candle Gazing (meditation_timer mode).
+_TRATAKA = (
+    "Ten minutes of soft, unblinking gaze on a candle flame, letting "
+    "intuitive imagery rise from the inner field.",
+    "Light a candle at eye level, an arm's length away. Sit upright "
+    "and rest your gaze on the flame without straining; blink only "
+    "when you must. After several minutes, close the eyes and watch "
+    "the afterimage settle into the dark. The halfway bell is your "
+    "cue to soften the gaze further or close the eyes if dryness "
+    "sets in.",
+)
+
+#: Stage 2 alternative — Dream Recollection (meditation_timer mode).
+_DREAM_RECOLLECTION = (
+    "Ten minutes of slow, attentive recollection of last night's "
+    "dreams, mapping the symbols that recurred.",
+    "Sit upright with a notebook within reach. Close the eyes and "
+    "travel backward into last night's sleep, surfacing whatever "
+    "images, settings, characters, or moods you can. Write each "
+    "fragment as it arrives without trying to order them. After the "
+    "halfway bell, look across the page for symbols that repeat or "
+    "echo and underline them.",
+)
+
+#: Stage 2 alternative — Archetypal Mantra (meditation_timer mode).
+_ARCHETYPAL_MANTRA = (
+    "Ten minutes of repetition of a single archetypal name — Hekate, "
+    "Lakshmi, Kuan Yin — as a doorway to that quality.",
+    "Choose one archetypal name that calls to you and sit upright "
+    "with your hands resting on your thighs. Repeat the name silently "
+    "on the exhale, letting the figure's quality — wisdom, abundance, "
+    "mercy — settle into the body. The halfway bell is your invitation "
+    "to ask what they would offer or what they would ask of you. "
+    "Return to the name until the closing bell.",
+)
+
+#: Stage 2 alternative — Totem Meditation (meditation_timer mode).
+_TOTEM_MEDITATION = (
+    "Five minutes of attention on a personal totem — an animal, an "
+    "object, a symbol — that has carried meaning across your life.",
+    "Bring to mind a personal totem you have felt connected to — an "
+    "animal, a stone, an inherited object, a recurring symbol. Hold "
+    "it in attention, or in your hands if it is physical. Notice "
+    "every feature you can — colour, shape, texture, the memories "
+    "braided into it. When you feel met by the totem, rest with "
+    "that meeting until the bell.",
+)
+
+
 PRESET_COPY: dict[str, tuple[str, str]] = {
     "5-4-3-2-1 grounding": _S1,
     "Tarot meditation": _S2,
@@ -261,4 +358,12 @@ PRESET_COPY: dict[str, tuple[str, str]] = {
     "Toe Wiggling": _TOE_WIGGLING,
     "Body Scan": _BODY_SCAN,
     "Progressive Muscle Relaxation": _PROGRESSIVE_MUSCLE_RELAXATION,
+    "Traffic Lights": _TRAFFIC_LIGHTS,
+    "I Ching Toss": _I_CHING_TOSS,
+    "Bibliomancy": _BIBLIOMANCY,
+    "Synchronicity Sweep": _SYNCHRONICITY_SWEEP,
+    "Trataka Candle Gazing": _TRATAKA,
+    "Dream Recollection": _DREAM_RECOLLECTION,
+    "Archetypal Mantra": _ARCHETYPAL_MANTRA,
+    "Totem Meditation": _TOTEM_MEDITATION,
 }

--- a/backend/src/seed_practice_copy.py
+++ b/backend/src/seed_practice_copy.py
@@ -449,19 +449,6 @@ _RED_SPHERE_VISUALIZATION = (
     "Hold the image until the closing bell.",
 )
 
-#: Stage 3 alternative — Love to Past Selves (meditation_timer mode).
-_LOVE_TO_PAST_SELVES = (
-    "Fifteen minutes of directing lovingkindness toward yourself at "
-    "progressively younger ages — a self-reparenting practice.",
-    "Sit comfortably with the eyes closed. Begin with your present "
-    "self — silently offer 'may you be safe, may you feel held, may "
-    "you know you are loved.' Then step backward in time: yourself "
-    "at twenty-five, fifteen, ten, five, two, in the womb. Offer the "
-    "same phrases at each age, lingering as long as feels right. "
-    "After the halfway bell, take a few breaths and re-emerge into "
-    "the present, offering the phrases one last time.",
-)
-
 
 # -- Stage 4 BLUE alternatives — heart / lovingkindness ----------------------
 
@@ -585,6 +572,25 @@ _ANCESTRAL_CONNECTION = (
     "lovingkindness in their direction. After the halfway bell, let "
     "their presence settle into your back and shoulders, and rest "
     "in the felt support until the closing bell.",
+)
+
+#: Stage 4 alternative — Love to Past Selves (meditation_timer mode).
+#:
+#: The source spreadsheet placed this row in the RED column (stage 3), but
+#: its mechanics — metta phrases toward progressively younger selves — are
+#: indistinguishable from the BLUE band's heart practices. Re-homed at the
+#: PR reviewer's request so it sits alongside Tonglen / Metta rather than
+#: warrior-stillness and fire-gazing.
+_LOVE_TO_PAST_SELVES = (
+    "Fifteen minutes of directing lovingkindness toward yourself at "
+    "progressively younger ages — a self-reparenting practice.",
+    "Sit comfortably with the eyes closed. Begin with your present "
+    "self — silently offer 'may you be safe, may you feel held, may "
+    "you know you are loved.' Then step backward in time: yourself "
+    "at twenty-five, fifteen, ten, five, two, in the womb. Offer the "
+    "same phrases at each age, lingering as long as feels right. "
+    "After the halfway bell, take a few breaths and re-emerge into "
+    "the present, offering the phrases one last time.",
 )
 
 

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -482,13 +482,6 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
         mode_config=_meditation_timer(10, halfway_bell=True),
         default_duration_minutes=10,
     ),
-    _build_preset(
-        3,
-        "Love to Past Selves",
-        mode="meditation_timer",
-        mode_config=_meditation_timer(15, halfway_bell=True),
-        default_duration_minutes=15,
-    ),
     # Stage 4 BLUE alternatives — heart / lovingkindness.
     _build_preset(
         4,
@@ -556,6 +549,15 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
     _build_preset(
         4,
         "Ancestral Connection",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
+    # Re-homed from stage 3 (source spreadsheet) at PR review request: a
+    # metta sit toward younger selves is heart-band, not energy-band.
+    _build_preset(
+        4,
+        "Love to Past Selves",
         mode="meditation_timer",
         mode_config=_meditation_timer(15, halfway_bell=True),
         default_duration_minutes=15,

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -489,6 +489,77 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
         mode_config=_meditation_timer(15, halfway_bell=True),
         default_duration_minutes=15,
     ),
+    # Stage 4 BLUE alternatives — heart / lovingkindness.
+    _build_preset(
+        4,
+        "Tonglen",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        4,
+        "I Am Love Through",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        4,
+        "Heart Centered Breath",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        4,
+        "Animist Gratitude",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        4,
+        "Hug Visualization",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        4,
+        "Relational Gratitude",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        4,
+        "Blessing Strangers",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        4,
+        "Heart Imagery",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        4,
+        "Just Like Me",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        4,
+        "Ancestral Connection",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
 ]
 
 _PRESET_PRACTICES: list[dict[str, Any]] = [*_CANONICAL_PRESETS, *_ALTERNATIVE_PRESETS]

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -617,6 +617,63 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
         mode_config=_meditation_timer(10),
         default_duration_minutes=10,
     ),
+    # Stage 6 GREEN alternatives — shadow work.
+    _build_preset(
+        6,
+        "Chair Work",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(30, halfway_bell=True),
+        default_duration_minutes=30,
+    ),
+    _build_preset(
+        6,
+        "Wording Through It",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(30, halfway_bell=True),
+        default_duration_minutes=30,
+    ),
+    _build_preset(
+        6,
+        "Wilber 3-2-1",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(30, halfway_bell=True),
+        default_duration_minutes=30,
+    ),
+    _build_preset(
+        6,
+        "Emotion Transmutation",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(30, halfway_bell=True),
+        default_duration_minutes=30,
+    ),
+    _build_preset(
+        6,
+        "Pain Body Meditation",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(30, halfway_bell=True),
+        default_duration_minutes=30,
+    ),
+    _build_preset(
+        6,
+        "Letter to the Repressed Self",
+        mode="count_up",
+        mode_config={"mode": "count_up", "soft_cap_minutes": None},
+        default_duration_minutes=_COUNT_UP_NOMINAL_DURATION_MINUTES,
+    ),
+    _build_preset(
+        6,
+        "Shadow Drawing",
+        mode="count_up",
+        mode_config={"mode": "count_up", "soft_cap_minutes": None},
+        default_duration_minutes=_COUNT_UP_NOMINAL_DURATION_MINUTES,
+    ),
+    _build_preset(
+        6,
+        "REACH Inward",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(30, halfway_bell=True),
+        default_duration_minutes=30,
+    ),
 ]
 
 _PRESET_PRACTICES: list[dict[str, Any]] = [*_CANONICAL_PRESETS, *_ALTERNATIVE_PRESETS]

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -418,6 +418,77 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
         mode_config=_meditation_timer(5),
         default_duration_minutes=5,
     ),
+    # Stage 3 RED alternatives — energy / power.
+    _build_preset(
+        3,
+        "Hand Energy Sensing",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        3,
+        "Windhorse Breathwork",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10, halfway_bell=True),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        3,
+        "Water Charging",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        3,
+        "Mini TED Talk",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        3,
+        "Power Posture",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        3,
+        "Mountain Pose Sit",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        3,
+        "Fire Gazing",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10, halfway_bell=True),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        3,
+        "Warrior Stillness",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        3,
+        "Red Sphere Visualization",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10, halfway_bell=True),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        3,
+        "Love to Past Selves",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
 ]
 
 _PRESET_PRACTICES: list[dict[str, Any]] = [*_CANONICAL_PRESETS, *_ALTERNATIVE_PRESETS]

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -674,6 +674,70 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
         mode_config=_meditation_timer(30, halfway_bell=True),
         default_duration_minutes=30,
     ),
+    # Stage 8 TEAL alternatives — integration / shamanic.
+    _build_preset(
+        8,
+        "Clairaudient Listening",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(20, halfway_bell=True),
+        default_duration_minutes=20,
+    ),
+    _build_preset(
+        8,
+        "Channeling Writing",
+        mode="count_up",
+        mode_config={"mode": "count_up", "soft_cap_minutes": None},
+        default_duration_minutes=_COUNT_UP_NOMINAL_DURATION_MINUTES,
+    ),
+    _build_preset(
+        8,
+        "Active Imagination Dialogue",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(30, halfway_bell=True),
+        default_duration_minutes=30,
+    ),
+    _build_preset(
+        8,
+        "Aura Scanning",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        8,
+        "Sangha Field Tuning",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        8,
+        "Freedom Log",
+        mode="count_up",
+        mode_config={"mode": "count_up", "soft_cap_minutes": None},
+        default_duration_minutes=_COUNT_UP_NOMINAL_DURATION_MINUTES,
+    ),
+    _build_preset(
+        8,
+        "Hierarchical Re-Feeling",
+        mode="count_up",
+        mode_config={"mode": "count_up", "soft_cap_minutes": None},
+        default_duration_minutes=_COUNT_UP_NOMINAL_DURATION_MINUTES,
+    ),
+    _build_preset(
+        8,
+        "Reflective Tarot Draw",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        8,
+        "Sacred Pause",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
 ]
 
 _PRESET_PRACTICES: list[dict[str, Any]] = [*_CANONICAL_PRESETS, *_ALTERNATIVE_PRESETS]

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -311,6 +311,56 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
         },
         default_duration_minutes=5,
     ),
+    # Stage 1 BEIGE alternatives — body-grounding / nervous-system regulation.
+    _build_preset(
+        1,
+        "Crystal Charging",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        1,
+        "Tense and Release",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5, halfway_bell=True),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        1,
+        "Contact Points",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        1,
+        "Box Breathing",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5, halfway_bell=True),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        1,
+        "Toe Wiggling",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(3),
+        default_duration_minutes=3,
+    ),
+    _build_preset(
+        1,
+        "Body Scan",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5, halfway_bell=True),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        1,
+        "Progressive Muscle Relaxation",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10, halfway_bell=True),
+        default_duration_minutes=10,
+    ),
 ]
 
 _PRESET_PRACTICES: list[dict[str, Any]] = [*_CANONICAL_PRESETS, *_ALTERNATIVE_PRESETS]

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -560,6 +560,63 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
         mode_config=_meditation_timer(15, halfway_bell=True),
         default_duration_minutes=15,
     ),
+    # Stage 5 ORANGE alternatives — activation / manifestation.
+    _build_preset(
+        5,
+        "Kapalabhati Skull Shining",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(15, halfway_bell=True),
+        default_duration_minutes=15,
+    ),
+    _build_preset(
+        5,
+        "Middle Pillar",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(20, halfway_bell=True),
+        default_duration_minutes=20,
+    ),
+    _build_preset(
+        5,
+        "Sigil Dhyana",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(20, halfway_bell=True),
+        default_duration_minutes=20,
+    ),
+    _build_preset(
+        5,
+        "Reality Selection Visualization",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(20, halfway_bell=True),
+        default_duration_minutes=20,
+    ),
+    _build_preset(
+        5,
+        "Single Instrument Listening",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(20),
+        default_duration_minutes=20,
+    ),
+    _build_preset(
+        5,
+        "Chanting or Kirtan",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(20),
+        default_duration_minutes=20,
+    ),
+    _build_preset(
+        5,
+        "Breath of Fire + Silence",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(20, halfway_bell=True),
+        default_duration_minutes=20,
+    ),
+    _build_preset(
+        5,
+        "Lion's Breath",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10),
+        default_duration_minutes=10,
+    ),
 ]
 
 _PRESET_PRACTICES: list[dict[str, Any]] = [*_CANONICAL_PRESETS, *_ALTERNATIVE_PRESETS]

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -361,6 +361,63 @@ _ALTERNATIVE_PRESETS: list[dict[str, Any]] = [
         mode_config=_meditation_timer(10, halfway_bell=True),
         default_duration_minutes=10,
     ),
+    # Stage 2 PURPLE alternatives — divination / symbolic intuition.
+    _build_preset(
+        2,
+        "Traffic Lights",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        2,
+        "I Ching Toss",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10, halfway_bell=True),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        2,
+        "Bibliomancy",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        2,
+        "Synchronicity Sweep",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
+    _build_preset(
+        2,
+        "Trataka Candle Gazing",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10, halfway_bell=True),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        2,
+        "Dream Recollection",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10, halfway_bell=True),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        2,
+        "Archetypal Mantra",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(10, halfway_bell=True),
+        default_duration_minutes=10,
+    ),
+    _build_preset(
+        2,
+        "Totem Meditation",
+        mode="meditation_timer",
+        mode_config=_meditation_timer(5),
+        default_duration_minutes=5,
+    ),
 ]
 
 _PRESET_PRACTICES: list[dict[str, Any]] = [*_CANONICAL_PRESETS, *_ALTERNATIVE_PRESETS]

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -397,7 +397,6 @@ _RED_ALTERNATIVE_SPECS: tuple[tuple[str, float, bool], ...] = (
     ("Fire Gazing", 10, True),
     ("Warrior Stillness", 10, False),
     ("Red Sphere Visualization", 10, True),
-    ("Love to Past Selves", 15, True),
 )
 
 
@@ -438,6 +437,8 @@ _BLUE_ALTERNATIVE_SPECS: tuple[tuple[str, float, bool], ...] = (
     ("Heart Imagery", 15, True),
     ("Just Like Me", 15, True),
     ("Ancestral Connection", 15, True),
+    # Re-homed from stage 3 RED at PR review request — see seed_practices.py.
+    ("Love to Past Selves", 15, True),
 )
 
 

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -385,6 +385,46 @@ async def test_purple_alternative_preset_seeds(
     assert cfg.end_bell is True
 
 
+#: ``(name, duration_minutes, halfway_bell)`` rows for each stage-3 RED
+#: alternative — drives :func:`test_red_alternative_preset_seeds`.
+_RED_ALTERNATIVE_SPECS: tuple[tuple[str, float, bool], ...] = (
+    ("Hand Energy Sensing", 5, False),
+    ("Windhorse Breathwork", 10, True),
+    ("Water Charging", 5, False),
+    ("Mini TED Talk", 10, False),
+    ("Power Posture", 10, False),
+    ("Mountain Pose Sit", 10, False),
+    ("Fire Gazing", 10, True),
+    ("Warrior Stillness", 10, False),
+    ("Red Sphere Visualization", 10, True),
+    ("Love to Past Selves", 15, True),
+)
+
+
+@pytest.mark.parametrize(("name", "duration_minutes", "halfway_bell"), _RED_ALTERNATIVE_SPECS)
+@pytest.mark.asyncio
+async def test_red_alternative_preset_seeds(
+    db_session: AsyncSession,
+    name: str,
+    duration_minutes: float,
+    halfway_bell: bool,
+) -> None:
+    """Each RED stage-3 alternative seeds as a meditation_timer with the spec's duration."""
+    row = await _seed_and_fetch(db_session, name)
+
+    assert row.stage_number == 3
+    assert row.mode == "meditation_timer"
+    assert row.description
+    assert row.instructions
+    assert row.default_duration_minutes == duration_minutes
+
+    cfg = MeditationTimerConfig.model_validate(row.mode_config)
+    assert cfg.duration_minutes == duration_minutes
+    assert cfg.halfway_bell is halfway_bell
+    assert cfg.start_bell is True
+    assert cfg.end_bell is True
+
+
 @pytest.mark.asyncio
 async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> None:
     """Re-running the seeder leaves exactly one row for each alternative preset."""
@@ -400,6 +440,7 @@ async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> 
         "Find Colors",
         *(name for name, _, _ in _BEIGE_ALTERNATIVE_SPECS),
         *(name for name, _, _ in _PURPLE_ALTERNATIVE_SPECS),
+        *(name for name, _, _ in _RED_ALTERNATIVE_SPECS),
     )
     for name in alternative_names:
         result = await db_session.execute(select(Practice).where(Practice.name == name))

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -465,6 +465,44 @@ async def test_blue_alternative_preset_seeds(
     assert cfg.end_bell is True
 
 
+#: ``(name, duration_minutes, halfway_bell)`` rows for each stage-5 ORANGE
+#: alternative — drives :func:`test_orange_alternative_preset_seeds`.
+_ORANGE_ALTERNATIVE_SPECS: tuple[tuple[str, float, bool], ...] = (
+    ("Kapalabhati Skull Shining", 15, True),
+    ("Middle Pillar", 20, True),
+    ("Sigil Dhyana", 20, True),
+    ("Reality Selection Visualization", 20, True),
+    ("Single Instrument Listening", 20, False),
+    ("Chanting or Kirtan", 20, False),
+    ("Breath of Fire + Silence", 20, True),
+    ("Lion's Breath", 10, False),
+)
+
+
+@pytest.mark.parametrize(("name", "duration_minutes", "halfway_bell"), _ORANGE_ALTERNATIVE_SPECS)
+@pytest.mark.asyncio
+async def test_orange_alternative_preset_seeds(
+    db_session: AsyncSession,
+    name: str,
+    duration_minutes: float,
+    halfway_bell: bool,
+) -> None:
+    """Each ORANGE stage-5 alternative seeds as a meditation_timer with the spec's duration."""
+    row = await _seed_and_fetch(db_session, name)
+
+    assert row.stage_number == 5
+    assert row.mode == "meditation_timer"
+    assert row.description
+    assert row.instructions
+    assert row.default_duration_minutes == duration_minutes
+
+    cfg = MeditationTimerConfig.model_validate(row.mode_config)
+    assert cfg.duration_minutes == duration_minutes
+    assert cfg.halfway_bell is halfway_bell
+    assert cfg.start_bell is True
+    assert cfg.end_bell is True
+
+
 @pytest.mark.asyncio
 async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> None:
     """Re-running the seeder leaves exactly one row for each alternative preset."""
@@ -482,6 +520,7 @@ async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> 
         *(name for name, _, _ in _PURPLE_ALTERNATIVE_SPECS),
         *(name for name, _, _ in _RED_ALTERNATIVE_SPECS),
         *(name for name, _, _ in _BLUE_ALTERNATIVE_SPECS),
+        *(name for name, _, _ in _ORANGE_ALTERNATIVE_SPECS),
     )
     for name in alternative_names:
         result = await db_session.execute(select(Practice).where(Practice.name == name))

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -11,6 +11,7 @@ from sqlmodel import select
 
 from models.practice import Practice
 from schemas.practice_mode_config import (
+    MeditationTimerConfig,
     MetronomeConfig,
     MindfulAnchorConfig,
     ModeConfigAdapter,
@@ -309,6 +310,43 @@ async def test_find_colors_preset_seeds(db_session: AsyncSession) -> None:
     assert all(c.target_count == 1 for c in cfg.categories)
 
 
+#: ``(name, duration_minutes, halfway_bell)`` rows for each stage-1 BEIGE
+#: alternative — drives :func:`test_beige_alternative_preset_seeds`.
+_BEIGE_ALTERNATIVE_SPECS: tuple[tuple[str, float, bool], ...] = (
+    ("Crystal Charging", 5, False),
+    ("Tense and Release", 5, True),
+    ("Contact Points", 5, False),
+    ("Box Breathing", 5, True),
+    ("Toe Wiggling", 3, False),
+    ("Body Scan", 5, True),
+    ("Progressive Muscle Relaxation", 10, True),
+)
+
+
+@pytest.mark.parametrize(("name", "duration_minutes", "halfway_bell"), _BEIGE_ALTERNATIVE_SPECS)
+@pytest.mark.asyncio
+async def test_beige_alternative_preset_seeds(
+    db_session: AsyncSession,
+    name: str,
+    duration_minutes: float,
+    halfway_bell: bool,
+) -> None:
+    """Each BEIGE stage-1 alternative seeds as a meditation_timer with the spec's duration."""
+    row = await _seed_and_fetch(db_session, name)
+
+    assert row.stage_number == 1
+    assert row.mode == "meditation_timer"
+    assert row.description
+    assert row.instructions
+    assert row.default_duration_minutes == duration_minutes
+
+    cfg = MeditationTimerConfig.model_validate(row.mode_config)
+    assert cfg.duration_minutes == duration_minutes
+    assert cfg.halfway_bell is halfway_bell
+    assert cfg.start_bell is True
+    assert cfg.end_bell is True
+
+
 @pytest.mark.asyncio
 async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> None:
     """Re-running the seeder leaves exactly one row for each alternative preset."""
@@ -317,7 +355,14 @@ async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> 
     assert first == _EXPECTED_PRESET_COUNT
     assert second == 0
 
-    for name in ("Touch Grass", "Mindful Eating", "Find Shapes", "Find Colors"):
+    alternative_names = (
+        "Touch Grass",
+        "Mindful Eating",
+        "Find Shapes",
+        "Find Colors",
+        *(name for name, _, _ in _BEIGE_ALTERNATIVE_SPECS),
+    )
+    for name in alternative_names:
         result = await db_session.execute(select(Practice).where(Practice.name == name))
         assert len(result.scalars().all()) == 1
 

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -565,6 +565,69 @@ async def test_green_count_up_preset_seeds(db_session: AsyncSession, name: str) 
     assert row.mode_config["soft_cap_minutes"] is None
 
 
+#: ``(name, duration_minutes, halfway_bell)`` rows for each meditation_timer
+#: stage-8 TEAL alternative — drives :func:`test_teal_timer_preset_seeds`.
+_TEAL_TIMER_SPECS: tuple[tuple[str, float, bool], ...] = (
+    ("Clairaudient Listening", 20, True),
+    ("Active Imagination Dialogue", 30, True),
+    ("Aura Scanning", 15, False),
+    ("Sangha Field Tuning", 15, False),
+    ("Reflective Tarot Draw", 5, False),
+    ("Sacred Pause", 5, False),
+)
+
+#: Open-ended count_up stage-8 TEAL alternatives —
+#: drives :func:`test_teal_count_up_preset_seeds`.
+_TEAL_COUNT_UP_NAMES: tuple[str, ...] = (
+    "Channeling Writing",
+    "Freedom Log",
+    "Hierarchical Re-Feeling",
+)
+
+#: All TEAL alternative names — used by the idempotency sweep below.
+_TEAL_ALTERNATIVE_NAMES: tuple[str, ...] = (
+    *(name for name, _, _ in _TEAL_TIMER_SPECS),
+    *_TEAL_COUNT_UP_NAMES,
+)
+
+
+@pytest.mark.parametrize(("name", "duration_minutes", "halfway_bell"), _TEAL_TIMER_SPECS)
+@pytest.mark.asyncio
+async def test_teal_timer_preset_seeds(
+    db_session: AsyncSession,
+    name: str,
+    duration_minutes: float,
+    halfway_bell: bool,
+) -> None:
+    """Each timer-mode TEAL stage-8 alternative seeds with the spec's duration."""
+    row = await _seed_and_fetch(db_session, name)
+
+    assert row.stage_number == 8
+    assert row.mode == "meditation_timer"
+    assert row.description
+    assert row.instructions
+    assert row.default_duration_minutes == duration_minutes
+
+    cfg = MeditationTimerConfig.model_validate(row.mode_config)
+    assert cfg.duration_minutes == duration_minutes
+    assert cfg.halfway_bell is halfway_bell
+    assert cfg.start_bell is True
+    assert cfg.end_bell is True
+
+
+@pytest.mark.parametrize("name", _TEAL_COUNT_UP_NAMES)
+@pytest.mark.asyncio
+async def test_teal_count_up_preset_seeds(db_session: AsyncSession, name: str) -> None:
+    """Each open-ended TEAL stage-8 alternative seeds as a count_up preset."""
+    row = await _seed_and_fetch(db_session, name)
+
+    assert row.stage_number == 8
+    assert row.mode == "count_up"
+    assert row.description
+    assert row.instructions
+    assert row.mode_config["soft_cap_minutes"] is None
+
+
 @pytest.mark.asyncio
 async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> None:
     """Re-running the seeder leaves exactly one row for each alternative preset."""
@@ -584,6 +647,7 @@ async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> 
         *(name for name, _, _ in _BLUE_ALTERNATIVE_SPECS),
         *(name for name, _, _ in _ORANGE_ALTERNATIVE_SPECS),
         *_GREEN_ALTERNATIVE_NAMES,
+        *_TEAL_ALTERNATIVE_NAMES,
     )
     for name in alternative_names:
         result = await db_session.execute(select(Practice).where(Practice.name == name))

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -425,6 +425,46 @@ async def test_red_alternative_preset_seeds(
     assert cfg.end_bell is True
 
 
+#: ``(name, duration_minutes, halfway_bell)`` rows for each stage-4 BLUE
+#: alternative — drives :func:`test_blue_alternative_preset_seeds`.
+_BLUE_ALTERNATIVE_SPECS: tuple[tuple[str, float, bool], ...] = (
+    ("Tonglen", 15, True),
+    ("I Am Love Through", 15, True),
+    ("Heart Centered Breath", 15, True),
+    ("Animist Gratitude", 10, False),
+    ("Hug Visualization", 10, False),
+    ("Relational Gratitude", 15, True),
+    ("Blessing Strangers", 10, False),
+    ("Heart Imagery", 15, True),
+    ("Just Like Me", 15, True),
+    ("Ancestral Connection", 15, True),
+)
+
+
+@pytest.mark.parametrize(("name", "duration_minutes", "halfway_bell"), _BLUE_ALTERNATIVE_SPECS)
+@pytest.mark.asyncio
+async def test_blue_alternative_preset_seeds(
+    db_session: AsyncSession,
+    name: str,
+    duration_minutes: float,
+    halfway_bell: bool,
+) -> None:
+    """Each BLUE stage-4 alternative seeds as a meditation_timer with the spec's duration."""
+    row = await _seed_and_fetch(db_session, name)
+
+    assert row.stage_number == 4
+    assert row.mode == "meditation_timer"
+    assert row.description
+    assert row.instructions
+    assert row.default_duration_minutes == duration_minutes
+
+    cfg = MeditationTimerConfig.model_validate(row.mode_config)
+    assert cfg.duration_minutes == duration_minutes
+    assert cfg.halfway_bell is halfway_bell
+    assert cfg.start_bell is True
+    assert cfg.end_bell is True
+
+
 @pytest.mark.asyncio
 async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> None:
     """Re-running the seeder leaves exactly one row for each alternative preset."""
@@ -441,6 +481,7 @@ async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> 
         *(name for name, _, _ in _BEIGE_ALTERNATIVE_SPECS),
         *(name for name, _, _ in _PURPLE_ALTERNATIVE_SPECS),
         *(name for name, _, _ in _RED_ALTERNATIVE_SPECS),
+        *(name for name, _, _ in _BLUE_ALTERNATIVE_SPECS),
     )
     for name in alternative_names:
         result = await db_session.execute(select(Practice).where(Practice.name == name))

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -503,6 +503,68 @@ async def test_orange_alternative_preset_seeds(
     assert cfg.end_bell is True
 
 
+#: ``(name, duration_minutes, halfway_bell)`` rows for each meditation_timer
+#: stage-6 GREEN alternative — drives :func:`test_green_timer_preset_seeds`.
+_GREEN_TIMER_SPECS: tuple[tuple[str, float, bool], ...] = (
+    ("Chair Work", 30, True),
+    ("Wording Through It", 30, True),
+    ("Wilber 3-2-1", 30, True),
+    ("Emotion Transmutation", 30, True),
+    ("Pain Body Meditation", 30, True),
+    ("REACH Inward", 30, True),
+)
+
+#: Open-ended count_up stage-6 GREEN alternatives —
+#: drives :func:`test_green_count_up_preset_seeds`.
+_GREEN_COUNT_UP_NAMES: tuple[str, ...] = (
+    "Letter to the Repressed Self",
+    "Shadow Drawing",
+)
+
+#: All GREEN alternative names — used by the idempotency sweep below.
+_GREEN_ALTERNATIVE_NAMES: tuple[str, ...] = (
+    *(name for name, _, _ in _GREEN_TIMER_SPECS),
+    *_GREEN_COUNT_UP_NAMES,
+)
+
+
+@pytest.mark.parametrize(("name", "duration_minutes", "halfway_bell"), _GREEN_TIMER_SPECS)
+@pytest.mark.asyncio
+async def test_green_timer_preset_seeds(
+    db_session: AsyncSession,
+    name: str,
+    duration_minutes: float,
+    halfway_bell: bool,
+) -> None:
+    """Each timer-mode GREEN stage-6 alternative seeds with the spec's duration."""
+    row = await _seed_and_fetch(db_session, name)
+
+    assert row.stage_number == 6
+    assert row.mode == "meditation_timer"
+    assert row.description
+    assert row.instructions
+    assert row.default_duration_minutes == duration_minutes
+
+    cfg = MeditationTimerConfig.model_validate(row.mode_config)
+    assert cfg.duration_minutes == duration_minutes
+    assert cfg.halfway_bell is halfway_bell
+    assert cfg.start_bell is True
+    assert cfg.end_bell is True
+
+
+@pytest.mark.parametrize("name", _GREEN_COUNT_UP_NAMES)
+@pytest.mark.asyncio
+async def test_green_count_up_preset_seeds(db_session: AsyncSession, name: str) -> None:
+    """Each open-ended GREEN stage-6 alternative seeds as a count_up preset."""
+    row = await _seed_and_fetch(db_session, name)
+
+    assert row.stage_number == 6
+    assert row.mode == "count_up"
+    assert row.description
+    assert row.instructions
+    assert row.mode_config["soft_cap_minutes"] is None
+
+
 @pytest.mark.asyncio
 async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> None:
     """Re-running the seeder leaves exactly one row for each alternative preset."""
@@ -521,6 +583,7 @@ async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> 
         *(name for name, _, _ in _RED_ALTERNATIVE_SPECS),
         *(name for name, _, _ in _BLUE_ALTERNATIVE_SPECS),
         *(name for name, _, _ in _ORANGE_ALTERNATIVE_SPECS),
+        *_GREEN_ALTERNATIVE_NAMES,
     )
     for name in alternative_names:
         result = await db_session.execute(select(Practice).where(Practice.name == name))

--- a/backend/tests/test_seed_practices.py
+++ b/backend/tests/test_seed_practices.py
@@ -347,6 +347,44 @@ async def test_beige_alternative_preset_seeds(
     assert cfg.end_bell is True
 
 
+#: ``(name, duration_minutes, halfway_bell)`` rows for each stage-2 PURPLE
+#: alternative — drives :func:`test_purple_alternative_preset_seeds`.
+_PURPLE_ALTERNATIVE_SPECS: tuple[tuple[str, float, bool], ...] = (
+    ("Traffic Lights", 5, False),
+    ("I Ching Toss", 10, True),
+    ("Bibliomancy", 5, False),
+    ("Synchronicity Sweep", 5, False),
+    ("Trataka Candle Gazing", 10, True),
+    ("Dream Recollection", 10, True),
+    ("Archetypal Mantra", 10, True),
+    ("Totem Meditation", 5, False),
+)
+
+
+@pytest.mark.parametrize(("name", "duration_minutes", "halfway_bell"), _PURPLE_ALTERNATIVE_SPECS)
+@pytest.mark.asyncio
+async def test_purple_alternative_preset_seeds(
+    db_session: AsyncSession,
+    name: str,
+    duration_minutes: float,
+    halfway_bell: bool,
+) -> None:
+    """Each PURPLE stage-2 alternative seeds as a meditation_timer with the spec's duration."""
+    row = await _seed_and_fetch(db_session, name)
+
+    assert row.stage_number == 2
+    assert row.mode == "meditation_timer"
+    assert row.description
+    assert row.instructions
+    assert row.default_duration_minutes == duration_minutes
+
+    cfg = MeditationTimerConfig.model_validate(row.mode_config)
+    assert cfg.duration_minutes == duration_minutes
+    assert cfg.halfway_bell is halfway_bell
+    assert cfg.start_bell is True
+    assert cfg.end_bell is True
+
+
 @pytest.mark.asyncio
 async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> None:
     """Re-running the seeder leaves exactly one row for each alternative preset."""
@@ -361,6 +399,7 @@ async def test_seed_is_idempotent_with_new_presets(db_session: AsyncSession) -> 
         "Find Shapes",
         "Find Colors",
         *(name for name, _, _ in _BEIGE_ALTERNATIVE_SPECS),
+        *(name for name, _, _ in _PURPLE_ALTERNATIVE_SPECS),
     )
     for name in alternative_names:
         result = await db_session.execute(select(Practice).where(Practice.name == name))

--- a/prompts/github-issues/README.md
+++ b/prompts/github-issues/README.md
@@ -218,6 +218,30 @@ Two new modes (`random_interval_bell`, `card_meditation`) round out the engine t
 | 06 | [Build `CardMeditationView` + image picker](custom-practices-06-card-meditation-frontend.md) | Frontend | ~350 |
 | 07 | [Catalog browse + Create-custom flow](custom-practices-07-catalog-and-create-flow.md) | Frontend | ~450 |
 
+### Spiral Dynamics practice-preset catalog expansion
+
+Seed ~60 alternative presets across stages 1-8 (BEIGE through TEAL) so each
+Spiral Dynamics frequency band offers a deeper menu of practices alongside
+its canonical stage practice. Pure content: no new modes, no migrations,
+no frontend work. Each sub-issue handles one color/stage and is fully
+independent of the others.
+
+| # | Issue | Stage | New presets | Est. LoC |
+|---|-------|-------|-------------|----------|
+| — | [Epic tracker](practice-presets-epic.md) | — | — | — |
+| 01 | [Seed BEIGE alternatives](practice-presets-01-beige-grounding.md)        | 1 | 7  | ~250 |
+| 02 | [Seed PURPLE alternatives](practice-presets-02-purple-divination.md)     | 2 | 8  | ~275 |
+| 03 | [Seed RED alternatives](practice-presets-03-red-energy.md)               | 3 | 10 | ~325 |
+| 04 | [Seed BLUE alternatives](practice-presets-04-blue-heart.md)              | 4 | 10 | ~325 |
+| 05 | [Seed ORANGE alternatives](practice-presets-05-orange-activation.md)     | 5 | 8  | ~275 |
+| 06 | [Seed GREEN alternatives](practice-presets-06-green-shadow.md)           | 6 | 8  | ~275 |
+| 07 | [Seed TEAL alternatives](practice-presets-07-teal-integration.md)        | 8 | 9  | ~300 |
+
+Stages 7 (YELLOW), 9 (ULTRAVIOLET), and 10 (CLEAR LIGHT) carry no
+alternatives in the source table and are not part of this epic. All seven
+sub-issues are fully independent — they touch the same three files but at
+disjoint locations and can ship in any order or in parallel.
+
 ### Generalize grounding techniques
 
 Add **Find Shapes**, **Find Colors**, **Touch Grass**, and **Mindful

--- a/prompts/github-issues/practice-presets-01-beige-grounding.md
+++ b/prompts/github-issues/practice-presets-01-beige-grounding.md
@@ -1,0 +1,128 @@
+# practice-presets-01: Seed BEIGE (stage 1) alternative grounding presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~250
+
+## Role
+
+You are a backend engineer adding stage-1 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **seven** new BEIGE-band grounding alternatives at stage 1 so the
+catalog menu for a stage-1 user offers a body-anchored toolkit beyond
+the canonical 5-4-3-2-1 grounding. The new presets are:
+
+| Name                           | Mode                | Duration | Notes                                       |
+|--------------------------------|---------------------|----------|---------------------------------------------|
+| Crystal Charging               | `meditation_timer`  | 5 min    | Hold a chosen crystal outdoors / on earth   |
+| Tense and Release              | `meditation_timer`  | 5 min    | Halfway bell. Clench/release body scan      |
+| Contact Points                 | `meditation_timer`  | 5 min    | Notice every point body meets a surface     |
+| Box Breathing                  | `meditation_timer`  | 5 min    | Halfway bell. 4-4-4-4 pattern               |
+| Toe Wiggling                   | `meditation_timer`  | 3 min    | Feel feet and wiggle toes                   |
+| Body Scan                      | `meditation_timer`  | 5 min    | Halfway bell. Toes-to-head sweep            |
+| Progressive Muscle Relaxation  | `meditation_timer`  | 10 min   | Halfway bell. Jacobson PMR                  |
+
+## Context
+
+`backend/src/seed_practices.py:257-314` shows the four existing stage-1
+alternatives (Touch Grass, Mindful Eating, Find Shapes, Find Colors).
+The source table's *Stand Barefoot Outdoors*, *Square-Circle-Triangle x5*,
+and *Colors of the Rainbow* are intentionally skipped because they are
+duplicates of those four — see the epic's constraints section.
+
+Every preset in this issue uses `meditation_timer` mode with the
+existing `_meditation_timer(...)` helper at `seed_practices.py:49-57`.
+No new mode helpers required.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One module-level `_TUPLE` constant per preset, named after the
+     practice (e.g. `_CRYSTAL_CHARGING`, `_BOX_BREATHING`).
+   - Append each to the `PRESET_COPY` dict at the bottom of the file,
+     keyed by the exact display name used in `seed_practices.py`.
+   - Each description: 1-2 sentences, plain English, ≤ 2000 chars.
+   - Each instructions block: 3-6 sentences, second-person imperative,
+     ≤ 10000 chars. Lift from the source-table cell and elaborate
+     enough that a first-timer can complete the practice.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All seven entries land at `stage_number=1`.
+   - Use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`
+     for each `mode_config`.
+   - Keep the new entries grouped together with a brief comment
+     describing the BEIGE block, e.g.:
+     ```python
+     # Stage 1 alternatives — body-grounding / nervous-system regulation.
+     _build_preset(1, "Crystal Charging", ...),
+     ...
+     ```
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset following the
+     `test_touch_grass_preset_seeds` pattern at line 233. Verify:
+     - The row is present after `seed_practices(session)`.
+     - `mode == "meditation_timer"`.
+     - `mode_config["duration_minutes"]` matches the spec.
+     - `mode_config["halfway_bell"]` matches where applicable.
+     - `stage_number == 1`.
+   - **Do not** add a new global-invariant test — the existing
+     `test_every_preset_sits_on_a_known_stage` and
+     `test_every_preset_mode_config_is_valid` automatically cover the
+     new rows.
+   - Update the `EXPECTED_PRESET_COUNT` literal at the top of the file
+     (line ~28) by +7.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] `pytest backend/ -k preset` green.
+- [ ] `python -c "from seed_practices import PRESET_PRACTICES; \
+       print(len([p for p in PRESET_PRACTICES if p['stage_number']==1]))"`
+       returns `12` (1 canonical + 4 prior alternatives + 7 new).
+- [ ] `GET /practices?stage=1` returns 12 rows.
+- [ ] `STAGE_TO_PRESET_NAME[1]` is still `"5-4-3-2-1 grounding"`.
+- [ ] Running the seeder twice still inserts 7 net new rows the first
+      time and 0 the second.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 7 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 7 copy tuples + entries in `PRESET_COPY` |
+| `backend/tests/test_seed_practices.py` | Modify — add 7 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`. None of the seven proposed
+  names collide with existing entries; do not rename them without
+  checking the duplicate-name guard at `seed_practices.py:337-341`.
+- Do not change `_CANONICAL_PRESETS` or the existing stage-1 alternatives.
+- Keep descriptions and instructions tight; second-person imperative
+  ("Sit upright. Inhale…") matches the existing copy voice at
+  `seed_practice_copy.py:36-104`.
+
+## Example output
+
+```bash
+$ curl -s 'http://localhost:8000/practices?stage=1' | jq '.[] | .name'
+"5-4-3-2-1 grounding"
+"Touch Grass"
+"Mindful Eating"
+"Find Shapes"
+"Find Colors"
+"Crystal Charging"
+"Tense and Release"
+"Contact Points"
+"Box Breathing"
+"Toe Wiggling"
+"Body Scan"
+"Progressive Muscle Relaxation"
+```

--- a/prompts/github-issues/practice-presets-02-purple-divination.md
+++ b/prompts/github-issues/practice-presets-02-purple-divination.md
@@ -1,0 +1,95 @@
+# practice-presets-02: Seed PURPLE (stage 2) alternative divination / symbol presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~275
+
+## Role
+
+You are a backend engineer adding stage-2 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **eight** new PURPLE-band divination / symbolic alternatives at
+stage 2 so the catalog menu offers a richer set of intuitive practices
+beyond the canonical daily Tarot draw. The new presets are:
+
+| Name                  | Mode               | Duration | Halfway bell | Source row                                             |
+|-----------------------|--------------------|----------|--------------|--------------------------------------------------------|
+| Traffic Lights        | `meditation_timer` | 5 min    | No           | "Traffic lights" — visualize and decode color signals  |
+| I Ching Toss          | `meditation_timer` | 10 min   | Yes          | "I Ching coin toss with meditative journaling"         |
+| Bibliomancy           | `meditation_timer` | 5 min    | No           | "Bibliomancy: random passage reading and reflection"   |
+| Synchronicity Sweep   | `meditation_timer` | 5 min    | No           | "Tracking Synchronicity"                               |
+| Trataka Candle Gazing | `meditation_timer` | 10 min   | Yes          | "Candle gazing (Trataka) while inviting intuitive imagery" |
+| Dream Recollection    | `meditation_timer` | 10 min   | Yes          | "Dream recollection and symbol mapping"                |
+| Archetypal Mantra     | `meditation_timer` | 10 min   | Yes          | "Repetitive mantra with archetypal resonance"          |
+| Totem Meditation      | `meditation_timer` | 5 min    | No           | "Meditating on a personal totem or object"             |
+
+## Context
+
+Stage 2's canonical preset is `Tarot meditation` (mode `tarot`). These
+alternatives all use the simpler `meditation_timer` engine with
+descriptive instructions so they pose zero migration / schema risk — the
+intuitive content is in the copy, not the mode.
+
+See `backend/src/seed_practices.py:179-189` for the canonical entry and
+`seed_practice_copy.py:26-33` for the voice / length of the canonical
+copy.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, named `_TRAFFIC_LIGHTS`, `_I_CHING_TOSS`,
+     `_BIBLIOMANCY`, `_SYNCHRONICITY_SWEEP`, `_TRATAKA`,
+     `_DREAM_RECOLLECTION`, `_ARCHETYPAL_MANTRA`, `_TOTEM_MEDITATION`.
+   - Each description: 1-2 sentences capturing the practice's flavour.
+   - Each instructions block: 3-6 sentences, second-person imperative,
+     covering setup, focus, and completion. For divination practices,
+     name the *posture* explicitly (e.g. "Sit with the coins in your
+     palm before the first toss") so a beginner can perform the
+     practice without further context.
+   - Append entries to `PRESET_COPY` keyed by display name.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All eight at `stage_number=2`.
+   - All use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Group under a brief comment, e.g.
+     `# Stage 2 alternatives — divination / symbolic intuition.`
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset, mirroring
+     `test_touch_grass_preset_seeds`. Verify the row's
+     `stage_number`, `mode`, `mode_config.duration_minutes`, and
+     `mode_config.halfway_bell` (where set).
+   - Bump `EXPECTED_PRESET_COUNT` by +8.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All eight rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[2]` is still `"Tarot meditation"`.
+- [ ] `GET /practices?stage=2` returns 9 rows (canonical + 8 new).
+- [ ] Re-running the seeder is a no-op (idempotent).
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 8 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 8 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 8 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Tarot meditation` entry or its config.
+- Do not introduce new modes. The intuitive flavour of these practices
+  belongs in the copy, not the engine. If you believe a row really
+  wants `tarot` or `metronome`, surface the choice in the PR description
+  before opening the PR.
+- Match the existing copy voice — declarative, present-tense, no
+  hedging, no marketing language.

--- a/prompts/github-issues/practice-presets-03-red-energy.md
+++ b/prompts/github-issues/practice-presets-03-red-energy.md
@@ -1,0 +1,94 @@
+# practice-presets-03: Seed RED (stage 3) alternative energy / power presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~325
+
+## Role
+
+You are a backend engineer adding stage-3 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **ten** new RED-band energy / power-building alternatives at
+stage 3 so the catalog menu offers a wider toolkit beyond canonical
+belly breathing. The new presets are:
+
+| Name                       | Mode               | Duration | Halfway bell | Source row                                                       |
+|----------------------------|--------------------|----------|--------------|------------------------------------------------------------------|
+| Hand Energy Sensing        | `meditation_timer` | 5 min    | No           | "Raise energy by rubbing hands together…"                        |
+| Windhorse Breathwork       | `meditation_timer` | 10 min   | Yes          | "'Windhorse' breathwork (stoking inner fire)"                    |
+| Water Charging             | `meditation_timer` | 5 min    | No           | "Charging Water using Damien Echols's techniques"                |
+| Mini TED Talk              | `meditation_timer` | 10 min   | No           | "Mini-TED Talk: describe something you understand well…"         |
+| Power Posture              | `meditation_timer` | 10 min   | No           | "Power posture meditation with steady breath"                    |
+| Mountain Pose Sit          | `meditation_timer` | 10 min   | No           | "Seated mountain pose visualization ('I cannot be moved')"       |
+| Fire Gazing                | `meditation_timer` | 10 min   | Yes          | "Fire gazing while anchoring into the solar plexus"              |
+| Warrior Stillness          | `meditation_timer` | 10 min   | No           | "Holding one physical posture (e.g., warrior pose) in stillness" |
+| Red Sphere Visualization   | `meditation_timer` | 10 min   | Yes          | "Visualizing a red sphere of light pulsing in your gut"          |
+| Love to Past Selves        | `meditation_timer` | 15 min   | Yes          | "Sending love to different ages of your past self"               |
+
+## Context
+
+Stage 3's canonical preset is `Belly breathing`
+(`meditation_timer`, 10 min). The new alternatives mostly follow the
+same 10-minute timer with a halfway bell for the longer / more
+demanding ones. `Love to Past Selves` is a 15-minute sit because the
+practice steps through multiple ages.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug (e.g.
+     `_HAND_ENERGY_SENSING`, `_MINI_TED_TALK`, `_RED_SPHERE_VISUALIZATION`).
+   - Each instructions block must include setup (posture, where to
+     focus attention), the practice itself, and a closing cue
+     ("until the bell," "for the rest of the timer").
+   - For `Mini TED Talk` specifically: spell out that the user should
+     speak aloud or sub-vocalize for the full duration, picking a topic
+     of genuine expertise.
+   - For `Water Charging`: brief framing of the Damien Echols technique
+     (sigil + intention into a held glass of water) without invoking
+     real ritual gear.
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All ten at `stage_number=3`.
+   - All use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Group under a `# Stage 3 alternatives — energy / power.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset, mirroring
+     `test_touch_grass_preset_seeds`. Verify the row's
+     `stage_number`, `mode`, and the `mode_config.duration_minutes` /
+     `mode_config.halfway_bell` flags.
+   - Bump `EXPECTED_PRESET_COUNT` by +10.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All ten rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[3]` is still `"Belly breathing"`.
+- [ ] `GET /practices?stage=3` returns 11 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 10 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 10 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 10 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Belly breathing` entry.
+- Do not introduce new modes; energy-raising flavour belongs in copy.
+- Keep instructions safe: no breath-retention practice longer than the
+  canonical Wim Hof preset, no advice that contradicts general medical
+  guidance. The `Windhorse Breathwork` and `Fire Gazing` instructions
+  should explicitly tell the user to ease off if they feel lightheaded.

--- a/prompts/github-issues/practice-presets-04-blue-heart.md
+++ b/prompts/github-issues/practice-presets-04-blue-heart.md
@@ -1,0 +1,90 @@
+# practice-presets-04: Seed BLUE (stage 4) alternative heart / lovingkindness presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~325
+
+## Role
+
+You are a backend engineer adding stage-4 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **ten** new BLUE-band heart / lovingkindness alternatives at
+stage 4 so the catalog menu carries a deep menu of relational practices
+beyond canonical Metta. The new presets are:
+
+| Name                    | Mode               | Duration | Halfway bell | Source row                                                   |
+|-------------------------|--------------------|----------|--------------|--------------------------------------------------------------|
+| Tonglen                 | `meditation_timer` | 15 min   | Yes          | "Tonglen: breathing in pain, breathing out compassion"       |
+| I Am Love Through       | `meditation_timer` | 15 min   | Yes          | "Selig's 'I am Love through so and so'"                      |
+| Heart Centered Breath   | `meditation_timer` | 15 min   | Yes          | "Heart-centered breath (inhale into heart, exhale out)"      |
+| Animist Gratitude       | `meditation_timer` | 10 min   | No           | "Animist Gratitude: Speaking thanks aloud for local beings"  |
+| Hug Visualization       | `meditation_timer` | 10 min   | No           | "Guided visualization of hugging someone you miss"           |
+| Relational Gratitude    | `meditation_timer` | 15 min   | Yes          | "Gratitude meditation focused on relationships"              |
+| Blessing Strangers      | `meditation_timer` | 10 min   | No           | "Mentally blessing strangers while people-watching"          |
+| Heart Imagery           | `meditation_timer` | 15 min   | Yes          | "Meditating on heart imagery (green rose, spiral, chalice)"  |
+| Just Like Me            | `meditation_timer` | 15 min   | Yes          | "Repeating the phrase: 'Just like me, this being seeks happiness'" |
+| Ancestral Connection    | `meditation_timer` | 15 min   | Yes          | "Establishing ancestral connection via gratitude or lovingkindness" |
+
+## Context
+
+Stage 4's canonical preset is `Metta` (`meditation_timer`, 15 min,
+halfway bell). The new alternatives keep the 15-minute heart-sit default
+for full-arc practices and drop to 10 minutes for the lighter
+"in-the-world" practices (`Animist Gratitude`, `Hug Visualization`,
+`Blessing Strangers`).
+
+`Blessing Strangers` is intended to be done in public (a café, a park);
+the instructions must make this explicit and tell the user they can do
+it with eyes open.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug.
+   - Each instructions block: 3-6 sentences. For phrase-based practices
+     (`Just Like Me`, `I Am Love Through`), quote the exact phrase the
+     user is meant to repeat so the preset is self-contained.
+   - For `Tonglen`: keep the breath-direction language unambiguous
+     ("inhale the discomfort of [target]; exhale ease toward them").
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All ten at `stage_number=4`.
+   - All use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Group under a `# Stage 4 alternatives — heart / lovingkindness.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset, mirroring
+     `test_touch_grass_preset_seeds`.
+   - Bump `EXPECTED_PRESET_COUNT` by +10.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All ten rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[4]` is still `"Metta"`.
+- [ ] `GET /practices?stage=4` returns 11 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 10 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 10 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 10 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Metta` entry.
+- Do not introduce new modes.
+- Heart practices benefit from a halfway bell as an "open the circle"
+  cue; default to `halfway_bell=True` for any 15-minute sit and
+  `halfway_bell=False` for 10-minute / in-the-world variants.

--- a/prompts/github-issues/practice-presets-05-orange-activation.md
+++ b/prompts/github-issues/practice-presets-05-orange-activation.md
@@ -1,0 +1,90 @@
+# practice-presets-05: Seed ORANGE (stage 5) alternative activation / manifestation presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~275
+
+## Role
+
+You are a backend engineer adding stage-5 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **eight** new ORANGE-band activation / manifestation alternatives
+at stage 5 so the catalog menu carries a wider menu of high-energy
+practices beyond canonical Wim Hof. The new presets are:
+
+| Name                              | Mode               | Duration | Halfway bell | Source row                                                       |
+|-----------------------------------|--------------------|----------|--------------|------------------------------------------------------------------|
+| Kapalabhati Skull Shining         | `meditation_timer` | 15 min   | Yes          | "Skull Shining (Kapalabhati) to boost focus and alertness"       |
+| Middle Pillar                     | `meditation_timer` | 20 min   | Yes          | "'Middle Pillar' Golden Dawn exercise (energy body building)"    |
+| Sigil Dhyana                      | `meditation_timer` | 20 min   | Yes          | "Chaos Magick's style meditation of Dhyana on Sigils…"           |
+| Reality Selection Visualization   | `meditation_timer` | 20 min   | Yes          | "Neville Goddard style hypnagogic visualization…"                |
+| Single Instrument Listening       | `meditation_timer` | 20 min   | No           | "Listen to energizing music, focusing on one instrument"         |
+| Chanting or Kirtan                | `meditation_timer` | 20 min   | No           | "Chanting or Kirtan"                                             |
+| Breath of Fire + Silence          | `meditation_timer` | 20 min   | Yes          | "Breath of Fire followed by a period of silence"                 |
+| Lion's Breath                     | `meditation_timer` | 10 min   | No           | "Lion's Breath"                                                  |
+
+## Context
+
+Stage 5's canonical preset is `Wim Hof method` (`meditation_timer`,
+20 min). The new alternatives mostly hold to a 20-minute sit so the
+heart-rate / energy-spike profile is consistent with the stage's
+intent. `Lion's Breath` is a shorter 10-minute session because the
+practice itself is cathartic and quick.
+
+`Breath of Fire + Silence` uses a halfway bell to mark the transition
+from active breathwork to silent integration.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug.
+   - For breath-intensive practices (`Kapalabhati`, `Breath of Fire`,
+     `Lion's Breath`): include an explicit safety note — "ease off if
+     you feel lightheaded; rest in normal breathing until it passes" —
+     consistent with the canonical Wim Hof copy at
+     `seed_practice_copy.py:56-61`.
+   - For `Middle Pillar` and `Sigil Dhyana`: brief framing without
+     requiring real ritual gear; the practice should be feasible from
+     a seat with eyes closed.
+   - For `Single Instrument Listening`: tell the user to queue a song
+     before starting and stay with the one instrument until the bell.
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - All eight at `stage_number=5`.
+   - All use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Group under a `# Stage 5 alternatives — activation / manifestation.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset.
+   - Bump `EXPECTED_PRESET_COUNT` by +8.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All eight rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[5]` is still `"Wim Hof method"`.
+- [ ] `GET /practices?stage=5` returns 9 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 8 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 8 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 8 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Wim Hof method` entry.
+- Do not introduce new modes.
+- Every breathwork preset must carry an explicit safety note in its
+  instructions.

--- a/prompts/github-issues/practice-presets-06-green-shadow.md
+++ b/prompts/github-issues/practice-presets-06-green-shadow.md
@@ -1,0 +1,111 @@
+# practice-presets-06: Seed GREEN (stage 6) alternative shadow-work presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~275
+
+## Role
+
+You are a backend engineer adding stage-6 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **eight** new GREEN-band shadow-work alternatives at stage 6 so
+the catalog menu carries a deeper toolkit beyond canonical "Coal to
+Gold" Shadow Work. The new presets are:
+
+| Name                            | Mode               | Duration | Halfway bell | Source row                                                       |
+|---------------------------------|--------------------|----------|--------------|------------------------------------------------------------------|
+| Chair Work                      | `meditation_timer` | 30 min   | Yes          | "Chair work (self vs. shadow) alternating every 5 min"           |
+| Wording Through It              | `meditation_timer` | 30 min   | Yes          | "Wording Through it" — speak the shadow content aloud            |
+| Wilber 3-2-1                    | `meditation_timer` | 30 min   | Yes          | "Wilber's '3-2-1' Practice"                                      |
+| Emotion Transmutation           | `meditation_timer` | 30 min   | Yes          | "Tibetan Buddhist emotion transmutation"                         |
+| Pain Body Meditation            | `meditation_timer` | 30 min   | Yes          | "Meditating on the Pain Body a la Eckhart Tolle"                 |
+| Letter to the Repressed Self    | `count_up`         | —        | —            | "Stream of consciousness quick-write of a letter to your most repressed self" |
+| Shadow Drawing                  | `count_up`         | —        | —            | "Drawing your shadow self and holding eye contact with it"       |
+| REACH Inward                    | `meditation_timer` | 30 min   | Yes          | "REACH directed inward (From Rise Above)"                        |
+
+## Context
+
+Stage 6's canonical preset is `Shadow work` (`metronome`, 30 min). The
+new alternatives mostly hold to a 30-minute sit consistent with the
+stage. **Two** of the alternatives are open-ended creative practices —
+`Letter to the Repressed Self` and `Shadow Drawing` — and use
+`count_up` mode so the user can take as long as the practice asks for.
+
+The `count_up` mode is already exercised by the canonical
+`Dog Walkin' Shamanism` preset
+(`seed_practices.py:230-236`). Use the same shape:
+```python
+mode="count_up",
+mode_config={"mode": "count_up", "soft_cap_minutes": None},
+default_duration_minutes=_COUNT_UP_NOMINAL_DURATION_MINUTES,
+```
+The `_COUNT_UP_NOMINAL_DURATION_MINUTES` constant is already defined
+at `seed_practices.py:46` — reuse it; do not introduce a per-issue
+duplicate.
+
+For `Chair Work`: the source row says "alternating every 5 min."
+Encode the cadence in the instructions ("every five minutes, swap
+chairs"), not in the engine. A `metronome` or `interval_bell`
+implementation might be a nicer fit later, but is out of scope for
+this content-only issue.
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug.
+   - For `Chair Work`: explain the two-chair / inner-critic technique
+     and tell the user to physically switch seats every five minutes.
+   - For `Wilber 3-2-1`: name the three steps (face it / talk to it /
+     be it) so a first-timer can perform the practice without a
+     reference.
+   - For `Pain Body Meditation`: include the Tolle framing — observe
+     the pain body as a distinct presence rather than identifying
+     with it.
+   - For the two `count_up` practices: tell the user they can stop
+     when the practice feels complete and mark the session done.
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - Six entries use `_meditation_timer(30, halfway_bell=True)`.
+   - Two entries (`Letter to the Repressed Self`, `Shadow Drawing`)
+     use the `count_up` shape above.
+   - Group under a `# Stage 6 alternatives — shadow work.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset. For the `count_up` presets,
+     verify `mode == "count_up"` and `mode_config["soft_cap_minutes"]
+     is None` (matching the canonical Dog Walkin' Shamanism test).
+   - Bump `EXPECTED_PRESET_COUNT` by +8.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All eight rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[6]` is still `"Shadow work"`.
+- [ ] `GET /practices?stage=6` returns 9 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 8 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 8 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 8 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Shadow work` entry.
+- Do not introduce new modes; the two `count_up` presets reuse the
+  already-validated shape from Dog Walkin' Shamanism.
+- Shadow-work copy should warn that strong emotion is possible and
+  invite the user to pause / journal rather than push through — match
+  the careful voice of the canonical entry at
+  `seed_practice_copy.py:64-70`.

--- a/prompts/github-issues/practice-presets-07-teal-integration.md
+++ b/prompts/github-issues/practice-presets-07-teal-integration.md
@@ -1,0 +1,109 @@
+# practice-presets-07: Seed TEAL (stage 8) alternative integration / shamanic presets
+
+**Labels:** `backend`, `feature`, `practice`, `seeding`
+**Epic:** [Spiral Dynamics practice-preset catalog expansion](practice-presets-epic.md)
+**Depends on:** none
+**Estimated LoC:** ~300
+
+## Role
+
+You are a backend engineer adding stage-8 alternative presets to the
+catalog. You follow the existing seed-preset pattern in
+`backend/src/seed_practices.py` and validate every payload at import
+time via `ModeConfigAdapter`.
+
+## Goal
+
+Seed **nine** new TEAL-band integration / shamanic alternatives at
+stage 8 so the catalog menu carries a deeper toolkit beyond canonical
+Dog Walkin' Shamanism. The new presets are:
+
+| Name                          | Mode               | Duration | Halfway bell | Source row                                                       |
+|-------------------------------|--------------------|----------|--------------|------------------------------------------------------------------|
+| Clairaudient Listening        | `meditation_timer` | 20 min   | Yes          | "Clairaudient Practice: Sitting and listening to the 'still small voice' inside" |
+| Channeling Writing            | `count_up`         | —        | —            | "Channeling writing: ask 'What would you have me know?'"         |
+| Active Imagination Dialogue   | `meditation_timer` | 30 min   | Yes          | "Jung's 'Active Imagination' dialogue with a part of self"       |
+| Aura Scanning                 | `meditation_timer` | 15 min   | No           | "Subtle energy scanning of your own aura"                        |
+| Sangha Field Tuning           | `meditation_timer` | 15 min   | No           | "Tuning into a collective prayer field or sangha field"          |
+| Freedom Log                   | `count_up`         | —        | —            | "Freedom Log: Re-patterning practice"                            |
+| Hierarchical Re-Feeling       | `count_up`         | —        | —            | "Hierarchical 'Re-Feeling' Journal"                              |
+| Reflective Tarot Draw         | `meditation_timer` | 5 min    | No           | "Tarot Draw: 'What was the lesson of today / this event / that relationship'" |
+| Sacred Pause                  | `meditation_timer` | 5 min    | No           | "Tara Brach's 'Sacred Pause' from Radical Acceptance"            |
+
+## Context
+
+Stage 8's canonical preset is `Dog Walkin' Shamanism` (`count_up`).
+The TEAL band includes a mix of contemplative sits, open-ended
+journaling, and short single-act practices.
+
+**Three** of the new presets are `count_up` (Channeling Writing,
+Freedom Log, Hierarchical Re-Feeling) — open-ended journaling
+practices that complete when the user feels done. Reuse the existing
+shape and the `_COUNT_UP_NOMINAL_DURATION_MINUTES` constant
+(`seed_practices.py:46`).
+
+`Reflective Tarot Draw` deliberately uses `meditation_timer` (not
+`tarot` mode) because there is no full Major-Arcana progression here —
+just a single card prompted by a reflective question. Treating it as
+a 5-minute timed sit keeps the engine choice the user-facing
+distinction (canonical 22-day Tarot meditation at stage 2 → `tarot`;
+reflective single-card pull at stage 8 → `meditation_timer`).
+
+## Tasks
+
+1. **Add `(description, instructions)` tuples to `seed_practice_copy.py`**
+   - One constant per preset, suffixed with the slug.
+   - For `Channeling Writing`: instruct the user to write the exact
+     prompt at the top of the page and then transcribe whatever
+     arises without editing.
+   - For `Active Imagination Dialogue`: name the Jung framing — invite
+     a figure or aspect to appear, address it directly, record what
+     it says.
+   - For `Freedom Log` and `Hierarchical Re-Feeling`: brief description
+     of the re-patterning intent; tell the user to journal until the
+     practice feels complete.
+   - For `Reflective Tarot Draw`: tell the user to shuffle, draw one
+     card, and sit with the question "what was the lesson of today /
+     this event / this relationship" for the full 5-minute timer.
+   - For `Sacred Pause`: lift directly from Tara Brach's framing —
+     stop, take a breath, notice what is here without trying to fix it.
+   - Append entries to `PRESET_COPY`.
+
+2. **Append `_build_preset(...)` rows to `_ALTERNATIVE_PRESETS` in `seed_practices.py`**
+   - Six entries use `_meditation_timer(duration_minutes, halfway_bell=<bool>)`.
+   - Three entries (`Channeling Writing`, `Freedom Log`,
+     `Hierarchical Re-Feeling`) use the `count_up` shape.
+   - Group under a `# Stage 8 alternatives — integration / shamanic.` comment.
+
+3. **Tests in `backend/tests/test_seed_practices.py`**
+   - One assertion test per preset. For the `count_up` presets, verify
+     `mode == "count_up"` and `mode_config["soft_cap_minutes"] is None`.
+   - Bump `EXPECTED_PRESET_COUNT` by +9.
+
+## Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_seed_practices.py` green.
+- [ ] All nine rows present after `seed_practices(session)`.
+- [ ] `STAGE_TO_PRESET_NAME[8]` is still `"Dog Walkin' Shamanism"`.
+- [ ] `GET /practices?stage=8` returns 10 rows.
+- [ ] Re-running the seeder is a no-op.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/seed_practices.py` | Modify — append 9 entries to `_ALTERNATIVE_PRESETS` |
+| `backend/src/seed_practice_copy.py` | Modify — add 9 copy tuples + `PRESET_COPY` entries |
+| `backend/tests/test_seed_practices.py` | Modify — add 9 assertion tests, bump expected count |
+
+## Constraints
+
+- Names must be unique across `PRESET_COPY`.
+- Do not change the canonical `Dog Walkin' Shamanism` entry.
+- Do not introduce new modes. `Reflective Tarot Draw` does *not* use
+  `tarot` mode — the engine would require a deck slug; this preset is
+  a single-card timed sit instead.
+- Keep instructions self-contained — TEAL practices often assume
+  background a beginner won't have. Give just enough framing that a
+  user encountering Active Imagination or Tonglen-style channeling
+  for the first time can complete the session.

--- a/prompts/github-issues/practice-presets-epic.md
+++ b/prompts/github-issues/practice-presets-epic.md
@@ -1,0 +1,147 @@
+# Epic: Spiral Dynamics practice-preset catalog expansion
+
+**Labels:** `epic`, `backend`, `feature`, `practice`, `seeding`
+**Scope:** Backend (preset rows + copy + tests). No new modes, no migrations,
+no frontend changes.
+**Estimated total LoC:** ~1,900 across 7 sub-issues.
+
+## Role
+
+You are a backend engineer extending the seeded practice catalog with
+alternative presets that share each stage with the canonical practice.
+You follow the established seed-preset pattern (`seed_practices.py` +
+`seed_practice_copy.py`) and validate every payload at import time via
+`ModeConfigAdapter`.
+
+## Goal
+
+Add **~60 alternative presets** across stages 1-8 so each Spiral Dynamics
+frequency band offers users a deep menu of practices they can swap in for
+the canonical stage practice. Source content is the practitioner-authored
+"alternative practices per frequency" table — one column per color, each
+row a discrete practice with its own instructions.
+
+After this epic ships, the catalog browse screen shows the canonical
+preset *plus* this color's alternatives whenever the user opens the
+practice catalog at a given stage.
+
+## Context
+
+The catalog is mode-discriminated and already supports multiple
+alternative presets per stage — see the stage-1 alternatives Touch Grass,
+Mindful Eating, Find Shapes, Find Colors in
+`backend/src/seed_practices.py:257-314`. The seeder is idempotent on
+`(stage_number, name)` and a partial unique index at the DB layer
+arbitrates races (migration `d2e3f4a5b6c7`). Adding a preset is a
+content-only change:
+
+1. Add `(description, instructions)` to `PRESET_COPY` in `seed_practice_copy.py`.
+2. Append a `_build_preset(...)` entry to `_ALTERNATIVE_PRESETS` in
+   `seed_practices.py` with a validated `mode_config`.
+3. Add catalog assertion tests in `tests/test_seed_practices.py`
+   (mode, key fields, idempotency).
+
+No new `PracticeMode` enum values are needed — every preset in the source
+table maps to an existing mode (`meditation_timer`, `count_up`, or
+`mindful_anchor`). No migrations are needed. No frontend changes are
+needed: the catalog screen, frequency banner, and `UserPractice`
+customization flow already iterate over whatever presets exist.
+
+## Stage-to-color mapping
+
+| Stage | Color       | Canonical (already seeded)          | Alternatives in source table |
+|-------|-------------|-------------------------------------|------------------------------|
+| 1     | BEIGE       | `5-4-3-2-1 grounding`               | 10 (3 already seeded as Touch Grass / Find Shapes / Find Colors) |
+| 2     | PURPLE      | `Tarot meditation`                  | 8 |
+| 3     | RED         | `Belly breathing`                   | 10 |
+| 4     | BLUE        | `Metta`                             | 10 |
+| 5     | ORANGE      | `Wim Hof method`                    | 8 |
+| 6     | GREEN       | `Shadow work`                       | 8 |
+| 7     | YELLOW      | `Blissy meditation`                 | 0 (source row is "see Blissy instructions") |
+| 8     | TEAL        | `Dog Walkin' Shamanism`             | 9 |
+| 9     | ULTRAVIOLET | `Concentration practice`            | 0 (no alternatives in source) |
+| 10    | CLEAR LIGHT | `Insight practice`                  | 0 (no alternatives in source) |
+
+YELLOW, ULTRAVIOLET, and CLEAR LIGHT have no alternatives in the source
+table and are not part of this epic.
+
+## Sub-issues
+
+| # | Title | Stage | New presets | LoC |
+|---|-------|-------|-------------|-----|
+| 01 | [Seed BEIGE alternatives](practice-presets-01-beige-grounding.md)        | 1 | 7 | ~250 |
+| 02 | [Seed PURPLE alternatives](practice-presets-02-purple-divination.md)     | 2 | 8 | ~275 |
+| 03 | [Seed RED alternatives](practice-presets-03-red-energy.md)               | 3 | 10 | ~325 |
+| 04 | [Seed BLUE alternatives](practice-presets-04-blue-heart.md)              | 4 | 10 | ~325 |
+| 05 | [Seed ORANGE alternatives](practice-presets-05-orange-activation.md)     | 5 | 8 | ~275 |
+| 06 | [Seed GREEN alternatives](practice-presets-06-green-shadow.md)           | 6 | 8 | ~275 |
+| 07 | [Seed TEAL alternatives](practice-presets-07-teal-integration.md)        | 8 | 9 | ~300 |
+
+All seven sub-issues are **fully independent** — they touch the same
+three files but at disjoint locations (different stage_number rows,
+different `PRESET_COPY` keys, different test functions). Conflicts on
+merge are limited to import-ordering / list-append friction that resolves
+trivially. They can ship in any order or in parallel.
+
+## Acceptance Criteria (epic-level)
+
+- [ ] ~60 new alternative presets seeded across 7 stages.
+- [ ] `STAGE_TO_PRESET_NAME` (canonical pointer) is unchanged after each PR.
+- [ ] `pytest backend/` green, coverage thresholds unchanged.
+- [ ] `pre-commit run --all-files` green on every sub-issue PR.
+- [ ] `python -m seed_practices` on a fresh DB inserts every new preset
+      exactly once and is idempotent on re-run.
+- [ ] `GET /practices?stage=N` returns each new preset alongside the
+      stage's canonical and any prior alternatives.
+
+## Constraints
+
+- **Do not** alter `_CANONICAL_PRESETS`. Only `_ALTERNATIVE_PRESETS` and
+  `PRESET_COPY` change.
+- **Do not** introduce new `PracticeMode` values, schemas, or Alembic
+  migrations. Every preset uses one of: `meditation_timer`, `count_up`,
+  `mindful_anchor`.
+- **Preset names must be unique** across the entire catalog (the
+  import-time guard at `seed_practices.py:337-341` enforces this). Pick
+  short, clear, capitalized names; do not reuse a name already in
+  `PRESET_COPY`.
+- **Skip source rows that duplicate an already-seeded preset.** For
+  stage 1 specifically:
+  - *Stand Barefoot Outdoors* ≈ existing `Touch Grass` — skip.
+  - *Square - Circle - Triangle x5* ≈ existing `Find Shapes` — skip.
+  - *Colors of the Rainbow* ≈ existing `Find Colors` — skip.
+- Each preset's `mode_config` must round-trip through
+  `ModeConfigAdapter.validate_python()` — the seeder does this at import
+  time so a typo crashes the seeder, not production startup.
+- Keep descriptions ≤ 2000 chars, instructions ≤ 10000 chars (matches
+  the `Practice` column caps).
+- Use the existing duration ladder for each stage as a default
+  (stage 1 ≈ 3-5 min, stage 3 ≈ 10 min, stage 4 ≈ 15 min, stages 5-6 ≈
+  20-30 min, stage 8 = `count_up` for open-ended).
+
+## Mode selection guidance
+
+| Source-row shape                                          | Mode             |
+|-----------------------------------------------------------|------------------|
+| Timed sit / breath / visualization with start/end bell    | `meditation_timer` |
+| Long sit benefiting from a mid-bell                       | `meditation_timer` with `halfway_bell=True` |
+| Open-ended journaling / drawing / walking                 | `count_up` |
+| Single-act presence with a chooser (e.g. Touch Grass)     | `mindful_anchor` |
+
+No source row in this epic requires `tarot`, `metronome`, `interval_bell`,
+`rep_counter`, `tallied_grounding`, `card_meditation`, or
+`random_interval_bell`. If a sub-issue author thinks a row really wants
+one of those, surface the choice in the PR description instead of
+silently switching — the bar for adding a different-mode alternative is
+higher than just "it might work."
+
+## References
+
+- `backend/src/models/practice.py:20-58` — `Practice` model
+- `backend/src/domain/practice_modes.py:15-28` — `PracticeMode` enum (closed)
+- `backend/src/seed_practices.py:166-314` — canonical + alternative preset list
+- `backend/src/seed_practices.py:316-358` — import-time validation + dedup guards
+- `backend/src/seed_practice_copy.py` — `PRESET_COPY` table
+- `backend/tests/test_seed_practices.py:233-313` — preset assertion test pattern
+- `backend/tests/test_seed_practices.py:339-356` — global preset invariants
+- `prompts/github-issues/grounding-techniques-03-presets-shapes-and-colors.md` — closest precedent


### PR DESCRIPTION
## Summary

Seeds **60 new alternative practice presets** across stages 1-8 (BEIGE through TEAL), one Spiral Dynamics frequency band per commit. Implements all seven sub-issues from the [practice-presets epic](prompts/github-issues/practice-presets-epic.md) merged in #380.

Pure content additions — **no new `PracticeMode` values, schemas, Alembic migrations, or frontend changes**. Every preset routes to an already-validated mode (`meditation_timer`, `count_up`). Catalog grew from **14 → 74** presets.

## Per-commit breakdown

| SHA | Stage | Band | Presets added | Modes |
|-----|-------|------|---------------|-------|
| `ffc7409` | 1 | BEIGE | 7 grounding (Crystal Charging, Tense and Release, Contact Points, Box Breathing, Toe Wiggling, Body Scan, Progressive Muscle Relaxation) | timer |
| `77828cc` | 2 | PURPLE | 8 divination (Traffic Lights, I Ching Toss, Bibliomancy, Synchronicity Sweep, Trataka Candle Gazing, Dream Recollection, Archetypal Mantra, Totem Meditation) | timer |
| `1db16e4` | 3 | RED | 10 energy/power (Hand Energy Sensing, Windhorse Breathwork, Water Charging, Mini TED Talk, Power Posture, Mountain Pose Sit, Fire Gazing, Warrior Stillness, Red Sphere Visualization, Love to Past Selves) | timer |
| `ed32b7d` | 4 | BLUE | 10 heart/lovingkindness (Tonglen, I Am Love Through, Heart Centered Breath, Animist Gratitude, Hug Visualization, Relational Gratitude, Blessing Strangers, Heart Imagery, Just Like Me, Ancestral Connection) | timer |
| `c43273f` | 5 | ORANGE | 8 activation (Kapalabhati, Middle Pillar, Sigil Dhyana, Reality Selection, Single Instrument Listening, Chanting/Kirtan, Breath of Fire + Silence, Lion's Breath) | timer |
| `b71aabd` | 6 | GREEN | 8 shadow work (Chair Work, Wording Through It, Wilber 3-2-1, Emotion Transmutation, Pain Body, Letter to Repressed Self, Shadow Drawing, REACH Inward) | 6 timer + 2 count_up |
| `09aa159` | 8 | TEAL | 9 integration (Clairaudient Listening, Channeling Writing, Active Imagination, Aura Scanning, Sangha Field, Freedom Log, Hierarchical Re-Feeling, Reflective Tarot Draw, Sacred Pause) | 6 timer + 3 count_up |

Stages 7 (YELLOW), 9 (ULTRAVIOLET), and 10 (CLEAR LIGHT) carry no alternatives in the source table and are out of scope.

## Notable decisions

- **Three BEIGE source rows skipped as duplicates** of already-seeded stage-1 alternatives: *Stand Barefoot Outdoors* ≈ Touch Grass, *Square-Circle-Triangle x5* ≈ Find Shapes, *Colors of the Rainbow* ≈ Find Colors.
- **`Reflective Tarot Draw` uses `meditation_timer`, not `tarot` mode** — a single reflective card pull has no deck-slug or per-card-minute config, so the simpler engine fits.
- **Breathwork presets carry safety notes** (`ease off if you feel lightheaded; resume when it passes`) consistent with the canonical Wim Hof copy voice.
- **Shadow-work presets carry caution notes** (`pause to breathe and journal rather than push through if strong emotion arises`) consistent with the canonical Shadow Work copy.
- **`count_up` presets reuse the validated shape** from Dog Walkin' Shamanism (`{"mode": "count_up", "soft_cap_minutes": None}`) — no new constant or helper introduced.
- **No canonical preset modified**; `STAGE_TO_PRESET_NAME[1-8]` resolves to the same value before and after.

## Test plan

- [x] `pytest backend/tests/test_seed_practices.py` green — 82 tests (22 pre-existing + 60 new parametrized cases).
- [x] All seven commits individually pass the full pre-push gate (`ruff`, `ruff-format`, `mypy --strict`, `isort`, `bandit`, `pip-audit`, `detect-secrets`, `xenon` complexity, `radon` maintainability, full pytest with 90% line / 80% branch coverage).
- [x] Import-time invariants pass: every `mode_config` round-trips through `ModeConfigAdapter`, every preset name is unique across `PRESET_COPY`, every preset sits on a known stage.
- [x] Idempotency: seeder run twice inserts 60 net rows the first time, 0 the second.
- [x] `STAGE_TO_PRESET_NAME` unchanged for every stage; canonical preset pointer remains stable.
- [ ] Manual smoke: `GET /practices?stage=N` returns the expected count for each affected stage (stages 1-6 and 8).

https://claude.ai/code/session_016qKChDRxgmZaRChMJbpKgF

---
_Generated by [Claude Code](https://claude.ai/code/session_016qKChDRxgmZaRChMJbpKgF)_