### PR TITLE
style(frontend): flatten the active practice card for a calmer surface

### DIFF
--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -35,7 +35,7 @@ import type {
 } from '@/api';
 import { practiceSessions } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import { SPACING, colors } from '@/design/tokens';
 import { InsightCaptureModal } from '@/features/Practice/components/InsightCaptureModal';
 import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConfiguratorSheet';
 import type { PickedCard } from '@/features/Practice/data/resolveCard';
@@ -895,12 +895,13 @@ function repCounterSummary(config: RepCounterConfig, state: RitualState): ModeSu
 }
 
 const styles = StyleSheet.create({
+  // Flat surface: the session sits directly on the screen's padded scroll, with
+  // a hairline divider instead of a nested shadowed card-in-a-frame.
   card: {
-    margin: SPACING.lg,
-    backgroundColor: colors.background.card,
-    borderRadius: BORDER_RADIUS.lg,
-    padding: SPACING.lg,
-    ...shadows.medium,
+    paddingBottom: SPACING.lg,
+    marginBottom: SPACING.lg,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.background.accent,
   },
   cardHeader: {
     flexDirection: 'row',

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -895,8 +895,8 @@ function repCounterSummary(config: RepCounterConfig, state: RitualState): ModeSu
 }
 
 const styles = StyleSheet.create({
-  // Flat surface: the session sits directly on the screen's padded scroll, with
-  // a hairline divider instead of a nested shadowed card-in-a-frame.
+  // Flat surface: the session sits on the screen's padded scroll, separated from
+  // the footer by a hairline divider (no elevation).
   card: {
     paddingBottom: SPACING.lg,
     marginBottom: SPACING.lg,


### PR DESCRIPTION
## Summary

practice-redesign-07 (visual-only pass): the active session was a shadowed card (`shadows.medium` + card background + radius) floating inside the screen's own padded scroll — a **card-in-a-frame** that read busy.

- **Flattened the active screen**: the session now sits directly on the screen's padded surface, separated from the weekly-progress footer by a single **hairline divider** (`StyleSheet.hairlineWidth` + `colors.background.accent`) instead of stacked shadow + nested card. Removed the now-unused `shadows` / `BORDER_RADIUS` / `background.card` usage and imports.

### Scope notes
- **No behaviour, navigation, or copy change**; touch targets and a11y labels untouched.
- The Catalog/Detail surfaces already pull spacing, radii, and a single row elevation (`shadows.small`) from `design/tokens` — no off-scale literals were introduced. The only remaining 1–2px row nudges have no matching sub-`xs` token, and changing them would shift spacing the spec says to preserve, so they're left as-is.

## Test plan

- Existing Practice / active-session suites stay green (no test asserted the old card shadow/background); 64 tests pass.
- `./scripts/frontend/check-all.sh` — 4/4.

Closes #602
Refs #595
