### PR TITLE
fix(frontend): align all screens to one universal course calendar

### DIFF
--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -594,19 +594,7 @@ export const isEarlyUnlocked = (habit: Habit): boolean => {
   return habit.revealed === true && new Date(habit.start_date).getTime() > Date.now();
 };
 
-/**
- * Whether a habit tile should render locked *today*, on the universal
- * course calendar.
- *
- * A habit's ``start_date`` is derived from the master program anchor
- * (``programStartDate``) via :func:`calculateHabitStartDate`, so it falls
- * exactly on the day the calendar enters that habit's stage. The lock must
- * therefore track the calendar: once ``start_date`` has arrived the habit
- * is active — regardless of a stale server ``revealed`` flag — so the
- * Habits screen agrees with the Map / Practice / Course stage. The
- * ``revealed`` flag still drives *manual* early unlock for habits whose
- * start date is in the future (see :func:`isEarlyUnlocked`).
- */
+/** Locked today iff unrevealed AND its calendar-anchored `start_date` is still in the future; once that date arrives the habit unlocks regardless of a stale `revealed` flag (which only gates manual early-unlock). */
 export const isHabitLockedToday = (habit: Habit, now: number = Date.now()): boolean => {
   return habit.revealed === false && new Date(habit.start_date).getTime() > now;
 };

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -593,3 +593,20 @@ export const calculateNetEnergy = (cost: number, returnValue: number): number =>
 export const isEarlyUnlocked = (habit: Habit): boolean => {
   return habit.revealed === true && new Date(habit.start_date).getTime() > Date.now();
 };
