### PR TITLE
feat(backend): paginate the practice-tags list endpoint

### DIFF
--- a/backend/src/routers/practice_tags.py
+++ b/backend/src/routers/practice_tags.py
@@ -31,6 +31,8 @@ from database import get_session
 from errors import conflict, forbidden, not_found
 from models.practice_tag import PracticeTag
 from routers.auth import get_current_user
+from schemas import Page, PaginationParams, build_page
+from schemas.pagination import paginate_query
 from schemas.practice_tag import PracticeTagCreate, PracticeTagOut, PracticeTagUpdate
 
 logger = logging.getLogger(__name__)
@@ -61,13 +63,18 @@ def _require_personal(tag: PracticeTag) -> None:
         raise forbidden("cannot_modify_system_tag")
 
 
-@router.get("/", response_model=list[PracticeTagOut])
+@router.get("/", response_model=None)
 async def list_practice_tags(
     user_id: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
-) -> list[PracticeTag]:
-    """List every tag the caller can see (system + own), label-sorted."""
-    result = await session.execute(
+    pagination: Annotated[PaginationParams, Depends()],
+) -> Page[PracticeTagOut] | list[PracticeTagOut]:
+    """List every tag the caller can see (system + own); paginated on ``?paginate=true``.
+
+    Ordering stays system-first then label so the bare-list contract is
+    unchanged; pagination slices that ordered set (issue #465).
+    """
+    query = (
         select(PracticeTag)
         .where(
             or_(
@@ -77,7 +84,11 @@ async def list_practice_tags(
         )
         .order_by(col(PracticeTag.owner_user_id).nulls_first(), PracticeTag.label)
     )
-    return list(result.scalars().all())
+    items, total = await paginate_query(session, query, pagination)
+    serialized = [PracticeTagOut.model_validate(tag, from_attributes=True) for tag in items]
+    if pagination.paginate:
+        return build_page(serialized, total, pagination)
+    return serialized
 
 
 @router.post("/", response_model=PracticeTagOut, status_code=status.HTTP_201_CREATED)

--- a/backend/tests/test_practice_tags_api.py
+++ b/backend/tests/test_practice_tags_api.py
@@ -193,3 +193,137 @@ async def test_delete_system_tag_403(async_client: AsyncClient, db_session: Asyn
 async def test_unauthenticated_rejected(async_client: AsyncClient) -> None:
     resp = await async_client.get("/practice-tags/")
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+# ── Pagination (issue #465) ────────────────────────────────────────────────
+
+_DEFAULT_PAGE_SIZE = 50  # mirror schemas.pagination.DEFAULT_PAGE_SIZE
+
+
+async def _seed_system_tags(db_session: AsyncSession, count: int) -> None:
+    """Seed ``count`` system tags with deterministically label-ordered rows."""
+    for i in range(count):
+        db_session.add(PracticeTag(slug=f"sys_{i:02d}", label=f"Sys {i:02d}", owner_user_id=None))
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_bare_path_returns_plain_list(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Omitting ?paginate=true returns the historical bare-list shape + order."""
+    await _seed_system_tags(db_session, 3)
+    headers = await _signup(async_client)
+
+    resp = await async_client.get("/practice-tags/", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert isinstance(body, list)
+    labels = [row["label"] for row in body]
+    assert labels == sorted(labels)
+
+
+@pytest.mark.asyncio
+async def test_list_paginated_returns_envelope(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """?paginate=true returns the Page envelope with the default limit."""
+    await _seed_system_tags(db_session, 3)
+    headers = await _signup(async_client)
+
+    resp = await async_client.get("/practice-tags/?paginate=true", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert set(body) == {"items", "total", "limit", "offset", "has_more"}
+    assert body["limit"] == _DEFAULT_PAGE_SIZE
+    assert body["offset"] == 0
+    assert body["total"] == 3
+    assert body["has_more"] is False
+    assert len(body["items"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_list_pagination_limit_offset_and_has_more(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The limit slices the page, offset skips, and total/has_more cover the set."""
+    await _seed_system_tags(db_session, 5)
+    headers = await _signup(async_client)
+
+    first = await async_client.get(
+        "/practice-tags/?paginate=true&limit=2&offset=0", headers=headers
+    )
+    page1 = first.json()
+    assert page1["total"] == 5
+    assert page1["limit"] == 2
+    assert page1["offset"] == 0
+    assert page1["has_more"] is True
+    assert len(page1["items"]) == 2
+
+    second = await async_client.get(
+        "/practice-tags/?paginate=true&limit=2&offset=2", headers=headers
+    )
+    page2 = second.json()
+    assert page2["offset"] == 2
+    assert page2["has_more"] is True
+    assert len(page2["items"]) == 2
+
+    page1_slugs = {row["slug"] for row in page1["items"]}
+    page2_slugs = {row["slug"] for row in page2["items"]}
+    assert page1_slugs.isdisjoint(page2_slugs)
+    combined = [row["label"] for row in page1["items"] + page2["items"]]
+    assert combined == sorted(combined)
+
+
+@pytest.mark.asyncio
+async def test_list_pagination_last_page_has_no_more(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The final slice reports has_more=false even with a partial page."""
+    await _seed_system_tags(db_session, 5)
+    headers = await _signup(async_client)
+
+    resp = await async_client.get("/practice-tags/?paginate=true&limit=2&offset=4", headers=headers)
+
+    body = resp.json()
+    assert body["total"] == 5
+    assert body["offset"] == 4
+    assert body["has_more"] is False
+    assert len(body["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_pagination_preserves_system_first_ordering(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """System tags (owner None) sort before personal tags through pagination."""
+    await _seed_system_tags(db_session, 2)
+    headers = await _signup(async_client)
+    # "AAA personal" sorts before the system labels by label alone, so seeing
+    # it last proves the system-first (nulls_first) ordering is authoritative.
+    await async_client.post(
+        "/practice-tags/",
+        json={"slug": "aaa_personal", "label": "AAA personal"},
+        headers=headers,
+    )
+
+    resp = await async_client.get("/practice-tags/?paginate=true", headers=headers)
+
+    items = resp.json()["items"]
+    owners = [row["owner_user_id"] for row in items]
+    personal_index = next(i for i, owner in enumerate(owners) if owner is not None)
+    assert all(owner is None for owner in owners[:personal_index])
+    assert items[-1]["slug"] == "aaa_personal"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [0, 201])
+async def test_list_pagination_rejects_out_of_range_limit(
+    async_client: AsyncClient, limit: int
+) -> None:
+    """The limit bounds are enforced by the shared PaginationParams validators."""
+    headers = await _signup(async_client)
+    resp = await async_client.get(f"/practice-tags/?paginate=true&limit={limit}", headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## Summary

- `GET /practice-tags` returned **every** visible tag (all system tags + the caller's personal tags) in a single unbounded `list[PracticeTagOut]`, so payload and query cost grew with a user's tag library (audit §4 "unbounded list", High). Unlike habits/practices it never adopted the shared `Page[T]` envelope.
- Wired `list_practice_tags` through the canonical pagination machinery (mirroring `routers/habits.py`): takes `PaginationParams`, `response_model=None`, routes the existing `or_(owner is None, owner == user_id)` filter + system-first/label ordering through `paginate_query`, and returns a `Page[PracticeTagOut]` envelope under `?paginate=true` or the bare list otherwise.
- Bare-list default shape and ordering are unchanged; `limit`/`offset` bounds come solely from the shared `PaginationParams` validators (no parallel validation added).

## Test plan

- Added cases to `test_practice_tags_api.py`: bare list shape/ordering unchanged; `?paginate=true` returns the `{items,total,limit,offset,has_more}` envelope with the default limit (50); `limit`/`offset` slice correctly with non-overlapping pages; `has_more` true mid-set and false on the last partial page; system-first ordering preserved through pagination (a personal tag whose label sorts first still appears last); out-of-range `limit` (0, 201) rejected with 422 by the shared validators.
- `./scripts/backend/check-all.sh` — all 7 checks pass; **1570 passed, 2 skipped**, coverage **95.36%**, ruff + mypy clean.

Closes #465
Refs #460
