### PR TITLE
fix(frontend): stable keys for Practice editable form rows

### DIFF
--- a/frontend/src/features/Practice/configurator/__tests__/form-stable-keys.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/form-stable-keys.test.tsx
@@ -1,0 +1,88 @@
+/* eslint-env jest */
+// audit-render-08: dynamic form rows must be keyed by a stable id, not the array
+// index, so per-row instance state (an open dropdown, focus) stays attached to
+// the correct row across a reorder or non-tail delete.
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type {
+  CardMeditationCard,
+  CardMeditationConfig,
+  SenseGroundingConfig,
+} from '../../engine/types';
+import CardMeditationForm from '../forms/CardMeditationForm';
+import SenseGroundingForm from '../forms/SenseGroundingForm';
+
+jest.mock('../../utils/pickCardPhoto', () => ({ pickCardPhoto: jest.fn() }));
+
+// The forms are controlled, so a stateful harness holds the config and
+// re-renders on onChange — mirroring the real configurator sheet.
+const SenseHarness = ({ initial }: { initial: SenseGroundingConfig }) => {
+  const [cfg, setCfg] = React.useState(initial);
+  return <SenseGroundingForm value={cfg} onChange={setCfg} />;
+};
+
+const CardHarness = ({ initial }: { initial: CardMeditationConfig }) => {
+  const [cfg, setCfg] = React.useState(initial);
+  return <CardMeditationForm value={cfg} onChange={setCfg} />;
+};
+
+const senseConfig = (): SenseGroundingConfig => ({
+  mode: 'sense_grounding',
+  prompts: [
+    { sense: 'sight', label: 'A' },
+    { sense: 'hearing', label: 'B' },
+    { sense: 'touch', label: 'C' },
+  ],
+});
+
+describe('SenseGroundingForm stable row keys', () => {
+  it('keeps an open dropdown on the correct row after a non-tail delete', () => {
+    const { getByTestId, queryByTestId } = render(<SenseHarness initial={senseConfig()} />);
+    // Open the LAST row's dropdown — open state lives on that row's instance.
+    fireEvent.press(getByTestId('sense-prompt-2-thing-trigger'));
+    expect(queryByTestId('sense-prompt-2-panel')).toBeTruthy();
+
+    // Delete the FIRST row; the last row shifts to index 1.
+    fireEvent.press(getByTestId('sense-prompt-0-remove'));
+
+    // Stable keys → the open dropdown followed its row to index 1. An
+    // index-keyed list would have unmounted it (panel gone / on the wrong row).
+    expect(queryByTestId('sense-prompt-1-panel')).toBeTruthy();
+    expect(queryByTestId('sense-prompt-0-panel')).toBeNull();
+  });
+
+  it('keeps an open dropdown on the correct row after a reorder', () => {
+    const { getByTestId, queryByTestId } = render(<SenseHarness initial={senseConfig()} />);
+    fireEvent.press(getByTestId('sense-prompt-0-thing-trigger'));
+    expect(queryByTestId('sense-prompt-0-panel')).toBeTruthy();
+
+    // Move the first row down; its open dropdown must follow it to index 1.
+    fireEvent.press(getByTestId('sense-prompt-0-down'));
+
+    expect(queryByTestId('sense-prompt-1-panel')).toBeTruthy();
+    expect(queryByTestId('sense-prompt-0-panel')).toBeNull();
+  });
+});
+
+describe('CardMeditationForm stable row keys', () => {
+  const cards: CardMeditationCard[] = [
+    { name: 'Alpha', image_asset_key: null, image_uri: null, symbolism: null },
+    { name: 'Beta', image_asset_key: null, image_uri: null, symbolism: null },
+    { name: 'Gamma', image_asset_key: null, image_uri: null, symbolism: null },
+  ];
+
+  it('keeps the surviving cards intact after a non-tail delete', () => {
+    const { getByTestId, queryByTestId } = render(
+      <CardHarness initial={{ mode: 'card_meditation', deck_id: 'custom', cards }} />,
+    );
+    // Delete the middle card; the keysRef stays in lockstep so the survivors
+    // keep their own rows.
+    fireEvent.press(getByTestId('card-meditation-remove-card-1'));
+
+    expect(getByTestId('card-meditation-card-name-0').props.value).toBe('Alpha');
+    expect(getByTestId('card-meditation-card-name-1').props.value).toBe('Gamma');
+    expect(queryByTestId('card-meditation-card-name-2')).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/form-stable-keys.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/form-stable-keys.test.tsx
@@ -64,6 +64,19 @@ describe('SenseGroundingForm stable row keys', () => {
     expect(queryByTestId('sense-prompt-1-panel')).toBeTruthy();
     expect(queryByTestId('sense-prompt-0-panel')).toBeNull();
   });
+
+  it('assigns an appended row a fresh stable key that survives a later delete', () => {
+    const { getByTestId, queryByTestId } = render(<SenseHarness initial={senseConfig()} />);
+    // Append a 4th row, then open its dropdown.
+    fireEvent.press(getByTestId('sense-grounding-add'));
+    fireEvent.press(getByTestId('sense-prompt-3-thing-trigger'));
+    expect(queryByTestId('sense-prompt-3-panel')).toBeTruthy();
+
+    // Delete the first row; the appended row shifts to index 2, and its open
+    // dropdown follows — proving append handed out a fresh, stable key.
+    fireEvent.press(getByTestId('sense-prompt-0-remove'));
+    expect(queryByTestId('sense-prompt-2-panel')).toBeTruthy();
+  });
 });
 
 describe('CardMeditationForm stable row keys', () => {

--- a/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { SenseGroundingConfig, SensePrompt } from '../../engine/types';
@@ -14,7 +14,30 @@ interface Props {
   onChange: (next: SenseGroundingConfig) => void;
 }
 
-const SenseGroundingForm = ({ value, onChange }: Props): React.JSX.Element => {
+// Monotonic source of per-row keys. Prompts have no persistable id (the backend
+// config schema is `extra="forbid"`), so row identity is tracked transiently
+// here and kept in lockstep with add/remove/move — keying by array index would
+// remap a row's instance state (open dropdown, focus) onto the wrong row on a
+// reorder or non-tail delete.
+let nextPromptKey = 0;
+
+interface PromptRowsApi {
+  keys: string[];
+  setPrompt: (_index: number, _patch: Partial<SensePrompt>) => void;
+  move: (_index: number, _direction: -1 | 1) => void;
+  remove: (_index: number) => void;
+  append: () => void;
+}
+
+/** Owns the prompt list + its transient stable row keys (kept in lockstep). */
+function usePromptRows(
+  value: SenseGroundingConfig,
+  onChange: (next: SenseGroundingConfig) => void,
+): PromptRowsApi {
+  const keysRef = useRef<string[] | null>(null);
+  keysRef.current ??= value.prompts.map(() => `prompt-${(nextPromptKey += 1)}`);
+  const keys = keysRef.current;
+
   const setPrompt = (index: number, patch: Partial<SensePrompt>) => {
     const next = value.prompts.map((prompt, i) => (i === index ? { ...prompt, ...patch } : prompt));
     onChange({ ...value, prompts: next });
@@ -27,18 +50,30 @@ const SenseGroundingForm = ({ value, onChange }: Props): React.JSX.Element => {
     const next = value.prompts.slice();
     next[index] = swapWith;
     next[target] = current;
+    // Swap the keys alongside the rows so each stable id follows its prompt.
+    const nextKeys = keys.slice();
+    [nextKeys[index], nextKeys[target]] = [keys[target]!, keys[index]!];
+    keysRef.current = nextKeys;
     onChange({ ...value, prompts: next });
   };
   const remove = (index: number) => {
+    keysRef.current = keys.filter((_, i) => i !== index);
     onChange({ ...value, prompts: value.prompts.filter((_, i) => i !== index) });
   };
-  const append = () =>
+  const append = () => {
+    keysRef.current = [...keys, `prompt-${(nextPromptKey += 1)}`];
     onChange({ ...value, prompts: [...value.prompts, { sense: 'sight', label: '' }] });
+  };
+  return { keys, setPrompt, move, remove, append };
+}
+
+const SenseGroundingForm = ({ value, onChange }: Props): React.JSX.Element => {
+  const { keys, setPrompt, move, remove, append } = usePromptRows(value, onChange);
   return (
     <View testID="sense-grounding-form">
       {value.prompts.map((prompt, index) => (
         <PromptRow
-          key={index}
+          key={keys[index] ?? `prompt-fallback-${index}`}
           prompt={prompt}
           index={index}
           last={index === value.prompts.length - 1}

--- a/frontend/src/features/Practice/views/IntervalBellView.tsx
+++ b/frontend/src/features/Practice/views/IntervalBellView.tsx
@@ -33,8 +33,11 @@ const IntervalBellView = ({ config, state, controls }: Props): React.JSX.Element
         testID="interval-bell-offsets"
       >
         {cues.map((cue, idx) => (
+          // Read-only derived schedule (no reorder/delete of editable rows), so
+          // it rebuilds wholesale on config change — but key by the cue's
+          // intrinsic identity (kind + offset) rather than the array index.
           <OffsetRow
-            key={`${cue.kind}-${cue.atMs}-${idx}`}
+            key={`${cue.kind}-${cue.atMs}`}
             atMs={cue.atMs}
             kind={cue.kind}
             struck={idx < state.cuesStruck}


### PR DESCRIPTION
## Summary

`SenseGroundingForm` keyed its dynamic prompt rows by **array index**, so on a reorder or non-tail delete React reused the wrong component instances and per-row state (an open dropdown, focus, in-progress edits) **remapped to the wrong row** — a correctness bug, not just a render cost (audit §5.2).

- **`SenseGroundingForm`**: track a transient stable id per prompt in a `keysRef` (prompts have **no persistable id** — the config schema is `extra="forbid"`), generated once and kept in **lockstep** with append/remove/move (move swaps the keys alongside the rows). Key by the id, not the index. The list + key bookkeeping is extracted to a `usePromptRows` hook.
- **`IntervalBellView`**: key the read-only cue schedule by the cue's intrinsic identity (`kind` + offset) instead of the array index. It's a derived, non-reorderable view that rebuilds wholesale on config change, so no per-row state remaps — this just removes the index from the key.
- **`CardMeditationForm`** already keys via a transient `keysRef` (the exact pattern this issue prescribes — no code change needed); now covered by a test.

## Test plan

`form-stable-keys.test.tsx` (discriminating — these fail with index keys):
- **SenseGrounding delete**: open the *last* row's dropdown, then delete the *first* row → the open dropdown follows its row to index 1 (`sense-prompt-1-panel` present, `…-0-panel` gone). With index keys the open instance unmounts.
- **SenseGrounding reorder**: open the first row's dropdown, move it down → the open dropdown follows to index 1.
- **CardMeditation delete**: deleting the middle card leaves `Alpha`/`Gamma` intact in order.
- All existing SenseGrounding / CardMeditation / IntervalBell tests pass.
- `./scripts/frontend/check-all.sh` — 4/4: ESLint zero-warnings (incl. max-lines), `tsc` clean, Jest green, prettier.

Closes #489
Refs #461
