### PR TITLE
fix(backend): load energy costs server-side (close BUG-PRACTICE-010)

### DIFF
--- a/backend/src/routers/energy.py
+++ b/backend/src/routers/energy.py
@@ -7,10 +7,12 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from database import get_session
 from routers.auth import get_current_user
 from schemas import EnergyPlanRequest, EnergyPlanResponse
-from services.energy import get_or_generate_plan
+from services.energy import get_or_generate_plan, resolve_trusted_habits
 
 logger = logging.getLogger(__name__)
 
@@ -21,38 +23,30 @@ router = APIRouter(prefix="/v1/energy", tags=["energy"])
 async def create_plan(
     payload: EnergyPlanRequest,
     current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
     x_idempotency_key: Annotated[str | None, Header()] = None,
 ) -> EnergyPlanResponse:
-    """Create an energy plan from submitted habits.
+    """Create an energy plan from the caller's own habits.
 
     Auth is required (BUG-PRACTICE-010): the planner runs CPU-bound
-    scheduling work on a thread pool, so an unauthenticated endpoint
-    would let a single attacker spawn arbitrary expensive work for free.
-    Habit list size is already capped at ``MAX_HABITS_PER_PLAN`` in the
-    request schema.
+    scheduling work on a thread pool, so an unauthenticated endpoint would let
+    a single attacker spawn arbitrary expensive work for free. Habit list size
+    is capped at ``MAX_HABITS_PER_PLAN`` in the request schema.
 
-    .. warning::
+    ``energy_cost`` / ``energy_return`` are loaded server-side from ``Habit``
+    rows owned by ``current_user`` (``resolve_trusted_habits``); client-sent
+    costs are ignored and a habit the caller does not own returns 403/404. This
+    closes the remainder of BUG-PRACTICE-010 — the plan can no longer be
+    steered by forged client values.
 
-       The auth gate alone does NOT close BUG-PRACTICE-010 in full.
-       The planner is still steered by client-supplied
-       ``energy_cost`` / ``energy_return`` values per habit, so an
-       authenticated user can submit any habit id with arbitrary costs
-       and influence the plan.  Loading those values server-side from
-       ``Habit`` rows owned by ``current_user`` -- and rejecting any
-       client-sent costs -- is the remaining piece.  It needs a
-       ``services.energy`` refactor and is deliberately deferred to
-       12B wave 2; the ``current_user`` parameter is plumbed in so the
-       follow-up is purely additive.
-
-    BUG-INFRA-009: ``generate_plan`` (called via :func:`get_or_generate_plan`)
-    performs CPU-bound scheduling work.  Running it inline on the event loop
-    would block every other request for the duration of the computation, so
-    we offload to the default executor via :func:`asyncio.to_thread`.  The
-    cache lookup itself is cheap and could run inline, but keeping the entire
-    call off-loop keeps the contract simple — every request returns control
-    to the loop while the worker thread runs.
+    BUG-INFRA-009: ``generate_plan`` performs CPU-bound scheduling work, so it
+    is offloaded via :func:`asyncio.to_thread`; the (async) habit lookup runs
+    on the event loop first, then the CPU work runs off-loop.
     """
-    response = await asyncio.to_thread(get_or_generate_plan, payload, x_idempotency_key)
+    trusted = await resolve_trusted_habits(session, current_user, payload)
+    response = await asyncio.to_thread(
+        get_or_generate_plan, trusted, payload.start_date, x_idempotency_key
+    )
     logger.info(
         "energy_plan_created",
         extra={"user_id": current_user, "reason_code": response.reason_code},

--- a/backend/src/schemas/energy.py
+++ b/backend/src/schemas/energy.py
@@ -20,8 +20,12 @@ MAX_HABITS_PER_PLAN = 100
 class Habit(BaseModel):
     id: int = Field(gt=0)
     name: str = Field(min_length=1, max_length=HABIT_NAME_MAX_LENGTH)
-    energy_cost: int = Field(ge=ENERGY_VALUE_MIN, le=ENERGY_VALUE_MAX)
-    energy_return: int = Field(ge=ENERGY_VALUE_MIN, le=ENERGY_VALUE_MAX)
+    # energy_cost / energy_return are loaded server-side from the caller's own
+    # Habit rows (BUG-PRACTICE-010); any client-sent values are ignored. They
+    # stay optional + bounded so existing clients that still send them validate,
+    # but the planner never trusts them.
+    energy_cost: int | None = Field(default=None, ge=ENERGY_VALUE_MIN, le=ENERGY_VALUE_MAX)
+    energy_return: int | None = Field(default=None, ge=ENERGY_VALUE_MIN, le=ENERGY_VALUE_MAX)
 
 
 class EnergyPlanItem(BaseModel):

--- a/backend/src/services/energy.py
+++ b/backend/src/services/energy.py
@@ -1,7 +1,8 @@
 """Energy-plan generation service with idempotency caching.
 
