### PR TITLE
refactor(backend): typed response contracts for week-count + UserPractice detail

### DIFF
--- a/backend/src/routers/practice_recipes.py
+++ b/backend/src/routers/practice_recipes.py
@@ -41,7 +41,11 @@ from models.practice import Practice
 from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
-from routers.user_practices import EmbeddedSessionsParams, load_recent_sessions
+from routers.user_practices import (
+    EmbeddedSessionsParams,
+    build_user_practice_detail,
+    load_recent_sessions,
+)
 from schemas import Page, PaginationParams, build_page
 from schemas.pagination import paginate_query
 from schemas.practice import UserPracticeDetail
@@ -360,7 +364,7 @@ async def apply_recipe_to_user_practice(
     session: Annotated[AsyncSession, Depends(get_session)],
     user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
     embed: Annotated[EmbeddedSessionsParams, Depends()],
-) -> dict[str, Any]:
+) -> UserPracticeDetail:
     """Materialise a recipe and store it as the UserPractice's override.
 
     Re-uses ``require_owned_user_practice`` (the same dependency the
@@ -389,9 +393,7 @@ async def apply_recipe_to_user_practice(
     # ``/user-practices/{id}`` and ``customize_user_practice`` return (the
     # frontend store merges it back, so it must stay present — but bounded,
     # issue #474). Older sessions remain reachable via ``list_sessions``.
-    sessions, sessions_total, sessions_has_more = await load_recent_sessions(
-        session, cast("int", user_practice.id), embed
-    )
+    sessions_page = await load_recent_sessions(session, cast("int", user_practice.id), embed)
     logger.info(
         "practice_recipe_applied",
         extra={
@@ -400,17 +402,9 @@ async def apply_recipe_to_user_practice(
             "user_id": user_id,
         },
     )
-    return {
-        "id": user_practice.id,
-        "practice_id": user_practice.practice_id,
-        "stage_number": user_practice.stage_number,
-        "start_date": user_practice.start_date,
-        "end_date": user_practice.end_date,
-        "custom_name": user_practice.custom_name,
-        "mode_config_override": user_practice.mode_config_override,
-        "effective_name": effective_name(practice, user_practice),
-        "effective_config": effective_config(practice, user_practice).model_dump(),
-        "sessions": sessions,
-        "sessions_total": sessions_total,
-        "sessions_has_more": sessions_has_more,
-    }
+    return build_user_practice_detail(
+        user_practice,
+        effective_name=effective_name(practice, user_practice),
+        effective_config=effective_config(practice, user_practice).model_dump(),
+        sessions_page=sessions_page,
+    )

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -29,6 +29,7 @@ from schemas.practice import (
     PracticeInsightsResponse,
     PracticeSessionCreate,
     PracticeSessionResponse,
+    WeekCountResponse,
 )
 from schemas.practice_mode_config import MindfulAnchorConfig
 from schemas.practice_session_metadata import MindfulAnchorMetadata
@@ -454,12 +455,12 @@ def _start_of_week_utc(tz_name: str) -> datetime:
     return local_midnight.astimezone(UTC)
 
 
-@router.get("/week-count")
+@router.get("/week-count", response_model=WeekCountResponse)
 async def week_count(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
     user_tz: Annotated[str, Depends(current_user_timezone)],
-) -> dict[str, int]:
+) -> WeekCountResponse:
     """Return the number of sessions the authenticated user completed this week.
 
     BUG-PRACTICE-009: the week boundary is derived from the user's stored
@@ -473,4 +474,4 @@ async def week_count(
     )
     result = await session.execute(statement)
     count = result.scalar_one()
-    return {"count": count}
+    return WeekCountResponse(count=count)

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -29,6 +29,7 @@ from schemas import MAX_PAGE_SIZE, Page, PaginationParams, build_page
 from schemas.frequency import FrequencyResponse, render_banner_text
 from schemas.pagination import paginate_query
 from schemas.practice import (
+    PracticeSessionSummary,
     UserPracticeCreate,
     UserPracticeCustomize,
     UserPracticeDetail,
@@ -307,6 +308,37 @@ def _user_practice_payload(user_practice: UserPractice) -> dict[str, Any]:
     }
 
 
