### PR TITLE
fix(frontend): position the toast overlay using safe-area insets

### DIFF
--- a/frontend/__tests__/App.bootstrap.test.tsx
+++ b/frontend/__tests__/App.bootstrap.test.tsx
@@ -9,6 +9,10 @@ import renderer from 'react-test-renderer';
 
 import App from '../src/App';
 
+// This suite renders the real App (real navigation stack), which needs the real
+// safe-area exports; opt out of the global jest.setup mock for this file only.
+jest.unmock('react-native-safe-area-context');
+
 jest.mock('expo-notifications', () => ({
   getPermissionsAsync: (jest.fn() as any).mockResolvedValue({ status: 'granted' }),
   requestPermissionsAsync: jest.fn() as any,

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -29,3 +29,23 @@ jest.mock('react-native-reanimated', () => {
     );
   }
 });
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const defaultInsets = { top: 0, bottom: 0, left: 0, right: 0 };
+  const defaultFrame = { x: 0, y: 0, width: 390, height: 844 };
+  const SafeAreaInsetsContext = React.createContext(null);
+  const SafeAreaFrameContext = React.createContext(defaultFrame);
+  const SafeAreaProvider = ({ children }) => React.createElement(React.Fragment, null, children);
+  const SafeAreaView = ({ children, ...props }) => React.createElement(View, props, children);
+  return {
+    SafeAreaInsetsContext,
+    SafeAreaFrameContext,
+    initialWindowMetrics: { insets: defaultInsets, frame: defaultFrame },
+    useSafeAreaInsets: () => React.useContext(SafeAreaInsetsContext) ?? defaultInsets,
+    useSafeAreaFrame: () => React.useContext(SafeAreaFrameContext) ?? defaultFrame,
+    SafeAreaProvider,
+    SafeAreaView,
+  };
+});

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -8,8 +8,16 @@ import React, {
   useState,
 } from 'react';
 import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import Toast, { type ToastConfig } from './Toast';
