### PR TITLE
feat: carry days_of_week through goal updates and recovery replay

### DIFF
--- a/backend/src/schemas/goal.py
+++ b/backend/src/schemas/goal.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from domain.streaks import WEEKDAY_ABBREVIATIONS
 from models.goal import GoalTier
+
+# Canonical-case lookup: "mon" -> "Mon", mirroring date.strftime("%a").
+_CANONICAL_WEEKDAY: dict[str, str] = {day.lower(): day for day in WEEKDAY_ABBREVIATIONS}
 
 
 class GoalCompletionPublic(BaseModel):
@@ -35,6 +39,7 @@ class Goal(BaseModel):
     frequency_unit: str
     is_additive: bool = True
     goal_group_id: int | None = None
+    days_of_week: list[str] | None = None
 
 
 class GoalWithCompletions(Goal):
@@ -74,6 +79,23 @@ class GoalUpdate(BaseModel):
     frequency_unit: str = Field(min_length=1, max_length=50)
     is_additive: bool = True
     goal_group_id: int | None = None
+    #: Weekly cadence, e.g. ["Mon", "Wed"]; None means every day.
+    days_of_week: list[str] | None = None
+
+    @field_validator("days_of_week")
+    @classmethod
+    def _validate_days_of_week(cls, value: list[str] | None) -> list[str] | None:
+        """Normalise entries to canonical "Mon".."Sun"; reject anything else."""
+        if value is None:
+            return None
+        normalised: list[str] = []
+        for day in value:
+            canonical = _CANONICAL_WEEKDAY.get(day.lower())
+            if canonical is None:
+                msg = f"days_of_week entries must be one of {WEEKDAY_ABBREVIATIONS}; got {day!r}"
+                raise ValueError(msg)
+            normalised.append(canonical)
+        return normalised
 
 
 class GoalUnitsUpdate(BaseModel):

--- a/backend/tests/schemas/test_goal_schema.py
+++ b/backend/tests/schemas/test_goal_schema.py
@@ -23,6 +23,7 @@ def test_goal_schema_round_trip() -> None:
         "frequency_unit": "per_day",
         "is_additive": True,
         "goal_group_id": None,
