### PR TITLE
feat(backend): re-anchor marginalia on entry edit (or mark stale)

### DIFF
--- a/backend/src/domain/marginalia_anchoring.py
+++ b/backend/src/domain/marginalia_anchoring.py
@@ -1,0 +1,38 @@
+"""Re-anchor margin notes after a journal entry's body changes.
+
+Pure string logic — no LLM, no DB. A note re-anchors to its span if its snapshot
+``anchor_text`` still exists in the new body; otherwise it is marked stale. Notes
+are never deleted on edit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReanchorResult:
+    """Outcome of re-anchoring one note: new span + whether it went stale."""
+
+    anchor_start: int
+    anchor_end: int
+    stale: bool
+
+
+def reanchor_one(anchor_text: str, anchor_start: int, new_body: str) -> ReanchorResult:
+    """Re-locate ``anchor_text`` in ``new_body``.
+
+    - Fast path: if the old offsets still spell ``anchor_text``, keep them.
+    - Else the **first** occurrence of ``anchor_text`` becomes the new span
+      (documented choice; duplicate passages anchor to the earliest match).
+    - Empty ``anchor_text`` or no occurrence → stale, offsets left unchanged.
+    """
+    if not anchor_text:
+        return ReanchorResult(anchor_start, anchor_start, stale=True)
+    end = anchor_start + len(anchor_text)
+    if anchor_start >= 0 and new_body[anchor_start:end] == anchor_text:
+        return ReanchorResult(anchor_start, end, stale=False)
+    found = new_body.find(anchor_text)
+    if found != -1:
+        return ReanchorResult(found, found + len(anchor_text), stale=False)
+    return ReanchorResult(anchor_start, end, stale=True)

--- a/backend/src/services/marginalia.py
+++ b/backend/src/services/marginalia.py
@@ -9,8 +9,11 @@ exists so the PATCH endpoint can call a stable, documented seam now.
 from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
+from domain.marginalia_anchoring import reanchor_one
 from models.journal_entry import JournalEntry
+from models.marginalia import Marginalia, MarginaliaStatus
 from services.botmason import generate_response
 
 
@@ -39,10 +42,23 @@ async def reanchor_entry_marginalia(
 ) -> None:
     """Re-anchor (or mark stale) the entry's marginalia after a body edit.
 
