### PR TITLE
feat(backend): wire content drift gate into ci and surface the live pin

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -203,3 +203,28 @@ jobs:
           # backend-quality job; this step only exercises the
           # pg_advisory_xact_lock branch that SQLite cannot.
           python -m pytest tests/test_pg_advisory_lock.py -q --no-cov
+
+  content-drift:
+    # Issue #397: the vendored backend/content/ must match its pinned
+    # CONTENT_VERSION (no silent drift, no hand edits) and the manifest
+    # must satisfy the frozen schema contract. Bootstrap state (nothing
+    # vendored yet) passes — the gate arms itself with the first pin.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Install drift-check deps
+        # The check needs only the sync script's imports, not the app.
+        run: uv pip install --system httpx 'jsonschema>=4.0'
+
+      - name: Verify vendored content matches CONTENT_VERSION
+        working-directory: backend
+        run: python -m scripts.sync_content --check

--- a/backend/scripts/sync_content.py
+++ b/backend/scripts/sync_content.py
@@ -207,15 +207,19 @@ def _stage_published_surface(source_root: Path, staging: Path, content_dir: Path
             shutil.copy(preserved, staging / name)
 
 
-def _validate_staged_manifest(staging: Path) -> None:
-    """Validate the staged manifest against the staged copy of the schema."""
-    schema_path = staging / "manifest.schema.json"
+def _validate_manifest_file(directory: Path) -> None:
+    """Validate ``directory``'s manifest against the schema beside it.
+
+    Used on the staging tree during a sync and on the live tree by
+    ``--check`` — the contract must hold in both places.
+    """
+    schema_path = directory / "manifest.schema.json"
     if not schema_path.is_file():
         msg = "manifest.schema.json is missing — cannot validate the vendored manifest"
         raise SyncContentError(msg)
     schema: Any = json.loads(schema_path.read_text())
     try:
-        manifest: Any = json.loads((staging / "manifest.json").read_text())
+        manifest: Any = json.loads((directory / "manifest.json").read_text())
     except json.JSONDecodeError as exc:
         msg = f"vendored manifest.json is not valid JSON: {exc}"
         raise SyncContentError(msg) from exc
@@ -264,7 +268,7 @@ def sync(
         staging = workspace_path / "staging"
         staging.mkdir()
         _stage_published_surface(source_root, staging, target)
-        _validate_staged_manifest(staging)
+        _validate_manifest_file(staging)
         digest = compute_tree_digest(staging)
         synced_at = datetime.now(UTC).isoformat()
         version_text = f"sha: {sha}\nsynced_at: {synced_at}\ndigest: {digest}\n"
@@ -273,13 +277,28 @@ def sync(
     return sha
 
 
-def check(content_dir: Path | None = None) -> None:
+def check(content_dir: Path | None = None) -> bool:
     """Verify ``content_dir`` matches its ``CONTENT_VERSION`` (CI drift gate).
 
-    Read-only: recomputes the tree digest and compares it to the recorded
-    one. Raises :class:`SyncContentError` on drift or a missing stamp.
+    Read-only. Returns ``True`` when vendored content was verified and
+    ``False`` in the bootstrap state (no manifest and no stamp — nothing
+    vendored yet, so there is nothing to gate; CI must stay green before
+    the first content pin lands). Everything else raises
+    :class:`SyncContentError`: a manifest without a stamp (hand-copied,
+    never synced), a digest mismatch (tampering/drift), or a manifest
+    that no longer satisfies the schema contract.
     """
     target = (content_dir or _DEFAULT_CONTENT_DIR).resolve()
+    manifest_exists = (target / "manifest.json").is_file()
+    stamp_exists = (target / CONTENT_VERSION_FILE).is_file()
+    if not manifest_exists and not stamp_exists:
+        return False
+    if manifest_exists and not stamp_exists:
+        msg = (
+            f"{target} has a manifest.json but no {CONTENT_VERSION_FILE} — "
+            "content must be vendored via scripts/sync_content.py, not copied by hand"
+        )
+        raise SyncContentError(msg)
     version = read_content_version(target)
     actual = compute_tree_digest(target)
     if actual != version["digest"]:
@@ -288,6 +307,8 @@ def check(content_dir: Path | None = None) -> None:
             f"match CONTENT_VERSION ({version['digest']}) — re-run the sync"
         )
         raise SyncContentError(msg)
+    _validate_manifest_file(target)
+    return True
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -312,8 +333,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         if args.check:
-            check(args.content_dir)
-            sys.stdout.write("content is in sync with CONTENT_VERSION\n")
+            if check(args.content_dir):
+                sys.stdout.write("content is in sync with CONTENT_VERSION\n")
+            else:
+                sys.stdout.write("no content vendored yet — nothing to check\n")
         else:
             sha = sync(args.ref, args.content_dir)
             sys.stdout.write(f"vendored {CONTENT_REPO}@{sha} into {args.content_dir}\n")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -50,6 +50,11 @@ from seed_content import seed_content
 from seed_practice_recipes import seed_practice_recipes
 from seed_practices import seed_practices
 from seed_stages import seed_stages
+from services.content_repository import (
+    ContentRepositoryError,
+    content_version_info,
+    get_content_repository,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -276,6 +281,29 @@ async def _seed_startup_data(session: AsyncSession) -> None:
             await session.rollback()
 
 
+def _log_content_status() -> None:
+    """Report the vendored content state at boot — loud on failure.
+
+    A missing or invalid content directory must never silently degrade to
+    a blank Course screen (issue #397): the error log names the problem
+    and the fix.  On success, the live pin is logged for observability.
+    """
+    try:
+        chapter_count = len(get_content_repository().list_chapters())
+    except ContentRepositoryError:
+        logger.exception(
+            "content_missing_or_invalid — Course screens will be empty "
+            "until a content pin is vendored (see docs/content.md)"
+        )
+        return
+    version = content_version_info() or {}
+    logger.info(
+        "content_loaded sha=%s chapters=%d",
+        version.get("sha", "unknown"),
+        chapter_count,
+    )
+
+
 @asynccontextmanager
 async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     """Startup/shutdown lifecycle for the application."""
@@ -307,6 +335,11 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
                 await _seed_startup_data(session)
         except Exception:
             logger.exception("startup seed failed; continuing without seeded catalog")
+
+    # Issue #397: surface a bad content deploy at boot, not at first
+    # chapter open.  Loud log rather than crash — the app's non-content
+    # features must stay serviceable, mirroring the seeder policy above.
+    _log_content_status()
 
     yield
 
@@ -445,4 +478,7 @@ async def health_check(
     except (TimeoutError, OSError, SQLAlchemyError) as exc:
         logger.exception("health_check_failed")
         raise HTTPException(status_code=503, detail="Database unavailable") from exc
-    return {"status": "healthy", "database": "connected"}
+    # Issue #397: surface the live content pin so dashboards can alert on
+    # an unexpected value after a deploy. "none" = nothing vendored yet.
+    content_version = (content_version_info() or {}).get("sha", "none")
+    return {"status": "healthy", "database": "connected", "content_version": content_version}

--- a/backend/src/services/content_repository.py
+++ b/backend/src/services/content_repository.py
@@ -36,6 +36,9 @@ _SUPPORTED_SCHEMA_MAJOR = 1
 # chapter enum (chapter|essay|prompt|video) — deliberately distinct.
 _RESOURCE_CONTENT_TYPE: Final[str] = "resource"
 
+#: Audit-trail stamp written by ``scripts/sync_content.py`` (issue #391).
+_CONTENT_VERSION_FILE: Final[str] = "CONTENT_VERSION"
+
 
 class ContentRepositoryError(Exception):
     """The content directory or manifest is missing, invalid, or unsafe."""
@@ -88,6 +91,35 @@ def _content_dir_from_env() -> Path:
     """Resolve the content root from ``CONTENT_DIR`` (default: backend/content)."""
     override = os.getenv("CONTENT_DIR")
     return Path(override) if override else _DEFAULT_CONTENT_DIR
+
+
+def _parse_stamp_entries(text: str) -> dict[str, str]:
+    """Parse ``key: value`` lines from a ``CONTENT_VERSION`` stamp."""
+    entries: dict[str, str] = {}
+    for line in text.splitlines():
+        # partition stops at the FIRST ": ", so "digest: sha256:..." survives.
+        key, separator, value = line.partition(": ")
+        if separator and key:
+            entries[key] = value
+    return entries
+
+
+def content_version_info(content_dir: Path | None = None) -> dict[str, str] | None:
+    """Parse the vendored ``CONTENT_VERSION`` stamp, or ``None`` if absent.
+
+    Observability helper (issue #397): boot logging and ``/health`` report
+    which content pin is live.  Tolerant by design — a missing or
+    malformed stamp returns ``None`` rather than raising, because the
+    caller is a probe, not a gate (the CI drift check in
+    ``scripts/sync_content.py`` is the gate).
+    """
+    path = (content_dir or _content_dir_from_env()) / _CONTENT_VERSION_FILE
+    try:
+        text = path.read_text()
+    except OSError:
+        return None
+    entries = _parse_stamp_entries(text)
+    return entries if "sha" in entries else None
 
 
 def _load_json(path: Path, description: str) -> dict[str, Any]:

--- a/backend/tests/scripts/test_sync_content.py
+++ b/backend/tests/scripts/test_sync_content.py
@@ -304,9 +304,39 @@ def test_check_fails_on_tampered_file(content_dir: Path) -> None:
         check(content_dir)
 
 
-def test_check_fails_without_content_version(content_dir: Path) -> None:
+def test_check_bootstrap_passes_without_manifest_or_stamp(content_dir: Path) -> None:
+    """Nothing vendored yet (no manifest, no stamp) — nothing to verify.
+
+    The gate must not block CI before the first content pin lands.
+    """
+    assert check(content_dir) is False
+
+
+def test_check_fails_when_manifest_present_but_unstamped(content_dir: Path) -> None:
+    """A manifest that was never synced (hand-copied) is a hard failure."""
+    (content_dir / "manifest.json").write_text(
+        json.dumps({"schema_version": "1.0.0", "chapters": [], "site_resources": []})
+    )
     with pytest.raises(SyncContentError):
         check(content_dir)
+
+
+def test_check_fails_on_schema_invalid_manifest_even_with_matching_digest(
+    content_dir: Path,
+) -> None:
+    """Digest match alone is not enough — the manifest must satisfy the contract."""
+    (content_dir / "manifest.json").write_text(json.dumps({"schema_version": "1.0.0"}))
+    digest = compute_tree_digest(content_dir)
+    (content_dir / "CONTENT_VERSION").write_text(
+        f"sha: {'b' * 40}\nsynced_at: 2026-06-10T00:00:00+00:00\ndigest: {digest}\n"
+    )
+    with pytest.raises(SyncContentError):
+        check(content_dir)
+
+
+def test_check_returns_true_after_sync(content_dir: Path) -> None:
+    sync(_SHA, content_dir, fetch=_fetch_for(_content_tarball()), sleep=lambda _: None)
+    assert check(content_dir) is True
 
 
 def test_check_fails_on_malformed_content_version(content_dir: Path) -> None:

--- a/backend/tests/test_content_repository.py
+++ b/backend/tests/test_content_repository.py
@@ -20,6 +20,7 @@ from services.content_repository import (
     ContentNotFoundError,
     ContentRepository,
     ContentRepositoryError,
+    content_version_info,
     get_content_repository,
     reset_content_repository_for_tests,
     set_content_repository_for_tests,
@@ -244,6 +245,25 @@ def test_resource_missing_description_is_rejected_at_construction(tmp_path: Path
     root = _write_content_dir(tmp_path / "content", sparse)
     with pytest.raises(ContentRepositoryError):
         ContentRepository(root)
+
+
+def test_content_version_info_parses_stamp(content_dir: Path) -> None:
+    (content_dir / "CONTENT_VERSION").write_text(
+        "sha: " + "a" * 40 + "\nsynced_at: 2026-06-10T00:00:00+00:00\ndigest: sha256:abc\n"
+    )
+    info = content_version_info(content_dir)
+    assert info is not None
+    assert info["sha"] == "a" * 40
+    assert info["digest"] == "sha256:abc"
+
+
+def test_content_version_info_none_when_missing(content_dir: Path) -> None:
+    assert content_version_info(content_dir) is None
+
+
+def test_content_version_info_none_when_malformed(content_dir: Path) -> None:
+    (content_dir / "CONTENT_VERSION").write_text("free-form text\n")
+    assert content_version_info(content_dir) is None
 
 
 # ── Singleton trio ──────────────────────────────────────────────────────

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -47,3 +47,18 @@ async def test_readiness_returns_ready_when_db_up(async_client: AsyncClient) -> 
     body = response.json()
     assert body["status"] == "ready"
     assert body["database"] == "connected"
+
+
+@pytest.mark.asyncio
+async def test_health_reports_content_version(async_client: AsyncClient) -> None:
+    """``/health`` surfaces the vendored CONTENT_VERSION sha (issue #397).
+
+    In the test environment nothing is vendored, so the field reports
+    ``none`` — the point is that the key is always present so dashboards
+    can alert on an unexpected value after a deploy.
+    """
+    response = await async_client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["content_version"] == "none"

--- a/backend/tests/test_lifespan_seeding.py
+++ b/backend/tests/test_lifespan_seeding.py
@@ -8,9 +8,11 @@ the seeders, idempotently, every time the app starts.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -21,12 +23,13 @@ from sqlmodel import select
 # object itself (so it can wire a session factory at it), not a per-test
 # session yielded from a fixture.
 from conftest import test_engine
-from main import _seed_startup_data, app, lifespan
+from main import _log_content_status, _seed_startup_data, app, lifespan
 from models.course_stage import CourseStage
 from models.practice import Practice
 from models.stage_content import StageContent
 from seed_content import desired_content_records
 from seed_practices import PRESET_PRACTICES
+from services.content_repository import reset_content_repository_for_tests
 
 #: Total preset rows the practice seeder inserts — sourced from
 #: ``PRESET_PRACTICES`` so adding a catalog preset doesn't silently drift
@@ -233,3 +236,47 @@ async def test_seed_startup_data_runs_stages_before_practices(
         await _seed_startup_data(db_session)
 
     assert call_log == ["stages", "practices", "content"]
+
+
+def test_content_status_logs_error_when_nothing_vendored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #397: a content-less deploy is loud at boot, not at first open."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("CONTENT_DIR", str(empty))
+    reset_content_repository_for_tests()
+    caplog.set_level(logging.ERROR, logger="main")
+    try:
+        _log_content_status()
+    finally:
+        reset_content_repository_for_tests()
+    assert any("content_missing_or_invalid" in r.getMessage() for r in caplog.records)
+
+
+def test_content_status_logs_pin_when_content_vendored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    root = tmp_path / "content"
+    root.mkdir()
+    (root / "manifest.json").write_text(
+        json.dumps({"schema_version": "1.0.0", "chapters": [], "site_resources": []})
+    )
+    (root / "CONTENT_VERSION").write_text(
+        "sha: " + "c" * 40 + "\nsynced_at: 2026-06-10T00:00:00+00:00\ndigest: sha256:x\n"
+    )
+    monkeypatch.setenv("CONTENT_DIR", str(root))
+    reset_content_repository_for_tests()
+    caplog.set_level(logging.INFO, logger="main")
+    try:
+        _log_content_status()
+    finally:
+        reset_content_repository_for_tests()
+    loaded = [r.getMessage() for r in caplog.records if "content_loaded" in r.getMessage()]
+    assert loaded
+    assert "c" * 40 in loaded[0]
+    assert "chapters=0" in loaded[0]

--- a/docs/content.md
+++ b/docs/content.md
@@ -101,11 +101,30 @@ manifest ships the stage.
 
 ## CI drift gate
 
-`make sync-content-check` recomputes the vendored tree's digest and
-compares it to `CONTENT_VERSION` without mutating anything — wire-up
-into the build pipeline is tracked in the cms-migration epic (#388,
-issue #397). A tampered or hand-edited `backend/content/` fails the
-check; re-run the sync to fix.
+The `content-drift` job in `.github/workflows/backend-ci.yml` runs
+`python -m scripts.sync_content --check` on every push/PR: it recomputes
+the vendored tree's digest against `CONTENT_VERSION` **and** re-validates
+`manifest.json` against the schema. A tampered or hand-edited
+`backend/content/` fails CI; re-run the sync to fix. The bootstrap state
+(nothing vendored yet) passes — the gate arms itself with the first pin.
+Run it locally with `make sync-content-check`.
+
+## Deploying on Railway
+
+Content is committed, so the Railway flow needs **no content-specific
+build configuration, env vars, or secrets** — the image Railway builds
+from the repo already contains `backend/content/` at the pinned SHA.
+
+Rolling content forward:
+
+1. `make sync-content REF=<new-sha>` locally.
+2. Commit the `backend/content/` diff (CI's `content-drift` job verifies
+   it), merge, and let Railway redeploy from `main`.
+3. Verify the deploy: the boot log prints
+   `content_loaded sha=<sha> chapters=<n>`, and `GET /health` includes
+   `"content_version": "<sha>"`. A bad deploy logs
+   `content_missing_or_invalid` at boot instead of failing silently at
+   the first chapter open.
 
 ## Local development
 


### PR DESCRIPTION
## Summary
- **CI (task 2)**: new `content-drift` job in `backend-ci.yml` runs `python -m scripts.sync_content --check` on every push/PR, mirroring the `migration-drift` pattern (single Python 3.12 — a digest+schema check has no version-compat surface, so running it 3× would be pure waste; the code itself is covered by the 3.11/3.13 compat matrix via the test suite).
- **`check()` hardened**: now re-validates `manifest.json` against the schema (a digest match alone would bless a hand-edit that was synced around), fails when a manifest exists without a `CONTENT_VERSION` stamp (hand-copied content), and returns `False` in the bootstrap state — nothing vendored yet → CI stays green until the first pin lands, at which point the gate arms itself. Vendoring decision (task 1) was already ratified as **committed** in #391/ADR 0001; this PR completes the committed-path wiring.
- **Boot assertion (task 3)**: `_log_content_status()` runs in the lifespan — `content_loaded sha=<pin> chapters=<n>` on success, a loud `content_missing_or_invalid` error log with the fix pointer on failure. Log-loud rather than crash, mirroring the seeder policy: non-content features stay serviceable (the issue's acceptance allows either).
- **Observability (task 5)**: `GET /health` now includes `content_version` (the pinned sha, or `none`), backed by a new tolerant `content_version_info()` helper in `services/content_repository.py` (probe, not gate — returns `None` instead of raising).
- **Docs (task 4)**: `docs/content.md` gains the Railway flow — no content-specific build config or env (content ships in the image), roll-forward = pin bump → merge → redeploy, with the boot log and health field as deploy verification.

## Test plan
- [x] `check()` semantics: bootstrap passes (returns False), manifest-without-stamp fails, schema-invalid manifest with a *matching* digest fails, post-sync returns True; CLI prints the bootstrap notice.
- [x] `content_version_info()`: parses a stamp, `None` on missing, `None` on malformed.
- [x] `_log_content_status()`: error log when nothing is vendored; `content_loaded` with sha+chapter count when a pin is installed (via `CONTENT_DIR` + singleton reset, caplog-asserted).
- [x] `/health` includes `content_version: none` in the unvendored test env.
- [x] Ran `python -m scripts.sync_content --check` against the real repo state → exits 0 with the bootstrap notice (exactly what the new CI job will see).
- [x] Full backend suite green at 94.88%; xenon all-A; `TZ=UTC pre-commit run --all-files` green twice.

Closes #397
Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)