### PR TITLE
ci: match real workflow names in iteration-trigger

### DIFF
--- a/.github/workflows/iteration-trigger.yml
+++ b/.github/workflows/iteration-trigger.yml
@@ -13,7 +13,9 @@ name: Iteration Trigger
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    # Must match the upstream workflows' ``name:`` exactly; the previous value
+    # matched no workflow in this repo, so the trigger never fired.
+    workflows: ["Backend CI", "Frontend CI"]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
## Summary

`iteration-trigger.yml` subscribed to `workflow_run` with `workflows: ["CI"]`, but **no workflow in this repo is named `CI`** — the real names are `Backend CI` and `Frontend CI` (verified against the `name:` lines in `backend-ci.yml` / `frontend-ci.yml`). GitHub matches `workflow_run.workflows` against the upstream `name:`, so the trigger **never fired** and the post-CI review nudge was silently dead (audit §9).

- Changed the match to `["Backend CI", "Frontend CI"]`.
- No job logic, the 10-post cap, PAT handling, verdict parsing, or permissions changed; the existing `if:` already guards on `conclusion == 'success'` + `event == 'pull_request'`, and the cap protects against double-fire.

## Test plan

- `grep '"CI"' .github/workflows/iteration-trigger.yml` → **clean** (no standalone `"CI"` name).
- Matched names verified against the live `name:` lines in both CI workflows.
- `pre-commit run --files .github/workflows/iteration-trigger.yml` passes (YAML-only).

Closes #508
Refs #496
