### PR TITLE
fix(backend): seed goal-group templates at startup, not on the GET

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -34,6 +34,7 @@ from routers.course import router as course_router
 from routers.energy import router as energy_router
 from routers.goal_completions import router as goal_completion_router
 from routers.goal_groups import router as goal_groups_router
+from routers.goal_groups import seed_goal_group_templates
 from routers.goals import router as goals_router
 from routers.habits import router as habits_router
 from routers.journal import router as journal_router
@@ -273,6 +274,7 @@ async def _seed_startup_data(session: AsyncSession) -> None:
         ("practices", seed_practices),
         ("practice_recipes", seed_practice_recipes),
         ("content", seed_content),
+        ("goal_group_templates", seed_goal_group_templates),
     ):
         try:
             inserted = await seeder(session)

--- a/backend/src/routers/goal_groups.py
+++ b/backend/src/routers/goal_groups.py
@@ -45,20 +45,28 @@ SEED_TEMPLATES: list[dict[str, object]] = [
 ]
 
 
-async def ensure_seed_templates(session: AsyncSession) -> None:
-    """Create built-in shared templates if they don't already exist."""
+async def seed_goal_group_templates(session: AsyncSession) -> int:
+    """Create the built-in shared templates if missing; return the count inserted.
+
+    Idempotent (keyed on template name), so it is safe to run repeatedly. Runs
+    at app startup rather than on the read path, so ``list_goal_groups`` performs
+    no write while users still get the defaults.
+    """
     result = await session.execute(
         select(GoalGroup).where(
             GoalGroup.shared_template == True,  # noqa: E712
             GoalGroup.source == "built-in",
         )
     )
-    existing = result.scalars().all()
-    existing_names = {t.name for t in existing}
+    existing_names = {t.name for t in result.scalars().all()}
+    inserted = 0
     for template in SEED_TEMPLATES:
         if template["name"] not in existing_names:
             session.add(GoalGroup(shared_template=True, user_id=None, **template))
-    await session.commit()
+            inserted += 1
+    if inserted:
+        await session.commit()
+    return inserted
 
 
 @router.get("/", response_model=None)
