### PR TITLE
feat: atomic all-tiers goal-unit updates via batch endpoint

### DIFF
--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -22,6 +22,8 @@ from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from routers.auth import get_current_user
 from schemas import Page, PaginationParams, build_page
+from schemas.goal import Goal as GoalSchema
+from schemas.goal import GoalUnitsUpdate
 from schemas.habit import Habit as HabitSchema
 from schemas.habit import HabitCreate, HabitWithGoals
 from schemas.habit_stats import HabitStats
@@ -273,6 +275,39 @@ async def _get_habit_with_completions(
         log_ownership_denied("habit", habit_id, current_user)
         raise forbidden("forbidden")
     return habit
+
+
+@router.put("/{habit_id}/goals/units", response_model=list[GoalSchema])
+async def update_goal_units(
+    payload: GoalUnitsUpdate,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    habit: Annotated[Habit, Depends(require_owned_habit)],
+) -> list[Goal]:
+    """Update the shared unit fields on every goal of the habit atomically.
+
+    Issue #289: the GoalUnitEditor previously fanned out one
+    ``PUT /goals/{id}`` per tier, so a mid-sequence failure left tiers
+    with mismatched units server-side.  A single transaction here makes
+    the all-tiers invariant atomic: either every goal moves to the new
+    unit fields or none do.  Tier identity and per-tier targets are
+    deliberately untouched.
+    """
+    result = await session.execute(select(Goal).where(Goal.habit_id == habit.id))
+    goals = list(result.scalars().all())
+    for goal in goals:
+        goal.target_unit = payload.target_unit
+        goal.frequency = payload.frequency
+        goal.frequency_unit = payload.frequency_unit
+        session.add(goal)
+    await session.commit()
+    for goal in goals:
+        await session.refresh(goal)
+    logger.info(
+        "goal_units_updated",
+        extra={"user_id": current_user, "habit_id": habit.id, "goal_count": len(goals)},
+    )
+    return goals
 
 
 @router.get("/{habit_id}/stats", response_model=HabitStats)

--- a/backend/src/schemas/goal.py
+++ b/backend/src/schemas/goal.py
@@ -74,3 +74,21 @@ class GoalUpdate(BaseModel):
     frequency_unit: str = Field(min_length=1, max_length=50)
     is_additive: bool = True
     goal_group_id: int | None = None
+
+
+class GoalUnitsUpdate(BaseModel):
+    """Payload for ``PUT /habits/{habit_id}/goals/units`` (issue #289).
+
+    The GoalUnitEditor edits the unit fields once for the user but they
+    apply to every tier goal; updating them through three separate
+    ``PUT /goals/{id}`` calls left a partial-failure window with tiers on
+    mismatched units server-side.  This batch payload carries exactly the
+    shared fields so the router can update all of a habit's goals inside
+    one transaction.  Bounds mirror :class:`GoalUpdate`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_unit: str = Field(min_length=1, max_length=50)
+    frequency: float = Field(gt=0)
+    frequency_unit: str = Field(min_length=1, max_length=50)

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -15,6 +15,7 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from models.goal import Goal
 from models.habit import Habit
@@ -186,4 +187,126 @@ async def test_update_goal_rejects_forged_habit_id(
         json={**_update_payload(target=99.0), "habit_id": 9999},
         headers=headers,
     )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ── Batch unit update (issue #289) ──────────────────────────────────────
+
+
+async def _seed_habit_with_tiers(db_session: AsyncSession, user_id: int) -> Habit:
+    """Create a habit with the standard three tier goals and return it."""
+    habit = Habit(
+        name="Reading",
+        icon="\U0001f4d6",
+        start_date=date(2025, 1, 1),
+        energy_cost=10,
+        energy_return=20,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    for tier, target in (("low", 1.0), ("clear", 2.0), ("stretch", 3.0)):
+        db_session.add(
+            Goal(
+                habit_id=habit.id,
+                title=tier.capitalize(),
+                tier=tier,
+                target=target,
+                target_unit="units",
+                frequency=1.0,
+                frequency_unit="per_day",
+                is_additive=True,
+            )
+        )
+    await db_session.commit()
+    return habit
+
+
+_UNITS_PAYLOAD = {"target_unit": "pages", "frequency": 2.0, "frequency_unit": "per_week"}
+
+
+@pytest.mark.asyncio
+async def test_update_goal_units_updates_every_tier_atomically(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """One PUT updates the unit fields on all the habit's goals (issue #289).
+
+    Replaces the GoalUnitEditor's three-PUT fan-out, whose partial failure
+    left tiers with mismatched units server-side.
+    """
+    headers, user_id = await _signup(async_client, "unitsbatcher")
+    habit = await _seed_habit_with_tiers(db_session, user_id)
+
+    resp = await async_client.put(
+        f"/habits/{habit.id}/goals/units", json=_UNITS_PAYLOAD, headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert len(body) == 3
+    assert all(g["target_unit"] == "pages" for g in body)
+    assert all(g["frequency"] == 2.0 for g in body)
+    assert all(g["frequency_unit"] == "per_week" for g in body)
+    # Tier identity and targets are untouched — only the unit fields move.
+    assert sorted(g["tier"] for g in body) == ["clear", "low", "stretch"]
+    assert sorted(g["target"] for g in body) == [1.0, 2.0, 3.0]
+
+    result = await db_session.execute(select(Goal).where(Goal.habit_id == habit.id))
+    persisted = list(result.scalars().all())
+    assert all(g.target_unit == "pages" for g in persisted)
+
+
+@pytest.mark.asyncio
+async def test_update_goal_units_requires_auth(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client, "unitsanon")
+    habit = await _seed_habit_with_tiers(db_session, user_id)
+    del headers  # the request below is deliberately anonymous
+
+    resp = await async_client.put(f"/habits/{habit.id}/goals/units", json=_UNITS_PAYLOAD)
+
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_update_goal_units_403_when_caller_not_owner(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, alice_id = await _signup(async_client, "unitsalice")
+    bob_headers, _ = await _signup(async_client, "unitsbob")
+    habit = await _seed_habit_with_tiers(db_session, alice_id)
+
+    resp = await async_client.put(
+        f"/habits/{habit.id}/goals/units", json=_UNITS_PAYLOAD, headers=bob_headers
+    )
+
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_update_goal_units_404_when_habit_missing(async_client: AsyncClient) -> None:
+    headers, _ = await _signup(async_client, "unitsghost")
+
+    resp = await async_client.put(
+        "/habits/999999/goals/units", json=_UNITS_PAYLOAD, headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_update_goal_units_422_on_nonpositive_frequency(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client, "unitszero")
+    habit = await _seed_habit_with_tiers(db_session, user_id)
+
+    resp = await async_client.put(
+        f"/habits/{habit.id}/goals/units",
+        json={**_UNITS_PAYLOAD, "frequency": 0},
+        headers=headers,
+    )
+
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -978,6 +978,18 @@ export const habits = {
   update(habitId: number, payload: HabitCreatePayload, token?: string): Promise<ApiHabit> {
     return request<ApiHabit>(`/habits/${habitId}`, { method: 'PUT', body: payload, token });
   },
+  /**
+   * Atomically update the shared unit fields on every goal of the habit
+   * (issue #289). Replaces the per-tier ``goals.update`` fan-out whose
+   * partial failure left tiers with mismatched units server-side.
+   */
+  updateGoalUnits(habitId: number, payload: GoalUnitsPayload, token?: string): Promise<ApiGoal[]> {
+    return request<ApiGoal[]>(`/habits/${habitId}/goals/units`, {
+      method: 'PUT',
+      body: payload,
+      token,
+    });
+  },
   delete(habitId: number, token?: string): Promise<void> {
     return request<void>(`/habits/${habitId}`, { method: 'DELETE', token });
   },
@@ -1031,6 +1043,13 @@ export const goalCompletions = {
 // Goal write payload — fields the editor exposes. ``habit_id`` is omitted
 // because a goal is bound to its parent habit for life and the server's
 // ``GoalUpdate`` schema rejects any attempt to forge it.
+/** Shared unit fields for the atomic all-tiers update (issue #289). */
+export interface GoalUnitsPayload {
+  target_unit: string;
+  frequency: number;
+  frequency_unit: string;
+}
+
 export interface GoalUpdatePayload {
   title: string;
   description?: string | null;

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -101,6 +101,11 @@ export interface GoalModalProps {
   habit: Habit | null;
   onClose: () => void;
   onUpdateGoal: (_habitId: number, _updatedGoal: Goal) => void;
+  /** Atomic all-tiers unit update — one batch PUT, one rollback (#289). */
+  onUpdateGoalUnits: (
+    _habitId: number,
+    _changes: Partial<Pick<Goal, 'target_unit' | 'frequency' | 'frequency_unit'>>,
+  ) => void;
   /** ``date`` backfills a past day; omit to log against today. */
   onLogUnit: (_habitId: number, _amount: number, _date?: Date) => void;
   onUpdateHabit: (_updatedHabit: Habit) => void;
@@ -178,6 +183,10 @@ export interface AddHabitInput {
 export interface HabitsActions {
   loadHabits: () => Promise<void>;
   updateGoal: (_habitId: number, _updatedGoal: Goal) => void;
+  updateGoalUnits: (
+    _habitId: number,
+    _changes: Partial<Pick<Goal, 'target_unit' | 'frequency' | 'frequency_unit'>>,
+  ) => void;
   /** ``date`` backfills a past day; omit to log against today. */
   logUnit: (_habitId: number, _amount: number, _date?: Date) => void;
   updateHabit: (_updatedHabit: Habit) => void;

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -227,6 +227,7 @@ const HabitDataModals = ({
       habit={selectedHabit}
       onClose={() => modals.close('goal')}
       onUpdateGoal={actions.updateGoal}
+      onUpdateGoalUnits={actions.updateGoalUnits}
       onLogUnit={actions.logUnit}
       onUpdateHabit={actions.updateHabit}
     />

--- a/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
@@ -74,6 +74,7 @@ describe('GoalModal hook order', () => {
         habit={null}
         onClose={() => {}}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -87,6 +88,7 @@ describe('GoalModal hook order', () => {
             habit={sampleHabit}
             onClose={() => {}}
             onUpdateGoal={() => {}}
+            onUpdateGoalUnits={() => {}}
             onLogUnit={() => {}}
             onUpdateHabit={() => {}}
           />,
@@ -104,6 +106,7 @@ describe('GoalModal progress', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -122,6 +125,7 @@ describe('GoalModal progress', () => {
           habit={updatedHabit}
           onClose={() => {}}
           onUpdateGoal={() => {}}
+          onUpdateGoalUnits={() => {}}
           onLogUnit={() => {}}
           onUpdateHabit={() => {}}
         />,
@@ -141,6 +145,7 @@ describe('GoalModal tooltips', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -168,6 +173,7 @@ describe('GoalModal target editor', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -187,6 +193,7 @@ describe('GoalModal target editor', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -209,6 +216,7 @@ describe('GoalModal target editor', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={onUpdateGoal}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -236,6 +244,33 @@ describe('GoalModal target editor', () => {
     expect(() => testRenderer.root.findByProps({ testID: 'goal-target-input-clear' })).toThrow();
   });
 
+  it('commits unit edits as ONE consolidated call, not a per-tier fan-out (#289)', () => {
+    const onUpdateGoal = jest.fn();
+    const onUpdateGoalUnits = jest.fn();
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={onUpdateGoal}
+        onUpdateGoalUnits={onUpdateGoalUnits}
+        onLogUnit={() => {}}
+        onUpdateHabit={() => {}}
+      />,
+    );
+    expandEditRegion(testRenderer);
+
+    renderer.act(() => {
+      testRenderer.root.findByProps({ testID: 'goal-target-unit-hours' }).props.onPress();
+    });
+
+    // The atomic batch endpoint replaces the three-PUT fan-out whose
+    // partial failure left tiers with mismatched units server-side.
+    expect(onUpdateGoalUnits).toHaveBeenCalledTimes(1);
+    expect(onUpdateGoalUnits).toHaveBeenCalledWith(sampleHabit.id, { target_unit: 'hours' });
+    expect(onUpdateGoal).not.toHaveBeenCalled();
+  });
+
   it('does not duplicate onUpdateGoal when both onEndEditing and onBlur could fire', () => {
     // React Native fires ``onEndEditing`` + ``onBlur`` back-to-back for a
     // single keyboard-dismissal action (the Done key, then the resulting
@@ -253,6 +288,7 @@ describe('GoalModal target editor', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={onUpdateGoal}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -280,6 +316,7 @@ describe('GoalModal target editor', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={onUpdateGoal}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -305,6 +342,7 @@ describe('GoalModal target editor', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={onUpdateGoal}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -335,6 +373,7 @@ describe('GoalModal backdrop close', () => {
         habit={sampleHabit}
         onClose={onClose}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -356,6 +395,7 @@ describe('GoalModal backdrop close', () => {
         habit={sampleHabit}
         onClose={onClose}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -387,6 +427,7 @@ describe('GoalModal edit toggle', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -409,6 +450,7 @@ describe('GoalModal edit toggle', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,
@@ -429,6 +471,7 @@ describe('GoalModal edit toggle', () => {
         habit={sampleHabit}
         onClose={() => {}}
         onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
         onLogUnit={() => {}}
         onUpdateHabit={() => {}}
       />,

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -771,7 +771,7 @@ interface GoalUnitEditorProps {
    */
   goals: NonEmptyGoals;
   habitId: number;
-  onUpdateGoal: GoalModalProps['onUpdateGoal'];
+  onUpdateGoalUnits: GoalModalProps['onUpdateGoalUnits'];
 }
 
 interface FrequencyInputProps {
@@ -794,24 +794,22 @@ const FrequencyInput = ({ draft, setDraft, onEnd }: FrequencyInputProps) => (
 
 /**
  * Edits ``target_unit`` / ``frequency`` / ``frequency_unit`` for a habit's
- * goals. The fields are shared across tiers (``normalizeGoalUnits``
- * propagates a single edit to all three), so the editor surfaces them once
- * — but ``onUpdateGoal`` only PUTs the goal whose id is sent, so a commit
- * fans out one update per tier. Without the fan-out, the ``clear`` and
- * ``stretch`` rows would stay on their old units server-side even though
- * the local store displays them as normalized.
+ * goals. The fields are shared across tiers, so the editor surfaces them
+ * once and commits through ``onUpdateGoalUnits`` — a single atomic batch
+ * update that moves every tier together (#289).
  */
-const GoalUnitEditor = ({ goals, habitId, onUpdateGoal }: GoalUnitEditorProps) => {
+const GoalUnitEditor = ({ goals, habitId, onUpdateGoalUnits }: GoalUnitEditorProps) => {
   const reference = goals[0];
   const [freqDraft, setFreqDraft] = useState(String(reference.frequency));
   useEffect(() => {
     setFreqDraft(String(reference.frequency));
   }, [reference.frequency]);
 
+  // Issue #289: ONE consolidated call — the backend updates every tier
+  // inside a single transaction, so a failure can never strand tiers on
+  // mismatched units the way the old per-tier fan-out could.
   const commit = (changes: Partial<Pick<Goal, 'target_unit' | 'frequency' | 'frequency_unit'>>) => {
-    for (const goal of goals) {
-      onUpdateGoal(habitId, { ...goal, ...changes });
-    }
+    onUpdateGoalUnits(habitId, changes);
   };
 
   const handleFreqEnd = () => {
@@ -909,6 +907,7 @@ const buildDirectionChangePayloads = (goals: readonly Goal[], newIsAdditive: boo
 interface GoalTargetEditorProps {
   habit: NonNullable<GoalModalProps['habit']>;
   onUpdateGoal: GoalModalProps['onUpdateGoal'];
+  onUpdateGoalUnits: GoalModalProps['onUpdateGoalUnits'];
 }
 
 /**
@@ -918,7 +917,7 @@ interface GoalTargetEditorProps {
  * triggered reliably under thumb input — closing the "no way to edit habit
  * goals on mobile" gap.
  */
-const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
+const GoalTargetEditor = ({ habit, onUpdateGoal, onUpdateGoalUnits }: GoalTargetEditorProps) => {
   // ``== null`` (not ``!habit.id``) so a hypothetical future habit with id 0
   // still surfaces the editor — falsy-zero is a real concern even if the
   // current backend autoincrements from 1.
@@ -949,7 +948,11 @@ const GoalTargetEditor = ({ habit, onUpdateGoal }: GoalTargetEditorProps) => {
           onCommit={(target) => onUpdateGoal(habitId, { ...goal, target })}
         />
       ))}
-      <GoalUnitEditor goals={nonEmptyGoals} habitId={habitId} onUpdateGoal={onUpdateGoal} />
+      <GoalUnitEditor
+        goals={nonEmptyGoals}
+        habitId={habitId}
+        onUpdateGoalUnits={onUpdateGoalUnits}
+      />
     </View>
   );
 };
@@ -1194,6 +1197,7 @@ interface GoalModalBodyProps {
   habit: NonNullable<GoalModalProps['habit']>;
   onClose: () => void;
   onUpdateGoal: GoalModalProps['onUpdateGoal'];
+  onUpdateGoalUnits: GoalModalProps['onUpdateGoalUnits'];
   onLogUnit: GoalModalProps['onLogUnit'];
   onUpdateHabit: GoalModalProps['onUpdateHabit'];
 }
@@ -1257,6 +1261,7 @@ const GoalModalBody = ({
   habit,
   onClose,
   onUpdateGoal,
+  onUpdateGoalUnits,
   onLogUnit,
   onUpdateHabit,
 }: GoalModalBodyProps) => {
@@ -1283,7 +1288,11 @@ const GoalModalBody = ({
       <GoalProgressBar {...buildProgressBarProps(habit, m, userTimezone)} />
       {isEditing && (
         <View testID="goal-modal-edit-region">
-          <GoalTargetEditor habit={habit} onUpdateGoal={onUpdateGoal} />
+          <GoalTargetEditor
+            habit={habit}
+            onUpdateGoal={onUpdateGoal}
+            onUpdateGoalUnits={onUpdateGoalUnits}
+          />
         </View>
       )}
       <LogUnitSection
@@ -1303,6 +1312,7 @@ export const GoalModal = ({
   habit,
   onClose,
   onUpdateGoal,
+  onUpdateGoalUnits,
   onLogUnit,
   onUpdateHabit,
 }: GoalModalProps) => {
@@ -1323,6 +1333,7 @@ export const GoalModal = ({
           habit={habit}
           onClose={onClose}
           onUpdateGoal={onUpdateGoal}
+          onUpdateGoalUnits={onUpdateGoalUnits}
           onLogUnit={onLogUnit}
           onUpdateHabit={onUpdateHabit}
         />

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -59,6 +59,7 @@ const renderModal = (
     habit,
     onClose: jest.fn(),
     onUpdateGoal: jest.fn(),
+    onUpdateGoalUnits: jest.fn(),
     onLogUnit: jest.fn(),
     onUpdateHabit: jest.fn(),
     ...overrides,
@@ -172,66 +173,46 @@ describe('GoalModal unit + frequency editor', () => {
     jest.clearAllMocks();
   });
 
-  it('fans out a target_unit change to ALL three tier goals', () => {
-    // Invariant: a unit edit must PUT every tier so the backend rows
-    // stay in lockstep with the locally-normalized state. ``onUpdateGoal``
-    // updates only the goal whose id is sent, so committing on the
-    // reference (low) tier alone leaves clear/stretch stale server-side.
+  it('commits a target_unit change as ONE atomic batch call (#289)', () => {
+    // Invariant: a unit edit moves every tier together. The old per-tier
+    // ``onUpdateGoal`` fan-out left tiers on mismatched units server-side
+    // when a mid-sequence PUT failed; the batch endpoint updates all the
+    // habit's goals inside a single transaction.
     const { getByTestId, props } = renderModal();
     fireEvent.press(getByTestId('goal-target-unit-minutes'));
 
-    expect(props.onUpdateGoal).toHaveBeenCalledTimes(3);
-    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
-      1,
-      42,
-      expect.objectContaining({ tier: 'low', target_unit: 'minutes' }),
-    );
-    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
-      2,
-      42,
-      expect.objectContaining({ tier: 'clear', target_unit: 'minutes' }),
-    );
-    expect(props.onUpdateGoal).toHaveBeenNthCalledWith(
-      3,
-      42,
-      expect.objectContaining({ tier: 'stretch', target_unit: 'minutes' }),
-    );
+    expect(props.onUpdateGoalUnits).toHaveBeenCalledTimes(1);
+    expect(props.onUpdateGoalUnits).toHaveBeenCalledWith(42, { target_unit: 'minutes' });
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
   });
 
-  it('fans out a frequency_unit change to ALL three tier goals', () => {
+  it('commits a frequency_unit change as ONE atomic batch call (#289)', () => {
     const { getByTestId, props } = renderModal();
     fireEvent.press(getByTestId('goal-frequency-unit-per_week'));
 
-    expect(props.onUpdateGoal).toHaveBeenCalledTimes(3);
-    for (const tier of ['low', 'clear', 'stretch'] as const) {
-      expect(props.onUpdateGoal).toHaveBeenCalledWith(
-        42,
-        expect.objectContaining({ tier, frequency_unit: 'per_week' }),
-      );
-    }
+    expect(props.onUpdateGoalUnits).toHaveBeenCalledTimes(1);
+    expect(props.onUpdateGoalUnits).toHaveBeenCalledWith(42, { frequency_unit: 'per_week' });
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
   });
 
-  it('commits a numeric frequency change on blur', () => {
+  it('commits a numeric frequency change on blur as ONE atomic batch call (#289)', () => {
     const { getByTestId, props } = renderModal();
     const input = getByTestId('goal-frequency-input');
     fireEvent.changeText(input, '3');
     fireEvent(input, 'endEditing');
 
-    expect(props.onUpdateGoal).toHaveBeenCalledTimes(3);
-    for (const tier of ['low', 'clear', 'stretch'] as const) {
-      expect(props.onUpdateGoal).toHaveBeenCalledWith(
-        42,
-        expect.objectContaining({ tier, frequency: 3 }),
-      );
-    }
+    expect(props.onUpdateGoalUnits).toHaveBeenCalledTimes(1);
+    expect(props.onUpdateGoalUnits).toHaveBeenCalledWith(42, { frequency: 3 });
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
   });
 
-  it('drops a non-finite frequency without firing onUpdateGoal', () => {
+  it('drops a non-finite frequency without firing any update', () => {
     const { getByTestId, props } = renderModal();
     const input = getByTestId('goal-frequency-input');
     fireEvent.changeText(input, 'abc');
     fireEvent(input, 'endEditing');
     expect(props.onUpdateGoal).not.toHaveBeenCalled();
+    expect(props.onUpdateGoalUnits).not.toHaveBeenCalled();
   });
 
   it('drops a zero or negative frequency (positivity invariant)', () => {

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -120,6 +120,7 @@ export const useHabitActions = (
       // Bound so retries replay queued check-ins against the stored zone (#269).
       loadHabits: () => habitManager.loadHabits(tz),
       updateGoal: habitManager.updateGoal,
+      updateGoalUnits: habitManager.updateGoalUnits,
       logUnit,
       updateHabit: habitManager.updateHabit,
       deleteHabit: habitManager.deleteHabit,

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -7,6 +7,7 @@ jest.mock('../../../../api', () => ({
     update: jest.fn(() => Promise.resolve({})),
     delete: jest.fn(() => Promise.resolve({})),
     getStats: jest.fn(() => Promise.resolve({})),
+    updateGoalUnits: jest.fn(() => Promise.resolve([])),
   },
   goalCompletions: {
     create: jest.fn(() => Promise.resolve({})),
@@ -450,6 +451,43 @@ describe('habitManager', () => {
         { goal_id: 2, did_complete: true, timestamp: '2025-04-02T00:00:00Z' },
         { goal_id: 3, did_complete: true, timestamp: '2025-04-03T00:00:00Z' },
       ]);
+    });
+  });
+
+  describe('updateGoalUnits', () => {
+    it('applies unit changes to every tier optimistically and PUTs once (#289)', () => {
+      useHabitStore.setState({ habits: [makeHabit()] });
+
+      habitManager.updateGoalUnits(1, { target_unit: 'hours' });
+
+      const goals = useHabitStore.getState().habits[0]!.goals;
+      expect(goals.every((g) => g.target_unit === 'hours')).toBe(true);
+      // ONE consolidated batch call — the atomic replacement for the
+      // three-PUT fan-out whose partial failure split tiers server-side.
+      expect(habitsApi.updateGoalUnits).toHaveBeenCalledTimes(1);
+      expect(habitsApi.updateGoalUnits).toHaveBeenCalledWith(1, {
+        target_unit: 'hours',
+        frequency: 1,
+        frequency_unit: 'per_day',
+      });
+      expect(saveHabits).toHaveBeenCalled();
+    });
+
+    it('rolls every tier back when the batch PUT rejects (#289)', async () => {
+      useHabitStore.setState({ habits: [makeHabit()] });
+      (
+        (habitsApi as unknown as { updateGoalUnits: jest.Mock }).updateGoalUnits as jest.Mock
+      ).mockRejectedValueOnce(new Error('boom') as never);
+
+      habitManager.updateGoalUnits(1, { target_unit: 'hours' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const goals = useHabitStore.getState().habits[0]!.goals;
+      // The single rollback restores the ORIGINAL units on every tier —
+      // no mismatched split between local and server state.
+      expect(goals.every((g) => g.target_unit === 'units')).toBe(true);
+      const { Alert } = jest.requireMock('react-native') as { Alert: { alert: jest.Mock } };
+      expect(Alert.alert).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -15,7 +15,12 @@ import {
   goalCompletions as goalCompletionsApi,
   goals as goalsApi,
 } from '../../../api';
-import type { CheckInResult, GoalUpdatePayload, HabitCreatePayload } from '../../../api';
+import type {
+  CheckInResult,
+  GoalUnitsPayload,
+  GoalUpdatePayload,
+  HabitCreatePayload,
+} from '../../../api';
 import { formatApiError } from '../../../api/errorMessages';
 import { flattenGoalCompletions } from '../../../api/flattenGoalCompletions';
 import type { ToastConfig } from '../../../components/Toast';
@@ -686,6 +691,43 @@ export const habitManager = {
         revertOnFailure(
           prev,
           "We couldn't save that goal change. Your local copy was restored — check your connection and try again.",
+        ),
+      );
+  },
+
+  /**
+   * Atomically update the shared unit fields across every tier goal of a
+   * habit (issue #289). One optimistic apply, one batch PUT, one rollback
+   * closure — replaces the GoalUnitEditor's three-call fan-out whose
+   * partial failure split tiers between old and new units server-side.
+   */
+  updateGoalUnits: (
+    habitId: number,
+    changes: Partial<Pick<Goal, 'target_unit' | 'frequency' | 'frequency_unit'>>,
+  ): void => {
+    const prev = getHabits();
+    const habit = prev.find((h) => h.id === habitId);
+    const reference = habit?.goals[0];
+    if (!habit || !reference) return;
+    const next = prev.map((h) =>
+      h.id === habitId ? { ...h, goals: h.goals.map((g) => ({ ...g, ...changes })) } : h,
+    );
+    setHabits(next);
+    void persistHabits(next);
+    // Synthetic ids (pre-sync onboarding state) stay local-only — the
+    // same contract as ``updateGoal``.
+    if (!habit.goals.every((g) => g.id)) return;
+    const payload: GoalUnitsPayload = {
+      target_unit: changes.target_unit ?? reference.target_unit,
+      frequency: changes.frequency ?? reference.frequency,
+      frequency_unit: changes.frequency_unit ?? reference.frequency_unit,
+    };
+    habitsApi
+      .updateGoalUnits(habitId, payload)
+      .catch(
+        revertOnFailure(
+          prev,
+          "We couldn't update those goal units on the server. Your changes were rolled back — check your connection and try again.",
         ),
       );
   },


### PR DESCRIPTION
## Summary

- Implements the issue's preferred approach 1: a backend batch endpoint `PUT /habits/{habit_id}/goals/units` updates the shared unit fields (`target_unit` / `frequency` / `frequency_unit`) on **every** goal of the owned habit inside one transaction — true server-side atomicity, eliminating the partial-failure window where the GoalUnitEditor's three-PUT fan-out stranded tiers on mismatched units.
- `GoalUnitsUpdate` schema mirrors `GoalUpdate`'s bounds (`extra="forbid"`, frequency > 0); tier identity and per-tier targets are deliberately untouched by the batch.
- Frontend: `habitManager.updateGoalUnits` does one optimistic apply across all tiers, one batch PUT, and one rollback closure (synthetic-id habits stay local-only, matching `updateGoal`'s contract). `GoalUnitEditor` commits through a new `onUpdateGoalUnits` prop threaded from `useHabitActions` → `HabitsScreen` → `GoalModal`.

## Test plan

- Backend (6 new): all-tiers update in one PUT with tiers/targets untouched + DB-level persistence assertion; 401 anonymous; 403 non-owner; 404 missing habit; 422 non-positive frequency. Full suite 94.25% coverage.
- Frontend (5 new/converted): the editor's unit, frequency-unit, and numeric-frequency commits each fire **one** consolidated `onUpdateGoalUnits` call and zero per-tier `onUpdateGoal` calls (these replace the old fan-out tests, per the acceptance criteria); manager tests cover the optimistic all-tiers apply + single batch PUT, and the all-tiers rollback + alert when the batch rejects. Full suite 1841 passing.
- `pre-commit run --all-files` exit 0 (TZ=UTC).

Closes #289
Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
