### PR TITLE
feat(backend): add ContentRepository backed by vendored local files

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -6,8 +6,7 @@ mypy
 pre-commit
 pytest
 pytest-cov
-# JSON Schema validation for the content manifest contract (issue #389).
-jsonschema>=4.0
+# Type stubs for the runtime jsonschema dependency (issues #389/#390).
 types-jsonschema>=4.0
 radon>=6.0
 ruff

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -117,3 +117,8 @@ uvicorn==0.44.0
     # via -r backend/requirements.txt
 wrapt==2.1.2
     # via deprecated
+attrs==26.1.0
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+referencing==0.37.0
+rpds-py==2026.5.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,8 @@
 # Only used by pip-audit hook in CI; adjust based on your actual deps.
 cachetools
+# Validates backend/content/manifest.json against the frozen contract at
+# startup (issues #389/#390); >=4.0 for JSON Schema draft 2020-12.
+jsonschema>=4.0
 fastapi
 uvicorn
 pydantic

--- a/backend/src/services/content_repository.py
+++ b/backend/src/services/content_repository.py
@@ -1,0 +1,223 @@
+"""Local-file content repository — the git-content replacement for Squarespace.
+
+Issue #390 (epic #388): loads the vendored ``backend/content/manifest.json``
+once, validates it against the frozen contract from issue #389
+(``manifest.schema.json``, ADR 0001), and serves chapter metadata plus raw
+Markdown bodies from disk.  Mirrors :mod:`services.squarespace`'s public
+surface — lazy singleton plus ``*_for_tests`` setters — so the router swap
+(a later issue) is a seam replacement, not a redesign.
+
+Read-only by design: this service never writes to the content directory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+# The manifest's schema ships with the app (it is code, not content), so a
+# mis-vendored content directory cannot substitute a permissive schema.
+_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "content" / "manifest.schema.json"
+
+# Default content root: ``backend/content``, overridable via CONTENT_DIR
+# for deployments that vendor content elsewhere in the image.
+_DEFAULT_CONTENT_DIR = Path(__file__).resolve().parents[2] / "content"
+
+# Major version of the manifest contract this reader understands.  ADR 0001
+# change control: reject manifests whose major version differs.
+_SUPPORTED_SCHEMA_MAJOR = 1
+
+
+class ContentRepositoryError(Exception):
+    """The content directory or manifest is missing, invalid, or unsafe."""
+
+
+class ContentNotFoundError(ContentRepositoryError):
+    """No chapter / resource with the requested identifier exists."""
+
+
+@dataclass(frozen=True)
+class ChapterMeta:
+    """One chapter's manifest metadata (the index entry, not the body)."""
+
+    id: str
+    stage: int
+    chapter: int
+    slug: str
+    title: str
+    content_type: str
+    release_day: int
+    order: int
+    path: str
+    summary: str | None = None
+
+
+@dataclass(frozen=True)
+class ContentBody:
+    """A rendered-ready body: raw Markdown plus the metadata the UI shows."""
+
+    body: str
+    title: str
+    content_type: str
+
+
+def _content_dir_from_env() -> Path:
+    """Resolve the content root from ``CONTENT_DIR`` (default: backend/content)."""
+    override = os.getenv("CONTENT_DIR")
+    return Path(override) if override else _DEFAULT_CONTENT_DIR
+
+
+def _load_json(path: Path, description: str) -> dict[str, Any]:
+    """Read and parse a JSON object file, mapping every failure to a typed error."""
+    try:
+        with path.open() as f:
+            data: object = json.load(f)
+    except FileNotFoundError as exc:
+        msg = f"{description} not found at {path}"
+        raise ContentRepositoryError(msg) from exc
+    except json.JSONDecodeError as exc:
+        msg = f"{description} at {path} is not valid JSON"
+        raise ContentRepositoryError(msg) from exc
+    if not isinstance(data, dict):
+        msg = f"{description} at {path} must be a JSON object"
+        raise ContentRepositoryError(msg)
+    return data
+
+
+class ContentRepository:
+    """Parse-once reader over the vendored content directory.
+
+    Construction loads and validates the manifest; every read after that is
+    an in-memory index lookup plus (for bodies) one local file read.  No
+    TTL cache is needed — the files are local and immutable per deploy.
+    """
+
+    def __init__(self, content_dir: Path | None = None) -> None:
+        """Load and validate the manifest under ``content_dir`` (or CONTENT_DIR)."""
+        self._content_dir = (content_dir or _content_dir_from_env()).resolve()
+        manifest = self._load_and_validate_manifest()
+        self._chapters: dict[str, ChapterMeta] = {}
+        for raw in manifest["chapters"]:
+            meta = ChapterMeta(
+                id=raw["id"],
+                stage=raw["stage"],
+                chapter=raw["chapter"],
+                slug=raw["slug"],
+                title=raw["title"],
+                content_type=raw["content_type"],
+                release_day=raw["release_day"],
+                order=raw["order"],
+                path=raw["path"],
+                summary=raw.get("summary"),
+            )
+            self._chapters[meta.id] = meta
+        self._resources: dict[str, dict[str, Any]] = {
+            r["slug"]: r for r in manifest["site_resources"]
+        }
+
+    def _load_and_validate_manifest(self) -> dict[str, Any]:
+        """Load ``manifest.json`` and enforce the issue #389 contract."""
+        schema = _load_json(_SCHEMA_PATH, "manifest schema")
+        manifest = _load_json(self._content_dir / "manifest.json", "content manifest")
+        try:
+            Draft202012Validator(schema).validate(manifest)
+        except ValidationError as exc:
+            msg = f"content manifest violates the contract: {exc.message}"
+            raise ContentRepositoryError(msg) from exc
+        major = int(manifest["schema_version"].split(".")[0])
+        if major != _SUPPORTED_SCHEMA_MAJOR:
+            msg = (
+                f"content manifest schema_version major {major} is not the "
+                f"supported major {_SUPPORTED_SCHEMA_MAJOR} (ADR 0001 change control)"
+            )
+            raise ContentRepositoryError(msg)
+        return manifest
+
+    def _read_markdown(self, rel_path: str) -> str:
+        """Read a Markdown file, enforcing the in-directory guard.
+
+        The LFI guard analogous to the old client's ``_validate_url``: a
+        manifest ``path`` must resolve INSIDE the content directory, so a
+        compromised or mis-generated manifest cannot read arbitrary files
+        from the image.
+        """
+        resolved = (self._content_dir / rel_path).resolve()
+        if not resolved.is_relative_to(self._content_dir):
+            msg = f"content path escapes the content directory: {rel_path!r}"
+            raise ContentRepositoryError(msg)
+        try:
+            return resolved.read_text()
+        except FileNotFoundError as exc:
+            msg = f"manifest references a missing file: {rel_path!r}"
+            raise ContentRepositoryError(msg) from exc
+
+    def list_chapters(self) -> list[ChapterMeta]:
+        """Every chapter, ordered by (stage, order, chapter)."""
+        return sorted(self._chapters.values(), key=lambda c: (c.stage, c.order, c.chapter))
+
+    def get_chapter(self, content_id: str) -> ChapterMeta | None:
+        """The chapter with ``content_id``, or ``None`` when unknown."""
+        return self._chapters.get(content_id)
+
+    def read_body(self, content_id: str) -> ContentBody:
+        """Raw Markdown + display metadata for a chapter, by id."""
+        meta = self._chapters.get(content_id)
+        if meta is None:
+            msg = f"unknown content id: {content_id!r}"
+            raise ContentNotFoundError(msg)
+        return ContentBody(
+            body=self._read_markdown(meta.path),
+            title=meta.title,
+            content_type=meta.content_type,
+        )
+
+    def read_resource_body(self, slug: str) -> ContentBody:
+        """Raw Markdown + title for a free site resource, by slug."""
+        resource = self._resources.get(slug)
+        if resource is None:
+            msg = f"unknown site resource slug: {slug!r}"
+            raise ContentNotFoundError(msg)
+        return ContentBody(
+            body=self._read_markdown(resource["path"]),
+            title=resource["title"],
+            content_type="resource",
+        )
+
+
+# Mutable container so the instance can be replaced without ``global``
+# (and therefore without a ruff PLW0603 suppression) — the same pattern
+# as :mod:`services.squarespace`.
+_state: dict[str, ContentRepository | None] = {"repository": None}
+
+
+def get_content_repository() -> ContentRepository:
+    """Return the process-wide repository, constructed lazily.
+
+    Lazy construction means a test run with no vendored content never
+    touches the filesystem unless a content endpoint is actually hit.
+    """
+    repository = _state["repository"]
+    if repository is None:
+        repository = ContentRepository()
+        _state["repository"] = repository
+    return repository
+
+
+def set_content_repository_for_tests(repository: ContentRepository | None) -> None:
+    """Replace (or clear) the process-wide repository.
+
+    Public on purpose — keeps the test contract on the module's public
+    API, mirroring ``set_squarespace_client_for_tests``.
+    """
+    _state["repository"] = repository
+
+
+def reset_content_repository_for_tests() -> None:
+    """Drop the singleton so the next caller builds a fresh repository."""
+    set_content_repository_for_tests(None)

