### PR TITLE
perf(backend): resolve user timezone once per request via cached dependency

### DIFF
--- a/backend/src/dependencies/timezone.py
+++ b/backend/src/dependencies/timezone.py
@@ -1,0 +1,40 @@
+"""Per-request cached resolution of the caller's IANA timezone (issue #262).
+
+PR #260 had every endpoint call ``services.users.get_user_timezone``
+imperatively inside the handler body.  Each call is a cheap single-column
+PK SELECT, but the pattern compounds when several dependencies in one
+request need the zone.  FastAPI caches dependency results within a request
+scope (``use_cache=True`` is the default), so routing every consumer
+through :func:`current_user_timezone` guarantees at most one lookup per
+request no matter how many handlers / sub-dependencies read it.
+
+``routers/auth.py::refresh_token`` deliberately keeps its direct
+``get_user_timezone`` call: this module imports
+:func:`routers.auth.get_current_user`, so importing back into
+``routers.auth`` would be circular — and that handler performs exactly one
+lookup per request already.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from routers.auth import get_current_user
+from services.users import get_user_timezone
+
+
+async def current_user_timezone(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> str:
+    """Resolve the authenticated caller's IANA timezone, once per request.
+
+    Returns ``"UTC"`` for missing / null / empty stored values — the same
+    fallback contract as :func:`services.users.get_user_timezone`, which
+    this wraps.
+    """
+    return await get_user_timezone(session, user_id)

--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -15,6 +15,7 @@ from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import log_ownership_denied
+from dependencies.timezone import current_user_timezone
 from domain.dates import day_bounds_in_tz, today_in_tz
 from domain.streaks import is_scheduled_on
 from errors import bad_request, forbidden, not_found
@@ -29,7 +30,6 @@ from services.streaks import (
     compute_consecutive_streak,
     update_streak,
 )
-from services.users import get_user_timezone
 
 
 @dataclass(frozen=True)
@@ -291,6 +291,7 @@ async def create_goal_completion(
     payload: GoalCompletionRequest,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> CheckInResult:
     """Record a check-in and return updated streak and milestones.
 
