### PR TITLE
feat: allow user to update timezone after signup

### DIFF
--- a/backend/src/domain/timezone.py
+++ b/backend/src/domain/timezone.py
@@ -1,0 +1,55 @@
+"""Shared IANA timezone validation for the signup and profile-update boundaries.
+
+Both ``POST /auth/signup`` and ``PUT /users/me/timezone`` accept an inbound
+IANA timezone name and must apply identical rules: blank / whitespace input
+coerces to the column default, names wider than the ``User.timezone`` column
+are rejected, and names that :mod:`zoneinfo` cannot resolve are rejected.
+Centralising the logic here keeps the two trust boundaries from drifting apart.
+"""
+
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+# Cap matches the ``User.timezone`` column width.  IANA names are at most 33
+# chars today (``America/Argentina/ComodRivadavia``); 64 leaves headroom.
+MAX_TIMEZONE_LENGTH = 64
+
+
+def coerce_timezone_input(value: object) -> str | None:
+    """Normalise an inbound ``timezone`` value to ``str | None``.
+
+    Returns ``None`` for inputs that should fall back to the column default
+    (missing, non-string, empty / whitespace-only); otherwise the trimmed
+    string, ready for downstream validation.
+    """
+    if value is None or not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    return candidate or None
+
+
+def check_timezone_resolves(candidate: str) -> None:
+    """Raise ``ValueError`` if ``candidate`` is too long or unknown to ``zoneinfo``."""
+    if len(candidate) > MAX_TIMEZONE_LENGTH:
+        msg = f"timezone must be {MAX_TIMEZONE_LENGTH} chars or fewer"
+        raise ValueError(msg)
+    try:
+        ZoneInfo(candidate)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        msg = f"unknown IANA timezone: {candidate!r}"
+        raise ValueError(msg) from exc
+
+
+def normalize_timezone(value: object, default: str) -> str:
+    """Coerce, default, and validate an inbound timezone value.
+
+    Blank / missing input returns ``default``; otherwise the trimmed name is
+    validated and returned, raising ``ValueError`` on an unknown or oversized
+    name so the trust boundary surfaces a 422 instead of storing bad data.
+    """
+    candidate = coerce_timezone_input(value)
+    if candidate is None:
+        return default
+    check_timezone_resolves(candidate)
+    return candidate

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -45,6 +45,7 @@ from routers.practices import router as practices_router
 from routers.prompts import router as prompts_router
 from routers.stages import router as stages_router
 from routers.user_practices import router as user_practices_router
+from routers.users import router as users_router
 from seed_content import seed_content
 from seed_practice_recipes import seed_practice_recipes
 from seed_practices import seed_practices
@@ -367,6 +368,7 @@ app.include_router(goal_completion_router)
 app.include_router(goal_groups_router)
 app.include_router(goals_router)
 app.include_router(stages_router)
+app.include_router(users_router)
 
 
 # BUG-APP-004: separate liveness from readiness so the orchestrator can

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -12,7 +12,6 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import bcrypt
 import jwt
@@ -24,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from domain.timezone import normalize_timezone
 from errors import bad_request
 from models.login_attempt import LoginAttempt
 from models.password_reset_token import PasswordResetToken
@@ -186,37 +186,6 @@ class AuthRequest(BaseModel):
         return value
 
 