-The router layer is a thin HTTP adapter: it accepts a request, hands the
-payload to :func:`get_or_generate_plan`, and returns the response.  The
+The router layer is a thin HTTP adapter: it accepts a request, resolves the
+caller's trusted habit costs server-side via :func:`resolve_trusted_habits`,
+then hands those to :func:`get_or_generate_plan` and returns the response. The
 idempotency cache lives here (not in the router) so background regeneration
 jobs, admin tools, and tests can share the same de-duplication semantics
 without reaching into route handlers.
@@ -11,12 +12,17 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict
+from datetime import date
 
 from cachetools import TTLCache
 from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
 
 from domain.energy import Habit as DomainHabit
 from domain.energy import generate_plan
+from errors import forbidden, not_found
+from models.habit import Habit
 from schemas import EnergyPlan, EnergyPlanRequest, EnergyPlanResponse
 
 logger = logging.getLogger(__name__)
@@ -34,16 +40,74 @@ idempotency_cache: TTLCache[str, EnergyPlanResponse] = TTLCache(
 )
 
 
-def build_energy_response(payload: EnergyPlanRequest) -> EnergyPlanResponse:
-    """Generate an energy plan from the request payload.
+async def _load_owned_habits(
+    session: AsyncSession, user_id: int, requested_ids: list[int]
+) -> dict[int, Habit]:
+    """Fetch the caller's Habit rows for ``requested_ids``, keyed by id."""
+    result = await session.execute(
+        select(Habit).where(col(Habit.id).in_(requested_ids), Habit.user_id == user_id)
+    )
+    return {habit.id: habit for habit in result.scalars().all() if habit.id is not None}
+
+
+async def _ensure_all_owned(
+    session: AsyncSession, requested_ids: list[int], owned: dict[int, Habit]
+) -> None:
+    """Raise 403/404 if any requested id is not owned by the caller.
+
+    403 ``habit_not_owned`` when the id exists for another user, else 404
+    ``habit`` — the 404→403 split from ``dependencies.ownership``.
+    """
+    missing = [habit_id for habit_id in requested_ids if habit_id not in owned]
+    if not missing:
+        return
+    existing = await session.execute(select(Habit.id).where(col(Habit.id).in_(missing)))
+    if set(existing.scalars().all()):
+        raise forbidden("habit_not_owned")
+    raise not_found("habit")
+
+
+def _build_domain_habits(payload: EnergyPlanRequest, owned: dict[int, Habit]) -> list[DomainHabit]:
+    """Build the domain habit list from stored costs, in request order."""
+    return [
+        DomainHabit(
+            id=requested.id,
+            name=owned[requested.id].name,
+            energy_cost=owned[requested.id].energy_cost,
+            energy_return=owned[requested.id].energy_return,
+        )
+        for requested in payload.habits
+    ]
+
+
+async def resolve_trusted_habits(
+    session: AsyncSession, user_id: int, payload: EnergyPlanRequest
+) -> list[DomainHabit]:
+    """Build the planner's habit list from the caller's own stored Habit rows.
+
+    Closes the remainder of BUG-PRACTICE-010: ``energy_cost`` / ``energy_return``
+    come solely from ``Habit`` rows owned by ``user_id``; any costs in the
+    request payload are ignored. A requested id the caller does not own raises
+    403/404. An empty request resolves to ``[]`` and the empty-plan 400 is
+    raised downstream.
+    """
+    requested_ids = [habit.id for habit in payload.habits]
+    if not requested_ids:
+        return []
+    owned = await _load_owned_habits(session, user_id, requested_ids)
+    await _ensure_all_owned(session, requested_ids, owned)
+    return _build_domain_habits(payload, owned)
+
+
+def build_energy_response(habits: list[DomainHabit], start_date: date) -> EnergyPlanResponse:
+    """Generate an energy plan from already-resolved (trusted) habits.
 
     ``domain.energy.generate_plan`` raises ``ValueError`` for empty habit
     lists; we translate that to a 400 so the HTTP surface is stable.  The
     reason code is logged for audit — it never changes the response body.
     """
-    habits = [DomainHabit(**h.model_dump()) for h in payload.habits]
     try:
