### PR TITLE
refactor(frontend): declutter practice catalog rows

### DIFF
--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -330,12 +330,7 @@ interface PracticeRowProps {
   onPress: () => void;
 }
 
-/**
- * Friendly presentation (human label + emoji anchor) for every mode,
- * derived from the single source the wizard already uses. Showing the raw
- * ``meditation_timer`` identifier reads as a database dump; the icon gives
- * each row a calm visual anchor and the label is plain English.
- */
+// Derived from MODE_CATEGORIES so adding a mode propagates here automatically.
 const MODE_PRESENTATION: Readonly<Record<PickableMode, { label: string; icon: string }>> =
   Object.fromEntries(
     MODE_CATEGORIES.flatMap((category) =>
@@ -358,9 +353,7 @@ const PracticeRow = ({ practice, onPress }: PracticeRowProps): React.JSX.Element
       style={styles.row}
       testID={`practice-catalog-row-${practice.id}`}
     >
-      {/* Decorative anchor; the row's accessibilityLabel already names the
-          mode, and the accessible TouchableOpacity merges children, so the
-          emoji is not separately announced to screen readers. */}
+      {/* Decorative; TouchableOpacity merges children, so screen readers use accessibilityLabel. */}
       <Text style={styles.rowIcon} testID={`practice-catalog-row-${practice.id}-icon`}>
         {icon}
       </Text>

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -330,26 +330,49 @@ interface PracticeRowProps {
   onPress: () => void;
 }
 
-const PracticeRow = ({ practice, onPress }: PracticeRowProps): React.JSX.Element => (
-  <TouchableOpacity
-    accessibilityRole="button"
-    accessibilityLabel={practice.name}
-    onPress={onPress}
-    style={styles.row}
-    testID={`practice-catalog-row-${practice.id}`}
-  >
-    <Text style={styles.rowName}>{practice.name}</Text>
-    <View style={styles.rowMeta}>
-      <View style={styles.rowBadge}>
-        <Text style={styles.rowBadgeText}>{practice.mode ?? 'meditation_timer'}</Text>
+/**
+ * Friendly presentation (human label + emoji anchor) for every mode,
+ * derived from the single source the wizard already uses. Showing the raw
+ * ``meditation_timer`` identifier reads as a database dump; the icon gives
+ * each row a calm visual anchor and the label is plain English.
+ */
+const MODE_PRESENTATION: Readonly<Record<PickableMode, { label: string; icon: string }>> =
+  Object.fromEntries(
+    MODE_CATEGORIES.flatMap((category) =>
+      category.modes.map((entry) => [entry.mode, { label: entry.label, icon: entry.icon }]),
+    ),
+  ) as Record<PickableMode, { label: string; icon: string }>;
+
+const FALLBACK_PRESENTATION = { label: 'Practice', icon: '🧘' } as const;
+
+const PracticeRow = ({ practice, onPress }: PracticeRowProps): React.JSX.Element => {
+  const mode = (practice.mode ?? 'meditation_timer') as PickableMode;
+  const { label, icon } = MODE_PRESENTATION[mode] ?? FALLBACK_PRESENTATION;
+  const duration = Math.round(practice.default_duration_minutes);
+  const subtitle = `${label} · ${duration} min`;
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={`${practice.name}. ${label}, ${duration} minutes.`}
+      onPress={onPress}
+      style={styles.row}
+      testID={`practice-catalog-row-${practice.id}`}
+    >
+      {/* Decorative anchor; the row's accessibilityLabel already names the
+          mode, and the accessible TouchableOpacity merges children, so the
+          emoji is not separately announced to screen readers. */}
+      <Text style={styles.rowIcon} testID={`practice-catalog-row-${practice.id}-icon`}>
+        {icon}
+      </Text>
+      <View style={styles.rowText}>
+        <Text style={styles.rowName} numberOfLines={1}>
+          {practice.name}
+        </Text>
+        <Text style={styles.rowSubtitle}>{subtitle}</Text>
       </View>
-      <View style={styles.rowBadge}>
-        <Text style={styles.rowBadgeText}>Stage {practice.stage_number}</Text>
-      </View>
-      <Text style={styles.rowDuration}>{Math.round(practice.default_duration_minutes)} min</Text>
-    </View>
-  </TouchableOpacity>
-);
+    </TouchableOpacity>
+  );
+};
 
 function applyFilters(
   items: readonly PracticeItem[],
@@ -479,28 +502,23 @@ const styles = StyleSheet.create({
   },
   emptyText: { color: colors.text.tertiaryAccessible, fontSize: 13 },
   row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.md,
     backgroundColor: colors.background.card,
     borderRadius: BORDER_RADIUS.lg,
     padding: SPACING.md,
     marginBottom: SPACING.sm,
     ...shadows.small,
   },
+  rowIcon: { fontSize: 24, width: 32, textAlign: 'center' },
+  rowText: { flex: 1 },
   rowName: { fontSize: 15, fontWeight: '700', color: colors.text.primary },
-  rowMeta: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    gap: SPACING.xs,
-    marginTop: SPACING.xs,
+  rowSubtitle: {
+    fontSize: 13,
+    color: colors.text.secondaryAccessible,
+    marginTop: 2,
   },
-  rowBadge: {
-    backgroundColor: colors.background.accent,
-    paddingHorizontal: SPACING.xs,
-    paddingVertical: 2,
-    borderRadius: BORDER_RADIUS.sm,
-  },
-  rowBadgeText: { fontSize: 11, color: colors.text.primary, fontWeight: '600' },
-  rowDuration: { fontSize: 12, color: colors.text.secondaryAccessible },
 });
 
 export default PracticeCatalogScreen;

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -134,6 +134,31 @@ describe('PracticeCatalogScreen — sections', () => {
   });
 });
 
