### PR TITLE
feat(backend): resonance generation service (LLM → anchored margin notes)

### DIFF
--- a/backend/src/domain/resonance.py
+++ b/backend/src/domain/resonance.py
@@ -82,23 +82,29 @@ def build_prompt(
     )
 
 
-def _parse_drafts(raw: str) -> list[MarginaliaDraft]:
-    """Defensively parse the model's JSON into drafts; never raise on bad input."""
+def _draft_from_item(item: object) -> MarginaliaDraft | None:
+    """Build a draft from one parsed JSON item, or None if it's the wrong shape."""
+    if not isinstance(item, dict):
+        return None
+    kind, quote, note = item.get("kind"), item.get("quote"), item.get("note")
+    if isinstance(kind, str) and isinstance(quote, str) and isinstance(note, str):
+        return MarginaliaDraft(kind=kind, quote=quote, note=note)
+    return None
+
+
+def _load_notes(raw: str) -> list[object]:
+    """Parse the completion to its ``notes`` list; [] on any malformed input."""
     try:
         payload = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
         return []
     notes = payload.get("notes") if isinstance(payload, dict) else None
-    if not isinstance(notes, list):
-        return []
-    drafts: list[MarginaliaDraft] = []
-    for item in notes:
-        if not isinstance(item, dict):
-            continue
-        kind, quote, note = item.get("kind"), item.get("quote"), item.get("note")
-        if isinstance(kind, str) and isinstance(quote, str) and isinstance(note, str):
-            drafts.append(MarginaliaDraft(kind=kind, quote=quote, note=note))
-    return drafts
+    return notes if isinstance(notes, list) else []
+
+
+def _parse_drafts(raw: str) -> list[MarginaliaDraft]:
+    """Defensively parse the model's JSON into drafts; never raise on bad input."""
+    return [draft for item in _load_notes(raw) if (draft := _draft_from_item(item)) is not None]
 
 
 def _sanitize_note(note: str) -> str | None:
@@ -110,17 +116,23 @@ def _sanitize_note(note: str) -> str | None:
     return cleaned or None
 
 
+def _quote_span(body: str, quote: str) -> tuple[int, int] | None:
+    """Locate ``quote`` verbatim in ``body``; return its offsets or None."""
+    if not quote or len(quote) > ANCHOR_TEXT_MAX:
+        return None
+    start = body.find(quote)
+    return None if start == -1 else (start, start + len(quote))
+
+
 def _anchor(body: str, draft: MarginaliaDraft) -> MarginaliaAnchored | None:
     """Resolve a draft to a span, or None if it can't anchor / validate."""
-    if draft.kind not in VALID_KINDS or not draft.quote or len(draft.quote) > ANCHOR_TEXT_MAX:
+    if draft.kind not in VALID_KINDS:
         return None
-    start = body.find(draft.quote)
-    if start == -1:
-        return None
+    span = _quote_span(body, draft.quote)
     note = _sanitize_note(draft.note)
-    if note is None:
+    if span is None or note is None:
         return None
