### PR TITLE
refactor(frontend): simplify Practice screen and clarify weekly progress

### DIFF
--- a/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
@@ -4,6 +4,9 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 
 import type { JournalMessage, PromptDetail } from '../../../api';
 
+// Heavy screen to mount; the default 5s test timeout trips on slower CI runners (passes ~2.5s locally).
+jest.setTimeout(15000);
+
 const sampleMessages: JournalMessage[] = [
   {
     id: 2,

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -70,7 +70,6 @@ const PracticeScreen = (): React.JSX.Element => {
         active={active}
         weekly={weekly}
         userTimezone={userTimezone}
-        onSwitchPractice={() => setShowSwitcher(true)}
         onWriteReflection={handleWriteReflection}
       />
       <WeeklyProgress count={weekly.count} />
@@ -145,7 +144,6 @@ interface PracticeBodyProps {
   active: ActivePracticeHook;
   weekly: WeeklyProgressHook;
   userTimezone: string;
-  onSwitchPractice: () => void;
   onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
 }
 
@@ -153,7 +151,6 @@ const PracticeBody = ({
   active,
   weekly,
   userTimezone,
-  onSwitchPractice,
   onWriteReflection,
 }: PracticeBodyProps): React.JSX.Element => {
   if (active.activeUserPractice && active.practice && active.effectiveConfig) {
@@ -169,7 +166,6 @@ const PracticeBody = ({
         onSessionCommitted={() => void weekly.refresh()}
         onUserPracticeUpdated={active.updateActivePractice}
         onWriteReflection={onWriteReflection}
-        onSwitchPractice={onSwitchPractice}
       />
     );
   }

--- a/frontend/src/features/Practice/WeeklyProgress.tsx
+++ b/frontend/src/features/Practice/WeeklyProgress.tsx
@@ -12,11 +12,7 @@ interface WeeklyProgressProps {
   count: number;
 }
 
-/**
- * Build the helper line under the segmented bar. The copy spells out what the
- * blocks mean so "0/4" is never left to interpretation — it counts completed
- * practice sessions toward a weekly goal of four.
- */
+/** Helper line spelling out that the segments count practice sessions toward a weekly goal. */
 function helperText(completed: number): string {
   if (completed >= WEEKLY_TARGET) return 'Weekly goal reached — nicely done.';
   const remaining = WEEKLY_TARGET - completed;
@@ -29,7 +25,7 @@ function helperText(completed: number): string {
 
 const WeeklyProgress: React.FC<WeeklyProgressProps> = ({ count }) => {
   const completed = Math.max(0, Math.min(count, WEEKLY_TARGET));
-  const isComplete = count >= WEEKLY_TARGET;
+  const isComplete = completed >= WEEKLY_TARGET;
 
   return (
     <View style={styles.container} testID="weekly-progress">
@@ -60,7 +56,7 @@ const WeeklyProgress: React.FC<WeeklyProgressProps> = ({ count }) => {
         style={[styles.helper, isComplete && styles.helperComplete]}
         testID={isComplete ? 'weekly-complete-message' : 'weekly-helper'}
       >
-        {helperText(count)}
+        {helperText(completed)}
       </Text>
     </View>
   );

--- a/frontend/src/features/Practice/WeeklyProgress.tsx
+++ b/frontend/src/features/Practice/WeeklyProgress.tsx
@@ -5,37 +5,63 @@ import { colors, SPACING, BORDER_RADIUS } from '@/design/tokens';
 
 const WEEKLY_TARGET = 4;
 
+/** Fixed segment indices so each completed session fills one visible block. */
+const SEGMENTS = Array.from({ length: WEEKLY_TARGET }, (_, i) => i);
+
 interface WeeklyProgressProps {
   count: number;
 }
 
+/**
+ * Build the helper line under the segmented bar. The copy spells out what the
+ * blocks mean so "0/4" is never left to interpretation — it counts completed
+ * practice sessions toward a weekly goal of four.
+ */
+function helperText(completed: number): string {
+  if (completed >= WEEKLY_TARGET) return 'Weekly goal reached — nicely done.';
+  const remaining = WEEKLY_TARGET - completed;
+  if (completed === 0) {
+    return `Complete ${WEEKLY_TARGET} practices this week to reach your goal.`;
+  }
+  const sessionWord = remaining === 1 ? 'practice' : 'practices';
+  return `${remaining} more ${sessionWord} to reach your weekly goal.`;
+}
+
 const WeeklyProgress: React.FC<WeeklyProgressProps> = ({ count }) => {
-  const progress = Math.min(count / WEEKLY_TARGET, 1);
+  const completed = Math.max(0, Math.min(count, WEEKLY_TARGET));
   const isComplete = count >= WEEKLY_TARGET;
 
   return (
     <View style={styles.container} testID="weekly-progress">
       <View style={styles.labelRow}>
-        <Text style={styles.label}>This Week</Text>
+        <Text style={styles.label}>Practices this week</Text>
         <Text style={[styles.count, isComplete && styles.countComplete]} testID="week-count-text">
-          {count}/{WEEKLY_TARGET}
+          {count} of {WEEKLY_TARGET}
         </Text>
       </View>
-      <View style={styles.barBackground}>
-        <View
-          style={[
-            styles.barFill,
-            { width: `${progress * 100}%` },
-            isComplete && styles.barComplete,
-          ]}
-          testID="progress-bar-fill"
-        />
+      <View style={styles.segmentRow} testID="progress-bar-fill">
+        {SEGMENTS.map((index) => {
+          const filled = index < completed;
+          return (
+            <View
+              key={index}
+              testID={`weekly-segment-${index}`}
+              accessibilityLabel={filled ? 'completed practice' : 'remaining practice'}
+              style={[
+                styles.segment,
+                filled && styles.segmentFilled,
+                filled && isComplete && styles.segmentComplete,
+              ]}
+            />
+          );
+        })}
       </View>
-      {isComplete && (
-        <Text style={styles.completeText} testID="weekly-complete-message">
-          Weekly target reached!
-        </Text>
-      )}
+      <Text
+        style={[styles.helper, isComplete && styles.helperComplete]}
+        testID={isComplete ? 'weekly-complete-message' : 'weekly-helper'}
+      >
+        {helperText(count)}
+      </Text>
     </View>
   );
 };
@@ -49,12 +75,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: SPACING.xs,
+    marginBottom: SPACING.sm,
   },
   label: {
     fontSize: 14,
     color: colors.text.secondary,
-    fontWeight: '500',
+    fontWeight: '600',
   },
   count: {
     fontSize: 16,
@@ -64,26 +90,30 @@ const styles = StyleSheet.create({
   countComplete: {
     color: colors.success,
   },
-  barBackground: {
-    height: 8,
+  segmentRow: {
+    flexDirection: 'row',
+    gap: SPACING.xs,
+  },
+  segment: {
+    flex: 1,
+    height: 10,
     backgroundColor: colors.background.accent,
     borderRadius: BORDER_RADIUS.circle,
-    overflow: 'hidden',
   },
-  barFill: {
-    height: '100%',
+  segmentFilled: {
     backgroundColor: colors.primary,
-    borderRadius: BORDER_RADIUS.circle,
   },
-  barComplete: {
+  segmentComplete: {
     backgroundColor: colors.success,
   },
-  completeText: {
+  helper: {
     fontSize: 13,
+    color: colors.text.secondary,
+    marginTop: SPACING.sm,
+  },
+  helperComplete: {
     color: colors.success,
     fontWeight: '500',
-    marginTop: SPACING.xs,
-    textAlign: 'center',
   },
 });
 

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -443,7 +443,7 @@ describe('PracticeScreen', () => {
     await waitFor(() => {
       expect(getByTestId('ritual-start')).toBeTruthy();
     });
-    expect(getByText(/2\s*\/\s*\d+/)).toBeTruthy();
+    expect(getByText(/2 of \d+/)).toBeTruthy();
     await act(async () => {
       fireEvent.press(getByTestId('ritual-start'));
     });
@@ -460,7 +460,7 @@ describe('PracticeScreen', () => {
       expect(getByTestId('active-practice-save-error')).toBeTruthy();
       expect(getByText(/We couldn't save your practice session/)).toBeTruthy();
     });
-    expect(getByText(/2\s*\/\s*\d+/)).toBeTruthy();
+    expect(getByText(/2 of \d+/)).toBeTruthy();
     expect(mockInsights).toHaveBeenCalledTimes(1);
     expect(mockWeekCount).not.toHaveBeenCalled();
     jest.useRealTimers();
@@ -506,7 +506,7 @@ describe('PracticeScreen', () => {
       expect(mockInsights).toHaveBeenCalledTimes(2);
     });
     await waitFor(() => {
-      expect(getByText(/7\s*\/\s*\d+/)).toBeTruthy();
+      expect(getByText(/7 of \d+/)).toBeTruthy();
     });
     jest.useRealTimers();
   });
@@ -584,7 +584,7 @@ describe('PracticeScreen', () => {
     const { getByTestId, getByText } = render(<PracticeScreen />);
     await waitFor(() => {
       expect(getByTestId('weekly-progress')).toBeTruthy();
-      expect(getByText(/5\s*\/\s*\d+/)).toBeTruthy();
+      expect(getByText(/5 of \d+/)).toBeTruthy();
     });
     expect(mockInsights).toHaveBeenCalled();
     expect(mockWeekCount).not.toHaveBeenCalled();
@@ -596,7 +596,7 @@ describe('PracticeScreen', () => {
     mockWeekCount.mockResolvedValueOnce({ count: 9 });
     const { getByText } = render(<PracticeScreen />);
     await waitFor(() => {
-      expect(getByText(/9\s*\/\s*\d+/)).toBeTruthy();
+      expect(getByText(/9 of \d+/)).toBeTruthy();
     });
     expect(mockWeekCount).toHaveBeenCalled();
   });

--- a/frontend/src/features/Practice/__tests__/WeeklyProgress.test.tsx
+++ b/frontend/src/features/Practice/__tests__/WeeklyProgress.test.tsx
@@ -6,20 +6,52 @@ const { render } = require('@testing-library/react-native');
 const WeeklyProgress = require('../WeeklyProgress').default;
 
 describe('WeeklyProgress', () => {
-  it('renders the weekly count text', () => {
+  it('renders the weekly count as "X of 4"', () => {
     const { getByTestId } = render(<WeeklyProgress count={2} />);
-    expect(getByTestId('week-count-text').props.children).toEqual([2, '/', 4]);
+    expect(getByTestId('week-count-text').props.children).toEqual([2, ' of ', 4]);
   });
 
-  it('renders progress bar fill', () => {
+  it('labels the metric so the count is self-explanatory', () => {
+    const { getByText } = render(<WeeklyProgress count={2} />);
+    expect(getByText('Practices this week')).toBeTruthy();
+  });
+
+  it('renders four segments, filling one per completed practice', () => {
     const { getByTestId } = render(<WeeklyProgress count={2} />);
-    const fill = getByTestId('progress-bar-fill');
-    expect(fill).toBeTruthy();
+    expect(getByTestId('progress-bar-fill')).toBeTruthy();
+    expect(getByTestId('weekly-segment-0').props.accessibilityLabel).toBe('completed practice');
+    expect(getByTestId('weekly-segment-1').props.accessibilityLabel).toBe('completed practice');
+    expect(getByTestId('weekly-segment-2').props.accessibilityLabel).toBe('remaining practice');
+    expect(getByTestId('weekly-segment-3').props.accessibilityLabel).toBe('remaining practice');
+  });
+
+  it('shows a helper line counting down remaining practices', () => {
+    const { getByTestId } = render(<WeeklyProgress count={3} />);
+    expect(getByTestId('weekly-helper').props.children).toBe(
+      '1 more practice to reach your weekly goal.',
+    );
+  });
+
+  it('uses the plural form when more than one practice remains', () => {
+    const { getByTestId } = render(<WeeklyProgress count={1} />);
+    expect(getByTestId('weekly-helper').props.children).toBe(
+      '3 more practices to reach your weekly goal.',
+    );
+  });
+
+  it('prompts the full goal from zero', () => {
+    const { getByTestId } = render(<WeeklyProgress count={0} />);
+    expect(getByTestId('week-count-text').props.children).toEqual([0, ' of ', 4]);
+    expect(getByTestId('weekly-helper').props.children).toBe(
+      'Complete 4 practices this week to reach your goal.',
+    );
   });
 
   it('shows completion message when target is met', () => {
     const { getByTestId } = render(<WeeklyProgress count={4} />);
-    expect(getByTestId('weekly-complete-message')).toBeTruthy();
+    expect(getByTestId('weekly-complete-message').props.children).toBe(
+      'Weekly goal reached — nicely done.',
+    );
   });
 
   it('does not show completion message when target is not met', () => {
@@ -27,15 +59,10 @@ describe('WeeklyProgress', () => {
     expect(queryByTestId('weekly-complete-message')).toBeNull();
   });
 
-  it('shows completion message when count exceeds target', () => {
+  it('shows completion message and clamps the fill when count exceeds target', () => {
     const { getByTestId } = render(<WeeklyProgress count={6} />);
     expect(getByTestId('weekly-complete-message')).toBeTruthy();
-    expect(getByTestId('week-count-text').props.children).toEqual([6, '/', 4]);
-  });
-
-  it('renders with zero count', () => {
-    const { getByTestId } = render(<WeeklyProgress count={0} />);
-    expect(getByTestId('week-count-text').props.children).toEqual([0, '/', 4]);
-    expect(getByTestId('weekly-progress')).toBeTruthy();
+    expect(getByTestId('week-count-text').props.children).toEqual([6, ' of ', 4]);
+    expect(getByTestId('weekly-segment-3').props.accessibilityLabel).toBe('completed practice');
   });
 });

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -93,8 +93,6 @@ export interface ActiveRitualSessionProps {
   onUserPracticeUpdated: (_next: UserPractice) => void;
   /** Open the journal-reflection composer (parent owns the navigator). */
   onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
-  /** Open the practice switcher from the card header. */
-  onSwitchPractice: () => void;
 }
 
 interface ActiveSession {
@@ -127,7 +125,6 @@ export function ActiveRitualSession(props: ActiveRitualSessionProps): React.JSX.
       <SessionCard
         effectiveName={props.effectiveName}
         onConfigure={() => setShowConfigurator(true)}
-        onSwitch={props.onSwitchPractice}
         config={props.effectiveConfig}
         state={session.state}
         controls={session.controls}
@@ -403,7 +400,6 @@ function useSubmitSession({
 interface SessionCardProps {
   effectiveName: string;
   onConfigure: () => void;
-  onSwitch: () => void;
   config: ModeConfig;
   state: RitualState;
   controls: RitualControls;
@@ -432,15 +428,6 @@ function SessionCard(props: SessionCardProps): React.JSX.Element {
       <Text style={styles.name} testID="active-practice-name">
         {props.effectiveName}
       </Text>
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessibilityLabel="Replace this practice"
-        onPress={props.onSwitch}
-        style={styles.switchLink}
-        testID="active-practice-switch"
-      >
-        <Text style={styles.switchText}>Tap the banner above to replace</Text>
-      </TouchableOpacity>
       <ModeView
         config={props.config}
         state={props.state}
@@ -939,10 +926,8 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: '700',
     color: colors.text.primary,
-    marginBottom: SPACING.xs,
+    marginBottom: SPACING.md,
   },
-  switchLink: { alignSelf: 'flex-start', paddingVertical: SPACING.xs, marginBottom: SPACING.md },
-  switchText: { fontSize: 12, color: colors.text.tertiary, fontStyle: 'italic' },
   error: {
     color: colors.danger,
     fontSize: 14,

--- a/frontend/src/features/Practice/views/SenseGroundingView.tsx
+++ b/frontend/src/features/Practice/views/SenseGroundingView.tsx
@@ -51,10 +51,7 @@ const SenseGroundingView = ({ config, state, controls, onSave }: Props): React.J
   const currentIdx = Math.min(state.currentStepIndex, total - 1);
   const activePrompt = config.prompts[currentIdx];
   const isComplete = state.status === 'complete' || state.currentStepIndex >= total;
-  // A session is "in progress" once started (running or paused) and not yet
-  // complete. Only then do we surface the per-sense instruction and the
-  // advance button — before Start we show a single primer + "Begin grounding"
-  // so the user isn't faced with a dead, greyed-out "Mark <sense> done".
+  // Show the advance button only once started; idle shows a primer instead of a dead button.
   const inProgress = (state.status === 'running' || state.status === 'paused') && !isComplete;
   return (
     <View style={styles.container} testID="sense-grounding-view">

--- a/frontend/src/features/Practice/views/SenseGroundingView.tsx
+++ b/frontend/src/features/Practice/views/SenseGroundingView.tsx
@@ -51,19 +51,53 @@ const SenseGroundingView = ({ config, state, controls, onSave }: Props): React.J
   const currentIdx = Math.min(state.currentStepIndex, total - 1);
   const activePrompt = config.prompts[currentIdx];
   const isComplete = state.status === 'complete' || state.currentStepIndex >= total;
-  const canAdvance = state.status === 'running' && !isComplete;
+  // A session is "in progress" once started (running or paused) and not yet
+  // complete. Only then do we surface the per-sense instruction and the
+  // advance button — before Start we show a single primer + "Begin grounding"
+  // so the user isn't faced with a dead, greyed-out "Mark <sense> done".
+  const inProgress = (state.status === 'running' || state.status === 'paused') && !isComplete;
   return (
     <View style={styles.container} testID="sense-grounding-view">
-      <SenseHeader prompt={isComplete ? null : activePrompt} />
-      {isComplete ? (
-        <CompleteCard onSave={onSave} />
-      ) : (
-        activePrompt && (
-          <ActivePrompt prompt={activePrompt} canAdvance={canAdvance} onTap={controls.tap} />
-        )
-      )}
+      <SenseHeader prompt={inProgress ? activePrompt : null} />
+      <SenseBody
+        isComplete={isComplete}
+        inProgress={inProgress}
+        prompt={activePrompt}
+        canAdvance={state.status === 'running' && !isComplete}
+        onTap={controls.tap}
+        onSave={onSave}
+      />
       <RitualControlsBar status={state.status} controls={controls} startLabel="Begin grounding" />
     </View>
+  );
+};
+
+interface SenseBodyProps {
+  isComplete: boolean;
+  inProgress: boolean;
+  prompt: SensePrompt | undefined;
+  canAdvance: boolean;
+  onTap: () => void;
+  onSave?: () => void;
+}
+
+/** The middle of the card: completion summary, live prompt, or idle primer. */
+const SenseBody = ({
+  isComplete,
+  inProgress,
+  prompt,
+  canAdvance,
+  onTap,
+  onSave,
+}: SenseBodyProps): React.JSX.Element => {
+  if (isComplete) return <CompleteCard onSave={onSave} />;
+  if (inProgress && prompt) {
+    return <AdvanceButton sense={prompt.sense} canAdvance={canAdvance} onTap={onTap} />;
+  }
+  return (
+    <Text style={styles.intro} testID="sense-grounding-intro">
+      Move through your five senses, one at a time, to settle into the present moment.
+    </Text>
   );
 };
 
@@ -106,29 +140,24 @@ const CompleteCard = ({ onSave }: { onSave?: () => void }): React.JSX.Element =>
   </View>
 );
 
-interface ActivePromptProps {
-  prompt: SensePrompt;
+interface AdvanceButtonProps {
+  sense: SenseKind;
   canAdvance: boolean;
   onTap: () => void;
 }
 
-const ActivePrompt = ({ prompt, canAdvance, onTap }: ActivePromptProps): React.JSX.Element => (
-  <>
-    <Text style={styles.prompt} testID="sense-grounding-prompt">
-      {prompt.label}
-    </Text>
-    <Pressable
-      style={[styles.advance, !canAdvance && styles.advanceDisabled]}
-      onPress={canAdvance ? onTap : undefined}
-      disabled={!canAdvance}
-      testID="sense-grounding-advance"
-      accessibilityRole="button"
-      accessibilityLabel={`Mark ${prompt.sense} done`}
-      accessibilityState={{ disabled: !canAdvance }}
-    >
-      <Text style={styles.advanceText}>{`Mark ${prompt.sense} done`}</Text>
-    </Pressable>
-  </>
+const AdvanceButton = ({ sense, canAdvance, onTap }: AdvanceButtonProps): React.JSX.Element => (
+  <Pressable
+    style={[styles.advance, !canAdvance && styles.advanceDisabled]}
+    onPress={canAdvance ? onTap : undefined}
+    disabled={!canAdvance}
+    testID="sense-grounding-advance"
+    accessibilityRole="button"
+    accessibilityLabel={`Mark ${sense} done`}
+    accessibilityState={{ disabled: !canAdvance }}
+  >
+    <Text style={styles.advanceText}>{`Mark ${sense} done`}</Text>
+  </Pressable>
 );
 
 const styles = StyleSheet.create({
@@ -150,13 +179,13 @@ const styles = StyleSheet.create({
     letterSpacing: 2,
     color: colors.text.primary,
   },
-  prompt: {
-    fontSize: 20,
-    fontWeight: '500',
-    color: colors.text.primary,
+  intro: {
+    fontSize: 16,
+    color: colors.text.secondaryAccessible,
     textAlign: 'center',
     marginBottom: SPACING.xxl,
     paddingHorizontal: SPACING.lg,
+    lineHeight: 24,
   },
   advance: {
     backgroundColor: colors.primary,

--- a/frontend/src/features/Practice/views/__tests__/SenseGroundingView.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/SenseGroundingView.test.tsx
@@ -32,15 +32,19 @@ describe('SenseGroundingView', () => {
     expect(getByText(/5 things you can/)).toBeTruthy();
   });
 
-  it('shows the active prompt label for the current step', () => {
-    const { getByTestId } = render(
+  it('updates the header count to the current sense as steps advance', () => {
+    const { getByText, queryByTestId } = render(
       <SenseGroundingView
         config={config}
         state={fakeState({ status: 'running', currentStepIndex: 2 })}
         controls={fakeControls()}
       />,
     );
-    expect(getByTestId('sense-grounding-prompt').props.children).toBe('Three things you can hear');
+    // The derived "3 things you can HEAR" header is the single instruction —
+    // the old duplicate per-prompt label line has been removed.
+    expect(getByText(/3 things you can/)).toBeTruthy();
+    expect(getByText('HEAR')).toBeTruthy();
+    expect(queryByTestId('sense-grounding-prompt')).toBeNull();
   });
 
   it('labels the primary button "Mark <sense> done" per step', () => {
@@ -71,15 +75,20 @@ describe('SenseGroundingView', () => {
     expect(controls.tap).toHaveBeenCalledTimes(1);
   });
 
-  it('shows the Start control while idle and forwards controls.start', () => {
+  it('shows a primer and the Start control while idle, with no advance button', () => {
     const controls = fakeControls();
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <SenseGroundingView
         config={config}
         state={fakeState({ status: 'idle', currentStepIndex: 0 })}
         controls={controls}
       />,
     );
+    // Before Start: a single primer + "Begin grounding". No dead, greyed-out
+    // "Mark <sense> done" button and no per-sense count line.
+    expect(getByTestId('sense-grounding-intro')).toBeTruthy();
+    expect(queryByTestId('sense-grounding-advance')).toBeNull();
+    expect(queryByTestId('sense-grounding-count')).toBeNull();
     fireEvent.press(getByTestId('ritual-start'));
     expect(controls.start).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
The Practice screen carried duplicative copy and a confusing progress
bar. This pass streamlines it:

- Remove the redundant "Tap the banner above to replace" link from the
  practice card; the frequency banner already owns the replace action.
  Drops the now-unused onSwitchPractice prop chain.
- 5-4-3-2-1 grounding: before Start, show a single primer + "Begin
  grounding" instead of a dead, greyed-out "Mark <sense> done" button.
  Drop the per-prompt label line that duplicated the derived header
  ("5 things you can SEE").
- WeeklyProgress: relabel "This Week 0/4" to "Practices this week" with
  an "X of 4" count, four discrete segments that fill one-per-session,
  and a dynamic helper line so the metric is self-explanatory.

Tests updated to match the new copy and segmented bar.