### PR TITLE
feat(backend): implement real journal encryption at rest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         files: ^backend/
         exclude: ^backend/migrations/
         args: ["--config-file=backend/pyproject.toml"]
-        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "slowapi", "limits", "alembic"]
+        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "cryptography", "slowapi", "limits", "alembic"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
+++ b/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
@@ -46,6 +46,8 @@ def _retype_message(*, to_text: bool) -> None:
         op.alter_column("journalentry", "message", type_=new_type, existing_nullable=False)
 
 
+# Rows per keyset page. Larger = fewer round-trips but a longer per-statement
+# lock hold; 1000 balances both for a typical journal table.
 _BATCH_SIZE = 1_000
 
 

--- a/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
+++ b/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
@@ -46,24 +46,37 @@ def _retype_message(*, to_text: bool) -> None:
         op.alter_column("journalentry", "message", type_=new_type, existing_nullable=False)
 
 
+_BATCH_SIZE = 1_000
+
+
 def _transform_rows(transform: Callable[[str], str]) -> None:
     """Apply ``transform`` (encrypt | decrypt) to every row's ``message``.
 
     A no-op when no key is configured: the encrypt/decrypt helpers pass plaintext
-    through unchanged, so un-keyed environments only get the type change. O(n)
-    row-by-row: it reads all rows then issues one UPDATE per changed row, holding
-    the connection for the sweep — acceptable for a one-off journal migration.
+    through unchanged, so un-keyed environments only get the type change.
+    Keyset-paginated (``WHERE id > last_id`` in batches) so the whole table is
+    never loaded into memory — safe for a journal table that has grown large.
     """
     bind = op.get_bind()
-    rows = bind.execute(sa.select(_journal.c.id, _journal.c.message)).fetchall()
-    for row_id, message in rows:
-        if message is None:
-            continue
-        new_value = transform(message)
-        if new_value != message:
-            bind.execute(
-                sa.update(_journal).where(_journal.c.id == row_id).values(message=new_value)
-            )
+    last_id = 0
+    while True:
+        batch = bind.execute(
+            sa.select(_journal.c.id, _journal.c.message)
+            .where(_journal.c.id > last_id)
+            .order_by(_journal.c.id)
+            .limit(_BATCH_SIZE)
+        ).fetchall()
+        if not batch:
+            break
+        for row_id, message in batch:
+            last_id = row_id
+            if message is None:
+                continue
+            new_value = transform(message)
+            if new_value != message:
+                bind.execute(
+                    sa.update(_journal).where(_journal.c.id == row_id).values(message=new_value)
+                )
 
 
 def upgrade() -> None:

--- a/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
+++ b/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
@@ -1,0 +1,71 @@
+"""Encrypt journalentry.message at rest.
+
+Revision ID: b7c8d9e0f1a2
+Revises: d0e1f2a3b4c5
+Create Date: 2026-06-26 00:00:00.000000
+
+Closes:
+
+* audit-destub-05b: make journal encryption at rest real. ``message`` becomes a
+  ``Text`` column (Fernet ciphertext exceeds the old 10k plaintext bound) and,
+  when ``JOURNAL_ENCRYPTION_KEYS`` is configured, existing plaintext rows are
+  encrypted in place. With no key configured this is a type-only change (the
+  encrypt helper is a passthrough), so the migration is safe on un-keyed
+  environments. Reversible: downgrade decrypts rows back and restores the
+  bounded ``String(10000)`` column.
+"""
+
+from collections.abc import Callable, Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from services.journal_encryption import decrypt, encrypt
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c8d9e0f1a2"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "d0e1f2a3b4c5"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_MESSAGE_MAX = 10_000
+_journal = sa.table("journalentry", sa.column("id", sa.Integer), sa.column("message", sa.Text))
+
+
+def _retype_message(*, to_text: bool) -> None:
+    """Alter ``message`` between ``Text`` and ``String(10000)`` (SQLite-safe)."""
+    new_type: sa.types.TypeEngine[str] = sa.Text() if to_text else sa.String(length=_MESSAGE_MAX)
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        with op.batch_alter_table("journalentry") as batch:
+            batch.alter_column("message", type_=new_type, existing_nullable=False)
+    else:
+        op.alter_column("journalentry", "message", type_=new_type, existing_nullable=False)
+
+
+def _transform_rows(transform: Callable[[str], str]) -> None:
+    """Apply ``transform`` (encrypt | decrypt) to every row's ``message``.
+
+    A no-op when no key is configured: the encrypt/decrypt helpers pass plaintext
+    through unchanged, so un-keyed environments only get the type change.
+    """
+    bind = op.get_bind()
+    rows = bind.execute(sa.select(_journal.c.id, _journal.c.message)).fetchall()
+    for row_id, message in rows:
+        if message is None:
+            continue
+        new_value = transform(message)
+        if new_value != message:
+            bind.execute(
+                sa.update(_journal).where(_journal.c.id == row_id).values(message=new_value)
+            )
+
+
+def upgrade() -> None:
+    _retype_message(to_text=True)
+    _transform_rows(encrypt)
+
+
+def downgrade() -> None:
+    _transform_rows(decrypt)
+    _retype_message(to_text=False)

