### PR TITLE
feat(backend): activate live botmason llm providers end-to-end

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         files: ^backend/
         exclude: ^backend/migrations/
         args: ["--config-file=backend/pyproject.toml"]
-        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "types-beautifulsoup4", "beautifulsoup4", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "slowapi", "limits", "alembic"]
+        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "slowapi", "limits", "alembic"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,10 +15,20 @@ PORT=8000
 WEB_CONCURRENCY=2
 
 # BotMason AI configuration
+#
+# Activation path (issue #402): the stub is the default everywhere. To serve
+# real completions in a deployed environment, set BOTMASON_PROVIDER to a real
+# provider AND give it a key:
+#   BOTMASON_PROVIDER=openai     LLM_API_KEY=sk-...
+#   BOTMASON_PROVIDER=anthropic  LLM_API_KEY=sk-ant-...
+# A user-supplied X-LLM-API-Key header (BYOK) overrides the server default
+# per request — the key's prefix selects its provider, so BYOK works even
+# when the server is configured as "stub". The boot log reports the active
+# provider; "stub" in a production ENV logs a loud warning.
 BOTMASON_PROVIDER=stub  # "stub" (default), "openai", or "anthropic"
 BOTMASON_SYSTEM_PROMPT=  # Path to a prompt file or inline text (optional, has built-in default)
-LLM_API_KEY=  # API key for the chosen LLM provider
-LLM_MODEL=  # Model name override (defaults: gpt-4o-mini for openai, claude-sonnet-4-20250514 for anthropic)
+LLM_API_KEY=  # Server-side API key for the chosen LLM provider (never required for stub)
+LLM_MODEL=  # Model override, allowlisted per provider (defaults: gpt-4o-mini / claude-sonnet-4-20250514)
 
 # Railway auto-injected (do not set manually)
 # RAILWAY_ENVIRONMENT=production

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -12,6 +12,8 @@ anyio==4.13.0
     # via
     #   httpx
     #   starlette
+anthropic==0.109.1
+    # via -r backend/requirements.txt
 asyncpg==0.31.0
     # via -r backend/requirements.txt
 bcrypt==5.0.0
@@ -26,8 +28,14 @@ click==8.3.2
     # via uvicorn
 deprecated==1.3.1
     # via limits
+distro==1.9.0
+    # via
+    #   anthropic
+    #   openai
 dnspython==2.8.0
     # via email-validator
+docstring-parser==0.18.0
+    # via anthropic
 email-validator==2.3.0
     # via -r backend/requirements.txt
 fastapi==0.136.0
@@ -49,12 +57,18 @@ idna==3.11
     #   httpx
 iniconfig==2.3.0
     # via pytest
+jiter==0.15.0
+    # via
+    #   anthropic
+    #   openai
 limits==5.8.0
     # via slowapi
 mako==1.3.11
     # via alembic
 markupsafe==3.0.3
     # via mako
+openai==2.41.1
+    # via -r backend/requirements.txt
 packaging==26.1
     # via
     #   limits
@@ -89,6 +103,8 @@ sqlmodel==0.0.38
     # via -r backend/requirements.txt
 starlette==1.0.0
     # via fastapi
+tqdm==4.68.2
+    # via openai
 typing-extensions==4.15.0
     # via
     #   alembic

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,7 @@ tzdata
 pytest
 pytest-asyncio
 httpx
+# LLM provider SDKs for BotMason (issue #402) — the stub provider stays the
+# default; these activate via BOTMASON_PROVIDER + LLM_API_KEY or a BYOK key.
+openai==2.41.1
+anthropic==0.109.1

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -50,6 +50,7 @@ from seed_content import seed_content
 from seed_practice_recipes import seed_practice_recipes
 from seed_practices import seed_practices
 from seed_stages import seed_stages
