### PR TITLE
fix(backend): map provider errors on the non-stream chat path

### DIFF
--- a/backend/src/routers/botmason.py
+++ b/backend/src/routers/botmason.py
@@ -40,7 +40,7 @@ from schemas.botmason import (
 )
 from services import chat_idempotency
 from services import wallet as wallet_service
-from services.botmason import resolve_chat_api_key
+from services.botmason import LLMProviderError, resolve_chat_api_key
 from services.chat_stream import PreflightedRequest, handle_chat_request, stream_bot_response
 from services.usage import get_monthly_cap
 from services.wallet import preflight_deduction, require_user_fresh, reset_monthly_usage_if_due
@@ -149,6 +149,13 @@ async def _handle_chat_with_idem_409(
         if idempotency_key is not None:
             raise HTTPException(status_code=409, detail="idempotency_key_in_flight") from exc
         raise
+    except LLMProviderError as exc:
+        # The provider call (BYOK key invalid, rate-limited, upstream down/timeout)
+        # failed. ``handle_chat_request`` already rolled back the staged wallet
+        # deduction, so no charge persists. Map to 502 ``llm_provider_error`` —
+        # mirroring the streaming path (``chat_stream``) so BYOK clients handle
+        # both paths uniformly — instead of letting it surface as an opaque 500.
+        raise HTTPException(status_code=502, detail="llm_provider_error") from exc
 
 
 @router.post(

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -23,8 +23,10 @@ from sqlmodel import col, select
 import services.botmason as botmason_mod
 from models.user import User
 from routers.botmason import LLM_API_KEY_HEADER
+from services import chat_stream
 from services.botmason import (
     LLM_API_KEY_MAX_LENGTH,
+    LLMProviderError,
     LLMResponse,
     generate_response,
     get_system_prompt,
@@ -306,6 +308,37 @@ async def test_chat_success(
     assert len(data["response"]) > 0
     assert data["remaining_balance"] == 4
     assert data["bot_entry_id"] is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("zero_monthly_cap")
+async def test_chat_provider_error_returns_502_without_charge(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider failure (bad key / busy / upstream down) maps to 502, not 500.
+
+    Mirrors the streaming path's ``llm_provider_error`` mapping, and the staged
+    wallet deduction is rolled back so a failed turn never charges the user.
+    """
+    headers = await _signup(async_client)
+    await _add_balance(db_session, amount=5)
+
+    async def _raise(*_args: object, **_kwargs: object) -> LLMResponse:
+        raise LLMProviderError("provider 503 unavailable")
+
+    monkeypatch.setattr(chat_stream, "generate_response", _raise)
+
+    resp = await async_client.post(
+        "/journal/chat", json={"message": "Hello BotMason"}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.BAD_GATEWAY
+    assert resp.json()["detail"] == "llm_provider_error"
+
+    # The deduction was staged but rolled back on the provider failure.
+    balance = await async_client.get("/user/balance", headers=headers)
+    assert balance.json()["balance"] == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The non-streaming chat handler (`chat_with_botmason` → `_handle_chat_with_idem_409` → `handle_chat_request`) only mapped `IntegrityError` → 409. A provider failure (invalid BYOK key, rate-limit, upstream down/timeout) — normalised to `LLMProviderError` by `services.botmason` — was re-raised by `handle_chat_request` *after* it rolled back the wallet deduction, but the router never mapped it, so it surfaced as an **opaque 500**. The streaming path already degrades these to `502 llm_provider_error` (audit §5.1 stub): BYOK users got clear errors when streaming but opaque 500s otherwise.

- `_handle_chat_with_idem_409` now catches `LLMProviderError` and raises `HTTPException(502, "llm_provider_error")`, **mirroring the stream path** so clients handle both paths uniformly. The wallet deduction is already rolled back inside `handle_chat_request` (BUG-BM-013), so no charge persists.

**Mirror, not diverge:** a single `502 llm_provider_error` matches the stream path rather than inventing a finer 401/429/503 split the stream path doesn't have — all provider failures are already normalised to `LLMProviderError` upstream, so the router can't (and shouldn't) distinguish them.

## Test plan

- New `test_chat_provider_error_returns_502_without_charge`: patches `generate_response` to raise `LLMProviderError`; `POST /journal/chat` returns **502** `llm_provider_error` (not 500), and `GET /user/balance` is unchanged (the staged deduction was rolled back).
- All existing `test_botmason_api.py` tests pass.
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy + xenon-A clean.

Closes #498
Refs #463