-        plan, reason = generate_plan(habits, payload.start_date)
+        plan, reason = generate_plan(habits, start_date)
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -56,7 +120,7 @@ def build_energy_response(payload: EnergyPlanRequest) -> EnergyPlanResponse:
 
 
 def get_or_generate_plan(
-    payload: EnergyPlanRequest, idempotency_key: str | None
+    habits: list[DomainHabit], start_date: date, idempotency_key: str | None
 ) -> EnergyPlanResponse:
     """Return a cached plan for ``idempotency_key`` or compute and cache a new one.
 
@@ -68,7 +132,7 @@ def get_or_generate_plan(
     if idempotency_key and idempotency_key in idempotency_cache:
         return idempotency_cache[idempotency_key]
 
-    response = build_energy_response(payload)
+    response = build_energy_response(habits, start_date)
 
     if idempotency_key:
         idempotency_cache[idempotency_key] = response

--- a/backend/tests/services/test_energy.py
+++ b/backend/tests/services/test_energy.py
@@ -1,13 +1,17 @@
-"""Unit tests for :mod:`services.energy` — idempotency cache + response building."""
+"""Unit tests for :mod:`services.energy`: cache, response building, trusted-cost resolution."""
 
 from __future__ import annotations
 
+from datetime import date
 from http import HTTPStatus
 
 import pytest
 from cachetools import TTLCache
 from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from domain.energy import Habit as DomainHabit
+from models.habit import Habit
 from schemas import EnergyPlanRequest
 from services.energy import (
     CACHE_MAX_ENTRIES,
@@ -15,17 +19,15 @@ from services.energy import (
     build_energy_response,
     get_or_generate_plan,
     idempotency_cache,
+    resolve_trusted_habits,
 )
 
+_START = date(2025, 6, 1)
 
-def _payload() -> EnergyPlanRequest:
-    """Return a minimal energy-plan request suitable for service-level tests."""
-    return EnergyPlanRequest.model_validate(
-        {
-            "habits": [{"id": 1, "name": "Run", "energy_cost": 1, "energy_return": 3}],
-            "start_date": "2025-06-01",
-        }
-    )
+
+def _habits() -> list[DomainHabit]:
+    """A minimal trusted habit list for response-building tests."""
+    return [DomainHabit(id=1, name="Run", energy_cost=1, energy_return=3)]
 
 
 def test_idempotency_cache_is_ttl_bounded() -> None:
@@ -36,15 +38,14 @@ def test_idempotency_cache_is_ttl_bounded() -> None:
 
 
 def test_build_energy_response_returns_21_day_plan() -> None:
-    response = build_energy_response(_payload())
+    response = build_energy_response(_habits(), _START)
     assert response.reason_code == "generated_21_day_plan"
     assert len(response.plan.items) == 21
 
 
 def test_build_energy_response_raises_400_on_empty_habits() -> None:
-    payload = EnergyPlanRequest.model_validate({"habits": [], "start_date": "2025-06-01"})
     with pytest.raises(HTTPException) as excinfo:
-        build_energy_response(payload)
+        build_energy_response([], _START)
     assert excinfo.value.status_code == HTTPStatus.BAD_REQUEST
     assert excinfo.value.detail == "habits_must_not_be_empty"
 
@@ -54,7 +55,7 @@ def test_get_or_generate_plan_without_key_skips_cache(monkeypatch: pytest.Monkey
     fresh_cache: TTLCache[str, object] = TTLCache(maxsize=100, ttl=60)
     monkeypatch.setattr("services.energy.idempotency_cache", fresh_cache)
 
-    get_or_generate_plan(_payload(), idempotency_key=None)
+    get_or_generate_plan(_habits(), _START, idempotency_key=None)
     assert len(fresh_cache) == 0
 
 
@@ -64,10 +65,95 @@ def test_get_or_generate_plan_returns_cached_response_for_same_key(
     fresh_cache: TTLCache[str, object] = TTLCache(maxsize=100, ttl=60)
     monkeypatch.setattr("services.energy.idempotency_cache", fresh_cache)
 
-    first = get_or_generate_plan(_payload(), idempotency_key="k")
-    second = get_or_generate_plan(_payload(), idempotency_key="k")
+    first = get_or_generate_plan(_habits(), _START, idempotency_key="k")
+    second = get_or_generate_plan(_habits(), _START, idempotency_key="k")
 
-    # Identity check would be too strict against our response model;
-    # equality is enough to prove the second call reused the cached entry.
     assert first == second
     assert len(fresh_cache) == 1
+
+
+# ── Server-side trusted-cost resolution (BUG-PRACTICE-010) ──────────────────
+
+
+async def _make_habit(
+    session: AsyncSession, user_id: int, *, energy_cost: int, energy_return: int
+) -> int:
+    """Persist a habit owned by ``user_id`` and return its id."""
+    habit = Habit(
+        name="Owned",
+        icon="⭐",
+        start_date=date(2025, 1, 1),
+        stage="1",
+        streak=0,
+        energy_cost=energy_cost,
+        energy_return=energy_return,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    assert habit.id is not None
+    return habit.id
+
+
+def _request(
+    habit_id: int, *, cost: int | None = None, ret: int | None = None
+) -> EnergyPlanRequest:
+    return EnergyPlanRequest.model_validate(
+        {
+            "habits": [{"id": habit_id, "name": "x", "energy_cost": cost, "energy_return": ret}],
+            "start_date": "2025-06-01",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_ignores_forged_client_costs(db_session: AsyncSession) -> None:
+    """Forged client costs are ignored; the resolved habit carries the stored costs."""
+    user_id = 1
+    habit_id = await _make_habit(db_session, user_id, energy_cost=2, energy_return=9)
+    payload = _request(habit_id, cost=1000, ret=0)  # client forges wildly different costs
+
+    resolved = await resolve_trusted_habits(db_session, user_id, payload)
+
+    assert len(resolved) == 1
+    assert resolved[0].energy_cost == 2
+    assert resolved[0].energy_return == 9
+
+
+@pytest.mark.asyncio
+async def test_resolve_works_when_costs_omitted(db_session: AsyncSession) -> None:
+    """A payload omitting costs still resolves to the stored values."""
+    user_id = 1
+    habit_id = await _make_habit(db_session, user_id, energy_cost=4, energy_return=7)
+
+    resolved = await resolve_trusted_habits(db_session, user_id, _request(habit_id))
+
+    assert resolved[0].energy_cost == 4
+    assert resolved[0].energy_return == 7
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_habit_owned_by_another_user(db_session: AsyncSession) -> None:
+    """A habit owned by someone else returns 403, not a plan."""
+    owner_id, attacker_id = 1, 2
+    habit_id = await _make_habit(db_session, owner_id, energy_cost=2, energy_return=3)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await resolve_trusted_habits(db_session, attacker_id, _request(habit_id))
+    assert excinfo.value.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_nonexistent_habit(db_session: AsyncSession) -> None:
+    """A habit id that exists for nobody returns 404."""
+    with pytest.raises(HTTPException) as excinfo:
+        await resolve_trusted_habits(db_session, 1, _request(99999))
+    assert excinfo.value.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_resolve_empty_payload_returns_empty(db_session: AsyncSession) -> None:
+    """An empty habit list resolves to ``[]`` (empty-plan 400 happens downstream)."""
+    payload = EnergyPlanRequest.model_validate({"habits": [], "start_date": "2025-06-01"})
+    assert await resolve_trusted_habits(db_session, 1, payload) == []

--- a/backend/tests/test_energy_api.py
+++ b/backend/tests/test_energy_api.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import date
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import patch
@@ -16,33 +17,62 @@ from unittest.mock import patch
 import pytest
 from cachetools import TTLCache
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from domain.energy import Habit as DomainHabit
 from main import app
+from models.habit import Habit
+from routers import energy as energy_router
 from services import energy
 from services.energy import idempotency_cache
 
 
 def sample_payload() -> dict[str, Any]:
+    """A valid-shape request (used by the no-auth test, which 401s before lookup)."""
     return {
-        "habits": [
-            {"id": 1, "name": "Run", "energy_cost": 2, "energy_return": 5},
-            {"id": 2, "name": "Sleep", "energy_cost": 1, "energy_return": 0},
-        ],
+        "habits": [{"id": 1, "name": "Run"}],
         "start_date": "2024-01-01",
     }
 
 
-async def _signup(client: AsyncClient) -> dict[str, str]:
-    """Sign up a user and return auth headers."""
+def _plan_request(ids: list[int]) -> dict[str, Any]:
+    return {
+        "habits": [{"id": habit_id, "name": f"H{habit_id}"} for habit_id in ids],
+        "start_date": "2024-01-01",
+    }
+
+
+async def _signup(client: AsyncClient, username: str = "energyuser") -> tuple[dict[str, str], int]:
+    """Sign up a user and return (auth headers, user_id)."""
     resp = await client.post(
         "/auth/signup",
         json={
-            "email": "energyuser@example.com",
+            "email": f"{username}@example.com",
             "password": "securepassword123",  # pragma: allowlist secret
         },
     )
     assert resp.status_code == HTTPStatus.OK
-    return {"Authorization": f"Bearer {resp.json()['token']}"}
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+async def _seed_habit(db_session: AsyncSession, user_id: int) -> int:
+    """Persist a habit owned by ``user_id`` and return its id."""
+    habit = Habit(
+        name="Owned",
+        icon="⭐",
+        start_date=date(2025, 1, 1),
+        stage="1",
+        streak=0,
+        energy_cost=2,
+        energy_return=5,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    assert habit.id is not None
+    return habit.id
 
 
 def test_idempotency_cache_is_ttl_bounded() -> None:
@@ -63,18 +93,18 @@ def test_idempotency_cache_evicts_when_full() -> None:
 
 
 @pytest.mark.asyncio
-async def test_idempotency_miss_after_cache_clear(async_client: AsyncClient) -> None:
+async def test_idempotency_miss_after_cache_clear(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
     """After clearing the cache, duplicate keys should recompute."""
-    headers = await _signup(async_client)
+    headers, user_id = await _signup(async_client)
+    habit_id = await _seed_habit(db_session, user_id)
+    payload = _plan_request([habit_id])
     with patch.object(energy, "idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
         idem_headers = {**headers, "X-Idempotency-Key": "unique-clear-test"}
-        res1 = await async_client.post(
-            "/v1/energy/plan", json=sample_payload(), headers=idem_headers
-        )
+        res1 = await async_client.post("/v1/energy/plan", json=payload, headers=idem_headers)
         energy.idempotency_cache.clear()
-        res2 = await async_client.post(
-            "/v1/energy/plan", json=sample_payload(), headers=idem_headers
-        )
+        res2 = await async_client.post("/v1/energy/plan", json=payload, headers=idem_headers)
         assert res1.status_code == HTTPStatus.OK
         assert res2.status_code == HTTPStatus.OK
 
@@ -88,18 +118,25 @@ async def test_create_plan_does_not_block_event_loop(async_client: AsyncClient) 
     the main loop is free during the sleep, so two concurrent requests
     complete in ~300ms total — not ~600ms serialised.
     """
