### PR TITLE
feat(backend): lazy cached essay-expansion endpoint

### DIFF
--- a/backend/src/domain/resonance.py
+++ b/backend/src/domain/resonance.py
@@ -20,6 +20,7 @@ from security import TextTooLongError, sanitize_user_text
 VALID_KINDS = frozenset({"theme", "connection", "symbol"})
 ANCHOR_TEXT_MAX = 280
 NOTE_MAX = 600
+ESSAY_MAX = 10_000
 _DEFAULT_MAX_NOTES = 5
 # Bound the prompt cost: at most this many prior entries, each truncated, so a
 # caller passing a long history can't blow up the context window / token bill.
@@ -176,3 +177,35 @@ async def generate_marginalia(
         if len(anchored) >= max_notes:
             break
     return anchored
+
+
+def _build_essay_prompt(body: str, anchor_text: str, kind: str, note: str) -> str:
+    """Build the prompt expanding one margin note into a short letter-like essay."""
+    return (
+        "You are writing a short, warm letter to the person whose journal this is, "
+        f"expanding on a margin note you left. Stay grounded in the passage you "
+        f"anchored to; speak in second person; never refer to yourself as an AI.\n\n"
+        f"Margin note kind: {kind}\n"
+        f"Your margin note: {note}\n"
+        f"The passage it anchors to:\n<passage>\n{anchor_text}\n</passage>\n\n"
+        f"The full entry for context:\n<entry>\n{body}\n</entry>\n\n"
+        "Write a few warm paragraphs. Plain prose only, no headings or JSON."
+    )
+
+
+def _sanitize_essay(text: str) -> str:
+    """Sanitize + cap an essay to ESSAY_MAX, truncating rather than raising."""
+    truncated = text[:ESSAY_MAX]
+    try:
+        return sanitize_user_text(truncated, max_len=ESSAY_MAX)
+    except TextTooLongError:
+        # NFC expansion pushed it back over the cap; trim with headroom.
+        return sanitize_user_text(truncated[: ESSAY_MAX // 2], max_len=ESSAY_MAX)
+
+
+async def generate_essay(
+    *, llm: ResonanceLLM, body: str, anchor_text: str, kind: str, note: str
+) -> str:
+    """Ask ``llm`` to expand a margin note into a sanitized, length-capped essay."""
+    raw = await llm.complete(_build_essay_prompt(body, anchor_text, kind, note))
+    return _sanitize_essay(raw)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -14,7 +14,7 @@ from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import require_owned_journal_entry
-from domain.resonance import MarginaliaAnchored, generate_marginalia
+from domain.resonance import MarginaliaAnchored, generate_essay, generate_marginalia
 from errors import not_found, unprocessable
 from models.journal_entry import JournalEntry, JournalTag
 from models.marginalia import Marginalia, MarginaliaStatus
@@ -402,6 +402,69 @@ async def list_marginalia(
     return MarginaliaListResponse(
         items=[MarginaliaResponse.model_validate(r, from_attributes=True) for r in rows]
     )
+
+
+# Economy seam: essay expansion is free by default. A future pricing pass would
+# charge here (and gate generation on capacity) — kept as a single named knob so
+# the policy lives in one place rather than scattered through the handler.
+ESSAY_PRICE_UNITS = 0
+
+
+async def _load_user_marginalia(
+    session: AsyncSession, marginalia_id: int, user_id: int
+) -> Marginalia | None:
+    """Load the caller's own marginalia row by id (denormalized user_id scope)."""
+    result = await session.execute(
+        select(Marginalia).where(
+            Marginalia.id == marginalia_id,
+            Marginalia.user_id == user_id,
+        )
+    )
+    return result.scalars().first()
+
+
+@router.post("/marginalia/{marginalia_id}/essay", response_model=MarginaliaResponse)
+@limiter.limit("10/minute")
+async def expand_marginalia_essay(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    marginalia_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    x_llm_api_key: Annotated[str | None, Header(alias="X-LLM-API-Key")] = None,
+) -> Marginalia:
+    """Lazily generate (and cache) a longer essay expanding one margin note.
+
+    Idempotent: once ``essay`` is set the cached value is returned without another
+    LLM call. Ownership is enforced via the marginalia's own ``user_id`` (404
+    otherwise). Essay generation is free by default (see ``ESSAY_PRICE_UNITS``).
+    """
+    note = await _load_user_marginalia(session, marginalia_id, current_user)
+    if note is None:
+        raise not_found("marginalia")
+    if note.essay is not None:
+        return note
+    entry = await _load_user_entry(session, note.journal_entry_id, current_user)
+    if entry is None:  # pragma: no cover — marginalia FK guarantees the parent
+        raise not_found("journal_entry")
+    llm = BotmasonResonanceLLM(resolve_chat_api_key(x_llm_api_key))
+    try:
+        essay = await generate_essay(
+            llm=llm,
+            body=entry.message,
+            anchor_text=note.anchor_text,
+            kind=note.kind,
+            note=note.note,
+        )
+    except LLMProviderError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY, detail="llm_provider_error"
+        ) from exc
+    note.essay = essay
+    note.essay_generated_at = datetime.now(UTC)
+    await session.commit()
+    await session.refresh(note)
+    logger.info("marginalia_essay_generated", extra={"user_id": current_user, "id": marginalia_id})
+    return note
 
 
 @router.delete("/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/tests/test_essay_endpoint.py
+++ b/backend/tests/test_essay_endpoint.py
@@ -1,0 +1,125 @@
+"""Tests for the lazy essay-expansion endpoint (journal-resonance-06)."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from types import SimpleNamespace
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import JournalEntry
+from models.marginalia import Marginalia, MarginaliaKind
+from routers import journal as journal_router
+from services import marginalia as marginalia_service
+
+_BODY = "I walked by the river and the willow bent without breaking."
+
+
+async def _signup(client: AsyncClient, username: str = "essay") -> tuple[dict[str, str], int]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    payload = resp.json()
+    return {"Authorization": f"Bearer {payload['token']}"}, int(payload["user_id"])
+
+
+async def _seed_marginalia(session: AsyncSession, user_id: int) -> int:
+    entry = JournalEntry(sender="user", user_id=user_id, message=_BODY)
+    session.add(entry)
+    await session.flush()
+    note = Marginalia(
+        journal_entry_id=entry.id,
+        user_id=user_id,
+        kind=MarginaliaKind.SYMBOL,
+        anchor_start=0,
+        anchor_end=6,
+        anchor_text="I walk",
+        note="A beginning.",
+    )
+    session.add(note)
+    await session.commit()
+    await session.refresh(note)
+    assert note.id is not None
+    return note.id
+
+
+class _CountingLLM:
+    """Patches the LLM seam, returning fixed text and counting calls."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.calls = 0
+
+    async def __call__(
+        self, prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> SimpleNamespace:
+        del prompt, history, system_prompt, api_key
+        self.calls += 1
+        return SimpleNamespace(text=self.text)
+
+
+@pytest.mark.asyncio
+async def test_essay_generates_then_caches(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """First call generates + caches; the second returns it without a new LLM call."""
+    headers, user_id = await _signup(async_client)
+    marg_id = await _seed_marginalia(db_session, user_id)
+    fake = _CountingLLM("A warm letter about beginnings.")
+    monkeypatch.setattr(marginalia_service, "generate_response", fake)
+
+    first = await async_client.post(f"/journal/marginalia/{marg_id}/essay", headers=headers)
+    assert first.status_code == HTTPStatus.OK
+    body = first.json()
+    assert body["essay"] == "A warm letter about beginnings."
+    assert body["essay_generated_at"] is not None
+    assert "user_id" not in body
+    assert fake.calls == 1
+
+    second = await async_client.post(f"/journal/marginalia/{marg_id}/essay", headers=headers)
+    assert second.status_code == HTTPStatus.OK
+    assert second.json()["essay"] == "A warm letter about beginnings."
+    assert fake.calls == 1  # cached — no second LLM call
+
+
+@pytest.mark.asyncio
+async def test_essay_other_users_marginalia_is_404(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user can't expand another user's margin note."""
+    _alice_headers, alice_id = await _signup(async_client, "alice_e")
+    bob_headers, _bob_id = await _signup(async_client, "bob_e")
+    marg_id = await _seed_marginalia(db_session, alice_id)
+    monkeypatch.setattr(marginalia_service, "generate_response", _CountingLLM("x"))
+    resp = await async_client.post(f"/journal/marginalia/{marg_id}/essay", headers=bob_headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_essay_is_sanitized_and_length_capped(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stored essay is sanitized and capped to the column limit."""
+    headers, user_id = await _signup(async_client, "cap")
+    marg_id = await _seed_marginalia(db_session, user_id)
+    # Oversized text with an embedded zero-width space.
+    monkeypatch.setattr(
+        marginalia_service, "generate_response", _CountingLLM("clean\u200bword " + "x" * 20000)
+    )
+    resp = await async_client.post(f"/journal/marginalia/{marg_id}/essay", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    essay = resp.json()["essay"]
+    assert len(essay) <= 10_000
+    assert "\u200b" not in essay
+
+
+def test_essay_is_free_by_default() -> None:
+    """The economy seam defaults essay generation to free."""
+    assert journal_router.ESSAY_PRICE_UNITS == 0


### PR DESCRIPTION
## Summary

journal-resonance-06: `POST /journal/marginalia/{id}/essay` lazily expands one margin note into a longer letter-like essay, **caches** it on the row, and is **idempotent**.

- **`domain/resonance.py`**: `generate_essay(*, llm, body, anchor_text, kind, note) -> str` — warm, second-person, grounded in the anchored passage; sanitized and capped to `ESSAY_MAX` (10000) by truncation (never raises).
- **Endpoint**: load the caller's own marginalia by its denormalized `user_id` (404 otherwise); if `essay` is already set, return it with **no LLM call and no charge**; else generate, set `essay` + `essay_generated_at`, commit, return the full `MarginaliaResponse` (`user_id` hidden). Provider error → 502. Rate-limited 10/min.
- **Economy seam**: essay generation is **free by default** via the single `ESSAY_PRICE_UNITS` knob (a later pricing pass charges there).

## Test plan

`test_essay_endpoint.py` (fake LLM): first call generates + caches; second returns the cached essay **without a second LLM call**; other user → 404; essay sanitized + length-capped; the free-by-default seam asserted.

`./scripts/backend/check-all.sh` — 7/7; xenon `-A` clean.

Closes #609
Refs #603
