### PR TITLE
perf(backend): offload bcrypt hashing to worker threads

### DIFF
--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -228,7 +228,7 @@ class AuthResponse(BaseModel):
     timezone: str = DEFAULT_USER_TIMEZONE
 
 
-def _hash_password(password: str) -> str:
+async def _hash_password(password: str) -> str:
     """Hash ``password`` with bcrypt-12 after enforcing the 72-byte input cap.
 
     bcrypt silently truncates input at 72 bytes (BUG-AUTH-004), so a
@@ -248,12 +248,17 @@ def _hash_password(password: str) -> str:
     if len(encoded) > _BCRYPT_MAX_PASSWORD_BYTES:
         msg = f"password exceeds bcrypt's {_BCRYPT_MAX_PASSWORD_BYTES}-byte limit"
         raise ValueError(msg)
-    hashed: bytes = bcrypt.hashpw(encoded, bcrypt.gensalt(rounds=12))
+    # bcrypt-12 is ~250 ms of CPU; run it in a worker thread so it does not
+    # block the event loop and serialize concurrent auth requests (§5.3).
+    hashed: bytes = await asyncio.to_thread(bcrypt.hashpw, encoded, bcrypt.gensalt(rounds=12))
     return hashed.decode("utf-8")
 
 
-def _verify_password(password: str, password_hash: str) -> bool:
-    return bool(bcrypt.checkpw(password.encode(), password_hash.encode("utf-8")))
+async def _verify_password(password: str, password_hash: str) -> bool:
+    """Constant-time bcrypt compare, offloaded to a worker thread (§5.3)."""
+    return bool(
+        await asyncio.to_thread(bcrypt.checkpw, password.encode(), password_hash.encode("utf-8"))
+    )
 
 
 def _new_jti() -> str:
@@ -505,7 +510,7 @@ async def signup(
     # response and we never store a row that bcrypt has silently
     # truncated (BUG-AUTH-004).
     try:
-        password_hash = _hash_password(payload.password)
+        password_hash = await _hash_password(payload.password)
     except ValueError as exc:
         raise bad_request("password_too_long") from exc
     user = User(
@@ -586,7 +591,7 @@ async def _verify_login_or_raise(
     result = await session.execute(select(User).where(User.email == payload.email))
     user = result.scalars().first()
 
-    if user is None or not _verify_password(payload.password, user.password_hash):
+    if user is None or not await _verify_password(payload.password, user.password_hash):
         await _record_attempt(session, payload.email, ip_address, success=False)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_credentials")
 
@@ -908,7 +913,7 @@ async def refresh_token(
 # ---------------------------------------------------------------------------
 
 
-def _hash_reset_token(plaintext: str) -> str:
+async def _hash_reset_token(plaintext: str) -> str:
     """Bcrypt-digest a reset-token plaintext at the cheap-cost (10) setting.
 
     These tokens are 256-bit randoms, not human input -- the cost-12
@@ -917,29 +922,34 @@ def _hash_reset_token(plaintext: str) -> str:
     constant-time miss-path computation in ``request`` stays in the
     SPEC R4 timing window.
     """
-    digest: bytes = bcrypt.hashpw(
+    digest: bytes = await asyncio.to_thread(
+        bcrypt.hashpw,
         plaintext.encode("utf-8"),
         bcrypt.gensalt(rounds=_PASSWORD_RESET_BCRYPT_ROUNDS),
     )
     return digest.decode("utf-8")
 
 
-def _verify_reset_token(plaintext: str, token_hash: str) -> bool:
-    """Constant-time bcrypt compare for reset-token verification."""
-    return bool(bcrypt.checkpw(plaintext.encode("utf-8"), token_hash.encode("utf-8")))
+async def _verify_reset_token(plaintext: str, token_hash: str) -> bool:
+    """Constant-time bcrypt compare for reset-token verification (offloaded)."""
+    return bool(
+        await asyncio.to_thread(
+            bcrypt.checkpw, plaintext.encode("utf-8"), token_hash.encode("utf-8")
+        )
+    )
 
 
-def _consume_dummy_bcrypt() -> None:
+async def _consume_dummy_bcrypt() -> None:
     """Spend the cost-10 reset-token verify budget on the request miss path.
 
     Mirrors the hit path's ``_verify_reset_token`` cost so the request
     endpoint cannot be timing-distinguished by an attacker scraping
     every email in a leak corpus (SPEC R4).
     """
-    bcrypt.checkpw(_DUMMY_BCRYPT_PASSWORD, _DUMMY_BCRYPT_HASH)
+    await asyncio.to_thread(bcrypt.checkpw, _DUMMY_BCRYPT_PASSWORD, _DUMMY_BCRYPT_HASH)
 
 
-def _consume_dummy_password_verify() -> None:
+async def _consume_dummy_password_verify() -> None:
     """Spend the cost-12 user-password verify budget on the confirm-miss path.
 
     Mirrors ``_verify_password(new_password, user.password_hash)`` cost
