### PR TITLE
perf(frontend): virtualize the Practice catalog with SectionList

### DIFF
--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -19,10 +19,10 @@
 
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  ScrollView,
+  SectionList,
   StyleSheet,
   Text,
   TextInput,
@@ -73,6 +73,58 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
   const [query, setQuery] = useState('');
   const [state, reload] = useCatalog(stageNumber, loadPractices);
 
+  const { onDetail, onCreate } = useCatalogNavigation(
+    navigation,
+    navigateToDetail,
+    navigateToCreate,
+  );
+
+  // Virtualized: bucket the filtered catalog into the three sections and let
+  // SectionList window the rows. Stable render callbacks keep rows from
+  // re-rendering on unrelated state (search keystrokes, chip toggles).
+  const sections = useMemo(
+    () => buildSections(state.practices, query, modeCategory),
+    [state.practices, query, modeCategory],
+  );
+  const renderItem = useCallback(
+    ({ item }: { item: PracticeItem }) => <PracticeRow practice={item} onDetail={onDetail} />,
+    [onDetail],
+  );
+
+  return (
+    <View style={styles.screen}>
+      <SectionList<PracticeItem, CatalogSection>
+        testID="practice-catalog-screen"
+        sections={state.loading || state.error !== null ? [] : sections}
+        keyExtractor={catalogKeyExtractor}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        renderSectionFooter={renderSectionFooter}
+        ListHeaderComponent={
+          <CatalogHeader
+            query={query}
+            onQueryChange={setQuery}
+            stageNumber={stageNumber}
+            onStage={setStageNumber}
+            modeCategory={modeCategory}
+            onMode={setModeCategory}
+            onCreate={onCreate}
+          />
+        }
+        ListFooterComponent={<CatalogStatus state={state} onRetry={reload} />}
+        contentContainerStyle={styles.body}
+        keyboardShouldPersistTaps="handled"
+        stickySectionHeadersEnabled={false}
+      />
+    </View>
+  );
+}
+
+function useCatalogNavigation(
+  navigation: NativeStackNavigationProp<RootStackParamList>,
+  navigateToDetail: CatalogProps['navigateToDetail'],
+  navigateToCreate: CatalogProps['navigateToCreate'],
+): { onDetail: (id: number) => void; onCreate: () => void } {
   const onDetail = useCallback(
     (id: number) =>
       navigateToDetail
@@ -84,25 +136,97 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
     () => (navigateToCreate ? navigateToCreate() : navigation.navigate('CreatePractice')),
     [navigation, navigateToCreate],
   );
-
-  return (
-    <View style={styles.screen}>
-      <ScrollView contentContainerStyle={styles.body} testID="practice-catalog-screen">
-        <Header onCreate={onCreate} />
-        <SearchBar value={query} onChange={setQuery} />
-        <StageChips selected={stageNumber} onSelect={setStageNumber} />
-        <ModeChips selected={modeCategory} onSelect={setModeCategory} />
-        <CatalogBody
-          state={state}
-          query={query}
-          modeCategory={modeCategory}
-          onDetail={onDetail}
-          onRetry={reload}
-        />
-      </ScrollView>
-    </View>
-  );
+  return { onDetail, onCreate };
 }