-    No-op for now — the diff-based re-anchoring is implemented in a follow-up.
-    Kept as a call seam so the edit endpoint's contract is stable: callers invoke
-    it whenever ``message`` changes, passing the old and new bodies.
+    Each active note re-anchors to its span if its ``anchor_text`` still occurs
+    in ``new_message``; otherwise it is marked stale. Stale notes stay stale and
+    nothing is deleted. Matching is on ``anchor_text`` (the snapshot), never on
+    offsets alone, so the new body is the only input the logic needs.
     """
-    # Arguments are accepted now to fix the seam's signature; the follow-up that
-    # implements re-anchoring will consume them.
-    del entry, old_message, new_message, session
+    # The match is against the snapshot text in the new body, so the pre-edit
+    # body isn't consulted here.
+    del old_message
+    result = await session.execute(
+        select(Marginalia).where(Marginalia.journal_entry_id == entry.id)
+    )
+    for note in result.scalars().all():
+        if note.status == MarginaliaStatus.STALE:
+            continue  # once stale, stays stale
+        outcome = reanchor_one(note.anchor_text, note.anchor_start, new_message)
+        if outcome.stale:
+            note.status = MarginaliaStatus.STALE
+        else:
+            note.anchor_start = outcome.anchor_start
+            note.anchor_end = outcome.anchor_end

--- a/backend/tests/test_marginalia_reanchoring.py
+++ b/backend/tests/test_marginalia_reanchoring.py
@@ -1,0 +1,122 @@
+"""Tests for re-anchoring marginalia on entry edit (journal-resonance-07)."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain.marginalia_anchoring import reanchor_one
+from models.journal_entry import JournalEntry
+from models.marginalia import Marginalia, MarginaliaKind, MarginaliaStatus
+
+_BODY = "I walked by the river and the willow bent without breaking."
+_ANCHOR = "the willow"
+
+
+def test_fast_path_keeps_offsets_when_unchanged() -> None:
+    start = _BODY.index(_ANCHOR)
+    out = reanchor_one(_ANCHOR, start, _BODY)
+    assert (out.anchor_start, out.anchor_end, out.stale) == (start, start + len(_ANCHOR), False)
+
+
+def test_insert_before_shifts_offsets_and_stays_active() -> None:
+    start = _BODY.index(_ANCHOR)
+    new_body = "Yesterday: " + _BODY
+    out = reanchor_one(_ANCHOR, start, new_body)
+    assert out.stale is False
+    assert new_body[out.anchor_start : out.anchor_end] == _ANCHOR
+    assert out.anchor_start == new_body.index(_ANCHOR)
+
+
+def test_deleted_passage_goes_stale() -> None:
+    start = _BODY.index(_ANCHOR)
+    out = reanchor_one(_ANCHOR, start, "An entirely different entry today.")
+    assert out.stale is True
+
+
+def test_duplicate_text_anchors_to_first_occurrence() -> None:
+    new_body = f"{_ANCHOR} ... and again {_ANCHOR}."
+    out = reanchor_one(_ANCHOR, 999, new_body)
+    assert out.stale is False
+    assert out.anchor_start == 0
+
+
+def test_empty_anchor_text_is_stale() -> None:
+    out = reanchor_one("", 5, _BODY)
+    assert out.stale is True
+
+
+async def _signup(client: AsyncClient, username: str = "anchor") -> tuple[dict[str, str], int]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    payload = resp.json()
+    return {"Authorization": f"Bearer {payload['token']}"}, int(payload["user_id"])
+
+
+async def _seed(session: AsyncSession, user_id: int) -> tuple[int, int]:
+    entry = JournalEntry(sender="user", user_id=user_id, message=_BODY)
+    session.add(entry)
+    await session.flush()
+    start = _BODY.index(_ANCHOR)
+    note = Marginalia(
+        journal_entry_id=entry.id,
+        user_id=user_id,
+        kind=MarginaliaKind.SYMBOL,
+        anchor_start=start,
+        anchor_end=start + len(_ANCHOR),
+        anchor_text=_ANCHOR,
+        note="It bends.",
+    )
+    session.add(note)
+    await session.commit()
+    await session.refresh(note)
+    assert entry.id is not None
+    assert note.id is not None
+    return entry.id, note.id
+
+
+@pytest.mark.asyncio
+async def test_patch_removing_passage_marks_note_stale(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Editing the body to drop the anchored passage flips the note stale."""
+    headers, user_id = await _signup(async_client)
+    entry_id, _note_id = await _seed(db_session, user_id)
+
+    resp = await async_client.patch(
+        f"/journal/{entry_id}", json={"message": "A completely new page."}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+    listing = await async_client.get(f"/journal/{entry_id}/marginalia", headers=headers)
+    items = listing.json()["items"]
+    assert len(items) == 1
+    assert items[0]["status"] == MarginaliaStatus.STALE
+
+
+@pytest.mark.asyncio
+async def test_patch_inserting_before_keeps_note_active_with_shifted_span(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Editing elsewhere re-anchors the survivor and keeps it active."""
+    headers, user_id = await _signup(async_client, "shift")
+    entry_id, _note_id = await _seed(db_session, user_id)
+    new_body = "Yesterday: " + _BODY
+
+    resp = await async_client.patch(
+        f"/journal/{entry_id}", json={"message": new_body}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+    items = (await async_client.get(f"/journal/{entry_id}/marginalia", headers=headers)).json()[
+        "items"
+    ]
+    assert items[0]["status"] == MarginaliaStatus.ACTIVE
+    assert items[0]["anchor_start"] == new_body.index(_ANCHOR)


### PR DESCRIPTION
## Summary

journal-resonance-07: fill the `reanchor_entry_marginalia` seam left by the PATCH endpoint with real, **pure string logic** — no LLM, no deletion.

- **`domain/marginalia_anchoring.py`**: `reanchor_one(anchor_text, anchor_start, new_body) -> ReanchorResult`. Fast-path keeps offsets when they still spell the anchor; else the **first occurrence** of `anchor_text` re-anchors (active); empty/absent → **stale** (offsets preserved). Matching is on `anchor_text`, never offsets alone.
- **`services/marginalia.reanchor_entry_marginalia`** now applies it to each of the entry's notes: survivors re-anchor and stay active, the rest flip **stale**; already-stale notes are skipped (stay stale); nothing is deleted. `updated_at` bumps via the column `onupdate` when offsets/status actually change.

## Test plan

- Unit: `reanchor_one` fast-path, insert-before shift, deletion→stale, duplicate→first occurrence, empty→stale.
- E2E via PATCH: dropping the passage flips the note **stale** and `GET .../marginalia` reflects it; inserting before keeps it **active** with a shifted span.

`./scripts/backend/check-all.sh` — 7/7; xenon `-A` clean.

Closes #610
Refs #603
