### PR TITLE
fix(ci): grant id-token write to the claude mention workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,6 +37,10 @@ jobs:
       pull-requests: read
       issues: read
       actions: read
+      # OIDC token for the claude action's auth exchange — without it every
+      # mention-triggered run fails with "Could not fetch an OIDC token".
+      # Mirrors claude-code-review.yml.
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Fixes issue #429: every `@claude` mention-triggered run of `claude.yml` died with `Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?` — so re-review requests via PR comment silently did nothing (observed live on PRs #414 and #428 during the autonomous loop; the workaround was re-running the push-triggered workflow).
- One-line fix: `id-token: write` joins the job's permissions block, mirroring the working `claude-code-review.yml`. A brief comment explains the non-obvious failure mode.
- The same workflow's dependabot-secrets gap remains separately tracked (and operator-blocked) in #411 — deliberately not bundled here.

## Test plan
- [x] YAML validates; `pre-commit run --all-files` green twice (check-yaml hook included).
- [x] True verification requires a live `@claude` mention after merge — the workflow only runs from the default branch's definition, so it cannot be exercised from this PR. Suggested post-merge check: comment `@claude please re-review` on any open PR and confirm the run reaches the action instead of failing at OIDC.

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)