### PR TITLE
feat(frontend): greyscale met/unmet tier stars and softer habit font

### DIFF
--- a/frontend/src/components/TierStar.tsx
+++ b/frontend/src/components/TierStar.tsx
@@ -1,19 +1,20 @@
-import React from 'react';
-import Svg, { Polygon } from 'react-native-svg';
+import React, { useId } from 'react';
+import Svg, { Defs, FeDropShadow, Filter, LinearGradient, Polygon, Stop } from 'react-native-svg';
+
+import { colors } from '../design/tokens';
 
 /**
  * Unlabeled goal-tier star markers.
  *
  * Each habit goal tier is denoted by a star whose point-count encodes the
  * tier — a 4-pointed star for Low Grit, a 5-pointed star for Clear Goal, and
- * a 10-pointed star for Stretch Goal — so the markers read at a glance
- * without the old "LG / CG / SG" text labels.
+ * a 10-pointed star for Stretch Goal — so the markers read at a glance.
  *
- * The visual style intentionally matches the bottom-tab navigation icons
- * (``lucide-react-native``): a 24×24 viewBox, stroke-only outline, 2dp
- * stroke, and rounded joins. ``lucide`` ships no 4- or 10-pointed star, so
- * the shape is generated here from first principles while keeping that same
- * outlined look.
+ * The stars are tier-agnostic greyscale. While a tier is unmet the star is a
+ * stroke-only outline in darkish grey (same lucide-style 24×24 / rounded-join
+ * look as the bottom-tab icons). Once the tier is achieved (``met``) it fills
+ * with a greyscale gradient and gains a white border glow. ``lucide`` ships no
+ * 4- or 10-pointed star, so the shape is generated here from first principles.
  */
 
 export type TierStarTier = 'low' | 'clear' | 'stretch';
