### PR TITLE
fix(backend): normalize day bounds to utc for sqlite-safe comparisons

### DIFF
--- a/backend/src/domain/dates.py
+++ b/backend/src/domain/dates.py
@@ -17,7 +17,7 @@ never produce a naive datetime.
 
 from __future__ import annotations
 
-from datetime import date, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Protocol, runtime_checkable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -104,22 +104,26 @@ def day_bounds_in_tz(
     user_or_tz: _HasTimezone | str | None,
     day: date,
 ) -> tuple[datetime, datetime]:
-    """Return ``[start, end)`` UTC-aware bounds for ``day`` in the user's TZ.
+    """Return ``[start, end)`` UTC-normalized bounds for ``day`` in the user's TZ.
 
-    The returned datetimes are timezone-aware and pinned to the user's
-    zone — but because Postgres ``timestamptz`` columns are stored as
-    UTC under the hood, comparing against these values in a SQL ``WHERE``
-    clause works without further conversion.  ``end`` is the start of
-    the *next* day so range queries stay half-open: ``WHERE col >= start
-    AND col < end`` correctly groups all timestamps that fall inside the
-    user's local calendar day, including the edge case where the local
-    day spans a DST jump (``end - start`` may be 23 or 25 hours, never
-    24 in DST-active zones).
+    Boundaries are computed at local midnight in the user's zone and then
+    converted to UTC (issue #412).  Postgres ``timestamptz`` compares
+    instants, so either representation works there — but SQLite stores
+    ``DateTime(timezone=True)`` as ISO strings and compares **lexically**,
+    ignoring the offset suffix, so bounds pinned to a non-UTC zone
+    mis-ordered against the UTC-rendered stored values.  Normalizing both
+    bounds to UTC makes every rendered string share the ``+00:00`` offset,
+    so the lexical comparison is also the chronological one.  ``end`` is
+    the start of the *next* day so range queries stay half-open: ``WHERE
+    col >= start AND col < end`` correctly groups all timestamps that
+    fall inside the user's local calendar day, including the edge case
+    where the local day spans a DST jump (``end - start`` may be 23 or
+    25 hours, never 24 in DST-active zones).
     """
     zone = _resolve_zone(user_or_tz)
     start = datetime.combine(day, time.min, tzinfo=zone)
     end = datetime.combine(day + timedelta(days=1), time.min, tzinfo=zone)
-    return start, end
+    return start.astimezone(UTC), end.astimezone(UTC)
 
 
 def to_user_date(

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -138,6 +138,48 @@ async def test_same_day_completion_is_idempotent(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("tz", ["America/Los_Angeles", "Pacific/Auckland"])
+async def test_same_day_completion_is_idempotent_for_non_utc_user(
+    async_client: AsyncClient, db_session: AsyncSession, tz: str
+) -> None:
+    """Issue #412: duplicate detection must hold for non-UTC users on SQLite.
+
+    ``day_bounds_in_tz`` used to return bounds pinned to the user's zone;
+    SQLite compares DateTime(timezone=True) values lexically and ignores
+    the offset suffix, so the in-day window query silently missed the
+    first completion and the streak double-counted.
+    """
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": f"tzdup-{tz.split('/')[-1].lower()}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+            "timezone": tz,
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+    goal = await _seed_goal(db_session, resp.json()["user_id"])
+
+    resp1 = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": goal.id, "did_complete": True},
+        headers=headers,
+    )
+    assert resp1.json()["reason_code"] == "streak_incremented"
+
+    resp2 = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": goal.id, "did_complete": True},
+        headers=headers,
+    )
+    assert resp2.status_code == HTTPStatus.OK
+    data = resp2.json()
+    assert data["reason_code"] == "already_logged_today"
+    assert data["streak"] == 1
+
+
+@pytest.mark.asyncio
 async def test_consecutive_day_completions_build_streak(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:


### PR DESCRIPTION
## Summary
- Fixes issue #412: `domain/dates.py::day_bounds_in_tz` returned `[start, end)` pinned to the user's zone. Postgres `timestamptz` compares instants so production was fine — but SQLite (the whole test suite + local dev) stores `DateTime(timezone=True)` as ISO strings and compares **lexically**, ignoring the offset suffix. A non-UTC user's in-day window query therefore mis-ordered against UTC-rendered stored rows: `_already_logged_on` found no same-day row and duplicate check-ins double-counted streaks.
- **Fix (the issue's suggested one)**: both bounds are converted with `.astimezone(UTC)` before returning. Postgres semantics are unchanged (same instants); SQLite's lexical comparison becomes the chronological one because every rendered string now shares the `+00:00` offset. Every other `day_bounds_in_tz` consumer inherits the fix. The docstring's incorrect "works without further conversion" claim is replaced with the real story.
- Whether the time-of-day window is open or shut decides if the bug reproduces — at this run's hour, `Pacific/Auckland` reproduced the double-count and `America/Los_Angeles` happened to pass, which is precisely the latent flakiness lexical comparison causes. The regression test parametrizes both zones so the suite covers a failing window around the clock.

## Test plan
- [x] New regression test: signup with `timezone=America/Los_Angeles` / `Pacific/Auckland`, two same-day check-ins → second returns `already_logged_today` with streak still 1 (Red on Auckland before the fix, green after).
- [x] All 26 existing goal-completion tests (incl. the UTC idempotency case and the 49-test TZ matrix elsewhere) pass unchanged.
- [x] Full backend suite green at 95.37%; xenon all-A; `pre-commit run --all-files` green twice.

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)