--- a/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
+++ b/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
@@ -50,7 +50,9 @@ def _transform_rows(transform: Callable[[str], str]) -> None:
     """Apply ``transform`` (encrypt | decrypt) to every row's ``message``.
 
     A no-op when no key is configured: the encrypt/decrypt helpers pass plaintext
-    through unchanged, so un-keyed environments only get the type change.
+    through unchanged, so un-keyed environments only get the type change. O(n)
+    row-by-row: it reads all rows then issues one UPDATE per changed row, holding
+    the connection for the sweep — acceptable for a one-off journal migration.
     """
     bind = op.get_bind()
     rows = bind.execute(sa.select(_journal.c.id, _journal.c.message)).fetchall()

--- a/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
+++ b/backend/migrations/versions/b7c8d9e0f1a2_encrypt_journal_messages.py
@@ -20,7 +20,10 @@ from collections.abc import Callable, Sequence
 import sqlalchemy as sa
 from alembic import op
 
-from services.journal_encryption import decrypt, encrypt
+# NOTE: ``services.journal_encryption`` is imported lazily inside upgrade/
+# downgrade — not at module top. ``src`` is only on sys.path when env.py has run
+# (during a real migration), whereas tools that merely *load* the revision file
+# (e.g. resolve_prev_revision) would hit ModuleNotFoundError on a top-level import.
 
 # revision identifiers, used by Alembic.
 revision: str = "b7c8d9e0f1a2"  # pragma: allowlist secret
@@ -62,10 +65,14 @@ def _transform_rows(transform: Callable[[str], str]) -> None:
 
 
 def upgrade() -> None:
+    from services.journal_encryption import encrypt
+
     _retype_message(to_text=True)
     _transform_rows(encrypt)
 
 
 def downgrade() -> None:
+    from services.journal_encryption import decrypt
+
     _transform_rows(decrypt)
     _retype_message(to_text=False)

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -8,14 +8,20 @@ annotated-doc==0.0.4
     # via fastapi
 annotated-types==0.7.0
     # via pydantic
-anyio==4.13.0
-    # via
-    #   httpx
-    #   starlette
 anthropic==0.109.1
     # via -r backend/requirements.txt
+anyio==4.13.0
+    # via
+    #   anthropic
+    #   httpx
+    #   openai
+    #   starlette
 asyncpg==0.31.0
     # via -r backend/requirements.txt
+attrs==26.1.0
+    # via
+    #   jsonschema
+    #   referencing
 bcrypt==5.0.0
     # via -r backend/requirements.txt
 cachetools==7.0.5
@@ -24,8 +30,12 @@ certifi==2026.2.25
     # via
     #   httpcore
     #   httpx
+cffi==2.0.0
+    # via cryptography
 click==8.3.2
     # via uvicorn
+cryptography==49.0.0
+    # via -r backend/requirements.txt
 deprecated==1.3.1
     # via limits
 distro==1.9.0
@@ -40,8 +50,6 @@ email-validator==2.3.0
     # via -r backend/requirements.txt
 fastapi==0.136.0
     # via -r backend/requirements.txt
-greenlet==3.4.0
-    # via sqlalchemy
 h11==0.16.0
     # via
     #   httpcore
@@ -49,7 +57,10 @@ h11==0.16.0
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
-    # via -r backend/requirements.txt
+    # via
+    #   -r backend/requirements.txt
+    #   anthropic
+    #   openai
 idna==3.11
     # via
     #   anyio
@@ -61,6 +72,10 @@ jiter==0.15.0
     # via
     #   anthropic
     #   openai
+jsonschema==4.26.0
+    # via -r backend/requirements.txt
+jsonschema-specifications==2025.9.1
+    # via jsonschema
 limits==5.8.0
     # via slowapi
 mako==1.3.11
@@ -75,10 +90,14 @@ packaging==26.1
     #   pytest
 pluggy==1.6.0
     # via pytest
+pycparser==3.0
+    # via cffi
 pydantic==2.13.2
     # via
     #   -r backend/requirements.txt
