### PR TITLE
fix(backend): remove the hollow journal encryption flag

### DIFF
--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -1,5 +1,4 @@
 import enum
-import os
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -9,13 +8,10 @@ from sqlmodel import Field, Relationship, SQLModel
 if TYPE_CHECKING:
     from .user import User
 
-# Feature flag for column-level encryption at rest (BUG-JOURNAL-012).
-# When enabled, ``message`` is encrypted before DB write and decrypted on read
-# using Fernet symmetric encryption.  The key must be provided via the
-# ``JOURNAL_ENCRYPTION_KEY`` env var.
-#
-# Tracked in GitHub issue #219: Fernet encrypt/decrypt hooks and key rotation via KMS.
-ENCRYPTION_AT_REST_ENABLED = os.getenv("JOURNAL_ENCRYPT_AT_REST", "").lower() == "true"
+# NOTE: ``message`` is stored as PLAINTEXT. Column-level encryption at rest is
+# not implemented — the previous ``ENCRYPTION_AT_REST_ENABLED`` flag advertised
+# a guarantee the code never delivered, so it was removed. Real Fernet
+# encryption (key rotation via KMS, row migration) is tracked in #219.
 
 
 class JournalTag(enum.StrEnum):

--- a/backend/tests/models/test_journal_entry_no_encryption_flag.py
+++ b/backend/tests/models/test_journal_entry_no_encryption_flag.py
@@ -9,6 +9,8 @@ without an actual encrypt/decrypt path.
 
 from __future__ import annotations
 
+import inspect
+
 import models.journal_entry as journal_entry_module
 
 
@@ -17,7 +19,8 @@ def test_hollow_encryption_flag_is_removed() -> None:
 
 
 def test_module_makes_no_false_encryption_claim() -> None:
-    """The module no longer claims ``message`` is encrypted before write."""
-    source = journal_entry_module.__doc__ or ""
-    # The module docstring (if any) must not assert message-level encryption.
-    assert "encrypted before" not in source.lower()
+    """The module source (comments included) must not claim ``message`` is encrypted."""
+    # Inspect the actual file text, not ``__doc__`` — the original false claim
+    # lived in a ``#`` comment, so a docstring check would pass vacuously.
+    source = inspect.getsource(journal_entry_module).lower()
+    assert "encrypted before" not in source

--- a/backend/tests/models/test_journal_entry_no_encryption_flag.py
+++ b/backend/tests/models/test_journal_entry_no_encryption_flag.py
@@ -1,0 +1,23 @@
+"""Regression: the hollow encryption flag must stay gone (audit-destub-05).
+
+``ENCRYPTION_AT_REST_ENABLED`` advertised Fernet column encryption that was
+never implemented — ``message`` was stored plaintext regardless. The flag was
+removed so the codebase stops promising a guarantee it does not keep; real
+encryption is tracked separately. This test fails if the flag is reintroduced
+without an actual encrypt/decrypt path.
+"""
+
+from __future__ import annotations
+
+import models.journal_entry as journal_entry_module
+
+
+def test_hollow_encryption_flag_is_removed() -> None:
+    assert not hasattr(journal_entry_module, "ENCRYPTION_AT_REST_ENABLED")
+
+
+def test_module_makes_no_false_encryption_claim() -> None:
+    """The module no longer claims ``message`` is encrypted before write."""
+    source = journal_entry_module.__doc__ or ""
+    # The module docstring (if any) must not assert message-level encryption.
+    assert "encrypted before" not in source.lower()

