### PR TITLE
fix(backend): disable CORS credentials for the cookieless Bearer API

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -400,7 +400,10 @@ app.add_middleware(SlowAPIMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
-    allow_credentials=True,
+    # The API authenticates with ``Authorization: Bearer`` tokens and sets no
+    # cookies, so credentials mode is unnecessary; disabling it shrinks the CORS
+    # attack surface and avoids the ``*``-origin restriction (audit §5.3).
+    allow_credentials=False,
     allow_methods=ALLOWED_METHODS,
     allow_headers=ALLOWED_HEADERS,
     expose_headers=EXPOSED_HEADERS,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -205,18 +205,18 @@ def get_cors_origins(env: str | None = None) -> list[str]:
 
 
 def _assert_credentials_safe(origins: list[str]) -> None:
-    """Reject ``*`` in the CORS allow-list when credentials are enabled.
+    """Reject ``*`` in the CORS allow-list; require explicit origins.
 
-    BUG-INFRA-005: ``Access-Control-Allow-Origin: *`` plus
-    ``Access-Control-Allow-Credentials: true`` is forbidden by the CORS
-    spec and silently ignored by browsers.  Failing closed at startup
-    surfaces the misconfiguration immediately instead of letting a
-    misbehaving prod env appear to be working.
+    Originally guarded the spec-forbidden ``Access-Control-Allow-Origin: *`` +
+    ``Access-Control-Allow-Credentials: true`` combo (BUG-INFRA-005). Credentials
+    mode is now off, but a wildcard origin is still rejected as defense-in-depth:
+    explicit origins keep fine-grained CORS control regardless of credentials.
+    Failing closed at startup surfaces the misconfiguration immediately.
     """
     if "*" in origins:
         raise RuntimeError(
-            "CORS allow-list contains '*' but allow_credentials=True. "
-            "Browsers will reject the response — pick explicit origins instead."
+            "CORS allow-list contains '*'. Use explicit origins — a wildcard "
+            "origin disables fine-grained CORS control regardless of credentials mode."
         )
 
 

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -118,8 +118,8 @@ def test_dev_env_warns_when_prod_domain_set(caplog: pytest.LogCaptureFixture) ->
 
 
 def test_credentials_with_wildcard_origin_raises() -> None:
-    """BUG-INFRA-005: ``*`` plus credentials must fail closed at startup."""
-    with pytest.raises(RuntimeError, match="allow_credentials"):
+    """BUG-INFRA-005: a wildcard origin must fail closed at startup."""
+    with pytest.raises(RuntimeError, match="explicit origins"):
         _assert_credentials_safe(["*"])
 
 
@@ -234,7 +234,8 @@ def test_cross_origin_post_omits_credentials_header() -> None:
     # must still be present so the browser can read the response.
     assert response.status_code == HTTPStatus.UNAUTHORIZED
     assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
-    assert response.headers.get("access-control-allow-credentials") != "true"
+    # Header omitted entirely (credentials mode off), not set to any value.
+    assert response.headers.get("access-control-allow-credentials") is None
 
 
 def test_forbidden_origin_no_cors_headers() -> None:

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -210,8 +210,13 @@ def test_cross_origin_get_allowed() -> None:
     assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
 
 
-def test_cross_origin_post_with_credentials() -> None:
-    """POST requests with credentials include CORS headers even when auth fails."""
+def test_cross_origin_post_omits_credentials_header() -> None:
+    """Cross-origin POSTs get the origin header but NOT allow-credentials.
+
+    The API is cookieless (Bearer-token auth), so credentials mode is disabled
+    (audit §5.3): the browser can still read the response (ACAO present) but the
+    response never advertises ``Access-Control-Allow-Credentials: true``.
+    """
     headers = {"Origin": ALLOWED_ORIGIN}
     ended = datetime.now(UTC)
     started = ended - timedelta(minutes=10)
@@ -220,18 +225,16 @@ def test_cross_origin_post_with_credentials() -> None:
         "started_at": started.isoformat(),
         "ended_at": ended.isoformat(),
     }
-    cookies = {"session": "abc"}
     response = client.post(
         "/practice-sessions/",
         json=payload,
         headers=headers,
-        cookies=cookies,
     )
-    # The endpoint requires Bearer auth, so we get 401, but CORS headers
+    # The endpoint requires Bearer auth, so we get 401, but the ACAO header
     # must still be present so the browser can read the response.
     assert response.status_code == HTTPStatus.UNAUTHORIZED
     assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
-    assert response.headers.get("access-control-allow-credentials") == "true"
+    assert response.headers.get("access-control-allow-credentials") != "true"
 
 
 def test_forbidden_origin_no_cors_headers() -> None:

--- a/backend/tests/test_cors_config.py
+++ b/backend/tests/test_cors_config.py
@@ -1,0 +1,67 @@
+"""CORS is configured for a cookieless Bearer-token API (audit §5.3).
+
+Credentials mode is disabled: the middleware is registered with
+``allow_credentials=False``, a preflight never advertises
+``Access-Control-Allow-Credentials: true``, and an ``Authorization: Bearer``
+request from an allowed origin still succeeds without relying on cookies.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+from httpx import AsyncClient
+
+from main import app
+
+ALLOWED_ORIGIN = "http://localhost:3000"
+_PASSWORD = "securepassword123"  # pragma: allowlist secret
+
+client = TestClient(app)
+
+
+def _cors_kwargs() -> dict[str, object]:
+    for middleware in app.user_middleware:
+        if getattr(middleware.cls, "__name__", "") == CORSMiddleware.__name__:
+            return dict(middleware.kwargs)
+    pytest.fail("CORSMiddleware is not registered")
+    return {}  # pragma: no cover - pytest.fail raises
+
+
+def test_cors_middleware_disables_credentials() -> None:
+    assert _cors_kwargs()["allow_credentials"] is False
+
+
+def test_preflight_omits_allow_credentials() -> None:
+    """A preflight OPTIONS must not return Access-Control-Allow-Credentials: true."""
+    response = client.options(
+        "/auth/login",
+        headers={
+            "Origin": ALLOWED_ORIGIN,
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+    assert response.headers.get("access-control-allow-credentials") != "true"
+
+
+@pytest.mark.asyncio
+async def test_bearer_request_from_allowed_origin_succeeds(async_client: AsyncClient) -> None:
+    """An authenticated Bearer request from an allowed origin still works (no cookies)."""
+    signup = await async_client.post(
+        "/auth/signup",
+        json={"email": "cors@example.com", "password": _PASSWORD},
+    )
+    assert signup.status_code == HTTPStatus.OK
+    token = signup.json()["token"]
+
+    resp = await async_client.get(
+        "/user/balance",
+        headers={"Authorization": f"Bearer {token}", "Origin": ALLOWED_ORIGIN},
+    )
+    assert resp.status_code == HTTPStatus.OK
+    # Auth rode entirely on the Bearer header — no Set-Cookie / cookie reliance.
+    assert "set-cookie" not in {k.lower() for k in resp.headers}

--- a/backend/tests/test_cors_config.py
+++ b/backend/tests/test_cors_config.py
@@ -45,7 +45,8 @@ def test_preflight_omits_allow_credentials() -> None:
         },
     )
     assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
-    assert response.headers.get("access-control-allow-credentials") != "true"
+    # Header omitted entirely (credentials mode off), not set to any value.
+    assert response.headers.get("access-control-allow-credentials") is None
 
 
 @pytest.mark.asyncio
@@ -63,5 +64,7 @@ async def test_bearer_request_from_allowed_origin_succeeds(async_client: AsyncCl
         headers={"Authorization": f"Bearer {token}", "Origin": ALLOWED_ORIGIN},
     )
     assert resp.status_code == HTTPStatus.OK
+    # CORS headers are still emitted for the authenticated cross-origin response.
+    assert resp.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
     # Auth rode entirely on the Bearer header — no Set-Cookie / cookie reliance.
     assert "set-cookie" not in {k.lower() for k in resp.headers}


### PR DESCRIPTION
## Summary

The CORS middleware ran with `allow_credentials=True`, but the API authenticates with `Authorization: Bearer` tokens and sets **no cookies**. Credentials mode is unneeded for a cookieless API and needlessly widens the CORS attack surface / constrains origin handling (audit §5.3).

- `main.py`: flipped `allow_credentials` → **`False`** on the single CORS registration.
- Updated the existing cross-origin POST test: the response keeps `Access-Control-Allow-Origin` (so the browser can still read it) but no longer advertises `Access-Control-Allow-Credentials: true`; dropped the cookie from that request since auth is Bearer-only.
- `allow_origins` / methods / headers are unchanged. The `_assert_credentials_safe` guard stays as defense-in-depth (explicit origins remain best practice regardless).

## Test plan

- New `tests/test_cors_config.py`: the registered `CORSMiddleware` has `allow_credentials=False`; a preflight `OPTIONS` omits `Allow-Credentials: true` (ACAO still present); a `Bearer`-token request from an allowed origin still **200s** with no `Set-Cookie` / cookie reliance.
- All existing `test_cors.py` tests pass (the credentials assertion is updated to expect the header absent).
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy clean.

Closes #487
Refs #459
