### PR TITLE
docs: correct stale version/count/path/import claims across docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 To set up the full development environment, run:
 
 ```bash
-bash /scripts/dev-setup.sh
+bash scripts/dev-setup.sh
 ```
 
 Agents working on this project must abide by the following operating principles:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ adepthood/
     src/
       main.py              # FastAPI app, CORS, router mounting
       database.py          # Async engine, session factory, get_session
-      models/              # 14 SQLModel ORM classes
+      models/              # 26 SQLModel ORM classes
       routers/             # Route handlers (auth, habits, practices, etc.)
       schemas/             # Pydantic request/response DTOs
       domain/              # Business logic (energy, streaks, goals, stages)

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Run the development setup script to install shared tooling:
 bash scripts/dev-setup.sh
 ```
  **Prerequisites** (Handled by Setup Script)
-- Node.js (v18+)
-- Python (3.10+)
+- Node.js (v20 — see `frontend/.nvmrc`)
+- Python (3.11+ — CI runs 3.11, 3.12, 3.13)
 - PostgreSQL
 
 ### Frontend

--- a/RECOVERY-RUNBOOK.md
+++ b/RECOVERY-RUNBOOK.md
@@ -157,6 +157,7 @@ container, with `SECRET_KEY` and `DATABASE_URL` already set):
 ```python
 from datetime import UTC, datetime
 from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlmodel import select
 from database import engine
 from models.user import User
 from routers.auth import _hash_password

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ scripts/
 │   ├── check-all.sh   # Run lint + format + typecheck + security + complexity + tests
 │   ├── fix-all.sh     # Auto-fix linting and formatting
 │   ├── lint.sh        # ruff
-│   ├── format.sh      # black + isort
+│   ├── format.sh      # ruff format (import order via ruff)
 │   ├── typecheck.sh   # mypy
 │   ├── test.sh        # pytest (--unit / --integration / --e2e / --all)
 │   ├── coverage.sh    # pytest with coverage (≥90%)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ scripts/
 │   ├── check-all.sh   # Run lint + format + typecheck + security + complexity + tests
 │   ├── fix-all.sh     # Auto-fix linting and formatting
 │   ├── lint.sh        # ruff
-│   ├── format.sh      # ruff format (import order via ruff)
+│   ├── format.sh      # ruff format
 │   ├── typecheck.sh   # mypy
 │   ├── test.sh        # pytest (--unit / --integration / --e2e / --all)
 │   ├── coverage.sh    # pytest with coverage (≥90%)

--- a/scripts/backend/check-all.sh
+++ b/scripts/backend/check-all.sh
@@ -24,7 +24,7 @@ Run all quality checks in sequence.
 
 Runs:
   1. Linting (Ruff)
-  2. Formatting (Black + isort)
+  2. Formatting (ruff format)
   3. Type checking (MyPy)
   4. Security checks (Bandit + Safety)
   5. Complexity analysis (Radon)

--- a/scripts/backend/format.sh
+++ b/scripts/backend/format.sh
@@ -72,7 +72,7 @@ else
     MODE=""
 fi
 
-# Run ruff format (plus isort-via-ruff for import order)
+# Run ruff format (style/whitespace only; import sorting is a lint-time `I` rule)
 if $VERBOSE; then
     echo "Running ruff format..."
 fi


### PR DESCRIPTION
## Summary

Several docs asserted facts that no longer match the tree (audit §9). Verified each against the live codebase and corrected:

- **README.md** prerequisites: Node `v18+` → **v20** (`frontend/.nvmrc` pins 20); Python `3.10+` → **3.11+** (`backend-ci` runs 3.11/3.12/3.13).
- **CLAUDE.md** architecture: "14 SQLModel ORM classes" → **26** (count of `table=True` classes in `backend/src/models/`).
- **scripts/README.md**: `format.sh` "black + isort" → **"ruff format"** (matches the real `scripts/backend/format.sh`).
- **AGENTS.md**: `bash /scripts/dev-setup.sh` → **`bash scripts/dev-setup.sh`** (the leading-slash absolute path didn't resolve; now repo-relative, matching README).
- **RECOVERY-RUNBOOK.md**: added `from sqlmodel import select` to the REPL snippet that used `select(User)` (it raised `NameError` as written; `sqlmodel` is where the backend imports `select`).

Verify-then-correct only — no doc restructuring, no behavior change. The `DEPLOYMENT.md` Alembic section is out of scope (that was audit-ci-02, #504).

## Test plan

- Each value checked against source: `.nvmrc` (20), `backend-ci.yml` matrix (3.11/3.13 + 3.12 quality), `grep -c table=True backend/src/models/*.py` (26), `scripts/backend/format.sh` (ruff format), `README.md:36` (repo-relative setup path), `grep 'import select' backend/src` (`from sqlmodel import select`).
- `pre-commit run --files <the 5 docs>` — all hooks pass.

Closes #517
Refs #496
