### PR TITLE
fix(frontend): make local gate 2 green on clean main

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,3 +1,10 @@
+// Issue #406: pin the suite to UTC so date math is hermetic — several tests
+// compute "today"/"yesterday" from the real clock, and without this a dev
+// machine in a negative-UTC-offset timezone fails what CI (UTC) passes.
+// Node latches TZ at first Date use; this file loads before any test code,
+// so the assignment is reliable on POSIX (mac/linux dev machines + CI).
+process.env.TZ = 'UTC';
+
 /** @type {import('jest').Config} */
 module.exports = {
   // Use the react-native preset to avoid requiring Expo-specific tooling

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,8 +1,4 @@
-// Issue #406: pin the suite to UTC so date math is hermetic — several tests
-// compute "today"/"yesterday" from the real clock, and without this a dev
-// machine in a negative-UTC-offset timezone fails what CI (UTC) passes.
-// Node latches TZ at first Date use; this file loads before any test code,
-// so the assignment is reliable on POSIX (mac/linux dev machines + CI).
+// Pin timezone so date-math tests are hermetic; Node latches TZ at first Date use.
 process.env.TZ = 'UTC';
 
 /** @type {import('jest').Config} */

--- a/scripts/frontend/format.sh
+++ b/scripts/frontend/format.sh
@@ -62,13 +62,13 @@ if $CHECK; then
     if $VERBOSE; then
         echo "Checking formatting..."
     fi
-    npx prettier --check "src/**/*.{ts,tsx}" "tests/**/*.{ts,tsx}" "*.{js,json}" || { echo "✗ Formatting check failed" >&2; exit 1; }
+    npx prettier --check "src/**/*.{ts,tsx}" "*.{js,json}" || { echo "✗ Formatting check failed" >&2; exit 1; }
     echo "✓ Code formatting check passed"
 else
     if $VERBOSE; then
         echo "Formatting code..."
     fi
-    npx prettier --write "src/**/*.{ts,tsx}" "tests/**/*.{ts,tsx}" "*.{js,json}" || { echo "✗ Formatting failed" >&2; exit 1; }
+    npx prettier --write "src/**/*.{ts,tsx}" "*.{js,json}" || { echo "✗ Formatting failed" >&2; exit 1; }
     echo "✓ Code formatted successfully"
 fi
 exit 0


### PR DESCRIPTION
## Summary
Two unrelated environment bugs made `./scripts/frontend/check-all.sh` permanently red on a clean `main` for any developer in a negative-UTC-offset timezone (issue #406):

- **`format.sh` globbed a non-existent path**: `tests/**/*.{ts,tsx}` matches nothing (tests live under `src/**/__tests__/`) and prettier hard-fails on a zero-match pattern. The glob is dropped from both the `--check` and `--write` invocations. CI was unaffected (it runs `prettier -c .` directly).
- **Non-hermetic timezone-dependent tests**: several suites (`useProgramStore`, `habitManager`, `HabitStats`, `AuthContext`) compute "today"/"yesterday" from the real clock — green under CI's UTC, one day off locally. `jest.config.js` now pins `process.env.TZ = 'UTC'` before any test loads (Node latches TZ at first `Date` use; the config file loads first, so this is reliable on the POSIX dev/CI platforms in play). One central pin beats per-test fake timers here: it covers all four suites plus any future date-math test, with zero per-file ceremony.

## Test plan (the issue's acceptance criteria, verbatim)
- [x] `scripts/frontend/format.sh --check` exits 0 on a clean tree.
- [x] The full suite (1846 tests) passes under `TZ=America/New_York npx jest` — not just the listed files.
- [x] `./scripts/frontend/check-all.sh` exits 0 (4/4 checks).
- [x] Bonus regression proof: `pre-commit run --all-files` now passes **without** the `TZ=UTC` env prefix this session had been using as a workaround for the frontend-tests hook.

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)