### PR TITLE
docs(backend): ratify git-content architecture + freeze manifest contract

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         files: ^backend/
         exclude: ^backend/migrations/
         args: ["--config-file=backend/pyproject.toml"]
-        additional_dependencies: ["types-cachetools", "types-requests", "types-beautifulsoup4", "beautifulsoup4", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "slowapi", "limits", "alembic"]
+        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "types-beautifulsoup4", "beautifulsoup4", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "slowapi", "limits", "alembic"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/backend/content/manifest.example.json
+++ b/backend/content/manifest.example.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1.0.0",
+  "chapters": [
+    {
+      "id": "beige-1",
+      "stage": 1,
+      "chapter": 1,
+      "slug": "survival",
+      "title": "Survival",
+      "content_type": "chapter",
+      "release_day": 0,
+      "order": 1,
+      "path": "markdown/01-beige/01-survival.md",
+      "summary": "Active yes-and-ness: the body's first intelligence."
+    },
+    {
+      "id": "beige-2",
+      "stage": 1,
+      "chapter": 2,
+      "slug": "breath-as-anchor",
+      "title": "Breath as Anchor",
+      "content_type": "essay",
+      "release_day": 3,
+      "order": 2,
+      "path": "markdown/01-beige/02-breath-as-anchor.md",
+      "media": ["markdown/01-beige/assets/breath-diagram.png"]
+    }
+  ],
+  "site_resources": [
+    {
+      "slug": "getting-started",
+      "title": "Getting Started",
+      "description": "Orientation guide for new practitioners.",
+      "path": "markdown/site/getting-started.md"
+    }
+  ]
+}

--- a/backend/content/manifest.schema.json
+++ b/backend/content/manifest.schema.json
@@ -5,7 +5,11 @@
   "description": "Frozen contract between the aptitude-course content repo (which generates this manifest from per-file YAML frontmatter) and the adepthood backend (which vendors and reads it). Changing this schema post-merge requires a schema_version bump and a note in docs/adr/0001-git-content-pipeline.md (issue #389).",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "chapters", "site_resources"],
+  "required": [
+    "schema_version",
+    "chapters",
+    "site_resources"
+  ],
   "properties": {
     "schema_version": {
       "description": "Semver of this contract. Readers must reject manifests with a different major version.",
@@ -14,19 +18,33 @@
     },
     "chapters": {
       "type": "array",
-      "items": { "$ref": "#/$defs/chapter" }
+      "items": {
+        "$ref": "#/$defs/chapter"
+      }
     },
     "site_resources": {
       "description": "Free site resources, mirroring the legacy SITE_RESOURCES table.",
       "type": "array",
-      "items": { "$ref": "#/$defs/site_resource" }
+      "items": {
+        "$ref": "#/$defs/site_resource"
+      }
     }
   },
   "$defs": {
     "chapter": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "stage", "chapter", "slug", "title", "content_type", "release_day", "order", "path"],
+      "required": [
+        "id",
+        "stage",
+        "chapter",
+        "slug",
+        "title",
+        "content_type",
+        "release_day",
+        "order",
+        "path"
+      ],
       "properties": {
         "id": {
           "description": "Stable identifier, e.g. 'beige-1'. Never reused or renumbered.",
@@ -34,7 +52,7 @@
           "minLength": 1
         },
         "stage": {
-          "description": "Curriculum stage 1..10 — identical numbering in both repos (see the ADR's stage-numbering reconciliation).",
+          "description": "Curriculum stage 1..10 \u2014 identical numbering in both repos (see the ADR's stage-numbering reconciliation).",
           "type": "integer",
           "minimum": 1,
           "maximum": 10
@@ -44,11 +62,22 @@
           "type": "integer",
           "minimum": 1
         },
-        "slug": { "type": "string", "minLength": 1 },
-        "title": { "type": "string", "minLength": 1 },
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
         "content_type": {
           "type": "string",
-          "enum": ["chapter", "essay", "prompt", "video"]
+          "enum": [
+            "chapter",
+            "essay",
+            "prompt",
+            "video"
+          ]
         },
         "release_day": {
           "description": "Days after the stage start when this item drips open (0 = immediately).",
@@ -56,7 +85,7 @@
           "minimum": 0
         },
         "order": {
-          "description": "Display order within the stage.",
+          "description": "Display order within the stage (ascending). Distinct from 'chapter': 'order' may interleave essays/prompts/videos between chapters; ties are resolved by 'chapter' then 'id'.",
           "type": "integer",
           "minimum": 0
         },
@@ -65,22 +94,44 @@
           "type": "string",
           "minLength": 1
         },
