### PR TITLE
ci: pin the claude workflow actions to commit shas

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0  # v1.0.158
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "dependabot[bot]"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,13 +43,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0  # v1.0.158
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

`claude.yml` and `claude-code-review.yml` consumed `actions/checkout@v6` and `anthropics/claude-code-action@v1` on **mutable tags**. Both workflows run with `id-token: write` (OIDC) and one with `pull-requests: write`, so a hijacked or force-moved tag would execute attacker code with write + token-exchange power (AGENTS.md §6; these were the only unpinned `uses:` in the repo — `backend-ci.yml`/`frontend-ci.yml` already pin everything).

Pinned all four `uses:` to immutable 40-char commit SHAs **resolved from the live tag refs** at implementation time:

- `actions/checkout` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (**v6.0.2**) — the same revision `backend-ci.yml`/`frontend-ci.yml` already use, keeping the repo on one checkout revision.
- `anthropics/claude-code-action` → `521136812280ae7ef256e06045655b9da02793f0` (**v1.0.158**) — dereferenced from the annotated `v1` tag to its underlying commit.

No workflow logic, permissions, triggers, or prompts changed.

## Test plan

- `grep -REn 'uses:.*@(v[0-9]+|main|master|latest)' .github/workflows/` → **clean** (no mutable tags remain).
- Every external `uses:` now pins a full 40-char SHA with a `# vX.Y.Z` comment, matching `backend-ci.yml`.
- `pre-commit run` on both files passes (YAML-only change; code hooks N/A).

Closes #501
Refs #496
