### PR TITLE
feat(backend): drive content_config and seed_content from the manifest

### DIFF
--- a/backend/src/content_config.py
+++ b/backend/src/content_config.py
@@ -1,67 +1,52 @@
-"""Declarative content config for Squarespace-hosted course material.
+"""Declarative content config: manifest-driven chapters + site resources.
 
-This module is the single source of truth for which Squarespace URLs the
-backend pulls into the app — both stage-locked drip-feed chapters and the
-always-available site resources surfaced on the Course screen.
+Stage-locked chapters are no longer hardcoded here (the old
+``STAGE_PLANS`` covered stage 1 only and built Squarespace URLs).  They
+now come from the vendored content manifest via
+:class:`services.content_repository.ContentRepository` — every stage the
+manifest ships, with ``title``/``content_type``/``release_day`` taken
+verbatim and a **local content reference** (``content://<chapter-id>``)
+written where the Squarespace URL used to go.  The stage-numbering
+reconciliation from ADR 0001 applies: manifest ``stage`` N maps onto the
+app's ``CourseStage.stage_number`` N, identity for 1..10.
 
-Editing rules
-=============
+The ``StageContent.url`` column is deliberately *repurposed* (not
+renamed) to hold the ``content://`` reference — no Alembic migration is
+needed, existing read-completion rows keep their foreign keys, and the
+column rename can ride the final cutover issue once the Squarespace
+reader is deleted.  See issue #392.
 
-To **add** a stage's chapters:
-    Append a new ``StageContentPlan`` to ``STAGE_PLANS``.  The seeder will
-    create one ``StageContent`` row per chapter on next boot.
+Site resources (philosophy, about, …) are still declared here and still
+point at the public site; they migrate in a later cms-migration issue.
 
-To **add** a site resource (philosophy, about, etc.):
-    Append a new ``SiteResource`` to ``SITE_RESOURCES``.  It becomes
-    available immediately via ``GET /course/site-resources`` — no DB
-    migration, no seed step.
-
-To **remove** a chapter:
-    Drop or shorten the relevant ``chapter_count`` and run
-    ``backend/scripts/resync_stage_content.py`` (or wait for next boot —
-    the seeder reconciles).
-
-See ``docs/content.md`` at the repo root for the full editor's guide.
-
-Why this lives in a Python module
-=================================
-Plain Python lets us validate at import time (uniqueness, URL sanity,
-release-day bounds) and lets type-checkers catch typos in field names.
-The "config feel" is preserved by keeping every URL pattern declarative.
+See ``docs/content.md`` for the editor's guide.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Final
 
-from domain.energy import PLAN_DURATION_DAYS
+from services.content_repository import ContentRepositoryError, get_content_repository
 
-#: Public-facing Squarespace site root. Used to build chapter URLs.
+logger = logging.getLogger(__name__)
+
+#: Public-facing site root. Used to build site-resource URLs (only).
 SITE_BASE_URL: Final[str] = "https://aptitude.guru"
 
+#: Scheme for local content references stored in ``StageContent.url``.
+CONTENT_REF_SCHEME: Final[str] = "content"
 
-@dataclass(frozen=True)
-class StageContentPlan:
-    """Declarative plan for one course stage's chapters.
 
-    ``slug`` is the Squarespace URL prefix — chapters are addressed as
-    ``{SITE_BASE_URL}/course/{slug}-{n}`` where ``n`` runs from 1 to
-    ``chapter_count``.
+def content_ref(chapter_id: str) -> str:
+    """The local reference written to ``StageContent.url`` for a chapter.
 
-    ``release_pattern`` controls how chapters are spaced across the stage.
-    Today we only ship ``"daily"``: one chapter per day starting at day 0,
-    with any remaining days in the stage left empty for catch-up.  Adding
-    another pattern (``"weekly"``, ``"front_loaded"``) means extending
-    :func:`build_chapter_release_days`.
+    The body endpoint resolves this back to the vendored Markdown via
+    :meth:`ContentRepository.read_body` (later cms-migration issue) —
+    nothing downstream should treat it as a fetchable URL.
     """
-
-    stage_number: int
-    slug: str
-    chapter_count: int
-    content_type: str = "chapter"
-    release_pattern: str = "daily"
-    title_template: str = "Chapter {n}"
+    return f"{CONTENT_REF_SCHEME}://{chapter_id}"
 
 
 @dataclass(frozen=True)
@@ -80,25 +65,9 @@ class SiteResource:
 
     @property
     def url(self) -> str:
-        """Absolute public URL on the Squarespace site."""
+        """Absolute public URL on the live site."""
         suffix = self.path or f"/{self.slug}"
         return f"{SITE_BASE_URL}{suffix}"
-
-
-# --------------------------------------------------------------------------- #
-# Stage-locked drip-feed plans                                                 #
-# --------------------------------------------------------------------------- #
-
-#: Per-stage chapter plans.  Stages not listed here keep whatever existing
-#: ``StageContent`` rows already live in the DB (placeholder seed data, in
-#: the case of stages 2 and 3 today).
-STAGE_PLANS: Final[list[StageContentPlan]] = [
-    StageContentPlan(
-        stage_number=1,
-        slug="beige",
-        chapter_count=14,
-    ),
-]
 
 
 # --------------------------------------------------------------------------- #
@@ -135,38 +104,8 @@ SITE_RESOURCES: Final[list[SiteResource]] = [
 
 
 # --------------------------------------------------------------------------- #
-# Derivations — kept pure so tests can call them without a DB                  #
+# Manifest-driven chapter records                                             #
 # --------------------------------------------------------------------------- #
-
-
-def build_chapter_release_days(plan: StageContentPlan) -> list[int]:
-    """Return the ``release_day`` value for each chapter in the plan.
-
-    The current ``"daily"`` pattern: chapter ``n`` (1-indexed) unlocks on
-    day ``n - 1``, capped by ``PLAN_DURATION_DAYS - 1`` so a too-long plan
-    cannot push a chapter past the end of its stage.  If a stage ships
-    fewer chapters than ``PLAN_DURATION_DAYS``, the trailing days remain
-    empty by design (catch-up window).
-    """
-    if plan.release_pattern != "daily":
-        msg = f"Unsupported release_pattern: {plan.release_pattern!r}"
-        raise ValueError(msg)
-    if plan.chapter_count < 1:
-        msg = f"chapter_count must be >= 1, got {plan.chapter_count}"
-        raise ValueError(msg)
-    cap = PLAN_DURATION_DAYS - 1
-    return [min(n, cap) for n in range(plan.chapter_count)]
-
-
-def chapter_url(plan: StageContentPlan, chapter_index: int) -> str:
-    """Return the absolute URL for the n-th chapter (1-indexed)."""
-    if not 1 <= chapter_index <= plan.chapter_count:
-        msg = (
-            f"chapter_index {chapter_index} out of range for "
-            f"stage {plan.stage_number} (1..{plan.chapter_count})"
-        )
-        raise ValueError(msg)
-    return f"{SITE_BASE_URL}/course/{plan.slug}-{chapter_index}"
 
 
 @dataclass(frozen=True)
@@ -180,30 +119,32 @@ class ChapterRecord:
     url: str
 
 
-def expand_plan(plan: StageContentPlan) -> list[ChapterRecord]:
-    """Expand a ``StageContentPlan`` into one ``ChapterRecord`` per chapter."""
-    release_days = build_chapter_release_days(plan)
-    records: list[ChapterRecord] = []
-    for index_zero_based, day in enumerate(release_days):
-        chapter_number = index_zero_based + 1
-        records.append(
-            ChapterRecord(
-                stage_number=plan.stage_number,
-                title=plan.title_template.format(n=chapter_number),
-                content_type=plan.content_type,
-                release_day=day,
-                url=chapter_url(plan, chapter_number),
-            )
-        )
-    return records
-
-
 def all_chapter_records() -> list[ChapterRecord]:
-    """Flatten every ``STAGE_PLANS`` entry into a single list of chapters."""
-    flat: list[ChapterRecord] = []
-    for plan in STAGE_PLANS:
-        flat.extend(expand_plan(plan))
-    return flat
+    """One ``ChapterRecord`` per manifest chapter, ordered by (stage, order).
+
+    Reads the process-wide :class:`ContentRepository` lazily at call time
+    (the seeder runs at boot, not at import).  When the content directory
+    has no usable manifest — the bootstrap state until the first
+    ``sync_content`` pin lands — this degrades to an empty list with a
+    warning rather than crashing boot: the app keeps serving non-content
+    features, and the CI drift gate (#397) catches bad manifests before
+    deploy.
+    """
+    try:
+        chapters = get_content_repository().list_chapters()
+    except ContentRepositoryError as exc:
+        logger.warning("No usable content manifest; seeding no chapters: %s", exc)
+        return []
+    return [
+        ChapterRecord(
+            stage_number=chapter.stage,
+            title=chapter.title,
+            content_type=chapter.content_type,
+            release_day=chapter.release_day,
+            url=content_ref(chapter.id),
+        )
+        for chapter in chapters
+    ]
 
 
 def find_resource(slug: str) -> SiteResource | None:
@@ -219,23 +160,6 @@ def find_resource(slug: str) -> SiteResource | None:
 # --------------------------------------------------------------------------- #
 
 
-def _validate_stage_plans(plans: list[StageContentPlan]) -> None:
-    """Reject duplicate stage_numbers or duplicate slugs at import time."""
-    stages_seen: set[int] = set()
-    slugs_seen: set[str] = set()
-    for plan in plans:
-        if plan.stage_number in stages_seen:
-            msg = f"Duplicate stage_number in STAGE_PLANS: {plan.stage_number}"
-            raise ValueError(msg)
-        if plan.slug in slugs_seen:
-            msg = f"Duplicate slug in STAGE_PLANS: {plan.slug!r}"
-            raise ValueError(msg)
-        stages_seen.add(plan.stage_number)
-        slugs_seen.add(plan.slug)
-        # Force release-day computation so a bad pattern blows up at boot.
-        build_chapter_release_days(plan)
-
-
 def _validate_site_resources(resources: list[SiteResource]) -> None:
     """Reject duplicate site-resource slugs at import time."""
     slugs_seen: set[str] = set()
@@ -246,21 +170,17 @@ def _validate_site_resources(resources: list[SiteResource]) -> None:
         slugs_seen.add(resource.slug)
 
 
-_validate_stage_plans(STAGE_PLANS)
 _validate_site_resources(SITE_RESOURCES)
 
 
 # Public surface — keep ``__all__`` small to make intent obvious.
 __all__ = [
+    "CONTENT_REF_SCHEME",
     "SITE_BASE_URL",
     "SITE_RESOURCES",
-    "STAGE_PLANS",
     "ChapterRecord",
     "SiteResource",
-    "StageContentPlan",
     "all_chapter_records",
-    "build_chapter_release_days",
-    "chapter_url",
-    "expand_plan",
+    "content_ref",
     "find_resource",
 ]

--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -1,14 +1,19 @@
-"""Seed StageContent rows from the declarative content config.
+"""Seed StageContent rows from the vendored content manifest.
 
-Stage 1 (Beige) is fully driven by ``content_config.STAGE_PLANS`` — its
-chapters reflect the live Squarespace site.  Stages 2 and 3 retain their
-historic placeholder rows so the rest of the app keeps something to render
-until those courses ship; once a stage is added to ``STAGE_PLANS`` the
-placeholders are reconciled against the plan (see :func:`seed_content`).
+Chapters are reconciled from ``manifest.json`` for **every stage the
+manifest ships** (issue #392): title, content type, and release day come
+from the manifest verbatim, and the ``url`` column carries a local
+``content://<chapter-id>`` reference instead of a Squarespace URL.
+Stages the manifest does not cover yet keep their historic placeholder
+rows so the rest of the app has something to render; the moment a stage
+appears in the manifest its placeholders stop seeding (suppression is
+decided at seed time because the manifest is runtime data).
 
-Editing rules live in ``backend/src/content_config.py`` and the editor
-guide in ``docs/content.md``.  Do not hand-edit URLs in this file — go
-update the config instead.
+Reconciliation is idempotent and never destructive: rows update in place
+when their fields drift, and nothing is ever deleted — rows referenced
+by ``ContentCompletion`` stay put.
+
+Editing happens in the content repo; see ``docs/content.md``.
 """
 
 from __future__ import annotations
@@ -16,13 +21,14 @@ from __future__ import annotations
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from content_config import STAGE_PLANS, ChapterRecord, all_chapter_records
+from content_config import ChapterRecord, all_chapter_records
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 
-# Placeholder rows for stages that don't yet have a Squarespace plan.
-# Once a stage is added to ``STAGE_PLANS`` (see content_config.py) its
-# entry here should be removed in the same commit.
+# Placeholder rows for stages the content manifest does not cover yet.
+# Once the manifest ships a stage, its placeholders are suppressed
+# automatically at seed time; remove the entries here once that stage's
+# content is live.
 _PLACEHOLDER_DEFINITIONS: list[dict[str, str | int]] = [
     # Stage 2 — Magick
     {
@@ -70,10 +76,6 @@ _PLACEHOLDER_DEFINITIONS: list[dict[str, str | int]] = [
     },
 ]
 
-#: Stage numbers that have a real Squarespace plan and should NOT receive
-#: placeholder rows even if some are listed historically.
-_PLANNED_STAGES: frozenset[int] = frozenset(plan.stage_number for plan in STAGE_PLANS)
-
 # BUG-SEED-001 (preserved): a duplicate (stage_number, release_day) on a
 # placeholder row would scramble drip-feed ordering.  Configured chapters
 # may legitimately share a release_day with a placeholder of a different
@@ -84,27 +86,14 @@ if len(set(_placeholder_pairs)) != len(_placeholder_pairs):
     _err = f"Duplicate (stage_number, release_day) in placeholders: {_dupes}"
     raise ValueError(_err)
 
-# Match the import-time validation philosophy from ``content_config.py``:
-# if a stage has been added to ``STAGE_PLANS`` but its placeholder rows
-# are still in this file, fail loudly at boot rather than seeding both
-# the planned chapters AND the stale placeholders side-by-side.
-_overlapping_stages = {int(d["stage_number"]) for d in _PLACEHOLDER_DEFINITIONS} & _PLANNED_STAGES
-if _overlapping_stages:
-    _err = (
-        "Stage(s) "
-        f"{sorted(_overlapping_stages)} have entries in both "
-        "STAGE_PLANS (content_config.py) and _PLACEHOLDER_DEFINITIONS — "
-        "remove the placeholders so the seeder isn't reconciling against a "
-        "stale source of truth."
-    )
-    raise ValueError(_err)
 
-
-def _placeholder_records() -> list[ChapterRecord]:
+def _placeholder_records(covered_stages: frozenset[int]) -> list[ChapterRecord]:
     """Convert placeholder dicts into ``ChapterRecord``.
 
-    Lets the seeder iterate a single uniform list regardless of whether the
-    record came from the declarative config or the legacy placeholder block.
+    ``covered_stages`` — stage numbers present in the content manifest —
+    suppresses placeholders for stages whose real content has shipped.
+    The old import-time overlap check is gone because the manifest is
+    runtime data; suppression replaces fail-loudly.
     """
     return [
         ChapterRecord(
@@ -115,18 +104,20 @@ def _placeholder_records() -> list[ChapterRecord]:
             url=str(d["url"]),
         )
         for d in _PLACEHOLDER_DEFINITIONS
-        if int(d["stage_number"]) not in _PLANNED_STAGES
+        if int(d["stage_number"]) not in covered_stages
     ]
 
 
 def desired_content_records() -> list[ChapterRecord]:
     """Return the full set of records that should exist after seeding.
 
-    Order is (configured chapters first, then placeholders) — callers that
-    need a stable ordering can ``sorted(...)`` on the fields they care
-    about.
+    Order is (manifest chapters first, then surviving placeholders) —
+    callers that need a stable ordering can ``sorted(...)`` on the fields
+    they care about.
     """
-    return [*all_chapter_records(), *_placeholder_records()]
+    manifest_records = all_chapter_records()
+    covered = frozenset(record.stage_number for record in manifest_records)
+    return [*manifest_records, *_placeholder_records(covered)]
 
 
 async def _load_stage_map(session: AsyncSession) -> dict[int, int]:

--- a/backend/tests/test_lifespan_seeding.py
+++ b/backend/tests/test_lifespan_seeding.py
@@ -21,11 +21,11 @@ from sqlmodel import select
 # object itself (so it can wire a session factory at it), not a per-test
 # session yielded from a fixture.
 from conftest import test_engine
-from content_config import STAGE_PLANS
 from main import _seed_startup_data, app, lifespan
 from models.course_stage import CourseStage
 from models.practice import Practice
 from models.stage_content import StageContent
+from seed_content import desired_content_records
 from seed_practices import PRESET_PRACTICES
 
 #: Total preset rows the practice seeder inserts — sourced from
@@ -33,13 +33,16 @@ from seed_practices import PRESET_PRACTICES
 #: this test's expectation.
 _EXPECTED_PRACTICE_COUNT = len(PRESET_PRACTICES)
 
-#: ``seed_content`` keeps placeholder rows for stages 2 and 3 (three each)
-#: until those stages get a real ``STAGE_PLANS`` entry.  Asserting on
-#: ``STAGE_PLANS.chapter_count + _PLACEHOLDER_CONTENT_ROWS`` means a
-#: regression that drops the content seeder fails this test, not just a
-#: ``/course`` smoke check; adjust this when ``_PLACEHOLDER_DEFINITIONS``
-#: in ``seed_content.py`` changes.
-_PLACEHOLDER_CONTENT_ROWS = 6
+
+def _expected_content_count() -> int:
+    """Rows the content seeder should produce in this environment.
+
+    Sourced from ``desired_content_records()`` — manifest chapters (none
+    in the test environment until a content pin is vendored) plus the
+    placeholder rows for stages the manifest does not cover.  Computed at
+    call time because the manifest is runtime data.
+    """
+    return len(desired_content_records())
 
 
 @asynccontextmanager
@@ -70,8 +73,8 @@ async def test_seed_startup_data_inserts_stages_practices_and_content(
 
     assert len(stages) == 10
     assert len(practices) == _EXPECTED_PRACTICE_COUNT
-    expected_content_count = sum(p.chapter_count for p in STAGE_PLANS) + _PLACEHOLDER_CONTENT_ROWS
-    assert len(contents) == expected_content_count
+    assert len(contents) == _expected_content_count()
+    assert len(contents) > 0, "content seeder must produce rows even without a manifest"
 
 
 @pytest.mark.asyncio
@@ -158,9 +161,8 @@ async def test_seed_startup_data_continues_after_per_seeder_failure(
 
     stages = (await db_session.execute(select(CourseStage))).scalars().all()
     contents = (await db_session.execute(select(StageContent))).scalars().all()
-    expected_content_count = sum(p.chapter_count for p in STAGE_PLANS) + _PLACEHOLDER_CONTENT_ROWS
     assert len(stages) == 10
-    assert len(contents) == expected_content_count
+    assert len(contents) == _expected_content_count()
 
     failure_logs = [r for r in caplog.records if "seed_failed" in r.getMessage()]
     assert failure_logs, "expected a logged failure for the practices seeder"

--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -1,23 +1,91 @@
-"""Tests for the seed_content script."""
+"""Tests for the manifest-driven seed_content script (issue #392).
+
+``StageContent`` rows are now reconciled from the vendored content
+manifest via :class:`ContentRepository` — not from the deleted
+``STAGE_PLANS`` hardcode. Chapters carry a local ``content://<id>``
+reference instead of a Squarespace URL; placeholder rows survive only
+for stages the manifest does not cover yet.
+"""
 
 from __future__ import annotations
 
+import json
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col, select
+from sqlmodel import select
 
-from content_config import STAGE_PLANS, all_chapter_records
+from content_config import all_chapter_records, content_ref
+from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
+from models.user import User
 from seed_content import desired_content_records, seed_content
+from services.content_repository import (
+    ContentRepository,
+    reset_content_repository_for_tests,
+    set_content_repository_for_tests,
+)
 
-# Chapters seeded for the live stages (today: just beige = 14).
-_PLANNED_CHAPTER_COUNT = sum(plan.chapter_count for plan in STAGE_PLANS)
-# Placeholders kept for stages 2 and 3 (3 each).
+# Placeholders kept for stages 2 and 3 (3 each) until the manifest covers them.
 _PLACEHOLDER_COUNT = 6
 
 
-async def _seed_stages(db_session: AsyncSession, count: int = 3) -> None:
+def _chapter(
+    chapter_id: str,
+    stage: int,
+    title: str,
+    release_day: int,
+    content_type: str = "chapter",
+) -> dict[str, Any]:
+    """One manifest chapter entry; the number comes from the id suffix."""
+    number = int(chapter_id.rsplit("-", 1)[1])
+    return {
+        "id": chapter_id,
+        "stage": stage,
+        "chapter": number,
+        "slug": title.lower().replace(" ", "-"),
+        "title": title,
+        "content_type": content_type,
+        "release_day": release_day,
+        "order": number,
+        "path": f"markdown/{stage:02d}/{number:02d}.md",
+    }
+
+
+_MANIFEST: dict[str, Any] = {
+    "schema_version": "1.0.0",
+    "chapters": [
+        _chapter("beige-1", 1, "Survival", 0),
+        _chapter("beige-2", 1, "Breath as Anchor", 3, content_type="essay"),
+        _chapter("teal-1", 4, "Systems Sight", 0),
+    ],
+    "site_resources": [],
+}
+
+
+@pytest.fixture
+def install_manifest(tmp_path: Path) -> Iterator[Callable[[dict[str, Any]], None]]:
+    """Install a manifest into the process-wide ContentRepository singleton."""
+
+    def install(manifest: dict[str, Any]) -> None:
+        root = tmp_path / "content"
+        root.mkdir(exist_ok=True)
+        (root / "manifest.json").write_text(json.dumps(manifest))
+        for chapter in manifest["chapters"]:
+            md = root / chapter["path"]
+            md.parent.mkdir(parents=True, exist_ok=True)
+            md.write_text(f"# {chapter['title']}\n")
+        set_content_repository_for_tests(ContentRepository(root))
+
+    yield install
+    reset_content_repository_for_tests()
+
+
+async def _seed_stages(db_session: AsyncSession, count: int = 4) -> None:
     """Insert test stages into the DB."""
     for i in range(1, count + 1):
         stage = CourseStage(
@@ -37,23 +105,68 @@ async def _seed_stages(db_session: AsyncSession, count: int = 3) -> None:
     await db_session.commit()
 
 
+# ── content_config: manifest-driven records ─────────────────────────────
+
+
+def test_all_chapter_records_come_from_manifest(
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    install_manifest(_MANIFEST)
+    records = all_chapter_records()
+    assert [(r.stage_number, r.title) for r in records] == [
+        (1, "Survival"),
+        (1, "Breath as Anchor"),
+        (4, "Systems Sight"),
+    ]
+    assert records[0].url == content_ref("beige-1")
+    assert records[1].release_day == 3
+    assert records[1].content_type == "essay"
+
+
+def test_all_chapter_records_empty_without_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bootstrap state — no vendored manifest yet — degrades to no records."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("CONTENT_DIR", str(empty))
+    reset_content_repository_for_tests()
+    try:
+        assert all_chapter_records() == []
+    finally:
+        reset_content_repository_for_tests()
+
+
+def test_content_ref_format() -> None:
+    assert content_ref("beige-1") == "content://beige-1"
+
+
+# ── seeding ─────────────────────────────────────────────────────────────
+
+
 @pytest.mark.asyncio
-async def test_seed_content_inserts_items(db_session: AsyncSession) -> None:
-    """Seeding with stages present inserts configured chapters + placeholders."""
-    await _seed_stages(db_session, count=3)
+async def test_seed_content_inserts_manifest_chapters_and_placeholders(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Every manifest chapter plus placeholders for uncovered stages."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=4)
     inserted = await seed_content(db_session)
-    expected_total = _PLANNED_CHAPTER_COUNT + _PLACEHOLDER_COUNT
+    expected_total = len(_MANIFEST["chapters"]) + _PLACEHOLDER_COUNT
     assert inserted == expected_total
 
     result = await db_session.execute(select(StageContent))
-    items = result.scalars().all()
-    assert len(items) == expected_total
+    assert len(result.scalars().all()) == expected_total
 
 
 @pytest.mark.asyncio
-async def test_seed_content_idempotent(db_session: AsyncSession) -> None:
-    """Running seed_content twice doesn't duplicate items."""
-    await _seed_stages(db_session, count=3)
+async def test_seed_content_idempotent(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=4)
     first = await seed_content(db_session)
     second = await seed_content(db_session)
     assert first > 0
@@ -61,62 +174,116 @@ async def test_seed_content_idempotent(db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def test_seed_content_no_stages(db_session: AsyncSession) -> None:
-    """Without stages, no content is inserted."""
+async def test_seed_content_no_stages(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    install_manifest(_MANIFEST)
     inserted = await seed_content(db_session)
     assert inserted == 0
 
 
 @pytest.mark.asyncio
-async def test_seed_content_creates_beige_chapters(db_session: AsyncSession) -> None:
-    """Stage 1 (Beige) gets the configured chapter set, not placeholders."""
-    await _seed_stages(db_session, count=1)
+async def test_seeded_rows_carry_local_refs_not_urls(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Manifest chapters land with content:// references; no Squarespace URLs."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=4)
     await seed_content(db_session)
 
     result = await db_session.execute(
-        select(StageContent)
-        .join(CourseStage)
-        .where(CourseStage.stage_number == 1)
-        .order_by(col(StageContent.release_day))
+        select(StageContent).join(CourseStage).where(CourseStage.stage_number == 1)
     )
-    items = list(result.scalars().all())
+    items = sorted(result.scalars().all(), key=lambda i: i.release_day)
+    assert [i.title for i in items] == ["Survival", "Breath as Anchor"]
+    assert [i.url for i in items] == [content_ref("beige-1"), content_ref("beige-2")]
+    assert [i.release_day for i in items] == [0, 3]
 
-    # The beige plan ships 14 chapters.
-    beige_plan = next(p for p in STAGE_PLANS if p.stage_number == 1)
-    assert len(items) == beige_plan.chapter_count
-    assert items[0].url == "https://aptitude.guru/course/beige-1"
-    assert items[-1].url == f"https://aptitude.guru/course/beige-{beige_plan.chapter_count}"
-    # Chapter type is uniform across the plan.
-    assert {item.content_type for item in items} == {"chapter"}
+    everything = (await db_session.execute(select(StageContent))).scalars().all()
+    assert not any("aptitude.guru" in row.url for row in everything)
 
 
 @pytest.mark.asyncio
-async def test_seed_content_reconciles_url_drift(db_session: AsyncSession) -> None:
-    """A row whose URL drifted from the config is updated in place, not duplicated."""
-    await _seed_stages(db_session, count=1)
+async def test_seed_content_reconciles_ref_drift(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """A row whose reference drifted is updated in place, not duplicated."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=4)
     await seed_content(db_session)
 
-    # Manually corrupt one URL — simulates a chapter being moved on the CMS.
-    result = await db_session.execute(select(StageContent).where(StageContent.title == "Chapter 1"))
+    result = await db_session.execute(select(StageContent).where(StageContent.title == "Survival"))
     row = result.scalars().one()
-    original_url = row.url
-    row.url = "https://aptitude.guru/course/beige-1-OLD"
+    row.url = "https://aptitude.guru/course/beige-1"
     await db_session.commit()
 
-    # Re-seeding should reset the URL to the config value without inserting
-    # a duplicate row.
     inserted = await seed_content(db_session)
     assert inserted == 0
     await db_session.refresh(row)
-    assert row.url == original_url
+    assert row.url == content_ref("beige-1")
 
 
-def test_desired_content_records_counts() -> None:
-    """Flat list of desired records covers every chapter plus surviving placeholders."""
+@pytest.mark.asyncio
+async def test_read_completions_survive_content_resync(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Regression: a re-seed after a manifest change never orphans read marks."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=4)
+    await seed_content(db_session)
+
+    result = await db_session.execute(select(StageContent).where(StageContent.title == "Survival"))
+    row = result.scalars().one()
+    assert row.id is not None
+    user = User(email="reader@example.com", password_hash="x")
+    db_session.add(user)
+    await db_session.commit()
+    assert user.id is not None
+    db_session.add(ContentCompletion(user_id=user.id, content_id=row.id))
+    await db_session.commit()
+
+    # Content team moves Survival's drip day; the row must update in place.
+    moved = json.loads(json.dumps(_MANIFEST))
+    moved["chapters"][0]["release_day"] = 1
+    install_manifest(moved)
+    inserted = await seed_content(db_session)
+    assert inserted == 0
+
+    await db_session.refresh(row)
+    assert row.release_day == 1
+    completions = (await db_session.execute(select(ContentCompletion))).scalars().all()
+    assert len(completions) == 1
+    assert completions[0].content_id == row.id
+
+
+@pytest.mark.asyncio
+async def test_placeholders_suppressed_when_manifest_covers_stage(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Once the manifest ships a stage, its placeholders stop seeding."""
+    covering = json.loads(json.dumps(_MANIFEST))
+    covering["chapters"].append(_chapter("purple-1", 2, "Tribal Rhythm", 0))
+    install_manifest(covering)
+    await _seed_stages(db_session, count=4)
+    await seed_content(db_session)
+
+    result = await db_session.execute(
+        select(StageContent).join(CourseStage).where(CourseStage.stage_number == 2)
+    )
+    stage_two = result.scalars().all()
+    assert [i.title for i in stage_two] == ["Tribal Rhythm"]
+
+
+def test_desired_content_records_counts(
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    install_manifest(_MANIFEST)
     records = desired_content_records()
-    planned = all_chapter_records()
-    assert len(records) == len(planned) + _PLACEHOLDER_COUNT
-    # All configured chapters should be present.
-    planned_urls = {r.url for r in planned}
-    record_urls = {r.url for r in records}
-    assert planned_urls.issubset(record_urls)
+    assert len(records) == len(_MANIFEST["chapters"]) + _PLACEHOLDER_COUNT
+    manifest_urls = {content_ref(c["id"]) for c in _MANIFEST["chapters"]}
+    assert manifest_urls.issubset({r.url for r in records})

--- a/docs/content.md
+++ b/docs/content.md
@@ -1,14 +1,20 @@
-# Editing Squarespace-Backed Course Content
+# Editing Course Content
 
-The Adepthood app pulls every course page from the password-protected
-Squarespace site at <https://aptitude.guru>.  This doc covers everything
-you need to know to add, remove, or rearrange that content.
+Stage-locked chapter metadata is driven by the **vendored content
+manifest** (`backend/content/manifest.json`, synced from the
+[`aptitude-course`](https://github.com/Geoffe-Ga/aptitude-course) repo —
+see ADR 0001 in `docs/adr/`).  Chapter *bodies* are still fetched from
+the password-protected Squarespace site until the body-endpoint rewrite
+lands; the Squarespace sections below remain operative until then.
 
 ## Where things live
 
 | What | File |
 | ---- | ---- |
-| Stage chapter plans (Beige, Purple, …) and site resource links | `backend/src/content_config.py` |
+| Vendored chapter metadata (all 10 stages) | `backend/content/manifest.json` (synced; do not hand-edit) |
+| Manifest contract + reader | `backend/content/manifest.schema.json`, `backend/src/services/content_repository.py` |
+| Sync command (pin bumps) | `backend/scripts/sync_content.py` / `make sync-content REF=<sha>` |
+| Manifest → seeder bridge and site resource links | `backend/src/content_config.py` |
 | Site password env var | `backend/.env` (`SQUARESPACE_SITE_PASSWORD=...`) |
 | Database seeder that materialises chapters into `StageContent` rows | `backend/src/seed_content.py` |
 | HTTP client that fetches and cleans Squarespace HTML | `backend/src/services/squarespace.py` |
@@ -18,60 +24,37 @@ you need to know to add, remove, or rearrange that content.
 
 ## How releases are timed
 
-Each stage runs for `PLAN_DURATION_DAYS = 21` calendar days (see
-`backend/src/domain/energy.py`).  Inside that window:
+Each chapter's `release_day` comes straight from the manifest (set via
+YAML frontmatter in the content repo): day `N` means the chapter drips
+open `N` days after the user starts the stage, with `0` unlocking
+immediately.  Days at the end of a stage with no new chapter are a
+catch-up window by design.
 
-* Chapter `n` (1-indexed) of a stage unlocks on `release_day = n - 1`.
-* If a stage ships fewer chapters than 21, the remaining days are a
-  catch-up window with no new reading.
-* The "daily" pattern is currently the only one supported.  Adding a
-  pattern (`weekly`, `front_loaded`, …) means extending
-  `build_chapter_release_days()` in `content_config.py`.
+## Adding, reordering, renaming, or removing chapters
 
-Today the Beige stage ships 14 chapters → days 0–13 unlock one new
-chapter each, days 14–20 are catch-up.
+All of it happens in the **content repo**, not here:
 
-## Adding chapters to a new stage
+1. Edit the Markdown/frontmatter in `aptitude-course` and merge; the
+   content repo regenerates `manifest.json`.
+2. Vendor the new pin: `make sync-content REF=<sha>` and commit the
+   `backend/content/` diff.
+3. Deploy.  The startup seeder reconciles `StageContent` rows from the
+   manifest for every stage it ships: new chapters insert, changed
+   fields (title-matched within a stage) update in place, and rows that
+   were marked read stay marked read.
 
-1. Publish the Squarespace pages.  Use the slug pattern that
-   `content_config.py` expects: `https://aptitude.guru/course/{slug}-{n}`
-   where `{n}` runs from 1.
-2. Append a `StageContentPlan` entry to `STAGE_PLANS`:
+The seeder never deletes rows (deletion would silently lose
+`ContentCompletion` references).  A chapter dropped from the manifest
+simply stops being referenced; if you actually want the row gone, write
+a one-off migration.
 
-   ```python
-   STAGE_PLANS: Final[list[StageContentPlan]] = [
-       StageContentPlan(stage_number=1, slug="beige",  chapter_count=14),
-       # New →
-       StageContentPlan(stage_number=2, slug="purple", chapter_count=10),
-   ]
-   ```
+Stages the manifest does not cover yet keep placeholder rows (defined in
+`seed_content.py`); they are suppressed automatically once the manifest
+ships that stage.
 
-3. Open `backend/src/seed_content.py` and drop the stage's placeholder
-   rows from `_PLACEHOLDER_DEFINITIONS` if any are still listed there —
-   the seeder already skips stages that have a plan, so leaving them
-   only wastes lines.
-4. Restart the backend.  The startup seeder will create one
-   `StageContent` row per chapter; subsequent boots are idempotent.
-
-## Reordering or renaming chapters
-
-Two paths, depending on what changed:
-
-* **Renamed the page on Squarespace, slug unchanged** — no action.
-  We always hit the same URL.
-* **Slug changed** — update `chapter_count` (or the `slug` field on
-  the plan).  Restart the backend.  The seeder's reconciliation step
-  updates the URL on existing rows in place; rows that were marked read
-  stay marked read.
-
-## Removing chapters
-
-Lower `chapter_count` in the relevant plan.  The seeder doesn't delete
-the now-orphaned `StageContent` row by itself (deletion would silently
-lose `ContentCompletion` rows referencing it).  If you actually want
-the row gone, write a one-off migration; otherwise the row simply
-stops appearing in the chapter list once `chapter_count` is below its
-index.
+`StageContent.url` holds a local `content://<chapter-id>` reference for
+manifest-driven rows — not a fetchable URL.  The body endpoint maps it
+back to the vendored Markdown (cms-migration epic #388).
 
 ## Adding a "From Aptitude Guru" link
 


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `STAGE_PLANS` (stage 1 only, Squarespace URL templates) with manifest-driven chapter records (issue #392, epic #388): `all_chapter_records()` reads `ContentRepository.list_chapters()` lazily at seed time for **every stage the manifest ships**, with `title`/`content_type`/`release_day` taken verbatim and manifest `stage` N mapped onto `CourseStage.stage_number` N (identity per ADR 0001's stage-numbering reconciliation).
- **Local reference decision (documented in the module docstring): `StageContent.url` is repurposed, not renamed** — it now carries `content://<chapter-id>` for manifest rows. No Alembic migration needed, read-completion FKs stay put, and the rename can ride the final cutover once the Squarespace reader is deleted. No Squarespace URL is written to the DB.
- Placeholder rows (stages 2–3) now suppress **at seed time** for any stage the manifest covers — the import-time overlap check is gone because the manifest is runtime data. Reconciliation stays idempotent and never deletes rows.
- A missing/invalid manifest degrades to zero chapter records with a logged warning instead of crashing boot — the bootstrap state until the first `sync_content` pin lands; the CI drift gate (#397) catches bad manifests pre-deploy.
- The stale `resync_stage_content.py` reference is gone (the script never existed; boot-time reconciliation supersedes it) and `docs/content.md` is rewritten to the content-repo workflow, with the Squarespace body-fetching sections kept until the body-endpoint rewrite (#393).
- Deleted: `StageContentPlan`, `STAGE_PLANS`, `build_chapter_release_days`, `chapter_url`, `expand_plan` (release days now come from the manifest). `SiteResource`/`SITE_RESOURCES` are untouched — they migrate in a later issue.

## Test plan
- [x] `backend/tests/test_seed_content.py` rewritten to a manifest fixture (tmp content dir + `set_content_repository_for_tests`): manifest-driven records across stages 1 and 4, `content://` refs, empty-manifest bootstrap degradation, insert counts (manifest chapters + surviving placeholders), idempotency, no-stages no-op, local refs with zero `aptitude.guru` URLs in the DB, drift reconciliation in place, **read-marked chapters survive a manifest resync** (release_day moved; row updated in place, completion intact — the issue's regression test), placeholder suppression once the manifest covers stage 2, and desired-record counts.
- [x] `test_lifespan_seeding.py` updated off `STAGE_PLANS` onto `desired_content_records()` computed at call time.
- [x] Full backend suite green at 94.81%; drip-feed gating tests (`test_course_api.py`) untouched and green; xenon all-A; `TZ=UTC pre-commit run --all-files` green twice.

Closes #392
Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)