### PR TITLE
feat(backend): serve site resources from the content manifest

### DIFF
--- a/backend/src/content_config.py
+++ b/backend/src/content_config.py
@@ -1,4 +1,4 @@
-"""Declarative content config: manifest-driven chapters + site resources.
+"""Declarative content config: manifest-driven chapter records.
 
 Stage-locked chapters are no longer hardcoded here (the old
 ``STAGE_PLANS`` covered stage 1 only and built Squarespace URLs).  They
@@ -16,8 +16,9 @@ needed, existing read-completion rows keep their foreign keys, and the
 column rename can ride the final cutover issue once the Squarespace
 reader is deleted.  See issue #392.
 
-Site resources (philosophy, about, …) are still declared here and still
-point at the public site; they migrate in a later cms-migration issue.
+Site resources (philosophy, about, …) moved out of this module in issue
+#395: the manifest's ``site_resources[]`` is their source of truth and
+the course router reads them straight from the repository.
 
 See ``docs/content.md`` for the editor's guide.
 """
@@ -32,9 +33,6 @@ from services.content_repository import ContentRepositoryError, get_content_repo
 
 logger = logging.getLogger(__name__)
 
-#: Public-facing site root. Used to build site-resource URLs (only).
-SITE_BASE_URL: Final[str] = "https://aptitude.guru"
-
 #: Scheme for local content references stored in ``StageContent.url``.
 CONTENT_REF_SCHEME: Final[str] = "content"
 
@@ -47,60 +45,6 @@ def content_ref(chapter_id: str) -> str:
     nothing downstream should treat it as a fetchable URL.
     """
     return f"{CONTENT_REF_SCHEME}://{chapter_id}"
-
-
-@dataclass(frozen=True)
-class SiteResource:
-    """A non-stage-locked link surfaced on the Course screen.
-
-    Use this for evergreen pages (philosophy, about, FAQ) that the adept
-    should be able to reach from inside the app at any point in the
-    program.  These are not tracked for read-completion.
-    """
-
-    slug: str
-    title: str
-    description: str = ""
-    path: str = ""
-
-    @property
-    def url(self) -> str:
-        """Absolute public URL on the live site."""
-        suffix = self.path or f"/{self.slug}"
-        return f"{SITE_BASE_URL}{suffix}"
-
-
-# --------------------------------------------------------------------------- #
-# Always-available site resources                                             #
-# --------------------------------------------------------------------------- #
-
-#: Pages that are not stage-gated. Order here is the order shown in the UI.
-SITE_RESOURCES: Final[list[SiteResource]] = [
-    SiteResource(
-        slug="liminal-creep",
-        title="Who Benefits?",
-        description="Why the program exists.",
-        path="/philosophy/liminal-creep",
-    ),
-    SiteResource(
-        slug="archetypal-wavelength",
-        title="Archetypal Wavelength Intro",
-        description="The shape of human development.",
-        path="/philosophy/archetypal-wavelength",
-    ),
-    SiteResource(
-        slug="aptitude-stages",
-        title="APTITUDE Stages",
-        description="The 36-week stage map.",
-        path="/philosophy/aptitude-stages",
-    ),
-    SiteResource(
-        slug="about",
-        title="APTITUDE Intro",
-        description="What Adepthood is and who it's for.",
-        path="/about",
-    ),
-]
 
 
 # --------------------------------------------------------------------------- #
@@ -147,40 +91,10 @@ def all_chapter_records() -> list[ChapterRecord]:
     ]
 
 
