### PR TITLE
perf(frontend): index stages O(1) and stabilize per-render literals

### DIFF
--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -212,23 +212,31 @@ const QuickDateButtons: React.FC<QuickDateButtonsProps> = ({
   minDate,
   maxDate,
   disabledDate,
-}) => (
-  <View style={ROW_STYLE}>
-    {QUICK_OPTIONS.map((option, idx) => (
-      <QuickButton
-        key={option.label}
-        candidate={option.factory()}
-        label={option.label}
-        a11yLabel={option.a11yLabel}
-        style={idx === 0 ? undefined : QUICK_BUTTON_STYLE}
-        onSelectDate={onSelectDate}
-        minDate={minDate}
-        maxDate={maxDate}
-        disabledDate={disabledDate}
-      />
-    ))}
-  </View>
-);
+}) => {
+  // Build the candidate dates once per mount instead of allocating a fresh
+  // Date for every option on every render.
+  const options = React.useMemo(
+    () => QUICK_OPTIONS.map((option) => ({ ...option, candidate: option.factory() })),
+    [],
+  );
+  return (
+    <View style={ROW_STYLE}>
+      {options.map((option, idx) => (
+        <QuickButton
+          key={option.label}
+          candidate={option.candidate}
+          label={option.label}
+          a11yLabel={option.a11yLabel}
+          style={idx === 0 ? undefined : QUICK_BUTTON_STYLE}
+          onSelectDate={onSelectDate}
+          minDate={minDate}
+          maxDate={maxDate}
+          disabledDate={disabledDate}
+        />
+      ))}
+    </View>
+  );
+};
 
 const useCommitDate = (
   onChange: (_value: string) => void,

--- a/frontend/src/features/Course/StageSelector.tsx
+++ b/frontend/src/features/Course/StageSelector.tsx
@@ -19,8 +19,8 @@ interface StageSelectorProps {
 }
 
 /** Get the spiral dynamics color for a stage number (1-indexed). */
-function getStageColor(stageNumber: number, stages: Stage[]): string {
-  const stage = stages.find((s) => s.stage_number === stageNumber);
+function getStageColor(stageNumber: number, stageById: Map<number, Stage>): string {
+  const stage = stageById.get(stageNumber);
   if (stage) {
     return STAGE_COLORS[stage.spiral_dynamics_color] ?? colors.neutral;
   }
@@ -29,22 +29,71 @@ function getStageColor(stageNumber: number, stages: Stage[]): string {
 }
 
 /** Determine if a stage is unlocked based on API data. */
-function isUnlocked(stageNumber: number, stagesList: Stage[]): boolean {
-  const stage = stagesList.find((s) => s.stage_number === stageNumber);
-  return stage?.is_unlocked ?? false;
+function isUnlocked(stageNumber: number, stageById: Map<number, Stage>): boolean {
+  return stageById.get(stageNumber)?.is_unlocked ?? false;
 }
 
 /** Determine if a stage has been completed (progress === 1.0). */
-function isCompleted(stageNumber: number, stagesList: Stage[]): boolean {
-  const stage = stagesList.find((s) => s.stage_number === stageNumber);
+function isCompleted(stageNumber: number, stageById: Map<number, Stage>): boolean {
+  const stage = stageById.get(stageNumber);
   return stage != null && stage.progress >= 1.0;
 }
+
+interface StagePillProps {
+  stageNumber: number;
+  unlocked: boolean;
+  completed: boolean;
+  isActive: boolean;
+  color: string;
+  onSelectStage: (_stageNumber: number) => void;
+}
+
+/** A single stage pill — extracted so the selector's render stays shallow. */
+const StagePill = ({
+  stageNumber,
+  unlocked,
+  completed,
+  isActive,
+  color,
+  onSelectStage,
+}: StagePillProps): React.JSX.Element => (
+  <TouchableOpacity
+    testID={`stage-pill-${stageNumber}`}
+    accessible
+    accessibilityRole="button"
+    accessibilityLabel={`Stage ${stageNumber}${!unlocked ? ', locked' : ''}${completed ? ', completed' : ''}`}
+    accessibilityState={{ selected: isActive, disabled: !unlocked }}
+    disabled={!unlocked}
+    onPress={() => onSelectStage(stageNumber)}
+    style={[
+      styles.stagePill,
+      { backgroundColor: color },
+      isActive && styles.stagePillActive,
+      !unlocked && styles.stagePillLocked,
+      completed && !isActive && styles.stagePillCompleted,
+    ]}
+  >
+    {completed ? (
+      <Text style={styles.stagePillCheck}>{'✓'}</Text>
+    ) : !unlocked ? (
+      <Text style={styles.stagePillLock}>{'🔒'}</Text>
+    ) : (
+      <Text style={styles.stagePillText}>{stageNumber}</Text>
+    )}
+  </TouchableOpacity>
+);
 
 const StageSelector = ({
   stages: stagesList,
   selectedStage,
   onSelectStage,
 }: StageSelectorProps): React.JSX.Element => {
+  // Index the stages once so each pill's lookup is O(1); the previous
+  // per-pill `stages.find()` made the render O(N²) in stage count.
+  const stageById = React.useMemo(
+    () => new Map(stagesList.map((s) => [s.stage_number, s])),
+    [stagesList],
+  );
   return (
     <View style={styles.stageSelectorContainer} testID="stage-selector">
       <ScrollView
@@ -54,37 +103,16 @@ const StageSelector = ({
       >
         {Array.from({ length: totalStageCount(stagesList) }, (_, i) => {
           const stageNumber = i + 1;
-          const unlocked = isUnlocked(stageNumber, stagesList);
-          const completed = isCompleted(stageNumber, stagesList);
-          const isActive = stageNumber === selectedStage;
-          const color = getStageColor(stageNumber, stagesList);
-
           return (
-            <TouchableOpacity
+            <StagePill
               key={stageNumber}
-              testID={`stage-pill-${stageNumber}`}
-              accessible
-              accessibilityRole="button"
-              accessibilityLabel={`Stage ${stageNumber}${!unlocked ? ', locked' : ''}${completed ? ', completed' : ''}`}
-              accessibilityState={{ selected: isActive, disabled: !unlocked }}
-              disabled={!unlocked}
-              onPress={() => onSelectStage(stageNumber)}
-              style={[
-                styles.stagePill,
-                { backgroundColor: color },
-                isActive && styles.stagePillActive,
-                !unlocked && styles.stagePillLocked,
-                completed && !isActive && styles.stagePillCompleted,
-              ]}
-            >
-              {completed ? (
-                <Text style={styles.stagePillCheck}>{'✓'}</Text>
-              ) : !unlocked ? (
-                <Text style={styles.stagePillLock}>{'🔒'}</Text>
-              ) : (
-                <Text style={styles.stagePillText}>{stageNumber}</Text>
-              )}
-            </TouchableOpacity>
+              stageNumber={stageNumber}
+              unlocked={isUnlocked(stageNumber, stageById)}
+              completed={isCompleted(stageNumber, stageById)}
+              isActive={stageNumber === selectedStage}
+              color={getStageColor(stageNumber, stageById)}
+              onSelectStage={onSelectStage}
+            />
           );
         })}
       </ScrollView>

--- a/frontend/src/features/Course/__tests__/StageSelector.test.tsx
+++ b/frontend/src/features/Course/__tests__/StageSelector.test.tsx
@@ -110,4 +110,27 @@ describe('StageSelector', () => {
     const pill = getByTestId('stage-pill-3');
     expect(pill.props.accessibilityState).toEqual({ selected: false, disabled: true });
   });
+
+  it('resolves per-stage state by stage_number regardless of array order', () => {
+    // The O(1) keyed-Map lookup must key on stage_number, not array position —
+    // so a shuffled API response still highlights/locks the correct pills.
+    const shuffled: Stage[] = [sampleStages[2]!, sampleStages[0]!, sampleStages[1]!];
+    const { getByTestId } = render(
+      <StageSelector stages={shuffled} selectedStage={2} onSelectStage={onSelectStage} />,
+    );
+
+    // Stage 1 completed (progress 1.0), stage 2 selected+unlocked, stage 3 locked.
+    expect(getByTestId('stage-pill-1').props.accessibilityState).toEqual({
+      selected: false,
+      disabled: false,
+    });
+    expect(getByTestId('stage-pill-2').props.accessibilityState).toEqual({
+      selected: true,
+      disabled: false,
+    });
+    expect(getByTestId('stage-pill-3').props.accessibilityState).toEqual({
+      selected: false,
+      disabled: true,
+    });
+  });
 });

--- a/frontend/src/features/Practice/components/FrequencyBanner.tsx
+++ b/frontend/src/features/Practice/components/FrequencyBanner.tsx
@@ -68,7 +68,9 @@ interface BannerContentProps {
 }
 
 function BannerContent({ data, swatch, onSwitch }: BannerContentProps) {
-  const textStyle = { color: swatch.text };
+  // Memoised so the three child <Text> rows below receive a stable style
+  // reference across renders instead of a fresh object each time.
+  const textStyle = React.useMemo(() => ({ color: swatch.text }), [swatch.text]);
   return (
     <TouchableOpacity
       accessibilityRole="button"

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -97,6 +97,36 @@ const TAB_CONFIGS: ReadonlyArray<{
   { name: 'Map', component: MapTab, icon: Compass },
 ];
 
+interface TabHeaderRightProps {
+  onSettings: () => void;
+  onLogout: () => void;
+}
+
+/** Header actions (settings + logout), hoisted to a stable component so it is
+ * not redefined on every ``BottomTabs`` render. */
+const TabHeaderRight = ({ onSettings, onLogout }: TabHeaderRightProps): React.JSX.Element => (
+  <View style={styles.headerRight}>
+    <TouchableOpacity
+      onPress={onSettings}
+      style={styles.headerButton}
+      accessibilityLabel="Open settings"
+      accessibilityRole="button"
+      testID="open-settings-button"
+    >
+      <Text style={styles.headerButtonText}>⚙︎</Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      onPress={onLogout}
+      style={styles.headerButton}
+      accessibilityLabel="Log out"
+      accessibilityRole="button"
+      testID="logout-button"
+    >
+      <Text style={styles.headerButtonText}>Logout</Text>
+    </TouchableOpacity>
+  </View>
+);
+
 /**
  * Application-wide bottom tab navigation.
  * Each tab corresponds to a major feature area.
@@ -109,34 +139,18 @@ const BottomTabs = (): React.JSX.Element => {
     navigation.navigate('ApiKeySettings');
   }, [navigation]);
 
+  const renderHeaderRight = React.useCallback(
+    () => <TabHeaderRight onSettings={openSettings} onLogout={logout} />,
+    [openSettings, logout],
+  );
+
   return (
     <Tab.Navigator
       initialRouteName="Habits"
       screenOptions={{
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.text.tertiaryAccessible,
-        headerRight: () => (
-          <View style={styles.headerRight}>
-            <TouchableOpacity
-              onPress={openSettings}
-              style={styles.headerButton}
-              accessibilityLabel="Open settings"
-              accessibilityRole="button"
-              testID="open-settings-button"
-            >
-              <Text style={styles.headerButtonText}>⚙︎</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={logout}
-              style={styles.headerButton}
-              accessibilityLabel="Log out"
-              accessibilityRole="button"
-              testID="logout-button"
-            >
-              <Text style={styles.headerButtonText}>Logout</Text>
-            </TouchableOpacity>
-          </View>
-        ),
+        headerRight: renderHeaderRight,
       }}
     >
       {TAB_CONFIGS.map(({ name, component, icon }) => (


### PR DESCRIPTION
## Summary

Lower-severity render costs from audit §5.2 (visual output + behavior unchanged):

- **`StageSelector`** ran an **O(N²)** render — three per-pill `stages.find()` scans inside the pill loop. Now indexes the stages once into a `Map<stage_number, Stage>` via `useMemo` and looks up **O(1)**; the per-pill body is extracted to a `StagePill` component. Highlighting/locking resolve by `stage_number` regardless of API array order.
- **`FrequencyBanner`**: the inline `{ color: swatch.text }` passed to three child `<Text>` rows is `useMemo`'d to a stable reference (it was defeating child memoization).
- **`BottomTabs`**: the inline `headerRight` JSX is hoisted to a module-level `TabHeaderRight` component behind a `useCallback`'d render function, so it isn't redefined every render.
- **`DatePicker`**: the quick-date `Date` objects are built once per mount via `useMemo` instead of a fresh `Date` per option on every render.

## Test plan

- `StageSelector.test.tsx`: existing highlight/completed/locked/tap tests pass; **added** a shuffled-array-order test proving the keyed-Map lookup resolves per-stage state by `stage_number`, not array position.
- Existing `FrequencyBanner` / `DatePicker` / navigation tests pass (identical render).
- `./scripts/frontend/check-all.sh` — 4/4: ESLint zero-warnings (incl. max-lines), `tsc` clean, Jest green, prettier.

Closes #493
Refs #461
