### PR TITLE
fix(backend): self-heal crash-stranded chat idempotency tombstones

### DIFF
--- a/backend/src/services/chat_idempotency.py
+++ b/backend/src/services/chat_idempotency.py
@@ -15,12 +15,24 @@ service → router).
 from __future__ import annotations
 
 import hashlib
+import logging
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from models.chat_spend import ChatSpend
+
+logger = logging.getLogger(__name__)
+
+# How long an in-flight tombstone (``result_json IS NULL``) may live before
+# a colliding retry evicts it (issue #320).  Without eviction, a server
+# crash between the tombstone insert and ``update_idem_result`` strands the
+# row forever and every retry with the same key 409s permanently.  LLM
+# calls can legitimately run 30+ seconds; 15 minutes sits far above any
+# provider's p99 so a genuinely-running request is never evicted.
+IN_FLIGHT_TTL = timedelta(minutes=15)
 
 
 def hash_idem_key(user_id: int, raw_key: str) -> str:
@@ -83,12 +95,67 @@ async def insert_idem_tombstone(
     savepoint removes the footgun.
     """
     hashed = hash_idem_key(user_id, raw_key)
-    try:
-        async with session.begin_nested():
-            session.add(ChatSpend(user_id=user_id, idem_key=hashed))
-            await session.flush()
-    except IntegrityError:
+    for attempt in (0, 1):
+        try:
+            async with session.begin_nested():
+                session.add(ChatSpend(user_id=user_id, idem_key=hashed))
+                await session.flush()
+        except IntegrityError:
+            # Issue #320: a collision against a crash-stranded tombstone
+            # (NULL result, older than the TTL) self-heals — evict it and
+            # retry the insert ONCE.  If two retries race here, both may
+            # evict but the UNIQUE constraint still serialises the
+            # re-insert: one wins, the other lands back in this branch on
+            # its second attempt and returns False (409).
+            if attempt == 0 and await _evict_expired_tombstone(session, user_id, hashed):
+                continue
+            return False
+        return True
+    return False
+
+
+def _tombstone_age(row: ChatSpend) -> timedelta:
+    """Age of a tombstone, dialect-safe.
+
+    SQLite returns ``created_at`` naive while Postgres returns it aware;
+    both store UTC, so normalising to naive UTC makes the subtraction
+    valid on either dialect (see issue #412 for the broader class).
+    """
+    created = row.created_at.replace(tzinfo=None) if row.created_at.tzinfo else row.created_at
+    return datetime.now(UTC).replace(tzinfo=None) - created
+
+
+async def _evict_expired_tombstone(session: AsyncSession, user_id: int, hashed: str) -> bool:
+    """Delete a crash-stranded in-flight tombstone; True when one was evicted.
+
+    Only rows with ``result_json IS NULL`` (never finalised) AND older
+    than :data:`IN_FLIGHT_TTL` qualify — a completed row replays its
+    cached body via :func:`check_idempotency`, and a fresh in-flight row
+    keeps its 409 dedup contract.
+    """
+    result = await session.execute(
+        select(ChatSpend).where(
+            ChatSpend.user_id == user_id,
+            col(ChatSpend.idem_key) == hashed,
+        )
+    )
+    row = result.scalars().first()
+    if row is None or row.result_json is not None:
         return False
+    age = _tombstone_age(row)
+    if age < IN_FLIGHT_TTL:
+        return False
+    await session.delete(row)
+    await session.flush()
+    # Support correlation: "user reports stuck retry" ↔ "row N evicted at T".
+    logger.info(
+        "chat_spend_tombstone_evicted",
+        extra={
+            "user_id": user_id,
+            "chat_spend_id": row.id,
+            "age_seconds": int(age.total_seconds()),
+        },
+    )
     return True
 
 

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -1875,24 +1875,65 @@ async def test_stream_idempotency_key_different_keys_charge_independently(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_monthly_cap")
-async def test_chat_stuck_in_flight_tombstone_returns_409_until_cleared(
+async def test_chat_stuck_tombstone_recovers_after_ttl(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """Pin the current behaviour of a tombstone whose ``result_json`` stayed NULL.
+    """Issue #320: a crash-stranded tombstone self-heals after the TTL.
 
-    Reviewer-flagged scenario: if the server crashes between
-    ``insert_idem_tombstone`` and ``update_idem_result`` (or rolls back the
-    whole transaction after the tombstone was committed in another flow),
-    the row sits forever with ``result_json = NULL``.  Today every retry
-    with the same key hits the UNIQUE constraint at the tombstone insert
-    and gets 409.  This test pins that behaviour so a future cleanup job
-    (tracked separately) has a regression target — the test will need to
-    flip to assert eventual recovery once the cleanup ships.
+    If the server crashes between ``insert_idem_tombstone`` and
+    ``update_idem_result``, the row sits with ``result_json = NULL``.  A
+    retry with the same key (which a sane mobile client reuses — the whole
+    point of idempotency) used to 409 forever.  Now an in-flight tombstone
+    older than the TTL is evicted on the next collision and the retry
+    proceeds to a real, fresh response.
+    """
+    from datetime import UTC, datetime, timedelta  # noqa: PLC0415
 
-    We simulate the crash by directly inserting a NULL-``result_json``
-    ``ChatSpend`` row (matching what a half-completed request would have
-    left behind), then verify the subsequent retry returns 409.
+    from models.chat_spend import ChatSpend  # noqa: PLC0415
+    from services.chat_idempotency import IN_FLIGHT_TTL, hash_idem_key  # noqa: PLC0415
+
+    headers = await _signup(async_client)
+    await _add_balance(db_session, amount=2)
+
+    user_row = (await db_session.execute(select(User))).scalars().first()
+    assert user_row is not None
+    assert user_row.id is not None
+
+    # Plant a crash-stranded tombstone whose age exceeds the TTL.
+    stuck_key = "crash-key-001"
+    stale_created = datetime.now(UTC).replace(tzinfo=None) - IN_FLIGHT_TTL - timedelta(minutes=1)
+    db_session.add(
+        ChatSpend(
+            user_id=user_row.id,
+            idem_key=hash_idem_key(user_row.id, stuck_key),
+            created_at=stale_created,
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.post(
+        "/journal/chat",
+        json={"message": "retry after crash"},
+        headers={**headers, "Idempotency-Key": stuck_key},
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["response"]
+
+    # Exactly one charge: the recovered retry spends once.
+    balance = await async_client.get("/user/balance", headers=headers)
+    assert balance.json()["balance"] == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_fresh_in_flight_tombstone_still_409s(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Issue #320 guard: a genuinely in-flight request (under TTL) stays 409.
+
+    The TTL eviction must not create false positives — a concurrent retry
+    while the original LLM call is still running keeps the dedup contract.
     """
     from models.chat_spend import ChatSpend  # noqa: PLC0415
     from services.chat_idempotency import hash_idem_key  # noqa: PLC0415
@@ -1900,21 +1941,18 @@ async def test_chat_stuck_in_flight_tombstone_returns_409_until_cleared(
     headers = await _signup(async_client)
     await _add_balance(db_session, amount=2)
 
-    # Find the user_id from the auth token's sub.
     user_row = (await db_session.execute(select(User))).scalars().first()
     assert user_row is not None
     assert user_row.id is not None
 
-    # Plant a stuck-in-flight tombstone with NULL result_json.
-    stuck_key = "crash-key-001"
-    db_session.add(ChatSpend(user_id=user_row.id, idem_key=hash_idem_key(user_row.id, stuck_key)))
+    fresh_key = "in-flight-key-001"
+    db_session.add(ChatSpend(user_id=user_row.id, idem_key=hash_idem_key(user_row.id, fresh_key)))
     await db_session.commit()
 
-    # A retry with the same key collides on UNIQUE → 409 (NOT a re-charge).
     resp = await async_client.post(
         "/journal/chat",
-        json={"message": "retry after crash"},
-        headers={**headers, "Idempotency-Key": stuck_key},
+        json={"message": "concurrent retry"},
+        headers={**headers, "Idempotency-Key": fresh_key},
     )
     assert resp.status_code == HTTPStatus.CONFLICT
     assert resp.json()["detail"] == "idempotency_key_in_flight"


### PR DESCRIPTION
## Summary

- Implements issue #320's option B (per-request self-healing): `insert_idem_tombstone` now evicts a colliding **crash-stranded** tombstone — `result_json IS NULL` **and** older than `IN_FLIGHT_TTL` (15 minutes, far above any LLM provider's p99) — and retries the insert exactly once. A server crash between the tombstone insert and `update_idem_result` no longer strands the user's idempotency key in a permanent 409 loop.
- The documented race (two retries both seeing the expired tombstone) stays safe: both may evict, but the UNIQUE constraint serialises the re-insert — one wins, the other returns 409.
- Evictions emit a structured `chat_spend_tombstone_evicted` log (user id, row id, age) so support can correlate stuck-retry reports, per the issue's constraints.
- Age comparison is dialect-safe (naive-UTC normalisation; SQLite returns naive, Postgres aware — the #412 class).

## Test plan

- The pinned `test_chat_stuck_in_flight_tombstone_returns_409_until_cleared` flips per its own docstring's instruction: now `test_chat_stuck_tombstone_recovers_after_ttl` plants a tombstone older than the TTL and asserts the same-key retry returns **201 with a real response and exactly one wallet charge**.
- New guard `test_chat_fresh_in_flight_tombstone_still_409s`: an under-TTL in-flight tombstone keeps the 409 contract with the wallet untouched — no false-positive evictions.
- Full backend suite: 94.34% coverage; xenon all-A; `pre-commit run --all-files` exit 0 (TZ=UTC).

Closes #320
Refs #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