@@ -300,7 +301,6 @@ async def create_goal_completion(
     expensive streak query so duplicate retries fail fast.
     """
     goal, habit, goal_id = await _get_owned_goal_and_habit(session, payload.goal_id, current_user)
-    user_tz = await get_user_timezone(session, current_user)
     target_day = _resolve_target_day(payload.completed_on, user_tz)
     subtractive = await _subtractive_context_for_goal(session, habit, goal)
 

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -13,6 +13,7 @@ from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import log_ownership_denied, require_owned_habit
+from dependencies.timezone import current_user_timezone
 from domain.habit_stats import compute_habit_stats
 from errors import conflict, forbidden, not_found
 from load_options import HABIT_WITH_GOALS_AND_COMPLETIONS
@@ -26,7 +27,6 @@ from schemas.habit import HabitCreate, HabitWithGoals
 from schemas.habit_stats import HabitStats
 from schemas.pagination import paginate_query
 from services.streaks import SubtractiveContext, compute_habit_streak
-from services.users import get_user_timezone
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +172,7 @@ async def list_habits(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
     pagination: Annotated[PaginationParams, Depends()],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> Page[HabitWithGoals] | list[HabitWithGoals]:
     """Return habits sorted by ``sort_order``; paginated when ``?paginate=true``."""
     # Eager-load goals + completions; dropping this triggers MissingGreenlet downstream.
@@ -182,7 +183,6 @@ async def list_habits(
         .order_by(Habit.sort_order.asc())  # type: ignore[union-attr]
     )
     items, total = await paginate_query(session, query, pagination)
-    user_tz = await get_user_timezone(session, current_user)
     for habit in items:
         _populate_streak(habit, current_user, user_tz)
         _filter_completions_to_caller(habit, current_user)
@@ -197,10 +197,10 @@ async def get_habit(
     habit_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> Habit:
     """Return a single habit (with eager-loaded goals + completions) for the caller."""
     habit = await _get_habit_with_completions(habit_id, current_user, session)
-    user_tz = await get_user_timezone(session, current_user)
     _populate_streak(habit, current_user, user_tz)
     _filter_completions_to_caller(habit, current_user)
     return habit
@@ -280,9 +280,9 @@ async def get_habit_stats(
     habit_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> HabitStats:
     """Return aggregated statistics for a habit's goal completions."""
     habit = await _get_habit_with_completions(habit_id, current_user, session)
     completions = [c for goal in habit.goals for c in goal.completions if c.user_id == current_user]
-    user_tz = await get_user_timezone(session, current_user)
     return compute_habit_stats(completions, user_tz, _subtractive_context(habit))

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -15,6 +15,7 @@ from sqlmodel import col, func, select
 
 from database import get_session
 from dependencies.ownership import require_owned_user_practice
+from dependencies.timezone import current_user_timezone
 from domain.practice_insights import build_insights
 from domain.practice_resolution import effective_config
 from errors import bad_request, forbidden, not_found
@@ -31,7 +32,6 @@ from schemas.practice import (
 )
 from schemas.practice_mode_config import MindfulAnchorConfig
 from schemas.practice_session_metadata import MindfulAnchorMetadata
-from services.users import get_user_timezone
 
 # Window for the insights SQL fetch.  Slightly larger than the 8-week rollup
 # (~56 days) so a session logged late in the oldest bucket still lands in
@@ -391,6 +391,7 @@ async def get_insights(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
     response: Response,
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> PracticeInsightsResponse:
     """Return the mode-aware analytics rollup for the authenticated user.
 
@@ -407,7 +408,6 @@ async def get_insights(
     # still has the right cache key when ``Vary: Authorization`` is set,
     # so one user's rollup cannot leak to another sharing the proxy.
     response.headers["Vary"] = "Authorization"
-    user_tz = await get_user_timezone(session, current_user)
     cutoff = datetime.now(UTC) - timedelta(days=_INSIGHTS_LOOKBACK_DAYS)
     rows = (
         (
@@ -458,6 +458,7 @@ def _start_of_week_utc(tz_name: str) -> datetime:
 async def week_count(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> dict[str, int]:
     """Return the number of sessions the authenticated user completed this week.
 
@@ -465,7 +466,6 @@ async def week_count(
     ``timezone`` field (``User.timezone``) so a user in ``America/Los_Angeles``
     sees their Monday-through-Sunday window, not the UTC equivalent.
     """
-    user_tz = await get_user_timezone(session, current_user)
     start_of_week = _start_of_week_utc(user_tz)
     statement = select(func.count()).where(
         PracticeSession.user_id == current_user,

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -14,6 +14,7 @@ from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import require_owned_user_practice
+from dependencies.timezone import current_user_timezone
 from domain.dates import today_in_tz
 from domain.practice_resolution import effective_config, effective_name
 from domain.stage_progress import get_user_progress, is_stage_unlocked
@@ -35,7 +36,6 @@ from schemas.practice import (
 from schemas.practice_mode_config import ModeConfigAdapter
 from seed_practices import STAGE_TO_PRESET_NAME
 from seed_stages import STAGE_DEFINITIONS
-from services.users import get_user_timezone
 
 # Stage 1 is always the curriculum's entry point — users without a
 # ``StageProgress`` row see the stage-1 banner because they have not yet
@@ -115,6 +115,7 @@ async def create_user_practice(
     payload: UserPracticeCreate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> UserPractice:
     """Select (or replace) the active practice for a stage.
 
@@ -147,7 +148,6 @@ async def create_user_practice(
     # uses the user's calendar, not server UTC.  A user in Pacific
     # signing up at 11:00 PM Pacific used to see "started tomorrow"
     # because UTC had already rolled over.
-    user_tz = await get_user_timezone(session, current_user)
     today = today_in_tz(user_tz)
 
     already_active = await _free_stage_slot(session, current_user, payload, today)

--- a/backend/tests/test_timezone_lookup_caching.py
+++ b/backend/tests/test_timezone_lookup_caching.py
@@ -1,0 +1,161 @@
+"""Regression tests for issue #262 — one timezone lookup per request.
+
+PR #260 threaded ``get_user_timezone`` through every endpoint that needs
+the caller's IANA zone.  Each call is a cheap single-column PK SELECT, but
+the pattern compounds across dependencies and helpers.  These tests pin the
+contract that a request resolves the zone at most once: the duplicate
+check-in path (the worst historical offender) and a representative
+habit-stats read both stay at a single ``user.timezone`` SELECT.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import event
+
+from conftest import test_engine
+from models.goal import Goal
+from models.habit import Habit
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+# Matches the single-column lookup rendered by
+# ``select(User.timezone).where(User.id == ...)`` regardless of dialect
+# quoting (`user.timezone` vs `"user".timezone`).
+_TZ_SELECT = re.compile(r'SELECT\s+"?user"?\.timezone', re.IGNORECASE)
+
+
+class _TimezoneSelectCounter:
+    """Counts ``user.timezone`` SELECTs crossing the engine."""
+
+    def __init__(self) -> None:
+        self.count = 0
+
+    def __call__(
+        self,
+        _conn: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        """SQLAlchemy ``before_cursor_execute`` hook: tally matching SELECTs."""
+        if _TZ_SELECT.search(statement):
+            self.count += 1
+
+
+@pytest.fixture
+def tz_select_counter() -> Iterator[_TimezoneSelectCounter]:
+    """Attach a statement counter to the test engine for one test."""
+    counter = _TimezoneSelectCounter()
+    sync_engine = test_engine.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", counter)
+    yield counter
+    event.remove(sync_engine, "before_cursor_execute", counter)
+
+
+async def _signup(client: AsyncClient, username: str = "tzcache") -> tuple[dict[str, str], int]:
+    """Create a user and return ``(auth headers, user_id)``.
+
+    Deliberately signs up with the default UTC zone: issue #412 documents a
+    SQLite-only lexical-comparison bug that breaks non-UTC day-bounds
+    queries (the duplicate check-in path misdetects for e.g.
+    ``America/Los_Angeles``).  These tests pin lookup *counts*, which are
+    zone-independent; switch to a non-UTC zone once #412 is fixed.
+    """
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, int(data["user_id"])
+
+
+async def _seed_goal(session: AsyncSession, user_id: int) -> Goal:
+    """Create a habit + goal directly in the DB and return the goal."""
+    habit = Habit(
+        name="Meditation",
+        icon="🧘",
+        start_date=date(2025, 1, 1),
+        energy_cost=10,
+        energy_return=20,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+
+    goal = Goal(
+        habit_id=habit.id,
+        title="Daily sit",
+        tier="clear",
+        target=10.0,
+        target_unit="minutes",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    return goal
+
+
+@pytest.mark.asyncio
+async def test_duplicate_checkin_issues_at_most_one_timezone_lookup(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    tz_select_counter: _TimezoneSelectCounter,
+) -> None:
+    """The ``already_logged_today`` path resolves the zone at most once."""
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+
+    first = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": goal.id, "did_complete": True},
+        headers=headers,
+    )
+    assert first.status_code == HTTPStatus.OK
+
+    tz_select_counter.count = 0
+    duplicate = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": goal.id, "did_complete": True},
+        headers=headers,
+    )
+
+    assert duplicate.status_code == HTTPStatus.OK
+    assert duplicate.json()["reason_code"] == "already_logged_today"
+    assert tz_select_counter.count <= 1
+
+
+@pytest.mark.asyncio
+async def test_habit_stats_issues_at_most_one_timezone_lookup(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    tz_select_counter: _TimezoneSelectCounter,
+) -> None:
+    """A habit-stats read resolves the zone at most once."""
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+
+    tz_select_counter.count = 0
+    resp = await async_client.get(f"/habits/{goal.habit_id}/stats", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert tz_select_counter.count <= 1


### PR DESCRIPTION
## Summary

- Adds a `current_user_timezone` FastAPI dependency (`dependencies/timezone.py`) that resolves the caller's IANA zone once per request — FastAPI's default request-scoped dependency cache guarantees at most one `user.timezone` SELECT regardless of how many handlers or sub-dependencies read it (issue #262, Option A).
- Replaces all seven imperative `await get_user_timezone(session, current_user)` router call sites (habits ×3, goal_completions, user_practices, practice_sessions ×2) with the dependency. `routers/auth.py::refresh_token` keeps its direct call: the dependency module imports `get_current_user` from `routers.auth`, so importing it back would be circular — and that handler already performs exactly one lookup per request.
- Chose Option A over the JWT-claim approach (Option B): a `tz` claim would carry a stale-zone window between a `PUT /users/me/timezone` (just shipped in #410) and the next token refresh, contradicting the live-update semantics that endpoint now provides.

## Test plan

- New `tests/test_timezone_lookup_caching.py` attaches a SQLAlchemy `before_cursor_execute` counter to the test engine and pins the acceptance-criterion contract: the duplicate check-in path and a habit-stats read each issue **at most one** `user.timezone` SELECT per request.
- Full backend suite: 1435 passed, coverage 94.35% (line) — no regression in the existing TZ tests.
- `pre-commit run --all-files` exits 0 (TZ=UTC, matching CI).

## Found during this work

- **#412** — non-UTC day-bounds queries are broken on SQLite (lexical comparison ignores UTC-offset suffixes), which makes duplicate check-in detection double-count streaks for e.g. `America/Los_Angeles` users in test/dev environments. Out of scope here; the new regression tests use a UTC user with a pointer to that issue.

Closes #262
Refs #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
