### PR TITLE
feat(backend): add Marginalia model + migration for anchored margin notes

### DIFF
--- a/backend/migrations/versions/f6e5d4c3b2a1_add_marginalia.py
+++ b/backend/migrations/versions/f6e5d4c3b2a1_add_marginalia.py
@@ -1,0 +1,52 @@
+"""add marginalia table for anchored AI margin notes
+
+Revision ID: f6e5d4c3b2a1
+Revises: b7c8d9e0f1a2
+Create Date: 2026-06-27 00:00:00.000000
+
+Purely additive: ``upgrade`` creates the ``marginalia`` table (margin notes
+anchored to a character span of a journal entry) plus its FK index; ``downgrade``
+drops them. No ``ALTER`` / ``DROP`` against existing tables. The ``journal_entry_id``
+FK cascades so deleting a journal entry removes its marginalia.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f6e5d4c3b2a1"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "b7c8d9e0f1a2"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the ``marginalia`` table and its FK index."""
+    op.create_table(
+        "marginalia",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("journal_entry_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(length=20), nullable=False),
+        sa.Column("anchor_start", sa.Integer(), nullable=False),
+        sa.Column("anchor_end", sa.Integer(), nullable=False),
+        sa.Column("anchor_text", sa.String(length=280), nullable=False),
+        sa.Column("note", sa.String(length=600), nullable=False),
+        sa.Column("essay", sa.String(length=10000), nullable=True),
+        sa.Column("essay_generated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journalentry.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_marginalia_journal_entry_id", "marginalia", ["journal_entry_id"])
+
+
+def downgrade() -> None:
+    """Drop the ``marginalia`` table and its index."""
+    op.drop_index("ix_marginalia_journal_entry_id", table_name="marginalia")
+    op.drop_table("marginalia")

--- a/backend/migrations/versions/f6e5d4c3b2a1_add_marginalia.py
+++ b/backend/migrations/versions/f6e5d4c3b2a1_add_marginalia.py
@@ -52,11 +52,17 @@ def upgrade() -> None:
         ),
         sa.CheckConstraint("anchor_start >= 0", name="ck_marginalia_anchor_start_nonneg"),
         sa.CheckConstraint("anchor_end > anchor_start", name="ck_marginalia_anchor_span_positive"),
+        sa.CheckConstraint(
+            "(essay IS NULL) = (essay_generated_at IS NULL)",
+            name="ck_marginalia_essay_timestamp_paired",
+        ),
     )
     op.create_index("ix_marginalia_journal_entry_id", "marginalia", ["journal_entry_id"])
+    op.create_index("ix_marginalia_user_id", "marginalia", ["user_id"])
 
 
 def downgrade() -> None:
-    """Drop the ``marginalia`` table and its index."""
+    """Drop the ``marginalia`` table and its indexes."""
+    op.drop_index("ix_marginalia_user_id", table_name="marginalia")
     op.drop_index("ix_marginalia_journal_entry_id", table_name="marginalia")
     op.drop_table("marginalia")

--- a/backend/migrations/versions/f6e5d4c3b2a1_add_marginalia.py
+++ b/backend/migrations/versions/f6e5d4c3b2a1_add_marginalia.py
@@ -42,6 +42,16 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["journal_entry_id"], ["journalentry.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "kind IN ('theme', 'connection', 'symbol')",
+            name="ck_marginalia_kind_valid",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'stale')",
+            name="ck_marginalia_status_valid",
+        ),
+        sa.CheckConstraint("anchor_start >= 0", name="ck_marginalia_anchor_start_nonneg"),
+        sa.CheckConstraint("anchor_end > anchor_start", name="ck_marginalia_anchor_span_positive"),
     )
     op.create_index("ix_marginalia_journal_entry_id", "marginalia", ["journal_entry_id"])
 

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -11,6 +11,7 @@ from .habit import Habit
 from .journal_entry import JournalEntry
 from .llm_usage_log import LLMUsageLog
 from .login_attempt import LoginAttempt
