### PR TITLE
fix(practice): replace active practice instead of 409 on switch

### DIFF
--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import date
 from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -78,21 +79,65 @@ async def _check_stage_eligibility(
         raise forbidden("stage_locked")
 
 
+async def _free_stage_slot(
+    session: AsyncSession,
+    current_user: int,
+    payload: UserPracticeCreate,
+    today: date,
+) -> UserPractice | None:
+    """Ready the stage's single open slot for a new selection.
+
+    Returns the existing open row **only** when it already points at the
+    requested practice -- the caller short-circuits on that to keep
+    re-selecting the current pick an idempotent no-op (no new row, no
+    ``start_date`` reset). In every other case it returns ``None`` after
+    closing any open row, so the caller can safely insert the new one.
+
+    The close is flushed before returning so the ``UPDATE`` lands ahead
+    of the caller's ``INSERT``; otherwise the unit of work could order
+    the insert first, momentarily leave two open rows for the stage, and
+    trip ``ix_user_practice_active_stage`` on a replacement that should
+    have succeeded.
+    """
+    existing = await _load_active_user_practice(session, current_user, payload.stage_number)
+    if existing is None:
+        return None
+    if existing.practice_id == payload.practice_id:
+        return existing
+    existing.end_date = today
+    session.add(existing)
+    await session.flush()
+    return None
+
+
 @router.post("/", response_model=UserPracticeResponse, status_code=status.HTTP_201_CREATED)
 async def create_user_practice(
     payload: UserPracticeCreate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> UserPractice:
-    """Select a practice for a stage, creating a UserPractice record.
+    """Select (or replace) the active practice for a stage.
 
-    The ``ix_user_practice_active_stage`` partial unique index enforces
-    "at most one open ``UserPractice`` per ``(user, stage)``" at the
-    database level (BUG-PRACTICE-005).  The earlier application-level
-    pre-check raced: two concurrent calls could both pass the existence
-    check and both insert.  We now rely on the constraint and surface
-    the loser as 409 ``active_practice_exists_for_stage`` so the client
-    gets a single deterministic response code regardless of timing.
+    This is the "Replace this practice" / "Use for stage" write. The
+    ``ix_user_practice_active_stage`` partial unique index enforces "at
+    most one open ``UserPractice`` per ``(user, stage)``" at the DB
+    level (BUG-PRACTICE-005) -- which means a bare insert *fails* when
+    the user already has an active pick for the stage. That is the
+    common case (switching away from the seeded default), so we close
+    the prior open row before inserting the new one rather than 409ing
+    the user out of ever switching (BUG-PRACTICE-012).
+
+    Concurrency is still safe: the close + insert happen in one
+    transaction, and the partial unique index remains the single source
+    of truth. If two replacements race, the index lets exactly one new
+    open row land and the loser rolls back to 409
+    ``active_practice_exists_for_stage`` -- now a transient "try again",
+    not a permanent wall.
+
+    Re-selecting the practice that is *already* active is a no-op: the
+    existing row is returned untouched so an accidental double-tap can't
+    reset ``start_date`` (the user-facing "I started this" label) or the
+    streak math that hangs off it.
     """
     practice = await _resolve_practice(session, payload.practice_id)
     await _check_stage_eligibility(session, current_user, practice, payload.stage_number)
@@ -103,21 +148,26 @@ async def create_user_practice(
     # signing up at 11:00 PM Pacific used to see "started tomorrow"
     # because UTC had already rolled over.
     user_tz = await get_user_timezone(session, current_user)
+    today = today_in_tz(user_tz)
+
+    already_active = await _free_stage_slot(session, current_user, payload, today)
+    if already_active is not None:
+        return already_active
+
     user_practice = UserPractice(
         user_id=current_user,
         practice_id=payload.practice_id,
         stage_number=payload.stage_number,
-        start_date=today_in_tz(user_tz),
+        start_date=today,
     )
     session.add(user_practice)
     try:
         await session.commit()
     except IntegrityError as exc:
         await session.rollback()
-        # The partial unique index fired because an open row already
-        # exists for ``(current_user, stage_number)``.  Return 409 so
-        # the client treats this as a state conflict, not a transient
-        # bad request.
+        # Lost a concurrent replacement race: another request already
+        # closed the prior row and opened its own. Surface 409 so the
+        # client retries against fresh state instead of double-inserting.
         raise conflict("active_practice_exists_for_stage") from exc
     await session.refresh(user_practice)
     logger.info(

--- a/backend/tests/test_user_practices_api.py
+++ b/backend/tests/test_user_practices_api.py
@@ -298,19 +298,19 @@ async def test_get_other_users_practice_forbidden(
 
 
 @pytest.mark.asyncio
-async def test_second_active_selection_for_same_stage_returns_409(
+async def test_second_active_selection_replaces_prior(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """Selecting a second active practice for the same stage must 409.
+    """Selecting a second practice for a stage replaces the first (BUG-PRACTICE-012).
 
-    The partial unique index on ``userpractice (user_id, stage_number)
-    WHERE end_date IS NULL`` enforces the rule at the DB level; the
-    router's ``IntegrityError → 409 active_practice_exists_for_stage``
-    handler maps it to a deterministic response so the client cannot
-    win the race silently and end up with two open rows for the same
-    stage (BUG-PRACTICE-005).
+    This is the "Replace this practice" / "Use for stage" flow. A
+    sequential second pick must succeed, close the prior open row
+    (``end_date`` set), and leave exactly one open row for the stage so
+    the partial unique index invariant still holds. The earlier
+    behaviour 409'd here, which made switching away from the seeded
+    default impossible from the UI.
     """
-    headers, _ = await _signup(async_client, "doublepick")
+    headers, user_id = await _signup(async_client, "doublepick")
     p1 = await _seed_practice(db_session, name="First")
     p2 = await _seed_practice(db_session, name="Second")
 
@@ -326,8 +326,67 @@ async def test_second_active_selection_for_same_stage_returns_409(
         json={"practice_id": p2.id, "stage_number": 1},
         headers=headers,
     )
-    assert second.status_code == HTTPStatus.CONFLICT
-    assert second.json()["detail"] == "active_practice_exists_for_stage"
+    assert second.status_code == HTTPStatus.CREATED
+    assert second.json()["practice_id"] == p2.id
+    assert second.json()["end_date"] is None
+
+    # Exactly one open row, and it is the replacement; the prior pick is closed.
+    rows = (
+        (
+            await db_session.execute(
+                select(UserPractice).where(
+                    UserPractice.user_id == user_id,
+                    UserPractice.stage_number == 1,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    open_rows = [r for r in rows if r.end_date is None]
+    assert len(open_rows) == 1
+    assert open_rows[0].practice_id == p2.id
+    closed = [r for r in rows if r.end_date is not None]
+    assert [r.practice_id for r in closed] == [p1.id]
+
+
+@pytest.mark.asyncio
+async def test_reselecting_active_practice_is_noop(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Re-picking the already-active practice keeps the original row (BUG-PRACTICE-012).
+
+    An accidental double-tap on the current selection must not open a
+    fresh row or reset ``start_date`` -- the user-facing "I started
+    this" label and the streak math that depends on it would otherwise
+    silently reset.
+    """
+    headers, user_id = await _signup(async_client, "reselect")
+    practice = await _seed_practice(db_session, name="Only")
+
+    first = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 1},
+        headers=headers,
+    )
+    assert first.status_code == HTTPStatus.CREATED
+    first_id = first.json()["id"]
+
+    again = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 1},
+        headers=headers,
+    )
+    assert again.status_code == HTTPStatus.CREATED
+    assert again.json()["id"] == first_id
+    assert again.json()["start_date"] == first.json()["start_date"]
+
+    rows = (
+        (await db_session.execute(select(UserPractice).where(UserPractice.user_id == user_id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
 
 
 _CONCURRENT_PICK_FANOUT = 5
@@ -341,10 +400,19 @@ async def test_concurrent_picks_for_same_stage_yield_one_open_row(
 ) -> None:
     """Five simultaneous selections for the same stage land exactly one open row.
 
-    The partial unique index closes the BUG-PRACTICE-005 race; without
-    it, both halves of the SELECT-then-INSERT pre-check could see "no
-    open row" and both insert.  The constraint catches all but one and
-    those losers surface as 409 ``active_practice_exists_for_stage``.
+    The partial unique index closes the BUG-PRACTICE-005 race: without
+    it, concurrent SELECT-then-INSERT calls could each see "no open row"
+    and both insert. The constraint guarantees the durable invariant
+    asserted here -- exactly one open row -- regardless of timing.
+
+    With the replace semantics (BUG-PRACTICE-012) the *response* mix is
+    no longer "one 201, rest 409". Because every request targets the
+    same practice, a request that observes the just-committed row treats
+    re-selecting it as an idempotent no-op (201), while a request that
+    raced ahead of that commit and lost the insert surfaces 409. Both
+    are acceptable; what must never happen is a second *open* row or an
+    unhandled 500. So we assert the durable invariant plus "every
+    response is 201 or 409, and at least one succeeded".
     """
     signup_resp = await concurrent_async_client.post(
         "/auth/signup",
@@ -391,8 +459,10 @@ async def test_concurrent_picks_for_same_stage_yield_one_open_row(
     status_codes = [r.status_code for r in responses]
     successes = status_codes.count(HTTPStatus.CREATED)
     conflicts = status_codes.count(HTTPStatus.CONFLICT)
-    assert successes == 1, f"expected exactly one CREATED, got {successes}: {status_codes}"
-    assert successes + conflicts == _CONCURRENT_PICK_FANOUT, status_codes
+    assert successes >= 1, f"expected at least one CREATED, got: {status_codes}"
+    assert successes + conflicts == _CONCURRENT_PICK_FANOUT, (
+        f"every response must be 201 or 409, got: {status_codes}"
+    )
 
     async with concurrent_session_factory() as session:
         result = await session.execute(

--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -41,6 +41,9 @@ describe('USER_FACING_ERROR_MESSAGES', () => {
       'cannot_go_backwards',
       'already_responded',
       'practice_not_approved',
+      'stage_locked',
+      'stage_number_mismatch',
+      'active_practice_exists_for_stage',
       'habits_must_not_be_empty',
       // wallet
       'payment_required',
@@ -79,6 +82,24 @@ describe('USER_FACING_ERROR_MESSAGES', () => {
     for (const message of Object.values(USER_FACING_ERROR_MESSAGES)) {
       expect(message).toMatch(/[.!?]$/);
     }
+  });
+});
+
+describe('practice-selection codes (BUG-PRACTICE-012)', () => {
+  it('maps stage_locked to actionable copy instead of the generic 403 wall', () => {
+    const err = new ApiError(403, 'stage_locked');
+    const msg = formatApiError(err);
+    expect(msg).toMatch(/unlock(ed)? this stage/i);
+    expect(msg).not.toMatch(/don't have access/i);
+  });
+
+  it('maps stage_number_mismatch to stage-specific guidance', () => {
+    expect(messageForCode('stage_number_mismatch')).toMatch(/different stage/i);
+  });
+
+  it('maps the transient replace conflict to a retry prompt', () => {
+    const err = new ApiError(409, 'active_practice_exists_for_stage');
+    expect(formatApiError(err)).toMatch(/try (switching )?again/i);
   });
 });
 

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -78,6 +78,17 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   already_responded: "You've already answered this week's prompt. A new one unlocks each week.",
   practice_not_approved:
     "That practice isn't available for selection yet. Pick one of the approved options for this stage.",
+  // --- Practice selection (BUG-PRACTICE-012) ---------------------------
+  // ``stage_locked`` (403) and ``stage_number_mismatch`` (400) used to
+  // fall through to the generic per-status copy ("You don't have access"
+  // / "That didn't go through"), which hid *why* assigning a practice
+  // failed. Name the cause and the way forward instead.
+  stage_locked:
+    "You haven't unlocked this stage yet. Finish the earlier stages first — this practice will be waiting when you get there.",
+  stage_number_mismatch:
+    'This practice belongs to a different stage. Open it from that stage to use it.',
+  active_practice_exists_for_stage:
+    'Another change to this stage just went through. Pull down to refresh, then try switching again.',
   habits_must_not_be_empty:
     'Add at least one habit before generating an energy plan. You can add habits from the Habits tab.',
 

--- a/frontend/src/features/Practice/components/PracticeSwitcherSheet.tsx
+++ b/frontend/src/features/Practice/components/PracticeSwitcherSheet.tsx
@@ -3,9 +3,9 @@
  * practice for the current stage so the user can replace their active
  * one without leaving the screen.
  *
- * - Selection writes via `userPractices.create`; the backend's partial
- *   unique index closes the prior `UserPractice` so the catalog stays
- *   "one active row per stage".
+ * - Selection writes via `userPractices.create`; the backend closes the
+ *   prior open `UserPractice` for the stage and opens the new one in a
+ *   single transaction, so the catalog stays "one active row per stage".
  * - "Submit my own" delegates to the existing practice-submission
  *   flow. The handler is injected so this component stays decoupled
  *   from the navigator wiring (and from whether the submission screen
@@ -24,6 +24,7 @@ import {
 } from 'react-native';
 
 import { practices, userPractices, type PracticeItem, type UserPractice } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 
 export interface PracticeSwitcherSheetProps {
@@ -144,8 +145,12 @@ function useSelect(
         if (!mountedRef.current) return;
         onReplaced(created);
         onClose();
-      } catch {
-        if (mountedRef.current) setWriteError(REPLACE_FAILED_MSG);
+      } catch (err) {
+        // Surface the specific cause (stage locked, transient conflict,
+        // …) via the shared error map; fall back to the generic
+        // connection copy only when the failure is unrecognised.
+        if (mountedRef.current)
+          setWriteError(formatApiError(err, { fallback: REPLACE_FAILED_MSG }));
       } finally {
         if (mountedRef.current) setSubmittingId(null);
       }

--- a/frontend/src/features/Practice/components/__tests__/PracticeSwitcherSheet.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/PracticeSwitcherSheet.test.tsx
@@ -205,6 +205,19 @@ describe('PracticeSwitcherSheet', () => {
     expect(onReplaced).not.toHaveBeenCalled();
   });
 
+  it('surfaces the specific backend reason (e.g. stage_locked) over the generic fallback', async () => {
+    mockPracticesList.mockResolvedValue(samplePractices);
+    // Reject with an ApiError-shaped object so formatApiError maps the
+    // ``detail`` code to its user-facing copy instead of the generic
+    // "check your connection" fallback.
+    mockUserPracticesCreate.mockRejectedValueOnce({ status: 403, detail: 'stage_locked' });
+    const { findByTestId, getByText } = renderSheet({ currentPracticeId: 1 });
+    const row = await findByTestId('practice-switcher-row-2');
+    fireEvent.press(row);
+    await findByTestId('practice-switcher-error');
+    expect(getByText(/unlock(ed)? this stage/i)).toBeTruthy();
+  });
+
   it('the close affordance fires onClose', async () => {
     mockPracticesList.mockResolvedValue(samplePractices);
     const onClose = jest.fn();


### PR DESCRIPTION
Switching practices (the "Replace this practice" sheet and the catalog
"Use for stage" action) both POST /user-practices/. That endpoint only
ever inserted a new row and relied on the ix_user_practice_active_stage
partial unique index to keep one open row per (user, stage) -- so once a
user had an active pick (the seeded default always counts), every switch
hit the index, 409'd, and surfaced as "We couldn't switch your practice"
/ "Could not assign practice". There was no code path that ever closed a
prior practice, making switching impossible.

create_user_practice now closes the prior open row (sets end_date) and
opens the new one in a single transaction, flushing the close before the
insert so the partial unique index stays satisfied. Re-selecting the
already-active practice is an idempotent no-op so a double-tap can't
reset start_date. Concurrent replacements still resolve to exactly one
open row; the loser gets a transient 409 to retry.

Frontend: map stage_locked, stage_number_mismatch and the (now
transient) active_practice_exists_for_stage to actionable copy, and route
the switcher's write error through formatApiError so the real reason
shows instead of the generic connection fallback.