### PR TITLE
feat(frontend): replace the verbose frequency banner with a slim chip

### DIFF
--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -52,12 +52,9 @@ type WeeklyProgressHook = ReturnType<typeof useWeeklyProgress>;
 /**
  * Returns the frequency chip as a memoized element (stable reference unless the
  * stage changes), so passing it as a FlatList ``ListHeaderComponent`` doesn't
- * re-diff every render.
- *
- * practice-redesign-02: the chip is display-only now — it no longer opens the
- * practice switcher. The explicit "Change practice" button (and the switcher's
- * re-wiring) lands in practice-redesign-03; ``PracticeSwitcherSheet`` is kept
- * until practice-redesign-04.
+ * re-diff every render. The chip is display-only; the explicit "Change practice"
+ * button and switcher wiring are deferred to a follow-up, and
+ * ``PracticeSwitcherSheet`` is retained until then.
  */
 function usePracticeChrome(stageNumber: number): { banner: React.JSX.Element } {
   const banner = useMemo(() => <FrequencyBanner stageNumber={stageNumber} />, [stageNumber]);

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -19,7 +19,7 @@
  */
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   ActivityIndicator,
   ScrollView,
@@ -33,13 +33,12 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import PracticeSelector from './PracticeSelector';
 import WeeklyProgress from './WeeklyProgress';
 
-import type { PracticeSessionResponse, UserPractice } from '@/api';
+import type { PracticeSessionResponse } from '@/api';
 import { useAuth } from '@/context/AuthContext';
 import { BORDER_RADIUS, SPACING, colors, touchTarget } from '@/design/tokens';
 import { stageService } from '@/features/Map/services/stageService';
 import ActiveRitualSession from '@/features/Practice/components/ActiveRitualSession';
 import { FrequencyBanner } from '@/features/Practice/components/FrequencyBanner';
-import { PracticeSwitcherSheet } from '@/features/Practice/components/PracticeSwitcherSheet';
 import { useActivePractice } from '@/features/Practice/hooks/useActivePractice';
 import { useWeeklyProgress } from '@/features/Practice/hooks/useWeeklyProgress';
 import { useAppNavigation, useAppRoute } from '@/navigation/hooks';
@@ -51,35 +50,18 @@ type ActivePracticeHook = ReturnType<typeof useActivePractice>;
 type WeeklyProgressHook = ReturnType<typeof useWeeklyProgress>;
 
 /**
- * Owns the switcher-visibility state and returns the banner + switcher as
- * memoized elements (stable references unless their inputs change), so passing
- * ``banner`` as a FlatList ``ListHeaderComponent`` doesn't re-diff every render.
+ * Returns the frequency chip as a memoized element (stable reference unless the
+ * stage changes), so passing it as a FlatList ``ListHeaderComponent`` doesn't
+ * re-diff every render.
+ *
+ * practice-redesign-02: the chip is display-only now — it no longer opens the
+ * practice switcher. The explicit "Change practice" button (and the switcher's
+ * re-wiring) lands in practice-redesign-03; ``PracticeSwitcherSheet`` is kept
+ * until practice-redesign-04.
  */
-function usePracticeChrome(
-  stageNumber: number,
-  currentPracticeId: number | null,
-  onReplaced: (_next: UserPractice) => void,
-): { banner: React.JSX.Element; switcher: React.JSX.Element } {
-  const [showSwitcher, setShowSwitcher] = useState(false);
-  const open = useCallback(() => setShowSwitcher(true), []);
-  const close = useCallback(() => setShowSwitcher(false), []);
-  const banner = useMemo(
-    () => <FrequencyBanner stageNumber={stageNumber} onSwitch={open} />,
-    [stageNumber, open],
-  );
-  const switcher = useMemo(
-    () => (
-      <PracticeSwitcherSheet
-        visible={showSwitcher}
-        stageNumber={stageNumber}
-        currentPracticeId={currentPracticeId}
-        onClose={close}
-        onReplaced={onReplaced}
-      />
-    ),
-    [showSwitcher, stageNumber, currentPracticeId, close, onReplaced],
-  );
-  return { banner, switcher };
+function usePracticeChrome(stageNumber: number): { banner: React.JSX.Element } {
+  const banner = useMemo(() => <FrequencyBanner stageNumber={stageNumber} />, [stageNumber]);
+  return { banner };
 }
 
 const PracticeScreen = (): React.JSX.Element => {
@@ -87,14 +69,9 @@ const PracticeScreen = (): React.JSX.Element => {
   const { userTimezone } = useAuth();
   const active = useActivePractice(stageNumber);
   const weekly = useWeeklyProgress();
-  const handleSwitcherReplaced = useSwitcherReplaced(active.updateActivePractice, weekly.refresh);
   const handleWriteReflection = useWriteReflection(active.effectiveName, active.practice);
   const currentPracticeId = active.activeUserPractice?.practice_id ?? null;
-  const { banner, switcher } = usePracticeChrome(
-    stageNumber,
-    currentPracticeId,
-    handleSwitcherReplaced,
-  );
+  const { banner } = usePracticeChrome(stageNumber);
 
   if (active.isLoading) return <LoadingView />;
   if (active.error && !active.activeUserPractice) {
@@ -112,7 +89,6 @@ const PracticeScreen = (): React.JSX.Element => {
         onUserPracticeUpdated={active.updateActivePractice}
         onWriteReflection={handleWriteReflection}
         banner={banner}
-        switcher={switcher}
         stageNumber={stageNumber}
       />
     );
@@ -124,7 +100,6 @@ const PracticeScreen = (): React.JSX.Element => {
       weekly={weekly}
       currentPracticeId={currentPracticeId}
       banner={banner}
-      switcher={switcher}
       stageNumber={stageNumber}
     />
   );
@@ -163,7 +138,6 @@ interface ActiveSessionViewProps {
   onUserPracticeUpdated: ActivePracticeHook['updateActivePractice'];
   onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
   banner: React.JSX.Element;
-  switcher: React.JSX.Element;
   stageNumber: number;
 }
 
@@ -177,7 +151,6 @@ const ActiveSessionView = ({
   onUserPracticeUpdated,
   onWriteReflection,
   banner,
-  switcher,
   stageNumber,
 }: ActiveSessionViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
@@ -209,7 +182,6 @@ const ActiveSessionView = ({
           onWriteReflection={onWriteReflection}
         />
         <WeeklyProgress count={weekly.count} />
-        {switcher}
       </ScrollView>
     </View>
   );
@@ -220,7 +192,6 @@ interface SelectionViewProps {
   weekly: WeeklyProgressHook;
   currentPracticeId: number | null;
   banner: React.JSX.Element;
-  switcher: React.JSX.Element;
   stageNumber: number;
 }
 
@@ -231,7 +202,6 @@ const SelectionView = ({
   weekly,
   currentPracticeId,
   banner,
-  switcher,
   stageNumber,
 }: SelectionViewProps): React.JSX.Element => {
   // ``selectPractice`` is already stable (useCallback in the hook); wrap it once
@@ -264,7 +234,6 @@ const SelectionView = ({
           ListFooterComponent={<WeeklyProgress count={weekly.count} />}
         />
       </View>
-      {switcher}
     </View>
   );
 };
@@ -282,22 +251,6 @@ function useResolvedStageNumber(): number {
     if (storeStages.length === 0) void stageService.loadStages();
   }, [storeStages.length]);
   return route.params?.stageNumber ?? derivedCurrentStage;
-}
-
-function useSwitcherReplaced(
-  updateActivePractice: ActivePracticeHook['updateActivePractice'],
-  refreshWeekly: WeeklyProgressHook['refresh'],
-): (_next: UserPractice) => void {
-  // Take stable function references (not the whole hook bag); the parent
-  // hook objects are new on every render, so depending on them would
-  // re-create the callback each pass.
-  return useCallback(
-    (next: UserPractice) => {
-      updateActivePractice(next);
-      void refreshWeekly();
-    },
-    [updateActivePractice, refreshWeekly],
-  );
 }
 
 function useWriteReflection(

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -378,18 +378,16 @@ describe('PracticeScreen', () => {
     }
   });
 
-  it('opens the practice switcher when the banner is tapped', async () => {
+  it('shows the frequency chip (display-only) on the active screen', async () => {
+    // practice-redesign-02: the chip replaced the tappable banner; it no longer
+    // opens the switcher (the explicit "Change practice" button is #598).
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
-    const { getByTestId } = render(<PracticeScreen />);
+    const { getByTestId, queryByTestId } = render(<PracticeScreen />);
     await waitFor(() => {
       expect(getByTestId('frequency-banner-content')).toBeTruthy();
     });
-    await act(async () => {
-      fireEvent.press(getByTestId('frequency-banner-content'));
-    });
-    await waitFor(() => {
-      expect(getByTestId('practice-switcher-sheet')).toBeTruthy();
-    });
+    expect(getByTestId('frequency-banner-content').props.accessibilityRole).toBe('text');
+    expect(queryByTestId('practice-switcher-sheet')).toBeNull();
   });
 
   describe.each(modeFixtures)('mode dispatch — $label', ({ practice, mountTestId }) => {

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -379,8 +379,8 @@ describe('PracticeScreen', () => {
   });
 
   it('shows the frequency chip (display-only) on the active screen', async () => {
-    // practice-redesign-02: the chip replaced the tappable banner; it no longer
-    // opens the switcher (the explicit "Change practice" button is #598).
+    // The chip replaced the tappable banner; it no longer opens the switcher
+    // (switching is a separate, explicit control).
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId, queryByTestId } = render(<PracticeScreen />);
     await waitFor(() => {

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -414,7 +414,8 @@ function SessionCard(props: SessionCardProps): React.JSX.Element {
   return (
     <View style={styles.card} testID="active-practice-card">
       <View style={styles.cardHeader}>
-        <Text style={styles.label}>Your Practice</Text>
+        {/* practice-redesign-02: the redundant "Your Practice" label is gone;
+            the practice name below stands on its own. */}
         <TouchableOpacity
           accessibilityRole="button"
           accessibilityLabel="Configure practice"
@@ -907,13 +908,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: SPACING.xs,
-  },
-  label: {
-    fontSize: 13,
-    color: colors.text.tertiary,
-    fontWeight: '500',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
   },
   gearButton: {
     minWidth: 44,

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -414,8 +414,6 @@ function SessionCard(props: SessionCardProps): React.JSX.Element {
   return (
     <View style={styles.card} testID="active-practice-card">
       <View style={styles.cardHeader}>
-        {/* practice-redesign-02: the redundant "Your Practice" label is gone;
-            the practice name below stands on its own. */}
         <TouchableOpacity
           accessibilityRole="button"
           accessibilityLabel="Configure practice"

--- a/frontend/src/features/Practice/components/FrequencyBanner.tsx
+++ b/frontend/src/features/Practice/components/FrequencyBanner.tsx
@@ -1,12 +1,8 @@
 /**
  * `FrequencyBanner` — display-only chip above the active Practice. Shows the
  * user's current spiral-dynamics colour (a swatch dot) and aspect of wholeness,
- * sourced from ritual-05's `GET /user-practices/current/frequency`.
- *
- * practice-redesign-02: collapsed from the old paragraph banner into a slim
- * pill. It is NOT the switch control any more (the verbose copy + disguised
- * "tap to replace" affordance were the screen's biggest source of clutter); the
- * explicit "Change practice" button arrives in practice-redesign-03.
+ * sourced from `GET /user-practices/current/frequency`. It is intentionally not
+ * interactive — switching practices is a separate, explicit control.
  */
 import React from 'react';
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';

--- a/frontend/src/features/Practice/components/FrequencyBanner.tsx
+++ b/frontend/src/features/Practice/components/FrequencyBanner.tsx
@@ -1,12 +1,12 @@
 /**
- * `FrequencyBanner` — display-only banner that sits above the active
- * Practice. Shows the user's current spiral-dynamics colour, aspect of
- * wholeness, and the server-formatted banner copy (verbatim — the client
- * never assembles the string itself; that's the whole point of
- * ritual-05's `GET /user-practices/current/frequency`).
+ * `FrequencyBanner` — display-only chip above the active Practice. Shows the
+ * user's current spiral-dynamics colour (a swatch dot) and aspect of wholeness,
+ * sourced from ritual-05's `GET /user-practices/current/frequency`.
  *
- * Tap target opens the practice switcher (parent owns the sheet's
- * visibility).
+ * practice-redesign-02: collapsed from the old paragraph banner into a slim
+ * pill. It is NOT the switch control any more (the verbose copy + disguised
+ * "tap to replace" affordance were the screen's biggest source of clutter); the
+ * explicit "Change practice" button arrives in practice-redesign-03.
  */
 import React from 'react';
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -16,6 +16,9 @@ import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 import { swatchFor, type ColorSwatch } from '@/features/Practice/data/colorPalette';
 import { useFrequency } from '@/features/Practice/hooks/useFrequency';
 
+/** Diameter of the colour swatch dot in the chip. */
+const SWATCH_DOT_SIZE = 14;
+
 export interface FrequencyBannerProps {
   /**
    * Pre-fetched payload. When provided, takes precedence over the hook —
@@ -24,14 +27,11 @@ export interface FrequencyBannerProps {
    */
   data?: FrequencyResponse;
   /**
-   * Pin the banner to a specific stage. When omitted the server picks
-   * the stage from the user's stored progress; passing the same stage
-   * the practice card resolves keeps the banner and the card in
-   * lockstep on every render.
+   * Pin the chip to a specific stage. When omitted the server picks the stage
+   * from the user's stored progress; passing the same stage the practice card
+   * resolves keeps the chip and the card in lockstep on every render.
    */
   stageNumber?: number | null;
-  /** Called when the banner body is tapped — open the switcher sheet. */
-  onSwitch: () => void;
 }
 
 function BannerSkeleton() {
@@ -61,45 +61,29 @@ function BannerError({ onRetry }: { onRetry: () => Promise<void> }) {
   );
 }
 
-interface BannerContentProps {
-  data: FrequencyResponse;
-  swatch: ColorSwatch;
-  onSwitch: () => void;
-}
-
-function BannerContent({ data, swatch, onSwitch }: BannerContentProps) {
-  // Memoised so the three child <Text> rows below receive a stable style
-  // reference across renders instead of a fresh object each time.
-  const textStyle = React.useMemo(() => ({ color: swatch.text }), [swatch.text]);
+function FrequencyChip({ data, swatch }: { data: FrequencyResponse; swatch: ColorSwatch }) {
   return (
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessibilityLabel={data.banner_text}
-      accessibilityHint="Tap to switch your current practice"
-      activeOpacity={0.85}
-      onPress={onSwitch}
-      style={[styles.content, { backgroundColor: swatch.bg }]}
+    <View
+      style={styles.chip}
+      accessibilityRole="text"
+      accessibilityLabel={`${data.color} frequency · ${data.aspect}`}
       testID="frequency-banner-content"
     >
-      <View style={styles.headerRow}>
-        <View style={[styles.aspectChip, { borderColor: swatch.text }]}>
-          <Text style={[styles.aspectChipText, textStyle]} testID="frequency-banner-aspect">
-            {data.aspect}
-          </Text>
-        </View>
-        <Text style={[styles.colorLabel, textStyle]} testID="frequency-banner-color">
-          {data.color}
-        </Text>
-      </View>
-      <Text style={[styles.bannerText, textStyle]} testID="frequency-banner-text">
-        {data.banner_text}
+      <View
+        style={[styles.swatchDot, { backgroundColor: swatch.bg }]}
+        testID="frequency-chip-dot"
+      />
+      <Text style={styles.colorLabel} testID="frequency-banner-color">
+        {data.color}
       </Text>
-      <Text style={[styles.switchHint, textStyle]}>Tap to replace this practice</Text>
-    </TouchableOpacity>
+      <Text style={styles.aspectText} testID="frequency-banner-aspect">
+        {data.aspect}
+      </Text>
+    </View>
   );
 }
 
-export function FrequencyBanner({ data: injected, stageNumber, onSwitch }: FrequencyBannerProps) {
+export function FrequencyBanner({ data: injected, stageNumber }: FrequencyBannerProps) {
   const hook = useFrequency(stageNumber);
   // Injected data wins for storybook / tests; otherwise consume the hook.
   const data = injected ?? hook.data;
@@ -109,7 +93,7 @@ export function FrequencyBanner({ data: injected, stageNumber, onSwitch }: Frequ
   if (isLoading && !data) return <BannerSkeleton />;
   if (error && !data) return <BannerError onRetry={hook.refetch} />;
   if (!data) return null;
-  return <BannerContent data={data} swatch={swatchFor(data.color)} onSwitch={onSwitch} />;
+  return <FrequencyChip data={data} swatch={swatchFor(data.color)} />;
 }
 
 const styles = StyleSheet.create({
@@ -152,43 +136,34 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     fontSize: 14,
   },
-  content: {
-    borderRadius: BORDER_RADIUS.lg,
-    padding: SPACING.lg,
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.circle,
+    backgroundColor: colors.background.card,
     marginBottom: SPACING.md,
     ...shadows.small,
   },
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: SPACING.sm,
-  },
-  aspectChip: {
-    paddingHorizontal: SPACING.sm,
-    paddingVertical: 2,
+  swatchDot: {
+    width: SWATCH_DOT_SIZE,
+    height: SWATCH_DOT_SIZE,
     borderRadius: BORDER_RADIUS.circle,
-    borderWidth: 1,
     marginRight: SPACING.sm,
-  },
-  aspectChipText: {
-    fontSize: 12,
-    fontWeight: '700',
-    letterSpacing: 0.5,
   },
   colorLabel: {
     fontSize: 12,
-    fontWeight: '600',
+    fontWeight: '700',
     textTransform: 'uppercase',
     letterSpacing: 0.5,
+    color: colors.text.primary,
+    marginRight: SPACING.sm,
   },
-  bannerText: {
-    fontSize: 15,
-    lineHeight: 22,
-  },
-  switchHint: {
-    marginTop: SPACING.sm,
+  aspectText: {
     fontSize: 12,
-    fontStyle: 'italic',
-    opacity: 0.8,
+    fontWeight: '600',
+    color: colors.text.secondary,
   },
 });

--- a/frontend/src/features/Practice/components/__tests__/FrequencyBanner.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/FrequencyBanner.test.tsx
@@ -32,6 +32,13 @@ describe('FrequencyBanner', () => {
     mockUseFrequency.mockReset();
   });
 
+  const flatBackground = (node: { props: { style: unknown } }): string => {
+    const style = Array.isArray(node.props.style)
+      ? Object.assign({}, ...(node.props.style as object[]))
+      : (node.props.style as { backgroundColor?: string });
+    return style.backgroundColor as string;
+  };
+
   it('renders a skeleton while the fetch is in flight', () => {
     mockUseFrequency.mockReturnValue({
       data: null,
@@ -39,7 +46,7 @@ describe('FrequencyBanner', () => {
       error: null,
       refetch: jest.fn(),
     });
-    const { getByTestId, queryByTestId } = render(<FrequencyBanner onSwitch={jest.fn()} />);
+    const { getByTestId, queryByTestId } = render(<FrequencyBanner />);
     expect(getByTestId('frequency-banner-skeleton')).toBeTruthy();
     expect(queryByTestId('frequency-banner-content')).toBeNull();
   });
@@ -52,41 +59,37 @@ describe('FrequencyBanner', () => {
       error: new Error('offline'),
       refetch,
     });
-    const { getByTestId } = render(<FrequencyBanner onSwitch={jest.fn()} />);
+    const { getByTestId } = render(<FrequencyBanner />);
     fireEvent.press(getByTestId('frequency-banner-retry'));
     expect(refetch).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the server banner_text verbatim — never assembles the copy itself', () => {
+  it('renders a slim colour/aspect chip — no paragraph, no switch hint', () => {
     mockUseFrequency.mockReturnValue({
       data: samplePayload,
       isLoading: false,
       error: null,
       refetch: jest.fn(),
     });
-    const { getByTestId } = render(<FrequencyBanner onSwitch={jest.fn()} />);
-    const body = getByTestId('frequency-banner-text');
-    expect(body.props.children).toBe(samplePayload.banner_text);
+    const { getByTestId, queryByTestId, queryByText } = render(<FrequencyBanner />);
+    expect(getByTestId('frequency-banner-color').props.children).toBe('Orange');
+    expect(getByTestId('frequency-banner-aspect').props.children).toBe('Mind');
+    // practice-redesign-02: the verbose paragraph + "tap to replace" hint are gone.
+    expect(queryByTestId('frequency-banner-text')).toBeNull();
+    expect(queryByText('Tap to replace this practice')).toBeNull();
   });
 
-  it('shows the aspect chip + colour swatch sourced from the server colour field', () => {
+  it('colours the swatch dot from the server colour field', () => {
     mockUseFrequency.mockReturnValue({
       data: samplePayload,
       isLoading: false,
       error: null,
       refetch: jest.fn(),
     });
-    const { getByTestId } = render(<FrequencyBanner onSwitch={jest.fn()} />);
-    expect(getByTestId('frequency-banner-aspect').props.children).toBe('Mind');
-    // The container's backgroundColor should track the Orange swatch.
-    const content = getByTestId('frequency-banner-content');
-    const flatStyle = Array.isArray(content.props.style)
-      ? Object.assign({}, ...content.props.style)
-      : content.props.style;
+    const { getByTestId } = render(<FrequencyBanner />);
     // Track the palette constant rather than a hardcoded hex so a designer
-    // tweak to the Orange swatch doesn't break this assertion before the
-    // WCAG-contrast contract has a chance to flag it.
-    expect(flatStyle.backgroundColor).toBe(COLOR_PALETTE.Orange.bg);
+    // tweak to the Orange swatch doesn't break this assertion.
+    expect(flatBackground(getByTestId('frequency-chip-dot'))).toBe(COLOR_PALETTE.Orange.bg);
   });
 
   it('falls back to the neutral swatch when the server sends an unknown colour', () => {
@@ -96,26 +99,19 @@ describe('FrequencyBanner', () => {
       error: null,
       refetch: jest.fn(),
     });
-    const { getByTestId } = render(<FrequencyBanner onSwitch={jest.fn()} />);
-    const content = getByTestId('frequency-banner-content');
-    const flatStyle = Array.isArray(content.props.style)
-      ? Object.assign({}, ...content.props.style)
-      : content.props.style;
-    // Clear Light fallback keeps the banner legible.
-    expect(flatStyle.backgroundColor).toBe(COLOR_PALETTE['Clear Light'].bg);
+    const { getByTestId } = render(<FrequencyBanner />);
+    expect(flatBackground(getByTestId('frequency-chip-dot'))).toBe(COLOR_PALETTE['Clear Light'].bg);
   });
 
-  it('invokes the onSwitch callback when the banner body is tapped', () => {
-    const onSwitch = jest.fn();
+  it('is display-only — the chip is not a button', () => {
     mockUseFrequency.mockReturnValue({
       data: samplePayload,
       isLoading: false,
       error: null,
       refetch: jest.fn(),
     });
-    const { getByTestId } = render(<FrequencyBanner onSwitch={onSwitch} />);
-    fireEvent.press(getByTestId('frequency-banner-content'));
-    expect(onSwitch).toHaveBeenCalledTimes(1);
+    const { getByTestId } = render(<FrequencyBanner />);
+    expect(getByTestId('frequency-banner-content').props.accessibilityRole).toBe('text');
   });
 
   it('accepts an injected data prop for storybook / testing — overrides the hook', () => {
@@ -127,10 +123,8 @@ describe('FrequencyBanner', () => {
       error: null,
       refetch: jest.fn(),
     });
-    const { getByTestId, queryByTestId } = render(
-      <FrequencyBanner data={samplePayload} onSwitch={jest.fn()} />,
-    );
-    expect(getByTestId('frequency-banner-text').props.children).toBe(samplePayload.banner_text);
+    const { getByTestId, queryByTestId } = render(<FrequencyBanner data={samplePayload} />);
+    expect(getByTestId('frequency-banner-color').props.children).toBe('Orange');
     // The hook's loading state must not bleed into the rendered output.
     expect(queryByTestId('frequency-banner-skeleton')).toBeNull();
   });

--- a/frontend/src/features/Practice/components/__tests__/FrequencyBanner.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/FrequencyBanner.test.tsx
@@ -74,7 +74,6 @@ describe('FrequencyBanner', () => {
     const { getByTestId, queryByTestId, queryByText } = render(<FrequencyBanner />);
     expect(getByTestId('frequency-banner-color').props.children).toBe('Orange');
     expect(getByTestId('frequency-banner-aspect').props.children).toBe('Mind');
-    // practice-redesign-02: the verbose paragraph + "tap to replace" hint are gone.
     expect(queryByTestId('frequency-banner-text')).toBeNull();
     expect(queryByText('Tap to replace this practice')).toBeNull();
   });


### PR DESCRIPTION
## Summary

practice-redesign-02: the paragraph banner — aspect chip + colour + full server `banner_text` + an italic *"Tap to replace this practice"* hint, with the **entire card a disguised switch button** — was the Practice screen's biggest source of clutter. This collapses it to a compact, **display-only** colour/aspect chip.

- **FrequencyBanner** now renders a slim pill: a colour swatch dot + colour name + aspect (still sourced from `useFrequency`/`swatchFor`). Dropped `banner_text`, the switch hint, and the `onSwitch` tap role (now `accessibilityRole="text"`). Loading / error / null branches kept.
- **ActiveRitualSession**: removed the redundant uppercase **"Your Practice"** label; the name stands alone.
- **PracticeScreen**: `usePracticeChrome` returns just the chip; it no longer opens the switcher.

### Sequencing note
Per the epic, the explicit **"Change practice" button** + switcher re-wiring are **practice-redesign-03 (#598)**, so the switcher *trigger* is intentionally absent in this PR. `PracticeSwitcherSheet` (and its own tests) are **kept** for #598/#599 (deletion is #599/04). This is the spec's staged hand-off, not a dropped feature.

## Test plan

- `FrequencyBanner.test`: chip shows colour + aspect; **no** paragraph, **no** "Tap to replace" hint; chip is **not** a button (`accessibilityRole="text"`); swatch dot colour tracks the palette; injected-data path.
- `PracticeScreen.test`: the chip is display-only and the switcher sheet is **not** mounted.
- `./scripts/frontend/check-all.sh` — 4/4.

Closes #597
Refs #595