+def build_user_practice_detail(
+    user_practice: UserPractice,
+    *,
+    effective_name: str | None,
+    effective_config: dict[str, Any] | None,
+    sessions_page: tuple[list[PracticeSession], int, bool],
+) -> UserPracticeDetail:
+    """Build the typed ``UserPracticeDetail`` from stored + resolved fields.
+
+    The single source of the response's key list — GET-one, customize, and
+    apply-recipe all build the model through here, so a field rename on
+    ``UserPracticeDetail`` flows to every endpoint without per-site edits.
+    ``sessions_page`` is the ``load_recent_sessions`` tuple ``(rows, total,
+    has_more)``; ``effective_config`` dicts and ``PracticeSession`` rows are
+    coerced by the model's validators / ``from_attributes``.
+    """
+    sessions, sessions_total, sessions_has_more = sessions_page
+    # Direct construction doesn't apply ``from_attributes`` to the nested ORM
+    # rows, so coerce them to the summary schema first; the rest are plain
+    # values / dicts the model validates inline.
+    summaries = [PracticeSessionSummary.model_validate(s, from_attributes=True) for s in sessions]
+    return UserPracticeDetail(
+        **_user_practice_payload(user_practice),
+        effective_name=effective_name,
+        effective_config=effective_config,
+        sessions=summaries,
+        sessions_total=sessions_total,
+        sessions_has_more=sessions_has_more,
+    )
+
+
 async def _load_course_stage(session: AsyncSession, stage_number: int) -> CourseStage:
     """Fetch the ``CourseStage`` for a stage number or raise 404.
 
@@ -556,7 +588,7 @@ async def get_user_practice(
     session: Annotated[AsyncSession, Depends(get_session)],
     user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
     embed: Annotated[EmbeddedSessionsParams, Depends()],
-) -> dict[str, Any]:
+) -> UserPracticeDetail:
     """Get a single user-practice with its (capped) recent session history.
 
     Ownership via ``require_owned_user_practice`` (404 → 403 split). The
