### PR TITLE
feat(practice): replace sense chips with searchable grounding dropdown

### DIFF
--- a/frontend/src/features/Practice/components/SearchableDropdown.tsx
+++ b/frontend/src/features/Practice/components/SearchableDropdown.tsx
@@ -20,6 +20,8 @@ export interface SearchableDropdownProps {
   searchTestID: string;
   /** Text shown on the collapsed trigger — the current selection. */
   triggerLabel: string;
+  /** Screen-reader phrasing for the trigger; defaults to a generic string. */
+  triggerAccessibilityLabel?: string;
   badge?: DropdownBadge;
   placeholder: string;
   /** Stable label for the search field; placeholders aren't read reliably. */
@@ -46,6 +48,7 @@ const SearchableDropdown = (props: SearchableDropdownProps): React.JSX.Element =
     <Trigger
       testID={props.triggerTestID}
       label={props.triggerLabel}
+      accessibilityLabel={props.triggerAccessibilityLabel}
       badge={props.badge}
       open={props.open}
       onPress={props.onToggle}
@@ -73,15 +76,23 @@ const SearchableDropdown = (props: SearchableDropdownProps): React.JSX.Element =
 interface TriggerProps {
   testID: string;
   label: string;
+  accessibilityLabel?: string;
   badge?: DropdownBadge;
   open: boolean;
   onPress: () => void;
 }
 
-const Trigger = ({ testID, label, badge, open, onPress }: TriggerProps): React.JSX.Element => (
+const Trigger = ({
+  testID,
+  label,
+  accessibilityLabel,
+  badge,
+  open,
+  onPress,
+}: TriggerProps): React.JSX.Element => (
   <TouchableOpacity
     accessibilityRole="button"
-    accessibilityLabel={`Choose an option, currently ${label}`}
+    accessibilityLabel={accessibilityLabel ?? `Choose an option, currently ${label}`}
     accessibilityState={{ expanded: open }}
     onPress={onPress}
     style={styles.trigger}

--- a/frontend/src/features/Practice/components/SearchableDropdown.tsx
+++ b/frontend/src/features/Practice/components/SearchableDropdown.tsx
@@ -22,6 +22,8 @@ export interface SearchableDropdownProps {
   triggerLabel: string;
   badge?: DropdownBadge;
   placeholder: string;
+  /** Stable label for the search field; placeholders aren't read reliably. */
+  searchAccessibilityLabel: string;
   open: boolean;
   query: string;
   onToggle: () => void;
@@ -55,6 +57,7 @@ const SearchableDropdown = (props: SearchableDropdownProps): React.JSX.Element =
           value={props.query}
           onChangeText={props.onQueryChange}
           placeholder={props.placeholder}
+          accessibilityLabel={props.searchAccessibilityLabel}
           autoCorrect={false}
           testID={props.searchTestID}
         />
@@ -100,7 +103,9 @@ const Trigger = ({ testID, label, badge, open, onPress }: TriggerProps): React.J
 
 /** Uppercase section header inside the results list. */
 export const DropdownGroupHeader = ({ label }: { label: string }): React.JSX.Element => (
-  <Text style={styles.groupHeader}>{label}</Text>
+  <Text accessibilityRole="header" style={styles.groupHeader}>
+    {label}
+  </Text>
 );
 
 export interface DropdownOptionRowProps {
@@ -227,6 +232,8 @@ export const dropdownCreateStyles = StyleSheet.create({
   },
   row: { paddingVertical: SPACING.xs, paddingHorizontal: SPACING.xs },
   rowText: { color: colors.primary, fontSize: 14, fontWeight: '600' },
+  /** Dim an action that is present but not yet actionable (e.g. empty form). */
+  disabled: { opacity: 0.4 },
   controls: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', gap: SPACING.xs },
   controlsLabel: { color: colors.text.secondaryAccessible, fontSize: 12, fontWeight: '600' },
   input: {

--- a/frontend/src/features/Practice/components/SearchableDropdown.tsx
+++ b/frontend/src/features/Practice/components/SearchableDropdown.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+/** Tallest the open results list grows before it scrolls internally. */
+const PANEL_MAX_HEIGHT = 280;
+
+/** Optional secondary tag shown on the closed trigger (e.g. a sense name). */
+export interface DropdownBadge {
+  text: string;
+  testID: string;
+}
+
+export interface SearchableDropdownProps {
+  /** Container handle. */
+  testID: string;
+  triggerTestID: string;
+  panelTestID: string;
+  searchTestID: string;
+  /** Text shown on the collapsed trigger — the current selection. */
+  triggerLabel: string;
+  badge?: DropdownBadge;
+  placeholder: string;
+  open: boolean;
+  query: string;
+  onToggle: () => void;
+  onQueryChange: (next: string) => void;
+  /** Static slot rendered above the scrolling results (e.g. a create row). */
+  createSlot?: React.ReactNode;
+  /** Scrolling results — grouped option rows / empty state. */
+  children: React.ReactNode;
+}
+
+/**
+ * Presentational chrome for a searchable dropdown: a collapsed trigger with
+ * an optional badge, and—when open—a search box, a static create slot, and a
+ * scrolling results region. Selection, filtering and "create your own" logic
+ * live in the consumer so the same chrome can sit over a static catalogue
+ * ({@link GroundingDropdown}) or a server-backed tag library (TagPicker).
+ */
+const SearchableDropdown = (props: SearchableDropdownProps): React.JSX.Element => (
+  <View testID={props.testID}>
+    <Trigger
+      testID={props.triggerTestID}
+      label={props.triggerLabel}
+      badge={props.badge}
+      open={props.open}
+      onPress={props.onToggle}
+    />
+    {props.open && (
+      <View style={styles.panel} testID={props.panelTestID}>
+        <TextInput
+          style={styles.search}
+          value={props.query}
+          onChangeText={props.onQueryChange}
+          placeholder={props.placeholder}
+          autoCorrect={false}
+          testID={props.searchTestID}
+        />
+        {props.createSlot}
+        <ScrollView style={styles.results} keyboardShouldPersistTaps="handled">
+          {props.children}
+        </ScrollView>
+      </View>
+    )}
+  </View>
+);
+
+interface TriggerProps {
+  testID: string;
+  label: string;
+  badge?: DropdownBadge;
+  open: boolean;
+  onPress: () => void;
+}
+
+const Trigger = ({ testID, label, badge, open, onPress }: TriggerProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={`Choose an option, currently ${label}`}
+    accessibilityState={{ expanded: open }}
+    onPress={onPress}
+    style={styles.trigger}
+    testID={testID}
+  >
+    <Text style={styles.triggerLabel} numberOfLines={1}>
+      {label}
+    </Text>
+    <View style={styles.triggerRight}>
+      {badge !== undefined && (
+        <Text style={styles.badge} testID={badge.testID}>
+          {badge.text}
+        </Text>
+      )}
+      <Text style={styles.caret}>{open ? '▲' : '▼'}</Text>
+    </View>
+  </TouchableOpacity>
+);
+
+/** Uppercase section header inside the results list. */
+export const DropdownGroupHeader = ({ label }: { label: string }): React.JSX.Element => (
+  <Text style={styles.groupHeader}>{label}</Text>
+);
+
+export interface DropdownOptionRowProps {
+  label: string;
+  caption?: string;
+  onPress: () => void;
+  testID: string;
+  accessibilityLabel: string;
+  selected?: boolean;
+}
+
+/** One selectable option row — a bold label over an optional caption. */
+export const DropdownOptionRow = ({
+  label,
+  caption,
+  onPress,
+  testID,
+  accessibilityLabel,
+  selected = false,
+}: DropdownOptionRowProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={accessibilityLabel}
+    accessibilityState={{ selected }}
+    onPress={onPress}
+    style={[styles.optionRow, selected && styles.optionRowSelected]}
+    testID={testID}
+  >
+    <Text style={styles.optionLabel}>{label}</Text>
+    {caption !== undefined && caption !== '' && (
+      <Text style={styles.optionCaption} numberOfLines={1}>
+        {caption}
+      </Text>
+    )}
+  </TouchableOpacity>
+);
+
+/** "No matches" placeholder shown when the filtered results are empty. */
+export const DropdownEmptyState = ({
+  label,
+  testID,
+}: {
+  label: string;
+  testID: string;
+}): React.JSX.Element => (
+  <Text style={styles.empty} testID={testID}>
+    {label}
+  </Text>
+);
+
+const styles = StyleSheet.create({
+  trigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.sm,
+    backgroundColor: colors.background.card,
+    gap: SPACING.sm,
+  },
+  triggerLabel: { color: colors.text.primary, fontSize: 14, fontWeight: '500', flexShrink: 1 },
+  triggerRight: { flexDirection: 'row', alignItems: 'center', gap: SPACING.xs },
+  badge: {
+    color: colors.text.secondaryAccessible,
+    fontSize: 12,
+    fontWeight: '600',
+    overflow: 'hidden',
+    backgroundColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: 2,
+  },
+  caret: { color: colors.text.secondaryAccessible, fontSize: 11 },
+  panel: {
+    marginTop: SPACING.xs,
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.card,
+    padding: SPACING.xs,
+    gap: SPACING.xs,
+  },
+  search: {
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    color: colors.text.primary,
+    fontSize: 14,
+    backgroundColor: colors.background.primary,
+  },
+  results: { maxHeight: PANEL_MAX_HEIGHT },
+  groupHeader: {
+    color: colors.text.tertiaryAccessible,
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginTop: SPACING.xs,
+    marginBottom: 2,
+  },
+  optionRow: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.xs,
+    borderRadius: BORDER_RADIUS.sm,
+  },
+  optionRowSelected: { backgroundColor: colors.background.accent },
+  optionLabel: { color: colors.text.primary, fontSize: 14, fontWeight: '500' },
+  optionCaption: { color: colors.text.secondaryAccessible, fontSize: 12 },
+  empty: { color: colors.text.secondaryAccessible, fontSize: 13, padding: SPACING.sm },
+});
+
+/** Create-slot styles shared so each consumer's "create your own" matches. */
+export const dropdownCreateStyles = StyleSheet.create({
+  section: {
+    backgroundColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    padding: SPACING.xs,
+    gap: SPACING.xs,
+  },
+  row: { paddingVertical: SPACING.xs, paddingHorizontal: SPACING.xs },
+  rowText: { color: colors.primary, fontSize: 14, fontWeight: '600' },
+  controls: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', gap: SPACING.xs },
+  controlsLabel: { color: colors.text.secondaryAccessible, fontSize: 12, fontWeight: '600' },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.background.card,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    color: colors.text.primary,
+    fontSize: 13,
+    backgroundColor: colors.background.primary,
+  },
+  error: { color: colors.danger, fontSize: 12 },
+});
+
+export default SearchableDropdown;

--- a/frontend/src/features/Practice/components/__tests__/SearchableDropdown.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/SearchableDropdown.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import SearchableDropdown, {
+  DropdownEmptyState,
+  DropdownGroupHeader,
+  DropdownOptionRow,
+} from '../SearchableDropdown';
+
+function renderShell(
+  overrides: Partial<React.ComponentProps<typeof SearchableDropdown>> = {},
+): ReturnType<typeof render> {
+  return render(
+    <SearchableDropdown
+      testID="dd"
+      triggerTestID="dd-trigger"
+      panelTestID="dd-panel"
+      searchTestID="dd-search"
+      triggerLabel="Pick one"
+      placeholder="Search…"
+      open={false}
+      query=""
+      onToggle={jest.fn()}
+      onQueryChange={jest.fn()}
+      {...overrides}
+    >
+      <DropdownGroupHeader label="Group" />
+      <DropdownOptionRow
+        label="Option A"
+        caption="caption a"
+        onPress={jest.fn()}
+        testID="dd-option-a"
+        accessibilityLabel="Option A"
+      />
+    </SearchableDropdown>,
+  );
+}
+
+describe('SearchableDropdown', () => {
+  it('renders the trigger label and stays collapsed when closed', () => {
+    const { getByTestId, queryByTestId } = renderShell();
+    expect(getByTestId('dd-trigger')).toBeTruthy();
+    expect(queryByTestId('dd-panel')).toBeNull();
+  });
+
+  it('shows an optional badge on the trigger', () => {
+    const { getByTestId } = renderShell({ badge: { text: 'Sight', testID: 'dd-badge' } });
+    expect(getByTestId('dd-badge')).toHaveTextContent('Sight');
+  });
+
+  it('fires onToggle when the trigger is pressed', () => {
+    const onToggle = jest.fn();
+    const { getByTestId } = renderShell({ onToggle });
+    fireEvent.press(getByTestId('dd-trigger'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('reveals the search box, create slot and results when open', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = renderShell({
+      open: true,
+      onQueryChange,
+      createSlot: <DropdownGroupHeader label="Create" />,
+    });
+    expect(getByTestId('dd-panel')).toBeTruthy();
+    expect(getByTestId('dd-option-a')).toBeTruthy();
+    fireEvent.changeText(getByTestId('dd-search'), 'abc');
+    expect(onQueryChange).toHaveBeenCalledWith('abc');
+  });
+
+  it('exposes an empty-state helper with a handle', () => {
+    const { getByTestId } = render(<DropdownEmptyState label="Nothing" testID="dd-empty" />);
+    expect(getByTestId('dd-empty')).toHaveTextContent('Nothing');
+  });
+
+  it('marks a selected option row', () => {
+    const { getByTestId } = render(
+      <DropdownOptionRow
+        label="Sel"
+        onPress={jest.fn()}
+        testID="dd-sel"
+        accessibilityLabel="Sel"
+        selected
+      />,
+    );
+    expect(getByTestId('dd-sel').props.accessibilityState.selected).toBe(true);
+  });
+});

--- a/frontend/src/features/Practice/components/__tests__/SearchableDropdown.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/SearchableDropdown.test.tsx
@@ -19,6 +19,7 @@ function renderShell(
       searchTestID="dd-search"
       triggerLabel="Pick one"
       placeholder="Search…"
+      searchAccessibilityLabel="Search options"
       open={false}
       query=""
       onToggle={jest.fn()}
@@ -67,6 +68,11 @@ describe('SearchableDropdown', () => {
     expect(getByTestId('dd-option-a')).toBeTruthy();
     fireEvent.changeText(getByTestId('dd-search'), 'abc');
     expect(onQueryChange).toHaveBeenCalledWith('abc');
+  });
+
+  it('labels the search field for screen readers', () => {
+    const { getByTestId } = renderShell({ open: true, searchAccessibilityLabel: 'Search tags' });
+    expect(getByTestId('dd-search').props.accessibilityLabel).toBe('Search tags');
   });
 
   it('exposes an empty-state helper with a handle', () => {

--- a/frontend/src/features/Practice/components/__tests__/SearchableDropdown.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/SearchableDropdown.test.tsx
@@ -50,6 +50,17 @@ describe('SearchableDropdown', () => {
     expect(getByTestId('dd-badge')).toHaveTextContent('Sight');
   });
 
+  it('defaults the trigger accessibility label and lets a consumer override it', () => {
+    const def = renderShell();
+    expect(def.getByTestId('dd-trigger').props.accessibilityLabel).toBe(
+      'Choose an option, currently Pick one',
+    );
+    const custom = renderShell({ triggerAccessibilityLabel: 'Choose a tag, currently Red' });
+    expect(custom.getByTestId('dd-trigger').props.accessibilityLabel).toBe(
+      'Choose a tag, currently Red',
+    );
+  });
+
   it('fires onToggle when the trigger is pressed', () => {
     const onToggle = jest.fn();
     const { getByTestId } = renderShell({ onToggle });

--- a/frontend/src/features/Practice/configurator/__tests__/SenseGroundingForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/SenseGroundingForm.test.tsx
@@ -32,10 +32,13 @@ describe('SenseGroundingForm', () => {
     });
   });
 
-  it('changes the sense for a prompt', () => {
+  it('changes the sense via the searchable dropdown, preserving a custom label', () => {
     const onChange = jest.fn();
     const { getByTestId } = render(<SenseGroundingForm value={base} onChange={onChange} />);
-    fireEvent.press(getByTestId('sense-prompt-0-smell'));
+    // Custom label ("5 things you can see") is not a catalogue prompt, so
+    // picking a new anchor only swaps the sense and keeps the wording.
+    fireEvent.press(getByTestId('sense-prompt-0-thing-trigger'));
+    fireEvent.press(getByTestId('sense-prompt-0-option-sense_smell'));
     expect(onChange).toHaveBeenCalledWith({
       mode: 'sense_grounding',
       prompts: [
@@ -43,6 +46,21 @@ describe('SenseGroundingForm', () => {
         base.prompts[1],
         base.prompts[2],
       ],
+    });
+  });
+
+  it('seeds the label when picking an anchor for a still-default prompt', () => {
+    const onChange = jest.fn();
+    const seeded: SenseGroundingConfig = {
+      mode: 'sense_grounding',
+      prompts: [{ sense: 'sight', label: '' }],
+    };
+    const { getByTestId } = render(<SenseGroundingForm value={seeded} onChange={onChange} />);
+    fireEvent.press(getByTestId('sense-prompt-0-thing-trigger'));
+    fireEvent.press(getByTestId('sense-prompt-0-option-colour_red'));
+    expect(onChange).toHaveBeenCalledWith({
+      mode: 'sense_grounding',
+      prompts: [{ sense: 'sight', label: 'something red' }],
     });
   });
 

--- a/frontend/src/features/Practice/configurator/forms/GroundingDropdown.tsx
+++ b/frontend/src/features/Practice/configurator/forms/GroundingDropdown.tsx
@@ -1,0 +1,338 @@
+import React, { useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+import {
+  GROUNDING_CATALOG,
+  GROUNDING_GROUPS,
+  type GroundingOption,
+  SENSE_DISPLAY,
+  findGroundingOption,
+  searchGroundingCatalog,
+} from '../../data/groundingCatalog';
+import type { SenseKind, SensePrompt } from '../../engine/types';
+import { ALLOWED_SENSES } from '../../engine/validation';
+
+import { Chip } from './shared';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+/** Tallest the open results panel grows before it scrolls internally. */
+const PANEL_MAX_HEIGHT = 280;
+
+interface Props {
+  index: number;
+  value: SensePrompt;
+  /** Patch the owning prompt; the form merges it into its prompt list. */
+  onChange: (patch: Partial<SensePrompt>) => void;
+}
+
+/**
+ * Searchable replacement for the old five-chip sense selector.
+ *
+ * Closed, it shows the prompt's current anchor ("Red", or the raw custom
+ * label) plus a sense badge. Open, it offers a search box, the grouped
+ * {@link GROUNDING_CATALOG}, and a "create your own" affordance so the
+ * library is a starting point rather than a fixed menu. Every choice
+ * resolves to one backend {@link SenseKind}, so the stored config shape
+ * never changes.
+ */
+const GroundingDropdown = ({ index, value, onChange }: Props): React.JSX.Element => {
+  const dd = useGroundingDropdown(value, onChange);
+  return (
+    <View testID={`sense-prompt-${index}-thing`}>
+      <Trigger
+        index={index}
+        label={triggerLabel(dd.selected, value)}
+        sense={value.sense}
+        open={dd.open}
+        onPress={dd.toggle}
+      />
+      {dd.open && (
+        <View style={styles.panel} testID={`sense-prompt-${index}-panel`}>
+          <TextInput
+            style={styles.search}
+            value={dd.query}
+            onChangeText={dd.setQuery}
+            placeholder="Search things to notice…"
+            autoCorrect={false}
+            testID={`sense-prompt-${index}-search`}
+          />
+          {dd.query.trim() !== '' && (
+            <CreateRow
+              index={index}
+              query={dd.query.trim()}
+              createSense={dd.createSense}
+              onPickSense={dd.setCreateSense}
+              onCreate={dd.createCustom}
+            />
+          )}
+          <ScrollView style={styles.results} keyboardShouldPersistTaps="handled">
+            <GroupedOptions index={index} results={dd.results} onPick={dd.pickOption} />
+          </ScrollView>
+        </View>
+      )}
+    </View>
+  );
+};
+
+interface DropdownController {
+  open: boolean;
+  query: string;
+  createSense: SenseKind;
+  results: readonly GroundingOption[];
+  selected: GroundingOption | undefined;
+  toggle: () => void;
+  setQuery: (next: string) => void;
+  setCreateSense: (next: SenseKind) => void;
+  pickOption: (opt: GroundingOption) => void;
+  createCustom: () => void;
+}
+
+/** Owns the open/search/create state so the view component stays declarative. */
+function useGroundingDropdown(
+  value: SensePrompt,
+  onChange: (patch: Partial<SensePrompt>) => void,
+): DropdownController {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [createSense, setCreateSense] = useState<SenseKind>(value.sense);
+  const results = useMemo(() => searchGroundingCatalog(query), [query]);
+  const close = (): void => {
+    setOpen(false);
+    setQuery('');
+  };
+  const pickOption = (opt: GroundingOption): void => {
+    onChange({ sense: opt.sense, ...(labelIsDefault(value.label) ? { label: opt.prompt } : {}) });
+    close();
+  };
+  const createCustom = (): void => {
+    const label = query.trim();
+    if (label === '') return;
+    onChange({ sense: createSense, label });
+    close();
+  };
+  return {
+    open,
+    query,
+    createSense,
+    results,
+    selected: findGroundingOption(value.sense, value.label),
+    toggle: () => setOpen((prev) => !prev),
+    setQuery,
+    setCreateSense,
+    pickOption,
+    createCustom,
+  };
+}
+
+/** A prompt's label is "default" until the user edits it off a catalogue prompt. */
+function labelIsDefault(label: string): boolean {
+  return label.trim() === '' || GROUNDING_CATALOG.some((opt) => opt.prompt === label);
+}
+
+function triggerLabel(selected: GroundingOption | undefined, value: SensePrompt): string {
+  if (selected !== undefined) return selected.label;
+  if (value.label.trim() !== '') return value.label.trim();
+  return 'Choose what to notice';
+}
+
+interface TriggerProps {
+  index: number;
+  label: string;
+  sense: SenseKind;
+  open: boolean;
+  onPress: () => void;
+}
+
+const Trigger = ({ index, label, sense, open, onPress }: TriggerProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={`Choose what to notice, currently ${label}`}
+    accessibilityState={{ expanded: open }}
+    onPress={onPress}
+    style={styles.trigger}
+    testID={`sense-prompt-${index}-thing-trigger`}
+  >
+    <Text style={styles.triggerLabel} numberOfLines={1}>
+      {label}
+    </Text>
+    <View style={styles.triggerRight}>
+      <Text style={styles.senseBadge} testID={`sense-prompt-${index}-sense-badge`}>
+        {SENSE_DISPLAY[sense]}
+      </Text>
+      <Text style={styles.caret}>{open ? '▲' : '▼'}</Text>
+    </View>
+  </TouchableOpacity>
+);
+
+interface CreateRowProps {
+  index: number;
+  query: string;
+  createSense: SenseKind;
+  onPickSense: (sense: SenseKind) => void;
+  onCreate: () => void;
+}
+
+const CreateRow = ({
+  index,
+  query,
+  createSense,
+  onPickSense,
+  onCreate,
+}: CreateRowProps): React.JSX.Element => (
+  <View style={styles.createSection} testID={`sense-prompt-${index}-create-section`}>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={`Use ${query} as a custom thing to notice`}
+      onPress={onCreate}
+      style={styles.createRow}
+      testID={`sense-prompt-${index}-create`}
+    >
+      <Text style={styles.createText} numberOfLines={1}>
+        {`+ Use “${query}”`}
+      </Text>
+    </TouchableOpacity>
+    <View style={styles.createSenses}>
+      <Text style={styles.createSensesLabel}>Sense</Text>
+      {ALLOWED_SENSES.map((sense) => (
+        <Chip
+          key={sense}
+          label={SENSE_DISPLAY[sense]}
+          active={createSense === sense}
+          onPress={() => onPickSense(sense)}
+          testID={`sense-prompt-${index}-create-sense-${sense}`}
+        />
+      ))}
+    </View>
+  </View>
+);
+
+interface GroupedOptionsProps {
+  index: number;
+  results: readonly GroundingOption[];
+  onPick: (opt: GroundingOption) => void;
+}
+
+const GroupedOptions = ({ index, results, onPick }: GroupedOptionsProps): React.JSX.Element => {
+  if (results.length === 0) {
+    return (
+      <Text style={styles.empty} testID={`sense-prompt-${index}-empty`}>
+        No matches — create your own above.
+      </Text>
+    );
+  }
+  return (
+    <>
+      {GROUNDING_GROUPS.map((group) => {
+        const inGroup = results.filter((opt) => opt.group === group);
+        if (inGroup.length === 0) return null;
+        return (
+          <View key={group} testID={`sense-prompt-${index}-group-${group}`}>
+            <Text style={styles.groupHeader}>{group}</Text>
+            {inGroup.map((opt) => (
+              <OptionRow key={opt.id} index={index} option={opt} onPick={() => onPick(opt)} />
+            ))}
+          </View>
+        );
+      })}
+    </>
+  );
+};
+
+interface OptionRowProps {
+  index: number;
+  option: GroundingOption;
+  onPick: () => void;
+}
+
+const OptionRow = ({ index, option, onPick }: OptionRowProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={`${option.label}, noticed through ${SENSE_DISPLAY[option.sense]}`}
+    onPress={onPick}
+    style={styles.optionRow}
+    testID={`sense-prompt-${index}-option-${option.id}`}
+  >
+    <Text style={styles.optionLabel}>{option.label}</Text>
+    <Text style={styles.optionPrompt} numberOfLines={1}>
+      {option.prompt}
+    </Text>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  trigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.sm,
+    backgroundColor: colors.background.card,
+    gap: SPACING.sm,
+  },
+  triggerLabel: { color: colors.text.primary, fontSize: 14, fontWeight: '500', flexShrink: 1 },
+  triggerRight: { flexDirection: 'row', alignItems: 'center', gap: SPACING.xs },
+  senseBadge: {
+    color: colors.text.secondaryAccessible,
+    fontSize: 12,
+    fontWeight: '600',
+    overflow: 'hidden',
+    backgroundColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: 2,
+  },
+  caret: { color: colors.text.secondaryAccessible, fontSize: 11 },
+  panel: {
+    marginTop: SPACING.xs,
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.background.card,
+    padding: SPACING.xs,
+    gap: SPACING.xs,
+  },
+  search: {
+    borderWidth: 1,
+    borderColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    color: colors.text.primary,
+    fontSize: 14,
+    backgroundColor: colors.background.primary,
+  },
+  results: { maxHeight: PANEL_MAX_HEIGHT },
+  groupHeader: {
+    color: colors.text.tertiaryAccessible,
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginTop: SPACING.xs,
+    marginBottom: 2,
+  },
+  optionRow: {
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.xs,
+    borderRadius: BORDER_RADIUS.sm,
+  },
+  optionLabel: { color: colors.text.primary, fontSize: 14, fontWeight: '500' },
+  optionPrompt: { color: colors.text.secondaryAccessible, fontSize: 12 },
+  empty: { color: colors.text.secondaryAccessible, fontSize: 13, padding: SPACING.sm },
+  createSection: {
+    backgroundColor: colors.background.accent,
+    borderRadius: BORDER_RADIUS.sm,
+    padding: SPACING.xs,
+    gap: SPACING.xs,
+  },
+  createRow: { paddingVertical: SPACING.xs, paddingHorizontal: SPACING.xs },
+  createText: { color: colors.primary, fontSize: 14, fontWeight: '600' },
+  createSenses: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', gap: SPACING.xs },
+  createSensesLabel: { color: colors.text.secondaryAccessible, fontSize: 12, fontWeight: '600' },
+});
+
+export default GroundingDropdown;

--- a/frontend/src/features/Practice/configurator/forms/GroundingDropdown.tsx
+++ b/frontend/src/features/Practice/configurator/forms/GroundingDropdown.tsx
@@ -48,6 +48,7 @@ const GroundingDropdown = ({ index, value, onChange }: Props): React.JSX.Element
       triggerLabel={triggerLabel(dd.selected, value)}
       badge={{ text: SENSE_DISPLAY[value.sense], testID: `${base}-sense-badge` }}
       placeholder="Search things to notice…"
+      searchAccessibilityLabel="Search things to notice"
       open={dd.open}
       query={dd.query}
       onToggle={dd.toggle}
@@ -94,6 +95,9 @@ function useGroundingDropdown(
   const close = (): void => {
     setOpen(false);
     setQuery('');
+    // Re-anchor the create-row sense to the prompt's current sense so a
+    // reopen never shows a stale pick from an abandoned create attempt.
+    setCreateSense(value.sense);
   };
   const pickOption = (opt: GroundingOption): void => {
     onChange({ sense: opt.sense, ...(labelIsDefault(value.label) ? { label: opt.prompt } : {}) });
@@ -126,8 +130,8 @@ function labelIsDefault(label: string): boolean {
 
 function triggerLabel(selected: GroundingOption | undefined, value: SensePrompt): string {
   if (selected !== undefined) return selected.label;
-  if (value.label.trim() !== '') return value.label.trim();
-  return 'Choose what to notice';
+  const trimmed = value.label.trim();
+  return trimmed !== '' ? trimmed : 'Choose what to notice';
 }
 
 interface CreateRowProps {

--- a/frontend/src/features/Practice/configurator/forms/GroundingDropdown.tsx
+++ b/frontend/src/features/Practice/configurator/forms/GroundingDropdown.tsx
@@ -39,13 +39,15 @@ interface Props {
 const GroundingDropdown = ({ index, value, onChange }: Props): React.JSX.Element => {
   const base = `sense-prompt-${index}`;
   const dd = useGroundingDropdown(value, onChange);
+  const label = triggerLabel(dd.selected, value);
   return (
     <SearchableDropdown
       testID={`${base}-thing`}
       triggerTestID={`${base}-thing-trigger`}
       panelTestID={`${base}-panel`}
       searchTestID={`${base}-search`}
-      triggerLabel={triggerLabel(dd.selected, value)}
+      triggerLabel={label}
+      triggerAccessibilityLabel={`Choose what to notice, currently ${label}`}
       badge={{ text: SENSE_DISPLAY[value.sense], testID: `${base}-sense-badge` }}
       placeholder="Search things to notice…"
       searchAccessibilityLabel="Search things to notice"

--- a/frontend/src/features/Practice/configurator/forms/GroundingDropdown.tsx
+++ b/frontend/src/features/Practice/configurator/forms/GroundingDropdown.tsx
@@ -1,6 +1,12 @@
 import React, { useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 
+import SearchableDropdown, {
+  DropdownEmptyState,
+  DropdownGroupHeader,
+  DropdownOptionRow,
+  dropdownCreateStyles,
+} from '../../components/SearchableDropdown';
 import {
   GROUNDING_CATALOG,
   GROUNDING_GROUPS,
@@ -14,11 +20,6 @@ import { ALLOWED_SENSES } from '../../engine/validation';
 
 import { Chip } from './shared';
 
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
-
-/** Tallest the open results panel grows before it scrolls internally. */
-const PANEL_MAX_HEIGHT = 280;
-
 interface Props {
   index: number;
   value: SensePrompt;
@@ -31,47 +32,40 @@ interface Props {
  *
  * Closed, it shows the prompt's current anchor ("Red", or the raw custom
  * label) plus a sense badge. Open, it offers a search box, the grouped
- * {@link GROUNDING_CATALOG}, and a "create your own" affordance so the
- * library is a starting point rather than a fixed menu. Every choice
- * resolves to one backend {@link SenseKind}, so the stored config shape
- * never changes.
+ * {@link GROUNDING_CATALOG}, and a "create your own" affordance. Every
+ * choice resolves to one backend {@link SenseKind}, so the stored config
+ * shape never changes.
  */
 const GroundingDropdown = ({ index, value, onChange }: Props): React.JSX.Element => {
+  const base = `sense-prompt-${index}`;
   const dd = useGroundingDropdown(value, onChange);
   return (
-    <View testID={`sense-prompt-${index}-thing`}>
-      <Trigger
-        index={index}
-        label={triggerLabel(dd.selected, value)}
-        sense={value.sense}
-        open={dd.open}
-        onPress={dd.toggle}
-      />
-      {dd.open && (
-        <View style={styles.panel} testID={`sense-prompt-${index}-panel`}>
-          <TextInput
-            style={styles.search}
-            value={dd.query}
-            onChangeText={dd.setQuery}
-            placeholder="Search things to notice…"
-            autoCorrect={false}
-            testID={`sense-prompt-${index}-search`}
+    <SearchableDropdown
+      testID={`${base}-thing`}
+      triggerTestID={`${base}-thing-trigger`}
+      panelTestID={`${base}-panel`}
+      searchTestID={`${base}-search`}
+      triggerLabel={triggerLabel(dd.selected, value)}
+      badge={{ text: SENSE_DISPLAY[value.sense], testID: `${base}-sense-badge` }}
+      placeholder="Search things to notice…"
+      open={dd.open}
+      query={dd.query}
+      onToggle={dd.toggle}
+      onQueryChange={dd.setQuery}
+      createSlot={
+        dd.query.trim() !== '' ? (
+          <CreateRow
+            base={base}
+            query={dd.query.trim()}
+            createSense={dd.createSense}
+            onPickSense={dd.setCreateSense}
+            onCreate={dd.createCustom}
           />
-          {dd.query.trim() !== '' && (
-            <CreateRow
-              index={index}
-              query={dd.query.trim()}
-              createSense={dd.createSense}
-              onPickSense={dd.setCreateSense}
-              onCreate={dd.createCustom}
-            />
-          )}
-          <ScrollView style={styles.results} keyboardShouldPersistTaps="handled">
-            <GroupedOptions index={index} results={dd.results} onPick={dd.pickOption} />
-          </ScrollView>
-        </View>
-      )}
-    </View>
+        ) : undefined
+      }
+    >
+      <GroupedOptions base={base} results={dd.results} onPick={dd.pickOption} />
+    </SearchableDropdown>
   );
 };
 
@@ -136,37 +130,8 @@ function triggerLabel(selected: GroundingOption | undefined, value: SensePrompt)
   return 'Choose what to notice';
 }
 
-interface TriggerProps {
-  index: number;
-  label: string;
-  sense: SenseKind;
-  open: boolean;
-  onPress: () => void;
-}
-
-const Trigger = ({ index, label, sense, open, onPress }: TriggerProps): React.JSX.Element => (
-  <TouchableOpacity
-    accessibilityRole="button"
-    accessibilityLabel={`Choose what to notice, currently ${label}`}
-    accessibilityState={{ expanded: open }}
-    onPress={onPress}
-    style={styles.trigger}
-    testID={`sense-prompt-${index}-thing-trigger`}
-  >
-    <Text style={styles.triggerLabel} numberOfLines={1}>
-      {label}
-    </Text>
-    <View style={styles.triggerRight}>
-      <Text style={styles.senseBadge} testID={`sense-prompt-${index}-sense-badge`}>
-        {SENSE_DISPLAY[sense]}
-      </Text>
-      <Text style={styles.caret}>{open ? '▲' : '▼'}</Text>
-    </View>
-  </TouchableOpacity>
-);
-
 interface CreateRowProps {
-  index: number;
+  base: string;
   query: string;
   createSense: SenseKind;
   onPickSense: (sense: SenseKind) => void;
@@ -174,33 +139,33 @@ interface CreateRowProps {
 }
 
 const CreateRow = ({
-  index,
+  base,
   query,
   createSense,
   onPickSense,
   onCreate,
 }: CreateRowProps): React.JSX.Element => (
-  <View style={styles.createSection} testID={`sense-prompt-${index}-create-section`}>
+  <View style={dropdownCreateStyles.section} testID={`${base}-create-section`}>
     <TouchableOpacity
       accessibilityRole="button"
       accessibilityLabel={`Use ${query} as a custom thing to notice`}
       onPress={onCreate}
-      style={styles.createRow}
-      testID={`sense-prompt-${index}-create`}
+      style={dropdownCreateStyles.row}
+      testID={`${base}-create`}
     >
-      <Text style={styles.createText} numberOfLines={1}>
+      <Text style={dropdownCreateStyles.rowText} numberOfLines={1}>
         {`+ Use “${query}”`}
       </Text>
     </TouchableOpacity>
-    <View style={styles.createSenses}>
-      <Text style={styles.createSensesLabel}>Sense</Text>
+    <View style={dropdownCreateStyles.controls}>
+      <Text style={dropdownCreateStyles.controlsLabel}>Sense</Text>
       {ALLOWED_SENSES.map((sense) => (
         <Chip
           key={sense}
           label={SENSE_DISPLAY[sense]}
           active={createSense === sense}
           onPress={() => onPickSense(sense)}
-          testID={`sense-prompt-${index}-create-sense-${sense}`}
+          testID={`${base}-create-sense-${sense}`}
         />
       ))}
     </View>
@@ -208,17 +173,15 @@ const CreateRow = ({
 );
 
 interface GroupedOptionsProps {
-  index: number;
+  base: string;
   results: readonly GroundingOption[];
   onPick: (opt: GroundingOption) => void;
 }
 
-const GroupedOptions = ({ index, results, onPick }: GroupedOptionsProps): React.JSX.Element => {
+const GroupedOptions = ({ base, results, onPick }: GroupedOptionsProps): React.JSX.Element => {
   if (results.length === 0) {
     return (
-      <Text style={styles.empty} testID={`sense-prompt-${index}-empty`}>
-        No matches — create your own above.
-      </Text>
+      <DropdownEmptyState label="No matches — create your own above." testID={`${base}-empty`} />
     );
   }
   return (
@@ -227,10 +190,17 @@ const GroupedOptions = ({ index, results, onPick }: GroupedOptionsProps): React.
         const inGroup = results.filter((opt) => opt.group === group);
         if (inGroup.length === 0) return null;
         return (
-          <View key={group} testID={`sense-prompt-${index}-group-${group}`}>
-            <Text style={styles.groupHeader}>{group}</Text>
+          <View key={group} testID={`${base}-group-${group}`}>
+            <DropdownGroupHeader label={group} />
             {inGroup.map((opt) => (
-              <OptionRow key={opt.id} index={index} option={opt} onPick={() => onPick(opt)} />
+              <DropdownOptionRow
+                key={opt.id}
+                label={opt.label}
+                caption={opt.prompt}
+                onPress={() => onPick(opt)}
+                testID={`${base}-option-${opt.id}`}
+                accessibilityLabel={`${opt.label}, noticed through ${SENSE_DISPLAY[opt.sense]}`}
+              />
             ))}
           </View>
         );
@@ -238,101 +208,5 @@ const GroupedOptions = ({ index, results, onPick }: GroupedOptionsProps): React.
     </>
   );
 };
-
-interface OptionRowProps {
-  index: number;
-  option: GroundingOption;
-  onPick: () => void;
-}
-
-const OptionRow = ({ index, option, onPick }: OptionRowProps): React.JSX.Element => (
-  <TouchableOpacity
-    accessibilityRole="button"
-    accessibilityLabel={`${option.label}, noticed through ${SENSE_DISPLAY[option.sense]}`}
-    onPress={onPick}
-    style={styles.optionRow}
-    testID={`sense-prompt-${index}-option-${option.id}`}
-  >
-    <Text style={styles.optionLabel}>{option.label}</Text>
-    <Text style={styles.optionPrompt} numberOfLines={1}>
-      {option.prompt}
-    </Text>
-  </TouchableOpacity>
-);
-
-const styles = StyleSheet.create({
-  trigger: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    borderWidth: 1,
-    borderColor: colors.background.accent,
-    borderRadius: BORDER_RADIUS.sm,
-    paddingVertical: SPACING.sm,
-    paddingHorizontal: SPACING.sm,
-    backgroundColor: colors.background.card,
-    gap: SPACING.sm,
-  },
-  triggerLabel: { color: colors.text.primary, fontSize: 14, fontWeight: '500', flexShrink: 1 },
-  triggerRight: { flexDirection: 'row', alignItems: 'center', gap: SPACING.xs },
-  senseBadge: {
-    color: colors.text.secondaryAccessible,
-    fontSize: 12,
-    fontWeight: '600',
-    overflow: 'hidden',
-    backgroundColor: colors.background.accent,
-    borderRadius: BORDER_RADIUS.sm,
-    paddingHorizontal: SPACING.xs,
-    paddingVertical: 2,
-  },
-  caret: { color: colors.text.secondaryAccessible, fontSize: 11 },
-  panel: {
-    marginTop: SPACING.xs,
-    borderWidth: 1,
-    borderColor: colors.background.accent,
-    borderRadius: BORDER_RADIUS.sm,
-    backgroundColor: colors.background.card,
-    padding: SPACING.xs,
-    gap: SPACING.xs,
-  },
-  search: {
-    borderWidth: 1,
-    borderColor: colors.background.accent,
-    borderRadius: BORDER_RADIUS.sm,
-    paddingVertical: SPACING.xs,
-    paddingHorizontal: SPACING.sm,
-    color: colors.text.primary,
-    fontSize: 14,
-    backgroundColor: colors.background.primary,
-  },
-  results: { maxHeight: PANEL_MAX_HEIGHT },
-  groupHeader: {
-    color: colors.text.tertiaryAccessible,
-    fontSize: 12,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-    letterSpacing: 1,
-    marginTop: SPACING.xs,
-    marginBottom: 2,
-  },
-  optionRow: {
-    paddingVertical: SPACING.xs,
-    paddingHorizontal: SPACING.xs,
-    borderRadius: BORDER_RADIUS.sm,
-  },
-  optionLabel: { color: colors.text.primary, fontSize: 14, fontWeight: '500' },
-  optionPrompt: { color: colors.text.secondaryAccessible, fontSize: 12 },
-  empty: { color: colors.text.secondaryAccessible, fontSize: 13, padding: SPACING.sm },
-  createSection: {
-    backgroundColor: colors.background.accent,
-    borderRadius: BORDER_RADIUS.sm,
-    padding: SPACING.xs,
-    gap: SPACING.xs,
-  },
-  createRow: { paddingVertical: SPACING.xs, paddingHorizontal: SPACING.xs },
-  createText: { color: colors.primary, fontSize: 14, fontWeight: '600' },
-  createSenses: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', gap: SPACING.xs },
-  createSensesLabel: { color: colors.text.secondaryAccessible, fontSize: 12, fontWeight: '600' },
-});
 
 export default GroundingDropdown;

--- a/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import type { SenseGroundingConfig, SenseKind, SensePrompt } from '../../engine/types';
-import { ALLOWED_SENSES, PROMPT_LABEL_MAX } from '../../engine/validation';
+import type { SenseGroundingConfig, SensePrompt } from '../../engine/types';
+import { PROMPT_LABEL_MAX } from '../../engine/validation';
 
-import { Chip, TextField } from './shared';
+import GroundingDropdown from './GroundingDropdown';
+import { TextField } from './shared';
 
 import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
@@ -77,17 +78,7 @@ const PromptRow = ({
   onRemove,
 }: PromptRowProps): React.JSX.Element => (
   <View style={localStyles.promptCard} testID={`sense-prompt-${index}`}>
-    <View style={localStyles.senseRow}>
-      {ALLOWED_SENSES.map((sense) => (
-        <Chip
-          key={sense}
-          label={sense}
-          active={prompt.sense === sense}
-          onPress={() => onChange({ sense: sense satisfies SenseKind })}
-          testID={`sense-prompt-${index}-${sense}`}
-        />
-      ))}
-    </View>
+    <GroundingDropdown index={index} value={prompt} onChange={onChange} />
     <TextField
       value={prompt.label}
       onChange={(label) => onChange({ label })}
@@ -146,7 +137,6 @@ const localStyles = StyleSheet.create({
     marginBottom: SPACING.sm,
     gap: SPACING.xs,
   },
-  senseRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
   actionsRow: { flexDirection: 'row', gap: SPACING.xs, marginTop: SPACING.xs },
   smallButton: {
     paddingVertical: SPACING.xs,

--- a/frontend/src/features/Practice/configurator/forms/__tests__/GroundingDropdown.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/GroundingDropdown.test.tsx
@@ -23,6 +23,16 @@ describe('GroundingDropdown', () => {
     expect(getByTestId('sense-prompt-0-sense-badge')).toHaveTextContent('Sight');
   });
 
+  it('shows a placeholder trigger label when the prompt is empty and uncatalogued', () => {
+    const { getByText, getByTestId } = render(
+      <GroundingDropdown index={0} value={{ sense: 'sight', label: '' }} onChange={jest.fn()} />,
+    );
+    expect(getByText('Choose what to notice')).toBeTruthy();
+    expect(getByTestId('sense-prompt-0-thing-trigger').props.accessibilityLabel).toBe(
+      'Choose what to notice, currently Choose what to notice',
+    );
+  });
+
   it('is collapsed until the trigger is pressed', () => {
     const { queryByTestId, getByTestId } = render(
       <GroundingDropdown index={0} value={prompt} onChange={jest.fn()} />,

--- a/frontend/src/features/Practice/configurator/forms/__tests__/GroundingDropdown.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/GroundingDropdown.test.tsx
@@ -68,6 +68,15 @@ describe('GroundingDropdown', () => {
     expect(getByTestId('sense-prompt-0-create-section')).toBeTruthy();
   });
 
+  it('defaults the create-row sense to the prompt’s current sense', () => {
+    // The prompt is on "hearing"; creating a custom anchor without touching
+    // the sense chips must inherit that sense, not fall back to a constant.
+    const { getByTestId, onChange } = open({ sense: 'hearing', label: 'a faraway sound' });
+    fireEvent.changeText(getByTestId('sense-prompt-0-search'), 'a ticking clock');
+    fireEvent.press(getByTestId('sense-prompt-0-create'));
+    expect(onChange).toHaveBeenCalledWith({ sense: 'hearing', label: 'a ticking clock' });
+  });
+
   it('keeps a user-edited custom label when only swapping the sense', () => {
     const custom: SensePrompt = { sense: 'sight', label: 'Name 5 things you can see' };
     const { getByTestId, onChange } = open(custom);

--- a/frontend/src/features/Practice/configurator/forms/__tests__/GroundingDropdown.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/GroundingDropdown.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { SensePrompt } from '../../../engine/types';
+import GroundingDropdown from '../GroundingDropdown';
+
+const prompt: SensePrompt = { sense: 'sight', label: 'something blue' };
+
+function open(value: SensePrompt = prompt): ReturnType<typeof render> & { onChange: jest.Mock } {
+  const onChange = jest.fn();
+  const utils = render(<GroundingDropdown index={0} value={value} onChange={onChange} />);
+  fireEvent.press(utils.getByTestId('sense-prompt-0-thing-trigger'));
+  return Object.assign(utils, { onChange });
+}
+
+describe('GroundingDropdown', () => {
+  it('echoes the catalogue label and sense for a known prompt', () => {
+    const { getByText, getByTestId } = render(
+      <GroundingDropdown index={0} value={prompt} onChange={jest.fn()} />,
+    );
+    expect(getByText('Blue')).toBeTruthy();
+    expect(getByTestId('sense-prompt-0-sense-badge')).toHaveTextContent('Sight');
+  });
+
+  it('is collapsed until the trigger is pressed', () => {
+    const { queryByTestId, getByTestId } = render(
+      <GroundingDropdown index={0} value={prompt} onChange={jest.fn()} />,
+    );
+    expect(queryByTestId('sense-prompt-0-panel')).toBeNull();
+    fireEvent.press(getByTestId('sense-prompt-0-thing-trigger'));
+    expect(getByTestId('sense-prompt-0-panel')).toBeTruthy();
+  });
+
+  it('picks a catalogue anchor, setting both sense and the seeded label', () => {
+    // "something blue" is a catalogue prompt, so it counts as default and the
+    // label is reseeded to the newly chosen anchor.
+    const { getByTestId, onChange } = open();
+    fireEvent.press(getByTestId('sense-prompt-0-option-sound_far'));
+    expect(onChange).toHaveBeenCalledWith({ sense: 'hearing', label: 'a faraway sound' });
+  });
+
+  it('filters the catalogue by search query', () => {
+    const { getByTestId, queryByTestId } = open();
+    fireEvent.changeText(getByTestId('sense-prompt-0-search'), 'triangle');
+    expect(getByTestId('sense-prompt-0-option-shape_triangle')).toBeTruthy();
+    expect(queryByTestId('sense-prompt-0-option-colour_red')).toBeNull();
+  });
+
+  it('shows an empty-state when nothing matches', () => {
+    const { getByTestId } = open();
+    fireEvent.changeText(getByTestId('sense-prompt-0-search'), 'zzzz-nope');
+    expect(getByTestId('sense-prompt-0-empty')).toBeTruthy();
+  });
+
+  it('creates a custom anchor from the search text with a chosen sense', () => {
+    const { getByTestId, onChange } = open();
+    fireEvent.changeText(getByTestId('sense-prompt-0-search'), 'a warm mug');
+    fireEvent.press(getByTestId('sense-prompt-0-create-sense-touch'));
+    fireEvent.press(getByTestId('sense-prompt-0-create'));
+    expect(onChange).toHaveBeenCalledWith({ sense: 'touch', label: 'a warm mug' });
+  });
+
+  it('does not offer create until the query is non-empty', () => {
+    const { getByTestId, queryByTestId } = open();
+    expect(queryByTestId('sense-prompt-0-create-section')).toBeNull();
+    fireEvent.changeText(getByTestId('sense-prompt-0-search'), 'x');
+    expect(getByTestId('sense-prompt-0-create-section')).toBeTruthy();
+  });
+
+  it('keeps a user-edited custom label when only swapping the sense', () => {
+    const custom: SensePrompt = { sense: 'sight', label: 'Name 5 things you can see' };
+    const { getByTestId, onChange } = open(custom);
+    fireEvent.press(getByTestId('sense-prompt-0-option-sense_hearing'));
+    expect(onChange).toHaveBeenCalledWith({ sense: 'hearing' });
+  });
+});

--- a/frontend/src/features/Practice/data/__tests__/groundingCatalog.test.ts
+++ b/frontend/src/features/Practice/data/__tests__/groundingCatalog.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { ALLOWED_SENSES } from '../../engine/validation';
+import {
+  GROUNDING_CATALOG,
+  GROUNDING_GROUPS,
+  findGroundingOption,
+  searchGroundingCatalog,
+} from '../groundingCatalog';
+
+describe('groundingCatalog', () => {
+  it('exposes a non-trivial, uniquely-keyed catalogue', () => {
+    expect(GROUNDING_CATALOG.length).toBeGreaterThan(20);
+    const ids = GROUNDING_CATALOG.map((opt) => opt.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('maps every option onto a real backend sense and known group', () => {
+    for (const opt of GROUNDING_CATALOG) {
+      expect(ALLOWED_SENSES).toContain(opt.sense);
+      expect(GROUNDING_GROUPS).toContain(opt.group);
+      expect(opt.label.trim().length).toBeGreaterThan(0);
+      expect(opt.prompt.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers all five senses and the colours/shapes history examples', () => {
+    const senses = new Set(GROUNDING_CATALOG.map((opt) => opt.sense));
+    expect(senses).toEqual(new Set(['sight', 'touch', 'hearing', 'smell', 'taste']));
+    const groups = new Set(GROUNDING_CATALOG.map((opt) => opt.group));
+    expect(groups).toContain('Colours');
+    expect(groups).toContain('Shapes');
+  });
+
+  it('returns the whole catalogue for an empty query', () => {
+    expect(searchGroundingCatalog('')).toEqual(GROUNDING_CATALOG);
+    expect(searchGroundingCatalog('   ')).toEqual(GROUNDING_CATALOG);
+  });
+
+  it('filters case-insensitively across label, prompt, group and sense', () => {
+    const red = searchGroundingCatalog('RED');
+    expect(red.some((opt) => opt.id === 'colour_red')).toBe(true);
+    expect(red.every((opt) => /red/i.test(`${opt.label} ${opt.prompt}`))).toBe(true);
+
+    const byGroup = searchGroundingCatalog('shape');
+    expect(byGroup.length).toBeGreaterThan(0);
+    expect(byGroup.every((opt) => opt.group === 'Shapes')).toBe(true);
+
+    const bySense = searchGroundingCatalog('hearing');
+    expect(bySense.every((opt) => opt.sense === 'hearing')).toBe(true);
+  });
+
+  it('returns nothing for a query that matches no option', () => {
+    expect(searchGroundingCatalog('zzzzzz-nope')).toEqual([]);
+  });
+
+  it('matches a stored prompt back to its catalogue option', () => {
+    const match = findGroundingOption('sight', 'something blue');
+    expect(match?.id).toBe('colour_blue');
+    expect(findGroundingOption('taste', 'something blue')).toBeUndefined();
+    expect(findGroundingOption('sight', 'a label nobody catalogued')).toBeUndefined();
+  });
+});

--- a/frontend/src/features/Practice/data/groundingCatalog.ts
+++ b/frontend/src/features/Practice/data/groundingCatalog.ts
@@ -1,0 +1,182 @@
+/**
+ * Searchable catalogue of "things to notice" for sense-grounding practices.
+ *
+ * The 5-4-3-2-1 configurator used to expose only the five raw senses as
+ * toggle chips. This catalogue widens that to a searchable library of
+ * concrete grounding anchors — colours, shapes, textures, sounds, scents,
+ * tastes and the classic elements — drawn from the same vocabulary the
+ * recipe seeder ships (`backend/src/seed_practice_recipes.py`: Find the
+ * Rainbow, Find Shapes, Four Elements …).
+ *
+ * Every option still resolves to exactly one of the five backend
+ * {@link SenseKind} values, so the stored `SenseGroundingConfig` and the
+ * 5-4-3-2-1 runtime view keep working unchanged — the catalogue is a
+ * richer *picker* over the same data model, never a new one. Users who
+ * need something we haven't catalogued create their own entry in the
+ * dropdown (label + sense), so the list is a starting point, not a cage.
+ */
+
+import type { SenseKind } from '../engine/types';
+
+/** Display name for each backend sense, shown as the option's sense badge. */
+export const SENSE_DISPLAY: Readonly<Record<SenseKind, string>> = Object.freeze({
+  sight: 'Sight',
+  touch: 'Touch',
+  hearing: 'Hearing',
+  smell: 'Smell',
+  taste: 'Taste',
+});
+
+/**
+ * One pickable anchor. `prompt` is the user-facing line seeded into the
+ * step (e.g. "something red"); `label` is the short dropdown caption
+ * (e.g. "Red"); `group` is the section header it sorts under.
+ */
+export interface GroundingOption {
+  /** Stable unique id — React key and test handle. */
+  readonly id: string;
+  /** Short caption shown in the dropdown row. */
+  readonly label: string;
+  /** Which of the five senses this anchor is noticed through. */
+  readonly sense: SenseKind;
+  /** Suggested prompt copy seeded into the step when picked. */
+  readonly prompt: string;
+  /** Section header the option sorts under. */
+  readonly group: string;
+}
+
+/** Section order for the grouped dropdown render. */
+export const GROUNDING_GROUPS = [
+  'Senses',
+  'Colours',
+  'Shapes',
+  'Textures',
+  'Sounds',
+  'Scents',
+  'Tastes',
+  'Elements',
+] as const;
+
+export type GroundingGroup = (typeof GROUNDING_GROUPS)[number];
+
+function option(
+  id: string,
+  label: string,
+  sense: SenseKind,
+  prompt: string,
+  group: GroundingGroup,
+): GroundingOption {
+  return { id, label, sense, prompt, group };
+}
+
+const SENSE_OPTIONS: readonly GroundingOption[] = [
+  option('sense_sight', 'Something to see', 'sight', 'something you can see', 'Senses'),
+  option('sense_touch', 'Something to touch', 'touch', 'something you can touch', 'Senses'),
+  option('sense_hearing', 'Something to hear', 'hearing', 'something you can hear', 'Senses'),
+  option('sense_smell', 'Something to smell', 'smell', 'something you can smell', 'Senses'),
+  option('sense_taste', 'Something to taste', 'taste', 'something you can taste', 'Senses'),
+];
+
+const COLOUR_OPTIONS: readonly GroundingOption[] = [
+  option('colour_red', 'Red', 'sight', 'something red', 'Colours'),
+  option('colour_orange', 'Orange', 'sight', 'something orange', 'Colours'),
+  option('colour_yellow', 'Yellow', 'sight', 'something yellow', 'Colours'),
+  option('colour_green', 'Green', 'sight', 'something green', 'Colours'),
+  option('colour_blue', 'Blue', 'sight', 'something blue', 'Colours'),
+  option('colour_indigo', 'Indigo', 'sight', 'something indigo', 'Colours'),
+  option('colour_violet', 'Violet', 'sight', 'something violet', 'Colours'),
+  option('colour_black', 'Black', 'sight', 'something black', 'Colours'),
+  option('colour_white', 'White', 'sight', 'something white', 'Colours'),
+];
+
+const SHAPE_OPTIONS: readonly GroundingOption[] = [
+  option('shape_circle', 'Circle', 'sight', 'a circle', 'Shapes'),
+  option('shape_square', 'Square', 'sight', 'a square', 'Shapes'),
+  option('shape_triangle', 'Triangle', 'sight', 'a triangle', 'Shapes'),
+  option('shape_rectangle', 'Rectangle', 'sight', 'a rectangle', 'Shapes'),
+  option('shape_curve', 'Curve', 'sight', 'a curved line', 'Shapes'),
+  option('shape_straight', 'Straight line', 'sight', 'a straight line', 'Shapes'),
+];
+
+const TEXTURE_OPTIONS: readonly GroundingOption[] = [
+  option('texture_smooth', 'Smooth', 'touch', 'a smooth texture', 'Textures'),
+  option('texture_rough', 'Rough', 'touch', 'a rough texture', 'Textures'),
+  option('texture_soft', 'Soft', 'touch', 'something soft', 'Textures'),
+  option('texture_hard', 'Hard', 'touch', 'something hard', 'Textures'),
+  option('texture_warm', 'Warm', 'touch', 'something warm', 'Textures'),
+  option('texture_cool', 'Cool', 'touch', 'something cool', 'Textures'),
+];
+
+const SOUND_OPTIONS: readonly GroundingOption[] = [
+  option('sound_far', 'Faraway sound', 'hearing', 'a faraway sound', 'Sounds'),
+  option('sound_near', 'Nearby sound', 'hearing', 'a sound close to you', 'Sounds'),
+  option('sound_voice', 'A voice', 'hearing', 'a voice', 'Sounds'),
+  option('sound_steady', 'A steady hum', 'hearing', 'a steady, continuous sound', 'Sounds'),
+  option(
+    'sound_quiet',
+    'The quietest sound',
+    'hearing',
+    'the quietest sound you can find',
+    'Sounds',
+  ),
+];
+
+const SCENT_OPTIONS: readonly GroundingOption[] = [
+  option('scent_fresh', 'Fresh scent', 'smell', 'something fresh', 'Scents'),
+  option('scent_sweet', 'Sweet scent', 'smell', 'something sweet', 'Scents'),
+  option('scent_earthy', 'Earthy scent', 'smell', 'something earthy', 'Scents'),
+  option('scent_air', 'The air itself', 'smell', 'the smell of the air around you', 'Scents'),
+];
+
+const TASTE_OPTIONS: readonly GroundingOption[] = [
+  option('taste_sweet', 'Sweet', 'taste', 'something sweet', 'Tastes'),
+  option('taste_bitter', 'Bitter', 'taste', 'something bitter', 'Tastes'),
+  option('taste_sour', 'Sour', 'taste', 'something sour', 'Tastes'),
+  option('taste_mouth', 'Your mouth', 'taste', 'the taste already in your mouth', 'Tastes'),
+];
+
+const ELEMENT_OPTIONS: readonly GroundingOption[] = [
+  option('element_earth', 'Earth', 'touch', 'the earth element: solidity and weight', 'Elements'),
+  option('element_water', 'Water', 'touch', 'the water element: fluidity and moisture', 'Elements'),
+  option('element_fire', 'Fire', 'sight', 'the fire element: warmth and light', 'Elements'),
+  option('element_air', 'Air', 'touch', 'the air element: movement and breath', 'Elements'),
+];
+
+/** The full catalogue, ordered by {@link GROUNDING_GROUPS}. */
+export const GROUNDING_CATALOG: readonly GroundingOption[] = Object.freeze([
+  ...SENSE_OPTIONS,
+  ...COLOUR_OPTIONS,
+  ...SHAPE_OPTIONS,
+  ...TEXTURE_OPTIONS,
+  ...SOUND_OPTIONS,
+  ...SCENT_OPTIONS,
+  ...TASTE_OPTIONS,
+  ...ELEMENT_OPTIONS,
+]);
+
+/**
+ * Case-insensitive search over an option's label, prompt, group and sense.
+ *
+ * An empty (or whitespace-only) query returns the whole catalogue so the
+ * dropdown shows everything before the user starts typing.
+ */
+export function searchGroundingCatalog(query: string): readonly GroundingOption[] {
+  const needle = query.trim().toLowerCase();
+  if (needle === '') return GROUNDING_CATALOG;
+  return GROUNDING_CATALOG.filter((opt) =>
+    [opt.label, opt.prompt, opt.group, SENSE_DISPLAY[opt.sense]].some((haystack) =>
+      haystack.toLowerCase().includes(needle),
+    ),
+  );
+}
+
+/**
+ * The catalogue option that exactly matches a stored prompt, if any.
+ *
+ * A prompt counts as catalogued when both its `sense` and `prompt` copy
+ * line up with an option — that lets the dropdown echo "Red" instead of
+ * the raw prompt while still treating user-edited copy as custom.
+ */
+export function findGroundingOption(sense: SenseKind, prompt: string): GroundingOption | undefined {
+  return GROUNDING_CATALOG.find((opt) => opt.sense === sense && opt.prompt === prompt);
+}

--- a/frontend/src/features/Practice/recipes/TagPicker.tsx
+++ b/frontend/src/features/Practice/recipes/TagPicker.tsx
@@ -1,10 +1,16 @@
 import React, { useMemo, useState } from 'react';
-import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+import SearchableDropdown, {
+  DropdownEmptyState,
+  DropdownGroupHeader,
+  DropdownOptionRow,
+  dropdownCreateStyles,
+} from '../components/SearchableDropdown';
 
 import { nameToSlug } from './types';
 
 import type { PracticeTag, PracticeTagCreate } from '@/api';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
 export interface TagPickerProps {
   stepIndex: number;
@@ -16,81 +22,197 @@ export interface TagPickerProps {
   onCreateTag: (payload: PracticeTagCreate) => Promise<void>;
 }
 
+const LABEL_MAX = 255;
+const SLUG_MAX = 64;
+
 /**
- * Two-state widget under a recipe step's tag chip row.
+ * Searchable dropdown over a recipe step's tag library.
  *
- * Default state: render every tag in ``tagLibrary`` as a selectable
- * chip plus a "+ New tag" affordance.  When the user taps "+ New tag"
- * the inline create form takes over with two inputs (label + slug)
- * and a Create button that mints a fresh tag and selects it.
- *
- * Slug auto-fills from the label via ``nameToSlug`` so the user
- * never has to think about snake-casing -- they only see it if they
- * want to override the derived value.
+ * Mirrors the configurator's grounding dropdown for a consistent feel:
+ * a collapsed trigger showing the chosen tag, then a search box, the
+ * library split into "Library" (system) and "Yours" (personal) sections,
+ * and an inline "create your own" tag form. Slug auto-fills from the
+ * label via {@link nameToSlug} so the user only sees it to override it.
  */
 const TagPicker = (props: TagPickerProps): React.JSX.Element => {
-  const [creating, setCreating] = useState(false);
-  const sortedTags = useMemo(() => sortTagsForPicker(props.tagLibrary), [props.tagLibrary]);
+  const base = `tag-picker-${props.stepIndex}`;
+  const dd = useTagDropdown(props);
   return (
-    <View style={styles.container} testID={`tag-picker-${props.stepIndex}`}>
-      <View style={styles.chipRow}>
-        {sortedTags.map((tag) => (
-          <TagChip
-            key={`${tag.owner_user_id ?? 'sys'}-${tag.id}`}
-            tag={tag}
-            active={tag.slug === props.selectedSlug}
-            onPress={() => props.onSelect(tag)}
-            testID={`tag-picker-${props.stepIndex}-chip-${tag.slug}`}
+    <SearchableDropdown
+      testID={base}
+      triggerTestID={`${base}-trigger`}
+      panelTestID={`${base}-panel`}
+      searchTestID={`${base}-search`}
+      triggerLabel={dd.triggerLabel}
+      badge={dd.badge}
+      placeholder="Search tags…"
+      open={dd.open}
+      query={dd.query}
+      onToggle={dd.toggle}
+      onQueryChange={dd.setQuery}
+      createSlot={
+        dd.creating ? (
+          <InlineTagCreator
+            base={base}
+            initialLabel={dd.query.trim()}
+            onCreate={dd.create}
+            onCancel={() => dd.setCreating(false)}
           />
-        ))}
-        {!creating && (
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessibilityLabel="Create new tag"
-            onPress={() => setCreating(true)}
-            style={[styles.chip, styles.newTagChip]}
-            testID={`tag-picker-${props.stepIndex}-new`}
-          >
-            <Text style={styles.newTagText}>+ New tag</Text>
-          </TouchableOpacity>
-        )}
-      </View>
-      {creating && (
-        <InlineTagCreator
-          stepIndex={props.stepIndex}
-          onCreate={async (payload) => {
-            await props.onCreateTag(payload);
-            setCreating(false);
-          }}
-          onCancel={() => setCreating(false)}
-        />
-      )}
-    </View>
+        ) : (
+          <NewTagButton base={base} onPress={() => dd.setCreating(true)} />
+        )
+      }
+    >
+      <TagOptions
+        base={base}
+        groups={dd.groups}
+        selectedSlug={props.selectedSlug}
+        onSelect={dd.select}
+      />
+    </SearchableDropdown>
   );
 };
 
-interface TagChipProps {
-  tag: PracticeTag;
-  active: boolean;
-  onPress: () => void;
-  testID: string;
+interface TagGroup {
+  key: string;
+  label: string;
+  tags: PracticeTag[];
 }
 
-const TagChip = ({ tag, active, onPress, testID }: TagChipProps): React.JSX.Element => (
+interface TagDropdownController {
+  open: boolean;
+  query: string;
+  creating: boolean;
+  groups: TagGroup[];
+  triggerLabel: string;
+  badge: { text: string; testID: string } | undefined;
+  toggle: () => void;
+  setQuery: (next: string) => void;
+  setCreating: (next: boolean) => void;
+  select: (tag: PracticeTag) => void;
+  create: (payload: PracticeTagCreate) => Promise<void>;
+}
+
+function useTagDropdown(props: TagPickerProps): TagDropdownController {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [creating, setCreating] = useState(false);
+  const groups = useMemo(() => groupTags(props.tagLibrary, query), [props.tagLibrary, query]);
+  const selected = props.tagLibrary.find((tag) => tag.slug === props.selectedSlug);
+  const reset = (): void => {
+    setOpen(false);
+    setQuery('');
+    setCreating(false);
+  };
+  return {
+    open,
+    query,
+    creating,
+    groups,
+    triggerLabel: triggerLabelFor(selected, props.selectedSlug),
+    badge:
+      selected === undefined
+        ? undefined
+        : {
+            text: selected.owner_user_id === null ? 'System' : 'Custom',
+            testID: `tag-picker-${props.stepIndex}-badge`,
+          },
+    toggle: () => setOpen((prev) => !prev),
+    setQuery,
+    setCreating,
+    select: (tag) => {
+      props.onSelect(tag);
+      reset();
+    },
+    create: async (payload) => {
+      await props.onCreateTag(payload);
+      reset();
+    },
+  };
+}
+
+function triggerLabelFor(selected: PracticeTag | undefined, selectedSlug: string): string {
+  if (selected !== undefined) return selected.label;
+  if (selectedSlug.length > 0) return selectedSlug;
+  return 'Choose a tag';
+}
+
+/** Split the library into system + personal sections, filtered + alphabetised. */
+function groupTags(tagLibrary: PracticeTag[], query: string): TagGroup[] {
+  const needle = query.trim().toLowerCase();
+  const matches = (tag: PracticeTag): boolean =>
+    needle === '' ||
+    tag.label.toLowerCase().includes(needle) ||
+    tag.slug.toLowerCase().includes(needle);
+  const byLabel = (a: PracticeTag, b: PracticeTag): number => a.label.localeCompare(b.label);
+  const system = tagLibrary.filter((t) => t.owner_user_id === null && matches(t)).sort(byLabel);
+  const personal = tagLibrary.filter((t) => t.owner_user_id !== null && matches(t)).sort(byLabel);
+  return [
+    { key: 'library', label: 'Library', tags: system },
+    { key: 'yours', label: 'Yours', tags: personal },
+  ].filter((group) => group.tags.length > 0);
+}
+
+interface TagOptionsProps {
+  base: string;
+  groups: TagGroup[];
+  selectedSlug: string;
+  onSelect: (tag: PracticeTag) => void;
+}
+
+const TagOptions = ({
+  base,
+  groups,
+  selectedSlug,
+  onSelect,
+}: TagOptionsProps): React.JSX.Element => {
+  if (groups.length === 0) {
+    return (
+      <DropdownEmptyState label="No tags match — create one below." testID={`${base}-empty`} />
+    );
+  }
+  return (
+    <>
+      {groups.map((group) => (
+        <View key={group.key} testID={`${base}-group-${group.key}`}>
+          <DropdownGroupHeader label={group.label} />
+          {group.tags.map((tag) => (
+            <DropdownOptionRow
+              key={`${tag.owner_user_id ?? 'sys'}-${tag.id}`}
+              label={tag.label}
+              onPress={() => onSelect(tag)}
+              selected={tag.slug === selectedSlug}
+              testID={`${base}-option-${tag.slug}`}
+              accessibilityLabel={tag.label}
+            />
+          ))}
+        </View>
+      ))}
+    </>
+  );
+};
+
+const NewTagButton = ({
+  base,
+  onPress,
+}: {
+  base: string;
+  onPress: () => void;
+}): React.JSX.Element => (
   <TouchableOpacity
     accessibilityRole="button"
-    accessibilityLabel={tag.label}
-    accessibilityState={{ selected: active }}
+    accessibilityLabel="Create new tag"
     onPress={onPress}
-    style={[styles.chip, active && styles.chipActive]}
-    testID={testID}
+    style={dropdownCreateStyles.row}
+    testID={`${base}-new`}
   >
-    <Text style={[styles.chipText, active && styles.chipTextActive]}>{tag.label}</Text>
+    <Text style={dropdownCreateStyles.rowText}>+ New tag</Text>
   </TouchableOpacity>
 );
 
 interface InlineTagCreatorProps {
-  stepIndex: number;
+  base: string;
+  initialLabel: string;
   onCreate: (payload: PracticeTagCreate) => Promise<void>;
   onCancel: () => void;
 }
@@ -108,9 +230,10 @@ interface CreatorFormState {
 }
 
 function useCreatorFormState(
+  initialLabel: string,
   onCreate: (payload: PracticeTagCreate) => Promise<void>,
 ): CreatorFormState {
-  const [label, setLabel] = useState('');
+  const [label, setLabel] = useState(initialLabel);
   const [slug, setSlug] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -131,34 +254,34 @@ function useCreatorFormState(
 }
 
 const InlineTagCreator = (props: InlineTagCreatorProps): React.JSX.Element => {
-  const form = useCreatorFormState(props.onCreate);
+  const form = useCreatorFormState(props.initialLabel, props.onCreate);
   return (
-    <View style={styles.creator} testID={`tag-picker-${props.stepIndex}-creator`}>
+    <View style={dropdownCreateStyles.section} testID={`${props.base}-creator`}>
       <TextInput
         value={form.label}
         onChangeText={form.setLabel}
-        style={styles.input}
+        style={dropdownCreateStyles.input}
         placeholder="Tag label (what users see)"
-        maxLength={255}
-        testID={`tag-picker-${props.stepIndex}-creator-label`}
+        maxLength={LABEL_MAX}
+        testID={`${props.base}-creator-label`}
       />
       <TextInput
         value={form.slug.length > 0 ? form.slug : form.derivedSlug}
         onChangeText={form.setSlug}
-        style={styles.input}
+        style={dropdownCreateStyles.input}
         placeholder="slug_in_snake_case"
-        maxLength={64}
+        maxLength={SLUG_MAX}
         autoCapitalize="none"
         autoCorrect={false}
-        testID={`tag-picker-${props.stepIndex}-creator-slug`}
+        testID={`${props.base}-creator-slug`}
       />
       {form.error !== null && (
-        <Text style={styles.error} testID={`tag-picker-${props.stepIndex}-creator-error`}>
+        <Text style={dropdownCreateStyles.error} testID={`${props.base}-creator-error`}>
           {form.error}
         </Text>
       )}
       <CreatorActions
-        stepIndex={props.stepIndex}
+        base={props.base}
         canCreate={form.canCreate}
         onCancel={props.onCancel}
         onConfirm={form.submit}
@@ -168,86 +291,34 @@ const InlineTagCreator = (props: InlineTagCreatorProps): React.JSX.Element => {
 };
 
 interface CreatorActionsProps {
-  stepIndex: number;
+  base: string;
   canCreate: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 }
 
 const CreatorActions = (props: CreatorActionsProps): React.JSX.Element => (
-  <View style={styles.creatorActions}>
+  <View style={dropdownCreateStyles.controls}>
     <TouchableOpacity
       accessibilityRole="button"
       accessibilityLabel="Cancel new tag"
       onPress={props.onCancel}
-      style={[styles.chip, styles.cancelChip]}
-      testID={`tag-picker-${props.stepIndex}-creator-cancel`}
+      style={dropdownCreateStyles.row}
+      testID={`${props.base}-creator-cancel`}
     >
-      <Text style={styles.chipText}>Cancel</Text>
+      <Text style={dropdownCreateStyles.controlsLabel}>Cancel</Text>
     </TouchableOpacity>
     <TouchableOpacity
       accessibilityRole="button"
       accessibilityLabel="Create tag"
       accessibilityState={{ disabled: !props.canCreate }}
       onPress={props.canCreate ? props.onConfirm : undefined}
-      style={[styles.chip, styles.confirmChip, !props.canCreate && styles.disabled]}
-      testID={`tag-picker-${props.stepIndex}-creator-confirm`}
+      style={dropdownCreateStyles.row}
+      testID={`${props.base}-creator-confirm`}
     >
-      <Text style={styles.confirmText}>Create</Text>
+      <Text style={dropdownCreateStyles.rowText}>Create</Text>
     </TouchableOpacity>
   </View>
 );
-
-function sortTagsForPicker(tags: PracticeTag[]): PracticeTag[] {
-  // System tags first, then personal, alphabetised within each group so
-  // the chip row stays predictable as the library grows.
-  return [...tags].sort((a, b) => {
-    const aSys = a.owner_user_id === null ? 0 : 1;
-    const bSys = b.owner_user_id === null ? 0 : 1;
-    if (aSys !== bSys) return aSys - bSys;
-    return a.label.localeCompare(b.label);
-  });
-}
-
-const styles = StyleSheet.create({
-  container: { gap: SPACING.xs },
-  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
-  chip: {
-    paddingVertical: SPACING.xs,
-    paddingHorizontal: SPACING.md,
-    borderRadius: BORDER_RADIUS.xl,
-    borderWidth: 1,
-    borderColor: colors.background.accent,
-    backgroundColor: colors.background.card,
-  },
-  chipActive: { backgroundColor: colors.primary, borderColor: colors.primary },
-  chipText: { color: colors.text.secondaryAccessible, fontSize: 13, fontWeight: '500' },
-  chipTextActive: { color: colors.text.light },
-  newTagChip: { borderStyle: 'dashed' },
-  newTagText: { color: colors.text.primary, fontSize: 13, fontWeight: '500' },
-  creator: {
-    marginTop: SPACING.xs,
-    padding: SPACING.sm,
-    borderRadius: BORDER_RADIUS.md,
-    backgroundColor: colors.background.accent,
-    gap: SPACING.xs,
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: colors.background.card,
-    borderRadius: BORDER_RADIUS.sm,
-    paddingVertical: SPACING.xs,
-    paddingHorizontal: SPACING.sm,
-    color: colors.text.primary,
-    fontSize: 13,
-    backgroundColor: colors.background.primary,
-  },
-  creatorActions: { flexDirection: 'row', gap: SPACING.xs, justifyContent: 'flex-end' },
-  cancelChip: { backgroundColor: colors.background.card },
-  confirmChip: { backgroundColor: colors.primary, borderColor: colors.primary },
-  confirmText: { color: colors.text.light, fontSize: 13, fontWeight: '600' },
-  disabled: { opacity: 0.4 },
-  error: { color: colors.danger, fontSize: 12 },
-});
 
 export default TagPicker;

--- a/frontend/src/features/Practice/recipes/TagPicker.tsx
+++ b/frontend/src/features/Practice/recipes/TagPicker.tsx
@@ -44,6 +44,7 @@ const TagPicker = (props: TagPickerProps): React.JSX.Element => {
       panelTestID={`${base}-panel`}
       searchTestID={`${base}-search`}
       triggerLabel={dd.triggerLabel}
+      triggerAccessibilityLabel={`Choose a tag, currently ${dd.triggerLabel}`}
       badge={dd.badge}
       placeholder="Search tags…"
       searchAccessibilityLabel="Search tags"

--- a/frontend/src/features/Practice/recipes/TagPicker.tsx
+++ b/frontend/src/features/Practice/recipes/TagPicker.tsx
@@ -46,6 +46,7 @@ const TagPicker = (props: TagPickerProps): React.JSX.Element => {
       triggerLabel={dd.triggerLabel}
       badge={dd.badge}
       placeholder="Search tags…"
+      searchAccessibilityLabel="Search tags"
       open={dd.open}
       query={dd.query}
       onToggle={dd.toggle}
@@ -313,7 +314,7 @@ const CreatorActions = (props: CreatorActionsProps): React.JSX.Element => (
       accessibilityLabel="Create tag"
       accessibilityState={{ disabled: !props.canCreate }}
       onPress={props.canCreate ? props.onConfirm : undefined}
-      style={dropdownCreateStyles.row}
+      style={[dropdownCreateStyles.row, !props.canCreate && dropdownCreateStyles.disabled]}
       testID={`${props.base}-creator-confirm`}
     >
       <Text style={dropdownCreateStyles.rowText}>Create</Text>

--- a/frontend/src/features/Practice/recipes/__tests__/RecipeEditorModal.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/RecipeEditorModal.test.tsx
@@ -143,9 +143,11 @@ describe('RecipeEditorModal', () => {
     const utils = mountEditor();
     await waitFor(() => expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy());
     fireEvent.press(utils.getByTestId('recipe-editor-add-step'));
-    // Select 'red' on both steps via the tag picker chip
-    await waitFor(() => expect(utils.getByTestId('tag-picker-0-chip-red')).toBeTruthy());
-    fireEvent.press(utils.getByTestId('tag-picker-1-chip-red'));
+    // Select 'red' on step 1 via the tag dropdown (step 0 already holds 'red')
+    await waitFor(() => expect(utils.getByTestId('tag-picker-1-trigger')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('tag-picker-1-trigger'));
+    await waitFor(() => expect(utils.getByTestId('tag-picker-1-option-red')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('tag-picker-1-option-red'));
     // Need a prompt for step 1 to clear the prompt error
     fireEvent.changeText(utils.getByTestId('recipe-editor-step-1-prompt'), 'Find red again');
     await waitFor(() => expect(utils.getByTestId('recipe-editor-errors')).toBeTruthy());

--- a/frontend/src/features/Practice/recipes/__tests__/TagPicker.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/TagPicker.test.tsx
@@ -11,63 +11,71 @@ const library: PracticeTag[] = [
   { id: 2, slug: 'blue', label: 'Blue', owner_user_id: null, created_at: '2026-01-01T00:00:00Z' },
 ];
 
+function renderPicker(
+  overrides: Partial<React.ComponentProps<typeof TagPicker>> = {},
+): ReturnType<typeof render> {
+  return render(
+    <TagPicker
+      stepIndex={0}
+      selectedSlug=""
+      tagLibrary={library}
+      onSelect={jest.fn()}
+      onCreateTag={jest.fn(async () => undefined)}
+      {...overrides}
+    />,
+  );
+}
+
 describe('TagPicker', () => {
-  it('renders one chip per tag in the library', () => {
-    const utils = render(
-      <TagPicker
-        stepIndex={0}
-        selectedSlug=""
-        tagLibrary={library}
-        onSelect={jest.fn()}
-        onCreateTag={jest.fn(async () => undefined)}
-      />,
-    );
-    expect(utils.getByTestId('tag-picker-0-chip-red')).toBeTruthy();
-    expect(utils.getByTestId('tag-picker-0-chip-blue')).toBeTruthy();
+  it('shows the selected tag on the collapsed trigger', () => {
+    const utils = renderPicker({ selectedSlug: 'red' });
+    expect(utils.getByTestId('tag-picker-0-trigger')).toBeTruthy();
+    expect(utils.getByText('Red')).toBeTruthy();
+    // Badge reflects ownership of the chosen tag.
+    expect(utils.getByTestId('tag-picker-0-badge')).toHaveTextContent('System');
   });
 
-  it('reflects active selection on the chosen chip', () => {
-    const utils = render(
-      <TagPicker
-        stepIndex={0}
-        selectedSlug="red"
-        tagLibrary={library}
-        onSelect={jest.fn()}
-        onCreateTag={jest.fn(async () => undefined)}
-      />,
-    );
-    expect(utils.getByTestId('tag-picker-0-chip-red').props.accessibilityState.selected).toBe(true);
+  it('opens to a searchable list of library tags', () => {
+    const utils = renderPicker();
+    expect(utils.queryByTestId('tag-picker-0-panel')).toBeNull();
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    expect(utils.getByTestId('tag-picker-0-option-red')).toBeTruthy();
+    expect(utils.getByTestId('tag-picker-0-option-blue')).toBeTruthy();
   });
 
-  it('selects a tag when its chip is pressed', () => {
+  it('filters the list by search query', () => {
+    const utils = renderPicker();
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    fireEvent.changeText(utils.getByTestId('tag-picker-0-search'), 'blue');
+    expect(utils.getByTestId('tag-picker-0-option-blue')).toBeTruthy();
+    expect(utils.queryByTestId('tag-picker-0-option-red')).toBeNull();
+  });
+
+  it('marks the active selection on its option row', () => {
+    const utils = renderPicker({ selectedSlug: 'red' });
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    expect(utils.getByTestId('tag-picker-0-option-red').props.accessibilityState.selected).toBe(
+      true,
+    );
+  });
+
+  it('selects a tag when its row is pressed', () => {
     const onSelect = jest.fn();
-    const utils = render(
-      <TagPicker
-        stepIndex={0}
-        selectedSlug=""
-        tagLibrary={library}
-        onSelect={onSelect}
-        onCreateTag={jest.fn(async () => undefined)}
-      />,
-    );
-    fireEvent.press(utils.getByTestId('tag-picker-0-chip-blue'));
+    const utils = renderPicker({ onSelect });
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    fireEvent.press(utils.getByTestId('tag-picker-0-option-blue'));
     expect(onSelect).toHaveBeenCalledWith(library[1]);
   });
 
-  it('shows the inline creator and submits a new tag', async () => {
+  it('shows the inline creator and submits a new tag, seeded from the query', async () => {
     const onCreateTag = jest.fn(async (_payload: { slug: string; label: string }) => undefined);
-    const utils = render(
-      <TagPicker
-        stepIndex={0}
-        selectedSlug=""
-        tagLibrary={library}
-        onSelect={jest.fn()}
-        onCreateTag={onCreateTag}
-      />,
-    );
+    const utils = renderPicker({ onCreateTag });
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    fireEvent.changeText(utils.getByTestId('tag-picker-0-search'), 'Crimson Star');
     fireEvent.press(utils.getByTestId('tag-picker-0-new'));
     expect(utils.getByTestId('tag-picker-0-creator')).toBeTruthy();
-    fireEvent.changeText(utils.getByTestId('tag-picker-0-creator-label'), 'Crimson Star');
+    // Label is pre-filled from the search query.
+    expect(utils.getByTestId('tag-picker-0-creator-label').props.value).toBe('Crimson Star');
     await act(async () => {
       fireEvent.press(utils.getByTestId('tag-picker-0-creator-confirm'));
     });
@@ -80,17 +88,57 @@ describe('TagPicker', () => {
   });
 
   it('cancels the inline creator', () => {
-    const utils = render(
-      <TagPicker
-        stepIndex={0}
-        selectedSlug=""
-        tagLibrary={library}
-        onSelect={jest.fn()}
-        onCreateTag={jest.fn(async () => undefined)}
-      />,
-    );
+    const utils = renderPicker();
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
     fireEvent.press(utils.getByTestId('tag-picker-0-new'));
     fireEvent.press(utils.getByTestId('tag-picker-0-creator-cancel'));
     expect(utils.queryByTestId('tag-picker-0-creator')).toBeNull();
+  });
+
+  it('groups personal tags under "Yours" and badges them Custom', () => {
+    const mixed: PracticeTag[] = [
+      ...library,
+      { id: 9, slug: 'mine', label: 'Mine', owner_user_id: 7, created_at: '2026-01-01T00:00:00Z' },
+    ];
+    const utils = renderPicker({ tagLibrary: mixed, selectedSlug: 'mine' });
+    expect(utils.getByTestId('tag-picker-0-badge')).toHaveTextContent('Custom');
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    expect(utils.getByTestId('tag-picker-0-group-library')).toBeTruthy();
+    expect(utils.getByTestId('tag-picker-0-group-yours')).toBeTruthy();
+    expect(utils.getByTestId('tag-picker-0-option-mine')).toBeTruthy();
+  });
+
+  it('filters by slug and shows the empty state when nothing matches', () => {
+    const utils = renderPicker();
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    fireEvent.changeText(utils.getByTestId('tag-picker-0-search'), 'blu'); // matches slug "blue"
+    expect(utils.getByTestId('tag-picker-0-option-blue')).toBeTruthy();
+    fireEvent.changeText(utils.getByTestId('tag-picker-0-search'), 'zzz');
+    expect(utils.getByTestId('tag-picker-0-empty')).toBeTruthy();
+  });
+
+  it('falls back to the raw slug when the selection is not in the library', () => {
+    const utils = renderPicker({ selectedSlug: 'ghost' });
+    expect(utils.getByText('ghost')).toBeTruthy();
+    // No badge when the tag is unknown to the library.
+    expect(utils.queryByTestId('tag-picker-0-badge')).toBeNull();
+  });
+
+  it('surfaces a create error without dismissing the form', async () => {
+    const onCreateTag = jest.fn(async () => {
+      throw new Error('Slug already exists');
+    });
+    const utils = renderPicker({ onCreateTag });
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    fireEvent.press(utils.getByTestId('tag-picker-0-new'));
+    fireEvent.changeText(utils.getByTestId('tag-picker-0-creator-label'), 'Dupe');
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('tag-picker-0-creator-confirm'));
+    });
+    await waitFor(() =>
+      expect(utils.getByTestId('tag-picker-0-creator-error')).toHaveTextContent(
+        'Slug already exists',
+      ),
+    );
   });
 });

--- a/frontend/src/features/Practice/recipes/__tests__/TagPicker.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/TagPicker.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
 import TagPicker from '../TagPicker';
 
@@ -93,6 +94,16 @@ describe('TagPicker', () => {
     fireEvent.press(utils.getByTestId('tag-picker-0-new'));
     fireEvent.press(utils.getByTestId('tag-picker-0-creator-cancel'));
     expect(utils.queryByTestId('tag-picker-0-creator')).toBeNull();
+  });
+
+  it('visibly dims the Create button while the form is incomplete', () => {
+    const utils = renderPicker();
+    fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    fireEvent.press(utils.getByTestId('tag-picker-0-new'));
+    // Empty label → not creatable → the Create button is dimmed so the
+    // user sees why a tap does nothing (regressed when chips were removed).
+    const confirm = utils.getByTestId('tag-picker-0-creator-confirm');
+    expect(StyleSheet.flatten(confirm.props.style).opacity).toBe(0.4);
   });
 
   it('groups personal tags under "Yours" and badges them Custom', () => {


### PR DESCRIPTION
The 5-4-3-2-1 grounding configurator only let users pick one of five
fixed sense chips per prompt. Replace that row with a searchable
dropdown backed by a curated catalogue of "things to notice" — the
five senses plus colours, shapes, textures, sounds, scents, tastes and
the classic elements, drawn from the same vocabulary the recipe seeder
ships (Find the Rainbow, Find Shapes, Four Elements) — plus a
create-your-own affordance for anything we haven't catalogued.

Every catalogue option (and every custom entry) still resolves to one
of the five backend SenseKind values, so the stored SenseGroundingConfig
and the 5-4-3-2-1 runtime view keep working unchanged; the catalogue is
a richer picker over the same data model, not a new one. Picking an
anchor seeds the prompt copy only while the label is still a default,
so user-edited wording survives a sense swap.

- add data/groundingCatalog.ts (catalogue + search/lookup helpers)
- add configurator/forms/GroundingDropdown.tsx (searchable picker)
- rewrite SenseGroundingForm prompt row to use the dropdown