### PR TITLE
feat(backend): paginate the practice-recipes list endpoint

### DIFF
--- a/backend/src/routers/practice_recipes.py
+++ b/backend/src/routers/practice_recipes.py
@@ -42,6 +42,8 @@ from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
 from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
+from schemas import Page, PaginationParams, build_page
+from schemas.pagination import paginate_query
 from schemas.practice import UserPracticeDetail
 from schemas.practice_mode_config import ModeConfigAdapter
 from schemas.practice_recipe import (
@@ -183,20 +185,28 @@ async def _hydrate_recipes_with_steps(
     return [_to_out(r, steps_by_recipe.get(cast("int", r.id), [])) for r in recipes]
 
 
-@router.get("/", response_model=list[PracticeRecipeOut])
+@router.get("/", response_model=None)
 async def list_practice_recipes(
     user_id: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    pagination: Annotated[PaginationParams, Depends()],
     mode: Annotated[str | None, Query(description="Filter by recipe mode.")] = None,
-) -> list[PracticeRecipeOut]:
-    """List every recipe visible to the caller, optionally filtered by mode.
+) -> Page[PracticeRecipeOut] | list[PracticeRecipeOut]:
+    """List recipes visible to the caller; paginated on ``?paginate=true``.
 
     Batches the step lookup into a single ``WHERE recipe_id IN (...)``
-    query so the picker, which fires this endpoint every time the
-    sheet opens, scales with library size instead of N+1.
+    query so the picker, which fires this endpoint every time the sheet
+    opens, scales with library size instead of N+1.  Pagination slices the
+    recipe rows (and the ``mode`` filter feeds the count) *before*
+    hydration, so the step lookup stays bounded to the current page
+    (issue #470).
     """
-    result = await session.execute(_build_recipe_list_query(user_id, mode))
-    return await _hydrate_recipes_with_steps(list(result.scalars().all()), session)
+    query = _build_recipe_list_query(user_id, mode)
+    recipes, total = await paginate_query(session, query, pagination)
+    hydrated = await _hydrate_recipes_with_steps(recipes, session)
+    if pagination.paginate:
+        return build_page(hydrated, total, pagination)
+    return hydrated
 
 
 @router.post("/", response_model=PracticeRecipeOut, status_code=status.HTTP_201_CREATED)

--- a/backend/tests/test_practice_recipes_api.py
+++ b/backend/tests/test_practice_recipes_api.py
@@ -530,3 +530,139 @@ async def test_list_batches_step_lookup(
 async def test_unauthenticated_rejected(async_client: AsyncClient) -> None:
     resp = await async_client.get("/practice-recipes/")
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+# -- Pagination (issue #470) ------------------------------------------------
+
+_DEFAULT_PAGE_SIZE = 50  # mirror schemas.pagination.DEFAULT_PAGE_SIZE
+
+
+async def _seed_system_recipes(db_session: AsyncSession, count: int) -> None:
+    """Seed ``count`` system recipes (each with one step), name-ordered."""
+    for i in range(count):
+        recipe = PracticeRecipe(
+            slug=f"sys_{i:02d}",
+            name=f"System {i:02d}",
+            description="",
+            owner_user_id=None,
+            mode="tallied_grounding",
+            rounds=1,
+        )
+        db_session.add(recipe)
+        await db_session.commit()
+        await db_session.refresh(recipe)
+        assert recipe.id is not None
+        db_session.add(
+            PracticeRecipeStep(
+                recipe_id=recipe.id,
+                position=0,
+                tag_slug="red",
+                tag_label="Red",
+                prompt_label="Find red",
+                target_count=1,
+            )
+        )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_bare_path_returns_plain_list_with_steps(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Omitting ?paginate=true returns the historical bare list (with steps)."""
+    await _seed_system_recipes(db_session, 3)
+    headers, _ = await _signup(async_client)
+
+    resp = await async_client.get("/practice-recipes/", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert isinstance(body, list)
+    assert all(len(recipe["steps"]) >= 1 for recipe in body)
+
+
+@pytest.mark.asyncio
+async def test_list_paginated_returns_envelope_with_steps(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """?paginate=true returns the Page envelope; the slice is still hydrated."""
+    await _seed_system_recipes(db_session, 3)
+    headers, _ = await _signup(async_client)
+
+    resp = await async_client.get("/practice-recipes/?paginate=true", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert set(body) == {"items", "total", "limit", "offset", "has_more"}
+    assert body["limit"] == _DEFAULT_PAGE_SIZE
+    assert body["offset"] == 0
+    assert body["total"] == 3
+    assert body["has_more"] is False
+    assert len(body["items"]) == 3
+    assert all(len(recipe["steps"]) >= 1 for recipe in body["items"])
+
+
+@pytest.mark.asyncio
+async def test_list_pagination_limit_offset_and_has_more(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The limit slices, offset skips, and total/has_more cover the full set."""
+    await _seed_system_recipes(db_session, 5)
+    headers, _ = await _signup(async_client)
+
+    first = await async_client.get(
+        "/practice-recipes/?paginate=true&limit=2&offset=0", headers=headers
+    )
+    page1 = first.json()
+    assert page1["total"] == 5
+    assert page1["limit"] == 2
+    assert page1["has_more"] is True
+    assert len(page1["items"]) == 2
+
+    last = await async_client.get(
+        "/practice-recipes/?paginate=true&limit=2&offset=4", headers=headers
+    )
+    page3 = last.json()
+    assert page3["offset"] == 4
+    assert page3["has_more"] is False
+    assert len(page3["items"]) == 1
+    assert {r["slug"] for r in page1["items"]}.isdisjoint({r["slug"] for r in page3["items"]})
+
+
+@pytest.mark.asyncio
+async def test_list_pagination_composes_with_mode_filter(async_client: AsyncClient) -> None:
+    """The mode filter feeds the count + slice, not the whole library."""
+    headers, _ = await _signup(async_client)
+    await async_client.post(
+        "/practice-recipes/", json=_sense_recipe_body("sense_a"), headers=headers
+    )
+    await async_client.post(
+        "/practice-recipes/", json=_sense_recipe_body("sense_b"), headers=headers
+    )
+    await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body("tallied_a"), headers=headers
+    )
+
+    resp = await async_client.get(
+        "/practice-recipes/?paginate=true&mode=sense_grounding&limit=1", headers=headers
+    )
+
+    body = resp.json()
+    # Only the two sense recipes are counted — the tallied one is excluded.
+    assert body["total"] == 2
+    assert body["has_more"] is True
+    assert len(body["items"]) == 1
+    assert body["items"][0]["mode"] == "sense_grounding"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [0, 201])
+async def test_list_pagination_rejects_out_of_range_limit(
+    async_client: AsyncClient, limit: int
+) -> None:
+    """The limit bounds are enforced by the shared PaginationParams validators."""
+    headers, _ = await _signup(async_client)
+    resp = await async_client.get(
+        f"/practice-recipes/?paginate=true&limit={limit}", headers=headers
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/backend/tests/test_practice_recipes_api.py
+++ b/backend/tests/test_practice_recipes_api.py
@@ -14,6 +14,7 @@ from models.practice import Practice
 from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
 from models.practice_session import PracticeSession
 from models.stage_progress import StageProgress
+from schemas import DEFAULT_PAGE_SIZE
 
 
 async def _signup(client: AsyncClient, username: str = "owner") -> tuple[dict[str, str], int]:
@@ -534,8 +535,6 @@ async def test_unauthenticated_rejected(async_client: AsyncClient) -> None:
 
 # -- Pagination (issue #470) ------------------------------------------------
 
-_DEFAULT_PAGE_SIZE = 50  # mirror schemas.pagination.DEFAULT_PAGE_SIZE
-
 
 async def _seed_system_recipes(db_session: AsyncSession, count: int) -> None:
     """Seed ``count`` system recipes (each with one step), name-ordered."""
@@ -578,7 +577,28 @@ async def test_list_bare_path_returns_plain_list_with_steps(
     assert resp.status_code == HTTPStatus.OK
     body = resp.json()
     assert isinstance(body, list)
+    assert len(body) == 3
     assert all(len(recipe["steps"]) >= 1 for recipe in body)
+
+
+@pytest.mark.asyncio
+async def test_list_bare_path_is_capped_at_default_page_size(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The bare list is intentionally capped at DEFAULT_PAGE_SIZE (no unbounded list).
+
+    Even without ?paginate=true the endpoint funnels through paginate_query, so a
+    library larger than one page returns at most DEFAULT_PAGE_SIZE rows — the
+    audit's "no unbounded list" guarantee. Documented here so a future change to
+    paginate_query can't silently restore the unbounded behaviour.
+    """
+    await _seed_system_recipes(db_session, DEFAULT_PAGE_SIZE + 1)
+    headers, _ = await _signup(async_client)
+
+    resp = await async_client.get("/practice-recipes/", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert len(resp.json()) == DEFAULT_PAGE_SIZE
 
 
 @pytest.mark.asyncio
@@ -594,7 +614,7 @@ async def test_list_paginated_returns_envelope_with_steps(
     assert resp.status_code == HTTPStatus.OK
     body = resp.json()
     assert set(body) == {"items", "total", "limit", "offset", "has_more"}
-    assert body["limit"] == _DEFAULT_PAGE_SIZE
+    assert body["limit"] == DEFAULT_PAGE_SIZE
     assert body["offset"] == 0
     assert body["total"] == 3
     assert body["has_more"] is False


### PR DESCRIPTION
## Summary

- `GET /practice-recipes` returned **every** visible recipe (all system + the caller's personal recipes) as an unbounded `list[PracticeRecipeOut]`; the `mode` param only filtered, it didn't bound. The picker fires this endpoint every time its sheet opens, so payload **and** the batched-step hydration cost grew with library size (audit §4 "unbounded list", High).
- Wired `list_practice_recipes` through the shared `Page[T]` machinery (matching habits / practice-tags): takes `PaginationParams`, `response_model=None`, and **paginates the recipe rows before hydration** so `_hydrate_recipes_with_steps` runs the `WHERE recipe_id IN (...)` lookup on the page slice only — not the whole library.
- Returns a `Page[PracticeRecipeOut]` envelope under `?paginate=true`, else the bare hydrated list. The `mode` filter feeds the count + slice, so `total`/`has_more` reflect the filtered set.

## Test plan

- Added cases to `test_practice_recipes_api.py`: bare list shape unchanged (with steps); `?paginate=true` returns the `{items,total,limit,offset,has_more}` envelope with the default limit (50) and hydrated steps on the slice; `limit`/`offset` slice with non-overlapping pages and correct `has_more`; `mode` filter composes with pagination (only the 2 sense recipes counted, tallied excluded, `total=2`); out-of-range `limit` (0, 201) → 422.
- `./scripts/backend/check-all.sh` — all 7 checks pass; **1581 passed, 2 skipped**, coverage **95.34%**, ruff + mypy clean.

Closes #470
Refs #460