@@ -47,9 +48,13 @@ const TIER_INNER_RATIO: Record<TierStarTier, number> = {
 // Match the lucide 24×24 grid so these sit alongside the tab icons cleanly.
 const VIEWBOX = 24;
 const CENTER = VIEWBOX / 2;
-// Leave a 2dp margin inside the viewBox so the 2dp stroke is never clipped.
+// Leave a 2dp margin inside the viewBox so the stroke + glow are never clipped.
 const OUTER_RADIUS = 10;
 const STROKE_WIDTH = 2;
+// Thinner border on the filled (met) star so the white edge reads as a rim, not a slab.
+const MET_STROKE_WIDTH = 1.5;
+const GLOW_BLUR = 1.2;
+const GLOW_OPACITY = 0.9;
 const QUARTER_TURN = Math.PI / 2;
 const COORD_PRECISION = 3;
 
@@ -79,7 +84,8 @@ const DEFAULT_SIZE = 14;
 
 interface TierStarProps {
   tier: TierStarTier;
-  color: string;
+  /** When true the star is filled (greyscale gradient + white glow); otherwise outline-only. */
+  met?: boolean;
   size?: number;
   testID?: string;
   /** Screen-reader label; defaults to the spoken tier name so the star is
@@ -87,31 +93,88 @@ interface TierStarProps {
   accessibilityLabel?: string;
 }
 
-/** Outlined, tier-encoding star marker (see module docstring). */
-export const TierStar = ({
-  tier,
-  color,
-  size = DEFAULT_SIZE,
+const svgProps = (size: number, testID: string | undefined, label: string) => ({
+  width: size,
+  height: size,
+  viewBox: `0 0 ${VIEWBOX} ${VIEWBOX}`,
   testID,
-  accessibilityLabel,
-}: TierStarProps) => (
-  <Svg
-    width={size}
-    height={size}
-    viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
-    testID={testID}
-    accessibilityRole="image"
-    accessibilityLabel={accessibilityLabel ?? TIER_LABELS[tier]}
-  >
+  accessibilityRole: 'image' as const,
+  accessibilityLabel: label,
+});
+
+interface StarVariantProps {
+  tier: TierStarTier;
+  size: number;
+  testID: string | undefined;
+  label: string;
+}
+
+/** Unmet state: darkish-grey, stroke-only outline. */
+const OutlineStar = ({ tier, size, testID, label }: StarVariantProps) => (
+  <Svg {...svgProps(size, testID, label)}>
     <Polygon
       points={STAR_POINTS[tier]}
       fill="none"
-      stroke={color}
+      stroke={colors.starMarker.outline}
       strokeWidth={STROKE_WIDTH}
       strokeLinejoin="round"
       strokeLinecap="round"
     />
   </Svg>
 );
+
+/** Met state: greyscale gradient fill with a white border glow. */
+const MetStar = ({ tier, size, testID, label }: StarVariantProps) => {
+  // Unique, SVG-id-safe suffix so multiple stars' gradients/filters never
+  // collide (ids are document-global on web). useId is stable across renders.
+  const uid = useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const gradientId = `tierStarFill-${uid}`;
+  const glowId = `tierStarGlow-${uid}`;
+  return (
+    <Svg {...svgProps(size, testID, label)}>
+      <Defs>
+        <LinearGradient id={gradientId} x1="0" y1="0" x2="1" y2="1">
+          <Stop offset="0" stopColor={colors.starMarker.gradientFrom} />
+          <Stop offset="1" stopColor={colors.starMarker.gradientTo} />
+        </LinearGradient>
+        <Filter id={glowId} x="-50%" y="-50%" width="200%" height="200%">
+          <FeDropShadow
+            dx="0"
+            dy="0"
+            stdDeviation={GLOW_BLUR}
+            floodColor={colors.starMarker.glow}
+            floodOpacity={GLOW_OPACITY}
+          />
+        </Filter>
+      </Defs>
+      <Polygon
+        points={STAR_POINTS[tier]}
+        fill={`url(#${gradientId})`}
+        stroke={colors.starMarker.glow}
+        strokeWidth={MET_STROKE_WIDTH}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        filter={`url(#${glowId})`}
+      />
+    </Svg>
+  );
+};
+
+/** Tier-encoding star marker: greyscale outline when unmet, filled + glowing when met. */
+export const TierStar = ({
+  tier,
+  met = false,
+  size = DEFAULT_SIZE,
+  testID,
+  accessibilityLabel,
+}: TierStarProps) => {
+  const variantProps: StarVariantProps = {
+    tier,
+    size,
+    testID,
+    label: accessibilityLabel ?? TIER_LABELS[tier],
+  };
+  return met ? <MetStar {...variantProps} /> : <OutlineStar {...variantProps} />;
+};
 
 export default TierStar;

--- a/frontend/src/components/__tests__/TierStar.test.tsx
+++ b/frontend/src/components/__tests__/TierStar.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
+import { colors } from '../../design/tokens';
 import { TierStar, type TierStarTier } from '../TierStar';
 
 // react-test-renderer ships no type definitions in this project, so test
@@ -14,16 +15,15 @@ interface TestNode {
 
 type Rendered = ReturnType<typeof renderer.create>;
 
-/** Pull the single star Polygon's vertex list out of a rendered TierStar. */
-const findStarVertices = (component: Rendered): string[][] => {
-  const polygon: TestNode = component.root.find(
-    (node: TestNode) => typeof node.props.points === 'string',
-  );
-  return String(polygon.props.points)
+const findPolygon = (component: Rendered): TestNode =>
+  component.root.find((node: TestNode) => typeof node.props.points === 'string');
+
+/** Pull the star Polygon's vertex list out of a rendered TierStar. */
+const findStarVertices = (component: Rendered): string[][] =>
+  String(findPolygon(component).props.points)
     .trim()
     .split(' ')
     .map((pair) => pair.split(','));
-};
 
 describe('TierStar', () => {
   // A star with N points is drawn as N outer + N inner vertices = 2N total.
@@ -34,7 +34,7 @@ describe('TierStar', () => {
   ];
 
   it.each(cases)('renders %s as a %d-pointed star', (tier, points) => {
-    const component = renderer.create(<TierStar tier={tier} color="#000000" />);
+    const component = renderer.create(<TierStar tier={tier} />);
     expect(findStarVertices(component)).toHaveLength(points * 2);
   });
 
@@ -45,37 +45,42 @@ describe('TierStar', () => {
       ['stretch', 'Stretch Goal'],
     ];
     for (const [tier, label] of labels) {
-      const component = renderer.create(<TierStar tier={tier} color="#000000" />);
+      const component = renderer.create(<TierStar tier={tier} />);
       const svg = component.root.findByProps({ accessibilityRole: 'image' });
       expect(svg.props.accessibilityLabel).toBe(label);
     }
   });
 
   it('allows the accessibilityLabel to be overridden', () => {
-    const component = renderer.create(
-      <TierStar tier="low" color="#000000" accessibilityLabel="Custom" />,
-    );
+    const component = renderer.create(<TierStar tier="low" accessibilityLabel="Custom" />);
     const svg = component.root.findByProps({ accessibilityRole: 'image' });
     expect(svg.props.accessibilityLabel).toBe('Custom');
   });
 
-  it('applies the tier color as the stroke', () => {
-    const component = renderer.create(<TierStar tier="clear" color="#be6e46" />);
-    const polygon: TestNode = component.root.find(
-      (node: TestNode) => typeof node.props.points === 'string',
+  it('renders an unmet star as a darkish-grey outline (no fill)', () => {
+    const polygon = findPolygon(renderer.create(<TierStar tier="clear" />)).props;
+    expect(polygon.fill).toBe('none');
+    expect(polygon.stroke).toBe(colors.starMarker.outline);
+    expect(polygon.filter).toBeUndefined();
+  });
+
+  it('renders a met star with a greyscale gradient fill and white glow', () => {
+    const component = renderer.create(<TierStar tier="clear" met />);
+    const polygon = findPolygon(component).props;
+    // Filled with the gradient and outlined/glowing in white.
+    expect(String(polygon.fill)).toMatch(/^url\(#/);
+    expect(polygon.stroke).toBe(colors.starMarker.glow);
+    expect(String(polygon.filter)).toMatch(/^url\(#/);
+    // The gradient is greyscale: its light stop is the configured grey.
+    const lightStop = component.root.find(
+      (node: TestNode) => node.props.offset === '0' && 'stopColor' in node.props,
     );
-    expect(polygon.props.stroke).toBe('#be6e46');
-    // Outlined (stroke-only) to match the lucide bottom-tab icon style.
-    expect(polygon.props.fill).toBe('none');
+    expect(lightStop.props.stopColor).toBe(colors.starMarker.gradientFrom);
   });
 
   it('honors an explicit size and forwards a testID', () => {
-    const component = renderer.create(
-      <TierStar tier="stretch" color="#8c3b2e" size={24} testID="my-star" />,
-    );
-    // The testID is forwarded onto the rendered SVG.
+    const component = renderer.create(<TierStar tier="stretch" size={24} testID="my-star" />);
     expect(component.root.findAllByProps({ testID: 'my-star' }).length).toBeGreaterThan(0);
-    // The explicit size flows through to a width/height-bearing node.
     expect(component.root.findAll((n: TestNode) => n.props.width === 24).length).toBeGreaterThan(0);
     expect(component.root.findAll((n: TestNode) => n.props.height === 24).length).toBeGreaterThan(
       0,
@@ -83,7 +88,7 @@ describe('TierStar', () => {
   });
 
   it('points every star straight up (top vertex centered on the x-axis)', () => {
-    const component = renderer.create(<TierStar tier="low" color="#000000" />);
+    const component = renderer.create(<TierStar tier="low" />);
     const [firstVertex] = findStarVertices(component);
     // First vertex is the top outer point: x at center (12), y above center.
     expect(Number(firstVertex![0])).toBeCloseTo(12, 3);

--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -66,6 +66,15 @@ describe('design tokens', () => {
       expect(colors.tier.default).toBe('#dad9d4');
     });
 
+    it('exports greyscale goal-tier star marker colors', () => {
+      // Tier-agnostic greyscale: darkish-grey outline (unmet) → greyscale
+      // gradient fill + white glow (met).
+      expect(colors.starMarker.outline).toBe('#555555');
+      expect(colors.starMarker.gradientFrom).toBe('#9c9c9c');
+      expect(colors.starMarker.gradientTo).toBe('#3a3a3a');
+      expect(colors.starMarker.glow).toBe('#ffffff');
+    });
+
     it('exports border color', () => {
       expect(colors.border).toBe('#ddd');
     });

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -67,6 +67,16 @@ export const colors = {
     default: '#dad9d4',
   },
 
+  // Goal-tier star markers are tier-agnostic greyscale: a darkish-grey outline
+  // while the tier is unmet, then a greyscale gradient fill with a white border
+  // glow once the tier is achieved.
+  starMarker: {
+    outline: '#555555', // darkish-grey outline (unmet) — AAA on #f8f8f8
+    gradientFrom: '#9c9c9c', // light end of the met greyscale fill
+    gradientTo: '#3a3a3a', // dark end of the met greyscale fill
+    glow: '#ffffff', // white border glow on the met star
+  },
+
   // Surface variants for destructive + success banners. ``danger`` above is
   // the button-fill swatch; these are the softer banner/card treatments.
   destructive: {

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 
 import { TierStar } from '../../components/TierStar';
-import { STAGE_COLORS, spacing } from '../../design/tokens';
+import { colors, STAGE_COLORS, spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 import { DEFAULT_TIMEZONE } from '../../utils/dateUtils';
 
@@ -22,6 +22,7 @@ import {
   getMarkerPositions,
   getProgressBarColor,
   getTierColor,
+  isGoalAchieved,
   isEarlyUnlocked,
   calculateTodaysProgress,
 } from './HabitUtils';
@@ -112,6 +113,7 @@ const GoalMarker = ({
 }: GoalMarkerProps) => {
   const clamped = clampPercentage(markerPosition);
   const starSize = markerStarSize(scale);
+  const met = isGoalAchieved(goal, habit, tz);
   return (
     <View
       style={{
@@ -133,7 +135,7 @@ const GoalMarker = ({
         onMouseEnter={() => setTooltip(tier)}
         onMouseLeave={() => setTooltip(null)}
       >
-        <TierStar tier={tier} color={getTierColor(tier)} size={starSize} />
+        <TierStar tier={tier} met={met} size={starSize} />
       </TouchableOpacity>
     </View>
   );
@@ -159,12 +161,40 @@ const getStreakStyle = (hasCompleted: boolean, stageColor: string, scale: number
       }
     : {};
 
+// Softened from default black to a darkish grey so the habit name reads
+// calmer / less abrasive against the tile.
+const HABIT_TEXT_COLOR = colors.text.secondaryAccessible;
+
 const nameStyle = (scale: number) => ({
   flex: 1 as const,
   fontSize: spacing(2, scale),
   fontWeight: '700' as const,
   textTransform: 'uppercase' as const,
+  color: HABIT_TEXT_COLOR,
 });
+
+const StreakText = ({
+  streakText,
+  streakStyle,
+  scale,
+}: {
+  streakText: string;
+  streakStyle: object;
+  scale: number;
+}) => (
+  <Text
+    style={[
+      {
+        fontSize: spacing(1.5, scale),
+        textTransform: 'uppercase' as const,
+        color: HABIT_TEXT_COLOR,
+      },
+      streakStyle,
+    ]}
+  >
+    {streakText}
+  </Text>
+);
 
 const HeaderRow = ({
   name,
@@ -179,9 +209,7 @@ const HeaderRow = ({
 }) => (
   <View testID="habit-header" style={{ flexDirection: 'row', alignItems: 'center' }}>
     <Text style={nameStyle(scale)}>{name}</Text>
-    <Text style={[{ fontSize: spacing(1.5, scale), textTransform: 'uppercase' }, streakStyle]}>
-      {streakText}
-    </Text>
+    <StreakText streakText={streakText} streakStyle={streakStyle} scale={scale} />
   </View>
 );
 
@@ -207,9 +235,7 @@ const HabitHeader = ({
           <Text style={{ fontSize: spacing(3, scale) }}>{habit.icon}</Text>
         </TouchableOpacity>
         <Text style={nameStyle(scale)}>{habit.name}</Text>
-        <Text style={[{ fontSize: spacing(1.5, scale), textTransform: 'uppercase' }, streakStyle]}>
-          {streakText}
-        </Text>
+        <StreakText streakText={streakText} streakStyle={streakStyle} scale={scale} />
       </View>
     );
   }

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -43,6 +43,7 @@ import {
   clampPercentage,
   getTierColor,
   getGoalTarget,
+  isGoalAchieved,
   calculateTodaysProgress,
 } from '../HabitUtils';
 
@@ -120,6 +121,7 @@ interface GoalMarkerItemProps {
   tier: 'low' | 'clear' | 'stretch';
   position: number;
   zIndex: number;
+  met: boolean;
   tooltip: 'low' | 'clear' | 'stretch' | null;
   setTooltip: (_v: 'low' | 'clear' | 'stretch' | null) => void;
   panHandlers?: GestureResponderHandlers;
@@ -130,6 +132,7 @@ const GoalMarkerItem = ({
   tier,
   position,
   zIndex,
+  met,
   tooltip,
   setTooltip,
   panHandlers,
@@ -156,7 +159,7 @@ const GoalMarkerItem = ({
           <Text style={tooltipTextStyle}>{formatGoalTooltip(goal)}</Text>
         </View>
       )}
-      <TierStar tier={tier} color={getTierColor(tier)} size={starSize} />
+      <TierStar tier={tier} met={met} size={starSize} />
     </Wrapper>
   );
 };
@@ -170,6 +173,9 @@ interface GoalProgressBarProps {
   lowMarker: number;
   clearMarker: number;
   stretchMarker: number;
+  lowMet: boolean;
+  clearMet: boolean;
+  stretchMet: boolean;
   tooltip: 'low' | 'clear' | 'stretch' | null;
   setTooltip: (_v: 'low' | 'clear' | 'stretch' | null) => void;
   lowPanHandlers: GestureResponderHandlers;
@@ -203,59 +209,66 @@ interface GoalMarkersRowProps {
   lowMarker: number;
   clearMarker: number;
   stretchMarker: number;
+  lowMet: boolean;
+  clearMet: boolean;
+  stretchMet: boolean;
   tooltip: 'low' | 'clear' | 'stretch' | null;
   setTooltip: (_v: 'low' | 'clear' | 'stretch' | null) => void;
   lowPanHandlers: GestureResponderHandlers;
   clearPanHandlers: GestureResponderHandlers;
 }
 
-const GoalMarkersRow = ({
-  lowGoal,
-  clearGoal,
-  stretchGoal,
-  lowMarker,
-  clearMarker,
-  stretchMarker,
-  tooltip,
-  setTooltip,
-  lowPanHandlers,
-  clearPanHandlers,
-}: GoalMarkersRowProps) => (
-  <>
-    {lowGoal && (
-      <GoalMarkerItem
-        goal={lowGoal}
-        tier="low"
-        position={lowMarker}
-        zIndex={1}
-        tooltip={tooltip}
-        setTooltip={setTooltip}
-        panHandlers={lowPanHandlers}
-      />
-    )}
-    {clearGoal && (
-      <GoalMarkerItem
-        goal={clearGoal}
-        tier="clear"
-        position={clearMarker}
-        zIndex={2}
-        tooltip={tooltip}
-        setTooltip={setTooltip}
-        panHandlers={clearPanHandlers}
-      />
-    )}
-    {stretchGoal && (
-      <GoalMarkerItem
-        goal={stretchGoal}
-        tier="stretch"
-        position={stretchMarker}
-        zIndex={3}
-        tooltip={tooltip}
-        setTooltip={setTooltip}
-      />
-    )}
-  </>
-);
+interface MarkerEntry {
+  tier: 'low' | 'clear' | 'stretch';
+  goal: Goal | undefined;
+  position: number;
+  zIndex: number;
+  met: boolean;
+  panHandlers?: GestureResponderHandlers;
+}
+
+const buildMarkerEntries = (p: GoalMarkersRowProps): MarkerEntry[] => [
+  {
+    tier: 'low',
+    goal: p.lowGoal,
+    position: p.lowMarker,
+    zIndex: 1,
+    met: p.lowMet,
+    panHandlers: p.lowPanHandlers,
+  },
+  {
+    tier: 'clear',
+    goal: p.clearGoal,
+    position: p.clearMarker,
+    zIndex: 2,
+    met: p.clearMet,
+    panHandlers: p.clearPanHandlers,
+  },
+  { tier: 'stretch', goal: p.stretchGoal, position: p.stretchMarker, zIndex: 3, met: p.stretchMet },
+];
+
+const GoalMarkersRow = (props: GoalMarkersRowProps) => {
+  const { tooltip, setTooltip } = props;
+  return (
+    <>
+      {buildMarkerEntries(props).map((it) =>
+        it.goal ? (
+          <GoalMarkerItem
+            key={it.tier}
+            goal={it.goal}
+            tier={it.tier}
+            position={it.position}
+            zIndex={it.zIndex}
+            met={it.met}
+            tooltip={tooltip}
+            setTooltip={setTooltip}
+            panHandlers={it.panHandlers}
+          />
+        ) : null,
+      )}
+    </>
+  );
+};
 
 const GoalProgressBar = ({
   progressPercentage,
@@ -266,6 +279,9 @@ const GoalProgressBar = ({
   lowMarker,
   clearMarker,
   stretchMarker,
+  lowMet,
+  clearMet,
+  stretchMet,
   tooltip,
   setTooltip,
   lowPanHandlers,
@@ -282,6 +298,9 @@ const GoalProgressBar = ({
         lowMarker={lowMarker}
         clearMarker={clearMarker}
         stretchMarker={stretchMarker}
+        lowMet={lowMet}
+        clearMet={clearMet}
+        stretchMet={stretchMet}
         tooltip={tooltip}
         setTooltip={setTooltip}
         lowPanHandlers={lowPanHandlers}
@@ -1186,6 +1205,9 @@ const buildProgressBarProps = (
   lowMarker: m.lowMarker,
   clearMarker: m.clearMarker,
   stretchMarker: m.stretchMarker,
+  lowMet: m.lowGoal ? isGoalAchieved(m.lowGoal, habit, tz) : false,
+  clearMet: m.clearGoal ? isGoalAchieved(m.clearGoal, habit, tz) : false,
+  stretchMet: m.stretchGoal ? isGoalAchieved(m.stretchGoal, habit, tz) : false,
   tooltip: m.tooltip,
   setTooltip: m.setTooltip,
   lowPanHandlers: m.lowPan.panHandlers,


### PR DESCRIPTION
## Summary

Reworks the goal-tier star markers to a **tier-agnostic greyscale** treatment with a met/unmet state, and softens the habit font.

### Stars: greyscale, outline → filled-on-achievement
- **Unmet tier** → darkish-grey (`#555`) **stroke-only outline**.
- **Met tier** → **greyscale gradient fill** (`#9c9c9c → #3a3a3a`) with a **white border glow** (SVG `FeDropShadow`) — the star "lights up" once the tier is achieved.
- `TierStar` gains a `met` prop (the old `color` prop is removed). `HabitTile` and `GoalModal` compute per-tier met state via `isGoalAchieved(goal, habit, tz)` and pass it in, so **low → clear → stretch fill in progressively** as the day's progress crosses each threshold.
- Each met star uses a `useId()`-derived, SVG-id-safe suffix for its gradient/filter so ids never collide when many stars render (ids are document-global on web).

### Softer habit font
- Habit name + streak text move from default **black → darkish grey** (`text.secondaryAccessible`, `#555`) so the tile reads calmer / less abrasive. The completed-state white streak chip is unaffected.

### Tokens
New `colors.starMarker` group (`outline` / `gradientFrom` / `gradientTo` / `glow`) is the single source of truth for the marker palette.

### Refactors (to satisfy `max-lines-per-function`)
- `TierStar` split into `OutlineStar` / `MetStar` variants.
- `HabitTile` streak text extracted into a shared `StreakText` (also unifies the grey across both header layouts).
- `GoalModal`'s marker row builds its entries via a `buildMarkerEntries` helper + `.map`.

## Testing
- `eslint . --max-warnings=0` — clean
- `tsc --noEmit` — clean
- `prettier -c .` — clean
- `jest` — all pass; `TierStar` tests updated for the new API (outline vs gradient-fill-with-glow, greyscale stop colors, `met` state) + new `starMarker` token assertions

## Notes
- The white glow is most visible where the met star sits on the colored progress-bar fill; on near-white areas it's intentionally subtle.
- Accessibility preserved: `TierStar` still carries the per-tier `accessibilityLabel`; tooltips and the GoalModal drag handles are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QewacjWNSWUTykERTH3uZj)_