### PR TITLE
perf(backend): cap the embedded UserPractice session history

### DIFF
--- a/backend/src/routers/practice_recipes.py
+++ b/backend/src/routers/practice_recipes.py
@@ -39,9 +39,9 @@ from domain.practice_resolution import effective_config, effective_name
 from errors import bad_request, conflict, forbidden, not_found
 from models.practice import Practice
 from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
-from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
+from routers.user_practices import EmbeddedSessionsParams, load_recent_sessions
 from schemas import Page, PaginationParams, build_page
 from schemas.pagination import paginate_query
 from schemas.practice import UserPracticeDetail
@@ -359,6 +359,7 @@ async def apply_recipe_to_user_practice(
     user_id: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
     user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
+    embed: Annotated[EmbeddedSessionsParams, Depends()],
 ) -> dict[str, Any]:
     """Materialise a recipe and store it as the UserPractice's override.
 
@@ -384,16 +385,13 @@ async def apply_recipe_to_user_practice(
     session.add(user_practice)
     await session.commit()
     await session.refresh(user_practice)
-    # Load real session history so the response matches what GET
-    # ``/user-practices/{id}`` and ``customize_user_practice`` return.
-    # Returning ``sessions: []`` here would clobber any frontend store
-    # that merges the response back into local state.
-    sessions_result = await session.execute(
-        select(PracticeSession)
-        .where(PracticeSession.user_practice_id == user_practice.id)
-        .order_by(col(PracticeSession.timestamp).desc())
+    # Load the capped recent session history so the response matches what GET
+    # ``/user-practices/{id}`` and ``customize_user_practice`` return (the
+    # frontend store merges it back, so it must stay present — but bounded,
+    # issue #474). Older sessions remain reachable via ``list_sessions``.
+    sessions, sessions_total, sessions_has_more = await load_recent_sessions(
+        session, cast("int", user_practice.id), embed
     )
-    sessions = list(sessions_result.scalars().all())
     logger.info(
         "practice_recipe_applied",
         extra={
@@ -413,4 +411,6 @@ async def apply_recipe_to_user_practice(
         "effective_name": effective_name(practice, user_practice),
         "effective_config": effective_config(practice, user_practice).model_dump(),
         "sessions": sessions,
+        "sessions_total": sessions_total,
+        "sessions_has_more": sessions_has_more,
     }

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import date
 from typing import Annotated, Any, cast
 
@@ -24,7 +25,7 @@ from models.practice import Practice
 from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
-from schemas import Page, PaginationParams, build_page
+from schemas import MAX_PAGE_SIZE, Page, PaginationParams, build_page
 from schemas.frequency import FrequencyResponse, render_banner_text
 from schemas.pagination import paginate_query
 from schemas.practice import (
@@ -507,21 +508,65 @@ async def get_current_frequency(
     return await _frequency_from_preset(session, course_stage, stage_number)
 
 
+# Cap on inline practice-session history embedded in a single user-practice
+# response. Older sessions stay reachable via the paginated list_sessions
+# endpoint (issue #474); the cap is applied in SQL (LIMIT), never by slicing a
+# full fetch, so a long history never materialises in one response.
+EMBEDDED_SESSIONS_DEFAULT_LIMIT = 50
+
+
+@dataclass
+class EmbeddedSessionsParams:
+    """Query params bounding the embedded ``sessions[]`` (issue #474).
+
+    Defaults keep the embed at the cap; clients can page within it (or fetch
+    older sessions through the standalone ``list_sessions`` endpoint).
+    """
+
+    sessions_limit: int = Query(default=EMBEDDED_SESSIONS_DEFAULT_LIMIT, ge=1, le=MAX_PAGE_SIZE)
+    sessions_offset: int = Query(default=0, ge=0)
+
+
+async def load_recent_sessions(
+    session: AsyncSession,
+    user_practice_id: int,
+    params: EmbeddedSessionsParams,
+) -> tuple[list[PracticeSession], int, bool]:
+    """Newest-first slice of a practice's sessions, capped in SQL (issue #474).
+
+    Returns ``(sessions, total, has_more)``. The ``LIMIT`` is applied in the
+    query, so a long history never materialises in one response; ``has_more``
+    tells the client older sessions exist behind ``list_sessions``.
+    """
+    query = (
+        select(PracticeSession)
+        .where(PracticeSession.user_practice_id == user_practice_id)
+        .order_by(col(PracticeSession.timestamp).desc())
+    )
+    page_params = PaginationParams(
+        limit=params.sessions_limit, offset=params.sessions_offset, paginate=True
+    )
+    sessions, total = await paginate_query(session, query, page_params)
+    has_more = (params.sessions_offset + params.sessions_limit) < total
+    return sessions, total, has_more
+
+
 @router.get("/{user_practice_id}", response_model=UserPracticeDetail)
 async def get_user_practice(
     session: Annotated[AsyncSession, Depends(get_session)],
     user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
+    embed: Annotated[EmbeddedSessionsParams, Depends()],
 ) -> dict[str, Any]:
-    """Get a single user-practice with its session history.
+    """Get a single user-practice with its (capped) recent session history.
 
-    Ownership via ``require_owned_user_practice`` (404 → 403 split).
+    Ownership via ``require_owned_user_practice`` (404 → 403 split). The
+    embedded ``sessions[]`` is bounded to ``EMBEDDED_SESSIONS_DEFAULT_LIMIT``
+    newest-first sessions; ``sessions_total`` / ``sessions_has_more`` report
+    whether older sessions remain (fetch them via ``list_sessions``). Issue #474.
     """
-    sessions_result = await session.execute(
-        select(PracticeSession)
-        .where(PracticeSession.user_practice_id == user_practice.id)
-        .order_by(col(PracticeSession.timestamp).desc())
+    sessions, total, has_more = await load_recent_sessions(
+        session, cast("int", user_practice.id), embed
     )
-    sessions = list(sessions_result.scalars().all())
     name, cfg = await _resolve_effective_fields(session, user_practice)
 
     return {
@@ -529,6 +574,8 @@ async def get_user_practice(
         "effective_name": name,
         "effective_config": cfg,
         "sessions": sessions,
+        "sessions_total": total,
+        "sessions_has_more": has_more,
     }
 
 
@@ -563,6 +610,7 @@ async def customize_user_practice(
     payload: UserPracticeCustomize,
     session: Annotated[AsyncSession, Depends(get_session)],
     user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
+    embed: Annotated[EmbeddedSessionsParams, Depends()],
 ) -> dict[str, Any]:
     """Per-user override of name + mode_config.
 
@@ -587,12 +635,9 @@ async def customize_user_practice(
     name = effective_name(practice, user_practice)
     cfg = effective_config(practice, user_practice).model_dump()
 
-    sessions_result = await session.execute(
-        select(PracticeSession)
-        .where(PracticeSession.user_practice_id == user_practice.id)
-        .order_by(col(PracticeSession.timestamp).desc())
+    sessions, total, has_more = await load_recent_sessions(
+        session, cast("int", user_practice.id), embed
     )
-    sessions = list(sessions_result.scalars().all())
     logger.info(
         "user_practice_customized",
         extra={
@@ -606,4 +651,6 @@ async def customize_user_practice(
         "effective_name": name,
         "effective_config": cfg,
         "sessions": sessions,
+        "sessions_total": total,
+        "sessions_has_more": has_more,
     }

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -217,7 +217,12 @@ class UserPracticeDetail(OwnedResourcePublic):
     mode_config_override: dict[str, Any] | None = None
     effective_name: str | None = None
     effective_config: ModeConfig | None = None
+    # ``sessions`` is the newest-first *capped* embed (issue #474). The page
+    # metadata below tells the client whether older sessions remain, reachable
+    # via the paginated ``list_sessions`` endpoint.
     sessions: list[PracticeSessionSummary]
+    sessions_total: int = 0
+    sessions_has_more: bool = False
 
 
 class UserPracticeCustomize(BaseModel):

--- a/backend/tests/test_practice_recipes_api.py
+++ b/backend/tests/test_practice_recipes_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from typing import Any
 
@@ -472,9 +472,58 @@ async def test_apply_preserves_existing_sessions(
         f"/practice-recipes/{recipe_id}/apply-to/{up_id}", headers=headers
     )
     assert resp.status_code == HTTPStatus.OK, resp.text
-    sessions = resp.json()["sessions"]
+    body = resp.json()
+    sessions = body["sessions"]
     assert len(sessions) == 1
     assert sessions[0]["duration_minutes"] == 4.5
+    # Backward compatible: under the cap, total/has_more report the full set.
+    assert body["sessions_total"] == 1
+    assert body["sessions_has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_apply_caps_embedded_sessions(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The apply response embeds at most the capped, newest-first sessions (issue #474)."""
+    headers, user_id = await _signup(async_client)
+    catalog = await _seed_catalog_practice(
+        db_session,
+        mode="tallied_grounding",
+        mode_config={
+            "mode": "tallied_grounding",
+            "rounds": 1,
+            "categories": [{"key": "red", "label": "Red", "target_count": 1}],
+        },
+    )
+    up_id = await _setup_user_practice(async_client, db_session, headers, user_id, catalog)
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    for i in range(5):
+        db_session.add(
+            PracticeSession(
+                user_id=user_id,
+                user_practice_id=up_id,
+                duration_minutes=4.5,
+                timestamp=base + timedelta(minutes=i),
+            )
+        )
+    await db_session.commit()
+    create_recipe = await async_client.post(
+        "/practice-recipes/", json=_tallied_recipe_body("apply_capped"), headers=headers
+    )
+    recipe_id = create_recipe.json()["id"]
+
+    resp = await async_client.post(
+        f"/practice-recipes/{recipe_id}/apply-to/{up_id}?sessions_limit=2", headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+    assert len(body["sessions"]) == 2
+    assert body["sessions_total"] == 5
+    assert body["sessions_has_more"] is True
+    timestamps = [s["timestamp"] for s in body["sessions"]]
+    assert timestamps == sorted(timestamps, reverse=True)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_user_practice_customization.py
+++ b/backend/tests/test_user_practice_customization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
 import pytest
@@ -9,6 +10,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.practice import Practice
+from models.practice_session import PracticeSession
 from models.stage_progress import StageProgress
 from models.user_practice import UserPractice
 
@@ -491,3 +493,39 @@ async def test_list_user_practices_populates_effective_fields(
     assert item["effective_config"] is not None
     assert item["effective_config"]["mode"] == "meditation_timer"
     assert item["effective_config"]["duration_minutes"] == 10
+
+
+@pytest.mark.asyncio
+async def test_customize_caps_embedded_sessions(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The customize response embeds at most the capped, newest-first sessions (issue #474)."""
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    for i in range(5):
+        db_session.add(
+            PracticeSession(
+                user_id=user_id,
+                user_practice_id=up_id,
+                duration_minutes=10.0,
+                timestamp=base + timedelta(minutes=i),
+            )
+        )
+    await db_session.commit()
+
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize?sessions_limit=2",
+        json={"custom_name": "Capped"},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    data = resp.json()
+    assert len(data["sessions"]) == 2
+    assert data["sessions_total"] == 5
+    assert data["sessions_has_more"] is True
+    timestamps = [s["timestamp"] for s in data["sessions"]]
+    assert timestamps == sorted(timestamps, reverse=True)

--- a/backend/tests/test_user_practices_api.py
+++ b/backend/tests/test_user_practices_api.py
@@ -12,8 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
 from models.practice import Practice
+from models.practice_session import PracticeSession
 from models.stage_progress import StageProgress
 from models.user_practice import UserPractice
+from routers.user_practices import EMBEDDED_SESSIONS_DEFAULT_LIMIT
 
 _EXPECTED_SELECTION_COUNT = 2
 _SESSION_DURATION = 10.0
@@ -266,6 +268,85 @@ async def test_get_user_practice_with_sessions(
     assert data["id"] == up_id
     assert len(data["sessions"]) == 1
     assert data["sessions"][0]["duration_minutes"] == _SESSION_DURATION
+    # Backward compatible: a user under the cap sees full history + metadata.
+    assert data["sessions_total"] == 1
+    assert data["sessions_has_more"] is False
+
+
+async def _create_owned_user_practice(
+    async_client: AsyncClient, db_session: AsyncSession, headers: dict[str, str]
+) -> int:
+    """Create a user-practice via the API and return its id."""
+    practice = await _seed_practice(db_session)
+    resp = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 1},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+    return int(resp.json()["id"])
+
+
+async def _seed_sessions(db_session: AsyncSession, user_id: int, up_id: int, count: int) -> None:
+    """Seed ``count`` sessions with strictly ascending timestamps (newest last)."""
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    for i in range(count):
+        db_session.add(
+            PracticeSession(
+                user_id=user_id,
+                user_practice_id=up_id,
+                duration_minutes=_SESSION_DURATION,
+                timestamp=base + timedelta(minutes=i),
+            )
+        )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_get_user_practice_caps_embedded_sessions(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A history larger than the cap embeds only the newest-first cap (issue #474)."""
+    headers, user_id = await _signup(async_client)
+    up_id = await _create_owned_user_practice(async_client, db_session, headers)
+    await _seed_sessions(db_session, user_id, up_id, EMBEDDED_SESSIONS_DEFAULT_LIMIT + 5)
+
+    resp = await async_client.get(f"/user-practices/{up_id}", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert len(data["sessions"]) == EMBEDDED_SESSIONS_DEFAULT_LIMIT
+    assert data["sessions_total"] == EMBEDDED_SESSIONS_DEFAULT_LIMIT + 5
+    assert data["sessions_has_more"] is True
+    timestamps = [s["timestamp"] for s in data["sessions"]]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_get_user_practice_sessions_paging(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """sessions_limit/offset page the embed; older sessions are reachable, newest-first."""
+    headers, user_id = await _signup(async_client)
+    up_id = await _create_owned_user_practice(async_client, db_session, headers)
+    await _seed_sessions(db_session, user_id, up_id, 5)
+
+    first = await async_client.get(
+        f"/user-practices/{up_id}?sessions_limit=2&sessions_offset=0", headers=headers
+    )
+    page1 = first.json()
+    assert len(page1["sessions"]) == 2
+    assert page1["sessions_total"] == 5
+    assert page1["sessions_has_more"] is True
+
+    second = await async_client.get(
+        f"/user-practices/{up_id}?sessions_limit=2&sessions_offset=2", headers=headers
+    )
+    page2 = second.json()
+    assert len(page2["sessions"]) == 2
+    assert {s["id"] for s in page1["sessions"]}.isdisjoint({s["id"] for s in page2["sessions"]})
+    combined = [s["timestamp"] for s in page1["sessions"] + page2["sessions"]]
+    assert combined == sorted(combined, reverse=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `get_user_practice`, `customize_user_practice`, and `apply_recipe_to_user_practice` each embedded the caller's **entire** practice-session history inline via an unbounded `select(PracticeSession)…order_by(timestamp.desc())` + `list(...)`, so a user with months of history paid the full cost on every detail GET / customize PATCH / recipe-apply POST (audit §4 "unbounded embed", High).
- Added one shared loader `load_recent_sessions` + `EmbeddedSessionsParams` + `EMBEDDED_SESSIONS_DEFAULT_LIMIT` (50) in `user_practices.py`, imported by `practice_recipes.py` (no import cycle). All three call sites use it; the unbounded `select` block is gone from each. The cap is applied in **SQL (`LIMIT` via `paginate_query`)**, never by slicing a full fetch.
- Embedded `sessions[]` stays **newest-first and present**; added `sessions_total` / `sessions_has_more` to `UserPracticeDetail` so the client knows older sessions exist and can page them via the existing `list_sessions` endpoint. `sessions_limit` / `sessions_offset` query params page the embed.
- A user with ≤ cap sessions sees the **same `sessions[]` as before** (backward compatible).

## Test plan

- For all three endpoints: history > cap embeds exactly the newest-first cap with correct `sessions_total`/`sessions_has_more`; `sessions_limit`/`sessions_offset` page to older, non-overlapping, still-newest-first sessions; and a ≤cap user sees the unchanged `sessions[]` plus `has_more=false`.
- All existing user-practice / customization / recipe-apply tests still pass (backward compat).
- `./scripts/backend/check-all.sh` — 7/7, **coverage 95%+**, ruff + mypy clean; xenon A-grade verified.

Closes #474
Refs #460
