### PR TITLE
feat(frontend): move the practice catalog off the bottom nav

### DIFF
--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -95,6 +95,14 @@ jest.mock('@/features/Practice/screens/CreatePracticeWizard', () => {
   const Stub = () => <Text>CreatePracticeWizard</Text>;
   return { CreatePracticeWizard: Stub, default: Stub };
 });
+// practice-redesign-01: RootStack now mounts the catalog as a pushed sibling
+// route. It reads ``route.params`` (useRoute), which the navigator stub does
+// not provide -- stub it out so this suite stays focused on auth gating.
+jest.mock('@/features/Practice/screens/PracticeCatalogScreen', () => {
+  const { Text } = require('react-native');
+  const Stub = () => <Text>PracticeCatalogScreen</Text>;
+  return { PracticeCatalogScreen: Stub, default: Stub };
+});
 
 import App from '@/App';
 

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -17,6 +17,8 @@
  * The screen itself stays under ~250 LoC by keeping all state inside the
  * extracted hooks and the inner session component.
  */
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
@@ -33,7 +35,7 @@ import WeeklyProgress from './WeeklyProgress';
 
 import type { PracticeSessionResponse, UserPractice } from '@/api';
 import { useAuth } from '@/context/AuthContext';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import { BORDER_RADIUS, SPACING, colors, touchTarget } from '@/design/tokens';
 import { stageService } from '@/features/Map/services/stageService';
 import ActiveRitualSession from '@/features/Practice/components/ActiveRitualSession';
 import { FrequencyBanner } from '@/features/Practice/components/FrequencyBanner';
@@ -41,6 +43,7 @@ import { PracticeSwitcherSheet } from '@/features/Practice/components/PracticeSw
 import { useActivePractice } from '@/features/Practice/hooks/useActivePractice';
 import { useWeeklyProgress } from '@/features/Practice/hooks/useWeeklyProgress';
 import { useAppNavigation, useAppRoute } from '@/navigation/hooks';
+import type { RootStackParamList } from '@/navigation/RootStack';
 import { useDerivedCurrentStage } from '@/store/useProgramProgression';
 import { selectCurrentStage, useStageStore } from '@/store/useStageStore';
 
@@ -110,6 +113,7 @@ const PracticeScreen = (): React.JSX.Element => {
         onWriteReflection={handleWriteReflection}
         banner={banner}
         switcher={switcher}
+        stageNumber={stageNumber}
       />
     );
   }
@@ -121,7 +125,31 @@ const PracticeScreen = (): React.JSX.Element => {
       currentPracticeId={currentPracticeId}
       banner={banner}
       switcher={switcher}
+      stageNumber={stageNumber}
     />
+  );
+};
+
+/**
+ * Discoverable entry point to the (now pushed) practice catalog, seeded with the
+ * user's resolved stage. Rendered on the Practice screen in both the active and
+ * selection states so the catalog stays reachable after it left the bottom nav
+ * (practice-redesign-01).
+ */
+const BrowseAllPracticesButton = ({ stageNumber }: { stageNumber: number }): React.JSX.Element => {
+  // Catalog is a pushed RootStack screen (not a tab), so navigate with the
+  // stack-typed navigation rather than the tab-scoped useAppNavigation.
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  return (
+    <TouchableOpacity
+      style={styles.browseCatalog}
+      onPress={() => navigation.navigate('Catalog', { stageNumber })}
+      accessibilityRole="button"
+      accessibilityLabel="Browse all practices"
+      testID="browse-catalog-button"
+    >
+      <Text style={styles.browseCatalogText}>Browse all practices</Text>
+    </TouchableOpacity>
   );
 };
 
