### PR TITLE
fix(backend): back practice-session idempotency with a DB table

### DIFF
--- a/backend/migrations/versions/d0e1f2a3b4c5_add_practice_session_idempotency.py
+++ b/backend/migrations/versions/d0e1f2a3b4c5_add_practice_session_idempotency.py
@@ -1,0 +1,49 @@
+"""add practicesessionspend table for DB-backed practice-session idempotency.
+
+Revision ID: d0e1f2a3b4c5
+Revises: c8d9e0f1a2b3
+Create Date: 2026-06-26 00:00:00.000000
+
+Practice-session idempotency lived in a per-process dict: it died on restart and
+did not hold across workers, so two requests with the same Idempotency-Key on
+different workers could both insert a PracticeSession. This table makes the dedup
+durable and cross-worker — the UNIQUE(user_id, idem_key) constraint serialises the
+check-then-insert race at the database. Purely additive: ``upgrade`` creates the
+table + its indexes; ``downgrade`` drops them.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d0e1f2a3b4c5"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "c8d9e0f1a2b3"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``practicesessionspend`` table and its indexes."""
+    op.create_table(
+        "practicesessionspend",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("idem_key", sa.String(length=128), nullable=False),
+        sa.Column("session_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["session_id"], ["practicesession.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "idem_key", name="uq_practicesessionspend_user_idem_key"),
+    )
+    op.create_index("ix_practicesessionspend_user_id", "practicesessionspend", ["user_id"])
+    op.create_index("ix_practicesessionspend_idem_key", "practicesessionspend", ["idem_key"])
+
+
+def downgrade() -> None:
+    """Drop the ``practicesessionspend`` table and its indexes."""
+    op.drop_index("ix_practicesessionspend_idem_key", table_name="practicesessionspend")
+    op.drop_index("ix_practicesessionspend_user_id", table_name="practicesessionspend")
+    op.drop_table("practicesessionspend")

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -15,6 +15,7 @@ from .password_reset_token import PasswordResetToken
 from .practice import Practice
 from .practice_recipe import PracticeRecipe, PracticeRecipeStep
 from .practice_session import PracticeSession
+from .practice_session_idempotency import PracticeSessionSpend
 from .practice_share_link import PracticeShareLink
 from .practice_tag import PracticeTag
 from .prompt_response import PromptResponse