@@ -72,8 +80,10 @@ async def list_goal_groups(
     BUG-INFRA-015: returns ``Page[GoalGroupResponse]`` when ``?paginate=true``
     is set; otherwise the legacy bare list is returned for one release while
     the frontend migrates to the envelope.
+
+    Seed templates are provisioned at app startup (``seed_goal_group_templates``
+    in the lifespan hook), so this read path performs no INSERT/commit.
     """
-    await ensure_seed_templates(session)
     query = (
         select(GoalGroup)
         .where(

--- a/backend/tests/routers/test_goal_groups_no_write_on_get.py
+++ b/backend/tests/routers/test_goal_groups_no_write_on_get.py
@@ -1,0 +1,105 @@
+"""``GET /goal-groups`` must not write (audit §5.3 GET-that-writes).
+
+Template seeding used to run inside the list handler — a SELECT + conditional
+INSERT + commit on every read. It now runs at app startup, so the read path is
+write-free. These tests pin that: the GET issues zero INSERTs and zero commits,
+and the relocated seeder still makes the templates available.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import event
+from sqlalchemy.engine import Connection, ExecutionContext
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlmodel import select
+
+from conftest import test_engine
+from models.goal_group import GoalGroup
+from routers.goal_groups import SEED_TEMPLATES, seed_goal_group_templates
+
+
+@contextmanager
+def _count_inserts(engine: AsyncEngine) -> Iterator[list[str]]:
+    """Yield a list of INSERT statements executed while the context is open."""
+    inserts: list[str] = []
+
+    def _before_cursor_execute(
+        _conn: Connection,
+        _cursor: object,
+        statement: str,
+        _params: object,
+        _context: ExecutionContext,
+        _executemany: bool,
+    ) -> None:
+        if statement.lstrip().upper().startswith("INSERT"):
+            inserts.append(statement)
+
+    sync_engine = engine.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", _before_cursor_execute)
+    try:
+        yield inserts
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _before_cursor_execute)
+
+
+async def _signup(client: AsyncClient, username: str = "reader") -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+@pytest.mark.asyncio
+async def test_list_goal_groups_get_performs_no_insert_or_commit(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GET to list_goal_groups issues no INSERT and no commit."""
+    headers = await _signup(async_client)
+
+    commits = 0
+    real_commit = db_session.commit
+
+    async def _spy_commit() -> None:
+        nonlocal commits
+        commits += 1
+        await real_commit()
+
+    monkeypatch.setattr(db_session, "commit", _spy_commit)
+
+    with _count_inserts(test_engine) as inserts:
+        resp = await async_client.get("/goal-groups/", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert inserts == [], f"GET must not INSERT, saw:\n{chr(10).join(inserts)}"
+    assert commits == 0
+
+
+@pytest.mark.asyncio
+async def test_seed_templates_available_after_relocated_seeder(
+    db_session: AsyncSession,
+) -> None:
+    """The startup seeder still provisions the built-in templates."""
+    inserted = await seed_goal_group_templates(db_session)
+    assert inserted == len(SEED_TEMPLATES)
+
+    result = await db_session.execute(
+        select(GoalGroup).where(
+            GoalGroup.shared_template == True,  # noqa: E712
+            GoalGroup.source == "built-in",
+        )
+    )
+    names = {g.name for g in result.scalars().all()}
+    assert names == {t["name"] for t in SEED_TEMPLATES}

--- a/backend/tests/test_goal_groups_api.py
+++ b/backend/tests/test_goal_groups_api.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.goal import Goal
+from routers.goal_groups import seed_goal_group_templates
 
 SEED_TEMPLATE_COUNT = 3
 GOAL_TIER_COUNT = 3
@@ -35,9 +36,14 @@ async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str
 
 @pytest.mark.asyncio
 async def test_list_goal_groups_includes_shared_templates(
-    async_client: AsyncClient,
+    async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """Listing goal groups returns shared templates even with no user groups."""
+    """Listing goal groups returns shared templates even with no user groups.
+
+    Templates are provisioned at startup; tests don't run the lifespan hook, so
+    seed them explicitly here (the read path no longer seeds).
+    """
+    await seed_goal_group_templates(db_session)
     headers = await _signup(async_client)
     resp = await async_client.get("/goal-groups/", headers=headers)
 
@@ -434,15 +440,16 @@ async def test_goal_group_response_includes_goals(
 
 @pytest.mark.asyncio
 async def test_seed_templates_are_idempotent(
-    async_client: AsyncClient,
+    async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """Calling list twice does not duplicate seed templates."""
+    """Running the seeder twice does not duplicate templates; the second run inserts 0."""
+    first = await seed_goal_group_templates(db_session)
+    second = await seed_goal_group_templates(db_session)
+
+    assert first == SEED_TEMPLATE_COUNT
+    assert second == 0
+
     headers = await _signup(async_client)
-
-    resp1 = await async_client.get("/goal-groups/", headers=headers)
-    count1 = len([g for g in resp1.json() if g["shared_template"]])
-
-    resp2 = await async_client.get("/goal-groups/", headers=headers)
-    count2 = len([g for g in resp2.json() if g["shared_template"]])
-
-    assert count1 == count2
+    resp = await async_client.get("/goal-groups/", headers=headers)
+    templates = [g for g in resp.json() if g["shared_template"]]
+    assert len(templates) == SEED_TEMPLATE_COUNT


### PR DESCRIPTION
## Summary

- `list_goal_groups` called `ensure_seed_templates` on **every GET** — a SELECT + conditional INSERT + commit on a hot read path, violating HTTP semantics and risking write contention (audit §5.3 GET-that-writes; mirrors the prior botmason `/user/usage` fix).
- Renamed `ensure_seed_templates` → `seed_goal_group_templates`, returning the inserted count and committing **only when it actually inserts** (idempotent).
- Moved the call into the app-startup seeder loop (`_seed_startup_data`) alongside the other idempotent seeders, so templates exist in production without any read-path write.
- Removed the call from the `list_goal_groups` GET. **Response schema unchanged.**

## Test plan

- New `tests/routers/test_goal_groups_no_write_on_get.py`: a GET issues **zero INSERTs** (statement listener) and **zero commits** (commit spy); the relocated seeder still provisions all built-in templates.
- Updated `test_goal_groups_api.py`: the template-presence test seeds explicitly (the lifespan hook doesn't run under the test client), and the idempotency test now asserts the seeder inserts the full set once and **0** on re-run.
- `./scripts/backend/check-all.sh` — 7/7, **1592 passed, 2 skipped**, coverage 95%+, ruff + mypy clean; xenon A verified.

Closes #476
Refs #459