--- a/backend/src/services/content_repository.py
+++ b/backend/src/services/content_repository.py
@@ -94,6 +94,40 @@ def _load_json(path: Path, description: str) -> dict[str, Any]:
     return data
 
 
+def _index_chapters(raw_chapters: list[dict[str, Any]]) -> dict[str, ChapterMeta]:
+    """Index chapters by id, rejecting duplicates (the schema cannot)."""
+    chapters: dict[str, ChapterMeta] = {}
+    for raw in raw_chapters:
+        meta = ChapterMeta(
+            id=raw["id"],
+            stage=raw["stage"],
+            chapter=raw["chapter"],
+            slug=raw["slug"],
+            title=raw["title"],
+            content_type=raw["content_type"],
+            release_day=raw["release_day"],
+            order=raw["order"],
+            path=raw["path"],
+            summary=raw.get("summary"),
+        )
+        if meta.id in chapters:
+            msg = f"duplicate chapter id in manifest: {meta.id!r}"
+            raise ContentRepositoryError(msg)
+        chapters[meta.id] = meta
+    return chapters
+
+
+def _index_resources(raw_resources: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index site resources by slug, rejecting duplicates (the schema cannot)."""
+    resources: dict[str, dict[str, Any]] = {}
+    for resource in raw_resources:
+        if resource["slug"] in resources:
+            msg = f"duplicate site resource slug in manifest: {resource['slug']!r}"
+            raise ContentRepositoryError(msg)
+        resources[resource["slug"]] = resource
+    return resources
+
+
 class ContentRepository:
     """Parse-once reader over the vendored content directory.
 
@@ -106,27 +140,8 @@ class ContentRepository:
         """Load and validate the manifest under ``content_dir`` (or CONTENT_DIR)."""
         self._content_dir = (content_dir or _content_dir_from_env()).resolve()
         manifest = self._load_and_validate_manifest()
-        self._chapters: dict[str, ChapterMeta] = {}
-        for raw in manifest["chapters"]:
-            meta = ChapterMeta(
-                id=raw["id"],
-                stage=raw["stage"],
-                chapter=raw["chapter"],
-                slug=raw["slug"],
-                title=raw["title"],
-                content_type=raw["content_type"],
-                release_day=raw["release_day"],
-                order=raw["order"],
-                path=raw["path"],
-                summary=raw.get("summary"),
-            )
-            if meta.id in self._chapters:
-                msg = f"duplicate chapter id in manifest: {meta.id!r}"
-                raise ContentRepositoryError(msg)
-            self._chapters[meta.id] = meta
-        self._resources: dict[str, dict[str, Any]] = {
-            r["slug"]: r for r in manifest["site_resources"]
-        }
+        self._chapters = _index_chapters(manifest["chapters"])
+        self._resources = _index_resources(manifest["site_resources"])
 
     def _load_and_validate_manifest(self) -> dict[str, Any]:
         """Load ``manifest.json`` and enforce the issue #389 contract."""
@@ -172,7 +187,13 @@ class ContentRepository:
         )
 
     def get_chapter(self, content_id: str) -> ChapterMeta | None:
-        """The chapter with ``content_id``, or ``None`` when unknown."""
+        """The chapter with ``content_id``, or ``None`` when unknown.
+
+        Optional lookup — returns ``None`` rather than raising, unlike
+        :meth:`read_body`, which treats an unknown id as
+        :class:`ContentNotFoundError` because fetching a body implies the
+        caller expects it to exist.
+        """
         return self._chapters.get(content_id)
 
     def read_body(self, content_id: str) -> ContentBody:

--- a/backend/src/services/content_repository.py
+++ b/backend/src/services/content_repository.py
@@ -16,7 +16,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import ValidationError
@@ -32,6 +32,10 @@ _DEFAULT_CONTENT_DIR = Path(__file__).resolve().parents[2] / "content"
 # Major version of the manifest contract this reader understands.  ADR 0001
 # change control: reject manifests whose major version differs.
 _SUPPORTED_SCHEMA_MAJOR = 1
+
+# Site resources are not chapters, so they get a content_type outside the
+# chapter enum (chapter|essay|prompt|video) — deliberately distinct.
+_RESOURCE_CONTENT_TYPE: Final[str] = "resource"
 
 
 class ContentRepositoryError(Exception):
@@ -116,6 +120,9 @@ class ContentRepository:
                 path=raw["path"],
                 summary=raw.get("summary"),
             )