+
+interface CatalogSection {
+  section: Section;
+  title: string;
+  data: readonly PracticeItem[];
+}
+
+const catalogKeyExtractor = (item: PracticeItem): string => `practice-${item.id}`;
+
+const renderSectionHeader = ({ section }: { section: CatalogSection }): React.JSX.Element => (
+  <View style={styles.section} testID={`practice-catalog-section-${section.section}`}>
+    <Text style={styles.sectionTitle}>{section.title}</Text>
+  </View>
+);
+
+const renderSectionFooter = ({ section }: { section: CatalogSection }): React.JSX.Element | null =>
+  section.data.length === 0 ? (
+    <Text style={styles.emptyText} testID={`practice-catalog-section-${section.section}-empty`}>
+      Nothing here yet.
+    </Text>
+  ) : null;
+
+/** Build the three catalog sections (always present, even when empty). */
+function buildSections(
+  items: readonly PracticeItem[],
+  query: string,
+  modeCategory: string | null,
+): CatalogSection[] {
+  const buckets = bucketSections(applyFilters(items, query, modeCategory));
+  return [
+    { section: 'presets', title: 'Presets', data: buckets.presets },
+    { section: 'drafts', title: 'My drafts', data: buckets.drafts },
+    { section: 'imported', title: 'Imported', data: buckets.imported },
+  ];
+}
+
+interface CatalogHeaderProps {
+  query: string;
+  onQueryChange: (next: string) => void;
+  stageNumber: number;
+  onStage: (stage: number) => void;
+  modeCategory: string | null;
+  onMode: (category: string | null) => void;
+  onCreate: () => void;
+}
+
+/** Non-scrolling-away header for the SectionList (kept as an element so the
+ * search TextInput keeps focus across re-renders). */
+const CatalogHeader = (props: CatalogHeaderProps): React.JSX.Element => (
+  <View>
+    <Header onCreate={props.onCreate} />
+    <SearchBar value={props.query} onChange={props.onQueryChange} />
+    <StageChips selected={props.stageNumber} onSelect={props.onStage} />
+    <ModeChips selected={props.modeCategory} onSelect={props.onMode} />
+  </View>
+);
+
+interface CatalogStatusProps {
+  state: CatalogState;
+  onRetry: () => void;
+}
+
+/** Loading spinner / error block rendered below the header while the list is empty. */
+const CatalogStatus = ({ state, onRetry }: CatalogStatusProps): React.JSX.Element | null => {
+  if (state.loading) {
+    return (
+      <View style={styles.loadingBlock} testID="practice-catalog-loading">
+        <ActivityIndicator color={colors.primary} />
+      </View>
+    );
+  }
+  if (state.error !== null) {
+    return (
+      <View style={styles.errorBlock} testID="practice-catalog-error">
+        <Text style={styles.errorText}>{state.error}</Text>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Retry"
+          onPress={onRetry}
+          style={styles.retryButton}
+          testID="practice-catalog-retry"
+        >
+          <Text style={styles.retryButtonText}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+  return null;
+};
 
 function useCatalog(
   stageNumber: number,
@@ -247,87 +371,9 @@ const FilterChip = ({ label, selected, onPress, testID }: FilterChipProps): Reac
   </TouchableOpacity>
 );
 
-interface CatalogBodyProps {
-  state: CatalogState;
-  query: string;
-  modeCategory: string | null;
-  onDetail: (id: number) => void;
-  onRetry: () => void;
-}
-
-const CatalogBody = (props: CatalogBodyProps): React.JSX.Element => {
-  if (props.state.loading) {
-    return (
-      <View style={styles.loadingBlock} testID="practice-catalog-loading">
-        <ActivityIndicator color={colors.primary} />
-      </View>
-    );
-  }
-  if (props.state.error !== null) {
-    return (
-      <View style={styles.errorBlock} testID="practice-catalog-error">
-        <Text style={styles.errorText}>{props.state.error}</Text>
-        <TouchableOpacity
-          accessibilityRole="button"
-          accessibilityLabel="Retry"
-          onPress={props.onRetry}
-          style={styles.retryButton}
-          testID="practice-catalog-retry"
-        >
-          <Text style={styles.retryButtonText}>Retry</Text>
-        </TouchableOpacity>
-      </View>
-    );
-  }
-  const filtered = applyFilters(props.state.practices, props.query, props.modeCategory);
-  const sections = bucketSections(filtered);
-  return (
-    <View testID="practice-catalog-sections">
-      <SectionView
-        title="Presets"
-        section="presets"
-        items={sections.presets}
-        onDetail={props.onDetail}
-      />
-      <SectionView
-        title="My drafts"
-        section="drafts"
-        items={sections.drafts}
-        onDetail={props.onDetail}
-      />
-      <SectionView
-        title="Imported"
-        section="imported"
-        items={sections.imported}
-        onDetail={props.onDetail}
-      />
-    </View>
-  );
-};
-
-interface SectionViewProps {
-  title: string;
-  section: Section;
-  items: readonly PracticeItem[];
-  onDetail: (id: number) => void;
-}
-
-const SectionView = ({ title, section, items, onDetail }: SectionViewProps): React.JSX.Element => (
-  <View style={styles.section} testID={`practice-catalog-section-${section}`}>
-    <Text style={styles.sectionTitle}>{title}</Text>
-    {items.length === 0 ? (
-      <Text style={styles.emptyText} testID={`practice-catalog-section-${section}-empty`}>
-        Nothing here yet.
-      </Text>
-    ) : (
-      items.map((p) => <PracticeRow key={p.id} practice={p} onPress={() => onDetail(p.id)} />)
-    )}
-  </View>
-);
-
 interface PracticeRowProps {
   practice: PracticeItem;
-  onPress: () => void;
+  onDetail: (id: number) => void;
 }
 
 // Derived from MODE_CATEGORIES so adding a mode propagates here automatically.
@@ -340,7 +386,7 @@ const MODE_PRESENTATION: Readonly<Record<PickableMode, { label: string; icon: st
 
 const FALLBACK_PRESENTATION = { label: 'Practice', icon: '🧘' } as const;
 
-const PracticeRow = ({ practice, onPress }: PracticeRowProps): React.JSX.Element => {
+const PracticeRowComponent = ({ practice, onDetail }: PracticeRowProps): React.JSX.Element => {
   const mode = (practice.mode ?? 'meditation_timer') as PickableMode;
   const { label, icon } = MODE_PRESENTATION[mode] ?? FALLBACK_PRESENTATION;
   const duration = Math.round(practice.default_duration_minutes);
@@ -349,7 +395,7 @@ const PracticeRow = ({ practice, onPress }: PracticeRowProps): React.JSX.Element
     <TouchableOpacity
       accessibilityRole="button"
       accessibilityLabel={`${practice.name}. ${label}, ${duration} minutes.`}
-      onPress={onPress}
+      onPress={() => onDetail(practice.id)}
       style={styles.row}
       testID={`practice-catalog-row-${practice.id}`}
     >
@@ -366,6 +412,10 @@ const PracticeRow = ({ practice, onPress }: PracticeRowProps): React.JSX.Element
     </TouchableOpacity>
   );
 };
+
+// Memoized so SectionList windowing + a stable ``onDetail`` keep unchanged rows
+// from re-rendering on search keystrokes or chip toggles.
+const PracticeRow = React.memo(PracticeRowComponent);
 
 function applyFilters(
   items: readonly PracticeItem[],

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -263,3 +263,24 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
     expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
   });
 });
