### PR TITLE
docs: correct the alembic section in deployment.md

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -268,62 +268,58 @@ domains you add for the frontend.
 
 ## Database Migrations (Alembic)
 
-### Current status
+### Setup (already in place)
 
-Alembic is **not yet configured**. The `migrations/` directory exists but is
-empty. The Dockerfile is already set up to run `alembic upgrade head` on
-deploy — once you create `alembic.ini`, migrations will run automatically.
+Alembic is fully configured — there is nothing to initialise:
 
-### Initial setup
+- `backend/alembic.ini` is committed.
+- `backend/migrations/versions/` holds the migration history (the live schema is
+  the sum of these revisions).
+- `backend/migrations/env.py` reads `DATABASE_URL` from the environment and
+  normalises the scheme via `normalize_database_url` (`backend/src/database.py`):
+  a `postgres://` or `postgresql://` URL is rewritten to the
+  `postgresql+asyncpg://` form SQLAlchemy's async engine requires. There is no
+  hardcoded URL in `alembic.ini`.
 
-```bash
-source .venv/bin/activate
-cd backend
+> **Do not** re-initialise Alembic from scratch, hand-edit a fresh `env.py`, or
+> bolt on an auto-`create_all` startup hook. The tree is already wired, and
+> auto-creating tables at startup would bypass the migration history and the CI
+> drift gate below.
 
-# Initialize Alembic
-pip install alembic   # Already in requirements.txt
-alembic init migrations
-
-# Edit alembic.ini: set sqlalchemy.url to empty string (we'll use env.py)
-# Edit migrations/env.py: import your models and configure the async engine
-```
-
-In `migrations/env.py`, you'll want to:
-1. Import your SQLModel metadata (`from models import *`)
-2. Read `DATABASE_URL` from the environment
-3. Use the async engine for migrations
-
-### Creating migrations
+### Creating a migration
 
 ```bash
 cd backend
 source ../.venv/bin/activate
-alembic revision --autogenerate -m "initial schema"
+alembic revision --autogenerate -m "<describe the change>"
 ```
 
-### Running migrations manually against Railway
+Review the generated file in `migrations/versions/` (autogenerate is a starting
+point, not a guarantee), then apply it locally:
 
 ```bash
-railway run alembic upgrade head
+alembic upgrade head
 ```
 
-### On deploy
+### Applying migrations
 
-The Dockerfile CMD checks for `alembic.ini`:
-```bash
-if [ -f alembic.ini ]; then python -m alembic upgrade head; fi
-```
-Once you commit `alembic.ini` and your migration files, they run automatically
-on every deploy.
+- **On deploy:** the Dockerfile `CMD` runs `python -m alembic upgrade head`
+  before starting uvicorn, so every deploy applies any pending migrations
+  automatically.
+- **Manually against Railway:** `railway run alembic upgrade head`.
 
-### Before Alembic is set up
+### CI safety net
 
-Without Alembic, tables are **not** auto-created in production. You have two
-options:
-1. Set up Alembic (recommended)
-2. Add a startup event in `main.py` that calls
-   `SQLModel.metadata.create_all()` — quick and dirty, not recommended for
-   production
+The `migration-drift` job in `.github/workflows/backend-ci.yml` gates every push:
+
+- runs `alembic upgrade head` against a real Postgres service, then a
+  downgrade → re-upgrade **round-trip through both parents of a merge head**
+  (so a broken `downgrade()` fails CI);
+- runs `alembic check`, which fails if a model changed without a matching
+  migration (model ↔ migration drift).
+
+Because of this gate, never hand-edit an applied migration or add a model
+without generating its migration — CI will reject it.
 
 ---
 


### PR DESCRIPTION
## Summary

`DEPLOYMENT.md`'s "Database Migrations (Alembic)" section claimed Alembic was **"not yet configured"** with an empty `migrations/` dir, then walked operators through `alembic init`, hand-editing `env.py`, and — as a fallback — a `create_all()` startup hook. **All false and dangerous** (audit §9): an operator following it would clobber the real setup or bypass the drift gate.

Verified against the live tree and rewrote the section to describe reality:

- `backend/alembic.ini` is committed; `backend/migrations/versions/` holds the migration history (**39** revisions).
- `migrations/env.py` reads `DATABASE_URL` and normalises the scheme via `normalize_database_url` (`database.py`) to `postgresql+asyncpg://`.
- Autogenerate → **review** → `alembic upgrade head` flow; deploy applies via the Dockerfile `CMD` (`python -m alembic upgrade head` before uvicorn); manual prod apply via `railway run alembic upgrade head`.
- The `migration-drift` CI job runs `alembic upgrade head` + a downgrade/re-upgrade **round-trip through both merge parents** + `alembic check` (model↔migration drift) — so don't hand-edit migrations or add a model without one.

Removed the `alembic init` / `create_all` instructions and the "Before Alembic is set up" subsection. **Docs-only** — no config, `env.py`, migrations, Dockerfile, or CI changed.

## Test plan

- `grep -nE 'not yet configured|alembic init|metadata.create_all' DEPLOYMENT.md` → **clean**.
- Section now names `alembic.ini`, the `migrations/versions/` history, the env-driven `DATABASE_URL`, the `migration-drift` gate, and `alembic check`.
- `pre-commit run --files DEPLOYMENT.md` passes.

Closes #504
Refs #496
