### PR TITLE
feat(frontend): add error + retry states to the Course screen

### DIFF
--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -292,6 +292,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   retryButton: {
+    marginTop: SPACING.md,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.lg,
     borderRadius: radius.md,

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, FlatList, Text, View } from 'react-native';
+import { ActivityIndicator, FlatList, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import {
@@ -34,32 +34,38 @@ function useStagesLoader() {
   const [allStages, setAllStages] = useState<Stage[]>([]);
   const [selectedStage, setSelectedStage] = useState(routeStageNumber ?? DEFAULT_STAGE_NUMBER);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
-  useEffect(() => {
-    const init = async () => {
-      setLoading(true);
-      try {
-        const stagesList = await stagesApi.listAll();
-        setAllStages(stagesList);
-        if (routeStageNumber === null) {
-          // Master date wins when the user has picked an anchor; otherwise
-          // fall back to the server-owned, count-based progression
-          // (``completed_count + 1``) — "max unlocked" would visually
-          // reward skip-ahead attempts whenever ``is_unlocked`` ran
-          // ahead of completion.
-          const dateDerived = programStage(programAnchor);
-          setSelectedStage(dateDerived ?? deriveCurrentStage(stagesList));
-        }
-      } catch (err) {
-        console.error('Failed to load stages:', err);
-      } finally {
-        setLoading(false);
+  const init = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const stagesList = await stagesApi.listAll();
+      setAllStages(stagesList);
+      if (routeStageNumber === null) {
+        // Master date wins when the user has picked an anchor; otherwise
+        // fall back to the server-owned, count-based progression
+        // (``completed_count + 1``) — "max unlocked" would visually
+        // reward skip-ahead attempts whenever ``is_unlocked`` ran
+        // ahead of completion.
+        const dateDerived = programStage(programAnchor);
+        setSelectedStage(dateDerived ?? deriveCurrentStage(stagesList));
       }
-    };
-    void init();
+    } catch (err) {
+      // Track failure explicitly so the screen can show error+retry instead of
+      // an empty course (audit-ux-04).
+      console.error('Failed to load stages:', err);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
   }, [routeStageNumber, programAnchor]);
 
-  return { allStages, selectedStage, setSelectedStage, loading };
+  useEffect(() => {
+    void init();
+  }, [init]);
+
+  return { allStages, selectedStage, setSelectedStage, loading, error, retry: init };
 }
 
 // --- Hook: load content for selected stage ---
@@ -68,9 +74,11 @@ function useStageContent(selectedStage: number, stagesLoaded: boolean) {
   const [content, setContent] = useState<ContentItem[]>([]);
   const [progress, setProgress] = useState<CourseProgress | null>(null);
   const [loadingContent, setLoadingContent] = useState(false);
+  const [error, setError] = useState(false);
 
   const refreshContent = useCallback(async () => {
     setLoadingContent(true);
+    setError(false);
     try {
       const [contentResult, progressResult] = await Promise.all([
         courseApi.stageContentAll(selectedStage),
@@ -79,9 +87,12 @@ function useStageContent(selectedStage: number, stagesLoaded: boolean) {
       setContent(contentResult);
       setProgress(progressResult);
     } catch (err) {
+      // A failed fetch is distinct from a genuinely empty stage: flag it so the
+      // screen shows error+retry rather than "No Content Yet" (audit-ux-04).
       console.error('Failed to load stage content:', err);
       setContent([]);
       setProgress(null);
+      setError(true);
     } finally {
       setLoadingContent(false);
     }
@@ -96,7 +107,7 @@ function useStageContent(selectedStage: number, stagesLoaded: boolean) {
     void refreshContent();
   }, [refreshContent]);
 
-  return { content, progress, loadingContent, handleMarkRead };
+  return { content, progress, loadingContent, handleMarkRead, error, retry: refreshContent };
 }
 
 // --- Sub-components ---
@@ -119,9 +130,19 @@ const StageMetadata = ({ stage }: { stage: Stage }): React.JSX.Element => (
 interface ProgressBarProps {
   progress: CourseProgress | null;
   spiralColor: string | undefined;
+  error?: boolean;
 }
 
-const CourseProgressBar = ({ progress, spiralColor }: ProgressBarProps): React.JSX.Element => {
+const progressLabel = (progress: CourseProgress | null, error: boolean): string => {
+  if (error) return 'Progress unavailable';
+  return progress ? `${progress.read_items}/${progress.total_items} completed` : 'Loading...';
+};
+
+const CourseProgressBar = ({
+  progress,
+  spiralColor,
+  error = false,
+}: ProgressBarProps): React.JSX.Element => {
   const progressPercent = progress ? progress.progress_percent : 0;
   const barColor = spiralColor ? STAGE_COLORS[spiralColor] ?? colors.neutral : colors.neutral;
 
@@ -136,9 +157,7 @@ const CourseProgressBar = ({ progress, spiralColor }: ProgressBarProps): React.J
           ]}
         />
       </View>
-      <Text style={styles.progressBarLabel}>
-        {progress ? `${progress.read_items}/${progress.total_items} completed` : 'Loading...'}
-      </Text>
+      <Text style={styles.progressBarLabel}>{progressLabel(progress, error)}</Text>
     </View>
   );
 };
@@ -153,6 +172,25 @@ const CourseEmptyState = (): React.JSX.Element => (
   </View>
 );
 
+const CourseErrorState = ({ onRetry }: { onRetry: () => void }): React.JSX.Element => (
+  <View style={styles.emptyContainer} testID="course-error">
+    <Text style={styles.emptyIcon}>{'⚠️'}</Text>
+    <Text style={styles.emptyTitle}>Couldn&apos;t load the course</Text>
+    <Text style={styles.emptySubtitle}>
+      Something went wrong loading this stage. Check your connection and try again.
+    </Text>
+    <TouchableOpacity
+      onPress={onRetry}
+      accessibilityRole="button"
+      accessibilityLabel="Try again"
+      style={styles.retryButton}
+      testID="course-retry"
+    >
+      <Text style={styles.retryText}>Try again</Text>
+    </TouchableOpacity>
+  </View>
+);
+
 const CourseLoadingState = (): React.JSX.Element => (
   <SafeAreaView style={styles.container}>
     <View style={styles.loadingContainer}>
@@ -164,13 +202,17 @@ const CourseLoadingState = (): React.JSX.Element => (
 interface ContentAreaProps {
   content: ContentItem[];
   loadingContent: boolean;
+  error: boolean;
   onContentPress: (_item: ContentItem) => void;
+  onRetry: () => void;
 }
 
 const ContentArea = ({
   content,
   loadingContent,
+  error,
   onContentPress,
+  onRetry,
 }: ContentAreaProps): React.JSX.Element => {
   const renderContentItem = useCallback(
     ({ item }: { item: ContentItem }) => <ContentCard item={item} onPress={onContentPress} />,
@@ -188,6 +230,11 @@ const ContentArea = ({
         <ActivityIndicator testID="content-loading" size="small" />
       </View>
     );
+  }
+
+  // A failed content fetch shows error+retry, distinct from the empty state.
+  if (error) {
+    return <CourseErrorState onRetry={onRetry} />;
   }
 
   return (
@@ -273,7 +320,7 @@ function renderOverlay(
 }
 
 const CourseScreen = (): React.JSX.Element => {
-  const { allStages, selectedStage, setSelectedStage, loading } = useStagesLoader();
+  const { allStages, selectedStage, setSelectedStage, loading, error, retry } = useStagesLoader();
   const stageContent = useStageContent(selectedStage, allStages.length > 0);
   const viewer = useCourseViewer(selectedStage);
 
@@ -290,6 +337,15 @@ const CourseScreen = (): React.JSX.Element => {
 
   if (loading) return <CourseLoadingState />;
 
+  // Stage-list fetch failed: show error+retry, not an empty course.
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container} edges={['bottom']}>
+        <CourseErrorState onRetry={retry} />
+      </SafeAreaView>
+    );
+  }
+
   const selectedStageData = allStages.find((s) => s.stage_number === selectedStage);
 
   return (
@@ -304,11 +360,14 @@ const CourseScreen = (): React.JSX.Element => {
       <CourseProgressBar
         progress={stageContent.progress}
         spiralColor={selectedStageData?.spiral_dynamics_color}
+        error={stageContent.error}
       />
       <ContentArea
         content={stageContent.content}
         loadingContent={stageContent.loadingContent}
+        error={stageContent.error}
         onContentPress={viewer.handleContentPress}
+        onRetry={stageContent.retry}
       />
     </SafeAreaView>
   );

--- a/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-env jest */
 // audit-ux-04: a failed stage-list / content fetch must show error+retry, not
 // masquerade as an empty course or a permanent "Loading..." progress bar.
@@ -43,9 +42,9 @@ const sampleProgress: CourseProgress = {
   next_unlock_day: null,
 };
 
-const mockStagesList = jest.fn() as any;
-const mockStageContent = jest.fn() as any;
-const mockStageProgress = jest.fn() as any;
+const mockStagesList = jest.fn<(...a: unknown[]) => Promise<Stage[]>>();
+const mockStageContent = jest.fn<(...a: unknown[]) => Promise<ContentItem[]>>();
+const mockStageProgress = jest.fn<(...a: unknown[]) => Promise<CourseProgress>>();
 
 jest.mock('../../../api', () => ({
   stages: { listAll: (...a: unknown[]) => mockStagesList(...a) },
@@ -54,7 +53,7 @@ jest.mock('../../../api', () => ({
     stageProgress: (...a: unknown[]) => mockStageProgress(...a),
     markRead: jest.fn(),
     contentBody: jest.fn(),
-    siteResources: (jest.fn() as any).mockResolvedValue([]),
+    siteResources: () => Promise.resolve([]),
     siteResourceBody: jest.fn(),
   },
 }));
@@ -117,6 +116,17 @@ describe('CourseScreen error + retry states', () => {
     await waitFor(() => expect(view.getByTestId('content-list')).toBeTruthy());
     expect(view.queryByTestId('course-error')).toBeNull();
     expect(mockStageContent).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the error state when retry also fails', async () => {
+    mockStagesList.mockRejectedValue(new Error('persistent'));
+    const view = render(<CourseScreen />);
+    await waitFor(() => expect(view.getByTestId('course-error')).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(view.getByTestId('course-retry'));
+    });
+    await waitFor(() => expect(view.getByTestId('course-error')).toBeTruthy());
+    expect(mockStagesList).toHaveBeenCalledTimes(2);
   });
 
   it('still shows "No Content Yet" for a genuinely empty stage', async () => {

--- a/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-env jest */
+// audit-ux-04: a failed stage-list / content fetch must show error+retry, not
+// masquerade as an empty course or a permanent "Loading..." progress bar.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+import type { ContentItem, CourseProgress, Stage } from '../../../api';
+
+const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
+  id: 1,
+  title: 'Stage 1',
+  subtitle: 'First stage',
+  stage_number: 1,
+  overview_url: 'https://example.com',
+  category: 'foundation',
+  aspect: 'body',
+  spiral_dynamics_color: 'Beige',
+  growing_up_stage: 'Archaic',
+  divine_gender_polarity: 'neutral',
+  relationship_to_free_will: 'reactive',
+  free_will_description: 'Instinctual survival',
+  is_unlocked: true,
+  progress: 0,
+  ...overrides,
+});
+
+const sampleStages: Stage[] = [makeStage({ id: 1, stage_number: 1 })];
+const sampleContent: ContentItem[] = [
+  {
+    id: 1,
+    title: 'Welcome Essay',
+    content_type: 'essay',
+    release_day: 0,
+    url: 'https://example.com/essay',
+    is_locked: false,
+    is_read: false,
+  },
+];
+const sampleProgress: CourseProgress = {
+  total_items: 1,
+  read_items: 0,
+  progress_percent: 0,
+  next_unlock_day: null,
+};
+
+const mockStagesList = jest.fn() as any;
+const mockStageContent = jest.fn() as any;
+const mockStageProgress = jest.fn() as any;
+
+jest.mock('../../../api', () => ({
+  stages: { listAll: (...a: unknown[]) => mockStagesList(...a) },
+  course: {
+    stageContentAll: (...a: unknown[]) => mockStageContent(...a),
+    stageProgress: (...a: unknown[]) => mockStageProgress(...a),
+    markRead: jest.fn(),
+    contentBody: jest.fn(),
+    siteResources: (jest.fn() as any).mockResolvedValue([]),
+    siteResourceBody: jest.fn(),
+  },
+}));
+
+jest.mock('../../../navigation/hooks', () => ({
+  useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: undefined }),
+  useAppNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactMod = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: unknown }) =>
+      ReactMod.createElement(ReactMod.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// eslint-disable-next-line import/order
+const { render, waitFor, fireEvent, act } = require('@testing-library/react-native');
+const CourseScreen = require('../CourseScreen').default;
+
+describe('CourseScreen error + retry states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStagesList.mockResolvedValue(sampleStages);
+    mockStageContent.mockResolvedValue(sampleContent);
+    mockStageProgress.mockResolvedValue(sampleProgress);
+  });
+
+  it('shows error+retry (not empty) when the stage list fails, and retry recovers', async () => {
+    mockStagesList.mockRejectedValueOnce(new Error('network'));
+    const view = render(<CourseScreen />);
+
+    await waitFor(() => expect(view.getByTestId('course-error')).toBeTruthy());
+    expect(view.queryByText('No Content Yet')).toBeNull();
+
+    // Retry succeeds → the error clears and the stage selector renders.
+    await act(async () => {
+      fireEvent.press(view.getByTestId('course-retry'));
+    });
+    await waitFor(() => expect(view.getByTestId('stage-selector')).toBeTruthy());
+    expect(view.queryByTestId('course-error')).toBeNull();
+    expect(mockStagesList).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows content error+retry (not "No Content Yet") and an unavailable progress label', async () => {
+    mockStageContent.mockRejectedValueOnce(new Error('boom'));
+    const view = render(<CourseScreen />);
+
+    await waitFor(() => expect(view.getByTestId('course-error')).toBeTruthy());
+    expect(view.queryByText('No Content Yet')).toBeNull();
+    expect(view.getByText('Progress unavailable')).toBeTruthy();
+    expect(view.queryByText('Loading...')).toBeNull();
+
+    // Retry re-runs the content fetch; this time it resolves with items.
+    await act(async () => {
+      fireEvent.press(view.getByTestId('course-retry'));
+    });
+    await waitFor(() => expect(view.getByTestId('content-list')).toBeTruthy());
+    expect(view.queryByTestId('course-error')).toBeNull();
+    expect(mockStageContent).toHaveBeenCalledTimes(2);
+  });
+
+  it('still shows "No Content Yet" for a genuinely empty stage', async () => {
+    mockStageContent.mockResolvedValue([]);
+    mockStageProgress.mockResolvedValue({
+      total_items: 0,
+      read_items: 0,
+      progress_percent: 0,
+      next_unlock_day: null,
+    });
+    const view = render(<CourseScreen />);
+
+    await waitFor(() => expect(view.getByText('No Content Yet')).toBeTruthy());
+    expect(view.queryByTestId('course-error')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`CourseScreen` swallowed fetch failures into empty/loading fallbacks (audit §8):

- the stage-list `catch` only `console.error`'d → `allStages` empty → "No Content Yet";
- the content `catch` reset content/progress to empty/null → "No Content Yet" + a **permanent "Loading..."** progress label.

A real failure was indistinguishable from an empty course, with no retry.

- `useStagesLoader` and `useStageContent` now track an explicit `error` flag (set in their `catch`, cleared on success) and expose a `retry` (`init` / `refreshContent`).
- New **`CourseErrorState`** (error copy + "Try again", `accessibilityRole="button"`).
- Stage-list error → `CourseErrorState` full-screen; content error → it replaces `CourseEmptyState` in `ContentArea`; the progress bar shows **"Progress unavailable"** instead of a permanent "Loading..." on content error.
- The genuinely-empty path keeps **"No Content Yet"**; loading keeps the spinner.
- Error copy says what failed + how to recover; no `error.message`/status leaks.

## Test plan

`CourseErrorStates.test.tsx`:
- Stage-list failure → error+retry (not empty); retry recovers (stage selector renders, `listAll` called 2×).
- Content failure → error+retry + "Progress unavailable" (not "No Content Yet" / "Loading..."); retry re-fetches (`stageContentAll` 2×).
- A genuinely empty stage still shows "No Content Yet" (no error node).
- Existing Course tests pass; `./scripts/frontend/check-all.sh` — 4/4.

Closes #513
Refs #495