-# Cap matches ``User.timezone`` column width.  IANA names are at most 33
-# chars today (``America/Argentina/ComodRivadavia``); 64 leaves headroom.
-_MAX_TIMEZONE_LENGTH = 64
-
-
-def _coerce_timezone_input(value: object) -> str | None:
-    """Normalise inbound ``timezone`` field values to ``str | None``.
-
-    Returns ``None`` for inputs that should fall back to the column
-    default (missing, non-string, empty / whitespace-only).  Anything
-    else is returned trimmed for downstream validation.  Split out so
-    the ``_validate_timezone`` validator stays at xenon rank A.
-    """
-    if value is None or not isinstance(value, str):
-        return None
-    candidate = value.strip()
-    return candidate or None
-
-
-def _check_timezone_resolves(candidate: str) -> None:
-    """Raise ``ValueError`` if ``candidate`` is too long or unknown to ``zoneinfo``."""
-    if len(candidate) > _MAX_TIMEZONE_LENGTH:
-        msg = f"timezone must be {_MAX_TIMEZONE_LENGTH} chars or fewer"
-        raise ValueError(msg)
-    try:
-        ZoneInfo(candidate)
-    except (ZoneInfoNotFoundError, ValueError) as exc:
-        msg = f"unknown IANA timezone: {candidate!r}"
-        raise ValueError(msg) from exc
-
-
 class SignupRequest(AuthRequest):
     """Signup payload — email + password + optional IANA ``timezone``.
 
@@ -240,11 +209,7 @@ class SignupRequest(AuthRequest):
     @classmethod
     def _validate_timezone(cls, value: object) -> str:
         """Reject malformed IANA strings before they reach the DB."""
-        candidate = _coerce_timezone_input(value)
-        if candidate is None:
-            return DEFAULT_USER_TIMEZONE
-        _check_timezone_resolves(candidate)
-        return candidate
+        return normalize_timezone(value, DEFAULT_USER_TIMEZONE)
 
 
 class AuthResponse(BaseModel):

--- a/backend/src/routers/users.py
+++ b/backend/src/routers/users.py
@@ -1,0 +1,53 @@
+"""User profile endpoints.
+
+Currently exposes a single ``PUT /users/me/timezone`` route so a user can
+correct the IANA timezone stored at signup (issue #261) — needed when they
+travel, immigrate, or signed up on a device whose clock / zone was wrong.
+Without it, streak and daily-completion math would use the original zone
+forever, re-introducing the off-by-one boundary bug PR #260 closed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from dependencies.auth import get_current_user_model
+from models.user import User
+from schemas.timezone import TimezoneRead, TimezoneUpdate
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.put("/me/timezone", response_model=TimezoneRead)
+async def update_my_timezone(
+    payload: TimezoneUpdate,
+    current_user: Annotated[User, Depends(get_current_user_model)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> TimezoneRead:
+    """Update the authenticated caller's IANA timezone.
+
+    Validation mirrors signup (see :class:`~schemas.timezone.TimezoneUpdate`):
+    an unknown or oversized name is rejected with 422 and blank input coerces
+    to ``"UTC"``.  The dependency resolves the caller from their JWT, so only
+    that user's own row is ever mutated.
+    """
+    previous = current_user.timezone
+    current_user.timezone = payload.timezone
+    session.add(current_user)
+    await session.commit()
+    logger.info(
+        "timezone_changed",
+        extra={
+            "user_id": current_user.id,
+            "old_timezone": previous,
+            "new_timezone": payload.timezone,
+        },
+    )
+    return TimezoneRead(timezone=payload.timezone)

--- a/backend/src/schemas/timezone.py
+++ b/backend/src/schemas/timezone.py
@@ -1,0 +1,32 @@
+"""Request / response schemas for the user timezone-update endpoint (issue #261)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, field_validator
+
+from domain.timezone import normalize_timezone
+from models.user import DEFAULT_USER_TIMEZONE
+
+
+class TimezoneUpdate(BaseModel):
+    """Inbound payload for ``PUT /users/me/timezone``.
+
+    The same trust-boundary rules as signup apply (see
+    :func:`domain.timezone.normalize_timezone`): blank / whitespace input
+    coerces to ``"UTC"``; an unknown or oversized IANA name is rejected
+    with 422 before it can reach the database.
+    """
+
+    timezone: str = DEFAULT_USER_TIMEZONE
+
+    @field_validator("timezone", mode="before")
+    @classmethod
+    def _validate_timezone(cls, value: object) -> str:
+        """Reject malformed IANA strings before they reach the DB."""
+        return normalize_timezone(value, DEFAULT_USER_TIMEZONE)
+
+
+class TimezoneRead(BaseModel):
+    """Response echoing the IANA timezone now stored for the caller."""
+
+    timezone: str

--- a/backend/tests/test_users_timezone.py
+++ b/backend/tests/test_users_timezone.py
@@ -1,0 +1,132 @@
+"""Tests for ``PUT /users/me/timezone`` (issue #261).
+
+Covers the acceptance criteria: a valid IANA name is persisted and echoed
+back by subsequent auth responses, invalid / oversized names are rejected
+with 422, blank input coerces to ``"UTC"``, the route requires auth (401),
+and one user's update never touches another's stored zone.
+"""
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+# A name comfortably over the 64-char ``User.timezone`` column cap.
+_OVERSIZED_TIMEZONE = "Area/" + ("x" * 70)
+
+
+async def _signup(
+    client: AsyncClient,
+    username: str = "tzuser",
+    timezone: str | None = None,
+) -> tuple[dict[str, str], int]:
+    """Create a user and return ``(auth headers, user_id)``."""
+    payload: dict[str, str] = {
+        "email": f"{username}@example.com",
+        "password": "securepassword123",  # pragma: allowlist secret
+    }
+    if timezone is not None:
+        payload["timezone"] = timezone
+    resp = await client.post("/auth/signup", json=payload)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+async def _login_timezone(client: AsyncClient, username: str = "tzuser") -> str:
+    """Log in as ``username`` and return the timezone the server echoes back."""
+    resp = await client.post(
+        "/auth/login",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    timezone = resp.json()["timezone"]
+    assert isinstance(timezone, str)
+    return timezone
+
+
+@pytest.mark.asyncio
+async def test_update_timezone_persists_valid_iana(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+
+    resp = await async_client.put(
+        "/users/me/timezone",
+        json={"timezone": "America/Los_Angeles"},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json() == {"timezone": "America/Los_Angeles"}
+    # Persisted: a fresh login echoes the updated zone (PR #260 contract).
+    assert await _login_timezone(async_client) == "America/Los_Angeles"
+
+
+@pytest.mark.asyncio
+async def test_update_timezone_rejects_unknown_iana(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+
+    resp = await async_client.put(
+        "/users/me/timezone",
+        json={"timezone": "Mars/Phobos"},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_update_timezone_rejects_oversized(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client)
+
+    resp = await async_client.put(
+        "/users/me/timezone",
+        json={"timezone": _OVERSIZED_TIMEZONE},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_update_timezone_blank_coerces_to_utc(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client, timezone="America/New_York")
+
+    resp = await async_client.put(
+        "/users/me/timezone",
+        json={"timezone": "   "},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json() == {"timezone": "UTC"}
+    assert await _login_timezone(async_client) == "UTC"
+
+
+@pytest.mark.asyncio
+async def test_update_timezone_requires_auth(async_client: AsyncClient) -> None:
+    resp = await async_client.put(
+        "/users/me/timezone",
+        json={"timezone": "America/Los_Angeles"},
+    )
+
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_update_timezone_is_scoped_to_caller(async_client: AsyncClient) -> None:
+    alice_headers, _ = await _signup(async_client, username="alice", timezone="Europe/Paris")
+    bob_headers, _ = await _signup(async_client, username="bob", timezone="Asia/Tokyo")
+
+    resp = await async_client.put(
+        "/users/me/timezone",
+        json={"timezone": "America/Chicago"},
+        headers=alice_headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    # Bob's stored zone is untouched by Alice's update.
+    assert await _login_timezone(async_client, username="bob") == "Asia/Tokyo"
+    assert await _login_timezone(async_client, username="alice") == "America/Chicago"

--- a/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
+++ b/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
@@ -86,6 +86,7 @@ type MockAuth = {
   // ``userTimezone`` mirrors the production AuthContextValue default so a
   // navigator render at any auth state has a non-null TZ string available.
   userTimezone: string;
+  setUserTimezone: jest.Mock;
   login: jest.Mock;
   signup: jest.Mock;
   logout: jest.Mock;
@@ -100,6 +101,7 @@ function buildAuth(overrides: Partial<MockAuth> = {}): MockAuth {
     authStatus: 'anonymous',
     isLoading: false,
     userTimezone: 'UTC',
+    setUserTimezone: jest.fn(),
     login: jest.fn(() => Promise.resolve()),
     signup: jest.fn(() => Promise.resolve()),
     logout: jest.fn(() => Promise.resolve()),

--- a/frontend/src/api/__tests__/users-api.test.ts
+++ b/frontend/src/api/__tests__/users-api.test.ts
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { users, ApiError, ApiValidationError } from '../index';
+
+// Mock global fetch
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+// Silence the API_BASE_URL import — just needs a string value
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+describe('users API client', () => {
+  test('users.updateMyTimezone sends PUT with the IANA name and auth header', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ timezone: 'America/Los_Angeles' }));
+
+    const result = await users.updateMyTimezone({ timezone: 'America/Los_Angeles' }, 'test-token');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/users/me/timezone');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toEqual({ timezone: 'America/Los_Angeles' });
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer test-token' });
+    expect(result).toEqual({ timezone: 'America/Los_Angeles' });
+  });
+
+  test('users.updateMyTimezone surfaces a 422 as ApiError with the server status', async () => {
+    expect.assertions(2);
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ detail: "unknown IANA timezone: 'Mars/Phobos'" }, 422),
+    );
+
+    try {
+      await users.updateMyTimezone({ timezone: 'Mars/Phobos' }, 'test-token');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(422);
+    }
+  });
+
+  test('users.updateMyTimezone rejects a malformed success body at the boundary', async () => {
+    // BUG-024 runtime validation: a response without ``timezone`` must not
+    // reach the AuthContext, where it would corrupt ``userTimezone``.
+    mockFetch.mockReturnValueOnce(jsonResponse({ unexpected: true }));
+
+    await expect(
+      users.updateMyTimezone({ timezone: 'America/Los_Angeles' }, 'test-token'),
+    ).rejects.toBeInstanceOf(ApiValidationError);
+  });
+});

--- a/frontend/src/api/__tests__/users-api.test.ts
+++ b/frontend/src/api/__tests__/users-api.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
-import { users, ApiError, ApiValidationError } from '../index';
+import { users, setTokenGetter, ApiError, ApiValidationError } from '../index';
 
 // Mock global fetch
 const mockFetch = jest.fn() as jest.Mock;
@@ -34,6 +34,22 @@ describe('users API client', () => {
     expect(JSON.parse(init.body)).toEqual({ timezone: 'America/Los_Angeles' });
     expect(init.headers).toMatchObject({ Authorization: 'Bearer test-token' });
     expect(result).toEqual({ timezone: 'America/Los_Angeles' });
+  });
+
+  test('users.updateMyTimezone authenticates via the global token getter when no token is passed', async () => {
+    // The production path: TimezoneSettingsScreen calls without an explicit
+    // token and relies on the AuthContext-installed getter.
+    setTokenGetter(() => 'getter-token');
+    try {
+      mockFetch.mockReturnValueOnce(jsonResponse({ timezone: 'America/Los_Angeles' }));
+
+      await users.updateMyTimezone({ timezone: 'America/Los_Angeles' });
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.headers).toMatchObject({ Authorization: 'Bearer getter-token' });
+    } finally {
+      setTokenGetter(null);
+    }
   });
 
   test('users.updateMyTimezone surfaces a 422 as ApiError with the server status', async () => {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -8,10 +8,12 @@ import {
   loginAuthResponseSchema,
   pageSchema,
   passwordResetAcceptedSchema,
+  timezoneReadSchema,
   unknownRecord,
   type Page,
   type PasswordResetAcceptedT,
   type Tier,
+  type TimezoneReadT,
 } from './schemas';
 import type { components, paths } from './types';
 
@@ -2500,6 +2502,32 @@ export const auth = {
   },
 };
 
+/** Inbound payload for ``PUT /users/me/timezone`` (issue #261). */
+export interface TimezoneUpdatePayload {
+  timezone: string;
+}
+
+// User profile client
+export const users = {
+  /**
+   * Update the authenticated caller's IANA timezone (issue #261).
+   *
+   * The server applies the same trust-boundary rules as signup: an
+   * unknown or oversized name is rejected with 422 and blank input
+   * coerces to ``"UTC"``.  On success the caller should push the echoed
+   * zone into ``AuthContext.setUserTimezone`` so user-local helpers
+   * (Habit stats, streaks, weekday charts) pick it up immediately.
+   */
+  updateMyTimezone(payload: TimezoneUpdatePayload, token?: string): Promise<TimezoneReadT> {
+    return request<TimezoneReadT>('/users/me/timezone', {
+      method: 'PUT',
+      body: payload,
+      token,
+      schema: timezoneReadSchema,
+    });
+  },
+};
+
 // Energy plan client
 export const energy = {
   createPlan(body: EnergyPlanRequest, idempotencyKey?: string): Promise<EnergyPlanResponse> {
@@ -2529,6 +2557,7 @@ export default {
   frequency,
   practiceSessions,
   auth,
+  users,
   energy,
   setTokenGetter,
   setOnUnauthorized,

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -105,6 +105,17 @@ export type AuthResponseT = z.infer<typeof authResponseSchema>;
 export type LoginAuthResponseT = z.infer<typeof loginAuthResponseSchema>;
 
 /**
+ * Response for ``PUT /users/me/timezone`` (issue #261): the IANA zone the
+ * server now has on record for the caller.  Validated at the boundary so a
+ * malformed body can never corrupt ``userTimezone`` in the AuthContext.
+ */
+export const timezoneReadSchema = z.object({
+  timezone: z.string(),
+});
+
+export type TimezoneReadT = z.infer<typeof timezoneReadSchema>;
+
+/**
  * Response for ``POST /auth/password-reset/request``.  Always 202 with
  * the same body shape regardless of whether the email is registered --
  * the message is the SPEC R4 anti-enumeration constant.

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -64,6 +64,13 @@ interface AuthContextValue {
    * default fallback so consumers never see a `null`-typed value.
    */
   userTimezone: string;
+  /**
+   * Push a server-confirmed IANA zone into ``userTimezone`` (issue #261).
+   * Call this ONLY with the zone echoed back by ``PUT /users/me/timezone``
+   * so the context never drifts from what the backend has on record —
+   * client-side guesses belong in the request, not here.
+   */
+  setUserTimezone: (_timezone: string) => void;
   login: LoginOrSignup;
   signup: LoginOrSignup;
   logout: () => Promise<void>;
@@ -449,7 +456,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const isLoading = authStatus === 'loading';
 
   const value = useMemo(
-    () => ({ token, authStatus, isLoading, userTimezone, ...actions }),
+    () => ({ token, authStatus, isLoading, userTimezone, setUserTimezone, ...actions }),
     [token, authStatus, isLoading, userTimezone, actions],
   );
 

--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -12,6 +12,7 @@ import {
 
 import { useApiKey } from '@/context/ApiKeyContext';
 import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import type { RootStackParamList } from '@/navigation/RootStack';
 
 /**
  * BYOK ("Bring Your Own Key") settings for BotMason chat.
@@ -63,8 +64,13 @@ function maskKey(key: string): string {
 interface Props {
   navigation?: {
     goBack?: () => void;
-    /** Stack navigate — used by the "Time zone" settings entry (issue #261). */
-    navigate?: (_screen: 'TimezoneSettings') => void;
+    /**
+     * Stack navigate — used by the "Time zone" settings entry (issue #261).
+     * Typed against the whole param list (not a single literal) so future
+     * entries from this screen don't require a Props change; duck-typed
+     * rather than ``NavigationProp`` so tests can pass a bare ``jest.fn()``.
+     */
+    navigate?: (_screen: keyof RootStackParamList) => void;
   };
 }
 

--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -61,7 +61,11 @@ function maskKey(key: string): string {
 }
 
 interface Props {
-  navigation?: { goBack?: () => void };
+  navigation?: {
+    goBack?: () => void;
+    /** Stack navigate — used by the "Time zone" settings entry (issue #261). */
+    navigate?: (_screen: 'TimezoneSettings') => void;
+  };
 }
 
 interface StoredKeyCardProps {
@@ -174,6 +178,7 @@ interface ScreenBodyProps {
   onRequestRemove: () => void;
   onSave: () => void;
   onBack?: () => void;
+  onOpenTimezone?: () => void;
 }
 
 const ScreenIntro = ({ apiKey }: { apiKey: string | null }): React.JSX.Element => (
@@ -195,10 +200,12 @@ const ScreenFooter = ({
   submitting,
   onSave,
   onBack,
+  onOpenTimezone,
 }: {
   submitting: boolean;
   onSave: () => void;
   onBack?: () => void;
+  onOpenTimezone?: () => void;
 }): React.JSX.Element => (
   <>
     <TouchableOpacity
@@ -212,6 +219,17 @@ const ScreenFooter = ({
     >
       <Text style={styles.primaryButtonText}>{submitting ? 'Saving…' : 'Save key'}</Text>
     </TouchableOpacity>
+    {onOpenTimezone && (
+      <TouchableOpacity
+        onPress={onOpenTimezone}
+        style={styles.linkRow}
+        testID="open-timezone-settings"
+        accessibilityLabel="Time zone settings"
+        accessibilityRole="link"
+      >
+        <Text style={styles.link}>Time zone settings</Text>
+      </TouchableOpacity>
+    )}
     {onBack && (
       <TouchableOpacity
         onPress={onBack}
@@ -237,6 +255,7 @@ const ScreenBody = ({
   onRequestRemove,
   onSave,
   onBack,
+  onOpenTimezone,
 }: ScreenBodyProps): React.JSX.Element => (
   <>
     <ScreenIntro apiKey={apiKey} />
@@ -251,7 +270,12 @@ const ScreenBody = ({
       onToggleReveal={onToggleReveal}
     />
     <FeedbackBanner error={error} status={status} />
-    <ScreenFooter submitting={submitting} onSave={onSave} onBack={onBack} />
+    <ScreenFooter
+      submitting={submitting}
+      onSave={onSave}
+      onBack={onBack}
+      onOpenTimezone={onOpenTimezone}
+    />
   </>
 );
 
@@ -353,6 +377,10 @@ export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.
     () => (navigation?.goBack ? () => navigation.goBack?.() : undefined),
     [navigation],
   );
+  const onOpenTimezone = useMemo(
+    () => (navigation?.navigate ? () => navigation.navigate?.('TimezoneSettings') : undefined),
+    [navigation],
+  );
 
   if (isLoading) {
     return (
@@ -376,6 +404,7 @@ export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.
         onRequestRemove={handleRequestRemove}
         onSave={handleSave}
         onBack={onBack}
+        onOpenTimezone={onOpenTimezone}
       />
     </ScrollView>
   );

--- a/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
+++ b/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
@@ -1,0 +1,324 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+import { ApiError, users } from '@/api';
+import { useAuth } from '@/context/AuthContext';
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import { detectDeviceTimezone } from '@/utils/dateUtils';
+
+/**
+ * "Time zone" settings entry (issue #261).
+ *
+ * Lets a user correct the IANA zone stored at signup — needed when they
+ * travel, immigrate, or signed up on a device whose clock / zone was wrong.
+ * Saves via ``PUT /users/me/timezone`` and pushes the server-confirmed zone
+ * into ``AuthContext.userTimezone`` so user-local helpers (Habit stats,
+ * streaks, weekday charts) reflect the change immediately.
+ */
+
+const EXAMPLE_ZONE = 'America/Los_Angeles';
+
+const EMPTY_ZONE_MESSAGE =
+  `Enter a time zone name like "${EXAMPLE_ZONE}", ` +
+  'or tap "Use device time zone" to detect it for you.';
+
+function unknownZoneMessage(zone: string): string {
+  return (
+    `"${zone}" isn't a recognized time zone. ` +
+    `Use an IANA name like "${EXAMPLE_ZONE}", or tap "Use device time zone".`
+  );
+}
+
+function saveErrorMessage(err: unknown, zone: string): string {
+  if (err instanceof ApiError && err.status === 422) {
+    return unknownZoneMessage(zone);
+  }
+  return err instanceof Error && err.message
+    ? err.message
+    : 'Could not save the time zone. Check your connection and try again.';
+}
+
+interface Props {
+  navigation?: { goBack?: () => void };
+}
+
+const CurrentZoneCard = ({ zone }: { zone: string }): React.JSX.Element => (
+  <View style={styles.currentCard}>
+    <Text style={styles.currentLabel}>Current time zone</Text>
+    <Text style={styles.currentValue} testID="current-timezone">
+      {zone}
+    </Text>
+  </View>
+);
+
+interface FeedbackBannerProps {
+  error: string | null;
+  status: string | null;
+}
+
+const FeedbackBanner = ({ error, status }: FeedbackBannerProps): React.JSX.Element | null => {
+  if (error) {
+    return (
+      <Text style={styles.error} testID="timezone-error">
+        {error}
+      </Text>
+    );
+  }
+  if (status) {
+    return (
+      <Text style={styles.success} testID="timezone-status">
+        {status}
+      </Text>
+    );
+  }
+  return null;
+};
+
+interface TimezoneScreenState {
+  draft: string;
+  submitting: boolean;
+  error: string | null;
+  status: string | null;
+  setDraft: React.Dispatch<React.SetStateAction<string>>;
+  setSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
+  setError: React.Dispatch<React.SetStateAction<string | null>>;
+  setStatus: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+function useTimezoneScreenState(initialZone: string): TimezoneScreenState {
+  const [draft, setDraft] = useState(initialZone);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  return { draft, submitting, error, status, setDraft, setSubmitting, setError, setStatus };
+}
+
+function useSaveTimezoneHandler(
+  state: TimezoneScreenState,
+  applyTimezone: (_timezone: string) => void,
+): () => Promise<void> {
+  const { draft, setSubmitting, setError, setStatus } = state;
+  return useCallback(async () => {
+    setStatus(null);
+    const candidate = draft.trim();
+    if (!candidate) {
+      setError(EMPTY_ZONE_MESSAGE);
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      const result = await users.updateMyTimezone({ timezone: candidate });
+      applyTimezone(result.timezone);
+      setStatus('Time zone updated. Streaks and daily stats now use it.');
+    } catch (err: unknown) {
+      setError(saveErrorMessage(err, candidate));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [draft, applyTimezone, setSubmitting, setError, setStatus]);
+}
+
+interface ScreenBodyProps {
+  currentZone: string;
+  state: TimezoneScreenState;
+  onChangeDraft: (_value: string) => void;
+  onUseDeviceZone: () => void;
+  onSave: () => void;
+  onBack?: () => void;
+}
+
+interface ZoneInputSectionProps {
+  draft: string;
+  onChangeDraft: (_value: string) => void;
+  onUseDeviceZone: () => void;
+}
+
+const ZoneInputSection = ({
+  draft,
+  onChangeDraft,
+  onUseDeviceZone,
+}: ZoneInputSectionProps): React.JSX.Element => (
+  <>
+    <Text style={styles.inputLabel}>New time zone</Text>
+    <TextInput
+      style={styles.input}
+      placeholder={EXAMPLE_ZONE}
+      value={draft}
+      onChangeText={onChangeDraft}
+      autoCapitalize="none"
+      autoCorrect={false}
+      testID="timezone-input"
+    />
+    <TouchableOpacity
+      onPress={onUseDeviceZone}
+      style={styles.secondaryButton}
+      testID="use-device-timezone-button"
+      accessibilityLabel="Use device time zone"
+      accessibilityRole="button"
+    >
+      <Text style={styles.secondaryButtonText}>Use device time zone</Text>
+    </TouchableOpacity>
+  </>
+);
+
+const ScreenFooter = ({
+  submitting,
+  onSave,
+  onBack,
+}: {
+  submitting: boolean;
+  onSave: () => void;
+  onBack?: () => void;
+}): React.JSX.Element => (
+  <>
+    <TouchableOpacity
+      onPress={onSave}
+      style={styles.primaryButton}
+      disabled={submitting}
+      testID="save-timezone-button"
+      accessibilityLabel="Save time zone"
+      accessibilityRole="button"
+      accessibilityState={{ disabled: submitting, busy: submitting }}
+    >
+      <Text style={styles.primaryButtonText}>{submitting ? 'Saving…' : 'Save'}</Text>
+    </TouchableOpacity>
+    {onBack && (
+      <TouchableOpacity
+        onPress={onBack}
+        style={styles.linkRow}
+        accessibilityLabel="Go back"
+        accessibilityRole="link"
+      >
+        <Text style={styles.link}>Back</Text>
+      </TouchableOpacity>
+    )}
+  </>
+);
+
+const ScreenBody = ({
+  currentZone,
+  state,
+  onChangeDraft,
+  onUseDeviceZone,
+  onSave,
+  onBack,
+}: ScreenBodyProps): React.JSX.Element => (
+  <ScrollView contentContainerStyle={styles.container}>
+    <Text style={styles.title}>Time zone</Text>
+    <Text style={styles.body}>
+      Streaks and daily stats count days in this time zone. Update it if you moved or if it was
+      detected wrong at signup.
+    </Text>
+    <CurrentZoneCard zone={currentZone} />
+    <ZoneInputSection
+      draft={state.draft}
+      onChangeDraft={onChangeDraft}
+      onUseDeviceZone={onUseDeviceZone}
+    />
+    <FeedbackBanner error={state.error} status={state.status} />
+    <ScreenFooter submitting={state.submitting} onSave={onSave} onBack={onBack} />
+  </ScrollView>
+);
+
+export default function TimezoneSettingsScreen({ navigation }: Props = {}): React.JSX.Element {
+  const { userTimezone, setUserTimezone } = useAuth();
+  const state = useTimezoneScreenState(userTimezone);
+  const handleSave = useSaveTimezoneHandler(state, setUserTimezone);
+
+  const onChangeDraft = useCallback(
+    (value: string) => {
+      state.setDraft(value);
+      state.setError(null);
+    },
+    [state],
+  );
+
+  const onUseDeviceZone = useCallback(() => {
+    state.setDraft(detectDeviceTimezone());
+    state.setError(null);
+  }, [state]);
+
+  const onBack = useMemo(
+    () => (navigation?.goBack ? () => navigation.goBack?.() : undefined),
+    [navigation],
+  );
+
+  return (
+    <ScreenBody
+      currentZone={userTimezone}
+      state={state}
+      onChangeDraft={onChangeDraft}
+      onUseDeviceZone={onUseDeviceZone}
+      onSave={handleSave}
+      onBack={onBack}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: SPACING.xl, backgroundColor: colors.background.card, flexGrow: 1 },
+  title: { fontSize: 22, fontWeight: '700', marginBottom: SPACING.md },
+  body: {
+    fontSize: 14,
+    color: colors.text.secondaryAccessible,
+    marginBottom: SPACING.xl,
+    lineHeight: 20,
+  },
+  currentCard: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.lg,
+    marginBottom: SPACING.xl,
+    backgroundColor: colors.background.accent,
+  },
+  currentLabel: {
+    fontSize: 12,
+    color: colors.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  currentValue: {
+    fontSize: 18,
+    fontFamily: 'Menlo',
+    marginTop: SPACING.sm,
+    color: colors.text.primary,
+  },
+  inputLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: SPACING.sm,
+    color: colors.text.primary,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md,
+    fontSize: 16,
+    marginBottom: SPACING.md,
+  },
+  secondaryButton: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md,
+    alignItems: 'center',
+    backgroundColor: colors.background.accent,
+    marginBottom: SPACING.md,
+  },
+  secondaryButtonText: { fontSize: 14, color: colors.text.primary, fontWeight: '600' },
+  error: { color: colors.danger, marginBottom: SPACING.md },
+  success: { color: colors.successText, marginBottom: SPACING.md },
+  primaryButton: {
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md + 2,
+    alignItems: 'center',
+    backgroundColor: colors.primary,
+    marginTop: SPACING.xs,
+  },
+  primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
+  linkRow: { marginTop: SPACING.xl, alignItems: 'center' },
+  link: { color: colors.primary, fontWeight: '600' },
+});

--- a/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
+++ b/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
@@ -18,6 +18,10 @@ import { detectDeviceTimezone } from '@/utils/dateUtils';
 
 const EXAMPLE_ZONE = 'America/Los_Angeles';
 
+// Visual parity with ApiKeySettingsScreen's primary button, whose padding is
+// also SPACING.md nudged up to balance the larger label font.
+const SAVE_BUTTON_PADDING = SPACING.md + 2;
+
 const EMPTY_ZONE_MESSAGE =
   `Enter a time zone name like "${EXAMPLE_ZONE}", ` +
   'or tap "Use device time zone" to detect it for you.';
@@ -226,18 +230,22 @@ export default function TimezoneSettingsScreen({ navigation }: Props = {}): Reac
   const state = useTimezoneScreenState(userTimezone);
   const handleSave = useSaveTimezoneHandler(state, setUserTimezone);
 
+  // Depend on the stable useState setters, not ``state`` itself — the hook
+  // returns a fresh object every render, so a ``[state]`` dependency would
+  // silently defeat the memoization.
+  const { setDraft, setError } = state;
   const onChangeDraft = useCallback(
     (value: string) => {
-      state.setDraft(value);
-      state.setError(null);
+      setDraft(value);
+      setError(null);
     },
-    [state],
+    [setDraft, setError],
   );
 
   const onUseDeviceZone = useCallback(() => {
-    state.setDraft(detectDeviceTimezone());
-    state.setError(null);
-  }, [state]);
+    setDraft(detectDeviceTimezone());
+    setError(null);
+  }, [setDraft, setError]);
 
   const onBack = useMemo(
     () => (navigation?.goBack ? () => navigation.goBack?.() : undefined),
@@ -313,7 +321,7 @@ const styles = StyleSheet.create({
   success: { color: colors.successText, marginBottom: SPACING.md },
   primaryButton: {
     borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md + 2,
+    padding: SAVE_BUTTON_PADDING,
     alignItems: 'center',
     backgroundColor: colors.primary,
     marginTop: SPACING.xs,

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -83,6 +83,16 @@ describe('ApiKeySettingsScreen', () => {
     expect(getByText(/••••/)).toBeTruthy();
   });
 
+  test('navigates to the Time zone settings from the footer entry', () => {
+    setApiKeyState({});
+    const navigate = jest.fn();
+    const { getByTestId } = render(<ApiKeySettingsScreen navigation={{ navigate }} />);
+
+    fireEvent.press(getByTestId('open-timezone-settings'));
+
+    expect(navigate).toHaveBeenCalledWith('TimezoneSettings');
+  });
+
   test('rejects a malformed key and does not persist it', async () => {
     const state = setApiKeyState({});
     const { getByTestId, findByTestId } = render(<ApiKeySettingsScreen />);

--- a/frontend/src/features/Settings/__tests__/TimezoneSettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/TimezoneSettingsScreen.test.tsx
@@ -1,0 +1,107 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import TimezoneSettingsScreen from '../TimezoneSettingsScreen';
+
+import { ApiError, users } from '@/api';
+import { useAuth } from '@/context/AuthContext';
+import { detectDeviceTimezone } from '@/utils/dateUtils';
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api');
+  return { ...actual, users: { updateMyTimezone: jest.fn() } };
+});
+
+jest.mock('@/utils/dateUtils', () => {
+  const actual = jest.requireActual('@/utils/dateUtils');
+  return { ...actual, detectDeviceTimezone: jest.fn(() => 'Pacific/Auckland') };
+});
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockUpdateMyTimezone = users.updateMyTimezone as jest.MockedFunction<
+  typeof users.updateMyTimezone
+>;
+const mockDetectDeviceTimezone = detectDeviceTimezone as jest.MockedFunction<
+  typeof detectDeviceTimezone
+>;
+
+function setAuthState(userTimezone = 'Europe/Paris') {
+  const setUserTimezone = jest.fn();
+  mockUseAuth.mockReturnValue({
+    userTimezone,
+    setUserTimezone,
+  } as unknown as ReturnType<typeof useAuth>);
+  return { setUserTimezone };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDetectDeviceTimezone.mockReturnValue('Pacific/Auckland');
+});
+
+describe('TimezoneSettingsScreen', () => {
+  test('shows the time zone the server has on record', () => {
+    setAuthState('Europe/Paris');
+    const { getByTestId } = render(<TimezoneSettingsScreen />);
+    expect(getByTestId('current-timezone').props.children).toContain('Europe/Paris');
+  });
+
+  test('saves a new zone and pushes it into the auth context on success', async () => {
+    const { setUserTimezone } = setAuthState('Europe/Paris');
+    mockUpdateMyTimezone.mockResolvedValueOnce({ timezone: 'America/Los_Angeles' });
+    const { getByTestId } = render(<TimezoneSettingsScreen />);
+
+    fireEvent.changeText(getByTestId('timezone-input'), 'America/Los_Angeles');
+    fireEvent.press(getByTestId('save-timezone-button'));
+
+    await waitFor(() => {
+      expect(mockUpdateMyTimezone).toHaveBeenCalledWith({ timezone: 'America/Los_Angeles' });
+      expect(setUserTimezone).toHaveBeenCalledWith('America/Los_Angeles');
+      expect(getByTestId('timezone-status')).toBeTruthy();
+    });
+  });
+
+  test('shows a friendly error on a 422 and leaves the auth context untouched', async () => {
+    const { setUserTimezone } = setAuthState('Europe/Paris');
+    mockUpdateMyTimezone.mockRejectedValueOnce(
+      new ApiError(422, "unknown IANA timezone: 'Mars/Phobos'"),
+    );
+    const { getByTestId } = render(<TimezoneSettingsScreen />);
+
+    fireEvent.changeText(getByTestId('timezone-input'), 'Mars/Phobos');
+    fireEvent.press(getByTestId('save-timezone-button'));
+
+    await waitFor(() => {
+      expect(getByTestId('timezone-error').props.children).toMatch(/recognized time zone/i);
+    });
+    expect(setUserTimezone).not.toHaveBeenCalled();
+  });
+
+  test('"Use device time zone" fills the input with the detected zone', () => {
+    setAuthState('UTC');
+    const { getByTestId } = render(<TimezoneSettingsScreen />);
+
+    fireEvent.press(getByTestId('use-device-timezone-button'));
+
+    expect(getByTestId('timezone-input').props.value).toBe('Pacific/Auckland');
+  });
+
+  test('a blank zone never reaches the API', () => {
+    setAuthState('Europe/Paris');
+    const { getByTestId } = render(<TimezoneSettingsScreen />);
+
+    fireEvent.changeText(getByTestId('timezone-input'), '   ');
+    fireEvent.press(getByTestId('save-timezone-button'));
+
+    expect(mockUpdateMyTimezone).not.toHaveBeenCalled();
+    expect(getByTestId('timezone-error')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Settings/__tests__/TimezoneSettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/TimezoneSettingsScreen.test.tsx
@@ -94,6 +94,16 @@ describe('TimezoneSettingsScreen', () => {
     expect(getByTestId('timezone-input').props.value).toBe('Pacific/Auckland');
   });
 
+  test('the Back link calls navigation.goBack', () => {
+    setAuthState('Europe/Paris');
+    const goBack = jest.fn();
+    const { getByText } = render(<TimezoneSettingsScreen navigation={{ goBack }} />);
+
+    fireEvent.press(getByText('Back'));
+
+    expect(goBack).toHaveBeenCalledTimes(1);
+  });
+
   test('a blank zone never reaches the API', () => {
     setAuthState('Europe/Paris');
     const { getByTestId } = render(<TimezoneSettingsScreen />);

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -6,6 +6,7 @@ import { CreatePracticeWizard } from '../features/Practice/screens/CreatePractic
 import { PracticeDetailScreen } from '../features/Practice/screens/PracticeDetailScreen';
 import SharePreviewScreen from '../features/Practice/screens/SharePreviewScreen';
 import ApiKeySettingsScreen from '../features/Settings/ApiKeySettingsScreen';
+import TimezoneSettingsScreen from '../features/Settings/TimezoneSettingsScreen';
 
 import type { RootTabParamList } from './BottomTabs';
 import BottomTabs from './BottomTabs';
@@ -36,6 +37,7 @@ export interface CreatePracticePrefill {
 export type RootStackParamList = {
   Tabs: NavigatorScreenParams<RootTabParamList>;
   ApiKeySettings: undefined;
+  TimezoneSettings: undefined;
   SharePreview: { token: string };
   PracticeDetail: { practiceId: number };
   CreatePractice: { prefill?: CreatePracticePrefill } | undefined;
@@ -50,6 +52,11 @@ const RootStack = (): React.JSX.Element => (
       name="ApiKeySettings"
       component={ApiKeySettingsScreen}
       options={{ title: 'API Key' }}
+    />
+    <Stack.Screen
+      name="TimezoneSettings"
+      component={TimezoneSettingsScreen}
+      options={{ title: 'Time zone' }}
     />
     <Stack.Screen
       name="SharePreview"


### PR DESCRIPTION
## Summary

- Adds `PUT /users/me/timezone` so an authenticated user can correct the IANA timezone stored at signup (travel, immigration, wrong device zone). Validation mirrors signup exactly — 422 on unknown or >64-char names, blank/whitespace coerces to `"UTC"` — via a shared `domain/timezone.py` module so the two trust boundaries cannot drift.
- Adds a frontend "Time zone" settings screen (linked from the existing settings screen) with a "Use device time zone" shortcut backed by `detectDeviceTimezone()`. Saving pushes the server-confirmed zone into `AuthContext.userTimezone` so streaks and daily stats reflect the change immediately.
- Emits a `timezone_changed` log entry (user id, old zone, new zone) for ops visibility into zone churn.

## Test plan

- Backend: `pytest tests/test_users_timezone.py` — valid name persisted (verified via a follow-up login echo), unknown → 422, oversized → 422, blank → UTC, unauthenticated → 401, cross-user isolation. Full suite: 1433 passed, coverage 94%.
- Frontend: `TZ=UTC npx jest` — 1783 passed. New suites cover the API client (PUT shape, auth header, 422 surfacing, malformed-body rejection at the Zod boundary) and the screen (save success updates context, 422 shows a friendly message, device-zone shortcut, blank input never reaches the API, settings entry navigation).
- `pre-commit run --all-files` exits 0 (TZ=UTC to match CI; see note below).

## Notes for follow-up (not addressed here, out of scope)

- `scripts/backend/check-all.sh` runs ruff/mypy from `backend/` but `pyproject.toml` paths (`[tool.ruff] src`, `mypy_path`) are repo-root-relative, producing ~120 spurious I001s and mypy import-not-found errors. `scripts/frontend/format.sh` passes a `tests/**/*.{ts,tsx}` glob that matches no files and fails prettier despite all files being clean.
- Seven habit-calendar tests (`HabitStats.test.ts`, `habitManager.test.ts`) are machine-timezone-sensitive: they fail on a non-UTC machine and pass with `TZ=UTC`. Pre-existing on `main`; jest should pin `TZ`.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