+
+/**
+ * Gap below the safe-area top inset so the toast clears the status bar / notch
+ * on every device. Replaces a hardcoded ``top: 60`` that clipped the message on
+ * phones reporting a larger top inset (audit-ux-06).
+ */
+export const TOAST_TOP_OFFSET = 8;
 
 interface ToastContextValue {
   showToast: (config: ToastConfig) => void;
@@ -84,6 +92,8 @@ function useToastQueue(): ToastQueue {
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const { showToast, handleDismiss, currentToast } = useToastQueue();
+  const insets = useSafeAreaInsets();
+  const overlayTop = insets.top + TOAST_TOP_OFFSET;
 
   // BUG-FRONTEND-INFRA-004: a fresh ``{ showToast }`` on every render would
   // force every consumer of ``useToast`` to re-render too. ``showToast`` is
@@ -94,7 +104,11 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <ToastContext.Provider value={contextValue}>
       {children}
-      <View style={styles.overlay} pointerEvents="none" testID="toast-overlay">
+      <View
+        style={[styles.overlay, { top: overlayTop }]}
+        pointerEvents="none"
+        testID="toast-overlay"
+      >
         {currentToast ? <Toast {...currentToast} onDismiss={handleDismiss} /> : null}
       </View>
     </ToastContext.Provider>
@@ -114,8 +128,8 @@ export function useToast(): ToastContextValue {
 
 const styles = StyleSheet.create({
   overlay: {
+    // ``top`` is applied inline from the safe-area inset (audit-ux-06).
     position: 'absolute',
-    top: 60,
     left: 0,
     right: 0,
     zIndex: 9999,

--- a/frontend/src/components/__tests__/ToastProvider.test.tsx
+++ b/frontend/src/components/__tests__/ToastProvider.test.tsx
@@ -11,9 +11,17 @@
  */
 import { act, render } from '@testing-library/react-native';
 import React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 
-import { ToastProvider, useToast } from '../ToastProvider';
+import { ToastProvider, TOAST_TOP_OFFSET, useToast } from '../ToastProvider';
+
+// Mutable so each test drives the safe-area top inset the provider reads.
+// Mocking the hook also keeps the real package's native module out of the
+// test (it throws under Jest).
+let mockInsets = { top: 0, bottom: 0, left: 0, right: 0 };
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => mockInsets,
+}));
 
 function Trigger({ messages }: { messages: string[] }) {
   const { showToast } = useToast();
@@ -26,6 +34,7 @@ function Trigger({ messages }: { messages: string[] }) {
 }
 
 beforeEach(() => {
+  mockInsets = { top: 0, bottom: 0, left: 0, right: 0 };
   jest.useFakeTimers();
 });
 
@@ -76,5 +85,34 @@ describe('ToastProvider', () => {
     // timer ID, but a strict-greater-than ensures the cleanup ran.
     expect(clearSpy.mock.calls.length).toBeGreaterThan(beforeUnmountClears);
     clearSpy.mockRestore();
+  });
+});
+
+describe('ToastProvider — safe-area top inset (audit-ux-06)', () => {
+  function overlayTop(screen: ReturnType<typeof render>): number {
+    const overlay = screen.getByTestId('toast-overlay');
+    return StyleSheet.flatten(overlay.props.style).top;
+  }
+
+  test('positions the overlay below a large top inset', () => {
+    mockInsets = { top: 59, bottom: 0, left: 0, right: 0 };
+    const screen = render(
+      <ToastProvider>
+        <Trigger messages={['celebrate']} />
+      </ToastProvider>,
+    );
+    expect(overlayTop(screen)).toBe(59 + TOAST_TOP_OFFSET);
+    expect(screen.getByText('celebrate')).toBeTruthy();
+  });
+
+  test('falls back to the bare offset when the top inset is zero', () => {
+    mockInsets = { top: 0, bottom: 0, left: 0, right: 0 };
+    const screen = render(
+      <ToastProvider>
+        <Trigger messages={['hi']} />
+      </ToastProvider>,
+    );
+    expect(overlayTop(screen)).toBe(TOAST_TOP_OFFSET);
+    expect(screen.getByText('hi')).toBeTruthy();
   });
 });

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -29,6 +29,8 @@ jest.mock('@/context/AuthContext', () => ({
 jest.mock('react-native-safe-area-context', () => ({
   SafeAreaProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   SafeAreaView: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  // ToastProvider (rendered inside App) reads the top inset.
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
 // Mock navigators to simple pass-through components.  ``useNavigation``

--- a/frontend/src/features/Practice/__tests__/PracticeSafeArea.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeSafeArea.test.tsx
@@ -9,6 +9,10 @@ import { render } from '@testing-library/react-native';
 import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
+// This suite deliberately exercises the REAL provider → useSafeAreaInsets chain,
+// so opt out of the global jest.setup safe-area mock for this file only.
+jest.unmock('react-native-safe-area-context');
+
 import type { PracticeItem, UserPractice } from '@/api';
 
 const mockPracticesCreate = jest.fn();


### PR DESCRIPTION
## Summary

`ToastProvider` positioned its overlay with a hardcoded `top: 60`. On devices whose status-bar / notch inset exceeds that (many phones report 47–59pt), the toast sat partly under the notch, clipping the celebration message (audit §8).

- Replaced the magic number with **`TOAST_TOP_OFFSET` (8)**, applied as an inline `top` of `useSafeAreaInsets().top + TOAST_TOP_OFFSET`; the static `position`/`left`/`right`/`zIndex` stay in the `StyleSheet`.

### Test-infra (why the diff is larger than ToastProvider)

`ToastProvider` is imported broadly (via `useToast` → `useHabits`), so it now pulls `react-native-safe-area-context` into many suites' require graph. That library loads a **native module at import** which throws under Jest, and the repo had no global mock (only per-file ones). I added a **synthetic global mock in `jest.setup.js`** — the same pattern as the existing reanimated mock — so every suite gets a non-native stand-in; per-file mocks still override it. The two suites that *deliberately* exercise the real provider chain (`App.bootstrap`'s root-tree `findAllByType(SafeAreaProvider)` and `PracticeSafeArea`'s provider→inset integration) opt out via `jest.unmock`.

## Test plan

`ToastProvider.test.tsx`:
- Overlay `top` resolves to `inset.top + TOAST_TOP_OFFSET` for a large inset (59 → 67) and to `TOAST_TOP_OFFSET` when the top inset is 0; the overlay still renders the current toast.
- Existing queue/gap/unmount tests unchanged.
- Full suite green: `./scripts/frontend/check-all.sh` — 4/4 (1963 tests).

Closes #518
Refs #495
