### PR TITLE
fix(frontend): wire the "Start from a preset" CTA to the catalog picker

### DIFF
--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -144,7 +144,7 @@ export function CreatePracticeWizard(props: CreatePracticeWizardProps): React.JS
           goTo={goTo}
           setMode={setMode}
           submit={submit}
-          onCancel={() => props.navigation.goBack()}
+          onPickPreset={() => props.navigation.navigate('Tabs', { screen: 'Catalog' })}
         />
       </ScrollView>
     </KeyboardAvoidingView>
@@ -175,13 +175,16 @@ interface StepViewProps {
   goTo: (step: WizardStep) => void;
   setMode: (mode: PickableMode) => void;
   submit: SubmitController;
-  onCancel: () => void;
+  /** Opens the Practice catalog (preset picker); a chosen preset copies into a fresh wizard via route prefill (issue #472). */
+  onPickPreset: () => void;
 }
 
 const StepView = (props: StepViewProps): React.JSX.Element => {
   switch (props.state.step) {
     case 'entry':
-      return <EntryStep onPickPreset={props.onCancel} onStartScratch={() => props.goTo('mode')} />;
+      return (
+        <EntryStep onPickPreset={props.onPickPreset} onStartScratch={() => props.goTo('mode')} />
+      );
     case 'mode':
       return (
         <ModeStep

--- a/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
@@ -116,11 +116,15 @@ describe('CreatePracticeWizard — step navigation', () => {
     expect(view.getByTestId('mode-picker')).toBeTruthy();
   });
 
-  it('start-from-preset routes the user back to the catalog via goBack', () => {
+  it('start-from-preset opens the catalog picker and never dismisses the wizard', () => {
+    // Issue #472: the CTA used to be wired to onCancel (goBack), silently
+    // closing the recommended on-ramp. It must open the Practice catalog
+    // (preset picker) instead, where a chosen preset copies into the wizard.
     const nav = makeNav();
     const { view } = renderScreen({}, nav);
     fireEvent.press(view.getByTestId('create-practice-from-preset'));
-    expect(nav.goBack).toHaveBeenCalled();
+    expect(nav.navigate).toHaveBeenCalledWith('Tabs', { screen: 'Catalog' });
+    expect(nav.goBack).not.toHaveBeenCalled();
   });
 
   it('back from the mode picker returns to the entry step', () => {


### PR DESCRIPTION
## Summary

- The wizard's entry-step **"Start from a preset"** CTA was wired straight to `onCancel` (`goBack`) — so the *recommended* on-ramp silently dismissed the wizard instead of opening the preset picker (audit §5.1 stub, the primary intended entry).
- Routed the CTA to the Practice catalog (the preset picker) via `navigate('Tabs', { screen: 'Catalog' })`. From there the **existing** catalog → `PracticeDetail` → "copy" flow navigates to the wizard with `route.params.prefill`, which `initialState` already lands on the **`configure`** step with the preset's mode + config applied.
- Removed the now-orphaned `onCancel` prop — cancel/close remains reachable via the native stack header back button. **"Start from scratch" is unchanged.**

## Test plan

- Updated the test that asserted the buggy behavior (`goBack`) to assert the CTA calls `navigate('Tabs', { screen: 'Catalog' })` and **never** calls `goBack` — covering acceptance "opens the picker / never dismisses."
- The existing "prefill mode" test already covers that a wizard opened with a preset's `prefill` lands on `configure` with the mode/config applied (the return half of the round-trip).
- `./scripts/frontend/check-all.sh` — all 4 checks pass; **1889 tests**, ESLint zero-warnings, `tsc --noEmit` clean, coverage ≥90%.

Closes #472
Refs #463
