### PR TITLE
ci: cache uv downloads across backend CI jobs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -25,6 +25,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          # Cache uv's download/build cache, keyed on the requirements files so
+          # a dependency change busts it (audit-ci-05).
+          enable-cache: true
+          cache-dependency-glob: backend/requirements*.txt
 
       - name: Install backend deps
         run: |
@@ -99,6 +104,12 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          # Cache uv's download/build cache, keyed on the requirements files so
+          # a dependency change busts it (audit-ci-05).
+          enable-cache: true
+          cache-dependency-glob: backend/requirements*.txt
+          cache-suffix: py${{ matrix.python-version }}
 
       - name: Install backend deps
         run: |
@@ -145,6 +156,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          # Cache uv's download/build cache, keyed on the requirements files so
+          # a dependency change busts it (audit-ci-05).
+          enable-cache: true
+          cache-dependency-glob: backend/requirements*.txt
 
       - name: Install backend deps
         run: |
@@ -226,6 +242,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          # Cache uv's download/build cache, keyed on the requirements files so
+          # a dependency change busts it (audit-ci-05).
+          enable-cache: true
+          cache-dependency-glob: backend/requirements*.txt
 
       - name: Install drift-check deps
         # The check needs only the sync script's imports, not the app.


### PR DESCRIPTION
## Summary

Every backend CI job reinstalled the full Python dependency tree from scratch — `uv pip install --system` re-resolved and re-downloaded ~5× per push with no cache layer, making the backend the slowest part of the pipeline (the frontend already caches npm via `setup-node`). Audit §9.

- Enabled **setup-uv's built-in cache** on every `Install uv` step: `enable-cache: true` with `cache-dependency-glob: backend/requirements*.txt`, so the cache key busts whenever any requirements file changes and a repeat run restores from cache.
- The **`backend-compat` matrix legs** add `cache-suffix: py${{ matrix.python-version }}` so the 3.11 and 3.13 caches don't collide.
- Applied to all four backend jobs: `backend-quality`, `backend-compat` (×2), `migration-drift`, `content-drift`.

No change to which deps install, version pins, gate logic, or the action SHA pins. The cache is provided by the already-SHA-pinned `astral-sh/setup-uv@…v8.1.0` (no new action added).

## Test plan

- `pre-commit run --files .github/workflows/backend-ci.yml` — passes (YAML valid).
- This run populates the cache; a subsequent run with unchanged `requirements*.txt` will restore it (visible as a uv cache hit in the Actions logs).
- Cache key invalidates on any `requirements*.txt` change (via `cache-dependency-glob`).

Closes #514
Refs #496
