### PR TITLE
fix(frontend): harden token refresh with timeout + in-flight dedupe

### DIFF
--- a/frontend/src/api/__tests__/token-refresh.test.ts
+++ b/frontend/src/api/__tests__/token-refresh.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-/* global describe, test, expect, beforeEach, jest */
+/* global describe, test, expect, beforeEach, afterEach, jest */
 import {
   habits,
   auth,
@@ -150,5 +150,66 @@ describe('retry-after-refresh on 401', () => {
 
     // Only the original call — no refresh attempt
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('in-flight dedupe + timeout (audit-contracts-05)', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('coalesces concurrent 401s into a single network refresh', async () => {
+    const newJwt = fixtureJwt('shared');
+    let refreshCalls = 0;
+    let refreshed = false;
+    // Branch on URL so both concurrent /habits requests 401 before either
+    // refresh completes, then succeed once the shared refresh has run.
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/auth/refresh')) {
+        refreshCalls += 1;
+        refreshed = true;
+        return jsonResponse({ token: newJwt, user_id: 1 });
+      }
+      return refreshed ? jsonResponse([]) : jsonResponse({ detail: 'unauthorized' }, 401);
+    });
+
+    const [first, second] = await Promise.all([habits.list(), habits.list()]);
+
+    // Two concurrent 401s, but exactly one refresh hit the network.
+    expect(refreshCalls).toBe(1);
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+
+    // The in-flight promise cleared on settle: a later refresh still fires.
+    refreshed = false;
+    refreshCalls = 0;
+    await habits.list();
+    expect(refreshCalls).toBe(1);
+  });
+
+  test('a refresh that times out resolves gracefully (onUnauthorized, no throw)', async () => {
+    jest.useFakeTimers();
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/auth/refresh')) {
+        // Never resolves on its own; rejects when fetchWithTimeout's clock wins.
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        });
+      }
+      return jsonResponse({ detail: 'unauthorized' }, 401);
+    });
+
+    const promise = habits.list();
+    promise.catch(() => {});
+    await jest.runAllTimersAsync();
+
+    // The timed-out refresh becomes a refresh failure (no uncaught throw): the
+    // original 401 surfaces as ApiError and the unauthorized handler fires.
+    await expect(promise).rejects.toThrow(ApiError);
+    expect(mockOnUnauthorized).toHaveBeenCalled();
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -410,25 +410,31 @@ async function parseResponse<T>(res: Response, path = '', schema?: z.ZodType<T>)
   return data as T;
 }
 
