### PR TITLE
feat(frontend): one explicit "Change practice" action via the catalog

### DIFF
--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -102,13 +102,18 @@ const PracticeScreen = (): React.JSX.Element => {
   );
 };
 
+interface CatalogButtonProps {
+  stageNumber: number;
+  label: string;
+  testID: string;
+}
+
 /**
- * Discoverable entry point to the (now pushed) practice catalog, seeded with the
- * user's resolved stage. Rendered on the Practice screen in both the active and
- * selection states so the catalog stays reachable after it left the bottom nav
- * (practice-redesign-01).
+ * Button-shaped entry point to the (pushed) practice catalog, seeded with the
+ * user's resolved stage. Used as "Change practice" in the active state and
+ * "Browse all practices" in the selection state — both open the same catalog.
  */
-const BrowseAllPracticesButton = ({ stageNumber }: { stageNumber: number }): React.JSX.Element => {
+const CatalogButton = ({ stageNumber, label, testID }: CatalogButtonProps): React.JSX.Element => {
   // Catalog is a pushed RootStack screen (not a tab), so navigate with the
   // stack-typed navigation rather than the tab-scoped useAppNavigation.
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -117,10 +122,10 @@ const BrowseAllPracticesButton = ({ stageNumber }: { stageNumber: number }): Rea
       style={styles.browseCatalog}
       onPress={() => navigation.navigate('Catalog', { stageNumber })}
       accessibilityRole="button"
-      accessibilityLabel="Browse all practices"
-      testID="browse-catalog-button"
+      accessibilityLabel={label}
+      testID={testID}
     >
-      <Text style={styles.browseCatalogText}>Browse all practices</Text>
+      <Text style={styles.browseCatalogText}>{label}</Text>
     </TouchableOpacity>
   );
 };