+from .marginalia import Marginalia
 from .password_reset_token import PasswordResetToken
 from .practice import Practice
 from .practice_recipe import PracticeRecipe, PracticeRecipeStep
@@ -38,6 +39,7 @@ __all__ = [
     "JournalEntry",
     "LLMUsageLog",
     "LoginAttempt",
+    "Marginalia",
     "PasswordResetToken",
     "Practice",
     "PracticeRecipe",

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -8,6 +8,7 @@ from sqlmodel import Field, Relationship, SQLModel
 from services.journal_encryption import EncryptedString
 
 if TYPE_CHECKING:
+    from .marginalia import Marginalia
     from .user import User
 
 
@@ -26,6 +27,17 @@ class JournalTag(enum.StrEnum):
     # distinct tag so stage-scoped aggregates (filtered by
     # ``STAGE_REFLECTION``) do not double-count them.
     WEEKLY_PROMPT = "weekly_prompt"
+
+
+class EntryStatus(enum.StrEnum):
+    """Lifecycle of a long-form journal entry: still being written vs committed.
+
+    The backing column lands in a follow-up; defined here so the resonance
+    feature can import a single source of truth for the value set.
+    """
+
+    DRAFT = "draft"
+    FINISHED = "finished"
 
 
 class JournalEntry(SQLModel, table=True):
@@ -76,3 +88,7 @@ class JournalEntry(SQLModel, table=True):
         sa_column=Column(DateTime(timezone=True), nullable=True),
     )
     user: "User" = Relationship(back_populates="journals")
+    marginalia: list["Marginalia"] = Relationship(
+        back_populates="entry",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )

--- a/backend/src/models/marginalia.py
+++ b/backend/src/models/marginalia.py
@@ -39,6 +39,18 @@ class MarginaliaStatus(enum.StrEnum):
     STALE = "stale"
 
 