-    headers = await _signup(async_client)
+    headers, _ = await _signup(async_client)
     sleep_seconds = 0.3
+    one_habit = [DomainHabit(id=1, name="Run", energy_cost=2, energy_return=5)]
 
-    def _slow_plan(payload: Any, _key: Any) -> Any:  # noqa: ANN401
+    async def _stub_resolve(_session: Any, _user_id: Any, _payload: Any) -> list[DomainHabit]:  # noqa: ANN401
+        return one_habit
+
+    def _slow_plan(_habits: Any, _start: Any, _key: Any) -> Any:  # noqa: ANN401
         time.sleep(sleep_seconds)
-        return energy.build_energy_response(payload)
+        return energy.build_energy_response(one_habit, date(2024, 1, 1))
 
-    # The blocking-event-loop assertion needs a real ASGI client (not the
-    # async_client fixture, which already runs against the in-memory app).
-    # Re-using the same app instance is fine — the dependency_overrides
-    # installed by ``async_client`` are still active for the duration.
-    with patch.object(energy, "get_or_generate_plan", _slow_plan):
+    # Patch the names the router bound, and stub the (async) habit lookup so the
+    # test isolates the CPU-offload behaviour from the DB. The blocking-event-loop
+    # assertion needs a real ASGI client; the async_client dependency overrides
+    # stay active for the duration.
+    with (
+        patch.object(energy_router, "resolve_trusted_habits", _stub_resolve),
+        patch.object(energy_router, "get_or_generate_plan", _slow_plan),
+    ):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             start = time.perf_counter()