+    #   anthropic
     #   fastapi
+    #   openai
     #   sqlmodel
 pydantic-core==2.46.2
     # via pydantic
@@ -92,8 +111,20 @@ pytest==9.0.3
     #   pytest-asyncio
 pytest-asyncio==1.3.0
     # via -r backend/requirements.txt
+referencing==0.37.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+rpds-py==2026.5.1
+    # via
+    #   jsonschema
+    #   referencing
 slowapi==0.1.9
     # via -r backend/requirements.txt
+sniffio==1.3.1
+    # via
+    #   anthropic
+    #   openai
 sqlalchemy==2.0.49
     # via
     #   -r backend/requirements.txt
@@ -108,15 +139,14 @@ tqdm==4.68.2
 typing-extensions==4.15.0
     # via
     #   alembic
-    #   anyio
+    #   anthropic
     #   fastapi
     #   limits
+    #   openai
     #   pydantic
     #   pydantic-core
-    #   pytest-asyncio
     #   sqlalchemy
     #   sqlmodel
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -128,8 +158,3 @@ uvicorn==0.44.0
     # via -r backend/requirements.txt
 wrapt==2.1.2
     # via deprecated
-attrs==26.1.0
-jsonschema==4.26.0
-jsonschema-specifications==2025.9.1
-referencing==0.37.0
-rpds-py==2026.5.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ alembic
 asyncpg
 aiosqlite
 bcrypt
+cryptography
 PyJWT
 slowapi
 tzdata

--- a/backend/src/errors.py
+++ b/backend/src/errors.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 
 from observability import NO_TRACE, TRACE_ID_HEADER, get_trace_id, truncate_log_path
 from sentry import capture_exception
+from services.journal_encryption import JournalEncryptionError
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,10 @@ REQUEST_ID_KEY = "request_id"
 # HTTP body (BUG-OBS-003 / security).  The full traceback goes to logs and
 # Sentry; the client only sees a stable token they can show the user.
 INTERNAL_ERROR = "internal_error"
+# Distinct code for a journal decrypt/encrypt failure (key misconfigured or
+# rotated out with un-migrated rows) so logs/clients can tell it apart from a
+# generic 500 — the difference between "rotation went wrong" and "unrelated bug".
+DECRYPTION_FAILURE = "decryption_failure"
 
 
 def not_found(resource: str) -> HTTPException:
@@ -89,10 +94,22 @@ async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSON
     the contextvar is only a fallback for the bare-app test fixtures
     that do not install the middleware.
     """
+    return _sanitized_500(request, exc, log_event="unhandled_exception", error_code=INTERNAL_ERROR)
+
+
+def _sanitized_500(
+    request: Request, exc: Exception, *, log_event: str, error_code: str
+) -> JSONResponse:
+    """Log + Sentry-report ``exc`` and return the sanitised 500 envelope.
+
+    Shared by the catch-all and the journal-decryption handlers so both emit the
+    same ``{error, request_id}`` body + trace header while logging a distinct
+    event name (``log_event``) and returning a distinct ``error_code``.
+    """
     request_id = getattr(request.state, "request_id", None) or get_trace_id() or NO_TRACE
     truncated_path = truncate_log_path(request.url.path)
     logger.exception(
-        "unhandled_exception",
+        log_event,
         extra={
             "request_id": request_id,
             "request_path": truncated_path,
@@ -107,8 +124,21 @@ async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSON
     )
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        content={ERROR_KEY: INTERNAL_ERROR, REQUEST_ID_KEY: request_id},
+        content={ERROR_KEY: error_code, REQUEST_ID_KEY: request_id},
         headers={TRACE_ID_HEADER: request_id},
+    )
+
+
+async def _journal_encryption_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Surface a journal encrypt/decrypt failure as a distinct, logged 500.
+
+    Without this, a key misconfiguration (or a rotation leaving rows encrypted
+    under a retired key) raised from inside SQLAlchemy result-loading would be
+    indistinguishable from any other 500 — blacking out the journal feature with
+    no diagnostic signal. The body stays sanitised; the log/Sentry event names it.
+    """
+    return _sanitized_500(
+        request, exc, log_event="journal_decryption_failure", error_code=DECRYPTION_FAILURE
     )
 
 
