### PR TITLE
feat(frontend): shared auth styles, keyboard handling, email canonicalization

### DIFF
--- a/frontend/src/features/Auth/AuthScreenContainer.tsx
+++ b/frontend/src/features/Auth/AuthScreenContainer.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { KeyboardAvoidingView, Platform, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { authStyles } from './auth.styles';
+
+interface Props {
+  /** testID prefix; renders ``<id>-screen`` + ``<id>-keyboard-avoiding``. */
+  testID: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared full-screen wrapper for the auth screens (audit-ux-08): SafeAreaView +
+ * KeyboardAvoidingView so the on-screen keyboard never covers the submit button.
+ */
+export function AuthScreenContainer({ testID, children }: Props): React.JSX.Element {
+  return (
+    <SafeAreaView style={authStyles.safeArea} testID={`${testID}-screen`}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={authStyles.container}
+        testID={`${testID}-keyboard-avoiding`}
+      >
+        <View style={authStyles.form}>{children}</View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/frontend/src/features/Auth/CancelResetScreen.tsx
+++ b/frontend/src/features/Auth/CancelResetScreen.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity } from 'react-native';
+
+import { authStyles as styles } from './auth.styles';
+import { AuthScreenContainer } from './AuthScreenContainer';
 
 import { auth as authApi } from '@/api';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import { SPACING, colors } from '@/design/tokens';
 
 const MIN_TOKEN_LENGTH = 32;
 
@@ -25,9 +28,9 @@ interface TerminalViewProps {
 
 function TerminalView({ title, body, onBackToLogin }: TerminalViewProps): React.JSX.Element {
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{title}</Text>
-      <Text style={styles.subtitle}>{body}</Text>
+    <AuthScreenContainer testID="cancel-reset">
+      <Text style={localStyles.title}>{title}</Text>
+      <Text style={localStyles.subtitle}>{body}</Text>
       <TouchableOpacity
         accessibilityLabel="Back to log in"
         accessibilityRole="button"
@@ -37,16 +40,16 @@ function TerminalView({ title, body, onBackToLogin }: TerminalViewProps): React.
       >
         <Text style={styles.buttonText}>Back to Log In</Text>
       </TouchableOpacity>
-    </View>
+    </AuthScreenContainer>
   );
 }
 
 function PendingView(): React.JSX.Element {
   return (
-    <View style={styles.container} testID="cancel-reset-pending">
-      <ActivityIndicator size="large" />
-      <Text style={styles.subtitle}>Cancelling that reset request...</Text>
-    </View>
+    <AuthScreenContainer testID="cancel-reset">
+      <ActivityIndicator size="large" testID="cancel-reset-pending" />
+      <Text style={localStyles.subtitle}>Cancelling that reset request...</Text>
+    </AuthScreenContainer>
   );
 }
 
@@ -100,13 +103,9 @@ export default function CancelResetScreen({ navigation, route }: Props) {
   return <TerminalView title={copy.title} body={copy.body} onBackToLogin={onBackToLogin} />;
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    padding: SPACING.xl,
-    backgroundColor: colors.background.card,
-  },
+// Confirmation-screen typography (smaller title than the form screens); the
+// container/button/buttonText come from the shared authStyles.
+const localStyles = StyleSheet.create({
   title: { fontSize: 24, fontWeight: 'bold', textAlign: 'center', marginBottom: SPACING.md },
   subtitle: {
     fontSize: 15,
@@ -114,12 +113,4 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: SPACING.xl,
   },
-  button: {
-    backgroundColor: colors.primary,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.buttonV,
-    alignItems: 'center',
-    marginBottom: SPACING.lg,
-  },
-  buttonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
 });

--- a/frontend/src/features/Auth/ForgotPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ForgotPasswordScreen.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
-import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+import { authStyles as styles } from './auth.styles';
+import { AuthScreenContainer } from './AuthScreenContainer';
+import { canonicalizeEmail } from './canonicalizeEmail';
 
 import { auth as authApi } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
 const FORGOT_FALLBACK =
   "We couldn't reach the server. Check your connection, then try again in a moment.";
@@ -105,7 +108,7 @@ export default function ForgotPasswordScreen({ navigation }: Props) {
     setError(null);
     setSubmitting(true);
     try {
-      await authApi.requestPasswordReset({ email: email.trim().toLowerCase() });
+      await authApi.requestPasswordReset({ email: canonicalizeEmail(email) });
       setSubmitted(true);
     } catch (err: unknown) {
       setError(formatApiError(err, { fallback: FORGOT_FALLBACK }));
@@ -116,15 +119,15 @@ export default function ForgotPasswordScreen({ navigation }: Props) {
 
   if (submitted) {
     return (
-      <View style={styles.container}>
+      <AuthScreenContainer testID="forgot-password">
         <Text style={styles.title}>Forgot Password</Text>
         <SuccessNotice onBackToLogin={() => navigation.navigate('Login')} />
-      </View>
+      </AuthScreenContainer>
     );
   }
 
   return (
-    <View style={styles.container}>
+    <AuthScreenContainer testID="forgot-password">
       <Text style={styles.title}>Forgot Password</Text>
       <Text style={styles.subtitle}>
         Enter your account email and we&apos;ll send a link to set a new password.
@@ -136,53 +139,6 @@ export default function ForgotPasswordScreen({ navigation }: Props) {
         onSubmit={handleSubmit}
         onBackToLogin={() => navigation.navigate('Login')}
       />
-    </View>
+    </AuthScreenContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    padding: SPACING.xl,
-    backgroundColor: colors.background.card,
-  },
-  title: { fontSize: 28, fontWeight: 'bold', textAlign: 'center', marginBottom: SPACING.lg },
-  subtitle: {
-    fontSize: 14,
-    color: colors.text.secondary,
-    textAlign: 'center',
-    marginBottom: SPACING.xl,
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md,
-    marginBottom: SPACING.md,
-    fontSize: 16,
-  },
-  error: { color: colors.danger, marginBottom: SPACING.md, textAlign: 'center' },
-  button: {
-    backgroundColor: colors.primary,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.buttonV,
-    alignItems: 'center',
-    marginBottom: SPACING.lg,
-  },
-  buttonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
-  link: { textAlign: 'center', color: colors.text.secondary },
-  linkBold: { color: colors.primary, fontWeight: '600' },
-  successTitle: {
-    fontSize: 20,
-    fontWeight: '600',
-    textAlign: 'center',
-    marginBottom: SPACING.md,
-  },
-  successBody: {
-    fontSize: 15,
-    color: colors.text.secondary,
-    textAlign: 'center',
-    marginBottom: SPACING.xl,
-  },
-});

--- a/frontend/src/features/Auth/LoginScreen.tsx
+++ b/frontend/src/features/Auth/LoginScreen.tsx
@@ -1,16 +1,15 @@
 import React, { useState } from 'react';
-import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Text, TextInput, TouchableOpacity } from 'react-native';
+
+import { authStyles as styles } from './auth.styles';
+import { AuthScreenContainer } from './AuthScreenContainer';
+import { canonicalizeEmail } from './canonicalizeEmail';
 
 import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
 const LOGIN_FALLBACK =
   "We couldn't sign you in. Check your connection, then try again in a moment.";
-
-// Cap the form width so fields don't stretch edge-to-edge on laptop/desktop
-// browsers; on phones the screen is narrower than this so it has no effect.
-const FORM_MAX_WIDTH = 480;
 
 interface Props {
   navigation: { navigate: (_screen: string) => void };
@@ -115,7 +114,7 @@ export default function LoginScreen({ navigation }: Props) {
       // BUG-FE-AUTH-015: lowercase the email client-side so the backend
       // receives the canonical form and a "Foo@bar.com" / "foo@bar.com"
       // login pair can't end up looking like two distinct accounts.
-      await login(email.trim().toLowerCase(), password);
+      await login(canonicalizeEmail(email), password);
     } catch (err: unknown) {
       // BUG-FRONTEND-INFRA-016: ``formatApiError`` returns a dedicated
       // timeout message when the new AbortController fires.
@@ -126,63 +125,21 @@ export default function LoginScreen({ navigation }: Props) {
   };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.form}>
-        <Text style={styles.title}>Adepthood</Text>
-        <LoginFields
-          email={email}
-          setEmail={setEmail}
-          password={password}
-          setPassword={setPassword}
-        />
-        {error && <Text style={styles.error}>{error}</Text>}
-        <LoginActions
-          submitting={submitting}
-          onLogin={handleLogin}
-          onNavigateSignup={() => navigation.navigate('Signup')}
-          onNavigateForgot={() => navigation.navigate('ForgotPassword')}
-        />
-      </View>
-    </View>
+    <AuthScreenContainer testID="login">
+      <Text style={styles.title}>Adepthood</Text>
+      <LoginFields
+        email={email}
+        setEmail={setEmail}
+        password={password}
+        setPassword={setPassword}
+      />
+      {error && <Text style={styles.error}>{error}</Text>}
+      <LoginActions
+        submitting={submitting}
+        onLogin={handleLogin}
+        onNavigateSignup={() => navigation.navigate('Signup')}
+        onNavigateForgot={() => navigation.navigate('ForgotPassword')}
+      />
+    </AuthScreenContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    padding: SPACING.xl,
-    backgroundColor: colors.background.card,
-  },
-  form: {
-    width: '100%',
-    maxWidth: FORM_MAX_WIDTH,
-    alignSelf: 'center',
-  },
-  title: { fontSize: 28, fontWeight: 'bold', textAlign: 'center', marginBottom: SPACING.xxl },
-  input: {
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md,
-    marginBottom: SPACING.md,
-    fontSize: 16,
-  },
-  error: { color: colors.danger, marginBottom: SPACING.md, textAlign: 'center' },
-  button: {
-    backgroundColor: colors.primary,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md + 2,
-    alignItems: 'center',
-    marginBottom: SPACING.lg,
-  },
-  buttonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
-  link: { textAlign: 'center', color: colors.text.secondary },
-  linkBold: { color: colors.primary, fontWeight: '600' },
-  forgotLink: {
-    textAlign: 'center',
-    color: colors.primary,
-    fontWeight: '500',
-    marginBottom: SPACING.md,
-  },
-});

--- a/frontend/src/features/Auth/ReauthSheet.tsx
+++ b/frontend/src/features/Auth/ReauthSheet.tsx
@@ -1,13 +1,18 @@
 import React, { useCallback, useState } from 'react';
 import {
   ActivityIndicator,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
+
+import { authStyles } from './auth.styles';
+import { canonicalizeEmail } from './canonicalizeEmail';
 
 import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
@@ -42,7 +47,7 @@ function ReauthActions({
         accessibilityLabel="Sign back in"
         accessibilityRole="button"
         accessibilityState={{ disabled: submitting, busy: submitting }}
-        style={styles.primaryButton}
+        style={localStyles.primaryButton}
         onPress={onSubmit}
         disabled={submitting}
         testID="reauth-submit"
@@ -50,7 +55,7 @@ function ReauthActions({
         {submitting ? (
           <ActivityIndicator color={colors.text.light} />
         ) : (
-          <Text style={styles.primaryButtonText}>Sign in</Text>
+          <Text style={authStyles.buttonText}>Sign in</Text>
         )}
       </TouchableOpacity>
       <TouchableOpacity
@@ -61,7 +66,7 @@ function ReauthActions({
         disabled={submitting}
         testID="reauth-dismiss"
       >
-        <Text style={styles.secondaryLink}>Sign out instead</Text>
+        <Text style={localStyles.secondaryLink}>Sign out instead</Text>
       </TouchableOpacity>
     </>
   );
@@ -71,14 +76,14 @@ function ReauthForm(props: ReauthFormProps): React.JSX.Element {
   const { email, password, error, submitting } = props;
   const { onEmailChange, onPasswordChange, onSubmit, onDismiss } = props;
   return (
-    <View style={styles.card}>
-      <Text style={styles.title}>Sign back in</Text>
-      <Text style={styles.subtitle}>
+    <View style={localStyles.card}>
+      <Text style={localStyles.title}>Sign back in</Text>
+      <Text style={localStyles.subtitle}>
         Your session expired. Enter your credentials to keep going where you left off.
       </Text>
       <TextInput
         accessibilityLabel="Email"
-        style={styles.input}
+        style={authStyles.input}
         placeholder="Email"
         value={email}
         onChangeText={onEmailChange}
@@ -88,14 +93,14 @@ function ReauthForm(props: ReauthFormProps): React.JSX.Element {
       />
       <TextInput
         accessibilityLabel="Password"
-        style={styles.input}
+        style={authStyles.input}
         placeholder="Password"
         value={password}
         onChangeText={onPasswordChange}
         secureTextEntry
         testID="reauth-password"
       />
-      {error ? <Text style={styles.error}>{error}</Text> : null}
+      {error ? <Text style={authStyles.error}>{error}</Text> : null}
       <ReauthActions submitting={submitting} onSubmit={onSubmit} onDismiss={onDismiss} />
     </View>
   );
@@ -118,7 +123,7 @@ export function ReauthSheet(): React.JSX.Element {
     setError(null);
     setSubmitting(true);
     try {
-      await login(email.trim(), password);
+      await login(canonicalizeEmail(email), password);
     } catch (err: unknown) {
       setError(formatApiError(err, { fallback: REAUTH_FALLBACK }));
     } finally {
@@ -138,7 +143,11 @@ export function ReauthSheet(): React.JSX.Element {
       onRequestClose={handleDismiss}
       testID="reauth-sheet"
     >
-      <View style={styles.backdrop}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={localStyles.backdrop}
+        testID="reauth-keyboard-avoiding"
+      >
         <ReauthForm
           email={email}
           password={password}
@@ -149,12 +158,14 @@ export function ReauthSheet(): React.JSX.Element {
           onSubmit={handleSubmit}
           onDismiss={handleDismiss}
         />
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }
 
-const styles = StyleSheet.create({
+// Sheet-specific styling (overlay backdrop + compact left-aligned card header);
+// the shared input/error/buttonText come from authStyles.
+const localStyles = StyleSheet.create({
   backdrop: {
     flex: 1,
     backgroundColor: 'rgba(0,0,0,0.45)',
@@ -177,27 +188,13 @@ const styles = StyleSheet.create({
     color: colors.text.secondary,
     marginBottom: SPACING.lg,
   },
-  input: {
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md,
-    marginBottom: SPACING.md,
-    fontSize: 16,
-  },
-  error: {
-    color: colors.danger,
-    marginBottom: SPACING.md,
-    textAlign: 'center',
-  },
   primaryButton: {
     backgroundColor: colors.primary,
     borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md + 2,
+    padding: SPACING.buttonV,
     alignItems: 'center',
     marginBottom: SPACING.md,
   },
-  primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
   secondaryLink: {
     textAlign: 'center',
     color: colors.text.secondary,

--- a/frontend/src/features/Auth/ResetPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ResetPasswordScreen.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
-import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Text, TextInput, TouchableOpacity } from 'react-native';
+
+import { authStyles as styles } from './auth.styles';
+import { AuthScreenContainer } from './AuthScreenContainer';
 
 import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
 const RESET_FALLBACK =
   "We couldn't apply that reset. The link may have expired -- request a new one and try again.";
@@ -95,7 +97,7 @@ function ResetActions({
 
 function MissingTokenView({ onRequestNew }: { onRequestNew: () => void }): React.JSX.Element {
   return (
-    <View style={styles.container}>
+    <AuthScreenContainer testID="reset-password">
       <Text style={styles.title}>Reset Link Invalid</Text>
       <Text style={styles.subtitle}>
         That link is missing or malformed. Request a fresh one to continue.
@@ -109,7 +111,7 @@ function MissingTokenView({ onRequestNew }: { onRequestNew: () => void }): React
       >
         <Text style={styles.buttonText}>Request New Link</Text>
       </TouchableOpacity>
-    </View>
+    </AuthScreenContainer>
   );
 }
 
@@ -158,7 +160,7 @@ export default function ResetPasswordScreen({ navigation, route }: Props) {
   };
 
   return (
-    <View style={styles.container}>
+    <AuthScreenContainer testID="reset-password">
       <Text style={styles.title}>Set New Password</Text>
       <Text style={styles.subtitle}>Pick a new password (at least 8 characters).</Text>
       <ResetFields
@@ -173,41 +175,6 @@ export default function ResetPasswordScreen({ navigation, route }: Props) {
         onSubmit={handleSubmit}
         onBackToLogin={() => navigation.navigate('Login')}
       />
-    </View>
+    </AuthScreenContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    padding: SPACING.xl,
-    backgroundColor: colors.background.card,
-  },
-  title: { fontSize: 28, fontWeight: 'bold', textAlign: 'center', marginBottom: SPACING.lg },
-  subtitle: {
-    fontSize: 14,
-    color: colors.text.secondary,
-    textAlign: 'center',
-    marginBottom: SPACING.xl,
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md,
-    marginBottom: SPACING.md,
-    fontSize: 16,
-  },
-  error: { color: colors.danger, marginBottom: SPACING.md, textAlign: 'center' },
-  button: {
-    backgroundColor: colors.primary,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.buttonV,
-    alignItems: 'center',
-    marginBottom: SPACING.lg,
-  },
-  buttonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
-  link: { textAlign: 'center', color: colors.text.secondary },
-  linkBold: { color: colors.primary, fontWeight: '600' },
-});

--- a/frontend/src/features/Auth/SignupScreen.tsx
+++ b/frontend/src/features/Auth/SignupScreen.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
-import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Text, TextInput, TouchableOpacity } from 'react-native';
+
+import { authStyles as styles } from './auth.styles';
+import { AuthScreenContainer } from './AuthScreenContainer';
+import { canonicalizeEmail } from './canonicalizeEmail';
 
 import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
 const SIGNUP_FALLBACK =
   "We couldn't create your account. Check your connection, then try again in a moment.";
@@ -118,7 +121,7 @@ export default function SignupScreen({ navigation }: Props) {
     try {
       // BUG-AUTH-010: trim at submit so paste/autofill whitespace doesn't
       // produce a confusing 422 from the backend.
-      await signup(email.trim(), password);
+      await signup(canonicalizeEmail(email), password);
     } catch (err: unknown) {
       // BUG-FRONTEND-INFRA-016 — timeout-specific message handled via
       // formatApiError; backend detail codes mapped through the shared
@@ -130,7 +133,7 @@ export default function SignupScreen({ navigation }: Props) {
   };
 
   return (
-    <View style={styles.container}>
+    <AuthScreenContainer testID="signup">
       <Text style={styles.title}>Create Account</Text>
       <SignupFields
         email={email}
@@ -146,35 +149,6 @@ export default function SignupScreen({ navigation }: Props) {
         onNavigateLogin={() => navigation.navigate('Login')}
         submitting={submitting}
       />
-    </View>
+    </AuthScreenContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    padding: SPACING.xl,
-    backgroundColor: colors.background.card,
-  },
-  title: { fontSize: 28, fontWeight: 'bold', textAlign: 'center', marginBottom: SPACING.xxl },
-  input: {
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md,
-    marginBottom: SPACING.md,
-    fontSize: 16,
-  },
-  error: { color: colors.danger, marginBottom: SPACING.md, textAlign: 'center' },
-  button: {
-    backgroundColor: colors.primary,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md + 2,
-    alignItems: 'center',
-    marginBottom: SPACING.lg,
-  },
-  buttonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
-  link: { textAlign: 'center', color: colors.text.secondary },
-  linkBold: { color: colors.primary, fontWeight: '600' },
-});

--- a/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
@@ -123,6 +123,29 @@ describe('SignupScreen', () => {
     });
   });
 
+  it('lowercases the email before submitting (audit-ux-08)', async () => {
+    // Previously signup submitted email.trim() only, so a "Foo@Bar.com" signup
+    // and a "foo@bar.com" login looked like two accounts client-side.
+    mockSignup.mockResolvedValue(undefined);
+    const { getByPlaceholderText, getByText } = render(
+      <SignupScreen navigation={mockNavigation} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), '  Foo@Bar.COM ');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'password123');
+    fireEvent.press(getByText('Sign Up'));
+
+    await waitFor(() => {
+      expect(mockSignup).toHaveBeenCalledWith('foo@bar.com', 'password123');
+    });
+  });
+
+  it('renders inside a KeyboardAvoidingView so the keyboard never covers submit', () => {
+    const { getByTestId } = render(<SignupScreen navigation={mockNavigation} />);
+    expect(getByTestId('signup-keyboard-avoiding')).toBeTruthy();
+  });
+
   it('has a link to navigate to login', () => {
     const { getByText } = render(<SignupScreen navigation={mockNavigation} />);
 

--- a/frontend/src/features/Auth/__tests__/canonicalizeEmail.test.ts
+++ b/frontend/src/features/Auth/__tests__/canonicalizeEmail.test.ts
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+import { describe, expect, it } from '@jest/globals';
+
+import { canonicalizeEmail } from '../canonicalizeEmail';
+
+describe('canonicalizeEmail', () => {
+  it('trims surrounding whitespace and lowercases', () => {
+    expect(canonicalizeEmail('  Foo@Bar.COM ')).toBe('foo@bar.com');
+  });
+
+  it('is idempotent on an already-canonical address', () => {
+    expect(canonicalizeEmail('foo@bar.com')).toBe('foo@bar.com');
+  });
+
+  it('leaves the local/domain content otherwise intact', () => {
+    expect(canonicalizeEmail('First.Last+tag@Example.org')).toBe('first.last+tag@example.org');
+  });
+});

--- a/frontend/src/features/Auth/auth.styles.ts
+++ b/frontend/src/features/Auth/auth.styles.ts
@@ -1,0 +1,67 @@
+import { StyleSheet } from 'react-native';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+// Cap the form width so fields don't stretch edge-to-edge on laptop/desktop
+// browsers; on phones the screen is narrower so it has no effect.
+export const FORM_MAX_WIDTH = 480;
+
+/**
+ * Shared styles for the auth screens (audit-ux-08). Previously each of the six
+ * screens defined its own near-identical container/input/button sheet, so the
+ * same rules were copy-pasted and drifted independently; this is the one source.
+ */
+export const authStyles = StyleSheet.create({
+  // Outer SafeAreaView wrapper for the full-screen auth screens.
+  safeArea: { flex: 1, backgroundColor: colors.background.card },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: SPACING.xl,
+    backgroundColor: colors.background.card,
+  },
+  form: {
+    width: '100%',
+    maxWidth: FORM_MAX_WIDTH,
+    alignSelf: 'center',
+  },
+  title: { fontSize: 28, fontWeight: 'bold', textAlign: 'center', marginBottom: SPACING.lg },
+  subtitle: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    marginBottom: SPACING.xl,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md,
+    marginBottom: SPACING.md,
+    fontSize: 16,
+  },
+  error: { color: colors.danger, marginBottom: SPACING.md, textAlign: 'center' },
+  button: {
+    backgroundColor: colors.primary,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.buttonV,
+    alignItems: 'center',
+    marginBottom: SPACING.lg,
+  },
+  buttonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
+  link: { textAlign: 'center', color: colors.text.secondary },
+  linkBold: { color: colors.primary, fontWeight: '600' },
+  forgotLink: {
+    textAlign: 'center',
+    color: colors.primary,
+    fontWeight: '500',
+    marginBottom: SPACING.md,
+  },
+  successTitle: { fontSize: 20, fontWeight: '600', textAlign: 'center', marginBottom: SPACING.md },
+  successBody: {
+    fontSize: 15,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    marginBottom: SPACING.xl,
+  },
+});

--- a/frontend/src/features/Auth/canonicalizeEmail.ts
+++ b/frontend/src/features/Auth/canonicalizeEmail.ts
@@ -1,0 +1,7 @@
+/**
+ * Canonicalize an email for submission: trim surrounding whitespace and
+ * lowercase. Login already did this; signup/reauth did not, so a user who
+ * signed up as ``Foo@Bar.com`` and logged in as ``foo@bar.com`` looked like two
+ * accounts client-side (audit-ux-08). One helper keeps every auth path aligned.
+ */
+export const canonicalizeEmail = (raw: string): string => raw.trim().toLowerCase();


### PR DESCRIPTION
## Summary

The six Auth screens each defined a near-identical container/input/button `StyleSheet` (copy-pasted ~6×, drifting independently), none of the full-screen ones wrapped in `KeyboardAvoidingView`/`SafeAreaView` (so the keyboard could cover the submit button), and email canonicalization was **asymmetric** — login submitted `trim().toLowerCase()` but signup/reauth submitted `trim()` only, so a user who signed up as `Foo@bar.com` and logged in as `foo@bar.com` looked like two accounts client-side (audit §8).

- **`auth.styles.ts`** — shared container/form/title/subtitle/input/error/button/link/success styles; all six screens import it (no duplicated blocks remain).
- **`AuthScreenContainer`** (SafeAreaView + KeyboardAvoidingView) used by the five full-screen screens; **ReauthSheet** (a sheet) wraps its card in `KeyboardAvoidingView` without full-screen safe-area.
- **`canonicalizeEmail(raw)`** = `trim().toLowerCase()`, used at every email submit site (login, signup, reauth, forgot-password) so all paths align.
- ReauthSheet / CancelReset keep a small local `StyleSheet` only for their intentionally-distinct (compact / confirmation) title+subtitle typography.

## Test plan

- `canonicalizeEmail` unit tests (`'  Foo@Bar.COM '` → `'foo@bar.com'`, idempotent, local/domain intact).
- `SignupScreen.test` now asserts a mixed-case email is **lowercased** on submit and that it renders inside a `KeyboardAvoidingView`.
- Existing `LoginScreen` / `SignupScreen` / `AppAuthFlow` / per-screen suites stay green.
- `./scripts/frontend/check-all.sh` — 4/4.

> Note: `AuthScreenContainer.tsx` was added (beyond the issue's file list) to DRY the wrapper and keep the wrapped screens under the `max-lines-per-function` limit.

Closes #523
Refs #495
