### PR TITLE
test(backend): end-to-end coverage of the local-content course flow

### DIFF
--- a/backend/tests/fixtures/content/manifest.json
+++ b/backend/tests/fixtures/content/manifest.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "1.0.0",
+  "chapters": [
+    {
+      "id": "beige-1",
+      "stage": 1,
+      "chapter": 1,
+      "slug": "survival",
+      "title": "Survival",
+      "content_type": "chapter",
+      "release_day": 0,
+      "order": 1,
+      "path": "markdown/01-beige/01-survival.md"
+    },
+    {
+      "id": "beige-2",
+      "stage": 1,
+      "chapter": 2,
+      "slug": "breath-as-anchor",
+      "title": "Breath as Anchor",
+      "content_type": "essay",
+      "release_day": 2,
+      "order": 2,
+      "path": "markdown/01-beige/02-breath.md"
+    },
+    {
+      "id": "beige-3",
+      "stage": 1,
+      "chapter": 3,
+      "slug": "tomorrow-prompt",
+      "title": "Tomorrow Prompt",
+      "content_type": "prompt",
+      "release_day": 3,
+      "order": 3,
+      "path": "markdown/01-beige/03-tomorrow.md"
+    },
+    {
+      "id": "beige-4",
+      "stage": 1,
+      "chapter": 4,
+      "slug": "late-chapter",
+      "title": "Late Chapter",
+      "content_type": "chapter",
+      "release_day": 9,
+      "order": 4,
+      "path": "markdown/01-beige/04-late.md"
+    },
+    {
+      "id": "purple-1",
+      "stage": 2,
+      "chapter": 1,
+      "slug": "tribal-rhythm",
+      "title": "Tribal Rhythm",
+      "content_type": "chapter",
+      "release_day": 0,
+      "order": 1,
+      "path": "markdown/02-purple/01-tribal.md"
+    }
+  ],
+  "site_resources": [
+    {
+      "slug": "getting-started",
+      "title": "Getting Started",
+      "description": "Orientation for new adepts.",
+      "path": "markdown/site/getting-started.md"
+    }
+  ]
+}

--- a/backend/tests/fixtures/content/markdown/01-beige/01-survival.md
+++ b/backend/tests/fixtures/content/markdown/01-beige/01-survival.md
@@ -1,0 +1,3 @@
+# Survival
+
+Active yes-and-ness: the body of the first chapter.

--- a/backend/tests/fixtures/content/markdown/01-beige/02-breath.md
+++ b/backend/tests/fixtures/content/markdown/01-beige/02-breath.md
@@ -1,0 +1,3 @@
+# Breath as Anchor
+
+An essay released on day two.

--- a/backend/tests/fixtures/content/markdown/01-beige/03-tomorrow.md
+++ b/backend/tests/fixtures/content/markdown/01-beige/03-tomorrow.md
@@ -1,0 +1,3 @@
+# Tomorrow Prompt
+
+A prompt that unlocks on day three.

--- a/backend/tests/fixtures/content/markdown/01-beige/04-late.md
+++ b/backend/tests/fixtures/content/markdown/01-beige/04-late.md
@@ -1,0 +1,3 @@
+# Late Chapter
+
+Deep-stage reading for day nine.

--- a/backend/tests/fixtures/content/markdown/02-purple/01-tribal.md
+++ b/backend/tests/fixtures/content/markdown/02-purple/01-tribal.md
@@ -1,0 +1,3 @@
+# Tribal Rhythm
+
+Stage-two opener.

--- a/backend/tests/fixtures/content/markdown/site/getting-started.md
+++ b/backend/tests/fixtures/content/markdown/site/getting-started.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+Welcome, adept.

