### PR TITLE
fix(frontend): restore days_of_week in goalSchema

### DIFF
--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -117,6 +117,29 @@ describe('goalSchema embedded completions', () => {
   });
 });
 
+describe('goalSchema days_of_week (schema-drift regression)', () => {
+  it('preserves days_of_week instead of stripping it', () => {
+    // Zod strips unknown keys; without the field declared, a weekly-cadence
+    // goal lost its schedule on every refetch.
+    const parsed = goalSchema.parse({ ...baseGoal, days_of_week: ['Mon', 'Wed'] });
+    expect(parsed.days_of_week).toEqual(['Mon', 'Wed']);
+  });
+
+  it('accepts null, undefined, and absent days_of_week (API back-compat)', () => {
+    expect(goalSchema.parse({ ...baseGoal, days_of_week: null }).days_of_week).toBeNull();
+    expect(goalSchema.parse({ ...baseGoal, days_of_week: undefined }).days_of_week).toBeUndefined();
+    expect(goalSchema.parse(baseGoal).days_of_week).toBeUndefined();
+  });
+
+  it('carries days_of_week through habitWithGoalsSchema', () => {
+    const parsed = habitWithGoalsSchema.parse({
+      ...baseHabit,
+      goals: [{ ...baseGoal, days_of_week: ['Tue'] }],
+    });
+    expect(parsed.goals[0]?.days_of_week).toEqual(['Tue']);
+  });
+});
+
 describe('habitSchema start_date validation', () => {
   it('accepts a valid YYYY-MM-DD date', () => {
     expect(() => habitSchema.parse(baseHabit)).not.toThrow();

--- a/frontend/src/api/__tests__/toLocalHabit.test.ts
+++ b/frontend/src/api/__tests__/toLocalHabit.test.ts
@@ -61,6 +61,15 @@ describe('toLocalHabit', () => {
     expect(local.goals[0]!.id).toBe(100);
   });
 
+  test('carries a goal days_of_week through to the local mapping', () => {
+    const withDays: ApiHabitWithGoals = {
+      ...apiHabit,
+      goals: [{ ...apiHabit.goals[0]!, days_of_week: ['Mon', 'Wed'] }],
+    };
+    const local = toLocalHabit(withDays);
+    expect(local.goals[0]!.days_of_week).toEqual(['Mon', 'Wed']);
+  });
+
   test('maps notification fields', () => {
     const local = toLocalHabit(apiHabit);
     expect(local.notificationTimes).toEqual(['08:00']);

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -889,6 +889,7 @@ export function toLocalHabit(apiHabit: ApiHabitWithGoals): LocalHabit {
       frequency_unit: g.frequency_unit,
       is_additive: g.is_additive,
       goal_group_id: g.goal_group_id ?? null,
+      days_of_week: g.days_of_week ?? undefined,
     })),
     completions: flattenGoalCompletions(apiHabit.goals),
     notificationTimes: apiHabit.notification_times ?? undefined,

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -162,6 +162,11 @@ export const goalSchema = z.object({
   frequency_unit: z.string(),
   is_additive: z.boolean(),
   goal_group_id: z.number().int().nullish(),
+  // Weekly cadence (e.g. ["Mon", "Wed"]). Zod strips unknown keys, so without
+  // this the backend's days_of_week was deleted on every validated response,
+  // silently dropping a goal's schedule on each refetch. `.nullish()` matches
+  // the backend's `list[str] | None` and tolerates older API builds.
+  days_of_week: z.array(z.string()).nullish(),
   completions: z.array(goalCompletionSchema).optional(),
 });
 


### PR DESCRIPTION
## Summary

`goalSchema` did not declare `days_of_week`, and **Zod strips unknown keys by default**, so the field was deleted from every validated `habits.list` / `habits.get` response even though the backend sends it (`goal.py`) and the frontend already types it on `ApiGoal`. A weekly-cadence goal ("Mon/Wed") **lost its schedule on every refetch** — audit §5.4 (the worst-severity row: schema drift causing live data loss).

- Add `days_of_week: z.array(z.string()).nullish()` to `goalSchema`, matching the backend's `list[str] | None` and the `ApiGoal` shape. `.nullish()` accepts `null`, `undefined`, and absent (older API builds).
- `toLocalHabit` now carries `days_of_week` through to its local goal mapping (it was silently dropped there), matching `habitManager`'s mapping so both consumers agree.

Backend schema and the `days_of_week` normalisation logic are unchanged (out of scope).

## Test plan

- `schemas.test.ts`: `days_of_week: ['Mon','Wed']` **survives** `goalSchema` validation; `null` / `undefined` / absent all parse (back-compat); value carries through `habitWithGoalsSchema`.
- `toLocalHabit.test.ts`: a goal carrying `days_of_week` reaches the local goal mapping intact.
- `./scripts/frontend/check-all.sh` — 4/4: ESLint, `tsc`, Jest, prettier all green.

Closes #497
Refs #491
