### PR TITLE
perf(backend): skip the wasted COUNT(*) on the bare-list pagination path

### DIFF
--- a/backend/src/schemas/pagination.py
+++ b/backend/src/schemas/pagination.py
@@ -98,16 +98,21 @@ async def paginate_query(
 ) -> tuple[list[Any], int]:
     """Apply ``offset`` / ``limit`` to ``query`` and return ``(items, total)``.
 
-    Performs two database round-trips: a ``SELECT COUNT(*)`` over the
-    pre-pagination query (to populate ``Page.total`` for "page X of Y"
-    displays) and the actual paged ``SELECT``.  Eager-loaded relationships
-    declared on ``query`` via ``selectinload`` continue to work because they
-    issue separate ``IN`` queries that aren't affected by the outer
-    ``OFFSET`` / ``LIMIT``.
+    The paged ``SELECT`` always runs. The ``SELECT COUNT(*)`` that populates
+    ``Page.total`` only runs on the envelope path (``params.paginate`` true):
+    the bare-list path discards ``total``, so issuing the count there was a
+    wasted round-trip on every non-paginated request (e.g. a picker open).
+    On the bare path ``total`` is reported as ``len(items)`` and the caller
+    ignores it. Eager-loaded relationships declared via ``selectinload``
+    continue to work — they issue separate ``IN`` queries unaffected by the
+    outer ``OFFSET`` / ``LIMIT``.
     """
-    total = await count_query_total(session, query)
-
     paged_query = query.offset(params.offset).limit(params.limit)
     result = await session.execute(paged_query)
     items = list(result.scalars().all())
+
+    if not params.paginate:
+        return items, len(items)
+
+    total = await count_query_total(session, query)
     return items, total

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -13,10 +13,12 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.practice import Practice
 from schemas import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page, PaginationParams, build_page
+from schemas import pagination as pag_mod
 
 _SEED_COUNT_SMALL = 3
 _SEED_COUNT_LARGE = 5
@@ -162,3 +164,37 @@ def test_page_schema_round_trip() -> None:
     restored = Page[dict[str, int]].model_validate_json(page.model_dump_json())
     assert restored.items == page.items
     assert restored.total == _ROUND_TRIP_COUNT
+
+
+@pytest.mark.asyncio
+async def test_paginate_query_skips_count_on_bare_path(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bare path issues no COUNT(*); the envelope path counts exactly once."""
+    await _seed(db_session, count=_SEED_COUNT_SMALL)
+    calls = {"n": 0}
+    real_count = pag_mod.count_query_total
+
+    async def _spy(session: AsyncSession, query: object) -> int:
+        calls["n"] += 1
+        return await real_count(session, query)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(pag_mod, "count_query_total", _spy)
+    query = select(Practice)
+
+    # Bare path: no COUNT(*); total is reported as len(items) and ignored upstream.
+    items, total = await pag_mod.paginate_query(
+        db_session, query, PaginationParams(limit=10, offset=0, paginate=False)
+    )
+    assert calls["n"] == 0
+    assert len(items) == _SEED_COUNT_SMALL
+    assert total == _SEED_COUNT_SMALL
+
+    # Envelope path: exactly one COUNT(*), accurate total despite the slice.
+    items_page, total_page = await pag_mod.paginate_query(
+        db_session, query, PaginationParams(limit=_SLICE_LIMIT, offset=0, paginate=True)
+    )
+    assert calls["n"] == 1
+    assert total_page == _SEED_COUNT_SMALL
+    assert len(items_page) == _SLICE_LIMIT


### PR DESCRIPTION
## Summary

`paginate_query` always issued a `SELECT COUNT(*)` over the pre-pagination query, even when `params.paginate` was `false`. Every list endpoint that funnels its bare-list path through `paginate_query` (habits, practice-tags, practice-recipes, …) paid that count round-trip on the common **non-paginated** request — e.g. every picker open — and discarded the result (surfaced in review on #470 / PR #533).

- `paginate_query` now runs the paged `SELECT` first, then issues the `COUNT(*)` **only on the envelope path** (`params.paginate` true). On the bare path `total` is reported as `len(items)` and the caller ignores it. The envelope path keeps an accurate `total` / `has_more`.

## Test plan

- New unit test spies on `count_query_total` and asserts it is **not** called on the bare path (`paginate=False`) and called **exactly once** (with an accurate `total` despite the slice) on the envelope path.
- `./scripts/backend/check-all.sh` — 7/7 (incl. coverage ≥90%); existing paginated-endpoint tests unchanged and green; xenon clean on the changed file.

Closes #535
Refs #460
