### PR TITLE
refactor(frontend): de-duplicate and tighten Practice copy

### DIFF
--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -257,10 +257,7 @@ interface EntryStepProps {
 
 const EntryStep = ({ onPickPreset, onStartScratch }: EntryStepProps): React.JSX.Element => (
   <View testID="create-practice-step-entry">
-    <Text style={styles.bodyLead}>
-      Most adepts find it fastest to copy a preset and tweak it. Start from scratch when no preset
-      is close to what you have in mind.
-    </Text>
+    <Text style={styles.bodyLead}>Start from a preset and tweak it, or build from scratch.</Text>
     <PrimaryCard
       title="Start from a preset"
       subtitle="Browse the catalog and customize a copy."
@@ -320,10 +317,7 @@ const ConfigureStep = (props: ConfigureStepProps): React.JSX.Element => {
   const canProceed = errors.length === 0;
   return (
     <View testID="create-practice-step-configure">
-      <Text style={styles.bodyLead}>
-        Smart defaults are already filled in. Tweak anything that doesn&apos;t fit, or jump ahead to
-        naming.
-      </Text>
+      <Text style={styles.bodyLead}>Defaults are filled in — tweak or continue.</Text>
       <ConfiguratorBody config={config} onChange={props.onChange} />
       <ErrorList errors={errors} />
       <NavRow

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -37,6 +37,7 @@ import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows, touchTarget } from '@/design/tokens';
 import { MODE_CATEGORIES, type PickableMode } from '@/features/Practice/components/ModePicker';
 import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
+import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 type Section = 'presets' | 'drafts' | 'imported';
@@ -448,13 +449,12 @@ const PracticeRowComponent = ({
 }: PracticeRowProps): React.JSX.Element => {
   const mode = (practice.mode ?? 'meditation_timer') as PickableMode;
   const { label, icon } = MODE_PRESENTATION[mode] ?? FALLBACK_PRESENTATION;
-  const duration = Math.round(practice.default_duration_minutes);
-  const subtitle = `${label} · ${duration} min`;
+  const subtitle = `${label} · ${formatDuration(practice.default_duration_minutes)}`;
   return (
     <View style={styles.rowContainer} testID={`practice-catalog-row-${practice.id}-container`}>
       <TouchableOpacity
         accessibilityRole="button"
-        accessibilityLabel={`${practice.name}. ${label}, ${duration} minutes.`}
+        accessibilityLabel={`${practice.name}. ${subtitle}.`}
         onPress={() => onDetail(practice.id)}
         style={styles.row}
         testID={`practice-catalog-row-${practice.id}`}

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -449,12 +449,11 @@ const PracticeRowComponent = ({
 }: PracticeRowProps): React.JSX.Element => {
   const mode = (practice.mode ?? 'meditation_timer') as PickableMode;
   const { label, icon } = MODE_PRESENTATION[mode] ?? FALLBACK_PRESENTATION;
-  const subtitle = `${label} · ${formatDuration(practice.default_duration_minutes)}`;
+  const rounded = Math.round(practice.default_duration_minutes);
+  const subtitle = `${label} · ${formatDuration(rounded)}`;
   // Spoken label avoids the visual "·" separator and spells out "minutes"
   // (abbreviations + glyphs read poorly under VoiceOver/TalkBack).
-  const a11yLabel = `${practice.name}. ${label}, ${Math.round(
-    practice.default_duration_minutes,
-  )} minutes.`;
+  const a11yLabel = `${practice.name}. ${label}, ${rounded} minutes.`;
   return (
     <View style={styles.rowContainer} testID={`practice-catalog-row-${practice.id}-container`}>
       <TouchableOpacity

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -450,11 +450,16 @@ const PracticeRowComponent = ({
   const mode = (practice.mode ?? 'meditation_timer') as PickableMode;
   const { label, icon } = MODE_PRESENTATION[mode] ?? FALLBACK_PRESENTATION;
   const subtitle = `${label} · ${formatDuration(practice.default_duration_minutes)}`;
+  // Spoken label avoids the visual "·" separator and spells out "minutes"
+  // (abbreviations + glyphs read poorly under VoiceOver/TalkBack).
+  const a11yLabel = `${practice.name}. ${label}, ${Math.round(
+    practice.default_duration_minutes,
+  )} minutes.`;
   return (
     <View style={styles.rowContainer} testID={`practice-catalog-row-${practice.id}-container`}>
       <TouchableOpacity
         accessibilityRole="button"
-        accessibilityLabel={`${practice.name}. ${subtitle}.`}
+        accessibilityLabel={a11yLabel}
         onPress={() => onDetail(practice.id)}
         style={styles.row}
         testID={`practice-catalog-row-${practice.id}`}

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -25,6 +25,7 @@ import { type PracticeItem, practices, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
 import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
+import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import type { RootStackParamList } from '@/navigation/RootStack';
 import { selectCurrentStage, useStageStore } from '@/store/useStageStore';
 
@@ -206,7 +207,7 @@ const DetailHeader = ({ practice }: DetailHeaderProps): React.JSX.Element => (
       <BadgeChip label={practice.mode ?? 'meditation_timer'} testID="practice-detail-mode-badge" />
       <BadgeChip label={`Stage ${practice.stage_number}`} testID="practice-detail-stage-badge" />
       <BadgeChip
-        label={`${Math.round(practice.default_duration_minutes)} min`}
+        label={formatDuration(practice.default_duration_minutes)}
         testID="practice-detail-duration-badge"
       />
     </View>

--- a/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
@@ -115,11 +115,12 @@ describe('CreatePracticeWizard — step navigation', () => {
     mockUserPracticesCreate.mockReset();
   });
 
-  it('opens on the entry step with two start options', () => {
+  it('opens on the entry step with two start options and a one-line lead', () => {
     const { view } = renderScreen();
     expect(view.getByTestId('create-practice-step-entry')).toBeTruthy();
     expect(view.getByTestId('create-practice-from-preset')).toBeTruthy();
     expect(view.getByTestId('create-practice-from-scratch')).toBeTruthy();
+    expect(view.getByText('Start from a preset and tweak it, or build from scratch.')).toBeTruthy();
   });
 
   it('applies safe-area insets to the wizard container', () => {

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -308,6 +308,16 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
     alertSpy.mockRestore();
   });
 
+  it('gives the row a spoken-friendly accessibility label (no glyphs, "minutes" spelled out)', async () => {
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    const view = render(<PracticeCatalogScreen initialStage={1} />);
+    await waitForLoad();
+    const label = view.getByTestId('practice-catalog-row-1').props.accessibilityLabel as string;
+    expect(label).toBe('Concentration on the breath. Meditation timer, 10 minutes.');
+    expect(label).not.toContain('·');
+    expect(label).not.toMatch(/\bmin\b/);
+  });
+
   it('navigates to PracticeDetail when a row is tapped without an override', async () => {
     mockPracticesList.mockResolvedValueOnce([presetA]);
     const view = render(<PracticeCatalogScreen initialStage={1} />);

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -102,6 +102,8 @@ describe('PracticeDetailScreen — read-only summary', () => {
     expect(view.getByTestId('practice-detail-instructions')).toBeTruthy();
     expect(view.getByTestId('practice-detail-mode-badge')).toBeTruthy();
     expect(view.getByTestId('practice-detail-stage-badge')).toBeTruthy();
+    // Duration badge uses the shared formatter ("{n} min").
+    expect(view.getByText('5 min')).toBeTruthy();
   });
 
   it('renders a per-mode config summary block', async () => {

--- a/frontend/src/features/Practice/utils/__tests__/formatDuration.test.ts
+++ b/frontend/src/features/Practice/utils/__tests__/formatDuration.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { formatDuration } from '../formatDuration';
+
+describe('formatDuration', () => {
+  it('renders whole minutes with the "min" unit', () => {
+    expect(formatDuration(10)).toBe('10 min');
+    expect(formatDuration(1)).toBe('1 min');
+    expect(formatDuration(0)).toBe('0 min');
+  });
+
+  it('rounds fractional minutes to the nearest whole minute', () => {
+    expect(formatDuration(9.4)).toBe('9 min');
+    expect(formatDuration(9.6)).toBe('10 min');
+  });
+});

--- a/frontend/src/features/Practice/utils/formatDuration.ts
+++ b/frontend/src/features/Practice/utils/formatDuration.ts
@@ -1,0 +1,11 @@
+/**
+ * Single source of truth for rendering a practice duration. Every surface
+ * (catalog rows, detail badge, …) phrases it the same way so the copy never
+ * drifts between screens.
+ *
+ * Rounds to whole minutes — sub-minute precision is noise for a practice
+ * length, and the API already stores minutes.
+ */
+export function formatDuration(minutes: number): string {
+  return `${Math.round(minutes)} min`;
+}


### PR DESCRIPTION
## Summary

practice-redesign-06: the same facts were phrased differently across surfaces and the guidance copy was wordy. This introduces **one shared duration formatter** and **trims the verbose helper sentences** (wording + a tiny util; no layout change — that's #602).

- **`utils/formatDuration.ts`** (single `"{n} min"` phrasing) + unit test; used for the catalog row subtitle and the detail duration badge, so duration reads identically everywhere.
- **Wizard copy shortened** to one line each:
  - entry lead → *"Start from a preset and tweak it, or build from scratch."*
  - configure-step lead → *"Defaults are filled in — tweak or continue."*

The detail screen already shows each fact **once** (mode/stage/duration as badges; the config summary lists per-mode config params, not a mode restatement). The `ModePicker` blurbs were already one short line each, so they were left as-is.

## Test plan

- `utils/__tests__/formatDuration.test.ts`: whole minutes, rounding, zero.
- Existing catalog/detail/wizard suites stay green with the shared phrasing (subtitle format `"{label} · {n} min"` unchanged).
- `./scripts/frontend/check-all.sh` — 4/4.

Closes #601
Refs #595