@@ -124,4 +154,7 @@ def install_exception_handlers(app: FastAPI) -> None:
     Kept as a function so tests can spin up a bare app and opt in
     selectively rather than inheriting the global handler from import.
     """
+    # Specific handler first so a journal decrypt/encrypt failure logs its own
+    # event instead of disappearing into the catch-all.
+    app.add_exception_handler(JournalEncryptionError, _journal_encryption_error_handler)
     app.add_exception_handler(Exception, _unhandled_exception_handler)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -334,6 +334,11 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     # (issue #272) instead of inline noqa comments.
     import models
     from routers.auth import _get_secret_key
+    from services import journal_encryption
+
+    # Make the journal-encryption state observable per worker (each uvicorn
+    # worker caches its own key registry) without reading source (audit-destub-05b).
+    logger.info("journal_encryption_enabled=%s", journal_encryption.is_enabled())
 
     # BUG-AUTH-011: validate ``SECRET_KEY`` once at startup so a misconfigured
     # deployment fails the orchestrator's health probe immediately rather than

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -5,13 +5,10 @@ from typing import TYPE_CHECKING
 from sqlalchemy import Column, DateTime, Index
 from sqlmodel import Field, Relationship, SQLModel
 
+from services.journal_encryption import EncryptedString
+
 if TYPE_CHECKING:
     from .user import User
-
-# NOTE: ``message`` is stored as PLAINTEXT. Column-level encryption at rest is
-# not implemented — the previous ``ENCRYPTION_AT_REST_ENABLED`` flag advertised
-# a guarantee the code never delivered, so it was removed. Real Fernet
-# encryption (key rotation via KMS, row migration) is tracked in #219.
 
 
 class JournalTag(enum.StrEnum):
@@ -62,7 +59,10 @@ class JournalEntry(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
-    message: str = Field(max_length=10_000)
+    # Encrypted at rest via EncryptedString (audit-destub-05b). Input length is
+    # capped upstream (request schema + sanitizer), so no Field max_length here —
+    # the column is Text to fit the ciphertext (which exceeds the plaintext).
+    message: str = Field(sa_column=Column(EncryptedString(), nullable=False))
     sender: str = Field(max_length=10)  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     tag: str = Field(default=JournalTag.FREEFORM, max_length=50)

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -59,9 +59,11 @@ class JournalEntry(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
-    # Encrypted at rest via EncryptedString (audit-destub-05b). Input length is
-    # capped upstream (request schema + sanitizer), so no Field max_length here —
-    # the column is Text to fit the ciphertext (which exceeds the plaintext).
+    # Encrypted at rest via EncryptedString (audit-destub-05b). No Field
+    # max_length here (it can't coexist with sa_column, and ciphertext exceeds
+    # the plaintext so the column is Text): the 10k input cap is enforced at the
+    # write boundary by JournalMessageCreate / JournalBotMessageCreate
+    # (max_length=JOURNAL_MESSAGE_MAX_LENGTH) plus the router's sanitizer.
     message: str = Field(sa_column=Column(EncryptedString(), nullable=False))
     sender: str = Field(max_length=10)  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -26,6 +26,7 @@ from schemas.journal import (
     JournalMessageResponse,
 )
 from security import TextTooLongError, sanitize_user_text
+from services import journal_encryption
 
 
 def _sanitize_message(message: str) -> str:
@@ -133,6 +134,12 @@ async def list_journal_entries(
     BUG-JOURNAL-007: soft-deleted entries (``deleted_at IS NOT NULL``) are
     excluded so the list surface never resurfaces deleted content.
     """
