### PR TITLE
perf(backend): batch the per-stage progress N+1 in list_stages

### DIFF
--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import cast
 
-from sqlalchemy import func
+from sqlalchemy import case, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -31,6 +31,7 @@ __all__ = [
     "TOTAL_STAGES",
     "AllStagesCompletedError",
     "compute_stage_progress",
+    "compute_stage_progress_batch",
     "ensure_user_progress",
     "get_stage_habit_history",
     "get_stage_practice_history",
@@ -211,6 +212,104 @@ async def compute_stage_progress(
         "practice_sessions_completed": practice_count,
         "course_items_completed": course_items,
         "overall_progress": round(overall, 2),
+    }
+
+
+async def _batch_habit_metrics(session: AsyncSession, user_id: int) -> dict[str, tuple[int, int]]:
+    """Per-stage ``(total_habits, active_habits)`` for a user in one query.
+
+    ``active_habits`` counts habits with ≥1 of the user's completions; an
+    outer join keeps habits with no goals/completions in the total. Keyed by
+    the habit's ``stage`` string (habits store stage as text).
+    """
+    result = await session.execute(
+        select(
+            Habit.stage,
+            func.count(func.distinct(Habit.id)).label("total"),
+            func.count(func.distinct(case((col(GoalCompletion.id).isnot(None), Habit.id)))).label(
+                "active"
+            ),
+        )
+        .select_from(Habit)
+        .outerjoin(Goal, col(Goal.habit_id) == col(Habit.id))
+        .outerjoin(
+            GoalCompletion,
+            (col(GoalCompletion.goal_id) == col(Goal.id))
+            & (col(GoalCompletion.user_id) == user_id),
+        )
+        .where(Habit.user_id == user_id)
+        .group_by(col(Habit.stage))
+    )
+    return {row.stage: (row.total, row.active) for row in result.all()}
+
+
+async def _batch_practice_counts(session: AsyncSession, user_id: int) -> dict[int, int]:
+    """Per-stage practice-session counts for a user in one query (keyed by stage number)."""
+    result = await session.execute(
+        select(UserPractice.stage_number, func.count(col(PracticeSession.id)))
+        .select_from(PracticeSession)
+        .join(UserPractice, col(PracticeSession.user_practice_id) == col(UserPractice.id))
+        .where(PracticeSession.user_id == user_id)
+        .group_by(col(UserPractice.stage_number))
+    )
+    return {row[0]: row[1] for row in result.all()}
+
+
+async def _batch_course_counts(session: AsyncSession, user_id: int) -> dict[int, int]:
+    """Per-stage completed-content counts for a user in one query (keyed by stage number)."""
+    result = await session.execute(
+        select(CourseStage.stage_number, func.count(col(ContentCompletion.id)))
+        .select_from(ContentCompletion)
+        .join(StageContent, col(ContentCompletion.content_id) == col(StageContent.id))
+        .join(CourseStage, col(StageContent.course_stage_id) == col(CourseStage.id))
+        .where(ContentCompletion.user_id == user_id)
+        .group_by(col(CourseStage.stage_number))
+    )
+    return {row[0]: row[1] for row in result.all()}
+
+
+def _assemble_stage_progress(
+    stage_number: int,
+    habit_metrics: dict[str, tuple[int, int]],
+    practice_counts: dict[int, int],
+    course_counts: dict[int, int],
+) -> dict[str, float | int]:
+    """Build one stage's progress dict from the batched lookups (parity with the loop)."""
+    total, active = habit_metrics.get(str(stage_number), (0, 0))
+    habits_progress = min(active / total, 1.0) if total > 0 else 0.0
+    practice_count = practice_counts.get(stage_number, 0)
+    overall = (habits_progress + (1.0 if practice_count > 0 else 0.0)) / 2
+    return {
+        "habits_progress": round(habits_progress, 2),
+        "practice_sessions_completed": practice_count,
+        "course_items_completed": course_counts.get(stage_number, 0),
+        "overall_progress": round(overall, 2),
+    }
+
+
+async def compute_stage_progress_batch(
+    session: AsyncSession,
+    user_id: int,
+    stage_numbers: list[int],
+) -> dict[int, dict[str, float | int]]:
+    """Batched equivalent of :func:`compute_stage_progress` for many stages.
+
+    Issues exactly three grouped queries (habits, practice sessions, course
+    items) regardless of stage count, then assembles a per-stage mapping with
+    values identical to calling :func:`compute_stage_progress` per stage —
+    eliminating the N+1 on ``list_stages`` (issue #473). Returns ``{}`` for an
+    empty ``stage_numbers``.
+    """
+    if not stage_numbers:
+        return {}
+    habit_metrics = await _batch_habit_metrics(session, user_id)
+    practice_counts = await _batch_practice_counts(session, user_id)
+    course_counts = await _batch_course_counts(session, user_id)
+    return {
+        stage_number: _assemble_stage_progress(
+            stage_number, habit_metrics, practice_counts, course_counts
+        )
+        for stage_number in stage_numbers
     }
 
 

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -299,6 +299,11 @@ async def compute_stage_progress_batch(
     values identical to calling :func:`compute_stage_progress` per stage —
     eliminating the N+1 on ``list_stages`` (issue #473). Returns ``{}`` for an
     empty ``stage_numbers``.
+
+    The helpers deliberately ``GROUP BY`` the user's whole dataset with no
+    ``IN (stage_numbers)`` filter: the curriculum is ≤36 stages, so the group
+    set is tiny and one grouped scan beats a parameterised per-stage filter
+    here. ``stage_numbers`` only selects which groups land in the result.
     """
     if not stage_numbers:
         return {}

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -73,6 +73,35 @@ def _build_stage_response(
     )
 
 
+def _overlay_stage(
+    stage: CourseStage,
+    unlocked: dict[int, bool],
+    batch: dict[int, dict[str, float | int]],
+) -> StageResponse:
+    """Assemble one stage response, reading its progress from the batch (0.0 if locked)."""
+    is_open = unlocked[stage.stage_number]
+    value = batch[stage.stage_number]["overall_progress"] if is_open else 0.0
+    return _build_stage_response(stage, value, unlocked=is_open)
+
+
+async def _stage_responses_with_progress(
+    session: AsyncSession,
+    user_id: int,
+    stages: list[CourseStage],
+) -> list[StageResponse]:
+    """Overlay batched progress onto a page of stages (issue #473).
+
+    Computes unlock state once, batches progress for the unlocked stages in
+    three grouped queries, then assembles a response per stage. Locked stages
+    report ``0.0`` without entering the batch.
+    """
+    progress = await get_user_progress(session, user_id)
+    unlocked = {s.stage_number: is_stage_unlocked(s.stage_number, progress) for s in stages}
+    unlocked_numbers = [n for n, ok in unlocked.items() if ok]
+    batch = await compute_stage_progress_batch(session, user_id, unlocked_numbers)
+    return [_overlay_stage(s, unlocked, batch) for s in stages]
+
+
 @router.get("", response_model=None)
 async def list_stages(
     current_user: Annotated[int, Depends(get_current_user)],
@@ -82,10 +111,11 @@ async def list_stages(
     """List all stages with per-user progress overlay.
 
     Each stage's ``progress`` field is populated from
-    ``compute_stage_progress`` so the frontend can render progress bars
-    without a follow-up call. This accepts an N+M round-trip (one query
-    per metric per stage) since N=10 stages is small and caching would
-    add complexity disproportionate to the benefit.
+    ``compute_stage_progress_batch`` — three grouped queries for the whole
+    list regardless of stage count — so the frontend can render progress bars
+    without a follow-up call and the endpoint no longer scales N-by-M with
+    course length (issue #473). Only unlocked stages feed the batch; locked
+    stages report ``0.0`` progress as before.
 
     BUG-INFRA-016: returns ``Page[StageResponse]`` when ``?paginate=true``
     is set; otherwise the legacy bare list is returned for one release while
@@ -93,21 +123,7 @@ async def list_stages(
     """
     query = select(CourseStage).order_by(col(CourseStage.stage_number).asc())
     stages, total = await paginate_query(session, query, pagination)
-    progress = await get_user_progress(session, current_user)
-
-    unlocked = {s.stage_number: is_stage_unlocked(s.stage_number, progress) for s in stages}
-    # Batch all per-stage progress in 3 grouped queries instead of N-by-M (issue #473).
-    batch = await compute_stage_progress_batch(
-        session, current_user, [n for n, ok in unlocked.items() if ok]
-    )
-    responses = [
-        _build_stage_response(
-            s,
-            float(batch[s.stage_number]["overall_progress"]) if unlocked[s.stage_number] else 0.0,
-            unlocked=unlocked[s.stage_number],
-        )
-        for s in stages
-    ]
+    responses = await _stage_responses_with_progress(session, current_user, stages)
 
     if pagination.paginate:
         return build_page(responses, total, pagination)

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -16,6 +16,7 @@ from domain.constants import TOTAL_STAGES
 from domain.program_calendar import calendar_stage, calendar_week, resolve_program_anchor
 from domain.stage_progress import (
     compute_stage_progress,
+    compute_stage_progress_batch,
     get_stage_habit_history,
     get_stage_practice_history,
     get_user_progress,
@@ -43,18 +44,17 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/stages", tags=["stages"])
 
 
-async def _build_stage_response(
+def _build_stage_response(
     stage: CourseStage,
-    session: AsyncSession,
-    user_id: int,
-    progress: StageProgress | None,
+    stage_progress: float,
+    *,
+    unlocked: bool,
 ) -> StageResponse:
-    """Assemble a :class:`StageResponse` with the current user's progress overlay."""
-    unlocked = is_stage_unlocked(stage.stage_number, progress)
-    stage_progress = 0.0
-    if unlocked:
-        data = await compute_stage_progress(session, user_id, stage.stage_number)
-        stage_progress = data["overall_progress"]
+    """Assemble a :class:`StageResponse` from a precomputed progress value.
+
+    Progress is computed in one batched pass by the caller (issue #473) rather
+    than per stage, so this stays a pure, query-free assembler.
+    """
     return StageResponse(
         id=stage.id,
         title=stage.title,
@@ -95,7 +95,19 @@ async def list_stages(
     stages, total = await paginate_query(session, query, pagination)
     progress = await get_user_progress(session, current_user)
 
-    responses = [await _build_stage_response(s, session, current_user, progress) for s in stages]
+    unlocked = {s.stage_number: is_stage_unlocked(s.stage_number, progress) for s in stages}
+    # Batch all per-stage progress in 3 grouped queries instead of N-by-M (issue #473).
+    batch = await compute_stage_progress_batch(
+        session, current_user, [n for n, ok in unlocked.items() if ok]
+    )
+    responses = [
+        _build_stage_response(
+            s,
+            float(batch[s.stage_number]["overall_progress"]) if unlocked[s.stage_number] else 0.0,
+            unlocked=unlocked[s.stage_number],
+        )
+        for s in stages
+    ]
 
     if pagination.paginate:
         return build_page(responses, total, pagination)

--- a/backend/tests/routers/test_stages_query_count.py
+++ b/backend/tests/routers/test_stages_query_count.py
@@ -1,0 +1,286 @@
+"""Query-budget + parity tests for the batched ``list_stages`` progress (issue #473).
+
+``list_stages`` used to call ``compute_stage_progress`` once per stage — an
+N-by-M round-trip that scaled with course length on the most-visited screen.
+``compute_stage_progress_batch`` collapses that to three grouped queries
+regardless of stage count. These tests pin the query budget and prove the
+batched values are identical to the per-stage loop they replace.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import JSON, event
+from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+from sqlalchemy.engine import Connection, ExecutionContext
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlmodel import SQLModel
+
+from domain.stage_progress import compute_stage_progress, compute_stage_progress_batch
+from models.content_completion import ContentCompletion
+from models.course_stage import CourseStage
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.practice import Practice
+from models.practice_session import PracticeSession
+from models.stage_content import StageContent
+from models.user_practice import UserPractice
+
+# The batch must issue exactly three grouped queries (habits, practice, course)
+# no matter how many stages are requested.
+_MAX_BATCH_QUERIES = 3
+_USER_ID = 1
+
+
+def _replace_array_columns_for_sqlite() -> None:
+    """SQLite cannot use PG ARRAY columns; swap them for JSON in tests."""
+    for table in SQLModel.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, PG_ARRAY):
+                column.type = JSON()
+
+
+@contextmanager
+def _count_select_statements(engine: AsyncEngine) -> Iterator[list[str]]:
+    """Yield a list whose length equals the number of SELECT statements run."""
+    counter: list[str] = []
+
+    def _before_cursor_execute(
+        _conn: Connection,
+        _cursor: object,
+        statement: str,
+        _params: object,
+        _context: ExecutionContext,
+        _executemany: bool,
+    ) -> None:
+        if statement.lstrip().upper().startswith("SELECT"):
+            counter.append(statement)
+
+    sync_engine = engine.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", _before_cursor_execute)
+    try:
+        yield counter
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _before_cursor_execute)
+
+
+@pytest_asyncio.fixture
+async def isolated_session() -> AsyncGenerator[tuple[AsyncSession, AsyncEngine], None]:
+    """Session bound to a fresh in-memory engine so SELECTs can be counted."""
+    _replace_array_columns_for_sqlite()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async with factory() as session:
+        yield session, engine
+    await engine.dispose()
+
+
+def _stage_fields(stage_number: int) -> dict[str, object]:
+    return {
+        "title": f"Stage {stage_number}",
+        "subtitle": f"Subtitle {stage_number}",
+        "stage_number": stage_number,
+        "overview_url": f"https://example.com/stage-{stage_number}",
+        "category": "test",
+        "aspect": "test-aspect",
+        "spiral_dynamics_color": "beige",
+        "growing_up_stage": "archaic",
+        "divine_gender_polarity": "masculine",
+        "relationship_to_free_will": "active",
+        "free_will_description": "Test description",
+    }
+
+
+@dataclass(frozen=True)
+class _Activity:
+    """Per-stage activity profile to seed (bundled so the seeder stays at ≤5 args)."""
+
+    habits: int
+    active_habits: int
+    practice_sessions: int
+    content_items: int
+
+
+async def _seed_stage_activity(
+    session: AsyncSession,
+    stage_number: int,
+    activity: _Activity,
+) -> None:
+    """Seed one stage with deterministic, per-stage-varying activity for user 1."""
+    stage = CourseStage(**_stage_fields(stage_number))
+    session.add(stage)
+    await session.commit()
+    await session.refresh(stage)
+
+    for i in range(activity.habits):
+        habit = Habit(
+            name=f"H{stage_number}-{i}",
+            icon="⭐",
+            start_date=date(2026, 1, 1),
+            energy_cost=1,
+            energy_return=1,
+            user_id=_USER_ID,
+            stage=str(stage_number),
+            streak=0,
+        )
+        session.add(habit)
+        await session.commit()
+        await session.refresh(habit)
+        goal = Goal(
+            habit_id=habit.id,
+            title="g",
+            tier="low",
+            target=1,
+            target_unit="reps",
+            frequency=1,
+            frequency_unit="per_day",
+        )
+        session.add(goal)
+        await session.commit()
+        await session.refresh(goal)
+        if i < activity.active_habits:
+            session.add(GoalCompletion(goal_id=goal.id, user_id=_USER_ID, completed_units=1))
+            await session.commit()
+
+    if activity.practice_sessions > 0:
+        practice = Practice(
+            stage_number=stage_number,
+            name=f"P{stage_number}",
+            description="d",
+            instructions="x",
+            default_duration_minutes=10,
+        )
+        session.add(practice)
+        await session.commit()
+        await session.refresh(practice)
+        up = UserPractice(
+            user_id=_USER_ID,
+            practice_id=practice.id,
+            stage_number=stage_number,
+            start_date=date(2026, 1, 1),
+        )
+        session.add(up)
+        await session.commit()
+        await session.refresh(up)
+        for _ in range(activity.practice_sessions):
+            session.add(
+                PracticeSession(
+                    user_id=_USER_ID,
+                    user_practice_id=up.id,
+                    duration_minutes=10.0,
+                    timestamp=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+                )
+            )
+        await session.commit()
+
+    for j in range(activity.content_items):
+        content = StageContent(
+            course_stage_id=stage.id,
+            title=f"C{stage_number}-{j}",
+            content_type="essay",
+            release_day=1,
+            url=f"https://example.com/c{stage_number}-{j}",
+        )
+        session.add(content)
+        await session.commit()
+        await session.refresh(content)
+        session.add(
+            ContentCompletion(
+                user_id=_USER_ID,
+                content_id=content.id,
+                completed_at=datetime(2026, 3, 1, tzinfo=UTC),
+            )
+        )
+    await session.commit()
+
+
+async def _seed_varied_stages(session: AsyncSession, stage_numbers: list[int]) -> None:
+    """Give each stage a different activity profile so parity is non-trivial."""
+    for n in stage_numbers:
+        await _seed_stage_activity(
+            session,
+            n,
+            _Activity(
+                habits=(n % 3) + 1,
+                active_habits=n % 2,
+                practice_sessions=(n + 1) % 2,
+                content_items=n % 3,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_batch_issues_at_most_three_queries(
+    isolated_session: tuple[AsyncSession, AsyncEngine],
+) -> None:
+    """The batch must run ≤3 SELECTs for many stages (no N+1)."""
+    session, engine = isolated_session
+    stages = [1, 2, 3, 4, 5]
+    await _seed_varied_stages(session, stages)
+
+    with _count_select_statements(engine) as queries:
+        await compute_stage_progress_batch(session, _USER_ID, stages)
+
+    assert len(queries) <= _MAX_BATCH_QUERIES, (
+        f"expected ≤{_MAX_BATCH_QUERIES} SELECTs, got {len(queries)}:\n" + "\n".join(queries)
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_query_count_is_constant_in_stage_count(
+    isolated_session: tuple[AsyncSession, AsyncEngine],
+) -> None:
+    """Doubling the stage count must not increase the query count."""
+    session, engine = isolated_session
+    stages = list(range(1, 9))
+    await _seed_varied_stages(session, stages)
+
+    with _count_select_statements(engine) as small:
+        await compute_stage_progress_batch(session, _USER_ID, stages[:3])
+    with _count_select_statements(engine) as large:
+        await compute_stage_progress_batch(session, _USER_ID, stages)
+
+    assert len(small) == len(large)
+    assert len(large) <= _MAX_BATCH_QUERIES
+
+
+@pytest.mark.asyncio
+async def test_batch_matches_per_stage_compute(
+    isolated_session: tuple[AsyncSession, AsyncEngine],
+) -> None:
+    """Batched per-stage values must equal the old per-stage loop exactly."""
+    session, _ = isolated_session
+    stages = [1, 2, 3, 4, 5, 6]
+    await _seed_varied_stages(session, stages)
+
+    batch = await compute_stage_progress_batch(session, _USER_ID, stages)
+
+    for n in stages:
+        expected = await compute_stage_progress(session, _USER_ID, n)
+        assert batch[n] == expected, f"stage {n}: {batch[n]} != {expected}"
+
+
+@pytest.mark.asyncio
+async def test_batch_empty_for_no_stages(
+    isolated_session: tuple[AsyncSession, AsyncEngine],
+) -> None:
+    """An empty stage list short-circuits to an empty mapping (and no queries)."""
+    session, engine = isolated_session
+    with _count_select_statements(engine) as queries:
+        result = await compute_stage_progress_batch(session, _USER_ID, [])
+    assert result == {}
+    assert len(queries) == 0


### PR DESCRIPTION
## Summary

- `list_stages` called `compute_stage_progress` once per stage inside a Python loop, so each request issued **N stages × M metric queries** — scaling linearly with course length (up to 36 stages) on the most-visited screen (audit §5.3 N+1).
- Added `compute_stage_progress_batch`: **three grouped queries** (habits total + active in one query via outer-join + `COUNT(DISTINCT CASE …)`, practice-session counts, course-item counts — each `GROUP BY` stage), assembled into a per-stage mapping whose values are **identical** to the per-stage loop. Query count is constant regardless of stage count.
- Rewired `list_stages` to compute progress once via the batch and build responses from the mapping; `_build_stage_response` is now a pure, query-free assembler. **Response schema, ordering, and pagination are unchanged.**

## Test plan

- New `tests/routers/test_stages_query_count.py` (reusing the established `before_cursor_execute` SELECT-counter + isolated in-memory engine):
  - `compute_stage_progress_batch` issues **≤3** SELECTs for 5 stages.
  - Query count is **constant** when stage count doubles (3 vs 8 stages).
  - **Parity:** `batch[n] == await compute_stage_progress(session, user, n)` for every stage in a varied six-stage fixture (habits with/without completions, practices, content).
  - Empty stage list short-circuits to `{}` with zero queries.
- Existing `test_stages_api.py` / `test_stages_history.py` / `test_stage_progress_queries.py` still pass.
- `./scripts/backend/check-all.sh` — all 7 checks pass; **1586 passed, 2 skipped**, coverage **95%+**, ruff + mypy clean.

Closes #473
Refs #459
