### PR TITLE
perf(backend): add composite index on goalcompletion

### DIFF
--- a/backend/migrations/versions/c1d2e3f4a5b6_add_goalcompletion_composite_index.py
+++ b/backend/migrations/versions/c1d2e3f4a5b6_add_goalcompletion_composite_index.py
@@ -1,0 +1,38 @@
+"""add goalcompletion composite (goal_id, user_id, timestamp) index
+
+Revision ID: c1d2e3f4a5b6
+Revises: 18c9d0e1f2a3
+Create Date: 2026-06-24 00:00:00.000000
+
+Issue #466: ``goalcompletion`` is the app's highest-write table yet had no
+index covering its hot read filters.  Every streak/stats query filters on
+``goal_id`` / ``user_id`` and sorts by ``timestamp``, so each one
+full-scanned and sorted the table (audit §5.3 missing index).  This adds a
+single composite b-tree index over ``(goal_id, user_id, timestamp)`` so the
+planner can satisfy those reads from the index.  Non-destructive and fully
+reversible: ``upgrade`` creates the index, ``downgrade`` drops it.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d2e3f4a5b6"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "18c9d0e1f2a3"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = "ix_goalcompletion_goal_user_ts"
+_TABLE_NAME = "goalcompletion"
+_INDEX_COLUMNS = ["goal_id", "user_id", "timestamp"]
+
+
+def upgrade() -> None:
+    """Create the composite read index covering streak/stats queries."""
+    op.create_index(_INDEX_NAME, _TABLE_NAME, _INDEX_COLUMNS, unique=False)
+
+
+def downgrade() -> None:
+    """Drop the composite read index (reverts to full-scan reads)."""
+    op.drop_index(_INDEX_NAME, table_name=_TABLE_NAME)

--- a/backend/src/models/goal_completion.py
+++ b/backend/src/models/goal_completion.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, DateTime, ForeignKey
+from sqlalchemy import Column, DateTime, ForeignKey, Index
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
@@ -19,6 +19,14 @@ class GoalCompletion(SQLModel, table=True):
     For subtractive goals, all logs in a day are summed, and the day is
     successful if total < target.
     """
+
+    # ``ix_goalcompletion_goal_user_ts`` is created by migration
+    # ``c1d2e3f4a5b6`` (issue #466).  Every streak/stats read filters on
+    # ``goal_id`` / ``user_id`` and orders by ``timestamp``; this composite
+    # index covers that hot path on the app's highest-write table.  Declared
+    # here so the model and migration agree — ``alembic check`` otherwise
+    # reports the index as drift and fails CI.
+    __table_args__ = (Index("ix_goalcompletion_goal_user_ts", "goal_id", "user_id", "timestamp"),)
 
     id: int | None = Field(default=None, primary_key=True)
     goal_id: int = Field(

--- a/backend/tests/models/test_goal_completion_index.py
+++ b/backend/tests/models/test_goal_completion_index.py
@@ -1,0 +1,23 @@
+"""Index coverage for the high-write :class:`GoalCompletion` table.
+
+Streak/stats reads filter on ``goal_id`` / ``user_id`` and sort by
+``timestamp``; without a covering composite index every such query
+full-scans and sorts this hottest-write table (audit §5.3). This pins the
+index onto the model metadata so the migration and model cannot drift.
+"""
+
+from __future__ import annotations
+
+from models.goal_completion import GoalCompletion
+
+_EXPECTED_INDEX_COLUMNS = ("goal_id", "user_id", "timestamp")
+_TABLE_NAME = "goalcompletion"
+
+
+def test_goal_completion_has_composite_read_index() -> None:
+    """A composite ``(goal_id, user_id, timestamp)`` index backs hot reads."""
+    table = GoalCompletion.metadata.tables[_TABLE_NAME]
+    index_column_tuples = {
+        tuple(column.name for column in index.columns) for index in table.indexes
+    }
+    assert _EXPECTED_INDEX_COLUMNS in index_column_tuples


### PR DESCRIPTION
## Summary

- `GoalCompletion` is the app's highest-write table yet had no index covering its hot read filters — every streak/stats query filters on `goal_id`/`user_id` and sorts by `timestamp`, so each one full-scanned and sorted the table (audit §5.3 missing index).
- Declared `__table_args__ = (Index("ix_goalcompletion_goal_user_ts", "goal_id", "user_id", "timestamp"),)` on the model (following the `journal_entry.py` comment+declaration convention) so `alembic check` sees model and migration agree.
- Added reversible Alembic revision `c1d2e3f4a5b6`: `upgrade()` creates the composite index, `downgrade()` drops it — no destructive operation.

## Test plan

- New `tests/models/test_goal_completion_index.py` asserts the table metadata carries a composite `(goal_id, user_id, timestamp)` index (failed before the model change, passes after).
- `alembic history` confirms the revision chains cleanly onto the current head (`18c9d0e1f2a3 → c1d2e3f4a5b6`, single head). The live `upgrade → downgrade → upgrade` round-trip and `alembic check` run on CI's Postgres service (migrations use Postgres-only types and don't execute on SQLite locally).
- The SQLite test mirror needs no change: `conftest` builds via `metadata.create_all`, which auto-creates this plain b-tree index; the manual list is only for functional/partial unique indexes.
- `./scripts/backend/check-all.sh` — all 7 checks pass; **1572 passed, 2 skipped**, coverage **95.33%**, ruff + mypy clean.

Closes #466
Refs #459