-        "summary": { "type": "string" },
+        "summary": {
+          "type": "string"
+        },
         "media": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     },
     "site_resource": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["slug", "title", "description", "path"],
+      "required": [
+        "slug",
+        "title",
+        "description",
+        "path"
+      ],
       "properties": {
-        "slug": { "type": "string", "minLength": 1 },
-        "title": { "type": "string", "minLength": 1 },
-        "description": { "type": "string" },
-        "path": { "type": "string", "minLength": 1 }
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable blurb. Deliberately allowed to be empty (unlike title/slug) \u2014 a resource may not need one."
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     }
   }

--- a/backend/content/manifest.schema.json
+++ b/backend/content/manifest.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Geoffe-Ga/adepthood/backend/content/manifest.schema.json",
+  "title": "APTITUDE content manifest",
+  "description": "Frozen contract between the aptitude-course content repo (which generates this manifest from per-file YAML frontmatter) and the adepthood backend (which vendors and reads it). Changing this schema post-merge requires a schema_version bump and a note in docs/adr/0001-git-content-pipeline.md (issue #389).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "chapters", "site_resources"],
+  "properties": {
+    "schema_version": {
+      "description": "Semver of this contract. Readers must reject manifests with a different major version.",
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "chapters": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/chapter" }
+    },
+    "site_resources": {
+      "description": "Free site resources, mirroring the legacy SITE_RESOURCES table.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/site_resource" }
+    }
+  },
+  "$defs": {
+    "chapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "stage", "chapter", "slug", "title", "content_type", "release_day", "order", "path"],
+      "properties": {
+        "id": {
+          "description": "Stable identifier, e.g. 'beige-1'. Never reused or renumbered.",
+          "type": "string",
+          "minLength": 1
+        },
+        "stage": {
+          "description": "Curriculum stage 1..10 — identical numbering in both repos (see the ADR's stage-numbering reconciliation).",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "chapter": {
+          "description": "1-based chapter number within the stage.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "slug": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "content_type": {
+          "type": "string",
+          "enum": ["chapter", "essay", "prompt", "video"]
+        },
+        "release_day": {
+          "description": "Days after the stage start when this item drips open (0 = immediately).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "order": {
+          "description": "Display order within the stage.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "path": {
+          "description": "Markdown path relative to the content repo root, e.g. 'markdown/01-beige/01-survival.md'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": { "type": "string" },
+        "media": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "site_resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slug", "title", "description", "path"],
+      "properties": {
+        "slug": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "path": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -7,8 +7,8 @@ pre-commit
 pytest
 pytest-cov
 # JSON Schema validation for the content manifest contract (issue #389).
-jsonschema
-types-jsonschema
+jsonschema>=4.0
+types-jsonschema>=4.0
 radon>=6.0
 ruff
 vulture>=2.13

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -6,6 +6,9 @@ mypy
 pre-commit
 pytest
 pytest-cov
+# JSON Schema validation for the content manifest contract (issue #389).
+jsonschema
+types-jsonschema
 radon>=6.0
 ruff
 vulture>=2.13

--- a/backend/tests/test_manifest_schema.py
+++ b/backend/tests/test_manifest_schema.py
@@ -1,0 +1,89 @@
+"""Contract tests for the content manifest schema (issue #389).
+
+The manifest is the frozen interface between the ``aptitude-course``
+content repo and this app: the content repo's frontmatter generates it,
+the sync script vendors it, and the backend reader consumes it.  These
+tests pin the contract — the example document must validate, and the
+schema must actually reject malformed manifests (a vacuously-permissive
+schema would "pass" everything and protect nothing).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+_CONTENT_DIR = Path(__file__).resolve().parent.parent / "content"
+_SCHEMA_PATH = _CONTENT_DIR / "manifest.schema.json"
+_EXAMPLE_PATH = _CONTENT_DIR / "manifest.example.json"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    with path.open() as f:
+        return cast("dict[str, Any]", json.load(f))
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    """The manifest JSON Schema, checked for self-validity once."""
+    document = _load(_SCHEMA_PATH)
+    Draft202012Validator.check_schema(document)
+    return document
+
+
+@pytest.fixture(scope="module")
+def example() -> dict[str, Any]:
+    return _load(_EXAMPLE_PATH)
+
+
+def test_example_manifest_validates(schema: dict[str, Any], example: dict[str, Any]) -> None:
+    """The shipped example is a conforming manifest — downstream tests build on it."""
+    Draft202012Validator(schema).validate(example)
+
+
+def test_example_covers_the_contract_surface(example: dict[str, Any]) -> None:
+    """Per the issue: one stage, two chapters, one site resource."""
+    assert len(example["chapters"]) == 2
+    assert len({c["stage"] for c in example["chapters"]}) == 1
+    assert len(example["site_resources"]) == 1
+    # Semver, the contract's change-control handle.
+    major, minor, patch = example["schema_version"].split(".")
+    assert all(part.isdigit() for part in (major, minor, patch))
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda m: m.pop("schema_version"), id="missing schema_version"),
+        pytest.param(lambda m: m.pop("chapters"), id="missing chapters"),
+        pytest.param(lambda m: m["chapters"][0].pop("id"), id="chapter missing id"),
+        pytest.param(lambda m: m["chapters"][0].pop("path"), id="chapter missing path"),
+        pytest.param(
+            lambda m: m["chapters"][0].update(content_type="podcast"),
+            id="content_type outside the enum",
+        ),
+        pytest.param(lambda m: m["chapters"][0].update(stage=0), id="stage below 1"),
+        pytest.param(
+            lambda m: m["chapters"][0].update(stage=11),
+            id="stage above the 10-stage curriculum",
+        ),
+        pytest.param(lambda m: m["chapters"][0].update(release_day=-1), id="negative release_day"),
+        pytest.param(lambda m: m.update(surprise_field=True), id="unknown top-level field"),
+    ],
+)
+def test_schema_rejects_malformed_manifests(
+    schema: dict[str, Any],
+    example: dict[str, Any],
+    mutate: Callable[[dict[str, Any]], object],
+) -> None:
+    """The schema must have teeth — each mutation must fail validation."""
+    broken = json.loads(json.dumps(example))
+    mutate(broken)
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(broken)

--- a/backend/tests/test_manifest_schema.py
+++ b/backend/tests/test_manifest_schema.py
@@ -75,6 +75,11 @@ def test_example_covers_the_contract_surface(example: dict[str, Any]) -> None:
         ),
         pytest.param(lambda m: m["chapters"][0].update(release_day=-1), id="negative release_day"),
         pytest.param(lambda m: m.update(surprise_field=True), id="unknown top-level field"),
+        pytest.param(lambda m: m["site_resources"][0].pop("slug"), id="site resource missing slug"),
+        pytest.param(
+            lambda m: m["site_resources"][0].update(extra=True),
+            id="site resource unknown field",
+        ),
     ],
 )
 def test_schema_rejects_malformed_manifests(

--- a/docs/adr/0001-git-content-pipeline.md
+++ b/docs/adr/0001-git-content-pipeline.md
@@ -1,0 +1,99 @@
+# ADR 0001: Git-based content pipeline for course material
+
+- **Status:** Accepted
+- **Date:** 2026-06-10
+- **Issue:** [#389](https://github.com/Geoffe-Ga/adepthood/issues/389) (epic [#388](https://github.com/Geoffe-Ga/adepthood/issues/388))
+
+## Context
+
+Course content (219 Markdown files across 10 stages) lives in
+[`Geoffe-Ga/aptitude-course`](https://github.com/Geoffe-Ga/aptitude-course).
+Today the app reaches it through `services/squarespace.py` plus a
+hardcoded `content_config.STAGE_PLANS` covering stage 1 only — a
+scraping dependency on a CMS we are leaving. This ADR ratifies how the
+app consumes the git-hosted content and freezes the manifest contract
+every downstream cms-migration issue builds on.
+
+## Decision 1 — The app gets content by vendoring a pinned commit
+
+A sync script (`scripts/sync_content.py`, issue #391) copies a pinned
+`aptitude-course` commit into `backend/content/`, which ships inside the
+Railway image. Content updates are a pin bump: explicit, reviewable,
+atomically deployed, and trivially rolled back with the image.
+
+**Rejected — git submodule:** submodules are a recurring footgun for
+both autonomous agents (clone-depth and init ordering) and Railway
+builds (extra checkout configuration), and they pin via repo state that
+tooling routinely fails to update consistently.
+
+**Rejected — runtime fetch from `raw.githubusercontent.com`:** puts a
+network dependency on every content read — precisely the failure mode
+(remote CMS availability coupling) this migration exists to escape.
+
+## Decision 2 — `manifest.json`, generated from per-file YAML frontmatter, is the source of truth
+
+Each Markdown file in the content repo carries YAML frontmatter
+(stage, chapter, slug, title, content type, release day, order); the
+content repo generates `manifest.json` from it. The app treats the
+manifest as the single index for stage → chapter → release-day data.
+
+**Rejected — hardcoded `STAGE_PLANS`:** the thing being deleted; it
+already drifted (stage 1 only) because editing app code to publish
+content couples two release cadences that should be independent.
+
+**Rejected — database-only:** loses git authorship, review, and history
+for content metadata, and adds a write pipeline where a read-only file
+suffices.
+
+## Decision 3 — Raw Markdown plus metadata over the wire
+
+Endpoints serve the Markdown body verbatim with manifest metadata; the
+client renders natively (issue #394 removes the WebView).
+
+**Rejected — server-rendered HTML:** reintroduces the
+sanitising/scraping surface the Squarespace exit removes, and binds
+client presentation to a server template cycle.
+
+## Decision 4 — The content repo stays public
+
+No token, no Railway secret, no auth failure mode in the sync script.
+
+**Rejected — private + GitHub token:** more deployment configuration
+and a new expiring credential, buying nothing for content that is
+already published to end users.
+
+## Stage-numbering reconciliation
+
+**The mapping is identity: content-repo stage N is app stage N, for
+N in 1..10.** The content repo's directories (`01-beige` …
+`10-clearlight`) match the app's seeded `CourseStage` rows (1..10).
+The historical confusion — the app's `TOTAL_STAGES` constant briefly
+said 36 — was a week/stage conflation corrected in issue #386
+(PR #432); the 36-week calendar is a *different axis* (see
+`domain/constants.STAGE_DURATIONS_DAYS`: eight 21-day stages plus two
+42-day stages = 252 days = 36 weeks). The manifest schema enforces
+`stage ∈ [1, 10]`; weekly pacing never appears in the manifest.
+
+## The manifest contract
+
+`backend/content/manifest.schema.json` (JSON Schema draft 2020-12) is
+the normative contract; `backend/content/manifest.example.json` is a
+conforming sample used by downstream tests, and
+`backend/tests/test_manifest_schema.py` pins both (the example must
+validate; mutations must fail).
+
+**Change control:** the schema is frozen at `schema_version 1.0.0`.
+Additive optional fields bump the minor version; anything that breaks
+an existing reader bumps the major version, and readers must reject a
+manifest whose major version differs from theirs. Every bump gets a
+dated note appended to this ADR.
+
+## Consequences
+
+- Issues #390–#399 implement against this contract without
+  re-litigating the design.
+- The content repo gains a frontmatter + manifest-generation
+  requirement (tracked in the aptitude-course repo).
+- Content freshness is bounded by pin bumps — an accepted trade
+  against runtime coupling; #397 wires the bump into CI with a drift
+  check.


### PR DESCRIPTION
## Summary

- **ADR 0001** (`docs/adr/0001-git-content-pipeline.md`) ratifies the four cms-migration consumption decisions with one-paragraph rationales each, per the issue's recommended defaults: vendor a pinned commit into `backend/content/` (rejecting submodules and runtime fetches), `manifest.json` generated from per-file YAML frontmatter as the source of truth (rejecting `STAGE_PLANS` and DB-only), raw Markdown + metadata over the wire (rejecting server-rendered HTML), and a public content repo (rejecting token auth).
- **Stage-numbering reconciliation:** the mapping is **identity over 1..10**. The issue's premise that "the app uses 1..36" was the week/stage conflation corrected in #386 (PR #432); the ADR documents the two axes (10 stages vs 36 weeks = 252 days) and the schema enforces `stage ∈ [1, 10]`.
- **The frozen contract:** `manifest.schema.json` (JSON Schema draft 2020-12, `additionalProperties: false` throughout, `schema_version` semver with documented major/minor change control) + `manifest.example.json` (1 stage, 2 chapters, 1 site resource, exercising optional `summary`/`media`).
- No reader/sync implementation — schema + ADR only, per the constraints. `jsonschema` + `types-jsonschema` added to dev requirements and the mypy hook venv.

## Test plan

- `backend/tests/test_manifest_schema.py`: the schema is itself valid 2020-12; the example validates; the example covers the issue-specified surface (2 chapters / 1 stage / 1 resource / semver); and **nine mutation cases** (missing required fields, enum violation, stage bounds 0 and 11, negative release_day, unknown top-level field) each fail validation — proving the contract has teeth rather than being vacuously permissive.
- Full backend suite 94.27% coverage; xenon all-A; `pre-commit run --all-files` exit 0 (TZ=UTC), including strict mypy with the new stubs.

Closes #389
Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)
