### PR TITLE
docs(course): add aptitude-course CMS migration issue specs

### DIFF
--- a/prompts/github-issues/cms-migration/README.md
+++ b/prompts/github-issues/cms-migration/README.md
@@ -1,0 +1,47 @@
+# CMS Migration — `aptitude-course` issue specs
+
+These are **ready-to-file GitHub issues for the [`Geoffe-Ga/aptitude-course`](https://github.com/Geoffe-Ga/aptitude-course) content repository**, part of the
+"Migrate course content CMS from Squarespace to a git-based content pipeline"
+epic ([adepthood #388](https://github.com/Geoffe-Ga/adepthood/issues/388)).
+
+## Why they live here
+
+The session that generated this epic had write access only to `adepthood`.
+The content-repo issues are captured here as spec files so nothing is lost and
+they are reviewable in a PR. To file them on `aptitude-course`:
+
+- **Option A (recommended):** add `Geoffe-Ga/aptitude-course` to a Claude Code
+  session's repository scope, then ask Claude to file each `content-*.md` below
+  as a GitHub issue (title = the `#` heading, body = the rest, labels as noted).
+- **Option B:** copy each file's contents into a new issue manually.
+
+## The adepthood side is already filed
+
+The eleven app-side issues are live GitHub issues: #389–#399 (see the epic
+checklist in #388). Only the content-repo issues (A–I) remain to be filed.
+
+## Dependency order
+
+```
+A (format + frontmatter schema)
+├─ B (normalize markdown)        ─┐
+├─ C (add frontmatter)            ├─ depend on A's schema
+├─ G (site-resource pages)       ─┘
+└─ D (manifest generator)  ── depends on C ── feeds adepthood #391/#392
+        └─ E (CI validation) ── depends on D
+F (consumption contract/versioning)  ── pairs with adepthood #391/#397
+H (authoring guide)  ── after A–E settle
+I (media/assets)     ── pairs with adepthood #394 rendering
+```
+
+| Spec | Title | Suggested labels |
+|------|-------|------------------|
+| `content-A-format-and-frontmatter-schema.md` | Define canonical content format + frontmatter schema | `spec`, `content` |
+| `content-B-normalize-markdown.md` | Normalize HTML-heavy Google-Docs Markdown → clean Markdown | `content` |
+| `content-C-add-frontmatter.md` | Add per-chapter YAML frontmatter | `content` |
+| `content-D-manifest-generator.md` | Build a `manifest.json` generator | `tooling` |
+| `content-E-ci.md` | CI: frontmatter validation, uniqueness, lint, link-check, manifest build | `tooling`, `ci` |
+| `content-F-consumption-contract-versioning.md` | Consumption contract + release versioning | `spec` |
+| `content-G-site-resources.md` | Migrate site-resource pages into the content format | `content` |
+| `content-H-authoring-guide.md` | Authoring guide (README/CONTRIBUTING) | `docs` |
+| `content-I-media-assets.md` | Media/asset handling for chapters | `content`, `spec` |

--- a/prompts/github-issues/cms-migration/content-A-format-and-frontmatter-schema.md
+++ b/prompts/github-issues/cms-migration/content-A-format-and-frontmatter-schema.md
@@ -1,0 +1,65 @@
+# Define canonical content format + frontmatter schema
+
+**Repo:** `Geoffe-Ga/aptitude-course` · **Labels:** `spec`, `content`
+**Epic:** adepthood#388 · **Depends on:** none (foundation) · **Blocks:** B, C, D, G
+
+## Role & context
+
+You are establishing the contract that the Adepthood app
+([adepthood#389](https://github.com/Geoffe-Ga/adepthood/issues/389)) will
+consume. Today this repo holds 219 Markdown files under
+`markdown/<NN-stage>/<NN-slug>.md` (10 stages, `01-beige`…`10-clearlight`),
+converted from Google Docs and **heavy with inline HTML**, with **no
+frontmatter** and **no machine-readable index**. The app cannot reliably parse
+this.
+
+## Goal
+
+Publish a written spec (`CONTENT_FORMAT.md`) defining (1) the canonical
+Markdown dialect and (2) the per-file YAML frontmatter schema, agreed against
+the app's manifest contract (adepthood#389). This is documentation only — no
+file edits to the 219 chapters yet (that's B/C).
+
+## Tasks
+
+1. Specify the **Markdown dialect**: CommonMark + a small, safe feature set
+   (headings, lists, emphasis, links, images, blockquotes, code, tables).
+   Explicitly **disallow raw HTML** in the body (the app renders Markdown
+   natively and will not execute HTML).
+2. Define the **frontmatter schema** (YAML), aligned field-for-field with the
+   app manifest in adepthood#389:
+
+   ```yaml
+   ---
+   id: beige-1            # stable, unique across the repo
+   stage: 1               # 1..10 (archetype index)
+   chapter: 1             # 1-based within the stage
+   order: 1               # display order within the stage
+   slug: what-is-beige    # URL-safe; matches filename slug
+   title: "What Is Beige?"
+   content_type: chapter  # chapter | essay | prompt | video
+   release_day: 0         # days after stage start (0 = unlocks immediately)
+   summary: "One-line teaser."   # optional
+   media: []              # optional; see issue I
+   ---
+   ```
+
+3. State **uniqueness/identity rules**: `id` unique repo-wide; (`stage`,
+   `chapter`) unique; `slug` matches the filename.
+4. State the **stage-numbering reconciliation** agreement with adepthood#389
+   (how content stages 1–10 map onto the app's stage model) so B/C and the
+   app's seed agree.
+5. Define `content_type` semantics and how `release_day` is authored.
+
+## Acceptance criteria
+
+- `CONTENT_FORMAT.md` merged, covering dialect + frontmatter + identity +
+  stage-mapping + `content_type`/`release_day` semantics.
+- Field names/types match adepthood#389's `manifest.schema.json` exactly
+  (cross-link both).
+- One worked example chapter shown end-to-end.
+
+## Constraints
+
+- Spec only; do not edit the 219 chapters here.
+- Any later schema change is a versioned change coordinated with adepthood#389.

--- a/prompts/github-issues/cms-migration/content-B-normalize-markdown.md
+++ b/prompts/github-issues/cms-migration/content-B-normalize-markdown.md
@@ -1,0 +1,44 @@
+# Normalize HTML-heavy Google-Docs Markdown → clean Markdown
+
+**Repo:** `Geoffe-Ga/aptitude-course` · **Labels:** `content`
+**Epic:** adepthood#388 · **Depends on:** A (format spec) · **Blocks:** D (manifest), adepthood#394 (rendering)
+
+## Role & context
+
+The 219 chapter files were converted from Google Docs and carry inline HTML
+(spans, styled tables, `&nbsp;`, font tags, anchor cruft). The app will render
+**Markdown natively** and disallows raw HTML, so the body of every file must be
+reduced to the clean dialect defined in A. GitHub reports this repo as ~99.9%
+HTML — that is the mess this issue removes.
+
+## Goal
+
+Every file under `markdown/**` contains clean CommonMark per `CONTENT_FORMAT.md`
+— no raw HTML, normalized headings/lists/links/images — with content meaning
+preserved.
+
+## Tasks
+
+1. Write a normalization script (`scripts/normalize_markdown.py` or a `pandoc`
+   pipeline in `convert_docs.sh`) that: strips/down-converts inline HTML to
+   Markdown, collapses `&nbsp;`/smart-quote noise, normalizes heading levels
+   (one H1 = title, sections start at H2), and fixes list/table syntax.
+2. Run it across all stages; commit the result in reviewable batches (per
+   stage) so diffs are auditable.
+3. Add a "no raw HTML" check (regex/`remark-lint`) to be enforced later by CI
+   (issue E).
+4. Manually spot-check the worst offenders (tables, embedded media) and record
+   any that need hand-editing.
+
+## Acceptance criteria
+
+- No file under `markdown/**` contains disallowed raw HTML (verified by the
+  check from task 3).
+- A diff review per stage confirms no content was lost (headings, links,
+  images, lists intact).
+- The normalization is reproducible via a committed script, not a one-off.
+
+## Constraints
+
+- Preserve authored meaning and structure; this is reformatting, not rewriting.
+- Do not add frontmatter here — that is issue C (keep the two diffs separate).

--- a/prompts/github-issues/cms-migration/content-C-add-frontmatter.md
+++ b/prompts/github-issues/cms-migration/content-C-add-frontmatter.md
@@ -1,0 +1,42 @@
+# Add per-chapter YAML frontmatter
+
+**Repo:** `Geoffe-Ga/aptitude-course` · **Labels:** `content`
+**Epic:** adepthood#388 · **Depends on:** A (schema), B (clean bodies) · **Blocks:** D (manifest generator)
+
+## Role & context
+
+With bodies cleaned (B) and the schema fixed (A), each chapter needs the YAML
+frontmatter block that makes the corpus machine-readable. This is what lets the
+manifest generator (D) — and ultimately the app's seed
+([adepthood#392](https://github.com/Geoffe-Ga/adepthood/issues/392)) — know
+each chapter's stage, order, `release_day`, and `content_type`.
+
+## Goal
+
+Every chapter file under `markdown/**` opens with a valid frontmatter block
+conforming to `CONTENT_FORMAT.md`, with correct `stage`/`chapter`/`order`,
+unique `id`/`slug`, and an authored `release_day`.
+
+## Tasks
+
+1. Derive `stage`/`chapter`/`order`/`slug` from the existing folder + filename
+   conventions (`<NN-stage>/<NN-slug>.md`) via a script to avoid manual error.
+2. Set `id` = `"<stage-slug>-<chapter>"` (e.g. `beige-1`) — stable and unique.
+3. Author `release_day` per stage's intended drip schedule (default: chapter
+   `n` → `release_day = n - 1`, matching today's "daily" pattern; adjust where
+   the curriculum intends otherwise).
+4. Set `content_type` (default `chapter`; mark prompts/essays/videos).
+5. Add a one-line `summary` where easy (optional field).
+
+## Acceptance criteria
+
+- Every `markdown/**` chapter has schema-valid frontmatter.
+- `id` and (`stage`,`chapter`) are unique repo-wide (checked by a script;
+  enforced by CI in E).
+- `slug` matches the filename slug for every file.
+
+## Constraints
+
+- Generate mechanically where possible; hand-author only `release_day`,
+  `content_type`, and `summary`.
+- Don't touch body content here (that was B) — frontmatter only.

--- a/prompts/github-issues/cms-migration/content-D-manifest-generator.md
+++ b/prompts/github-issues/cms-migration/content-D-manifest-generator.md
@@ -1,0 +1,44 @@
+# Build a `manifest.json` generator
+
+**Repo:** `Geoffe-Ga/aptitude-course` · **Labels:** `tooling`
+**Epic:** adepthood#388 · **Depends on:** C (frontmatter) · **Blocks:** E (CI), adepthood#391 (sync), adepthood#392 (seed)
+
+## Role & context
+
+The Adepthood app consumes a single machine-readable index, not 219 loose
+files. `manifest.json` is the published contract
+([adepthood#389](https://github.com/Geoffe-Ga/adepthood/issues/389) defines its
+schema). It is **generated** from the per-file frontmatter so the files stay the
+source of truth and the manifest never drifts by hand.
+
+## Goal
+
+`scripts/build_manifest.py` walks `markdown/**`, reads frontmatter, and emits a
+schema-valid `manifest.json` at the repo root (plus `site_resources[]` from
+issue G), with a `schema_version` matching adepthood#389.
+
+## Tasks
+
+1. Implement `scripts/build_manifest.py`: collect every chapter's frontmatter +
+   relative `path`, sort by (`stage`,`order`), and assemble `chapters[]` and
+   `site_resources[]`.
+2. Emit `schema_version` (semver) aligned with adepthood#389's
+   `manifest.schema.json`; validate the output against that schema (vendor or
+   fetch the schema; document which).
+3. Fail loudly on duplicate `id`/(`stage`,`chapter`), missing required fields,
+   or `slug`/filename mismatch.
+4. Make output deterministic (stable key order) so manifest diffs are clean.
+5. Commit the generated `manifest.json` (the app vendors a pinned commit that
+   must include it).
+
+## Acceptance criteria
+
+- `python scripts/build_manifest.py` produces a deterministic, schema-valid
+  `manifest.json` covering all stages.
+- Re-running with no content change yields a byte-identical manifest.
+- Duplicate/invalid frontmatter aborts with a precise error.
+
+## Constraints
+
+- Generator is pure/deterministic; no network.
+- Schema version is the coordination point with the app — bump it deliberately.

--- a/prompts/github-issues/cms-migration/content-E-ci.md
+++ b/prompts/github-issues/cms-migration/content-E-ci.md
@@ -1,0 +1,42 @@
+# CI: frontmatter validation, uniqueness, lint, link-check, manifest build
+
+**Repo:** `Geoffe-Ga/aptitude-course` · **Labels:** `tooling`, `ci`
+**Epic:** adepthood#388 · **Depends on:** D (manifest generator) · **Blocks:** F (contract), adepthood#397 (build wiring)
+
+## Role & context
+
+This repo currently has **no CI**. Since the app pins and ships a commit of this
+repo, a malformed chapter or a drifted manifest would break the live Course
+screen. CI here is the first line of defense — broken content never reaches a
+pinned SHA.
+
+## Goal
+
+A GitHub Actions workflow that, on every PR/push, validates the content corpus
+and the generated manifest, failing the build on any violation.
+
+## Tasks
+
+1. Add `.github/workflows/content-ci.yml` running:
+   - **Frontmatter schema validation** for every `markdown/**` file (against
+     `CONTENT_FORMAT.md`/the schema).
+   - **Uniqueness checks**: `id`, (`stage`,`chapter`), `slug`↔filename.
+   - **Markdown lint** (`remark-lint`/`markdownlint`) incl. the "no raw HTML"
+     rule from issue B.
+   - **Link check** (internal links + images resolve; external optional/soft).
+   - **Manifest build + schema validation** (`scripts/build_manifest.py`) and a
+     **drift check**: committed `manifest.json` matches a fresh build.
+2. Cache tooling for fast runs; keep the workflow self-contained (no secrets).
+3. Document required status checks for branch protection.
+
+## Acceptance criteria
+
+- CI fails on: invalid/missing frontmatter, duplicate id/slug, raw HTML in
+  body, broken internal link/image, or a stale committed manifest.
+- A clean corpus passes end-to-end.
+- The manifest drift check guarantees `manifest.json` is always current.
+
+## Constraints
+
+- No secrets/tokens (public repo).
+- Keep checks fast enough to run on every push.

--- a/prompts/github-issues/cms-migration/content-F-consumption-contract-versioning.md
+++ b/prompts/github-issues/cms-migration/content-F-consumption-contract-versioning.md
@@ -1,0 +1,39 @@
+# Consumption contract + release versioning
+
+**Repo:** `Geoffe-Ga/aptitude-course` · **Labels:** `spec`
+**Epic:** adepthood#388 · **Depends on:** D (manifest), E (CI) · **Pairs with:** adepthood#391 (sync), adepthood#397 (build wiring)
+
+## Role & context
+
+The app vendors a **pinned commit** of this repo (adepthood#391 writes the SHA
+to `CONTENT_VERSION`). Both sides need a stable, documented contract so content
+can ship independently of app deploys without surprise breakage.
+
+## Goal
+
+Document the consumption contract and adopt a release/versioning convention so
+the app can pin, audit, and upgrade content deterministically.
+
+## Tasks
+
+1. Write `CONSUMPTION.md` defining the **published surface** the app may rely
+   on: `manifest.json` (with `schema_version`), `markdown/**` bodies referenced
+   by `path`, and assets (issue I). Everything else is internal.
+2. Define **manifest schema semver** rules: patch = content-only; minor =
+   additive fields; major = breaking — coordinated with adepthood#389. State
+   the app's compatibility expectation.
+3. Adopt **release tagging** (e.g. `content-vYYYY.MM.DD` or semver tags) so the
+   app pins a tag/SHA rather than a moving branch; document the cut process.
+4. Document the **update handshake**: content PR merges → CI green → tag → app
+   bumps pinned SHA (adepthood#391) → redeploy.
+
+## Acceptance criteria
+
+- `CONSUMPTION.md` merged: published surface, semver rules, tagging, handshake.
+- A first release tag exists and is referenced by adepthood#391's default pin.
+- Breaking-change policy is explicit and cross-linked to adepthood#389.
+
+## Constraints
+
+- Never break the published surface without a major version + coordinated app
+  change.

--- a/prompts/github-issues/cms-migration/content-G-site-resources.md
+++ b/prompts/github-issues/cms-migration/content-G-site-resources.md
@@ -1,0 +1,47 @@
+# Migrate site-resource ("free page") content into the repo
+
+**Repo:** `Geoffe-Ga/aptitude-course` · **Labels:** `content`
+**Epic:** adepthood#388 · **Depends on:** A (schema) · **Blocks:** adepthood#395 (site resources from local content)
+
+## Role & context
+
+The app's "From Aptitude Guru" chips (the only things currently rendering) map
+to four public Squarespace pages: `liminal-creep` (Who Benefits?),
+`archetypal-wavelength`, `aptitude-stages`, and `about`. To fully delete
+Squarespace, these must also live here as Markdown and appear in
+`manifest.json`'s `site_resources[]`.
+
+## Goal
+
+The four site-resource pages exist as clean Markdown in this repo with
+frontmatter, and the manifest generator (D) emits them under `site_resources[]`
+for the app (adepthood#395) to serve.
+
+## Tasks
+
+1. Author/port the four pages as Markdown (this repo already has
+   `ArchetypalWavelengthIntroduction.md`, `APTITUDELandingPage.md`, etc. — reuse
+   where they exist):
+   - `liminal-creep` — "Who Benefits?"
+   - `archetypal-wavelength` — "Archetypal Wavelength Intro"
+   - `aptitude-stages` — "APTITUDE Stages"
+   - `about` — "APTITUDE Intro"
+2. Give each frontmatter with `content_type: essay` (or a `resource` type) and a
+   `slug` matching the app's current `SITE_RESOURCES` slugs (so the app's
+   public surface is unchanged).
+3. Decide a location (e.g. `markdown/resources/`) and ensure the manifest
+   generator (D) lists them under `site_resources[]`, not `chapters[]` (not
+   stage-gated).
+
+## Acceptance criteria
+
+- All four resources are clean Markdown with valid frontmatter, slugs matching
+  the app's existing list.
+- `manifest.json` `site_resources[]` includes all four with correct
+  slug/title/path.
+- Bodies render with the same Markdown dialect as chapters.
+
+## Constraints
+
+- Keep the existing slugs stable — the app keys on them.
+- Not stage-gated; do not give these a `release_day`/stage.

--- a/prompts/github-issues/cms-migration/content-H-authoring-guide.md
+++ b/prompts/github-issues/cms-migration/content-H-authoring-guide.md
@@ -1,0 +1,43 @@
+# Authoring guide (README / CONTRIBUTING)
+
+**Repo:** `Geoffe-Ga/aptitude-course` · **Labels:** `docs`
+**Epic:** adepthood#388 · **Depends on:** A–E settled
+
+## Role & context
+
+Once the format, frontmatter, manifest, and CI exist, contributors (human or
+Claude) need one page that says how to add or change content correctly so the
+app picks it up. The existing `CLAUDE.md`/`README.md` predate this pipeline.
+
+## Goal
+
+A `CONTRIBUTING.md` (and refreshed `README.md`) that makes "add a chapter",
+"edit a chapter", and "schedule a release" unambiguous and CI-passable on the
+first try.
+
+## Tasks
+
+1. Document the workflow: create `markdown/<stage>/<NN-slug>.md` → add
+   frontmatter (link the schema) → run `build_manifest.py` → CI green.
+2. Explain `release_day` semantics (days after stage start; 0 = immediate) with
+   examples, and the `content_type` values.
+3. Explain the **stage-numbering** mapping and identity rules (`id`,
+   (`stage`,`chapter`), `slug`↔filename).
+4. Explain the release/handshake from issue F (how a content change reaches the
+   app: tag → app pins SHA → deploy).
+5. Add a short "editing with Claude" section: the corpus is plain Markdown
+   files; an agent can edit them directly and run `build_manifest.py` +
+   `content-ci` locally.
+
+## Acceptance criteria
+
+- A new contributor can add a valid chapter using only `CONTRIBUTING.md` and
+  pass CI on first push.
+- `release_day`, `content_type`, identity rules, and the release handshake are
+  all documented with examples.
+- `README.md` points to `CONTENT_FORMAT.md`, `CONSUMPTION.md`, and
+  `CONTRIBUTING.md`.
+
+## Constraints
+
+- Docs must match the actual scripts/CI (no aspirational instructions).

--- a/prompts/github-issues/cms-migration/content-I-media-assets.md
+++ b/prompts/github-issues/cms-migration/content-I-media-assets.md
@@ -1,0 +1,48 @@
+# Media / asset handling for chapters
+
+**Repo:** `Geoffe-Ga/aptitude-course` · **Labels:** `content`, `spec`
+**Epic:** adepthood#388 · **Depends on:** A (schema) · **Pairs with:** adepthood#394 (native Markdown rendering)
+
+## Role & context
+
+Chapters reference images and (per the original spec) videos. Under Squarespace
+these were remote URLs on the site. With local Markdown rendered natively
+(adepthood#394), the app needs a defined, stable way to resolve assets — ideally
+without a runtime network dependency, consistent with the "ships in the image"
+architecture.
+
+## Goal
+
+A documented, enforced convention for where assets live and how chapters
+reference them, so the app can resolve every image/video deterministically.
+
+## Tasks
+
+1. Decide asset storage:
+   - **Option A (recommended for images):** commit assets under
+     `markdown/<stage>/assets/` and reference them with **repo-relative paths**
+     in Markdown, so they vendor into the app image with the content.
+   - **Option B (video / large media):** reference a stable external/CDN URL in
+     frontmatter `media[]`; the app streams it. Document size thresholds for A
+     vs B.
+2. Specify the Markdown reference convention (relative image links) and the
+   `media[]` frontmatter shape for non-inline media (type, url/path, poster,
+   caption).
+3. Ensure `build_manifest.py` (D) includes/validates `media[]` and that the
+   link-check (E) verifies relative asset paths resolve.
+4. Define how the app maps a relative asset path to a served URL (coordinate
+   with adepthood#394) — e.g. backend exposes `backend/content/**` assets under
+   a static route.
+
+## Acceptance criteria
+
+- Asset convention documented in `CONTENT_FORMAT.md`; chapters follow it.
+- Relative image paths resolve in CI link-check; `media[]` validated by the
+  manifest build.
+- The app-side resolution rule is agreed and cross-linked to adepthood#394.
+
+## Constraints
+
+- Prefer in-repo committed images (no runtime fetch) over external URLs except
+  for large video.
+- Keep asset paths repo-relative and stable.


### PR DESCRIPTION
Captures the content-repo half of the Squarespace->git-content migration
epic (adepthood #388) as ready-to-file issue specs. The app-side issues
(#389-#399) are filed directly on GitHub; these nine specs target the
aptitude-course content repo, which is outside this session's write scope.

https://claude.ai/code/session_01QuharcfHX3VDkXyXZbXB27