### PR TITLE
fix(frontend): auto-resync habits when a check-in hits stale goal ids

### DIFF
--- a/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
@@ -9,20 +9,33 @@ import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react-native';
 import React from 'react';
 
-jest.mock('../../../../api', () => ({
-  habits: {
-    list: jest.fn(() => Promise.resolve([])),
-    create: jest.fn(() => Promise.resolve({})),
-    update: jest.fn(() => Promise.resolve({})),
-    delete: jest.fn(() => Promise.resolve({})),
-  },
-  goalCompletions: {
-    create: jest.fn(() => Promise.resolve({ streak: 1, milestones: [], reason_code: 'ok' })),
-  },
-  goals: {
-    update: jest.fn(() => Promise.resolve({})),
-  },
-}));
+jest.mock('../../../../api', () => {
+  class MockApiError extends Error {
+    status: number;
+    detail: string;
+    constructor(status: number, detail: string) {
+      super(`Request failed with status ${status}: ${detail}`);
+      this.name = 'ApiError';
+      this.status = status;
+      this.detail = detail;
+    }
+  }
+  return {
+    ApiError: MockApiError,
+    habits: {
+      list: jest.fn(() => Promise.resolve([])),
+      create: jest.fn(() => Promise.resolve({})),
+      update: jest.fn(() => Promise.resolve({})),
+      delete: jest.fn(() => Promise.resolve({})),
+    },
+    goalCompletions: {
+      create: jest.fn(() => Promise.resolve({ streak: 1, milestones: [], reason_code: 'ok' })),
+    },
+    goals: {
+      update: jest.fn(() => Promise.resolve({})),
+    },
+  };
+});
 
 jest.mock('../../../../storage/habitStorage', () => ({
   saveHabits: jest.fn(() => Promise.resolve(undefined)),
@@ -47,7 +60,11 @@ jest.mock('react-native', () => ({
   StyleSheet: { create: (s: Record<string, unknown>) => s },
 }));
 
-import { goalCompletions as goalCompletionsApi, habits as habitsApi } from '../../../../api';
+import {
+  ApiError as MockApiError,
+  goalCompletions as goalCompletionsApi,
+  habits as habitsApi,
+} from '../../../../api';
 import { saveHabits } from '../../../../storage/habitStorage';
 import { useHabitStore } from '../../../../store/useHabitStore';
 import type { Habit } from '../../Habits.types';
@@ -151,6 +168,46 @@ describe('useHabitActions.logUnit', () => {
     expect(showToast.mock.calls[0]?.[0]).toMatchObject({
       message: expect.stringMatching(/Low Goal achieved/i) as unknown,
     });
+  });
+
+  it('auto-resyncs habits when a check-in 404s with goal_not_found (#282)', async () => {
+    // The stale-synthetic-ID symptom: onboarding POSTs succeeded but the
+    // trailing GET failed, so the store still holds synthetic goal ids
+    // the server has never heard of.
+    useHabitStore.setState({ habits: [makeHabit()] });
+    (goalCompletionsApi.create as jest.Mock).mockImplementationOnce(() =>
+      Promise.reject(new MockApiError(404, 'goal_not_found')),
+    );
+    const { result, showToast } = renderActions();
+
+    await act(async () => {
+      result.current.actions.logUnit(1, 1);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // One background refresh re-fetches the server's authoritative ids…
+    expect(habitsApi.list).toHaveBeenCalledTimes(1);
+    // …and the toast tells the user to simply tap again.
+    expect(showToast.mock.calls.at(-1)?.[0]).toMatchObject({
+      message: expect.stringMatching(/refreshed/i) as unknown,
+    });
+  });
+
+  it('does NOT resync habits on unrelated check-in failures (#282)', async () => {
+    useHabitStore.setState({ habits: [makeHabit()] });
+    (goalCompletionsApi.create as jest.Mock).mockImplementationOnce(() =>
+      Promise.reject(new Error('network down')),
+    );
+    const { result } = renderActions();
+
+    await act(async () => {
+      result.current.actions.logUnit(1, 1);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(habitsApi.list).not.toHaveBeenCalled();
   });
 
   it('rolls BOTH store AND disk back when the API rejects (BUG-FE-HABIT-001)', async () => {

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
+import { ApiError } from '../../../api';
 import { formatApiError } from '../../../api/errorMessages';
 import { colors } from '../../../design/tokens';
 import { useOptimisticMutation } from '../../../hooks/useOptimisticMutation';
@@ -13,6 +14,15 @@ const SYNC_ERROR_ICON = '\u{26A0}\u{FE0F}';
 
 /** Show the rejection long enough to read on a phone before auto-dismiss. */
 const SYNC_ERROR_TOAST_DURATION_MS = 6000;
+
+/**
+ * The stale-synthetic-ID symptom (issue #282): onboarding's POSTs landed
+ * but the trailing ``loadHabits`` refresh failed, so the store still
+ * holds goal ids the server has never issued — every check-in 404s with
+ * ``goal_not_found`` until the ids are resynced.
+ */
+const isStaleGoalIdError = (err: unknown): boolean =>
+  err instanceof ApiError && err.status === 404 && err.detail === 'goal_not_found';
 
 /**
  * Wire `habitManager.{prepare,apply,commit,rollback}LogUnitContext` into
@@ -36,6 +46,20 @@ const useLogUnitMutation = (
     commit: (ctx) => habitManager.commitLogUnitContext(ctx),
     rollback: (ctx, err) => {
       habitManager.rollbackLogUnitContext(ctx);
+      if (isStaleGoalIdError(err)) {
+        // Issue #282 recovery path: re-fetch the server's authoritative
+        // ids in the background so the user's NEXT tap succeeds, instead
+        // of leaving them stuck until an app restart.
+        void habitManager.loadHabits(tz);
+        showToast({
+          message:
+            'Your habits were out of sync with the server — we just refreshed them. Tap to log that unit again.',
+          icon: SYNC_ERROR_ICON,
+          color: colors.danger,
+          duration: SYNC_ERROR_TOAST_DURATION_MS,
+        });
+        return;
+      }
       showToast({
         message: formatApiError(err, {
           fallback:


### PR DESCRIPTION
## Summary

- Implements the issue's recommended approach A: recovery at the point the user feels the bug, not a guard bypass. When a check-in 404s with `goal_not_found` — the exact symptom of synthetic ids surviving a failed post-onboarding `loadHabits()` (PR #281's known gap) — the logUnit rollback now fires one background `loadHabits(tz)` to pull the server's authoritative ids and toasts "we just refreshed them — tap to log that unit again."
- The `handleApiError` live-store guard stays intact for every other caller; unrelated check-in failures keep the existing restore-and-retry toast and trigger no resync.

## Test plan

- New: a `goal_not_found` 404 on `goalCompletions.create` triggers exactly one `habits.list` refresh and the recovery toast (Red on the old code, verified).
- New: an unrelated network failure triggers **no** resync — pinning that the guard's protection isn't diluted.
- Full Habits suite, full frontend jest, eslint zero warnings, `tsc --noEmit` clean, `pre-commit run --all-files` exit 0 (TZ=UTC).

Closes #282
Refs #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