--- a/backend/tests/test_energy_integration.py
+++ b/backend/tests/test_energy_integration.py
@@ -1,12 +1,15 @@
 """Integration tests for the energy planning system.
 
-These tests exercise the energy plan endpoint with realistic habit data,
-verifying plan generation, idempotency behavior, and error handling work
-correctly together.
+These exercise the energy plan endpoint with realistic habit data. Costs are
+now loaded server-side from the caller's own ``Habit`` rows (BUG-PRACTICE-010),
+so each plan-generating test seeds habits owned by the signed-up user and uses
+their real ids; client-sent costs are ignored.
 """
 
 from __future__ import annotations
 
+import itertools
+from datetime import date
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import patch
@@ -14,33 +17,18 @@ from unittest.mock import patch
 import pytest
 from cachetools import TTLCache
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.habit import Habit
 from services import energy as energy_service
 
-
-def _habits_payload(count: int = 3) -> list[dict[str, Any]]:
-    """Generate a list of habit payloads for energy plan requests."""
-    return [
-        {
-            "id": i + 1,
-            "name": f"Habit {i + 1}",
-            "energy_cost": i + 1,
-            "energy_return": (i + 1) * 2,
-        }
-        for i in range(count)
-    ]
+# Per-user habit names are unique (ix_habit_user_lower_name_unique_test); a
+# global counter keeps every seeded habit's name distinct within a test.
+_habit_names = itertools.count()
 
 
-def _plan_request(habits: list[dict[str, Any]] | None = None) -> dict[str, Any]:
-    """Build a complete energy plan request payload."""
-    return {
-        "habits": habits if habits is not None else _habits_payload(),
-        "start_date": "2025-01-01",
-    }
-
-
-async def _auth_headers(client: AsyncClient, suffix: str = "") -> dict[str, str]:
-    """Sign up a user and return auth headers (BUG-PRACTICE-010 makes auth required)."""
+async def _auth_headers(client: AsyncClient, suffix: str = "") -> tuple[dict[str, str], int]:
+    """Sign up a user and return (auth headers, user_id)."""
     resp = await client.post(
         "/auth/signup",
         json={
@@ -49,55 +37,130 @@ async def _auth_headers(client: AsyncClient, suffix: str = "") -> dict[str, str]
         },
     )
     assert resp.status_code == HTTPStatus.OK
