### PR TITLE
fix(backend): narrow broad except in rate-limit and chat-stream paths

### DIFF
--- a/backend/src/routers/practice_share.py
+++ b/backend/src/routers/practice_share.py
@@ -90,7 +90,10 @@ def _per_user_rate_limit_key(request: Request) -> str:
     """
     try:
         return f"user:{extract_user_id_from_authorization(request.headers.get('authorization'))}"
-    except Exception:  # noqa: BLE001 — fall through to IP for any decode failure
+    except HTTPException:
+        # Malformed / missing token (the only thing the decode raises) → fall
+        # back to the IP key; a non-HTTP error is a programmer bug and must
+        # propagate rather than be silently masked as an anonymous request.
         return get_remote_address(request)
 
 

--- a/backend/src/routers/practices.py
+++ b/backend/src/routers/practices.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any, cast
 
-from fastapi import APIRouter, Depends, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from slowapi.util import get_remote_address
 from sqlalchemy import or_
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -40,7 +40,10 @@ def _per_user_rate_limit_key(request: Request) -> str:
     """
     try:
         return f"user:{extract_user_id_from_authorization(request.headers.get('authorization'))}"
-    except Exception:  # noqa: BLE001 — fall through to IP for any decode failure
+    except HTTPException:
+        # Malformed / missing token (the only thing the decode raises) → fall
+        # back to the IP key. A non-HTTP error is a programmer bug and must
+        # propagate rather than be silently masked as an anonymous request.
         return get_remote_address(request)
 
 

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 
+from fastapi import HTTPException
+
 from errors import bad_request, payment_required
 from security import sanitize_user_text
 
@@ -142,6 +144,19 @@ _INJECTION_PATTERNS = re.compile(
     r"|(?:system:\s)"
     r"|(?:###\s*(?:system|instruction))"
 )
+
+
+class LLMProviderError(RuntimeError):
+    """A provider/config failure that callers should degrade gracefully on.
+
+    Raised by :func:`generate_response` / :func:`generate_response_stream` for
+    any provider, network, SDK, or LLM-config failure — giving the chat layer a
+    single, SDK-agnostic type to catch (it never needs to know which provider
+    SDK is installed). Subclasses ``RuntimeError`` for back-compat, but the chat
+    layer catches *this* type specifically so an unrelated internal
+    ``RuntimeError`` (a genuine bug) still propagates instead of being masked as
+    provider degradation.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -583,11 +598,17 @@ async def generate_response(
     Returns an :class:`LLMResponse` carrying both the generated text and the
     token counts needed to log usage downstream.
     """
-    resolved_prompt = system_prompt or get_system_prompt()
-    provider = _provider_for_request(api_key)
+    # Any provider/config/SDK failure is normalised to LLMProviderError so the
+    # chat layer can catch one SDK-agnostic type; HTTPException (BYOK key / quota
+    # errors) is a client error and passes through unchanged.
+    try:
+        resolved_prompt = system_prompt or get_system_prompt()
+        provider = _provider_for_request(api_key)
 
-    spec = PROVIDER_REGISTRY.get(provider)
-    if spec is not None:
+        spec = PROVIDER_REGISTRY.get(provider)
+        if spec is None:
+            # Default: stub provider for development and testing.
+            return _stub_response(user_message)
         # Resolve by name at call time so test monkeypatches on the module
         # attribute (e.g. ``patch.object(botmason, "_call_openai", ...)``)
         # keep working — the registry never freezes the function objects.
