### PR TITLE
feat(frontend): build configurator forms for tallied_grounding and mindful_anchor

### DIFF
--- a/frontend/src/features/Practice/components/ModePicker.tsx
+++ b/frontend/src/features/Practice/components/ModePicker.tsx
@@ -18,12 +18,12 @@ import type { ModeConfig } from '../engine/types';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 
 /**
- * Discriminator union for every mode shown in the picker. ``mindful_anchor``
- * has no frontend type yet (the runtime engine + form land in a follow-up),
- * so it is added inline here so the picker still surfaces it under
- * Grounding — selecting it routes to a "Coming soon" notice in the wizard.
+ * Discriminator union for every mode shown in the picker. Every mode now has a
+ * frontend config type and a configurator form, so this is exactly the
+ * ``ModeConfig`` mode set — the picker surfaces them all and the wizard renders
+ * each one's form.
  */
-export type PickableMode = ModeConfig['mode'] | 'mindful_anchor';
+export type PickableMode = ModeConfig['mode'];
 
 const NEW_MODES = new Set<PickableMode>([
   'tallied_grounding',

--- a/frontend/src/features/Practice/configurator/__tests__/MindfulAnchorForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/MindfulAnchorForm.test.tsx
@@ -66,4 +66,29 @@ describe('MindfulAnchorForm', () => {
     fireEvent.press(getByTestId('anchor-option-0-remove'));
     expect(onChange).toHaveBeenCalledWith({ ...base, options: [] });
   });
+
+  it('renders with no options and still offers the add button', () => {
+    const onChange = jest.fn();
+    const empty: MindfulAnchorConfig = { ...base, options: [] };
+    const { getByTestId, queryByTestId } = render(
+      <MindfulAnchorForm value={empty} onChange={onChange} />,
+    );
+    expect(getByTestId('mindful-anchor-form')).toBeTruthy();
+    expect(getByTestId('anchor-add-option')).toBeTruthy();
+    expect(queryByTestId('anchor-option-0')).toBeNull();
+  });
+
+  it('keeps the surviving option after a non-tail delete (stable keys)', () => {
+    const two: MindfulAnchorConfig = {
+      ...base,
+      options: [
+        { key: 'o1', label: 'Bare feet' },
+        { key: 'o2', label: 'Socks' },
+      ],
+    };
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MindfulAnchorForm value={two} onChange={onChange} />);
+    fireEvent.press(getByTestId('anchor-option-0-remove'));
+    expect(onChange).toHaveBeenCalledWith({ ...base, options: [{ key: 'o2', label: 'Socks' }] });
+  });
 });

--- a/frontend/src/features/Practice/configurator/__tests__/MindfulAnchorForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/MindfulAnchorForm.test.tsx
@@ -1,0 +1,69 @@
+/* eslint-env jest */
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { MindfulAnchorConfig } from '../../engine/types';
+import MindfulAnchorForm from '../forms/MindfulAnchorForm';
+
+const base: MindfulAnchorConfig = {
+  mode: 'mindful_anchor',
+  instruction: 'Stand on grass',
+  min_duration_seconds: 60,
+  options: [{ key: 'o1', label: 'Bare feet' }],
+  require_option_choice: false,
+};
+
+describe('MindfulAnchorForm', () => {
+  it('edits the instruction', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MindfulAnchorForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('anchor-instruction'), 'Stand on grass and breathe');
+    expect(onChange).toHaveBeenCalledWith({ ...base, instruction: 'Stand on grass and breathe' });
+  });
+
+  it('edits the minimum duration', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MindfulAnchorForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('anchor-min-duration'), '90');
+    expect(onChange).toHaveBeenCalledWith({ ...base, min_duration_seconds: 90 });
+  });
+
+  it('toggles require-option-choice', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MindfulAnchorForm value={base} onChange={onChange} />);
+    fireEvent(getByTestId('anchor-require-choice'), 'valueChange', true);
+    expect(onChange).toHaveBeenCalledWith({ ...base, require_option_choice: true });
+  });
+
+  it('edits an option label and description', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MindfulAnchorForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('anchor-option-0-label'), 'Socks');
+    expect(onChange).toHaveBeenCalledWith({
+      ...base,
+      options: [{ key: 'o1', label: 'Socks' }],
+    });
+    fireEvent.changeText(getByTestId('anchor-option-0-description'), 'Thin socks');
+    expect(onChange).toHaveBeenCalledWith({
+      ...base,
+      options: [{ key: 'o1', label: 'Bare feet', description: 'Thin socks' }],
+    });
+  });
+
+  it('appends a new option with a generated stable key', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MindfulAnchorForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('anchor-add-option'));
+    const next = onChange.mock.calls[0]![0] as MindfulAnchorConfig;
+    expect(next.options).toHaveLength(2);
+    expect(next.options[1]!.key).not.toBe('o1');
+  });
+
+  it('removes an option', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<MindfulAnchorForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('anchor-option-0-remove'));
+    expect(onChange).toHaveBeenCalledWith({ ...base, options: [] });
+  });
+});

