### PR TITLE
feat(frontend): forward queued check-in day through offline replay

### DIFF
--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -461,17 +461,24 @@ async def test_completion_request_rejects_unknown_fields(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("days_back", [1, 3])
 async def test_backfill_past_date_records_completion(
-    async_client: AsyncClient, db_session: AsyncSession
+    async_client: AsyncClient, db_session: AsyncSession, days_back: int
 ) -> None:
-    """``completed_on`` logs a check-in against a past calendar day."""
+    """``completed_on`` logs a check-in against that past calendar day.
+
+    The 3-days-back case pins issue #269's offline-replay contract: a
+    check-in queued offline on day T and replayed on T+3 must land on T's
+    calendar day in the user's recorded timezone, not on the wall-clock
+    day the device reconnected.
+    """
     headers, user_id = await _signup(async_client, "backfiller")
     goal = await _seed_goal(db_session, user_id)
-    yesterday = today_in_tz("UTC") - timedelta(days=1)
+    target_day = today_in_tz("UTC") - timedelta(days=days_back)
 
     resp = await async_client.post(
         "/goal_completions/",
-        json={"goal_id": goal.id, "completed_on": yesterday.isoformat()},
+        json={"goal_id": goal.id, "completed_on": target_day.isoformat()},
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.OK
@@ -482,7 +489,7 @@ async def test_backfill_past_date_records_completion(
     )
     completions = list(result.scalars().all())
     assert len(completions) == 1
-    assert completions[0].timestamp.date() == yesterday
+    assert completions[0].timestamp.date() == target_day
 
 
 @pytest.mark.asyncio

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -93,8 +93,7 @@ export const useHabitActions = (
 
   return useMemo(
     () => ({
-      // Bound so a retry replays queued check-ins against the user's
-      // stored zone, not the API default (#269).
+      // Bound so retries replay queued check-ins against the stored zone (#269).
       loadHabits: () => habitManager.loadHabits(tz),
       updateGoal: habitManager.updateGoal,
       logUnit,

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -93,7 +93,9 @@ export const useHabitActions = (
 
   return useMemo(
     () => ({
-      loadHabits: habitManager.loadHabits,
+      // Bound so a retry replays queued check-ins against the user's
+      // stored zone, not the API default (#269).
+      loadHabits: () => habitManager.loadHabits(tz),
       updateGoal: habitManager.updateGoal,
       logUnit,
       updateHabit: habitManager.updateHabit,
@@ -109,6 +111,6 @@ export const useHabitActions = (
       lockUnstartedHabits: habitManager.lockUnstartedHabits,
       unlockHabit: habitManager.unlockHabit,
     }),
-    [logUnit, iconPress, emojiSelect, onboardingSave],
+    [logUnit, iconPress, emojiSelect, onboardingSave, tz],
   );
 };

--- a/frontend/src/features/Habits/hooks/useHabits.ts
+++ b/frontend/src/features/Habits/hooks/useHabits.ts
@@ -11,7 +11,9 @@ import { registerForPushNotificationsAsync, reconcileNotifications } from './use
 import { useHabitUI } from './useHabitUI';
 
 const useBootstrapHabits = (userTimezone: string): void => {
-  // Day buckets depend on the zone, so re-fetching when auth hydrates it is correct (#269).
+  // Runs twice on cold start (UTC default, then the auth-hydrated zone).
+  // The second fetch is intentional, not a bug: day buckets and queued
+  // check-in replay days both depend on the zone (#269).
   useEffect(() => {
     void habitManager.loadHabits(userTimezone);
   }, [userTimezone]);

--- a/frontend/src/features/Habits/hooks/useHabits.ts
+++ b/frontend/src/features/Habits/hooks/useHabits.ts
@@ -11,10 +11,7 @@ import { registerForPushNotificationsAsync, reconcileNotifications } from './use
 import { useHabitUI } from './useHabitUI';
 
 const useBootstrapHabits = (userTimezone: string): void => {
-  // Re-runs when the auth context hydrates the user's stored zone (e.g.
-  // UTC → America/Los_Angeles after a cold-start refresh): day buckets
-  // and queued-check-in replay days both depend on it, so a re-fetch on
-  // zone change is the correct behavior, not an accident (#269).
+  // Day buckets depend on the zone, so re-fetching when auth hydrates it is correct (#269).
   useEffect(() => {
     void habitManager.loadHabits(userTimezone);
   }, [userTimezone]);

--- a/frontend/src/features/Habits/hooks/useHabits.ts
+++ b/frontend/src/features/Habits/hooks/useHabits.ts
@@ -10,10 +10,14 @@ import { useHabitActions } from './useHabitActions';
 import { registerForPushNotificationsAsync, reconcileNotifications } from './useHabitNotifications';
 import { useHabitUI } from './useHabitUI';
 
-const useBootstrapHabits = (): void => {
+const useBootstrapHabits = (userTimezone: string): void => {
+  // Re-runs when the auth context hydrates the user's stored zone (e.g.
+  // UTC → America/Los_Angeles after a cold-start refresh): day buckets
+  // and queued-check-in replay days both depend on it, so a re-fetch on
+  // zone change is the correct behavior, not an accident (#269).
   useEffect(() => {
-    void habitManager.loadHabits();
-  }, []);
+    void habitManager.loadHabits(userTimezone);
+  }, [userTimezone]);
   useEffect(() => {
     void registerForPushNotificationsAsync();
     void reconcileNotifications();
@@ -35,7 +39,7 @@ export const useHabits = (): UseHabitsReturn => {
   const { showToast } = useToast();
   const { userTimezone } = useAuth();
   const ui = useHabitUI();
-  useBootstrapHabits();
+  useBootstrapHabits(userTimezone);
   const actions = useHabitActions(ui, showToast, userTimezone);
 
   return {

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -267,6 +267,42 @@ describe('habitManager', () => {
       expect(replacePendingCheckIns).not.toHaveBeenCalled();
     });
 
+    it('forwards a queued past-day timestamp as completed_on (#269, BUG-FE-HABIT-205)', async () => {
+      (loadHabits as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+      (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([
+        { goal_id: 1, did_complete: true, timestamp: '2025-04-01T12:00:00Z' },
+      ] as never);
+
+      await habitManager.loadHabits('UTC');
+
+      // The check-in queued on April 1 lands on April 1 — not on the
+      // wall-clock day the device happened to reconnect.
+      expect(goalCompletionsApi.create).toHaveBeenCalledWith({
+        goal_id: 1,
+        did_complete: true,
+        completed_on: '2025-04-01',
+      });
+    });
+
+    it('omits completed_on when the queued check-in is from today', async () => {
+      (loadHabits as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+      (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([
+        { goal_id: 1, did_complete: true, timestamp: new Date().toISOString() },
+      ] as never);
+
+      await habitManager.loadHabits('UTC');
+
+      // Same-day replays let the server stamp real wall-clock time —
+      // mirrors the online path's genuine-backfill rule.
+      expect(goalCompletionsApi.create).toHaveBeenCalledWith({
+        goal_id: 1,
+        did_complete: true,
+        completed_on: undefined,
+      });
+    });
+
     it('keeps only the unprocessed suffix when replay fails mid-batch (BUG-FE-HABIT-205)', async () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce([] as never);
       (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -303,7 +303,7 @@ describe('habitManager', () => {
       });
     });
 
-    it('tz-less internal re-fetches reuse the last known zone (#414 review)', async () => {
+    it('tz-less internal re-fetches reuse the last known zone (#269)', async () => {
       (loadHabits as jest.Mock).mockResolvedValue([] as never);
       (habitsApi.list as jest.Mock).mockResolvedValue([] as never);
       (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -303,6 +303,26 @@ describe('habitManager', () => {
       });
     });
 
+    it('tz-less internal re-fetches reuse the last known zone (#414 review)', async () => {
+      (loadHabits as jest.Mock).mockResolvedValue([] as never);
+      (habitsApi.list as jest.Mock).mockResolvedValue([] as never);
+      (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+        // 22:00 UTC is already April 2 in Pacific/Kiritimati (UTC+14),
+        // so the expected day proves the remembered zone is used — the
+        // device-zone fallback (UTC under jest) would say April 1.
+        { goal_id: 9, did_complete: true, timestamp: '2025-04-01T22:00:00Z' },
+      ] as never);
+
+      await habitManager.loadHabits('Pacific/Kiritimati');
+      await habitManager.loadHabits();
+
+      expect(goalCompletionsApi.create).toHaveBeenCalledWith({
+        goal_id: 9,
+        did_complete: true,
+        completed_on: '2025-04-02',
+      });
+    });
+
     it('keeps only the unprocessed suffix when replay fails mid-batch (BUG-FE-HABIT-205)', async () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce([] as never);
       (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../storage/habitStorage';
 import { useHabitStore } from '../../../store/useHabitStore';
 import { useProgramStore } from '../../../store/useProgramStore';
-import { dayKeyInTZ, todayInUserTZ } from '../../../utils/dateUtils';
+import { dayKeyInTZ, detectDeviceTimezone, todayInUserTZ } from '../../../utils/dateUtils';
 import { HABIT_DEFAULTS } from '../HabitDefaults';
 import type { AddHabitInput, Goal, Habit, OnboardingHabit } from '../Habits.types';
 import { getGoalTier, getGoalTarget, calculateTodaysProgress, logHabitUnits } from '../HabitUtils';
@@ -494,20 +494,29 @@ const revertOnFailure = (prev: Habit[], fallback: string): ((err: unknown) => vo
 /**
  * Replay pending check-ins captured by an earlier offline session. On
  * partial failure, the suffix that didn't post is rewritten back to
- * disk so we don't double-post on the next replay. NOTE: the API does
- * not yet accept a client-supplied timestamp; queued check-ins replay
- * with the server's wall-clock time. See the follow-up issue tracking
- * BUG-FE-HABIT-205's timestamp-forwarding requirement.
+ * disk so we don't double-post on the next replay.
+ *
+ * Each queued timestamp is forwarded as ``completed_on`` (the user-local
+ * calendar day) so a check-in queued offline on Monday lands on Monday's
+ * streak bucket, not on the wall-clock day the device reconnects (#269,
+ * BUG-FE-HABIT-205). Same-day replays omit the field so the server
+ * stamps real wall-clock time — the online path's genuine-backfill rule.
  */
-const replayPendingCheckIns = async (): Promise<void> => {
+const replayPendingCheckIns = async (tz?: string): Promise<void> => {
   const pending = await loadPendingCheckIns();
   if (pending.length === 0) return;
+  // The stored zone is authoritative for the server's day buckets; the
+  // device zone is the best stand-in when auth hasn't hydrated it yet.
+  const zone = tz ?? detectDeviceTimezone();
+  const today = todayInUserTZ(zone);
   for (let i = 0; i < pending.length; i += 1) {
     const checkIn = pending[i]!;
+    const dayKey = dayKeyInTZ(checkIn.timestamp, zone);
     try {
       await goalCompletionsApi.create({
         goal_id: checkIn.goal_id,
         did_complete: checkIn.did_complete,
+        completed_on: dayKey !== today ? dayKey : undefined,
       });
     } catch {
       // Still offline (or the server rejected this one). Persist only
@@ -526,7 +535,7 @@ const replayPendingCheckIns = async (): Promise<void> => {
 // but not itself a hook. Every method is independently unit-testable.
 // ---------------------------------------------------------------------------
 
-const loadHabits = async (): Promise<void> => {
+const loadHabits = async (tz?: string): Promise<void> => {
   setLoading(true);
   setError(null);
   const cached = await loadCachedHabits();
@@ -550,7 +559,7 @@ const loadHabits = async (): Promise<void> => {
   // ``return``-ed from the first failure with the successful prefix still
   // in the queue, so on the next load every check-in that had already
   // posted would post AGAIN — silent duplication of the user's streak.
-  await replayPendingCheckIns();
+  await replayPendingCheckIns(tz);
 };
 
 export const habitManager = {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -505,8 +505,7 @@ const revertOnFailure = (prev: Habit[], fallback: string): ((err: unknown) => vo
 const replayPendingCheckIns = async (tz?: string): Promise<void> => {
   const pending = await loadPendingCheckIns();
   if (pending.length === 0) return;
-  // The stored zone is authoritative for the server's day buckets; the
-  // device zone is the best stand-in when auth hasn't hydrated it yet.
+  // Device zone is the stand-in until auth hydrates the stored zone.
   const zone = tz ?? detectDeviceTimezone();
   const today = todayInUserTZ(zone);
   for (let i = 0; i < pending.length; i += 1) {
@@ -535,7 +534,18 @@ const replayPendingCheckIns = async (tz?: string): Promise<void> => {
 // but not itself a hook. Every method is independently unit-testable.
 // ---------------------------------------------------------------------------
 
+/**
+ * Zone from the most recent tz-carrying ``loadHabits`` call. Internal
+ * re-fetches (``addHabit``, ``onboardingSave``) call ``loadHabits()``
+ * without a zone; remembering the hook-supplied value here keeps their
+ * queued-check-in replays on the user's stored zone instead of silently
+ * falling back to the device's (#414 review).
+ */
+let lastKnownTz: string | undefined;
+
 const loadHabits = async (tz?: string): Promise<void> => {
+  if (tz !== undefined) lastKnownTz = tz;
+  const zone = tz ?? lastKnownTz;
   setLoading(true);
   setError(null);
   const cached = await loadCachedHabits();
@@ -559,7 +569,7 @@ const loadHabits = async (tz?: string): Promise<void> => {
   // ``return``-ed from the first failure with the successful prefix still
   // in the queue, so on the next load every check-in that had already
   // posted would post AGAIN — silent duplication of the user's streak.
-  await replayPendingCheckIns(tz);
+  await replayPendingCheckIns(zone);
 };
 
 export const habitManager = {


### PR DESCRIPTION
## Summary

- `replayPendingCheckIns` now forwards each queued check-in's persisted timestamp as `completed_on` (the user-local calendar day), so a check-in queued offline on Monday lands on Monday's streak bucket instead of the day the device reconnects (issue #269, the second half of BUG-FE-HABIT-205).
- Uses the backend's existing `completed_on` backfill field — which landed after #269 was written and already provides the validation the issue asked for (future dates rejected, 30-day window, TZ-anchored mid-day timestamp) — rather than adding a redundant `timestamp` wire field.
- Same-day replays omit the field so the server stamps real wall-clock time, mirroring the online path's genuine-backfill rule. The user's stored zone threads from `AuthContext` through `useHabits`/`useHabitActions`, with the device zone as fallback before auth hydrates. The stale code comment claiming "the API does not yet accept a client-supplied timestamp" is gone.

## Test plan

- Frontend (new): replay of a queued past-day check-in calls `goalCompletions.create` with `completed_on: '2025-04-01'`; a same-day queued check-in sends `completed_on: undefined`. Full Habits suite: 336 passing, eslint zero warnings, `tsc --noEmit` clean.
- Backend (new): the past-day backfill test is parametrized over 1 and 3 days back, pinning the acceptance criterion that a `completed_on = T-3d` completion's stored calendar day equals T-3d. Suite passes.
- `pre-commit run --all-files` exits 0 (TZ=UTC, matching CI).

## Notes

- Discovered while scoping: `savePendingCheckIn` has **no production call site** — nothing currently enqueues offline check-ins, so the replay loop drains a queue that never fills. Out of scope here; filing separately.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