-def find_resource(slug: str) -> SiteResource | None:
-    """Look up a ``SiteResource`` by its slug, or ``None`` if not configured."""
-    for resource in SITE_RESOURCES:
-        if resource.slug == slug:
-            return resource
-    return None
-
-
-# --------------------------------------------------------------------------- #
-# Import-time validation — fail fast on bad config rather than at request time #
-# --------------------------------------------------------------------------- #
-
-
-def _validate_site_resources(resources: list[SiteResource]) -> None:
-    """Reject duplicate site-resource slugs at import time."""
-    slugs_seen: set[str] = set()
-    for resource in resources:
-        if resource.slug in slugs_seen:
-            msg = f"Duplicate slug in SITE_RESOURCES: {resource.slug!r}"
-            raise ValueError(msg)
-        slugs_seen.add(resource.slug)
-
-
-_validate_site_resources(SITE_RESOURCES)
-
-
 # Public surface — keep ``__all__`` small to make intent obvious.
 __all__ = [
     "CONTENT_REF_SCHEME",
-    "SITE_BASE_URL",
-    "SITE_RESOURCES",
     "ChapterRecord",
-    "SiteResource",
     "all_chapter_records",
     "content_ref",
-    "find_resource",
 ]

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
-from content_config import CONTENT_REF_SCHEME, SITE_RESOURCES, find_resource
+from content_config import CONTENT_REF_SCHEME, content_ref
 from database import get_session
 from domain.course import compute_days_elapsed, filter_content_for_user, next_unlock_day
 from domain.stage_progress import ensure_user_progress, get_user_progress, is_stage_unlocked
@@ -511,20 +511,29 @@ async def get_content_body(
 async def list_site_resources(
     _current_user: Annotated[int, Depends(get_current_user)],
 ) -> list[SiteResourceResponse]:
-    """Return the configured site-wide resource links.
+    """Return the site-wide resource links from the content manifest.
 
     These pages (philosophy, about, …) are not stage-gated, but we still
     require authentication so the list is not crawlable by anyone with
-    the URL.  Editing this list happens in ``content_config.py``.
+    the URL.  The manifest's ``site_resources[]`` is the source of truth
+    (issue #395); without a usable manifest — the bootstrap state before
+    the first content pin — the list is simply empty.  ``url`` is kept
+    for response-surface stability and carries the local content
+    reference, not a fetchable address.
     """
+    try:
+        resources = get_content_repository().list_resources()
+    except ContentRepositoryError as exc:
+        logger.warning("No usable content manifest; no site resources: %s", exc)
+        return []
     return [
         SiteResourceResponse(
             slug=resource.slug,
             title=resource.title,
             description=resource.description,
-            url=resource.url,
+            url=content_ref(resource.slug),
         )
-        for resource in SITE_RESOURCES
+        for resource in resources
     ]
 
 
@@ -535,13 +544,9 @@ async def get_site_resource_body(
     slug: str,
     _current_user: Annotated[int, Depends(get_current_user)],
 ) -> ContentBodyResponse:
-    """Return raw Markdown for a configured site resource.
+    """Return raw Markdown for a manifest-listed site resource.
 
-    ``find_resource`` keeps the config list as the gate on which slugs
-    exist; the body itself comes from the vendored content.  A configured
-    slug the manifest has not shipped yet 404s like any other miss.
+    The manifest is the gate on which slugs exist — an unknown slug is a
+    plain 404 via the repository's ``ContentNotFoundError``.
     """
-    resource = find_resource(slug)
-    if resource is None:
-        raise not_found("resource")
     return _read_local_body(lambda: get_content_repository().read_resource_body(slug), slug)

--- a/backend/src/services/content_repository.py
+++ b/backend/src/services/content_repository.py
@@ -63,6 +63,16 @@ class ChapterMeta:
 
 
 @dataclass(frozen=True)
+class SiteResourceMeta:
+    """One free site resource's manifest metadata (issue #395)."""
+
+    slug: str
+    title: str
+    description: str
+    path: str
+
+
+@dataclass(frozen=True)
 class ContentBody:
     """A rendered-ready body: raw Markdown plus the metadata the UI shows."""
 
@@ -207,6 +217,18 @@ class ContentRepository:
             title=meta.title,
             content_type=meta.content_type,
         )
+
+    def list_resources(self) -> list[SiteResourceMeta]:
+        """Every site resource, in manifest order (the UI display order)."""
+        return [
+            SiteResourceMeta(
+                slug=raw["slug"],
+                title=raw["title"],
+                description=raw["description"],
+                path=raw["path"],
+            )
+            for raw in self._resources.values()
+        ]
 
     def read_resource_body(self, slug: str) -> ContentBody:
         """Raw Markdown + title for a free site resource, by slug."""

--- a/backend/src/services/content_repository.py
+++ b/backend/src/services/content_repository.py
@@ -64,12 +64,16 @@ class ChapterMeta:
 
 @dataclass(frozen=True)
 class SiteResourceMeta:
-    """One free site resource's manifest metadata (issue #395)."""
+    """One free site resource's manifest metadata (issue #395).
+
+    Deliberately omits the manifest ``path`` — body reads go through
+    :meth:`ContentRepository.read_resource_body`, which resolves the path
+    internally with the traversal guard; no caller needs it raw.
+    """
 
     slug: str
     title: str
     description: str
-    path: str
 
 
 @dataclass(frozen=True)
@@ -219,13 +223,16 @@ class ContentRepository:
         )
 
     def list_resources(self) -> list[SiteResourceMeta]:
