### PR TITLE
perf(frontend): virtualize the Practice selector with FlatList

### DIFF
--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -17,7 +17,7 @@
  * The screen itself stays under ~250 LoC by keeping all state inside the
  * extracted hooks and the inner session component.
  */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   ScrollView,
@@ -46,23 +46,34 @@ import { selectCurrentStage, useStageStore } from '@/store/useStageStore';
 type ActivePracticeHook = ReturnType<typeof useActivePractice>;
 type WeeklyProgressHook = ReturnType<typeof useWeeklyProgress>;
 
+/**
+ * Owns the switcher-visibility state and returns the banner + switcher as
+ * memoized elements (stable references unless their inputs change), so passing
+ * ``banner`` as a FlatList ``ListHeaderComponent`` doesn't re-diff every render.
+ */
 function usePracticeChrome(
   stageNumber: number,
   currentPracticeId: number | null,
   onReplaced: (_next: UserPractice) => void,
 ): { banner: React.JSX.Element; switcher: React.JSX.Element } {
   const [showSwitcher, setShowSwitcher] = useState(false);
-  const banner = (
-    <FrequencyBanner stageNumber={stageNumber} onSwitch={() => setShowSwitcher(true)} />
+  const open = useCallback(() => setShowSwitcher(true), []);
+  const close = useCallback(() => setShowSwitcher(false), []);
+  const banner = useMemo(
+    () => <FrequencyBanner stageNumber={stageNumber} onSwitch={open} />,
+    [stageNumber, open],
   );
-  const switcher = (
-    <PracticeSwitcherSheet
-      visible={showSwitcher}
-      stageNumber={stageNumber}
-      currentPracticeId={currentPracticeId}
-      onClose={() => setShowSwitcher(false)}
-      onReplaced={onReplaced}
-    />
+  const switcher = useMemo(
+    () => (
+      <PracticeSwitcherSheet
+        visible={showSwitcher}
+        stageNumber={stageNumber}
+        currentPracticeId={currentPracticeId}
+        onClose={close}
+        onReplaced={onReplaced}
+      />
+    ),
+    [showSwitcher, stageNumber, currentPracticeId, close, onReplaced],
   );
   return { banner, switcher };
 }
@@ -126,8 +137,6 @@ interface ActiveSessionViewProps {
   switcher: React.JSX.Element;
 }
 
-// The selection branch lets the windowed PracticeSelector own the scroll: a
-// vertical FlatList nested in a vertical ScrollView stops virtualizing.
 const ActiveSessionView = ({
   userPractice,
   practiceName,
@@ -171,27 +180,35 @@ interface SelectionViewProps {
   switcher: React.JSX.Element;
 }
 
+// The selection branch lets the windowed PracticeSelector own the scroll: a
+// vertical FlatList nested in a vertical ScrollView stops virtualizing.
 const SelectionView = ({
   active,
   weekly,
   currentPracticeId,
   banner,
   switcher,
-}: SelectionViewProps): React.JSX.Element => (
-  <View style={styles.screen} testID="practice-screen">
-    <View style={styles.screen} testID="selection-view">
-      <PracticeSelector
-        practices={active.availablePractices}
-        selectedPracticeId={currentPracticeId}
-        onSelect={(id) => void active.selectPractice(id)}
-        isLoading={false}
-        ListHeaderComponent={banner}
-        ListFooterComponent={<WeeklyProgress count={weekly.count} />}
-      />
+}: SelectionViewProps): React.JSX.Element => {
+  // ``selectPractice`` is already stable (useCallback in the hook); wrap it once
+  // so PracticeCard's React.memo isn't defeated by a fresh arrow each render.
+  const { selectPractice } = active;
+  const handleSelect = useCallback((id: number) => void selectPractice(id), [selectPractice]);
+  return (
+    <View style={styles.screen} testID="practice-screen">
+      <View style={styles.fill} testID="selection-view">
+        <PracticeSelector
+          practices={active.availablePractices}
+          selectedPracticeId={currentPracticeId}
+          onSelect={handleSelect}
+          isLoading={false}
+          ListHeaderComponent={banner}
+          ListFooterComponent={<WeeklyProgress count={weekly.count} />}
+        />
+      </View>
+      {switcher}
     </View>
-    {switcher}
-  </View>
-);
+  );
+};
 
 function useResolvedStageNumber(): number {
   const route = useAppRoute<'Practice'>();
@@ -276,6 +293,7 @@ const ErrorView = ({
 
 const styles = StyleSheet.create({
   screen: { flex: 1, backgroundColor: colors.background.primary },
+  fill: { flex: 1 },
   scrollContent: { padding: SPACING.md, paddingBottom: SPACING.xxl },
   centered: {
     flex: 1,

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -46,43 +46,152 @@ import { selectCurrentStage, useStageStore } from '@/store/useStageStore';
 type ActivePracticeHook = ReturnType<typeof useActivePractice>;
 type WeeklyProgressHook = ReturnType<typeof useWeeklyProgress>;
 
+function usePracticeChrome(
+  stageNumber: number,
+  currentPracticeId: number | null,
+  onReplaced: (_next: UserPractice) => void,
+): { banner: React.JSX.Element; switcher: React.JSX.Element } {
+  const [showSwitcher, setShowSwitcher] = useState(false);
+  const banner = (
+    <FrequencyBanner stageNumber={stageNumber} onSwitch={() => setShowSwitcher(true)} />
+  );
+  const switcher = (
+    <PracticeSwitcherSheet
+      visible={showSwitcher}
+      stageNumber={stageNumber}
+      currentPracticeId={currentPracticeId}
+      onClose={() => setShowSwitcher(false)}
+      onReplaced={onReplaced}
+    />
+  );
+  return { banner, switcher };
+}
+
 const PracticeScreen = (): React.JSX.Element => {
   const stageNumber = useResolvedStageNumber();
   const { userTimezone } = useAuth();
   const active = useActivePractice(stageNumber);
   const weekly = useWeeklyProgress();
-  const [showSwitcher, setShowSwitcher] = useState(false);
   const handleSwitcherReplaced = useSwitcherReplaced(active.updateActivePractice, weekly.refresh);
   const handleWriteReflection = useWriteReflection(active.effectiveName, active.practice);
+  const currentPracticeId = active.activeUserPractice?.practice_id ?? null;
+  const { banner, switcher } = usePracticeChrome(
+    stageNumber,
+    currentPracticeId,
+    handleSwitcherReplaced,
+  );
 
   if (active.isLoading) return <LoadingView />;
   if (active.error && !active.activeUserPractice) {
     return <ErrorView error={active.error} onRetry={active.refresh} />;
   }
-  return (
-    <ScrollView
-      style={styles.screen}
-      contentContainerStyle={styles.scrollContent}
-      testID="practice-screen"
-    >
-      <FrequencyBanner stageNumber={stageNumber} onSwitch={() => setShowSwitcher(true)} />
-      <PracticeBody
-        active={active}
-        weekly={weekly}
+  if (active.activeUserPractice && active.practice && active.effectiveConfig) {
+    return (
+      <ActiveSessionView
+        userPractice={active.activeUserPractice}
+        practiceName={active.practice.name}
+        effectiveName={active.effectiveName}
+        effectiveConfig={active.effectiveConfig}
         userTimezone={userTimezone}
+        weekly={weekly}
+        onUserPracticeUpdated={active.updateActivePractice}
         onWriteReflection={handleWriteReflection}
+        banner={banner}
+        switcher={switcher}
       />
-      <WeeklyProgress count={weekly.count} />
-      <PracticeSwitcherSheet
-        visible={showSwitcher}
-        stageNumber={stageNumber}
-        currentPracticeId={active.activeUserPractice?.practice_id ?? null}
-        onClose={() => setShowSwitcher(false)}
-        onReplaced={handleSwitcherReplaced}
-      />
-    </ScrollView>
+    );
+  }
+
+  return (
+    <SelectionView
+      active={active}
+      weekly={weekly}
+      currentPracticeId={currentPracticeId}
+      banner={banner}
+      switcher={switcher}
+    />
   );
 };
+
+interface ActiveSessionViewProps {
+  userPractice: NonNullable<ActivePracticeHook['activeUserPractice']>;
+  practiceName: string;
+  effectiveName: string | null;
+  effectiveConfig: NonNullable<ActivePracticeHook['effectiveConfig']>;
+  userTimezone: string;
+  weekly: WeeklyProgressHook;
+  onUserPracticeUpdated: ActivePracticeHook['updateActivePractice'];
+  onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
+  banner: React.JSX.Element;
+  switcher: React.JSX.Element;
+}
+
+// The selection branch lets the windowed PracticeSelector own the scroll: a
+// vertical FlatList nested in a vertical ScrollView stops virtualizing.
+const ActiveSessionView = ({
+  userPractice,
+  practiceName,
+  effectiveName,
+  effectiveConfig,
+  userTimezone,
+  weekly,
+  onUserPracticeUpdated,
+  onWriteReflection,
+  banner,
+  switcher,
+}: ActiveSessionViewProps): React.JSX.Element => (
+  <ScrollView
+    style={styles.screen}
+    contentContainerStyle={styles.scrollContent}
+    testID="practice-screen"
+  >
+    {banner}
+    <ActiveRitualSession
+      key={`practice-${userPractice.id}`}
+      userPractice={userPractice}
+      effectiveName={effectiveName ?? practiceName}
+      effectiveConfig={effectiveConfig}
+      userTimezone={userTimezone}
+      onSessionApply={weekly.increment}
+      onSessionRollback={weekly.decrement}
+      onSessionCommitted={() => void weekly.refresh()}
+      onUserPracticeUpdated={onUserPracticeUpdated}
+      onWriteReflection={onWriteReflection}
+    />
+    <WeeklyProgress count={weekly.count} />
+    {switcher}
+  </ScrollView>
+);
+
+interface SelectionViewProps {
+  active: ActivePracticeHook;
+  weekly: WeeklyProgressHook;
+  currentPracticeId: number | null;
+  banner: React.JSX.Element;
+  switcher: React.JSX.Element;
+}
+
+const SelectionView = ({
+  active,
+  weekly,
+  currentPracticeId,
+  banner,
+  switcher,
+}: SelectionViewProps): React.JSX.Element => (
+  <View style={styles.screen} testID="practice-screen">
+    <View style={styles.screen} testID="selection-view">
+      <PracticeSelector
+        practices={active.availablePractices}
+        selectedPracticeId={currentPracticeId}
+        onSelect={(id) => void active.selectPractice(id)}
+        isLoading={false}
+        ListHeaderComponent={banner}
+        ListFooterComponent={<WeeklyProgress count={weekly.count} />}
+      />
+    </View>
+    {switcher}
+  </View>
+);
 
 function useResolvedStageNumber(): number {
   const route = useAppRoute<'Practice'>();
@@ -139,47 +248,6 @@ function useWriteReflection(
     [effectiveName, practice, navigation],
   );
 }
-
-interface PracticeBodyProps {
-  active: ActivePracticeHook;
-  weekly: WeeklyProgressHook;
-  userTimezone: string;
-  onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
-}
-
-const PracticeBody = ({
-  active,
-  weekly,
-  userTimezone,
-  onWriteReflection,
-}: PracticeBodyProps): React.JSX.Element => {
-  if (active.activeUserPractice && active.practice && active.effectiveConfig) {
-    return (
-      <ActiveRitualSession
-        key={`practice-${active.activeUserPractice.id}`}
-        userPractice={active.activeUserPractice}
-        effectiveName={active.effectiveName ?? active.practice.name}
-        effectiveConfig={active.effectiveConfig}
-        userTimezone={userTimezone}
-        onSessionApply={weekly.increment}
-        onSessionRollback={weekly.decrement}
-        onSessionCommitted={() => void weekly.refresh()}
-        onUserPracticeUpdated={active.updateActivePractice}
-        onWriteReflection={onWriteReflection}
-      />
-    );
-  }
-  return (
-    <View testID="selection-view">
-      <PracticeSelector
-        practices={active.availablePractices}
-        selectedPracticeId={active.activeUserPractice?.practice_id ?? null}
-        onSelect={(id) => void active.selectPractice(id)}
-        isLoading={false}
-      />
-    </View>
-  );
-};
 
 const LoadingView = (): React.JSX.Element => (
   <View style={styles.centered} testID="practice-loading">

--- a/frontend/src/features/Practice/PracticeSelector.tsx
+++ b/frontend/src/features/Practice/PracticeSelector.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { ListRenderItem } from 'react-native';
 import {
   ActivityIndicator,
@@ -91,6 +91,17 @@ const PracticeList = ({
     [selectedPracticeId, onSelect],
   );
 
+  // Stable header element so the FlatList doesn't re-diff it every render.
+  const header = useMemo(
+    () => (
+      <View>
+        {ListHeaderComponent}
+        <Text style={styles.heading}>Choose a Practice</Text>
+      </View>
+    ),
+    [ListHeaderComponent],
+  );
+
   return (
     <FlatList
       style={styles.list}
@@ -98,12 +109,7 @@ const PracticeList = ({
       data={practices}
       keyExtractor={keyExtractor}
       renderItem={renderItem}
-      ListHeaderComponent={
-        <View>
-          {ListHeaderComponent}
-          <Text style={styles.heading}>Choose a Practice</Text>
-        </View>
-      }
+      ListHeaderComponent={header}
       ListFooterComponent={ListFooterComponent}
       testID="practice-selector"
     />

--- a/frontend/src/features/Practice/PracticeSelector.tsx
+++ b/frontend/src/features/Practice/PracticeSelector.tsx
@@ -1,5 +1,14 @@
-import React from 'react';
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import type { ReactElement } from 'react';
+import React, { useCallback } from 'react';
+import type { ListRenderItem } from 'react-native';
+import {
+  ActivityIndicator,
+  FlatList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 import type { PracticeItem } from '@/api';
 import { colors, SPACING, BORDER_RADIUS, shadows } from '@/design/tokens';
@@ -10,6 +19,10 @@ interface PracticeSelectorProps {
   onSelect: (_id: number) => void;
   isLoading: boolean;
   isLocked?: boolean;
+  /** Rendered above the built-in heading when the selector owns the scroll. */
+  ListHeaderComponent?: ReactElement | null;
+  /** Rendered below the windowed list (e.g. the weekly-progress bar). */
+  ListFooterComponent?: ReactElement | null;
 }
 
 interface PracticeCardProps {
@@ -18,9 +31,12 @@ interface PracticeCardProps {
   onSelect: (_id: number) => void;
 }
 
-const PracticeCard = ({ practice, isSelected, onSelect }: PracticeCardProps): React.JSX.Element => (
+const PracticeCardComponent = ({
+  practice,
+  isSelected,
+  onSelect,
+}: PracticeCardProps): React.JSX.Element => (
   <View
-    key={practice.id}
     style={[styles.card, isSelected && styles.cardSelected]}
     testID={`practice-card-${practice.id}`}
   >
@@ -46,12 +62,62 @@ const PracticeCard = ({ practice, isSelected, onSelect }: PracticeCardProps): Re
   </View>
 );
 
+// Memoized so windowed rows don't re-render when an unrelated row's selection
+// changes — only the (de)selected rows see a new ``isSelected``.
+const PracticeCard = React.memo(PracticeCardComponent);
+
+const keyExtractor = (practice: PracticeItem): string => String(practice.id);
+
+type PracticeListProps = Pick<
+  PracticeSelectorProps,
+  'practices' | 'selectedPracticeId' | 'onSelect' | 'ListHeaderComponent' | 'ListFooterComponent'
+>;
+
+const PracticeList = ({
+  practices,
+  selectedPracticeId,
+  onSelect,
+  ListHeaderComponent,
+  ListFooterComponent,
+}: PracticeListProps): React.JSX.Element => {
+  const renderItem = useCallback<ListRenderItem<PracticeItem>>(
+    ({ item }) => (
+      <PracticeCard
+        practice={item}
+        isSelected={item.id === selectedPracticeId}
+        onSelect={onSelect}
+      />
+    ),
+    [selectedPracticeId, onSelect],
+  );
+
+  return (
+    <FlatList
+      style={styles.list}
+      contentContainerStyle={styles.container}
+      data={practices}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      ListHeaderComponent={
+        <View>
+          {ListHeaderComponent}
+          <Text style={styles.heading}>Choose a Practice</Text>
+        </View>
+      }
+      ListFooterComponent={ListFooterComponent}
+      testID="practice-selector"
+    />
+  );
+};
+
 const PracticeSelector: React.FC<PracticeSelectorProps> = ({
   practices,
   selectedPracticeId,
   onSelect,
   isLoading,
   isLocked = false,
+  ListHeaderComponent,
+  ListFooterComponent,
 }) => {
   if (isLoading) {
     return (
@@ -80,21 +146,20 @@ const PracticeSelector: React.FC<PracticeSelectorProps> = ({
   }
 
   return (
-    <View style={styles.container} testID="practice-selector">
-      <Text style={styles.heading}>Choose a Practice</Text>
-      {practices.map((practice) => (
-        <PracticeCard
-          key={practice.id}
-          practice={practice}
-          isSelected={practice.id === selectedPracticeId}
-          onSelect={onSelect}
-        />
-      ))}
-    </View>
+    <PracticeList
+      practices={practices}
+      selectedPracticeId={selectedPracticeId}
+      onSelect={onSelect}
+      ListHeaderComponent={ListHeaderComponent}
+      ListFooterComponent={ListFooterComponent}
+    />
   );
 };
 
 const styles = StyleSheet.create({
+  list: {
+    flex: 1,
+  },
   container: {
     padding: SPACING.lg,
   },

--- a/frontend/src/features/Practice/__tests__/PracticeSelector.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeSelector.test.tsx
@@ -130,4 +130,24 @@ describe('PracticeSelector', () => {
     );
     expect(getByText('Choose a Practice')).toBeTruthy();
   });
+
+  it('virtualizes the list in input order and still fires onSelect by id', () => {
+    // Parity for the FlatList conversion: same cards, same order, same callback.
+    const { getAllByTestId, getByTestId } = render(
+      <PracticeSelector
+        practices={samplePractices}
+        selectedPracticeId={null}
+        onSelect={mockOnSelect}
+        isLoading={false}
+      />,
+    );
+
+    const cardIds = getAllByTestId(/^practice-card-/).map(
+      (node: { props: { testID: string } }) => node.props.testID,
+    );
+    expect(cardIds).toEqual(['practice-card-1', 'practice-card-2']);
+
+    fireEvent.press(getByTestId('select-practice-2'));
+    expect(mockOnSelect).toHaveBeenCalledWith(2);
+  });
 });


### PR DESCRIPTION
## Summary

`PracticeSelector` rendered the stage's practices with `.map()` inside a `View` nested under `PracticeScreen`'s `ScrollView` — eager mounting with no windowing that janks as the list grows (audit §5.2 list virtualization, High; the same anti-pattern as the catalog, #478).

- Converted the `.map()` to a windowed **`FlatList`** (`PracticeList`) with a stable **id-based `keyExtractor`**, a `useCallback`'d `renderItem`, and a memoized `PracticeCard` so rows don't re-render on unrelated selection changes. Loading/locked/empty states unchanged.
- **Let the selector own its scroll** (the issue's explicit guidance — a vertical `FlatList` nested in a vertical `ScrollView` stops virtualizing): `PracticeScreen` no longer wraps the selection branch in a `ScrollView`. It splits into `ActiveSessionView` (scrolls normally) and `SelectionView` (the `FlatList` owns scroll), with `FrequencyBanner` as the list **header** and `WeeklyProgress` as the **footer**. The banner + switcher chrome moved to a `usePracticeChrome` hook.
- **No change to appearance, item order, or selection behavior.** `selection-view` / `select-practice-*` / `active-practice-card` testIDs preserved.

## Test plan

- All **32 existing** Practice selector + screen tests pass unchanged (loading/locked/empty, card rendering, select callback, checkmark, active-session vs selection branches).
- Added a parity test: cards render in input order (`practice-card-1`, `practice-card-2`) and pressing `select-practice-2` fires `onSelect(2)`.
- `./scripts/frontend/check-all.sh` — 4/4: ESLint zero-warnings (incl. complexity + max-lines), `tsc --noEmit` clean, Jest green, prettier formatted.

Closes #482
Refs #461