+def _kind_check() -> CheckConstraint:
+    """CHECK derived from ``MarginaliaKind`` so the DB set can't drift from the enum."""
+    quoted = ", ".join(f"'{k.value}'" for k in MarginaliaKind)
+    return CheckConstraint(f"kind IN ({quoted})", name="ck_marginalia_kind_valid")
+
+
+def _status_check() -> CheckConstraint:
+    """CHECK derived from ``MarginaliaStatus`` so the DB set can't drift from the enum."""
+    quoted = ", ".join(f"'{s.value}'" for s in MarginaliaStatus)
+    return CheckConstraint(f"status IN ({quoted})", name="ck_marginalia_status_valid")
+
+
 class Marginalia(SQLModel, table=True):
     """A single anchored margin note on a journal entry.
 
@@ -56,14 +68,8 @@ class Marginalia(SQLModel, table=True):
         # Index the denormalized owner FK so "all marginalia for a user" is a
         # range scan, not a full-table scan (the reason the column exists).
         Index("ix_marginalia_user_id", "user_id"),
-        CheckConstraint(
-            "kind IN ('theme', 'connection', 'symbol')",
-            name="ck_marginalia_kind_valid",
-        ),
-        CheckConstraint(
-            "status IN ('active', 'stale')",
-            name="ck_marginalia_status_valid",
-        ),
+        _kind_check(),
+        _status_check(),
         CheckConstraint("anchor_start >= 0", name="ck_marginalia_anchor_start_nonneg"),
         CheckConstraint("anchor_end > anchor_start", name="ck_marginalia_anchor_span_positive"),
         # essay and its generated-at timestamp are set together or not at all.
@@ -80,8 +86,8 @@ class Marginalia(SQLModel, table=True):
     # entry's owner; enforcing that invariant is tracked for the endpoint layer.
     user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     kind: str = Field(max_length=20)
-    anchor_start: int
-    anchor_end: int
+    anchor_start: int = Field(ge=0)
+    anchor_end: int = Field(ge=1)  # DB CHECK also enforces anchor_end > anchor_start
     anchor_text: str = Field(max_length=_ANCHOR_TEXT_MAX)
     note: str = Field(max_length=_NOTE_MAX)
     essay: str | None = Field(default=None, max_length=_ESSAY_MAX)

--- a/backend/src/models/marginalia.py
+++ b/backend/src/models/marginalia.py
@@ -1,0 +1,80 @@
+"""AI margin notes anchored to spans of a journal page.
+
+A ``Marginalia`` row is a short note (optionally expanded into an essay) that the
+resonance feature attaches to a character span of a journal entry. Data-layer
+only — endpoints and LLM generation live in later issues.
+"""
+
+import enum
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Column, DateTime, Index
+from sqlmodel import Field, Relationship, SQLModel
+
+if TYPE_CHECKING:
+    from .journal_entry import JournalEntry
+
+_ANCHOR_TEXT_MAX = 280
+_NOTE_MAX = 600
+_ESSAY_MAX = 10_000
+
+
+class MarginaliaKind(enum.StrEnum):
+    """What a margin note surfaces about the anchored span."""
+
+    THEME = "theme"
+    CONNECTION = "connection"
+    SYMBOL = "symbol"
+
+
+class MarginaliaStatus(enum.StrEnum):
+    """Whether a note still anchors cleanly or has drifted.
+
+    ``active`` anchors cleanly; ``stale`` means the underlying text changed
+    enough that the note may no longer fit its span.
+    """
+
+    ACTIVE = "active"
+    STALE = "stale"
+
+
+class Marginalia(SQLModel, table=True):
+    """A single anchored margin note on a journal entry.
+
+    ``anchor_start`` / ``anchor_end`` are character offsets into the entry's
+    text; ``anchor_text`` snapshots the spanned substring so the note survives
+    later edits (and can be marked ``stale`` when it no longer matches).
+    """
+
+    # The hot read is "all marginalia for an entry", so index the FK.
+    __table_args__ = (Index("ix_marginalia_journal_entry_id", "journal_entry_id"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    journal_entry_id: int = Field(foreign_key="journalentry.id", ondelete="CASCADE")
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
+    kind: str = Field(max_length=20)
+    anchor_start: int
+    anchor_end: int
+    anchor_text: str = Field(max_length=_ANCHOR_TEXT_MAX)
+    note: str = Field(max_length=_NOTE_MAX)
+    essay: str | None = Field(default=None, max_length=_ESSAY_MAX)
+    essay_generated_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    status: str = Field(default=MarginaliaStatus.ACTIVE, max_length=20)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            onupdate=lambda: datetime.now(UTC),
+        ),
+    )
+
+    entry: "JournalEntry" = Relationship(back_populates="marginalia")

--- a/backend/src/models/marginalia.py
+++ b/backend/src/models/marginalia.py
@@ -9,7 +9,7 @@ import enum
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, DateTime, Index
+from sqlalchemy import CheckConstraint, Column, DateTime, Index
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
@@ -47,8 +47,23 @@ class Marginalia(SQLModel, table=True):
     later edits (and can be marked ``stale`` when it no longer matches).
     """
 
-    # The hot read is "all marginalia for an entry", so index the FK.
-    __table_args__ = (Index("ix_marginalia_journal_entry_id", "journal_entry_id"),)
+    # The hot read is "all marginalia for an entry", so index the FK. The CHECK
+    # constraints keep enum-valued columns and anchor bounds honest at the DB
+    # level (matching the Practice.mode / PracticeRecipeStep.position precedents),
+    # so a non-ORM writer can't persist an invalid kind/status or inverted span.
+    __table_args__ = (
+        Index("ix_marginalia_journal_entry_id", "journal_entry_id"),
+        CheckConstraint(
+            "kind IN ('theme', 'connection', 'symbol')",
+            name="ck_marginalia_kind_valid",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'stale')",
+            name="ck_marginalia_status_valid",
+        ),
+        CheckConstraint("anchor_start >= 0", name="ck_marginalia_anchor_start_nonneg"),
+        CheckConstraint("anchor_end > anchor_start", name="ck_marginalia_anchor_span_positive"),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     journal_entry_id: int = Field(foreign_key="journalentry.id", ondelete="CASCADE")

