### PR TITLE
perf(frontend): dedup the stats fetch on stats modal open

### DIFF
--- a/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
+++ b/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
@@ -1,0 +1,110 @@
+// Dedup guard: opening the Habits stats modal must fire habitsApi.getStats
+// exactly once. Previously both useHabitStats and a useEffect inside StatsModal
+// fetched, doubling the call. This drives the real open flow through
+// HabitsScreen with the real StatsModal, so a re-introduced second fetch would
+// make the count 2.
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import HabitsScreen from '../HabitsScreen';
+
+const mockGetStats = jest.fn();
+
+jest.mock('../../../api', () => ({
+  habits: {
+    // One unlocked habit (past start_date) so the tile renders and is pressable.
+    list: () =>
+      Promise.resolve([
+        {
+          id: 1,
+          name: 'Meditate',
+          icon: '🧘',
+          stage: 'Beige',
+          streak: 0,
+          energy_cost: 1,
+          energy_return: 1,
+          start_date: new Date(2020, 0, 1),
+          goals: [
+            {
+              title: 'Low',
+              tier: 'low',
+              target: 1,
+              target_unit: 'u',
+              frequency: 1,
+              frequency_unit: 'per_day',
+              is_additive: true,
+            },
+          ],
+          completions: [],
+          revealed: true,
+        },
+      ]),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    getStats: (...args: unknown[]) => {
+      mockGetStats(...args);
+      return Promise.resolve({
+        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        values: [0, 0, 0, 0, 0, 0, 0],
+        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+        longest_streak: 0,
+        current_streak: 0,
+        total_completions: 0,
+        completion_rate: 0,
+        completion_dates: [],
+      });
+    },
+  },
+  goalCompletions: { create: jest.fn() },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: () => Promise.resolve({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getAllScheduledNotificationsAsync: () => Promise.resolve([]),
+  getExpoPushTokenAsync: () => Promise.resolve({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactModule = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// Chart/calendar libs don't render under the test renderer.
+jest.mock('react-native-calendars', () => ({ Calendar: () => null }));
+jest.mock('react-native-chart-kit', () => ({ LineChart: () => null, BarChart: () => null }));
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+describe('Habits stats modal fetch dedup', () => {
+  it('fires getStats exactly once when the stats modal opens', async () => {
+    const { getByTestId, getAllByTestId, getByText } = render(<HabitsScreen />);
+
+    // Wait for the habit list to load, then drive: overflow menu → Stats mode →
+    // tap the tile (which opens the stats modal in stats mode).
+    const toggle = await waitFor(() => getByTestId('overflow-menu-toggle'));
+    fireEvent.press(toggle);
+    fireEvent.press(getByText('Stats'));
+    fireEvent.press(getAllByTestId('habit-tile')[0]!);
+
+    await waitFor(() => expect(mockGetStats).toHaveBeenCalledTimes(1));
+    expect(mockGetStats).toHaveBeenCalledWith(1, 'test-token');
+  });
+});

--- a/frontend/src/features/Habits/components/StatsModal.tsx
+++ b/frontend/src/features/Habits/components/StatsModal.tsx
@@ -1,13 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { View, Text, useWindowDimensions, TouchableOpacity, Modal, ScrollView } from 'react-native';
 import { Calendar } from 'react-native-calendars';
 import { LineChart, BarChart } from 'react-native-chart-kit';
 
-import { habits as habitsApi } from '../../../api';
 import { CHART_AXIS_LABEL_COLOR, CHART_STYLE, SPACING, STAGE_COLORS } from '../../../design/tokens';
 import styles from '../Habits.styles';
 import type { HabitStatsData, StatsModalProps } from '../Habits.types';
-import { generateStatsForHabit, toLocalHabitStats } from '../HabitUtils';
+import { generateStatsForHabit } from '../HabitUtils';
 
 const FALLBACK_CHART_COLOR = 'rgba(134, 65, 244, 1)';
 const FALLBACK_CALENDAR_COLOR = '#50cebb';
@@ -243,39 +242,16 @@ const StatsContent = (props: StatsContentProps) => {
   );
 };
 
-export const StatsModal = ({ visible, habit, stats: localStats, onClose }: StatsModalProps) => {
+export const StatsModal = ({ visible, habit, stats: hookStats, onClose }: StatsModalProps) => {
   const [selectedTab, setSelectedTab] = useState('calendar');
-  const [apiStats, setApiStats] = useState<HabitStatsData | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    if (!visible || !habit) {
-      setApiStats(null);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-    habitsApi
-      .getStats(habit.id)
-      .then((response) => {
-        if (!cancelled) setApiStats(toLocalHabitStats(response));
-      })
-      .catch(() => {
-        if (!cancelled) setApiStats(null);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [visible, habit]);
 
   if (!habit) return null;
 
-  const stats = apiStats ?? localStats ?? generateStatsForHabit(habit);
+  // Stats are owned by ``useHabitStats`` (one fetch per open); the modal only
+  // consumes the result. While the open fetch is in flight ``hookStats`` is
+  // null, so we render the local fallback under a loading indicator.
+  const loading = visible && hookStats == null;
+  const stats = hookStats ?? generateStatsForHabit(habit);
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>

--- a/frontend/src/features/Habits/components/__tests__/StatsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/StatsModal.test.tsx
@@ -75,17 +75,6 @@ const localStats: HabitStatsData = {
   completionDates: [],
 };
 
-const apiResponse = {
-  day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-  values: [1, 3, 2, 2, 3, 2, 2],
-  completions_by_day: [1, 2, 1, 2, 3, 1, 5],
-  longest_streak: 7,
-  current_streak: 3,
-  total_completions: 15,
-  completion_rate: 0.75,
-  completion_dates: ['2024-01-01', '2024-01-02', '2024-01-03'],
-};
-
 describe('StatsModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -98,59 +87,41 @@ describe('StatsModal', () => {
     expect(toJSON()).toBeNull();
   });
 
-  it('fetches stats from API when opened', async () => {
-    (mockGetStats as any).mockResolvedValueOnce(apiResponse);
-
-    const { getByText } = render(
-      <StatsModal visible={true} habit={baseHabit} stats={localStats} onClose={jest.fn() as any} />,
-    );
-
-    // Should show loading state
-    expect(getByText('Loading stats...')).toBeTruthy();
-
-    await waitFor(() => {
-      expect(mockGetStats).toHaveBeenCalledWith(42);
-    });
-
-    // After API response, should show API stats
-    await waitFor(() => {
-      expect(getByText('7 days')).toBeTruthy(); // longest streak
-      expect(getByText('3 days')).toBeTruthy(); // current streak
-      expect(getByText('75%')).toBeTruthy(); // completion rate
-      expect(getByText('15')).toBeTruthy(); // total completions
-    });
-  });
-
-  it('falls back to local stats when API fails', async () => {
-    (mockGetStats as any).mockRejectedValueOnce(new Error('Network error'));
-
-    const fallbackStats: HabitStatsData = {
+  it('renders the stats provided by the owner without fetching itself', () => {
+    // The fetch is owned by useHabitStats (dedup); the modal only consumes the
+    // result, so it must never call the API.
+    const ownerStats: HabitStatsData = {
       ...localStats,
-      longestStreak: 2,
-      currentStreak: 1,
-      totalCompletions: 4,
-      completionRate: 0.5,
+      values: [1, 3, 2, 2, 3, 2, 2],
+      completionsByDay: [1, 2, 1, 2, 3, 1, 5],
+      longestStreak: 7,
+      currentStreak: 3,
+      totalCompletions: 15,
+      completionRate: 0.75,
+      completionDates: ['2024-01-01', '2024-01-02', '2024-01-03'],
     };
 
     const { getByText } = render(
-      <StatsModal
-        visible={true}
-        habit={baseHabit}
-        stats={fallbackStats}
-        onClose={jest.fn() as any}
-      />,
+      <StatsModal visible={true} habit={baseHabit} stats={ownerStats} onClose={jest.fn() as any} />,
     );
 
-    await waitFor(() => {
-      expect(getByText('2 days')).toBeTruthy(); // longest streak from local
-      expect(getByText('4')).toBeTruthy(); // total completions from local
-      expect(getByText('50%')).toBeTruthy(); // completion rate from local
-    });
+    expect(getByText('7 days')).toBeTruthy(); // longest streak
+    expect(getByText('3 days')).toBeTruthy(); // current streak
+    expect(getByText('75%')).toBeTruthy(); // completion rate
+    expect(getByText('15')).toBeTruthy(); // total completions
+    expect(mockGetStats).not.toHaveBeenCalled();
+  });
+
+  it('shows the loading state until the owner provides stats', () => {
+    const { getByText } = render(
+      <StatsModal visible={true} habit={baseHabit} stats={null} onClose={jest.fn() as any} />,
+    );
+
+    expect(getByText('Loading stats...')).toBeTruthy();
+    expect(mockGetStats).not.toHaveBeenCalled();
   });
 
   it('displays habit name and icon in header', async () => {
-    (mockGetStats as any).mockResolvedValueOnce(apiResponse);
-
     const { getByText } = render(
       <StatsModal visible={true} habit={baseHabit} stats={localStats} onClose={jest.fn() as any} />,
     );
@@ -160,7 +131,6 @@ describe('StatsModal', () => {
   });
 
   it('calls onClose when close button is pressed', async () => {
-    (mockGetStats as any).mockResolvedValueOnce(apiResponse);
     const onClose = jest.fn() as any;
 
     const { getByText } = render(
@@ -172,8 +142,6 @@ describe('StatsModal', () => {
   });
 
   it('switches between tabs', async () => {
-    (mockGetStats as any).mockResolvedValueOnce(apiResponse);
-
     const { getByText } = render(
       <StatsModal visible={true} habit={baseHabit} stats={localStats} onClose={jest.fn() as any} />,
     );


### PR DESCRIPTION
## Summary

- Opening the Habits stats modal fired `habitsApi.getStats(id)` **twice** — once in `useHabitStats` (HabitsScreen) and again in a `useEffect` inside `StatsModal` — doubling network traffic, doubling latency, and risking a race between the two in-flight responses (audit §5.2 render cost, High).
- Made `useHabitStats` the **single owner** of the fetch; turned `StatsModal` into a pure consumer that renders the `stats` prop, derives `loading` from `stats == null` while the open fetch is in flight, and falls back to `generateStatsForHabit` when no stats are provided. Removed the duplicate `useEffect` / `apiStats` state and the now-unused `api` / `toLocalHabitStats` imports.
- **No change to displayed stats, loading/empty states, or visual output** — only the number of fetches.

## Test plan

- New `StatsModal.fetch-dedup.test.tsx`: drives the **real** open flow through `HabitsScreen` (overflow menu → Stats → tap tile) with the real `StatsModal` and a mocked `getStats`, asserting it's called **exactly once** with the habit id. A re-introduced second fetch would make the count 2.
- `StatsModal.test.tsx` rewritten to the consumer contract: renders the provided `stats`, shows the loading state when `stats` is null, and **never** calls `getStats`.
- `./scripts/frontend/check-all.sh` — all 4 checks pass; **1890 tests**, ESLint zero-warnings, `tsc --noEmit` clean, coverage ≥90%.

Closes #475
Refs #461