+
+describe('PracticeCatalogScreen — virtualization parity', () => {
+  it('renders every section + row through the windowed list and still navigates on press', async () => {
+    const { view, navigateToDetail } = renderScreen();
+    await waitForLoad();
+
+    // All three section headers render (the empty Imported section keeps its footer).
+    expect(view.getByTestId('practice-catalog-section-presets')).toBeTruthy();
+    expect(view.getByTestId('practice-catalog-section-drafts')).toBeTruthy();
+    expect(view.getByTestId('practice-catalog-section-imported-empty')).toBeTruthy();
+
+    // Rows from different sections all appear in the same windowed pass...
+    expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
+    expect(view.getByTestId('practice-catalog-row-2')).toBeTruthy();
+    expect(view.getByTestId('practice-catalog-row-9')).toBeTruthy();
+
+    // ...and pressing a row still navigates (behavior unchanged by virtualization).
+    fireEvent.press(view.getByTestId('practice-catalog-row-9'));
+    expect(navigateToDetail).toHaveBeenCalledWith(9);
+  });
+});


### PR DESCRIPTION
## Summary

- `PracticeCatalogScreen` rendered the whole catalog with nested `.map()` inside a `ScrollView` — every preset and draft mounted up front, so the screen janked and memory grew as the catalog expands (audit §5.2 list virtualization, High).
- Converted the `ScrollView` + per-section `.map()` to a windowed **`SectionList`** with a stable **id-based `keyExtractor`** (`practice-${id}`). The three sections (Presets / My drafts / Imported) stay always-present: `renderSectionHeader` carries the section testID, `renderSectionFooter` renders the "Nothing here yet." empty state — grouping/order/empty behavior identical.
- Header + search + chips moved to `ListHeaderComponent` (passed as an **element** so the search `TextInput` keeps focus across re-renders); loading/error moved to `ListFooterComponent` so the chips stay interactive while loading.
- Stabilized `renderItem` (`useCallback`) and memoized `PracticeRow` so rows don't re-render on search keystrokes / chip toggles. **No layout, grouping, appearance, or navigation change.**

## Test plan

- All **17 existing** catalog tests pass unchanged (sections, rows, row icons, filtering by name/mode/stage, error+retry, navigation, fallbacks) — full behavior parity.
- Added a virtualization-parity test: every section header + the empty-Imported footer + rows from different sections all render through the windowed list, and pressing a row still navigates.
- `./scripts/frontend/check-all.sh` — all 4 checks pass; **1891 tests**, ESLint zero-warnings, `tsc --noEmit` clean, coverage ≥90%.

Closes #478
Refs #461