--- a/backend/tests/test_course_local_content.py
+++ b/backend/tests/test_course_local_content.py
@@ -1,0 +1,217 @@
+"""End-to-end tests for the local-content course flow (issue #398).
+
+The committed fixture tree at ``tests/fixtures/content/`` drives the
+whole journey the user actually takes: manifest → seeder → gated chapter
+list → released body → read-tracking → progress math — deterministic,
+offline, against real files instead of mocks of a third party.
+
+Fixture shape: stage 1 ships chapters at release days 0/2/3/9, stage 2
+ships one chapter (locked until the user reaches the stage), plus one
+site resource.  Every test pins the user at **day 2 of stage 1**, so the
+drip-feed boundary cases fall out naturally: day 0 is past, day 2 is
+"today" (boundary — must unlock), day 3 is tomorrow (boundary — must
+stay locked), day 9 is deep future.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models.course_stage import CourseStage
+from models.stage_content import StageContent
+from models.stage_progress import StageProgress
+from seed_content import seed_content
+from services.content_repository import (
+    ContentRepository,
+    reset_content_repository_for_tests,
+    set_content_repository_for_tests,
+)
+
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "content"
+
+#: Day the test user is pinned to within stage 1.
+_DAYS_ELAPSED = 2
+
+
+@pytest_asyncio.fixture
+async def seeded_course(db_session: AsyncSession) -> AsyncIterator[None]:
+    """Install the fixture content tree and seed the database from it."""
+    set_content_repository_for_tests(ContentRepository(_FIXTURE_DIR))
+    for number in (1, 2):
+        db_session.add(
+            CourseStage(
+                title=f"Stage {number}",
+                subtitle=f"Subtitle {number}",
+                stage_number=number,
+                overview_url=f"https://example.com/stage-{number}",
+                category="test",
+                aspect="test-aspect",
+                spiral_dynamics_color="beige",
+                growing_up_stage="archaic",
+                divine_gender_polarity="masculine",
+                relationship_to_free_will="active",
+                free_will_description="Active Yes-And-Ness",
+            )
+        )
+    await db_session.commit()
+    await seed_content(db_session)
+    yield
+    reset_content_repository_for_tests()
+
+
+async def _signup_at_day_two(
+    async_client: AsyncClient, db_session: AsyncSession, username: str
+) -> dict[str, str]:
+    """Sign up a user and pin them at day 2 of stage 1."""
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    user_id = resp.json()["user_id"]
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            stage_started_at=datetime.now(UTC) - timedelta(days=_DAYS_ELAPSED),
+        )
+    )
+    await db_session.commit()
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _stage_one_items(
+    async_client: AsyncClient, headers: dict[str, str]
+) -> dict[str, dict[str, object]]:
+    resp = await async_client.get("/course/stages/1/content", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    return {item["title"]: item for item in resp.json()}
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("seeded_course")
+async def test_list_reflects_drip_feed_boundaries(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Day < N locked, day == N unlocked (boundary), day > N unlocked."""
+    headers = await _signup_at_day_two(async_client, db_session, "journey")
+    items = await _stage_one_items(async_client, headers)
+
+    assert items["Survival"]["is_locked"] is False  # day 0 — past
+    assert items["Breath as Anchor"]["is_locked"] is False  # day 2 — today (boundary)
+    assert items["Tomorrow Prompt"]["is_locked"] is True  # day 3 — tomorrow (boundary)
+    assert items["Late Chapter"]["is_locked"] is True  # day 9 — deep future
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("seeded_course")
+async def test_released_body_serves_fixture_markdown(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The body endpoint returns the literal fixture file for a released id."""
+    headers = await _signup_at_day_two(async_client, db_session, "reader")
+    items = await _stage_one_items(async_client, headers)
+
+    resp = await async_client.get(
+        f"/course/content/{items['Survival']['id']}/body", headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+    payload = resp.json()
+    expected = (_FIXTURE_DIR / "markdown/01-beige/01-survival.md").read_text()
+    assert payload["body_markdown"] == expected
+    assert payload["title"] == "Survival"
+    assert payload["content_type"] == "chapter"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("seeded_course")
+async def test_gating_mask_for_unreleased_locked_and_unknown(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Unreleased, locked-stage, and nonexistent ids are indistinguishable."""
+    headers = await _signup_at_day_two(async_client, db_session, "masked")
+    items = await _stage_one_items(async_client, headers)
+
+    # Unreleased (day 3 > day 2).
+    resp = await async_client.get(
+        f"/course/content/{items['Tomorrow Prompt']['id']}/body", headers=headers
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "content_not_found"
+
+    # Stage 2 is locked for a stage-1 user; fetch its seeded row id from
+    # the DB directly (the list endpoint rightly refuses locked stages).
+    result = await db_session.execute(
+        select(StageContent).where(StageContent.title == "Tribal Rhythm")
+    )
+    purple = result.scalars().one()
+    resp = await async_client.get(f"/course/content/{purple.id}/body", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "content_not_found"
+
+    # Nonexistent id.
+    resp = await async_client.get("/course/content/999999/body", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "content_not_found"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("seeded_course")
+async def test_site_resource_journey(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    """List the manifest resource, then read its body from the fixture file."""
+    headers = await _signup_at_day_two(async_client, db_session, "resourceful")
+
+    resp = await async_client.get("/course/site-resources", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    listing = resp.json()
+    assert [r["slug"] for r in listing] == ["getting-started"]
+    assert listing[0]["description"] == "Orientation for new adepts."
+
+    body_resp = await async_client.get(
+        "/course/site-resources/getting-started/body", headers=headers
+    )
+    assert body_resp.status_code == HTTPStatus.OK
+    expected = (_FIXTURE_DIR / "markdown/site/getting-started.md").read_text()
+    assert body_resp.json()["body_markdown"] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("seeded_course")
+async def test_progress_math_and_read_tracking(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Progress counts released items only; mark-read moves the needle."""
+    headers = await _signup_at_day_two(async_client, db_session, "progressing")
+    items = await _stage_one_items(async_client, headers)
+
+    resp = await async_client.get("/course/stages/1/progress", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    before = resp.json()
+    assert before["read_items"] == 0
+    # The next chapter after day 2 drips on day 3.
+    assert before["next_unlock_day"] == 3
+
+    mark = await async_client.post(
+        f"/course/content/{items['Survival']['id']}/mark-read", headers=headers
+    )
+    assert mark.status_code == HTTPStatus.OK
+
+    after = (await async_client.get("/course/stages/1/progress", headers=headers)).json()
+    assert after["read_items"] == before["read_items"] + 1
+    assert after["progress_percent"] > before["progress_percent"]
+
+    relisted = await _stage_one_items(async_client, headers)
+    assert relisted["Survival"]["is_read"] is True


### PR DESCRIPTION
## Summary
- Adds the committed fixture tree `backend/tests/fixtures/content/` (issue #398, epic #388): a minimal valid manifest — **two stages** (stage 1 at release days 0/2/3/9, stage 2 with one chapter that stays locked for a stage-1 user) plus **one site resource** — and its six tiny Markdown files. Offline, deterministic, loads through the real `ContentRepository` (schema-validated like production).
- Adds `backend/tests/test_course_local_content.py` — five journey tests over `async_client` that exercise the whole path the user takes (manifest → seeder → gated list → released body → read-tracking → progress), with no mocks of any third party:
  - **Drip-feed boundaries** pinned at day 2: day 0 past-unlocked, day 2 **today (== boundary) unlocked**, day 3 **tomorrow (day-1 boundary) locked**, day 9 locked — gating parity with the pre-migration `test_course_api.py` cases, new source (task 4).
  - **Released body** returns the literal fixture file bytes with manifest title/content_type.
  - **404-mask parity**: unreleased, locked-stage (row id fetched from the DB since the list endpoint rightly refuses locked stages), and nonexistent ids are indistinguishable (`content_not_found`).
  - **Site-resource journey**: manifest-driven list then fixture-file body.
  - **Progress math**: `next_unlock_day == 3` at day 2, mark-read increments `read_items`/`progress_percent`, and the relisted item shows `is_read`.
- **Frontend (task 3) — already covered, no new code needed**: `ContentCard.test.tsx` asserts the locked card shows "Unlocks on day N"; #394's `ChapterReader.test.tsx` covers native Markdown render, generic load-failure + retry, and the empty state. Referenced here for the parity audit rather than duplicated.

## Test plan
- [x] New suite: 5/5 green, runs in ~2s, fully offline.
- [x] Full backend suite green at 94.86% line (branch gate ≥80% holds); xenon all-A; `TZ=UTC pre-commit run --all-files` green twice. No coverage/config thresholds touched.
- [x] Fixture validates against `manifest.schema.json` via `ContentRepository` construction in every test.

Closes #398
Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)