@@ -564,19 +596,15 @@ async def get_user_practice(
     newest-first sessions; ``sessions_total`` / ``sessions_has_more`` report
     whether older sessions remain (fetch them via ``list_sessions``). Issue #474.
     """
-    sessions, total, has_more = await load_recent_sessions(
-        session, cast("int", user_practice.id), embed
-    )
+    sessions_page = await load_recent_sessions(session, cast("int", user_practice.id), embed)
     name, cfg = await _resolve_effective_fields(session, user_practice)
 
-    return {
-        **_user_practice_payload(user_practice),
-        "effective_name": name,
-        "effective_config": cfg,
-        "sessions": sessions,
-        "sessions_total": total,
-        "sessions_has_more": has_more,
-    }
+    return build_user_practice_detail(
+        user_practice,
+        effective_name=name,
+        effective_config=cfg,
+        sessions_page=sessions_page,
+    )
 
 
 def _validate_override_against_catalog(override: dict[str, Any] | None, practice: Practice) -> None:
@@ -611,7 +639,7 @@ async def customize_user_practice(
     session: Annotated[AsyncSession, Depends(get_session)],
     user_practice: Annotated[UserPractice, Depends(require_owned_user_practice)],
     embed: Annotated[EmbeddedSessionsParams, Depends()],
-) -> dict[str, Any]:
+) -> UserPracticeDetail:
     """Per-user override of name + mode_config.
 
     Both fields are nullable; passing ``None`` clears the override and
@@ -635,9 +663,7 @@ async def customize_user_practice(
     name = effective_name(practice, user_practice)
     cfg = effective_config(practice, user_practice).model_dump()
 
-    sessions, total, has_more = await load_recent_sessions(
-        session, cast("int", user_practice.id), embed
-    )
+    sessions_page = await load_recent_sessions(session, cast("int", user_practice.id), embed)
     logger.info(
         "user_practice_customized",
         extra={
@@ -646,11 +672,9 @@ async def customize_user_practice(
             "fields_changed": sorted(fields_set),
         },
     )
-    return {
-        **_user_practice_payload(user_practice),
-        "effective_name": name,
-        "effective_config": cfg,
-        "sessions": sessions,
-        "sessions_total": total,
-        "sessions_has_more": has_more,
-    }
+    return build_user_practice_detail(
+        user_practice,
+        effective_name=name,
+        effective_config=cfg,
+        sessions_page=sessions_page,
+    )

--- a/backend/src/schemas/practice.py
+++ b/backend/src/schemas/practice.py
@@ -348,6 +348,18 @@ class PracticeSessionResponse(OwnedResourcePublic):
     insight: str | None = None
 
 
+class WeekCountResponse(BaseModel):
+    """Typed contract for ``GET /practice-sessions/week-count``.
+
+    ``extra="forbid"`` so a stray key (a drifting hand-built dict) is rejected
+    rather than silently passed through — the wire shape stays exactly ``{count}``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    count: int
+
+
 class PracticeSessionWeeklyCount(BaseModel):
     """One bucket of the rolling weekly-count series for the insights endpoint."""
 

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -9,13 +9,16 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from httpx import AsyncClient
+from pydantic import ValidationError
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
+from main import app
 from models.practice import Practice
 from models.practice_session import PracticeSession
 from models.user import User
+from schemas.practice import WeekCountResponse
 
 _DEFAULT_DURATION = 5.0
 _EXPECTED_SESSION_COUNT = 2
@@ -373,6 +376,23 @@ async def test_week_count_counts_current_week(
     resp = await async_client.get("/practice-sessions/week-count", headers=headers)
     assert resp.status_code == HTTPStatus.OK
     assert resp.json()["count"] == _EXPECTED_SESSION_COUNT
+
+
+@pytest.mark.asyncio
+async def test_week_count_typed_contract_and_openapi(async_client: AsyncClient) -> None:
+    """week-count is typed: shape stays {count}, a stray key is rejected, schema in OpenAPI."""
+    headers, _ = await _signup(async_client)
+    resp = await async_client.get("/practice-sessions/week-count", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+    body = resp.json()
+    assert set(body) == {"count"}  # wire shape unchanged
+    assert WeekCountResponse.model_validate(body).count == 0
+    # ``extra="forbid"`` rejects a drifting extra key.
+    with pytest.raises(ValidationError):
+        WeekCountResponse.model_validate({"count": 0, "stray": 1})
+    # The typed contract is exposed in OpenAPI (it wasn't, as a raw dict).
+    assert "WeekCountResponse" in app.openapi()["components"]["schemas"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_user_practices_api.py
+++ b/backend/tests/test_user_practices_api.py
@@ -16,6 +16,7 @@ from models.practice_session import PracticeSession
 from models.stage_progress import StageProgress
 from models.user_practice import UserPractice
 from routers.user_practices import EMBEDDED_SESSIONS_DEFAULT_LIMIT
+from schemas.practice import UserPracticeDetail
 
 _EXPECTED_SELECTION_COUNT = 2
 _SESSION_DURATION = 10.0
@@ -271,6 +272,9 @@ async def test_get_user_practice_with_sessions(
     # Backward compatible: a user under the cap sees full history + metadata.
     assert data["sessions_total"] == 1
     assert data["sessions_has_more"] is False
+    # Contract: the response keys are exactly UserPracticeDetail's fields, so a
+    # schema rename flows through the shared builder instead of drifting.
+    assert set(data) == set(UserPracticeDetail.model_fields)
 
 
 async def _create_owned_user_practice(


### PR DESCRIPTION
## Summary

Several practice responses were untyped or hand-assembled, so the wire contract wasn't enforced by a Pydantic model and could drift (audit §5.3 response contracts):

- `week_count` returned a raw `dict[str, int]` with **no OpenAPI schema**.
- `get_user_practice`, `customize_user_practice`, and `apply_recipe_to_user_practice` each hand-built a `dict[str, Any]` **duplicating the `UserPracticeDetail` keys** — a field rename wouldn't flag them.

Changes (contract-tightening, **not** a behaviour change):

- `schemas/practice.py`: add `WeekCountResponse(count: int)` with `extra="forbid"`.
- `practice_sessions.week_count`: declare `response_model=WeekCountResponse` and return the model — the `{count}` wire shape is unchanged but now appears in OpenAPI.
- `user_practices`: add **`build_user_practice_detail`** — the single place the detail response keys live. All three endpoints build `UserPracticeDetail` through it, so a schema field rename flows everywhere without per-site edits. ORM `PracticeSession` rows are coerced to `PracticeSessionSummary` in the builder (kwargs construction doesn't apply `from_attributes` to nested ORM rows).

## Test plan

- week-count: response validates against `WeekCountResponse`, shape is exactly `{count}`, a stray key is rejected (`extra="forbid"`), and `WeekCountResponse` is in `app.openapi()` components.
- UserPractice detail: the GET response keys equal `UserPracticeDetail.model_fields` (drift guard); all existing get/customize/apply session-cap + effective-field tests pass unchanged.
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy clean; xenon A.

Closes #484
Refs #460
