### PR TITLE
fix(frontend): replace hand-rolled practiceTags validator with Zod

### DIFF
--- a/frontend/src/api/__tests__/practiceRecipes-api.test.ts
+++ b/frontend/src/api/__tests__/practiceRecipes-api.test.ts
@@ -211,8 +211,22 @@ describe('practiceTags', () => {
     expect(init.method).toBe('DELETE');
   });
 
-  test('list rejects invalid payload', async () => {
+  test('list raises ApiValidationError on an invalid payload', async () => {
     mockFetch.mockReturnValueOnce(jsonResponse([{ slug: 'no-id' }]));
-    await expect(practiceTags.list()).rejects.toThrow('Invalid practice-tags response');
+    await expect(practiceTags.list()).rejects.toThrow(ApiValidationError);
+  });
+
+  test('list raises ApiValidationError on a drifted row (renamed owner field)', async () => {
+    const drifted = { ...tagFixture, owner_user_id: undefined, ownerUserId: null };
+    mockFetch.mockReturnValueOnce(jsonResponse([tagFixture, drifted]));
+    await expect(practiceTags.list()).rejects.toThrow(ApiValidationError);
+  });
+
+  test('create raises ApiValidationError on a drifted response', async () => {
+    const drifted = { ...tagFixture, label: undefined, displayLabel: 'Red' };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted, 201));
+    await expect(practiceTags.create({ slug: 'red', label: 'Red' })).rejects.toThrow(
+      ApiValidationError,
+    );
   });
 });

--- a/frontend/src/api/__tests__/practiceRecipes-api.test.ts
+++ b/frontend/src/api/__tests__/practiceRecipes-api.test.ts
@@ -229,4 +229,10 @@ describe('practiceTags', () => {
       ApiValidationError,
     );
   });
+
+  test('update raises ApiValidationError on a drifted response', async () => {
+    const drifted = { ...tagFixture, created_at: undefined, createdAt: '2026-05-23T00:00:00Z' };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+    await expect(practiceTags.update(3, { label: 'Crimson' })).rejects.toThrow(ApiValidationError);
+  });
 });

