### PR TITLE
feat(frontend): disentangle the adjust / duplicate / switch affordances

### DIFF
--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -302,14 +302,20 @@ describe('PracticeScreen', () => {
     expect(getByTestId('practice-error')).toHaveStyle({ paddingTop: 47, paddingBottom: 34 });
   });
 
-  it('renders the active practice card with configure gear when a practice is selected', async () => {
+  it('renders the active practice card with an "Adjust" control when a practice is selected', async () => {
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
-    const { getByTestId } = render(<PracticeScreen />);
+    const { getByTestId, getByText } = render(<PracticeScreen />);
     await waitFor(() => {
       expect(getByTestId('active-practice-card')).toBeTruthy();
       expect(getByTestId('active-practice-configure')).toBeTruthy();
       expect(getByTestId('meditation-timer-view')).toBeTruthy();
     });
+    // The settings control reads "Adjust" (per-user override), distinct from
+    // the "Change practice" switch CTA.
+    expect(getByText('Adjust')).toBeTruthy();
+    expect(getByTestId('active-practice-configure').props.accessibilityLabel).toBe(
+      "Adjust this practice's settings",
+    );
   });
 
   it('change-practice opens the Catalog seeded to the current stage', async () => {

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -310,8 +310,6 @@ describe('PracticeScreen', () => {
       expect(getByTestId('active-practice-configure')).toBeTruthy();
       expect(getByTestId('meditation-timer-view')).toBeTruthy();
     });
-    // The settings control reads "Adjust" (per-user override), distinct from
-    // the "Change practice" switch CTA.
     expect(getByText('Adjust')).toBeTruthy();
     expect(getByTestId('active-practice-configure').props.accessibilityLabel).toBe(
       "Adjust this practice's settings",

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -912,6 +912,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: SPACING.xs,
+    minWidth: 44,
     minHeight: 44,
     paddingHorizontal: SPACING.sm,
   },

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -416,12 +416,13 @@ function SessionCard(props: SessionCardProps): React.JSX.Element {
       <View style={styles.cardHeader}>
         <TouchableOpacity
           accessibilityRole="button"
-          accessibilityLabel="Configure practice"
+          accessibilityLabel="Adjust this practice's settings"
           onPress={props.onConfigure}
           style={styles.gearButton}
           testID="active-practice-configure"
         >
           <Text style={styles.gearText}>⚙︎</Text>
+          <Text style={styles.gearLabel}>Adjust</Text>
         </TouchableOpacity>
       </View>
       <Text style={styles.name} testID="active-practice-name">
@@ -903,17 +904,19 @@ const styles = StyleSheet.create({
   },
   cardHeader: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-end',
     alignItems: 'center',
     marginBottom: SPACING.xs,
   },
   gearButton: {
-    minWidth: 44,
-    minHeight: 44,
+    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
+    gap: SPACING.xs,
+    minHeight: 44,
+    paddingHorizontal: SPACING.sm,
   },
-  gearText: { fontSize: 22, color: colors.text.secondary },
+  gearText: { fontSize: 18, color: colors.text.secondary },
+  gearLabel: { fontSize: 14, fontWeight: '600', color: colors.text.secondary },
   name: {
     fontSize: 20,
     fontWeight: '700',

--- a/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
+++ b/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
@@ -185,6 +185,19 @@ const ResetButton = ({ disabled, onPress }: ResetButtonProps): React.JSX.Element
   </TouchableOpacity>
 );
 
+/** States plainly that the configurator edits the user's own copy, not the
+ * shared practice — disambiguates "Adjust" from "Duplicate & edit"/"Change". */
+const ConfiguratorTitle = (): React.JSX.Element => (
+  <>
+    <Text style={styles.headerTitle} testID="ritual-configurator-title">
+      Adjust your practice
+    </Text>
+    <Text style={styles.headerSubtitle} testID="ritual-configurator-subtitle">
+      Changes apply only to your copy — the shared practice is unchanged.
+    </Text>
+  </>
+);
+
 interface HeaderProps {
   name: string;
   aspect: string | null;
@@ -203,6 +216,7 @@ const ConfiguratorHeader = ({
   canSave,
 }: HeaderProps): React.JSX.Element => (
   <View style={styles.header}>
+    <ConfiguratorTitle />
     <View style={styles.nameRow}>
       <TextInput
         style={styles.nameInput}
@@ -366,6 +380,8 @@ const styles = StyleSheet.create({
     borderBottomColor: colors.background.accent,
     gap: SPACING.sm,
   },
+  headerTitle: { fontSize: 18, fontWeight: '700', color: colors.text.primary },
+  headerSubtitle: { fontSize: 13, color: colors.text.secondary },
   nameRow: { flexDirection: 'row', alignItems: 'center', gap: SPACING.sm },
   nameInput: {
     flex: 1,

--- a/frontend/src/features/Practice/configurator/__tests__/RitualConfiguratorSheet.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/RitualConfiguratorSheet.test.tsx
@@ -50,6 +50,12 @@ describe('RitualConfiguratorSheet', () => {
     expect(getByTestId('ritual-configurator-aspect')).toBeTruthy();
   });
 
+  it('header makes the per-user-override scope explicit', () => {
+    const { getByTestId } = renderSheet();
+    expect(getByTestId('ritual-configurator-title').props.children).toBe('Adjust your practice');
+    expect(getByTestId('ritual-configurator-subtitle').props.children).toContain('your copy');
+  });
+
   it('disables save until the form is dirty', () => {
     const { getByTestId } = renderSheet();
     const save = getByTestId('ritual-configurator-save');

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -341,9 +341,10 @@ const ActionRow = ({
       testID="practice-detail-use-for-stage"
     />
     <ActionButton
-      label="Customize a copy"
+      label="Duplicate & edit"
       onPress={onCustomizeCopy}
       testID="practice-detail-customize-copy"
+      accessibilityLabel="Duplicate this practice into a new, editable copy"
       disabled={practice.mode_config === undefined}
     />
   </View>
@@ -355,6 +356,7 @@ interface ActionButtonProps {
   testID: string;
   primary?: boolean;
   disabled?: boolean;
+  accessibilityLabel?: string;
 }
 
 const ActionButton = ({
@@ -363,10 +365,11 @@ const ActionButton = ({
   testID,
   primary = false,
   disabled = false,
+  accessibilityLabel,
 }: ActionButtonProps): React.JSX.Element => (
   <TouchableOpacity
     accessibilityRole="button"
-    accessibilityLabel={label}
+    accessibilityLabel={accessibilityLabel ?? label}
     accessibilityState={{ disabled }}
     onPress={disabled ? undefined : onPress}
     style={[

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -176,13 +176,18 @@ describe('PracticeDetailScreen — Use for stage', () => {
   });
 });
 
-describe('PracticeDetailScreen — Customize a copy', () => {
-  it('navigates to CreatePractice with this practice prefilled', async () => {
+describe('PracticeDetailScreen — Duplicate & edit', () => {
+  it('reads "Duplicate & edit" and navigates to CreatePractice with this practice prefilled', async () => {
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
     const nav = makeNav();
     const { view } = renderScreen(77, nav);
     await waitForLoad();
-    fireEvent.press(view.getByTestId('practice-detail-customize-copy'));
+    const button = view.getByTestId('practice-detail-customize-copy');
+    expect(view.getByText('Duplicate & edit')).toBeTruthy();
+    expect(button.props.accessibilityLabel).toBe(
+      'Duplicate this practice into a new, editable copy',
+    );
+    fireEvent.press(button);
     expect(nav.navigate).toHaveBeenCalledWith(
       'CreatePractice',
       expect.objectContaining({


### PR DESCRIPTION
## Summary

practice-redesign-05: three actions all read like "edit" and were indistinguishable ("edit buttons edit the wrong thing"). This makes each verb distinct in **label and presentation only** — no behaviour change to what any action does.

- **Active card → "Adjust"**: the bare gear glyph becomes a labelled control (gear adornment + visible **"Adjust"** text, `accessibilityLabel="Adjust this practice's settings"`). It edits the per-user override, not the shared practice.
- **Detail → "Duplicate & edit"**: renamed "Customize a copy" (testID unchanged) with a clearer `accessibilityLabel`; `navigateToCopy` behaviour unchanged.
- **Configurator header**: a title **"Adjust your practice"** + subtitle stating *changes apply only to your copy*, so the per-user-override scope is obvious. "Reset to default" kept.
- The #598 **"Change practice"** (switch → catalog) and this **"Adjust"** (→ configurator) are now visibly distinct.

## Test plan

- `PracticeScreen.test`: the active card shows **"Adjust"** with the new a11y label.
- `PracticeDetailScreen.test`: the copy action reads **"Duplicate & edit"** with its a11y label.
- `RitualConfiguratorSheet.test`: header states the per-user scope ("Adjust your practice" + "your copy").
- `./scripts/frontend/check-all.sh` — 4/4.

Closes #600
Refs #595