-    return {"Authorization": f"Bearer {resp.json()['token']}"}
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+async def _seed_habit(
+    db_session: AsyncSession, user_id: int, *, cost: int, ret: int, name: str | None = None
+) -> int:
+    """Persist a habit owned by ``user_id`` and return its id (unique name)."""
+    habit = Habit(
+        name=name or f"Habit-{next(_habit_names)}",
+        icon="⭐",
+        start_date=date(2025, 1, 1),
+        stage="1",
+        streak=0,
+        energy_cost=cost,
+        energy_return=ret,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    assert habit.id is not None
+    return habit.id
+
+
+def _plan_request(ids: list[int], start_date: str = "2025-01-01") -> dict[str, Any]:
+    """Build a request referencing habit ids (costs omitted — loaded server-side)."""
+    return {
+        "habits": [{"id": habit_id, "name": f"Habit {habit_id}"} for habit_id in ids],
+        "start_date": start_date,
+    }
 
 
 @pytest.mark.asyncio
-async def test_energy_plan_generates_21_day_plan(async_client: AsyncClient) -> None:
-    """Energy plan endpoint generates a 21-day plan cycling through habits."""
-    headers = await _auth_headers(async_client, "21day")
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request(), headers=headers)
-    assert resp.status_code == HTTPStatus.OK
-
-    data = resp.json()
-    assert data["reason_code"] == "generated_21_day_plan"
-
-    plan = data["plan"]
-    items = plan["items"]
-    assert len(items) == 21
-
-    # Verify items cycle through habits correctly
-    habit_ids = [item["habit_id"] for item in items]
-    for i, habit_id in enumerate(habit_ids):
-        expected_habits = _habits_payload()
-        expected_id = expected_habits[i % len(expected_habits)]["id"]
-        assert habit_id == expected_id
-
-
-@pytest.mark.asyncio
-async def test_energy_plan_net_energy_calculation(async_client: AsyncClient) -> None:
-    """Net energy is calculated correctly as sum of (return - cost) per day."""
-    headers = await _auth_headers(async_client, "net")
-    habits = [
-        {"id": 1, "name": "Run", "energy_cost": 3, "energy_return": 8},
-        {"id": 2, "name": "Read", "energy_cost": 1, "energy_return": 4},
+async def test_energy_plan_generates_21_day_plan(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Energy plan endpoint generates a 21-day plan cycling through the caller's habits."""
+    headers, user_id = await _auth_headers(async_client, "21day")
+    ids = [
+        await _seed_habit(db_session, user_id, cost=1, ret=2),
+        await _seed_habit(db_session, user_id, cost=2, ret=4),
+        await _seed_habit(db_session, user_id, cost=3, ret=6),
     ]
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request(habits), headers=headers)
+
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request(ids), headers=headers)
     assert resp.status_code == HTTPStatus.OK
 
-    data = resp.json()
-    # 21 days: habit 1 on days 0,2,4,...,20 (11 days), habit 2 on days 1,3,...,19 (10 days)
-    # Net = 11 * (8-3) + 10 * (4-1) = 55 + 30 = 85
-    expected_net = 11 * (8 - 3) + 10 * (4 - 1)
-    assert data["plan"]["net_energy"] == expected_net
+    items = resp.json()["plan"]["items"]
+    assert len(items) == 21
+    for i, item in enumerate(items):
+        assert item["habit_id"] == ids[i % len(ids)]
 
 
 @pytest.mark.asyncio
