### PR TITLE
feat(backend): anchor stage/week gating to a stored program start date

### DIFF
--- a/backend/migrations/versions/18c9d0e1f2a3_add_program_started_at.py
+++ b/backend/migrations/versions/18c9d0e1f2a3_add_program_started_at.py
@@ -1,0 +1,60 @@
+"""add stageprogress.program_started_at program-wide anchor
+
+Revision ID: 18c9d0e1f2a3
+Revises: 07b8c9d0e1f2
+Create Date: 2026-06-10 00:00:00.000000
+
+Issue #386: gives the backend the single program-start anchor the
+frontend (#384) already treats as canonical, so server-side stage/week
+gating can derive the same date-based calendar instead of disagreeing
+with what the user sees.
+
+Backfill: existing users anchor on the earliest start date among their
+habits — the same source the frontend's onboarding anchor uses — falling
+back to ``stage_started_at`` (conservative: later for anyone past stage
+1, which only makes the time gate stricter).  The column stays nullable
+so ``resolve_program_anchor`` can fall back at read time for any row a
+future code path creates without it.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "18c9d0e1f2a3"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "07b8c9d0e1f2"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the nullable anchor column, then backfill from habit history."""
+    op.add_column(
+        "stageprogress",
+        sa.Column("program_started_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Earliest habit start date per user (a DATE — midnight is the right
+    # anchor semantics), else the per-stage timestamp.  A correlated
+    # subquery keeps this portable across Postgres and SQLite.
+    op.execute(
+        sa.text(
+            """
+            UPDATE stageprogress
+            SET program_started_at = COALESCE(
+                (
+                    SELECT MIN(habit.start_date)
+                    FROM habit
+                    WHERE habit.user_id = stageprogress.user_id
+                ),
+                stageprogress.stage_started_at
+            )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Drop the anchor column; gating reverts to advancement/completion only."""
+    op.drop_column("stageprogress", "program_started_at")

--- a/backend/migrations/versions/18c9d0e1f2a3_add_program_started_at.py
+++ b/backend/migrations/versions/18c9d0e1f2a3_add_program_started_at.py
@@ -55,6 +55,15 @@ def upgrade() -> None:
     )
 
 
+    # Issue #386 guard: TOTAL_STAGES was corrected from 36 (a week/stage
+    # conflation) to the seeded curriculum's 10.  Any row that advanced
+    # into the phantom range under the old bound is clamped to the real
+    # final stage so reads, gating, and the tightened schema validation
+    # all agree.  (``completed_stages`` may retain phantom entries — they
+    # are cosmetic and never gate anything.)
+    op.execute(sa.text("UPDATE stageprogress SET current_stage = 10 WHERE current_stage > 10"))
+
+
 def downgrade() -> None:
     """Drop the anchor column; gating reverts to advancement/completion only."""
     op.drop_column("stageprogress", "program_started_at")

--- a/backend/src/domain/constants.py
+++ b/backend/src/domain/constants.py
@@ -6,9 +6,21 @@ curriculum length without triggering a ``schemas <-> domain`` import cycle.
 
 from __future__ import annotations
 
-# Declared length of the APTITUDE curriculum.  Router-level stage mutations
-# clamp their inputs to this range and callers use it to detect the
+# Number of stages in the APTITUDE curriculum, matching the rows seeded by
+# :mod:`seed_stages` (stages 1..10).  Router-level stage mutations clamp
+# their inputs to this range and callers use it to detect the
 # "everything is done" boundary.  Re-exported as ``TOTAL_STAGES`` from
 # :mod:`domain.stage_progress` and aliased as ``MAX_STAGE_NUMBER`` by the
-# Pydantic schemas.
-TOTAL_STAGES = 36
+# Pydantic schemas.  (Issue #386: the previous value, 36, conflated the
+# 36-week calendar with the 10-stage curriculum.)
+TOTAL_STAGES = 10
+
+# Days each stage lasts, in stage order — eight 3-week stages followed by
+# two 6-week integration stages.  CROSS-STACK CONTRACT (issue #386): this
+# tuple mirrors ``STAGE_DURATIONS_DAYS`` in
+# ``frontend/src/constants/program.ts`` literal-for-literal; both stacks
+# pin it with tests, so a schedule change must touch both files together.
+STAGE_DURATIONS_DAYS: tuple[int, ...] = (21, 21, 21, 21, 21, 21, 21, 21, 42, 42)
+
+# 252 days — exactly the 36-week curriculum (sum of the stage durations).
+TOTAL_PROGRAM_DAYS = sum(STAGE_DURATIONS_DAYS)

--- a/backend/src/domain/program_calendar.py
+++ b/backend/src/domain/program_calendar.py
@@ -1,0 +1,72 @@
+"""Date-derived program calendar — the backend mirror of the frontend anchor.
+
+Issue #386: PR #384 made the frontend treat one program-start anchor as
+canonical — every screen derives stage/week from
+``programStartDate`` + ``STAGE_DURATIONS_DAYS``.  The backend's gating
+used different models (prompt-completion counts for weeks, the validated
+advancement chain for stages), so the server could 403 a week or stage
+the calendar says is open.  These helpers compute the same calendar
+server-side; the gating call sites combine them with the existing models
+via ``max(...)`` so time can OPEN access but never revoke what
+advancement already granted — and never let a client skip past the
+calendar.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from domain.constants import STAGE_DURATIONS_DAYS, TOTAL_STAGES
+from domain.weekly_prompts import TOTAL_WEEKS
+
+if TYPE_CHECKING:
+    from models.stage_progress import StageProgress
+
+_DAYS_PER_WEEK = 7
+
+
+def _normalize(moment: datetime) -> datetime:
+    """Strip tzinfo so naive (SQLite) and aware (Postgres) values compare.
+
+    Both dialects store UTC; only the tzinfo flag differs (issue #412
+    class).  Subtracting mixed naive/aware datetimes raises, so every
+    calendar computation funnels through this.
+    """
+    return moment.replace(tzinfo=None) if moment.tzinfo else moment
+
+
+def _elapsed_days(anchor: datetime, now: datetime) -> int:
+    """Whole days since the anchor, floored at zero for clock skew."""
+    delta = _normalize(now) - _normalize(anchor)
+    return max(0, delta.days)
+
+
+def calendar_week(anchor: datetime, now: datetime | None = None) -> int:
+    """The 1-based program week ``now`` falls in, clamped to the curriculum."""
+    moment = now if now is not None else datetime.now(UTC)
+    week = _elapsed_days(anchor, moment) // _DAYS_PER_WEEK + 1
+    return min(week, TOTAL_WEEKS)
+
+
+def calendar_stage(anchor: datetime, now: datetime | None = None) -> int:
+    """The 1-based stage ``now`` falls in, walking the duration schedule."""
+    moment = now if now is not None else datetime.now(UTC)
+    remaining = _elapsed_days(anchor, moment)
+    for stage_number, duration in enumerate(STAGE_DURATIONS_DAYS, start=1):
+        if remaining < duration:
+            return stage_number
+        remaining -= duration
+    return TOTAL_STAGES
+
+
+def resolve_program_anchor(progress: StageProgress) -> datetime:
+    """The user's program-start anchor.
+
+    Prefers the stored ``program_started_at`` (set at progress creation
+    and backfilled by migration from the earliest habit start date);
+    legacy rows that pre-date the column fall back to the per-stage
+    ``stage_started_at`` — conservative (later) for anyone past stage 1,
+    which only makes the time gate stricter, never looser.
+    """
+    return progress.program_started_at or progress.stage_started_at

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import cast
 
 from sqlalchemy import func
@@ -96,7 +97,9 @@ async def ensure_user_progress(session: AsyncSession, user_id: int) -> StageProg
     return progress
 
 
-def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool:
+def is_stage_unlocked(
+    stage_number: int, progress: StageProgress | None, now: datetime | None = None
+) -> bool:
     """Return True iff the stage is open by advancement OR by the calendar.
 
     Advancement: ``N <= current_stage``, which only moves via the
@@ -114,7 +117,7 @@ def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool
         return False
     unlocked_through = max(
         progress.current_stage,
-        calendar_stage(resolve_program_anchor(progress)),
+        calendar_stage(resolve_program_anchor(progress), now),
     )
     return stage_number <= unlocked_through
 

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from domain.constants import TOTAL_STAGES
+from domain.program_calendar import calendar_stage, resolve_program_anchor
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.goal import Goal
@@ -96,18 +97,26 @@ async def ensure_user_progress(session: AsyncSession, user_id: int) -> StageProg
 
 
 def is_stage_unlocked(stage_number: int, progress: StageProgress | None) -> bool:
-    """Return True iff ``N <= current_stage`` (or N is stage 1).
+    """Return True iff the stage is open by advancement OR by the calendar.
 
-    Relies on the invariant that ``current_stage`` is only advanced via
-    the validated router path (advance must equal ``current + 1``); a
-    direct DB write that bumps ``current_stage`` would unlock prior
-    stages without their prerequisites being completed.
+    Advancement: ``N <= current_stage``, which only moves via the
+    validated router path (advance must equal ``current + 1``).
+    Calendar (issue #386): ``N <= calendar_stage(anchor)``, the same
+    date-derived schedule the frontend renders, so the server never 403s
+    a stage the user can see is open.  ``max`` of the two means time can
+    OPEN stages but never revoke advancement-granted access — and the
+    calendar itself is server-computed, so a client cannot skip ahead of
+    the schedule.
     """
     if stage_number == _STAGE_1:
         return True
     if progress is None:
         return False
-    return stage_number <= progress.current_stage
+    unlocked_through = max(
+        progress.current_stage,
+        calendar_stage(resolve_program_anchor(progress)),
+    )
+    return stage_number <= unlocked_through
 
 
 def next_stage_for(progress: StageProgress | None) -> int:

--- a/backend/src/models/stage_progress.py
+++ b/backend/src/models/stage_progress.py
@@ -22,5 +22,15 @@ class StageProgress(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
+    # Program-wide start anchor (issue #386): the single date every
+    # stage/week calendar derivation keys off, mirroring the frontend's
+    # ``programStartDate``.  Nullable for legacy rows; the migration
+    # backfills from the earliest habit start date (else
+    # ``stage_started_at``), and ``resolve_program_anchor`` falls back at
+    # read time for anything the backfill missed.
+    program_started_at: datetime | None = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
     user_id: int = Field(foreign_key="user.id", unique=True, ondelete="CASCADE")
     user: "User" = Relationship(back_populates="stage_progress")

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -13,6 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from domain.program_calendar import calendar_week, resolve_program_anchor
+from domain.stage_progress import get_user_progress
 from domain.weekly_prompts import TOTAL_WEEKS, get_prompt_for_week
 from errors import conflict, forbidden, not_found, unprocessable
 from models.journal_entry import JournalEntry, JournalTag
@@ -32,22 +34,29 @@ router = APIRouter(prefix="/prompts", tags=["prompts"])
 
 
 async def _get_user_week(session: AsyncSession, user_id: int) -> int:
-    """Derive the user's current week from the count of completed prompts.
+    """The user's current week: completion-derived OR calendar, whichever leads.
 
-    Switching from ``max(week_number) + 1`` to ``count(responses) + 1``
-    closes the skip-ahead vector where a single POST to
-    ``/prompts/36/respond`` would set ``max = 36`` and advance the user
-    past every intermediate week.  Because the submit endpoint now rejects
-    any ``week_number > user_week`` (see :func:`_check_week_unlocked`),
-    the count only ever equals the number of contiguously completed weeks,
-    so ``count + 1`` is the first unfinished week.  The result is clamped
-    to ``[1, TOTAL_WEEKS]``.
+    Completion model: ``count(responses) + 1`` — the count only ever
+    equals the number of contiguously completed weeks (the submit
+    endpoint rejects ``week_number > user_week``), so ``count + 1`` is
+    the first unfinished week and a single POST cannot skip ahead.
+
+    Calendar model (issue #386): ``calendar_week(program anchor)`` — the
+    same date-derived schedule the frontend renders, so a user eight days
+    into the program can read week 2 without having answered week 1.
+
+    ``max`` of the two: time opens weeks, completions can run ahead of a
+    backdated anchor, and both are server-computed so neither adds a
+    skip-ahead vector.  Clamped to ``[1, TOTAL_WEEKS]``.
     """
     result = await session.execute(
         select(func.count()).select_from(PromptResponse).where(PromptResponse.user_id == user_id)
     )
     completed = int(result.scalar() or 0)
-    return int(max(1, min(completed + 1, TOTAL_WEEKS)))
+    completion_week = completed + 1
+    progress = await get_user_progress(session, user_id)
+    time_week = calendar_week(resolve_program_anchor(progress)) if progress else 1
+    return int(max(1, min(max(completion_week, time_week), TOTAL_WEEKS)))
 
 
 async def _check_week_unlocked(session: AsyncSession, user_id: int, week_number: int) -> None:

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -13,6 +13,7 @@ from sqlmodel import col, select
 
 from database import get_session
 from domain.constants import TOTAL_STAGES
+from domain.program_calendar import calendar_stage, calendar_week, resolve_program_anchor
 from domain.stage_progress import (
     compute_stage_progress,
     get_stage_habit_history,
@@ -29,6 +30,7 @@ from routers.auth import get_current_user
 from schemas import Page, PaginationParams, build_page
 from schemas.pagination import paginate_query
 from schemas.stage import (
+    ProgramCalendarResponse,
     StageHistoryResponse,
     StageProgressRecord,
     StageProgressResponse,
@@ -98,6 +100,30 @@ async def list_stages(
     if pagination.paginate:
         return build_page(responses, total, pagination)
     return responses
+
+
+@router.get("/program-calendar", response_model=ProgramCalendarResponse)
+async def get_program_calendar(
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ProgramCalendarResponse:
+    """The server's view of the date-derived program calendar (issue #386).
+
+    Registered ABOVE ``/{stage_number}`` so the static path wins route
+    matching.  A user with no progress row yet sees the day-zero shape.
+    """
+    progress = await get_user_progress(session, current_user)
+    if progress is None:
+        return ProgramCalendarResponse(
+            program_started_at=None, calendar_stage=1, calendar_week=1, current_stage=1
+        )
+    anchor = resolve_program_anchor(progress)
+    return ProgramCalendarResponse(
+        program_started_at=anchor,
+        calendar_stage=calendar_stage(anchor),
+        calendar_week=calendar_week(anchor),
+        current_stage=progress.current_stage,
+    )
 
 
 @router.get("/{stage_number}", response_model=StageResponse)

--- a/backend/src/schemas/stage.py
+++ b/backend/src/schemas/stage.py
@@ -28,6 +28,23 @@ class StageResponse(BaseModel):
     progress: float = 0.0
 
 
+class ProgramCalendarResponse(BaseModel):
+    """The server's date-derived program calendar (issue #386).
+
+    Exposes the anchor and both gating views so the frontend can drop its
+    client-only fallback if desired: ``calendar_stage``/``calendar_week``
+    are derived from ``program_started_at`` against the shared
+    ``STAGE_DURATIONS_DAYS`` schedule; ``current_stage`` is the
+    advancement-chain value.  Effective unlock is the max of the two —
+    the same reconciliation the gating endpoints apply.
+    """
+
+    program_started_at: datetime | None
+    calendar_stage: int
+    calendar_week: int
+    current_stage: int
+
+
 class StageProgressResponse(BaseModel):
     """Detailed progress breakdown for a single stage."""
 

--- a/backend/tests/test_program_calendar.py
+++ b/backend/tests/test_program_calendar.py
@@ -1,0 +1,122 @@
+"""Tests for the program-calendar domain (issue #386).
+
+The frontend (#384) made the date-derived calendar canonical for display:
+``programWeek()`` / ``programStage()`` walk ``STAGE_DURATIONS_DAYS``
+against one program-start anchor.  These tests pin the backend mirror of
+that math plus the cross-stack constants contract, so server gating can
+agree with what the user sees.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from domain.constants import STAGE_DURATIONS_DAYS, TOTAL_PROGRAM_DAYS, TOTAL_STAGES
+from domain.program_calendar import calendar_stage, calendar_week, resolve_program_anchor
+from domain.weekly_prompts import TOTAL_WEEKS
+from models.stage_progress import StageProgress
+
+_ANCHOR = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _at(days: int) -> datetime:
+    """Moment ``days`` after the anchor (mid-day to dodge boundary jitter)."""
+    return _ANCHOR + timedelta(days=days, hours=12)
+
+
+# ── Cross-stack constants contract ──────────────────────────────────────
+
+
+def test_stage_durations_mirror_the_frontend_contract() -> None:
+    """One schedule, two stacks (issue #386).
+
+    ``frontend/src/constants/program.ts`` declares
+    ``STAGE_DURATIONS_DAYS = [21 x 8, 42 x 2]``.  This pins the backend copy
+    to the identical literals so the two cannot drift silently; any
+    schedule change must touch both files and both pins.
+    """
+    assert STAGE_DURATIONS_DAYS == (21, 21, 21, 21, 21, 21, 21, 21, 42, 42)
+    assert len(STAGE_DURATIONS_DAYS) == TOTAL_STAGES
+    assert sum(STAGE_DURATIONS_DAYS) == TOTAL_PROGRAM_DAYS
+    # 252 days == exactly the 36-week curriculum.
+    assert TOTAL_PROGRAM_DAYS == TOTAL_WEEKS * 7
+
+
+def test_total_stages_matches_the_seeded_curriculum() -> None:
+    """The curriculum seeds stages 1..10 — TOTAL_STAGES must agree.
+
+    The previous value (36) conflated weeks with stages, letting
+    ``current_stage`` advance past every real stage and schema payloads
+    carry phantom stage numbers.
+    """
+    assert TOTAL_STAGES == 10
+
+
+# ── calendar_week ───────────────────────────────────────────────────────
+
+
+def test_calendar_week_boundaries() -> None:
+    assert calendar_week(_ANCHOR, _at(0)) == 1
+    assert calendar_week(_ANCHOR, _at(6)) == 1
+    assert calendar_week(_ANCHOR, _at(7)) == 2
+    assert calendar_week(_ANCHOR, _at(245)) == 36
+    assert calendar_week(_ANCHOR, _at(251)) == 36
+
+
+def test_calendar_week_clamps_outside_the_program() -> None:
+    assert calendar_week(_ANCHOR, _at(252)) == TOTAL_WEEKS
+    assert calendar_week(_ANCHOR, _at(10_000)) == TOTAL_WEEKS
+    # A clock-skewed pre-anchor moment clamps to week 1, never 0/negative.
+    assert calendar_week(_ANCHOR, _ANCHOR - timedelta(days=3)) == 1
+
+
+def test_calendar_week_accepts_naive_anchor() -> None:
+    """SQLite returns naive datetimes; the math must not raise (issue #412 class)."""
+    naive_anchor = _ANCHOR.replace(tzinfo=None)
+    assert calendar_week(naive_anchor, _at(7)) == 2
+
+
+# ── calendar_stage ──────────────────────────────────────────────────────
+
+
+def test_calendar_stage_walks_the_duration_schedule() -> None:
+    assert calendar_stage(_ANCHOR, _at(0)) == 1
+    assert calendar_stage(_ANCHOR, _at(20)) == 1
+    assert calendar_stage(_ANCHOR, _at(21)) == 2
+    assert calendar_stage(_ANCHOR, _at(167)) == 8
+    assert calendar_stage(_ANCHOR, _at(168)) == 9
+    assert calendar_stage(_ANCHOR, _at(209)) == 9
+    assert calendar_stage(_ANCHOR, _at(210)) == 10
+    assert calendar_stage(_ANCHOR, _at(251)) == 10
+
+
+def test_calendar_stage_clamps_outside_the_program() -> None:
+    assert calendar_stage(_ANCHOR, _at(252)) == TOTAL_STAGES
+    assert calendar_stage(_ANCHOR, _at(10_000)) == TOTAL_STAGES
+    assert calendar_stage(_ANCHOR, _ANCHOR - timedelta(days=3)) == 1
+
+
+# ── resolve_program_anchor ──────────────────────────────────────────────
+
+
+def test_resolve_anchor_prefers_stored_program_start() -> None:
+    progress = StageProgress(
+        user_id=1,
+        current_stage=1,
+        completed_stages=[],
+        stage_started_at=_at(30),
+        program_started_at=_ANCHOR,
+    )
+    assert resolve_program_anchor(progress) == _ANCHOR
+
+
+def test_resolve_anchor_falls_back_to_stage_started_at() -> None:
+    """Legacy rows (pre-migration) anchor on the per-stage timestamp."""
+    progress = StageProgress(
+        user_id=1,
+        current_stage=1,
+        completed_stages=[],
+        stage_started_at=_ANCHOR,
+        program_started_at=None,
+    )
+    assert resolve_program_anchor(progress) == _ANCHOR

--- a/backend/tests/test_program_gating.py
+++ b/backend/tests/test_program_gating.py
@@ -155,3 +155,11 @@ async def test_program_calendar_endpoint_day_zero_shape_without_progress(
     assert body["calendar_stage"] == 1
     assert body["calendar_week"] == 1
     assert body["current_stage"] == 1
+
+
+def test_is_stage_unlocked_accepts_an_explicit_now() -> None:
+    """PR #432 review: deterministic clock injection, matching the calendar API."""
+    progress = _progress_at(0, current_stage=1)
+    later = datetime.now(UTC) + timedelta(days=22)
+    assert is_stage_unlocked(2, progress, now=later) is True
+    assert is_stage_unlocked(3, progress, now=later) is False

--- a/backend/tests/test_program_gating.py
+++ b/backend/tests/test_program_gating.py
@@ -1,0 +1,157 @@
+"""Gating reconciliation tests for the program-start anchor (issue #386).
+
+The calendar can OPEN weeks and stages the user hasn't manually advanced
+to, but never beyond the schedule — and advancement-derived access is
+never revoked.  ``max(advancement, calendar)`` on both gates.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from domain.stage_progress import is_stage_unlocked
+from models.stage_progress import StageProgress
+from models.user import User
+
+
+async def _signup(client: AsyncClient, username: str = "anchored") -> dict[str, str]:
+    """Create a user and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _plant_progress(
+    session: AsyncSession, *, days_into_program: int, current_stage: int = 1
+) -> StageProgress:
+    """Create a StageProgress row anchored ``days_into_program`` days ago."""
+    user = (await session.execute(select(User))).scalars().first()
+    assert user is not None
+    assert user.id is not None
+    anchor = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days_into_program)
+    progress = StageProgress(
+        user_id=user.id,
+        current_stage=current_stage,
+        completed_stages=[],
+        stage_started_at=anchor,
+        program_started_at=anchor,
+    )
+    session.add(progress)
+    await session.commit()
+    await session.refresh(progress)
+    return progress
+
+
+# ── Week gate (prompts) ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_calendar_opens_weeks_without_prompt_completions(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Eight days in with zero responses, week 2 is readable (was 403)."""
+    headers = await _signup(async_client)
+    await _plant_progress(db_session, days_into_program=8)
+
+    week2 = await async_client.get("/prompts/2", headers=headers)
+    assert week2.status_code == HTTPStatus.OK
+
+    # The calendar says week 2 — week 3 stays locked: no skip-ahead.
+    week3 = await async_client.get("/prompts/3", headers=headers)
+    assert week3.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_completion_derived_week_still_governs_without_anchor_lead(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Day 0 of the program: only week 1 is open — the old contract holds."""
+    headers = await _signup(async_client)
+    await _plant_progress(db_session, days_into_program=0)
+
+    week1 = await async_client.get("/prompts/1", headers=headers)
+    assert week1.status_code == HTTPStatus.OK
+    week2 = await async_client.get("/prompts/2", headers=headers)
+    assert week2.status_code == HTTPStatus.FORBIDDEN
+
+
+# ── Stage gate (domain) ─────────────────────────────────────────────────
+
+
+def _progress_at(days: int, current_stage: int = 1) -> StageProgress:
+    anchor = datetime.now(UTC) - timedelta(days=days)
+    return StageProgress(
+        user_id=1,
+        current_stage=current_stage,
+        completed_stages=[],
+        stage_started_at=anchor,
+        program_started_at=anchor,
+    )
+
+
+def test_calendar_unlocks_stage_without_advancement() -> None:
+    """22 days in, stage 2 opens by time alone; stage 3 stays locked."""
+    progress = _progress_at(22, current_stage=1)
+    assert is_stage_unlocked(2, progress) is True
+    assert is_stage_unlocked(3, progress) is False
+
+
+def test_advancement_unlock_is_never_revoked_by_the_calendar() -> None:
+    """A user who advanced to stage 4 on day 1 keeps every unlocked stage."""
+    progress = _progress_at(1, current_stage=4)
+    for stage in (1, 2, 3, 4):
+        assert is_stage_unlocked(stage, progress) is True
+    assert is_stage_unlocked(5, progress) is False
+
+
+def test_missing_progress_still_locks_everything_past_stage_one() -> None:
+    assert is_stage_unlocked(1, None) is True
+    assert is_stage_unlocked(2, None) is False
+
+
+# ── Anchor exposure ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_program_calendar_endpoint_exposes_anchor_and_derivations(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _signup(async_client, "calendarreader")
+    await _plant_progress(db_session, days_into_program=22, current_stage=1)
+
+    resp = await async_client.get("/stages/program-calendar", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["program_started_at"] is not None
+    assert body["calendar_stage"] == 2
+    assert body["calendar_week"] == 4
+    assert body["current_stage"] == 1
+
+
+@pytest.mark.asyncio
+async def test_program_calendar_endpoint_day_zero_shape_without_progress(
+    async_client: AsyncClient,
+) -> None:
+    headers = await _signup(async_client, "freshcalendar")
+
+    resp = await async_client.get("/stages/program-calendar", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["program_started_at"] is None
+    assert body["calendar_stage"] == 1
+    assert body["calendar_week"] == 1
+    assert body["current_stage"] == 1

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -11,6 +11,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
+from domain.constants import TOTAL_STAGES
 from models.course_stage import CourseStage
 from models.practice import Practice
 from models.practice_session import PracticeSession
@@ -492,24 +493,31 @@ async def test_update_progress_advances_from_current_stage_only(
 async def test_advance_returns_409_when_all_stages_completed(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """Advancing past the final stage must 409 instead of re-issuing 36.
+    """Advancing past the final stage must 409 instead of re-issuing it.
 
     When the user already has ``completed_stages`` covering the full
     curriculum, ``next_stage_for`` has no hole to fill and
     ``raise conflict('all_stages_completed')`` stops the request before it
-    writes nonsense state.
+    writes nonsense state.  (Issue #386 corrected ``TOTAL_STAGES`` from 36
+    — a week/stage conflation — to the seeded curriculum's 10; this test
+    now exercises the true boundary.)
     """
     headers, user_id = await _signup(async_client, "finished")
     # Canonical "current_stage == N implies completed_stages == {1..N-1}" shape.
-    # The router simulates marking current_stage=36 complete on a candidate,
-    # so candidate_completed becomes {1..36}; next_stage_for has no hole and 409s.
-    progress = StageProgress(user_id=user_id, current_stage=36, completed_stages=list(range(1, 36)))
+    # The router simulates marking the final stage complete on a candidate,
+    # so candidate_completed covers the whole curriculum; next_stage_for has
+    # no hole and 409s.
+    progress = StageProgress(
+        user_id=user_id,
+        current_stage=TOTAL_STAGES,
+        completed_stages=list(range(1, TOTAL_STAGES)),
+    )
     db_session.add(progress)
     await db_session.commit()
 
     resp = await async_client.put(
         "/stages/progress",
-        json={"current_stage": 36},
+        json={"current_stage": TOTAL_STAGES},
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.CONFLICT


### PR DESCRIPTION
## Summary

- Gives the backend the single program-start anchor the frontend made canonical in #384, so server gating and the user's screens finally agree (issue #386): `StageProgress.program_started_at` (nullable, defaulted at creation) + an Alembic migration backfilling existing rows from the **earliest habit start date** — the same source as the frontend's onboarding anchor — falling back to `stage_started_at` (conservative: only ever stricter).
- New `domain/program_calendar`: `calendar_week` / `calendar_stage` walk `STAGE_DURATIONS_DAYS` against the anchor (dialect-safe naive/aware handling), with `resolve_program_anchor` covering legacy rows.
- **Gating policy — `max(advancement, calendar)` on both gates.** The product call was already made in #384 (calendar is canonical for what users see); `max` reconciles it with the existing security invariants: time *opens* weeks/stages on schedule, advancement-granted access is never revoked, and both inputs are server-computed so no skip-ahead vector is added (`_check_week_unlocked` and the stage chain validation are untouched).
- **Cross-stack constants contract:** backend `STAGE_DURATIONS_DAYS` mirrors `frontend/src/constants/program.ts` literal-for-literal, pinned by tests on both stacks (sum = 252 days = exactly the 36-week curriculum). Along the way: `TOTAL_STAGES` corrected from **36 to 10** — the old value conflated weeks with stages, letting `current_stage` advance past every real stage and schemas accept phantom stage numbers; the one test built on the old constant now exercises the true boundary via the constant.
- `GET /stages/program-calendar` (registered above `/{stage_number}`) exposes the anchor plus both derived views so the frontend can drop its client-only fallback if desired.

## Test plan

- 16 new tests: calendar math boundaries/clamps (week 1→36, stage 1→10 across the 21/42-day schedule, pre-anchor clock skew, naive-anchor safety), anchor resolution precedence, the constants contract, week-gate time-unlock (day 8 → week 2 readable, week 3 still 403), day-zero no-regression, stage-gate time-unlock + advancement-never-revoked + missing-progress lockout, and both shapes of the new endpoint.
- Existing prompts (31) and stages (31) suites pass; full backend 94.36% coverage; xenon all-A; `pre-commit run --all-files` exit 0 (TZ=UTC).
- The migration's round-trip + drift check runs in this PR's `migration-drift` job against live Postgres.

Closes #386
Refs #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
