### PR TITLE
perf(backend): compute the consecutive streak once per check-in

### DIFF
--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -46,8 +46,6 @@ class _CheckInJob:
     did_complete: bool
     is_scheduled: bool
     old_streak: int
-    # Post-insert streak, computed alongside ``old_streak`` from one history
-    # read (no second recompute on the persist path).
     new_streak: int
     # Explicit completion time for a backfilled past day; ``None`` lets the
     # ``GoalCompletion`` model default (``datetime.now(UTC)``) stand.
@@ -235,7 +233,7 @@ def _completion_timestamp(completed_on: date | None, user_timezone: str) -> date
 
 
 async def _persist_and_build_response(session: AsyncSession, job: _CheckInJob) -> CheckInResult:
-    """Persist + read streak/milestones inside one savepoint; reads streak post-flush."""
+    """Persist the completion and build a CheckInResult; streak values arrive pre-computed."""
     completion = GoalCompletion(
         goal_id=job.goal_id,
         user_id=job.user_id,

--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -25,9 +25,12 @@ from models.habit import Habit
 from routers.auth import get_current_user
 from schemas import CheckInResult
 from services.streaks import (
+    PendingCompletion,
+    StreakScope,
     SubtractiveContext,
     check_milestones,
     compute_consecutive_streak,
+    compute_streak_before_and_after,
     update_streak,
 )
 
@@ -43,6 +46,9 @@ class _CheckInJob:
     did_complete: bool
     is_scheduled: bool
     old_streak: int
+    # Post-insert streak, computed alongside ``old_streak`` from one history
+    # read (no second recompute on the persist path).
+    new_streak: int
     # Explicit completion time for a backfilled past day; ``None`` lets the
     # ``GoalCompletion`` model default (``datetime.now(UTC)``) stand.
     timestamp: datetime | None
@@ -240,30 +246,25 @@ async def _persist_and_build_response(session: AsyncSession, job: _CheckInJob) -
     async with session.begin_nested():
         session.add(completion)
         await session.flush()
-        new_streak = await compute_consecutive_streak(
-            session,
-            job.goal_id,
-            job.user_id,
-            job.user_timezone,
-            job.subtractive,
-        )
-        _, reason = update_streak(
-            job.old_streak,
-            did_check_in=job.did_complete,
-            is_scheduled_today=job.is_scheduled,
-        )
-        milestones = check_milestones(new_streak, _DEFAULT_THRESHOLDS, job.old_streak)
     await session.commit()
+    # ``new_streak`` was computed alongside ``old_streak`` from one history read
+    # (issue dedup); these are pure derivations, no DB recompute.
+    _, reason = update_streak(
+        job.old_streak,
+        did_check_in=job.did_complete,
+        is_scheduled_today=job.is_scheduled,
+    )
+    milestones = check_milestones(job.new_streak, _DEFAULT_THRESHOLDS, job.old_streak)
     logger.info(
         "goal_completion_recorded",
         extra={
             "user_id": job.user_id,
             "goal_id": job.goal_id,
             "did_complete": job.did_complete,
-            "streak": new_streak,
+            "streak": job.new_streak,
         },
     )
-    return CheckInResult(streak=new_streak, milestones=milestones, reason_code=reason)
+    return CheckInResult(streak=job.new_streak, milestones=milestones, reason_code=reason)
 
 
 async def _try_persist_or_idempotent(session: AsyncSession, job: _CheckInJob) -> CheckInResult:
@@ -310,16 +311,24 @@ async def create_goal_completion(
         )
 
     is_scheduled = is_scheduled_on(habit.notification_days, target_day.strftime("%a"))
-    # ``old_streak`` is also the held-path response value, so it has to
-    # be read before the unscheduled-miss early return; the cheap
-    # idempotency check above has already short-circuited duplicate
-    # retries so only legitimate fresh requests pay the cost.
-    old_streak = await compute_consecutive_streak(
-        session, goal_id, current_user, user_tz, subtractive
-    )
 
+    # Unscheduled miss holds the current streak without inserting — only the
+    # pre-insert streak is needed, so compute it once here.
     if not payload.did_complete and not is_scheduled:
+        old_streak = await compute_consecutive_streak(
+            session, goal_id, current_user, user_tz, subtractive
+        )
         return _held_response(current_user, goal_id, old_streak)
+
+    # Persist path: derive the pre- and post-insert streak from ONE history
+    # read instead of recomputing on each branch (the day is fresh — the
+    # idempotency check above ruled out an existing log for it).
+    pending_units = goal.target if payload.did_complete else 0.0
+    old_streak, new_streak = await compute_streak_before_and_after(
+        session,
+        StreakScope(goal_id, current_user, user_tz, subtractive),
+        PendingCompletion(target_day, pending_units),
+    )
 
     job = _CheckInJob(
         goal_id=goal_id,
@@ -329,6 +338,7 @@ async def create_goal_completion(
         did_complete=payload.did_complete,
         is_scheduled=is_scheduled,
         old_streak=old_streak,
+        new_streak=new_streak,
         timestamp=_completion_timestamp(payload.completed_on, user_tz),
         subtractive=subtractive,
     )

--- a/backend/src/services/streaks.py
+++ b/backend/src/services/streaks.py
@@ -30,10 +30,13 @@ from models.goal_completion import GoalCompletion
 from schemas.milestone import Milestone
 
 __all__ = [
+    "PendingCompletion",
+    "StreakScope",
     "SubtractiveContext",
     "check_milestones",
     "compute_consecutive_streak",
     "compute_habit_streak",
+    "compute_streak_before_and_after",
     "update_streak",
 ]
 
@@ -143,17 +146,32 @@ async def compute_consecutive_streak(
     legacy additive behavior, so callers that don't know the habit's
     polarity stay safe.
     """
+    day_totals = await _fetch_day_totals(session, goal_id, user_id, user_timezone)
+    return _streak_from_day_totals(day_totals, user_timezone, subtractive)
+
+
+async def _fetch_day_totals(
+    session: AsyncSession, goal_id: int, user_id: int, user_timezone: str
+) -> dict[date, float]:
+    """Sum a goal's completion units per user-local calendar day (one query)."""
     rows = await session.execute(
         select(GoalCompletion.timestamp, GoalCompletion.completed_units)
         .where(GoalCompletion.goal_id == goal_id, GoalCompletion.user_id == user_id)
         .order_by(col(GoalCompletion.timestamp).desc())
     )
-
     day_totals: dict[date, float] = {}
     for ts, units in rows:
         day = _to_user_date(ts, user_timezone)
         day_totals[day] = day_totals.get(day, 0.0) + units
+    return day_totals
 
+
+def _streak_from_day_totals(
+    day_totals: dict[date, float],
+    user_timezone: str,
+    subtractive: SubtractiveContext | None,
+) -> int:
+    """Count the consecutive-day streak from pre-bucketed day totals."""
     if subtractive is not None:
         return _compute_subtractive_streak(day_totals, user_timezone, subtractive)
 
@@ -167,6 +185,44 @@ async def compute_consecutive_streak(
         return 0
     day_ok = {d: day_totals[d] > 0 for d in sorted_days}
     return _count_consecutive_days(sorted_days, day_ok)
+
+
+@dataclass(frozen=True)
+class StreakScope:
+    """The goal + calendar + polarity that fully specify a streak computation."""
+
+    goal_id: int
+    user_id: int
+    user_timezone: str
+    subtractive: SubtractiveContext | None
+
+
+@dataclass(frozen=True)
+class PendingCompletion:
+    """A not-yet-persisted completion to fold into the post-insert streak."""
+
+    day: date
+    units: float
+
+
+async def compute_streak_before_and_after(
+    session: AsyncSession,
+    scope: StreakScope,
+    pending: PendingCompletion,
+) -> tuple[int, int]:
+    """Return ``(streak_before, streak_after)`` from a single history read.
+
+    Lets the check-in path obtain the pre- and post-insert streak without
+    computing the streak twice. ``pending`` is folded into the day buckets
+    exactly as the about-to-be-inserted ``GoalCompletion`` would be, so
+    ``streak_after`` matches recomputing after the insert.
+    """
+    day_totals = await _fetch_day_totals(session, scope.goal_id, scope.user_id, scope.user_timezone)
+    before = _streak_from_day_totals(day_totals, scope.user_timezone, scope.subtractive)
+    after_totals = dict(day_totals)
+    after_totals[pending.day] = after_totals.get(pending.day, 0.0) + pending.units
+    after = _streak_from_day_totals(after_totals, scope.user_timezone, scope.subtractive)
+    return before, after
 
 
 def _completed_user_dates(

--- a/backend/tests/routers/test_goal_completions_streak_dedup.py
+++ b/backend/tests/routers/test_goal_completions_streak_dedup.py
@@ -1,0 +1,183 @@
+"""A check-in must compute the consecutive streak at most once (audit §5.3).
+
+The handler used to call ``compute_consecutive_streak`` in several branches of
+the same request. It now derives the pre- and post-insert streak from a single
+history read, so ``compute_consecutive_streak`` is invoked at most once per
+request — while the persisted/response values stay identical, including the
+backfill case where deriving from ``update_streak`` (old + 1) would be wrong.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import routers.goal_completions as gc_module
+from domain.dates import today_in_tz
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from services.streaks import SubtractiveContext
+
+
+def _noon(day: date) -> datetime:
+    """A tz-aware UTC timestamp at midday on ``day`` (unambiguous calendar bucket)."""
+    return datetime.combine(day, datetime.min.time(), tzinfo=UTC) + timedelta(hours=12)
+
+
+async def _signup(client: AsyncClient, username: str = "dedupuser") -> tuple[dict[str, str], int]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+async def _seed_goal(db_session: AsyncSession, user_id: int) -> Goal:
+    habit = Habit(
+        name="Meditation",
+        icon="🧘",
+        start_date=date(2025, 1, 1),
+        energy_cost=10,
+        energy_return=20,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    goal = Goal(
+        habit_id=habit.id,
+        title="Daily sit",
+        tier="clear",
+        target=10.0,
+        target_unit="minutes",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    db_session.add(goal)
+    await db_session.commit()
+    await db_session.refresh(goal)
+    return goal
+
+
+async def _seed_completion(db_session: AsyncSession, goal: Goal, user_id: int, day: date) -> None:
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal.id, user_id=user_id, completed_units=goal.target, timestamp=_noon(day)
+        )
+    )
+    await db_session.commit()
+
+
+def _spy_streak_calls(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Patch the router's ``compute_consecutive_streak`` to count invocations."""
+    counter = [0]
+    real = gc_module.compute_consecutive_streak
+
+    async def _counting(
+        session: AsyncSession,
+        goal_id: int,
+        user_id: int,
+        user_timezone: str = "UTC",
+        subtractive: SubtractiveContext | None = None,
+    ) -> int:
+        counter[0] += 1
+        return await real(session, goal_id, user_id, user_timezone, subtractive)
+
+    monkeypatch.setattr(gc_module, "compute_consecutive_streak", _counting)
+    return counter
+
+
+@pytest.mark.asyncio
+async def test_checkin_computes_streak_at_most_once(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh check-in invokes compute_consecutive_streak at most once."""
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+    calls = _spy_streak_calls(monkeypatch)
+
+    resp = await async_client.post(
+        "/goal_completions/", json={"goal_id": goal.id, "did_complete": True}, headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["streak"] == 1  # work still happened
+    assert calls[0] <= 1
+
+
+@pytest.mark.asyncio
+async def test_idempotent_checkin_computes_streak_at_most_once(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A duplicate same-day check-in also computes the streak at most once."""
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+    await async_client.post(
+        "/goal_completions/", json={"goal_id": goal.id, "did_complete": True}, headers=headers
+    )
+
+    calls = _spy_streak_calls(monkeypatch)
+    resp = await async_client.post(
+        "/goal_completions/", json={"goal_id": goal.id, "did_complete": True}, headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert calls[0] <= 1
+
+
+@pytest.mark.asyncio
+async def test_streak_value_parity_for_multiday_chain(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Checking in today on top of two prior days yields streak 3 (unchanged)."""
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+    today = today_in_tz("UTC")
+    await _seed_completion(db_session, goal, user_id, today - timedelta(days=1))
+    await _seed_completion(db_session, goal, user_id, today - timedelta(days=2))
+
+    resp = await async_client.post(
+        "/goal_completions/", json={"goal_id": goal.id, "did_complete": True}, headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["streak"] == 3
+
+
+@pytest.mark.asyncio
+async def test_backfill_streak_is_a_true_recompute_not_old_plus_one(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Backfilling the gap day bridges the chain to 2, proving a real recompute.
+
+    The pre-backfill streak is a stale 0 (lone completion two days ago), so
+    ``update_streak`` would have given old + 1 = 1; the correct recompute is 2.
+    """
+    headers, user_id = await _signup(async_client)
+    goal = await _seed_goal(db_session, user_id)
+    today = today_in_tz("UTC")
+    await _seed_completion(db_session, goal, user_id, today - timedelta(days=2))
+
+    resp = await async_client.post(
+        "/goal_completions/",
+        json={
+            "goal_id": goal.id,
+            "did_complete": True,
+            "completed_on": (today - timedelta(days=1)).isoformat(),
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["streak"] == 2

--- a/backend/tests/routers/test_goal_completions_streak_dedup.py
+++ b/backend/tests/routers/test_goal_completions_streak_dedup.py
@@ -21,7 +21,7 @@ from domain.dates import today_in_tz
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
-from services.streaks import SubtractiveContext
+from services.streaks import PendingCompletion, StreakScope, SubtractiveContext
 
 
 def _noon(day: date) -> datetime:
@@ -79,33 +79,48 @@ async def _seed_completion(db_session: AsyncSession, goal: Goal, user_id: int, d
     await db_session.commit()
 
 
-def _spy_streak_calls(monkeypatch: pytest.MonkeyPatch) -> list[int]:
-    """Patch the router's ``compute_consecutive_streak`` to count invocations."""
-    counter = [0]
-    real = gc_module.compute_consecutive_streak
+def _spy_streak_calls(monkeypatch: pytest.MonkeyPatch) -> tuple[list[int], list[int]]:
+    """Count BOTH streak entry points so a regression on either path is caught.
 
-    async def _counting(
+    Returns ``(consecutive_calls, before_after_calls)``. The persist path uses
+    ``compute_streak_before_and_after``; the held/idempotent paths use
+    ``compute_consecutive_streak``. Spying only one would let a double-call on
+    the other slip through.
+    """
+    consecutive = [0]
+    before_after = [0]
+    real_consecutive = gc_module.compute_consecutive_streak
+    real_before_after = gc_module.compute_streak_before_and_after
+
+    async def _count_consecutive(
         session: AsyncSession,
         goal_id: int,
         user_id: int,
         user_timezone: str = "UTC",
         subtractive: SubtractiveContext | None = None,
     ) -> int:
-        counter[0] += 1
-        return await real(session, goal_id, user_id, user_timezone, subtractive)
+        consecutive[0] += 1
+        return await real_consecutive(session, goal_id, user_id, user_timezone, subtractive)
 
-    monkeypatch.setattr(gc_module, "compute_consecutive_streak", _counting)
-    return counter
+    async def _count_before_after(
+        session: AsyncSession, scope: StreakScope, pending: PendingCompletion
+    ) -> tuple[int, int]:
+        before_after[0] += 1
+        return await real_before_after(session, scope, pending)
+
+    monkeypatch.setattr(gc_module, "compute_consecutive_streak", _count_consecutive)
+    monkeypatch.setattr(gc_module, "compute_streak_before_and_after", _count_before_after)
+    return consecutive, before_after
 
 
 @pytest.mark.asyncio
 async def test_checkin_computes_streak_at_most_once(
     async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A fresh check-in invokes compute_consecutive_streak at most once."""
+    """A fresh check-in computes the streak exactly once (one combined read)."""
     headers, user_id = await _signup(async_client)
     goal = await _seed_goal(db_session, user_id)
-    calls = _spy_streak_calls(monkeypatch)
+    consecutive, before_after = _spy_streak_calls(monkeypatch)
 
     resp = await async_client.post(
         "/goal_completions/", json={"goal_id": goal.id, "did_complete": True}, headers=headers
@@ -113,27 +128,31 @@ async def test_checkin_computes_streak_at_most_once(
 
     assert resp.status_code == HTTPStatus.OK
     assert resp.json()["streak"] == 1  # work still happened
-    assert calls[0] <= 1
+    # Persist path: one combined read, no separate consecutive recompute.
+    assert before_after[0] == 1
+    assert consecutive[0] == 0
 
 
 @pytest.mark.asyncio
 async def test_idempotent_checkin_computes_streak_at_most_once(
     async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A duplicate same-day check-in also computes the streak at most once."""
+    """A duplicate same-day check-in short-circuits with a single streak read."""
     headers, user_id = await _signup(async_client)
     goal = await _seed_goal(db_session, user_id)
     await async_client.post(
         "/goal_completions/", json={"goal_id": goal.id, "did_complete": True}, headers=headers
     )
 
-    calls = _spy_streak_calls(monkeypatch)
+    consecutive, before_after = _spy_streak_calls(monkeypatch)
     resp = await async_client.post(
         "/goal_completions/", json={"goal_id": goal.id, "did_complete": True}, headers=headers
     )
 
     assert resp.status_code == HTTPStatus.OK
-    assert calls[0] <= 1
+    # Idempotent path: one consecutive read, no persist-path combined read.
+    assert consecutive[0] == 1
+    assert before_after[0] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- A single goal check-in recomputed `compute_consecutive_streak` up to three times — once to capture `old_streak` (pre-insert) and once post-insert for `new_streak`, each a full completion-history scan (audit §5.3 redundant queries).
- `streaks.py`: extracted `_fetch_day_totals` + `_streak_from_day_totals` (pure core) and added **`compute_streak_before_and_after`**, which reads the history **once** and returns `(streak_before, streak_after)` by folding a pending completion into the day buckets exactly as the inserted row would be — so `streak_after` matches a post-insert recompute, **including backfill** (where `update_streak`'s `old + 1` would be wrong).
- `goal_completions.py`: the persist path derives both `old_streak` and `new_streak` from that single read and threads `new_streak` through `_persist_and_build_response` (no second recompute); the held path keeps its single pre-insert compute. `compute_consecutive_streak` now runs **at most once** per request.

## Test plan

- New `test_goal_completions_streak_dedup.py`: a fresh check-in and an idempotent (duplicate) check-in each invoke `compute_consecutive_streak` **≤1** (spy on the router-bound name).
- Value parity: a 2-prior-day chain + today's check-in → streak **3**; and a **backfill** that bridges a gap → streak **2** (proves the post-insert value is a true recompute, not `update_streak`'s `old + 1 = 1`).
- All existing `test_goal_completions.py` + `test_streaks.py` pass unchanged.
- `./scripts/backend/check-all.sh` — 7/7, coverage 95%+, ruff + mypy clean; xenon A verified.

Closes #479
Refs #459
