### PR TITLE
feat(frontend): adopt the page envelope in feature screens via fetch-all

### DIFF
--- a/frontend/src/api/__tests__/pagination-api.test.ts
+++ b/frontend/src/api/__tests__/pagination-api.test.ts
@@ -1,6 +1,8 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
 import {
+  fetchAllPages,
+  habits,
   practices,
   practiceSessions,
   goalGroups,
@@ -131,5 +133,78 @@ describe('paginated list endpoints (issue #221 — Page envelope)', () => {
     );
 
     await expect(goalGroups.listPaginated({}, 'tok')).rejects.toThrow(ApiValidationError);
+  });
+});
+
+describe('fetchAllPages + listAll helpers (issue #408 — screen adoption)', () => {
+  test('fetchAllPages drains pages until has_more is false', async () => {
+    const pages = [
+      page([{ id: 1 }, { id: 2 }], { total: 3, has_more: true }),
+      page([{ id: 3 }], { total: 3, offset: 2 }),
+    ];
+    const fetchPage = jest.fn((params: { offset?: number }) =>
+      Promise.resolve(pages[params.offset ? 1 : 0]),
+    );
+
+    const items = await fetchAllPages(fetchPage as Parameters<typeof fetchAllPages>[0]);
+
+    expect(items).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(fetchPage.mock.calls[1]?.[0]?.offset).toBe(2);
+  });
+
+  test('fetchAllPages stops on an empty page even if has_more lies', async () => {
+    const fetchPage = jest.fn(() => Promise.resolve(page([], { total: 99, has_more: true })));
+    const items = await fetchAllPages(fetchPage as Parameters<typeof fetchAllPages>[0]);
+    expect(items).toEqual([]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  test('stages.listAll drains the paginated endpoint into a flat list', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(page([{ id: 1, stage_number: 1 }], { total: 1 })));
+    const result = await stages.listAll('tok');
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain('/stages?paginate=true');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer tok' });
+    expect(result).toEqual([{ id: 1, stage_number: 1 }]);
+  });
+
+  test('habits.listAll aggregates multiple pages', async () => {
+    const habit = (id: number) => ({
+      id,
+      name: `h${id}`,
+      icon: '🌱',
+      start_date: '2026-01-01',
+      energy_cost: 1,
+      energy_return: 2,
+      milestone_notifications: false,
+      stage: 'beige',
+      streak: 0,
+      goals: [],
+    });
+    mockFetch
+      .mockReturnValueOnce(jsonResponse(page([habit(1)], { total: 2, has_more: true })))
+      .mockReturnValueOnce(jsonResponse(page([habit(2)], { total: 2, offset: 1 })));
+    const result = await habits.listAll();
+    expect(result.map((h) => h.id)).toEqual([1, 2]);
+  });
+
+  test('course.stageContentAll drains the stage content envelope', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(page([{ id: 7, title: 'Survival' }])));
+    const result = await course.stageContentAll(1, 'tok');
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/course/stages/1/content?paginate=true');
+    expect(result).toEqual([{ id: 7, title: 'Survival' }]);
+  });
+
+  test('practices.listAll forwards include_mine and filters invalid items', async () => {
+    const valid = { id: 1, stage_number: 3, name: 'Box Breath', default_duration_minutes: 5 };
+    mockFetch.mockReturnValueOnce(jsonResponse(page([valid, { bogus: true }])));
+    const result = await practices.listAll({ stageNumber: 3, includeMine: true });
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('stage_number=3');
+    expect(url).toContain('include_mine=true');
+    expect(url).toContain('paginate=true');
+    expect(result).toEqual([valid]);
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -934,6 +934,29 @@ function pageQuery(extra: Record<string, string | number>, params: PaginationPar
   return query.toString();
 }
 
+/**
+ * Drain every page of a ``listPaginated``-style helper into one flat array.
+ *
+ * The screen-adoption path for the ``Page`` envelope (issue #408): every
+ * list in the app is small today, so screens keep their whole-list render
+ * while the wire contract moves to the envelope. A screen that later needs
+ * true incremental loading calls its ``listPaginated`` helper directly with
+ * offsets instead. The empty-page guard stops a buggy server from looping
+ * forever on ``has_more: true``.
+ */
+export async function fetchAllPages<T>(
+  fetchPage: (_params: PaginationParams) => Promise<Page<T>>,
+): Promise<T[]> {
+  const items: T[] = [];
+  let offset = 0;
+  for (;;) {
+    const result = await fetchPage({ offset });
+    items.push(...result.items);
+    if (!result.has_more || result.items.length === 0) return items;
+    offset += result.items.length;
+  }
+}
+
 // Collection-level habit URLs use a trailing slash to match the FastAPI route
 // (`prefix="/habits"` + `@router.{get,post}("/")`). Without the slash, every
 // request hit a 307 redirect — a wasted round-trip in the happy path and an
@@ -965,6 +988,10 @@ export const habits = {
       token,
       schema: habitPageSchema as unknown as z.ZodType<Page<ApiHabitWithGoals>>,
     });
+  },
+  /** Whole habits list via the ``Page`` envelope (issue #408). */
+  listAll(token?: string): Promise<ApiHabitWithGoals[]> {
+    return fetchAllPages((params) => habits.listPaginated(params, token));
   },
   get(habitId: number, token?: string): Promise<ApiHabitWithGoals> {
     return request<ApiHabitWithGoals>(`/habits/${habitId}`, {
@@ -1561,6 +1588,10 @@ export const stages = {
       schema: loosePageSchema as unknown as z.ZodType<Page<Stage>>,
     });
   },
+  /** Whole stages list via the ``Page`` envelope (issue #408). */
+  listAll(token?: string): Promise<Stage[]> {
+    return fetchAllPages((params) => stages.listPaginated(params, token));
+  },
   get(stageNumber: number, token?: string): Promise<Stage> {
     return request<Stage>(`/stages/${stageNumber}`, { token });
   },
@@ -1635,6 +1666,10 @@ export const course = {
         schema: loosePageSchema as unknown as z.ZodType<Page<ContentItem>>,
       },
     );
+  },
+  /** Whole stage-content list via the ``Page`` envelope (issue #408). */
+  stageContentAll(stageNumber: number, token?: string): Promise<ContentItem[]> {
+    return fetchAllPages((params) => course.stageContentPaginated(stageNumber, params, token));
   },
   markRead(contentId: number, token?: string): Promise<ContentCompletion> {
     return request<ContentCompletion>(`/course/content/${contentId}/mark-read`, {
@@ -1917,17 +1952,31 @@ export const practices = {
    * by stage). Prefer this over ``list`` when ``total`` / ``has_more`` matter.
    */
   listPaginated(
-    params: { stageNumber: number } & PaginationParams,
+    params: { stageNumber: number; includeMine?: boolean } & PaginationParams,
     token?: string,
   ): Promise<Page<PracticeItem>> {
-    const { stageNumber, ...page } = params;
-    return request<Page<PracticeItem>>(
-      `/practices/?${pageQuery({ stage_number: stageNumber }, page)}`,
-      {
-        token,
-        schema: loosePageSchema as unknown as z.ZodType<Page<PracticeItem>>,
-      },
+    const { stageNumber, includeMine, ...page } = params;
+    const extra: Record<string, string | number> = { stage_number: stageNumber };
+    if (includeMine === true) extra.include_mine = 'true';
+    return request<Page<PracticeItem>>(`/practices/?${pageQuery(extra, page)}`, {
+      token,
+      schema: loosePageSchema as unknown as z.ZodType<Page<PracticeItem>>,
+    });
+  },
+  /**
+   * Whole practices list via the ``Page`` envelope (issue #408). Applies the
+   * same ``validatePracticeItem`` filter as the bare ``list`` so malformed
+   * rows never reach a screen.
+   */
+  async listAll(
+    options: { stageNumber: number; includeMine?: boolean } | number,
+    token?: string,
+  ): Promise<PracticeItem[]> {
+    const params = typeof options === 'number' ? { stageNumber: options } : options;
+    const items = await fetchAllPages((pageParams) =>
+      practices.listPaginated({ ...params, ...pageParams }, token),
     );
+    return items.filter(validatePracticeItem);
   },
   async get(practiceId: number, token?: string): Promise<PracticeItem> {
     const data = await request<PracticeItem>(`/practices/${practiceId}`, { token });

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -39,7 +39,7 @@ function useStagesLoader() {
     const init = async () => {
       setLoading(true);
       try {
-        const stagesList = await stagesApi.list();
+        const stagesList = await stagesApi.listAll();
         setAllStages(stagesList);
         if (routeStageNumber === null) {
           // Master date wins when the user has picked an anchor; otherwise
@@ -73,7 +73,7 @@ function useStageContent(selectedStage: number, stagesLoaded: boolean) {
     setLoadingContent(true);
     try {
       const [contentResult, progressResult] = await Promise.all([
-        courseApi.stageContent(selectedStage),
+        courseApi.stageContentAll(selectedStage),
         courseApi.stageProgress(selectedStage),
       ]);
       setContent(contentResult);

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -111,10 +111,10 @@ const mockSiteResourceBody = (jest.fn() as any).mockResolvedValue({
 
 jest.mock('../../../api', () => ({
   stages: {
-    list: (...args: unknown[]) => mockStagesList(...args),
+    listAll: (...args: unknown[]) => mockStagesList(...args),
   },
   course: {
-    stageContent: (...args: unknown[]) => mockStageContent(...args),
+    stageContentAll: (...args: unknown[]) => mockStageContent(...args),
     stageProgress: (...args: unknown[]) => mockStageProgress(...args),
     markRead: (...args: unknown[]) => mockMarkRead(...args),
     contentBody: (...args: unknown[]) => mockContentBody(...args),

--- a/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
@@ -38,7 +38,7 @@ const buildApiHabits = (count: number) =>
 
 jest.mock('../../../api', () => ({
   habits: {
-    list: jest.fn() as any,
+    listAll: jest.fn() as any,
     create: jest.fn() as any,
     update: jest.fn() as any,
     delete: jest.fn() as any,
@@ -92,7 +92,7 @@ const { habits: habitsApi } = require('../../../api');
 const HabitsScreen = require('../HabitsScreen').default;
 
 const renderScreen = async (apiHabits: ReturnType<typeof buildApiHabits>) => {
-  habitsApi.list.mockResolvedValue(apiHabits);
+  habitsApi.listAll.mockResolvedValue(apiHabits);
   jest
     .spyOn(require('react-native'), 'useWindowDimensions')
     .mockReturnValue({ width: 400, height: 800, scale: 1, fontScale: 1 });

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
@@ -23,7 +23,7 @@ jest.mock('../../../../api', () => {
   return {
     ApiError: MockApiError,
     habits: {
-      list: jest.fn(() => Promise.resolve([])),
+      listAll: jest.fn(() => Promise.resolve([])),
       create: jest.fn(() => Promise.resolve({})),
       update: jest.fn(() => Promise.resolve({})),
       delete: jest.fn(() => Promise.resolve({})),
@@ -187,7 +187,7 @@ describe('useHabitActions.logUnit', () => {
     });
 
     // One background refresh re-fetches the server's authoritative ids…
-    expect(habitsApi.list).toHaveBeenCalledTimes(1);
+    expect(habitsApi.listAll).toHaveBeenCalledTimes(1);
     // …and the toast tells the user to simply tap again.
     expect(showToast.mock.calls.at(-1)?.[0]).toMatchObject({
       message: expect.stringMatching(/refreshed/i) as unknown,
@@ -207,7 +207,7 @@ describe('useHabitActions.logUnit', () => {
       await Promise.resolve();
     });
 
-    expect(habitsApi.list).not.toHaveBeenCalled();
+    expect(habitsApi.listAll).not.toHaveBeenCalled();
   });
 
   it('rolls BOTH store AND disk back when the API rejects (BUG-FE-HABIT-001)', async () => {

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('../../../../api', () => ({
   habits: {
-    list: jest.fn(() => Promise.resolve([])),
+    listAll: jest.fn(() => Promise.resolve([])),
     create: jest.fn(() => Promise.resolve({})),
     update: jest.fn(() => Promise.resolve({})),
     delete: jest.fn(() => Promise.resolve({})),
@@ -130,7 +130,7 @@ describe('habitManager', () => {
   describe('loadHabits', () => {
     it('replaces state with fallback habits when API returns empty and no cache', async () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never);
 
       await habitManager.loadHabits();
 
@@ -143,7 +143,7 @@ describe('habitManager', () => {
       const userBuilt: Habit[] = [makeHabit({ id: 1, name: 'My Habit' })];
       useHabitStore.setState({ habits: userBuilt });
       (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never);
 
       await habitManager.loadHabits();
 
@@ -157,7 +157,7 @@ describe('habitManager', () => {
       const userBuilt: Habit[] = [makeHabit({ id: 1, name: 'My Habit' })];
       useHabitStore.setState({ habits: userBuilt });
       (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
-      (habitsApi.list as jest.Mock).mockRejectedValueOnce(new Error('boom') as never);
+      (habitsApi.listAll as jest.Mock).mockRejectedValueOnce(new Error('boom') as never);
 
       await habitManager.loadHabits();
 
@@ -174,7 +174,7 @@ describe('habitManager', () => {
         g.tier === 'clear' ? { ...g, target: 30, target_unit: 'minutes' } : g,
       );
       (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
         {
           id: 99,
           name: 'Pranayama',
@@ -220,7 +220,7 @@ describe('habitManager', () => {
         return g;
       });
       (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
         {
           id: 99,
           name: 'Pranayama',
@@ -269,7 +269,7 @@ describe('habitManager', () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
       // First GET: empty (stuck state). Second GET (after recovery push):
       // the habit re-appears with its newly-assigned server id.
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
         {
           id: 99,
           name: 'Pranayama',
@@ -299,7 +299,7 @@ describe('habitManager', () => {
       // the recovery push — that would create duplicates server-side.
       const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
       (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
         {
           id: 99,
           name: 'Pranayama',
@@ -322,7 +322,7 @@ describe('habitManager', () => {
     it('uses cached habits when available and then replaces with API data', async () => {
       const cached: Habit[] = [makeHabit({ id: 99, name: 'Cached' })];
       (loadHabits as jest.Mock).mockResolvedValueOnce(cached as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
         {
           id: 2,
           name: 'From API',
@@ -348,7 +348,7 @@ describe('habitManager', () => {
 
     it('records an error message when the API fails and no cache exists', async () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
-      (habitsApi.list as jest.Mock).mockRejectedValueOnce(new Error('boom') as never);
+      (habitsApi.listAll as jest.Mock).mockRejectedValueOnce(new Error('boom') as never);
 
       await habitManager.loadHabits();
 
@@ -360,7 +360,7 @@ describe('habitManager', () => {
 
     it('replays the full queue and clears it when every check-in posts', async () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce([] as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never);
       (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([
         { goal_id: 1, did_complete: true, timestamp: '2025-04-01T00:00:00Z' },
         { goal_id: 2, did_complete: true, timestamp: '2025-04-02T00:00:00Z' },
@@ -375,7 +375,7 @@ describe('habitManager', () => {
 
     it('forwards a queued past-day timestamp as completed_on (#269, BUG-FE-HABIT-205)', async () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce([] as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never);
       (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([
         { goal_id: 1, did_complete: true, timestamp: '2025-04-01T12:00:00Z' },
       ] as never);
@@ -393,7 +393,7 @@ describe('habitManager', () => {
 
     it('omits completed_on when the queued check-in is from today', async () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce([] as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never);
       (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([
         { goal_id: 1, did_complete: true, timestamp: new Date().toISOString() },
       ] as never);
@@ -411,7 +411,7 @@ describe('habitManager', () => {
 
     it('tz-less internal re-fetches reuse the last known zone (#269)', async () => {
       (loadHabits as jest.Mock).mockResolvedValue([] as never);
-      (habitsApi.list as jest.Mock).mockResolvedValue([] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValue([] as never);
       (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
         // 22:00 UTC is already April 2 in Pacific/Kiritimati (UTC+14),
         // so the expected day proves the remembered zone is used — the
@@ -431,7 +431,7 @@ describe('habitManager', () => {
 
     it('keeps only the unprocessed suffix when replay fails mid-batch (BUG-FE-HABIT-205)', async () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce([] as never);
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never);
       (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([
         { goal_id: 1, did_complete: true, timestamp: '2025-04-01T00:00:00Z' },
         { goal_id: 2, did_complete: true, timestamp: '2025-04-02T00:00:00Z' },
@@ -680,7 +680,7 @@ describe('habitManager', () => {
         start_date: '2026-05-10',
         milestone_notifications: false,
       };
-      (habitsApi.list as jest.Mock).mockImplementationOnce(() => Promise.resolve([serverHabit]));
+      (habitsApi.listAll as jest.Mock).mockImplementationOnce(() => Promise.resolve([serverHabit]));
 
       await habitManager.addHabit({
         name: 'Brand New',
@@ -1040,7 +1040,7 @@ describe('habitManager', () => {
       ];
       // Server returns the habit with a real autoincrement id (47), real
       // goal ids (101/102/103), and the same name we POSTed.
-      (habitsApi.list as jest.Mock).mockResolvedValueOnce([
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
         {
           id: 47,
           name: 'Meditate',

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -444,7 +444,7 @@ type FetchResult = { kind: 'ok'; count: number } | { kind: 'error' };
 
 const fetchFromApi = async (hasCachedData: boolean): Promise<FetchResult> => {
   try {
-    const apiHabits = await habitsApi.list();
+    const apiHabits = await habitsApi.listAll();
     await handleApiSuccess(apiHabits, hasCachedData);
     setError(null);
     return { kind: 'ok', count: apiHabits.length };

--- a/frontend/src/features/Map/hooks/__tests__/useStageAdvance.test.tsx
+++ b/frontend/src/features/Map/hooks/__tests__/useStageAdvance.test.tsx
@@ -14,7 +14,7 @@ import { useStageAdvance } from '../useStageAdvance';
 
 const mockList = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<Stage[]>>;
 jest.mock('../../../../api', () => ({
-  stages: { list: (...args: [string?]) => mockList(...args) },
+  stages: { listAll: (...args: [string?]) => mockList(...args) },
 }));
 
 function makeApiStage(stageNumber: number, overrides: Partial<Stage> = {}): Stage {

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -6,7 +6,7 @@ import { clampProgress, isStageUnlocked } from '../stageService';
 
 const mockList = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<Stage[]>>;
 jest.mock('../../../../api', () => ({
-  stages: { list: (...args: [string?]) => mockList(...args) },
+  stages: { listAll: (...args: [string?]) => mockList(...args) },
 }));
 
 /** Build a fake API Stage response. */

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -100,7 +100,7 @@ export const stageService = {
     store.setLoading(true);
     store.setError(null);
     try {
-      const apiStages = await stagesApi.list(token);
+      const apiStages = await stagesApi.listAll(token);
       // Sort descending by stage_number (10 at top, 1 at bottom) to match
       // the background artwork.
       const sorted = [...apiStages].sort((a, b) => b.stage_number - a.stage_number);
@@ -158,7 +158,7 @@ export const stageService = {
     store.setLoading(true);
     store.setError(null);
     try {
-      const apiStages = await stagesApi.list(token);
+      const apiStages = await stagesApi.listAll(token);
       const sorted = [...apiStages].sort((a, b) => b.stage_number - a.stage_number);
       useStageStore.getState().setStages(sorted.map(toStageData));
       useStageStore.getState().setCurrentStage(deriveCurrentStage(apiStages));

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -59,7 +59,7 @@ const mockFrequency = (jest.fn() as any).mockResolvedValue(sampleFrequency);
 
 jest.mock('../../../api', () => ({
   practices: {
-    list: (...args: unknown[]) => mockPracticesList(...args),
+    listAll: (...args: unknown[]) => mockPracticesList(...args),
     get: jest.fn() as any,
   },
   userPractices: {

--- a/frontend/src/features/Practice/components/PracticeSwitcherSheet.tsx
+++ b/frontend/src/features/Practice/components/PracticeSwitcherSheet.tsx
@@ -98,7 +98,7 @@ function useLoadList(
     setIsLoading(true);
     setLoadError(null);
     try {
-      const list = await practices.list(stageNumber);
+      const list = await practices.listAll(stageNumber);
       if (mountedRef.current) setItems(list);
     } catch {
       if (mountedRef.current) setLoadError(LOAD_FAILED_MSG);

--- a/frontend/src/features/Practice/components/__tests__/PracticeSwitcherSheet.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/PracticeSwitcherSheet.test.tsx
@@ -56,7 +56,7 @@ const mockUserPracticesCreate = jest.fn() as jest.MockedFunction<
 
 jest.mock('@/api', () => ({
   practices: {
-    list: (...args: unknown[]) =>
+    listAll: (...args: unknown[]) =>
       (mockPracticesList as unknown as (...a: unknown[]) => Promise<PracticeItem[]>)(...args),
   },
   userPractices: {

--- a/frontend/src/features/Practice/hooks/useActivePractice.ts
+++ b/frontend/src/features/Practice/hooks/useActivePractice.ts
@@ -93,7 +93,7 @@ function useRefreshAction(
     setState((prev) => ({ ...prev, isLoading: true, error: null }));
     try {
       const [practiceList, userPracticeList] = await Promise.all([
-        practices.list(stageNumber),
+        practices.listAll(stageNumber),
         userPractices.list(),
       ]);
       if (!mountedRef.current) return;

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -118,7 +118,7 @@ function useCatalog(
     try {
       const list = loadPractices
         ? await loadPractices(stageNumber)
-        : await practices.list({ stageNumber, includeMine: true });
+        : await practices.listAll({ stageNumber, includeMine: true });
       setState({ practices: list, loading: false, error: null });
     } catch (err) {
       setState((prev) => ({

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -68,7 +68,7 @@ const mockPracticesList = jest.fn() as jest.MockedFunction<
 
 jest.mock('@/api', () => ({
   practices: {
-    list: (...args: unknown[]) =>
+    listAll: (...args: unknown[]) =>
       (mockPracticesList as unknown as (...a: unknown[]) => Promise<PracticeItem[]>)(...args),
   },
 }));


### PR DESCRIPTION
## Summary
- Migrates every screen named in issue #408's now-work to the `Page` envelope using the issue's **"fetch all pages" affordance** rather than per-screen load-more UI. Rationale: none of these lists approaches one page today (10 stages, ~14 content items/stage, small habit/practice sets), so fetch-all preserves whole-list rendering byte-for-byte — zero truncation risk and zero UX change — while the wire contract moves to `paginate=true`. A screen that later needs true incremental loading calls its `listPaginated` helper directly.
- **API layer**: new exported `fetchAllPages` (drain loop with an empty-page guard so a server lying with `has_more: true` can't loop forever), plus thin wrappers `stages.listAll`, `habits.listAll`, `course.stageContentAll`, and `practices.listAll` (which keeps the bare `list`'s `validatePracticeItem` filter; `practices.listPaginated` gains `include_mine` support for the catalog's drafts section).
- **Call sites migrated (7)**: `CourseScreen` (stages + stage content), `Map/stageService` (both load paths, token-forwarding preserved), `habitManager`, `PracticeCatalogScreen`, `PracticeSwitcherSheet`, `useActivePractice`. No bare-list call site remains for these four endpoint groups outside tests.
- **Deliberately deferred per the issue**: goal groups, user-practices, and practice-session history stay on bare `list()` ("as their screens gain pagination"), and therefore the backend follow-up to default `paginate=true` is **not** filed yet — the issue gates it on full migration.

## Test plan
- [x] 6 new API tests: multi-page drain with offset advancement, the empty-page/`has_more`-lie guard, `stages.listAll`/`habits.listAll` (multi-page, schema-validated)/`course.stageContentAll` URL + aggregation, and `practices.listAll` forwarding `include_mine` + filtering malformed rows.
- [x] 9 screen/service test suites updated to the new mocks; full frontend suite **1852/1852** (also green under `TZ=America/New_York` thanks to #406).
- [x] `npx tsc --noEmit` clean; `npm run lint` zero warnings; `pre-commit run --all-files` green twice.

Closes #408
Refs #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)