### PR TITLE
perf(backend): add composite index on journalentry chat read path

### DIFF
--- a/backend/migrations/versions/e3f4a5b6c7d8_add_journalentry_composite_index.py
+++ b/backend/migrations/versions/e3f4a5b6c7d8_add_journalentry_composite_index.py
@@ -1,0 +1,38 @@
+"""add journalentry composite (user_id, sender, deleted_at) index
+
+Revision ID: e3f4a5b6c7d8
+Revises: c1d2e3f4a5b6
+Create Date: 2026-06-24 00:00:00.000000
+
+Issue #469: ``load_recent_conversation`` filters ``journalentry`` on
+``(user_id, sender, deleted_at)`` and orders by ``id DESC``, but the only
+index was the single-column ``ix_journalentry_deleted_at``, so every chat
+turn scanned the user's full journal history (audit §5.3 missing composite
+index).  This adds a composite b-tree index over
+``(user_id, sender, deleted_at)`` covering that read.  The original
+``deleted_at`` index is left intact.  Non-destructive and fully reversible.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e3f4a5b6c7d8"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "c1d2e3f4a5b6"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = "ix_journalentry_user_sender_deleted"
+_TABLE_NAME = "journalentry"
+_INDEX_COLUMNS = ["user_id", "sender", "deleted_at"]
+
+
+def upgrade() -> None:
+    """Create the composite index covering the chat read path."""
+    op.create_index(_INDEX_NAME, _TABLE_NAME, _INDEX_COLUMNS, unique=False)
+
+
+def downgrade() -> None:
+    """Drop the composite index (reverts to scanning + the deleted_at index)."""
+    op.drop_index(_INDEX_NAME, table_name=_TABLE_NAME)

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -50,9 +50,16 @@ class JournalEntry(SQLModel, table=True):
     """
 
     # ``ix_journalentry_deleted_at`` is created by migration ``a0b1c2d3e4f5``
-    # (BUG-JOURNAL-007).  Declared here so the model and the migration agree
-    # — ``alembic check`` otherwise reports the index as drift and fails CI.
-    __table_args__ = (Index("ix_journalentry_deleted_at", "deleted_at"),)
+    # (BUG-JOURNAL-007).  ``ix_journalentry_user_sender_deleted`` is created by
+    # migration ``e3f4a5b6c7d8`` (issue #469): ``load_recent_conversation``
+    # filters on ``(user_id, sender, deleted_at)`` and orders by ``id DESC``, so
+    # this composite index covers that hot chat read.  Both are declared here so
+    # the model and migrations agree — ``alembic check`` otherwise reports the
+    # indexes as drift and fails CI.
+    __table_args__ = (
+        Index("ix_journalentry_deleted_at", "deleted_at"),
+        Index("ix_journalentry_user_sender_deleted", "user_id", "sender", "deleted_at"),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     timestamp: datetime = Field(

--- a/backend/tests/models/test_journal_entry_index.py
+++ b/backend/tests/models/test_journal_entry_index.py
@@ -1,0 +1,31 @@
+"""Index coverage for the :class:`JournalEntry` chat read path.
+
+``load_recent_conversation`` filters on ``(user_id, sender, deleted_at)`` and
+orders by ``id DESC``; without a covering composite index every chat turn
+scans the user's full journal history (audit §5.3). This pins the index onto
+the model metadata so the migration and model cannot drift, while retaining
+the original single-column ``deleted_at`` index.
+"""
+
+from __future__ import annotations
+
+from models.journal_entry import JournalEntry
+
+_TABLE_NAME = "journalentry"
+_COMPOSITE_INDEX_COLUMNS = ("user_id", "sender", "deleted_at")
+_DELETED_AT_INDEX_COLUMNS = ("deleted_at",)
+
+
+def _index_column_tuples() -> set[tuple[str, ...]]:
+    table = JournalEntry.metadata.tables[_TABLE_NAME]
+    return {tuple(column.name for column in index.columns) for index in table.indexes}
+
+
+def test_journal_entry_has_composite_chat_read_index() -> None:
+    """A composite ``(user_id, sender, deleted_at)`` index backs the chat read."""
+    assert _COMPOSITE_INDEX_COLUMNS in _index_column_tuples()
+
+
+def test_journal_entry_retains_deleted_at_index() -> None:
+    """The original soft-delete ``deleted_at`` index is not removed."""
+    assert _DELETED_AT_INDEX_COLUMNS in _index_column_tuples()


### PR DESCRIPTION
## Summary

- `load_recent_conversation` filters `JournalEntry` on `(user_id, sender, deleted_at)` and orders by `id DESC`, but the only index was the single-column `ix_journalentry_deleted_at` — so every chat turn scanned the user's full journal history (audit §5.3 missing composite index).
- Added `Index("ix_journalentry_user_sender_deleted", "user_id", "sender", "deleted_at")` to the model's `__table_args__` (retaining the existing `deleted_at` index) so `alembic check` sees model and migration agree.
- Added reversible Alembic revision `e3f4a5b6c7d8`: `upgrade()` creates the composite index, `downgrade()` drops it — no destructive op.

## Test plan

- New `tests/models/test_journal_entry_index.py`: asserts the composite `(user_id, sender, deleted_at)` index exists **and** the original `deleted_at` index is retained (composite assertion failed before the model change, passes after).
- `alembic history` confirms a single head chaining cleanly (`c1d2e3f4a5b6 → e3f4a5b6c7d8`). The live `upgrade → downgrade → upgrade` round-trip + `alembic check` run on CI's Postgres (migrations use Postgres-only types, so they don't execute on SQLite locally).
- Conftest needs no change: it builds via `metadata.create_all`, which auto-creates plain b-tree indexes; its manual list is only for functional/partial unique indexes.
- `./scripts/backend/check-all.sh` — all 7 checks pass; **1575 passed, 2 skipped**, coverage **95.33%**, ruff + mypy clean.

Closes #469
Refs #459