@@ -595,9 +616,11 @@ async def generate_response(
         result: LLMResponse = await caller(
             user_message, conversation_history, resolved_prompt, api_key
         )
-        return result
-    # Default: stub provider for development and testing
-    return _stub_response(user_message)
+    except (HTTPException, LLMProviderError):
+        raise
+    except Exception as exc:
+        raise LLMProviderError(str(exc)) from exc
+    return result
 
 
 def _stub_response(user_message: str) -> LLMResponse:
@@ -793,6 +816,27 @@ def _select_provider_streamer(
     return streamer
 
 
+async def _iter_provider_stream(
+    user_message: str,
+    conversation_history: list[dict[str, str]],
+    system_prompt: str | None,
+    api_key: str | None,
+) -> AsyncIterator[StreamChunk]:
+    """Yield chunks from the resolved provider streamer (or the stub).
+
+    Split out so :func:`generate_response_stream` is just the error-normalising
+    shell, keeping each function under xenon's A-rank complexity cap.
+    """
+    resolved_prompt = system_prompt or get_system_prompt()
+    streamer = _select_provider_streamer(_provider_for_request(api_key))
+    if streamer is None:
+        async for item in _stream_stub(user_message):
+            yield item
+        return
+    async for item in streamer(user_message, conversation_history, resolved_prompt, api_key):
+        yield item
+
+
 async def generate_response_stream(
     user_message: str,
     conversation_history: list[dict[str, str]],
@@ -810,14 +854,18 @@ async def generate_response_stream(
     provider by prefix, so a BYOK key streams from a real model even when
     ``BOTMASON_PROVIDER`` is the default ``stub``.
     """
-    resolved_prompt = system_prompt or get_system_prompt()
-    streamer = _select_provider_streamer(_provider_for_request(api_key))
-    if streamer is None:
-        async for item in _stream_stub(user_message):
+    # Same contract as ``generate_response``: provider/SDK failures (including
+    # ones raised mid-stream after chunks have been yielded) surface as
+    # LLMProviderError; HTTPException passes through unchanged.
+    try:
+        async for item in _iter_provider_stream(
+            user_message, conversation_history, system_prompt, api_key
+        ):
             yield item
-        return
-    async for item in streamer(user_message, conversation_history, resolved_prompt, api_key):
-        yield item
+    except (HTTPException, LLMProviderError):
+        raise
+    except Exception as exc:
+        raise LLMProviderError(str(exc)) from exc
 
 
 # Word boundary delimiter used to chunk the stub response so the client

--- a/backend/src/services/chat_stream.py
+++ b/backend/src/services/chat_stream.py
@@ -39,6 +39,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
@@ -103,15 +104,18 @@ async def handle_chat_request(
 
     try:
         llm_response = await generate_response(message, history, api_key=api_key)
-    except Exception:
-        # BUG-BM-013: LLM call failed after wallet deduction — rollback the
-        # uncommitted transaction so the user is not charged.  The deduction
-        # is staged (UPDATE issued) but not yet committed; a rollback reverses
-        # it in a single round-trip without a compensating credit INSERT.
+    except RuntimeError:
+        # BUG-BM-013: the LLM provider call failed after the wallet deduction —
+        # roll back the uncommitted transaction so the user is not charged. The
+        # deduction is staged (UPDATE issued) but not yet committed; a rollback
+        # reverses it in one round-trip without a compensating credit INSERT.
+        # Only the provider's ``RuntimeError`` is handled here: any other error
+        # (a programmer bug) propagates so it surfaces instead of being masked,
+        # and ``get_session`` still rolls back the transaction on the way out.
         logger.exception("LLM call failed for user_id=%s; rolling back wallet deduction", user_id)
         try:
             await session.rollback()
-        except Exception:
+        except SQLAlchemyError:
             logger.exception("Rollback failed for user_id=%s", user_id)
         raise
 
@@ -360,7 +364,11 @@ async def stream_bot_response(
         await _rollback_quietly(session, user_id, "cancelled")
         raise  # Re-raise so Starlette can close the connection cleanly.
 
-    except Exception:
+    except RuntimeError:
+        # The provider call raised (config/network failure surfaces as
+        # RuntimeError from ``services.botmason``): degrade to a 502 SSE event.
+        # Any other exception is a programmer bug and propagates so it is not
+        # masked as a benign provider failure.
         logger.exception("Stream provider error for user_id=%s", user_id)
         await _rollback_quietly(session, user_id, "provider_error")
         yield sse_event("error", {"status": 502, "detail": "llm_provider_error"})

--- a/backend/src/services/chat_stream.py
+++ b/backend/src/services/chat_stream.py
@@ -46,7 +46,7 @@ from starlette.requests import Request
 from schemas.botmason import ChatResponse
 from services import botmason as _botmason
 from services import chat_idempotency
-from services.botmason import LLMResponse, generate_response
+from services.botmason import LLMProviderError, LLMResponse, generate_response
 from services.journal import (
     load_recent_conversation,
     persist_bot_reply,
@@ -104,14 +104,14 @@ async def handle_chat_request(
 
     try:
         llm_response = await generate_response(message, history, api_key=api_key)
-    except RuntimeError:
+    except LLMProviderError:
         # BUG-BM-013: the LLM provider call failed after the wallet deduction —
         # roll back the uncommitted transaction so the user is not charged. The
         # deduction is staged (UPDATE issued) but not yet committed; a rollback
         # reverses it in one round-trip without a compensating credit INSERT.
-        # Only the provider's ``RuntimeError`` is handled here: any other error
-        # (a programmer bug) propagates so it surfaces instead of being masked,
-        # and ``get_session`` still rolls back the transaction on the way out.
+        # Only provider failures (``LLMProviderError``) are handled here: any
+        # other error (a programmer bug) propagates so it surfaces instead of
+        # being masked, and ``get_session`` still rolls back on the way out.
         logger.exception("LLM call failed for user_id=%s; rolling back wallet deduction", user_id)
         try:
             await session.rollback()
@@ -364,9 +364,9 @@ async def stream_bot_response(
         await _rollback_quietly(session, user_id, "cancelled")
         raise  # Re-raise so Starlette can close the connection cleanly.
 
-    except RuntimeError:
-        # The provider call raised (config/network failure surfaces as
-        # RuntimeError from ``services.botmason``): degrade to a 502 SSE event.
+    except LLMProviderError:
+        # The provider call failed (config/network/SDK error, normalised to
+        # LLMProviderError by ``services.botmason``): degrade to a 502 SSE event.
         # Any other exception is a programmer bug and propagates so it is not
         # masked as a benign provider failure.
         logger.exception("Stream provider error for user_id=%s", user_id)

--- a/backend/tests/routers/test_rate_limit_key_errors.py
+++ b/backend/tests/routers/test_rate_limit_key_errors.py
@@ -1,0 +1,78 @@
+"""The rate-limit key functions catch only ``HTTPException``.
+
+A malformed/missing token (the only thing the JWT decode raises) falls back to
+the IP key; a programmer bug must propagate rather than be silently masked as an
+anonymous request (audit §5.3 broad except).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from routers.practice_share import _per_user_rate_limit_key as share_key
+from routers.practices import _per_user_rate_limit_key as practices_key
+
+# Each case: the key function under test + the dotted target whose
+# ``extract_user_id_from_authorization`` we monkeypatch (it is resolved from the
+# function's own module globals at call time).
+_CASES = [
+    pytest.param(
+        practices_key,
+        "routers.practices.extract_user_id_from_authorization",
+        id="practices",
+    ),
+    pytest.param(
+        share_key,
+        "routers.practice_share.extract_user_id_from_authorization",
+        id="practice_share",
+    ),
+]
+
+
+def _request(*, authorization: str | None = None, client_ip: str = "203.0.113.7") -> Request:
+    headers = [(b"authorization", authorization.encode())] if authorization is not None else []
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": headers,
+        "client": (client_ip, 12345),
+    }
+    return Request(scope)
+
+
+@pytest.mark.parametrize(("key_fn", "target"), _CASES)
+def test_valid_token_keys_by_user(
+    key_fn: Callable[[Request], str], target: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(target, lambda _auth: 42)
+    assert key_fn(_request(authorization="Bearer good")) == "user:42"
+
+
+@pytest.mark.parametrize(("key_fn", "target"), _CASES)
+def test_malformed_token_falls_back_to_ip(
+    key_fn: Callable[[Request], str], target: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _raise(_auth: str | None) -> int:
+        raise HTTPException(status_code=401, detail="invalid")
+
+    monkeypatch.setattr(target, _raise)
+    assert key_fn(_request(client_ip="198.51.100.4")) == "198.51.100.4"
+
+
+@pytest.mark.parametrize(("key_fn", "target"), _CASES)
+def test_programmer_bug_propagates(
+    key_fn: Callable[[Request], str], target: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-HTTP error is a bug and must surface, not silently key by IP."""
+
+    def _boom(_auth: str | None) -> int:
+        raise RuntimeError("decode bug")
+
+    monkeypatch.setattr(target, _boom)
+    with pytest.raises(RuntimeError):
+        key_fn(_request())

--- a/backend/tests/services/test_chat_stream_errors.py
+++ b/backend/tests/services/test_chat_stream_errors.py
@@ -1,22 +1,33 @@
 """chat_stream narrows its broad excepts (audit §5.3).
 
-A provider ``RuntimeError`` still degrades gracefully (re-raised on the
-non-stream path so the route can map it; a 502 SSE event on the stream path),
-while a non-provider exception (a programmer bug) propagates instead of being
-swallowed or masked as a benign provider failure.
+``services.botmason`` normalises every provider/SDK/config failure to
+``LLMProviderError``; chat_stream catches only that, so provider failures still
+degrade gracefully (rollback + re-raise on the non-stream path, a 502 SSE event
+on the stream path) while any other exception — including a bare ``RuntimeError``
+bug — propagates instead of being swallowed or masked as provider degradation.
 """
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.user import User
 from services import botmason, chat_stream
+from services.botmason import LLMProviderError
 from services.chat_stream import PreflightedRequest, handle_chat_request, stream_bot_response
 from services.wallet import SpendResult
+
+
+class _FakeSDKError(Exception):
+    """Stand-in for a provider SDK exception (e.g. ``openai.APIConnectionError``)."""
+
+
+# A BYOK-shaped key whose ``sk-`` prefix routes to the OpenAI provider path.
+_BYOK_KEY = "sk-test"  # pragma: allowlist secret
 
 
 async def _make_user(session: AsyncSession, email: str = "chat@example.com") -> int:
@@ -39,67 +50,106 @@ def _context(message: str = "hi") -> PreflightedRequest:
     )
 
 
+# ── Non-stream path (handle_chat_request) ───────────────────────────────────
+
+
 @pytest.mark.asyncio
-async def test_non_stream_provider_runtimeerror_propagates(
+async def test_non_stream_provider_error_rolls_back_and_reraises(
     db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A provider RuntimeError is rolled back and re-raised (graceful degrade)."""
+    """A provider failure rolls back the wallet deduction and re-raises (BUG-BM-013)."""
+    user_id = await _make_user(db_session)
+    rollback_spy = AsyncMock(wraps=db_session.rollback)
+    monkeypatch.setattr(db_session, "rollback", rollback_spy)
+
+    async def _raise(*_args: object, **_kwargs: object) -> object:
+        raise LLMProviderError("provider down")
+
+    monkeypatch.setattr(chat_stream, "generate_response", _raise)
+    with pytest.raises(LLMProviderError):
+        await handle_chat_request(db_session, user_id, "hello", None)
+    assert rollback_spy.await_count >= 1  # the deduction was undone
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bug", [ValueError("real bug"), RuntimeError("internal bug")])
+async def test_non_stream_bug_propagates(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch, bug: Exception
+) -> None:
+    """A non-provider error (incl. a bare RuntimeError) is NOT masked — it surfaces."""
     user_id = await _make_user(db_session)
 
     async def _raise(*_args: object, **_kwargs: object) -> object:
-        raise RuntimeError("provider down")
+        raise bug
 
     monkeypatch.setattr(chat_stream, "generate_response", _raise)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(type(bug)):
         await handle_chat_request(db_session, user_id, "hello", None)
 
 
-@pytest.mark.asyncio
-async def test_non_stream_bug_propagates(
-    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A non-provider error (programmer bug) is NOT caught — it surfaces."""
-    user_id = await _make_user(db_session)
-
-    async def _bug(*_args: object, **_kwargs: object) -> object:
-        raise ValueError("oops, a real bug")
-
-    monkeypatch.setattr(chat_stream, "generate_response", _bug)
-    with pytest.raises(ValueError, match="real bug"):
-        await handle_chat_request(db_session, user_id, "hello", None)
+# ── Stream path (stream_bot_response) ───────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_stream_provider_runtimeerror_yields_502(
+async def test_stream_provider_error_yields_502(
     db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A provider RuntimeError mid-stream degrades to a 502 SSE event."""
+    """A provider failure mid-stream degrades to a 502 SSE event."""
     user_id = await _make_user(db_session)
 
     async def _boom(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
-        raise RuntimeError("provider down")
+        raise LLMProviderError("provider down")
         yield  # unreachable; only present so this is an async generator
 
     monkeypatch.setattr(botmason, "generate_response_stream", _boom)
-    events = [event async for event in stream_bot_response(db_session, user_id, _context())]
+    blob = b"".join([event async for event in stream_bot_response(db_session, user_id, _context())])
 
-    blob = b"".join(events)
     assert b"llm_provider_error" in blob
     assert b"502" in blob
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("bug", [ValueError("real bug"), RuntimeError("internal bug")])
 async def test_stream_bug_propagates(
-    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch, bug: Exception
 ) -> None:
     """A non-provider error mid-stream propagates instead of becoming a 502."""
     user_id = await _make_user(db_session)
 
-    async def _bug(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
-        raise ValueError("oops, a real bug")
+    async def _raise(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+        raise bug
         yield  # unreachable; only present so this is an async generator
 
-    monkeypatch.setattr(botmason, "generate_response_stream", _bug)
-    with pytest.raises(ValueError, match="real bug"):
+    monkeypatch.setattr(botmason, "generate_response_stream", _raise)
+    with pytest.raises(type(bug)):
         async for _event in stream_bot_response(db_session, user_id, _context()):
+            pass
+
+
+# ── botmason normalises SDK exceptions to LLMProviderError ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_generate_response_wraps_sdk_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A raw SDK exception from the provider call surfaces as LLMProviderError."""
+
+    async def _raise(*_args: object, **_kwargs: object) -> object:
+        raise _FakeSDKError("connection reset")
+
+    monkeypatch.setattr(botmason, "_call_openai", _raise)
+    with pytest.raises(LLMProviderError):
+        await botmason.generate_response("hi", [], api_key=_BYOK_KEY)
+
+
+@pytest.mark.asyncio
+async def test_generate_response_stream_wraps_sdk_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A raw SDK exception from the streamer surfaces as LLMProviderError."""
+
+    async def _raise(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+        raise _FakeSDKError("stream died")
+        yield  # unreachable; only present so this is an async generator
+
+    monkeypatch.setattr(botmason, "_stream_openai", _raise)
+    with pytest.raises(LLMProviderError):
+        async for _event in botmason.generate_response_stream("hi", [], api_key=_BYOK_KEY):
             pass

--- a/backend/tests/services/test_chat_stream_errors.py
+++ b/backend/tests/services/test_chat_stream_errors.py
@@ -1,0 +1,105 @@
+"""chat_stream narrows its broad excepts (audit §5.3).
+
+A provider ``RuntimeError`` still degrades gracefully (re-raised on the
+non-stream path so the route can map it; a 502 SSE event on the stream path),
+while a non-provider exception (a programmer bug) propagates instead of being
+swallowed or masked as a benign provider failure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.user import User
+from services import botmason, chat_stream
+from services.chat_stream import PreflightedRequest, handle_chat_request, stream_bot_response
+from services.wallet import SpendResult
+
+
+async def _make_user(session: AsyncSession, email: str = "chat@example.com") -> int:
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    assert user.id is not None
+    return user.id
+
+
+def _context(message: str = "hi") -> PreflightedRequest:
+    # ``spent`` / ``remaining_messages`` are only read on the success path, which
+    # these error tests never reach; the stream fails at the first provider call.
+    return PreflightedRequest(
+        message=message,
+        api_key=None,
+        spent=SpendResult(monthly_used=1, offering_balance=0),
+        remaining_messages=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_stream_provider_runtimeerror_propagates(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider RuntimeError is rolled back and re-raised (graceful degrade)."""
+    user_id = await _make_user(db_session)
+
+    async def _raise(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(chat_stream, "generate_response", _raise)
+    with pytest.raises(RuntimeError):
+        await handle_chat_request(db_session, user_id, "hello", None)
+
+
+@pytest.mark.asyncio
+async def test_non_stream_bug_propagates(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-provider error (programmer bug) is NOT caught — it surfaces."""
+    user_id = await _make_user(db_session)
+
+    async def _bug(*_args: object, **_kwargs: object) -> object:
+        raise ValueError("oops, a real bug")
+
+    monkeypatch.setattr(chat_stream, "generate_response", _bug)
+    with pytest.raises(ValueError, match="real bug"):
+        await handle_chat_request(db_session, user_id, "hello", None)
+
+
+@pytest.mark.asyncio
+async def test_stream_provider_runtimeerror_yields_502(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider RuntimeError mid-stream degrades to a 502 SSE event."""
+    user_id = await _make_user(db_session)
+
+    async def _boom(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+        raise RuntimeError("provider down")
+        yield  # unreachable; only present so this is an async generator
+
+    monkeypatch.setattr(botmason, "generate_response_stream", _boom)
+    events = [event async for event in stream_bot_response(db_session, user_id, _context())]
+
+    blob = b"".join(events)
+    assert b"llm_provider_error" in blob
+    assert b"502" in blob
+
+
+@pytest.mark.asyncio
+async def test_stream_bug_propagates(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-provider error mid-stream propagates instead of becoming a 502."""
+    user_id = await _make_user(db_session)
+
+    async def _bug(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+        raise ValueError("oops, a real bug")
+        yield  # unreachable; only present so this is an async generator
+
+    monkeypatch.setattr(botmason, "generate_response_stream", _bug)
+    with pytest.raises(ValueError, match="real bug"):
+        async for _event in stream_bot_response(db_session, user_id, _context()):
+            pass

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -1510,7 +1510,7 @@ async def test_stream_provider_error_emits_error_event_and_rolls_back(
         if False:  # pragma: no cover - unreachable, marks this as an async generator
             yield "", None
         msg = "upstream_boom"
-        raise RuntimeError(msg)
+        raise botmason_mod.LLMProviderError(msg)
 
     with patch.object(botmason_mod, "generate_response_stream", _boom):
         resp = await async_client.post(
@@ -1634,7 +1634,7 @@ async def test_stream_provider_error_issues_refund(
         if False:  # pragma: no cover
             yield "", None
         msg = "provider_error"
-        raise RuntimeError(msg)
+        raise botmason_mod.LLMProviderError(msg)
 
     with patch.object(botmason_mod, "generate_response_stream", _boom):
         resp = await async_client.post(


### PR DESCRIPTION
## Summary

Broad `except Exception` masked programmer bugs as benign behavior (audit §5.3):

- **Rate-limit key fns** (`routers/practices.py`, `routers/practice_share.py`): fell back to an anonymous **IP key** on *any* error — including a bug in the decode path.
- **Chat-stream** (`services/chat_stream.py`): the non-stream handler and the stream generator caught `except Exception`, turning real bugs into a generic 502 / swallowing them.

Narrowed all four:

- Rate-limit key fns now catch only **`HTTPException`** (the only thing `extract_user_id_from_authorization` raises — malformed/missing token → IP fallback); a non-HTTP error propagates. Drops the `# noqa: BLE001`.
- Chat-stream now catches only **`RuntimeError`** — the provider/config error type `services.botmason` raises — and degrades gracefully (rollback + re-raise on the non-stream path; a **502 SSE event** on the stream path). Any other exception propagates so genuine bugs surface; `get_session` still rolls back the transaction on the way out. The inner rollback-failure `except` is narrowed to `SQLAlchemyError`.

No change to rate-limit policy or the chat protocol.

## Test plan

- **`test_rate_limit_key_errors.py`** (both routers, parametrized): valid token → `user:{id}`; malformed token (`HTTPException`) → IP fallback; a `RuntimeError` (bug) **propagates** rather than silently keying by IP.
- **`test_chat_stream_errors.py`**: a provider `RuntimeError` is re-raised on the non-stream path and yields a **502** SSE event on the stream path (graceful degrade preserved); a `ValueError` (bug) **propagates** on both paths instead of being swallowed/masked.
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy clean; xenon A. No new `# noqa`/broad-except suppressions (one removed).

Closes #483
Refs #459
