### PR TITLE
fix(backend): fold course completion into stage overall-progress

### DIFF
--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -132,10 +132,15 @@ def next_stage_for(progress: StageProgress | None) -> int:
     return progress.current_stage + 1
 
 
-async def _compute_habits_progress(session: AsyncSession, user_id: int, stage_number: int) -> float:
-    """Compute ratio of habits with ≥1 completion to total habits for a stage.
+async def _compute_habits_progress(
+    session: AsyncSession, user_id: int, stage_number: int
+) -> tuple[float, bool]:
+    """Return ``(progress, present)`` for the stage's habit component.
 
-    Returns 0.0 when the user has no habits for this stage.
+    ``progress`` is the ratio of habits with ≥1 completion to total habits;
+    ``present`` is whether the stage has any habits at all. A stage with no
+    habits reports ``(0.0, False)`` so it is excluded from the overall average
+    rather than dragging it down as a 0% component.
     """
     stage_str = str(stage_number)
     # Count total habits for this stage
@@ -146,7 +151,7 @@ async def _compute_habits_progress(session: AsyncSession, user_id: int, stage_nu
     )
     total_habits: int = total_result.scalar() or 0
     if total_habits == 0:
-        return 0.0
+        return 0.0, False
 
     # Count habits that have at least one GoalCompletion (via Goal)
     active_result = await session.execute(
@@ -161,7 +166,7 @@ async def _compute_habits_progress(session: AsyncSession, user_id: int, stage_nu
         .where(Habit.user_id == user_id, Habit.stage == stage_str)
     )
     active_habits: int = active_result.scalar() or 0
-    return min(active_habits / total_habits, 1.0)
+    return min(active_habits / total_habits, 1.0), True
 
 
 async def _compute_course_items_completed(
@@ -179,6 +184,49 @@ async def _compute_course_items_completed(
         )
     )
     return result.scalar() or 0
+
+
+async def _compute_course_items_total(session: AsyncSession, stage_number: int) -> int:
+    """Count the content items that exist for a stage (the course denominator).
+
+    Stage content is global (not per-user), so this is the total a user's
+    completed count is measured against to derive a ``[0, 1]`` fraction.
+    """
+    result = await session.execute(
+        select(func.count())
+        .select_from(StageContent)
+        .join(CourseStage, col(StageContent.course_stage_id) == col(CourseStage.id))
+        .where(CourseStage.stage_number == stage_number)
+    )
+    return result.scalar() or 0
+
+
+async def _count_user_practices(session: AsyncSession, user_id: int, stage_number: int) -> int:
+    """Count the user's selected practices for a stage (the practice presence signal).
+
+    Used to decide whether the practice component is part of the stage at all —
+    a stage the user has selected practices for counts practice in the overall
+    average (as 0% until they log a session), whereas a stage with none excludes
+    it entirely rather than reporting a permanent 0.
+    """
+    result = await session.execute(
+        select(func.count())
+        .select_from(UserPractice)
+        .where(UserPractice.user_id == user_id, UserPractice.stage_number == stage_number)
+    )
+    return result.scalar() or 0
+
+
+def _average_present(components: list[tuple[float, bool]]) -> float:
+    """Average the ``value`` of every present component, or ``0.0`` if none are.
+
+    The overall stage percentage is the mean of the components that actually
+    have data for the stage (habits, practice, course) — so the divisor adapts
+    instead of always being a hardcoded 2, and a stage with a single component
+    reports that component's progress directly.
+    """
+    present = [value for value, is_present in components if is_present]
+    return sum(present) / len(present) if present else 0.0
 
 
 async def compute_stage_progress(
@@ -199,13 +247,21 @@ async def compute_stage_progress(
     )
     practice_count: int = ps_result.scalar() or 0
 
-    habits_progress = await _compute_habits_progress(session, user_id, stage_number)
+    habits_progress, habits_present = await _compute_habits_progress(session, user_id, stage_number)
+    practice_present = await _count_user_practices(session, user_id, stage_number) > 0
     course_items = await _compute_course_items_completed(session, user_id, stage_number)
+    course_total = await _compute_course_items_total(session, stage_number)
 
-    # Overall progress: simple average of available metrics
-    total = habits_progress + (1.0 if practice_count > 0 else 0.0)
-    divisor = 2
-    overall = total / divisor if divisor > 0 else 0.0
+    # Overall = mean of the components that have data; course completion now
+    # moves the headline number, and the divisor adapts to what's present.
+    course_progress = min(course_items / course_total, 1.0) if course_total else 0.0
+    overall = _average_present(
+        [
+            (habits_progress, habits_present),
+            (1.0 if practice_count > 0 else 0.0, practice_present),
+            (course_progress, course_total > 0),
+        ]
+    )
 
     return {
         "habits_progress": round(habits_progress, 2),
@@ -243,46 +299,82 @@ async def _batch_habit_metrics(session: AsyncSession, user_id: int) -> dict[str,
     return {row.stage: (row.total, row.active) for row in result.all()}
 
 
-async def _batch_practice_counts(session: AsyncSession, user_id: int) -> dict[int, int]:
-    """Per-stage practice-session counts for a user in one query (keyed by stage number)."""
+async def _batch_practice_metrics(
+    session: AsyncSession, user_id: int
+) -> dict[int, tuple[int, int]]:
+    """Per-stage ``(selected_practices, sessions)`` for a user in one query.
+
+    Based on ``UserPractice`` (outer-joined to sessions) so the practice
+    component's *presence* is "the user selected a practice for this stage",
+    independent of whether any session was logged — matching the per-stage
+    :func:`_count_user_practices` presence signal.
+    """
     result = await session.execute(
-        select(UserPractice.stage_number, func.count(col(PracticeSession.id)))
-        .select_from(PracticeSession)
-        .join(UserPractice, col(PracticeSession.user_practice_id) == col(UserPractice.id))
-        .where(PracticeSession.user_id == user_id)
+        select(
+            UserPractice.stage_number,
+            func.count(func.distinct(UserPractice.id)).label("selected"),
+            func.count(col(PracticeSession.id)).label("sessions"),
+        )
+        .select_from(UserPractice)
+        .outerjoin(
+            PracticeSession,
+            (col(PracticeSession.user_practice_id) == col(UserPractice.id))
+            & (col(PracticeSession.user_id) == user_id),
+        )
+        .where(UserPractice.user_id == user_id)
         .group_by(col(UserPractice.stage_number))
     )
-    return {row[0]: row[1] for row in result.all()}
+    return {row.stage_number: (row.selected, row.sessions) for row in result.all()}
 
 
-async def _batch_course_counts(session: AsyncSession, user_id: int) -> dict[int, int]:
-    """Per-stage completed-content counts for a user in one query (keyed by stage number)."""
+async def _batch_course_metrics(session: AsyncSession, user_id: int) -> dict[int, tuple[int, int]]:
+    """Per-stage ``(total_items, completed_items)`` for a user in one query.
+
+    Based on ``StageContent`` (outer-joined to the user's completions) so the
+    course component carries both its denominator (presence) and the user's
+    completed count for the ``[0, 1]`` fraction folded into overall progress.
+    """
     result = await session.execute(
-        select(CourseStage.stage_number, func.count(col(ContentCompletion.id)))
-        .select_from(ContentCompletion)
-        .join(StageContent, col(ContentCompletion.content_id) == col(StageContent.id))
+        select(
+            CourseStage.stage_number,
+            func.count(func.distinct(StageContent.id)).label("total"),
+            func.count(func.distinct(ContentCompletion.id)).label("completed"),
+        )
+        .select_from(StageContent)
         .join(CourseStage, col(StageContent.course_stage_id) == col(CourseStage.id))
-        .where(ContentCompletion.user_id == user_id)
+        .outerjoin(
+            ContentCompletion,
+            (col(ContentCompletion.content_id) == col(StageContent.id))
+            & (col(ContentCompletion.user_id) == user_id),
+        )
         .group_by(col(CourseStage.stage_number))
     )
-    return {row[0]: row[1] for row in result.all()}
+    return {row.stage_number: (row.total, row.completed) for row in result.all()}
 
 
 def _assemble_stage_progress(
     stage_number: int,
     habit_metrics: dict[str, tuple[int, int]],
-    practice_counts: dict[int, int],
-    course_counts: dict[int, int],
+    practice_metrics: dict[int, tuple[int, int]],
+    course_metrics: dict[int, tuple[int, int]],
 ) -> dict[str, float | int]:
     """Build one stage's progress dict from the batched lookups (parity with the loop)."""
-    total, active = habit_metrics.get(str(stage_number), (0, 0))
-    habits_progress = min(active / total, 1.0) if total > 0 else 0.0
-    practice_count = practice_counts.get(stage_number, 0)
-    overall = (habits_progress + (1.0 if practice_count > 0 else 0.0)) / 2
+    total_habits, active_habits = habit_metrics.get(str(stage_number), (0, 0))
+    habits_progress = min(active_habits / total_habits, 1.0) if total_habits > 0 else 0.0
+    selected, sessions = practice_metrics.get(stage_number, (0, 0))
+    total_course, completed_course = course_metrics.get(stage_number, (0, 0))
+    course_progress = min(completed_course / total_course, 1.0) if total_course > 0 else 0.0
+    overall = _average_present(
+        [
+            (habits_progress, total_habits > 0),
+            (1.0 if sessions > 0 else 0.0, selected > 0),
+            (course_progress, total_course > 0),
+        ]
+    )
     return {
         "habits_progress": round(habits_progress, 2),
-        "practice_sessions_completed": practice_count,
-        "course_items_completed": course_counts.get(stage_number, 0),
+        "practice_sessions_completed": sessions,
+        "course_items_completed": completed_course,
         "overall_progress": round(overall, 2),
     }
 
@@ -308,11 +400,11 @@ async def compute_stage_progress_batch(
     if not stage_numbers:
         return {}
     habit_metrics = await _batch_habit_metrics(session, user_id)
-    practice_counts = await _batch_practice_counts(session, user_id)
-    course_counts = await _batch_course_counts(session, user_id)
+    practice_metrics = await _batch_practice_metrics(session, user_id)
+    course_metrics = await _batch_course_metrics(session, user_id)
     return {
         stage_number: _assemble_stage_progress(
-            stage_number, habit_metrics, practice_counts, course_counts
+            stage_number, habit_metrics, practice_metrics, course_metrics
         )
         for stage_number in stage_numbers
     }

--- a/backend/tests/domain/test_stage_progress_queries.py
+++ b/backend/tests/domain/test_stage_progress_queries.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Iterator
 from contextlib import contextmanager
-from datetime import date
+from datetime import UTC, date, datetime
 
 import pytest
 import pytest_asyncio
@@ -25,10 +25,16 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlmodel import SQLModel
 
-from domain.stage_progress import get_stage_habit_history
+from domain.stage_progress import compute_stage_progress, get_stage_habit_history
+from models.content_completion import ContentCompletion
+from models.course_stage import CourseStage
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
+from models.practice import Practice
+from models.practice_session import PracticeSession
+from models.stage_content import StageContent
+from models.user_practice import UserPractice
 
 # Aggregation should be O(1) queries irrespective of habit/goal count.
 _MAX_QUERIES_FOR_HABIT_HISTORY = 2
@@ -289,3 +295,181 @@ async def test_habit_history_is_empty_when_user_has_no_habits(
     assert result == []
     # Only the habits SELECT should have been issued; no follow-up join.
     assert len(queries) == 1
+
+
+# -- audit-destub-07: compute_stage_progress overall calc -------------------
+
+_STAGE = 1
+_USER = 1
+
+
+async def _seed_habits(
+    session: AsyncSession, user_id: int, stage: int, *, total: int, active: int
+) -> None:
+    """Seed ``total`` habits for a stage, ``active`` of which have a completion."""
+    habits = [
+        Habit(
+            name=f"H{i}",
+            icon="⭐",
+            start_date=date(2026, 1, 1),
+            energy_cost=1,
+            energy_return=1,
+            user_id=user_id,
+            stage=str(stage),
+            streak=0,
+        )
+        for i in range(total)
+    ]
+    session.add_all(habits)
+    await session.commit()
+    for h in habits:
+        await session.refresh(h)
+    for i, h in enumerate(habits):
+        goal = Goal(
+            habit_id=h.id,
+            title="g",
+            tier="t",
+            target=10,
+            target_unit="reps",
+            frequency=1,
+            frequency_unit="per_day",
+        )
+        session.add(goal)
+        await session.commit()
+        await session.refresh(goal)
+        if i < active:
+            session.add(GoalCompletion(goal_id=goal.id, user_id=user_id, completed_units=10))
+            await session.commit()
+
+
+async def _seed_course(
+    session: AsyncSession, user_id: int, stage: int, *, total: int, completed: int
+) -> None:
+    """Seed ``total`` content items for a stage, ``completed`` marked done by the user."""
+    course_stage = CourseStage(
+        title="t",
+        subtitle="s",
+        stage_number=stage,
+        overview_url="u",
+        category="c",
+        aspect="a",
+        spiral_dynamics_color="beige",
+        growing_up_stage="g",
+        divine_gender_polarity="p",
+        relationship_to_free_will="r",
+        free_will_description="d",
+    )
+    session.add(course_stage)
+    await session.commit()
+    await session.refresh(course_stage)
+    contents = [
+        StageContent(
+            course_stage_id=course_stage.id,
+            title=f"c{i}",
+            content_type="essay",
+            release_day=i,
+            url="u",
+        )
+        for i in range(total)
+    ]
+    session.add_all(contents)
+    await session.commit()
+    for c in contents:
+        await session.refresh(c)
+    for i in range(completed):
+        session.add(ContentCompletion(user_id=user_id, content_id=contents[i].id))
+    await session.commit()
+
+
+async def _seed_practice(
+    session: AsyncSession, user_id: int, stage: int, *, logged_session: bool
+) -> None:
+    """Seed a selected practice for a stage, optionally with a logged session."""
+    practice = Practice(
+        stage_number=stage,
+        name="P",
+        description="d",
+        instructions="i",
+        default_duration_minutes=5.0,
+        approved=True,
+    )
+    session.add(practice)
+    await session.commit()
+    await session.refresh(practice)
+    user_practice = UserPractice(
+        user_id=user_id, practice_id=practice.id, stage_number=stage, start_date=date(2026, 1, 1)
+    )
+    session.add(user_practice)
+    await session.commit()
+    await session.refresh(user_practice)
+    if logged_session:
+        session.add(
+            PracticeSession(
+                user_id=user_id,
+                user_practice_id=user_practice.id,
+                duration_minutes=5.0,
+                timestamp=datetime(2026, 1, 2, tzinfo=UTC),
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_overall_progress_is_zero_when_no_component_has_data(
+    isolated_session: tuple[AsyncSession, AsyncEngine],
+) -> None:
+    """A stage with no habits, practices, or course content reports 0.0 (no ZeroDivision)."""
+    session, _ = isolated_session
+    result = await compute_stage_progress(session, _USER, _STAGE)
+    assert result["overall_progress"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_overall_progress_reflects_course_completion_alone(
+    isolated_session: tuple[AsyncSession, AsyncEngine],
+) -> None:
+    """Course-only stage: completion moves the headline number, divisor is 1."""
+    session, _ = isolated_session
+    await _seed_course(session, _USER, _STAGE, total=4, completed=2)
+    result = await compute_stage_progress(session, _USER, _STAGE)
+    # 2/4 course, no other component → overall == course fraction (divisor 1).
+    assert result["course_items_completed"] == 2
+    assert result["overall_progress"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_overall_progress_uses_single_component_directly(
+    isolated_session: tuple[AsyncSession, AsyncEngine],
+) -> None:
+    """Habits-only stage reports the habit fraction directly (divisor adapts to 1)."""
+    session, _ = isolated_session
+    await _seed_habits(session, _USER, _STAGE, total=2, active=1)
+    result = await compute_stage_progress(session, _USER, _STAGE)
+    assert result["habits_progress"] == 0.5
+    assert result["overall_progress"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_overall_progress_averages_all_present_components(
+    isolated_session: tuple[AsyncSession, AsyncEngine],
+) -> None:
+    """All three present → mean of habits (0.5), practice (1.0), course (0.5) = 0.67."""
+    session, _ = isolated_session
+    await _seed_habits(session, _USER, _STAGE, total=2, active=1)
+    await _seed_practice(session, _USER, _STAGE, logged_session=True)
+    await _seed_course(session, _USER, _STAGE, total=4, completed=2)
+    result = await compute_stage_progress(session, _USER, _STAGE)
+    assert result["overall_progress"] == round((0.5 + 1.0 + 0.5) / 3, 2)
+
+
+@pytest.mark.asyncio
+async def test_present_but_incomplete_practice_drags_the_average(
+    isolated_session: tuple[AsyncSession, AsyncEngine],
+) -> None:
+    """A selected-but-unlogged practice counts as a present 0% component, not excluded."""
+    session, _ = isolated_session
+    await _seed_habits(session, _USER, _STAGE, total=1, active=1)  # habits 1.0
+    await _seed_practice(session, _USER, _STAGE, logged_session=False)  # practice 0.0, present
+    result = await compute_stage_progress(session, _USER, _STAGE)
+    assert result["practice_sessions_completed"] == 0
+    assert result["overall_progress"] == 0.5  # (1.0 + 0.0) / 2


### PR DESCRIPTION
## Summary

`overall_progress` was `(habits + practice) / 2` with a **hardcoded divisor of 2**. It fetched `course_items_completed` but **silently dropped it from the headline number**, and the divisor never adapted when a stage had no practice or no habits (audit §5.1 stub). The overall % is the primary signal the Map screen reads, so it must reflect every component a stage actually has.

- **Adaptive divisor + course folded in**: each component contributes only when *present* — habits when the stage has habits, practice when the user has selected a practice for it, course when the stage has content items. `overall = mean(present components)` (course as `completed / total`), guarding the empty case to `0.0`.
- `_compute_habits_progress` now returns `(progress, present)` so "no habits" is excluded rather than counted as 0%. Added `_compute_course_items_total` + `_count_user_practices` presence helpers and an `_average_present` combinator.
- **Parity**: applied the identical logic to `compute_stage_progress_batch` (the batched Map-screen path). `_batch_practice_metrics` / `_batch_course_metrics` now carry presence + the course denominator, still **three grouped queries** — no N+1 reintroduced (that shape is out of scope).

Response keys and the 2-dp rounding are unchanged (frontend needs no update).

## Test plan

`test_stage_progress_queries.py` (unit, `compute_stage_progress`):
- All three present → mean of habits/practice/course; **course-only** → course fraction (divisor 1); **habits-only** → habit fraction directly; **none present** → `0.0` (no divide-by-zero); a present-but-unlogged practice drags the average as a 0% component.
- Existing `test_stages_query_count.py` parity (`batch == per-stage`) + ≤3-query budget still hold; `test_stages_api.py` / `test_admin_stage_progress.py` green.
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy + xenon-A clean.

Closes #492
Refs #463
