### PR TITLE
fix(frontend): validate journal.list and prompts.history envelopes

### DIFF
--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -271,4 +271,14 @@ describe('journalListResponseSchema validation', () => {
       }),
     ).toThrow();
   });
+
+  it('rejects a non-ISO timestamp (same contract as other timestamp columns)', () => {
+    expect(() =>
+      journalListResponseSchema.parse({
+        items: [{ ...message, timestamp: 'not-a-date' }],
+        total: 1,
+        has_more: false,
+      }),
+    ).toThrow();
+  });
 });

--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -5,6 +5,7 @@ import {
   goalSchema,
   habitSchema,
   habitWithGoalsSchema,
+  journalListResponseSchema,
   promptListResponseSchema,
 } from '../schemas';
 
@@ -214,6 +215,60 @@ describe('promptListResponseSchema total nullability', () => {
   it('rejects a non-integer total', () => {
     expect(() =>
       promptListResponseSchema.parse({ items: [item], total: 1.5, has_more: false }),
+    ).toThrow();
+  });
+
+  it('rejects a non-array items envelope', () => {
+    expect(() =>
+      promptListResponseSchema.parse({ items: 'nope', total: null, has_more: false }),
+    ).toThrow();
+  });
+
+  it('rejects an envelope missing has_more', () => {
+    expect(() => promptListResponseSchema.parse({ items: [], total: null })).toThrow();
+  });
+});
+
+describe('journalListResponseSchema validation', () => {
+  const message = {
+    id: 1,
+    message: 'A quiet morning.',
+    sender: 'user',
+    timestamp: '2026-05-09T22:31:22Z',
+    tag: 'freeform',
+    practice_session_id: null,
+    user_practice_id: null,
+  };
+
+  it('round-trips a well-formed envelope with nullable links intact', () => {
+    const parsed = journalListResponseSchema.parse({
+      items: [message, { ...message, id: 2, sender: 'bot', practice_session_id: 7 }],
+      total: 2,
+      has_more: false,
+    });
+    expect(parsed.items).toHaveLength(2);
+    expect(parsed.items[0]?.practice_session_id).toBeNull();
+    expect(parsed.items[1]?.practice_session_id).toBe(7);
+    expect(parsed.total).toBe(2);
+  });
+
+  it('rejects a non-array items envelope', () => {
+    expect(() =>
+      journalListResponseSchema.parse({ items: null, total: 0, has_more: false }),
+    ).toThrow();
+  });
+
+  it('rejects an envelope missing has_more', () => {
+    expect(() => journalListResponseSchema.parse({ items: [message], total: 1 })).toThrow();
+  });
+
+  it('rejects an unknown sender', () => {
+    expect(() =>
+      journalListResponseSchema.parse({
+        items: [{ ...message, sender: 'system' }],
+        total: 1,
+        has_more: false,
+      }),
     ).toThrow();
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -5,6 +5,7 @@ import {
   authResponseSchema,
   habitWithGoalsSchema,
   isTier,
+  journalListResponseSchema,
   loginAuthResponseSchema,
   pageSchema,
   passwordResetAcceptedSchema,
@@ -1178,7 +1179,10 @@ export const journal = {
     if (params.limit != null) query.set('limit', String(params.limit));
     if (params.offset != null) query.set('offset', String(params.offset));
     const qs = query.toString();
-    return request<JournalListResponse>(`/journal${qs ? `?${qs}` : ''}`, { token });
+    return request<JournalListResponse>(`/journal${qs ? `?${qs}` : ''}`, {
+      token,
+      schema: journalListResponseSchema as unknown as z.ZodType<JournalListResponse>,
+    });
   },
   get(entryId: number, token?: string): Promise<JournalMessage> {
     return request<JournalMessage>(`/journal/${entryId}`, { token });

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -228,6 +228,33 @@ export const promptListResponseSchema = z.object({
 
 export type PromptListResponseSchemaT = z.infer<typeof promptListResponseSchema>;
 
+export const journalTagSchema = z.enum([
+  'freeform',
+  'stage_reflection',
+  'practice_note',
+  'habit_note',
+]);
+
+/** One journal message (mirrors the backend ``JournalMessage`` response). */
+export const journalMessageSchema = z.object({
+  id: z.number().int(),
+  message: z.string(),
+  sender: z.enum(['user', 'bot']),
+  timestamp: z.string(),
+  tag: journalTagSchema,
+  practice_session_id: z.number().int().nullable(),
+  user_practice_id: z.number().int().nullable(),
+});
+
+/** Journal list envelope: ``{ items, total, has_more }`` (bespoke, not ``Page``). */
+export const journalListResponseSchema = z.object({
+  items: z.array(journalMessageSchema),
+  total: z.number().int(),
+  has_more: z.boolean(),
+});
+
+export type JournalListResponseSchemaT = z.infer<typeof journalListResponseSchema>;
+
 // ---------------------------------------------------------------------------
 // Lenient schemas for legacy endpoints (gradually tightened)
 // ---------------------------------------------------------------------------

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -240,7 +240,9 @@ export const journalMessageSchema = z.object({
   id: z.number().int(),
   message: z.string(),
   sender: z.enum(['user', 'bot']),
-  timestamp: z.string(),
+  // Same ISO-8601 contract as every other timestamp column (goal completions
+  // etc.) — bare z.string() would silently accept "not-a-date".
+  timestamp: isoDateTime,
   tag: journalTagSchema,
   practice_session_id: z.number().int().nullable(),
   user_practice_id: z.number().int().nullable(),


### PR DESCRIPTION
## Summary

`journal.list` and `prompts.history` called `request<T>()` with **no `schema`**, so `parseResponse` fell through to `return data as T` — an unchecked cast. A mis-shaped envelope (non-array `items`, missing `has_more`, a renamed key, a `null` where an object is expected) sailed past the API edge and detonated as a deep `TypeError` inside the Journal/Prompts screens, with no API-layer stack frame (audit §5.4 — unvalidated contracts).

- Added `journalMessageSchema` + `journalListResponseSchema` (the bespoke `{ items, total, has_more }` envelope — not the generic `Page<T>`) and wired it into `journal.list`.
- `prompts.history` already validates via `promptListResponseSchema` (added in #502); this PR confirms that wiring and adds mis-shape rejection cases for it.

Now no `request<…ListResponse>()` call in `index.ts` is schema-less.

## Test plan

`schemas.test.ts`:
- A well-formed journal envelope round-trips with nullable `practice_session_id` / `user_practice_id` intact.
- `items: null`, a missing `has_more`, and an unknown `sender` each throw (→ `ApiValidationError` at the edge).
- Added the same mis-shape rejections (non-array `items`, missing `has_more`) for the prompt envelope.
- `./scripts/frontend/check-all.sh` — 4/4 (ESLint, `tsc`, Jest, prettier).

Closes #507
Refs #491
