### PR TITLE
perf(frontend): memoize Journal MessageBubble

### DIFF
--- a/frontend/src/features/Journal/MessageBubble.tsx
+++ b/frontend/src/features/Journal/MessageBubble.tsx
@@ -135,17 +135,14 @@ const MessageBubbleComponent = ({
 };
 
 /**
- * Custom equality for {@link MessageBubble}'s {@link React.memo}.
+ * Custom equality for {@link MessageBubble}'s {@link React.memo}: compare only
+ * the fields the bubble renders so an unchanged bubble bails out (audit §5.2).
  *
- * The Journal conversation is a long inverted FlatList; without memoization
- * every bubble re-renders whenever the list does (new message, streaming
- * chunk, unrelated state). We compare exactly the fields the bubble renders
- * so an unchanged bubble bails out (audit §5.2).
- *
- * ``onRetry`` is intentionally excluded: the list rebuilds it per render as a
- * closure bound to the same message, so comparing its identity would defeat
- * the memo without any behavioural difference — ``_errored`` already captures
- * whether the retry affordance shows.
+ * ``onRetry`` is excluded because the list rebuilds it per render bound to the
+ * same message. That is safe only while ``_retryText`` / ``_retryTag`` are
+ * immutable once ``_errored`` is set (they are written on error and cleared on
+ * success, never mutated in place); if that ever changes, the retained closure
+ * could capture stale retry values.
  */
 export function messageBubblePropsAreEqual(
   prev: MessageBubbleProps,

--- a/frontend/src/features/Journal/MessageBubble.tsx
+++ b/frontend/src/features/Journal/MessageBubble.tsx
@@ -100,7 +100,11 @@ interface MessageBubbleProps {
   onRetry?: () => void;
 }
 
-const MessageBubble = ({ message, errorLabel, onRetry }: MessageBubbleProps): React.JSX.Element => {
+const MessageBubbleComponent = ({
+  message,
+  errorLabel,
+  onRetry,
+}: MessageBubbleProps): React.JSX.Element => {
   const isUser = message.sender === 'user';
   const tagLabel = TAG_LABELS[message.tag];
   const showCursor = message._streaming === true;
@@ -129,5 +133,39 @@ const MessageBubble = ({ message, errorLabel, onRetry }: MessageBubbleProps): Re
     </View>
   );
 };
+
+/**
+ * Custom equality for {@link MessageBubble}'s {@link React.memo}.
+ *
+ * The Journal conversation is a long inverted FlatList; without memoization
+ * every bubble re-renders whenever the list does (new message, streaming
+ * chunk, unrelated state). We compare exactly the fields the bubble renders
+ * so an unchanged bubble bails out (audit §5.2).
+ *
+ * ``onRetry`` is intentionally excluded: the list rebuilds it per render as a
+ * closure bound to the same message, so comparing its identity would defeat
+ * the memo without any behavioural difference — ``_errored`` already captures
+ * whether the retry affordance shows.
+ */
+export function messageBubblePropsAreEqual(
+  prev: MessageBubbleProps,
+  next: MessageBubbleProps,
+): boolean {
+  const a = prev.message;
+  const b = next.message;
+  return (
+    a.id === b.id &&
+    a.sender === b.sender &&
+    a.tag === b.tag &&
+    a.message === b.message &&
+    a.timestamp === b.timestamp &&
+    a.practice_session_id === b.practice_session_id &&
+    a._streaming === b._streaming &&
+    a._errored === b._errored &&
+    prev.errorLabel === next.errorLabel
+  );
+}
+
+const MessageBubble = React.memo(MessageBubbleComponent, messageBubblePropsAreEqual);
 
 export default MessageBubble;

--- a/frontend/src/features/Journal/__tests__/MessageBubble.rendercount.test.tsx
+++ b/frontend/src/features/Journal/__tests__/MessageBubble.rendercount.test.tsx
@@ -1,11 +1,8 @@
-// Render-isolation guard for issue #471. MessageBubble is a hookless leaf in a
-// long inverted FlatList, so the deterministic proof that "unchanged bubbles do
-// not re-render" is its React.memo comparator: React skips re-rendering a memo
-// component exactly when the comparator returns true. We assert the memo wiring,
-// exhaustively check the comparator's bail/re-render decisions, and simulate a
-// single-message append to show every existing bubble bails (zero re-renders).
+// Render-isolation guard (issue #471): React.memo skips a memo component's
+// render exactly when its comparator returns true, so the comparator is the
+// deterministic render-decision for this hookless bubble.
 import { describe, expect, it } from '@jest/globals';
-import { render } from '@testing-library/react-native';
+import { render, screen } from '@testing-library/react-native';
 import React from 'react';
 
 import type { JournalTag } from '../../../api';
@@ -36,6 +33,8 @@ function propsFor(message: ChatMessage, overrides: Partial<BubbleProps> = {}): B
 
 describe('MessageBubble is memoized', () => {
   it('wraps the component in React.memo with the custom comparator', () => {
+    // Intentional coupling to React's memo object shape ($$typeof + compare):
+    // the only way to assert the wiring without a flaky render-count harness.
     const memoized = MessageBubble as unknown as { compare: unknown; $$typeof: symbol };
     expect(memoized.compare).toBe(messageBubblePropsAreEqual);
     expect(memoized.$$typeof).toBe(Symbol.for('react.memo'));
@@ -44,6 +43,16 @@ describe('MessageBubble is memoized', () => {
   it('renders its message content (visual output unchanged)', () => {
     const { getByText } = render(<MessageBubble message={makeMessage(1, { message: 'hello' })} />);
     expect(getByText('hello')).toBeTruthy();
+  });
+
+  it('re-renders with new content when a compared field changes', () => {
+    const { rerender } = render(<MessageBubble message={makeMessage(1, { message: 'first' })} />);
+    expect(screen.getByText('first')).toBeTruthy();
+
+    rerender(<MessageBubble message={makeMessage(1, { message: 'second' })} />);
+
+    expect(screen.getByText('second')).toBeTruthy();
+    expect(screen.queryByText('first')).toBeNull();
   });
 });
 
@@ -78,6 +87,18 @@ describe('messageBubblePropsAreEqual', () => {
     const a = propsFor(message, { errorLabel: 'Network error' });
     const b = propsFor(message, { errorLabel: 'Timed out' });
     expect(messageBubblePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it.each([
+    ['_errorDetail', makeMessage(1, { _errored: true, _errorDetail: 'changed detail' })],
+    ['_retryText', makeMessage(1, { _retryText: 'changed retry text' })],
+    ['_retryTag', makeMessage(1, { _retryTag: 'reflection' as JournalTag })],
+  ])('ignores non-rendered metadata field %s (stays bailed)', (_label, changed) => {
+    // The bubble never reads these directly (errorLabel carries the displayed
+    // error text), so changing one alone must not force a re-render. Guards
+    // against someone adding one to the comparator and over-rendering.
+    const base = makeMessage(1, _label === '_errorDetail' ? { _errored: true } : {});
+    expect(messageBubblePropsAreEqual(propsFor(base), propsFor(changed))).toBe(true);
   });
 
   it('appending one message re-renders zero existing bubbles', () => {

--- a/frontend/src/features/Journal/__tests__/MessageBubble.rendercount.test.tsx
+++ b/frontend/src/features/Journal/__tests__/MessageBubble.rendercount.test.tsx
@@ -1,0 +1,99 @@
+// Render-isolation guard for issue #471. MessageBubble is a hookless leaf in a
+// long inverted FlatList, so the deterministic proof that "unchanged bubbles do
+// not re-render" is its React.memo comparator: React skips re-rendering a memo
+// component exactly when the comparator returns true. We assert the memo wiring,
+// exhaustively check the comparator's bail/re-render decisions, and simulate a
+// single-message append to show every existing bubble bails (zero re-renders).
+import { describe, expect, it } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { JournalTag } from '../../../api';
+import MessageBubble, { type ChatMessage, messageBubblePropsAreEqual } from '../MessageBubble';
+
+interface BubbleProps {
+  message: ChatMessage;
+  errorLabel?: string;
+  onRetry?: () => void;
+}
+
+function makeMessage(id: number, overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id,
+    message: `message ${id}`,
+    sender: 'bot',
+    timestamp: '2026-06-24T10:00:00.000Z',
+    tag: 'freeform' as JournalTag,
+    practice_session_id: null,
+    user_practice_id: null,
+    ...overrides,
+  };
+}
+
+function propsFor(message: ChatMessage, overrides: Partial<BubbleProps> = {}): BubbleProps {
+  return { message, onRetry: () => {}, ...overrides };
+}
+
+describe('MessageBubble is memoized', () => {
+  it('wraps the component in React.memo with the custom comparator', () => {
+    const memoized = MessageBubble as unknown as { compare: unknown; $$typeof: symbol };
+    expect(memoized.compare).toBe(messageBubblePropsAreEqual);
+    expect(memoized.$$typeof).toBe(Symbol.for('react.memo'));
+  });
+
+  it('renders its message content (visual output unchanged)', () => {
+    const { getByText } = render(<MessageBubble message={makeMessage(1, { message: 'hello' })} />);
+    expect(getByText('hello')).toBeTruthy();
+  });
+});
+
+describe('messageBubblePropsAreEqual', () => {
+  it('bails (returns true) when content is identical across new object refs', () => {
+    const a = propsFor(makeMessage(1));
+    const b = propsFor(makeMessage(1)); // distinct object, same content
+    expect(messageBubblePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it('ignores onRetry identity — a fresh closure must not force a re-render', () => {
+    const message = makeMessage(1, { _errored: true });
+    const a = propsFor(message, { onRetry: () => {}, errorLabel: 'Failed' });
+    const b = propsFor(message, { onRetry: () => {}, errorLabel: 'Failed' });
+    expect(messageBubblePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it.each([
+    ['message text', makeMessage(1, { message: 'changed' })],
+    ['streaming flag', makeMessage(1, { _streaming: true })],
+    ['errored flag', makeMessage(1, { _errored: true })],
+    ['timestamp', makeMessage(1, { timestamp: '2026-06-24T11:11:11.000Z' })],
+    ['tag', makeMessage(1, { tag: 'reflection' as JournalTag })],
+    ['sender', makeMessage(1, { sender: 'user' })],
+    ['practice badge', makeMessage(1, { practice_session_id: 7 })],
+  ])('re-renders (returns false) when %s changes', (_label, changed) => {
+    expect(messageBubblePropsAreEqual(propsFor(makeMessage(1)), propsFor(changed))).toBe(false);
+  });
+
+  it('re-renders when the error label changes', () => {
+    const message = makeMessage(1, { _errored: true });
+    const a = propsFor(message, { errorLabel: 'Network error' });
+    const b = propsFor(message, { errorLabel: 'Timed out' });
+    expect(messageBubblePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it('appending one message re-renders zero existing bubbles', () => {
+    // A conversation of three bubbles; the list re-renders to prepend a new
+    // message. Each existing bubble receives the same content it had before, so
+    // the comparator bails for all of them — only the new bubble renders.
+    const existing = [makeMessage(1), makeMessage(2), makeMessage(3)];
+    const reRendered = existing
+      .map((message, index) => {
+        const before = propsFor(message);
+        // The list rebuilds props (new onRetry closure) but identical content.
+        const after = propsFor(makeMessage(message.id as number), { onRetry: () => {} });
+        return messageBubblePropsAreEqual(before, after) ? null : index;
+      })
+      .filter((index) => index !== null);
+
+    expect(reRendered).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- The Journal conversation is a long inverted `FlatList` (gold-standard virtualization), but `MessageBubble` was **not** memoized — so every bubble re-rendered whenever the list did (new message, streaming chunk, unrelated state), even when its content was unchanged (audit §5.2 render cost, High).
- Wrapped `MessageBubble` in `React.memo` with a custom comparator (`messageBubblePropsAreEqual`) keyed on the fields the bubble actually renders: id, sender, tag, message, timestamp, practice_session_id, `_streaming`, `_errored`, and `errorLabel`.
- `onRetry` is **intentionally excluded** from the comparator — the list rebuilds it per render as a closure bound to the same message, so comparing its identity would defeat the memo with no behavioral difference (`_errored` already captures whether the retry affordance shows).
- The list's `renderItem` is already `useCallback`-stabilized; the value-based comparator makes bubbles bail regardless of handler identity, so no screen change was needed. **No appearance/formatting/interaction change.**

## Test plan

- New `MessageBubble.rendercount.test.tsx`: asserts the memo wiring (`MessageBubble.compare === messageBubblePropsAreEqual`, `$$typeof === react.memo`); exhaustively checks the comparator's bail/re-render decisions per rendered field (text, streaming, errored, timestamp, tag, sender, practice badge, errorLabel); verifies `onRetry` identity is ignored; and simulates a single-message append, asserting **zero** existing bubbles re-render. Since React skips a memo component's render exactly when the comparator returns true, the comparator is the deterministic render-count proof for this hookless leaf.
- A render smoke test confirms visual output is unchanged.
- `./scripts/frontend/check-all.sh` — all 4 checks pass; **1885 tests** (existing MessageBubble tests still green), ESLint zero-warnings, `tsc --noEmit` clean, coverage ≥90%.

Closes #471
Refs #461