-    end = start + len(draft.quote)
+    start, end = span
     return MarginaliaAnchored(
         kind=draft.kind,
         anchor_start=start,
@@ -133,6 +145,11 @@ def _anchor(body: str, draft: MarginaliaDraft) -> MarginaliaAnchored | None:
 def _overlaps(a: MarginaliaAnchored, b: MarginaliaAnchored) -> bool:
     """True when two anchored spans intersect."""
     return a.anchor_start < b.anchor_end and b.anchor_start < a.anchor_end
+
+
+def _overlaps_any(candidate: MarginaliaAnchored, kept: list[MarginaliaAnchored]) -> bool:
+    """True when ``candidate`` overlaps any already-kept anchor."""
+    return any(_overlaps(candidate, other) for other in kept)
 
 
 async def generate_marginalia(
@@ -153,7 +170,7 @@ async def generate_marginalia(
     anchored: list[MarginaliaAnchored] = []
     for draft in _parse_drafts(raw):
         candidate = _anchor(body, draft)
-        if candidate is None or any(_overlaps(candidate, kept) for kept in anchored):
+        if candidate is None or _overlaps_any(candidate, anchored):
             continue
         anchored.append(candidate)
         if len(anchored) >= max_notes:

--- a/backend/src/domain/resonance.py
+++ b/backend/src/domain/resonance.py
@@ -1,0 +1,156 @@
+"""Resonance generation: turn a journal entry into anchored margin notes.
+
+Pure domain logic with the LLM injected — no FastAPI, no DB. The model proposes
+short notes with a verbatim ``quote`` from the body; we resolve each quote to
+character offsets *ourselves* (never trusting model-supplied indices) and drop
+anything that doesn't anchor cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from security import TextTooLongError, sanitize_user_text
+
+# Kept as literals (not imported from models.marginalia) so the domain stays
+# free of DB imports; ``test_resonance_service`` guards this against enum drift.
+VALID_KINDS = frozenset({"theme", "connection", "symbol"})
+_ANCHOR_TEXT_MAX = 280
+_NOTE_MAX = 600
+_DEFAULT_MAX_NOTES = 5
+
+
+@dataclass(frozen=True)
+class MarginaliaDraft:
+    """A model-proposed note before anchoring: a kind, a verbatim quote, a note."""
+
+    kind: str
+    quote: str
+    note: str
+
+
+@dataclass(frozen=True)
+class MarginaliaAnchored:
+    """A note resolved to a character span of the entry body."""
+
+    kind: str
+    anchor_start: int
+    anchor_end: int
+    anchor_text: str
+    note: str
+
+
+class ResonanceLLM(Protocol):
+    """Minimal injected LLM seam: prompt in, raw completion text out."""
+
+    async def complete(self, prompt: str) -> str: ...
+
+
+def build_prompt(
+    body: str, prior_entries: Sequence[str] | None = None, max_notes: int = _DEFAULT_MAX_NOTES
+) -> str:
+    """Build the structured prompt asking for up to ``max_notes`` margin notes."""
+    prior_block = ""
+    if prior_entries:
+        joined = "\n---\n".join(prior_entries)
+        prior_block = (
+            "\n\nEarlier entries (context for 'connection' notes only):\n"
+            f"<prior>\n{joined}\n</prior>"
+        )
+    return (
+        "You are a thoughtful reader leaving margin notes on someone's journal "
+        "page. Read the entry and surface up to "
+        f"{max_notes} of the most resonant observations.\n\n"
+        "For each note:\n"
+        '- "kind" is one of: theme, connection, symbol.\n'
+        '- "quote" is a VERBATIM substring copied exactly from the entry '
+        f"(<= {_ANCHOR_TEXT_MAX} characters), never paraphrased.\n"
+        '- "note" is 1-2 warm, second-person sentences spoken to the writer. '
+        'Never refer to yourself or say "as an AI".\n'
+        "- Use 'connection' only when linking to an earlier entry.\n\n"
+        "Return STRICT JSON only, no prose, of the form:\n"
+        '{"notes": [{"kind": "theme", "quote": "...", "note": "..."}]}\n\n'
+        f"<entry>\n{body}\n</entry>{prior_block}"
+    )
+
+
+def _parse_drafts(raw: str) -> list[MarginaliaDraft]:
+    """Defensively parse the model's JSON into drafts; never raise on bad input."""
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    notes = payload.get("notes") if isinstance(payload, dict) else None
+    if not isinstance(notes, list):
+        return []
+    drafts: list[MarginaliaDraft] = []
+    for item in notes:
+        if not isinstance(item, dict):
+            continue
+        kind, quote, note = item.get("kind"), item.get("quote"), item.get("note")
+        if isinstance(kind, str) and isinstance(quote, str) and isinstance(note, str):
+            drafts.append(MarginaliaDraft(kind=kind, quote=quote, note=note))
+    return drafts
+
+
+def _sanitize_note(note: str) -> str | None:
+    """Sanitize a note; return None if it can't fit the column after sanitizing."""
+    try:
+        cleaned = sanitize_user_text(note, max_len=_NOTE_MAX)
+    except TextTooLongError:
+        return None
+    return cleaned or None
+
+
+def _anchor(body: str, draft: MarginaliaDraft) -> MarginaliaAnchored | None:
+    """Resolve a draft to a span, or None if it can't anchor / validate."""
+    if draft.kind not in VALID_KINDS or not draft.quote or len(draft.quote) > _ANCHOR_TEXT_MAX:
+        return None
+    start = body.find(draft.quote)
+    if start == -1:
+        return None
+    note = _sanitize_note(draft.note)
+    if note is None:
+        return None
+    end = start + len(draft.quote)
+    return MarginaliaAnchored(
+        kind=draft.kind,
+        anchor_start=start,
+        anchor_end=end,
+        anchor_text=body[start:end],
+        note=note,
+    )
+
+
+def _overlaps(a: MarginaliaAnchored, b: MarginaliaAnchored) -> bool:
+    """True when two anchored spans intersect."""
+    return a.anchor_start < b.anchor_end and b.anchor_start < a.anchor_end
+
+
+async def generate_marginalia(
+    body: str,
+    *,
+    llm: ResonanceLLM,
+    prior_entries: Sequence[str] | None = None,
+    max_notes: int = _DEFAULT_MAX_NOTES,
+) -> list[MarginaliaAnchored]:
+    """Ask ``llm`` to read ``body`` and return anchored, validated margin notes.
+
+    Quotes are located verbatim in ``body`` (model indices are never trusted);
+    notes that don't anchor, have an unknown kind, or can't be sanitized are
+    dropped. Overlapping spans are de-duplicated (first wins) and the result is
+    capped at ``max_notes``.
+    """
+    raw = await llm.complete(build_prompt(body, prior_entries, max_notes))
+    anchored: list[MarginaliaAnchored] = []
+    for draft in _parse_drafts(raw):
+        candidate = _anchor(body, draft)
+        if candidate is None or any(_overlaps(candidate, kept) for kept in anchored):
+            continue
+        anchored.append(candidate)
+        if len(anchored) >= max_notes:
+            break
+    return anchored

--- a/backend/src/domain/resonance.py
+++ b/backend/src/domain/resonance.py
@@ -18,9 +18,13 @@ from security import TextTooLongError, sanitize_user_text
 # Kept as literals (not imported from models.marginalia) so the domain stays
 # free of DB imports; ``test_resonance_service`` guards this against enum drift.
 VALID_KINDS = frozenset({"theme", "connection", "symbol"})
-_ANCHOR_TEXT_MAX = 280
-_NOTE_MAX = 600
+ANCHOR_TEXT_MAX = 280
+NOTE_MAX = 600
 _DEFAULT_MAX_NOTES = 5
+# Bound the prompt cost: at most this many prior entries, each truncated, so a
+# caller passing a long history can't blow up the context window / token bill.
+MAX_PRIOR_ENTRIES = 5
+_PRIOR_ENTRY_CHARS = 1000
 
 
 @dataclass(frozen=True)
@@ -55,7 +59,8 @@ def build_prompt(
     """Build the structured prompt asking for up to ``max_notes`` margin notes."""
     prior_block = ""
     if prior_entries:
-        joined = "\n---\n".join(prior_entries)
+        capped = [entry[:_PRIOR_ENTRY_CHARS] for entry in prior_entries[:MAX_PRIOR_ENTRIES]]
+        joined = "\n---\n".join(capped)
         prior_block = (
             "\n\nEarlier entries (context for 'connection' notes only):\n"
             f"<prior>\n{joined}\n</prior>"
@@ -67,7 +72,7 @@ def build_prompt(
         "For each note:\n"
         '- "kind" is one of: theme, connection, symbol.\n'
         '- "quote" is a VERBATIM substring copied exactly from the entry '
-        f"(<= {_ANCHOR_TEXT_MAX} characters), never paraphrased.\n"
+        f"(<= {ANCHOR_TEXT_MAX} characters), never paraphrased.\n"
         '- "note" is 1-2 warm, second-person sentences spoken to the writer. '
         'Never refer to yourself or say "as an AI".\n'
         "- Use 'connection' only when linking to an earlier entry.\n\n"
@@ -99,7 +104,7 @@ def _parse_drafts(raw: str) -> list[MarginaliaDraft]:
 def _sanitize_note(note: str) -> str | None:
     """Sanitize a note; return None if it can't fit the column after sanitizing."""
     try:
-        cleaned = sanitize_user_text(note, max_len=_NOTE_MAX)
+        cleaned = sanitize_user_text(note, max_len=NOTE_MAX)
     except TextTooLongError:
         return None
     return cleaned or None
@@ -107,7 +112,7 @@ def _sanitize_note(note: str) -> str | None:
 
 def _anchor(body: str, draft: MarginaliaDraft) -> MarginaliaAnchored | None:
     """Resolve a draft to a span, or None if it can't anchor / validate."""
-    if draft.kind not in VALID_KINDS or not draft.quote or len(draft.quote) > _ANCHOR_TEXT_MAX:
+    if draft.kind not in VALID_KINDS or not draft.quote or len(draft.quote) > ANCHOR_TEXT_MAX:
         return None
     start = body.find(draft.quote)
     if start == -1:

--- a/backend/tests/test_resonance_service.py
+++ b/backend/tests/test_resonance_service.py
@@ -1,0 +1,121 @@
+"""Tests for the resonance generation domain service (journal-resonance-04)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from domain import resonance
+from domain.resonance import generate_marginalia
+from models.marginalia import MarginaliaKind
+
+_BODY = (
+    "Today I walked by the river and felt the old fear rise again. "
+    "But I noticed the willow bending without breaking, and something settled."
+)
+
+
+class FakeLLM:
+    """Injected LLM stub: returns a fixed completion, records the prompt."""
+
+    def __init__(self, completion: str) -> None:
+        """Store the canned completion this fake will return."""
+        self._completion = completion
+        self.prompt: str | None = None
+
+    async def complete(self, prompt: str) -> str:
+        self.prompt = prompt
+        return self._completion
+
+
+def _notes_json(*notes: dict[str, str]) -> str:
+    return json.dumps({"notes": list(notes)})
+
+
+def test_valid_kinds_match_the_model_enum() -> None:
+    """The domain's local kind set must not drift from MarginaliaKind."""
+    assert {k.value for k in MarginaliaKind} == resonance.VALID_KINDS
+
+
+@pytest.mark.asyncio
+async def test_valid_drafts_become_anchored_notes() -> None:
+    """Each kept note's offsets exactly index the body."""
+    llm = FakeLLM(
+        _notes_json(
+            {"kind": "theme", "quote": "the old fear rise again", "note": "Fear returns, gently."},
+            {"kind": "symbol", "quote": "the willow bending", "note": "The willow holds you."},
+        )
+    )
+    out = await generate_marginalia(_BODY, llm=llm)
+    assert len(out) == 2
+    for note in out:
+        assert _BODY[note.anchor_start : note.anchor_end] == note.anchor_text
+        assert note.anchor_text in _BODY
+        assert note.kind in {k.value for k in MarginaliaKind}
+
+
+@pytest.mark.asyncio
+async def test_absent_quote_is_dropped_not_raised() -> None:
+    """A quote that isn't a verbatim substring is silently dropped."""
+    llm = FakeLLM(
+        _notes_json(
+            {"kind": "theme", "quote": "a phrase not in the entry", "note": "n"},
+            {"kind": "theme", "quote": "the willow bending", "note": "kept"},
+        )
+    )
+    out = await generate_marginalia(_BODY, llm=llm)
+    assert len(out) == 1
+    assert out[0].note == "kept"
+
+
+@pytest.mark.asyncio
+async def test_unknown_kind_is_dropped() -> None:
+    """A note with an out-of-set kind is dropped."""
+    llm = FakeLLM(_notes_json({"kind": "vibe", "quote": "the willow bending", "note": "n"}))
+    assert await generate_marginalia(_BODY, llm=llm) == []
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_returns_empty() -> None:
+    """Non-JSON / wrong-shape completions never raise — they yield no notes."""
+    assert await generate_marginalia(_BODY, llm=FakeLLM("not json at all")) == []
+    assert await generate_marginalia(_BODY, llm=FakeLLM('{"notes": "nope"}')) == []
+    assert await generate_marginalia(_BODY, llm=FakeLLM("{}")) == []
+
+
+@pytest.mark.asyncio
+async def test_overlapping_spans_are_deduped() -> None:
+    """Two notes anchoring to overlapping spans keep only the first."""
+    llm = FakeLLM(
+        _notes_json(
+            {"kind": "theme", "quote": "the willow bending without breaking", "note": "first"},
+            {"kind": "symbol", "quote": "willow bending", "note": "overlaps-first"},
+        )
+    )
+    out = await generate_marginalia(_BODY, llm=llm)
+    assert len(out) == 1
+    assert out[0].note == "first"
+
+
+@pytest.mark.asyncio
+async def test_max_notes_is_respected() -> None:
+    """No more than max_notes are returned even when more anchor cleanly."""
+    llm = FakeLLM(
+        _notes_json(
+            {"kind": "theme", "quote": "Today", "note": "1"},
+            {"kind": "theme", "quote": "river", "note": "2"},
+            {"kind": "theme", "quote": "fear", "note": "3"},
+        )
+    )
+    out = await generate_marginalia(_BODY, llm=llm, max_notes=2)
+    assert len(out) == 2
+
+
+@pytest.mark.asyncio
+async def test_prompt_includes_prior_entries_for_connection_context() -> None:
+    """prior_entries are embedded in the prompt for connection notes."""
+    llm = FakeLLM(_notes_json())
+    await generate_marginalia(_BODY, llm=llm, prior_entries=["An earlier page about the river."])
+    assert llm.prompt is not None
+    assert "An earlier page about the river." in llm.prompt

--- a/backend/tests/test_resonance_service.py
+++ b/backend/tests/test_resonance_service.py
@@ -8,7 +8,7 @@ import pytest
 
 from domain import resonance
 from domain.resonance import generate_marginalia
-from models.marginalia import MarginaliaKind
+from models.marginalia import Marginalia, MarginaliaKind
 
 _BODY = (
     "Today I walked by the river and felt the old fear rise again. "
@@ -36,6 +36,26 @@ def _notes_json(*notes: dict[str, str]) -> str:
 def test_valid_kinds_match_the_model_enum() -> None:
     """The domain's local kind set must not drift from MarginaliaKind."""
     assert {k.value for k in MarginaliaKind} == resonance.VALID_KINDS
+
+
+def test_size_constants_match_the_model_columns() -> None:
+    """The domain's anchor/note caps must match the actual DB column lengths."""
+    columns = Marginalia.__table__.columns  # type: ignore[attr-defined]
+    assert columns["anchor_text"].type.length == resonance.ANCHOR_TEXT_MAX
+    assert columns["note"].type.length == resonance.NOTE_MAX
+
+
+@pytest.mark.asyncio
+async def test_prior_entries_are_capped_in_the_prompt() -> None:
+    """At most MAX_PRIOR_ENTRIES prior entries reach the prompt, each truncated."""
+    llm = FakeLLM(_notes_json())
+    priors = [f"PRIOR_{i}_" + ("x" * 5000) for i in range(10)]
+    await generate_marginalia(_BODY, llm=llm, prior_entries=priors)
+    assert llm.prompt is not None
+    included = sum(f"PRIOR_{i}_" in llm.prompt for i in range(10))
+    assert included == resonance.MAX_PRIOR_ENTRIES
+    # Each included entry is truncated to the per-entry budget.
+    assert ("x" * 5000) not in llm.prompt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

journal-resonance-04: **pure domain logic** in `domain/resonance.py` — no FastAPI, no DB. The injected LLM proposes short notes with a **verbatim quote**; the service resolves each quote to character offsets *itself* (model indices never trusted) and drops anything that doesn't anchor cleanly.

- `MarginaliaDraft {kind, quote, note}` + `MarginaliaAnchored {kind, anchor_start, anchor_end, anchor_text, note}`; `ResonanceLLM` Protocol (prompt → text).
- `build_prompt`: up to `max_notes` (default 5) warm second-person notes, each a verbatim ≤280-char quote classified `theme`/`connection`/`symbol`, strict JSON out, optional `prior_entries` for connection context.
- `generate_marginalia`: defensively parse JSON (never raises), validate kind, locate the quote verbatim, sanitize the note, de-dup overlapping spans (first wins), cap at `max_notes`.
- `VALID_KINDS` is a local literal set (keeps the domain DB-free); a test guards it against `MarginaliaKind` drift.

## Test plan

`test_resonance_service.py` (fake injected LLM, no network):
- valid drafts → anchored notes where `body[start:end] == anchor_text`;
- absent-quote / malformed-JSON / unknown-kind dropped **without raising**;
- overlapping spans de-duped; `max_notes` respected; `prior_entries` reach the prompt;
- `VALID_KINDS` matches `MarginaliaKind`.

`./scripts/backend/check-all.sh` — 7/7; xenon clean; zero FastAPI/DB imports.

Closes #607
Refs #603