@@ -949,7 +959,7 @@ def _consume_dummy_password_verify() -> None:
     ``bcrypt.gensalt(rounds=12)``) so the masking dummy must also be
     cost-12 -- the cost-10 one is too fast.
     """
-    bcrypt.checkpw(_DUMMY_BCRYPT_PASSWORD, _DUMMY_PASSWORD_VERIFY_HASH)
+    await asyncio.to_thread(bcrypt.checkpw, _DUMMY_BCRYPT_PASSWORD, _DUMMY_PASSWORD_VERIFY_HASH)
 
 
 def _build_reset_email(to_address: str, plaintext_token: str) -> EmailMessagePayload:
@@ -1092,7 +1102,7 @@ async def _mint_and_persist_reset_token(
     row = PasswordResetToken(
         user_id=user.id,
         lookup_key=_make_lookup_key(plaintext),
-        token_hash=_hash_reset_token(plaintext),
+        token_hash=await _hash_reset_token(plaintext),
         requested_ip=_get_client_ip(request),
         requested_user_agent=user_agent,
         expires_at=datetime.now(UTC) + _PASSWORD_RESET_TTL,
@@ -1211,7 +1221,7 @@ async def request_password_reset(
         # operators chasing a missing SMTP delivery for an email that
         # was never sent.  The constant-time bcrypt below preserves
         # SPEC R4 timing parity.
-        _consume_dummy_bcrypt()
+        await _consume_dummy_bcrypt()
         return PasswordResetAccepted(message=_RESET_REQUEST_GENERIC_MESSAGE)
     plaintext = await _mint_and_persist_reset_token(session, user, request)
     await _send_reset_email_safely(sender, payload.email, plaintext)
@@ -1247,7 +1257,7 @@ async def _select_active_token_only(
     # re-requests a reset.  No security loss; cleaner than a for loop
     # that almost never iterates.
     row = result.scalars().first()
-    if row is None or not _verify_reset_token(plaintext, row.token_hash):
+    if row is None or not await _verify_reset_token(plaintext, row.token_hash):
         return None
     return row
 
@@ -1305,9 +1315,9 @@ async def _select_active_token_for_email(
     return token_row, user_row
 
 
-def _reject_if_password_reuse(user: User, new_password: str) -> None:
+async def _reject_if_password_reuse(user: User, new_password: str) -> None:
     """Reject reuse of the current password (SPEC R10)."""
-    if _verify_password(new_password, user.password_hash):
+    if await _verify_password(new_password, user.password_hash):
         raise bad_request("password_unchanged")
 
 
@@ -1383,17 +1393,17 @@ async def confirm_password_reset(
         # cannot be timing-distinguished.  The user's stored hash is
         # cost-12 so the dummy must match that cost; the cost-10
         # ``_consume_dummy_bcrypt`` is too fast to mask the verify.
-        _consume_dummy_password_verify()
+        await _consume_dummy_password_verify()
         _log_reset_event("confirm_rejected", "", request)
         raise bad_request("invalid_or_expired_token")
     token_row, user = found
-    _reject_if_password_reuse(user, payload.new_password)
+    await _reject_if_password_reuse(user, payload.new_password)
     # Hash the new password only AFTER the token is validated -- bcrypt
     # is the most expensive operation in this handler (~250 ms cost-12),
     # so deferring saves the cost on the (expected-common) invalid-token
     # path.
     try:
-        new_password_hash = _hash_password(payload.new_password)
+        new_password_hash = await _hash_password(payload.new_password)
     except ValueError as exc:
         raise bad_request("password_too_long") from exc
     await _apply_reset_to_user(session, user, token_row, new_password_hash)

--- a/backend/tests/routers/test_auth_async.py
+++ b/backend/tests/routers/test_auth_async.py
@@ -1,0 +1,201 @@
+"""Async-offload tests: bcrypt CPU work must run off the event-loop thread.
+
+Guards §5.3 (event-loop blocking) for ``routers.auth``: every bcrypt hash
+or verify reachable from an ``async def`` handler must execute via
+``asyncio.to_thread`` so the ~250 ms cost-12 work does not pin the single
+worker and serialize concurrent auth requests.  Each helper test records
+the thread bcrypt actually runs on and asserts it differs from the
+event-loop thread, so reverting any helper to a synchronous call fails its
+test.  The integration tests then confirm the call sites stay offloaded and
+that status codes / anti-enumeration behaviour are unchanged.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import bcrypt
+import pytest
+
+from models.user import User
+from routers.auth import (
+    _consume_dummy_bcrypt,
+    _consume_dummy_password_verify,
+    _hash_password,
+    _hash_reset_token,
+    _reject_if_password_reuse,
+    _verify_password,
+    _verify_reset_token,
+)
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+# A syntactically valid 60-char bcrypt digest (``$2b$12$`` + 53 chars) so the
+# hash helpers' ``.decode()`` / ``str`` handling still works while the real
+# (slow) KDF is replaced by a thread-recording stub.
+_FAKE_BCRYPT_HASH = "$2b$12$" + "a" * 53
+
+_VALID_PASSWORD = "securepassword123"  # pragma: allowlist secret
+
+
+def _recording_stub(recorder: dict[str, int], result: object) -> Callable[..., object]:
+    """Return a bcrypt stand-in that records the thread it runs on.
+
+    ``recorder["thread_ident"]`` captures ``threading.get_ident()`` at call
+    time so a test can assert the work executed off the event-loop thread.
+    """
+
+    def _stub(*_args: object, **_kwargs: object) -> object:
+        recorder["thread_ident"] = threading.get_ident()
+        return result
+
+    return _stub
+
+
+@pytest.mark.asyncio
+async def test_hash_password_offloads_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_hash_password`` runs bcrypt.hashpw off the event-loop thread."""
+    recorder: dict[str, int] = {}
+    monkeypatch.setattr(bcrypt, "hashpw", _recording_stub(recorder, _FAKE_BCRYPT_HASH.encode()))
+
+    result = await _hash_password(_VALID_PASSWORD)
+
+    assert result == _FAKE_BCRYPT_HASH
+    assert recorder["thread_ident"] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_verify_password_offloads_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_verify_password`` runs bcrypt.checkpw off the event-loop thread."""
+    recorder: dict[str, int] = {}
+    monkeypatch.setattr(bcrypt, "checkpw", _recording_stub(recorder, result=True))
+
+    assert await _verify_password(_VALID_PASSWORD, _FAKE_BCRYPT_HASH) is True
+    assert recorder["thread_ident"] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_hash_reset_token_offloads_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_hash_reset_token`` runs bcrypt.hashpw off the event-loop thread."""
+    recorder: dict[str, int] = {}
+    monkeypatch.setattr(bcrypt, "hashpw", _recording_stub(recorder, _FAKE_BCRYPT_HASH.encode()))
+
+    result = await _hash_reset_token("a-256-bit-random-token")
+
+    assert result == _FAKE_BCRYPT_HASH
+    assert recorder["thread_ident"] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_verify_reset_token_offloads_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_verify_reset_token`` runs bcrypt.checkpw off the event-loop thread."""
+    recorder: dict[str, int] = {}
+    monkeypatch.setattr(bcrypt, "checkpw", _recording_stub(recorder, result=True))
+
+    assert await _verify_reset_token("plaintext", _FAKE_BCRYPT_HASH) is True
+    assert recorder["thread_ident"] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_consume_dummy_bcrypt_offloads_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The reset-request anti-enumeration dummy verify runs off the loop thread."""
+    recorder: dict[str, int] = {}
+    monkeypatch.setattr(bcrypt, "checkpw", _recording_stub(recorder, result=False))
+
+    await _consume_dummy_bcrypt()
+
+    assert recorder["thread_ident"] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_consume_dummy_password_verify_offloads_to_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The confirm-miss anti-enumeration dummy verify runs off the loop thread."""
+    recorder: dict[str, int] = {}
+    monkeypatch.setattr(bcrypt, "checkpw", _recording_stub(recorder, result=False))
+
+    await _consume_dummy_password_verify()
+
+    assert recorder["thread_ident"] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_reject_if_password_reuse_offloads_to_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_reject_if_password_reuse`` verifies the password off the loop thread."""
+    recorder: dict[str, int] = {}
+    # ``False`` -> not a reuse, so the helper returns without raising.
+    monkeypatch.setattr(bcrypt, "checkpw", _recording_stub(recorder, result=False))
+    user = User(email="reuse@example.com", password_hash=_FAKE_BCRYPT_HASH)
+
+    await _reject_if_password_reuse(user, "a-fresh-password")
+
+    assert recorder["thread_ident"] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_signup_hashes_password_off_event_loop_thread(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real signup request hashes the password off the event-loop thread.
+
+    Exercises the call site (not just the helper) so reverting ``signup`` to
+    a synchronous hash is caught even if the helper stays async.
+    """
+    recorder: dict[str, int] = {}
+    real_hashpw = bcrypt.hashpw
+
+    def spy(password: bytes, salt: bytes) -> bytes:
+        recorder["thread_ident"] = threading.get_ident()
+        return real_hashpw(password, salt)
+
+    monkeypatch.setattr(bcrypt, "hashpw", spy)
+
+    resp = await async_client.post(
+        "/auth/signup",
+        json={"email": "async-offload@example.com", "password": _VALID_PASSWORD},
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert recorder["thread_ident"] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_signup_login_status_codes_unchanged(async_client: AsyncClient) -> None:
+    """Offloading must not change signup/login status codes or anti-enumeration.
+
+    Success paths still return 200; a wrong password and a nonexistent
+    account both still return 401 (the absent-account path runs without a
+    real verify, exactly as before).
+    """
+    email = "regression@example.com"
+    signup = await async_client.post(
+        "/auth/signup",
+        json={"email": email, "password": _VALID_PASSWORD},
+    )
+    assert signup.status_code == HTTPStatus.OK
+
+    good_login = await async_client.post(
+        "/auth/login",
+        json={"email": email, "password": _VALID_PASSWORD},
+    )
+    assert good_login.status_code == HTTPStatus.OK
+
+    wrong_password = await async_client.post(
+        "/auth/login",
+        json={"email": email, "password": "wrongpassword123"},  # pragma: allowlist secret
+    )
+    assert wrong_password.status_code == HTTPStatus.UNAUTHORIZED
+
+    absent_account = await async_client.post(
+        "/auth/login",
+        json={"email": "nobody@example.com", "password": _VALID_PASSWORD},
+    )
+    assert absent_account.status_code == HTTPStatus.UNAUTHORIZED

--- a/backend/tests/security/test_password_reset_timing.py
+++ b/backend/tests/security/test_password_reset_timing.py
@@ -59,7 +59,7 @@ async def _seed_user(db_session: AsyncSession, email: str) -> None:
     db_session.add(
         User(
             email=email,
-            password_hash=_hash_password(_PASSWORD),
+            password_hash=await _hash_password(_PASSWORD),
             created_at=datetime.now(UTC),
         )
     )

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -60,7 +60,7 @@ async def _create_user(
 ) -> User:
     user = User(
         email=email,
-        password_hash=_hash_password(_PASSWORD),
+        password_hash=await _hash_password(_PASSWORD),
         is_active=is_active,
         deleted_at=datetime.now(UTC) if deleted else None,
     )
@@ -745,10 +745,11 @@ async def test_token_issued_in_same_second_as_reset_is_rejected(
     assert response.status_code == 401
 
 
-def test_hash_reset_token_roundtrips() -> None:
+@pytest.mark.asyncio
+async def test_hash_reset_token_roundtrips() -> None:
     """``_hash_reset_token`` produces a digest verifiable by bcrypt.checkpw."""
     plain = "abc" * 11
-    digest = _hash_reset_token(plain)
+    digest = await _hash_reset_token(plain)
     assert bcrypt.checkpw(plain.encode(), digest.encode())
 
 


### PR DESCRIPTION
## Summary

- bcrypt cost-12 hash/verify (~250ms each) ran **synchronously inside the async auth handlers** — signup, login, email-confirm, password-reset, and the anti-enumeration dummy verifies — pinning the single event-loop worker so concurrent auth requests serialized (§5.3 event-loop blocking).
- Made the six bcrypt helpers (`_hash_password`, `_verify_password`, `_hash_reset_token`, `_verify_reset_token`, `_consume_dummy_bcrypt`, `_consume_dummy_password_verify`) and `_reject_if_password_reuse` `async`, running the CPU work via `asyncio.to_thread`, and `await`ed them at all 9 call sites.
- **No behavior change** other than where the work runs: bcrypt cost factors, the password policy, the anti-enumeration masking (including the login short-circuit for absent accounts), and every response shape/status code are unchanged.

## Test plan

- New `backend/tests/routers/test_auth_async.py`: each helper test records the thread bcrypt runs on and asserts it differs from the event-loop thread — **reverting any helper or call site to a synchronous call fails the test**. Plus a real-signup off-thread assertion and a signup/login regression covering unchanged status codes (200 success; 401 for wrong password and absent account).
- Updated existing `test_password_reset.py` / `test_password_reset_timing.py` callers to `await` the now-async helpers (no assertions weakened).
- `./scripts/backend/check-all.sh` — all 7 quality checks pass; full suite **1563 passed, 2 skipped**, coverage **95.36%**, ruff + mypy clean.

Closes #462
Refs #459