--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -9,6 +9,7 @@ import {
   habitWithGoalsSchema,
   journalListResponseSchema,
   practiceItemSchema,
+  practiceTagSchema,
   practiceRecipeSchema,
   practiceSessionResponseSchema,
   promptListResponseSchema,
@@ -446,5 +447,22 @@ describe('apiGoalGroupSchema + contentItemSchema (audit-contracts-08)', () => {
     expect(contentItemSchema.parse(content).url).toBeNull();
     expect(() => contentItemSchema.parse({ ...content, is_locked: undefined })).toThrow();
     expect(() => contentItemSchema.parse({ ...content, release_day: '0' })).toThrow();
+  });
+});
+
+describe('practiceTagSchema (audit-contracts-09)', () => {
+  const tag = {
+    id: 3,
+    slug: 'red',
+    label: 'Red',
+    owner_user_id: null,
+    created_at: '2026-05-23T00:00:00Z',
+  };
+
+  it('accepts a valid tag (nullable owner) and rejects drift', () => {
+    expect(practiceTagSchema.parse(tag).owner_user_id).toBeNull();
+    expect(practiceTagSchema.parse({ ...tag, owner_user_id: 9 }).owner_user_id).toBe(9);
+    expect(() => practiceTagSchema.parse({ ...tag, slug: undefined })).toThrow();
+    expect(() => practiceTagSchema.parse({ ...tag, id: '3' })).toThrow();
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -14,6 +14,7 @@ import {
   practiceItemSchema,
   practiceRecipeSchema,
   practiceSessionResponseSchema,
+  practiceTagSchema,
   promptListResponseSchema,
   stageSchema,
   timezoneReadSchema,
@@ -2104,46 +2105,30 @@ export interface PracticeTagUpdate {
   label: string;
 }
 
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function validatePracticeTag(data: unknown): data is PracticeTag {
-  if (!isObject(data)) return false;
-  return (
-    typeof data.id === 'number' &&
-    typeof data.slug === 'string' &&
-    typeof data.label === 'string' &&
-    (data.owner_user_id === null || typeof data.owner_user_id === 'number') &&
-    typeof data.created_at === 'string'
-  );
-}
+// PracticeTag responses validate via practiceTagSchema so a drifted field raises
+// ApiValidationError instead of a generic Error (audit-contracts-09).
+const tagSchema = practiceTagSchema as unknown as z.ZodType<PracticeTag>;
+const tagArraySchema = z.array(practiceTagSchema) as unknown as z.ZodType<PracticeTag[]>;
 
 export const practiceTags = {
-  async list(token?: string): Promise<PracticeTag[]> {
-    const data = await request<unknown>('/practice-tags/', { token });
-    if (!Array.isArray(data) || !data.every(validatePracticeTag)) {
-      throw new Error('Invalid practice-tags response');
-    }
-    return data;
+  list(token?: string): Promise<PracticeTag[]> {
+    return request<PracticeTag[]>('/practice-tags/', { token, schema: tagArraySchema });
   },
-  async create(payload: PracticeTagCreate, token?: string): Promise<PracticeTag> {
-    const data = await request<unknown>('/practice-tags/', {
+  create(payload: PracticeTagCreate, token?: string): Promise<PracticeTag> {
+    return request<PracticeTag>('/practice-tags/', {
       method: 'POST',
       body: payload,
       token,
+      schema: tagSchema,
     });
-    if (!validatePracticeTag(data)) throw new Error('Invalid practice-tag response');
-    return data;
   },
-  async update(tagId: number, payload: PracticeTagUpdate, token?: string): Promise<PracticeTag> {
-    const data = await request<unknown>(`/practice-tags/${tagId}`, {
+  update(tagId: number, payload: PracticeTagUpdate, token?: string): Promise<PracticeTag> {
+    return request<PracticeTag>(`/practice-tags/${tagId}`, {
       method: 'PATCH',
       body: payload,
       token,
+      schema: tagSchema,
     });
-    if (!validatePracticeTag(data)) throw new Error('Invalid practice-tag response');
-    return data;
   },
   remove(tagId: number, token?: string): Promise<void> {
     return request<void>(`/practice-tags/${tagId}`, { method: 'DELETE', token });

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -347,6 +347,15 @@ export const practiceSessionResponseSchema = z.object({
   insight: z.string().nullish(),
 });
 
+/** A practice tag (mirrors ``PracticeTag``; audit-contracts-09). */
+export const practiceTagSchema = z.object({
+  id: z.number().int(),
+  slug: z.string(),
+  label: z.string(),
+  owner_user_id: z.number().int().nullable(),
+  created_at: z.string(),
+});
+
 /** A goal group with its embedded goals (mirrors ``ApiGoalGroup``; audit-contracts-08). */
 export const apiGoalGroupSchema = z.object({
   id: z.number().int(),


### PR DESCRIPTION
## Summary

Follow-up to #519: `practiceTags` still validated responses with a hand-rolled `validatePracticeTag` `typeof` guard and threw an opaque `Error` — the same class #519 replaced for practices/recipes, and the only remaining user of the `isObject` helper (audit §5.4).

- Added **`practiceTagSchema`** (`id`, `slug`, `label`, `owner_user_id` nullable, `created_at`).
- `practiceTags.list` / `.create` / `.update` now validate via the schema through `request()`'s `schema` path → a drifted tag field raises **`ApiValidationError`** instead of a generic `Error`.
- **Deleted `validatePracticeTag` and the now-unused `isObject` helper.**

## Test plan

- `practiceTags.list` raises `ApiValidationError` on an invalid payload and on a drifted row; `create` raises on a drifted response.
- `practiceTagSchema` unit test: accepts a valid tag (nullable owner), rejects missing/type-flipped fields.
- `grep` confirms `validatePracticeTag`/`isObject` are gone; `./scripts/frontend/check-all.sh` — 4/4.

Closes #583
Refs #491
