### PR TITLE
fix(frontend): tolerate omitted submitted_by_user_id in practiceItemSchema

### DIFF
--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -337,6 +337,30 @@ describe('per-item paginated schemas', () => {
     expect(() => practiceItemSchema.parse({ ...practiceItem, name: undefined })).toThrow();
   });
 
+  it('practiceItemSchema accepts the live backend shape that omits submitted_by_user_id', () => {
+    // PracticeResponse deliberately excludes ``submitted_by_user_id``
+    // (BUG-PRACTICE-001 / BUG-SCHEMA-010) to avoid leaking who proposed a
+    // draft. The field is therefore ABSENT on the wire, not null. A
+    // ``.nullable()`` (non-optional) schema rejected ``undefined`` and made
+    // every catalog/practice fetch fail validation -> the "Something changed
+    // on the server" banner. The mode + mode_config keys are always present
+    // on the real response.
+    const wire = {
+      id: 7,
+      stage_number: 2,
+      name: 'Breath',
+      description: 'desc',
+      instructions: 'inst',
+      default_duration_minutes: 10,
+      approved: true,
+      mode: 'meditation_timer',
+      mode_config: { mode: 'meditation_timer', duration_minutes: 10 },
+    };
+    const parsed = practiceItemSchema.parse(wire);
+    expect(parsed.submitted_by_user_id).toBeUndefined();
+    expect(parsed.name).toBe('Breath');
+  });
+
   const userPractice = {
     id: 3,
     user_id: 1,

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1752,7 +1752,11 @@ export interface PracticeItem {
   description: string;
   instructions: string;
   default_duration_minutes: number;
-  submitted_by_user_id: number | null;
+  // Absent on the wire — the backend ``PracticeResponse`` omits it to avoid
+  // leaking who proposed a draft (BUG-PRACTICE-001 / BUG-SCHEMA-010). Optional
+  // here so callers don't assume a value the server never sends; see
+  // ``practiceItemSchema`` in ``schemas.ts``.
+  submitted_by_user_id?: number | null;
   approved: boolean;
   /** ritual-01: discriminator for ``mode_config``. Older fixtures may omit. */
   mode?: string;

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -291,7 +291,16 @@ export const practiceItemSchema = z.object({
   description: z.string(),
   instructions: z.string(),
   default_duration_minutes: z.number(),
-  submitted_by_user_id: z.number().int().nullable(),
+  // The backend ``PracticeResponse`` intentionally OMITS this field
+  // (BUG-PRACTICE-001 / BUG-SCHEMA-010): echoing the submitter's user id on
+  // a catalog GET turns the endpoint into a user-id enumeration oracle. The
+  // field is therefore ABSENT on the wire, not ``null``. ``.nullish()``
+  // (``number | null | undefined``) tolerates the absence; a plain
+  // ``.nullable()`` rejected the missing key and failed every practice fetch
+  // with ``ApiValidationError`` — the "Something changed on the server"
+  // banner on the Practice and Catalog screens. Keep this absent-tolerant
+  // unless the backend re-introduces the field.
+  submitted_by_user_id: z.number().int().nullish(),
   approved: z.boolean(),
   mode: z.string().optional(),
   mode_config: z.record(z.unknown()).optional(),


### PR DESCRIPTION
## Summary

The **Practice** and **Catalog** screens were both showing the `ApiValidationError` banner — *"Something changed on the server and we couldn't read the response."* Every `GET /practices/` response failed the frontend's Zod validation.

**Root cause:** The backend `PracticeResponse` (`backend/src/schemas/practice.py:97`) **intentionally omits** `submitted_by_user_id` (BUG-PRACTICE-001 / BUG-SCHEMA-010) so the catalog GET can't be used to enumerate who proposed which draft. The field is therefore **absent on the wire**, not `null`. The frontend `practiceItemSchema` required it as `z.number().int().nullable()` — `.nullable()` accepts `null` but **rejects an absent key**, so every practice row failed validation.

This was latent drift activated by #582 ("replace hand-rolled practice validators with Zod"): the old hand-rolled validator tolerated the missing field; the strict Zod schema did not. Same class as the documented `habitSchema.user_id` removal (BUG-T7 / #265).

## Changes

- `practiceItemSchema.submitted_by_user_id` → `.nullish()` (tolerates `number | null | undefined`/absent).
- `PracticeItem.submitted_by_user_id` TS field → optional, so callers don't assume a value the server never sends.
- Added a regression test asserting the real backend wire shape (no `submitted_by_user_id`, with `mode` + `mode_config`) parses — the existing fixture always included the field, which is why this slipped through.

## Testing

- jest: 796 passing (schemas + Practice), 215 passing (api) — incl. the new regression test (confirmed red → green)
- `tsc --noEmit`: clean
- eslint: clean on all changed files

> Note: `pre-commit` could not run in the sandbox (org egress policy 403s `github.com`, where it fetches hook repos), so the equivalent gates were run manually as above. CI runs them authoritatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACun9ReyoTyjatdqgrjzmo)_