### PR TITLE
feat(backend): support keyword search over encrypted journal entries

### DIFF
--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -59,6 +59,11 @@ router = APIRouter(prefix="/journal", tags=["journal"])
 JOURNAL_SEARCH_MIN_LENGTH = 3
 JOURNAL_SEARCH_MAX_LENGTH = 64
 
+# Encrypted search scans a user's entries in memory (ciphertext can't be ILIKE'd).
+# Fine for a personal journal (~3 entries/day over a 36-week program ≈ 750 rows);
+# warn past this so a future blind-index/FTS need is observable, not a surprise.
+_ENCRYPTED_SCAN_WARN_THRESHOLD = 2000
+
 
 @dataclass
 class _ListFilters:
@@ -128,7 +133,7 @@ def _build_filter_conditions(filters: _ListFilters) -> list[ColumnElement[bool]]
 
 
 async def _encrypted_search_page(
-    session: AsyncSession, user_id: int, filters: _ListFilters
+    session: AsyncSession, user_id: int, filters: _ListFilters, *, search: str
 ) -> JournalListResponse:
     """Keyword search when messages are encrypted at rest (audit-destub-05c).
 
@@ -146,7 +151,11 @@ async def _encrypted_search_page(
         .order_by(col(JournalEntry.id).desc())
     )
     rows = list((await session.execute(query)).scalars().all())
-    needle = (filters.search or "").lower()
+    if len(rows) > _ENCRYPTED_SCAN_WARN_THRESHOLD:
+        # In-memory scan is fine for a personal journal; warn before it isn't, so
+        # a future blind-index/FTS need is observable rather than a surprise.
+        logger.warning("encrypted_search_large_scan", extra={"user_id": user_id, "rows": len(rows)})
+    needle = search.lower()
     matched = [row for row in rows if needle in row.message.lower()]
     page = matched[filters.offset : filters.offset + filters.limit]
     return JournalListResponse(
@@ -173,7 +182,7 @@ async def list_journal_entries(
     # encryption is on — so route encrypted search through a decrypt-then-filter
     # path in Python (audit-destub-05c) instead of the SQL ILIKE.
     if filters.search is not None and journal_encryption.is_enabled():
-        return await _encrypted_search_page(session, current_user, filters)
+        return await _encrypted_search_page(session, current_user, filters, search=filters.search)
     conditions = _build_filter_conditions(filters)
     query = select(JournalEntry).where(
         JournalEntry.user_id == current_user,

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -108,17 +108,52 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
-def _build_filter_conditions(filters: _ListFilters) -> list[ColumnElement[bool]]:
-    """Build SQLAlchemy where-clauses from the filter parameters."""
+def _non_search_conditions(filters: _ListFilters) -> list[ColumnElement[bool]]:
+    """Tag / practice-session filters that work as plain column equality."""
     conditions: list[ColumnElement[bool]] = []
-    if filters.search is not None:
-        escaped = _escape_like(filters.search)
-        conditions.append(col(JournalEntry.message).ilike(f"%{escaped}%", escape="\\"))
     if filters.tag is not None:
         conditions.append(col(JournalEntry.tag) == filters.tag.value)
     if filters.practice_session_id is not None:
         conditions.append(col(JournalEntry.practice_session_id) == filters.practice_session_id)
     return conditions
+
+
+def _build_filter_conditions(filters: _ListFilters) -> list[ColumnElement[bool]]:
+    """All where-clauses, including a SQL ILIKE keyword search (plaintext path)."""
+    conditions = _non_search_conditions(filters)
+    if filters.search is not None:
+        escaped = _escape_like(filters.search)
+        conditions.append(col(JournalEntry.message).ilike(f"%{escaped}%", escape="\\"))
+    return conditions
+
+
+async def _encrypted_search_page(
+    session: AsyncSession, user_id: int, filters: _ListFilters
+) -> JournalListResponse:
+    """Keyword search when messages are encrypted at rest (audit-destub-05c).
+
+    Ciphertext can't be ILIKE'd, so the non-search filters run in SQL and the
+    substring match is applied in Python after the ORM transparently decrypts.
+    Scoped to one user's own (non-deleted) entries, so the corpus is small.
+    """
+    query = (
+        select(JournalEntry)
+        .where(
+            JournalEntry.user_id == user_id,
+            col(JournalEntry.deleted_at).is_(None),
+            *_non_search_conditions(filters),
+        )
+        .order_by(col(JournalEntry.id).desc())
+    )
+    rows = list((await session.execute(query)).scalars().all())
+    needle = (filters.search or "").lower()
+    matched = [row for row in rows if needle in row.message.lower()]
+    page = matched[filters.offset : filters.offset + filters.limit]
+    return JournalListResponse(
+        items=[JournalMessageResponse.model_validate(e, from_attributes=True) for e in page],
+        total=len(matched),
+        has_more=(filters.offset + filters.limit) < len(matched),
+    )
 
 
 @router.get("/", response_model=JournalListResponse)
@@ -134,12 +169,11 @@ async def list_journal_entries(
     BUG-JOURNAL-007: soft-deleted entries (``deleted_at IS NOT NULL``) are
     excluded so the list surface never resurfaces deleted content.
     """