--- a/backend/src/models/marginalia.py
+++ b/backend/src/models/marginalia.py
@@ -52,6 +52,9 @@ class Marginalia(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     journal_entry_id: int = Field(foreign_key="journalentry.id", ondelete="CASCADE")
+    # Denormalized owner FK (in addition to the owner reachable via the entry) so
+    # "all marginalia for a user" reads need no JOIN. Writers must set it to the
+    # entry's owner; enforcing that invariant is tracked for the endpoint layer.
     user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     kind: str = Field(max_length=20)
     anchor_start: int

--- a/backend/src/models/marginalia.py
+++ b/backend/src/models/marginalia.py
@@ -53,6 +53,9 @@ class Marginalia(SQLModel, table=True):
     # so a non-ORM writer can't persist an invalid kind/status or inverted span.
     __table_args__ = (
         Index("ix_marginalia_journal_entry_id", "journal_entry_id"),
+        # Index the denormalized owner FK so "all marginalia for a user" is a
+        # range scan, not a full-table scan (the reason the column exists).
+        Index("ix_marginalia_user_id", "user_id"),
         CheckConstraint(
             "kind IN ('theme', 'connection', 'symbol')",
             name="ck_marginalia_kind_valid",
@@ -63,6 +66,11 @@ class Marginalia(SQLModel, table=True):
         ),
         CheckConstraint("anchor_start >= 0", name="ck_marginalia_anchor_start_nonneg"),
         CheckConstraint("anchor_end > anchor_start", name="ck_marginalia_anchor_span_positive"),
+        # essay and its generated-at timestamp are set together or not at all.
+        CheckConstraint(
+            "(essay IS NULL) = (essay_generated_at IS NULL)",
+            name="ck_marginalia_essay_timestamp_paired",
+        ),
     )
 
     id: int | None = Field(default=None, primary_key=True)

--- a/backend/tests/test_marginalia_model.py
+++ b/backend/tests/test_marginalia_model.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -71,6 +73,7 @@ async def test_kind_and_status_round_trip(db_session: AsyncSession) -> None:
             kind=MarginaliaKind.CONNECTION,
             status=MarginaliaStatus.STALE,
             essay="A longer expansion.",
+            essay_generated_at=datetime.now(UTC),
         ),
     )
     await db_session.commit()
@@ -79,6 +82,7 @@ async def test_kind_and_status_round_trip(db_session: AsyncSession) -> None:
     assert row.kind == MarginaliaKind.CONNECTION
     assert row.status == MarginaliaStatus.STALE
     assert row.essay == "A longer expansion."
+    assert row.essay_generated_at is not None
 
 
 @pytest.mark.asyncio
@@ -140,6 +144,16 @@ async def test_inverted_anchor_span_is_rejected(db_session: AsyncSession) -> Non
     user_id = await _user(db_session)
     entry_id = await _entry(db_session, user_id)
     db_session.add(_marginalia(entry_id, user_id, anchor_start=5, anchor_end=3))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_essay_without_timestamp_is_rejected(db_session: AsyncSession) -> None:
