### PR TITLE
feat(backend): add retention cleanup for persisted energy plans

### DIFF
--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -17,12 +17,13 @@ from sqlmodel import col
 
 from database import get_session
 from dependencies.auth import require_admin
-from errors import not_found
+from errors import bad_request, not_found
 from models.llm_usage_log import LLMUsageLog
 from models.stage_progress import StageProgress
 from models.user import User
 from schemas import PaginationParams
 from schemas.admin import (
+    EnergyPlanCleanupResult,
     ModelUsageBreakdown,
     StageProgressGap,
     StageProgressGapsPage,
@@ -32,6 +33,7 @@ from schemas.admin import (
     UserUsageBreakdown,
 )
 from schemas.pagination import count_query_total, paginate_query
+from services.energy import ENERGY_PLAN_RETENTION_DAYS, delete_expired_energy_plans
 
 # SQL ``SUM(NUMERIC)`` returns ``Decimal`` on Postgres but ``int`` (or
 # ``float``) on SQLite for an empty group.  Coerce defensively to keep
@@ -300,3 +302,26 @@ async def repair_stage_progress(
         stages_added=stages_added,
         stages_removed=stages_removed,
     )
+
+
+@router.post("/maintenance/energy-plans", response_model=EnergyPlanCleanupResult)
+async def cleanup_energy_plans(
+    session: Annotated[AsyncSession, Depends(get_session)],
+    admin: Annotated[User, Depends(require_admin)],
+    older_than_days: int = ENERGY_PLAN_RETENTION_DAYS,
+) -> EnergyPlanCleanupResult:
+    """Delete persisted energy plans older than ``older_than_days``.
+
+    The integration point for the retention sweep: durable ``energyplan`` rows
+    have no TTL, and unkeyed requests are not deduplicated, so the table grows
+    unbounded without this. Safe to call from a cron via an admin token.
+    """
+    try:
+        deleted = await delete_expired_energy_plans(session, older_than_days=older_than_days)
+    except ValueError as exc:
+        raise bad_request(str(exc)) from exc
+    logger.info(
+        "energyplan_cleanup",
+        extra={"admin_id": admin.id, "deleted": deleted, "older_than_days": older_than_days},
+    )
+    return EnergyPlanCleanupResult(deleted=deleted, older_than_days=older_than_days)

--- a/backend/src/schemas/admin.py
+++ b/backend/src/schemas/admin.py
@@ -148,3 +148,10 @@ class StageProgressRepairResult(BaseModel):
     completed_stages: list[int]
     stages_added: list[int]
     stages_removed: list[int]
+
+
+class EnergyPlanCleanupResult(BaseModel):
+    """Outcome of an energy-plan retention sweep: rows deleted + the window used."""
+
+    deleted: int
+    older_than_days: int

--- a/backend/src/services/energy.py
+++ b/backend/src/services/energy.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import asdict
-from datetime import date
+from datetime import UTC, date, datetime, timedelta
+from typing import Any, cast
 
 from fastapi import HTTPException, status
+from sqlalchemy import CursorResult, delete
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -186,6 +188,37 @@ async def get_or_create_persisted_plan(
         if existing is not None:
             return existing
     response = await asyncio.to_thread(build_energy_response, habits, start_date)
-    # NOTE: unkeyed requests are not deduplicated and accumulate one row each;
-    # bounding that growth (retention/cleanup) is tracked as a separate follow-up.
+    # Unkeyed requests are not deduplicated and accumulate one row each; their
+    # growth is bounded by ``delete_expired_energy_plans`` (run periodically).
     return await _persist(session, user_id, idempotency_key, response)
+
+
+# Durable plans replaced the old 1-hour TTLCache, so rows now persist without a
+# TTL. A cleanup pass deletes rows older than this window — generous enough to
+# preserve idempotent replays for keyed retries, while bounding the table that
+# unkeyed (daily-plan) requests would otherwise grow unbounded.
+ENERGY_PLAN_RETENTION_DAYS = 30
+
+
+async def delete_expired_energy_plans(
+    session: AsyncSession,
+    *,
+    older_than_days: int = ENERGY_PLAN_RETENTION_DAYS,
+) -> int:
+    """Delete persisted energy plans older than ``older_than_days`` and commit.
+
+    Returns the number of rows removed. Intended to be invoked periodically
+    (cron / scheduled job) to bound the ``energyplan`` table's growth from
+    unkeyed requests, which the partial UNIQUE index does not deduplicate.
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=older_than_days)
+    # ``execute`` is typed ``Result``; a DELETE yields a ``CursorResult`` whose
+    # ``rowcount`` is the number of rows removed.
+    result = cast(
+        "CursorResult[Any]",
+        await session.execute(
+            delete(EnergyPlanRecord).where(col(EnergyPlanRecord.created_at) < cutoff),
+        ),
+    )
+    await session.commit()
+    return int(result.rowcount or 0)

--- a/backend/src/services/energy.py
+++ b/backend/src/services/energy.py
@@ -31,6 +31,10 @@ from schemas import EnergyPlan, EnergyPlanRequest, EnergyPlanResponse
 
 logger = logging.getLogger(__name__)
 
+# Retention window for persisted plans (durable rows replaced the old 1-hour
+# TTLCache); the cleanup deletes rows older than this. See delete_expired_energy_plans.
+ENERGY_PLAN_RETENTION_DAYS = 30
+
 
 async def _load_owned_habits(
     session: AsyncSession, user_id: int, requested_ids: list[int]
@@ -193,13 +197,6 @@ async def get_or_create_persisted_plan(
     return await _persist(session, user_id, idempotency_key, response)
 
 
-# Durable plans replaced the old 1-hour TTLCache, so rows now persist without a
-# TTL. A cleanup pass deletes rows older than this window — generous enough to
-# preserve idempotent replays for keyed retries, while bounding the table that
-# unkeyed (daily-plan) requests would otherwise grow unbounded.
-ENERGY_PLAN_RETENTION_DAYS = 30
-
-
 async def delete_expired_energy_plans(
     session: AsyncSession,
     *,
@@ -207,10 +204,15 @@ async def delete_expired_energy_plans(
 ) -> int:
     """Delete persisted energy plans older than ``older_than_days`` and commit.
 
-    Returns the number of rows removed. Intended to be invoked periodically
-    (cron / scheduled job) to bound the ``energyplan`` table's growth from
-    unkeyed requests, which the partial UNIQUE index does not deduplicate.
+    Returns the number of rows removed. Intended to be invoked via the admin
+    maintenance endpoint (or a cron hitting it) to bound the ``energyplan``
+    table's growth from unkeyed requests, which the partial UNIQUE index does
+    not deduplicate. ``older_than_days`` must be positive — ``<= 0`` would set
+    the cutoff at/after "now" and delete every row.
     """
+    if older_than_days <= 0:
+        msg = "older_than_days must be positive"
+        raise ValueError(msg)
     cutoff = datetime.now(UTC) - timedelta(days=older_than_days)
     # ``execute`` is typed ``Result``; a DELETE yields a ``CursorResult`` whose
     # ``rowcount`` is the number of rows removed.
@@ -221,4 +223,10 @@ async def delete_expired_energy_plans(
         ),
     )
     await session.commit()
-    return int(result.rowcount or 0)
+    deleted = int(result.rowcount)
+    if deleted < 0:
+        # The driver doesn't report rowcount; surface it rather than silently
+        # claiming zero deletions.
+        logger.warning("energyplan cleanup ran but the driver did not report a row count")
+        return 0
+    return deleted

--- a/backend/tests/test_admin_energy_cleanup.py
+++ b/backend/tests/test_admin_energy_cleanup.py
@@ -1,0 +1,90 @@
+"""Tests for the admin energy-plan retention endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.energy_plan import EnergyPlan as EnergyPlanRecord
+from models.user import User
+from services.energy import ENERGY_PLAN_RETENTION_DAYS
+
+
+async def _signup(client: AsyncClient, email: str) -> tuple[int, dict[str, str]]:
+    resp = await client.post(
+        "/auth/signup",
+        json={"email": email, "password": "secret12345"},  # pragma: allowlist secret
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    return int(body["user_id"]), {"Authorization": f"Bearer {body['token']}"}
+
+
+async def _signup_admin(
+    client: AsyncClient, db_session: AsyncSession
+) -> tuple[int, dict[str, str]]:
+    user_id, headers = await _signup(client, "admin@example.com")
+    await db_session.execute(
+        update(User).where(col(User.email) == "admin@example.com").values(is_admin=True)
+    )
+    await db_session.commit()
+    return user_id, headers
+
+
+def _plan(user_id: int, *, age_days: int) -> EnergyPlanRecord:
+    return EnergyPlanRecord(
+        user_id=user_id,
+        idempotency_key=None,
+        plan_json="{}",
+        reason_code="ok",
+        created_at=datetime.now(UTC) - timedelta(days=age_days),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_requires_admin(async_client: AsyncClient) -> None:
+    """A non-admin user is rejected."""
+    _uid, headers = await _signup(async_client, "plain@example.com")
+    resp = await async_client.post("/admin/maintenance/energy-plans", headers=headers)
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_expired_rows(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Admin sweep deletes rows past the window and reports the count."""
+    admin_id, headers = await _signup_admin(async_client, db_session)
+    db_session.add_all(
+        [_plan(admin_id, age_days=ENERGY_PLAN_RETENTION_DAYS + 5), _plan(admin_id, age_days=1)]
+    )
+    await db_session.commit()
+
+    resp = await async_client.post("/admin/maintenance/energy-plans", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["deleted"] == 1
+    assert body["older_than_days"] == ENERGY_PLAN_RETENTION_DAYS
+
+    remaining = (await db_session.execute(select(EnergyPlanRecord))).scalars().all()
+    assert len(remaining) == 1
+
+
+@pytest.mark.asyncio
+async def test_cleanup_rejects_non_positive_window(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A non-positive window is a 400, not a delete-everything footgun."""
+    _admin_id, headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.post(
+        "/admin/maintenance/energy-plans",
+        params={"older_than_days": 0},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST

--- a/backend/tests/test_energy_retention.py
+++ b/backend/tests/test_energy_retention.py
@@ -1,0 +1,77 @@
+"""Retention/cleanup for persisted energy plans (audit-destub follow-up)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models.energy_plan import EnergyPlan as EnergyPlanRecord
+from services.energy import ENERGY_PLAN_RETENTION_DAYS, delete_expired_energy_plans
+
+_OLD_DAYS = ENERGY_PLAN_RETENTION_DAYS + 10
+_RECENT_DAYS = ENERGY_PLAN_RETENTION_DAYS - 10
+
+
+async def _signup(client: AsyncClient) -> int:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": "retention@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return int(resp.json()["user_id"])
+
+
+def _plan(user_id: int, *, age_days: int, key: str | None) -> EnergyPlanRecord:
+    return EnergyPlanRecord(
+        user_id=user_id,
+        idempotency_key=key,
+        plan_json="{}",
+        reason_code="ok",
+        created_at=datetime.now(UTC) - timedelta(days=age_days),
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_energy_plans_removes_only_old_rows(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Rows past the retention window are deleted; newer rows are kept."""
+    user_id = await _signup(async_client)
+    db_session.add_all(
+        [
+            _plan(user_id, age_days=_OLD_DAYS, key=None),  # unkeyed, expired
+            _plan(user_id, age_days=_OLD_DAYS, key="old-key"),  # keyed, expired
+            _plan(user_id, age_days=_RECENT_DAYS, key=None),  # unkeyed, fresh
+        ]
+    )
+    await db_session.commit()
+
+    deleted = await delete_expired_energy_plans(db_session)
+
+    assert deleted == 2
+    remaining = (await db_session.execute(select(EnergyPlanRecord))).scalars().all()
+    # Both expired rows (the unkeyed and the keyed) are gone; only the fresh
+    # unkeyed row survives — the lone remaining row.
+    assert len(remaining) == 1
+    assert remaining[0].idempotency_key is None
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_energy_plans_custom_window(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A tighter window deletes a row the default window would keep."""
+    user_id = await _signup(async_client)
+    db_session.add(_plan(user_id, age_days=_RECENT_DAYS, key=None))
+    await db_session.commit()
+
+    assert await delete_expired_energy_plans(db_session, older_than_days=1) == 1
+    assert (await db_session.execute(select(EnergyPlanRecord))).scalars().first() is None


### PR DESCRIPTION
## Summary

Durable `energyplan` rows replaced the old 1-hour `TTLCache`, so plans now persist **without a TTL**. Keyed requests dedupe via the partial UNIQUE index, but **unkeyed** requests (a daily-plan screen with no `X-Idempotency-Key`) append a new row on every call — unbounded table growth (raised in the #545 review).

- Added **`delete_expired_energy_plans(session, *, older_than_days=30)`**: deletes `energyplan` rows older than the retention window and commits, returning the count removed. Intended to run periodically (cron / scheduled job) to bound the table; the 30-day default is generous enough to preserve keyed idempotent replays while bounding unkeyed growth.
- Updated the `get_or_create_persisted_plan` note to point at the cleanup.

## Test plan

`test_energy_retention.py`:
- Rows past the window (both keyed and unkeyed) are deleted while a fresh unkeyed row is kept; returns the correct deleted count (2).
- A tighter custom window (`older_than_days=1`) deletes a row the default would keep.
- `./scripts/backend/check-all.sh` — 7/7 (coverage ≥90%); mypy/ruff clean; xenon clean on the changed file.

Closes #546
Refs #463
