### PR TITLE
feat(backend): resonance + marginalia endpoints

### DIFF
--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -392,7 +392,10 @@ async def list_marginalia(
         raise not_found("journal_entry")
     result = await session.execute(
         select(Marginalia)
-        .where(Marginalia.journal_entry_id == entry_id)
+        .where(
+            Marginalia.journal_entry_id == entry_id,
+            Marginalia.user_id == current_user,  # defense-in-depth alongside the entry check
+        )
         .order_by(col(Marginalia.anchor_start))
     )
     rows = result.scalars().all()

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -7,15 +7,17 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from sqlalchemy import ColumnElement, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import require_owned_journal_entry
+from domain.resonance import MarginaliaAnchored, generate_marginalia
 from errors import not_found, unprocessable
 from models.journal_entry import JournalEntry, JournalTag
+from models.marginalia import Marginalia, MarginaliaStatus
 from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.journal import (
@@ -26,9 +28,17 @@ from schemas.journal import (
     JournalMessageCreate,
     JournalMessageResponse,
 )
+from schemas.marginalia import (
+    MarginaliaListResponse,
+    MarginaliaResponse,
+    ResonanceResponse,
+)
 from security import TextTooLongError, sanitize_user_text
 from services import journal_encryption
-from services.marginalia import reanchor_entry_marginalia
+from services.botmason import LLMProviderError, resolve_chat_api_key
+from services.marginalia import BotmasonResonanceLLM, reanchor_entry_marginalia
+from services.usage import get_monthly_cap
+from services.wallet import preflight_deduction, require_user_fresh
 
 
 def _sanitize_message(message: str) -> str:
@@ -269,6 +279,126 @@ async def update_journal_entry(
     await session.refresh(entry)
     logger.info("journal_entry_updated", extra={"user_id": current_user, "entry_id": entry_id})
     return entry
+
+
+_RESONANCE_PRIOR_LIMIT = 3
+
+
+async def _load_user_entry(
+    session: AsyncSession, entry_id: int, user_id: int
+) -> JournalEntry | None:
+    """Load the caller's own non-deleted entry, or None (404-scoped)."""
+    result = await session.execute(
+        select(JournalEntry).where(
+            JournalEntry.id == entry_id,
+            JournalEntry.user_id == user_id,
+            col(JournalEntry.deleted_at).is_(None),
+        )
+    )
+    return result.scalars().first()
+
+
+async def _recent_prior_bodies(session: AsyncSession, user_id: int, exclude_id: int) -> list[str]:
+    """The caller's most recent other entry bodies, for connection context."""
+    result = await session.execute(
+        select(JournalEntry)
+        .where(
+            JournalEntry.user_id == user_id,
+            JournalEntry.id != exclude_id,
+            col(JournalEntry.deleted_at).is_(None),
+        )
+        .order_by(col(JournalEntry.id).desc())
+        .limit(_RESONANCE_PRIOR_LIMIT)
+    )
+    return [row.message for row in result.scalars().all()]
+
+
+def _persist_marginalia(
+    session: AsyncSession, entry_id: int, user_id: int, anchored: list[MarginaliaAnchored]
+) -> list[Marginalia]:
+    """Stage one Marginalia row per anchored note (active, no essay yet)."""
+    rows = [
+        Marginalia(
+            journal_entry_id=entry_id,
+            user_id=user_id,
+            kind=note.kind,
+            anchor_start=note.anchor_start,
+            anchor_end=note.anchor_end,
+            anchor_text=note.anchor_text,
+            note=note.note,
+            status=MarginaliaStatus.ACTIVE,
+        )
+        for note in anchored
+    ]
+    session.add_all(rows)
+    return rows
+
+
+@router.post("/{entry_id}/resonance", response_model=ResonanceResponse)
+@limiter.limit("10/minute")
+async def run_resonance(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    entry_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    x_llm_api_key: Annotated[str | None, Header(alias="X-LLM-API-Key")] = None,
+) -> ResonanceResponse:
+    """Run a resonance pass over the caller's entry, persist notes, charge one unit.
+
+    Wallet pre-flight deducts one message (402 when out of capacity). The LLM
+    pass + persistence + the charge commit atomically; any provider error rolls
+    the deduction back so a failed pass never charges (502 ``llm_provider_error``).
+    """
+    entry = await _load_user_entry(session, entry_id, current_user)
+    if entry is None:
+        raise not_found("journal_entry")
+    spent = await preflight_deduction(session, current_user)
+    prior = await _recent_prior_bodies(session, current_user, entry_id)
+    llm = BotmasonResonanceLLM(resolve_chat_api_key(x_llm_api_key))
+    try:
+        anchored = await generate_marginalia(entry.message, llm=llm, prior_entries=prior)
+    except LLMProviderError as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY, detail="llm_provider_error"
+        ) from exc
+    rows = _persist_marginalia(session, entry_id, current_user, anchored)
+    user = await require_user_fresh(session, current_user)
+    reset_date = user.monthly_reset_date
+    await session.commit()
+    for row in rows:
+        await session.refresh(row)
+    logger.info(
+        "journal_resonance_generated",
+        extra={"user_id": current_user, "entry_id": entry_id, "count": len(rows)},
+    )
+    return ResonanceResponse(
+        marginalia=[MarginaliaResponse.model_validate(r, from_attributes=True) for r in rows],
+        remaining_messages=max(get_monthly_cap() - spent.monthly_used, 0),
+        remaining_balance=spent.offering_balance,
+        monthly_reset_date=reset_date,
+    )
+
+
+@router.get("/{entry_id}/marginalia", response_model=MarginaliaListResponse)
+async def list_marginalia(
+    entry_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> MarginaliaListResponse:
+    """List the caller's marginalia for an entry, ordered by anchor position."""
+    entry = await _load_user_entry(session, entry_id, current_user)
+    if entry is None:
+        raise not_found("journal_entry")
+    result = await session.execute(
+        select(Marginalia)
+        .where(Marginalia.journal_entry_id == entry_id)
+        .order_by(col(Marginalia.anchor_start))
+    )
+    rows = result.scalars().all()
+    return MarginaliaListResponse(
+        items=[MarginaliaResponse.model_validate(r, from_attributes=True) for r in rows]
+    )
 
 
 @router.delete("/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/schemas/marginalia.py
+++ b/backend/src/schemas/marginalia.py
@@ -1,0 +1,46 @@
+"""Response schemas for resonance + marginalia endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from models.marginalia import MarginaliaKind, MarginaliaStatus
+
+
+class MarginaliaResponse(BaseModel):
+    """A single margin note returned to clients.
+
+    ``user_id`` is intentionally excluded — the client already knows its own
+    identity and exposing surrogate keys aids enumeration (mirrors the journal
+    entry response).
+    """
+
+    id: int
+    journal_entry_id: int
+    kind: MarginaliaKind
+    anchor_start: int
+    anchor_end: int
+    anchor_text: str
+    note: str
+    essay: str | None
+    essay_generated_at: datetime | None
+    status: MarginaliaStatus
+    created_at: datetime
+    updated_at: datetime
+
+
+class ResonanceResponse(BaseModel):
+    """Result of a resonance pass: the new notes plus refreshed wallet balances."""
+
+    marginalia: list[MarginaliaResponse]
+    remaining_messages: int
+    remaining_balance: int
+    monthly_reset_date: datetime
+
+
+class MarginaliaListResponse(BaseModel):
+    """All marginalia for an entry (active + stale)."""
+
+    items: list[MarginaliaResponse]

--- a/backend/src/services/marginalia.py
+++ b/backend/src/services/marginalia.py
@@ -11,6 +11,24 @@ from __future__ import annotations
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.journal_entry import JournalEntry
+from services.botmason import generate_response
+
+
+class BotmasonResonanceLLM:
+    """Adapts the BotMason provider to the resonance domain's ``ResonanceLLM``.
+
+    The domain only needs ``complete(prompt) -> text``; this maps that onto
+    ``generate_response`` (no conversation history, no system prompt) so the
+    resonance feature reuses the single LLM integration / BYOK seam.
+    """
+
+    def __init__(self, api_key: str | None) -> None:
+        """Store the optional BYOK key used for each completion."""
+        self._api_key = api_key
+
+    async def complete(self, prompt: str) -> str:
+        response = await generate_response(prompt, [], system_prompt=None, api_key=self._api_key)
+        return response.text
 
 
 async def reanchor_entry_marginalia(

--- a/backend/tests/test_resonance_endpoints.py
+++ b/backend/tests/test_resonance_endpoints.py
@@ -1,0 +1,158 @@
+"""Tests for the resonance + marginalia HTTP endpoints (journal-resonance-05)."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from types import SimpleNamespace
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from models.marginalia import Marginalia
+from models.user import User
+from services import marginalia as marginalia_service
+from services.botmason import LLMProviderError
+
+_BODY = "I walked by the river and the willow bent without breaking."
+
+
+async def _signup(client: AsyncClient, username: str = "reson") -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _create_entry(client: AsyncClient, headers: dict[str, str], body: str = _BODY) -> int:
+    resp = await client.post("/journal/", json={"message": body}, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+def _fake_llm(monkeypatch: pytest.MonkeyPatch, *notes: dict[str, str]) -> None:
+    """Patch the resonance LLM seam to return canned JSON notes."""
+    payload = json.dumps({"notes": list(notes)})
+
+    async def _complete(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> SimpleNamespace:
+        del prompt, history, system_prompt, api_key
+        return SimpleNamespace(text=payload)
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _complete)
+
+
+def _raise_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _boom(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> None:
+        del prompt, history, system_prompt, api_key
+        raise LLMProviderError("provider down")
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _boom)
+
+
+@pytest.mark.asyncio
+async def test_resonance_persists_notes_and_charges_one(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful pass persists the anchored notes and charges one message."""
+    _fake_llm(
+        monkeypatch,
+        {"kind": "symbol", "quote": "the willow bent without breaking", "note": "It holds."},
+        {"kind": "theme", "quote": "I walked by the river", "note": "You return to water."},
+    )
+    headers = await _signup(async_client)
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert len(body["marginalia"]) == 2
+    assert body["remaining_messages"] == 49  # DEFAULT_MONTHLY_CAP (50) - 1
+    persisted = (
+        await db_session.execute(select(func.count()).select_from(Marginalia))
+    ).scalar_one()
+    assert persisted == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("zero_monthly_cap")
+async def test_resonance_insufficient_wallet_is_402_no_rows(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no wallet capacity the pass is 402 and persists nothing / no LLM call."""
+    _fake_llm(monkeypatch, {"kind": "theme", "quote": _BODY, "note": "n"})
+    headers = await _signup(async_client, "broke")
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.PAYMENT_REQUIRED
+    assert resp.json()["detail"] == "insufficient_offerings"
+    rows = (await db_session.execute(select(func.count()).select_from(Marginalia))).scalar_one()
+    assert rows == 0
+
+
+@pytest.mark.asyncio
+async def test_resonance_other_users_entry_is_404(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resonance on another user's entry is 404, not 403."""
+    _fake_llm(monkeypatch, {"kind": "theme", "quote": _BODY, "note": "n"})
+    alice = await _signup(async_client, "alice_r")
+    bob = await _signup(async_client, "bob_r")
+    entry_id = await _create_entry(async_client, alice)
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=bob)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_resonance_llm_error_is_502_without_charge(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider error rolls back the deduction — 502 and nothing persisted/charged."""
+    _raise_llm(monkeypatch)
+    headers = await _signup(async_client, "err")
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_GATEWAY
+    rows = (await db_session.execute(select(func.count()).select_from(Marginalia))).scalar_one()
+    assert rows == 0
+    # The deduction was rolled back: the user's monthly usage is still zero.
+    user = (
+        await db_session.execute(select(User).where(col(User.email) == "err@example.com"))
+    ).scalar_one()
+    assert user.monthly_messages_used == 0
+
+
+@pytest.mark.asyncio
+async def test_list_marginalia_is_ordered_and_hides_user_id(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The marginalia list is ordered by anchor_start and omits user_id."""
+    _fake_llm(
+        monkeypatch,
+        {"kind": "symbol", "quote": "the willow bent without breaking", "note": "later span"},
+        {"kind": "theme", "quote": "I walked by the river", "note": "earlier span"},
+    )
+    headers = await _signup(async_client, "lister")
+    entry_id = await _create_entry(async_client, headers)
+    await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+
+    resp = await async_client.get(f"/journal/{entry_id}/marginalia", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()["items"]
+    assert [i["note"] for i in items] == ["earlier span", "later span"]
+    starts = [i["anchor_start"] for i in items]
+    assert starts == sorted(starts)
+    assert all("user_id" not in i for i in items)

--- a/backend/tests/test_resonance_endpoints.py
+++ b/backend/tests/test_resonance_endpoints.py
@@ -156,3 +156,17 @@ async def test_list_marginalia_is_ordered_and_hides_user_id(
     starts = [i["anchor_start"] for i in items]
     assert starts == sorted(starts)
     assert all("user_id" not in i for i in items)
+
+
+@pytest.mark.asyncio
+async def test_list_marginalia_other_users_entry_is_404(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Listing marginalia on another user's entry is 404 (ownership-scoped)."""
+    _fake_llm(monkeypatch, {"kind": "theme", "quote": "I walked by the river", "note": "n"})
+    alice = await _signup(async_client, "alice_l")
+    bob = await _signup(async_client, "bob_l")
+    entry_id = await _create_entry(async_client, alice)
+    await async_client.post(f"/journal/{entry_id}/resonance", headers=alice)
+    resp = await async_client.get(f"/journal/{entry_id}/marginalia", headers=bob)
+    assert resp.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
## Summary

journal-resonance-05: expose the resonance service over HTTP, persist results, and charge the existing wallet.

- **`schemas/marginalia.py`**: `MarginaliaResponse` (omits `user_id`; `kind`/`status` typed as enums), `ResonanceResponse {marginalia, remaining_messages, remaining_balance, monthly_reset_date}`, `MarginaliaListResponse`.
- **`services/marginalia.py`**: `BotmasonResonanceLLM` adapts `generate_response` to the domain's `ResonanceLLM` seam (reuses the single LLM integration + BYOK `X-LLM-API-Key`).
- **`POST /journal/{id}/resonance`**: load the caller's own non-deleted entry or **404**; wallet **preflight (402** when out of capacity); `generate_marginalia` over the body with the caller's recent entries as connection context; persist one **active** `Marginalia` per anchored note; charge **exactly one unit**. Pass + persistence + charge commit **atomically**; a provider error rolls the deduction back and returns **502** (never a partial charge). Rate-limited 10/min.
- **`GET /journal/{id}/marginalia`**: caller's entry or 404; notes ordered by `anchor_start`, `user_id` hidden.

## Test plan

`test_resonance_endpoints.py` (fake LLM + wallet): success persists N rows and charges one (remaining 49/50); insufficient wallet → 402, no rows; other user → 404; provider error → 502, no rows, monthly usage still 0; list ordered + `user_id` absent.

`./scripts/backend/check-all.sh` — 7/7; xenon `-A` clean; mypy clean (incl. tests).

Closes #608
Refs #603
