### PR TITLE
fix(frontend): gate FeatureErrorBoundary's raw error message behind __DEV__

### DIFF
--- a/frontend/src/components/FeatureErrorBoundary.tsx
+++ b/frontend/src/components/FeatureErrorBoundary.tsx
@@ -105,7 +105,10 @@ class FeatureErrorBoundaryClass extends React.Component<
         <Text style={styles.body}>
           Something went wrong while loading this section. The rest of the app is still usable.
         </Text>
-        <Text style={styles.message}>{this.state.error.message}</Text>
+        {/* Dev-only: a thrown error's message can carry internal detail (paths,
+            library internals) a production user must never see — mirror the
+            top-level ErrorBoundary's __DEV__ gate (audit-ux-05). */}
+        {__DEV__ && <Text style={styles.message}>{this.state.error.message}</Text>}
         <TouchableOpacity
           accessibilityLabel={`Retry loading ${name}`}
           accessibilityRole="button"

--- a/frontend/src/components/FeatureErrorBoundary.tsx
+++ b/frontend/src/components/FeatureErrorBoundary.tsx
@@ -106,8 +106,10 @@ class FeatureErrorBoundaryClass extends React.Component<
           Something went wrong while loading this section. The rest of the app is still usable.
         </Text>
         {/* Dev-only: a thrown error's message can carry internal detail (paths,
-            library internals) a production user must never see — mirror the
-            top-level ErrorBoundary's __DEV__ gate (audit-ux-05). */}
+            library internals). Unlike the top-level ErrorBoundary — which shows
+            the message in every build alongside a "copy to support" prompt — this
+            inline recovery card has no such affordance, so a production user has
+            no safe channel for the raw text. Hide it here. (audit-ux-05) */}
         {__DEV__ && <Text style={styles.message}>{this.state.error.message}</Text>}
         <TouchableOpacity
           accessibilityLabel={`Retry loading ${name}`}

--- a/frontend/src/components/__tests__/FeatureErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/FeatureErrorBoundary.test.tsx
@@ -162,3 +162,50 @@ describe('FeatureErrorBoundary', () => {
     expect(getByText('recovered manually')).toBeTruthy();
   });
 });
+
+describe('FeatureErrorBoundary — raw message gating (audit-ux-05)', () => {
+  const devGlobal = global as { __DEV__?: boolean };
+  const originalDev = devGlobal.__DEV__;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    reportException.mockClear();
+    focusListeners.length = 0;
+    mockNavigatorState.useSecond = false;
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    devGlobal.__DEV__ = originalDev;
+    errorSpy.mockRestore();
+  });
+
+  function SecretBoom(): React.JSX.Element {
+    throw new Error('secret-internal-detail');
+  }
+
+  it('hides the raw error message in production builds (__DEV__ false)', () => {
+    devGlobal.__DEV__ = false;
+    const { queryByText, getByText } = render(
+      <FeatureErrorBoundary name="Habits">
+        <SecretBoom />
+      </FeatureErrorBoundary>,
+    );
+    // The internal detail must never reach a production user…
+    expect(queryByText('secret-internal-detail')).toBeNull();
+    // …but the friendly explanation and retry control still render.
+    expect(getByText(/hit a snag/)).toBeTruthy();
+    expect(getByText('Try again')).toBeTruthy();
+  });
+
+  it('shows the raw error message in dev builds (__DEV__ true)', () => {
+    devGlobal.__DEV__ = true;
+    const { getByText } = render(
+      <FeatureErrorBoundary name="Habits">
+        <SecretBoom />
+      </FeatureErrorBoundary>,
+    );
+    expect(getByText('secret-internal-detail')).toBeTruthy();
+    expect(getByText(/hit a snag/)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/__tests__/FeatureErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/FeatureErrorBoundary.test.tsx
@@ -171,6 +171,7 @@ describe('FeatureErrorBoundary — raw message gating (audit-ux-05)', () => {
   beforeEach(() => {
     reportException.mockClear();
     focusListeners.length = 0;
+    mockSecondNavigatorListeners.length = 0;
     mockNavigatorState.useSecond = false;
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });


### PR DESCRIPTION
## Summary

`FeatureErrorBoundary` rendered `{this.state.error.message}` directly into the fallback UI in **every** build, including production. A thrown error's `message` can carry internal detail (endpoint paths, library internals, stack-derived strings) a production user must never see.

- Gated the raw-message `<Text>` behind `{__DEV__ && ...}`.
- The friendly heading ("… hit a snag"), body, and "Try again" retry render in **all** builds; only the developer-aid message line is now dev-only.

**Note (corrected):** this does **not** mirror the top-level `ErrorBoundary`, which intentionally shows `error.message` in every build alongside a *copy-to-support* prompt (gating only the raw stack). This inline recovery card has no support-handoff affordance, so the raw message has no safe channel in production — hence hiding it here.

## Test plan

`FeatureErrorBoundary.test.tsx` (existing 5 + 2 new):
- `__DEV__ === false`: an error whose message is `'secret-internal-detail'` is **not** rendered; friendly copy and "Try again" still are.
- `__DEV__ === true`: the raw message renders for debugging.
- `./scripts/frontend/check-all.sh` — 4/4.

Closes #516
Refs #495