### PR TITLE
feat(frontend): add paginated listPaginated helpers for Page envelope (#221)

### DIFF
--- a/frontend/src/api/__tests__/pagination-api.test.ts
+++ b/frontend/src/api/__tests__/pagination-api.test.ts
@@ -1,0 +1,135 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import {
+  practices,
+  practiceSessions,
+  goalGroups,
+  stages,
+  userPractices,
+  course,
+  ApiValidationError,
+} from '../index';
+
+// Mock global fetch
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+// Silence the API_BASE_URL import — just needs a string value
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+/** A well-formed Page envelope wrapping the supplied items. */
+function page(items: unknown[], over: Record<string, unknown> = {}) {
+  return {
+    items,
+    total: items.length,
+    limit: 50,
+    offset: 0,
+    has_more: false,
+    ...over,
+  };
+}
+
+describe('paginated list endpoints (issue #221 — Page envelope)', () => {
+  test('practices.listPaginated opts into the envelope and forwards stage_number', async () => {
+    const envelope = page([{ id: 1, stage_number: 3, name: 'Box Breath' }]);
+    mockFetch.mockReturnValueOnce(jsonResponse(envelope));
+
+    const result = await practices.listPaginated({ stageNumber: 3 }, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/?paginate=true&stage_number=3');
+    expect(init.method).toBeUndefined(); // GET
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer tok' });
+    expect(result).toEqual(envelope);
+  });
+
+  test('practices.listPaginated forwards limit and offset when supplied', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(page([], { total: 120, has_more: true })));
+
+    await practices.listPaginated({ stageNumber: 2, limit: 50, offset: 50 }, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/?paginate=true&stage_number=2&limit=50&offset=50');
+  });
+
+  test('practiceSessions.listPaginated forwards user_practice_id', async () => {
+    const envelope = page([{ id: 9, user_practice_id: 5 }]);
+    mockFetch.mockReturnValueOnce(jsonResponse(envelope));
+
+    const result = await practiceSessions.listPaginated({ userPracticeId: 5 }, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-sessions/?paginate=true&user_practice_id=5');
+    expect(result.items).toHaveLength(1);
+  });
+
+  test('goalGroups.listPaginated hits /goal-groups/ with the envelope flag', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(page([{ id: 1, name: 'Morning' }])));
+
+    await goalGroups.listPaginated({ limit: 10 }, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/goal-groups/?paginate=true&limit=10');
+  });
+
+  test('stages.listPaginated hits /stages (no trailing slash) with the envelope flag', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(page([{ stage_number: 1, name: 'Beige' }])));
+
+    await stages.listPaginated({}, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/stages?paginate=true');
+  });
+
+  test('userPractices.listPaginated hits /user-practices/ with the envelope flag', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(page([{ id: 1, practice_id: 2 }])));
+
+    await userPractices.listPaginated({ offset: 0 }, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/user-practices/?paginate=true&offset=0');
+  });
+
+  test('course.stageContentPaginated targets the stage content path with the envelope flag', async () => {
+    const envelope = page([{ id: 1, title: 'Intro', release_day: 0 }], {
+      total: 3,
+      has_more: true,
+    });
+    mockFetch.mockReturnValueOnce(jsonResponse(envelope));
+
+    const result = await course.stageContentPaginated(3, { limit: 50 }, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/course/stages/3/content?paginate=true&limit=50');
+    expect(result.has_more).toBe(true);
+    expect(result.total).toBe(3);
+  });
+
+  test('a malformed envelope (missing has_more) raises ApiValidationError', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ items: [], total: 0, limit: 50, offset: 0 }), // no has_more
+    );
+
+    await expect(stages.listPaginated({}, 'tok')).rejects.toThrow(ApiValidationError);
+  });
+
+  test('a non-array items field raises ApiValidationError', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ items: 'nope', total: 0, limit: 50, offset: 0, has_more: false }),
+    );
+
+    await expect(goalGroups.listPaginated({}, 'tok')).rejects.toThrow(ApiValidationError);
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -8,6 +8,7 @@ import {
   loginAuthResponseSchema,
   pageSchema,
   passwordResetAcceptedSchema,
+  unknownRecord,
   type Page,
   type PasswordResetAcceptedT,
   type Tier,
@@ -898,6 +899,39 @@ export function toLocalHabit(apiHabit: ApiHabitWithGoals): LocalHabit {
 const habitWithGoalsArraySchema = z.array(habitWithGoalsSchema);
 const habitPageSchema = pageSchema(habitWithGoalsSchema);
 
+/**
+ * Standard ``limit`` / ``offset`` knobs every ``listPaginated`` helper accepts.
+ * Both default to the server's values (limit 50, offset 0) when omitted.
+ */
+export interface PaginationParams {
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * ``Page`` envelope validator for endpoints that do not yet have a strict
+ * per-item Zod schema (BUG-INFRA-012-018). The envelope itself — ``items`` is
+ * an array, ``total`` / ``limit`` / ``offset`` are non-negative ints,
+ * ``has_more`` is a boolean — is validated; items are checked only as objects
+ * and narrowed to their TypeScript type by the caller's cast. Strict item
+ * schemas (cf. ``habitPageSchema``) replace this as they are written.
+ */
+const loosePageSchema = pageSchema(unknownRecord);
+
+/**
+ * Build the query string shared by every ``listPaginated`` helper: always opt
+ * into the ``Page`` envelope (``paginate=true``), append any endpoint-specific
+ * filters (e.g. ``stage_number``), then ``limit`` / ``offset`` only when the
+ * caller supplies them — mirroring ``habits.listPaginated`` above.
+ */
+function pageQuery(extra: Record<string, string | number>, params: PaginationParams): string {
+  const query = new URLSearchParams({ paginate: 'true' });
+  for (const [key, value] of Object.entries(extra)) query.set(key, String(value));
+  if (params.limit != null) query.set('limit', String(params.limit));
+  if (params.offset != null) query.set('offset', String(params.offset));
+  return query.toString();
+}
+
 // Collection-level habit URLs use a trailing slash to match the FastAPI route
 // (`prefix="/habits"` + `@router.{get,post}("/")`). Without the slash, every
 // request hit a 307 redirect — a wasted round-trip in the happy path and an
@@ -1017,6 +1051,17 @@ export const goals = {
 export const goalGroups = {
   list(token?: string): Promise<ApiGoalGroup[]> {
     return request<ApiGoalGroup[]>('/goal-groups/', { token });
+  },
+  /**
+   * Paginated goal-groups list (BUG-INFRA-015). Opts into the ``Page``
+   * envelope; prefer this over the bare-list variant when ``total`` /
+   * ``has_more`` are needed for a "load more" control.
+   */
+  listPaginated(params: PaginationParams = {}, token?: string): Promise<Page<ApiGoalGroup>> {
+    return request<Page<ApiGoalGroup>>(`/goal-groups/?${pageQuery({}, params)}`, {
+      token,
+      schema: loosePageSchema as unknown as z.ZodType<Page<ApiGoalGroup>>,
+    });
   },
   get(groupId: number, token?: string): Promise<ApiGoalGroup> {
     return request<ApiGoalGroup>(`/goal-groups/${groupId}`, { token });
@@ -1485,6 +1530,16 @@ export const stages = {
   list(token?: string): Promise<Stage[]> {
     return request<Stage[]>('/stages', { token });
   },
+  /**
+   * Paginated stages list (BUG-INFRA-016). Opts into the ``Page`` envelope.
+   * Note the route has no trailing slash (``/stages``), matching the backend.
+   */
+  listPaginated(params: PaginationParams = {}, token?: string): Promise<Page<Stage>> {
+    return request<Page<Stage>>(`/stages?${pageQuery({}, params)}`, {
+      token,
+      schema: loosePageSchema as unknown as z.ZodType<Page<Stage>>,
+    });
+  },
   get(stageNumber: number, token?: string): Promise<Stage> {
     return request<Stage>(`/stages/${stageNumber}`, { token });
   },
@@ -1539,6 +1594,26 @@ export interface SiteResource {
 export const course = {
   stageContent(stageNumber: number, token?: string): Promise<ContentItem[]> {
     return request<ContentItem[]>(`/course/stages/${stageNumber}/content`, { token });
+  },
+  /**
+   * Paginated stage content (BUG-INFRA-018). Opts into the ``Page`` envelope.
+   *
+   * Caveat: pagination is applied *after* drip-feed filtering, so ``total``
+   * reflects only the items the user can currently see — it grows as content
+   * unlocks over time, without new database rows being added.
+   */
+  stageContentPaginated(
+    stageNumber: number,
+    params: PaginationParams = {},
+    token?: string,
+  ): Promise<Page<ContentItem>> {
+    return request<Page<ContentItem>>(
+      `/course/stages/${stageNumber}/content?${pageQuery({}, params)}`,
+      {
+        token,
+        schema: loosePageSchema as unknown as z.ZodType<Page<ContentItem>>,
+      },
+    );
   },
   markRead(contentId: number, token?: string): Promise<ContentCompletion> {
     return request<ContentCompletion>(`/course/content/${contentId}/mark-read`, {
@@ -1815,6 +1890,24 @@ export const practices = {
     const data = await request<PracticeItem[]>(`/practices/?${query.toString()}`, { token });
     return data.filter(validatePracticeItem);
   },
+  /**
+   * Paginated practices list for a stage (BUG-INFRA-012). Opts into the
+   * ``Page`` envelope; ``stage_number`` is required (the backend route filters
+   * by stage). Prefer this over ``list`` when ``total`` / ``has_more`` matter.
+   */
+  listPaginated(
+    params: { stageNumber: number } & PaginationParams,
+    token?: string,
+  ): Promise<Page<PracticeItem>> {
+    const { stageNumber, ...page } = params;
+    return request<Page<PracticeItem>>(
+      `/practices/?${pageQuery({ stage_number: stageNumber }, page)}`,
+      {
+        token,
+        schema: loosePageSchema as unknown as z.ZodType<Page<PracticeItem>>,
+      },
+    );
+  },
   async get(practiceId: number, token?: string): Promise<PracticeItem> {
     const data = await request<PracticeItem>(`/practices/${practiceId}`, { token });
     if (!validatePracticeItem(data)) throw new Error('Invalid practice response');
@@ -1837,6 +1930,17 @@ export const userPractices = {
   },
   list(token?: string): Promise<UserPractice[]> {
     return request<UserPractice[]>('/user-practices/', { token });
+  },
+  /**
+   * Paginated user-practices list (BUG-INFRA-017). Opts into the ``Page``
+   * envelope; prefer this over the bare-list variant when ``total`` /
+   * ``has_more`` are needed.
+   */
+  listPaginated(params: PaginationParams = {}, token?: string): Promise<Page<UserPractice>> {
+    return request<Page<UserPractice>>(`/user-practices/?${pageQuery({}, params)}`, {
+      token,
+      schema: loosePageSchema as unknown as z.ZodType<Page<UserPractice>>,
+    });
   },
   /**
    * PATCH the per-user overrides (custom name + mode_config_override).
@@ -2149,6 +2253,24 @@ export const practiceSessions = {
       body: payload,
       token,
     });
+  },
+  /**
+   * Paginated session history for one user-practice (BUG-INFRA-014). Opts into
+   * the ``Page`` envelope; ``userPracticeId`` is required (the backend route
+   * scopes sessions to a single user-practice).
+   */
+  listPaginated(
+    params: { userPracticeId: number } & PaginationParams,
+    token?: string,
+  ): Promise<Page<PracticeSessionResponse>> {
+    const { userPracticeId, ...page } = params;
+    return request<Page<PracticeSessionResponse>>(
+      `/practice-sessions/?${pageQuery({ user_practice_id: userPracticeId }, page)}`,
+      {
+        token,
+        schema: loosePageSchema as unknown as z.ZodType<Page<PracticeSessionResponse>>,
+      },
+    );
   },
   weekCount(token?: string): Promise<WeekCountResponse> {
     return request<WeekCountResponse>('/practice-sessions/week-count', { token });


### PR DESCRIPTION
## Summary

- Extends the opt-in `Page<T>` envelope migration (BUG-INFRA-012-018) from the already-migrated `habits` client to the remaining **six** list endpoints, each with a Zod-validated envelope and a back-compat bare `list()` left in place:
  - `practices.listPaginated({ stageNumber, limit?, offset? })` — forwards `stage_number` (BUG-INFRA-012)
  - `practiceSessions.listPaginated({ userPracticeId, limit?, offset? })` — new client method; forwards `user_practice_id` (BUG-INFRA-014)
  - `goalGroups.listPaginated` (BUG-INFRA-015)
  - `stages.listPaginated` — no trailing slash, matching the backend route (BUG-INFRA-016)
  - `userPractices.listPaginated` (BUG-INFRA-017)
  - `course.stageContentPaginated(stageNumber, ...)` (BUG-INFRA-018)
- Adds a shared `PaginationParams` type and a `pageQuery()` helper that always sends `?paginate=true` and appends `limit`/`offset` only when supplied (mirrors the existing `habits.listPaginated`).
- Reuses the existing `pageSchema()` factory + `Page<T>` type from `schemas.ts`; envelopes are validated at the client edge and raise `ApiValidationError` on a malformed shape.

## Scope & deliberate deferrals (please read)

Issue #221's checklist also asks to migrate feature screens to `has_more`-driven infinite scroll and drop bare-list call sites. I deliberately **deferred** those here, because doing them naively would be a regression:

- **None** of these seven endpoints' screens paginate today — they fetch whole small lists and render them (only the Journal screen does infinite scroll, and it already uses its own paginated API).
- Switching those screens to `?paginate=true&limit=50` **without** first adding a load-more control would silently truncate any stage with >50 practices / content items to 50 rows. The issue itself flags this for `/course/stages/{n}/content` (where `total` also grows as content drips).

So this PR lands the **safe, non-breaking API layer** (helpers + types + runtime validation + tests). The bare `list()` methods stay until each consuming screen grows a load-more affordance. The backend still defaults to bare list, so nothing changes for existing callers.

**Follow-up filed as #408** — per-screen load-more adoption, then bare-list call-site removal, then the backend-default flip the issue mentions (only valid once the frontend is *fully* migrated).

Note: #221 says to add the types to `frontend/src/api/types.ts`, but that file is auto-generated by openapi-typescript (`Do not make direct changes`). `Page<T>` already lives in `schemas.ts`; `PaginationParams` is added next to the helpers in `index.ts`.

## Test plan

- New `frontend/src/api/__tests__/pagination-api.test.ts` (9 cases): URL/`paginate=true` construction for all six helpers, `stage_number` / `user_practice_id` / `limit` / `offset` forwarding, envelope return shape, and `ApiValidationError` on a malformed envelope (missing `has_more`, non-array `items`).
- `npx eslint . --max-warnings=0` → clean
- `npx tsc -p tsconfig.json --noEmit` → clean
- `npx prettier -c .` → clean
- `TZ=UTC npx jest` → **168 suites / 1774 tests pass** (includes the 9 new cases)

### Heads-up: pre-existing local-only failures (filed as #406)

On a clean `main`, the local `./scripts/frontend/check-all.sh` is red for two reasons **unrelated to this change**, both green in CI:
1. `scripts/frontend/format.sh` globs a non-existent `tests/**` path (CI uses `npx prettier -c .` directly, so it's unaffected).
2. Some date tests (`GoalModal` stepper, `useProgramStore` stage math) are non-hermetic and fail under a non-UTC local timezone (off-by-one day); they pass under `TZ=UTC`.

Verified: `TZ=UTC npx jest` is fully green. Tracked in #406.

Closes #221
Refs #408, #223
