### PR TITLE
ci: fail the branch-coverage step on a pytest crash

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -59,9 +59,15 @@ jobs:
           # Verify branch coverage meets the threshold by parsing coverage.xml.
           # Threshold starts at 80% (current baseline ~82%); tighten as test
           # coverage improves, especially in services/botmason.py (70%).
-          pytest --cov=src --cov-report=xml --cov-branch -q --no-header 2>/dev/null || true
+          # Error suppression removed: a pytest crash (collection/import/plugin
+          # error) must fail this step, not let the parser read a stale or
+          # partial coverage.xml from a prior run.
+          pytest --cov=src --cov-report=xml --cov-branch -q --no-header
           python3 -c "
-          import sys, xml.etree.ElementTree as ET
+          import os, sys, xml.etree.ElementTree as ET
+          if not os.path.exists('coverage.xml'):
+              print('::error::coverage.xml not found — pytest produced no report')
+              sys.exit(1)
           tree = ET.parse('coverage.xml')
           rate = float(tree.getroot().attrib['branch-rate']) * 100
           threshold = 80


### PR DESCRIPTION
## Summary

The `Branch coverage ≥80%` step ran the coverage producer as `pytest ... 2>/dev/null || true`. The `2>/dev/null` hid every error and `|| true` forced exit 0, so a pytest crash (collection error, import failure, plugin breakage) was **silently swallowed**. The parser then read whatever `coverage.xml` was on disk — possibly stale from a prior run or partially written — so the 80% branch gate could not fail for the one reason it most needs to: a broken test run (audit §9).

- Removed `2>/dev/null || true`: a non-zero pytest exit now fails the step before the parser runs (each `run:` block is its own `set -e` shell, so the parse short-circuits).
- **Defensive:** the inline parser now exits with a clear `::error::` if `coverage.xml` is absent, instead of an opaque `FileNotFoundError`.

The 80% threshold and the parsing logic are unchanged; no change to what tests run.

## Test plan

- `grep -nE '2>/dev/null|\|\| true' .github/workflows/backend-ci.yml` → **clean** (none anywhere).
- The branch-coverage `pytest` line now propagates failure; a crash fails `backend-quality` before the parse.
- `pre-commit run --files .github/workflows/backend-ci.yml` passes (YAML-only).

Closes #511
Refs #496
