### PR TITLE
test(backend): replace hollow model tests with schema assertions

### DIFF
--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,60 +1,227 @@
+"""Schema-contract tests for the ``models`` package.
+
+These pin the load-bearing facts a mutation could silently break — table names,
+primary keys, foreign keys + ``ondelete``, unique constraints, column types /
+nullability, and relationship ``back_populates`` pairs. The previous tests only
+checked that each discovered object "is a class" with a ``str`` ``__name__``,
+which survived renaming a column, flipping nullability, or dropping an FK.
+
+Assertions go through SQLAlchemy's ``Model.__table__`` / ``__mapper__`` so they
+fail when the underlying schema changes, not just the Python attribute.
+"""
+
 from __future__ import annotations
 
 import importlib
-import unittest
-from collections.abc import Iterable, Sequence
-from types import ModuleType
-from typing import ClassVar
+from typing import cast
 
+import pytest
+from sqlalchemy import DateTime, Table
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm import Mapper
 from sqlmodel import SQLModel
 
+from models import (
+    ChatSpend,
+    ContentCompletion,
+    EnergyPlan,
+    Goal,
+    GoalCompletion,
+    GoalGroup,
+    Habit,
+    JournalEntry,
+    LLMUsageLog,
+    PasswordResetToken,
+    Practice,
+    PracticeRecipe,
+    PracticeRecipeStep,
+    PracticeSession,
+    PracticeSessionSpend,
+    PracticeShareLink,
+    PracticeTag,
+    PromptResponse,
+    StageContent,
+    StageProgress,
+    User,
+    UserPractice,
+    WalletAudit,
+)
 
-class TestModels(unittest.TestCase):
-    """Structural tests for ``src.models`` package.
+# Every table model maps to exactly this table name (renaming a table fails here).
+EXPECTED_TABLES: dict[type, str] = {
+    User: "user",
+    Habit: "habit",
+    Goal: "goal",
+    GoalCompletion: "goalcompletion",
+    GoalGroup: "goalgroup",
+    JournalEntry: "journalentry",
+    PromptResponse: "promptresponse",
+    StageProgress: "stageprogress",
+    StageContent: "stagecontent",
+    PracticeSession: "practicesession",
+    UserPractice: "userpractice",
+    Practice: "practice",
+    PracticeShareLink: "practicesharelink",
+    PracticeTag: "practicetag",
+    PracticeRecipe: "practicerecipe",
+    PracticeRecipeStep: "practicerecipestep",
+    ContentCompletion: "contentcompletion",
+    ChatSpend: "chatspend",
+    EnergyPlan: "energyplan",
+    PracticeSessionSpend: "practicesessionspend",
+    WalletAudit: "walletaudit",
+    LLMUsageLog: "llmusagelog",
+    PasswordResetToken: "passwordresettoken",  # pragma: allowlist secret
+}
 
-    Importing the package executes model class bodies (fields/relationships),
-    which suffices to fully cover a declarative models package without a DB.
-    """
+# (Model, column, target_table, expected_ondelete) — ``None`` means no ondelete.
+FOREIGN_KEYS: list[tuple[type, str, str, str | None]] = [
+    (Habit, "user_id", "user", "CASCADE"),
+    (Goal, "habit_id", "habit", "CASCADE"),
+    (Goal, "goal_group_id", "goalgroup", "SET NULL"),
+    (GoalCompletion, "goal_id", "goal", "CASCADE"),
+    (GoalCompletion, "user_id", "user", "CASCADE"),
+    (GoalGroup, "user_id", "user", "SET NULL"),
+    (JournalEntry, "user_id", "user", "CASCADE"),
+    (JournalEntry, "practice_session_id", "practicesession", None),
+    (JournalEntry, "user_practice_id", "userpractice", None),
+    (PromptResponse, "user_id", "user", "CASCADE"),
+    (StageProgress, "user_id", "user", "CASCADE"),
+    (StageContent, "course_stage_id", "coursestage", None),
+    (PracticeSession, "user_id", "user", "CASCADE"),
+    (PracticeSession, "user_practice_id", "userpractice", None),
+    (UserPractice, "user_id", "user", "CASCADE"),
+    (UserPractice, "practice_id", "practice", None),
+    (PracticeShareLink, "practice_id", "practice", "CASCADE"),
+    (PracticeTag, "owner_user_id", "user", "CASCADE"),
+    (PracticeRecipe, "owner_user_id", "user", "CASCADE"),
+    (PracticeRecipeStep, "recipe_id", "practicerecipe", "CASCADE"),
+    (ContentCompletion, "user_id", "user", "CASCADE"),
+    (ContentCompletion, "content_id", "stagecontent", None),
+    (ChatSpend, "user_id", "user", "CASCADE"),
+    (EnergyPlan, "user_id", "user", "CASCADE"),
+    (PracticeSessionSpend, "user_id", "user", "CASCADE"),
+    (PracticeSessionSpend, "session_id", "practicesession", "CASCADE"),
+    (WalletAudit, "user_id", "user", "CASCADE"),
+    (WalletAudit, "actor_user_id", "user", "SET NULL"),
+    (LLMUsageLog, "user_id", "user", "CASCADE"),
+    (LLMUsageLog, "journal_entry_id", "journalentry", None),
+    (PasswordResetToken, "user_id", "user", "CASCADE"),
+]
 
