### PR TITLE
feat(frontend): add an empty state to the Habits screen

### DIFF
--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -667,15 +667,14 @@ export const HabitsContent = ({
   onAddHabit,
   pagination,
 }: HabitsContentProps) => {
-  // First-run cohort: a zero-habit user gets guidance, not a blank surface
-  // (audit-ux-07). Suppressed while loading (spinner wins) and when an error
-  // banner owns the surface — the error branch below is unchanged.
+  // First-run guidance; suppressed during loading/error (audit-ux-07).
   const showEmpty = !loading && !error && habits.length === 0;
   return (
     <>
       {error && <ErrorBanner error={error} onRetry={onRetry} />}
       {loading && <LoadingSpinner />}
       {showEmpty && <HabitsEmptyState onAdd={onAddHabit} />}
+      {/* List co-renders under the error banner (unchanged); only loading/empty replace it. */}
       {!loading && !showEmpty && (
         <>
           <HabitList

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -22,6 +22,7 @@ import useResponsive from '../../design/useResponsive';
 
 import AddHabitModal from './components/AddHabitModal';
 import GoalModal from './components/GoalModal';
+import { HabitsEmptyState } from './components/HabitsEmptyState';
 import HabitSettingsModal from './components/HabitSettingsModal';
 import MissedDaysModal from './components/MissedDaysModal';
 import OnboardingModal from './components/OnboardingModal';
@@ -651,10 +652,11 @@ interface HabitsContentProps {
   gridGutter: number;
   renderItem: (_info: { item: Habit; index: number }) => React.ReactElement;
   onRetry: () => void;
+  onAddHabit: () => void;
   pagination: PaginationBarProps | null;
 }
 
-const HabitsContent = ({
+export const HabitsContent = ({
   habits,
   loading,
   error,
@@ -662,33 +664,40 @@ const HabitsContent = ({
   gridGutter,
   renderItem,
   onRetry,
+  onAddHabit,
   pagination,
-}: HabitsContentProps) => (
-  <>
-    {error && <ErrorBanner error={error} onRetry={onRetry} />}
-    {loading ? (
-      <LoadingSpinner />
-    ) : (
-      <>
-        <HabitList
-          habits={habits}
-          columns={columns}
-          gridGutter={gridGutter}
-          renderItem={renderItem}
-        />
-        {pagination && (
-          <PaginationBar
-            page={pagination.page}
-            pageCount={pagination.pageCount}
-            onPrev={pagination.onPrev}
-            onNext={pagination.onNext}
-            scale={pagination.scale}
+}: HabitsContentProps) => {
+  // First-run cohort: a zero-habit user gets guidance, not a blank surface
+  // (audit-ux-07). Suppressed while loading (spinner wins) and when an error
+  // banner owns the surface — the error branch below is unchanged.
+  const showEmpty = !loading && !error && habits.length === 0;
+  return (
+    <>
+      {error && <ErrorBanner error={error} onRetry={onRetry} />}
+      {loading && <LoadingSpinner />}
+      {showEmpty && <HabitsEmptyState onAdd={onAddHabit} />}
+      {!loading && !showEmpty && (
+        <>
+          <HabitList
+            habits={habits}
+            columns={columns}
+            gridGutter={gridGutter}
+            renderItem={renderItem}
           />
-        )}
-      </>
-    )}
-  </>
-);
+          {pagination && (
+            <PaginationBar
+              page={pagination.page}
+              pageCount={pagination.pageCount}
+              onPrev={pagination.onPrev}
+              onNext={pagination.onNext}
+              scale={pagination.scale}
+            />
+          )}
+        </>
+      )}
+    </>
+  );
+};
 
 const useHabitsScreenState = () => {
   const habitsReturn = useHabits();
@@ -780,6 +789,7 @@ const HabitsScreen = () => {
         gridGutter={gridGutter}
         renderItem={state.renderHabitTile}
         onRetry={() => void actions.loadHabits()}
+        onAddHabit={() => modals.open('addHabit')}
         pagination={paginationProps}
       />
       <EnergyFooter

--- a/frontend/src/features/Habits/__tests__/HabitsEmptyState.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEmptyState.test.tsx
@@ -1,0 +1,95 @@
+/* eslint-env jest */
+// audit-ux-07: a zero-habit (first-run) user must see guidance, not a blank screen.
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import { HabitsEmptyState } from '../components/HabitsEmptyState';
+import type { Habit } from '../Habits.types';
+import { HabitsContent } from '../HabitsScreen';
+
+// HabitsContent lives in HabitsScreen.tsx, whose module graph pulls in the
+// add-habit modal stack + notifications; mock those (same preamble the
+// flatlist-config suite uses) so importing the screen's exports is cheap.
+// jest hoists these above the imports above, so the mocks apply on load.
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+}));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/StatsModal', () => () => null);
+
+describe('HabitsEmptyState', () => {
+  it('renders the guidance title and subtitle', () => {
+    const { getByText, getByTestId } = render(<HabitsEmptyState />);
+    expect(getByTestId('habits-empty-state')).toBeTruthy();
+    expect(getByText('No habits yet')).toBeTruthy();
+    expect(getByText(/start building momentum/i)).toBeTruthy();
+  });
+
+  it('omits the CTA when no onAdd is provided', () => {
+    const { queryByTestId } = render(<HabitsEmptyState />);
+    expect(queryByTestId('habits-empty-add')).toBeNull();
+  });
+
+  it('renders a screen-reader-labeled CTA that fires onAdd', () => {
+    const onAdd = jest.fn();
+    const { getByTestId, getByLabelText } = render(<HabitsEmptyState onAdd={onAdd} />);
+    expect(getByLabelText('Add a habit')).toBeTruthy();
+    fireEvent.press(getByTestId('habits-empty-add'));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+});
+
+const sampleHabit = { id: 1, name: 'Meditate' } as unknown as Habit;
+const renderTile = () => (<></>) as unknown as React.ReactElement;
+const baseProps = {
+  columns: 2,
+  gridGutter: 8,
+  renderItem: renderTile,
+  onRetry: jest.fn(),
+  onAddHabit: jest.fn(),
+  pagination: null,
+};
+
+describe('HabitsContent empty branch (audit-ux-07)', () => {
+  it('shows the empty state (not the list) for a zero-habit, loaded, error-free screen', () => {
+    const { getByTestId, queryByTestId } = render(
+      <HabitsContent {...baseProps} habits={[]} loading={false} error={null} />,
+    );
+    expect(getByTestId('habits-empty-state')).toBeTruthy();
+    expect(queryByTestId('habits-list')).toBeNull();
+  });
+
+  it('shows the list (not the empty state) when habits are present', () => {
+    const { getByTestId, queryByTestId } = render(
+      <HabitsContent {...baseProps} habits={[sampleHabit]} loading={false} error={null} />,
+    );
+    expect(getByTestId('habits-list')).toBeTruthy();
+    expect(queryByTestId('habits-empty-state')).toBeNull();
+  });
+
+  it('suppresses the empty state while loading (spinner wins)', () => {
+    const { getByTestId, queryByTestId } = render(
+      <HabitsContent {...baseProps} habits={[]} loading error={null} />,
+    );
+    expect(getByTestId('loading-spinner')).toBeTruthy();
+    expect(queryByTestId('habits-empty-state')).toBeNull();
+  });
+
+  it('suppresses the empty state when an error banner is shown', () => {
+    const { getByTestId, queryByTestId } = render(
+      <HabitsContent {...baseProps} habits={[]} loading={false} error="Network down" />,
+    );
+    expect(getByTestId('retry-button')).toBeTruthy();
+    expect(queryByTestId('habits-empty-state')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/components/HabitsEmptyState.tsx
+++ b/frontend/src/features/Habits/components/HabitsEmptyState.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import { colors, radius, spacing } from '../../../design/tokens';
+import { colors, radius, spacing, touchTarget } from '../../../design/tokens';
 
 interface HabitsEmptyStateProps {
   /** When provided, renders an "Add a habit" CTA wired to the add-habit modal. */
@@ -52,8 +52,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: 14,
-    // text.secondary on the light Habits canvas (#f8f8f8) meets WCAG AA; the
-    // CTA text below stays text.light on the dark colors.secondary button.
+    // AA on #f8f8f8 (5.41:1); CTA text.light sits on the dark secondary button.
     color: colors.text.secondary,
     textAlign: 'center',
     lineHeight: 20,
@@ -64,6 +63,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing(3),
     borderRadius: radius.md,
     backgroundColor: colors.secondary,
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
   },
   ctaText: {
     fontSize: 15,

--- a/frontend/src/features/Habits/components/HabitsEmptyState.tsx
+++ b/frontend/src/features/Habits/components/HabitsEmptyState.tsx
@@ -15,7 +15,7 @@ interface HabitsEmptyStateProps {
  */
 export const HabitsEmptyState = ({ onAdd }: HabitsEmptyStateProps): React.JSX.Element => (
   <View style={styles.container} testID="habits-empty-state">
-    <Text style={styles.icon}>{'🌱'}</Text>
+    <Text style={styles.icon}>{'+'}</Text>
     <Text style={styles.title}>No habits yet</Text>
     <Text style={styles.subtitle}>
       Add your first habit to start building momentum. Small, daily actions compound.
@@ -44,6 +44,7 @@ const styles = StyleSheet.create({
   },
   icon: {
     fontSize: 40,
+    color: colors.text.light,
     marginBottom: spacing(1.5),
   },
   title: {
@@ -55,7 +56,9 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: 14,
-    color: colors.mystical.transparentLight,
+    // Muted body text via the semantic text token (not the overlay palette).
+    color: colors.text.light,
+    opacity: 0.7,
     textAlign: 'center',
     lineHeight: 20,
   },

--- a/frontend/src/features/Habits/components/HabitsEmptyState.tsx
+++ b/frontend/src/features/Habits/components/HabitsEmptyState.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { colors, radius, spacing } from '../../../design/tokens';
+
+interface HabitsEmptyStateProps {
+  /** When provided, renders an "Add a habit" CTA wired to the add-habit modal. */
+  onAdd?: () => void;
+}
+
+/**
+ * First-run fallback for the Habits screen (audit-ux-07). A zero-habit user
+ * previously saw a blank surface below the top bar; this guides them to add
+ * their first habit instead. Mirrors the Journal feature's empty-state shape.
+ */
+export const HabitsEmptyState = ({ onAdd }: HabitsEmptyStateProps): React.JSX.Element => (
+  <View style={styles.container} testID="habits-empty-state">
+    <Text style={styles.icon}>{'🌱'}</Text>
+    <Text style={styles.title}>No habits yet</Text>
+    <Text style={styles.subtitle}>
+      Add your first habit to start building momentum. Small, daily actions compound.
+    </Text>
+    {onAdd && (
+      <TouchableOpacity
+        onPress={onAdd}
+        accessibilityRole="button"
+        accessibilityLabel="Add a habit"
+        style={styles.cta}
+        testID="habits-empty-add"
+      >
+        <Text style={styles.ctaText}>Add a habit</Text>
+      </TouchableOpacity>
+    )}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing(3),
+    paddingVertical: spacing(4),
+  },
+  icon: {
+    fontSize: 40,
+    marginBottom: spacing(1.5),
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text.light,
+    textAlign: 'center',
+    marginBottom: spacing(1),
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.mystical.transparentLight,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  cta: {
+    marginTop: spacing(2.5),
+    paddingVertical: spacing(1),
+    paddingHorizontal: spacing(3),
+    borderRadius: radius.md,
+    backgroundColor: colors.secondary,
+  },
+  ctaText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.light,
+  },
+});

--- a/frontend/src/features/Habits/components/HabitsEmptyState.tsx
+++ b/frontend/src/features/Habits/components/HabitsEmptyState.tsx
@@ -8,11 +8,7 @@ interface HabitsEmptyStateProps {
   onAdd?: () => void;
 }
 
-/**
- * First-run fallback for the Habits screen (audit-ux-07). A zero-habit user
- * previously saw a blank surface below the top bar; this guides them to add
- * their first habit instead. Mirrors the Journal feature's empty-state shape.
- */
+/** First-run fallback guiding a zero-habit user to add their first (audit-ux-07). */
 export const HabitsEmptyState = ({ onAdd }: HabitsEmptyStateProps): React.JSX.Element => (
   <View style={styles.container} testID="habits-empty-state">
     <Text style={styles.icon}>{'+'}</Text>
@@ -44,21 +40,21 @@ const styles = StyleSheet.create({
   },
   icon: {
     fontSize: 40,
-    color: colors.text.light,
+    color: colors.text.primary,
     marginBottom: spacing(1.5),
   },
   title: {
     fontSize: 18,
     fontWeight: '600',
-    color: colors.text.light,
+    color: colors.text.primary,
     textAlign: 'center',
     marginBottom: spacing(1),
   },
   subtitle: {
     fontSize: 14,
-    // Muted body text via the semantic text token (not the overlay palette).
-    color: colors.text.light,
-    opacity: 0.7,
+    // text.secondary on the light Habits canvas (#f8f8f8) meets WCAG AA; the
+    // CTA text below stays text.light on the dark colors.secondary button.
+    color: colors.text.secondary,
     textAlign: 'center',
     lineHeight: 20,
   },


### PR DESCRIPTION
## Summary

`HabitsContent` rendered the error banner, then either a spinner or the habit list. When `habits` was an empty array — a brand-new user with zero habits — `HabitList` rendered nothing and there was no fallback, leaving a **blank surface** below the top bar with no guidance (audit §8; the Journal feature already ships a real empty state).

- Added **`HabitsEmptyState`** (icon + title + guidance copy + optional **"Add a habit"** CTA with `accessibilityRole="button"` / label), mirroring the Journal empty-state shape.
- `HabitsContent` now renders it when `!loading && !error && habits.length === 0`, wired to the existing add-habit modal via `onAddHabit`. The error banner still renders above content and the loading spinner still wins, so the empty state is **suppressed during loading and while an error is shown** (error/loading branches otherwise unchanged).

## Test plan

`HabitsEmptyState.test.tsx`:
- Component renders its title; given `onAdd`, renders the screen-reader-labeled CTA that fires `onAdd`; omits the CTA when `onAdd` is absent.
- `HabitsContent` shows the empty state (not the list) for a zero-habit, loaded, error-free screen; shows the list when habits exist; **suppresses** the empty state while loading (spinner) and when an error banner is up.
- `./scripts/frontend/check-all.sh` — 4/4.

Closes #521
Refs #495
