### PR TITLE
fix(backend): price every allowlisted BotMason model

### DIFF
--- a/backend/src/services/llm_pricing.py
+++ b/backend/src/services/llm_pricing.py
@@ -70,10 +70,16 @@ MODEL_PRICING: dict[str, ModelPricing] = {
     # OpenAI — https://openai.com/api/pricing/
     "gpt-4o-mini": _price("0.15", "0.60"),
     "gpt-4o": _price("2.50", "10.00"),
+    "gpt-4-turbo": _price("10.00", "30.00"),
     # Anthropic — https://www.anthropic.com/pricing
     "claude-sonnet-4-20250514": _price("3.00", "15.00"),
+    "claude-haiku-4-5-20251001": _price("1.00", "5.00"),
     "claude-3-5-sonnet-20241022": _price("3.00", "15.00"),
     "claude-3-5-haiku-20241022": _price("0.80", "4.00"),
+    # Floating aliases (track the latest minor) — priced at the family's current
+    # list price; the price follows the alias as Anthropic rolls it forward.
+    "claude-opus-4-7": _price("15.00", "75.00"),
+    "claude-sonnet-4-6": _price("3.00", "15.00"),
 }
 
 

--- a/backend/tests/test_llm_pricing.py
+++ b/backend/tests/test_llm_pricing.py
@@ -13,6 +13,7 @@ from decimal import Decimal
 
 import pytest
 
+from services.botmason import PROVIDER_REGISTRY
 from services.llm_pricing import (
     MODEL_PRICING,
     ModelPricing,
@@ -123,3 +124,27 @@ class TestModelPricingTable:
         )
         with pytest.raises(AttributeError):
             pricing.input_usd_per_million = Decimal("99.0")  # type: ignore[misc]
+
+
+class TestAllowlistPricingReconciliation:
+    """Every allowlisted BotMason model must have a pricing row.
+
+    The provider allowlist and the pricing table drifted apart: allowlisted
+    models with no MODEL_PRICING row logged cost as None, blinding the per-model
+    admin cost view. This guard fails if a future allowlist entry is unpriced.
+    """
+
+    def test_every_allowlisted_model_is_priced(self) -> None:
+        unpriced = sorted(
+            model
+            for spec in PROVIDER_REGISTRY.values()
+            for model in spec.allowed_models
+            if get_model_pricing(model) is None
+        )
+        assert unpriced == [], f"allowlisted models missing a price: {unpriced}"
+
+    def test_allowlisted_models_estimate_a_real_cost(self) -> None:
+        """A reachable allowlisted model never estimates cost as None."""
+        for spec in PROVIDER_REGISTRY.values():
+            for model in spec.allowed_models:
+                assert estimate_cost_usd(model, 1000, 1000) is not None


### PR DESCRIPTION
## Summary

The BotMason provider allowlist permitted models with **no `MODEL_PRICING` row** — `gpt-4-turbo` (openai) and `claude-haiku-4-5-20251001`, `claude-opus-4-7`, `claude-sonnet-4-6` (anthropic). On those models `estimate_cost_usd` returns `None` (correct for *unpriced*), so every call logged cost as `None` and the per-model admin cost view was blind to them (audit §5.1 drift). Metering must be real for ship: an allowlisted model must be priced or unreachable.

- Added the four missing pricing rows at published list prices: `gpt-4-turbo` ($10/$30), `claude-haiku-4-5-20251001` ($1/$5), `claude-opus-4-7` ($15/$75), `claude-sonnet-4-6` ($3/$15). Floating aliases are priced at the family's current list price with a comment noting the price tracks the alias.
- Added a **reconciliation guard**: every model in every `PROVIDER_REGISTRY[*].allowed_models` set has a pricing row, and `estimate_cost_usd` never returns `None` for a reachable allowlisted model. This gate prevents the drift from recurring.
- The `None`-for-truly-unknown contract (BUG-BM-008) is unchanged.

## Test plan

- New `TestAllowlistPricingReconciliation`: `test_every_allowlisted_model_is_priced` (the drift guard — would fail on the four unpriced models pre-fix) and `test_allowlisted_models_estimate_a_real_cost`.
- All existing `test_llm_pricing.py` tests pass (unknown-model → `None` contract intact).
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy clean.

Closes #488
Refs #463