-    # Keyword search ILIKEs the message column; with encryption on, the stored
-    # value is Fernet ciphertext, so substring search cannot work. Reject it
-    # explicitly rather than silently returning nothing (audit-destub-05b);
-    # encrypted search is tracked as follow-up feature work.
+    # Keyword search ILIKEs the message column, which is Fernet ciphertext when
+    # encryption is on — so route encrypted search through a decrypt-then-filter
+    # path in Python (audit-destub-05c) instead of the SQL ILIKE.
     if filters.search is not None and journal_encryption.is_enabled():
-        raise unprocessable("search_unavailable_with_encryption")
+        return await _encrypted_search_page(session, current_user, filters)
     conditions = _build_filter_conditions(filters)
     query = select(JournalEntry).where(
         JournalEntry.user_id == current_user,

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -539,22 +539,45 @@ def _encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("_encryption_key")
-async def test_search_rejected_when_encryption_enabled(async_client: AsyncClient) -> None:
-    """With encryption on, keyword search 422s instead of silently returning nothing.
+async def test_search_works_with_encryption_via_decrypt_then_filter(
+    async_client: AsyncClient,
+) -> None:
+    """With encryption on, keyword search decrypts then substring-filters in Python.
 
-    The message column holds Fernet ciphertext, so an ILIKE substring match can
-    never hit; the endpoint rejects search explicitly (audit-destub-05b).
+    Ciphertext can't be ILIKE'd, so the endpoint matches on the decrypted text
+    (audit-destub-05c) — case-insensitively — instead of returning nothing.
     """
     headers = await _signup(async_client, "searcher")
-    await async_client.post(
-        "/journal/", json=_message_payload(message="encrypted guitar note"), headers=headers
-    )
+    for msg in ("encrypted Guitar note", "meditation log", "guitar scales"):
+        await async_client.post("/journal/", json=_message_payload(message=msg), headers=headers)
+
     resp = await async_client.get("/journal/?search=guitar", headers=headers)
-    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    # A non-search list still works (and round-trips decrypted content).
-    ok = await async_client.get("/journal/", headers=headers)
-    assert ok.status_code == HTTPStatus.OK
-    assert ok.json()["items"][0]["message"] == "encrypted guitar note"
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["total"] == 2  # case-insensitive: "Guitar" + "guitar"
+    messages = {item["message"] for item in body["items"]}
+    assert messages == {"encrypted Guitar note", "guitar scales"}
+
+    # A non-matching search returns an empty page (not an error).
+    none = await async_client.get("/journal/?search=zzzznomatch", headers=headers)
+    assert none.status_code == HTTPStatus.OK
+    assert none.json()["total"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_encryption_key")
+async def test_encrypted_search_paginates(async_client: AsyncClient) -> None:
+    """Encrypted-search pagination (Python-side) reports total + has_more correctly."""
+    headers = await _signup(async_client, "pager")
+    for i in range(3):
+        await async_client.post(
+            "/journal/", json=_message_payload(message=f"yoga session {i}"), headers=headers
+        )
+    resp = await async_client.get("/journal/?search=yoga&limit=2&offset=0", headers=headers)
+    data = resp.json()
+    assert data["total"] == 3
+    assert len(data["items"]) == 2
+    assert data["has_more"] is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -579,6 +579,34 @@ async def test_encrypted_search_paginates(async_client: AsyncClient) -> None:
     assert len(data["items"]) == 2
     assert data["has_more"] is True
 
+    # Page 2: the remaining item, has_more clears.
+    page2 = await async_client.get("/journal/?search=yoga&limit=2&offset=2", headers=headers)
+    body2 = page2.json()
+    assert body2["total"] == 3
+    assert len(body2["items"]) == 1
+    assert body2["has_more"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_encryption_key")
+async def test_encrypted_search_is_scoped_to_the_requesting_user(
+    async_client: AsyncClient,
+) -> None:
+    """Encrypted search never returns another user's entries (audit-destub-05c)."""
+    alice = await _signup(async_client, "alice_enc")
+    bob = await _signup(async_client, "bob_enc")
+    await async_client.post(
+        "/journal/", json=_message_payload(message="alice secret kayak"), headers=alice
+    )
+    await async_client.post(
+        "/journal/", json=_message_payload(message="bob secret kayak"), headers=bob
+    )
+
+    resp = await async_client.get("/journal/?search=kayak", headers=bob)
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["message"] == "bob secret kayak"
+
 
 @pytest.mark.asyncio
 async def test_decryption_failure_returns_distinct_500(


### PR DESCRIPTION
## Summary

Follow-up to #550: with encryption on, `message` is Fernet ciphertext so the SQL `ILIKE` keyword search couldn't match — #550 shipped a `422 search_unavailable_with_encryption` guard. This makes search **work** under encryption (audit-destub-05c) and removes the guard.

- When search is requested and `journal_encryption.is_enabled()`, route through a **decrypt-then-filter** path: the non-search filters (tag, practice_session_id, user, not-deleted) run in SQL, then the substring match is applied in Python (case-insensitive) after the ORM transparently decrypts. Scoped to the user's own non-deleted entries, so the corpus is small.
- The **plaintext path keeps the efficient SQL `ILIKE`**. Pagination (`total`/`has_more`) is computed over the filtered set.

## Test plan

- Encrypted search matches **case-insensitively** (`guitar` finds `Guitar` + `guitar`), returns an **empty page** for a non-match (not an error), and **paginates** with correct `total`/`has_more`.
- Removed the now-obsolete 422-guard test; plaintext search tests unchanged.
- `./scripts/backend/check-all.sh` — 7/7 (coverage ≥90%); xenon clean.

Closes #594
Refs #219
