### PR TITLE
feat(frontend): editorial design tokens for the journal surface

### DIFF
--- a/frontend/src/design/__tests__/editorialTokens.test.ts
+++ b/frontend/src/design/__tests__/editorialTokens.test.ts
@@ -1,0 +1,94 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { colors, editorialType, journalLayout } from '../tokens';
+
+/** WCAG relative luminance of a #rrggbb color. */
+const luminance = (hex: string): number => {
+  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
+  const channels = [match[1], match[2], match[3]].map((pair) => {
+    const c = Number.parseInt(pair!, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+};
+
+const contrast = (a: string, b: string): number => {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+const AA_NORMAL = 4.5;
+
+describe('editorial tokens', () => {
+  describe('colors.paper', () => {
+    it('exports the paper palette keys', () => {
+      expect(Object.keys(colors.paper)).toEqual(
+        expect.arrayContaining([
+          'background',
+          'backgroundAlt',
+          'ink',
+          'inkSoft',
+          'hairline',
+          'anchorHighlight',
+        ]),
+      );
+    });
+
+    it('meets WCAG AA for ink and inkSoft on the paper ground', () => {
+      expect(contrast(colors.paper.ink, colors.paper.background)).toBeGreaterThanOrEqual(AA_NORMAL);
+      expect(contrast(colors.paper.inkSoft, colors.paper.background)).toBeGreaterThanOrEqual(
+        AA_NORMAL,
+      );
+    });
+  });
+
+  describe('colors.marginalia', () => {
+    it('exports an accent per note kind', () => {
+      expect(Object.keys(colors.marginalia)).toEqual(['theme', 'connection', 'symbol']);
+    });
+
+    it('every kind accent meets AA on the paper ground', () => {
+      for (const accent of Object.values(colors.marginalia)) {
+        expect(contrast(accent, colors.paper.background)).toBeGreaterThanOrEqual(AA_NORMAL);
+      }
+    });
+  });
+
+  describe('journalLayout', () => {
+    it('exports the page metrics as positive numbers', () => {
+      expect(Object.keys(journalLayout)).toEqual([
+        'marginColumnWidth',
+        'pageHorizontalPadding',
+        'pageMaxWidth',
+        'marginNoteGap',
+      ]);
+      for (const value of Object.values(journalLayout)) {
+        expect(value).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('editorialType', () => {
+    it('resolves a non-empty serif stack', () => {
+      expect(typeof editorialType.serif).toBe('string');
+      expect(editorialType.serif.length).toBeGreaterThan(0);
+    });
+
+    it('exports the long-form scale + a margin-note style', () => {
+      for (const key of ['display', 'title', 'body', 'note', 'caption', 'marginNote'] as const) {
+        const style = editorialType[key];
+        expect(style.fontFamily).toBe(editorialType.serif);
+        expect(style.fontSize).toBeGreaterThan(0);
+        expect(style.lineHeight).toBeGreaterThan(style.fontSize);
+      }
+    });
+
+    it('uses a body size in the editorial 17-18px range', () => {
+      expect(editorialType.body.fontSize).toBeGreaterThanOrEqual(17);
+      expect(editorialType.body.fontSize).toBeLessThanOrEqual(18);
+    });
+  });
+});

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -5,6 +5,8 @@
  * should be imported from this module. Do not define design constants elsewhere.
  */
 
+import { Platform } from 'react-native';
+
 // ---------------------------------------------------------------------------
 // Colors
 // ---------------------------------------------------------------------------
@@ -102,6 +104,33 @@ export const colors = {
     recessedSurface: '#e9e9e9',
     edgeDark: '#bcbcbc',
     edgeLight: '#ffffff',
+  },
+
+  /**
+   * Warm editorial palette for the journal-resonance surface only. A paper-like
+   * off-white ground with dark ink, a faint rule, and a soft anchor highlight.
+   * Contrast on the primary ground (#faf6ef):
+   *   ink     #2b2620 = 13.9:1 — AAA
+   *   inkSoft #5a5046 =  7.3:1 — AAA
+   * The anchor highlight is a background wash (text keeps its own ink colour).
+   */
+  paper: {
+    background: '#faf6ef',
+    backgroundAlt: '#f3ecdf',
+    ink: '#2b2620',
+    inkSoft: '#5a5046',
+    hairline: '#e3dccd',
+    anchorHighlight: '#f0e3c2',
+  },
+
+  /**
+   * Subtle accent per margin-note kind. Used for the kind dot / rule beside a
+   * note; each clears AA as text on the paper ground (>= 4.5:1 on #faf6ef).
+   */
+  marginalia: {
+    theme: '#8a6a2f',
+    connection: '#4f6173',
+    symbol: '#7a4f63',
   },
 } as const;
 
@@ -360,3 +389,52 @@ export const typography = (width: number) => {
     caption: base * 0.8,
   } as const;
 };
+
+// ---------------------------------------------------------------------------
+// Editorial / journal-resonance tokens (additive — journal surface only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Layout metrics for the two-column journal page (writing column + margin
+ * notes). ``marginColumnWidth`` is the fixed gutter the margin notes occupy;
+ * ``pageMaxWidth`` keeps the reading measure comfortable on tablets.
+ */
+export const journalLayout = {
+  marginColumnWidth: 220,
+  pageHorizontalPadding: 24,
+  pageMaxWidth: 680,
+  marginNoteGap: 16,
+} as const;
+
+/**
+ * Warm, long-form serif typography for the journal surface. Uses the platform
+ * serif stack (no bundled font asset): Georgia on iOS, the system ``serif``
+ * family on Android, and a CSS-style stack on web. Line-heights are generous
+ * (~1.6 on body) for a calm reading rhythm.
+ *
+ * Resolved from ``Platform.OS`` (not ``Platform.select``) at module load: this
+ * file is imported app-wide, and the repo's hand-rolled ``react-native`` test
+ * mocks expose ``Platform.OS`` but not ``Platform.select`` — keeping the tokens
+ * module loadable under every mock.
+ */
+const serifByPlatform: Record<string, string> = {
+  ios: 'Georgia',
+  android: 'serif',
+};
+const serifStack = serifByPlatform[Platform.OS] ?? 'Georgia, "Times New Roman", serif';
+
+export const editorialType = {
+  serif: serifStack,
+  display: { fontFamily: serifStack, fontSize: 34, lineHeight: 42, fontWeight: '700' as const },
+  title: { fontFamily: serifStack, fontSize: 26, lineHeight: 34, fontWeight: '600' as const },
+  body: { fontFamily: serifStack, fontSize: 18, lineHeight: 29, fontWeight: '400' as const },
+  note: { fontFamily: serifStack, fontSize: 15, lineHeight: 24, fontWeight: '400' as const },
+  caption: { fontFamily: serifStack, fontSize: 13, lineHeight: 20, fontWeight: '400' as const },
+  marginNote: {
+    fontFamily: serifStack,
+    fontSize: 14,
+    lineHeight: 21,
+    fontStyle: 'italic' as const,
+    fontWeight: '400' as const,
+  },
+} as const;


### PR DESCRIPTION
## Summary

journal-resonance-09: add a warm, **editorial token group** for the new journal surface — additive only, no existing token renamed/removed, nothing outside the journal changes visually.

- **`colors.paper`**: warm off-white grounds, dark ink + soft ink, faint hairline, soft anchor highlight. ink (13.9:1) and inkSoft (7.3:1) clear WCAG AA on the paper ground.
- **`colors.marginalia`**: a subtle accent per note kind (theme/connection/symbol), each ≥ 4.5:1 on the paper ground.
- **`journalLayout`**: `marginColumnWidth`, `pageHorizontalPadding`, `pageMaxWidth`, `marginNoteGap`.
- **`editorialType`**: platform serif stack (Georgia / system `serif` / web stack) + a long-form scale (display/title/body/note/caption) at an ~18px body with generous line-height, and a `marginNote` style.

The serif stack resolves from `Platform.OS` (not `Platform.select`) at module load: `tokens.ts` is imported app-wide and the repo's hand-rolled `react-native` test mocks expose `Platform.OS` but not `Platform.select` — this keeps the module loadable under every mock.

## Test plan

`editorialTokens.test.ts`: token groups/keys exist; serif resolves non-empty; paper ink/inkSoft and every marginalia accent meet AA on the paper ground (luminance-based contrast helper); body size in the 17–18px range.

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #612
Refs #603
