### PR TITLE
fix(frontend): import Habits icons from lucide-react-native

### DIFF
--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -85,6 +85,22 @@ module.exports = tseslint.config(
       'sonarjs/prefer-single-boolean-return': 'error',
       'sonarjs/no-redundant-jump': 'error',
 
+      // Ban the DOM/web lucide package: its icons return SVG DOM nodes that
+      // React Native cannot mount, so they render nothing or crash on device
+      // (audit §5.2). `lucide-react-native` exposes the same icon names/props.
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'lucide-react',
+              message:
+                "Import icons from 'lucide-react-native', not 'lucide-react' (DOM-only; crashes on native — audit §5.2).",
+            },
+          ],
+        },
+      ],
+
       // TS hygiene
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-explicit-any': 'warn',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,6 @@
         "expo-notifications": "~0.29.14",
         "expo-secure-store": "^55.0.11",
         "expo-status-bar": "~2.0.1",
-        "lucide-react": "0.542.0",
         "lucide-react-native": "0.542.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -14038,15 +14037,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.542.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
-      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lucide-react-native": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "expo-notifications": "~0.29.14",
     "expo-secure-store": "^55.0.11",
     "expo-status-bar": "~2.0.1",
-    "lucide-react": "0.542.0",
     "lucide-react-native": "0.542.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -1,6 +1,15 @@
 // HabitsScreen.tsx
 
-import { BarChart2, Check, Lock, MoreHorizontal, Pencil, Plus, Unlock, Zap } from 'lucide-react';
+import {
+  BarChart2,
+  Check,
+  Lock,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Unlock,
+  Zap,
+} from 'lucide-react-native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, FlatList, Text, TouchableOpacity, View, Modal } from 'react-native';
 import EmojiSelector from 'react-native-emoji-selector';

--- a/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import HabitsScreen from '../HabitsScreen';
+
+// Mock the API so HabitsScreen loads instantly with an empty list. Plain
+// promise-returning functions avoid the typed-mock `never` inference of
+// `@jest/globals`' `jest.fn().mockResolvedValue(...)`.
+jest.mock('../../../api', () => ({
+  habits: {
+    list: () => Promise.resolve([]),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    getStats: () =>
+      Promise.resolve({
+        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        values: [0, 0, 0, 0, 0, 0, 0],
+        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+        longest_streak: 0,
+        current_streak: 0,
+        total_completions: 0,
+        completion_rate: 0,
+        completion_dates: [],
+      }),
+  },
+  goalCompletions: { create: jest.fn() },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: () => Promise.resolve({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getAllScheduledNotificationsAsync: () => Promise.resolve([]),
+  getExpoPushTokenAsync: () => Promise.resolve({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactModule = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/StatsModal', () => ({ __esModule: true, default: jest.fn(() => null) }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+describe('HabitsScreen icon chrome (lucide-react-native)', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('mounts the top-bar overflow toggle without throwing', async () => {
+    const { getByTestId } = render(<HabitsScreen />);
+
+    // The top-bar MoreHorizontal icon lives inside this toggle; mounting it
+    // proves the native lucide icon renders under @testing-library/react-native.
+    await waitFor(() => expect(getByTestId('overflow-menu-toggle')).toBeTruthy());
+  });
+
+  it('renders the overflow menu icons when the toggle is pressed', async () => {
+    const { getByTestId, getByText } = render(<HabitsScreen />);
+
+    const toggle = await waitFor(() => getByTestId('overflow-menu-toggle'));
+    fireEvent.press(toggle);
+
+    // The menu rows each render a lucide-react-native icon next to a label;
+    // their presence proves the icon chrome mounts without throwing on native.
+    expect(getByTestId('overflow-menu')).toBeTruthy();
+    expect(getByText('Quick Log')).toBeTruthy();
+    expect(getByText('Stats')).toBeTruthy();
+    expect(getByText('Add Habit')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Habits/__tests__/no-lucide-react-dom.test.ts
+++ b/frontend/src/features/Habits/__tests__/no-lucide-react-dom.test.ts
@@ -1,0 +1,50 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, it, expect } from '@jest/globals';
+
+/**
+ * Guard against the §5.2 "Critical" render bug: importing icons from the
+ * DOM/web package `lucide-react` instead of `lucide-react-native`. The web
+ * package returns SVG DOM nodes React Native cannot mount, so the screen
+ * renders nothing or crashes on a real device while still "demoing" on web.
+ *
+ * This test walks every app source file under `frontend/src` and fails on a
+ * `from 'lucide-react'` (non-native) import, so the mistake cannot silently
+ * recur. It is backed by an ESLint `no-restricted-imports` rule as well.
+ */
+
+// __dirname -> frontend/src/features/Habits/__tests__; climb to frontend/src.
+const SRC_ROOT = path.join(__dirname, '..', '..', '..');
+
+// Matches `from 'lucide-react'` / `from "lucide-react"` and
+// `require('lucide-react')`, but NOT `lucide-react-native` (the next char
+// after the package name is `-`, not a closing quote).
+const DOM_LUCIDE_IMPORT = /['"]lucide-react['"]/;
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+describe('lucide icon imports', () => {
+  it('never imports the DOM package lucide-react in app source', () => {
+    const offenders = collectSourceFiles(SRC_ROOT)
+      // Skip this guard's own source — it deliberately mentions the string.
+      .filter((file) => file !== __filename)
+      .filter((file) => DOM_LUCIDE_IMPORT.test(readFileSync(file, 'utf8')))
+      .map((file) => path.relative(SRC_ROOT, file));
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- `HabitsScreen.tsx` imported its top-bar / overflow-menu / mode-bar icons from **`lucide-react`** (the DOM/web package). Its icons return SVG DOM nodes React Native cannot mount, so the Habits chrome rendered nothing or crashed on a real device — it only "demoed" on web (audit §5.2, **Critical**; #1 in the audit's top-10 user-facing issues).
- Switched the import to **`lucide-react-native`** (identical icon names + prop API → visually identical output) and dropped the now-unused `lucide-react` dependency so `lucide-react-native` is the only lucide package in the tree.
- Added two recurrence guards: an ESLint `no-restricted-imports` rule banning `lucide-react`, and a filesystem test that scans `frontend/src` and fails on any `lucide-react` (non-native) import.

## Test plan

- New `no-lucide-react-dom.test.ts`: scans every `frontend/src/**/*.{ts,tsx}` and asserts none import `lucide-react` (failed before the fix, passes after).
- New `HabitsScreenIconChrome.test.tsx`: mounts `HabitsScreen` under `@testing-library/react-native`, asserts the top-bar overflow toggle mounts and that pressing it renders the icon-bearing menu (Quick Log / Stats / Add Habit) without throwing.
- Repo sweep confirmed `HabitsScreen.tsx` was the only offender; `GoalModal`, `BottomTabs`, etc. already used `-native`.
- `./scripts/frontend/check-all.sh` — all 4 checks pass; **1863 tests pass**, ESLint zero-warnings (incl. the new rule), `tsc --noEmit` clean, coverage ≥ 90%.

Closes #464
Refs #461