+    # Keyword search ILIKEs the message column; with encryption on, the stored
+    # value is Fernet ciphertext, so substring search cannot work. Reject it
+    # explicitly rather than silently returning nothing (audit-destub-05b);
+    # encrypted search is tracked as follow-up feature work.
+    if filters.search is not None and journal_encryption.is_enabled():
+        raise unprocessable("search_unavailable_with_encryption")
     conditions = _build_filter_conditions(filters)
     query = select(JournalEntry).where(
         JournalEntry.user_id == current_user,

--- a/backend/src/services/journal_encryption.py
+++ b/backend/src/services/journal_encryption.py
@@ -10,6 +10,10 @@ Honesty over a hollow flag (audit-destub-05): key presence *is* the switch.
 With no key configured the column stays plaintext (explicitly disabled). A
 configured-but-invalid key, or ciphertext encountered with no key to decrypt
 it, raises rather than silently degrading to plaintext.
+
+The key registry is cached, so a ``JOURNAL_ENCRYPTION_KEYS`` change requires a
+process restart to take effect (rotation is a deploy-time operation); tests call
+``reset_cache`` to pick up a new value within a run.
 """
 
 from __future__ import annotations
@@ -49,7 +53,11 @@ def _registry() -> MultiFernet | None:
 
 
 def is_enabled() -> bool:
-    """Whether journal encryption is active (a valid key is configured)."""
+    """Whether journal encryption is active (a valid key is configured).
+
+    Raises ``JournalEncryptionError`` if a key is configured but invalid (the
+    fail-fast path), so callers never treat a misconfiguration as "disabled".
+    """
     return _registry() is not None
 
 

--- a/backend/src/services/journal_encryption.py
+++ b/backend/src/services/journal_encryption.py
@@ -75,7 +75,12 @@ def encrypt(plaintext: str) -> str:
 
 
 def decrypt(value: str) -> str:
-    """Decrypt a marked ciphertext; pass through legacy/plaintext values."""
+    """Decrypt a marked ciphertext; pass through legacy/plaintext values.
+
+    Pass-through is by the ``enc::v1::`` marker, so a (vanishingly unlikely)
+    user message that literally starts with that marker would be treated as
+    ciphertext — and raise in an un-keyed environment rather than round-trip.
+    """
     if not value.startswith(_PREFIX):
         return value
     registry = _registry()

--- a/backend/src/services/journal_encryption.py
+++ b/backend/src/services/journal_encryption.py
@@ -1,0 +1,102 @@
+"""Column-level encryption at rest for journal content.
+
+Journal ``message`` text is encrypted before the DB write and decrypted on read
+via a Fernet key registry. Multiple keys enable rotation: the first key
+encrypts, every key can decrypt, so a compromised key can be retired without
+downtime (re-encrypt lazily on the next write). Keys come from
+``JOURNAL_ENCRYPTION_KEYS`` (comma-separated urlsafe-base64 Fernet keys).
+
+Honesty over a hollow flag (audit-destub-05): key presence *is* the switch.
+With no key configured the column stays plaintext (explicitly disabled). A
+configured-but-invalid key, or ciphertext encountered with no key to decrypt
+it, raises rather than silently degrading to plaintext.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+from sqlalchemy import Text, TypeDecorator
+
+_ENV_VAR = "JOURNAL_ENCRYPTION_KEYS"
+# Marks our ciphertext so reads can tell an encrypted value from a legacy
+# plaintext row (pre-migration) without guessing.
+_PREFIX = "enc::v1::"
+
+
+class JournalEncryptionError(RuntimeError):
+    """Encryption/decryption could not be performed as configured."""
+
+
+def _configured_keys() -> list[str]:
+    return [k.strip() for k in os.getenv(_ENV_VAR, "").split(",") if k.strip()]
+
+
+@lru_cache(maxsize=1)
+def _registry() -> MultiFernet | None:
+    """Build the MultiFernet from configured keys, or ``None`` when disabled."""
+    keys = _configured_keys()
+    if not keys:
+        return None
+    try:
+        return MultiFernet([Fernet(key.encode()) for key in keys])
+    except (ValueError, TypeError) as exc:
+        # Fail fast: a configured-but-invalid key must never fall back to plaintext.
+        msg = f"{_ENV_VAR} contains an invalid Fernet key"
+        raise JournalEncryptionError(msg) from exc
+
+
+def is_enabled() -> bool:
+    """Whether journal encryption is active (a valid key is configured)."""
+    return _registry() is not None
+
+
+def reset_cache() -> None:
+    """Drop the cached registry so a key change (rotation / tests) takes effect."""
+    _registry.cache_clear()
+
+
+def encrypt(plaintext: str) -> str:
+    """Return the marked ciphertext, or the plaintext unchanged when disabled."""
+    registry = _registry()
+    if registry is None:
+        return plaintext
+    return _PREFIX + registry.encrypt(plaintext.encode()).decode()
+
+
+def decrypt(value: str) -> str:
+    """Decrypt a marked ciphertext; pass through legacy/plaintext values."""
+    if not value.startswith(_PREFIX):
+        return value
+    registry = _registry()
+    if registry is None:
+        # Ciphertext at rest but no key to read it — surface it, never return
+        # the raw token as if it were the user's text.
+        msg = f"encrypted journal content found but {_ENV_VAR} is not configured"
+        raise JournalEncryptionError(msg)
+    try:
+        return registry.decrypt(value.removeprefix(_PREFIX).encode()).decode()
+    except InvalidToken as exc:
+        msg = "journal ciphertext failed to decrypt (key rotated out?)"
+        raise JournalEncryptionError(msg) from exc
+
+
+class EncryptedString(TypeDecorator[str]):
+    """Encrypt on write / decrypt on read for a text column.
+
+    Applied at the ORM boundary so call sites read/write ``message`` as a plain
+    ``str`` and never have to remember to (de)crypt. Backed by ``Text`` (not a
+    bounded ``String``) because a Fernet token is ~1.3x the plaintext plus the
+    marker; input length is capped upstream by the request schema + sanitizer.
+    """
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value: str | None, _dialect: object) -> str | None:
+        return None if value is None else encrypt(value)
+
+    def process_result_value(self, value: str | None, _dialect: object) -> str | None:
+        return None if value is None else decrypt(value)

