### PR TITLE
feat(backend): persist energy plans to a durable table

### DIFF
--- a/backend/migrations/versions/c8d9e0f1a2b3_add_energy_plan.py
+++ b/backend/migrations/versions/c8d9e0f1a2b3_add_energy_plan.py
@@ -1,0 +1,60 @@
+"""add energyplan table for durable energy-plan persistence
+
+Revision ID: c8d9e0f1a2b3
+Revises: e3f4a5b6c7d8
+Create Date: 2026-06-25 00:00:00.000000
+
+Generated energy plans used to live only in a per-process ``TTLCache``: lost on
+restart and divergent across workers for the same ``idempotency_key``. This
+table makes a plan a durable, cross-worker record so a keyed retry replays the
+stored plan verbatim.
+
+Purely additive: ``upgrade`` creates the table and its two indexes; ``downgrade``
+drops them. No ``ALTER`` / ``DROP`` against existing tables. The partial UNIQUE
+index on ``(user_id, idempotency_key)`` only constrains non-NULL keys, so
+unkeyed requests each get their own row.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d9e0f1a2b3"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e3f4a5b6c7d8"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the ``energyplan`` table and its indexes."""
+    op.create_table(
+        "energyplan",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=255), nullable=True),
+        sa.Column("plan_json", sa.Text(), nullable=False),
+        sa.Column("reason_code", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_energyplan_user_id", "energyplan", ["user_id"])
+    # Deduplicate keyed requests per (user, key); NULL keys are unconstrained
+    # so unkeyed plans each get their own row.
+    op.create_index(
+        "ix_energyplan_user_idem_key",
+        "energyplan",
+        ["user_id", "idempotency_key"],
+        unique=True,
+        postgresql_where=sa.text("idempotency_key IS NOT NULL"),
+        sqlite_where=sa.text("idempotency_key IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``energyplan`` table and its indexes."""
+    op.drop_index("ix_energyplan_user_idem_key", table_name="energyplan")
+    op.drop_index("ix_energyplan_user_id", table_name="energyplan")
+    op.drop_table("energyplan")

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -3,6 +3,7 @@
 from .chat_spend import ChatSpend
 from .content_completion import ContentCompletion
 from .course_stage import CourseStage
+from .energy_plan import EnergyPlan
 from .goal import Goal
 from .goal_completion import GoalCompletion
 from .goal_group import GoalGroup
@@ -28,6 +29,7 @@ __all__ = [
     "ChatSpend",
     "ContentCompletion",
     "CourseStage",
+    "EnergyPlan",
     "Goal",
     "GoalCompletion",
     "GoalGroup",

--- a/backend/src/models/energy_plan.py
+++ b/backend/src/models/energy_plan.py
@@ -1,0 +1,70 @@
+"""Durable storage for generated energy plans.
+
+Generated plans used to live only in a per-process ``TTLCache``: they were
+lost on restart and, under multiple workers, the same ``idempotency_key``
+yielded different plans on different workers. This table makes the plan a
+durable, cross-worker record — a keyed retry returns the stored plan verbatim.
+
+One row is written per generated plan. Keyed requests are deduplicated by a
+partial UNIQUE index on ``(user_id, idempotency_key)`` (only where the key is
+non-NULL), mirroring the prod/SQLite partial-index convention used elsewhere.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, DateTime, Index, String, Text
+from sqlmodel import Field, SQLModel
+
+# Client-supplied idempotency keys are short opaque tokens; 255 leaves ample
+# headroom while keeping the partial-unique index narrow.
+_IDEM_KEY_WIDTH = 255
+# Reason codes are bounded enum-like strings (e.g. ``generated_21_day_plan``).
+_REASON_CODE_WIDTH = 64
+
+# Detached column used ONLY to build the partial-index WHERE expression
+# (mirrors the ``_OWNER_COLUMN`` pattern in ``practice_recipe``). It matches
+# the real ``idempotency_key`` column by name at DDL-compile time and is never
+# attached to the table itself.
+_IDEM_KEY_COLUMN = Column("idempotency_key", String(_IDEM_KEY_WIDTH), nullable=True)
+
+
+class EnergyPlan(SQLModel, table=True):
+    """A durably-stored generated energy plan, deduplicated by idempotency key.
+
+    ``plan_json`` is the serialized ``schemas.energy.EnergyPlan`` payload and
+    ``reason_code`` the generator's reason; together they reconstruct the exact
+    ``EnergyPlanResponse`` a retry should replay. ``idempotency_key`` is NULL
+    for unkeyed requests (each gets its own row); keyed requests collide on the
+    partial UNIQUE index so a concurrent duplicate insert raises
+    ``IntegrityError`` and the caller re-reads the stored row.
+    """
+
+    __tablename__ = "energyplan"
+    __table_args__ = (
+        Index(
+            "ix_energyplan_user_idem_key",
+            "user_id",
+            "idempotency_key",
+            unique=True,
+            postgresql_where=_IDEM_KEY_COLUMN.is_not(None),
+            sqlite_where=_IDEM_KEY_COLUMN.is_not(None),
+        ),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
+    idempotency_key: str | None = Field(
+        default=None,
+        sa_column=Column(String(_IDEM_KEY_WIDTH), nullable=True),
+    )
+    # Serialized ``schemas.energy.EnergyPlan`` (JSON string). ``Text`` (not
+    # ``String``) so the model matches the migration's ``sa.Text()`` exactly and
+    # ``alembic --autogenerate`` does not flag a spurious diff.
+    plan_json: str = Field(sa_column=Column(Text, nullable=False))
+    reason_code: str = Field(sa_column=Column(String(_REASON_CODE_WIDTH), nullable=False))
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/src/models/energy_plan.py
+++ b/backend/src/models/energy_plan.py
@@ -18,8 +18,10 @@ from sqlalchemy import Column, DateTime, Index, String, Text
 from sqlmodel import Field, SQLModel
 
 # Client-supplied idempotency keys are short opaque tokens; 255 leaves ample
-# headroom while keeping the partial-unique index narrow.
-_IDEM_KEY_WIDTH = 255
+# headroom while keeping the partial-unique index narrow. Public so the router
+# can reject an over-long ``X-Idempotency-Key`` with a clean 422 instead of a
+# native DB error.
+IDEM_KEY_MAX_LENGTH = 255
 # Reason codes are bounded enum-like strings (e.g. ``generated_21_day_plan``).
 _REASON_CODE_WIDTH = 64
 
@@ -27,7 +29,7 @@ _REASON_CODE_WIDTH = 64
 # (mirrors the ``_OWNER_COLUMN`` pattern in ``practice_recipe``). It matches
 # the real ``idempotency_key`` column by name at DDL-compile time and is never
 # attached to the table itself.
-_IDEM_KEY_COLUMN = Column("idempotency_key", String(_IDEM_KEY_WIDTH), nullable=True)
+_IDEM_KEY_COLUMN = Column("idempotency_key", String(IDEM_KEY_MAX_LENGTH), nullable=True)
 
 
 class EnergyPlan(SQLModel, table=True):
@@ -57,7 +59,7 @@ class EnergyPlan(SQLModel, table=True):
     user_id: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
     idempotency_key: str | None = Field(
         default=None,
-        sa_column=Column(String(_IDEM_KEY_WIDTH), nullable=True),
+        sa_column=Column(String(IDEM_KEY_MAX_LENGTH), nullable=True),
     )
     # Serialized ``schemas.energy.EnergyPlan`` (JSON string). ``Text`` (not
     # ``String``) so the model matches the migration's ``sa.Text()`` exactly and

--- a/backend/src/routers/energy.py
+++ b/backend/src/routers/energy.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, Header
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import get_session
+from models.energy_plan import IDEM_KEY_MAX_LENGTH
 from routers.auth import get_current_user
 from schemas import EnergyPlanRequest, EnergyPlanResponse
 from services.energy import get_or_create_persisted_plan, resolve_trusted_habits
@@ -23,7 +24,7 @@ async def create_plan(
     payload: EnergyPlanRequest,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
-    x_idempotency_key: Annotated[str | None, Header()] = None,
+    x_idempotency_key: Annotated[str | None, Header(max_length=IDEM_KEY_MAX_LENGTH)] = None,
 ) -> EnergyPlanResponse:
     """Create an energy plan from the caller's own habits.
 

--- a/backend/src/routers/energy.py
+++ b/backend/src/routers/energy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Annotated
 
@@ -12,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from database import get_session
 from routers.auth import get_current_user
 from schemas import EnergyPlanRequest, EnergyPlanResponse
-from services.energy import get_or_generate_plan, resolve_trusted_habits
+from services.energy import get_or_create_persisted_plan, resolve_trusted_habits
 
 logger = logging.getLogger(__name__)
 
@@ -39,13 +38,14 @@ async def create_plan(
     closes the remainder of BUG-PRACTICE-010 — the plan can no longer be
     steered by forged client values.
 
-    BUG-INFRA-009: ``generate_plan`` performs CPU-bound scheduling work, so it
-    is offloaded via :func:`asyncio.to_thread`; the (async) habit lookup runs
-    on the event loop first, then the CPU work runs off-loop.
+    The generated plan is persisted to the ``energyplan`` table keyed by
+    ``(current_user, X-Idempotency-Key)``, so a keyed retry replays the stored
+    plan across restarts and workers. ``generate_plan`` is CPU-bound and runs
+    off the event loop (BUG-INFRA-009); see ``get_or_create_persisted_plan``.
     """
     trusted = await resolve_trusted_habits(session, current_user, payload)
-    response = await asyncio.to_thread(
-        get_or_generate_plan, trusted, payload.start_date, x_idempotency_key
+    response = await get_or_create_persisted_plan(
+        session, current_user, trusted, payload.start_date, x_idempotency_key
     )
     logger.info(
         "energy_plan_created",

--- a/backend/src/services/energy.py
+++ b/backend/src/services/energy.py
@@ -1,43 +1,33 @@
-"""Energy-plan generation service with idempotency caching.
+"""Energy-plan generation service with durable, cross-worker persistence.
 
-The router layer is a thin HTTP adapter: it accepts a request, resolves the
-caller's trusted habit costs server-side via :func:`resolve_trusted_habits`,
-then hands those to :func:`get_or_generate_plan` and returns the response. The
-idempotency cache lives here (not in the router) so background regeneration
-jobs, admin tools, and tests can share the same de-duplication semantics
-without reaching into route handlers.
+The router layer is a thin HTTP adapter: it resolves the caller's trusted habit
+costs server-side via :func:`resolve_trusted_habits`, then hands those to
+:func:`get_or_create_persisted_plan`, which generates the plan (CPU-bound work
+off-loaded to a thread) and stores it in the ``energyplan`` table. A keyed
+retry returns the stored plan verbatim — across process restarts and workers —
+instead of regenerating (the per-process ``TTLCache`` this replaces could not).
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import asdict
 from datetime import date
 
-from cachetools import TTLCache
 from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from domain.energy import Habit as DomainHabit
 from domain.energy import generate_plan
 from errors import forbidden, not_found
+from models.energy_plan import EnergyPlan as EnergyPlanRecord
 from models.habit import Habit
 from schemas import EnergyPlan, EnergyPlanRequest, EnergyPlanResponse
 
 logger = logging.getLogger(__name__)
-
-# Idempotency cache prevents duplicate plan generation within the same session.
-# - ``CACHE_MAX_ENTRIES = 1000`` supports ~1000 concurrent users before LRU
-#   eviction starts.
-# - ``CACHE_TTL_SECONDS = 3600`` (1 hour) matches ``_TOKEN_TTL`` in ``auth.py``
-#   so cached plans expire alongside the JWT that initiated them.
-CACHE_MAX_ENTRIES = 1000
-CACHE_TTL_SECONDS = 3600
-
-idempotency_cache: TTLCache[str, EnergyPlanResponse] = TTLCache(
-    maxsize=CACHE_MAX_ENTRIES, ttl=CACHE_TTL_SECONDS
-)
 
 
 async def _load_owned_habits(
@@ -119,22 +109,74 @@ def build_energy_response(habits: list[DomainHabit], start_date: date) -> Energy
     return response
 
 
-def get_or_generate_plan(
-    habits: list[DomainHabit], start_date: date, idempotency_key: str | None
+def _row_to_response(row: EnergyPlanRecord) -> EnergyPlanResponse:
+    """Rebuild the response from a stored row (reverse of :func:`_persist`)."""
+    return EnergyPlanResponse(
+        plan=EnergyPlan.model_validate_json(row.plan_json),
+        reason_code=row.reason_code,
+    )
+
+
+async def _load_persisted_plan(
+    session: AsyncSession, user_id: int, idempotency_key: str
+) -> EnergyPlanResponse | None:
+    """Return the stored plan for ``(user_id, idempotency_key)`` if one exists."""
+    result = await session.execute(
+        select(EnergyPlanRecord).where(
+            EnergyPlanRecord.user_id == user_id,
+            EnergyPlanRecord.idempotency_key == idempotency_key,
+        )
+    )
+    row = result.scalars().first()
+    return _row_to_response(row) if row is not None else None
+
+
+async def _persist(
+    session: AsyncSession, user_id: int, idempotency_key: str | None, response: EnergyPlanResponse
 ) -> EnergyPlanResponse:
-    """Return a cached plan for ``idempotency_key`` or compute and cache a new one.
+    """Store ``response`` and return it; on a keyed race, return the stored row.
 
-    Callers that do not pass a key always get a freshly-generated plan and
-    nothing is cached.  When a key is supplied the cached response is used
-    verbatim — including the ``reason_code`` — so clients retrying a failed
-    request never see a different outcome for the same request ID.
+    Unkeyed requests (``idempotency_key is None``) each get their own row — the
+    partial UNIQUE index only constrains non-NULL keys. A concurrent insert for
+    the same ``(user_id, key)`` raises ``IntegrityError``; we roll back and read
+    the winner's row so both callers see the same plan.
     """
-    if idempotency_key and idempotency_key in idempotency_cache:
-        return idempotency_cache[idempotency_key]
-
-    response = build_energy_response(habits, start_date)
-
-    if idempotency_key:
-        idempotency_cache[idempotency_key] = response
-
+    row = EnergyPlanRecord(
+        user_id=user_id,
+        idempotency_key=idempotency_key,
+        plan_json=response.plan.model_dump_json(),
+        reason_code=response.reason_code,
+    )
+    session.add(row)
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        if idempotency_key is not None:
+            existing = await _load_persisted_plan(session, user_id, idempotency_key)
+            if existing is not None:
+                return existing
+        raise
     return response
+
+
+async def get_or_create_persisted_plan(
+    session: AsyncSession,
+    user_id: int,
+    habits: list[DomainHabit],
+    start_date: date,
+    idempotency_key: str | None,
+) -> EnergyPlanResponse:
+    """Return the caller's stored plan for ``idempotency_key`` or generate + store one.
+
+    A keyed request first reads the persisted ``EnergyPlan`` row; on a hit it is
+    replayed verbatim (cross-restart / cross-worker). On a miss — or for an
+    unkeyed request — the plan is generated (CPU-bound work off-loaded via
+    :func:`asyncio.to_thread` per BUG-INFRA-009) and persisted before returning.
+    """
+    if idempotency_key is not None:
+        existing = await _load_persisted_plan(session, user_id, idempotency_key)
+        if existing is not None:
+            return existing
+    response = await asyncio.to_thread(build_energy_response, habits, start_date)
+    return await _persist(session, user_id, idempotency_key, response)

--- a/backend/src/services/energy.py
+++ b/backend/src/services/energy.py
@@ -156,12 +156,13 @@ async def _persist(
             existing = await _load_persisted_plan(session, user_id, idempotency_key)
             if existing is not None:
                 return existing
-        # Index violation with no readable winner (e.g. the row vanished between
-        # rollback and re-read): surface it rather than masking a real conflict.
-        logger.exception(
-            "energy_plan_persist_conflict_unresolved",
-            extra={"user_id": user_id, "has_idempotency_key": idempotency_key is not None},
-        )
+            # Keyed conflict with no readable winner (e.g. the row vanished
+            # between rollback and re-read): surface it, don't mask a real race.
+            logger.exception("energy_plan_persist_conflict_unresolved", extra={"user_id": user_id})
+        else:
+            # Unkeyed insert can't hit the partial unique index, so this is a
+            # different constraint failure (e.g. a user_id FK violation).
+            logger.exception("energy_plan_persist_failed", extra={"user_id": user_id})
         raise
     return response
 
@@ -185,4 +186,6 @@ async def get_or_create_persisted_plan(
         if existing is not None:
             return existing
     response = await asyncio.to_thread(build_energy_response, habits, start_date)
+    # NOTE: unkeyed requests are not deduplicated and accumulate one row each;
+    # bounding that growth (retention/cleanup) is tracked as a separate follow-up.
     return await _persist(session, user_id, idempotency_key, response)

--- a/backend/src/services/energy.py
+++ b/backend/src/services/energy.py
@@ -156,6 +156,12 @@ async def _persist(
             existing = await _load_persisted_plan(session, user_id, idempotency_key)
             if existing is not None:
                 return existing
+        # Index violation with no readable winner (e.g. the row vanished between
+        # rollback and re-read): surface it rather than masking a real conflict.
+        logger.exception(
+            "energy_plan_persist_conflict_unresolved",
+            extra={"user_id": user_id, "has_idempotency_key": idempotency_key is not None},
+        )
         raise
     return response
 

--- a/backend/tests/services/test_energy.py
+++ b/backend/tests/services/test_energy.py
@@ -1,4 +1,4 @@
-"""Unit tests for :mod:`services.energy`: cache, response building, trusted-cost resolution."""
+"""Unit tests for :mod:`services.energy`: response building, persistence, resolution."""
 
 from __future__ import annotations
 
@@ -6,19 +6,17 @@ from datetime import date
 from http import HTTPStatus
 
 import pytest
-from cachetools import TTLCache
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from domain.energy import Habit as DomainHabit
+from models.energy_plan import EnergyPlan as EnergyPlanRecord
 from models.habit import Habit
 from schemas import EnergyPlanRequest
 from services.energy import (
-    CACHE_MAX_ENTRIES,
-    CACHE_TTL_SECONDS,
     build_energy_response,
-    get_or_generate_plan,
-    idempotency_cache,
+    get_or_create_persisted_plan,
     resolve_trusted_habits,
 )
 
@@ -30,11 +28,11 @@ def _habits() -> list[DomainHabit]:
     return [DomainHabit(id=1, name="Run", energy_cost=1, energy_return=3)]
 
 
-def test_idempotency_cache_is_ttl_bounded() -> None:
-    """The module-level cache should be a TTLCache with the documented limits."""
-    assert isinstance(idempotency_cache, TTLCache)
-    assert idempotency_cache.maxsize == CACHE_MAX_ENTRIES
-    assert idempotency_cache.ttl == CACHE_TTL_SECONDS
+async def _count_plans(session: AsyncSession, user_id: int) -> int:
+    rows = await session.execute(
+        select(EnergyPlanRecord).where(EnergyPlanRecord.user_id == user_id)
+    )
+    return len(rows.scalars().all())
 
 
 def test_build_energy_response_returns_21_day_plan() -> None:
@@ -50,26 +48,59 @@ def test_build_energy_response_raises_400_on_empty_habits() -> None:
     assert excinfo.value.detail == "habits_must_not_be_empty"
 
 
-def test_get_or_generate_plan_without_key_skips_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No idempotency key means no cache write — subsequent calls recompute."""
-    fresh_cache: TTLCache[str, object] = TTLCache(maxsize=100, ttl=60)
-    monkeypatch.setattr("services.energy.idempotency_cache", fresh_cache)
-
-    get_or_generate_plan(_habits(), _START, idempotency_key=None)
-    assert len(fresh_cache) == 0
+# ── Durable plan persistence (audit-destub) ─────────────────────────────────
 
 
-def test_get_or_generate_plan_returns_cached_response_for_same_key(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    fresh_cache: TTLCache[str, object] = TTLCache(maxsize=100, ttl=60)
-    monkeypatch.setattr("services.energy.idempotency_cache", fresh_cache)
+@pytest.mark.asyncio
+async def test_keyed_retry_replays_the_persisted_plan(db_session: AsyncSession) -> None:
+    """Two keyed calls write one row and return an identical plan (cross-restart).
 
-    first = get_or_generate_plan(_habits(), _START, idempotency_key="k")
-    second = get_or_generate_plan(_habits(), _START, idempotency_key="k")
+    There is no in-memory cache anymore — the only shared state is the DB row,
+    so the second call's match proves the read-through, i.e. the behaviour a
+    fresh process / other worker would also see.
+    """
+    first = await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "k1")
+    second = await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "k1")
 
     assert first == second
-    assert len(fresh_cache) == 1
+    assert await _count_plans(db_session, 1) == 1  # one row despite two calls
+
+
+@pytest.mark.asyncio
+async def test_keyed_retry_returns_stored_plan_ignoring_new_inputs(
+    db_session: AsyncSession,
+) -> None:
+    """A retry with the same key replays the stored plan, never regenerating."""
+    first = await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "k")
+    # Same key, different habits + start_date: the stored plan must win.
+    other = [DomainHabit(id=2, name="Read", energy_cost=2, energy_return=9)]
+    second = await get_or_create_persisted_plan(db_session, 1, other, date(2030, 1, 1), "k")
+
+    assert second == first
+
+
+@pytest.mark.asyncio
+async def test_distinct_keys_produce_distinct_rows(db_session: AsyncSession) -> None:
+    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "a")
+    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "b")
+    assert await _count_plans(db_session, 1) == 2
+
+
+@pytest.mark.asyncio
+async def test_same_key_different_users_are_isolated(db_session: AsyncSession) -> None:
+    """The partial UNIQUE index is per (user, key), so users don't collide."""
+    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "shared")
+    await get_or_create_persisted_plan(db_session, 2, _habits(), _START, "shared")
+    assert await _count_plans(db_session, 1) == 1
+    assert await _count_plans(db_session, 2) == 1
+
+
+@pytest.mark.asyncio
+async def test_unkeyed_request_writes_a_row_each_call(db_session: AsyncSession) -> None:
+    """Unkeyed requests are not deduplicated — each generated plan is recorded."""
+    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, None)
+    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, None)
+    assert await _count_plans(db_session, 1) == 2
 
 
 # ── Server-side trusted-cost resolution (BUG-PRACTICE-010) ──────────────────

--- a/backend/tests/services/test_energy.py
+++ b/backend/tests/services/test_energy.py
@@ -96,6 +96,7 @@ async def test_keyed_retry_returns_stored_plan_ignoring_new_inputs(
 
 @pytest.mark.asyncio
 async def test_distinct_keys_produce_distinct_rows(db_session: AsyncSession) -> None:
+    """Two different keys for one user persist two independent plan rows."""
     uid = await _make_user(db_session, "distinct@example.com")
     await get_or_create_persisted_plan(db_session, uid, _habits(), _START, "a")
     await get_or_create_persisted_plan(db_session, uid, _habits(), _START, "b")

--- a/backend/tests/services/test_energy.py
+++ b/backend/tests/services/test_energy.py
@@ -7,6 +7,7 @@ from http import HTTPStatus
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -15,6 +16,7 @@ from models.energy_plan import EnergyPlan as EnergyPlanRecord
 from models.habit import Habit
 from schemas import EnergyPlanRequest
 from services.energy import (
+    _persist,
     build_energy_response,
     get_or_create_persisted_plan,
     resolve_trusted_habits,
@@ -101,6 +103,44 @@ async def test_unkeyed_request_writes_a_row_each_call(db_session: AsyncSession) 
     await get_or_create_persisted_plan(db_session, 1, _habits(), _START, None)
     await get_or_create_persisted_plan(db_session, 1, _habits(), _START, None)
     assert await _count_plans(db_session, 1) == 2
+
+
+@pytest.mark.asyncio
+async def test_persist_integrity_race_returns_stored_winner(db_session: AsyncSession) -> None:
+    """A duplicate-key insert (concurrent winner exists) rolls back to the stored row.
+
+    Exercises ``_persist``'s ``IntegrityError`` fallback directly: a row for
+    ``(1, "race")`` already exists, so inserting another for the same key hits
+    the partial UNIQUE index — the fallback must re-read and return the winner,
+    not the losing response, leaving exactly one row.
+    """
+    winner = await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "race")
+    loser = build_energy_response(
+        [DomainHabit(id=9, name="X", energy_cost=2, energy_return=9)], date(2030, 1, 1)
+    )
+
+    result = await _persist(db_session, 1, "race", loser)
+
+    assert result == winner
+    assert result != loser
+    assert await _count_plans(db_session, 1) == 1
+
+
+@pytest.mark.asyncio
+async def test_persist_reraises_when_winner_not_readable(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the conflict has no readable winner after rollback, the error surfaces."""
+    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "race2")
+
+    async def _missing(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr("services.energy._load_persisted_plan", _missing)
+    loser = build_energy_response(_habits(), _START)
+
+    with pytest.raises(IntegrityError):
+        await _persist(db_session, 1, "race2", loser)
 
 
 # ── Server-side trusted-cost resolution (BUG-PRACTICE-010) ──────────────────

--- a/backend/tests/services/test_energy.py
+++ b/backend/tests/services/test_energy.py
@@ -14,6 +14,7 @@ from sqlmodel import select
 from domain.energy import Habit as DomainHabit
 from models.energy_plan import EnergyPlan as EnergyPlanRecord
 from models.habit import Habit
+from models.user import User
 from schemas import EnergyPlanRequest
 from services.energy import (
     _persist,
@@ -35,6 +36,16 @@ async def _count_plans(session: AsyncSession, user_id: int) -> int:
         select(EnergyPlanRecord).where(EnergyPlanRecord.user_id == user_id)
     )
     return len(rows.scalars().all())
+
+
+async def _make_user(session: AsyncSession, email: str) -> int:
+    """Insert a real User row so FK constraints (EnergyPlan/Habit → user) hold."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    assert user.id is not None
+    return user.id
 
 
 def test_build_energy_response_returns_21_day_plan() -> None:
@@ -61,11 +72,12 @@ async def test_keyed_retry_replays_the_persisted_plan(db_session: AsyncSession) 
     so the second call's match proves the read-through, i.e. the behaviour a
     fresh process / other worker would also see.
     """
-    first = await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "k1")
-    second = await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "k1")
+    uid = await _make_user(db_session, "keyed@example.com")
+    first = await get_or_create_persisted_plan(db_session, uid, _habits(), _START, "k1")
+    second = await get_or_create_persisted_plan(db_session, uid, _habits(), _START, "k1")
 
     assert first == second
-    assert await _count_plans(db_session, 1) == 1  # one row despite two calls
+    assert await _count_plans(db_session, uid) == 1  # one row despite two calls
 
 
 @pytest.mark.asyncio
@@ -73,36 +85,41 @@ async def test_keyed_retry_returns_stored_plan_ignoring_new_inputs(
     db_session: AsyncSession,
 ) -> None:
     """A retry with the same key replays the stored plan, never regenerating."""
-    first = await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "k")
+    uid = await _make_user(db_session, "inv@example.com")
+    first = await get_or_create_persisted_plan(db_session, uid, _habits(), _START, "k")
     # Same key, different habits + start_date: the stored plan must win.
     other = [DomainHabit(id=2, name="Read", energy_cost=2, energy_return=9)]
-    second = await get_or_create_persisted_plan(db_session, 1, other, date(2030, 1, 1), "k")
+    second = await get_or_create_persisted_plan(db_session, uid, other, date(2030, 1, 1), "k")
 
     assert second == first
 
 
 @pytest.mark.asyncio
 async def test_distinct_keys_produce_distinct_rows(db_session: AsyncSession) -> None:
-    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "a")
-    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "b")
-    assert await _count_plans(db_session, 1) == 2
+    uid = await _make_user(db_session, "distinct@example.com")
+    await get_or_create_persisted_plan(db_session, uid, _habits(), _START, "a")
+    await get_or_create_persisted_plan(db_session, uid, _habits(), _START, "b")
+    assert await _count_plans(db_session, uid) == 2
 
 
 @pytest.mark.asyncio
 async def test_same_key_different_users_are_isolated(db_session: AsyncSession) -> None:
     """The partial UNIQUE index is per (user, key), so users don't collide."""
-    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "shared")
-    await get_or_create_persisted_plan(db_session, 2, _habits(), _START, "shared")
-    assert await _count_plans(db_session, 1) == 1
-    assert await _count_plans(db_session, 2) == 1
+    uid1 = await _make_user(db_session, "iso1@example.com")
+    uid2 = await _make_user(db_session, "iso2@example.com")
+    await get_or_create_persisted_plan(db_session, uid1, _habits(), _START, "shared")
+    await get_or_create_persisted_plan(db_session, uid2, _habits(), _START, "shared")
+    assert await _count_plans(db_session, uid1) == 1
+    assert await _count_plans(db_session, uid2) == 1
 
 
 @pytest.mark.asyncio
 async def test_unkeyed_request_writes_a_row_each_call(db_session: AsyncSession) -> None:
     """Unkeyed requests are not deduplicated — each generated plan is recorded."""
-    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, None)
-    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, None)
-    assert await _count_plans(db_session, 1) == 2
+    uid = await _make_user(db_session, "unkeyed@example.com")
+    await get_or_create_persisted_plan(db_session, uid, _habits(), _START, None)
+    await get_or_create_persisted_plan(db_session, uid, _habits(), _START, None)
+    assert await _count_plans(db_session, uid) == 2
 
 
 @pytest.mark.asyncio
@@ -114,16 +131,17 @@ async def test_persist_integrity_race_returns_stored_winner(db_session: AsyncSes
     the partial UNIQUE index — the fallback must re-read and return the winner,
     not the losing response, leaving exactly one row.
     """
-    winner = await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "race")
+    uid = await _make_user(db_session, "race@example.com")
+    winner = await get_or_create_persisted_plan(db_session, uid, _habits(), _START, "race")
     loser = build_energy_response(
         [DomainHabit(id=9, name="X", energy_cost=2, energy_return=9)], date(2030, 1, 1)
     )
 
-    result = await _persist(db_session, 1, "race", loser)
+    result = await _persist(db_session, uid, "race", loser)
 
     assert result == winner
     assert result != loser
-    assert await _count_plans(db_session, 1) == 1
+    assert await _count_plans(db_session, uid) == 1
 
 
 @pytest.mark.asyncio
@@ -131,7 +149,8 @@ async def test_persist_reraises_when_winner_not_readable(
     db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """If the conflict has no readable winner after rollback, the error surfaces."""
-    await get_or_create_persisted_plan(db_session, 1, _habits(), _START, "race2")
+    uid = await _make_user(db_session, "race2@example.com")
+    await get_or_create_persisted_plan(db_session, uid, _habits(), _START, "race2")
 
     async def _missing(*_args: object, **_kwargs: object) -> None:
         return None
@@ -140,7 +159,7 @@ async def test_persist_reraises_when_winner_not_readable(
     loser = build_energy_response(_habits(), _START)
 
     with pytest.raises(IntegrityError):
-        await _persist(db_session, 1, "race2", loser)
+        await _persist(db_session, uid, "race2", loser)
 
 
 # ── Server-side trusted-cost resolution (BUG-PRACTICE-010) ──────────────────
@@ -181,7 +200,7 @@ def _request(
 @pytest.mark.asyncio
 async def test_resolve_ignores_forged_client_costs(db_session: AsyncSession) -> None:
     """Forged client costs are ignored; the resolved habit carries the stored costs."""
-    user_id = 1
+    user_id = await _make_user(db_session, "forge@example.com")
     habit_id = await _make_habit(db_session, user_id, energy_cost=2, energy_return=9)
     payload = _request(habit_id, cost=1000, ret=0)  # client forges wildly different costs
 
@@ -195,7 +214,7 @@ async def test_resolve_ignores_forged_client_costs(db_session: AsyncSession) -> 
 @pytest.mark.asyncio
 async def test_resolve_works_when_costs_omitted(db_session: AsyncSession) -> None:
     """A payload omitting costs still resolves to the stored values."""
-    user_id = 1
+    user_id = await _make_user(db_session, "omit@example.com")
     habit_id = await _make_habit(db_session, user_id, energy_cost=4, energy_return=7)
 
     resolved = await resolve_trusted_habits(db_session, user_id, _request(habit_id))
@@ -207,7 +226,8 @@ async def test_resolve_works_when_costs_omitted(db_session: AsyncSession) -> Non
 @pytest.mark.asyncio
 async def test_resolve_rejects_habit_owned_by_another_user(db_session: AsyncSession) -> None:
     """A habit owned by someone else returns 403, not a plan."""
-    owner_id, attacker_id = 1, 2
+    owner_id = await _make_user(db_session, "owner@example.com")
+    attacker_id = await _make_user(db_session, "attacker@example.com")
     habit_id = await _make_habit(db_session, owner_id, energy_cost=2, energy_return=3)
 
     with pytest.raises(HTTPException) as excinfo:

--- a/backend/tests/test_energy_api.py
+++ b/backend/tests/test_energy_api.py
@@ -156,3 +156,18 @@ async def test_energy_plan_requires_auth(async_client: AsyncClient) -> None:
     """BUG-PRACTICE-010: an unauthenticated POST must be rejected at the gate."""
     resp = await async_client.post("/v1/energy/plan", json=sample_payload())
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_over_long_idempotency_key_rejected(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An X-Idempotency-Key longer than the column width 422s, not a DB error."""
+    headers, user_id = await _signup(async_client)
+    habit_id = await _seed_habit(db_session, user_id)
+    resp = await async_client.post(
+        "/v1/energy/plan",
+        json=_plan_request([habit_id]),
+        headers={**headers, "X-Idempotency-Key": "x" * 256},
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/backend/tests/test_energy_api.py
+++ b/backend/tests/test_energy_api.py
@@ -25,7 +25,7 @@ from main import app
 from models.energy_plan import EnergyPlan as EnergyPlanRecord
 from models.habit import Habit
 from routers import energy as energy_router
-from schemas import EnergyPlanResponse
+from schemas import EnergyPlanRequest, EnergyPlanResponse
 from services import energy
 
 
@@ -114,17 +114,19 @@ async def test_create_plan_does_not_block_event_loop(async_client: AsyncClient) 
     one_habit = [DomainHabit(id=1, name="Run", energy_cost=2, energy_return=5)]
     real_response = energy.build_energy_response(one_habit, date(2024, 1, 1))
 
-    async def _stub_resolve(_session: Any, _user_id: Any, _payload: Any) -> list[DomainHabit]:  # noqa: ANN401
+    async def _stub_resolve(
+        _session: AsyncSession, _user_id: int, _payload: EnergyPlanRequest
+    ) -> list[DomainHabit]:
         return one_habit
 
-    def _slow_build(_habits: Any, _start: Any) -> EnergyPlanResponse:  # noqa: ANN401
+    def _slow_build(_habits: list[DomainHabit], _start: date) -> EnergyPlanResponse:
         time.sleep(sleep_seconds)
         return real_response
 
     async def _noop_persist(
-        _session: Any,  # noqa: ANN401
-        _user_id: Any,  # noqa: ANN401
-        _key: Any,  # noqa: ANN401
+        _session: AsyncSession,
+        _user_id: int,
+        _key: str | None,
         response: EnergyPlanResponse,
     ) -> EnergyPlanResponse:
         return response

--- a/backend/tests/test_energy_api.py
+++ b/backend/tests/test_energy_api.py
@@ -1,8 +1,9 @@
-"""Unit-ish tests for the energy plan TTL cache and idempotency helpers.
+"""Tests for the energy plan endpoint's persistence and concurrency behaviour.
 
-Endpoint coverage (auth, validation, plan generation) lives in
-``test_energy_integration.py``.  The blocking-event-loop test stays here
-because it monkeypatches the service.
+Auth/validation/plan-generation coverage lives in ``test_energy_integration.py``
+and the service-level persistence tests in ``tests/services/test_energy.py``;
+this file covers HTTP-layer idempotency and the BUG-INFRA-009 offload, both of
+which monkeypatch the service.
 """
 
 from __future__ import annotations
@@ -15,16 +16,17 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from cachetools import TTLCache
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from domain.energy import Habit as DomainHabit
 from main import app
+from models.energy_plan import EnergyPlan as EnergyPlanRecord
 from models.habit import Habit
 from routers import energy as energy_router
+from schemas import EnergyPlanResponse
 from services import energy
-from services.energy import idempotency_cache
 
 
 def sample_payload() -> dict[str, Any]:
@@ -75,67 +77,62 @@ async def _seed_habit(db_session: AsyncSession, user_id: int) -> int:
     return habit.id
 
 
-def test_idempotency_cache_is_ttl_bounded() -> None:
-    """The idempotency cache should be a TTLCache with bounded size."""
-    assert isinstance(idempotency_cache, TTLCache)
-    assert idempotency_cache.maxsize == 1000
-    assert idempotency_cache.ttl == 3600
-
-
-def test_idempotency_cache_evicts_when_full() -> None:
-    """When the cache is full, new entries should evict old ones."""
-    small_cache: TTLCache[str, str] = TTLCache(maxsize=2, ttl=3600)
-    small_cache["a"] = "val_a"
-    small_cache["b"] = "val_b"
-    small_cache["c"] = "val_c"
-    assert "a" not in small_cache
-    assert "c" in small_cache
-
-
 @pytest.mark.asyncio
-async def test_idempotency_miss_after_cache_clear(
+async def test_keyed_requests_replay_identical_persisted_plan(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """After clearing the cache, duplicate keys should recompute."""
+    """Two POSTs with the same X-Idempotency-Key return one plan, one stored row."""
     headers, user_id = await _signup(async_client)
     habit_id = await _seed_habit(db_session, user_id)
     payload = _plan_request([habit_id])
-    with patch.object(energy, "idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
-        idem_headers = {**headers, "X-Idempotency-Key": "unique-clear-test"}
-        res1 = await async_client.post("/v1/energy/plan", json=payload, headers=idem_headers)
-        energy.idempotency_cache.clear()
-        res2 = await async_client.post("/v1/energy/plan", json=payload, headers=idem_headers)
-        assert res1.status_code == HTTPStatus.OK
-        assert res2.status_code == HTTPStatus.OK
+    idem_headers = {**headers, "X-Idempotency-Key": "k-http"}
+
+    res1 = await async_client.post("/v1/energy/plan", json=payload, headers=idem_headers)
+    res2 = await async_client.post("/v1/energy/plan", json=payload, headers=idem_headers)
+
+    assert res1.status_code == HTTPStatus.OK
+    assert res2.status_code == HTTPStatus.OK
+    assert res1.json() == res2.json()
+    rows = await db_session.execute(
+        select(EnergyPlanRecord).where(EnergyPlanRecord.user_id == user_id)
+    )
+    assert len(rows.scalars().all()) == 1  # deduplicated, not regenerated
 
 
 @pytest.mark.asyncio
 async def test_create_plan_does_not_block_event_loop(async_client: AsyncClient) -> None:
     """BUG-INFRA-009: slow plan generation must not starve concurrent requests.
 
-    We replace ``get_or_generate_plan`` with a sync sleep that would block
-    the event loop for 300ms if executed inline.  With ``asyncio.to_thread``
-    the main loop is free during the sleep, so two concurrent requests
-    complete in ~300ms total — not ~600ms serialised.
+    Replace ``build_energy_response`` (the CPU-bound step) with a sync sleep
+    that would block the loop for 300ms if run inline; ``get_or_create_persisted_plan``
+    runs it via ``asyncio.to_thread``, so two concurrent requests overlap and
+    finish in ~300ms, not ~600ms. ``_persist`` is stubbed to a no-op and the
+    habit lookup is stubbed so the test isolates the offload from the DB.
     """
     headers, _ = await _signup(async_client)
     sleep_seconds = 0.3
     one_habit = [DomainHabit(id=1, name="Run", energy_cost=2, energy_return=5)]
+    real_response = energy.build_energy_response(one_habit, date(2024, 1, 1))
 
     async def _stub_resolve(_session: Any, _user_id: Any, _payload: Any) -> list[DomainHabit]:  # noqa: ANN401
         return one_habit
 
-    def _slow_plan(_habits: Any, _start: Any, _key: Any) -> Any:  # noqa: ANN401
+    def _slow_build(_habits: Any, _start: Any) -> EnergyPlanResponse:  # noqa: ANN401
         time.sleep(sleep_seconds)
-        return energy.build_energy_response(one_habit, date(2024, 1, 1))
+        return real_response
 
-    # Patch the names the router bound, and stub the (async) habit lookup so the
-    # test isolates the CPU-offload behaviour from the DB. The blocking-event-loop
-    # assertion needs a real ASGI client; the async_client dependency overrides
-    # stay active for the duration.
+    async def _noop_persist(
+        _session: Any,  # noqa: ANN401
+        _user_id: Any,  # noqa: ANN401
+        _key: Any,  # noqa: ANN401
+        response: EnergyPlanResponse,
+    ) -> EnergyPlanResponse:
+        return response
+
     with (
         patch.object(energy_router, "resolve_trusted_habits", _stub_resolve),
-        patch.object(energy_router, "get_or_generate_plan", _slow_plan),
+        patch.object(energy, "build_energy_response", _slow_build),
+        patch.object(energy, "_persist", _noop_persist),
     ):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:

--- a/backend/tests/test_energy_integration.py
+++ b/backend/tests/test_energy_integration.py
@@ -12,15 +12,12 @@ import itertools
 from datetime import date
 from http import HTTPStatus
 from typing import Any
-from unittest.mock import patch
 
 import pytest
-from cachetools import TTLCache
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.habit import Habit
-from services import energy as energy_service
 
 # Per-user habit names are unique (ix_habit_user_lower_name_unique_test); a
 # global counter keeps every seeded habit's name distinct within a test.
@@ -174,23 +171,22 @@ async def test_idempotency_returns_cached_response(
 async def test_different_idempotency_keys_produce_independent_results(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """Different idempotency keys are cached independently."""
+    """Different idempotency keys persist independent plans."""
     auth, user_id = await _auth_headers(async_client, "diffidem")
     id_a = await _seed_habit(db_session, user_id, cost=1, ret=2, name="A")
     id_b = await _seed_habit(db_session, user_id, cost=5, ret=1, name="B")
-    with patch.object(energy_service, "idempotency_cache", TTLCache(maxsize=1000, ttl=3600)):
-        resp_a = await async_client.post(
-            "/v1/energy/plan",
-            json=_plan_request([id_a]),
-            headers={**auth, "X-Idempotency-Key": "key-a"},
-        )
-        resp_b = await async_client.post(
-            "/v1/energy/plan",
-            json=_plan_request([id_b]),
-            headers={**auth, "X-Idempotency-Key": "key-b"},
-        )
+    resp_a = await async_client.post(
+        "/v1/energy/plan",
+        json=_plan_request([id_a]),
+        headers={**auth, "X-Idempotency-Key": "key-a"},
+    )
+    resp_b = await async_client.post(
+        "/v1/energy/plan",
+        json=_plan_request([id_b]),
+        headers={**auth, "X-Idempotency-Key": "key-b"},
+    )
 
-        assert resp_a.json()["plan"]["net_energy"] != resp_b.json()["plan"]["net_energy"]
+    assert resp_a.json()["plan"]["net_energy"] != resp_b.json()["plan"]["net_energy"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Generated energy plans lived only in a per-process `TTLCache(maxsize=1000, ttl=3600)`: lost on restart and divergent across workers for the same `idempotency_key` (audit §5.1 fake / per-process cache). The plan is supposed to be real for ship, so it now has durable, cross-worker storage. Builds on #477 (server-side trusted costs), so persisted plans store trusted inputs.

- **New `energyplan` table** (`models/energy_plan.py`): `user_id` (FK `ondelete=CASCADE`), nullable `idempotency_key`, serialized `plan_json` + `reason_code`, `created_at`, and a **partial UNIQUE index** on `(user_id, idempotency_key)` `WHERE idempotency_key IS NOT NULL` — keyed requests dedupe, unkeyed ones each get a row.
- **Reversible additive migration** (`c8d9e0f1a2b3`): `upgrade` creates the table + two indexes; `downgrade` drops them. No `ALTER`/`DROP` on existing tables.
- **Service rewrite**: `get_or_create_persisted_plan` reads the stored plan for a keyed request and replays it verbatim (cross-restart / cross-worker); on a miss — or for an unkeyed request — it generates (CPU work still off-loaded via `asyncio.to_thread`, BUG-INFRA-009) and persists, with an `IntegrityError` race fallback that re-reads the winner's row. The `TTLCache` is removed; the router threads the session + `current_user` into the service.

## Test plan

- **Service** (`tests/services/test_energy.py`): keyed retry replays the persisted plan with exactly one row (cross-restart — the only state is the DB row); same-key retry with *different* inputs returns the stored plan; distinct keys → distinct rows; same key across users isolated (partial index is per-user); unkeyed writes a row each call.
- **HTTP** (`test_energy_api.py`): two same-key POSTs return identical JSON and persist one row; the BUG-INFRA-009 offload test now patches `build_energy_response` + `_persist`.
- **Integration**: distinct keys produce independent persisted plans (cache patch removed — DB isolation is per-test).
- `./scripts/backend/check-all.sh` — 7/7, **1615 passed**, coverage 95.35%, ruff + mypy clean; xenon A verified. `alembic check` (model↔migration) runs in the CI migration-drift gate; the migration mirrors the existing partial-unique-index convention (`practicetag`/`practicerecipe`).

Closes #481
Refs #463

## Follow-ups

- **#546** — retention/cleanup for unbounded unkeyed `energyplan` rows (the old `TTLCache` had a 1h TTL / 1000-LRU; this is intentionally out of scope for #481, whose spec keeps `idempotency_key` nullable).