-    MODULE_PATH: ClassVar[str] = "models"
-    mod: ClassVar[ModuleType]
+# Named composite UNIQUE constraints that must exist on the table.
+COMPOSITE_UNIQUES: list[tuple[type, str]] = [
+    (PromptResponse, "uq_promptresponse_user_week"),
+    (ChatSpend, "uq_chatspend_user_idem_key"),
+    (PracticeSessionSpend, "uq_practicesessionspend_user_idem_key"),
+    (ContentCompletion, "uq_contentcompletion_user_content"),
+]
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        """Import the models module once for all tests."""
-        cls.mod = importlib.import_module(cls.MODULE_PATH)
-
-    def _iter_model_classes(self) -> Iterable[tuple[str, type[SQLModel]]]:
-        """Yield (name, class) for SQLModel subclasses declared in the module."""
-        for name, obj in vars(self.mod).items():
-            if name.startswith("_"):
-                continue
-            if isinstance(obj, type) and issubclass(obj, SQLModel) and obj is not SQLModel:
-                yield name, obj
-
-    def test_module_imports(self) -> None:
-        assert self.mod is not None, "models module should import"
-
-    def test_discovers_at_least_one_model(self) -> None:
-        discovered = tuple(self._iter_model_classes())
-        assert len(discovered) > 0, "Expected at least one SQLModel subclass in the module."
-
-    def test_discovered_models_have_basic_metadata(self) -> None:
-        for name, cls in self._iter_model_classes():
-            with self.subTest(model=name):
-                assert isinstance(cls, type), f"{name} is not a class"
-                # All classes should have these basic Python attributes.
-                assert isinstance(getattr(cls, "__name__", None), str)
-                assert isinstance(getattr(cls, "__module__", None), str)
-
-    def test_no_runtime_side_effects_on_import(self) -> None:
-        """Guard against engines/sessions created at import time."""
-        prohibited: Sequence[str] = ("engine", "SessionLocal", "session", "db")
-        for attr in prohibited:
-            assert not hasattr(self.mod, attr), (
-                f"Module unexpectedly defines runtime object '{attr}' at import time."
-            )
+# (Model, attr, expected back_populates) relationship pairs.
+RELATIONSHIPS: list[tuple[type, str, str]] = [
+    (User, "habits", "user"),
+    (Habit, "user", "habits"),
+    (Habit, "goals", "habit"),
+    (Goal, "habit", "goals"),
+    (Goal, "completions", "goal"),
+    (GoalCompletion, "goal", "completions"),
+    (Goal, "goal_group", "goals"),
+    (GoalGroup, "goals", "goal_group"),
+    (User, "stage_progress", "user"),
+    (StageProgress, "user", "stage_progress"),
+    (User, "journals", "user"),
+    (JournalEntry, "user", "journals"),
+]
 
 
-if __name__ == "__main__":
-    unittest.main()
+def _table(model: type[SQLModel]) -> Table:
+    """Return the mapped :class:`Table` for a model (typed for mypy)."""
+    return cast("Table", _mapper(model).local_table)
+
+
+def _mapper(model: type[SQLModel]) -> Mapper[SQLModel]:
+    """Return the ORM mapper for a model (carries the relationship registry)."""
+    return cast("Mapper[SQLModel]", sa_inspect(model))
+
+
+@pytest.mark.parametrize(("model", "table"), list(EXPECTED_TABLES.items()))
+def test_table_name(model: type[SQLModel], table: str) -> None:
+    """Each model maps to its expected table name."""
+    assert _table(model).name == table
+
+
+@pytest.mark.parametrize("model", list(EXPECTED_TABLES))
+def test_has_primary_key(model: type[SQLModel]) -> None:
+    """Every table defines at least one primary-key column."""
+    assert len(_table(model).primary_key.columns) >= 1
+
+
+@pytest.mark.parametrize(("model", "column", "target", "ondelete"), FOREIGN_KEYS)
+def test_foreign_key_target_and_ondelete(
+    model: type[SQLModel], column: str, target: str, ondelete: str | None
+) -> None:
+    """Each FK points at the right table with the right ``ondelete`` rule."""
+    fks = list(_table(model).columns[column].foreign_keys)
+    assert len(fks) == 1, f"{model.__name__}.{column} should have exactly one FK"
+    fk = fks[0]
+    assert fk.column.table.name == target
+    assert fk.ondelete == ondelete
+
+
+@pytest.mark.parametrize(("model", "constraint_name"), COMPOSITE_UNIQUES)
+def test_composite_unique_constraint(model: type[SQLModel], constraint_name: str) -> None:
+    """The named composite UNIQUE constraint exists on the table."""
+    names = {c.name for c in _table(model).constraints}
+    assert constraint_name in names
+
+
+@pytest.mark.parametrize(("model", "attr", "back_populates"), RELATIONSHIPS)
+def test_relationship_back_populates(model: type[SQLModel], attr: str, back_populates: str) -> None:
+    """Relationship pairs declare matching ``back_populates``."""
+    rel = _mapper(model).relationships[attr]
+    assert rel.back_populates == back_populates
+
+
+def test_single_column_unique_fields() -> None:
+    """``unique=True`` scalar columns carry the constraint at the column level."""
+    assert _table(User).columns["email"].unique is True
+    assert _table(StageProgress).columns["user_id"].unique is True
+    assert _table(PracticeShareLink).columns["token"].unique is True
+
+
+def _max_length(model: type[SQLModel], column: str) -> int:
+    """Return a string column's declared length (SQLModel uses ``AutoString``)."""
+    length = getattr(_table(model).columns[column].type, "length", None)
+    assert isinstance(length, int)
+    return length
+
+
+def test_string_column_max_lengths() -> None:
+    """Length-bounded text columns keep their declared ``max_length``."""
+    assert _max_length(Practice, "name") == 255
+    assert _max_length(User, "email") == 254
+    assert _max_length(PracticeShareLink, "token") == 64
+
+
+def test_goal_completion_timestamp_is_tz_aware_non_null() -> None:
+    """GoalCompletion.timestamp is a non-null timezone-aware DateTime."""
+    column = _table(GoalCompletion).columns["timestamp"]
+    assert isinstance(column.type, DateTime)
+    assert column.type.timezone is True
+    assert column.nullable is False
+
+
+def test_key_columns_are_non_null() -> None:
+    """Owner FKs that anchor a row are NOT NULL (a row cannot orphan)."""
+    assert _table(Habit).columns["user_id"].nullable is False
+    assert _table(GoalCompletion).columns["goal_id"].nullable is False
+    assert _table(PracticeSession).columns["user_id"].nullable is False
+
+
+def test_no_runtime_side_effects_on_import() -> None:
+    """Guard against engines/sessions created at import time."""
+    mod = importlib.import_module("models")
+    for attr in ("engine", "SessionLocal", "session", "db"):
+        assert not hasattr(mod, attr), (
+            f"Module unexpectedly defines runtime object '{attr}' at import time."
+        )

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -24,6 +24,7 @@ from sqlmodel import SQLModel
 from models import (
     ChatSpend,
     ContentCompletion,
+    CourseStage,
     EnergyPlan,
     Goal,
     GoalCompletion,
@@ -31,6 +32,7 @@ from models import (
     Habit,
     JournalEntry,
     LLMUsageLog,
+    LoginAttempt,
     PasswordResetToken,
     Practice,
     PracticeRecipe,
@@ -40,6 +42,7 @@ from models import (
     PracticeShareLink,
     PracticeTag,
     PromptResponse,
+    RevokedToken,
     StageContent,
     StageProgress,
     User,
@@ -72,6 +75,9 @@ EXPECTED_TABLES: dict[type, str] = {
     WalletAudit: "walletaudit",
     LLMUsageLog: "llmusagelog",
     PasswordResetToken: "passwordresettoken",  # pragma: allowlist secret
+    CourseStage: "coursestage",
+    LoginAttempt: "loginattempt",
+    RevokedToken: "revokedtoken",  # pragma: allowlist secret
 }
 
 # (Model, column, target_table, expected_ondelete) — ``None`` means no ondelete.
@@ -93,6 +99,7 @@ FOREIGN_KEYS: list[tuple[type, str, str, str | None]] = [
     (UserPractice, "user_id", "user", "CASCADE"),
     (UserPractice, "practice_id", "practice", None),
     (PracticeShareLink, "practice_id", "practice", "CASCADE"),
+    (PracticeShareLink, "created_by_user_id", "user", "SET NULL"),
     (PracticeTag, "owner_user_id", "user", "CASCADE"),
     (PracticeRecipe, "owner_user_id", "user", "CASCADE"),
     (PracticeRecipeStep, "recipe_id", "practicerecipe", "CASCADE"),
@@ -201,14 +208,19 @@ def test_string_column_max_lengths() -> None:
     assert _max_length(Practice, "name") == 255
     assert _max_length(User, "email") == 254
     assert _max_length(PracticeShareLink, "token") == 64
+    assert _max_length(RevokedToken, "jti") == 64
 
 
-def test_goal_completion_timestamp_is_tz_aware_non_null() -> None:
-    """GoalCompletion.timestamp is a non-null timezone-aware DateTime."""
-    column = _table(GoalCompletion).columns["timestamp"]
-    assert isinstance(column.type, DateTime)
-    assert column.type.timezone is True
-    assert column.nullable is False
+@pytest.mark.parametrize(
+    ("model", "column"),
+    [(GoalCompletion, "timestamp"), (RevokedToken, "expires_at")],
+)
+def test_datetime_columns_are_tz_aware_non_null(model: type[SQLModel], column: str) -> None:
+    """Timestamp columns are non-null timezone-aware DateTimes."""
+    col = _table(model).columns[column]
+    assert isinstance(col.type, DateTime)
+    assert col.type.timezone is True
+    assert col.nullable is False
 
 
 def test_key_columns_are_non_null() -> None:


### PR DESCRIPTION
## Summary

`test_models.py` had three tests that nominally guarded all SQLModel ORM classes but only asserted each object "is a class" with a `str` `__name__`/`__module__` and count > 0. Those survived almost **any** mutation — renaming a column, flipping nullability, dropping a `foreign_key` or its `ondelete`, changing a `max_length` all left the suite green (audit §5.4 "test that doesn't test").

Replaced them with **mutation-grade** assertions driven off SQLAlchemy's mapper / `__table__`:

- **Table name** for all 23 table models.
- **Primary key** present on every model.
- **31 foreign keys** assert target table + exact `ondelete` — `CASCADE` / `SET NULL` / `None` (e.g. `Habit.user_id` CASCADE, `GoalCompletion.goal_id` CASCADE, `WalletAudit.actor_user_id` SET NULL, `Goal.goal_group_id` SET NULL).
- The four named **composite UNIQUE** constraints.
- Twelve **relationship `back_populates`** pairs (`Habit.goals` ↔ `Goal.habit`, `Goal.completions` ↔ `GoalCompletion.goal`, …).
- Single-column **unique** fields, string **max_lengths**, and a tz-aware **non-null** `GoalCompletion.timestamp`.

Kept `test_no_runtime_side_effects_on_import` (a genuine guard). No model definitions changed.

## Test plan

- 98 assertions; all pass on the current schema. Locally flipping any asserted `nullable=` / `foreign_key=` / `ondelete=` / `max_length=` turns a test red (verified the values against live introspection).
- `./scripts/backend/check-all.sh` — 7/7, coverage ≥90%, ruff + mypy clean.

Closes #499
Refs #494
