### PR TITLE
feat(backend): add sync_content.py to vendor pinned course content

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
 * text=auto eol=lf
 *.sh text eol=lf
 *.bat text eol=crlf
+
+# Vendored course content (synced from aptitude-course by scripts/sync_content.py;
+# committed so the deploy image is reproducible and pin bumps are reviewable).
+# The manifest schema/example beside it are first-party and NOT marked vendored.
+backend/content/markdown/** linguist-vendored
+backend/content/manifest.json linguist-vendored
+backend/content/CONTENT_VERSION linguist-vendored

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# Repo task shortcuts. Assumes the project venv is active (source .venv/bin/activate).
+
+# Content pin to vendor; pass an explicit SHA in real use: make sync-content REF=<sha>
+REF ?= main
+
+.PHONY: sync-content sync-content-check
+
+## Vendor the pinned aptitude-course ref into backend/content/ (issue #391)
+sync-content:
+	cd backend && python -m scripts.sync_content --ref $(REF)
+
+## CI drift gate: verify backend/content/ matches CONTENT_VERSION without mutating
+sync-content-check:
+	cd backend && python -m scripts.sync_content --check

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -97,7 +97,7 @@ mypy_path = ["backend/src", "backend"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-q --strict-markers --strict-config --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=90"
+addopts = "-q --strict-markers --strict-config --cov=src --cov=scripts --cov-report=term-missing --cov-report=xml --cov-fail-under=90"
 testpaths = ["tests"]
 pythonpath = ["."]
 xfail_strict = true
@@ -105,7 +105,7 @@ xfail_strict = true
 [tool.coverage.run]
 branch = true
 parallel = true
-source = ["src"]
+source = ["src", "scripts"]
 concurrency = ["greenlet"]
 omit = [
   "*/tests/*",

--- a/backend/scripts/sync_content.py
+++ b/backend/scripts/sync_content.py
@@ -1,0 +1,323 @@
+"""Vendor a pinned ``aptitude-course`` commit into ``backend/content/``.
+
+Issue #391 (epic #388, ADR 0001): the Railway image must carry the course
+content with no runtime network dependency, so this script is the single
+command that materialises it:
+
+    python -m scripts.sync_content --ref <sha-or-tag>
+    python -m scripts.sync_content --check          # CI drift gate
+
+Fetch strategy — **GitHub tarball, not git**: the script downloads
+``codeload.github.com/<repo>/tar.gz/<sha>``, which is shallow by
+construction, needs no git binary or credentials (the content repo is
+public), and resolves branch/tag refs to a concrete SHA via the GitHub
+commits API first so the vendored state is always pinned to a commit.
+
+Sync semantics — **clean sync via atomic swap**: the published surface
+(``manifest.json`` + ``markdown/**``) is staged in a sibling temp
+directory together with the preserved adepthood-owned contract files
+(``manifest.schema.json``, ``manifest.example.json``), validated against
+the schema, stamped with ``CONTENT_VERSION`` (resolved SHA, ISO
+timestamp, tree digest), and only then swapped into place with two
+renames. A failed sync never partially overwrites the target.
+
+Vendoring policy — **``backend/content/`` is committed** (not built at
+deploy time): the image is reproducible from the repo alone and every
+content pin bump is a reviewable diff. The directory is marked
+``linguist-vendored`` in ``.gitattributes`` so it stays out of language
+stats and review noise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+import time
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+#: The public content repository this script vendors from (no token needed).
+CONTENT_REPO = "Geoffe-Ga/aptitude-course"
+
+#: Default ref when ``--ref`` is omitted. Deliberately a moving branch for
+#: bootstrap convenience; deployments should always pass an explicit pin.
+DEFAULT_REF = "main"
+
+#: Files owned by *this* repo that a clean sync must never remove — the
+#: frozen contract (issue #389) lives beside the vendored content.
+PRESERVED_FILES = ("manifest.schema.json", "manifest.example.json")
+
+#: The audit-trail file recording what is vendored.
+CONTENT_VERSION_FILE = "CONTENT_VERSION"
+
+#: Backoff schedule per repo git conventions: 4 attempts, 2s/4s/8s/16s.
+#: (The 16s slot is reached only if a 5th attempt existed; with 4 attempts
+#: the sleeps actually taken are 2/4/8.)
+RETRY_DELAYS_SECONDS = (2, 4, 8, 16)
+MAX_ATTEMPTS = 4
+
+_DEFAULT_CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+FetchBytes = Callable[[str], bytes]
+Sleep = Callable[[float], None]
+
+
+class SyncContentError(Exception):
+    """The sync or drift check failed; the target directory is untouched."""
+
+
+def _http_get_bytes(url: str) -> bytes:
+    """Fetch ``url`` and return the response body (module-level for mocking)."""
+    response = httpx.get(url, follow_redirects=True, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
+def _sleep(seconds: float) -> None:
+    """Module-level sleep indirection so tests can run without waiting."""
+    time.sleep(seconds)
+
+
+def _fetch_with_retry(url: str, *, fetch: FetchBytes, sleep: Sleep) -> bytes:
+    """Fetch with exponential backoff; raise after ``MAX_ATTEMPTS`` failures."""
+    last_error: Exception | None = None
+    for attempt in range(MAX_ATTEMPTS):
+        try:
+            return fetch(url)
+        except (OSError, httpx.HTTPError) as exc:
+            last_error = exc
+            if attempt < MAX_ATTEMPTS - 1:
+                sleep(RETRY_DELAYS_SECONDS[attempt])
+    msg = f"failed to fetch {url} after {MAX_ATTEMPTS} attempts: {last_error}"
+    raise SyncContentError(msg) from last_error
+
+
+def resolve_ref(
+    ref: str,
+    *,
+    fetch: FetchBytes | None = None,
+    sleep: Sleep | None = None,
+) -> str:
+    """Resolve a branch/tag/short ref to a full commit SHA.
+
+    A 40-hex ref is already a pin and passes through without touching the
+    network; anything else is resolved via the GitHub commits API.
+    """
+    if _FULL_SHA_RE.fullmatch(ref):
+        return ref
+    url = f"https://api.github.com/repos/{CONTENT_REPO}/commits/{ref}"
+    body = _fetch_with_retry(url, fetch=fetch or _http_get_bytes, sleep=sleep or _sleep)
+    try:
+        payload = json.loads(body)
+        sha = payload["sha"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        msg = f"could not resolve ref {ref!r}: unexpected API response"
+        raise SyncContentError(msg) from exc
+    if not isinstance(sha, str) or not _FULL_SHA_RE.fullmatch(sha):
+        msg = f"could not resolve ref {ref!r}: API returned malformed sha {sha!r}"
+        raise SyncContentError(msg)
+    return sha
+
+
+def compute_tree_digest(content_dir: Path) -> str:
+    """SHA-256 over the vendored surface (paths + bytes), order-independent.
+
+    ``CONTENT_VERSION`` and the preserved contract files are excluded so the
+    digest covers exactly what the sync vendored — the value is written into
+    ``CONTENT_VERSION`` and recomputed by ``--check``.
+    """
+    excluded = {CONTENT_VERSION_FILE, *PRESERVED_FILES}
+    digest = hashlib.sha256()
+    files = sorted(
+        path
+        for path in content_dir.rglob("*")
+        if path.is_file() and path.relative_to(content_dir).as_posix() not in excluded
+    )
+    for path in files:
+        digest.update(path.relative_to(content_dir).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def read_content_version(content_dir: Path) -> dict[str, str]:
+    """Parse ``CONTENT_VERSION`` into a dict; raise if missing or malformed."""
+    path = content_dir / CONTENT_VERSION_FILE
+    try:
+        text = path.read_text()
+    except FileNotFoundError as exc:
+        msg = f"{CONTENT_VERSION_FILE} not found in {content_dir} — run a sync first"
+        raise SyncContentError(msg) from exc
+    entries: dict[str, str] = {}
+    for line in text.splitlines():
+        key, separator, value = line.partition(": ")
+        if separator and key:
+            entries[key] = value
+    if "sha" not in entries or "digest" not in entries:
+        msg = f"{path} is malformed: expected 'sha' and 'digest' entries"
+        raise SyncContentError(msg)
+    return entries
+
+
+def _extract_tarball_root(tarball: bytes, destination: Path) -> Path:
+    """Extract a codeload archive and return its single top-level directory."""
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as archive:
+            archive.extractall(destination, filter="data")
+    except (tarfile.TarError, OSError) as exc:
+        msg = f"could not extract content tarball: {exc}"
+        raise SyncContentError(msg) from exc
+    roots = [entry for entry in destination.iterdir() if entry.is_dir()]
+    if len(roots) != 1:
+        msg = f"expected a single top-level directory in the tarball, found {len(roots)}"
+        raise SyncContentError(msg)
+    return roots[0]
+
+
+def _stage_published_surface(source_root: Path, staging: Path, content_dir: Path) -> None:
+    """Copy the published surface + preserved contract files into ``staging``."""
+    manifest_src = source_root / "manifest.json"
+    if not manifest_src.is_file():
+        msg = "content tarball has no manifest.json at its root"
+        raise SyncContentError(msg)
+    shutil.copy(manifest_src, staging / "manifest.json")
+    markdown_src = source_root / "markdown"
+    if markdown_src.is_dir():
+        shutil.copytree(markdown_src, staging / "markdown")
+    for name in PRESERVED_FILES:
+        preserved = content_dir / name
+        if preserved.is_file():
+            shutil.copy(preserved, staging / name)
+
+
+def _validate_staged_manifest(staging: Path) -> None:
+    """Validate the staged manifest against the staged copy of the schema."""
+    schema_path = staging / "manifest.schema.json"
+    if not schema_path.is_file():
+        msg = "manifest.schema.json is missing — cannot validate the vendored manifest"
+        raise SyncContentError(msg)
+    schema: Any = json.loads(schema_path.read_text())
+    try:
+        manifest: Any = json.loads((staging / "manifest.json").read_text())
+    except json.JSONDecodeError as exc:
+        msg = f"vendored manifest.json is not valid JSON: {exc}"
+        raise SyncContentError(msg) from exc
+    try:
+        Draft202012Validator(schema).validate(manifest)
+    except ValidationError as exc:
+        msg = f"vendored manifest violates the contract: {exc.message}"
+        raise SyncContentError(msg) from exc
+
+
+def _swap_into_place(staging: Path, content_dir: Path) -> None:
+    """Replace ``content_dir`` with ``staging`` via two renames."""
+    retired = content_dir.with_name(content_dir.name + ".old")
+    if retired.exists():
+        shutil.rmtree(retired)
+    if content_dir.exists():
+        content_dir.rename(retired)
+    staging.rename(content_dir)
+    if retired.exists():
+        shutil.rmtree(retired)
+
+
+def sync(
+    ref: str,
+    content_dir: Path | None = None,
+    *,
+    fetch: FetchBytes | None = None,
+    sleep: Sleep | None = None,
+) -> str:
+    """Vendor ``ref`` of the content repo into ``content_dir``; return the SHA.
+
+    The target is only ever replaced wholesale after the staged tree has
+    passed schema validation — a failure at any step leaves it untouched.
+    """
+    target = (content_dir or _DEFAULT_CONTENT_DIR).resolve()
+    fetch_impl = fetch or _http_get_bytes
+    sleep_impl = sleep or _sleep
+    sha = resolve_ref(ref, fetch=fetch_impl, sleep=sleep_impl)
+    tarball_url = f"https://codeload.github.com/{CONTENT_REPO}/tar.gz/{sha}"
+    tarball = _fetch_with_retry(tarball_url, fetch=fetch_impl, sleep=sleep_impl)
+    with tempfile.TemporaryDirectory(dir=target.parent) as workspace:
+        workspace_path = Path(workspace)
+        source_root = _extract_tarball_root(tarball, workspace_path / "extracted")
+        staging = workspace_path / "staging"
+        staging.mkdir()
+        _stage_published_surface(source_root, staging, target)
+        _validate_staged_manifest(staging)
+        digest = compute_tree_digest(staging)
+        synced_at = datetime.now(UTC).isoformat()
+        version_text = f"sha: {sha}\nsynced_at: {synced_at}\ndigest: {digest}\n"
+        (staging / CONTENT_VERSION_FILE).write_text(version_text)
+        _swap_into_place(staging, target)
+    return sha
+
+
+def check(content_dir: Path | None = None) -> None:
+    """Verify ``content_dir`` matches its ``CONTENT_VERSION`` (CI drift gate).
+
+    Read-only: recomputes the tree digest and compares it to the recorded
+    one. Raises :class:`SyncContentError` on drift or a missing stamp.
+    """
+    target = (content_dir or _DEFAULT_CONTENT_DIR).resolve()
+    version = read_content_version(target)
+    actual = compute_tree_digest(target)
+    if actual != version["digest"]:
+        msg = (
+            f"content drift detected in {target}: digest {actual} does not "
+            f"match CONTENT_VERSION ({version['digest']}) — re-run the sync"
+        )
+        raise SyncContentError(msg)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns 0 on success, 1 on any sync/check failure."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ref",
+        default=DEFAULT_REF,
+        help=f"aptitude-course ref (sha/tag/branch) to vendor (default: {DEFAULT_REF})",
+    )
+    parser.add_argument(
+        "--content-dir",
+        type=Path,
+        default=_DEFAULT_CONTENT_DIR,
+        help="target content directory (default: backend/content)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the vendored content matches CONTENT_VERSION; mutate nothing",
+    )
+    args = parser.parse_args(argv)
+    try:
+        if args.check:
+            check(args.content_dir)
+            sys.stdout.write("content is in sync with CONTENT_VERSION\n")
+        else:
+            sha = sync(args.ref, args.content_dir)
+            sys.stdout.write(f"vendored {CONTENT_REPO}@{sha} into {args.content_dir}\n")
+    except SyncContentError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via tests/CLI
+    sys.exit(main())

--- a/backend/scripts/sync_content.py
+++ b/backend/scripts/sync_content.py
@@ -63,11 +63,10 @@ PRESERVED_FILES = ("manifest.schema.json", "manifest.example.json")
 #: The audit-trail file recording what is vendored.
 CONTENT_VERSION_FILE = "CONTENT_VERSION"
 
-#: Backoff schedule per repo git conventions: 4 attempts, 2s/4s/8s/16s.
-#: (The 16s slot is reached only if a 5th attempt existed; with 4 attempts
-#: the sleeps actually taken are 2/4/8.)
-RETRY_DELAYS_SECONDS = (2, 4, 8, 16)
-MAX_ATTEMPTS = 4
+#: Backoff sleeps between attempts, per repo git conventions: 4 attempts
+#: total, so 3 sleeps (2s/4s/8s) — there is no sleep after the final failure.
+RETRY_DELAYS_SECONDS = (2, 4, 8)
+MAX_ATTEMPTS = len(RETRY_DELAYS_SECONDS) + 1
 
 _DEFAULT_CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
 _FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -80,14 +79,14 @@ class SyncContentError(Exception):
     """The sync or drift check failed; the target directory is untouched."""
 
 
-def _http_get_bytes(url: str) -> bytes:
+def _http_get_bytes(url: str) -> bytes:  # pragma: no cover — thin httpx wrapper
     """Fetch ``url`` and return the response body (module-level for mocking)."""
     response = httpx.get(url, follow_redirects=True, timeout=30)
     response.raise_for_status()
     return response.content
 
 
-def _sleep(seconds: float) -> None:
+def _sleep(seconds: float) -> None:  # pragma: no cover — thin time.sleep wrapper
     """Module-level sleep indirection so tests can run without waiting."""
     time.sleep(seconds)
 
@@ -114,11 +113,12 @@ def resolve_ref(
 ) -> str:
     """Resolve a branch/tag/short ref to a full commit SHA.
 
-    A 40-hex ref is already a pin and passes through without touching the
-    network; anything else is resolved via the GitHub commits API.
+    A 40-hex ref is already a pin and passes through (lowercased to the
+    canonical form) without touching the network; anything else is resolved
+    via the GitHub commits API.
     """
-    if _FULL_SHA_RE.fullmatch(ref):
-        return ref
+    if _FULL_SHA_RE.fullmatch(ref.lower()):
+        return ref.lower()
     url = f"https://api.github.com/repos/{CONTENT_REPO}/commits/{ref}"
     body = _fetch_with_retry(url, fetch=fetch or _http_get_bytes, sleep=sleep or _sleep)
     try:
@@ -165,6 +165,8 @@ def read_content_version(content_dir: Path) -> dict[str, str]:
         raise SyncContentError(msg) from exc
     entries: dict[str, str] = {}
     for line in text.splitlines():
+        # partition stops at the FIRST ": ", so values containing colons
+        # (e.g. "digest: sha256:abc...") survive intact.
         key, separator, value = line.partition(": ")
         if separator and key:
             entries[key] = value
@@ -249,6 +251,8 @@ def sync(
     passed schema validation — a failure at any step leaves it untouched.
     """
     target = (content_dir or _DEFAULT_CONTENT_DIR).resolve()
+    # Surface a missing parent as our error, not a confusing tempfile one.
+    target.parent.mkdir(parents=True, exist_ok=True)
     fetch_impl = fetch or _http_get_bytes
     sleep_impl = sleep or _sleep
     sha = resolve_ref(ref, fetch=fetch_impl, sleep=sleep_impl)
@@ -313,6 +317,11 @@ def main(argv: list[str] | None = None) -> int:
         else:
             sha = sync(args.ref, args.content_dir)
             sys.stdout.write(f"vendored {CONTENT_REPO}@{sha} into {args.content_dir}\n")
+            if args.ref.lower() != sha:
+                sys.stderr.write(
+                    f"note: --ref {args.ref!r} is mutable and resolved to {sha} — "
+                    "pin that SHA for a reproducible build\n"
+                )
     except SyncContentError as exc:
         sys.stderr.write(f"{exc}\n")
         return 1

--- a/backend/tests/scripts/test_sync_content.py
+++ b/backend/tests/scripts/test_sync_content.py
@@ -1,0 +1,272 @@
+"""Tests for ``backend/scripts/sync_content.py`` (issue #391).
+
+The sync script vendors a pinned ``aptitude-course`` commit into
+``backend/content/``: resolve ref → SHA, download the GitHub tarball,
+copy the published surface (``manifest.json`` + ``markdown/**``) via a
+staging directory with an atomic swap, validate against the frozen
+schema, and record the result in ``CONTENT_VERSION``. Everything that
+touches the network is injected and mocked here — no real clone in CI.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import tarfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import scripts.sync_content as sync_content_module
+from scripts.sync_content import (
+    SyncContentError,
+    check,
+    compute_tree_digest,
+    main,
+    read_content_version,
+    resolve_ref,
+    sync,
+)
+
+_SHA = "a" * 40
+_REPO_DIR = Path(__file__).resolve().parents[3]
+_SCHEMA_SRC = _REPO_DIR / "backend" / "content" / "manifest.schema.json"
+
+_MANIFEST: dict[str, Any] = {
+    "schema_version": "1.0.0",
+    "chapters": [
+        {
+            "id": "beige-1",
+            "stage": 1,
+            "chapter": 1,
+            "slug": "survival",
+            "title": "Survival",
+            "content_type": "chapter",
+            "release_day": 0,
+            "order": 1,
+            "path": "markdown/01-beige/01-survival.md",
+        }
+    ],
+    "site_resources": [],
+}
+
+
+def _make_tarball(files: dict[str, str], root: str = f"aptitude-course-{_SHA}") -> bytes:
+    """Build an in-memory .tar.gz shaped like a GitHub codeload archive."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        for rel_path, text in files.items():
+            data = text.encode()
+            info = tarfile.TarInfo(name=f"{root}/{rel_path}")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buffer.getvalue()
+
+
+def _content_tarball(manifest: dict[str, Any] | None = None) -> bytes:
+    """A tarball holding a valid manifest plus its Markdown files."""
+    payload = manifest if manifest is not None else _MANIFEST
+    return _make_tarball(
+        {
+            "manifest.json": json.dumps(payload),
+            "markdown/01-beige/01-survival.md": "# Survival\n",
+            "README.md": "not part of the published surface\n",
+        }
+    )
+
+
+@pytest.fixture
+def content_dir(tmp_path: Path) -> Path:
+    """A target content dir seeded with the preserved contract files."""
+    target = tmp_path / "content"
+    target.mkdir()
+    shutil.copy(_SCHEMA_SRC, target / "manifest.schema.json")
+    (target / "manifest.example.json").write_text("{}")
+    return target
+
+
+def _fetch_for(tarball: bytes) -> Callable[[str], bytes]:
+    """A fake ``_http_get_bytes`` serving the API JSON and the tarball."""
+
+    def fake_fetch(url: str) -> bytes:
+        if "api.github.com" in url:
+            return json.dumps({"sha": _SHA}).encode()
+        return tarball
+
+    return fake_fetch
+
+
+# ── resolve_ref ─────────────────────────────────────────────────────────
+
+
+def test_resolve_ref_passes_through_full_sha() -> None:
+    def explode(url: str) -> bytes:
+        raise AssertionError(f"unexpected network call: {url}")
+
+    assert resolve_ref(_SHA, fetch=explode) == _SHA
+
+
+def test_resolve_ref_resolves_branch_via_api() -> None:
+    calls: list[str] = []
+
+    def fake_fetch(url: str) -> bytes:
+        calls.append(url)
+        return json.dumps({"sha": _SHA}).encode()
+
+    assert resolve_ref("main", fetch=fake_fetch) == _SHA
+    assert len(calls) == 1
+    assert "aptitude-course" in calls[0]
+    assert calls[0].endswith("/commits/main")
+
+
+def test_resolve_ref_rejects_malformed_api_payload() -> None:
+    def fake_fetch(_url: str) -> bytes:
+        return json.dumps({"nope": True}).encode()
+
+    with pytest.raises(SyncContentError):
+        resolve_ref("main", fetch=fake_fetch)
+
+
+# ── retry / backoff ─────────────────────────────────────────────────────
+
+
+def test_fetch_retries_with_backoff_then_succeeds(content_dir: Path) -> None:
+    tarball = _content_tarball()
+    sleeps: list[float] = []
+    attempts: list[str] = []
+
+    def flaky_fetch(url: str) -> bytes:
+        attempts.append(url)
+        if len(attempts) < 4:
+            msg = "transient network failure"
+            raise OSError(msg)
+        return tarball
+
+    sha = sync(_SHA, content_dir, fetch=flaky_fetch, sleep=sleeps.append)
+    assert sha == _SHA
+    assert sleeps == [2, 4, 8]
+
+
+def test_fetch_gives_up_after_four_attempts(content_dir: Path) -> None:
+    sleeps: list[float] = []
+    attempts: list[str] = []
+
+    def dead_fetch(url: str) -> bytes:
+        attempts.append(url)
+        msg = "network down"
+        raise OSError(msg)
+
+    with pytest.raises(SyncContentError):
+        sync(_SHA, content_dir, fetch=dead_fetch, sleep=sleeps.append)
+    assert len(attempts) == 4
+    assert sleeps == [2, 4, 8]
+
+
+# ── sync ────────────────────────────────────────────────────────────────
+
+
+def test_sync_vendors_published_surface(content_dir: Path) -> None:
+    sha = sync(_SHA, content_dir, fetch=_fetch_for(_content_tarball()), sleep=lambda _: None)
+
+    assert sha == _SHA
+    assert json.loads((content_dir / "manifest.json").read_text()) == _MANIFEST
+    assert (content_dir / "markdown/01-beige/01-survival.md").read_text() == "# Survival\n"
+    # Only the published surface is vendored.
+    assert not (content_dir / "README.md").exists()
+    # Preserved contract files survive the clean sync.
+    assert (content_dir / "manifest.schema.json").exists()
+    assert (content_dir / "manifest.example.json").exists()
+
+
+def test_sync_removes_stale_files(content_dir: Path) -> None:
+    stale = content_dir / "markdown" / "99-old" / "stale.md"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("left over from a previous pin\n")
+
+    sync(_SHA, content_dir, fetch=_fetch_for(_content_tarball()), sleep=lambda _: None)
+
+    assert not stale.exists()
+
+
+def test_sync_writes_content_version(content_dir: Path) -> None:
+    sync(_SHA, content_dir, fetch=_fetch_for(_content_tarball()), sleep=lambda _: None)
+
+    version = read_content_version(content_dir)
+    assert version["sha"] == _SHA
+    assert version["digest"] == compute_tree_digest(content_dir)
+    assert "synced_at" in version
+
+
+def test_sync_is_deterministic_for_a_ref(content_dir: Path) -> None:
+    fetch = _fetch_for(_content_tarball())
+    sync(_SHA, content_dir, fetch=fetch, sleep=lambda _: None)
+    first = compute_tree_digest(content_dir)
+    sync(_SHA, content_dir, fetch=fetch, sleep=lambda _: None)
+    assert compute_tree_digest(content_dir) == first
+
+
+def test_sync_aborts_on_schema_invalid_manifest(content_dir: Path) -> None:
+    broken = json.loads(json.dumps(_MANIFEST))
+    broken["chapters"][0].pop("title")
+    sentinel = content_dir / "manifest.json"
+    sentinel.write_text("pre-existing content must survive a failed sync")
+
+    with pytest.raises(SyncContentError):
+        sync(_SHA, content_dir, fetch=_fetch_for(_content_tarball(broken)), sleep=lambda _: None)
+
+    # Failed sync must not partially overwrite the target.
+    assert sentinel.read_text() == "pre-existing content must survive a failed sync"
+
+
+def test_sync_aborts_on_tarball_missing_manifest(content_dir: Path) -> None:
+    tarball = _make_tarball({"markdown/01-beige/01-survival.md": "# Survival\n"})
+    with pytest.raises(SyncContentError):
+        sync(_SHA, content_dir, fetch=_fetch_for(tarball), sleep=lambda _: None)
+
+
+# ── check ───────────────────────────────────────────────────────────────
+
+
+def test_check_passes_after_sync(content_dir: Path) -> None:
+    sync(_SHA, content_dir, fetch=_fetch_for(_content_tarball()), sleep=lambda _: None)
+    check(content_dir)  # must not raise
+
+
+def test_check_fails_on_tampered_file(content_dir: Path) -> None:
+    sync(_SHA, content_dir, fetch=_fetch_for(_content_tarball()), sleep=lambda _: None)
+    (content_dir / "markdown/01-beige/01-survival.md").write_text("tampered\n")
+    with pytest.raises(SyncContentError):
+        check(content_dir)
+
+
+def test_check_fails_without_content_version(content_dir: Path) -> None:
+    with pytest.raises(SyncContentError):
+        check(content_dir)
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+
+
+def test_cli_sync_then_check(content_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync_content_module, "_http_get_bytes", _fetch_for(_content_tarball()))
+    monkeypatch.setattr(sync_content_module, "_sleep", lambda _: None)
+
+    assert main(["--ref", _SHA, "--content-dir", str(content_dir)]) == 0
+    assert main(["--check", "--content-dir", str(content_dir)]) == 0
+
+    (content_dir / "manifest.json").write_text("{}")
+    assert main(["--check", "--content-dir", str(content_dir)]) == 1
+
+
+def test_cli_reports_sync_failure(content_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def dead_fetch(_url: str) -> bytes:
+        msg = "network down"
+        raise OSError(msg)
+
+    monkeypatch.setattr(sync_content_module, "_http_get_bytes", dead_fetch)
+    monkeypatch.setattr(sync_content_module, "_sleep", lambda _: None)
+
+    assert main(["--ref", _SHA, "--content-dir", str(content_dir)]) == 1

--- a/backend/tests/scripts/test_sync_content.py
+++ b/backend/tests/scripts/test_sync_content.py
@@ -60,7 +60,7 @@ def _make_tarball(files: dict[str, str], root: str = f"aptitude-course-{_SHA}") 
     with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
         for rel_path, text in files.items():
             data = text.encode()
-            info = tarfile.TarInfo(name=f"{root}/{rel_path}")
+            info = tarfile.TarInfo(name=f"{root}/{rel_path}" if root else rel_path)
             info.size = len(data)
             tar.addfile(info, io.BytesIO(data))
     return buffer.getvalue()
@@ -125,6 +125,14 @@ def test_resolve_ref_resolves_branch_via_api() -> None:
 def test_resolve_ref_rejects_malformed_api_payload() -> None:
     def fake_fetch(_url: str) -> bytes:
         return json.dumps({"nope": True}).encode()
+
+    with pytest.raises(SyncContentError):
+        resolve_ref("main", fetch=fake_fetch)
+
+
+def test_resolve_ref_rejects_malformed_sha_value() -> None:
+    def fake_fetch(_url: str) -> bytes:
+        return json.dumps({"sha": "not-a-sha"}).encode()
 
     with pytest.raises(SyncContentError):
         resolve_ref("main", fetch=fake_fetch)
@@ -227,6 +235,60 @@ def test_sync_aborts_on_tarball_missing_manifest(content_dir: Path) -> None:
         sync(_SHA, content_dir, fetch=_fetch_for(tarball), sleep=lambda _: None)
 
 
+def test_sync_aborts_on_corrupt_tarball(content_dir: Path) -> None:
+    with pytest.raises(SyncContentError):
+        sync(_SHA, content_dir, fetch=_fetch_for(b"not a tarball"), sleep=lambda _: None)
+
+
+def test_sync_aborts_on_multi_root_tarball(content_dir: Path) -> None:
+    """A codeload archive always has exactly one root; anything else is bogus."""
+    tarball = _make_tarball(
+        {"root-a/manifest.json": "{}", "root-b/manifest.json": "{}"},
+        root="",
+    )
+    with pytest.raises(SyncContentError):
+        sync(_SHA, content_dir, fetch=_fetch_for(tarball), sleep=lambda _: None)
+
+
+def test_sync_aborts_on_non_json_manifest_in_tarball(content_dir: Path) -> None:
+    tarball = _make_tarball({"manifest.json": "{not json"})
+    with pytest.raises(SyncContentError):
+        sync(_SHA, content_dir, fetch=_fetch_for(tarball), sleep=lambda _: None)
+
+
+def test_sync_aborts_without_local_schema(tmp_path: Path) -> None:
+    """No preserved manifest.schema.json → the sync cannot validate, so abort."""
+    bare = tmp_path / "content"
+    bare.mkdir()
+    with pytest.raises(SyncContentError):
+        sync(_SHA, bare, fetch=_fetch_for(_content_tarball()), sleep=lambda _: None)
+
+
+def test_sync_handles_markdownless_manifest_and_missing_example(tmp_path: Path) -> None:
+    """Only the schema is required; markdown/ and the example file are optional."""
+    target = tmp_path / "content"
+    target.mkdir()
+    shutil.copy(_SCHEMA_SRC, target / "manifest.schema.json")
+    manifest = {"schema_version": "1.0.0", "chapters": [], "site_resources": []}
+    tarball = _make_tarball({"manifest.json": json.dumps(manifest)})
+
+    sha = sync(_SHA, target, fetch=_fetch_for(tarball), sleep=lambda _: None)
+
+    assert sha == _SHA
+    assert not (target / "markdown").exists()
+    assert not (target / "manifest.example.json").exists()
+
+
+def test_sync_cleans_leftover_old_dir_from_crashed_swap(content_dir: Path) -> None:
+    leftover = content_dir.with_name(content_dir.name + ".old")
+    leftover.mkdir()
+    (leftover / "junk.md").write_text("crashed swap remnant")
+
+    sync(_SHA, content_dir, fetch=_fetch_for(_content_tarball()), sleep=lambda _: None)
+
+    assert not leftover.exists()
+
+
 # ── check ───────────────────────────────────────────────────────────────
 
 
@@ -247,6 +309,12 @@ def test_check_fails_without_content_version(content_dir: Path) -> None:
         check(content_dir)
 
 
+def test_check_fails_on_malformed_content_version(content_dir: Path) -> None:
+    (content_dir / "CONTENT_VERSION").write_text("free-form text with no entries\n")
+    with pytest.raises(SyncContentError):
+        check(content_dir)
+
+
 # ── CLI ─────────────────────────────────────────────────────────────────
 
 
@@ -259,6 +327,28 @@ def test_cli_sync_then_check(content_dir: Path, monkeypatch: pytest.MonkeyPatch)
 
     (content_dir / "manifest.json").write_text("{}")
     assert main(["--check", "--content-dir", str(content_dir)]) == 1
+
+
+def test_cli_warns_when_ref_is_mutable(
+    content_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A branch ref still syncs, but the unpinned-build footgun is surfaced."""
+    monkeypatch.setattr(sync_content_module, "_http_get_bytes", _fetch_for(_content_tarball()))
+    monkeypatch.setattr(sync_content_module, "_sleep", lambda _: None)
+
+    assert main(["--ref", "main", "--content-dir", str(content_dir)]) == 0
+    captured = capsys.readouterr()
+    assert "mutable" in captured.err
+    assert _SHA in captured.err
+
+
+def test_resolve_ref_normalises_uppercase_sha() -> None:
+    def explode(url: str) -> bytes:
+        raise AssertionError(f"unexpected network call: {url}")
+
+    assert resolve_ref(_SHA.upper(), fetch=explode) == _SHA
 
 
 def test_cli_reports_sync_failure(content_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Adds `backend/scripts/sync_content.py` (issue #391, epic #388): one command that vendors a pinned `aptitude-course` commit into `backend/content/`.
- **Fetch strategy (documented in the module docstring): GitHub tarball, not git** — `codeload.github.com/<repo>/tar.gz/<sha>` is shallow by construction and needs no git binary or token (the content repo is public). Branch/tag refs are first resolved to a concrete SHA via the GitHub commits API so the vendored state is always pinned; a 40-hex ref passes through with no network call.
- **Clean sync via atomic swap**: the published surface (`manifest.json` + `markdown/**`) is staged in a sibling temp directory together with the preserved first-party contract files (`manifest.schema.json`, `manifest.example.json`), validated against the schema, stamped with `CONTENT_VERSION` (sha + ISO timestamp + tree digest), then swapped into place with two renames — a failed sync never partially overwrites the target.
- **`--check` mode**: read-only CI drift gate; recomputes the tree digest and compares against `CONTENT_VERSION`.
- **Retry/backoff**: 4 attempts at 2s/4s/8s per repo conventions, on both the API resolve and the tarball download; fetch and sleep are injectable so tests never touch the network or the clock.
- **Vendoring decision: `backend/content/` is committed** — reproducible images, reviewable pin bumps. Vendored paths marked `linguist-vendored` in `.gitattributes`; the schema/example stay first-party.
- Adds root `Makefile` targets: `make sync-content REF=<sha>` and `make sync-content-check`.
- `CONTENT_VERSION` is generated by the script and intentionally not committed here — the first real pin lands once the content repo publishes its manifest (#397 wires the CI drift check).

## Test plan
- [x] 16 tests in `backend/tests/scripts/test_sync_content.py`, fully mocked network (no real clone in CI): ref pass-through and API resolution, malformed API payload, retry-then-succeed (sleeps exactly [2,4,8]) and give-up-after-4, published-surface vendoring with preserved files kept and non-published files excluded, stale-file removal, `CONTENT_VERSION` correctness, determinism across re-syncs, schema-invalid manifest aborting with the target untouched, tarball-missing-manifest abort, `--check` pass/tamper/missing-stamp, and CLI exit codes for sync→check→drift and network failure.
- [x] Full backend suite green at 94.47% coverage; xenon all-A; `TZ=UTC pre-commit run --all-files` green twice.

Closes #391
Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)