@@ -162,10 +167,13 @@ const ActiveSessionView = ({
         testID="practice-screen"
       >
         {banner}
-        {/* Above the session by design: the catalog must be reachable from the
-            active state too (practice-redesign-01). It sits in the scroll header,
-            not over the timer, so it doesn't intercept mid-session taps. */}
-        <BrowseAllPracticesButton stageNumber={stageNumber} />
+        {/* The primary switch affordance, in the scroll header (not over the
+            timer, so it doesn't intercept mid-session taps). */}
+        <CatalogButton
+          stageNumber={stageNumber}
+          label="Change practice"
+          testID="change-practice-button"
+        />
         <ActiveRitualSession
           key={`practice-${userPractice.id}`}
           userPractice={userPractice}
@@ -211,7 +219,11 @@ const SelectionView = ({
     () => (
       <>
         {banner}
-        <BrowseAllPracticesButton stageNumber={stageNumber} />
+        <CatalogButton
+          stageNumber={stageNumber}
+          label="Browse all practices"
+          testID="browse-catalog-button"
+        />
       </>
     ),
     [banner, stageNumber],

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -323,12 +323,12 @@ describe('PracticeScreen', () => {
     });
   });
 
-  it('browse-all-practices opens the Catalog from the active-session state too', async () => {
+  it('change-practice opens the Catalog seeded to the current stage', async () => {
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId } = render(<PracticeScreen />);
     await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
 
-    fireEvent.press(getByTestId('browse-catalog-button'));
+    fireEvent.press(getByTestId('change-practice-button'));
     expect(mockRootNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: 1 });
   });
 

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -22,6 +22,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   SectionList,
   StyleSheet,
   Text,
@@ -31,9 +32,9 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { type PracticeItem, practices } from '@/api';
+import { type PracticeItem, practices, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import { BORDER_RADIUS, SPACING, colors, shadows, touchTarget } from '@/design/tokens';
 import { MODE_CATEGORIES, type PickableMode } from '@/features/Practice/components/ModePicker';
 import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
 import type { RootStackParamList } from '@/navigation/RootStack';
@@ -49,6 +50,8 @@ interface CatalogProps {
   navigateToDetail?: (practiceId: number) => void;
   /** Override for tests; otherwise opens ``CreatePractice``. */
   navigateToCreate?: () => void;
+  /** Override for tests; otherwise sets the active practice via the API. */
+  setActive?: (practiceId: number, stageNumber: number) => Promise<void>;
 }
 
 interface CatalogState {
@@ -65,7 +68,7 @@ interface CatalogState {
 export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Element {
   // Destructure so the useCallback deps below are stable field refs, not the
   // ``props`` object (a fresh ref each render that would defeat memoization).
-  const { initialStage, loadPractices, navigateToDetail, navigateToCreate } = props;
+  const { initialStage, loadPractices, navigateToDetail, navigateToCreate, setActive } = props;
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const seededStage = useSeededStage(initialStage);
   const [stageNumber, setStageNumber] = useState(seededStage);
@@ -78,8 +81,9 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
     navigateToDetail,
     navigateToCreate,
   );
+  const onUse = useCatalogSetActive(stageNumber, navigation, setActive);
 
-  const { sections, renderItem } = useCatalogList(state, query, modeCategory, onDetail);
+  const { sections, renderItem } = useCatalogList(state, query, modeCategory, onDetail, onUse);
   const insets = useSafeAreaInsets();
   const containerStyle = [styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom }];
 
@@ -129,16 +133,45 @@ function useCatalogList(
   query: string,
   modeCategory: string | null,
   onDetail: (id: number) => void,
+  onUse: (id: number) => void,
 ): { sections: CatalogSection[]; renderItem: (info: { item: PracticeItem }) => React.JSX.Element } {
   const sections = useMemo(
     () => buildSections(state.practices, query, modeCategory),
     [state.practices, query, modeCategory],
   );
   const renderItem = useCallback(
-    ({ item }: { item: PracticeItem }) => <PracticeRow practice={item} onDetail={onDetail} />,
-    [onDetail],
+    ({ item }: { item: PracticeItem }) => (
+      <PracticeRow practice={item} onDetail={onDetail} onUse={onUse} />
+    ),
+    [onDetail, onUse],
   );
   return { sections, renderItem };
+}
+
+/** One-tap "use this practice" — set it active for the catalog's current stage,
+ * then return to the Practice screen. Errors surface in an alert. */
+function useCatalogSetActive(
+  stageNumber: number,
+  navigation: NativeStackNavigationProp<RootStackParamList>,
+  override: CatalogProps['setActive'],
+): (id: number) => void {
+  return useCallback(
+    (id: number) => {
+      void (async () => {
+        try {
+          if (override) {
+            await override(id, stageNumber);
+          } else {
+            await userPractices.create({ practice_id: id, stage_number: stageNumber });
+          }
+          navigation.goBack();
+        } catch (err) {
+          Alert.alert('Could not set practice', formatApiError(err, { fallback: 'Try again.' }));
+        }
+      })();
+    },
+    [stageNumber, navigation, override],
+  );
 }
 
 function useCatalogNavigation(
@@ -395,6 +428,7 @@ const FilterChip = ({ label, selected, onPress, testID }: FilterChipProps): Reac
 interface PracticeRowProps {
   practice: PracticeItem;
   onDetail: (id: number) => void;
+  onUse: (id: number) => void;
 }
 
 // Derived from MODE_CATEGORIES so adding a mode propagates here automatically.
@@ -407,30 +441,45 @@ const MODE_PRESENTATION: Readonly<Record<PickableMode, { label: string; icon: st
 
 const FALLBACK_PRESENTATION = { label: 'Practice', icon: '🧘' } as const;
 
-const PracticeRowComponent = ({ practice, onDetail }: PracticeRowProps): React.JSX.Element => {
+const PracticeRowComponent = ({
+  practice,
+  onDetail,
+  onUse,
+}: PracticeRowProps): React.JSX.Element => {
   const mode = (practice.mode ?? 'meditation_timer') as PickableMode;
   const { label, icon } = MODE_PRESENTATION[mode] ?? FALLBACK_PRESENTATION;
   const duration = Math.round(practice.default_duration_minutes);
   const subtitle = `${label} · ${duration} min`;
   return (
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessibilityLabel={`${practice.name}. ${label}, ${duration} minutes.`}
-      onPress={() => onDetail(practice.id)}
-      style={styles.row}
-      testID={`practice-catalog-row-${practice.id}`}
-    >
-      {/* Decorative; TouchableOpacity merges children, so screen readers use accessibilityLabel. */}
-      <Text style={styles.rowIcon} testID={`practice-catalog-row-${practice.id}-icon`}>
-        {icon}
-      </Text>
-      <View style={styles.rowText}>
-        <Text style={styles.rowName} numberOfLines={1}>
-          {practice.name}
+    <View style={styles.rowContainer} testID={`practice-catalog-row-${practice.id}-container`}>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={`${practice.name}. ${label}, ${duration} minutes.`}
+        onPress={() => onDetail(practice.id)}
+        style={styles.row}
+        testID={`practice-catalog-row-${practice.id}`}
+      >
+        {/* Decorative; TouchableOpacity merges children, so screen readers use accessibilityLabel. */}
+        <Text style={styles.rowIcon} testID={`practice-catalog-row-${practice.id}-icon`}>
+          {icon}
         </Text>
-        <Text style={styles.rowSubtitle}>{subtitle}</Text>
-      </View>
-    </TouchableOpacity>
+        <View style={styles.rowText}>
+          <Text style={styles.rowName} numberOfLines={1}>
+            {practice.name}
+          </Text>
+          <Text style={styles.rowSubtitle}>{subtitle}</Text>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={`Use ${practice.name}`}
+        onPress={() => onUse(practice.id)}
+        style={styles.rowUse}
+        testID={`practice-catalog-row-${practice.id}-use`}
+      >
+        <Text style={styles.rowUseText}>Use</Text>
+      </TouchableOpacity>
+    </View>
   );
 };
 
@@ -565,16 +614,33 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.sm,
   },
   emptyText: { color: colors.text.tertiaryAccessible, fontSize: 13 },
+  rowContainer: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: SPACING.sm,
+    marginBottom: SPACING.sm,
+  },
   row: {
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     gap: SPACING.md,
     backgroundColor: colors.background.card,
     borderRadius: BORDER_RADIUS.lg,
     padding: SPACING.md,
-    marginBottom: SPACING.sm,
     ...shadows.small,
   },
+  rowUse: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: SPACING.md,
+    minWidth: touchTarget.minimum,
+    minHeight: touchTarget.minimum,
+    backgroundColor: colors.primary,
+    borderRadius: BORDER_RADIUS.lg,
+    ...shadows.small,
+  },
+  rowUseText: { color: colors.text.light, fontWeight: '700', fontSize: 14 },
   rowIcon: { fontSize: 24, width: 32, textAlign: 'center' },
   rowText: { flex: 1 },
   rowName: { fontSize: 15, fontWeight: '700', color: colors.text.primary },

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -26,6 +26,7 @@ import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
 import type { RootStackParamList } from '@/navigation/RootStack';
+import { selectCurrentStage, useStageStore } from '@/store/useStageStore';
 
 export type PracticeDetailScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -64,6 +65,7 @@ function initialState(): ScreenState {
 export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JSX.Element {
   const { practiceId } = props.route.params;
   const state = usePracticeDetail(practiceId);
+  const currentStage = useStageStore(selectCurrentStage);
   if (state.loading) {
     return (
       <View style={styles.loading} testID="practice-detail-loading">
@@ -92,6 +94,7 @@ export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JS
       )}
       <ActionRow
         practice={state.practice}
+        onUseForCurrentStage={() => void state.assign(currentStage)}
         onUseForStage={state.openPicker}
         onCustomizeCopy={() => navigateToCopy(props, state.practice!)}
       />
@@ -306,12 +309,14 @@ function summarizeConfig(config: ModeConfig): readonly string[] {
 
 interface ActionRowProps {
   practice: PracticeItem;
+  onUseForCurrentStage: () => void;
   onUseForStage: () => void;
   onCustomizeCopy: () => void;
 }
 
 const ActionRow = ({
   practice,
+  onUseForCurrentStage,
   onUseForStage,
   onCustomizeCopy,
 }: ActionRowProps): React.JSX.Element => (
@@ -322,10 +327,15 @@ const ActionRow = ({
   // adds an owner hint.
   <View style={styles.actionRow}>
     <ActionButton
+      label="Use for current stage"
+      onPress={onUseForCurrentStage}
+      testID="practice-detail-use-current-stage"
+      primary
+    />
+    <ActionButton
       label="Use for stage…"
       onPress={onUseForStage}
       testID="practice-detail-use-for-stage"
-      primary
     />
     <ActionButton
       label="Customize a copy"

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -326,6 +326,9 @@ const ActionRow = ({
   // "Customize a copy" covers the in-app equivalent until the backend
   // adds an owner hint.
   <View style={styles.actionRow}>
+    {/* "Use for current stage" is the common one-tap path; "Use for stage…"
+        keeps the explicit 1–10 picker for assigning to a different stage. The
+        current stage overlaps one picker option by design. */}
     <ActionButton
       label="Use for current stage"
       onPress={onUseForCurrentStage}

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { act, fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
+import { Alert } from 'react-native';
 
 import type { PracticeItem } from '@/api';
 
@@ -74,7 +75,10 @@ jest.mock('@react-navigation/native', () => ({
   useRoute: () => mockRoute,
 }));
 
-const mockNavigation = { navigate: jest.fn() as jest.Mock<(...args: unknown[]) => void> };
+const mockNavigation = {
+  navigate: jest.fn() as jest.Mock<(...args: unknown[]) => void>,
+  goBack: jest.fn() as jest.Mock<() => void>,
+};
 const mockRoute: { params?: { stageNumber?: number } } = { params: undefined };
 
 const mockPracticesList = jest.fn() as jest.MockedFunction<
@@ -251,6 +255,7 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
   beforeEach(() => {
     mockPracticesList.mockReset();
     mockNavigation.navigate.mockReset();
+    mockNavigation.goBack.mockReset();
     mockRoute.params = undefined;
   });
 
@@ -277,7 +282,7 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
     expect(mockPracticesList).toHaveBeenCalledWith({ stageNumber: 6, includeMine: true });
   });
 
-  it('sets the practice active for the seeded stage when "Use" is tapped', async () => {
+  it('sets the practice active for the seeded stage when "Use" is tapped, then goes back', async () => {
     const setActive = jest.fn(async () => undefined) as jest.MockedFunction<
       (id: number, stage: number) => Promise<void>
     >;
@@ -286,6 +291,21 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
     await waitForLoad();
     fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
     expect(setActive).toHaveBeenCalledWith(1, 2);
+    await waitFor(() => expect(mockNavigation.goBack).toHaveBeenCalledTimes(1));
+  });
+
+  it('alerts and stays put when setting the practice active fails', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    const setActive = jest.fn(async () => {
+      throw new Error('boom');
+    }) as jest.MockedFunction<(id: number, stage: number) => Promise<void>>;
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    const view = render(<PracticeCatalogScreen initialStage={2} setActive={setActive} />);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(1));
+    expect(mockNavigation.goBack).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
   });
 
   it('navigates to PracticeDetail when a row is tapped without an override', async () => {

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -277,6 +277,17 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
     expect(mockPracticesList).toHaveBeenCalledWith({ stageNumber: 6, includeMine: true });
   });
 
+  it('sets the practice active for the seeded stage when "Use" is tapped', async () => {
+    const setActive = jest.fn(async () => undefined) as jest.MockedFunction<
+      (id: number, stage: number) => Promise<void>
+    >;
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    const view = render(<PracticeCatalogScreen initialStage={2} setActive={setActive} />);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
+    expect(setActive).toHaveBeenCalledWith(1, 2);
+  });
+
   it('navigates to PracticeDetail when a row is tapped without an override', async () => {
     mockPracticesList.mockResolvedValueOnce([presetA]);
     const view = render(<PracticeCatalogScreen initialStage={1} />);

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -129,6 +129,21 @@ describe('PracticeDetailScreen — Use for stage', () => {
     mockUserPracticesCreate.mockReset();
   });
 
+  it('sets the practice active for the current stage in one tap (no picker)', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
+    const { view } = renderScreen();
+    await waitForLoad();
+    await act(async () => {
+      fireEvent.press(view.getByTestId('practice-detail-use-current-stage'));
+      await flushPromises();
+    });
+    // Store default current stage is 1; no stage picker is opened.
+    expect(mockUserPracticesCreate).toHaveBeenCalledWith({ practice_id: 77, stage_number: 1 });
+    expect(view.queryByTestId('practice-detail-stage-picker')).toBeNull();
+    expect(view.getByTestId('practice-detail-assigned-banner')).toBeTruthy();
+  });
+
   it('opens the stage picker and writes via userPractices.create on pick', async () => {
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
     mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);


### PR DESCRIPTION
## Summary

practice-redesign-03: replace the disguised banner-tap switch (the "message that doesn't look clickable") with **one obvious, button-shaped action**, and let the catalog set the active practice directly.

- **PracticeScreen** (active view): a clearly-labelled **"Change practice"** button opens the catalog seeded to the resolved current stage. The selection view keeps **"Browse all practices"** — both go through a shared `CatalogButton`.
- **PracticeCatalogScreen**: each row gets a one-tap **"Use"** button that sets the active `UserPractice` for the catalog's current stage (`userPractices.create`), then navigates back; failures surface via `Alert` + `formatApiError`. A test-only `setActive` override mirrors the existing injection props.
- **PracticeDetailScreen**: added a primary **"Use for current stage"** action (sets active for the store's current stage in one tap) alongside the existing "Use for stage…" picker.

The frequency chip + `PracticeSwitcherSheet` are unchanged; the sheet is still not mounted by `PracticeScreen` (removed in #597) and is left for a later cleanup (#599/04).

## Test plan

- `PracticeScreen`: "Change practice" navigates to `Catalog` with the current stage.
- `PracticeCatalogScreen`: "Use" sets active for the seeded stage (asserts `setActive(id, stage)`).
- `PracticeDetailScreen`: "Use for current stage" sets active (`create({practice_id, stage_number: 1})`) **without** opening the picker.
- `./scripts/frontend/check-all.sh` — 4/4.

Closes #598
Refs #595