--- a/frontend/src/features/Practice/configurator/__tests__/TalliedGroundingForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/TalliedGroundingForm.test.tsx
@@ -56,4 +56,44 @@ describe('TalliedGroundingForm', () => {
     fireEvent.press(getByTestId('tallied-category-0-remove'));
     expect(onChange).toHaveBeenCalledWith({ ...base, categories: [] });
   });
+
+  it('decrements rounds and target count via the minus steppers', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TalliedGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('tallied-rounds-minus'));
+    expect(onChange).toHaveBeenCalledWith({ ...base, rounds: 1 });
+    fireEvent.press(getByTestId('tallied-category-0-count-minus'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...base,
+      categories: [{ key: 'c1', label: 'Red things', target_count: 2 }],
+    });
+  });
+
+  it('renders with no categories and still offers the add button', () => {
+    const onChange = jest.fn();
+    const empty: TalliedGroundingConfig = { ...base, categories: [] };
+    const { getByTestId, queryByTestId } = render(
+      <TalliedGroundingForm value={empty} onChange={onChange} />,
+    );
+    expect(getByTestId('tallied-grounding-form')).toBeTruthy();
+    expect(getByTestId('tallied-add-category')).toBeTruthy();
+    expect(queryByTestId('tallied-category-0')).toBeNull();
+  });
+
+  it('keeps the surviving category after a non-tail delete (stable keys)', () => {
+    const two: TalliedGroundingConfig = {
+      ...base,
+      categories: [
+        { key: 'c1', label: 'Red things', target_count: 3 },
+        { key: 'c2', label: 'Round things', target_count: 5 },
+      ],
+    };
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TalliedGroundingForm value={two} onChange={onChange} />);
+    fireEvent.press(getByTestId('tallied-category-0-remove'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...base,
+      categories: [{ key: 'c2', label: 'Round things', target_count: 5 }],
+    });
+  });
 });

--- a/frontend/src/features/Practice/configurator/__tests__/TalliedGroundingForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/TalliedGroundingForm.test.tsx
@@ -1,0 +1,59 @@
+/* eslint-env jest */
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { TalliedGroundingConfig } from '../../engine/types';
+import TalliedGroundingForm from '../forms/TalliedGroundingForm';
+
+const base: TalliedGroundingConfig = {
+  mode: 'tallied_grounding',
+  rounds: 2,
+  categories: [{ key: 'c1', label: 'Red things', target_count: 3 }],
+};
+
+describe('TalliedGroundingForm', () => {
+  it('increments the rounds count', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TalliedGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('tallied-rounds-plus'));
+    expect(onChange).toHaveBeenCalledWith({ ...base, rounds: 3 });
+  });
+
+  it('edits a category label', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TalliedGroundingForm value={base} onChange={onChange} />);
+    fireEvent.changeText(getByTestId('tallied-category-0-label'), 'Blue things');
+    expect(onChange).toHaveBeenCalledWith({
+      ...base,
+      categories: [{ key: 'c1', label: 'Blue things', target_count: 3 }],
+    });
+  });
+
+  it('changes a category target count', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TalliedGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('tallied-category-0-count-plus'));
+    expect(onChange).toHaveBeenCalledWith({
+      ...base,
+      categories: [{ key: 'c1', label: 'Red things', target_count: 4 }],
+    });
+  });
+
+  it('appends a new category with a generated stable key', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TalliedGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('tallied-add-category'));
+    const next = onChange.mock.calls[0]![0] as TalliedGroundingConfig;
+    expect(next.categories).toHaveLength(2);
+    expect(next.categories[1]!.key).not.toBe('c1');
+    expect(next.categories[1]!.label).toBe('');
+  });
+
+  it('removes a category', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TalliedGroundingForm value={base} onChange={onChange} />);
+    fireEvent.press(getByTestId('tallied-category-0-remove'));
+    expect(onChange).toHaveBeenCalledWith({ ...base, categories: [] });
+  });
+});