-        """Every site resource, in manifest order (the UI display order)."""
+        """Every site resource, in manifest order (the UI display order).
+
+        Direct ``raw[...]`` access is safe: the schema requires every
+        resource field and the manifest was validated at construction.
+        """
         return [
             SiteResourceMeta(
                 slug=raw["slug"],
                 title=raw["title"],
                 description=raw["description"],
-                path=raw["path"],
             )
             for raw in self._resources.values()
         ]

--- a/backend/tests/test_content_repository.py
+++ b/backend/tests/test_content_repository.py
@@ -219,6 +219,20 @@ def test_missing_markdown_for_known_id_raises_repository_error(content_dir: Path
         repo.read_body("beige-1")
 
 
+def test_list_resources_in_manifest_order(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    resources = repo.list_resources()
+    assert [r.slug for r in resources] == ["getting-started"]
+    assert resources[0].title == "Getting Started"
+    assert resources[0].description == "Orientation guide."
+
+
+def test_list_resources_empty_manifest(tmp_path: Path) -> None:
+    manifest: dict[str, Any] = {"schema_version": "1.0.0", "chapters": [], "site_resources": []}
+    root = _write_content_dir(tmp_path / "content", manifest)
+    assert ContentRepository(root).list_resources() == []
+
+
 # ── Singleton trio ──────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_content_repository.py
+++ b/backend/tests/test_content_repository.py
@@ -233,6 +233,20 @@ def test_list_resources_empty_manifest(tmp_path: Path) -> None:
     assert ContentRepository(root).list_resources() == []
 
 
+def test_resource_missing_description_is_rejected_at_construction(tmp_path: Path) -> None:
+    """A sparse resource entry never reaches ``list_resources()``.
+
+    The schema requires every resource field (slug/title/description/path),
+    so construction fails validation first — direct ``raw[...]`` access in
+    ``list_resources`` cannot KeyError.
+    """
+    sparse = copy.deepcopy(_VALID_MANIFEST)
+    del sparse["site_resources"][0]["description"]
+    root = _write_content_dir(tmp_path / "content", sparse)
+    with pytest.raises(ContentRepositoryError):
+        ContentRepository(root)
+
+
 # ── Singleton trio ──────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_course_body_endpoints.py
+++ b/backend/tests/test_course_body_endpoints.py
@@ -25,7 +25,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from content_config import SITE_RESOURCES, content_ref
+from content_config import content_ref
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 from models.stage_progress import StageProgress
@@ -337,18 +337,36 @@ async def test_site_resources_requires_auth(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_site_resources_lists_configured_entries(async_client: AsyncClient) -> None:
+@pytest.mark.usefixtures("content_dir")
+async def test_site_resources_lists_manifest_entries(async_client: AsyncClient) -> None:
+    """The list comes from the manifest, in manifest order, auth required."""
     headers = await _signup(async_client, "lister")
     resp = await async_client.get("/course/site-resources", headers=headers)
     assert resp.status_code == HTTPStatus.OK
     payload = resp.json()
-    assert len(payload) == len(SITE_RESOURCES)
-    by_slug = {r["slug"]: r for r in payload}
-    for configured in SITE_RESOURCES:
-        assert configured.slug in by_slug
-        entry = by_slug[configured.slug]
-        assert entry["title"] == configured.title
-        assert entry["url"] == configured.url
+    assert [r["slug"] for r in payload] == ["about", "aptitude-stages"]
+    assert payload[0]["title"] == "About Adepthood"
+    assert payload[0]["description"] == "What this is."
+    # ``url`` is kept for surface stability; it now carries the local ref.
+    assert payload[0]["url"] == content_ref("about")
+
+
+@pytest.mark.asyncio
+async def test_site_resources_empty_without_manifest(
+    async_client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bootstrap state — no vendored manifest — degrades to an empty list."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("CONTENT_DIR", str(empty))
+    reset_content_repository_for_tests()
+    try:
+        headers = await _signup(async_client, "bootstrap")
+        resp = await async_client.get("/course/site-resources", headers=headers)
+        assert resp.status_code == HTTPStatus.OK
+        assert resp.json() == []
+    finally:
+        reset_content_repository_for_tests()
 
 
 @pytest.mark.asyncio
@@ -369,18 +387,6 @@ async def test_site_resource_body_unknown_slug_returns_404(async_client: AsyncCl
     resp = await async_client.get(
         "/course/site-resources/this-does-not-exist/body", headers=headers
     )
-    assert resp.status_code == HTTPStatus.NOT_FOUND
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("content_dir")
-async def test_site_resource_body_404_when_configured_but_not_in_manifest(
-    async_client: AsyncClient,
-) -> None:
-    """A configured slug the manifest hasn't shipped yet 404s like any miss."""
-    headers = await _signup(async_client, "premanifest")
-    # 'liminal-creep' is in SITE_RESOURCES but not in the test manifest.
-    resp = await async_client.get("/course/site-resources/liminal-creep/body", headers=headers)
     assert resp.status_code == HTTPStatus.NOT_FOUND
 
 

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -17,7 +17,6 @@ from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
-from content_config import SITE_RESOURCES
 from models.user import User
 from rate_limit import DEFAULT_RATE_LIMIT
 
@@ -235,7 +234,7 @@ async def test_content_body_rate_limit_returns_429(async_client: AsyncClient) ->
 async def test_site_resource_body_rate_limit_returns_429(async_client: AsyncClient) -> None:
     """GET /course/site-resources/{slug}/body returns 429 after 30 requests/minute."""
     headers = await _signup(async_client)
-    slug = SITE_RESOURCES[0].slug
+    slug = "about"  # any slug works — the limiter fires before the handler
 
     for _ in range(30):
         await async_client.get(f"/course/site-resources/{slug}/body", headers=headers)


### PR DESCRIPTION
## Summary
- The manifest's `site_resources[]` is now the source of truth for the free site pages (issue #395, epic #388) — **decision for task 1: source the list from the manifest**, consistent with the #392 seed rewrite, rather than keeping a hardcoded list with locally-resolved bodies.
- `ContentRepository` gains a `SiteResourceMeta` dataclass and `list_resources()` returning resources in manifest order (the UI display order).
- `GET /course/site-resources` reads the repository: auth still required (not crawlable), no stage gating; the bootstrap state with no vendored manifest degrades to an empty list with a logged warning (the panel already hides itself on empty).
- `GET /course/site-resources/{slug}/body` drops the `find_resource` config gate — the manifest is the gate, and an unknown slug 404s via `ContentNotFoundError`.
- The hardcoded `SITE_RESOURCES` / `SiteResource` / `find_resource` / `SITE_BASE_URL` block in `content_config.py` is deleted; the module is now purely the manifest→seeder bridge.
- `SiteResourceResponse` stays shape-stable for the frontend (`{slug, title, description, url}`); `url` now carries the local `content://<slug>` reference (the frontend only consumes `slug`/`title`).

## Test plan
- [x] New repository tests: `list_resources()` order/fields and the empty-manifest case (module stays at 100% coverage).
- [x] Endpoint tests updated: list comes from the manifest fixture in manifest order with the local-ref `url`; new bootstrap test (no manifest → `200 []`); unknown-slug 404 and missing-file 502 retained; the now-obsolete configured-but-not-in-manifest case removed.
- [x] `test_rate_limits.py` decoupled from the deleted config list (slug literal — the limiter fires before the handler).
- [x] Full backend suite green at 94.67%; xenon all-A; `TZ=UTC pre-commit run --all-files` green twice.

Closes #395
Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)