+from services.botmason import get_provider
 from services.content_repository import (
     ContentRepositoryError,
     content_version_info,
@@ -281,6 +282,23 @@ async def _seed_startup_data(session: AsyncSession) -> None:
             await session.rollback()
 
 
+def _log_botmason_provider() -> None:
+    """Report the active LLM provider at boot (issue #402).
+
+    Stub-in-production must be an explicit, visible choice — a deploy that
+    forgot ``BOTMASON_PROVIDER``/``LLM_API_KEY`` would otherwise silently
+    serve canned chat responses to real users.
+    """
+    provider = get_provider()
+    logger.info("botmason_provider provider=%s", provider)
+    if provider == "stub" and os.getenv("ENV", "development") == "production":
+        logger.warning(
+            "botmason_stub_in_production: BOTMASON_PROVIDER is 'stub' — real "
+            "users will get canned responses. Set BOTMASON_PROVIDER and "
+            "LLM_API_KEY (see backend/.env.example) if this is unintentional."
+        )
+
+
 def _log_content_status() -> None:
     """Report the vendored content state at boot — loud on failure.
 
@@ -340,6 +358,8 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     # chapter open.  Loud log rather than crash — the app's non-content
     # features must stay serviceable, mirroring the seeder policy above.
     _log_content_status()
+    # Issue #402: make the active LLM provider observable at startup.
+    _log_botmason_provider()
 
     yield
 

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import logging
 import pathlib
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from http import HTTPStatus
+from typing import ClassVar
 from unittest.mock import AsyncMock, patch
 
+import anthropic
+import openai
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import delete, update
@@ -1960,3 +1964,91 @@ async def test_chat_fresh_in_flight_tombstone_still_409s(
     # Wallet stays untouched -- no LLM call was made.
     balance = await async_client.get("/user/balance", headers=headers)
     assert balance.json()["balance"] == 2
+
+
+# ── Issue #402: live-provider activation ────────────────────────────────
+
+
+class _FakeOpenAIClient:
+    """Stands in for ``openai.AsyncOpenAI`` — records ctor args, returns a completion."""
+
+    last_kwargs: ClassVar[dict[str, object]] = {}
+
+    def __init__(self, **kwargs: object) -> None:
+        type(self).last_kwargs = kwargs
+
+        class _Completions:
+            @staticmethod
+            async def create(**_call: object) -> object:
+                message = type("Msg", (), {"content": "A real OpenAI completion."})()
+                choice = type("Choice", (), {"message": message})()
+                usage = type("Usage", (), {"prompt_tokens": 42, "completion_tokens": 17})()
+                return type("Completion", (), {"choices": [choice], "usage": usage})()
+
+        self.chat = type("Chat", (), {"completions": _Completions()})()
+
+
+class _FakeAnthropicClient:
+    """Stands in for ``anthropic.AsyncAnthropic`` — records ctor args, returns a message."""
+
+    last_kwargs: ClassVar[dict[str, object]] = {}
+
+    def __init__(self, **kwargs: object) -> None:
+        type(self).last_kwargs = kwargs
+
+        class _Messages:
+            @staticmethod
+            async def create(**_call: object) -> object:
+                block = type("Block", (), {"text": "A real Anthropic completion."})()
+                usage = type("Usage", (), {"input_tokens": 33, "output_tokens": 9})()
+                return type("Message", (), {"content": [block], "usage": usage})()
+
+        self.messages = _Messages()
+
+
+@pytest.mark.asyncio
+async def test_generate_response_routes_to_openai_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The openai provider routes through the real SDK import path.
+
+    Model text and non-zero token counts come back (issue #402).
+    """
+    monkeypatch.setattr(openai, "AsyncOpenAI", _FakeOpenAIClient)
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", "sk-server-key")  # pragma: allowlist secret
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+
+    result = await generate_response("Hello", [])
+
+    assert result.text == "A real OpenAI completion."
+    assert result.provider == "openai"
+    assert result.prompt_tokens == 42
+    assert result.completion_tokens == 17
+    assert _FakeOpenAIClient.last_kwargs["api_key"] == "sk-server-key"  # pragma: allowlist secret
+
+
+@pytest.mark.asyncio
+async def test_generate_response_routes_to_anthropic_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same end-to-end proof for the anthropic provider."""
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", _FakeAnthropicClient)
+    monkeypatch.setenv("BOTMASON_PROVIDER", "anthropic")
+    monkeypatch.setenv("LLM_API_KEY", "sk-ant-server-key")  # pragma: allowlist secret
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+
+    result = await generate_response("Hello", [])
+
+    assert result.text == "A real Anthropic completion."
+    assert result.provider == "anthropic"
+    assert result.prompt_tokens == 33
+    assert result.completion_tokens == 9
+    expected_key = "sk-ant-server-key"  # pragma: allowlist secret
+    assert _FakeAnthropicClient.last_kwargs["api_key"] == expected_key
+
+
+def test_provider_sdks_are_installed_dependencies() -> None:
+    """The SDKs are declared dependencies that import cleanly."""
+    assert importlib.import_module("openai") is not None
+    assert importlib.import_module("anthropic") is not None

--- a/backend/tests/test_lifespan_seeding.py
+++ b/backend/tests/test_lifespan_seeding.py
@@ -23,7 +23,7 @@ from sqlmodel import select
 # object itself (so it can wire a session factory at it), not a per-test
 # session yielded from a fixture.
 from conftest import test_engine
-from main import _log_content_status, _seed_startup_data, app, lifespan
+from main import _log_botmason_provider, _log_content_status, _seed_startup_data, app, lifespan
 from models.course_stage import CourseStage
 from models.practice import Practice
 from models.stage_content import StageContent
@@ -280,3 +280,41 @@ def test_content_status_logs_pin_when_content_vendored(
     assert loaded
     assert "c" * 40 in loaded[0]
     assert "chapters=0" in loaded[0]
+
+
+def test_botmason_provider_logged_at_boot(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #402: the active LLM provider is observable at startup."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("ENV", "development")
+    caplog.set_level(logging.INFO, logger="main")
+    _log_botmason_provider()
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("botmason_provider" in m and "openai" in m for m in messages)
+
+
+def test_stub_in_production_warns_loudly(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Stub in production must be an explicit, visible choice — never silent."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    monkeypatch.setenv("ENV", "production")
+    caplog.set_level(logging.WARNING, logger="main")
+    _log_botmason_provider()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("botmason_stub_in_production" in r.getMessage() for r in warnings)
+
+
+def test_stub_in_development_does_not_warn(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    monkeypatch.setenv("ENV", "development")
+    caplog.set_level(logging.INFO, logger="main")
+    _log_botmason_provider()
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == []


### PR DESCRIPTION
## Summary
- **Dependencies (task 1)**: `openai==2.41.1` and `anthropic==0.109.1` are now pinned runtime deps (plus their new transitives `distro`/`jiter`/`tqdm`/`docstring-parser` in the lock). The provider clients existed and worked, but `_import_optional` raised `RuntimeError` the moment a real provider was selected because the SDKs weren't declared. pip-audit and the dependency hooks stay green.
- **Config & docs (task 2)**: `.env.example`'s BotMason block now documents the full activation path — `BOTMASON_PROVIDER=openai|anthropic` + `LLM_API_KEY`, the allowlisted `LLM_MODEL` override, and the BYOK `X-LLM-API-Key` header that selects its own provider per request even on a stub-configured server.
- **Production safety (task 3)**: the lifespan logs `botmason_provider provider=<x>` on every boot, and `stub` + `ENV=production` logs a loud `botmason_stub_in_production` warning naming the fix — canned responses become an explicit choice, never an accident.
- **Verification (task 4)**: new tests route `generate_response` through the **real SDK import path** with the client classes monkeypatched — asserting the model text comes back, token counts are non-zero (42/17 OpenAI, 33/9 Anthropic), and the resolved server key reaches the client constructor. A third test pins that both SDKs import cleanly as declared deps. Real-key manual verification is left to deploy time (no live key in CI by design).
- **Error surfaces (task 5)**: existing coverage verified intact — `llm_key_required` (402) when a real provider lacks a key, `invalid_llm_api_key_format` (400) for malformed BYOK headers, and `RuntimeError` fail-fast for missing server keys; all pre-existing tests untouched and green.
- Housekeeping: the pre-commit mypy env gains the two SDKs and sheds the stale `beautifulsoup4`/`types-beautifulsoup4` pair that #396's scrub missed.

## Test plan
- [x] 3 new tests (SDK routing ×2 through real imports, dependency import check); stub remains default — `test_stub_provider_works_without_api_key` and the rest of the botmason suite unchanged and green.
- [x] 3 new boot-observability tests (provider logged; stub+production warns; stub+development silent).
- [x] Full backend suite green at 95.34%; xenon all-A; `TZ=UTC pre-commit run --all-files` green twice (incl. pip-audit over the new pins and detect-secrets over the test keys via allowlist pragmas).

Closes #402
Refs #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)