### PR TITLE
feat(backend): add PATCH /journal/{id} edit-entry endpoint

### DIFF
--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -14,19 +14,21 @@ from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import require_owned_journal_entry
-from errors import unprocessable
+from errors import not_found, unprocessable
 from models.journal_entry import JournalEntry, JournalTag
 from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.journal import (
     JOURNAL_MESSAGE_MAX_LENGTH,
     JournalBotMessageCreate,
+    JournalEntryUpdate,
     JournalListResponse,
     JournalMessageCreate,
     JournalMessageResponse,
 )
 from security import TextTooLongError, sanitize_user_text
 from services import journal_encryption
+from services.marginalia import reanchor_entry_marginalia
 
 
 def _sanitize_message(message: str) -> str:
@@ -215,6 +217,55 @@ async def get_journal_entry(
     Ownership is verified by ``require_owned_journal_entry``: 404 when the
     row does not exist, 403 when it exists but belongs to another user.
     """
+    return entry
+
+
+async def _apply_entry_update(
+    entry: JournalEntry, payload: JournalEntryUpdate, session: AsyncSession
+) -> None:
+    """Apply the provided fields to ``entry``, re-anchoring marginalia on a body edit."""
+    if payload.message is not None:
+        old_message = entry.message
+        new_message = _sanitize_message(payload.message)
+        if new_message != old_message:
+            entry.message = new_message
+            await reanchor_entry_marginalia(entry, old_message, new_message, session)
+    if payload.title is not None:
+        entry.title = payload.title
+    if payload.status is not None:
+        entry.status = payload.status
+    entry.updated_at = datetime.now(UTC)
+
+
+@router.patch("/{entry_id}", response_model=JournalMessageResponse)
+async def update_journal_entry(
+    entry_id: int,
+    payload: JournalEntryUpdate,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> JournalEntry:
+    """Patch ``message`` / ``title`` / ``status`` on the caller's own entry.
+
+    Scoped to the caller's non-deleted rows: a missing id, a soft-deleted row, or
+    another user's entry all resolve to 404 (enumeration-safe). Editing the body
+    re-sanitizes it and invokes the marginalia re-anchor seam; ``updated_at`` is
+    refreshed.
+    """
+    result = await session.execute(
+        select(JournalEntry).where(
+            JournalEntry.id == entry_id,
+            JournalEntry.user_id == current_user,
+            col(JournalEntry.deleted_at).is_(None),
+        )
+    )
+    entry = result.scalars().first()
+    if entry is None:
+        raise not_found("journal_entry")
+    await _apply_entry_update(entry, payload, session)
+    session.add(entry)
+    await session.commit()
+    await session.refresh(entry)
+    logger.info("journal_entry_updated", extra={"user_id": current_user, "entry_id": entry_id})
     return entry
 
 

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -234,7 +234,8 @@ async def _apply_entry_update(
         entry.title = payload.title
     if payload.status is not None:
         entry.status = payload.status
-    entry.updated_at = datetime.now(UTC)
+    # ``updated_at`` is bumped by the column's ``onupdate`` only when a value
+    # actually changes, so a same-value PATCH doesn't move it.
 
 
 @router.patch("/{entry_id}", response_model=JournalMessageResponse)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -256,6 +256,7 @@ async def update_journal_entry(
         select(JournalEntry).where(
             JournalEntry.id == entry_id,
             JournalEntry.user_id == current_user,
+            JournalEntry.sender == "user",  # bot-authored entries are not user-editable
             col(JournalEntry.deleted_at).is_(None),
         )
     )

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from models.journal_entry import EntryStatus, JournalTag
 
@@ -36,6 +37,25 @@ class JournalBotMessageCreate(BaseModel):
     tag: JournalTag = JournalTag.FREEFORM
     practice_session_id: int | None = None
     user_practice_id: int | None = None
+
+
+class JournalEntryUpdate(BaseModel):
+    """Partial update for a journal entry (PATCH).
+
+    Every field is optional; an empty payload is rejected (422) so a no-op PATCH
+    can't silently bump ``updated_at``. ``message`` is re-sanitized server-side.
+    """
+
+    message: str | None = Field(default=None, min_length=1, max_length=JOURNAL_MESSAGE_MAX_LENGTH)
+    title: str | None = Field(default=None, max_length=200)
+    status: EntryStatus | None = None
+
+    @model_validator(mode="after")
+    def _require_at_least_one_field(self) -> Self:
+        if self.message is None and self.title is None and self.status is None:
+            msg = "at least one field must be provided"
+            raise ValueError(msg)
+        return self
 
 
 class JournalMessageResponse(BaseModel):

--- a/backend/src/services/marginalia.py
+++ b/backend/src/services/marginalia.py
@@ -1,0 +1,30 @@
+"""Marginalia maintenance hooks.
+
+The re-anchoring seam is intentionally a no-op here: editing a journal entry's
+body can shift or invalidate the character spans that marginalia anchor to, but
+the actual re-anchor / mark-stale logic lands in a later issue. This module
+exists so the PATCH endpoint can call a stable, documented seam now.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import JournalEntry
+
+
+async def reanchor_entry_marginalia(
+    entry: JournalEntry,
+    old_message: str,
+    new_message: str,
+    session: AsyncSession,
+) -> None:
+    """Re-anchor (or mark stale) the entry's marginalia after a body edit.
+
+    No-op for now — the diff-based re-anchoring is implemented in a follow-up.
+    Kept as a call seam so the edit endpoint's contract is stable: callers invoke
+    it whenever ``message`` changes, passing the old and new bodies.
+    """
+    # Arguments are accepted now to fix the seam's signature; the follow-up that
+    # implements re-anchoring will consume them.
+    del entry, old_message, new_message, session

--- a/backend/tests/test_journal_patch.py
+++ b/backend/tests/test_journal_patch.py
@@ -47,6 +47,24 @@ async def test_patch_updates_message_title_status(async_client: AsyncClient) -> 
 
 
 @pytest.mark.asyncio
+async def test_patch_same_value_does_not_bump_updated_at(async_client: AsyncClient) -> None:
+    """A PATCH that doesn't actually change anything leaves updated_at untouched."""
+    headers = await _signup(async_client, "noop")
+    entry_id = await _create(async_client, headers)
+    first = (
+        await async_client.patch(
+            f"/journal/{entry_id}", json={"status": "finished"}, headers=headers
+        )
+    ).json()
+    again = (
+        await async_client.patch(
+            f"/journal/{entry_id}", json={"status": "finished"}, headers=headers
+        )
+    ).json()
+    assert again["updated_at"] == first["updated_at"]
+
+
+@pytest.mark.asyncio
 async def test_patch_empty_payload_is_422(async_client: AsyncClient) -> None:
     """An empty PATCH body is rejected so a no-op can't bump updated_at."""
     headers = await _signup(async_client, "empty")

--- a/backend/tests/test_journal_patch.py
+++ b/backend/tests/test_journal_patch.py
@@ -98,6 +98,20 @@ async def test_patch_soft_deleted_entry_is_404(async_client: AsyncClient) -> Non
 
 
 @pytest.mark.asyncio
+async def test_patch_bot_entry_is_404(async_client: AsyncClient) -> None:
+    """A bot-authored entry shares the user's id but isn't user-editable (404)."""
+    headers = await _signup(async_client, "botpatch")
+    resp = await async_client.post(
+        "/journal/bot-response", json={"message": "AI says hi"}, headers=headers
+    )
+    entry_id = resp.json()["id"]
+    patch = await async_client.patch(
+        f"/journal/{entry_id}", json={"title": "tampered"}, headers=headers
+    )
+    assert patch.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
 async def test_patch_missing_entry_is_404(async_client: AsyncClient) -> None:
     """Patching a nonexistent id is a 404."""
     headers = await _signup(async_client, "missing")

--- a/backend/tests/test_journal_patch.py
+++ b/backend/tests/test_journal_patch.py
@@ -1,0 +1,101 @@
+"""Tests for PATCH /journal/{id} (journal-resonance-03)."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+
+async def _signup(client: AsyncClient, username: str = "patcher") -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _create(client: AsyncClient, headers: dict[str, str], message: str = "Original.") -> int:
+    resp = await client.post("/journal/", json={"message": message}, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+@pytest.mark.asyncio
+async def test_patch_updates_message_title_status(async_client: AsyncClient) -> None:
+    """A PATCH applies the provided fields and advances updated_at."""
+    headers = await _signup(async_client)
+    entry_id = await _create(async_client, headers)
+    before = (await async_client.get(f"/journal/{entry_id}", headers=headers)).json()
+
+    resp = await async_client.patch(
+        f"/journal/{entry_id}",
+        json={"message": "Revised body.", "title": "A Title", "status": "finished"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["message"] == "Revised body."
+    assert body["title"] == "A Title"
+    assert body["status"] == "finished"
+    assert body["updated_at"] >= before["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_patch_empty_payload_is_422(async_client: AsyncClient) -> None:
+    """An empty PATCH body is rejected so a no-op can't bump updated_at."""
+    headers = await _signup(async_client, "empty")
+    entry_id = await _create(async_client, headers)
+    resp = await async_client.patch(f"/journal/{entry_id}", json={}, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_patch_other_users_entry_is_404(async_client: AsyncClient) -> None:
+    """Another user's entry is invisible (404), not 403."""
+    alice = await _signup(async_client, "alice_p")
+    bob = await _signup(async_client, "bob_p")
+    entry_id = await _create(async_client, alice)
+    resp = await async_client.patch(f"/journal/{entry_id}", json={"title": "hijack"}, headers=bob)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_patch_soft_deleted_entry_is_404(async_client: AsyncClient) -> None:
+    """A soft-deleted entry can no longer be patched."""
+    headers = await _signup(async_client, "deleted")
+    entry_id = await _create(async_client, headers)
+    assert (
+        await async_client.delete(f"/journal/{entry_id}", headers=headers)
+    ).status_code == HTTPStatus.NO_CONTENT
+    resp = await async_client.patch(
+        f"/journal/{entry_id}", json={"title": "ghost"}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_patch_missing_entry_is_404(async_client: AsyncClient) -> None:
+    """Patching a nonexistent id is a 404."""
+    headers = await _signup(async_client, "missing")
+    resp = await async_client.patch("/journal/999999", json={"title": "x"}, headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_patch_sanitizes_message(async_client: AsyncClient) -> None:
+    """The patched body is sanitized — an embedded zero-width space is stripped."""
+    headers = await _signup(async_client, "sanitize")
+    entry_id = await _create(async_client, headers)
+    resp = await async_client.patch(
+        f"/journal/{entry_id}",
+        json={"message": "clean\u200bbody"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["message"] == "cleanbody"


### PR DESCRIPTION
## Summary

journal-resonance-03: let a user edit their own entry's `message`/`title`/`status`.

- **`JournalEntryUpdate`** schema: all fields optional (`message ≤10000`, `title ≤200`, `status`); a `model_validator` rejects an **empty payload (422)** so a no-op PATCH can't bump `updated_at`.
- **`PATCH /journal/{entry_id}`**: loads the caller's own non-deleted entry **or 404** (missing id, soft-deleted row, or another user's entry are all 404 — enumeration-safe, not 403). Re-sanitizes `message`, applies fields, refreshes `updated_at`, returns the entry.
- **Re-anchor seam**: when the body changes, calls `services.marginalia.reanchor_entry_marginalia(entry, old, new, session)` — a documented **no-op stub** here; the diff-based re-anchoring lands in #608/07.

## Test plan

`test_journal_patch.py`:
- message/title/status update + `updated_at` advances;
- empty payload → 422; other user → 404; soft-deleted → 404; missing → 404;
- body is sanitized (zero-width space stripped).

`./scripts/backend/check-all.sh` — 7/7; xenon clean.

Closes #606
Refs #603
