### PR TITLE
fix(backend): bound the per-email login-lock cache

### DIFF
--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -7,7 +7,6 @@ import hashlib
 import logging
 import os
 import secrets
-from collections import defaultdict
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
@@ -15,6 +14,7 @@ from typing import Annotated
 
 import bcrypt
 import jwt
+from cachetools import TTLCache
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, EmailStr, Field, field_validator
 from sqlalchemy import text
@@ -386,11 +386,38 @@ async def _is_account_locked(session: AsyncSession, email: str) -> bool:
 # attempt-record sequence so two concurrent failed attempts inside the same
 # worker cannot both pass the check at the threshold-1 boundary
 # (BUG-AUTH-007). For multi-worker deployments the matching PostgreSQL
-# advisory lock below closes the cross-process race.  The dict is unbounded
-# in principle but each entry is a bare ``asyncio.Lock`` (a few hundred
-# bytes) and the email keys are already gated by per-route rate limits, so
-# memory growth is naturally capped at the legitimate-user fan-out.
-_login_locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+# advisory lock below closes the cross-process race.
+#
+# Issue #273: a TTL+LRU cache, not a defaultdict — an adversary cycling
+# unique synthesized emails across enough source IPs to dodge per-IP rate
+# limits could otherwise grow the dict by one Lock per address for the
+# life of the worker.  Eviction is safe: a lock is held only for a single
+# sub-second login flow, and a fresh lock after eviction reopens no race
+# because the cross-worker ``pg_advisory_xact_lock`` layer is independent
+# of this in-process one.
+_LOGIN_LOCKS_MAX = 10_000
+# Matches ``LOCKOUT_DURATION`` so a hot email's lock survives the whole
+# window it is serializing.
+_LOGIN_LOCKS_TTL_SECONDS = LOCKOUT_DURATION.total_seconds()
+
+_login_locks: TTLCache[str, asyncio.Lock] = TTLCache(
+    maxsize=_LOGIN_LOCKS_MAX, ttl=_LOGIN_LOCKS_TTL_SECONDS
+)
+
+
+def _login_lock_for(email: str) -> asyncio.Lock:
+    """Get-or-create the serialization lock for ``email``.
+
+    Safe without its own guard: coroutines on one event loop cannot
+    interleave between the ``get`` miss and the store, so two concurrent
+    callers for the same email always share one lock instance.
+    """
+    lock = _login_locks.get(email)
+    if lock is None:
+        lock = asyncio.Lock()
+        _login_locks[email] = lock
+    return lock
+
 
 # 8-byte advisory-lock key derived from a SHA-256 of the normalized email.
 # Pinned to int8 because pg_advisory_xact_lock(bigint) is the single-arg
@@ -432,7 +459,7 @@ async def _serialize_login(session: AsyncSession, email: str) -> AsyncIterator[N
     back at the end of the request — no manual ``pg_advisory_unlock``
     needed.
     """
-    async with _login_locks[email]:
+    async with _login_lock_for(email):
         await _acquire_email_lock_pg(session, email)
         yield
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1428,3 +1428,40 @@ async def test_existing_token_rejected_after_user_soft_deleted(
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_login_locks_bounded_under_distinct_email_flood() -> None:
+    """Issue #273: the per-email lock cache must not grow without bound.
+
+    An adversary cycling unique synthesized emails across enough source
+    IPs to dodge per-IP rate limits used to grow the old ``defaultdict``
+    by one ``asyncio.Lock`` per address for the life of the worker.  The
+    bounded cache caps residency regardless of distinct-key volume.
+    """
+    from routers.auth import _LOGIN_LOCKS_MAX, _login_lock_for, _login_locks  # noqa: PLC0415
+
+    _login_locks.clear()
+    try:
+        for i in range(100_000):
+            _login_lock_for(f"flood-{i}@example.com")
+        assert len(_login_locks) <= _LOGIN_LOCKS_MAX
+    finally:
+        _login_locks.clear()
+
+
+def test_login_lock_identity_stable_for_same_email() -> None:
+    """Issue #273: repeated lookups for one email return the SAME lock object.
+
+    The per-email serialization guarantee (BUG-AUTH-007) depends on every
+    concurrent coroutine for an email awaiting one shared lock; a cache
+    that handed out fresh locks per call would silently void it.
+    """
+    from routers.auth import _login_lock_for, _login_locks  # noqa: PLC0415
+
+    _login_locks.clear()
+    try:
+        first = _login_lock_for("same@example.com")
+        second = _login_lock_for("same@example.com")
+        assert first is second
+    finally:
+        _login_locks.clear()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -16,10 +16,13 @@ from sqlmodel import select
 from models.login_attempt import LoginAttempt
 from models.user import User
 from routers.auth import (
+    _LOGIN_LOCKS_MAX,
     _SECRET_PLACEHOLDER,
     LOCKOUT_DURATION,
     MAX_FAILED_ATTEMPTS,
     _get_secret_key,
+    _login_lock_for,
+    _login_locks,
 )
 
 SIGNUP_URL = "/auth/signup"
@@ -1438,8 +1441,6 @@ def test_login_locks_bounded_under_distinct_email_flood() -> None:
     by one ``asyncio.Lock`` per address for the life of the worker.  The
     bounded cache caps residency regardless of distinct-key volume.
     """
-    from routers.auth import _LOGIN_LOCKS_MAX, _login_lock_for, _login_locks  # noqa: PLC0415
-
     _login_locks.clear()
     try:
         for i in range(100_000):
@@ -1456,8 +1457,6 @@ def test_login_lock_identity_stable_for_same_email() -> None:
     concurrent coroutine for an email awaiting one shared lock; a cache
     that handed out fresh locks per call would silently void it.
     """
-    from routers.auth import _login_lock_for, _login_locks  # noqa: PLC0415
-
     _login_locks.clear()
     try:
         first = _login_lock_for("same@example.com")


### PR DESCRIPTION
## Summary

- Replaces the unbounded `_login_locks` defaultdict with a `cachetools.TTLCache` (`maxsize=10_000`, TTL matched to `LOCKOUT_DURATION`) behind a `_login_lock_for` get-or-create helper — closing the slow memory-leak vector both PR #266 reviews flagged as 🟡 HIGH: an adversary cycling unique synthesized emails across enough source IPs to dodge per-IP rate limiting could previously grow the dict by one `asyncio.Lock` per address for the life of the worker.
- Eviction is safe per the issue's analysis: a lock is held only for a single sub-second login flow, and the cross-worker `pg_advisory_xact_lock` layer is independent of the in-process lock, so a fresh lock after eviction reopens no race. The get-or-create helper needs no extra guard — coroutines on one event loop cannot interleave between the cache miss and the store.
- `cachetools` was already a pinned dependency (7.0.5); no new packages.

## Test plan

- New: a synthetic 100k-distinct-email flood leaves the cache at ≤ maxsize (the old defaultdict held 100k entries).
- New: repeated lookups for one email return the *identical* lock object — pinning the BUG-AUTH-007 per-email serialization guarantee against a cache that might hand out fresh locks.
- Existing `test_concurrent_failed_logins_cannot_outpace_lockout` regression passes unchanged, as do all 68 auth tests.
- Full backend suite: 94.33% coverage; `pre-commit run --all-files` exit 0 (TZ=UTC).

Closes #273
Refs #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