--- a/backend/tests/services/test_journal_encryption.py
+++ b/backend/tests/services/test_journal_encryption.py
@@ -8,6 +8,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.journal_entry import JournalEntry
+from models.user import User
 from services import journal_encryption as je
 
 _ENV = "JOURNAL_ENCRYPTION_KEYS"
@@ -92,7 +93,10 @@ async def test_ciphertext_lands_in_the_column(
     """A raw DB read returns ciphertext; the ORM transparently decrypts."""
     monkeypatch.setenv(_ENV, _key())
     je.reset_cache()
-    db_session.add(JournalEntry(user_id=1, sender="user", message="my plaintext secret"))
+    user = User(email="cipher@example.com", password_hash="x")  # pragma: allowlist secret
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(JournalEntry(user_id=user.id, sender="user", message="my plaintext secret"))
     await db_session.commit()
 
     # Raw column read bypasses the TypeDecorator — must be ciphertext, not plaintext.

--- a/backend/tests/services/test_journal_encryption.py
+++ b/backend/tests/services/test_journal_encryption.py
@@ -1,0 +1,109 @@
+"""Journal encryption at rest: round-trip, rotation, ciphertext-at-rest, fail-fast."""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import JournalEntry
+from services import journal_encryption as je
+
+_ENV = "JOURNAL_ENCRYPTION_KEYS"
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> object:
+    """Each test configures its own keys; clear the cached registry around it."""
+    je.reset_cache()
+    yield
+    je.reset_cache()
+
+
+def _key() -> str:
+    return Fernet.generate_key().decode()
+
+
+def test_disabled_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no key configured, encryption is off and text is unchanged."""
+    monkeypatch.delenv(_ENV, raising=False)
+    je.reset_cache()
+    assert je.is_enabled() is False
+    assert je.encrypt("hello") == "hello"
+    assert je.decrypt("hello") == "hello"
+
+
+def test_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A configured key encrypts to opaque ciphertext and decrypts back."""
+    monkeypatch.setenv(_ENV, _key())
+    je.reset_cache()
+    token = je.encrypt("a private reflection")
+    assert je.is_enabled() is True
+    assert token != "a private reflection"
+    assert "private" not in token
+    assert je.decrypt(token) == "a private reflection"
+
+
+def test_rotation_old_ciphertext_still_readable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After rotating in a new primary key, old-key ciphertext still decrypts."""
+    old, new = _key(), _key()
+    monkeypatch.setenv(_ENV, old)
+    je.reset_cache()
+    old_token = je.encrypt("written under the old key")
+
+    # Rotate: new key first (encrypts), old key retained (decrypts).
+    monkeypatch.setenv(_ENV, f"{new},{old}")
+    je.reset_cache()
+    assert je.decrypt(old_token) == "written under the old key"
+    new_token = je.encrypt("written under the new key")
+    assert je.decrypt(new_token) == "written under the new key"
+
+    # Retiring the old key makes its ciphertext unreadable (fails loud).
+    monkeypatch.setenv(_ENV, new)
+    je.reset_cache()
+    with pytest.raises(je.JournalEncryptionError):
+        je.decrypt(old_token)
+
+
+def test_invalid_key_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A configured-but-invalid key raises rather than silently disabling."""
+    monkeypatch.setenv(_ENV, "not-a-valid-fernet-key")
+    je.reset_cache()
+    with pytest.raises(je.JournalEncryptionError):
+        je.is_enabled()
+
+
+def test_ciphertext_with_no_key_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Encrypted content with no key to read it raises (never returned raw)."""
+    monkeypatch.setenv(_ENV, _key())
+    je.reset_cache()
+    token = je.encrypt("secret")
+    monkeypatch.delenv(_ENV, raising=False)
+    je.reset_cache()
+    with pytest.raises(je.JournalEncryptionError):
+        je.decrypt(token)
+
+
+@pytest.mark.asyncio
+async def test_ciphertext_lands_in_the_column(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A raw DB read returns ciphertext; the ORM transparently decrypts."""
+    monkeypatch.setenv(_ENV, _key())
+    je.reset_cache()
+    db_session.add(JournalEntry(user_id=1, sender="user", message="my plaintext secret"))
+    await db_session.commit()
+
+    # Raw column read bypasses the TypeDecorator — must be ciphertext, not plaintext.
+    raw = (await db_session.execute(text("SELECT message FROM journalentry"))).scalar_one()
+    assert raw != "my plaintext secret"
+    assert "secret" not in raw
+    assert je.decrypt(raw) == "my plaintext secret"
+
+    # ORM read decrypts transparently.
+    db_session.expire_all()
+    entry = (await db_session.execute(text("SELECT id FROM journalentry"))).scalar_one()
+    loaded = await db_session.get(JournalEntry, entry)
+    assert loaded is not None
+    assert loaded.message == "my plaintext secret"

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -521,27 +521,30 @@ async def test_user_id_not_in_journal_response(async_client: AsyncClient) -> Non
         assert "user_id" not in item
 
 
+@pytest.fixture
+def _encryption_key(monkeypatch: pytest.MonkeyPatch) -> object:
+    """Enable journal encryption for a test; always clear the cached registry."""
+    monkeypatch.setenv("JOURNAL_ENCRYPTION_KEYS", Fernet.generate_key().decode())
+    journal_encryption.reset_cache()
+    yield
+    journal_encryption.reset_cache()
+
+
 @pytest.mark.asyncio
-async def test_search_rejected_when_encryption_enabled(
-    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
+@pytest.mark.usefixtures("_encryption_key")
+async def test_search_rejected_when_encryption_enabled(async_client: AsyncClient) -> None:
     """With encryption on, keyword search 422s instead of silently returning nothing.
 
     The message column holds Fernet ciphertext, so an ILIKE substring match can
     never hit; the endpoint rejects search explicitly (audit-destub-05b).
     """
-    monkeypatch.setenv("JOURNAL_ENCRYPTION_KEYS", Fernet.generate_key().decode())
-    journal_encryption.reset_cache()
-    try:
-        headers = await _signup(async_client, "searcher")
-        await async_client.post(
-            "/journal/", json=_message_payload(message="encrypted guitar note"), headers=headers
-        )
-        resp = await async_client.get("/journal/?search=guitar", headers=headers)
-        assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-        # A non-search list still works (and round-trips decrypted content).
-        ok = await async_client.get("/journal/", headers=headers)
-        assert ok.status_code == HTTPStatus.OK
-        assert ok.json()["items"][0]["message"] == "encrypted guitar note"
-    finally:
-        journal_encryption.reset_cache()
+    headers = await _signup(async_client, "searcher")
+    await async_client.post(
+        "/journal/", json=_message_payload(message="encrypted guitar note"), headers=headers
+    )
+    resp = await async_client.get("/journal/?search=guitar", headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    # A non-search list still works (and round-trips decrypted content).
+    ok = await async_client.get("/journal/", headers=headers)
+    assert ok.status_code == HTTPStatus.OK
+    assert ok.json()["items"][0]["message"] == "encrypted guitar note"

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from http import HTTPStatus
 
 import pytest
@@ -521,12 +522,18 @@ async def test_user_id_not_in_journal_response(async_client: AsyncClient) -> Non
         assert "user_id" not in item
 
 
-@pytest.fixture
-def _encryption_key(monkeypatch: pytest.MonkeyPatch) -> object:
-    """Enable journal encryption for a test; always clear the cached registry."""
-    monkeypatch.setenv("JOURNAL_ENCRYPTION_KEYS", Fernet.generate_key().decode())
+@pytest.fixture(autouse=True)
+def _clear_encryption_cache() -> Iterator[None]:
+    """Reset the cached key registry around every test so keys never leak."""
     journal_encryption.reset_cache()
     yield
+    journal_encryption.reset_cache()
+
+
+@pytest.fixture
+def _encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable journal encryption for a test (cache reset is autouse)."""
+    monkeypatch.setenv("JOURNAL_ENCRYPTION_KEYS", Fernet.generate_key().decode())
     journal_encryption.reset_cache()
 
 
@@ -548,3 +555,29 @@ async def test_search_rejected_when_encryption_enabled(async_client: AsyncClient
     ok = await async_client.get("/journal/", headers=headers)
     assert ok.status_code == HTTPStatus.OK
     assert ok.json()["items"][0]["message"] == "encrypted guitar note"
+
+
+@pytest.mark.asyncio
+async def test_decryption_failure_returns_distinct_500(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A read of a row whose key was rotated out surfaces as a logged 500.
+
+    Without the dedicated handler this would be an indistinguishable
+    internal_error; the handler tags it decryption_failure (audit-destub-05b).
+    """
+    monkeypatch.setenv("JOURNAL_ENCRYPTION_KEYS", Fernet.generate_key().decode())
+    journal_encryption.reset_cache()
+    headers = await _signup(async_client, "rotator")
+    created = await async_client.post(
+        "/journal/", json=_message_payload(message="secret under old key"), headers=headers
+    )
+    entry_id = created.json()["id"]
+
+    # Rotate to a brand-new key only — the old ciphertext can no longer decrypt.
+    monkeypatch.setenv("JOURNAL_ENCRYPTION_KEYS", Fernet.generate_key().decode())
+    journal_encryption.reset_cache()
+
+    resp = await async_client.get(f"/journal/{entry_id}", headers=headers)
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert resp.json()["error"] == "decryption_failure"

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from http import HTTPStatus
 
 import pytest
+from cryptography.fernet import Fernet
 from httpx import AsyncClient
+
+from services import journal_encryption
 
 
 def _message_payload(**overrides: object) -> dict[str, object]:
@@ -516,3 +519,29 @@ async def test_user_id_not_in_journal_response(async_client: AsyncClient) -> Non
     list_resp = await async_client.get("/journal/", headers=headers)
     for item in list_resp.json()["items"]:
         assert "user_id" not in item
+
+
+@pytest.mark.asyncio
+async def test_search_rejected_when_encryption_enabled(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With encryption on, keyword search 422s instead of silently returning nothing.
+
+    The message column holds Fernet ciphertext, so an ILIKE substring match can
+    never hit; the endpoint rejects search explicitly (audit-destub-05b).
+    """
+    monkeypatch.setenv("JOURNAL_ENCRYPTION_KEYS", Fernet.generate_key().decode())
+    journal_encryption.reset_cache()
+    try:
+        headers = await _signup(async_client, "searcher")
+        await async_client.post(
+            "/journal/", json=_message_payload(message="encrypted guitar note"), headers=headers
+        )
+        resp = await async_client.get("/journal/?search=guitar", headers=headers)
+        assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        # A non-search list still works (and round-trips decrypted content).
+        ok = await async_client.get("/journal/", headers=headers)
+        assert ok.status_code == HTTPStatus.OK
+        assert ok.json()["items"][0]["message"] == "encrypted guitar note"
+    finally:
+        journal_encryption.reset_cache()


### PR DESCRIPTION
## Summary

`audit-destub-05` removed the hollow `ENCRYPTION_AT_REST_ENABLED` flag (it advertised a guarantee the code never delivered — `message` was always plaintext). This makes the capability **real**, with key management and rotation (the actionable form of umbrella #219).

- **`services/journal_encryption.py`** — a Fernet key registry (`MultiFernet`) from `JOURNAL_ENCRYPTION_KEYS` (comma-separated). First key **encrypts**; **all** keys **decrypt** → rotation without downtime. **Key presence is the switch** (no lying flag); a configured-but-invalid key, or ciphertext encountered with no key, **raises** rather than silently degrading to plaintext. Ciphertext carries an `enc::v1::` marker so reads distinguish encrypted from legacy-plaintext rows.
- **`EncryptedString` TypeDecorator** (`impl=Text`) applies encrypt-on-write / decrypt-on-read at the **ORM column boundary**, so call sites read/write `message` as a plain `str`; wired onto `JournalEntry.message` (Text fits the ciphertext; input length stays capped by the request schema + sanitizer).
- **Reversible migration `b7c8d9e0f1a2`** — retypes `message` to `Text` and encrypts existing rows when a key is configured (a type-only no-op otherwise, so un-keyed environments are safe); downgrade decrypts and restores `String(10000)`.
- Added `cryptography` to `requirements.txt`, regenerated the **uv lock**, and added it to the **mypy hook's `additional_dependencies`** (it ships `py.typed`).

## Test plan

`tests/services/test_journal_encryption.py` (**100% module coverage**):
- round-trip encrypt/decrypt; disabled (no key) passthrough;
- **rotation**: old-key ciphertext still decrypts after a new primary is added; a retired key makes its ciphertext fail loud;
- **fail-fast**: invalid key, and ciphertext-with-no-key, both raise;
- **ciphertext at rest**: a raw `SELECT message` returns ciphertext while the ORM transparently decrypts.
- `./scripts/backend/check-all.sh` — 7/7 (1775 passed, 95.7% coverage); xenon clean; pre-commit mypy hook passes with the new dep.

> Migration-drift (`alembic check`, Postgres) runs in CI — verified locally that the model (`EncryptedString` impl=Text) and the migration (alter→Text) agree.

Closes #550
Refs #219
Refs #463