--- a/prompts/github-issues/audit-destub-05b-journal-encryption-real.md
+++ b/prompts/github-issues/audit-destub-05b-journal-encryption-real.md
@@ -1,0 +1,46 @@
+# audit-destub-05b: Implement real journal encryption at rest
+
+**Labels:** `audit-destub`, `backend`, `security`, `priority-medium`
+**Epic:** De-Stub: Make Aspirational Features Real
+**Depends on:** audit-destub-05 (removed the hollow flag)
+**Estimated LoC:** ~500 (hard cap 700)
+
+## Role
+
+You are a backend engineer implementing column-level encryption at rest for journal content, properly — with key management, not a half-wired flag.
+
+## Goal
+
+`JournalEntry.message` (and any other sensitive free-text columns) are encrypted before the DB write and decrypted on read, with a real, rotatable key. Setting the feature on must deliver the guarantee it advertises — the failure mode that motivated audit-destub-05, where a flag read as a shippable guarantee but stored plaintext, must not recur.
+
+## Context
+
+audit-destub-05 deleted the misleading `ENCRYPTION_AT_REST_ENABLED` flag and its docstring claim because no encrypt/decrypt hooks existed and `message` was stored as plaintext regardless. This issue does the capability for real. It is the actionable form of the long-standing umbrella issue #219.
+
+## Scope
+
+**Covers:**
+- A Fernet (or envelope-encryption) encrypt-on-write / decrypt-on-read layer for `JournalEntry.message`, applied transparently at the model/repository boundary so call sites don't each remember to encrypt.
+- Key provisioning from a secret (env/KMS), with **key rotation** support (multi-key decrypt, single-key encrypt) so a compromised key can be retired without downtime.
+- A reversible migration to encrypt existing plaintext rows (and a documented rollback).
+- Tests: round-trip encrypt/decrypt, rotation (old-key rows still readable), and that ciphertext (not plaintext) is what lands in the column.
+
+**Does NOT cover:** encrypting non-journal tables, full-disk encryption (an ops concern), or search-over-ciphertext.
+
+## Acceptance Criteria
+
+- [ ] `message` is stored as ciphertext; a raw DB read never returns plaintext.
+- [ ] Decryption is transparent on read; existing API responses are unchanged.
+- [ ] Key rotation is supported (decrypt with any active key, encrypt with the current one).
+- [ ] A migration encrypts pre-existing rows and is reversible.
+- [ ] Enabling/disabling is honest: if a key is missing the app fails fast rather than silently storing plaintext.
+- [ ] Coverage ≥ 90%; all pre-commit hooks pass.
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `backend/src/services/journal_encryption.py` | Create (Fernet/envelope encrypt-decrypt + key registry) |
+| `backend/src/models/journal_entry.py` | Modify (encrypt-on-write / decrypt-on-read boundary) |
+| `backend/alembic/versions/<rev>_encrypt_journal_messages.py` | Create (reversible row migration) |
+| `backend/tests/services/test_journal_encryption.py` | Create (round-trip + rotation + ciphertext-at-rest) |


### PR DESCRIPTION
## Summary

`models/journal_entry.py` defined `ENCRYPTION_AT_REST_ENABLED` (from `JOURNAL_ENCRYPT_AT_REST`) with a docstring claiming `message` was **Fernet-encrypted before write and decrypted on read** — but no encrypt/decrypt hooks existed anywhere and `message` was stored as **plaintext** regardless (audit §5.1 fake / hollow security contract). An operator who set the env var would believe journal content was encrypted at rest when it wasn't.

Per the issue's chosen zero-question path — **remove the hollow flag now**, don't half-implement Fernet:

- Deleted the flag and the false "encrypted before DB write / decrypted on read" comment; replaced it with an honest note that `message` is **plaintext** and real encryption is tracked in #219. Dropped the now-unused `import os`.
- The constant was referenced **nowhere but its own definition** (grep-clean across the repo).
- Filed the follow-up **#550** (`audit-destub-05b`: real Fernet at-rest encryption with key rotation + row migration) and added its prompt file, so the capability is tracked, not lost.

No behaviour change (the flag did nothing); this removes a misleading guarantee.

## Test plan

- New `tests/models/test_journal_entry_no_encryption_flag.py`: asserts `ENCRYPTION_AT_REST_ENABLED` is gone and the module makes no "encrypted before…" claim (fails if the hollow flag is reintroduced without a real path).
- All existing journal model/API tests pass.
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy clean.

Closes #485
Refs #463
