### PR TITLE
feat(frontend): multi-provider byok with per-provider key-page links

### DIFF
--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Linking,
   ScrollView,
   StyleSheet,
   Text,
@@ -9,6 +10,8 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+
+import { BYOK_PROVIDERS, providerForKey } from './byokProviders';
 
 import { useApiKey } from '@/context/ApiKeyContext';
 import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
@@ -24,12 +27,14 @@ import type { RootStackParamList } from '@/navigation/RootStack';
  * toggles only show the value locally in this screen.
  */
 
-const OPENAI_PREFIX = 'sk-';
-const ANTHROPIC_PREFIX = 'sk-ant-';
 const MAX_KEY_LENGTH = 256;
 const MIN_KEY_LENGTH = 10;
 const PLACEHOLDER_KEY = 'sk-... or sk-ant-...';
 const MASK_VISIBLE_CHARS = 4;
+
+// Built from the provider map so the error copy can never drift from the
+// supported set: e.g. `"sk-" (OpenAI) or "sk-ant-" (Anthropic)`.
+const _PREFIX_SUMMARY = BYOK_PROVIDERS.map((p) => `"${p.keyPrefix}" (${p.label})`).join(' or ');
 
 interface KeyValidationError {
   code: 'empty' | 'too_short' | 'too_long' | 'bad_prefix';
@@ -47,10 +52,10 @@ export function validateUserApiKey(raw: string): KeyValidationError | null {
   if (key.length > MAX_KEY_LENGTH) {
     return { code: 'too_long', message: 'This key is longer than any real API key.' };
   }
-  if (!key.startsWith(OPENAI_PREFIX) && !key.startsWith(ANTHROPIC_PREFIX)) {
+  if (providerForKey(key) === null) {
     return {
       code: 'bad_prefix',
-      message: `API keys start with "${OPENAI_PREFIX}" (OpenAI) or "${ANTHROPIC_PREFIX}" (Anthropic).`,
+      message: `API keys start with ${_PREFIX_SUMMARY}.`,
     };
   }
   return null;
@@ -191,8 +196,8 @@ const ScreenIntro = ({ apiKey }: { apiKey: string | null }): React.JSX.Element =
   <>
     <Text style={styles.title}>BotMason API Key</Text>
     <Text style={styles.body}>
-      Bring your own OpenAI or Anthropic API key. It is stored only on this device and sent with
-      every BotMason request via the X-LLM-API-Key header. We never upload it to our servers.
+      Bring your own API key from a supported provider. It is stored only on this device and sent
+      with every BotMason request via the X-LLM-API-Key header. We never upload it to our servers.
     </Text>
     {!apiKey && (
       <Text style={styles.hint} testID="no-key-hint">
@@ -201,6 +206,38 @@ const ScreenIntro = ({ apiKey }: { apiKey: string | null }): React.JSX.Element =
     )}
   </>
 );
+
+const ProviderDirectory = (): React.JSX.Element => (
+  <View style={styles.providerSection} testID="provider-directory">
+    <Text style={styles.inputLabel}>Supported providers</Text>
+    {BYOK_PROVIDERS.map((provider) => (
+      <View key={provider.id} style={styles.providerRow}>
+        <View style={styles.providerInfo}>
+          <Text style={styles.providerName}>{provider.label}</Text>
+          <Text style={styles.providerHint}>{provider.hint}</Text>
+        </View>
+        <TouchableOpacity
+          onPress={() => void Linking.openURL(provider.keyPageUrl)}
+          testID={`get-key-link-${provider.id}`}
+          accessibilityLabel={`Get your ${provider.label} API key`}
+          accessibilityRole="link"
+        >
+          <Text style={styles.link}>Get your API key</Text>
+        </TouchableOpacity>
+      </View>
+    ))}
+  </View>
+);
+
+const DetectedProvider = ({ draft }: { draft: string }): React.JSX.Element | null => {
+  const provider = providerForKey(draft.trim());
+  if (!provider) return null;
+  return (
+    <Text style={styles.detected} testID="detected-provider">
+      {provider.label} key detected — it will be saved on this device only.
+    </Text>
+  );
+};
 
 const ScreenFooter = ({
   submitting,
@@ -265,6 +302,7 @@ const ScreenBody = ({
 }: ScreenBodyProps): React.JSX.Element => (
   <>
     <ScreenIntro apiKey={apiKey} />
+    <ProviderDirectory />
     {apiKey && (
       <StoredKeyCard apiKey={apiKey} disabled={submitting} onRequestRemove={onRequestRemove} />
     )}
@@ -275,6 +313,7 @@ const ScreenBody = ({
       onChangeText={onChangeDraft}
       onToggleReveal={onToggleReveal}
     />
+    <DetectedProvider draft={draft} />
     <FeedbackBanner error={error} status={status} />
     <ScreenFooter
       submitting={submitting}
@@ -492,4 +531,17 @@ const styles = StyleSheet.create({
   destructiveButtonText: { color: colors.destructive.text, fontWeight: '600' },
   linkRow: { marginTop: SPACING.xl, alignItems: 'center' },
   link: { color: colors.primary, fontWeight: '600' },
+  providerSection: { marginBottom: SPACING.xl },
+  providerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: SPACING.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  providerInfo: { flex: 1, paddingRight: SPACING.md },
+  providerName: { fontSize: 15, fontWeight: '600', color: colors.text.primary },
+  providerHint: { fontSize: 13, color: colors.text.secondaryAccessible, marginTop: 2 },
+  detected: { color: colors.successText, marginBottom: SPACING.md, fontSize: 13 },
 });

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -2,9 +2,10 @@
 /* global describe, test, expect, beforeEach, jest */
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
-import { Alert } from 'react-native';
+import { Alert, Linking } from 'react-native';
 
 import ApiKeySettingsScreen, { validateUserApiKey } from '../ApiKeySettingsScreen';
+import { BYOK_PROVIDERS, providerForKey } from '../byokProviders';
 
 import { useApiKey } from '@/context/ApiKeyContext';
 
@@ -56,6 +57,49 @@ describe('validateUserApiKey', () => {
 
   test('rejects a key that is too long', () => {
     expect(validateUserApiKey(`sk-${'x'.repeat(300)}`)?.code).toBe('too_long');
+  });
+});
+
+describe('byokProviders', () => {
+  test('detects each supported provider from its key prefix', () => {
+    expect(providerForKey(VALID_KEY)?.id).toBe('openai');
+    expect(providerForKey(`sk-ant-${'x'.repeat(60)}`)?.id).toBe('anthropic');
+  });
+
+  test('returns null for an unrecognized key', () => {
+    expect(providerForKey('definitely-not-real-enough')).toBeNull();
+  });
+
+  test('every provider carries a key-page url and a hint', () => {
+    expect(BYOK_PROVIDERS.length).toBeGreaterThanOrEqual(2);
+    for (const provider of BYOK_PROVIDERS) {
+      expect(provider.keyPageUrl).toMatch(/^https:\/\//);
+      expect(provider.hint).toContain(provider.keyPrefix);
+    }
+  });
+});
+
+describe('provider deep links and detection', () => {
+  test('renders a "Get your API key" link per provider opening its key page', async () => {
+    const openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(true as never);
+    setApiKeyState({});
+    const { getByTestId } = render(<ApiKeySettingsScreen />);
+    for (const provider of BYOK_PROVIDERS) {
+      fireEvent.press(getByTestId(`get-key-link-${provider.id}`));
+      expect(openURL).toHaveBeenLastCalledWith(provider.keyPageUrl);
+    }
+    expect(openURL).toHaveBeenCalledTimes(BYOK_PROVIDERS.length);
+  });
+
+  test('shows the detected provider while typing a recognizable key', () => {
+    setApiKeyState({});
+    const { getByTestId, queryByTestId } = render(<ApiKeySettingsScreen />);
+    fireEvent.changeText(getByTestId('api-key-input'), `sk-ant-${'x'.repeat(60)}`);
+    expect(getByTestId('detected-provider').props.children.join('')).toContain('Anthropic');
+    fireEvent.changeText(getByTestId('api-key-input'), VALID_KEY);
+    expect(getByTestId('detected-provider').props.children.join('')).toContain('OpenAI');
+    fireEvent.changeText(getByTestId('api-key-input'), 'garbage');
+    expect(queryByTestId('detected-provider')).toBeNull();
   });
 });
 

--- a/frontend/src/features/Settings/byokProviders.ts
+++ b/frontend/src/features/Settings/byokProviders.ts
@@ -1,0 +1,59 @@
+/**
+ * Single source of truth for BYOK providers (issue #403).
+ *
+ * Adding a provider is a one-entry edit here — label, key prefix, the
+ * console page where keys are created, and the user-facing hint. The
+ * prefix rules mirror the backend's `_PROVIDER_KEY_RULES` in
+ * `backend/src/services/botmason.py` (Anthropic keys carry the more
+ * specific `sk-ant-` prefix, so OpenAI disallows it to prevent
+ * cross-wiring); keep the two maps in sync when extending.
+ */
+
+export interface ByokProvider {
+  id: 'openai' | 'anthropic';
+  label: string;
+  keyPrefix: string;
+  /** More-specific prefixes that must NOT match (prevents cross-wiring). */
+  disallowedPrefixes: readonly string[];
+  /** The provider console page where the user creates a key. */
+  keyPageUrl: string;
+  /** Short guidance shown beside the provider entry. */
+  hint: string;
+}
+
+export const BYOK_PROVIDERS: readonly ByokProvider[] = [
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    keyPrefix: 'sk-',
+    disallowedPrefixes: ['sk-ant-'],
+    keyPageUrl: 'https://platform.openai.com/api-keys',
+    hint: 'Paste your OpenAI key — starts with "sk-".',
+  },
+  {
+    id: 'anthropic',
+    label: 'Anthropic',
+    keyPrefix: 'sk-ant-',
+    disallowedPrefixes: [],
+    keyPageUrl: 'https://console.anthropic.com/settings/keys',
+    hint: 'Paste your Anthropic key — starts with "sk-ant-".',
+  },
+];
+
+/**
+ * Detect which provider a pasted key belongs to, or `null` for garbage.
+ *
+ * The disallowed-prefix rule makes matching order-independent: an
+ * `sk-ant-` key fails the OpenAI rule and matches only Anthropic.
+ */
+export function providerForKey(key: string): ByokProvider | null {
+  for (const provider of BYOK_PROVIDERS) {
+    if (
+      key.startsWith(provider.keyPrefix) &&
+      !provider.disallowedPrefixes.some((bad) => key.startsWith(bad))
+    ) {
+      return provider;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Adds `frontend/src/features/Settings/byokProviders.ts` (issue #403, epic #401) — the **single source of truth** for supported BYOK providers: label, key prefix, disallowed more-specific prefixes (mirroring the backend's `_PROVIDER_KEY_RULES` cross-wiring guard), the console key-page URL, and the per-provider guidance hint. Adding a provider is a one-entry edit.
- The settings screen now renders a **Supported providers** directory: each provider shows its hint ("Paste your OpenAI key — starts with \"sk-\"") and a tappable **Get your API key** link (`Linking.openURL`) to the exact console page — OpenAI → `platform.openai.com/api-keys`, Anthropic → `console.anthropic.com/settings/keys`.
- **Provider detection while typing**: a recognizable pasted key shows "<Provider> key detected — it will be saved on this device only" before save; garbage shows nothing.
- `validateUserApiKey` is generalized: prefix acceptance and the error copy both derive from the map (`providerForKey` uses the same disallowed-prefix rule as the backend, so matching is order-independent).
- **Security contract unchanged** (task 4): on-device-only storage via `ApiKeyContext`/`llmKeyStorage` and per-request `X-LLM-API-Key` forwarding are untouched — this PR doesn't modify either file.

## Test plan
- [x] New tests: `providerForKey` detects each provider and rejects garbage; every map entry carries an https key-page URL and a hint containing its prefix; each rendered `get-key-link-<id>` opens exactly that provider's URL; the detected-provider label tracks typing across both providers and disappears for garbage.
- [x] All existing validation tests pass unchanged (same accepted/rejected inputs, derived error copy).
- [x] Full frontend suite 1846/1846 under `TZ=UTC`; `npx tsc --noEmit` clean; `npm run lint` zero warnings; `TZ=UTC pre-commit run --all-files` green twice.

Closes #403
Refs #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)