+describe('PracticeCatalogScreen — row presentation', () => {
+  it('renders the friendly mode label and duration, never the raw snake_case mode', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.getByText('Meditation timer · 10 min')).toBeTruthy();
+    expect(view.getByText('Random interval bell · 20 min')).toBeTruthy();
+    expect(view.queryByText('meditation_timer')).toBeNull();
+    expect(view.queryByText('random_interval_bell')).toBeNull();
+  });
+
+  it('does not repeat the already-selected stage as a per-row badge', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    // The only "Stage 1" text on screen is the active filter chip, not a
+    // redundant badge stamped onto every row.
+    expect(view.getAllByText('Stage 1')).toHaveLength(1);
+  });
+
+  it('gives each row a leading mode icon as a visual anchor', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.getByTestId('practice-catalog-row-1-icon')).toBeTruthy();
+  });
+});
+
 describe('PracticeCatalogScreen — filters', () => {
   it('filters by name with the search bar', async () => {
     const { view } = renderScreen();

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -152,10 +152,21 @@ describe('PracticeCatalogScreen — row presentation', () => {
     expect(view.getAllByText('Stage 1')).toHaveLength(1);
   });
 
-  it('gives each row a leading mode icon as a visual anchor', async () => {
+  it('gives each row the mode-specific emoji as a leading visual anchor', async () => {
     const { view } = renderScreen();
     await waitForLoad();
-    expect(view.getByTestId('practice-catalog-row-1-icon')).toBeTruthy();
+    expect(view.getByTestId('practice-catalog-row-1-icon').props.children).toBe('⏳');
+  });
+
+  it('falls back to a generic label and icon when the mode is unrecognised', async () => {
+    const unknown: PracticeItem = {
+      ...presetA,
+      mode: 'totally_new_server_mode' as PracticeItem['mode'],
+    };
+    const { view } = renderScreen({ loadPractices: jest.fn(async () => [unknown]) });
+    await waitForLoad();
+    expect(view.getByText('Practice · 10 min')).toBeTruthy();
+    expect(view.getByTestId('practice-catalog-row-1-icon').props.children).toBe('🧘');
   });
 });
 


### PR DESCRIPTION
Reduce the visual density of the practice catalog list so the screen
reads as approachable cards rather than a database dump.

- Replace the raw ``meditation_timer`` snake_case badge with the friendly
  mode label and emoji icon already defined in ModePicker (e.g. ⏳
  "Meditation timer").
- Drop the redundant per-row "Stage N" badge — the catalog is already
  scoped to the stage chosen in the stage chip, so it repeated the same
  value on every row.
- Collapse the three-badge metadata row into a single quiet subtitle
  line ("Meditation timer · 5 min") with a leading icon as a calm
  visual anchor.