-/**
- * Try to refresh the current token. Returns the new token on success, or
- * null if the refresh itself fails (e.g. the token is fully expired).
- *
- * Returns ``null`` immediately when the session has no token at all so
- * an anonymous request that hit a protected endpoint (BUG-API-018) does
- * NOT issue a doomed POST to /auth/refresh that would 401 again.  The
- * caller distinguishes "no token" from "refresh failed" via the second
- * tuple element.
- */
-async function attemptTokenRefresh(): Promise<{ token: string | null; hadToken: boolean }> {
-  const currentToken = tokenGetter?.();
-  if (!currentToken) return { token: null, hadToken: false };
+/** Outcome of a refresh attempt; ``hadToken`` separates "no session" from "refresh failed". */
+type RefreshResult = { token: string | null; hadToken: boolean };
 
+/**
+ * Shared in-flight refresh (audit-contracts-05). When several requests 401 at
+ * once — the common cold-start / expired-token case — each used to call
+ * ``attemptTokenRefresh`` independently, firing a storm of concurrent refreshes
+ * against the same token. We now keep a single promise so N concurrent callers
+ * await exactly one network refresh; it is cleared on settle so a later,
+ * genuine refresh still fires.
+ */
+let inFlightRefresh: Promise<RefreshResult> | null = null;
+
+async function performTokenRefresh(currentToken: string): Promise<RefreshResult> {
   try {
-    const refreshRes = await fetch(`${API_BASE_URL}/auth/refresh`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${currentToken}` },
-    });
+    // Route through ``fetchWithTimeout`` so a hung refresh aborts instead of
+    // pinning the 401-retry loop; the ApiTimeoutError it throws on the clock
+    // winning is caught below and surfaced as a refresh failure.
+    const refreshRes = await fetchWithTimeout(
+      `${API_BASE_URL}/auth/refresh`,
+      { method: 'POST', headers: { Authorization: `Bearer ${currentToken}` } },
+      FETCH_TIMEOUT_MS,
+      undefined,
+      '/auth/refresh',
+    );
     if (!refreshRes.ok) return { token: null, hadToken: true };
     const raw: unknown = await refreshRes.json();
     // BUG-API-007 / BUG-API-017: the prior cast (``as AuthResponse``)
@@ -458,6 +464,28 @@ async function attemptTokenRefresh(): Promise<{ token: string | null; hadToken: 
   } catch {
     return { token: null, hadToken: true };
   }
+}
+
+/**
+ * Try to refresh the current token. Returns the new token on success, or
+ * null if the refresh itself fails (e.g. the token is fully expired).
+ *
+ * Returns ``null`` immediately when the session has no token at all so
+ * an anonymous request that hit a protected endpoint (BUG-API-018) does
+ * NOT issue a doomed POST to /auth/refresh that would 401 again.  The
+ * caller distinguishes "no token" from "refresh failed" via the second
+ * tuple element.
+ */
+async function attemptTokenRefresh(): Promise<RefreshResult> {
+  const currentToken = tokenGetter?.();
+  if (!currentToken) return { token: null, hadToken: false };
+
+  // Coalesce concurrent 401s onto a single refresh; clear on settle.
+  if (inFlightRefresh) return inFlightRefresh;
+  inFlightRefresh = performTokenRefresh(currentToken).finally(() => {
+    inFlightRefresh = null;
+  });
+  return inFlightRefresh;
 }
 
 /**


### PR DESCRIPTION
## Summary

`attemptTokenRefresh` issued `POST /auth/refresh` with a **raw `fetch`** — no timeout, no `AbortSignal`, none of the abort/timeout contract the rest of the client gets from `fetchWithTimeout`. And with **no in-flight dedupe**, N requests that 401 at once (the common cold-start / expired-token case) each fired their own refresh, storming the same token (audit §5.4).

- Split out **`performTokenRefresh`**, routed through **`fetchWithTimeout`** (`FETCH_TIMEOUT_MS`) so a hung refresh aborts instead of pinning the 401-retry loop; the `ApiTimeoutError` it raises is caught and surfaced as a refresh failure (`{ token: null, hadToken: true }`), not an uncaught throw.
- Added a module-level **`inFlightRefresh`** promise: concurrent callers await exactly one network refresh; it is cleared in `finally` on settle so a later, genuine refresh still fires.
- The no-token short-circuit, `safeParse` failure path, and `onTokenRefreshedCallback` (timezone forwarding) are **unchanged** — only transport and concurrency change. The `retryStreamWithRefresh` SSE path inherits the dedupe for free.

## Test plan

`token-refresh.test.ts` (existing 6 + 2 new, all green):
- Two **concurrent** `habits.list()` 401s → exactly **one** refresh hit the network (call-count assertion); the in-flight promise clears on settle (a later refresh still fires).
- A refresh that **times out** via `fetchWithTimeout` resolves gracefully: the original 401 surfaces as `ApiError`, `onUnauthorized` fires, no uncaught throw.
- Existing refresh behaviour (no-token short-circuit, malformed-body rejection, timezone forwarding, retry-after-refresh) unchanged.
- `./scripts/frontend/check-all.sh` — 4/4.

> Note: the new cases live in the dedicated `token-refresh.test.ts` (alongside the existing refresh coverage) rather than `retryAndValidation.test.ts` named in the issue — same module, more cohesive home.

Closes #515
Refs #491
