### PR TITLE
perf(frontend): habits FlatList getItemLayout + gate missed-days scan

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -273,7 +273,7 @@ const TOTAL_HABITS = 10;
 /** Tile border thickness so the aptitude/stage color reads clearly at a glance. */
 export const TILE_BORDER_WIDTH = 3;
 
-const useTileLayout = () => {
+export const useTileLayout = () => {
   const { width, height, columns, scale, gridGutter } = useResponsive();
   const rows = columns === 2 ? TOTAL_HABITS / columns : TOTAL_HABITS;
   const tileMinHeight = height / rows - 2 * spacing(1, scale) - gridGutter;

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -29,7 +29,7 @@ import ReorderHabitsModal from './components/ReorderHabitsModal';
 import StatsModal from './components/StatsModal';
 import styles from './Habits.styles';
 import type { AddHabitInput, Habit, HabitStatsData } from './Habits.types';
-import HabitTile from './HabitTile';
+import HabitTile, { useTileLayout } from './HabitTile';
 import {
   generateStatsForHabit,
   toLocalHabitStats,
@@ -224,6 +224,16 @@ interface HabitModalsProps {
   onAddHabit: (_input: AddHabitInput) => Promise<void>;
 }
 
+/**
+ * Missed-days for the modal, gated on modal-open. ``calculateMissedDays`` scans
+ * every completion, so it must not run on the (frequent) closed-modal renders —
+ * the modal is hidden unless ``open`` is set. Extracted so the gate is unit-testable.
+ */
+export const missedDaysFor = (
+  open: boolean,
+  habit: Habit | null,
+): ReturnType<typeof calculateMissedDays> => (open && habit ? calculateMissedDays(habit) : []);
+
 const HabitDataModals = ({
   modals,
   selectedHabit,
@@ -249,7 +259,7 @@ const HabitDataModals = ({
     <MissedDaysModal
       visible={modals.missedDays}
       habit={selectedHabit}
-      missedDays={selectedHabit ? calculateMissedDays(selectedHabit) : []}
+      missedDays={missedDaysFor(modals.missedDays, selectedHabit)}
       onClose={() => modals.close('missedDays')}
       onBackfill={actions.backfillMissedDays}
       onNewStartDate={actions.setNewStartDate}
@@ -361,21 +371,44 @@ interface HabitListProps {
   renderItem: (_info: { item: Habit; index: number }) => React.ReactElement;
 }
 
-const HabitList = ({ habits, columns, gridGutter, renderItem }: HabitListProps) => (
-  <FlatList
-    key={`cols-${columns}`}
-    testID="habits-list"
-    data={habits}
-    keyExtractor={(item) => item.id?.toString() ?? item.name}
-    renderItem={renderItem}
-    numColumns={columns}
-    columnWrapperStyle={columns > 1 ? { gap: gridGutter } : undefined}
-    contentContainerStyle={[
-      styles.habitsGrid,
-      { padding: gridGutter / 2, paddingBottom: gridGutter / 2 },
-    ]}
-  />
-);
+export const HabitList = ({ habits, columns, gridGutter, renderItem }: HabitListProps) => {
+  // Fixed row pitch = tile min-height + its top/bottom margins (gridGutter/2
+  // each). Supplying getItemLayout lets the list skip async measurement and
+  // restore scroll synchronously. Derived from the same useTileLayout the tiles
+  // size themselves with, so there are no magic numbers and the two can't drift.
+  const { tileMinHeight } = useTileLayout();
+  const rowHeight = tileMinHeight + gridGutter;
+  const getItemLayout = useCallback(
+    (_data: ArrayLike<Habit> | null | undefined, index: number) => ({
+      length: rowHeight,
+      offset: rowHeight * Math.floor(index / columns),
+      index,
+    }),
+    [rowHeight, columns],
+  );
+  return (
+    <FlatList
+      // ``key`` on numColumns is required, not incidental: RN's FlatList throws
+      // an invariant ("Changing numColumns on the fly is not supported") when
+      // numColumns changes on a live instance (FlatList.js), so a column flip
+      // (portrait↔landscape) must remount. It only changes on that flip — not
+      // on every render — and this grid is paginated to fit the viewport, so
+      // there is no in-page scroll position to preserve.
+      key={`cols-${columns}`}
+      testID="habits-list"
+      data={habits}
+      keyExtractor={(item) => item.id?.toString() ?? item.name}
+      renderItem={renderItem}
+      numColumns={columns}
+      getItemLayout={getItemLayout}
+      columnWrapperStyle={columns > 1 ? { gap: gridGutter } : undefined}
+      contentContainerStyle={[
+        styles.habitsGrid,
+        { padding: gridGutter / 2, paddingBottom: gridGutter / 2 },
+      ]}
+    />
+  );
+};
 
 interface PaginationBarProps {
   page: number;

--- a/frontend/src/features/Habits/__tests__/HabitsScreen.flatlist-config.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreen.flatlist-config.test.tsx
@@ -1,0 +1,102 @@
+/* eslint-env jest */
+// audit-render-07: the Habits FlatList must supply getItemLayout (so it can skip
+// async measurement) and the per-completion missed-days scan must be gated on
+// the modal being open rather than running on every render.
+import { describe, expect, it, jest } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { View } from 'react-native';
+
+import type { Habit } from '../Habits.types';
+import { HabitList, missedDaysFor } from '../HabitsScreen';
+
+// Stub the modal components — importing HabitsScreen pulls them in, and some
+// carry native deps (e.g. datetimepicker) that don't load under jest.
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getExpoPushTokenAsync: jest.fn(() => Promise.resolve({ data: 'token' })),
+}));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/StatsModal', () => () => null);
+
+const mockCalculateMissedDays = jest.fn((_habit: unknown) => [{ date: '2026-06-01' }]);
+jest.mock('../HabitUtils', () => ({
+  ...(jest.requireActual('../HabitUtils') as Record<string, unknown>),
+  calculateMissedDays: (habit: unknown) => mockCalculateMissedDays(habit),
+}));
+
+function makeHabit(id: number): Habit {
+  return {
+    id,
+    name: `Habit ${id}`,
+    icon: '🧪',
+    stage: 'Beige',
+    streak: 0,
+    energy_cost: 5,
+    energy_return: 7,
+    start_date: new Date(2020, 0, 1),
+    goals: [],
+    completions: [],
+    revealed: true,
+  } as Habit;
+}
+
+const renderRow = ({ item }: { item: Habit }) => <View testID={`row-${item.id}`} />;
+
+describe('Habits FlatList getItemLayout', () => {
+  it('supplies getItemLayout with correct multi-column row offsets', () => {
+    const habits = [1, 2, 3, 4, 5].map(makeHabit);
+    const { getByTestId } = render(
+      <HabitList habits={habits} columns={2} gridGutter={8} renderItem={renderRow} />,
+    );
+
+    const getItemLayout = getByTestId('habits-list').props.getItemLayout as (
+      _d: unknown,
+      _i: number,
+    ) => { length: number; offset: number; index: number };
+    expect(typeof getItemLayout).toBe('function');
+
+    const row0 = getItemLayout(null, 0);
+    const rowHeight = row0.length;
+    expect(rowHeight).toBeGreaterThan(0);
+    expect(row0.offset).toBe(0);
+    // 2 columns: index 2 and 3 are the second row; index 4 is the third row.
+    expect(getItemLayout(null, 2).offset).toBe(rowHeight);
+    expect(getItemLayout(null, 3).offset).toBe(rowHeight);
+    expect(getItemLayout(null, 4).offset).toBe(rowHeight * 2);
+    expect(getItemLayout(null, 4).index).toBe(4);
+  });
+});
+
+describe('missed-days computation gating', () => {
+  it('does not scan completions while the modal is closed', () => {
+    mockCalculateMissedDays.mockClear();
+    const result = missedDaysFor(false, makeHabit(1));
+    expect(mockCalculateMissedDays).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('scans (once) and returns the value when the modal is open', () => {
+    mockCalculateMissedDays.mockClear();
+    const habit = makeHabit(1);
+    const result = missedDaysFor(true, habit);
+    expect(mockCalculateMissedDays).toHaveBeenCalledTimes(1);
+    expect(mockCalculateMissedDays).toHaveBeenCalledWith(habit);
+    expect(result).toEqual([{ date: '2026-06-01' }]);
+  });
+
+  it('returns [] without scanning when there is no selected habit', () => {
+    mockCalculateMissedDays.mockClear();
+    expect(missedDaysFor(true, null)).toEqual([]);
+    expect(mockCalculateMissedDays).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

The Habits `FlatList` had no `getItemLayout` (couldn't skip async row measurement), and `calculateMissedDays` scanned every completion on **every render** even while the missed-days modal was closed (audit §5.2).

- **`getItemLayout`**: fixed row pitch = tile `minHeight` + its top/bottom margins, derived from the same `useTileLayout` the tiles size themselves with (now exported) — no magic numbers, no drift. Multi-column offsets use `floor(index / columns)`.
- **Gate the missed-days scan**: extracted a pure `missedDaysFor(open, habit)` helper that calls `calculateMissedDays` only when the modal is open, wired into `MissedDaysModal`'s prop. No more per-render scans while it's closed.

### Note on the `key={cols-${columns}}` (task 2)

The issue asked to **remove** the key, on the premise that RN's FlatList re-lays-out on a `numColumns` change without one. **That does not hold on RN 0.76**: `FlatList` throws an `invariant` — *"Changing numColumns on the fly is not supported. Change the key prop on FlatList when changing numColumns…"* (`react-native/Libraries/Lists/FlatList.js:461`) — when `numColumns` changes on a live instance. Removing the key would crash on a portrait↔landscape flip, and the issue's own "change columns without a remount" test is infeasible on this RN. So the **key is kept** (documented inline). It only changes on a column flip (not every render), and this grid is **paginated to fit the viewport**, so there is no in-page scroll position to preserve. The real render-cost wins — `getItemLayout` and gating the scan — are delivered.

## Test plan

- `getItemLayout` is supplied and computes correct multi-column offsets (`index 2,3 → row 1`, `index 4 → row 2`).
- `calculateMissedDays` is **not** invoked while the modal is closed (spy), runs **once** with the right value when open, and returns `[]` with no scan when there's no selected habit.
- All existing Habits tests pass.
- `./scripts/frontend/check-all.sh` — 4/4: ESLint zero-warnings, `tsc` clean, Jest green, prettier formatted.

Closes #486
Refs #461
