### PR TITLE
fix(frontend): per-item Zod schemas for goal-groups & course-content pages

### DIFF
--- a/frontend/src/api/__tests__/pagination-api.test.ts
+++ b/frontend/src/api/__tests__/pagination-api.test.ts
@@ -91,6 +91,27 @@ const validSession = (over: Record<string, unknown> = {}) => ({
   reflection: null,
   ...over,
 });
+const validGoalGroup = (over: Record<string, unknown> = {}) => ({
+  id: 1,
+  name: 'Morning',
+  icon: null,
+  description: null,
+  user_id: null,
+  shared_template: true,
+  source: null,
+  goals: [],
+  ...over,
+});
+const validContentItem = (over: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: 'Intro',
+  content_type: 'essay',
+  release_day: 0,
+  url: null,
+  is_locked: false,
+  is_read: false,
+  ...over,
+});
 
 describe('paginated list endpoints (issue #221 — Page envelope)', () => {
   test('practices.listPaginated opts into the envelope and forwards stage_number', async () => {
@@ -127,7 +148,7 @@ describe('paginated list endpoints (issue #221 — Page envelope)', () => {
   });
 
   test('goalGroups.listPaginated hits /goal-groups/ with the envelope flag', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse(page([{ id: 1, name: 'Morning' }])));
+    mockFetch.mockReturnValueOnce(jsonResponse(page([validGoalGroup()])));
 
     await goalGroups.listPaginated({ limit: 10 }, 'tok');
 
@@ -154,7 +175,7 @@ describe('paginated list endpoints (issue #221 — Page envelope)', () => {
   });
 
   test('course.stageContentPaginated targets the stage content path with the envelope flag', async () => {
-    const envelope = page([{ id: 1, title: 'Intro', release_day: 0 }], {
+    const envelope = page([validContentItem()], {
       total: 3,
       has_more: true,
     });
@@ -240,11 +261,12 @@ describe('fetchAllPages + listAll helpers (issue #408 — screen adoption)', () 
   });
 
   test('course.stageContentAll drains the stage content envelope', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse(page([{ id: 7, title: 'Survival' }])));
+    const item = validContentItem({ id: 7, title: 'Survival' });
+    mockFetch.mockReturnValueOnce(jsonResponse(page([item])));
     const result = await course.stageContentAll(1, 'tok');
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain('/course/stages/1/content?paginate=true');
-    expect(result).toEqual([{ id: 7, title: 'Survival' }]);
+    expect(result).toEqual([item]);
   });
 
   test('practices.listAll forwards include_mine and returns validated items', async () => {

--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -1,6 +1,8 @@
 /* eslint-env jest */
 /* global describe, it, expect */
 import {
+  apiGoalGroupSchema,
+  contentItemSchema,
   goalCompletionSchema,
   goalSchema,
   habitSchema,
@@ -401,5 +403,48 @@ describe('practiceRecipeSchema (audit-contracts-06)', () => {
 
   it('rejects a missing required field', () => {
     expect(() => practiceRecipeSchema.parse({ ...recipe, slug: undefined })).toThrow();
+  });
+});
+
+describe('apiGoalGroupSchema + contentItemSchema (audit-contracts-08)', () => {
+  const group = {
+    id: 1,
+    name: 'Morning',
+    icon: null,
+    description: null,
+    user_id: null,
+    shared_template: true,
+    source: null,
+    goals: [],
+  };
+  const content = {
+    id: 7,
+    title: 'Intro',
+    content_type: 'essay',
+    release_day: 0,
+    url: null,
+    is_locked: false,
+    is_read: false,
+  };
+
+  it('apiGoalGroupSchema accepts a valid group and rejects a drifted one', () => {
+    expect(apiGoalGroupSchema.parse(group).shared_template).toBe(true);
+    expect(() => apiGoalGroupSchema.parse({ ...group, shared_template: undefined })).toThrow();
+    expect(() => apiGoalGroupSchema.parse({ ...group, name: 123 })).toThrow();
+  });
+
+  it('apiGoalGroupSchema validates nested goals via goalSchema', () => {
+    const withGoal = {
+      ...group,
+      goals: [{ ...baseGoal, days_of_week: ['Mon'] }],
+    };
+    expect(apiGoalGroupSchema.parse(withGoal).goals[0]?.days_of_week).toEqual(['Mon']);
+    expect(() => apiGoalGroupSchema.parse({ ...group, goals: [{ bogus: true }] })).toThrow();
+  });
+
+  it('contentItemSchema accepts a valid item and rejects drift', () => {
+    expect(contentItemSchema.parse(content).url).toBeNull();
+    expect(() => contentItemSchema.parse({ ...content, is_locked: undefined })).toThrow();
+    expect(() => contentItemSchema.parse({ ...content, release_day: '0' })).toThrow();
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 
 import { flattenGoalCompletions } from './flattenGoalCompletions';
 import {
+  apiGoalGroupSchema,
   authResponseSchema,
+  contentItemSchema,
   habitWithGoalsSchema,
   isTier,
   journalListResponseSchema,
@@ -15,7 +17,6 @@ import {
   promptListResponseSchema,
   stageSchema,
   timezoneReadSchema,
-  unknownRecord,
   userPracticeSchema,
   type Page,
   type PasswordResetAcceptedT,
@@ -962,16 +963,6 @@ export interface PaginationParams {
 }
 
 /**
- * ``Page`` envelope validator for endpoints that do not yet have a strict
- * per-item Zod schema (BUG-INFRA-012-018). The envelope itself — ``items`` is
- * an array, ``total`` / ``limit`` / ``offset`` are non-negative ints,
- * ``has_more`` is a boolean — is validated; items are checked only as objects
- * and narrowed to their TypeScript type by the caller's cast. Strict item
- * schemas (cf. ``habitPageSchema``) replace this as they are written.
- */
-const loosePageSchema = pageSchema(unknownRecord);
-
-/**
  * Build the query string shared by every ``listPaginated`` helper: always opt
  * into the ``Page`` envelope (``paginate=true``), append any endpoint-specific
  * filters (e.g. ``stage_number``), then ``limit`` / ``offset`` only when the
@@ -1160,7 +1151,7 @@ export const goalGroups = {
   listPaginated(params: PaginationParams = {}, token?: string): Promise<Page<ApiGoalGroup>> {
     return request<Page<ApiGoalGroup>>(`/goal-groups/?${pageQuery({}, params)}`, {
       token,
-      schema: loosePageSchema as unknown as z.ZodType<Page<ApiGoalGroup>>,
+      schema: pageSchema(apiGoalGroupSchema) as unknown as z.ZodType<Page<ApiGoalGroup>>,
     });
   },
   get(groupId: number, token?: string): Promise<ApiGoalGroup> {
@@ -1723,7 +1714,7 @@ export const course = {
       `/course/stages/${stageNumber}/content?${pageQuery({}, params)}`,
       {
         token,
-        schema: loosePageSchema as unknown as z.ZodType<Page<ContentItem>>,
+        schema: pageSchema(contentItemSchema) as unknown as z.ZodType<Page<ContentItem>>,
       },
     );
   },

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -347,6 +347,29 @@ export const practiceSessionResponseSchema = z.object({
   insight: z.string().nullish(),
 });
 
+/** A goal group with its embedded goals (mirrors ``ApiGoalGroup``; audit-contracts-08). */
+export const apiGoalGroupSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  icon: z.string().nullish(),
+  description: z.string().nullish(),
+  user_id: z.number().int().nullish(),
+  shared_template: z.boolean(),
+  source: z.string().nullish(),
+  goals: z.array(goalSchema),
+});
+
+/** A course-content item (mirrors ``ContentItem``; audit-contracts-08). */
+export const contentItemSchema = z.object({
+  id: z.number().int(),
+  title: z.string(),
+  content_type: z.string(),
+  release_day: z.number().int(),
+  url: z.string().nullable(),
+  is_locked: z.boolean(),
+  is_read: z.boolean(),
+});
+
 // ---------------------------------------------------------------------------
 // Lenient schemas for legacy endpoints (gradually tightened)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #512: the last two paginated endpoints still validated items as `z.record(z.unknown())` via `loosePageSchema`, so item-level drift in **goal groups** and **course content** stayed invisible (audit §5.4).

- Added **`apiGoalGroupSchema`** (reusing `goalSchema` for the embedded `goals`) and **`contentItemSchema`**, modelling the full `ApiGoalGroup` / `ContentItem` shapes.
- Wired `pageSchema(...)` at the goal-groups and course-content call sites, replacing the `loosePageSchema` casts.
- **Removed the now-unused `loosePageSchema`** (+ its `unknownRecord` import): all six paginated endpoints now validate their items.

## Test plan

- `schemas.test.ts`: each schema accepts a valid item and rejects a drifted one (missing/renamed/type-flipped field); goal-group nested goals validate via `goalSchema`.
- Updated `pagination-api.test.ts` fixtures to well-formed goal-group / content items.
- `grep` confirms no `loosePageSchema` remains; `./scripts/frontend/check-all.sh` — 4/4.

Closes #578
Refs #491