--- a/frontend/src/features/Practice/configurator/forms/MindfulAnchorForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/MindfulAnchorForm.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import type { MindfulAnchorConfig, MindfulAnchorOption } from '../../engine/types';
+
+import { LabeledRow, NumericField, TextField, ToggleRow } from './shared';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+interface Props {
+  value: MindfulAnchorConfig;
+  onChange: (next: MindfulAnchorConfig) => void;
+}
+
+const INSTRUCTION_MAX = 280;
+const LABEL_MAX = 60;
+const DESCRIPTION_MAX = 120;
+
+// Monotonic source of new option keys — the machine id recorded in session
+// metadata, generated once and never derived from the array index (audit
+// section 5.2 stable-key guidance).
+let nextOptionKey = 0;
+
+interface OptionRowProps {
+  option: MindfulAnchorOption;
+  index: number;
+  onChange: (_patch: Partial<MindfulAnchorOption>) => void;
+  onRemove: () => void;
+}
+
+const OptionRow = ({ option, index, onChange, onRemove }: OptionRowProps) => (
+  <View style={localStyles.card} testID={`anchor-option-${index}`}>
+    <TextField
+      value={option.label}
+      onChange={(label) => onChange({ label })}
+      placeholder="Option label (e.g. Bare feet)"
+      maxLength={LABEL_MAX}
+      testID={`anchor-option-${index}-label`}
+    />
+    <TextField
+      value={option.description ?? ''}
+      onChange={(description) => onChange({ description })}
+      placeholder="Hint (optional)"
+      maxLength={DESCRIPTION_MAX}
+      testID={`anchor-option-${index}-description`}
+    />
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={`Remove option ${index + 1}`}
+      onPress={onRemove}
+      style={localStyles.removeButton}
+      testID={`anchor-option-${index}-remove`}
+    >
+      <Text style={localStyles.removeButtonText}>Remove</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+/** The scalar settings (instruction, minimum duration, require-choice toggle). */
+const AnchorSettings = ({ value, onChange }: Props): React.JSX.Element => (
+  <>
+    <LabeledRow label="Instruction">
+      <TextField
+        value={value.instruction}
+        onChange={(instruction) => onChange({ ...value, instruction })}
+        placeholder="What to do (e.g. Stand on grass and breathe)"
+        maxLength={INSTRUCTION_MAX}
+        testID="anchor-instruction"
+      />
+    </LabeledRow>
+    <LabeledRow label="Minimum duration (seconds)">
+      <NumericField
+        value={value.min_duration_seconds}
+        onChange={(seconds) => onChange({ ...value, min_duration_seconds: seconds ?? 0 })}
+        testID="anchor-min-duration"
+      />
+    </LabeledRow>
+    <ToggleRow
+      label="Require choosing an option"
+      value={value.require_option_choice}
+      onChange={(require_option_choice) => onChange({ ...value, require_option_choice })}
+      testID="anchor-require-choice"
+    />
+  </>
+);
+
+const MindfulAnchorForm = ({ value, onChange }: Props): React.JSX.Element => {
+  const setOption = (index: number, patch: Partial<MindfulAnchorOption>) => {
+    const options = value.options.map((o, i) => (i === index ? { ...o, ...patch } : o));
+    onChange({ ...value, options });
+  };
+  const removeOption = (index: number) =>
+    onChange({ ...value, options: value.options.filter((_, i) => i !== index) });
+  const addOption = () => {
+    const key = `option-${(nextOptionKey += 1)}`;
+    const next: MindfulAnchorOption = { key, label: '' };
+    onChange({ ...value, options: [...value.options, next] });
+  };
+  return (
+    <View testID="mindful-anchor-form">
+      <AnchorSettings value={value} onChange={onChange} />
+      {value.options.map((option, index) => (
+        <OptionRow
+          key={option.key}
+          option={option}
+          index={index}
+          onChange={(patch) => setOption(index, patch)}
+          onRemove={() => removeOption(index)}
+        />
+      ))}
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Add option"
+        onPress={addOption}
+        style={localStyles.addButton}
+        testID="anchor-add-option"
+      >
+        <Text style={localStyles.addButtonText}>+ Add option</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.sm,
+    marginBottom: SPACING.sm,
+  },
+  addButton: { paddingVertical: SPACING.sm },
+  addButtonText: { color: colors.primary, fontWeight: '600' },
+  removeButton: { paddingVertical: SPACING.xs },
+  removeButtonText: { color: colors.danger },
+});
+
+export default MindfulAnchorForm;

