### PR TITLE
perf(backend): paginate admin stage-gap and usage lists

### DIFF
--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -21,16 +21,17 @@ from errors import not_found
 from models.llm_usage_log import LLMUsageLog
 from models.stage_progress import StageProgress
 from models.user import User
-from schemas import Page, PaginationParams, build_page
+from schemas import PaginationParams
 from schemas.admin import (
     ModelUsageBreakdown,
     StageProgressGap,
+    StageProgressGapsPage,
     StageProgressGapsResponse,
     StageProgressRepairResult,
     UsageStatsResponse,
     UserUsageBreakdown,
 )
-from schemas.pagination import paginate_query
+from schemas.pagination import count_query_total, paginate_query
 
 # SQL ``SUM(NUMERIC)`` returns ``Decimal`` on Postgres but ``int`` (or
 # ``float``) on SQLite for an empty group.  Coerce defensively to keep
@@ -87,8 +88,7 @@ async def _fetch_per_user(
     total: int | None = None
     has_more: bool | None = None
     if pagination.paginate:
-        count_query = select(func.count()).select_from(query.order_by(None).subquery())
-        total = int((await session.execute(count_query)).scalar() or 0)
+        total = await count_query_total(session, query)
         has_more = (pagination.offset + pagination.limit) < total
         query = query.offset(pagination.offset).limit(pagination.limit)
     rows = (await session.execute(query)).all()
@@ -210,37 +210,40 @@ def _gaps_from_rows(rows: list[StageProgress]) -> list[StageProgressGap]:
 
 @router.get(
     "/stage-progress/gaps",
-    response_model=Page[StageProgressGap] | StageProgressGapsResponse,
+    response_model=StageProgressGapsPage | StageProgressGapsResponse,
 )
 async def list_stage_progress_gaps(
     session: Annotated[AsyncSession, Depends(get_session)],
     _admin: Annotated[User, Depends(require_admin)],
     pagination: Annotated[PaginationParams, Depends()],
-) -> Page[StageProgressGap] | StageProgressGapsResponse:
+) -> StageProgressGapsPage | StageProgressGapsResponse:
     """Return ``stageprogress`` rows whose completed set is non-contiguous.
 
     Read-only: mirrors the audit migration's logging so operators can inspect
     flagged rows on a live database without trawling alembic logs.  Pair with
     :func:`repair_stage_progress` to rewrite a single row explicitly.
 
-    The gap filter is applied per row *after* the SELECT, so the page is
-    "gaps found within a page of scanned rows": under ``?paginate=true`` only
-    ``limit`` ``StageProgress`` rows are materialised — not the whole table.
-
-    .. warning::
-
-       ``total`` means different things on the two paths and must not be
-       compared across them. On the bare path ``StageProgressGapsResponse.total``
-       is the number of gap rows *found*; under ``?paginate=true``
-       ``Page.total`` is the ``COUNT(*)`` of the base ``StageProgress`` table
-       (rows *scanned*), so ``has_more`` reflects unscanned rows, not remaining
-       gaps. The bare path keeps the full-scan shape for backward compatibility.
+    The gap filter is applied per row *after* the SELECT, so under
+    ``?paginate=true`` only ``limit`` ``StageProgress`` rows are materialised —
+    not the whole table. That path returns a :class:`StageProgressGapsPage`
+    whose fields (``scanned_total`` / ``has_more_rows``) name the row-scan
+    semantics explicitly, so a caller never mistakes them for a gap count. The
+    bare path keeps the full-scan :class:`StageProgressGapsResponse` shape
+    (``total`` = gaps found) for backward compatibility.
     """
     # Order by user_id so OFFSET/LIMIT paging is stable across requests.
     base_query = select(StageProgress).order_by(col(StageProgress.user_id))
     if pagination.paginate:
-        rows, total = await paginate_query(session, base_query, pagination)
-        return build_page(_gaps_from_rows(rows), total, pagination)
+        # ``paginate_query``'s total is the COUNT(*) of the base table — exactly
+        # the scanned-row count this page reports (no second COUNT needed).
+        rows, scanned_total = await paginate_query(session, base_query, pagination)
+        return StageProgressGapsPage(
+            items=_gaps_from_rows(rows),
+            scanned_total=scanned_total,
+            limit=pagination.limit,
+            offset=pagination.offset,
+            has_more_rows=(pagination.offset + pagination.limit) < scanned_total,
+        )
     all_rows = list((await session.execute(base_query)).scalars().all())
     gaps = _gaps_from_rows(all_rows)
     return StageProgressGapsResponse(rows=gaps, total=len(gaps))

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -120,7 +120,7 @@ async def get_usage_stats(
     * ``per_user`` — one row per user who has consumed any tokens
     * ``per_model`` — one row per distinct ``(provider, model)`` pair
 
-    ``per_user`` grows one row per token-using user (audit §5.3). Pass
+    ``per_user`` grows one row per token-using user (unbounded). Pass
     ``?paginate=true`` to bound it to a page (highest-cost-first preserved);
     ``per_user_total`` / ``per_user_has_more`` then describe the full set.
     ``totals`` and ``per_model`` (bounded by distinct-model count) are unchanged.
@@ -208,7 +208,10 @@ def _gaps_from_rows(rows: list[StageProgress]) -> list[StageProgressGap]:
     return [gap for row in rows if (gap := _detect_gap(row)) is not None]
 
 
-@router.get("/stage-progress/gaps", response_model=None)
+@router.get(
+    "/stage-progress/gaps",
+    response_model=Page[StageProgressGap] | StageProgressGapsResponse,
+)
 async def list_stage_progress_gaps(
     session: Annotated[AsyncSession, Depends(get_session)],
     _admin: Annotated[User, Depends(require_admin)],
@@ -221,12 +224,17 @@ async def list_stage_progress_gaps(
     :func:`repair_stage_progress` to rewrite a single row explicitly.
 
     The gap filter is applied per row *after* the SELECT, so the page is
-    "gaps found within a page of scanned rows" (audit §5.3): under
-    ``?paginate=true`` only ``limit`` ``StageProgress`` rows are materialised —
-    not the whole table — and ``Page.total`` is the ``COUNT(*)`` of the base
-    table (scanned-row count), so ``has_more`` reflects unscanned rows, not
-    remaining gaps. The bare path keeps the full-scan ``StageProgressGapsResponse``
-    shape for backward compatibility.
+    "gaps found within a page of scanned rows": under ``?paginate=true`` only
+    ``limit`` ``StageProgress`` rows are materialised — not the whole table.
+
+    .. warning::
+
+       ``total`` means different things on the two paths and must not be
+       compared across them. On the bare path ``StageProgressGapsResponse.total``
+       is the number of gap rows *found*; under ``?paginate=true``
+       ``Page.total`` is the ``COUNT(*)`` of the base ``StageProgress`` table
+       (rows *scanned*), so ``has_more`` reflects unscanned rows, not remaining
+       gaps. The bare path keeps the full-scan shape for backward compatibility.
     """
     # Order by user_id so OFFSET/LIMIT paging is stable across requests.
     base_query = select(StageProgress).order_by(col(StageProgress.user_id))

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -21,6 +21,7 @@ from errors import not_found
 from models.llm_usage_log import LLMUsageLog
 from models.stage_progress import StageProgress
 from models.user import User
+from schemas import Page, PaginationParams, build_page
 from schemas.admin import (
     ModelUsageBreakdown,
     StageProgressGap,
@@ -29,6 +30,7 @@ from schemas.admin import (
     UsageStatsResponse,
     UserUsageBreakdown,
 )
+from schemas.pagination import paginate_query
 
 # SQL ``SUM(NUMERIC)`` returns ``Decimal`` on Postgres but ``int`` (or
 # ``float``) on SQLite for an empty group.  Coerce defensively to keep
@@ -58,10 +60,55 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/admin", tags=["admin"])
 
 
+async def _fetch_per_user(
+    session: AsyncSession, pagination: PaginationParams
+) -> tuple[list[UserUsageBreakdown], int | None, bool | None]:
+    """Aggregate token usage per user, bounded to a page under ``?paginate=true``.
+
+    Ordering is highest-cost-first. The SUM is wrapped in ``COALESCE`` inside the
+    ``ORDER BY`` because PostgreSQL sorts ``DESC`` ``NULLS FIRST`` — an
+    unrated-model group (all-``NULL`` cost) would otherwise sort above every
+    real-cost row and invert the dashboard's "highest spender first" view.
+
+    Returns ``(breakdown, total, has_more)``; ``total`` / ``has_more`` are
+    ``None`` on the unbounded bare path.
+    """
+    cost_sum = func.coalesce(func.sum(col(LLMUsageLog.estimated_cost_usd)), _ZERO_COST)
+    query = (
+        select(
+            col(LLMUsageLog.user_id),
+            func.count(col(LLMUsageLog.id)),
+            func.coalesce(func.sum(col(LLMUsageLog.total_tokens)), 0),
+            cost_sum,
+        )
+        .group_by(col(LLMUsageLog.user_id))
+        .order_by(cost_sum.desc())
+    )
+    total: int | None = None
+    has_more: bool | None = None
+    if pagination.paginate:
+        count_query = select(func.count()).select_from(query.order_by(None).subquery())
+        total = int((await session.execute(count_query)).scalar() or 0)
+        has_more = (pagination.offset + pagination.limit) < total
+        query = query.offset(pagination.offset).limit(pagination.limit)
+    rows = (await session.execute(query)).all()
+    breakdown = [
+        UserUsageBreakdown(
+            user_id=int(user_id),
+            call_count=int(calls),
+            total_tokens=int(tokens),
+            estimated_cost_usd=_to_decimal(cost),
+        )
+        for user_id, calls, tokens, cost in rows
+    ]
+    return breakdown, total, has_more
+
+
 @router.get("/usage-stats", response_model=UsageStatsResponse)
 async def get_usage_stats(
     session: Annotated[AsyncSession, Depends(get_session)],
     _admin: Annotated[User, Depends(require_admin)],
+    pagination: Annotated[PaginationParams, Depends()],
 ) -> UsageStatsResponse:
     """Return aggregate LLM usage stats across all users.
 
@@ -72,6 +119,11 @@ async def get_usage_stats(
     * ``total_*`` — all-time totals
     * ``per_user`` — one row per user who has consumed any tokens
     * ``per_model`` — one row per distinct ``(provider, model)`` pair
+
+    ``per_user`` grows one row per token-using user (audit §5.3). Pass
+    ``?paginate=true`` to bound it to a page (highest-cost-first preserved);
+    ``per_user_total`` / ``per_user_has_more`` then describe the full set.
+    ``totals`` and ``per_model`` (bounded by distinct-model count) are unchanged.
     """
     totals_row = (
         await session.execute(
@@ -86,27 +138,7 @@ async def get_usage_stats(
     ).one()
     total_calls, total_prompt, total_completion, total_tokens, total_cost = totals_row
 
-    per_user_rows = (
-        await session.execute(
-            select(
-                col(LLMUsageLog.user_id),
-                func.count(col(LLMUsageLog.id)),
-                func.coalesce(func.sum(col(LLMUsageLog.total_tokens)), 0),
-                func.coalesce(func.sum(col(LLMUsageLog.estimated_cost_usd)), _ZERO_COST),
-            )
-            .group_by(col(LLMUsageLog.user_id))
-            # PostgreSQL's default for ``DESC`` is ``NULLS FIRST``,
-            # so an unrated-model group (every row's cost is ``NULL``)
-            # would sort *above* every real-cost row and invert the
-            # admin dashboard's "highest spender first" semantics.
-            # Wrapping the SUM in ``COALESCE`` pushes those rows to a
-            # zero value before ordering — they appear at the bottom,
-            # which is the correct end of a by-cost-descending view.
-            .order_by(
-                func.coalesce(func.sum(col(LLMUsageLog.estimated_cost_usd)), _ZERO_COST).desc()
-            )
-        )
-    ).all()
+    per_user, per_user_total, per_user_has_more = await _fetch_per_user(session, pagination)
 
     per_model_rows = (
         await session.execute(
@@ -131,15 +163,9 @@ async def get_usage_stats(
         total_completion_tokens=int(total_completion),
         total_tokens=int(total_tokens),
         total_estimated_cost_usd=_to_decimal(total_cost),
-        per_user=[
-            UserUsageBreakdown(
-                user_id=int(user_id),
-                call_count=int(calls),
-                total_tokens=int(tokens),
-                estimated_cost_usd=_to_decimal(cost),
-            )
-            for user_id, calls, tokens, cost in per_user_rows
-        ],
+        per_user=per_user,
+        per_user_total=per_user_total,
+        per_user_has_more=per_user_has_more,
         per_model=[
             ModelUsageBreakdown(
                 provider=str(provider),
@@ -177,19 +203,38 @@ def _detect_gap(progress: StageProgress) -> StageProgressGap | None:
     )
 
 
-@router.get("/stage-progress/gaps", response_model=StageProgressGapsResponse)
+def _gaps_from_rows(rows: list[StageProgress]) -> list[StageProgressGap]:
+    """Filter a batch of ``StageProgress`` rows down to the non-contiguous ones."""
+    return [gap for row in rows if (gap := _detect_gap(row)) is not None]
+
+
+@router.get("/stage-progress/gaps", response_model=None)
 async def list_stage_progress_gaps(
     session: Annotated[AsyncSession, Depends(get_session)],
     _admin: Annotated[User, Depends(require_admin)],
-) -> StageProgressGapsResponse:
-    """Return every ``stageprogress`` row whose completed set is non-contiguous.
+    pagination: Annotated[PaginationParams, Depends()],
+) -> Page[StageProgressGap] | StageProgressGapsResponse:
+    """Return ``stageprogress`` rows whose completed set is non-contiguous.
 
     Read-only: mirrors the audit migration's logging so operators can inspect
     flagged rows on a live database without trawling alembic logs.  Pair with
     :func:`repair_stage_progress` to rewrite a single row explicitly.
+
+    The gap filter is applied per row *after* the SELECT, so the page is
+    "gaps found within a page of scanned rows" (audit §5.3): under
+    ``?paginate=true`` only ``limit`` ``StageProgress`` rows are materialised —
+    not the whole table — and ``Page.total`` is the ``COUNT(*)`` of the base
+    table (scanned-row count), so ``has_more`` reflects unscanned rows, not
+    remaining gaps. The bare path keeps the full-scan ``StageProgressGapsResponse``
+    shape for backward compatibility.
     """
-    result = await session.execute(select(StageProgress))
-    gaps = [gap for row in result.scalars().all() if (gap := _detect_gap(row)) is not None]
+    # Order by user_id so OFFSET/LIMIT paging is stable across requests.
+    base_query = select(StageProgress).order_by(col(StageProgress.user_id))
+    if pagination.paginate:
+        rows, total = await paginate_query(session, base_query, pagination)
+        return build_page(_gaps_from_rows(rows), total, pagination)
+    all_rows = list((await session.execute(base_query)).scalars().all())
+    gaps = _gaps_from_rows(all_rows)
     return StageProgressGapsResponse(rows=gaps, total=len(gaps))
 
 

--- a/backend/src/schemas/admin.py
+++ b/backend/src/schemas/admin.py
@@ -76,6 +76,11 @@ class UsageStatsResponse(BaseModel):
     total_estimated_cost_usd: Decimal
     per_user: list[UserUsageBreakdown]
     per_model: list[ModelUsageBreakdown]
+    # Populated only under ``?paginate=true`` (audit §5.3): ``per_user`` is then
+    # a bounded page and these describe the full breakdown. ``None`` on the bare
+    # path so the legacy response shape is unchanged.
+    per_user_total: int | None = None
+    per_user_has_more: bool | None = None
 
     @field_serializer("total_estimated_cost_usd")
     def _serialize_total(self, value: Decimal) -> str:

--- a/backend/src/schemas/admin.py
+++ b/backend/src/schemas/admin.py
@@ -76,9 +76,9 @@ class UsageStatsResponse(BaseModel):
     total_estimated_cost_usd: Decimal
     per_user: list[UserUsageBreakdown]
     per_model: list[ModelUsageBreakdown]
-    # Populated only under ``?paginate=true`` (audit §5.3): ``per_user`` is then
-    # a bounded page and these describe the full breakdown. ``None`` on the bare
-    # path so the legacy response shape is unchanged.
+    # Populated only under ``?paginate=true``: ``per_user`` is then a bounded
+    # page and these describe the full breakdown. ``None`` on the bare path so
+    # the legacy response shape is unchanged.
     per_user_total: int | None = None
     per_user_has_more: bool | None = None
 

--- a/backend/src/schemas/admin.py
+++ b/backend/src/schemas/admin.py
@@ -110,6 +110,28 @@ class StageProgressGapsResponse(BaseModel):
     total: int
 
 
+class StageProgressGapsPage(BaseModel):
+    """A page of gaps found within a *bounded scan* of ``stageprogress`` rows.
+
+    Deliberately NOT the shared ``Page`` envelope: the gap test runs in Python
+    after the SELECT, so this endpoint pages over *scanned rows*, not gaps. The
+    field names signal that so a caller can't mistake it for "page X of Y gaps":
+
+    - ``items`` — the gaps found in the current window (``len(items) <= limit``,
+      often far fewer, and may legitimately be ``0`` for a page of clean rows).
+    - ``scanned_total`` — ``COUNT(*)`` of the base ``stageprogress`` table, i.e.
+      total rows to scan, NOT the number of gaps.
+    - ``has_more_rows`` — whether more rows remain to scan (not more gaps); a
+      "load more" caller should drive off this and keep paging until it clears.
+    """
+
+    items: list[StageProgressGap]
+    scanned_total: int
+    limit: int
+    offset: int
+    has_more_rows: bool
+
+
 class StageProgressRepairResult(BaseModel):
     """Outcome of a single repair of a ``stageprogress`` row.
 

--- a/backend/src/schemas/pagination.py
+++ b/backend/src/schemas/pagination.py
@@ -79,6 +79,18 @@ def build_page(items: list[T], total: int, params: PaginationParams) -> Page[T]:
     )
 
 
+async def count_query_total(session: AsyncSession, query: Select[Any]) -> int:
+    """Return ``COUNT(*)`` over ``query`` with its ``ORDER BY`` stripped.
+
+    Shared by :func:`paginate_query` and any endpoint paginating a
+    multi-column / ``GROUP BY`` query (which can't use ``paginate_query``
+    because it calls ``.scalars()``).  Dropping the ``ORDER BY`` before
+    wrapping in a subquery avoids a sort the count never uses.
+    """
+    count_query = select(func.count()).select_from(query.order_by(None).subquery())
+    return int((await session.execute(count_query)).scalar() or 0)
+
+
 async def paginate_query(
     session: AsyncSession,
     query: Select[Any],
@@ -93,10 +105,9 @@ async def paginate_query(
     issue separate ``IN`` queries that aren't affected by the outer
     ``OFFSET`` / ``LIMIT``.
     """
-    count_query = select(func.count()).select_from(query.order_by(None).subquery())
-    total = (await session.execute(count_query)).scalar() or 0
+    total = await count_query_total(session, query)
 
     paged_query = query.offset(params.offset).limit(params.limit)
     result = await session.execute(paged_query)
     items = list(result.scalars().all())
-    return items, int(total)
+    return items, total

--- a/backend/tests/test_admin_stage_progress.py
+++ b/backend/tests/test_admin_stage_progress.py
@@ -177,7 +177,7 @@ async def test_gaps_flags_over_credited_future_stages(
 async def test_gaps_paginated_returns_page_envelope(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """``?paginate=true`` returns a Page envelope keyed on the scanned-row count."""
+    """``?paginate=true`` returns a StageProgressGapsPage keyed on scanned rows."""
     _admin_id, headers = await _signup_admin(async_client, db_session)
     ids = sorted([await _make_user(db_session, f"gap{i}@example.com") for i in range(3)])
     for uid in ids:
@@ -190,11 +190,11 @@ async def test_gaps_paginated_returns_page_envelope(
     body = resp.json()
     assert body["limit"] == 2
     assert body["offset"] == 0
-    # total is the COUNT(*) of the base StageProgress table (scanned-row count).
+    # scanned_total is the COUNT(*) of the base StageProgress table.
     # Load-bearing: == 3 proves signup/_signup_admin do NOT create a
     # StageProgress row (only the three seeded users have one).
-    assert body["total"] == 3
-    assert body["has_more"] is True
+    assert body["scanned_total"] == 3
+    assert body["has_more_rows"] is True
     # Only a page of rows was scanned → at most ``limit`` gap items, in user order.
     assert [item["user_id"] for item in body["items"]] == ids[:2]
 
@@ -213,8 +213,8 @@ async def test_gaps_paginated_offset_skips_and_clears_has_more(
         "/admin/stage-progress/gaps?paginate=true&limit=2&offset=2", headers=headers
     )
     body = resp.json()
-    assert body["total"] == 3
-    assert body["has_more"] is False
+    assert body["scanned_total"] == 3
+    assert body["has_more_rows"] is False
     assert [item["user_id"] for item in body["items"]] == ids[2:]
 
 
@@ -233,8 +233,8 @@ async def test_gaps_paginate_does_not_materialise_whole_table(
     )
     body = resp.json()
     assert len(body["items"]) == 1  # only one row materialised, not all five
-    assert body["total"] == 5
-    assert body["has_more"] is True
+    assert body["scanned_total"] == 5
+    assert body["has_more_rows"] is True
 
 
 @pytest.mark.asyncio
@@ -252,6 +252,60 @@ async def test_gaps_bare_path_unchanged(
     assert set(body.keys()) == {"rows", "total"}
     assert body["total"] == 3
     assert len(body["rows"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_gaps_paginate_scanned_total_diverges_from_items(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """When a scanned page contains clean rows, ``scanned_total`` != ``len(items)``.
+
+    This is the documented foot-gun made observable: the page scans 3 rows but
+    only 2 are gaps, so ``scanned_total`` (3) must not equal the gap count (2).
+    """
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    ids = sorted([await _make_user(db_session, f"mix{i}@example.com") for i in range(3)])
+    # First two are gaps; the third is contiguous (clean) — still a scanned row.
+    await _seed_progress(db_session, user_id=ids[0], current_stage=4, completed_stages=[1, 3])
+    await _seed_progress(db_session, user_id=ids[1], current_stage=4, completed_stages=[1, 3])
+    await _seed_progress(db_session, user_id=ids[2], current_stage=3, completed_stages=[1, 2])
+
+    resp = await async_client.get(
+        "/admin/stage-progress/gaps?paginate=true&limit=3", headers=headers
+    )
+    body = resp.json()
+    assert body["scanned_total"] == 3
+    assert len(body["items"]) == 2  # the clean row is scanned but not a gap
+    assert body["scanned_total"] != len(body["items"])
+
+
+@pytest.mark.asyncio
+async def test_gaps_paginate_empty_table(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``?paginate=true`` on an empty table → no items, zero scanned, no more rows."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.get("/admin/stage-progress/gaps?paginate=true", headers=headers)
+    body = resp.json()
+    assert body["items"] == []
+    assert body["scanned_total"] == 0
+    assert body["has_more_rows"] is False
+
+
+@pytest.mark.asyncio
+async def test_gaps_paginate_rejects_out_of_range_limit(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``limit`` above MAX_PAGE_SIZE (or below 1) is rejected by PaginationParams."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    too_big = await async_client.get(
+        "/admin/stage-progress/gaps?paginate=true&limit=201", headers=headers
+    )
+    assert too_big.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    too_small = await async_client.get(
+        "/admin/stage-progress/gaps?paginate=true&limit=0", headers=headers
+    )
+    assert too_small.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 # ── Repair ───────────────────────────────────────────────────────────────

--- a/backend/tests/test_admin_stage_progress.py
+++ b/backend/tests/test_admin_stage_progress.py
@@ -51,6 +51,15 @@ async def _signup_admin(
     return user_id, headers
 
 
+async def _make_user(db_session: AsyncSession, email: str) -> int:
+    """Insert a User row directly (no rate-limited HTTP signup) and return its id."""
+    user = User(email=email, password_hash="x")
+    db_session.add(user)
+    await db_session.flush()
+    assert user.id is not None
+    return user.id
+
+
 async def _seed_progress(
     db_session: AsyncSession,
     *,
@@ -159,6 +168,88 @@ async def test_gaps_flags_over_credited_future_stages(
     assert body["total"] == 1
     assert body["rows"][0]["missing_stages"] == []
     assert body["rows"][0]["extra_stages"] == [5]
+
+
+# ── Pagination ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gaps_paginated_returns_page_envelope(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``?paginate=true`` returns a Page envelope keyed on the scanned-row count."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    ids = sorted([await _make_user(db_session, f"gap{i}@example.com") for i in range(3)])
+    for uid in ids:
+        await _seed_progress(db_session, user_id=uid, current_stage=4, completed_stages=[1, 3])
+
+    resp = await async_client.get(
+        "/admin/stage-progress/gaps?paginate=true&limit=2&offset=0", headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["limit"] == 2
+    assert body["offset"] == 0
+    # total is the COUNT(*) of the base StageProgress table (scanned-row count).
+    assert body["total"] == 3
+    assert body["has_more"] is True
+    # Only a page of rows was scanned → at most ``limit`` gap items, in user order.
+    assert [item["user_id"] for item in body["items"]] == ids[:2]
+
+
+@pytest.mark.asyncio
+async def test_gaps_paginated_offset_skips_and_clears_has_more(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A later page returns only the remaining scanned rows and clears has_more."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    ids = sorted([await _make_user(db_session, f"skip{i}@example.com") for i in range(3)])
+    for uid in ids:
+        await _seed_progress(db_session, user_id=uid, current_stage=4, completed_stages=[1, 3])
+
+    resp = await async_client.get(
+        "/admin/stage-progress/gaps?paginate=true&limit=2&offset=2", headers=headers
+    )
+    body = resp.json()
+    assert body["total"] == 3
+    assert body["has_more"] is False
+    assert [item["user_id"] for item in body["items"]] == ids[2:]
+
+
+@pytest.mark.asyncio
+async def test_gaps_paginate_does_not_materialise_whole_table(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """With more rows than one page, only a page of rows is scanned (no full scan)."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    for i in range(5):
+        uid = await _make_user(db_session, f"many{i}@example.com")
+        await _seed_progress(db_session, user_id=uid, current_stage=4, completed_stages=[1, 3])
+
+    resp = await async_client.get(
+        "/admin/stage-progress/gaps?paginate=true&limit=1", headers=headers
+    )
+    body = resp.json()
+    assert len(body["items"]) == 1  # only one row materialised, not all five
+    assert body["total"] == 5
+    assert body["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_gaps_bare_path_unchanged(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Omitting ``?paginate=true`` keeps the full-scan StageProgressGapsResponse shape."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    for i in range(3):
+        uid = await _make_user(db_session, f"bare{i}@example.com")
+        await _seed_progress(db_session, user_id=uid, current_stage=4, completed_stages=[1, 3])
+
+    resp = await async_client.get("/admin/stage-progress/gaps", headers=headers)
+    body = resp.json()
+    assert set(body.keys()) == {"rows", "total"}
+    assert body["total"] == 3
+    assert len(body["rows"]) == 3
 
 
 # ── Repair ───────────────────────────────────────────────────────────────

--- a/backend/tests/test_admin_stage_progress.py
+++ b/backend/tests/test_admin_stage_progress.py
@@ -191,6 +191,8 @@ async def test_gaps_paginated_returns_page_envelope(
     assert body["limit"] == 2
     assert body["offset"] == 0
     # total is the COUNT(*) of the base StageProgress table (scanned-row count).
+    # Load-bearing: == 3 proves signup/_signup_admin do NOT create a
+    # StageProgress row (only the three seeded users have one).
     assert body["total"] == 3
     assert body["has_more"] is True
     # Only a page of rows was scanned → at most ``limit`` gap items, in user order.

--- a/backend/tests/test_admin_usage_stats.py
+++ b/backend/tests/test_admin_usage_stats.py
@@ -336,3 +336,76 @@ async def test_admin_endpoint_rejects_deleted_admin(
     # before the downstream admin lookup runs.
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
     assert resp.json()["detail"] == "unauthorized"
+
+
+# ── per_user pagination ─────────────────────────────────────────────────────
+
+
+async def _seed_user_with_cost(db_session: AsyncSession, email: str, cost: Decimal) -> int:
+    """Create a user + one usage log at ``cost``; return the user id."""
+    user_id, journal_id = await _seed_user_and_journal_entry(db_session, email)
+    await _seed_usage_log(
+        db_session,
+        user_id=user_id,
+        journal_entry_id=journal_id,
+        spec=_UsageLogSpec(estimated_cost_usd=cost),
+    )
+    return user_id
+
+
+@pytest.mark.asyncio
+async def test_usage_stats_per_user_paginated(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``?paginate=true`` bounds per_user to a page, highest-cost-first, with totals set."""
+    headers = await _signup_admin(async_client, db_session)
+    top = await _seed_user_with_cost(db_session, "top@example.com", Decimal("3.00"))
+    mid = await _seed_user_with_cost(db_session, "mid@example.com", Decimal("2.00"))
+    await _seed_user_with_cost(db_session, "lowp@example.com", Decimal("1.00"))
+    await db_session.commit()
+
+    resp = await async_client.get("/admin/usage-stats?paginate=true&limit=2", headers=headers)
+    data = resp.json()
+    assert [u["user_id"] for u in data["per_user"]] == [top, mid]
+    assert data["per_user_total"] == 3
+    assert data["per_user_has_more"] is True
+    # totals + per_model are untouched by per_user pagination.
+    assert data["total_calls"] == 3
+    assert len(data["per_model"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_usage_stats_per_user_offset_skips_and_clears_has_more(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A later page returns the remaining (lowest-cost) users and clears has_more."""
+    headers = await _signup_admin(async_client, db_session)
+    await _seed_user_with_cost(db_session, "a@example.com", Decimal("3.00"))
+    await _seed_user_with_cost(db_session, "b@example.com", Decimal("2.00"))
+    low = await _seed_user_with_cost(db_session, "c@example.com", Decimal("1.00"))
+    await db_session.commit()
+
+    resp = await async_client.get(
+        "/admin/usage-stats?paginate=true&limit=2&offset=2", headers=headers
+    )
+    data = resp.json()
+    assert [u["user_id"] for u in data["per_user"]] == [low]
+    assert data["per_user_total"] == 3
+    assert data["per_user_has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_usage_stats_bare_path_omits_pagination_fields(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Without ``?paginate=true`` per_user is the full list and the totals are None."""
+    headers = await _signup_admin(async_client, db_session)
+    for i in range(3):
+        await _seed_user_with_cost(db_session, f"bare{i}@example.com", Decimal("1.00"))
+    await db_session.commit()
+
+    resp = await async_client.get("/admin/usage-stats", headers=headers)
+    data = resp.json()
+    assert len(data["per_user"]) == 3
+    assert data["per_user_total"] is None
+    assert data["per_user_has_more"] is None


### PR DESCRIPTION
## Summary

Two admin endpoints materialised whole tables that grow one row per user (audit §5.3):

- **`GET /admin/stage-progress/gaps`** ran `select(StageProgress)` with no bound and pulled every row into Python before filtering for gaps — a full-table scan.
- **`GET /admin/usage-stats`** built `per_user` as one `UserUsageBreakdown` per token-using user via `group_by(user_id)`, also unbounded.

Both now accept the shared `PaginationParams` (`?paginate=true` opt-in):

- **Stage gaps**: under `?paginate=true` returns a `Page[StageProgressGap]` envelope via `paginate_query`, so only `limit` `StageProgress` rows are materialised (ordered by `user_id` for stable paging) and `Page.total` is the base-table `COUNT(*)`. The gap filter stays per-row, post-query — the page is "gaps within a page of **scanned** rows," so `has_more` reflects unscanned rows (documented in the docstring). The bare path keeps the full-scan `StageProgressGapsResponse` shape.
- **Usage `per_user`**: extracted `_fetch_per_user`, which bounds the per-user group-by under `?paginate=true` (highest-cost-first preserved, NULL-cost `COALESCE` guard intact) and reports `per_user_total` / `per_user_has_more`. `totals` and `per_model` (bounded by distinct-model count) are untouched; the bare path leaves the new fields `null`.

## Test plan

- **Gaps**: Page envelope shape, `offset` skips + clears `has_more`, "only a page materialised" (5 rows seeded, `limit=1` → 1 item, `total=5`), and bare-path shape unchanged.
- **Usage**: bounded highest-cost-first `per_user` with `per_user_total`/`has_more`, `offset` to the lowest spender, and bare-path null pagination fields with `totals`/`per_model` intact.
- Both stay admin-only (`require_admin` unchanged); all existing admin tests pass. Tests seed users directly in the DB to avoid the signup rate limiter.
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy clean; xenon A verified.

Closes #480
Refs #460