+    """Essay and essay_generated_at must be set together (paired CHECK)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    db_session.add(_marginalia(entry_id, user_id, essay="Orphan essay, no timestamp."))
     with pytest.raises(IntegrityError):
         await db_session.commit()
 

--- a/backend/tests/test_marginalia_model.py
+++ b/backend/tests/test_marginalia_model.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.journal_entry import EntryStatus, JournalEntry
@@ -121,6 +122,26 @@ async def test_updated_at_advances_on_mutate(db_session: AsyncSession) -> None:
     await db_session.commit()
     await db_session.refresh(row)
     assert row.updated_at > original
+
+
+@pytest.mark.asyncio
+async def test_invalid_kind_is_rejected(db_session: AsyncSession) -> None:
+    """A kind outside the enum set violates the CHECK constraint."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    db_session.add(_marginalia(entry_id, user_id, kind="bogus"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_inverted_anchor_span_is_rejected(db_session: AsyncSession) -> None:
+    """anchor_end must be greater than anchor_start (CHECK constraint)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    db_session.add(_marginalia(entry_id, user_id, anchor_start=5, anchor_end=3))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
 
 
 def test_enum_values() -> None:

--- a/backend/tests/test_marginalia_model.py
+++ b/backend/tests/test_marginalia_model.py
@@ -139,6 +139,16 @@ async def test_invalid_kind_is_rejected(db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
+async def test_negative_anchor_start_is_rejected(db_session: AsyncSession) -> None:
+    """anchor_start must be non-negative (CHECK constraint)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    db_session.add(_marginalia(entry_id, user_id, anchor_start=-1, anchor_end=4))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
 async def test_inverted_anchor_span_is_rejected(db_session: AsyncSession) -> None:
     """anchor_end must be greater than anchor_start (CHECK constraint)."""
     user_id = await _user(db_session)

--- a/backend/tests/test_marginalia_model.py
+++ b/backend/tests/test_marginalia_model.py
@@ -1,0 +1,111 @@
+"""Data-layer tests for the Marginalia model (journal-resonance-01)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import EntryStatus, JournalEntry
+from models.marginalia import Marginalia, MarginaliaKind, MarginaliaStatus
+from models.user import User
+
+
+async def _user(session: AsyncSession, email: str = "marg@example.com") -> int:
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.flush()
+    assert user.id is not None
+    return user.id
+
+
+async def _entry(session: AsyncSession, user_id: int) -> int:
+    entry = JournalEntry(sender="user", user_id=user_id, message="a page of thoughts")
+    session.add(entry)
+    await session.flush()
+    assert entry.id is not None
+    return entry.id
+
+
+def _marginalia(entry_id: int, user_id: int, **over: object) -> Marginalia:
+    base: dict[str, object] = {
+        "journal_entry_id": entry_id,
+        "user_id": user_id,
+        "kind": MarginaliaKind.THEME,
+        "anchor_start": 0,
+        "anchor_end": 4,
+        "anchor_text": "page",
+        "note": "Recurring theme of beginnings.",
+    }
+    base.update(over)
+    return Marginalia(**base)
+
+
+@pytest.mark.asyncio
+async def test_insert_and_read(db_session: AsyncSession) -> None:
+    """A marginalia row persists and reads back with its defaults."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    db_session.add(_marginalia(entry_id, user_id))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(Marginalia))).scalar_one()
+    assert row.journal_entry_id == entry_id
+    assert row.anchor_text == "page"
+    # status defaults to active; essay is optional.
+    assert row.status == MarginaliaStatus.ACTIVE
+    assert row.essay is None
+    assert row.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_kind_and_status_round_trip(db_session: AsyncSession) -> None:
+    """Non-default kind/status values survive a write/read cycle."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    db_session.add(
+        _marginalia(
+            entry_id,
+            user_id,
+            kind=MarginaliaKind.CONNECTION,
+            status=MarginaliaStatus.STALE,
+            essay="A longer expansion.",
+        ),
+    )
+    await db_session.commit()
+
+    row = (await db_session.execute(select(Marginalia))).scalar_one()
+    assert row.kind == MarginaliaKind.CONNECTION
+    assert row.status == MarginaliaStatus.STALE
+    assert row.essay == "A longer expansion."
+
+
+@pytest.mark.asyncio
+async def test_parent_delete_cascades(db_session: AsyncSession) -> None:
+    """Deleting the parent journal entry removes its marginalia (delete-orphan)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    db_session.add_all(
+        [
+            _marginalia(entry_id, user_id),
+            _marginalia(entry_id, user_id, kind=MarginaliaKind.SYMBOL, note="A candle recurs."),
+        ],
+    )
+    await db_session.commit()
+
+    loaded = await db_session.get(JournalEntry, entry_id)
+    assert loaded is not None
+    await db_session.delete(loaded)
+    await db_session.commit()
+
+    remaining = (
+        await db_session.execute(select(func.count()).select_from(Marginalia))
+    ).scalar_one()
+    assert remaining == 0
+
+
+def test_enum_values() -> None:
+    """The enum value sets match the contract."""
+    assert {k.value for k in MarginaliaKind} == {"theme", "connection", "symbol"}
+    assert {s.value for s in MarginaliaStatus} == {"active", "stale"}
+    assert {e.value for e in EntryStatus} == {"draft", "finished"}

