### PR TITLE
fix(frontend): replace hand-rolled practice validators with Zod

### DIFF
--- a/frontend/src/api/__tests__/pagination-api.test.ts
+++ b/frontend/src/api/__tests__/pagination-api.test.ts
@@ -265,3 +265,24 @@ describe('fetchAllPages + listAll helpers (issue #408 — screen adoption)', () 
     await expect(practices.listAll({ stageNumber: 3 })).rejects.toThrow(ApiValidationError);
   });
 });
+
+describe('practices.list (bare array, audit-contracts-06)', () => {
+  test('round-trips every valid row intact', async () => {
+    const rows = [validPractice({ id: 1 }), validPractice({ id: 2 })];
+    mockFetch.mockReturnValueOnce(jsonResponse(rows));
+    const result = await practices.list({ stageNumber: 3 });
+    expect(result).toEqual(rows);
+  });
+
+  test('raises ApiValidationError on a drifted row instead of dropping it', async () => {
+    // A renamed field used to make the row silently fail the typeof guard and
+    // vanish from the catalog; it must now surface as a validation error.
+    const drifted = {
+      ...validPractice({ id: 2 }),
+      default_duration_minutes: undefined,
+      duration: 5,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse([validPractice({ id: 1 }), drifted]));
+    await expect(practices.list({ stageNumber: 3 })).rejects.toThrow(ApiValidationError);
+  });
+});

--- a/frontend/src/api/__tests__/practiceRecipes-api.test.ts
+++ b/frontend/src/api/__tests__/practiceRecipes-api.test.ts
@@ -104,6 +104,20 @@ describe('practiceRecipes.create', () => {
     expect(JSON.parse(init.body).slug).toBe('my_recipe');
     expect(out).toEqual(recipeFixture);
   });
+
+  test('raises ApiValidationError on a drifted create response', async () => {
+    const drifted = { ...recipeFixture, slug: undefined, identifier: 'x' };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted, 201));
+    await expect(
+      practiceRecipes.create({
+        slug: 'x',
+        name: 'X',
+        mode: 'tallied_grounding',
+        rounds: 1,
+        steps: [],
+      }),
+    ).rejects.toThrow(ApiValidationError);
+  });
 });
 
 describe('practiceRecipes.update', () => {
@@ -117,6 +131,14 @@ describe('practiceRecipes.update', () => {
     const [url, init] = mockFetch.mock.calls[0];
     expect(url).toBe('http://test/practice-recipes/7');
     expect(init.method).toBe('PATCH');
+  });
+
+  test('raises ApiValidationError on a drifted update response', async () => {
+    const drifted = { ...recipeFixture, rounds: undefined, roundCount: 2 };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+    await expect(practiceRecipes.update(7, { name: 'X', rounds: 1, steps: [] })).rejects.toThrow(
+      ApiValidationError,
+    );
   });
 });
 

--- a/frontend/src/api/__tests__/practiceRecipes-api.test.ts
+++ b/frontend/src/api/__tests__/practiceRecipes-api.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
-import { practiceRecipes, practiceTags } from '../index';
+import { ApiValidationError, practiceRecipes, practiceTags } from '../index';
 
 const mockFetch = jest.fn() as jest.Mock;
 global.fetch = mockFetch;
@@ -56,9 +56,28 @@ describe('practiceRecipes.list', () => {
     expect(url).toBe('http://test/practice-recipes/?mode=tallied_grounding');
   });
 
-  test('rejects payload with missing fields', async () => {
+  test('raises ApiValidationError on a payload with missing fields', async () => {
     mockFetch.mockReturnValueOnce(jsonResponse([{ slug: 'incomplete' }]));
-    await expect(practiceRecipes.list()).rejects.toThrow('Invalid practice-recipes response');
+    await expect(practiceRecipes.list()).rejects.toThrow(ApiValidationError);
+  });
+
+  test('raises ApiValidationError on a drifted row (renamed step field) — not a dropped row', async () => {
+    const drifted = {
+      ...recipeFixture,
+      steps: [{ ...recipeFixture.steps[0], target_count: undefined, targetCount: 1 }],
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse([recipeFixture, drifted]));
+    // Zod parses the whole array: the bad row makes the response invalid rather
+    // than silently shortening the list to the one valid recipe.
+    await expect(practiceRecipes.list()).rejects.toThrow(ApiValidationError);
+  });
+});
+
+describe('practiceRecipes.get drift', () => {
+  test('raises ApiValidationError when a required field is renamed', async () => {
+    const drifted = { ...recipeFixture, owner_user_id: undefined, ownerUserId: null };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+    await expect(practiceRecipes.get(7)).rejects.toThrow(ApiValidationError);
   });
 });
 