+            if meta.id in self._chapters:
+                msg = f"duplicate chapter id in manifest: {meta.id!r}"
+                raise ContentRepositoryError(msg)
             self._chapters[meta.id] = meta
         self._resources: dict[str, dict[str, Any]] = {
             r["slug"]: r for r in manifest["site_resources"]
@@ -158,8 +165,11 @@ class ContentRepository:
             raise ContentRepositoryError(msg) from exc
 
     def list_chapters(self) -> list[ChapterMeta]:
-        """Every chapter, ordered by (stage, order, chapter)."""
-        return sorted(self._chapters.values(), key=lambda c: (c.stage, c.order, c.chapter))
+        """Every chapter, ordered by (stage, order, chapter, id)."""
+        return sorted(
+            self._chapters.values(),
+            key=lambda c: (c.stage, c.order, c.chapter, c.id),
+        )
 
     def get_chapter(self, content_id: str) -> ChapterMeta | None:
         """The chapter with ``content_id``, or ``None`` when unknown."""
@@ -186,7 +196,7 @@ class ContentRepository:
         return ContentBody(
             body=self._read_markdown(resource["path"]),
             title=resource["title"],
-            content_type="resource",
+            content_type=_RESOURCE_CONTENT_TYPE,
         )
 
 

--- a/backend/tests/test_content_repository.py
+++ b/backend/tests/test_content_repository.py
@@ -10,6 +10,7 @@ including the traversal guard that stands in for the old client's
 
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
 from typing import Any
@@ -79,7 +80,7 @@ def _write_content_dir(root: Path, manifest: dict[str, Any]) -> Path:
 
 @pytest.fixture
 def content_dir(tmp_path: Path) -> Path:
-    return _write_content_dir(tmp_path / "content", json.loads(json.dumps(_VALID_MANIFEST)))
+    return _write_content_dir(tmp_path / "content", copy.deepcopy(_VALID_MANIFEST))
 
 
 # ── Happy path ──────────────────────────────────────────────────────────
@@ -131,6 +132,24 @@ def test_unknown_resource_slug_raises_not_found(content_dir: Path) -> None:
         repo.read_resource_body("missing-slug")
 
 
+def test_duplicate_chapter_id_raises_repository_error(tmp_path: Path) -> None:
+    """A duplicate id passes the schema but must not silently drop a chapter."""
+    doubled = copy.deepcopy(_VALID_MANIFEST)
+    doubled["chapters"][1]["id"] = doubled["chapters"][0]["id"]
+    root = _write_content_dir(tmp_path / "content", doubled)
+    with pytest.raises(ContentRepositoryError):
+        ContentRepository(root)
+
+
+def test_missing_markdown_for_known_resource_raises_repository_error(
+    content_dir: Path,
+) -> None:
+    (content_dir / "markdown/site/getting-started.md").unlink()
+    repo = ContentRepository(content_dir)
+    with pytest.raises(ContentRepositoryError):
+        repo.read_resource_body("getting-started")
+
+
 def test_malformed_json_manifest_raises_repository_error(tmp_path: Path) -> None:
     root = tmp_path / "content"
     root.mkdir()
@@ -154,7 +173,7 @@ def test_missing_manifest_raises_repository_error(tmp_path: Path) -> None:
 
 
 def test_invalid_manifest_raises_repository_error(tmp_path: Path) -> None:
-    broken = json.loads(json.dumps(_VALID_MANIFEST))
+    broken = copy.deepcopy(_VALID_MANIFEST)
     broken["chapters"][0].pop("title")
     root = _write_content_dir(tmp_path / "content", broken)
     with pytest.raises(ContentRepositoryError):
@@ -163,7 +182,7 @@ def test_invalid_manifest_raises_repository_error(tmp_path: Path) -> None:
 
 def test_wrong_major_schema_version_is_rejected(tmp_path: Path) -> None:
     """ADR 0001 change control: readers reject a different major version."""
-    future = json.loads(json.dumps(_VALID_MANIFEST))
+    future = copy.deepcopy(_VALID_MANIFEST)
     future["schema_version"] = "2.0.0"
     root = _write_content_dir(tmp_path / "content", future)
     with pytest.raises(ContentRepositoryError):
@@ -172,7 +191,7 @@ def test_wrong_major_schema_version_is_rejected(tmp_path: Path) -> None:
 
 def test_path_traversal_is_rejected(tmp_path: Path) -> None:
     """The LFI guard analogous to the old client's _validate_url."""
-    evil = json.loads(json.dumps(_VALID_MANIFEST))
+    evil = copy.deepcopy(_VALID_MANIFEST)
     evil["chapters"][0]["path"] = "../../etc/passwd"
     root = _write_content_dir(tmp_path / "content", evil)
     # The escape target genuinely exists, so only the guard stops the read.

--- a/backend/tests/test_content_repository.py
+++ b/backend/tests/test_content_repository.py
@@ -141,6 +141,15 @@ def test_duplicate_chapter_id_raises_repository_error(tmp_path: Path) -> None:
         ContentRepository(root)
 
 
+def test_duplicate_resource_slug_raises_repository_error(tmp_path: Path) -> None:
+    """Duplicate slugs must fail loudly, consistent with chapter ids."""
+    doubled = copy.deepcopy(_VALID_MANIFEST)
+    doubled["site_resources"].append(dict(doubled["site_resources"][0]))
+    root = _write_content_dir(tmp_path / "content", doubled)
+    with pytest.raises(ContentRepositoryError):
+        ContentRepository(root)
+
+
 def test_missing_markdown_for_known_resource_raises_repository_error(
     content_dir: Path,
 ) -> None:

--- a/backend/tests/test_content_repository.py
+++ b/backend/tests/test_content_repository.py
@@ -1,0 +1,217 @@
+"""Unit tests for the local-file ContentRepository (issue #390).
+
+The repository is the seam that replaces ``SquarespaceClient``: it loads
+``manifest.json`` once, validates it against the frozen contract from
+issue #389, and serves chapter metadata plus raw Markdown bodies from the
+vendored content directory.  These tests cover the full public surface —
+including the traversal guard that stands in for the old client's
+``_validate_url`` SSRF protection.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from services.content_repository import (
+    ContentNotFoundError,
+    ContentRepository,
+    ContentRepositoryError,
+    get_content_repository,
+    reset_content_repository_for_tests,
+    set_content_repository_for_tests,
+)
+
+_VALID_MANIFEST: dict[str, Any] = {
+    "schema_version": "1.0.0",
+    "chapters": [
+        {
+            "id": "beige-1",
+            "stage": 1,
+            "chapter": 1,
+            "slug": "survival",
+            "title": "Survival",
+            "content_type": "chapter",
+            "release_day": 0,
+            "order": 1,
+            "path": "markdown/01-beige/01-survival.md",
+        },
+        {
+            "id": "beige-2",
+            "stage": 1,
+            "chapter": 2,
+            "slug": "breath",
+            "title": "Breath as Anchor",
+            "content_type": "essay",
+            "release_day": 3,
+            "order": 2,
+            "path": "markdown/01-beige/02-breath.md",
+        },
+    ],
+    "site_resources": [
+        {
+            "slug": "getting-started",
+            "title": "Getting Started",
+            "description": "Orientation guide.",
+            "path": "markdown/site/getting-started.md",
+        }
+    ],
+}
+
+
+def _write_content_dir(root: Path, manifest: dict[str, Any]) -> Path:
+    """Materialise a content dir with the manifest and matching Markdown files."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "manifest.json").write_text(json.dumps(manifest))
+    for chapter in manifest.get("chapters", []):
+        md = root / chapter["path"]
+        md.parent.mkdir(parents=True, exist_ok=True)
+        md.write_text(f"# {chapter.get('title', chapter['id'])}\n\nBody of {chapter['id']}.\n")
+    for resource in manifest.get("site_resources", []):
+        md = root / resource["path"]
+        md.parent.mkdir(parents=True, exist_ok=True)
+        md.write_text(f"# {resource['title']}\n")
+    return root
+
+
+@pytest.fixture
+def content_dir(tmp_path: Path) -> Path:
+    return _write_content_dir(tmp_path / "content", json.loads(json.dumps(_VALID_MANIFEST)))
+
+
+# ── Happy path ──────────────────────────────────────────────────────────
+
+
+def test_lists_chapters_in_stage_then_order(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    chapters = repo.list_chapters()
+    assert [c.id for c in chapters] == ["beige-1", "beige-2"]
+    assert chapters[0].title == "Survival"
+    assert chapters[0].content_type == "chapter"
+
+
+def test_get_chapter_by_id(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    chapter = repo.get_chapter("beige-2")
+    assert chapter is not None
+    assert chapter.slug == "breath"
+    assert repo.get_chapter("nope") is None
+
+
+def test_read_body_returns_markdown_with_metadata(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    body = repo.read_body("beige-1")
+    assert body.title == "Survival"
+    assert body.content_type == "chapter"
+    assert "Body of beige-1." in body.body
+
+
+def test_read_resource_body(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    body = repo.read_resource_body("getting-started")
+    assert body.title == "Getting Started"
+    assert "# Getting Started" in body.body
+
+
+# ── Error paths ─────────────────────────────────────────────────────────
+
+
+def test_unknown_chapter_id_raises_not_found(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    with pytest.raises(ContentNotFoundError):
+        repo.read_body("missing-id")
+
+
+def test_unknown_resource_slug_raises_not_found(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    with pytest.raises(ContentNotFoundError):
+        repo.read_resource_body("missing-slug")
+
+
+def test_malformed_json_manifest_raises_repository_error(tmp_path: Path) -> None:
+    root = tmp_path / "content"
+    root.mkdir()
+    (root / "manifest.json").write_text("{not valid json")
+    with pytest.raises(ContentRepositoryError):
+        ContentRepository(root)
+
+
+def test_non_object_json_manifest_raises_repository_error(tmp_path: Path) -> None:
+    root = tmp_path / "content"
+    root.mkdir()
+    (root / "manifest.json").write_text("[]")
+    with pytest.raises(ContentRepositoryError):
+        ContentRepository(root)
+
+
+def test_missing_manifest_raises_repository_error(tmp_path: Path) -> None:
+    (tmp_path / "empty").mkdir()
+    with pytest.raises(ContentRepositoryError):
+        ContentRepository(tmp_path / "empty")
+
+
+def test_invalid_manifest_raises_repository_error(tmp_path: Path) -> None:
+    broken = json.loads(json.dumps(_VALID_MANIFEST))
+    broken["chapters"][0].pop("title")
+    root = _write_content_dir(tmp_path / "content", broken)
+    with pytest.raises(ContentRepositoryError):
+        ContentRepository(root)
+
+
+def test_wrong_major_schema_version_is_rejected(tmp_path: Path) -> None:
+    """ADR 0001 change control: readers reject a different major version."""
+    future = json.loads(json.dumps(_VALID_MANIFEST))
+    future["schema_version"] = "2.0.0"
+    root = _write_content_dir(tmp_path / "content", future)
+    with pytest.raises(ContentRepositoryError):
+        ContentRepository(root)
+
+
+def test_path_traversal_is_rejected(tmp_path: Path) -> None:
+    """The LFI guard analogous to the old client's _validate_url."""
+    evil = json.loads(json.dumps(_VALID_MANIFEST))
+    evil["chapters"][0]["path"] = "../../etc/passwd"
+    root = _write_content_dir(tmp_path / "content", evil)
+    # The escape target genuinely exists, so only the guard stops the read.
+    outside = tmp_path / "etc"
+    outside.mkdir(parents=True, exist_ok=True)
+    (outside / "passwd").write_text("root:x:0:0\n")
+    repo = ContentRepository(root)
+    with pytest.raises(ContentRepositoryError):
+        repo.read_body("beige-1")
+
+
+def test_missing_markdown_for_known_id_raises_repository_error(content_dir: Path) -> None:
+    (content_dir / "markdown/01-beige/01-survival.md").unlink()
+    repo = ContentRepository(content_dir)
+    with pytest.raises(ContentRepositoryError):
+        repo.read_body("beige-1")
+
+
+# ── Singleton trio ──────────────────────────────────────────────────────
+
+
+def test_singleton_set_and_reset_for_tests(content_dir: Path) -> None:
+    custom = ContentRepository(content_dir)
+    set_content_repository_for_tests(custom)
+    try:
+        assert get_content_repository() is custom
+    finally:
+        reset_content_repository_for_tests()
+
+
+def test_lazy_singleton_builds_from_content_dir_env(
+    content_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """First call constructs from CONTENT_DIR; later calls reuse the instance."""
+    monkeypatch.setenv("CONTENT_DIR", str(content_dir))
+    reset_content_repository_for_tests()
+    try:
+        first = get_content_repository()
+        assert get_content_repository() is first
+        assert [c.id for c in first.list_chapters()] == ["beige-1", "beige-2"]
+    finally:
+        reset_content_repository_for_tests()


### PR DESCRIPTION
## Summary
- Adds `backend/src/services/content_repository.py`: loads `manifest.json` from the vendored content directory (`CONTENT_DIR` env, default `backend/content`) once at construction and validates it against the frozen issue #389 contract (`manifest.schema.json`, JSON Schema draft 2020-12).
- Enforces ADR 0001 change control: a manifest whose `schema_version` major differs from 1 is rejected with a typed `ContentRepositoryError`.
- Serves chapter metadata (`list_chapters()` ordered by stage/order, `get_chapter(id)`) and raw Markdown bodies (`read_body(id)`, `read_resource_body(slug)`); unknown identifiers raise `ContentNotFoundError`.
- Path-traversal guard: a manifest `path` must resolve inside the content directory — the local-file analogue of the Squarespace client's `_validate_url` SSRF guard.
- Lazy singleton trio (`get_content_repository` / `set_content_repository_for_tests` / `reset_content_repository_for_tests`) mirroring `services/squarespace.py`, so the router swap in a later cms-migration issue is a seam replacement.
- Promotes `jsonschema` from dev to runtime dependency (validation now runs in production code) with lock pins; `types-jsonschema` stays dev-only.

## Test plan
- [x] 15 new unit tests in `backend/tests/test_content_repository.py` — happy paths (ordering, lookup, bodies, resources), error paths (missing/malformed/non-object/invalid manifest, wrong schema major, path traversal with the escape target actually present, missing markdown for a known id), and the singleton trio including lazy construction from `CONTENT_DIR`.
- [x] New module at 100% line+branch coverage; full backend suite green at 94.33%.
- [x] `xenon --max-absolute A --max-modules A --max-average A src` passes.
- [x] `TZ=UTC pre-commit run --all-files` green twice.

Closes #390
Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)