+        "days_of_week": None,
     }
 
     schema_goal = GoalSchema.model_validate(record)

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -168,6 +168,82 @@ async def test_update_goal_persists_target_unit_frequency_and_is_additive(
 
 
 @pytest.mark.asyncio
+async def test_update_goal_persists_days_of_week(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Issue #426: the weekly cadence round-trips through PUT and the response."""
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(days_of_week=["Mon", "Wed", "Fri"]),
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["days_of_week"] == ["Mon", "Wed", "Fri"]
+
+
+@pytest.mark.asyncio
+async def test_update_goal_normalises_weekday_case(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(days_of_week=["mon", "FRI"]),
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["days_of_week"] == ["Mon", "Fri"]
+
+
+@pytest.mark.asyncio
+async def test_update_goal_rejects_invalid_weekday(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(days_of_week=["Monday"]),
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_update_goal_omitting_days_of_week_clears_it(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Full-replace PUT semantics: an omitted optional field reverts to None.
+
+    Pins the documented GoalUpdate contract so frontend callers know they
+    must resend days_of_week (all call sites now do).
+    """
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+
+    first = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(days_of_week=["Tue"]),
+        headers=headers,
+    )
+    assert first.json()["days_of_week"] == ["Tue"]
+
+    second = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(),
+        headers=headers,
+    )
+    assert second.status_code == HTTPStatus.OK
+    assert second.json()["days_of_week"] is None
+
+
+@pytest.mark.asyncio
 async def test_update_goal_rejects_forged_habit_id(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -766,6 +766,8 @@ export interface ApiGoal {
   frequency_unit: string;
   is_additive: boolean;
   goal_group_id?: number | null;
+  /** Weekly cadence ("Mon".."Sun"); null/absent means every day. */
+  days_of_week?: string[] | null;
   /** Optional for back-compat with API builds that don't yet embed completions. */
   completions?: ApiGoalCompletion[];
 }
@@ -1087,6 +1089,7 @@ export interface GoalUpdatePayload {
   frequency_unit: string;
   is_additive: boolean;
   goal_group_id?: number | null;
+  days_of_week?: string[] | null;
 }
 
 export const goals = {

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -212,6 +212,41 @@ describe('habitManager', () => {
       expect(clear.target_unit).toBe('minutes');
     });
 
+    it('replays days_of_week customizations after recovery (#426)', async () => {
+      const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
+      cachedHabit.goals = cachedHabit.goals.map((g) =>
+        g.tier === 'clear' ? { ...g, days_of_week: ['Mon', 'Wed'] } : g,
+      );
+      (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+        {
+          id: 99,
+          name: 'Pranayama',
+          icon: cachedHabit.icon,
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [
+            freshServerGoal(991, 'Low', 'low', 1),
+            freshServerGoal(992, 'Clear', 'clear', 2),
+            freshServerGoal(993, 'Stretch', 'stretch', 3),
+          ],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(goalsApi.update).toHaveBeenCalledWith(
+        992,
+        expect.objectContaining({ days_of_week: ['Mon', 'Wed'] }),
+      );
+      const clear = useHabitStore.getState().habits[0]!.goals.find((g) => g.tier === 'clear')!;
+      expect(clear.days_of_week).toEqual(['Mon', 'Wed']);
+    });
+
     it('restores a surviving goal-group association during replay (#425)', async () => {
       const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
       cachedHabit.goals = cachedHabit.goals.map((g) =>

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -118,6 +118,7 @@ const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.list>>): Ha
       frequency_unit: g.frequency_unit,
       is_additive: g.is_additive,
       goal_group_id: g.goal_group_id ?? null,
+      days_of_week: g.days_of_week ?? undefined,
     })),
     // Shared with ``toLocalHabit`` -- single-source dedupe + Date rehydration.
     completions: flattenGoalCompletions(h.goals ?? []),
@@ -471,6 +472,13 @@ const recoverStuckHabits = async (cached: Habit[]): Promise<void> => {
   }
 };
 
+/** Order-sensitive equality with null/undefined/empty treated as "every day". */
+const sameDaysOfWeek = (a: string[] | undefined, b: string[] | undefined): boolean => {
+  const left = a ?? [];
+  const right = b ?? [];
+  return left.length === right.length && left.every((day, i) => day === right[i]);
+};
+
 /**
  * The cached group association, kept only if that group still exists
  * server-side — recovery may have outlived the groups the id pointed at,
@@ -499,7 +507,8 @@ const goalNeedsReplay = (cached: Goal, fresh: Goal, validGroupIds: Set<number>):
   cached.frequency !== fresh.frequency ||
   cached.frequency_unit !== fresh.frequency_unit ||
   cached.is_additive !== fresh.is_additive ||
-  sanitizedGroupId(cached, validGroupIds) !== (fresh.goal_group_id ?? null);
+  sanitizedGroupId(cached, validGroupIds) !== (fresh.goal_group_id ?? null) ||
+  !sameDaysOfWeek(cached.days_of_week, fresh.days_of_week);
 
 /** PUT one cached customization onto its freshly-seeded server goal. */
 const replayOneGoal = async (
@@ -516,8 +525,9 @@ const replayOneGoal = async (
     frequency: cached.frequency,
     frequency_unit: cached.frequency_unit,
     is_additive: cached.is_additive,
-    // Full-replace PUT: omitting this wiped any surviving association.
+    // Full-replace PUT: omitting these would wipe surviving values.
     goal_group_id: sanitizedGroupId(cached, validGroupIds),
+    days_of_week: cached.days_of_week ?? null,
   });
 };
 
@@ -542,6 +552,7 @@ const mergeReplayedGoals = (
       is_additive: cg.is_additive,
       // Mirror what the PUT actually sent, not the raw cached value.
       goal_group_id: sanitizedGroupId(cg, validGroupIds),
+      days_of_week: cg.days_of_week,
     };
   }),
 });
@@ -572,8 +583,7 @@ const replayHabitGoals = async (
  * only server-accepted tiers. Reads the immutable ``fresh`` snapshot —
  * deliberately NOT ``applyGoalUpdate``, whose in-place tier normalization
  * would cascade phantom replays. Goal-group associations replay only when
- * the group still exists server-side. Known field gap: days_of_week
- * (#426, blocked on GoalUpdate schema support).
+ * the group still exists server-side; days_of_week replays verbatim.
  */
 const replayCachedGoalTargets = async (cached: Habit[], fresh: Habit[]): Promise<void> => {
   const validGroupIds = await fetchServerGroupIds();
@@ -725,6 +735,7 @@ export const habitManager = {
       frequency_unit: updatedGoal.frequency_unit,
       is_additive: updatedGoal.is_additive,
       goal_group_id: updatedGoal.goal_group_id ?? null,
+      days_of_week: updatedGoal.days_of_week ?? null,
     };
     goalsApi
       .update(updatedGoal.id, payload)


### PR DESCRIPTION
## Summary
- Fixes issue #426 (the #424 round-2 follow-up, sibling of #425). `days_of_week` could not be transmitted by `PUT /goals/{id}` at all — `GoalUpdate` had no such field and `extra='forbid'` 422'd any payload carrying it — so the stuck-user recovery replay silently dropped weekly cadences.
- **Backend (fix-shape step 1)**: `GoalUpdate` gains `days_of_week: list[str] | None` with a validator that case-normalises to the canonical `Mon..Sun` abbreviations shared with `domain.streaks` and 422s anything else (`"Monday"` rejected, `"mon"`/`"FRI"` normalised). The `Goal` **response** schema gains the field too — without it the replay's diff could never see the server side. A new test pins the documented full-replace contract: omitting the field clears it.
- **Frontend (step 2)**: `ApiGoal`/`GoalUpdatePayload` carry the field; `toLocalHabit` maps it; and because of the full-replace contract **every** PUT call site now resends it — `updateGoal` forwards the edited goal's value (previously a target edit would have begun wiping cadences the moment the schema accepted the field), and the recovery replay diffs it (order-sensitive; null/undefined/empty all mean "every day"), includes the cached cadence in `replayOneGoal`, and mirrors it in `mergeReplayedGoals` — the same pattern as #425's `goal_group_id`.
- **Regression test (step 3)**: mirrors #424's tier-replay tests — a cached `['Mon','Wed']` cadence replays onto the fresh server goal and lands in the merged store. Red before the wiring (422 + dropped field), green after.

## Test plan
- [x] 4 new backend tests: round-trip, case normalisation, invalid-weekday 422, omission-clears (contract pin); existing goals suite green; schema round-trip fixture updated for the new response field.
- [x] New frontend replay test (Red first); all #286/#424/#425 replay tests pass unchanged.
- [x] Backend 95.36% / xenon all-A; frontend 1858/1858, tsc + eslint clean; `pre-commit run --all-files` green twice.

Closes #426
Refs #286, #424, #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)