### PR TITLE
fix(backend): filter habit completions at the query layer, not in memory

### DIFF
--- a/backend/src/load_options.py
+++ b/backend/src/load_options.py
@@ -43,23 +43,32 @@ HABIT_WITH_GOALS_AND_COMPLETIONS: _AbstractLoad = HABIT_WITH_GOALS.selectinload(
 )
 
 
-def habit_with_recent_completions(cutoff: datetime) -> _AbstractLoad:
-    """Habit -> goals -> completions newer than ``cutoff`` (issue #294).
+def habit_with_recent_completions(cutoff: datetime, user_id: int) -> _AbstractLoad:
+    """Habit -> goals -> caller-owned completions newer than ``cutoff``.
 
-    The unbounded ``HABIT_WITH_GOALS_AND_COMPLETIONS`` chain ships an
-    account's entire completion history on every habit GET — linear
-    payload growth over the account's lifetime.  This windowed variant
-    trims the *transport* via a query-time ``.and_()`` predicate; the
-    rows themselves stay in the database and still feed the unwindowed
-    consumers (the stats endpoint's all-time aggregates).  Built per
-    request because ``cutoff`` is relative to now.
+    Two query-time predicates, one loader:
+
+    * ``timestamp >= cutoff`` (issue #294) bounds the transport so habit
+      GET payloads stop growing with account age.  Rows stay in the DB
+      and still feed the unwindowed stats consumers.
+    * ``user_id`` (issue #296) replaces the old in-memory
+      ``_filter_completions_to_caller``, whose collection replacement
+      marked cross-tenant rows for a ``goal_id=NULL`` flush — a
+      data-loss/IntegrityError footgun for any write issued after a GET.
+      Filtering in SQL means the ORM relation is never mutated in Python
+      and misuse is impossible by construction.
+
+    Built per request: ``cutoff`` is relative to now and ``user_id`` is
+    the caller.
     """
     # ``attr-defined``: SQLModel types ``Goal.completions`` statically as
     # ``list[GoalCompletion]``; SQLAlchemy's relationship comparator adds
     # ``.and_`` at runtime — the same class-vs-instance attr quirk the
     # bare ``selectinload`` ignores above paper over (issue #294).
     return selectinload(Habit.goals).selectinload(  # type: ignore[arg-type]
-        Goal.completions.and_(GoalCompletion.timestamp >= cutoff)  # type: ignore[attr-defined]
+        Goal.completions.and_(  # type: ignore[attr-defined]
+            (GoalCompletion.timestamp >= cutoff) & (GoalCompletion.user_id == user_id)
+        )
     )
 
 

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -121,12 +121,6 @@ async def _streak_completions_by_habit(
     return by_habit
 
 
-def _filter_completions_to_caller(habit: Habit, current_user: int) -> None:
-    """Drop cross-tenant completions; callers must NOT commit (orphan-delete cascade)."""
-    for goal in habit.goals:
-        goal.completions = [c for c in goal.completions if c.user_id == current_user]
-
-
 def _build_default_goals(habit_id: int, habit_name: str) -> list[Goal]:
     """Three-tier default goals for a newly-created habit."""
     return [
@@ -188,12 +182,12 @@ async def _persist_habit_with_default_goals(session: AsyncSession, habit: Habit)
     return new_id
 
 
-async def _refetch_with_goals(session: AsyncSession, habit_id: int) -> Habit:
+async def _refetch_with_goals(session: AsyncSession, habit_id: int, current_user: int) -> Habit:
     """Re-load a habit with eager goals to avoid greenlet lazy-load errors."""
     statement = (
         select(Habit)
         .where(Habit.id == habit_id)
-        .options(habit_with_recent_completions(_recent_completions_cutoff()))
+        .options(habit_with_recent_completions(_recent_completions_cutoff(), current_user))
         .execution_options(populate_existing=True)
     )
     result = await session.execute(statement)
@@ -218,7 +212,7 @@ async def create_habit(
     await _ensure_unique_name(session, current_user, payload.name)
     habit = Habit(user_id=current_user, **payload.model_dump())
     new_id = await _persist_habit_with_default_goals(session, habit)
-    refreshed = await _refetch_with_goals(session, new_id)
+    refreshed = await _refetch_with_goals(session, new_id, current_user)
     logger.info("habit_created", extra={"user_id": current_user, "habit_id": refreshed.id})
     return refreshed
 
@@ -235,7 +229,7 @@ async def list_habits(
     query = (
         select(Habit)
         .where(Habit.user_id == current_user)
-        .options(habit_with_recent_completions(_recent_completions_cutoff()))
+        .options(habit_with_recent_completions(_recent_completions_cutoff(), current_user))
         # See _get_habit_with_completions: keep the windowed view authoritative
         # even when an unwindowed loader ran earlier on this session.
         .execution_options(populate_existing=True)
@@ -243,8 +237,6 @@ async def list_habits(
     )
     items, total = await paginate_query(session, query, pagination)
     await _populate_streaks_for(session, items, current_user, user_tz)
-    for habit in items:
-        _filter_completions_to_caller(habit, current_user)
     serialized = [HabitWithGoals.model_validate(h, from_attributes=True) for h in items]
     if pagination.paginate:
         return build_page(serialized, total, pagination)
@@ -261,7 +253,6 @@ async def get_habit(
     """Return a single habit (with eager-loaded goals + completions) for the caller."""
     habit = await _get_habit_with_completions(habit_id, current_user, session)
     await _populate_streaks_for(session, [habit], current_user, user_tz)
-    _filter_completions_to_caller(habit, current_user)
     return habit
 
 
@@ -329,7 +320,7 @@ async def _get_habit_with_completions(
     full history for all-time consumers like the stats endpoint.
     """
     loader = (
-        habit_with_recent_completions(_recent_completions_cutoff())
+        habit_with_recent_completions(_recent_completions_cutoff(), current_user)
         if windowed
         else HABIT_WITH_GOALS_AND_COMPLETIONS
     )

--- a/backend/tests/test_habits_api.py
+++ b/backend/tests/test_habits_api.py
@@ -715,3 +715,40 @@ async def test_streak_is_not_clipped_by_the_transport_window(
     collection = await async_client.get("/habits/", headers=headers)
     listed = next(h for h in collection.json() if h["id"] == habit_id)
     assert listed["streak"] == streak_days
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_completions_survive_a_commit_after_get(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Issue #296: the completions filter must be query-time, not in-memory.
+
+    The old ``_filter_completions_to_caller`` replaced the back-populated
+    ORM collection, so any ``commit()`` issued after a habit GET flushed
+    the filtered-out rows' disassociation to disk — a cross-tenant
+    data-loss footgun guarded only by a docstring. With the filter at the
+    query layer the relation is never touched in Python and this commit
+    is a harmless no-op.
+    """
+    headers = await _signup(async_client, "tenantguard")
+    create_resp = await async_client.post("/habits/", json=sample_payload(), headers=headers)
+    habit_id = create_resp.json()["id"]
+    goal_id = next(g["id"] for g in create_resp.json()["goals"] if g["tier"] == "clear")
+
+    stray = GoalCompletion(goal_id=goal_id, user_id=999_999, completed_units=42.0)
+    db_session.add(stray)
+    await db_session.commit()
+    stray_id = stray.id
+
+    # Both GET paths run the filter; the route shares this session.
+    await async_client.get(f"/habits/{habit_id}", headers=headers)
+    await async_client.get("/habits/", headers=headers)
+
+    # The write a future caller might add after the filter (the footgun).
+    await db_session.commit()
+
+    db_session.expire_all()
+    persisted = await db_session.get(GoalCompletion, stray_id)
+    assert persisted is not None, "cross-tenant completion row was lost by a post-GET commit"
+    assert persisted.goal_id == goal_id
+    assert persisted.user_id == 999_999


### PR DESCRIPTION
## Summary

- Replaces the in-memory `_filter_completions_to_caller` — flagged 🟡 HIGH in PR #293's review as a cross-tenant delete-orphan footgun — with a `user_id` predicate on the same query-time `.and_()` loader that #294 introduced for the transport window (`habit_with_recent_completions(cutoff, user_id)`). The filter now happens in SQL; the ORM relation is never mutated in Python, so misuse is impossible by construction and the WARNING-block documentation guard is gone along with the function.
- The footgun was worse than documented: the new regression test showed that any `commit()` after a habit GET raised `IntegrityError` (`NOT NULL constraint failed: goalcompletion.goal_id`) from the flushed disassociation — under a nullable schema it would have been silent cross-tenant data loss instead.
- Out-of-scope paths untouched per the acceptance criteria: `_populate_streaks_for` (already query-filtered by user) and `get_habit_stats` (filters in Python on the unwindowed loader).

## Test plan

- New regression guard: seeds a foreign tenant's completion, GETs both habit endpoints on the shared session, issues the "future caller" `commit()`, and asserts the stray row survives intact (id, goal_id, user_id). Red before the fix with the IntegrityError above; green now.
- `test_get_habit_completions_filtered_to_caller` passes **unmodified** — identical contract, implementation moved (the acceptance bar).
- Full backend suite: 94.37% coverage; xenon all-A; `pre-commit run --all-files` exit 0 (TZ=UTC).

Closes #296
Refs #293, #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)