@@ -42,6 +43,7 @@ __all__ = [
     "PracticeRecipe",
     "PracticeRecipeStep",
     "PracticeSession",
+    "PracticeSessionSpend",
     "PracticeShareLink",
     "PracticeTag",
     "PromptResponse",

--- a/backend/src/models/practice_session_idempotency.py
+++ b/backend/src/models/practice_session_idempotency.py
@@ -1,0 +1,55 @@
+"""DB-backed idempotency store for practice-session creation.
+
+Replaces a per-process ``dict`` (which only deduplicated within one worker and
+lost its state on restart): two requests carrying the same ``Idempotency-Key``
+on different workers could both insert a fresh ``PracticeSession``. One row per
+``(user_id, idem_key)`` records the deduplicated ``session_id``; the UNIQUE
+constraint lets the database serialise the check-then-insert race across workers
+without process-local locks. Modelled on :class:`models.chat_spend.ChatSpend`.
+
+Unlike chat (slow LLM calls need an in-flight tombstone window), practice-session
+writes are fast and synchronous, so there is no tombstone: the row is inserted in
+the same transaction as the session and always carries a real ``session_id``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, DateTime, String, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+# SHA-256 hex digest is 64 chars; column headroom to 128 for a future hash
+# algorithm migration (mirrors ``ChatSpend.idem_key``).
+_IDEM_KEY_COLUMN_WIDTH = 128
+
+
+class PracticeSessionSpend(SQLModel, table=True):
+    """Records that a ``(user_id, idem_key)`` pair already created a session.
+
+    A row is inserted atomically alongside the ``PracticeSession`` it
+    deduplicates; on a duplicate ``idem_key`` the ``UNIQUE`` constraint raises
+    an ``IntegrityError`` which the service translates to "return the recorded
+    session". The raw ``Idempotency-Key`` header is never stored — ``idem_key``
+    is a SHA-256 digest of ``(user_id, raw_key)``.
+    """
+
+    __tablename__ = "practicesessionspend"
+    __table_args__ = (
+        UniqueConstraint("user_id", "idem_key", name="uq_practicesessionspend_user_idem_key"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
+    idem_key: str = Field(
+        sa_column=Column(String(_IDEM_KEY_COLUMN_WIDTH), nullable=False, index=True),
+    )
+    # The deduplicated session. ``ondelete=CASCADE`` so deleting the session
+    # drops its idempotency record too — a later replay then logs a fresh
+    # session rather than resolving a dangling id (matching the old in-memory
+    # behaviour where a vanished session id fell through to a new insert).
+    session_id: int = Field(foreign_key="practicesession.id", ondelete="CASCADE")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
-import hashlib
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import Annotated
+from typing import Annotated, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Depends, Header, Response, status
@@ -18,7 +16,7 @@ from dependencies.ownership import require_owned_user_practice
 from dependencies.timezone import current_user_timezone
 from domain.practice_insights import build_insights
 from domain.practice_resolution import effective_config
-from errors import bad_request, forbidden, not_found
+from errors import bad_request, conflict, forbidden, not_found
 from models.practice import Practice
 from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
@@ -33,6 +31,7 @@ from schemas.practice import (
 )
 from schemas.practice_mode_config import MindfulAnchorConfig
 from schemas.practice_session_metadata import MindfulAnchorMetadata
+from services.practice_session_idempotency import record_session, recorded_session_id
 
 # Window for the insights SQL fetch.  Slightly larger than the 8-week rollup
 # (~56 days) so a session logged late in the oldest bucket still lands in
@@ -168,82 +167,42 @@ async def _resolve_practice_with_mode(
     return practice
 
 
-def _idempotency_cache_key(user_id: int, raw_key: str) -> str:
-    """Return a stable, opaque hash for ``(user_id, raw_key)`` idempotency storage.
+async def _load_session(session: AsyncSession, session_id: int) -> PracticeSession:
+    """Load the recorded idempotent ``PracticeSession`` by id.
 
-    The raw header value may be up to 256 chars of client-controlled text.
-    Hashing it with SHA-256 (a) keeps the cache key bounded, (b) prevents
-    a crafted key from escaping the per-user namespace via a collision
-    across users, and (c) means the raw client token is never stored or
-    logged -- same reasoning as the rate-limit key in ``practices.py``.
-    The ``user:`` prefix keeps the key space disjoint from the raw hash
-    space in any future backing store (Redis, DB column, …).
+    The spend row is FK-tied to the session with ``ondelete=CASCADE``, so a
+    recorded id always resolves to a live row; a miss is an unreachable
+    inconsistency surfaced as 404 rather than silently returning ``None``.
     """
-    digest = hashlib.sha256(f"{user_id}:{raw_key}".encode()).hexdigest()
-    return f"user:{digest}"
+    result = await session.execute(select(PracticeSession).where(PracticeSession.id == session_id))
+    row = result.scalars().first()
+    if row is None:
+        raise not_found("practice_session")
+    return row
 
 
-# Module-level in-process idempotency store.  Maps ``cache_key → session_id``
-# for the lifetime of the process.  This is sufficient for a single-worker
-# deployment; a multi-worker production deployment should replace this with a
-# shared backing store (Redis, DB table) at the same interface.
-# The store is intentionally not bounded -- sessions are small ints so memory
-# growth is negligible for realistic request rates.
-_IDEMPOTENCY_STORE: dict[str, int] = {}
-
-# Per-cache-key locks that serialise the check-then-insert critical section
-# inside ``create_session`` so two concurrent requests with the same
-# ``(user_id, Idempotency-Key)`` cannot both pass the lookup, both insert a
-# fresh row, and both call ``_remember_idempotent_session``.  Without these,
-# the late writer overwrites the early writer's ``session_id`` and the second
-# response no longer matches the first — breaking the idempotency guarantee.
-# The lookup of the lock itself is guarded by a coarser ``_IDEMPOTENCY_LOCKS_GUARD``
-# so the per-key Lock object is initialised exactly once even under contention.
-_IDEMPOTENCY_LOCKS: dict[str, asyncio.Lock] = {}
-_IDEMPOTENCY_LOCKS_GUARD = asyncio.Lock()
-
-
-async def _acquire_idem_lock(cache_key: str) -> asyncio.Lock:
-    """Return the ``asyncio.Lock`` for ``cache_key``, creating it if needed.
-
-    The double-check pattern under ``_IDEMPOTENCY_LOCKS_GUARD`` keeps the
-    lazy initialisation atomic — two concurrent first-time requests cannot
-    each create their own Lock and then race past each other holding
-    different lock objects.
-    """
-    async with _IDEMPOTENCY_LOCKS_GUARD:
-        lock = _IDEMPOTENCY_LOCKS.get(cache_key)
-        if lock is None:
-            lock = asyncio.Lock()
-            _IDEMPOTENCY_LOCKS[cache_key] = lock
-        return lock
-
-
-async def _lookup_idempotent_session(
+async def _insert_with_idempotency(
     session: AsyncSession,
     user_id: int,
     idempotency_key: str,
-) -> PracticeSession | None:
-    """Return the cached ``PracticeSession`` row for an idempotency key, if any.
+    practice_session: PracticeSession,
+) -> PracticeSession:
+    """Record the spend row for the just-staged session, resolving a lost race.
 
-    Split out of ``create_session`` to keep the route handler under
-    xenon's A-rank complexity cap.  Returns ``None`` when no cached
-    session id is known OR when the cached id no longer resolves (the
-    row was deleted between requests, in which case the next POST is
-    treated as a fresh log).
+    Flushes to assign the session id, then records the ``(user_id, key)`` spend.
+    On a duplicate-key collision (another worker recorded this key first) the
+    staged session is rolled back and the winner's recorded session is returned
+    — so concurrent same-key requests yield one session, serialised by the DB
+    UNIQUE constraint rather than a process-local lock.
     """
-    cache_key = _idempotency_cache_key(user_id, idempotency_key)
-    existing_id = _IDEMPOTENCY_STORE.get(cache_key)
-    if existing_id is None:
-        return None
-    result = await session.execute(select(PracticeSession).where(PracticeSession.id == existing_id))
-    return result.scalars().first()
-
-
-def _remember_idempotent_session(user_id: int, idempotency_key: str, session_id: int) -> None:
-    """Persist the ``(user_id, idempotency_key) → session_id`` mapping for future replays."""
-    cache_key = _idempotency_cache_key(user_id, idempotency_key)
-    _IDEMPOTENCY_STORE[cache_key] = session_id
+    await session.flush()
+    if await record_session(session, user_id, idempotency_key, cast("int", practice_session.id)):
+        return practice_session
+    await session.rollback()
+    winner_id = await recorded_session_id(session, user_id, idempotency_key)
+    if winner_id is None:
+        raise conflict("idempotency_in_flight")
+    return await _load_session(session, winner_id)
 
 
 def _build_practice_session(
@@ -280,17 +239,16 @@ async def _perform_create_session(
 ) -> PracticeSession:
     """Lookup-or-insert the practice session under the optional idempotency key.
 
-    Extracted from ``create_session`` so the caller can wrap the entire
-    critical section in a per-key ``asyncio.Lock`` (BUG-PRACTICE-007
-    follow-up): the lookup, the DB insert, and the ``_remember_…`` write
-    must all execute as one atomic unit so two concurrent requests with
-    the same key cannot both miss the cache, both insert, and both
-    remember — clobbering each other's ``session_id`` mapping.
+    The dedup is DB-backed (``services.practice_session_idempotency``): a replay
+    returns the recorded session, and a first write records a spend row in the
+    same transaction. The ``UNIQUE(user_id, idem_key)`` constraint serialises
+    concurrent same-key requests across workers, so no process-local lock is
+    needed (BUG-PRACTICE-007, made durable + cross-worker).
     """
     if idempotency_key is not None:
-        cached = await _lookup_idempotent_session(session, current_user, idempotency_key)
-        if cached is not None:
-            return cached
+        cached_id = await recorded_session_id(session, current_user, idempotency_key)
+        if cached_id is not None:
+            return await _load_session(session, cached_id)
 
     user_practice = await _resolve_user_practice_for_session(
         session, payload.user_practice_id, current_user
@@ -301,11 +259,16 @@ async def _perform_create_session(
         user_id=current_user, payload=payload, practice=practice
     )
     session.add(practice_session)
+
+    if idempotency_key is not None:
+        outcome = await _insert_with_idempotency(
+            session, current_user, idempotency_key, practice_session
+        )
+        if outcome is not practice_session:
+            return outcome  # lost the race; our insert was rolled back
+
     await session.commit()
     await session.refresh(practice_session)
-
-    if idempotency_key is not None and practice_session.id is not None:
-        _remember_idempotent_session(current_user, idempotency_key, practice_session.id)
 
     logger.info(
         "practice_session_logged",
@@ -341,17 +304,13 @@ async def create_session(
 
     Accepts an optional ``Idempotency-Key`` header (BUG-PRACTICE-007): if a
     key is present and a session was already created under the same
-    ``(user_id, key)`` pair, the cached session row is returned without
-    creating a duplicate.  The check-then-insert critical section runs
-    under a per-key ``asyncio.Lock`` so concurrent same-key requests on
-    one worker can never both produce a row.
+    ``(user_id, key)`` pair, the recorded session row is returned without
+    creating a duplicate.  The dedup is backed by the ``practicesessionspend``
+    table (``UNIQUE(user_id, idem_key)``), so it holds across process restarts
+    and workers — the database serialises the check-then-insert race, no
+    process-local lock required.
     """
-    if idempotency_key is None:
-        return await _perform_create_session(payload, current_user, session, None)
-    cache_key = _idempotency_cache_key(current_user, idempotency_key)
-    lock = await _acquire_idem_lock(cache_key)
-    async with lock:
-        return await _perform_create_session(payload, current_user, session, idempotency_key)
+    return await _perform_create_session(payload, current_user, session, idempotency_key)
 
 
 @router.get("/", response_model=None)

--- a/backend/src/services/practice_session_idempotency.py
+++ b/backend/src/services/practice_session_idempotency.py
@@ -1,0 +1,70 @@
+"""DB-backed idempotency for practice-session creation.
+
+The read/insert primitives for the ``PracticeSessionSpend`` table that backs the
+``POST /practice-sessions`` ``Idempotency-Key`` dedup. Mirrors
+``services.chat_idempotency`` but is simpler: practice-session writes are fast and
+synchronous (no slow LLM call), so there is no in-flight tombstone window — the
+spend row is inserted in the same transaction as the session and always carries a
+real ``session_id``. Cross-worker serialisation comes from the
+``UNIQUE(user_id, idem_key)`` constraint, not a process-local lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.practice_session_idempotency import PracticeSessionSpend
+
+
+def hash_idem_key(user_id: int, raw_key: str) -> str:
+    """Return a stable SHA-256 hash of ``(user_id, raw_key)`` for the column value.
+
+    The raw client header is never stored. Hashing keeps the column width
+    bounded and one-way, and the ``user_id`` prefix keeps the hash space
+    disjoint across users so a crafted key cannot collide into another user's
+    namespace (same scheme as ``services.chat_idempotency.hash_idem_key``).
+    """
+    return hashlib.sha256(f"{user_id}:{raw_key}".encode()).hexdigest()
+
+
+async def recorded_session_id(
+    session: AsyncSession, user_id: int, raw_key: str | None
+) -> int | None:
+    """Return the ``session_id`` already recorded for this key, or ``None``."""
+    if raw_key is None:
+        return None
+    hashed = hash_idem_key(user_id, raw_key)
+    result = await session.execute(
+        select(PracticeSessionSpend.session_id).where(
+            PracticeSessionSpend.user_id == user_id,
+            col(PracticeSessionSpend.idem_key) == hashed,
+        )
+    )
+    return result.scalars().first()
+
+
+async def record_session(
+    session: AsyncSession, user_id: int, raw_key: str, session_id: int
+) -> bool:
+    """Insert the spend row, returning ``False`` on a duplicate-key collision.
+
+    The INSERT is wrapped in a ``begin_nested()`` SAVEPOINT so a collision only
+    rolls back this insert — any work already staged on the session (the
+    just-flushed ``PracticeSession``) is left for the caller to roll back as a
+    unit. ``False`` means another request already recorded this key; the caller
+    re-reads it via :func:`recorded_session_id` and returns that session.
+    """
+    hashed = hash_idem_key(user_id, raw_key)
+    try:
+        async with session.begin_nested():
+            session.add(
+                PracticeSessionSpend(user_id=user_id, idem_key=hashed, session_id=session_id)
+            )
+            await session.flush()
+    except IntegrityError:
+        return False
+    return True

--- a/backend/tests/test_practice_session_idempotency.py
+++ b/backend/tests/test_practice_session_idempotency.py
@@ -1,0 +1,134 @@
+"""Service-level + migration tests for DB-backed practice-session idempotency.
+
+Covers the ``services.practice_session_idempotency`` primitives (hash, check,
+atomic insert) and a SQLite round-trip of the migration that adds the backing
+``practicesessionspend`` table. The router-level cross-restart / single-session
+regression lives in ``test_practice_sessions.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.practice_session_idempotency import (
+    hash_idem_key,
+    record_session,
+    recorded_session_id,
+)
+
+
+class TestHashIdemKey:
+    """The column value hashes ``(user_id, raw_key)`` one-way and per-user."""
+
+    def test_is_deterministic_and_user_scoped(self) -> None:
+        """Same inputs hash equal; a different user yields a disjoint hash."""
+        assert hash_idem_key(1, "k") == hash_idem_key(1, "k")
+        assert hash_idem_key(1, "k") != hash_idem_key(2, "k")
+
+    def test_never_contains_the_raw_key(self) -> None:
+        """The raw client header never appears in the stored digest."""
+        assert "secret-key" not in hash_idem_key(1, "secret-key")
+
+
+@pytest.mark.asyncio
+class TestRecordedSessionId:
+    """``recorded_session_id`` reads back the deduplicated session id."""
+
+    async def test_none_for_unseen_key(self, db_session: AsyncSession) -> None:
+        """An unrecorded key resolves to ``None``."""
+        assert await recorded_session_id(db_session, 1, "unseen") is None
+
+    async def test_none_when_raw_key_is_none(self, db_session: AsyncSession) -> None:
+        """A missing header (``None``) short-circuits to ``None``."""
+        assert await recorded_session_id(db_session, 1, None) is None
+
+    async def test_returns_recorded_id(self, db_session: AsyncSession) -> None:
+        """After recording, the same key resolves to the recorded session id."""
+        assert await record_session(db_session, 1, "key-x", 4242) is True
+        await db_session.commit()
+        assert await recorded_session_id(db_session, 1, "key-x") == 4242
+
+
+@pytest.mark.asyncio
+class TestRecordSession:
+    """``record_session`` is an atomic, collision-aware insert."""
+
+    async def test_duplicate_key_collides_without_clobbering(
+        self, db_session: AsyncSession
+    ) -> None:
+        """A second record under the same key returns ``False`` and keeps the winner."""
+        assert await record_session(db_session, 1, "dup", 1) is True
+        await db_session.commit()
+        # Same (user, key) again → UNIQUE collision → False, no second row.
+        assert await record_session(db_session, 1, "dup", 2) is False
+        await db_session.rollback()
+        # The recorded mapping is unchanged — the first writer wins.
+        assert await recorded_session_id(db_session, 1, "dup") == 1
+
+    async def test_distinct_key_or_user_does_not_collide(self, db_session: AsyncSession) -> None:
+        """Different keys, and the same key under a different user, are independent."""
+        assert await record_session(db_session, 1, "a", 10) is True
+        assert await record_session(db_session, 1, "b", 11) is True  # different key
+        assert await record_session(db_session, 2, "a", 12) is True  # different user
+        await db_session.commit()
+        assert await recorded_session_id(db_session, 2, "a") == 12
+
+
+# -- Migration round-trip ---------------------------------------------------
+
+_IDEM_REVISION = "d0e1f2a3b4c5"  # pragma: allowlist secret
+_IDEM_BASE_REVISION = "c8d9e0f1a2b3"  # pragma: allowlist secret
+
+
+def _bootstrap_idem_dependencies(sync_url: str) -> None:
+    """Pre-create the ``user`` + ``practicesession`` tables the FKs reference.
+
+    Mirrors ``test_migrations`` style: stamp at the base revision and run only
+    this migration, rather than replaying the whole chain on SQLite.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE user (id INTEGER PRIMARY KEY, email VARCHAR(255))"))
+        conn.execute(text("CREATE TABLE practicesession (id INTEGER PRIMARY KEY, user_id INTEGER)"))
+    engine.dispose()
+
+
+def _has_table(sync_url: str, table: str) -> bool:
+    """Return whether ``table`` exists in the SQLite database at ``sync_url``."""
+    engine = create_engine(sync_url)
+    try:
+        return inspect(engine).has_table(table)
+    finally:
+        engine.dispose()
+
+
+def test_idempotency_migration_round_trips_on_sqlite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Upgrade creates ``practicesessionspend``; downgrade drops it; re-upgrade is clean."""
+    db_path = tmp_path / "psidem_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    _bootstrap_idem_dependencies(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _IDEM_BASE_REVISION)
+
+    command.upgrade(cfg, _IDEM_REVISION)
+    assert _has_table(sync_url, "practicesessionspend")
+
+    command.downgrade(cfg, _IDEM_BASE_REVISION)
+    assert not _has_table(sync_url, "practicesessionspend")
+
+    command.upgrade(cfg, _IDEM_REVISION)
+    assert _has_table(sync_url, "practicesessionspend")

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -11,8 +11,8 @@ import pytest
 from httpx import AsyncClient
 from pydantic import ValidationError
 from sqlalchemy import update
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import col, select
 
 from main import app
 from models.practice import Practice
@@ -1114,6 +1114,40 @@ async def test_duplicate_idempotency_key_returns_same_session(
 
 
 @pytest.mark.asyncio
+async def test_idempotency_survives_simulated_process_restart(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The dedup is durable: a replay after dropping in-memory state still echoes the row.
+
+    The old in-process dict lost its mapping on restart, so a retry after a deploy
+    or crash created a duplicate. With the DB-backed store, expunging the ORM
+    identity map (a stand-in for a fresh process with empty caches) and replaying
+    the key still resolves the recorded session — no second row.
+    """
+    headers, _ = await _signup(async_client)
+    up_id = await _create_user_practice(async_client, db_session, headers)
+    idem_headers = {**headers, "Idempotency-Key": "restart-key-001"}
+
+    resp1 = await async_client.post(
+        "/practice-sessions/", json=_session_payload(up_id), headers=idem_headers
+    )
+    assert resp1.status_code == HTTPStatus.CREATED
+    first_id = resp1.json()["id"]
+
+    # Simulate a process restart: nothing is cached in memory anymore.
+    db_session.expunge_all()
+
+    resp2 = await async_client.post(
+        "/practice-sessions/", json=_session_payload(up_id), headers=idem_headers
+    )
+    assert resp2.status_code in (HTTPStatus.OK, HTTPStatus.CREATED)
+    assert resp2.json()["id"] == first_id
+
+    wk = await async_client.get("/practice-sessions/week-count", headers=headers)
+    assert wk.json()["count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_different_idempotency_keys_create_separate_sessions(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
@@ -1155,38 +1189,69 @@ async def test_no_idempotency_key_still_works(
 
 @pytest.mark.asyncio
 async def test_concurrent_idempotency_key_creates_one_session(
-    async_client: AsyncClient, db_session: AsyncSession
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Address-feedback regression: TOCTOU race on the in-process store.
+    """The DB UNIQUE(user_id, idem_key) — not a process lock — serialises the race.
 
-    Without a per-key lock, two coroutines that race through the
-    ``_lookup_idempotent_session`` check before either reaches
-    ``_remember_idempotent_session`` would both pass the cache check, both
-    INSERT a fresh ``PracticeSession`` row, and both update the dict —
-    leaving two rows in the DB and the dict mapping the late writer's
-    session id (or even an orphan).
-
-    With the lock, the second coroutine waits for the first to finish the
-    DB write + dict update, then sees the cached id and returns the same
-    row.  Exactly one session must land in the DB.
+    Runs against the file-backed concurrent DB where each request gets its OWN
+    session (the real multi-worker shape, which a process-local lock cannot
+    cover). Several same-key requests race through the check-then-insert; the
+    constraint guarantees the durable invariant — exactly one PracticeSession,
+    every successful response describing that one row. A request that lost the
+    insert and re-read the winner replays it (2xx); one that raced ahead of the
+    winner's commit may surface 409 — both are fine, what must never happen is a
+    duplicate session or an unhandled 500.
     """
-    headers, _ = await _signup(async_client)
-    up_id = await _create_user_practice(async_client, db_session, headers)
-    idem_headers = {**headers, "Idempotency-Key": "race-key-001"}
-    body = _session_payload(up_id)
+    _password = "securepassword123"  # pragma: allowlist secret
+    signup = await concurrent_async_client.post(
+        "/auth/signup",
+        json={"email": "race@example.com", "password": _password},
+    )
+    headers = {"Authorization": f"Bearer {signup.json()['token']}"}
 
-    resp_a, resp_b = await asyncio.gather(
-        async_client.post("/practice-sessions/", json=body, headers=idem_headers),
-        async_client.post("/practice-sessions/", json=body, headers=idem_headers),
+    async with concurrent_session_factory() as session:
+        practice = Practice(
+            stage_number=1,
+            name="Race",
+            description="x",
+            instructions="y",
+            default_duration_minutes=5,
+            approved=True,
+        )
+        session.add(practice)
+        await session.commit()
+        await session.refresh(practice)
+        practice_id = practice.id
+
+    up = await concurrent_async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice_id, "stage_number": 1},
+        headers=headers,
+    )
+    assert up.status_code == HTTPStatus.CREATED
+    body = _session_payload(up.json()["id"])
+    idem_headers = {**headers, "Idempotency-Key": "race-key-001"}
+
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post("/practice-sessions/", json=body, headers=idem_headers)
+            for _ in range(4)
+        ]
     )
 
-    assert resp_a.status_code in (HTTPStatus.OK, HTTPStatus.CREATED)
-    assert resp_b.status_code in (HTTPStatus.OK, HTTPStatus.CREATED)
-    # Both responses describe the SAME row -- no duplicate created.
-    assert resp_a.json()["id"] == resp_b.json()["id"]
+    codes = [r.status_code for r in responses]
+    successes = [r for r in responses if r.status_code in (HTTPStatus.OK, HTTPStatus.CREATED)]
+    conflicts = [c for c in codes if c == HTTPStatus.CONFLICT]
+    assert len(successes) >= 1, f"expected at least one success, got {codes}"
+    assert len(successes) + len(conflicts) == len(responses), f"every response 2xx or 409: {codes}"
+    # Every successful response describes the SAME row — idempotent replay.
+    assert len({r.json()["id"] for r in successes}) == 1
 
-    wk = await async_client.get("/practice-sessions/week-count", headers=headers)
-    assert wk.json()["count"] == 1
+    # Durable invariant: exactly one PracticeSession landed in the DB.
+    async with concurrent_session_factory() as session:
+        rows = (await session.execute(select(PracticeSession))).scalars().all()
+    assert len(rows) == 1
 
 
 # -- BUG-PRACTICE-009: week_count uses user's local timezone ----------------


### PR DESCRIPTION
## Summary

Practice-session idempotency lived in a module-level dict (`_IDEMPOTENCY_STORE`) guarded by per-key `asyncio.Lock`s. That dedup **died on restart** and — critically — **did not hold across workers**: two requests carrying the same `Idempotency-Key` could land on different workers, miss each other's in-memory entry, and both insert a fresh `PracticeSession` (audit §5.3 response-contract finding). Rebuilt on the existing `ChatSpend` pattern so the database serialises the race.

- **Model + migration**: new `PracticeSessionSpend` — `UNIQUE(user_id, idem_key)`, a **hashed** `idem_key` (SHA-256; the raw header is never stored), the recorded `session_id`, FKs to `user`/`practicesession` (`ondelete=CASCADE`). Reversible Alembic migration (`d0e1f2a3b4c5`) creates/drops the table + its indexes.
- **Service** `practice_session_idempotency`: `hash_idem_key`, `recorded_session_id` (check), `record_session` (atomic `begin_nested()` insert, `False` on collision). **No in-flight tombstone** — practice-session writes are fast and synchronous (unlike LLM calls), so the spend row is inserted in the same transaction as the session and always carries a real `session_id`.
- **Router**: removed `_IDEMPOTENCY_STORE`, `_IDEMPOTENCY_LOCKS`, `_acquire_idem_lock`, `_lookup_idempotent_session`, `_remember_idempotent_session`, and the per-key lock. The check-then-insert relies on the DB `UNIQUE` constraint for cross-worker serialisation; a lost race rolls back the staged session and replays the winner.

The `POST /practice-sessions` response shape is unchanged.

## Test plan

- `test_practice_sessions.py`: same key → same `session_id` + exactly one `PracticeSession`; **survives a simulated process restart** (`expunge_all`, replay → same row); **concurrent** same-key requests on the file-backed DB (separate per-request sessions, the real multi-worker shape) → one row, every response 2xx/409, successes share one id, no 500.
- `test_practice_session_idempotency.py` (new): `hash_idem_key` determinism / user-scoping / raw-key-absent; `recorded_session_id` None/hit; `record_session` collision (returns `False`, winner preserved) and independence across key/user; **migration round-trip** (upgrade → downgrade → re-upgrade) on SQLite.
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy + xenon A clean. `alembic check` / migration-drift run against Postgres in CI (the model↔migration columns mirror the `ChatSpend` alignment).

Closes #490
Refs #460