+
+/**
+ * Whether a habit tile should render locked *today*, on the universal
+ * course calendar.
+ *
+ * A habit's ``start_date`` is derived from the master program anchor
+ * (``programStartDate``) via :func:`calculateHabitStartDate`, so it falls
+ * exactly on the day the calendar enters that habit's stage. The lock must
+ * therefore track the calendar: once ``start_date`` has arrived the habit
+ * is active — regardless of a stale server ``revealed`` flag — so the
+ * Habits screen agrees with the Map / Practice / Course stage. The
+ * ``revealed`` flag still drives *manual* early unlock for habits whose
+ * start date is in the future (see :func:`isEarlyUnlocked`).
+ */
+export const isHabitLockedToday = (habit: Habit, now: number = Date.now()): boolean => {
+  return habit.revealed === false && new Date(habit.start_date).getTime() > now;
+};

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -439,11 +439,7 @@ const useHabitTileRenderer = (
   pageOffset = 0,
 ) => {
   const renderHabitTile = ({ item, index }: { item: Habit; index: number }) => {
-    // Lock state follows the universal course calendar: a habit's
-    // ``start_date`` lands on the day the calendar enters its stage, so once
-    // that date passes the tile unlocks even if the server ``revealed`` flag
-    // is stale. This keeps the Habits screen in lockstep with the Map /
-    // Practice / Course stage. ``revealed`` still gates manual early unlock.
+    // Calendar-driven: unlocks when the anchored start_date arrives, not on the stale `revealed` flag — keeps Habits in lockstep with Map/Practice/Course.
     const isLocked = isHabitLockedToday(item);
     const globalIndex = pageOffset + index;
     // index is page-relative, so each page restarts the Beige → Clear Light gradient.

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -21,7 +21,12 @@ import StatsModal from './components/StatsModal';
 import styles from './Habits.styles';
 import type { AddHabitInput, Habit, HabitStatsData } from './Habits.types';
 import HabitTile from './HabitTile';
-import { generateStatsForHabit, toLocalHabitStats, calculateMissedDays } from './HabitUtils';
+import {
+  generateStatsForHabit,
+  toLocalHabitStats,
+  calculateMissedDays,
+  isHabitLockedToday,
+} from './HabitUtils';
 import { useHabits } from './hooks/useHabits';
 import { useModalCoordinator } from './hooks/useModalCoordinator';
 import { usePagination } from './hooks/usePagination';
@@ -434,7 +439,12 @@ const useHabitTileRenderer = (
   pageOffset = 0,
 ) => {
   const renderHabitTile = ({ item, index }: { item: Habit; index: number }) => {
-    const isLocked = item.revealed === false;
+    // Lock state follows the universal course calendar: a habit's
+    // ``start_date`` lands on the day the calendar enters its stage, so once
+    // that date passes the tile unlocks even if the server ``revealed`` flag
+    // is stale. This keeps the Habits screen in lockstep with the Map /
+    // Practice / Course stage. ``revealed`` still gates manual early unlock.
+    const isLocked = isHabitLockedToday(item);
     const globalIndex = pageOffset + index;
     // index is page-relative, so each page restarts the Beige → Clear Light gradient.
     const stageColor = STAGE_COLORS[STAGE_ORDER[index % STAGE_ORDER.length]!]!;

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -12,6 +12,7 @@ import {
   calculateTodaysProgress,
   getProgressBarColor,
   isGoalAchieved,
+  isHabitLockedToday,
   logHabitUnits,
   calculateHabitStartDate,
   STAGE_DURATIONS_DAYS,
@@ -592,5 +593,59 @@ describe('HabitUtils', () => {
       expect(currentGoal.tier).toBe('low');
       expect(completedAllGoals).toBe(false);
     });
+  });
+});
+
+describe('isHabitLockedToday', () => {
+  const NOW = new Date('2026-04-06T12:00:00Z').getTime();
+  const make = (overrides: Partial<Habit>): Habit =>
+    ({
+      id: 1,
+      name: 'H',
+      icon: '🔒',
+      stage: 'Purple',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date('2026-04-06T00:00:00Z'),
+      goals: [],
+      completions: [],
+      ...overrides,
+    }) as Habit;
+
+  test('locked when unrevealed and start_date is still in the future', () => {
+    const habit = make({ revealed: false, start_date: new Date('2026-05-01T00:00:00Z') });
+    expect(isHabitLockedToday(habit, NOW)).toBe(true);
+  });
+
+  test('unlocked once the calendar reaches its start_date, even if revealed is stale-false', () => {
+    // The Purple habit: start_date has passed but the server flag was never
+    // flipped. The calendar (start_date <= today) must win so the screen
+    // tracks the same stage the Map/Practice show.
+    const habit = make({ revealed: false, start_date: new Date('2026-04-01T00:00:00Z') });
+    expect(isHabitLockedToday(habit, NOW)).toBe(false);
+  });
+
+  test('unlocked when manually revealed ahead of its start_date', () => {
+    const habit = make({ revealed: true, start_date: new Date('2026-05-01T00:00:00Z') });
+    expect(isHabitLockedToday(habit, NOW)).toBe(false);
+  });
+
+  test('unrevealed (undefined) future habit is treated as unlocked, matching prior contract', () => {
+    const habit = make({ revealed: undefined, start_date: new Date('2026-05-01T00:00:00Z') });
+    expect(isHabitLockedToday(habit, NOW)).toBe(false);
+  });
+
+  test('accepts ISO string start dates (server payloads arrive unparsed)', () => {
+    // The API delivers ``start_date`` as an ISO string before it is mapped to
+    // a Date, so the helper must tolerate both. Cast through ``unknown`` since
+    // the Habit type declares the post-parse ``Date``.
+    const iso = (value: string) => value as unknown as Date;
+    expect(isHabitLockedToday(make({ revealed: false, start_date: iso('2999-01-01') }), NOW)).toBe(
+      true,
+    );
+    expect(isHabitLockedToday(make({ revealed: false, start_date: iso('2000-01-01') }), NOW)).toBe(
+      false,
+    );
   });
 });

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -53,6 +53,7 @@ import {
   replacePendingCheckIns,
 } from '../../../../storage/habitStorage';
 import { useHabitStore } from '../../../../store/useHabitStore';
+import { useProgramStore } from '../../../../store/useProgramStore';
 import { dayKeyInTZ } from '../../../../utils/dateUtils';
 import type { Goal, Habit, OnboardingHabit } from '../../Habits.types';
 import { habitManager } from '../habitManager';
@@ -789,6 +790,39 @@ describe('habitManager', () => {
       expect(useHabitStore.getState().habits[0]!.goals).toHaveLength(3);
       expect(habitsApi.create).toHaveBeenCalled();
       expect(showToast).toHaveBeenCalled();
+    });
+
+    it('anchors the universal program calendar to the earliest habit start date', async () => {
+      useProgramStore.getState().hydrateProgramStartDate(null);
+      const newHabits: OnboardingHabit[] = [
+        {
+          id: 'b',
+          name: 'Belong',
+          icon: '\u{1F49C}',
+          energy_cost: 1,
+          energy_return: 3,
+          stage: 'Purple',
+          start_date: new Date('2026-01-22'),
+        },
+        {
+          id: 'a',
+          name: 'Survive',
+          icon: '\u{1F9D8}',
+          energy_cost: 1,
+          energy_return: 3,
+          stage: 'Beige',
+          start_date: new Date('2026-01-01'),
+        },
+      ];
+
+      await habitManager.onboardingSave(newHabits, jest.fn());
+
+      const anchor = useProgramStore.getState().programStartDate;
+      // Normalised to local midnight by the store; compare the calendar day.
+      expect(anchor).not.toBeNull();
+      expect(anchor!.getFullYear()).toBe(2026);
+      expect(anchor!.getMonth()).toBe(0);
+      expect(anchor!.getDate()).toBe(1);
     });
 
     it('refreshes habits from the server after sync so local IDs match the wire', async () => {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -288,11 +288,7 @@ const buildAddedHabit = (input: AddHabitInput, existingCount: number): Habit => 
   };
 };
 
-/**
- * Earliest habit start date — the day the program begins. Habit start dates
- * are laid out by stage position, so index 0 is normally the earliest, but we
- * take the min defensively in case a caller hands us an unsorted list.
- */
+/** Earliest habit start date (the program start); takes the min, not index 0, in case the list is unsorted. */
 const earliestStartDate = (habits: OnboardingHabit[]): Date | null => {
   let earliest: number | null = null;
   for (const habit of habits) {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -28,6 +28,7 @@ import {
   replacePendingCheckIns,
 } from '../../../storage/habitStorage';
 import { useHabitStore } from '../../../store/useHabitStore';
+import { useProgramStore } from '../../../store/useProgramStore';
 import { dayKeyInTZ, todayInUserTZ } from '../../../utils/dateUtils';
 import { HABIT_DEFAULTS } from '../HabitDefaults';
 import type { AddHabitInput, Goal, Habit, OnboardingHabit } from '../Habits.types';
@@ -285,6 +286,21 @@ const buildAddedHabit = (input: AddHabitInput, existingCount: number): Habit => 
     revealed: true,
     sort_order: existingCount,
   };
+};
+
+/**
+ * Earliest habit start date — the day the program begins. Habit start dates
+ * are laid out by stage position, so index 0 is normally the earliest, but we
+ * take the min defensively in case a caller hands us an unsorted list.
+ */
+const earliestStartDate = (habits: OnboardingHabit[]): Date | null => {
+  let earliest: number | null = null;
+  for (const habit of habits) {
+    const time = new Date(habit.start_date).getTime();
+    if (Number.isNaN(time)) continue;
+    if (earliest === null || time < earliest) earliest = time;
+  }
+  return earliest === null ? null : new Date(earliest);
 };
 
 const syncOnboardingHabits = async (fullHabits: ReturnType<typeof buildOnboardingHabits>) => {
@@ -783,6 +799,13 @@ export const habitManager = {
   onboardingSave: async (newHabits: OnboardingHabit[], showToast?: ShowToast): Promise<void> => {
     const fullHabits = buildOnboardingHabits(newHabits);
     setHabits(fullHabits as Habit[]);
+    // Anchor the universal course calendar to the first habit's start date so
+    // the Map, Practice, Course, Journal and habit-unlock logic all derive the
+    // same stage/week from one source. Without this a freshly-onboarded user
+    // has a null anchor and every screen silently falls back to divergent
+    // server/position values.
+    const anchor = earliestStartDate(newHabits);
+    if (anchor) useProgramStore.getState().setProgramStartDate(anchor);
     showToast?.({
       message: 'Tap a habit tile to edit its goals.',
       icon: '\u{1F449}',

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -29,7 +29,7 @@ import {
 } from '../../store/useStageStore';
 
 import styles from './Map.styles';
-import { stageService } from './services/stageService';
+import { stageService, isStageUnlocked } from './services/stageService';
 import type { StageData } from './stageData';
 
 const FULL_PROGRESS = 1;
@@ -62,7 +62,7 @@ const ConnectionLines = ({ stages }: { stages: StageData[] }): React.JSX.Element
 );
 
 const getHotspotStyle = (stage: StageData, currentStage: number | null) => {
-  if (!stage.isUnlocked) return styles.hotspotLocked;
+  if (!isStageUnlocked(stage, currentStage)) return styles.hotspotLocked;
   if (stage.stageNumber === currentStage) return styles.hotspotCurrent;
   if (stage.progress >= FULL_PROGRESS) return styles.hotspotCompleted;
   return null;
@@ -99,7 +99,7 @@ const StageHotspots = ({
           accessibilityLabel={`${stage.title} - ${stage.subtitle}`}
           accessibilityRole="button"
         >
-          {!stage.isUnlocked && (
+          {!isStageUnlocked(stage, currentStage) && (
             <View style={styles.lockOverlay}>
               <Text style={styles.lockText}>🔒</Text>
             </View>

--- a/frontend/src/features/Map/__tests__/MapHistory.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapHistory.test.tsx
@@ -72,6 +72,10 @@ const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
 const mockLoadStages = jest.fn();
 jest.mock('../services/stageService', () => ({
   stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+  isStageUnlocked: (
+    stage: { isUnlocked: boolean; stageNumber: number },
+    currentStage: number | null,
+  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
 }));
 
 const buildMockStageState = () => ({

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -24,6 +24,15 @@ jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
+// Control the date-derived current stage without importing the real program
+// store (which trips this suite's brittle Image-effect teardown). MapScreen
+// consumes ``useDerivedCurrentStage`` directly, so mocking it here drives both
+// the "current" highlight and the calendar-based unlock.
+let mockDerivedStage = 1;
+jest.mock('../../../store/useProgramProgression', () => ({
+  useDerivedCurrentStage: (fallback: number) => mockDerivedStage ?? fallback,
+}));
+
 /** Build a realistic StageData for testing (must be prefixed with mock). */
 function mockMakeStage(stageNumber: number) {
   return {
@@ -54,6 +63,10 @@ const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
 const mockLoadStages = jest.fn();
 jest.mock('../services/stageService', () => ({
   stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+  isStageUnlocked: (
+    stage: { isUnlocked: boolean; stageNumber: number },
+    currentStage: number | null,
+  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
 }));
 
 const buildMockStageState = () => ({
@@ -86,10 +99,28 @@ jest.mock('../../../store/useStageStore', () => ({
 
 import MapScreen from '../MapScreen';
 
+const countLockIcons = (tree: ReturnType<typeof create>): number =>
+  tree.root.findAll(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (node: any) => typeof node.props.children === 'string' && node.props.children === '🔒',
+  ).length;
+
+/** Whether the first hotspot of ``stageNumber`` renders a padlock overlay. */
+const hotspotHasLock = (tree: ReturnType<typeof create>, stageNumber: number): boolean => {
+  const hotspot = tree.root.findByProps({ testID: `stage-hotspot-${stageNumber}-0` });
+  return (
+    hotspot.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) => typeof node.props.children === 'string' && node.props.children === '🔒',
+    ).length > 0
+  );
+};
+
 describe('MapScreen', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
     mockLoadStages.mockClear();
+    mockDerivedStage = 1;
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 
@@ -197,12 +228,26 @@ describe('MapScreen', () => {
 
   it('shows lock icon on locked stages', () => {
     const tree = create(<MapScreen />);
-    // Stages 3–10 are locked in test data (isUnlocked: stageNumber <= 2)
-    const lockTexts = tree.root.findAll(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (node: any) => typeof node.props.children === 'string' && node.props.children === '🔒',
-    );
+    // Stages 3–10 are locked in test data (isUnlocked: stageNumber <= 2) and
+    // the derived current stage is 1, so the server flags stand.
     // 8 locked stages × 2 hotspots each; findAll may traverse into React internals
-    expect(lockTexts.length).toBeGreaterThanOrEqual(16);
+    expect(countLockIcons(tree)).toBeGreaterThanOrEqual(16);
+  });
+
+  it('unlocks stages up to the date-derived current stage even when the server still locks them', () => {
+    // Calendar has reached stage 5. Stages 3–5 are server-locked
+    // (isUnlocked: stageNumber <= 2) but the calendar overrides, so only
+    // stages 6–10 stay padlocked: 5 stages × 2 hotspots = 10.
+    mockDerivedStage = 5;
+    let tree!: ReturnType<typeof create>;
+    act(() => {
+      tree = create(<MapScreen />);
+    });
+    // Stage 4 is server-locked but the calendar (stage 5) has reached it → no
+    // padlock. Stage 8 is beyond the calendar → still padlocked.
+    expect(hotspotHasLock(tree, 4)).toBe(false);
+    expect(hotspotHasLock(tree, 5)).toBe(false);
+    expect(hotspotHasLock(tree, 8)).toBe(true);
+    act(() => tree.unmount());
   });
 });

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -99,21 +99,18 @@ jest.mock('../../../store/useStageStore', () => ({
 
 import MapScreen from '../MapScreen';
 
+// react-test-renderer ships no types here, so structurally type just the prop
+// we read instead of reaching for `any`.
+const isLockIcon = (node: { props: { children?: unknown } }): boolean =>
+  node.props.children === '🔒';
+
 const countLockIcons = (tree: ReturnType<typeof create>): number =>
-  tree.root.findAll(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (node: any) => typeof node.props.children === 'string' && node.props.children === '🔒',
-  ).length;
+  tree.root.findAll(isLockIcon).length;
 
 /** Whether the first hotspot of ``stageNumber`` renders a padlock overlay. */
 const hotspotHasLock = (tree: ReturnType<typeof create>, stageNumber: number): boolean => {
   const hotspot = tree.root.findByProps({ testID: `stage-hotspot-${stageNumber}-0` });
-  return (
-    hotspot.findAll(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (node: any) => typeof node.props.children === 'string' && node.props.children === '🔒',
-    ).length > 0
-  );
+  return hotspot.findAll(isLockIcon).length > 0;
 };
 
 describe('MapScreen', () => {

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach, jest } from '@jest/globals';
 import { act } from '@testing-library/react-native';
 
 import type { Stage } from '../../../../api';
-import { clampProgress } from '../stageService';
+import { clampProgress, isStageUnlocked } from '../stageService';
 
 const mockList = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<Stage[]>>;
 jest.mock('../../../../api', () => ({
@@ -246,6 +246,27 @@ describe('stageService', () => {
       expect(clampProgress(-0.5)).toBe(0);
       expect(clampProgress(1.1)).toBe(1);
       expect(clampProgress(42)).toBe(1);
+    });
+  });
+
+  describe('isStageUnlocked (calendar alignment)', () => {
+    it('honours the server flag when it is set', () => {
+      expect(isStageUnlocked({ isUnlocked: true, stageNumber: 7 }, 1)).toBe(true);
+    });
+
+    it('unlocks stages at or below the date-derived current stage', () => {
+      // Calendar says Purple (stage 2); the server still locks it.
+      expect(isStageUnlocked({ isUnlocked: false, stageNumber: 2 }, 2)).toBe(true);
+      expect(isStageUnlocked({ isUnlocked: false, stageNumber: 1 }, 2)).toBe(true);
+    });
+
+    it('keeps stages above the current stage locked', () => {
+      expect(isStageUnlocked({ isUnlocked: false, stageNumber: 3 }, 2)).toBe(false);
+    });
+
+    it('falls back to the server flag when there is no calendar anchor', () => {
+      expect(isStageUnlocked({ isUnlocked: false, stageNumber: 2 }, null)).toBe(false);
+      expect(isStageUnlocked({ isUnlocked: true, stageNumber: 2 }, null)).toBe(true);
     });
   });
 });

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -73,6 +73,21 @@ export const deriveCurrentStage = (apiStages: Stage[]): number => {
 };
 
 /**
+ * Whether a stage reads as unlocked on the map.
+ *
+ * Unlocked when the server's ``is_unlocked`` flag is set *or* when the
+ * date-driven course calendar (``programStage``) has already reached it. The
+ * map must honour the same derived current stage the Practice and Course
+ * screens use, so a user whose calendar says "Purple" never sees the Purple
+ * stage padlocked while practising it. Stages at or below ``currentStage``
+ * are, by the chain-validation invariant, all reachable.
+ */
+export const isStageUnlocked = (
+  stage: Pick<StageData, 'isUnlocked' | 'stageNumber'>,
+  currentStage: number | null,
+): boolean => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage);
+
+/**
  * Snapshot captured by `prepareAdvanceStage` and consumed by
  * `applyAdvanceStage` / `rollbackAdvanceStage`. Holding the previous
  * `currentStage` here (rather than re-reading the store inside

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -72,16 +72,7 @@ export const deriveCurrentStage = (apiStages: Stage[]): number => {
   return Math.min(Math.max(1, completed + 1), STAGE_COUNT);
 };
 
-/**
- * Whether a stage reads as unlocked on the map.
- *
- * Unlocked when the server's ``is_unlocked`` flag is set *or* when the
- * date-driven course calendar (``programStage``) has already reached it. The
- * map must honour the same derived current stage the Practice and Course
- * screens use, so a user whose calendar says "Purple" never sees the Purple
- * stage padlocked while practising it. Stages at or below ``currentStage``
- * are, by the chain-validation invariant, all reachable.
- */
+/** Unlocked on the map when the server `is_unlocked` flag is set OR the date-derived current stage has reached it, so the padlock matches the Practice/Course stage. */
 export const isStageUnlocked = (
   stage: Pick<StageData, 'isUnlocked' | 'stageNumber'>,
   currentStage: number | null,


### PR DESCRIPTION
## Problem

All screens are supposed to operate on one course calendar, but a user "on Purple" could see **Purple padlocked on the Map** and the **Purple habit still locked**, even while the Practice screen happily showed the Purple practice.

## Audit

The frontend already has a single source of truth — `useProgramStore.programStartDate`, from which `programStage()`/`programWeek()` derive the stage (1–10) and week (1–36) by walking `STAGE_DURATIONS_DAYS = [21×8, 42×2]`. **Practice, Course, and Journal** already consume it via `useDerivedCurrentStage`/`useDerivedCurrentWeek`. Three places broke the chain:

1. **Onboarding never set the anchor.** `OnboardingModal` computed each habit's `start_date` from a local date but never called `setProgramStartDate` (only `ReorderHabitsModal` did) → a freshly-onboarded user had `programStartDate === null`, so every screen fell back to divergent server/position values.
2. **The Map's padlock ignored the calendar.** It highlighted the date-derived "current" stage but drew 🔒 from the server's `is_unlocked`.
3. **Habits never auto-unlocked.** Onboarding set `revealed` only for the Beige (stage-1) habit; the only reconciliation against `start_date` was a *manual* toggle, so later-stage habits stayed locked forever.

## Changes (all traced to the one anchor)

- **`habitManager.onboardingSave`** now writes `programStartDate` from the earliest habit start date — engaging the universal calendar at onboarding.
- **`isStageUnlocked(stage, currentStage)`** (new, in `stageService`) — the Map treats a stage as unlocked when the server flag is set **or** the date-derived current stage has reached it.
- **`isHabitLockedToday(habit)`** (new, in `HabitUtils`) — habit tiles unlock when `start_date` arrives (itself anchored to `programStartDate`), regardless of a stale `revealed` flag. `revealed` still gates *manual* early-unlock.

Because each habit's `start_date` is laid out from the same anchor with the same `STAGE_DURATIONS_DAYS`, **habit N's start date is precisely the day the calendar enters stage N** — so Map, Practice, Course, Journal, and Habits now report the same stage/week from one source.

Tile **coloring was not a misalignment**: with 10 stages cycling per 10-habit page, position-based color already tracks each habit's stage (pinned by existing `HabitsStageColors` tests), so it was left unchanged.

## Testing

- New/updated unit tests for `isStageUnlocked`, `isHabitLockedToday`, the onboarding anchor write, and the Map unlock wiring.
- Full frontend suite: **1758 passed**. `tsc`, ESLint, prettier, commitlint all green via pre-commit/pre-push.

## Scope / follow-up

This aligns everything on the **frontend** date calendar; the frontend now overrides server gating for display. The backend still derives week from prompt-completion count and stage from explicit advancement, so server-enforced unlocks can lag the calendar. Tracked as a follow-up to anchor backend gating to a stored program start date.

https://claude.ai/code/session_01BphYodE3ReTmVzQMeWth6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01BphYodE3ReTmVzQMeWth6z)_