-async def test_idempotency_returns_cached_response(async_client: AsyncClient) -> None:
+async def test_energy_plan_uses_stored_costs_not_forged(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A forged client cost does not change the plan — stored costs win (BUG-PRACTICE-010)."""
+    headers, user_id = await _auth_headers(async_client, "forged")
+    habit_id = await _seed_habit(db_session, user_id, cost=2, ret=3)
+    payload = {
+        "habits": [{"id": habit_id, "name": "Forged", "energy_cost": 999, "energy_return": 999}],
+        "start_date": "2025-01-01",
+    }
+
+    resp = await async_client.post("/v1/energy/plan", json=payload, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    # 21 days * (3 - 2) = 21, NOT a forged value.
+    assert resp.json()["plan"]["net_energy"] == 21
+
+
+@pytest.mark.asyncio
+async def test_energy_plan_net_energy_calculation(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Net energy is the sum of (return - cost) per scheduled day, from stored costs."""
+    headers, user_id = await _auth_headers(async_client, "net")
+    ids = [
+        await _seed_habit(db_session, user_id, cost=3, ret=8, name="Run"),
+        await _seed_habit(db_session, user_id, cost=1, ret=4, name="Read"),
+    ]
+
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request(ids), headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+    # 21 days: habit 0 on 11 days, habit 1 on 10 days.
+    expected_net = 11 * (8 - 3) + 10 * (4 - 1)
+    assert resp.json()["plan"]["net_energy"] == expected_net
+
+
+@pytest.mark.asyncio
+async def test_energy_plan_rejects_unowned_habit(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Referencing a habit owned by another user returns 403, not a plan."""
+    _, owner_id = await _auth_headers(async_client, "owner")
+    habit_id = await _seed_habit(db_session, owner_id, cost=1, ret=2)
+    attacker_headers, _ = await _auth_headers(async_client, "attacker")
+
+    resp = await async_client.post(
+        "/v1/energy/plan", json=_plan_request([habit_id]), headers=attacker_headers
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_energy_plan_rejects_nonexistent_habit(async_client: AsyncClient) -> None:
+    """Referencing a habit id that exists for nobody returns 404."""
+    headers, _ = await _auth_headers(async_client, "ghost")
+    resp = await async_client.post("/v1/energy/plan", json=_plan_request([99999]), headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_idempotency_returns_cached_response(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
     """Same idempotency key returns identical response without recomputation."""
-    auth = await _auth_headers(async_client, "idem")
+    auth, user_id = await _auth_headers(async_client, "idem")
+    ids = [await _seed_habit(db_session, user_id, cost=1, ret=2)]
     headers = {**auth, "X-Idempotency-Key": "test-idempotency-key-123"}
-    payload = _plan_request()
+    payload = _plan_request(ids)
 
     resp1 = await async_client.post("/v1/energy/plan", json=payload, headers=headers)
     resp2 = await async_client.post("/v1/energy/plan", json=payload, headers=headers)
@@ -109,22 +172,21 @@ async def test_idempotency_returns_cached_response(async_client: AsyncClient) ->
 
 @pytest.mark.asyncio
 async def test_different_idempotency_keys_produce_independent_results(
-    async_client: AsyncClient,
+    async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
     """Different idempotency keys are cached independently."""
-    auth = await _auth_headers(async_client, "diffidem")
+    auth, user_id = await _auth_headers(async_client, "diffidem")
+    id_a = await _seed_habit(db_session, user_id, cost=1, ret=2, name="A")
+    id_b = await _seed_habit(db_session, user_id, cost=5, ret=1, name="B")
     with patch.object(energy_service, "idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
-        payload_a = _plan_request([{"id": 1, "name": "A", "energy_cost": 1, "energy_return": 2}])
-        payload_b = _plan_request([{"id": 2, "name": "B", "energy_cost": 5, "energy_return": 1}])
-
         resp_a = await async_client.post(
             "/v1/energy/plan",
-            json=payload_a,
+            json=_plan_request([id_a]),
             headers={**auth, "X-Idempotency-Key": "key-a"},
         )
         resp_b = await async_client.post(
             "/v1/energy/plan",
-            json=payload_b,
+            json=_plan_request([id_b]),
             headers={**auth, "X-Idempotency-Key": "key-b"},
         )
 
@@ -134,7 +196,7 @@ async def test_different_idempotency_keys_produce_independent_results(
 @pytest.mark.asyncio
 async def test_empty_habits_returns_400(async_client: AsyncClient) -> None:
     """POST with empty habits list returns 400, not 500."""
-    headers = await _auth_headers(async_client, "empty")
+    headers, _ = await _auth_headers(async_client, "empty")
     resp = await async_client.post(
         "/v1/energy/plan",
         json={"habits": [], "start_date": "2025-01-01"},
@@ -148,10 +210,13 @@ async def test_empty_habits_returns_400(async_client: AsyncClient) -> None:
 @pytest.mark.parametrize("field", ["energy_cost", "energy_return"])
 async def test_negative_energy_value_rejected(async_client: AsyncClient, field: str) -> None:
     """BUG-SCHEMA-007: clients can't smuggle negative energy values past Pydantic."""
-    headers = await _auth_headers(async_client, f"neg{field}")
-    habit = {"id": 1, "name": "X", "energy_cost": 1, "energy_return": 1}
-    habit[field] = -1
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request([habit]), headers=headers)
+    headers, _ = await _auth_headers(async_client, f"neg{field}")
+    habit: dict[str, Any] = {"id": 1, "name": "X", field: -1}
+    resp = await async_client.post(
+        "/v1/energy/plan",
+        json={"habits": [habit], "start_date": "2025-01-01"},
+        headers=headers,
+    )
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
@@ -159,44 +224,55 @@ async def test_negative_energy_value_rejected(async_client: AsyncClient, field: 
 @pytest.mark.parametrize("field", ["energy_cost", "energy_return"])
 async def test_oversized_energy_value_rejected(async_client: AsyncClient, field: str) -> None:
     """BUG-SCHEMA-007: values above the documented cap are rejected, not clamped."""
-    headers = await _auth_headers(async_client, f"big{field}")
-    habit = {"id": 1, "name": "X", "energy_cost": 1, "energy_return": 1}
-    habit[field] = 10_001
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request([habit]), headers=headers)
+    headers, _ = await _auth_headers(async_client, f"big{field}")
+    habit: dict[str, Any] = {"id": 1, "name": "X", field: 10_001}
+    resp = await async_client.post(
+        "/v1/energy/plan",
+        json={"habits": [habit], "start_date": "2025-01-01"},
+        headers=headers,
+    )
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
 async def test_zero_id_habit_rejected(async_client: AsyncClient) -> None:
     """``id`` must be positive — a zero id would never round-trip to a real habit."""
-    headers = await _auth_headers(async_client, "zeroid")
-    habit = {"id": 0, "name": "X", "energy_cost": 1, "energy_return": 1}
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request([habit]), headers=headers)
+    headers, _ = await _auth_headers(async_client, "zeroid")
+    resp = await async_client.post(
+        "/v1/energy/plan",
+        json={"habits": [{"id": 0, "name": "X"}], "start_date": "2025-01-01"},
+        headers=headers,
+    )
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
 async def test_too_many_habits_rejected(async_client: AsyncClient) -> None:
     """A pathological 101-habit payload is rejected before it hits the planner."""
