### PR TITLE
fix(frontend): replay goal-group associations in stuck-user recovery

### DIFF
--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -286,6 +286,44 @@ describe('habitManager', () => {
       expect(clear.goal_group_id ?? null).toBeNull();
     });
 
+    it('replays goal fields even when the goal-group list is unavailable (#425)', async () => {
+      const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
+      cachedHabit.goals = cachedHabit.goals.map((g) =>
+        g.tier === 'clear' ? { ...g, target: 30, goal_group_id: 5 } : g,
+      );
+      (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
+      (goalGroupsApi.list as jest.Mock).mockRejectedValueOnce(new Error('offline') as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+        {
+          id: 99,
+          name: 'Pranayama',
+          icon: cachedHabit.icon,
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [
+            freshServerGoal(991, 'Low', 'low', 1),
+            freshServerGoal(992, 'Clear', 'clear', 2),
+            freshServerGoal(993, 'Stretch', 'stretch', 3),
+          ],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      // The target customization still replays; the unverifiable
+      // association is dropped rather than failing the recovery.
+      expect(goalsApi.update).toHaveBeenCalledWith(
+        992,
+        expect.objectContaining({ target: 30, goal_group_id: null }),
+      );
+      const clear = useHabitStore.getState().habits[0]!.goals.find((g) => g.tier === 'clear')!;
+      expect(clear.target).toBe(30);
+    });
+
     it('one failed replay PUT does not abort the remaining goals (#286)', async () => {
       // Both clear AND stretch carry customizations; the clear PUT fails.
       // Best-effort-per-goal is the core design choice: stretch must still

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -15,6 +15,9 @@ jest.mock('../../../../api', () => ({
   goals: {
     update: jest.fn(() => Promise.resolve({})),
   },
+  goalGroups: {
+    list: jest.fn(() => Promise.resolve([])),
+  },
 }));
 
 jest.mock('../../../../storage/habitStorage', () => ({
@@ -44,6 +47,7 @@ jest.mock('react-native', () => ({
 import {
   habits as habitsApi,
   goalCompletions as goalCompletionsApi,
+  goalGroups as goalGroupsApi,
   goals as goalsApi,
 } from '../../../../api';
 import {
@@ -206,6 +210,80 @@ describe('habitManager', () => {
       const clear = useHabitStore.getState().habits[0]!.goals.find((g) => g.tier === 'clear')!;
       expect(clear.target).toBe(30);
       expect(clear.target_unit).toBe('minutes');
+    });
+
+    it('restores a surviving goal-group association during replay (#425)', async () => {
+      const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
+      cachedHabit.goals = cachedHabit.goals.map((g) =>
+        g.tier === 'clear' ? { ...g, target: 30, goal_group_id: 5 } : g,
+      );
+      (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
+      (goalGroupsApi.list as jest.Mock).mockResolvedValueOnce([
+        { id: 5, name: 'Morning Flow' },
+      ] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+        {
+          id: 99,
+          name: 'Pranayama',
+          icon: cachedHabit.icon,
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [
+            freshServerGoal(991, 'Low', 'low', 1),
+            freshServerGoal(992, 'Clear', 'clear', 2),
+            freshServerGoal(993, 'Stretch', 'stretch', 3),
+          ],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(goalsApi.update).toHaveBeenCalledWith(
+        992,
+        expect.objectContaining({ goal_group_id: 5 }),
+      );
+      const clear = useHabitStore.getState().habits[0]!.goals.find((g) => g.tier === 'clear')!;
+      expect(clear.goal_group_id).toBe(5);
+    });
+
+    it('drops a goal-group id the server no longer knows (#425)', async () => {
+      const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
+      cachedHabit.goals = cachedHabit.goals.map((g) =>
+        g.tier === 'clear' ? { ...g, target: 30, goal_group_id: 7 } : g,
+      );
+      (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
+      (goalGroupsApi.list as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+        {
+          id: 99,
+          name: 'Pranayama',
+          icon: cachedHabit.icon,
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [
+            freshServerGoal(991, 'Low', 'low', 1),
+            freshServerGoal(992, 'Clear', 'clear', 2),
+            freshServerGoal(993, 'Stretch', 'stretch', 3),
+          ],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(goalsApi.update).toHaveBeenCalledWith(
+        992,
+        expect.objectContaining({ goal_group_id: null }),
+      );
+      const clear = useHabitStore.getState().habits[0]!.goals.find((g) => g.tier === 'clear')!;
+      expect(clear.goal_group_id ?? null).toBeNull();
     });
 
     it('one failed replay PUT does not abort the remaining goals (#286)', async () => {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -13,6 +13,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   habits as habitsApi,
   goalCompletions as goalCompletionsApi,
+  goalGroups as goalGroupsApi,
   goals as goalsApi,
 } from '../../../api';
 import type {
@@ -470,16 +471,43 @@ const recoverStuckHabits = async (cached: Habit[]): Promise<void> => {
   }
 };
 
+/**
+ * The cached group association, kept only if that group still exists
+ * server-side — recovery may have outlived the groups the id pointed at,
+ * and PUTting a dead id would fail the whole goal replay.
+ */
+const sanitizedGroupId = (cached: Goal, validGroupIds: Set<number>): number | null =>
+  cached.goal_group_id != null && validGroupIds.has(cached.goal_group_id)
+    ? cached.goal_group_id
+    : null;
+
+/** Server-side goal-group ids, for validating cached associations. */
+const fetchServerGroupIds = async (): Promise<Set<number>> => {
+  try {
+    const groups = await goalGroupsApi.list();
+    return new Set(groups.map((g) => g.id));
+  } catch {
+    // Best-effort: with no list, replay proceeds without associations.
+    return new Set();
+  }
+};
+
 /** True when the cached goal carries values the freshly-seeded one lacks. */
-const goalNeedsReplay = (cached: Goal, fresh: Goal): boolean =>
+const goalNeedsReplay = (cached: Goal, fresh: Goal, validGroupIds: Set<number>): boolean =>
   cached.target !== fresh.target ||
   cached.target_unit !== fresh.target_unit ||
   cached.frequency !== fresh.frequency ||
   cached.frequency_unit !== fresh.frequency_unit ||
-  cached.is_additive !== fresh.is_additive;
+  cached.is_additive !== fresh.is_additive ||
+  sanitizedGroupId(cached, validGroupIds) !== (fresh.goal_group_id ?? null);
 
 /** PUT one cached customization onto its freshly-seeded server goal. */
-const replayOneGoal = async (cached: Goal, freshGoalId: number, title: string): Promise<void> => {
+const replayOneGoal = async (
+  cached: Goal,
+  freshGoalId: number,
+  title: string,
+  validGroupIds: Set<number>,
+): Promise<void> => {
   await goalsApi.update(freshGoalId, {
     title,
     tier: cached.tier,
@@ -488,6 +516,8 @@ const replayOneGoal = async (cached: Goal, freshGoalId: number, title: string): 
     frequency: cached.frequency,
     frequency_unit: cached.frequency_unit,
     is_additive: cached.is_additive,
+    // Full-replace PUT: omitting this wiped any surviving association.
+    goal_group_id: sanitizedGroupId(cached, validGroupIds),
   });
 };
 
@@ -496,6 +526,7 @@ const mergeReplayedGoals = (
   habit: Habit,
   cachedHabit: Habit,
   replayedTiers: Set<string>,
+  validGroupIds: Set<number>,
 ): Habit => ({
   ...habit,
   goals: habit.goals.map((fg) => {
@@ -509,18 +540,24 @@ const mergeReplayedGoals = (
       frequency: cg.frequency,
       frequency_unit: cg.frequency_unit,
       is_additive: cg.is_additive,
+      // Mirror what the PUT actually sent, not the raw cached value.
+      goal_group_id: sanitizedGroupId(cg, validGroupIds),
     };
   }),
 });
 
 /** Replay one habit's customized goals; returns the tiers the server accepted. */
-const replayHabitGoals = async (cachedHabit: Habit, freshHabit: Habit): Promise<Set<string>> => {
+const replayHabitGoals = async (
+  cachedHabit: Habit,
+  freshHabit: Habit,
+  validGroupIds: Set<number>,
+): Promise<Set<string>> => {
   const replayedTiers = new Set<string>();
   for (const cachedGoal of cachedHabit.goals) {
     const freshGoal = freshHabit.goals.find((g) => g.tier === cachedGoal.tier);
-    if (!freshGoal?.id || !goalNeedsReplay(cachedGoal, freshGoal)) continue;
+    if (!freshGoal?.id || !goalNeedsReplay(cachedGoal, freshGoal, validGroupIds)) continue;
     try {
-      await replayOneGoal(cachedGoal, freshGoal.id, freshGoal.title);
+      await replayOneGoal(cachedGoal, freshGoal.id, freshGoal.title, validGroupIds);
       replayedTiers.add(cachedGoal.tier);
     } catch (err) {
       console.warn('replayCachedGoalTargets: failed for', cachedHabit.name, cachedGoal.tier, err);
@@ -534,17 +571,19 @@ const replayHabitGoals = async (cachedHabit: Habit, freshHabit: Habit): Promise<
  * matched by (habit name, tier). Best-effort per goal; the store merges
  * only server-accepted tiers. Reads the immutable ``fresh`` snapshot —
  * deliberately NOT ``applyGoalUpdate``, whose in-place tier normalization
- * would cascade phantom replays. Known field gaps: goal_group_id (#425)
- * and days_of_week (#426, blocked on GoalUpdate schema support).
+ * would cascade phantom replays. Goal-group associations replay only when
+ * the group still exists server-side. Known field gap: days_of_week
+ * (#426, blocked on GoalUpdate schema support).
  */
 const replayCachedGoalTargets = async (cached: Habit[], fresh: Habit[]): Promise<void> => {
+  const validGroupIds = await fetchServerGroupIds();
   for (const cachedHabit of cached) {
     const freshHabit = fresh.find((h) => h.name === cachedHabit.name);
     if (!freshHabit?.id) continue;
-    const replayedTiers = await replayHabitGoals(cachedHabit, freshHabit);
+    const replayedTiers = await replayHabitGoals(cachedHabit, freshHabit, validGroupIds);
     if (replayedTiers.size === 0) continue;
     const next = getHabits().map((h) =>
-      h.id === freshHabit.id ? mergeReplayedGoals(h, cachedHabit, replayedTiers) : h,
+      h.id === freshHabit.id ? mergeReplayedGoals(h, cachedHabit, replayedTiers, validGroupIds) : h,
     );
     setHabits(next);
     void persistHabits(next);


### PR DESCRIPTION
## Summary
- Fixes issue #425 (filed from PR #424's review): `replayOneGoal` omitted `goal_group_id` — and because `GoalUpdate` is a full-replace PUT, the recovery replay didn't just fail to restore associations, it actively **wiped** any that had survived server-side.
- **The fix**: `replayCachedGoalTargets` fetches the server's goal groups once per recovery pass and forwards the cached `goal_group_id` only when that group still exists (`sanitizedGroupId`) — a dead id would 4xx the whole goal PUT and lose the target/unit replay with it. Otherwise the PUT sends an explicit `null`. `goalNeedsReplay` now treats an association difference as replay-worthy on its own, and `mergeReplayedGoals` mirrors the sanitized value the PUT actually sent rather than the raw cached one.
- **On name-based matching** (the issue's speculative suggestion): not possible as stated — the cached `Goal` stores only the group *id*, never its name, so there's nothing to match by. Dropping ids that didn't survive recovery aligns with the issue's own assessment that a verbatim copy may be wrong anyway; if group-name caching lands later, matching can be revisited.
- The known-gaps comment now lists only `days_of_week` (#426, blocked on `GoalUpdate` schema support).

## Test plan
- [x] New tests (Red first): a cached association whose group survived replays — PUT includes `goal_group_id: 5` and the merged store carries it; a cached id the server no longer knows is dropped — PUT sends `goal_group_id: null`. `goalGroups.list` joins the test harness mock.
- [x] All prior replay tests (#286/#424 suite) pass unchanged, including best-effort-per-goal failure isolation.
- [x] Full frontend suite 1857/1857 under `TZ=UTC`; `npx tsc --noEmit` clean; `npm run lint` zero warnings; `pre-commit run --all-files` green twice.

Closes #425
Refs #286, #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)