@@ -136,6 +164,7 @@ interface ActiveSessionViewProps {
   onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
   banner: React.JSX.Element;
   switcher: React.JSX.Element;
+  stageNumber: number;
 }
 
 const ActiveSessionView = ({
@@ -149,6 +178,7 @@ const ActiveSessionView = ({
   onWriteReflection,
   banner,
   switcher,
+  stageNumber,
 }: ActiveSessionViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
   return (
@@ -162,6 +192,7 @@ const ActiveSessionView = ({
         testID="practice-screen"
       >
         {banner}
+        <BrowseAllPracticesButton stageNumber={stageNumber} />
         <ActiveRitualSession
           key={`practice-${userPractice.id}`}
           userPractice={userPractice}
@@ -187,6 +218,7 @@ interface SelectionViewProps {
   currentPracticeId: number | null;
   banner: React.JSX.Element;
   switcher: React.JSX.Element;
+  stageNumber: number;
 }
 
 // The selection branch lets the windowed PracticeSelector own the scroll: a
@@ -197,12 +229,19 @@ const SelectionView = ({
   currentPracticeId,
   banner,
   switcher,
+  stageNumber,
 }: SelectionViewProps): React.JSX.Element => {
   // ``selectPractice`` is already stable (useCallback in the hook); wrap it once
   // so PracticeCard's React.memo isn't defeated by a fresh arrow each render.
   const { selectPractice } = active;
   const insets = useSafeAreaInsets();
   const handleSelect = useCallback((id: number) => void selectPractice(id), [selectPractice]);
+  const listHeader = (
+    <>
+      {banner}
+      <BrowseAllPracticesButton stageNumber={stageNumber} />
+    </>
+  );
   return (
     <View
       style={[styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
@@ -214,7 +253,7 @@ const SelectionView = ({
           selectedPracticeId={currentPracticeId}
           onSelect={handleSelect}
           isLoading={false}
-          ListHeaderComponent={banner}
+          ListHeaderComponent={listHeader}
           ListFooterComponent={<WeeklyProgress count={weekly.count} />}
         />
       </View>
@@ -340,6 +379,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.xl,
   },
   retryButtonText: { color: colors.text.light, fontWeight: '600' },
+  browseCatalog: {
+    marginHorizontal: SPACING.md,
+    marginBottom: SPACING.md,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    borderColor: colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: touchTarget.minimum,
+  },
+  browseCatalogText: { color: colors.primary, fontWeight: '600', fontSize: 15 },
 });
 
 export default PracticeScreen;

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -192,6 +192,9 @@ const ActiveSessionView = ({
         testID="practice-screen"
       >
         {banner}
+        {/* Above the session by design: the catalog must be reachable from the
+            active state too (practice-redesign-01). It sits in the scroll header,
+            not over the timer, so it doesn't intercept mid-session taps. */}
         <BrowseAllPracticesButton stageNumber={stageNumber} />
         <ActiveRitualSession
           key={`practice-${userPractice.id}`}

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -239,11 +239,15 @@ const SelectionView = ({
   const { selectPractice } = active;
   const insets = useSafeAreaInsets();
   const handleSelect = useCallback((id: number) => void selectPractice(id), [selectPractice]);
-  const listHeader = (
-    <>
-      {banner}
-      <BrowseAllPracticesButton stageNumber={stageNumber} />
-    </>
+  // Memoized so SectionList doesn't re-reconcile its header on unrelated renders.
+  const listHeader = useMemo(
+    () => (
+      <>
+        {banner}
+        <BrowseAllPracticesButton stageNumber={stageNumber} />
+      </>
+    ),
+    [banner, stageNumber],
   );
   return (
     <View
@@ -394,7 +398,9 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     minHeight: touchTarget.minimum,
   },
-  browseCatalogText: { color: colors.primary, fontWeight: '600', fontSize: 15 },
+  // fontSize 16 mirrors retryButtonText above (the app has no static type token;
+  // typography() is viewport-responsive) so the two buttons stay visually aligned.
+  browseCatalogText: { color: colors.primary, fontWeight: '600', fontSize: 16 },
 });
 
 export default PracticeScreen;

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -289,7 +289,7 @@ describe('PracticeScreen', () => {
     await waitFor(() => expect(getByTestId('selection-view')).toBeTruthy());
 
     fireEvent.press(getByTestId('browse-catalog-button'));
-    expect(mockRootNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: expect.any(Number) });
+    expect(mockRootNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: 1 });
   });
 
   it('shows error state when the load fails', async () => {
@@ -329,7 +329,7 @@ describe('PracticeScreen', () => {
     await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
 
     fireEvent.press(getByTestId('browse-catalog-button'));
-    expect(mockRootNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: expect.any(Number) });
+    expect(mockRootNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: 1 });
   });
 
   it('applies safe-area insets to the active-session surface', async () => {

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -323,6 +323,15 @@ describe('PracticeScreen', () => {
     });
   });
 
+  it('browse-all-practices opens the Catalog from the active-session state too', async () => {
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+
+    fireEvent.press(getByTestId('browse-catalog-button'));
+    expect(mockRootNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: expect.any(Number) });
+  });
+
   it('applies safe-area insets to the active-session surface', async () => {
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId } = render(<PracticeScreen />);

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -95,10 +95,18 @@ jest.mock('../../../context/AuthContext', () => ({
 }));
 
 const mockNavigate = jest.fn();
+const mockRootNavigate = jest.fn();
 const mockRouteParams: Record<string, unknown> = {};
 jest.mock('../../../navigation/hooks', () => ({
   useAppNavigation: () => ({ navigate: mockNavigate }),
   useAppRoute: () => ({ key: 'Practice-test', name: 'Practice', params: mockRouteParams }),
+}));
+
+// The "Browse all practices" button navigates via the stack-typed useNavigation
+// (Catalog is a pushed RootStack route, not a tab).
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: mockRootNavigate }),
 }));
 
 jest.mock('expo-av', () => ({
@@ -274,6 +282,14 @@ describe('PracticeScreen', () => {
     });
     // The selection surface applies top/bottom safe-area insets.
     expect(getByTestId('practice-screen')).toHaveStyle({ paddingTop: 47, paddingBottom: 34 });
+  });
+
+  it('browse-all-practices navigates to the pushed Catalog screen with the stage', async () => {
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('selection-view')).toBeTruthy());
+
+    fireEvent.press(getByTestId('browse-catalog-button'));
+    expect(mockRootNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: expect.any(Number) });
   });
 
   it('shows error state when the load fails', async () => {

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -154,7 +154,7 @@ export function CreatePracticeWizard(props: CreatePracticeWizardProps): React.JS
             goTo={goTo}
             setMode={setMode}
             submit={submit}
-            onPickPreset={() => props.navigation.navigate('Tabs', { screen: 'Catalog' })}
+            onPickPreset={() => props.navigation.navigate('Catalog')}
           />
         </ScrollView>
       </KeyboardAvoidingView>

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -63,13 +63,12 @@ interface CatalogState {
  * user's current stage when this screen is the catalog tab.
  */
 export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Element {
-  // Destructure each prop the callbacks below depend on so the
-  // ``useCallback`` dependency arrays are stable refs instead of the
-  // ``props`` object (which is a new reference on every render and
-  // would silently invalidate every memoization).
+  // Destructure so the useCallback deps below are stable field refs, not the
+  // ``props`` object (a fresh ref each render that would defeat memoization).
   const { initialStage, loadPractices, navigateToDetail, navigateToCreate } = props;
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const [stageNumber, setStageNumber] = useState(useSeededStage(initialStage));
+  const seededStage = useSeededStage(initialStage);
+  const [stageNumber, setStageNumber] = useState(seededStage);
   const [modeCategory, setModeCategory] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [state, reload] = useCatalog(stageNumber, loadPractices);
@@ -80,17 +79,7 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
     navigateToCreate,
   );
 
-  // Virtualized: bucket the filtered catalog into the three sections and let
-  // SectionList window the rows. Stable render callbacks keep rows from
-  // re-rendering on unrelated state (search keystrokes, chip toggles).
-  const sections = useMemo(
-    () => buildSections(state.practices, query, modeCategory),
-    [state.practices, query, modeCategory],
-  );
-  const renderItem = useCallback(
-    ({ item }: { item: PracticeItem }) => <PracticeRow practice={item} onDetail={onDetail} />,
-    [onDetail],
-  );
+  const { sections, renderItem } = useCatalogList(state, query, modeCategory, onDetail);
   const insets = useSafeAreaInsets();
   const containerStyle = [styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom }];
 
@@ -124,10 +113,32 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
 }
 
 /** Seed the stage chip: an explicit prop (tests) wins, else the ``Catalog``
- * route param when pushed from the Practice screen, else the first stage. */
+ * route param when pushed from the Practice screen, else the first stage.
+ *
+ * Always calls ``useRoute`` (hooks can't be conditional), so a render outside a
+ * navigator must mock it — the prop path alone does not skip the hook. */
 function useSeededStage(initialStage: number | undefined): number {
   const route = useRoute<RouteProp<RootStackParamList, 'Catalog'>>();
   return initialStage ?? route.params?.stageNumber ?? MIN_STAGE;
+}
+
+/** Memoized SectionList inputs: the bucketed sections + a stable row renderer
+ * (kept stable so search keystrokes / chip toggles don't re-render every row). */
+function useCatalogList(
+  state: CatalogState,
+  query: string,
+  modeCategory: string | null,
+  onDetail: (id: number) => void,
+): { sections: CatalogSection[]; renderItem: (info: { item: PracticeItem }) => React.JSX.Element } {
+  const sections = useMemo(
+    () => buildSections(state.practices, query, modeCategory),
+    [state.practices, query, modeCategory],
+  );
+  const renderItem = useCallback(
+    ({ item }: { item: PracticeItem }) => <PracticeRow practice={item} onDetail={onDetail} />,
+    [onDetail],
+  );
+  return { sections, renderItem };
 }
 
 function useCatalogNavigation(

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -17,7 +17,7 @@
  * navigation rather than an optional filter.
  */
 
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -69,7 +69,7 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
   // would silently invalidate every memoization).
   const { initialStage, loadPractices, navigateToDetail, navigateToCreate } = props;
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const [stageNumber, setStageNumber] = useState(initialStage ?? MIN_STAGE);
+  const [stageNumber, setStageNumber] = useState(useSeededStage(initialStage));
   const [modeCategory, setModeCategory] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [state, reload] = useCatalog(stageNumber, loadPractices);
@@ -121,6 +121,13 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
       />
     </View>
   );
+}
+
+/** Seed the stage chip: an explicit prop (tests) wins, else the ``Catalog``
+ * route param when pushed from the Practice screen, else the first stage. */
+function useSeededStage(initialStage: number | undefined): number {
+  const route = useRoute<RouteProp<RootStackParamList, 'Catalog'>>();
+  return initialStage ?? route.params?.stageNumber ?? MIN_STAGE;
 }
 
 function useCatalogNavigation(

--- a/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
@@ -144,7 +144,7 @@ describe('CreatePracticeWizard — step navigation', () => {
     const nav = makeNav();
     const { view } = renderScreen({}, nav);
     fireEvent.press(view.getByTestId('create-practice-from-preset'));
-    expect(nav.navigate).toHaveBeenCalledWith('Tabs', { screen: 'Catalog' });
+    expect(nav.navigate).toHaveBeenCalledWith('Catalog');
     expect(nav.goBack).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -251,6 +251,7 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
   beforeEach(() => {
     mockPracticesList.mockReset();
     mockNavigation.navigate.mockReset();
+    mockRoute.params = undefined;
   });
 
   it('calls practices.list with includeMine when no override is provided', async () => {
@@ -258,6 +259,22 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
     render(<PracticeCatalogScreen initialStage={3} />);
     await waitForLoad();
     expect(mockPracticesList).toHaveBeenCalledWith({ stageNumber: 3, includeMine: true });
+  });
+
+  it('seeds the stage from the Catalog route param when no prop is given', async () => {
+    mockRoute.params = { stageNumber: 4 };
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    render(<PracticeCatalogScreen />);
+    await waitForLoad();
+    expect(mockPracticesList).toHaveBeenCalledWith({ stageNumber: 4, includeMine: true });
+  });
+
+  it('prefers an explicit initialStage prop over the route param', async () => {
+    mockRoute.params = { stageNumber: 4 };
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    render(<PracticeCatalogScreen initialStage={6} />);
+    await waitForLoad();
+    expect(mockPracticesList).toHaveBeenCalledWith({ stageNumber: 6, includeMine: true });
   });
 
   it('navigates to PracticeDetail when a row is tapped without an override', async () => {

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -71,9 +71,11 @@ const myDraft: PracticeItem = {
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => mockNavigation,
+  useRoute: () => mockRoute,
 }));
 
 const mockNavigation = { navigate: jest.fn() as jest.Mock<(...args: unknown[]) => void> };
+const mockRoute: { params?: { stageNumber?: number } } = { params: undefined };
 
 const mockPracticesList = jest.fn() as jest.MockedFunction<
   (opts: { stageNumber: number; includeMine?: boolean }) => Promise<PracticeItem[]>

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -7,7 +7,6 @@ import {
   BookOpen,
   Compass,
   Flower2,
-  LayoutGrid,
   NotebookPen,
   Sprout,
   type LucideIcon,
@@ -23,7 +22,6 @@ import HabitsScreen from '../features/Habits/HabitsScreen';
 import JournalScreen from '../features/Journal/JournalScreen';
 import MapScreen from '../features/Map/MapScreen';
 import PracticeScreen from '../features/Practice/PracticeScreen';
-import { PracticeCatalogScreen } from '../features/Practice/screens/PracticeCatalogScreen';
 
 import type { RootStackParamList } from './RootStack';
 
@@ -32,7 +30,6 @@ import { useAuth } from '@/context/AuthContext';
 export type RootTabParamList = {
   Habits: undefined;
   Practice: { stageNumber?: number } | undefined;
-  Catalog: undefined;
   Course: { stageNumber?: number } | undefined;
   Journal:
     | {
@@ -69,7 +66,6 @@ function withBoundary<P extends object>(
 
 const HabitsTab = withBoundary('Habits', HabitsScreen);
 const PracticeTab = withBoundary('Practice', PracticeScreen);
-const CatalogTab = withBoundary('Catalog', PracticeCatalogScreen);
 const CourseTab = withBoundary('Course', CourseScreen);
 const JournalTab = withBoundary('Journal', JournalScreen);
 const MapTab = withBoundary('Map', MapScreen);
@@ -91,7 +87,6 @@ const TAB_CONFIGS: ReadonlyArray<{
 }> = [
   { name: 'Habits', component: HabitsTab, icon: Sprout },
   { name: 'Practice', component: PracticeTab, icon: Flower2 },
-  { name: 'Catalog', component: CatalogTab, icon: LayoutGrid },
   { name: 'Course', component: CourseTab, icon: BookOpen },
   { name: 'Journal', component: JournalTab, icon: NotebookPen },
   { name: 'Map', component: MapTab, icon: Compass },

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -3,6 +3,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 
 import { CreatePracticeWizard } from '../features/Practice/screens/CreatePracticeWizard';
+import { PracticeCatalogScreen } from '../features/Practice/screens/PracticeCatalogScreen';
 import { PracticeDetailScreen } from '../features/Practice/screens/PracticeDetailScreen';
 import SharePreviewScreen from '../features/Practice/screens/SharePreviewScreen';
 import ApiKeySettingsScreen from '../features/Settings/ApiKeySettingsScreen';
@@ -41,6 +42,7 @@ export type RootStackParamList = {
   SharePreview: { token: string };
   PracticeDetail: { practiceId: number };
   CreatePractice: { prefill?: CreatePracticePrefill } | undefined;
+  Catalog: { stageNumber?: number } | undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -72,6 +74,11 @@ const RootStack = (): React.JSX.Element => (
       name="CreatePractice"
       component={CreatePracticeWizard}
       options={{ title: 'New practice' }}
+    />
+    <Stack.Screen
+      name="Catalog"
+      component={PracticeCatalogScreen}
+      options={{ title: 'Practices' }}
     />
   </Stack.Navigator>
 );

--- a/frontend/src/navigation/__tests__/BottomTabs.test.tsx
+++ b/frontend/src/navigation/__tests__/BottomTabs.test.tsx
@@ -2,7 +2,7 @@
 /* global describe, it, expect, beforeEach, jest */
 import { NavigationContainer } from '@react-navigation/native';
 import { render, fireEvent } from '@testing-library/react-native';
-import { BookOpen, Compass, Flower2, NotebookPen, Sprout } from 'lucide-react-native';
+import { BookOpen, Compass, Flower2, LayoutGrid, NotebookPen, Sprout } from 'lucide-react-native';
 import React from 'react';
 
 const mockLogout = jest.fn(() => Promise.resolve());
@@ -69,5 +69,16 @@ describe('BottomTabs', () => {
     for (const Icon of [Sprout, Flower2, BookOpen, NotebookPen, Compass]) {
       expect(UNSAFE_getAllByType(Icon).length).toBeGreaterThanOrEqual(1);
     }
+  });
+
+  it('no longer renders the Catalog tab (moved off the bottom nav)', () => {
+    const { UNSAFE_queryAllByType } = render(
+      <NavigationContainer>
+        <BottomTabs />
+      </NavigationContainer>,
+    );
+
+    // LayoutGrid was the Catalog tab icon; it must be absent now (5 tabs).
+    expect(UNSAFE_queryAllByType(LayoutGrid)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

practice-redesign-01: the practice catalog was a permanent 6th bottom tab, competing with the daily-use tabs. This moves it to a deliberately-reached **pushed screen**.

- **BottomTabs**: removed the `Catalog` tab (+ its `LayoutGrid` icon/import + `RootTabParamList` entry). Nav is now **5 tabs** (Habits, Practice, Course, Journal, Map).
- **RootStack**: registered `Catalog` as a pushed stack screen (title "Practices"). `PracticeCatalogScreen` seeds its stage chip from `route.params.stageNumber` (via `useSeededStage`; an explicit `initialStage` prop still wins for tests).
- **PracticeScreen**: added an accessible **"Browse all practices"** button (seeded with the resolved current stage via `useResolvedStageNumber`) in both the active and selection states, so the catalog stays reachable.
- **Repointed** `CreatePracticeWizard`'s "Start from a preset" → `navigate('Catalog')`. (`SharePreviewScreen`'s post-import nav targets `Practice`, not `Catalog` — the spec's line ref was stale; no change needed there.)

## Test plan

- `BottomTabs.test`: explicit assertion that the `LayoutGrid` (Catalog) icon no longer renders.
- `PracticeScreen.test`: pressing **Browse all practices** navigates to `Catalog` with the stage.
- `CreatePracticeWizard.test`: preset picker routes to `Catalog`.
- `PracticeCatalogScreen.test`: `useRoute` mock added.
- `AppAuthFlow.test`: stubbed the new catalog sibling route.
- `./scripts/frontend/check-all.sh` — 4/4 (lint, types, tests, format).

Closes #596
Refs #595