--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -7,6 +7,7 @@ import {
   habitWithGoalsSchema,
   journalListResponseSchema,
   practiceItemSchema,
+  practiceRecipeSchema,
   practiceSessionResponseSchema,
   promptListResponseSchema,
   stageSchema,
@@ -365,5 +366,40 @@ describe('per-item paginated schemas', () => {
     expect(() =>
       practiceSessionResponseSchema.parse({ ...session, user_practice_id: undefined }),
     ).toThrow();
+  });
+});
+
+describe('practiceRecipeSchema (audit-contracts-06)', () => {
+  const recipe = {
+    id: 7,
+    slug: 'find_the_rainbow',
+    name: 'Find the Rainbow',
+    description: '',
+    owner_user_id: null,
+    mode: 'tallied_grounding',
+    rounds: 3,
+    created_at: '2026-05-23T00:00:00Z',
+    steps: [
+      { position: 0, tag_slug: 'red', tag_label: 'Red', prompt_label: 'Find red', target_count: 1 },
+    ],
+  };
+
+  it('accepts a valid recipe (nullable owner, enum mode, nested steps)', () => {
+    const parsed = practiceRecipeSchema.parse(recipe);
+    expect(parsed.owner_user_id).toBeNull();
+    expect(parsed.steps[0]?.tag_slug).toBe('red');
+  });
+
+  it('rejects an unknown mode value', () => {
+    expect(() => practiceRecipeSchema.parse({ ...recipe, mode: 'mystery_mode' })).toThrow();
+  });
+
+  it('rejects a drifted step (renamed target_count)', () => {
+    const steps = [{ ...recipe.steps[0], target_count: undefined, targetCount: 1 }];
+    expect(() => practiceRecipeSchema.parse({ ...recipe, steps })).toThrow();
+  });
+
+  it('rejects a missing required field', () => {
+    expect(() => practiceRecipeSchema.parse({ ...recipe, slug: undefined })).toThrow();
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -10,6 +10,7 @@ import {
   pageSchema,
   passwordResetAcceptedSchema,
   practiceItemSchema,
+  practiceRecipeSchema,
   practiceSessionResponseSchema,
   promptListResponseSchema,
   stageSchema,
@@ -1939,17 +1940,6 @@ export interface PracticeInsightsResponse {
   last_insight: string | null;
 }
 
-function validatePracticeItem(item: unknown): item is PracticeItem {
-  if (typeof item !== 'object' || item === null) return false;
-  const p = item as Record<string, unknown>;
-  return (
-    typeof p.id === 'number' &&
-    typeof p.name === 'string' &&
-    typeof p.stage_number === 'number' &&
-    typeof p.default_duration_minutes === 'number'
-  );
-}
-
 /**
  * Payload for ``POST /practices/`` (custom-practices-07).
  *
@@ -1989,8 +1979,12 @@ export const practices = {
     const query = new URLSearchParams();
     query.set('stage_number', String(params.stageNumber));
     if (params.includeMine === true) query.set('include_mine', 'true');
-    const data = await request<PracticeItem[]>(`/practices/?${query.toString()}`, { token });
-    return data.filter(validatePracticeItem);
+    // Parse the array (don't filter): a drifted row now raises
+    // ApiValidationError instead of silently vanishing from the catalog.
+    return request<PracticeItem[]>(`/practices/?${query.toString()}`, {
+      token,
+      schema: z.array(practiceItemSchema) as unknown as z.ZodType<PracticeItem[]>,
+    });
   },
   /**
    * Paginated practices list for a stage (BUG-INFRA-012). Opts into the
@@ -2024,10 +2018,11 @@ export const practices = {
       practices.listPaginated({ ...params, ...pageParams }, token),
     );
   },
-  async get(practiceId: number, token?: string): Promise<PracticeItem> {
-    const data = await request<PracticeItem>(`/practices/${practiceId}`, { token });
-    if (!validatePracticeItem(data)) throw new Error('Invalid practice response');
-    return data;
+  get(practiceId: number, token?: string): Promise<PracticeItem> {
+    return request<PracticeItem>(`/practices/${practiceId}`, {
+      token,
+      schema: practiceItemSchema as unknown as z.ZodType<PracticeItem>,
+    });
   },
   /**
    * Submit a new user-created practice (custom-practices-07).
@@ -2202,87 +2197,41 @@ export interface PracticeRecipeUpdate {
   steps: PracticeRecipeStepInput[];
 }
 
-function validatePracticeRecipeStep(data: unknown): data is PracticeRecipeStep {
-  if (!isObject(data)) return false;
-  return (
-    typeof data.position === 'number' &&
-    typeof data.tag_slug === 'string' &&
-    typeof data.tag_label === 'string' &&
-    typeof data.prompt_label === 'string' &&
-    typeof data.target_count === 'number'
-  );
-}
-
-function hasRecipeOwnerShape(data: Record<string, unknown>): boolean {
-  return data.owner_user_id === null || typeof data.owner_user_id === 'number';
-}
-
-function hasRecipeModeShape(data: Record<string, unknown>): boolean {
-  return data.mode === 'sense_grounding' || data.mode === 'tallied_grounding';
-}
-
-function hasRecipeStringFields(data: Record<string, unknown>): boolean {
-  return (
-    typeof data.slug === 'string' &&
-    typeof data.name === 'string' &&
-    typeof data.description === 'string' &&
-    typeof data.created_at === 'string'
-  );
-}
-
-function hasRecipeStepsArray(data: Record<string, unknown>): boolean {
-  return Array.isArray(data.steps) && data.steps.every(validatePracticeRecipeStep);
-}
-
-function validatePracticeRecipe(data: unknown): data is PracticeRecipe {
-  if (!isObject(data)) return false;
-  return (
-    typeof data.id === 'number' &&
-    typeof data.rounds === 'number' &&
-    hasRecipeStringFields(data) &&
-    hasRecipeOwnerShape(data) &&
-    hasRecipeModeShape(data) &&
-    hasRecipeStepsArray(data)
-  );
-}
-
-const INVALID_RECIPE_RESPONSE = 'Invalid practice-recipe response';
+// PracticeRecipe responses are validated via ``practiceRecipeSchema`` so a
+// drifted field raises ApiValidationError instead of being silently rejected
+// with an opaque Error (audit-contracts-06).
+const recipeSchema = practiceRecipeSchema as unknown as z.ZodType<PracticeRecipe>;
+const recipeArraySchema = z.array(practiceRecipeSchema) as unknown as z.ZodType<PracticeRecipe[]>;
 
 export const practiceRecipes = {
-  async list(mode?: RecipeMode, token?: string): Promise<PracticeRecipe[]> {
+  list(mode?: RecipeMode, token?: string): Promise<PracticeRecipe[]> {
     const qs = mode ? `?mode=${encodeURIComponent(mode)}` : '';
-    const data = await request<unknown>(`/practice-recipes/${qs}`, { token });
-    if (!Array.isArray(data) || !data.every(validatePracticeRecipe)) {
-      throw new Error('Invalid practice-recipes response');
-    }
-    return data;
+    return request<PracticeRecipe[]>(`/practice-recipes/${qs}`, {
+      token,
+      schema: recipeArraySchema,
+    });
   },
-  async get(recipeId: number, token?: string): Promise<PracticeRecipe> {
-    const data = await request<unknown>(`/practice-recipes/${recipeId}`, { token });
-    if (!validatePracticeRecipe(data)) throw new Error(INVALID_RECIPE_RESPONSE);
-    return data;
+  get(recipeId: number, token?: string): Promise<PracticeRecipe> {
+    return request<PracticeRecipe>(`/practice-recipes/${recipeId}`, {
+      token,
+      schema: recipeSchema,
+    });
   },
-  async create(payload: PracticeRecipeCreate, token?: string): Promise<PracticeRecipe> {
-    const data = await request<unknown>('/practice-recipes/', {
+  create(payload: PracticeRecipeCreate, token?: string): Promise<PracticeRecipe> {
+    return request<PracticeRecipe>('/practice-recipes/', {
       method: 'POST',
       body: payload,
       token,
+      schema: recipeSchema,
     });
-    if (!validatePracticeRecipe(data)) throw new Error(INVALID_RECIPE_RESPONSE);
-    return data;
   },
-  async update(
-    recipeId: number,
-    payload: PracticeRecipeUpdate,
-    token?: string,
-  ): Promise<PracticeRecipe> {
-    const data = await request<unknown>(`/practice-recipes/${recipeId}`, {
+  update(recipeId: number, payload: PracticeRecipeUpdate, token?: string): Promise<PracticeRecipe> {
+    return request<PracticeRecipe>(`/practice-recipes/${recipeId}`, {
       method: 'PATCH',
       body: payload,
       token,
+      schema: recipeSchema,
     });
-    if (!validatePracticeRecipe(data)) throw new Error(INVALID_RECIPE_RESPONSE);
-    return data;
   },
   remove(recipeId: number, token?: string): Promise<void> {
     return request<void>(`/practice-recipes/${recipeId}`, { method: 'DELETE', token });

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -297,6 +297,28 @@ export const practiceItemSchema = z.object({
   mode_config: z.record(z.unknown()).optional(),
 });
 
+/** One step of a practice recipe (mirrors ``PracticeRecipeStep``). */
+export const practiceRecipeStepSchema = z.object({
+  position: z.number().int(),
+  tag_slug: z.string(),
+  tag_label: z.string(),
+  prompt_label: z.string(),
+  target_count: z.number(),
+});
+
+/** A practice recipe (mirrors ``PracticeRecipe``). */
+export const practiceRecipeSchema = z.object({
+  id: z.number().int(),
+  slug: z.string(),
+  name: z.string(),
+  description: z.string(),
+  owner_user_id: z.number().int().nullable(),
+  mode: z.enum(['sense_grounding', 'tallied_grounding']),
+  rounds: z.number(),
+  created_at: z.string(),
+  steps: z.array(practiceRecipeStepSchema),
+});
+
 /** A user's selected practice (mirrors ``UserPractice``). */
 export const userPracticeSchema = z.object({
   id: z.number().int(),


### PR DESCRIPTION
## Summary

The practice client validated responses with partial `typeof` guards (`validatePracticeItem` checked only 4 of the item's fields) and applied them as a **filter**: `practices.list` did `data.filter(validatePracticeItem)`. So a backend field rename made every row fail the guard and **silently drop** — the user saw an empty catalog with no error, no log, no `ApiValidationError` (audit §7).

- Added **`practiceRecipeStepSchema`** + **`practiceRecipeSchema`** (reusing `practiceItemSchema` from #512), modelling the full shapes.
- **`practices.list` / `.get`** now parse via `z.array(practiceItemSchema)` / the item schema through `request()`'s schema path: a drifted row **raises** `ApiValidationError` instead of vanishing. `listAll` already routes through the validated `listPaginated`.
- **`practiceRecipes.list` / `.get` / `.create` / `.update`** validate via `practiceRecipeSchema`, replacing the opaque `"Invalid practice-recipe response"` `Error` with a typed `ApiValidationError`.
- **Deleted** the dead guards: `validatePracticeItem`, `validatePracticeRecipe`, `validatePracticeRecipeStep`, and the `hasRecipe*` helpers. (`isObject` stays — used by the out-of-scope practice-tags validator.)

## Test plan

- `practices.list` / `practiceRecipes.list` with one **drifted row** (renamed `default_duration_minutes` / `target_count`) now throws `ApiValidationError` — proven to be the throw, not a silently shortened array.
- A valid list **round-trips all rows** intact; `practiceRecipes.get` drift raises.
- `practiceRecipeSchema` unit tests: accepts valid, rejects unknown `mode` / renamed step / missing field.
- `grep` confirms no `data.filter(validate…)` remains in `index.ts`.
- `./scripts/frontend/check-all.sh` — 4/4.

Closes #519
Refs #491