-    headers = await _auth_headers(async_client, "many")
-    too_many = [
-        {"id": i + 1, "name": f"H{i}", "energy_cost": 1, "energy_return": 2} for i in range(101)
-    ]
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request(too_many), headers=headers)
+    headers, _ = await _auth_headers(async_client, "many")
+    too_many = [{"id": i + 1, "name": f"H{i}"} for i in range(101)]
+    resp = await async_client.post(
+        "/v1/energy/plan",
+        json={"habits": too_many, "start_date": "2025-01-01"},
+        headers=headers,
+    )
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
-async def test_single_habit_fills_all_21_days(async_client: AsyncClient) -> None:
+async def test_single_habit_fills_all_21_days(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
     """A single habit is scheduled for all 21 days of the plan."""
-    headers = await _auth_headers(async_client, "single")
-    single = [{"id": 42, "name": "Solo", "energy_cost": 2, "energy_return": 3}]
-    resp = await async_client.post("/v1/energy/plan", json=_plan_request(single), headers=headers)
+    headers, user_id = await _auth_headers(async_client, "single")
+    habit_id = await _seed_habit(db_session, user_id, cost=2, ret=3, name="Solo")
+
+    resp = await async_client.post(
+        "/v1/energy/plan", json=_plan_request([habit_id]), headers=headers
+    )
     assert resp.status_code == HTTPStatus.OK
 
     items = resp.json()["plan"]["items"]
     assert len(items) == 21
-    assert all(item["habit_id"] == 42 for item in items)
-
-    # Net energy: 21 * (3 - 2) = 21
-    assert resp.json()["plan"]["net_energy"] == 21
+    assert all(item["habit_id"] == habit_id for item in items)
+    assert resp.json()["plan"]["net_energy"] == 21  # 21 * (3 - 2)


### PR DESCRIPTION
## Summary

- The energy planner trusted **client-supplied** `energy_cost`/`energy_return` per habit — an authenticated user could POST any habit id with arbitrary costs and bias the resulting plan (audit §5.1 fake / authz gap; the open remainder of **BUG-PRACTICE-010**).
- Added `services.energy.resolve_trusted_habits`: loads each requested habit's cost/return from the `Habit` rows **owned by `current_user`**, ignoring any costs in the payload. A habit the caller doesn't own returns **403** (exists for another user) or **404** (exists for nobody) — the `dependencies.ownership` split.
- Threaded `AsyncSession` + `current_user` from `routers/energy.py` into the service; the habit lookup runs on the event loop, then the CPU-bound `generate_plan` stays on `asyncio.to_thread`. `build_energy_response` / `get_or_generate_plan` now take the resolved habits + start_date.
- Made `energy_cost`/`energy_return` **optional + ignored** on the request DTO so the contract no longer advertises client-controllable costs. Removed the BUG-PRACTICE-010 warning docstring.

## Test plan

- Service (`test_energy.py`): a **forged** client cost resolves to the **stored** value; omitting costs still resolves; an unowned habit → 403; a nonexistent one → 404; empty → `[]`.
- Endpoint (`test_energy_integration.py`): seeds habits owned by the caller and uses real ids — a forged cost does not change `net_energy`; unowned → 403; nonexistent → 404; plan generation / idempotency / validation paths preserved.
- `test_energy_api.py`: offload test patches the router-bound names and stubs the async lookup to isolate the `to_thread` behaviour.
- `./scripts/backend/check-all.sh` — 7/7, **1600 passed, 2 skipped**, coverage 95%+, ruff + mypy clean; xenon A verified.

Closes #477
Refs #463
