### PR TITLE
fix(frontend): make useOptimisticMutation pending track overlapping calls

### DIFF
--- a/frontend/src/hooks/__tests__/useOptimisticMutation.test.ts
+++ b/frontend/src/hooks/__tests__/useOptimisticMutation.test.ts
@@ -116,6 +116,52 @@ describe('useOptimisticMutation', () => {
     expect(result.current.pending).toBe(false);
   });
 
+  it('pending tracks the union of overlapping mutate calls (#271)', async () => {
+    let resolveFirst: (_v: string) => void = () => {};
+    let resolveSecond: (_v: string) => void = () => {};
+    const commit = jest
+      .fn<() => Promise<string>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((r) => {
+            resolveFirst = r;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((r) => {
+            resolveSecond = r;
+          }),
+      );
+
+    const { result } = renderHook(() =>
+      useOptimisticMutation({ apply: jest.fn(), commit, rollback: jest.fn() }),
+    );
+
+    let first: Promise<string> = Promise.resolve('');
+    let second: Promise<string> = Promise.resolve('');
+    await act(async () => {
+      first = result.current.mutate({});
+      second = result.current.mutate({});
+    });
+    expect(result.current.pending).toBe(true);
+
+    // The SECOND call settles while the first is still in flight. A naive
+    // boolean would flip pending to false here and re-enable a Save
+    // button mid-request — the double-tap bug this guard exists to catch.
+    await act(async () => {
+      resolveSecond('second');
+      await second;
+    });
+    expect(result.current.pending).toBe(true);
+
+    await act(async () => {
+      resolveFirst('first');
+      await first;
+    });
+    expect(result.current.pending).toBe(false);
+  });
+
   it('keeps a stable `mutate` reference across re-renders even when callers pass fresh cfg', async () => {
     let renderConfig = {
       apply: jest.fn(),

--- a/frontend/src/hooks/useOptimisticMutation.ts
+++ b/frontend/src/hooks/useOptimisticMutation.ts
@@ -38,7 +38,7 @@ export interface OptimisticMutationConfig<TInput, TResult> {
 export interface OptimisticMutation<TInput, TResult> {
   /** Run apply → commit → rollback. Re-throws on failure after rolling back. */
   mutate: (_input: TInput) => Promise<TResult>;
-  /** True while a `commit` is in flight. */
+  /** True while ANY `commit` is in flight — overlapping calls included (#271). */
   pending: boolean;
 }
 
@@ -55,12 +55,16 @@ export function useOptimisticMutation<TInput, TResult>(
   const cfgRef = useRef(cfg);
   cfgRef.current = cfg;
 
-  const [pending, setPending] = useState(false);
+  // Issue #271: a counter, not a boolean. With overlapping `mutate` calls
+  // (user double-taps a Save button), a boolean's `finally` from the
+  // first-settled call would report idle while the other commit is still
+  // in flight — re-enabling UI mid-request. `pending` is the union.
+  const [inFlight, setInFlight] = useState(0);
 
   const mutate = useCallback(async (input: TInput): Promise<TResult> => {
     const c = cfgRef.current;
     c.apply(input);
-    setPending(true);
+    setInFlight((n) => n + 1);
     try {
       const result = await c.commit(input);
       c.onSuccess?.(input, result);
@@ -72,9 +76,9 @@ export function useOptimisticMutation<TInput, TResult>(
       // `max-quality-no-shortcuts`: the hook never swallows failures.
       throw err;
     } finally {
-      setPending(false);
+      setInFlight((n) => n - 1);
     }
   }, []);
 
-  return { mutate, pending };
+  return { mutate, pending: inFlight > 0 };
 }


### PR DESCRIPTION
## Summary

- `useOptimisticMutation.pending` now tracks the **union** of in-flight commits via a counter instead of a single boolean (issue #271, item 1). Previously, when two `mutate` calls overlapped (a Save-button double-tap), the first call to settle flipped `pending` false while the other commit was still in flight — re-enabling UI mid-request across every consumer (Habits, Journal, Practice, Map).
- Item 2 (relocating `_resetSerializedWriteForTests`) resolved as the issue's Option 3 — leave as-is — with the rationale recorded in an issue comment: no module-boundary lint rule exists today, the `_*ForTests` naming signals intent, and both relocation options add complexity without removing the export.

## Test plan

- New regression test drives two overlapping commits through `renderHook` and asserts `pending` stays `true` after the second-issued call settles first, flipping only when the last one resolves. Red on the old boolean implementation (verified), green on the counter.
- Full frontend suite passes; eslint zero warnings; `tsc --noEmit` clean; `pre-commit run --all-files` exit 0 (TZ=UTC).

Closes #271
Refs #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)
