### PR TITLE
fix(frontend): make PromptListResponse.total nullable

### DIFF
--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -1,6 +1,12 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { goalCompletionSchema, goalSchema, habitSchema, habitWithGoalsSchema } from '../schemas';
+import {
+  goalCompletionSchema,
+  goalSchema,
+  habitSchema,
+  habitWithGoalsSchema,
+  promptListResponseSchema,
+} from '../schemas';
 
 const baseGoal = {
   id: 1,
@@ -180,6 +186,34 @@ describe('habitWithGoalsSchema end-to-end', () => {
           },
         ],
       }),
+    ).toThrow();
+  });
+});
+
+describe('promptListResponseSchema total nullability', () => {
+  const item = {
+    week_number: 1,
+    question: 'How did this week feel?',
+    has_responded: true,
+    response: 'Steady.',
+    timestamp: '2026-05-09T22:31:22Z',
+  };
+
+  it('accepts a null total (count not requested) and keeps it null', () => {
+    const parsed = promptListResponseSchema.parse({ items: [item], total: null, has_more: false });
+    expect(parsed.total).toBeNull();
+    // The fallback a consumer must use never produces NaN.
+    expect(parsed.total ?? parsed.items.length).toBe(1);
+  });
+
+  it('accepts an integer total', () => {
+    const parsed = promptListResponseSchema.parse({ items: [item], total: 42, has_more: true });
+    expect(parsed.total).toBe(42);
+  });
+
+  it('rejects a non-integer total', () => {
+    expect(() =>
+      promptListResponseSchema.parse({ items: [item], total: 1.5, has_more: false }),
     ).toThrow();
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -8,6 +8,7 @@ import {
   loginAuthResponseSchema,
   pageSchema,
   passwordResetAcceptedSchema,
+  promptListResponseSchema,
   timezoneReadSchema,
   unknownRecord,
   type Page,
@@ -1505,7 +1506,9 @@ export interface PromptDetail {
 
 export interface PromptListResponse {
   items: PromptDetail[];
-  total: number;
+  // ``int | None`` on the backend — null when the count was not requested.
+  // Consumers must guard (e.g. ``total ?? items.length``) before arithmetic.
+  total: number | null;
   has_more: boolean;
 }
 
@@ -1528,7 +1531,10 @@ export const prompts = {
     if (params.limit != null) query.set('limit', String(params.limit));
     if (params.offset != null) query.set('offset', String(params.offset));
     const qs = query.toString();
-    return request<PromptListResponse>(`/prompts/history${qs ? `?${qs}` : ''}`, { token });
+    return request<PromptListResponse>(`/prompts/history${qs ? `?${qs}` : ''}`, {
+      token,
+      schema: promptListResponseSchema as unknown as z.ZodType<PromptListResponse>,
+    });
   },
 };
 

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -206,6 +206,28 @@ export type HabitSchemaT = z.infer<typeof habitSchema>;
 export type HabitWithGoalsSchemaT = z.infer<typeof habitWithGoalsSchema>;
 export type GoalSchemaT = z.infer<typeof goalSchema>;
 
+/** One weekly prompt + the user's response state (mirrors backend ``PromptDetail``). */
+export const promptDetailSchema = z.object({
+  week_number: z.number().int(),
+  question: z.string(),
+  has_responded: z.boolean(),
+  response: z.string().nullable(),
+  timestamp: z.string().nullable(),
+});
+
+/**
+ * Paginated prompt history. ``total`` is ``int | None`` on the backend — it is
+ * ``null`` when the count was not requested — so the schema (and the consumer
+ * type) must accept ``null`` rather than coerce it to ``NaN`` in arithmetic.
+ */
+export const promptListResponseSchema = z.object({
+  items: z.array(promptDetailSchema),
+  total: z.number().int().nullable(),
+  has_more: z.boolean(),
+});
+
+export type PromptListResponseSchemaT = z.infer<typeof promptListResponseSchema>;
+
 // ---------------------------------------------------------------------------
 // Lenient schemas for legacy endpoints (gradually tightened)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`PromptListResponse.total` was typed as a non-nullable `number`, but the backend declares it `int | None` ("`total` is `None` when not requested", `prompt.py`). The compile-time type lied about the wire, so any arithmetic on `total` (`total - offset`, a "showing N of total" label) could silently produce `NaN` (audit §5.4 — schema drift).

- `total` is now `number | null` on the interface.
- Added `promptDetailSchema` + `promptListResponseSchema` (`total: z.number().int().nullable()`) and wired it into `prompts.history` via the `schema:` option, so a `null` total validates instead of slipping through unvalidated.

**No consumers to guard:** `PromptListResponse` / `prompts.history` are referenced only in `api/index.ts` — no UI reads `.total` yet. The nullable type now forces a null-check (e.g. `total ?? items.length`) at any future call site, which is the durable fix.

## Test plan

- `schemas.test.ts`: a `prompts.history` response with `total: null` validates and stays `null`; the `total ?? items.length` fallback is `NaN`-free; integer totals pass; non-integer totals reject.
- `tsc --noEmit` passes — every consumer compiles against the nullable type.
- `./scripts/frontend/check-all.sh` — 4/4 (ESLint, tsc, Jest, prettier).

Closes #502
Refs #491
