### PR TITLE
feat(frontend): safe-area insets across Practice full-screen surfaces

### DIFF
--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -152,30 +152,32 @@ const ActiveSessionView = ({
 }: ActiveSessionViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
   return (
-    <ScrollView
-      style={styles.screen}
-      contentContainerStyle={[
-        styles.scrollContent,
-        { paddingTop: insets.top, paddingBottom: insets.bottom },
-      ]}
-      testID="practice-screen"
-    >
-      {banner}
-      <ActiveRitualSession
-        key={`practice-${userPractice.id}`}
-        userPractice={userPractice}
-        effectiveName={effectiveName ?? practiceName}
-        effectiveConfig={effectiveConfig}
-        userTimezone={userTimezone}
-        onSessionApply={weekly.increment}
-        onSessionRollback={weekly.decrement}
-        onSessionCommitted={() => void weekly.refresh()}
-        onUserPracticeUpdated={onUserPracticeUpdated}
-        onWriteReflection={onWriteReflection}
-      />
-      <WeeklyProgress count={weekly.count} />
-      {switcher}
-    </ScrollView>
+    // paddingTop lives on the wrapper so the ScrollView's *viewport* starts
+    // below the notch (content can't scroll up behind it); paddingBottom rides
+    // contentContainerStyle so the scroll content clears the home indicator.
+    <View style={[styles.screen, { paddingTop: insets.top }]} testID="practice-screen-safe-area">
+      <ScrollView
+        style={styles.fill}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom }]}
+        testID="practice-screen"
+      >
+        {banner}
+        <ActiveRitualSession
+          key={`practice-${userPractice.id}`}
+          userPractice={userPractice}
+          effectiveName={effectiveName ?? practiceName}
+          effectiveConfig={effectiveConfig}
+          userTimezone={userTimezone}
+          onSessionApply={weekly.increment}
+          onSessionRollback={weekly.decrement}
+          onSessionCommitted={() => void weekly.refresh()}
+          onUserPracticeUpdated={onUserPracticeUpdated}
+          onWriteReflection={onWriteReflection}
+        />
+        <WeeklyProgress count={weekly.count} />
+        {switcher}
+      </ScrollView>
+    </View>
   );
 };
 

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -26,6 +26,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import PracticeSelector from './PracticeSelector';
 import WeeklyProgress from './WeeklyProgress';