--- a/backend/tests/test_marginalia_model.py
+++ b/backend/tests/test_marginalia_model.py
@@ -104,6 +104,25 @@ async def test_parent_delete_cascades(db_session: AsyncSession) -> None:
     assert remaining == 0
 
 
+@pytest.mark.asyncio
+async def test_updated_at_advances_on_mutate(db_session: AsyncSession) -> None:
+    """updated_at advances when the row is flushed after a mutation (onupdate)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    row = _marginalia(entry_id, user_id)
+    db_session.add(row)
+    await db_session.commit()
+    # Refresh so ``original`` is the stored value (SQLite returns naive datetimes,
+    # so capturing the in-memory tz-aware value would make the comparison invalid).
+    await db_session.refresh(row)
+    original = row.updated_at
+
+    row.note = "Revised note."
+    await db_session.commit()
+    await db_session.refresh(row)
+    assert row.updated_at > original
+
+
 def test_enum_values() -> None:
     """The enum value sets match the contract."""
     assert {k.value for k in MarginaliaKind} == {"theme", "connection", "symbol"}


### PR DESCRIPTION
## Summary

journal-resonance-01 (**data-layer only** — no endpoints, no LLM): introduce the `Marginalia` table for AI margin notes anchored to a character span of a journal entry.

- **`models/marginalia.py`**: `MarginaliaKind` (`theme|connection|symbol`) and `MarginaliaStatus` (`active|stale`) enums + the `Marginalia` table — `journal_entry_id` (FK `journalentry.id` CASCADE, indexed), `user_id` (FK `user.id` CASCADE), `kind`, `anchor_start`/`anchor_end`, `anchor_text(280)`, `note(600)`, `essay(10000)|None`, `essay_generated_at|None`, `status` (default `active`), `created_at`, `updated_at` (`onupdate=now`).
- **`journal_entry.py`**: `EntryStatus` (`draft|finished`) enum (its column lands in #605/02) + a `JournalEntry.marginalia` relationship with `cascade="all, delete-orphan"`.
- Registered `Marginalia` in the models package.
- **Migration `f6e5d4c3b2a1`** (down_revision `b7c8d9e0f1a2`): create table + FKs + the `journal_entry_id` index; working `downgrade`. (Revision id grep-checked against existing migrations for collisions.)

## Test plan

`tests/test_marginalia_model.py`:
- insert/read with defaults (`status=active`, `essay=None`);
- `kind`/`status` round-trip (non-default values);
- **parent-delete cascades** the marginalia (ORM `delete-orphan`);
- enum value sets match the contract.

`./scripts/backend/check-all.sh` — 7/7 (90/80/85 thresholds); xenon A; migration bare-loads cleanly.

Closes #604
Refs #603
