### PR TITLE
fix(frontend): stop filter tabs from advancing the reflection week

### DIFF
--- a/frontend/src/features/Journal/JournalScreen.tsx
+++ b/frontend/src/features/Journal/JournalScreen.tsx
@@ -937,14 +937,26 @@ function useJournalInit(
   loadPrompt: () => Promise<void>,
   loadUsage: () => Promise<void>,
 ) {
+  // Mount-only: the weekly prompt and wallet are independent of list
+  // filters.  Bundling them with the message loader re-fetched
+  // ``/prompts/current`` on every filter tap, letting the banner's week
+  // drift from the global program week (issue #400).  ``loadPrompt`` and
+  // ``loadUsage`` are stable []-dep useCallbacks, so this runs once.
+  useEffect(() => {
+    void loadPrompt();
+    void loadUsage();
+  }, [loadPrompt, loadUsage]);
+
+  // Filter-driven: ``loadMessages`` is rebuilt when searchQuery/activeTag
+  // change, so this effect re-runs to reload the list — and ONLY the list.
   useEffect(() => {
     const init = async () => {
       setLoading(true);
-      await Promise.all([loadMessages(0), loadPrompt(), loadUsage()]);
+      await loadMessages(0);
       setLoading(false);
     };
     void init();
-  }, [loadMessages, loadPrompt, loadUsage, setLoading]);
+  }, [loadMessages, setLoading]);
 }
 
 // --- Hook: prompt responding ---

--- a/frontend/src/features/Journal/JournalScreen.tsx
+++ b/frontend/src/features/Journal/JournalScreen.tsx
@@ -937,18 +937,13 @@ function useJournalInit(
   loadPrompt: () => Promise<void>,
   loadUsage: () => Promise<void>,
 ) {
-  // Mount-only: the weekly prompt and wallet are independent of list
-  // filters.  Bundling them with the message loader re-fetched
-  // ``/prompts/current`` on every filter tap, letting the banner's week
-  // drift from the global program week (issue #400).  ``loadPrompt`` and
-  // ``loadUsage`` are stable []-dep useCallbacks, so this runs once.
+  // Mount-only (stable []-dep callbacks): bundling these with loadMessages re-fetched the prompt on every filter tap.
   useEffect(() => {
     void loadPrompt();
     void loadUsage();
   }, [loadPrompt, loadUsage]);
 
-  // Filter-driven: ``loadMessages`` is rebuilt when searchQuery/activeTag
-  // change, so this effect re-runs to reload the list — and ONLY the list.
+  // Filter-driven: loadMessages rebuilds on activeTag/searchQuery changes — reload the list and ONLY the list.
   useEffect(() => {
     const init = async () => {
       setLoading(true);

--- a/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
@@ -222,6 +222,33 @@ describe('JournalScreen', () => {
     });
   });
 
+  it('keeps the weekly prompt untouched when filter tabs change (issue #400)', async () => {
+    const { getByTestId, getByText } = renderJournal();
+    await waitFor(() => {
+      expect(getByTestId('weekly-prompt-banner')).toBeTruthy();
+    });
+    expect(getByText('Week 3 Reflection')).toBeTruthy();
+    const promptFetchesAfterInit = mockPromptsCurrent.mock.calls.length;
+
+    // Pretend the server would now report a different week — if filtering
+    // re-fetched the prompt, the banner would advance.
+    mockPromptsCurrent.mockResolvedValue({ ...samplePrompt, week_number: 9 });
+
+    fireEvent.press(getByTestId('tag-chip-stage_reflection'));
+    await waitFor(() => {
+      expect(mockJournalList).toHaveBeenCalledWith(
+        expect.objectContaining({ tag: 'stage_reflection' }),
+      );
+    });
+    fireEvent.press(getByTestId('tag-chip-all'));
+    await waitFor(() => {
+      expect(getByText('Week 3 Reflection')).toBeTruthy();
+    });
+
+    // Filtering filters the list ONLY — no extra /prompts/current calls.
+    expect(mockPromptsCurrent.mock.calls.length).toBe(promptFetchesAfterInit);
+  });
+
   it('hides weekly prompt banner when prompt is already responded', async () => {
     mockPromptsCurrent.mockResolvedValue({ ...samplePrompt, has_responded: true });
 

--- a/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalScreen.test.tsx
@@ -195,10 +195,8 @@ describe('JournalScreen', () => {
   });
 
   it('shows loading spinner initially', () => {
-    // Don't resolve the API calls immediately
+    // Only the unresolved message list gates the spinner — prompt/usage are side data.
     mockJournalList.mockReturnValue(new Promise(() => {}));
-    mockPromptsCurrent.mockReturnValue(new Promise(() => {}));
-    mockBotmasonGetUsage.mockReturnValue(new Promise(() => {}));
 
     const { getByTestId } = renderJournal();
     expect(getByTestId('journal-loading')).toBeTruthy();


### PR DESCRIPTION
## Summary
- Fixes issue #400: toggling the Journal filter tabs re-ran the whole `useJournalInit` effect — including `loadPrompt()` → `GET /prompts/current` — because `loadMessages` (rebuilt on every `activeTag`/`searchQuery` change) shared the effect's dependency array with the prompt/wallet loaders. Each filter tap could therefore advance the "WEEK N REFLECTION" banner.
- **Fix (option A from the issue)**: `useJournalInit` is split in two — a mount-only effect for `loadPrompt` + `loadUsage` (both stable `[]`-dep `useCallback`s, so it runs exactly once) and a filter-driven effect that reloads the message list and only the list. The server's `week_number` becomes a one-time hydration source; with the `programStartDate` anchor set, `useDerivedCurrentWeek` already prefers the global program week, and without it the single fetch keeps the fallback stable.
- Side benefit: filter taps no longer burn a `/prompts/current` round-trip.

## Test plan
- [x] New regression test: after init, the mock server is switched to report week 9; tapping `Reflections` then `All` re-queries the journal list (asserted) but the banner still reads "Week 3 Reflection" and `promptsApi.current` has zero additional calls. Red before the fix (banner advanced), green after.
- [x] Full frontend suite 1841/1841 under `TZ=UTC`; `npx tsc --noEmit` clean; `npm run lint` zero warnings; `TZ=UTC pre-commit run --all-files` green twice.

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)