@@ -148,29 +149,35 @@ const ActiveSessionView = ({
   onWriteReflection,
   banner,
   switcher,
-}: ActiveSessionViewProps): React.JSX.Element => (
-  <ScrollView
-    style={styles.screen}
-    contentContainerStyle={styles.scrollContent}
-    testID="practice-screen"
-  >
-    {banner}
-    <ActiveRitualSession
-      key={`practice-${userPractice.id}`}
-      userPractice={userPractice}
-      effectiveName={effectiveName ?? practiceName}
-      effectiveConfig={effectiveConfig}
-      userTimezone={userTimezone}
-      onSessionApply={weekly.increment}
-      onSessionRollback={weekly.decrement}
-      onSessionCommitted={() => void weekly.refresh()}
-      onUserPracticeUpdated={onUserPracticeUpdated}
-      onWriteReflection={onWriteReflection}
-    />
-    <WeeklyProgress count={weekly.count} />
-    {switcher}
-  </ScrollView>
-);
+}: ActiveSessionViewProps): React.JSX.Element => {
+  const insets = useSafeAreaInsets();
+  return (
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={[
+        styles.scrollContent,
+        { paddingTop: insets.top, paddingBottom: insets.bottom },
+      ]}
+      testID="practice-screen"
+    >
+      {banner}
+      <ActiveRitualSession
+        key={`practice-${userPractice.id}`}
+        userPractice={userPractice}
+        effectiveName={effectiveName ?? practiceName}
+        effectiveConfig={effectiveConfig}
+        userTimezone={userTimezone}
+        onSessionApply={weekly.increment}
+        onSessionRollback={weekly.decrement}
+        onSessionCommitted={() => void weekly.refresh()}
+        onUserPracticeUpdated={onUserPracticeUpdated}
+        onWriteReflection={onWriteReflection}
+      />
+      <WeeklyProgress count={weekly.count} />
+      {switcher}
+    </ScrollView>
+  );
+};
 
 interface SelectionViewProps {
   active: ActivePracticeHook;
@@ -192,9 +199,13 @@ const SelectionView = ({
   // ``selectPractice`` is already stable (useCallback in the hook); wrap it once
   // so PracticeCard's React.memo isn't defeated by a fresh arrow each render.
   const { selectPractice } = active;
+  const insets = useSafeAreaInsets();
   const handleSelect = useCallback((id: number) => void selectPractice(id), [selectPractice]);
   return (
-    <View style={styles.screen} testID="practice-screen">
+    <View
+      style={[styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
+      testID="practice-screen"
+    >
       <View style={styles.fill} testID="selection-view">
         <PracticeSelector
           practices={active.availablePractices}
@@ -266,11 +277,17 @@ function useWriteReflection(
   );
 }
 
-const LoadingView = (): React.JSX.Element => (
-  <View style={styles.centered} testID="practice-loading">
-    <ActivityIndicator size="large" color={colors.primary} />
-  </View>
-);
+const LoadingView = (): React.JSX.Element => {
+  const insets = useSafeAreaInsets();
+  return (
+    <View
+      style={[styles.centered, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
+      testID="practice-loading"
+    >
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  );
+};
 
 const ErrorView = ({
   error,
@@ -278,18 +295,24 @@ const ErrorView = ({
 }: {
   error: string;
   onRetry: () => Promise<void> | void;
-}): React.JSX.Element => (
-  <View style={styles.centered} testID="practice-error">
-    <Text style={styles.errorText}>{error}</Text>
-    <TouchableOpacity
-      style={styles.retryButton}
-      onPress={() => void onRetry()}
-      testID="retry-button"
+}): React.JSX.Element => {
+  const insets = useSafeAreaInsets();
+  return (
+    <View
+      style={[styles.centered, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
+      testID="practice-error"
     >
-      <Text style={styles.retryButtonText}>Retry</Text>
-    </TouchableOpacity>
-  </View>
-);
+      <Text style={styles.errorText}>{error}</Text>
+      <TouchableOpacity
+        style={styles.retryButton}
+        onPress={() => void onRetry()}
+        testID="retry-button"
+      >
+        <Text style={styles.retryButtonText}>Retry</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   screen: { flex: 1, backgroundColor: colors.background.primary },

--- a/frontend/src/features/Practice/__tests__/PracticeSafeArea.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeSafeArea.test.tsx
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+// audit-ux-02: end-to-end check that the real SafeAreaProvider feeds device
+// insets into a Practice full-screen surface. Per-screen inset coverage (via a
+// stubbed useSafeAreaInsets) lives in each screen's own suite; this proves the
+// provider → useSafeAreaInsets → padding chain with the real provider, so it
+// would catch the provider being unmounted from the tree.
+import { describe, expect, it, jest } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import type { PracticeItem, UserPractice } from '@/api';
+
+const mockPracticesCreate = jest.fn();
+const mockUserPracticesCreate = jest.fn();
+
+jest.mock('@/api', () => ({
+  practices: {
+    create: (...args: unknown[]) =>
+      (mockPracticesCreate as unknown as (...a: unknown[]) => Promise<PracticeItem>)(...args),
+  },
+  userPractices: {
+    create: (...args: unknown[]) =>
+      (mockUserPracticesCreate as unknown as (...a: unknown[]) => Promise<UserPractice>)(...args),
+  },
+}));
+
+const { CreatePracticeWizard } = require('../screens/CreatePracticeWizard');
+
+// A fixed inset frame the real SafeAreaProvider exposes to its subtree, standing
+// in for a notched device (no native measurement happens in tests).
+const INITIAL_METRICS = {
+  frame: { x: 0, y: 0, width: 390, height: 844 },
+  insets: { top: 47, bottom: 34, left: 0, right: 0 },
+};
+
+const nav = {
+  goBack: jest.fn(),
+  replace: jest.fn(),
+  navigate: jest.fn(),
+};
+const route = { key: 'k', name: 'CreatePractice' as const, params: undefined };
+
+describe('Practice safe-area integration (real provider)', () => {
+  it('feeds provider insets into the wizard surface without throwing', () => {
+    const Screen = CreatePracticeWizard as unknown as React.ComponentType<{
+      navigation: typeof nav;
+      route: typeof route;
+    }>;
+    const { getByTestId } = render(
+      <SafeAreaProvider initialMetrics={INITIAL_METRICS}>
+        <Screen navigation={nav} route={route} />
+      </SafeAreaProvider>,
+    );
+    // Renders (no "no safe area value" throw) and applies the provider's insets.
+    expect(getByTestId('create-practice-step-entry')).toBeTruthy();
+    expect(getByTestId('create-practice-wizard')).toHaveStyle({
+      paddingTop: 47,
+      paddingBottom: 34,
+    });
+  });
+});

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -4,6 +4,19 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 
 import type { FrequencyResponse, PracticeItem, UserPractice } from '../../../api';
 
+// PracticeScreen reads useSafeAreaInsets; stub it with non-zero insets (no
+// SafeAreaProvider in tests) so the safe-area padding is observable.
+jest.mock('react-native-safe-area-context', () => {
+  const ReactMod = require('react');
+  const passthrough = ({ children }: { children: unknown }) =>
+    ReactMod.createElement(ReactMod.Fragment, null, children);
+  return {
+    SafeAreaProvider: passthrough,
+    SafeAreaView: passthrough,
+    useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+  };
+});
+
 const samplePractice = (overrides: Partial<PracticeItem> = {}): PracticeItem => ({
   id: 1,
   stage_number: 1,
@@ -245,6 +258,8 @@ describe('PracticeScreen', () => {
     mockFrequency.mockReturnValue(new Promise(() => {}));
     const { getByTestId } = render(<PracticeScreen />);
     expect(getByTestId('practice-loading')).toBeTruthy();
+    // Loading state respects device insets too.
+    expect(getByTestId('practice-loading')).toHaveStyle({ paddingTop: 47, paddingBottom: 34 });
     await act(async () => {
       await Promise.resolve();
     });
@@ -257,6 +272,8 @@ describe('PracticeScreen', () => {
       expect(getByText('Breath Awareness')).toBeTruthy();
       expect(getByTestId('weekly-progress')).toBeTruthy();
     });
+    // The selection surface applies top/bottom safe-area insets.
+    expect(getByTestId('practice-screen')).toHaveStyle({ paddingTop: 47, paddingBottom: 34 });
   });
 
   it('shows error state when the load fails', async () => {
@@ -266,6 +283,7 @@ describe('PracticeScreen', () => {
       expect(getByTestId('practice-error')).toBeTruthy();
       expect(getByText(/couldn't load your practices/i)).toBeTruthy();
     });
+    expect(getByTestId('practice-error')).toHaveStyle({ paddingTop: 47, paddingBottom: 34 });
   });
 
   it('selects a practice via the selector', async () => {

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -307,6 +307,21 @@ describe('PracticeScreen', () => {
     });
   });
 
+  it('applies safe-area insets to the active-session surface', async () => {
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => {
+      expect(getByTestId('active-practice-card')).toBeTruthy();
+    });
+    // Top inset constrains the wrapper viewport (so content can't scroll behind
+    // the notch); bottom inset rides the ScrollView's contentContainerStyle.
+    expect(getByTestId('practice-screen-safe-area')).toHaveStyle({ paddingTop: 47 });
+    const scroll = getByTestId('practice-screen');
+    expect(scroll.props.contentContainerStyle).toEqual(
+      expect.arrayContaining([expect.objectContaining({ paddingBottom: 34 })]),
+    );
+  });
+
   it('opens the configurator sheet when the gear is pressed', async () => {
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId } = render(<PracticeScreen />);

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -29,6 +29,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { defaultConfigFor, suggestedDurationFor } from '../configurator/defaults';
 import CardMeditationForm from '../configurator/forms/CardMeditationForm';
@@ -132,24 +133,32 @@ export function CreatePracticeWizard(props: CreatePracticeWizardProps): React.JS
   const submit = useSubmitController(props, state);
   const goTo = (next: WizardStep) => setState((prev) => ({ ...prev, step: next }));
   const setMode = (mode: PickableMode) => setState((prev) => transitionMode(prev, mode));
+  const insets = useSafeAreaInsets();
+  // Insets live on an outer View (not the KeyboardAvoidingView, which owns its
+  // own bottom padding from the keyboard height); the KAV composes inside it.
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      style={styles.screen}
+    <View
+      style={[styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
       testID="create-practice-wizard"
     >
-      <StepIndicator step={state.step} />
-      <ScrollView contentContainerStyle={styles.body} keyboardShouldPersistTaps="handled">
-        <StepView
-          state={state}
-          setState={setState}
-          goTo={goTo}
-          setMode={setMode}
-          submit={submit}
-          onPickPreset={() => props.navigation.navigate('Tabs', { screen: 'Catalog' })}
-        />
-      </ScrollView>
-    </KeyboardAvoidingView>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.screen}
+        testID="create-practice-keyboard-avoider"
+      >
+        <StepIndicator step={state.step} />
+        <ScrollView contentContainerStyle={styles.body} keyboardShouldPersistTaps="handled">
+          <StepView
+            state={state}
+            setState={setState}
+            goTo={goTo}
+            setMode={setMode}
+            submit={submit}
+            onPickPreset={() => props.navigation.navigate('Tabs', { screen: 'Catalog' })}
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
   );
 }
 

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -29,6 +29,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { type PracticeItem, practices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
@@ -90,9 +91,11 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
     ({ item }: { item: PracticeItem }) => <PracticeRow practice={item} onDetail={onDetail} />,
     [onDetail],
   );
+  const insets = useSafeAreaInsets();
+  const containerStyle = [styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom }];
 
   return (
-    <View style={styles.screen}>
+    <View style={containerStyle} testID="practice-catalog-safe-area">
       <SectionList<PracticeItem, CatalogSection>
         testID="practice-catalog-screen"
         sections={state.loading || state.error !== null ? [] : sections}

--- a/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
@@ -6,6 +6,19 @@ import React from 'react';
 import type { PracticeItem, UserPractice } from '@/api';
 import type { ModeConfig } from '@/features/Practice/engine/types';
 
+// The wizard reads useSafeAreaInsets; stub it with non-zero insets (no
+// SafeAreaProvider in tests) so the safe-area padding is observable.
+jest.mock('react-native-safe-area-context', () => {
+  const ReactMod = require('react');
+  const passthrough = ({ children }: { children: unknown }) =>
+    ReactMod.createElement(ReactMod.Fragment, null, children);
+  return {
+    SafeAreaProvider: passthrough,
+    SafeAreaView: passthrough,
+    useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+  };
+});
+
 const createdPractice: PracticeItem = {
   id: 501,
   stage_number: 4,
@@ -107,6 +120,14 @@ describe('CreatePracticeWizard — step navigation', () => {
     expect(view.getByTestId('create-practice-step-entry')).toBeTruthy();
     expect(view.getByTestId('create-practice-from-preset')).toBeTruthy();
     expect(view.getByTestId('create-practice-from-scratch')).toBeTruthy();
+  });
+
+  it('applies safe-area insets to the wizard container', () => {
+    const { view } = renderScreen();
+    expect(view.getByTestId('create-practice-wizard')).toHaveStyle({
+      paddingTop: 47,
+      paddingBottom: 34,
+    });
   });
 
   it('start-from-scratch advances to the mode picker', () => {

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -5,6 +5,19 @@ import React from 'react';
 
 import type { PracticeItem } from '@/api';
 
+// The catalog reads useSafeAreaInsets; stub it with non-zero insets (no
+// SafeAreaProvider in tests) so the safe-area padding is observable.
+jest.mock('react-native-safe-area-context', () => {
+  const ReactMod = require('react');
+  const passthrough = ({ children }: { children: unknown }) =>
+    ReactMod.createElement(ReactMod.Fragment, null, children);
+  return {
+    SafeAreaProvider: passthrough,
+    SafeAreaView: passthrough,
+    useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+  };
+});
+
 const presetA: PracticeItem = {
   id: 1,
   stage_number: 1,
@@ -111,6 +124,15 @@ describe('PracticeCatalogScreen — sections', () => {
     expect(drafts).toBeTruthy();
     expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
     expect(view.getByTestId('practice-catalog-row-9')).toBeTruthy();
+  });
+
+  it('applies safe-area insets to the catalog container', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.getByTestId('practice-catalog-safe-area')).toHaveStyle({
+      paddingTop: 47,
+      paddingBottom: 34,
+    });
   });
 
   it('renders an empty Imported section because no share-token signal exists yet', async () => {


### PR DESCRIPTION
## Summary

The Practice full-screen surfaces had **no safe-area handling** (a grep for `SafeAreaView`/`useSafeAreaInsets` across `features/Practice/` returned zero hits), so on notched devices header text collided with the status-bar cutout and bottom content sat under the home indicator (audit §8). `SafeAreaProvider` is already mounted in `App.tsx` (task 1 — verified, no change needed).

- **`PracticeScreen`**: `useSafeAreaInsets` top/bottom padding applied to **all four** return paths — the active-session `ScrollView` (`contentContainerStyle`), the selection `View`, and the loading/error views.
- **`PracticeCatalogScreen`**: inset-pad the outer container (`testID="practice-catalog-safe-area"`); the `SectionList` keeps `practice-catalog-screen`.
- **`CreatePracticeWizard`**: wrap the `KeyboardAvoidingView` in an inset-padded `View` — the KAV (`behavior="padding"`) owns its own bottom padding from the keyboard height and would clobber a bottom inset, so insets live on an outer node. `testID="create-practice-wizard"` moves to that View; the KAV is inner.

All existing `testID`s preserved. No layout/styling/copy changes beyond inset padding.

## Test plan

- Each screen's existing suite stubs `useSafeAreaInsets` → `{top:47,bottom:34}` and asserts the surface (`practice-screen`, `practice-loading`, `practice-error`, `practice-catalog-safe-area`, `create-practice-wizard`) applies the padding via `toHaveStyle`.
- **New** `PracticeSafeArea.test.tsx`: drives the wizard through the **real** `SafeAreaProvider` (`initialMetrics`) — proves the provider → `useSafeAreaInsets` → padding chain end-to-end and that it doesn't throw (would catch the provider being unmounted).
- `./scripts/frontend/check-all.sh` — 4/4 (ESLint incl. max-lines, `tsc`, Jest, prettier).

Closes #505
Refs #495
