### PR TITLE
feat(backend): add journal entry document fields (title, status, updated_at)

### DIFF
--- a/backend/migrations/versions/d4c3b2a1f6e5_journalentry_document_fields.py
+++ b/backend/migrations/versions/d4c3b2a1f6e5_journalentry_document_fields.py
@@ -34,7 +34,9 @@ def upgrade() -> None:
     # Existing rows predate the draft workflow, so they are finished pages; their
     # last-edit time is best approximated by the original timestamp.
     op.execute("UPDATE journalentry SET status = 'finished' WHERE status IS NULL")
-    op.execute("UPDATE journalentry SET updated_at = timestamp WHERE updated_at IS NULL")
+    # ``"timestamp"`` is quoted to read unambiguously as the column (not the SQL
+    # type keyword / CURRENT_TIMESTAMP).
+    op.execute('UPDATE journalentry SET updated_at = "timestamp" WHERE updated_at IS NULL')
     with op.batch_alter_table("journalentry") as batch:
         batch.alter_column("status", existing_type=sa.String(length=20), nullable=False)
         batch.alter_column("updated_at", existing_type=sa.DateTime(timezone=True), nullable=False)

--- a/backend/migrations/versions/d4c3b2a1f6e5_journalentry_document_fields.py
+++ b/backend/migrations/versions/d4c3b2a1f6e5_journalentry_document_fields.py
@@ -1,0 +1,47 @@
+"""add journalentry document fields: title, status, updated_at
+
+Revision ID: d4c3b2a1f6e5
+Revises: f6e5d4c3b2a1
+Create Date: 2026-06-27 00:00:00.000000
+
+Evolves a journal entry from a discrete chat message into a long-form page:
+``title`` (optional), ``status`` (draft|finished), and ``updated_at``. Columns
+are added nullable, existing rows are backfilled (status='finished' since they
+predate the draft workflow; updated_at = the original timestamp), then status and
+updated_at are tightened to NOT NULL to match the model. ``downgrade`` drops them.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4c3b2a1f6e5"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "f6e5d4c3b2a1"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add title/status/updated_at, backfill existing rows, tighten NOT NULL."""
+    op.add_column("journalentry", sa.Column("title", sa.String(length=200), nullable=True))
+    op.add_column("journalentry", sa.Column("status", sa.String(length=20), nullable=True))
+    op.add_column(
+        "journalentry",
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Existing rows predate the draft workflow, so they are finished pages; their
+    # last-edit time is best approximated by the original timestamp.
+    op.execute("UPDATE journalentry SET status = 'finished' WHERE status IS NULL")
+    op.execute("UPDATE journalentry SET updated_at = timestamp WHERE updated_at IS NULL")
+    with op.batch_alter_table("journalentry") as batch:
+        batch.alter_column("status", existing_type=sa.String(length=20), nullable=False)
+        batch.alter_column("updated_at", existing_type=sa.DateTime(timezone=True), nullable=False)
+
+
+def downgrade() -> None:
+    """Drop the document fields."""
+    op.drop_column("journalentry", "updated_at")
+    op.drop_column("journalentry", "status")
+    op.drop_column("journalentry", "title")

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -30,10 +30,9 @@ class JournalTag(enum.StrEnum):
 
 
 class EntryStatus(enum.StrEnum):
-    """Lifecycle of a long-form journal entry: still being written vs committed.
+    """Lifecycle of a long-form journal entry, backing ``JournalEntry.status``.
 
-    The backing column lands in a follow-up; defined here so the resonance
-    feature can import a single source of truth for the value set.
+    ``draft`` while being written; ``finished`` once committed.
     """
 
     DRAFT = "draft"

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -77,6 +77,10 @@ class JournalEntry(SQLModel, table=True):
     # write boundary by JournalMessageCreate / JournalBotMessageCreate
     # (max_length=JOURNAL_MESSAGE_MAX_LENGTH) plus the router's sanitizer.
     message: str = Field(sa_column=Column(EncryptedString(), nullable=False))
+    # Long-form page metadata: an optional title and a draft/finished lifecycle.
+    # ``message`` remains the body. ``updated_at`` tracks the last edit.
+    title: str | None = Field(default=None, max_length=200)
+    status: str = Field(default=EntryStatus.DRAFT, max_length=20)
     sender: str = Field(max_length=10)  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     tag: str = Field(default=JournalTag.FREEFORM, max_length=50)
@@ -86,6 +90,14 @@ class JournalEntry(SQLModel, table=True):
     deleted_at: datetime | None = Field(
         default=None,
         sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            onupdate=lambda: datetime.now(UTC),
+        ),
     )
     user: "User" = Relationship(back_populates="journals")
     marginalia: list["Marginalia"] = Relationship(

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -46,9 +46,12 @@ class JournalMessageResponse(BaseModel):
     """
 
     id: int
+    title: str | None
     message: str
+    status: str
     sender: str
     timestamp: datetime
+    updated_at: datetime
     tag: str
     practice_session_id: int | None
     user_practice_id: int | None

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from models.journal_entry import JournalTag
+from models.journal_entry import EntryStatus, JournalTag
 
 JOURNAL_MESSAGE_MAX_LENGTH = 10_000
 
@@ -48,7 +48,7 @@ class JournalMessageResponse(BaseModel):
     id: int
     title: str | None
     message: str
-    status: str
+    status: EntryStatus
     sender: str
     timestamp: datetime
     updated_at: datetime

--- a/backend/tests/test_journal_entry_document_fields.py
+++ b/backend/tests/test_journal_entry_document_fields.py
@@ -1,0 +1,102 @@
+"""Tests for the JournalEntry document fields (journal-resonance-02)."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import EntryStatus, JournalEntry
+from models.user import User
+
+
+async def _signup(client: AsyncClient, username: str = "doc") -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+@pytest.mark.asyncio
+async def test_new_entry_defaults_to_draft_with_no_title(async_client: AsyncClient) -> None:
+    """A freshly created entry is a draft with a null title and an updated_at."""
+    headers = await _signup(async_client)
+    resp = await async_client.post("/journal/", json={"message": "First page."}, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    body = resp.json()
+    assert body["status"] == EntryStatus.DRAFT
+    assert body["title"] is None
+    assert body["updated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_response_still_hides_user_id(async_client: AsyncClient) -> None:
+    """The document fields are serialized; user_id stays excluded."""
+    headers = await _signup(async_client, "hide")
+    await async_client.post("/journal/", json={"message": "A page."}, headers=headers)
+    resp = await async_client.get("/journal/", headers=headers)
+    item = resp.json()["items"][0]
+    assert {"title", "status", "updated_at"} <= item.keys()
+    assert "user_id" not in item
+
+
+@pytest.mark.asyncio
+async def test_model_defaults(db_session: AsyncSession) -> None:
+    """The model defaults status to draft and stamps updated_at."""
+    user = User(email="m@example.com", password_hash="x")  # pragma: allowlist secret
+    db_session.add(user)
+    await db_session.flush()
+    entry = JournalEntry(sender="user", user_id=user.id, message="body")
+    db_session.add(entry)
+    await db_session.commit()
+    await db_session.refresh(entry)
+    assert entry.status == EntryStatus.DRAFT
+    assert entry.title is None
+    assert entry.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_finished_status_round_trips(db_session: AsyncSession) -> None:
+    """The 'finished' status (what the migration backfills existing rows to) persists.
+
+    The migration's NULL->finished backfill is exercised by the Postgres
+    migration-drift gate; here we assert the value the backfill writes survives a
+    write/read cycle through the model.
+    """
+    user = User(email="b@example.com", password_hash="x")  # pragma: allowlist secret
+    db_session.add(user)
+    await db_session.flush()
+    entry = JournalEntry(
+        sender="user", user_id=user.id, message="legacy", status=EntryStatus.FINISHED
+    )
+    db_session.add(entry)
+    await db_session.commit()
+
+    row = await db_session.get(JournalEntry, entry.id)
+    assert row is not None
+    assert row.status == EntryStatus.FINISHED
+
+
+@pytest.mark.asyncio
+async def test_updated_at_advances_on_edit(db_session: AsyncSession) -> None:
+    """updated_at advances when the entry is mutated and flushed (onupdate)."""
+    user = User(email="u@example.com", password_hash="x")  # pragma: allowlist secret
+    db_session.add(user)
+    await db_session.flush()
+    entry = JournalEntry(sender="user", user_id=user.id, message="v1")
+    db_session.add(entry)
+    await db_session.commit()
+    await db_session.refresh(entry)
+    original = entry.updated_at
+
+    entry.title = "Now titled"
+    await db_session.commit()
+    await db_session.refresh(entry)
+    assert entry.updated_at > original


### PR DESCRIPTION
## Summary

journal-resonance-02: evolve a `JournalEntry` from a discrete chat message into a long-form **page**. The body stays in `message`.

- **Model**: `title` (`str|None`, ≤200), `status` (`str` default `EntryStatus.DRAFT`, ≤20), `updated_at` (`DateTime` tz, `onupdate=now`). New entries default to **draft**.
- **Migration `d4c3b2a1f6e5`**: add the three columns nullable, **backfill** existing rows (`status='finished'` since they predate the draft workflow; `updated_at = timestamp`), then tighten `status`/`updated_at` to `NOT NULL`; working `downgrade`.
- **`JournalMessageResponse`** now returns `title`/`status`/`updated_at` and still **omits `user_id`**. Population is automatic via the model defaults + `from_attributes`.

(Editing/PATCH is #606/03 — not here.)

## Test plan

`test_journal_entry_document_fields.py`:
- new entry → `draft` + null `title` + stamped `updated_at`;
- response exposes the new fields and still hides `user_id`;
- model defaults; the `finished` status round-trips; `updated_at` advances on edit (onupdate).

`./scripts/backend/check-all.sh` — 7/7; migration bare-loads; backfill verified by the Postgres `migration-drift` gate.

Closes #605
Refs #603
