### PR TITLE
perf(frontend): memoize HabitTile + stabilize renderHabitTile

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -700,6 +700,10 @@ const HabitTileComponent = ({
   const { scale, gridGutter, tileMinHeight } = useTileLayout();
   const color = stageColor ?? STAGE_COLORS[habit.stage] ?? '#000';
 
+  // Handlers are always provided (so they stay stable for React.memo), but
+  // LockedTile deliberately does NOT expose onOpenGoals/onLongPress/onIconPress
+  // in its UI — its only interaction is the unlock dialog. So those handlers
+  // are never invoked for a locked row; the rendercount test pins this.
   if (locked) {
     return (
       <LockedTile

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -686,7 +686,7 @@ const UnlockedTile = ({
   );
 };
 
-export const HabitTile = ({
+const HabitTileComponent = ({
   habit,
   locked,
   onOpenGoals,
@@ -695,6 +695,7 @@ export const HabitTile = ({
   onUnlockHabit,
   tz = DEFAULT_TIMEZONE,
   stageColor,
+  globalIndex = 0,
 }: HabitTileProps) => {
   const { scale, gridGutter, tileMinHeight } = useTileLayout();
   const color = stageColor ?? STAGE_COLORS[habit.stage] ?? '#000';
@@ -712,16 +713,24 @@ export const HabitTile = ({
     );
   }
 
+  // Bind the stable parent handlers to this tile's habit/index. These wrappers
+  // are recreated only when the tile actually re-renders (below the memo
+  // boundary), so they never defeat React.memo on unchanged rows.
   return (
     <UnlockedTile
       habit={habit}
       stageColor={color}
-      onOpenGoals={onOpenGoals}
-      onLongPress={onLongPress}
-      onIconPress={onIconPress}
+      onOpenGoals={onOpenGoals ? () => onOpenGoals(habit) : undefined}
+      onLongPress={onLongPress ? () => onLongPress(habit) : undefined}
+      onIconPress={onIconPress ? () => onIconPress(globalIndex) : undefined}
       tz={tz}
     />
   );
 };
+
+// Memoized so a state change elsewhere (logging a unit, opening a modal) does
+// not re-render every visible row — only rows whose props actually changed
+// (issue #468). Relies on the parent passing stable handler references.
+export const HabitTile = React.memo(HabitTileComponent);
 
 export default HabitTile;

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -127,9 +127,13 @@ export interface EditableGoalProps {
 export interface HabitTileProps {
   habit: Habit;
   locked?: boolean;
-  onOpenGoals?: () => void;
-  onLongPress?: () => void;
-  onIconPress?: () => void;
+  // Handlers take the tile's own habit / index so the parent can pass stable
+  // (useCallback) references shared across all rows; the tile binds them to its
+  // habit internally. This keeps React.memo effective — a single-habit update
+  // re-renders only that row (issue #468).
+  onOpenGoals?: (_habit: Habit) => void;
+  onLongPress?: (_habit: Habit) => void;
+  onIconPress?: (_index: number) => void;
   onUnlockHabit?: (_habitId: number) => void;
   /**
    * IANA timezone used to bucket completions into the user's calendar day
@@ -139,6 +143,8 @@ export interface HabitTileProps {
   tz?: string;
   /** Border/accent color; falls back to ``STAGE_COLORS[habit.stage]`` when omitted. */
   stageColor?: string;
+  /** Global (page-offset) index passed to ``onIconPress``; defaults to 0. */
+  globalIndex?: number;
 }
 
 export interface HabitSettingsModalProps {

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -81,14 +81,14 @@ const ModeBar = ({ mode, onExit }: { mode: string; onExit: () => void }) => (
 
 const openModalForMode = (
   mode: string,
-  modals: ReturnType<typeof useModalCoordinator>,
+  open: ReturnType<typeof useModalCoordinator>['open'],
   actions: ReturnType<typeof useHabits>['actions'],
   itemId: number,
 ) => {
-  if (mode === 'stats') modals.open('stats');
-  else if (mode === 'edit') modals.open('settings');
+  if (mode === 'stats') open('stats');
+  else if (mode === 'edit') open('settings');
   else if (mode === 'quickLog') actions.logUnit(itemId, 1);
-  else modals.open('goal');
+  else open('goal');
 };
 
 interface OverflowMenuProps {
@@ -440,6 +440,44 @@ const EnergyFooter = ({
   </>
 );
 
+interface TileHandlers {
+  handleOpenGoals: (_item: Habit) => void;
+  handleLongPress: (_item: Habit) => void;
+  handleIconPress: (_index: number) => void;
+}
+
+// Stable per-tile handlers: the tile binds these to its own habit/index, so
+// unchanged rows keep identical prop references and React.memo skips them.
+const useTileHandlers = (
+  mode: string,
+  open: ReturnType<typeof useModalCoordinator>['open'],
+  actions: ReturnType<typeof useHabits>['actions'],
+  setSelectedHabit: (_h: Habit) => void,
+): TileHandlers => {
+  const handleOpenGoals = useCallback(
+    (item: Habit) => {
+      setSelectedHabit(item);
+      openModalForMode(mode, open, actions, item.id!);
+    },
+    [mode, open, actions, setSelectedHabit],
+  );
+  const handleLongPress = useCallback(
+    (item: Habit) => {
+      setSelectedHabit(item);
+      open('settings');
+    },
+    [open, setSelectedHabit],
+  );
+  const handleIconPress = useCallback(
+    (globalIndex: number) => {
+      actions.iconPress(globalIndex);
+      open('emojiPicker');
+    },
+    [actions, open],
+  );
+  return { handleOpenGoals, handleLongPress, handleIconPress };
+};
+
 const useHabitTileRenderer = (
   mode: string,
   modals: ReturnType<typeof useModalCoordinator>,
@@ -448,46 +486,36 @@ const useHabitTileRenderer = (
   tz: string,
   pageOffset = 0,
 ) => {
-  const renderHabitTile = ({ item, index }: { item: Habit; index: number }) => {
-    // Calendar-driven: unlocks when the anchored start_date arrives, not on the stale `revealed` flag — keeps Habits in lockstep with Map/Practice/Course.
-    const isLocked = isHabitLockedToday(item);
-    const globalIndex = pageOffset + index;
-    // index is page-relative, so each page restarts the Beige → Clear Light gradient.
-    const stageColor = STAGE_COLORS[STAGE_ORDER[index % STAGE_ORDER.length]!]!;
-    return (
-      <HabitTile
-        habit={item}
-        locked={isLocked}
-        stageColor={stageColor}
-        onOpenGoals={
-          isLocked
-            ? undefined
-            : () => {
-                setSelectedHabit(item);
-                openModalForMode(mode, modals, actions, item.id!);
-              }
-        }
-        onLongPress={
-          isLocked
-            ? undefined
-            : () => {
-                setSelectedHabit(item);
-                modals.open('settings');
-              }
-        }
-        onIconPress={
-          isLocked
-            ? undefined
-            : () => {
-                actions.iconPress(globalIndex);
-                modals.open('emojiPicker');
-              }
-        }
-        onUnlockHabit={actions.unlockHabit}
-        tz={tz}
-      />
-    );
-  };
+  const { handleOpenGoals, handleLongPress, handleIconPress } = useTileHandlers(
+    mode,
+    modals.open,
+    actions,
+    setSelectedHabit,
+  );
+  const { unlockHabit } = actions;
+  const renderHabitTile = useCallback(
+    ({ item, index }: { item: Habit; index: number }) => {
+      // Calendar-driven: unlocks when the anchored start_date arrives, not on the stale `revealed` flag — keeps Habits in lockstep with Map/Practice/Course.
+      const isLocked = isHabitLockedToday(item);
+      const globalIndex = pageOffset + index;
+      // index is page-relative, so each page restarts the Beige → Clear Light gradient.
+      const stageColor = STAGE_COLORS[STAGE_ORDER[index % STAGE_ORDER.length]!]!;
+      return (
+        <HabitTile
+          habit={item}
+          locked={isLocked}
+          stageColor={stageColor}
+          globalIndex={globalIndex}
+          onOpenGoals={handleOpenGoals}
+          onLongPress={handleLongPress}
+          onIconPress={handleIconPress}
+          onUnlockHabit={unlockHabit}
+          tz={tz}
+        />
+      );
+    },
+    [pageOffset, tz, handleOpenGoals, handleLongPress, handleIconPress, unlockHabit],
+  );
   return renderHabitTile;
 };
 

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -82,12 +82,12 @@ const ModeBar = ({ mode, onExit }: { mode: string; onExit: () => void }) => (
 const openModalForMode = (
   mode: string,
   open: ReturnType<typeof useModalCoordinator>['open'],
-  actions: ReturnType<typeof useHabits>['actions'],
+  logUnit: ReturnType<typeof useHabits>['actions']['logUnit'],
   itemId: number,
 ) => {
   if (mode === 'stats') open('stats');
   else if (mode === 'edit') open('settings');
-  else if (mode === 'quickLog') actions.logUnit(itemId, 1);
+  else if (mode === 'quickLog') logUnit(itemId, 1);
   else open('goal');
 };
 
@@ -454,12 +454,16 @@ const useTileHandlers = (
   actions: ReturnType<typeof useHabits>['actions'],
   setSelectedHabit: (_h: Habit) => void,
 ): TileHandlers => {
+  // Depend on the specific stable function refs, not the whole ``actions``
+  // object, so the memo optimization holds even if ``actions`` were ever
+  // rebuilt per render (issue #468 review).
+  const { iconPress, logUnit } = actions;
   const handleOpenGoals = useCallback(
     (item: Habit) => {
       setSelectedHabit(item);
-      openModalForMode(mode, open, actions, item.id!);
+      openModalForMode(mode, open, logUnit, item.id!);
     },
-    [mode, open, actions, setSelectedHabit],
+    [mode, open, logUnit, setSelectedHabit],
   );
   const handleLongPress = useCallback(
     (item: Habit) => {
@@ -470,10 +474,10 @@ const useTileHandlers = (
   );
   const handleIconPress = useCallback(
     (globalIndex: number) => {
-      actions.iconPress(globalIndex);
+      iconPress(globalIndex);
       open('emojiPicker');
     },
-    [actions, open],
+    [iconPress, open],
   );
   return { handleOpenGoals, handleLongPress, handleIconPress };
 };

--- a/frontend/src/features/Habits/__tests__/HabitTile.rendercount.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTile.rendercount.test.tsx
@@ -1,0 +1,116 @@
+// Render-count guard for issue #468: a single-habit update must re-render only
+// that row. HabitTile (and its UnlockedTile child) call useResponsive() on
+// every render via useTileLayout, so spying on it counts actual tile renders.
+// With React.memo + stable handlers, bumping one habit's reference re-renders
+// exactly one tile's worth of work — not the whole list.
+import { describe, expect, it, jest } from '@jest/globals';
+import React, { useCallback, useState } from 'react';
+import renderer from 'react-test-renderer';
+
+import * as useResponsiveModule from '../../../design/useResponsive';
+import type { Habit } from '../Habits.types';
+import { HabitTile } from '../HabitTile';
+
+const makeGoals = () => [
+  {
+    title: 'Low',
+    tier: 'low' as const,
+    target: 1,
+    target_unit: 'u',
+    frequency: 1,
+    frequency_unit: 'per_day',
+    is_additive: true,
+  },
+  {
+    title: 'Clear',
+    tier: 'clear' as const,
+    target: 2,
+    target_unit: 'u',
+    frequency: 1,
+    frequency_unit: 'per_day',
+    is_additive: true,
+  },
+  {
+    title: 'Stretch',
+    tier: 'stretch' as const,
+    target: 3,
+    target_unit: 'u',
+    frequency: 1,
+    frequency_unit: 'per_day',
+    is_additive: true,
+  },
+];
+
+function makeHabit(id: number): Habit {
+  return {
+    id,
+    name: `Habit ${id}`,
+    icon: '🧪',
+    stage: 'Beige',
+    streak: 0,
+    energy_cost: 5,
+    energy_return: 7,
+    start_date: new Date(2020, 0, 1),
+    goals: makeGoals(),
+    completions: [],
+    revealed: true,
+  } as Habit;
+}
+
+let bumpHabit: (_id: number) => void = () => {};
+
+function Harness({ initial }: { initial: readonly Habit[] }) {
+  const [habits, setHabits] = useState<readonly Habit[]>(initial);
+  // Stable handlers — exactly what HabitsScreen now passes so memo can work.
+  const onOpenGoals = useCallback(() => {}, []);
+  const onLongPress = useCallback(() => {}, []);
+  const onIconPress = useCallback(() => {}, []);
+
+  bumpHabit = (id: number) =>
+    setHabits((current) => current.map((h) => (h.id === id ? { ...h, name: 'bumped' } : h)));
+
+  return (
+    <>
+      {habits.map((habit, index) => (
+        <HabitTile
+          key={habit.id}
+          habit={habit}
+          stageColor="#abcdef"
+          globalIndex={index}
+          onOpenGoals={onOpenGoals}
+          onLongPress={onLongPress}
+          onIconPress={onIconPress}
+        />
+      ))}
+    </>
+  );
+}
+
+describe('HabitTile render isolation (issue #468)', () => {
+  it('re-renders only the updated row when one habit changes', () => {
+    const renderSpy = jest.spyOn(useResponsiveModule, 'default');
+    const habits = [makeHabit(1), makeHabit(2), makeHabit(3)];
+
+    renderer.act(() => {
+      renderer.create(<Harness initial={habits} />);
+    });
+
+    const mountCalls = renderSpy.mock.calls.length;
+    // Each row does a fixed amount of useResponsive work per render.
+    const callsPerTile = mountCalls / habits.length;
+    expect(Number.isInteger(callsPerTile)).toBe(true);
+
+    renderSpy.mockClear();
+    renderer.act(() => {
+      bumpHabit(2);
+    });
+    const afterBumpCalls = renderSpy.mock.calls.length;
+
+    // Exactly one tile re-rendered — not the whole list (which would be
+    // ``mountCalls`` again). This is the regression the memo fix prevents.
+    expect(afterBumpCalls).toBe(callsPerTile);
+    expect(afterBumpCalls).toBeLessThan(mountCalls);
+
+    renderSpy.mockRestore();
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitTile.rendercount.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTile.rendercount.test.tsx
@@ -1,11 +1,13 @@
-// Render-count guard for issue #468: a single-habit update must re-render only
-// that row. HabitTile (and its UnlockedTile child) call useResponsive() on
-// every render via useTileLayout, so spying on it counts actual tile renders.
-// With React.memo + stable handlers, bumping one habit's reference re-renders
-// exactly one tile's worth of work — not the whole list.
+// Render-isolation guards for issue #468. HabitTile (and its UnlockedTile
+// child) call useResponsive() on every render via useTileLayout, so spying on
+// it counts actual tile renders. With React.memo + stable handlers, updating
+// one habit's reference re-renders exactly one tile's worth of work — not the
+// whole list. A second test pins the locked-tile invariant: locked rows never
+// invoke the row handlers (they only expose the unlock dialog).
 import { describe, expect, it, jest } from '@jest/globals';
-import React, { useCallback, useState } from 'react';
-import renderer from 'react-test-renderer';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Alert } from 'react-native';
 
 import * as useResponsiveModule from '../../../design/useResponsive';
 import type { Habit } from '../Habits.types';
@@ -41,7 +43,7 @@ const makeGoals = () => [
   },
 ];
 
-function makeHabit(id: number): Habit {
+function makeHabit(id: number, overrides: Partial<Habit> = {}): Habit {
   return {
     id,
     name: `Habit ${id}`,
@@ -54,21 +56,24 @@ function makeHabit(id: number): Habit {
     goals: makeGoals(),
     completions: [],
     revealed: true,
+    ...overrides,
   } as Habit;
 }
 
-let bumpHabit: (_id: number) => void = () => {};
-
-function Harness({ initial }: { initial: readonly Habit[] }) {
-  const [habits, setHabits] = useState<readonly Habit[]>(initial);
-  // Stable handlers — exactly what HabitsScreen now passes so memo can work.
-  const onOpenGoals = useCallback(() => {}, []);
-  const onLongPress = useCallback(() => {}, []);
-  const onIconPress = useCallback(() => {}, []);
-
-  bumpHabit = (id: number) =>
-    setHabits((current) => current.map((h) => (h.id === id ? { ...h, name: 'bumped' } : h)));
-
+// Plain (non-memoized) list so it always re-renders on rerender — only the
+// memoized HabitTiles decide whether to skip. Handlers are passed by the test
+// as stable references, mirroring HabitsScreen's useCallback handlers.
+function TileList({
+  habits,
+  onOpenGoals,
+  onLongPress,
+  onIconPress,
+}: {
+  habits: readonly Habit[];
+  onOpenGoals: (_h: Habit) => void;
+  onLongPress: (_h: Habit) => void;
+  onIconPress: (_i: number) => void;
+}) {
   return (
     <>
       {habits.map((habit, index) => (
@@ -89,28 +94,72 @@ function Harness({ initial }: { initial: readonly Habit[] }) {
 describe('HabitTile render isolation (issue #468)', () => {
   it('re-renders only the updated row when one habit changes', () => {
     const renderSpy = jest.spyOn(useResponsiveModule, 'default');
+    // Defined once → stable references across the rerender (what useCallback
+    // gives HabitsScreen in production).
+    const onOpenGoals = (): void => {};
+    const onLongPress = (): void => {};
+    const onIconPress = (): void => {};
     const habits = [makeHabit(1), makeHabit(2), makeHabit(3)];
 
-    renderer.act(() => {
-      renderer.create(<Harness initial={habits} />);
-    });
+    const view = render(
+      <TileList
+        habits={habits}
+        onOpenGoals={onOpenGoals}
+        onLongPress={onLongPress}
+        onIconPress={onIconPress}
+      />,
+    );
 
     const mountCalls = renderSpy.mock.calls.length;
-    // Each row does a fixed amount of useResponsive work per render.
     const callsPerTile = mountCalls / habits.length;
     expect(Number.isInteger(callsPerTile)).toBe(true);
+    expect(callsPerTile).toBeGreaterThan(0);
 
     renderSpy.mockClear();
-    renderer.act(() => {
-      bumpHabit(2);
-    });
+    const bumped = habits.map((h) => (h.id === 2 ? { ...h, name: 'bumped' } : h));
+    view.rerender(
+      <TileList
+        habits={bumped}
+        onOpenGoals={onOpenGoals}
+        onLongPress={onLongPress}
+        onIconPress={onIconPress}
+      />,
+    );
     const afterBumpCalls = renderSpy.mock.calls.length;
 
-    // Exactly one tile re-rendered — not the whole list (which would be
-    // ``mountCalls`` again). This is the regression the memo fix prevents.
+    // The changed tile did re-render (work happened)…
+    expect(afterBumpCalls).toBeGreaterThan(0);
+    // …but only that one tile — not the whole list.
     expect(afterBumpCalls).toBe(callsPerTile);
     expect(afterBumpCalls).toBeLessThan(mountCalls);
 
     renderSpy.mockRestore();
+  });
+
+  it('never invokes the row handlers for a locked tile', () => {
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const onOpenGoals = jest.fn();
+    const onLongPress = jest.fn();
+    const onIconPress = jest.fn();
+
+    const { getByTestId } = render(
+      <HabitTile
+        habit={makeHabit(1, { revealed: false })}
+        locked
+        onOpenGoals={onOpenGoals}
+        onLongPress={onLongPress}
+        onIconPress={onIconPress}
+        onUnlockHabit={jest.fn()}
+      />,
+    );
+
+    // Locked tiles only expose the unlock affordance (long-press → dialog);
+    // the three row handlers must stay wired out of the locked UI.
+    fireEvent(getByTestId('habit-tile'), 'longPress');
+    fireEvent.press(getByTestId('habit-tile'));
+
+    expect(onOpenGoals).not.toHaveBeenCalled();
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(onIconPress).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- `renderHabitTile` was a fresh closure on every render and `HabitTile` was not memoized (the Habits tree had **zero** `React.memo`), so logging one unit, opening a modal, or any unrelated state change re-rendered **every visible row** (audit §5.2 render cost, High).
- Wrapped `HabitTile` in `React.memo`. Its handler props now take the tile's own habit/index, so the parent can share **stable** references across rows; the tile binds them to its habit internally (below the memo boundary).
- Stabilized the renderer: extracted stable `useCallback` handlers (`useTileHandlers`) and wrapped `renderHabitTile` in `useCallback`, so the `FlatList` gets one `renderItem` ref and unchanged rows keep identical props. `openModalForMode` now takes the stable `modals.open`.
- **No layout, styling, or interaction change** — purely render cost.

## Test plan

- New `HabitTile.rendercount.test.tsx`: renders a list with stable handlers, bumps one habit's reference, and asserts only **one tile's** render work runs (counted via the per-render `useResponsive` call) — not the whole list. Without `React.memo` this fails (all rows would re-render), so it's a real regression guard.
- Existing `HabitTile` tests (interactions, locked long-press, tooltip, stage colors, manual unlock) still pass — the handler-signature change is backward compatible (they pass `() => {}` / `jest.fn()` and assert `toHaveBeenCalled()`).
- `./scripts/frontend/check-all.sh` — all 4 checks pass; **1871 tests**, ESLint zero-warnings, `tsc --noEmit` clean, coverage ≥90%.

Closes #468
Refs #461