--- a/frontend/src/features/Practice/configurator/forms/TalliedGroundingForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/TalliedGroundingForm.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import type { TalliedCategory, TalliedGroundingConfig } from '../../engine/types';
+
+import { LabeledRow, NumberStepper, TextField } from './shared';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+interface Props {
+  value: TalliedGroundingConfig;
+  onChange: (next: TalliedGroundingConfig) => void;
+}
+
+const ROUNDS_MIN = 1;
+const ROUNDS_MAX = 10;
+const TARGET_MIN = 1;
+const TARGET_MAX = 20;
+const LABEL_MAX = 60;
+
+// Monotonic source of new category keys. The key is the machine id the engine
+// records in session metadata, so it is generated once and never derived from
+// the array position (stable-key guidance, audit section 5.2).
+let nextCategoryKey = 0;
+
+interface CategoryRowProps {
+  category: TalliedCategory;
+  index: number;
+  onChange: (_patch: Partial<TalliedCategory>) => void;
+  onRemove: () => void;
+}
+
+const CategoryRow = ({ category, index, onChange, onRemove }: CategoryRowProps) => (
+  <View style={localStyles.card} testID={`tallied-category-${index}`}>
+    <TextField
+      value={category.label}
+      onChange={(label) => onChange({ label })}
+      placeholder="What to find (e.g. red things)"
+      maxLength={LABEL_MAX}
+      testID={`tallied-category-${index}-label`}
+    />
+    <LabeledRow label="How many to find">
+      <NumberStepper
+        value={category.target_count}
+        onChange={(target_count) => onChange({ target_count })}
+        step={1}
+        min={TARGET_MIN}
+        max={TARGET_MAX}
+        testID={`tallied-category-${index}-count`}
+      />
+    </LabeledRow>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={`Remove category ${index + 1}`}
+      onPress={onRemove}
+      style={localStyles.removeButton}
+      testID={`tallied-category-${index}-remove`}
+    >
+      <Text style={localStyles.removeButtonText}>Remove</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+const TalliedGroundingForm = ({ value, onChange }: Props): React.JSX.Element => {
+  const setCategory = (index: number, patch: Partial<TalliedCategory>) => {
+    const categories = value.categories.map((c, i) => (i === index ? { ...c, ...patch } : c));
+    onChange({ ...value, categories });
+  };
+  const removeCategory = (index: number) =>
+    onChange({ ...value, categories: value.categories.filter((_, i) => i !== index) });
+  const addCategory = () => {
+    const key = `category-${(nextCategoryKey += 1)}`;
+    const next: TalliedCategory = { key, label: '', target_count: 1 };
+    onChange({ ...value, categories: [...value.categories, next] });
+  };
+  return (
+    <View testID="tallied-grounding-form">
+      <LabeledRow label="Rounds">
+        <NumberStepper
+          value={value.rounds}
+          onChange={(rounds) => onChange({ ...value, rounds })}
+          step={1}
+          min={ROUNDS_MIN}
+          max={ROUNDS_MAX}
+          testID="tallied-rounds"
+        />
+      </LabeledRow>
+      {value.categories.map((category, index) => (
+        <CategoryRow
+          key={category.key}
+          category={category}
+          index={index}
+          onChange={(patch) => setCategory(index, patch)}
+          onRemove={() => removeCategory(index)}
+        />
+      ))}
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Add category"
+        onPress={addCategory}
+        style={localStyles.addButton}
+        testID="tallied-add-category"
+      >
+        <Text style={localStyles.addButtonText}>+ Add category</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.sm,
+    marginBottom: SPACING.sm,
+  },
+  addButton: { paddingVertical: SPACING.sm },
+  addButtonText: { color: colors.primary, fontWeight: '600' },
+  removeButton: { paddingVertical: SPACING.xs },
+  removeButtonText: { color: colors.danger },
+});
+
+export default TalliedGroundingForm;

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -154,9 +154,8 @@ export function CreatePracticeWizard(props: CreatePracticeWizardProps): React.JS
 }
 
 function transitionMode(prev: WizardState, mode: PickableMode): WizardState {
-  if (!isSupportedMode(mode)) {
-    return { ...prev, mode, config: null, step: 'configure' };
-  }
+  // Every pickable mode has a default config + form, so there is no
+  // "unsupported" branch — build the config and advance.
   const config = defaultConfigFor(mode);
   return {
     ...prev,
@@ -165,13 +164,6 @@ function transitionMode(prev: WizardState, mode: PickableMode): WizardState {
     duration: prev.duration === 0 ? suggestedDurationFor(config) : prev.duration,
     step: 'configure',
   };
-}
-
-function isSupportedMode(mode: PickableMode): mode is ModeConfig['mode'] {
-  // Every wizard-pickable mode now has a default config + configurator form
-  // (mindful_anchor and tallied_grounding were the last holdouts). The guard
-  // remains as the type narrowing site + a defensive seam for any future mode.
-  return true;
 }
 
 interface StepViewProps {
@@ -302,7 +294,9 @@ const ConfigureStep = (props: ConfigureStepProps): React.JSX.Element => {
   if (mode === null) {
     return <NoticeView testID="create-practice-configure-empty" message="Pick a mode first." />;
   }
-  if (config === null || !isSupportedMode(mode)) {
+  if (config === null) {
+    // Defensive: defaultConfigFor covers every mode, so this is unreachable in
+    // practice — it guards against a future mode added without a default.
     return (
       <View testID="create-practice-step-configure">
         <NoticeView

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -36,10 +36,12 @@ import CountUpForm from '../configurator/forms/CountUpForm';
 import IntervalBellForm from '../configurator/forms/IntervalBellForm';
 import MeditationTimerForm from '../configurator/forms/MeditationTimerForm';
 import MetronomeForm from '../configurator/forms/MetronomeForm';
+import MindfulAnchorForm from '../configurator/forms/MindfulAnchorForm';
 import RandomIntervalBellForm from '../configurator/forms/RandomIntervalBellForm';
 import RepCounterForm from '../configurator/forms/RepCounterForm';
 import SenseGroundingForm from '../configurator/forms/SenseGroundingForm';
 import { ErrorList } from '../configurator/forms/shared';
+import TalliedGroundingForm from '../configurator/forms/TalliedGroundingForm';
 import TarotForm from '../configurator/forms/TarotForm';
 import type { ModeConfig } from '../engine/types';
 import { validateModeConfig } from '../engine/validation';
@@ -166,7 +168,10 @@ function transitionMode(prev: WizardState, mode: PickableMode): WizardState {
 }
 
 function isSupportedMode(mode: PickableMode): mode is ModeConfig['mode'] {
-  return mode !== 'mindful_anchor';
+  // Every wizard-pickable mode now has a default config + configurator form
+  // (mindful_anchor and tallied_grounding were the last holdouts). The guard
+  // remains as the type narrowing site + a defensive seam for any future mode.
+  return true;
 }
 
 interface StepViewProps {
@@ -351,13 +356,14 @@ const MODE_FORMS: FormTable = {
   sense_grounding: SenseGroundingForm,
   tarot: TarotForm,
   card_meditation: CardMeditationForm,
-  // ``tallied_grounding`` ships a runtime engine + view but no configurator
-  // form yet — the wizard saves the smart defaults verbatim until the
-  // dedicated form lands in a follow-up.
-  tallied_grounding: null,
-  // ``mindful_anchor`` ships a runtime engine + view but no configurator
-  // form yet — same deferral pattern as ``tallied_grounding``.
-  mindful_anchor: null,
+  tallied_grounding: TalliedGroundingForm,
+  mindful_anchor: MindfulAnchorForm,
+};
+
+/** Title-case a mode key for user-facing copy (e.g. ``mindful_anchor`` → "Mindful anchor"). */
+const humanizeMode = (mode: string): string => {
+  const spaced = mode.replace(/_/g, ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 };
 
 const ConfiguratorBody = ({ config, onChange }: ConfiguratorBodyProps): React.JSX.Element => {
@@ -367,10 +373,12 @@ const ConfiguratorBody = ({ config, onChange }: ConfiguratorBodyProps): React.JS
   }>;
   const Form = MODE_FORMS[config.mode] as AnyForm | null;
   if (Form === null) {
+    // Defensive: every current mode has a form, but if a future mode maps to
+    // null the notice must name *that* mode, not a hardcoded one.
     return (
       <NoticeView
-        testID="create-practice-configure-tallied"
-        message="Tallied grounding will ship with a configurator soon. The defaults below will be saved as-is."
+        testID="create-practice-configure-fallback"
+        message={`${humanizeMode(config.mode)} will ship with a configurator soon. The defaults below will be saved as-is.`}
       />
     );
   }

--- a/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
@@ -152,18 +152,21 @@ describe('CreatePracticeWizard — mode → configure dispatch', () => {
     expect(view.getByTestId('meditation-timer-form')).toBeTruthy();
   });
 
-  it('shows a coming-soon notice for mindful_anchor', () => {
+  it('renders the configurator form for mindful_anchor', () => {
     const { view } = renderScreen();
     fireEvent.press(view.getByTestId('create-practice-from-scratch'));
     fireEvent.press(view.getByTestId('mode-picker-mode-mindful_anchor'));
-    expect(view.getByTestId('create-practice-configure-unsupported')).toBeTruthy();
+    expect(view.getByTestId('mindful-anchor-form')).toBeTruthy();
+    expect(view.queryByTestId('create-practice-configure-unsupported')).toBeNull();
+    expect(view.queryByTestId('create-practice-configure-fallback')).toBeNull();
   });
 
-  it('renders a defaults-only notice for tallied_grounding', () => {
+  it('renders the configurator form for tallied_grounding', () => {
     const { view } = renderScreen();
     fireEvent.press(view.getByTestId('create-practice-from-scratch'));
     fireEvent.press(view.getByTestId('mode-picker-mode-tallied_grounding'));
-    expect(view.getByTestId('create-practice-configure-tallied')).toBeTruthy();
+    expect(view.getByTestId('tallied-grounding-form')).toBeTruthy();
+    expect(view.queryByTestId('create-practice-configure-fallback')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

`tallied_grounding` and `mindful_anchor` ship a runtime engine + view but had **no configurator form** — `MODE_FORMS` mapped both to `null`, so the wizard fell through to a dead-end `NoticeView` ("will ship with a configurator soon") whose copy was **hardcoded to "Tallied grounding"**, so `mindful_anchor` showed the wrong feature name (audit §5.1 stub). `mindful_anchor` was additionally gated out by `isSupportedMode`, landing on the generic "unsupported" notice.

- **`TalliedGroundingForm`**: a rounds stepper + add/remove categories (each a label + target count).
- **`MindfulAnchorForm`**: instruction, minimum duration, require-choice toggle, and add/remove options (label + optional hint).
- Both key their list rows by the config row's **persistable `key`**, never the array index (stable-key guidance, §5.2).
- Wired both into `MODE_FORMS`; dropped the `mindful_anchor` special-case from `isSupportedMode` (every wizard mode now has a default config + form).
- **De-hardcoded the fallback notice**: its message now derives from the selected mode (humanized → e.g. "Mindful anchor") and its testID is generic, so no mode ever shows another mode's name. The branch is now defensive (unreachable for current modes).

## Test plan

- `TalliedGroundingForm.test.tsx` / `MindfulAnchorForm.test.tsx`: each form renders, edits every field, and emits the updated `ModeConfig` via `onChange` (including add/remove with freshly-generated stable keys, and the toggle/numeric paths).
- `CreatePracticeWizard.test.tsx`: selecting each mode now renders **its form** (not the "ships soon"/"unsupported" notice).
- `./scripts/frontend/check-all.sh` — 4/4 (ESLint incl. max-lines, `tsc`, Jest, prettier).

Closes #503
Refs #463
