### PR TITLE
feat(frontend): typed client for entry edit, resonance, marginalia, essay

### DIFF
--- a/frontend/src/api/__tests__/resonance.test.ts
+++ b/frontend/src/api/__tests__/resonance.test.ts
@@ -1,0 +1,140 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { ApiError, LLM_API_KEY_HEADER, journal, resonance } from '../index';
+import type { Marginalia, ResonanceResponse } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function marginalia(overrides: Partial<Marginalia> = {}): Marginalia {
+  return {
+    id: 1,
+    journal_entry_id: 7,
+    kind: 'theme',
+    anchor_start: 0,
+    anchor_end: 5,
+    anchor_text: 'I walk',
+    note: 'A beginning.',
+    essay: null,
+    essay_generated_at: null,
+    status: 'active',
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function resonancePayload(): ResonanceResponse {
+  return {
+    marginalia: [marginalia()],
+    remaining_messages: 49,
+    remaining_balance: 0,
+    monthly_reset_date: '2026-07-01T00:00:00Z',
+  };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('journal.update', () => {
+  test('PATCHes the entry and serializes only the provided fields', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ id: 7, message: 'edited', sender: 'user' }));
+    await journal.update(7, { title: 'New title' }, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/7');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body)).toEqual({ title: 'New title' });
+  });
+
+  test('omits undefined fields from the body', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ id: 7, message: 'edited', sender: 'user' }));
+    await journal.update(7, { message: 'edited', title: undefined }, 'tok');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ message: 'edited' });
+    expect('title' in body).toBe(false);
+  });
+});
+
+describe('resonance.generate', () => {
+  test('POSTs the resonance endpoint and parses the response', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(resonancePayload(), 200));
+    const result = await resonance.generate(7, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/7/resonance');
+    expect(init.method).toBe('POST');
+    expect(result.remaining_messages).toBe(49);
+    expect(result.marginalia[0]!.kind).toBe('theme');
+  });
+
+  test('sends the BYOK header only when an api key is supplied', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(resonancePayload(), 200));
+    await resonance.generate(7, 'tok', 'sk-byok');
+    expect(mockFetch.mock.calls[0][1].headers[LLM_API_KEY_HEADER]).toBe('sk-byok');
+
+    mockFetch.mockReturnValueOnce(jsonResponse(resonancePayload(), 200));
+    await resonance.generate(7, 'tok');
+    expect(mockFetch.mock.calls[1][1].headers[LLM_API_KEY_HEADER]).toBeUndefined();
+  });
+
+  test('surfaces a 402 as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'insufficient_offerings' }, 402));
+    await expect(resonance.generate(7, 'tok')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 402,
+      detail: 'insufficient_offerings',
+    });
+  });
+});
+
+describe('resonance.list', () => {
+  test('GETs the marginalia list and parses items', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ items: [marginalia(), marginalia({ id: 2 })] }));
+    const result = await resonance.list(7, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/7/marginalia');
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(result.items).toHaveLength(2);
+  });
+
+  test('surfaces a 404 as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'journal_entry_not_found' }, 404));
+    const err = await resonance.list(7, 'tok').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(404);
+  });
+});
+
+describe('resonance.essay', () => {
+  test('POSTs the essay endpoint and parses the cached note', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(marginalia({ essay: 'A warm letter.' })));
+    const result = await resonance.essay(1, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/marginalia/1/essay');
+    expect(init.method).toBe('POST');
+    expect(result.essay).toBe('A warm letter.');
+  });
+
+  test('surfaces a 404 (marginalia not found) as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'marginalia_not_found' }, 404));
+    await expect(resonance.essay(999, 'tok')).rejects.toMatchObject({
+      status: 404,
+      detail: 'marginalia_not_found',
+    });
+  });
+});

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -60,6 +60,8 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   habit_not_found: `We couldn't find that habit — it may have been deleted. ${PULL_TO_REFRESH}`,
   journal_entry_not_found:
     "We couldn't find that journal entry. It may have been deleted from another device.",
+  marginalia_not_found:
+    "We couldn't find that margin note. It may have been removed when the entry changed.",
   goal_not_found: `We couldn't find that goal. ${PULL_TO_REFRESH}`,
   goal_group_not_found: `We couldn't find that goal group. ${PULL_TO_REFRESH}`,
   prompt_not_found:

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1183,6 +1183,8 @@ export interface JournalMessageCreate {
   user_practice_id?: number | null;
 }
 
+export type EntryStatus = 'draft' | 'finished';
+
 export interface JournalMessage {
   id: number;
   message: string;
@@ -1191,6 +1193,47 @@ export interface JournalMessage {
   tag: JournalTag;
   practice_session_id: number | null;
   user_practice_id: number | null;
+  /** Editorial document fields (journal-resonance). */
+  title?: string | null;
+  status?: EntryStatus;
+  updated_at?: string;
+}
+
+/** PATCH body for editing an entry — only the provided fields are sent. */
+export interface JournalEntryUpdate {
+  message?: string;
+  title?: string | null;
+  status?: EntryStatus;
+  tag?: JournalTag;
+}
+
+export type MarginaliaKind = 'theme' | 'connection' | 'symbol';
+export type MarginaliaStatus = 'active' | 'stale';
+
+export interface Marginalia {
+  id: number;
+  journal_entry_id: number;
+  kind: MarginaliaKind;
+  anchor_start: number;
+  anchor_end: number;
+  anchor_text: string;
+  note: string;
+  essay: string | null;
+  essay_generated_at: string | null;
+  status: MarginaliaStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ResonanceResponse {
+  marginalia: Marginalia[];
+  remaining_messages: number;
+  remaining_balance: number;
+  monthly_reset_date: string;
+}
+
+export interface MarginaliaListResponse {
+  items: Marginalia[];
 }
 
 export interface JournalListResponse {
@@ -1232,8 +1275,51 @@ export const journal = {
       token,
     });
   },
+  /**
+   * Edit an entry. Only the fields present on ``patch`` are sent (``JSON`` drops
+   * ``undefined``), so callers can update the title without touching the body.
+   */
+  update(entryId: number, patch: JournalEntryUpdate, token?: string): Promise<JournalMessage> {
+    return request<JournalMessage>(`/journal/${entryId}`, {
+      method: 'PATCH',
+      body: patch,
+      token,
+    });
+  },
   delete(entryId: number, token?: string): Promise<void> {
     return request<void>(`/journal/${entryId}`, { method: 'DELETE', token });
+  },
+};
+
+/** Optional bring-your-own-key header for the resonance LLM endpoints. */
+const byokHeaders = (apiKey?: string): Record<string, string> | undefined =>
+  apiKey ? { [LLM_API_KEY_HEADER]: apiKey } : undefined;
+
+/**
+ * Resonance + marginalia client (journal-resonance). ``generate`` and ``essay``
+ * call the LLM (and may surface ``402 insufficient_offerings`` /
+ * ``502 llm_provider_error`` as an ``ApiError``); ``list`` is a plain read.
+ */
+export const resonance = {
+  /** Run a resonance pass over an entry: persists + returns notes and balances. */
+  generate(entryId: number, token?: string, apiKey?: string): Promise<ResonanceResponse> {
+    return request<ResonanceResponse>(`/journal/${entryId}/resonance`, {
+      method: 'POST',
+      token,
+      headers: byokHeaders(apiKey),
+    });
+  },
+  /** List an entry's margin notes (ordered by anchor position). */
+  list(entryId: number, token?: string): Promise<MarginaliaListResponse> {
+    return request<MarginaliaListResponse>(`/journal/${entryId}/marginalia`, { token });
+  },
+  /** Lazily generate (and cache) the long-form essay for one margin note. */
+  essay(marginaliaId: number, token?: string, apiKey?: string): Promise<Marginalia> {
+    return request<Marginalia>(`/journal/marginalia/${marginaliaId}/essay`, {
+      method: 'POST',
+      token,
+      headers: byokHeaders(apiKey),
+    });
   },
 };
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1199,12 +1199,15 @@ export interface JournalMessage {
   updated_at?: string;
 }
 
-/** PATCH body for editing an entry — only the provided fields are sent. */
+/**
+ * PATCH body for editing an entry — only the provided fields are sent. Mirrors
+ * the backend schema (message / title / status); ``tag`` is set at create time
+ * and is not editable here.
+ */
 export interface JournalEntryUpdate {
   message?: string;
   title?: string | null;
   status?: EntryStatus;
-  tag?: JournalTag;
 }
 
 export type MarginaliaKind = 'theme' | 'connection' | 'symbol';

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -246,6 +246,11 @@ export const journalMessageSchema = z.object({
   tag: journalTagSchema,
   practice_session_id: z.number().int().nullable(),
   user_practice_id: z.number().int().nullable(),
+  // Editorial document fields (journal-resonance). Optional so fixtures /
+  // responses predating the columns still validate.
+  title: z.string().nullable().optional(),
+  status: z.enum(['draft', 'finished']).optional(),
+  updated_at: isoDateTime.optional(),
 });
 
 /** Journal list envelope: ``{ items, total, has_more }`` (bespoke, not ``Page``). */


### PR DESCRIPTION
## Summary

journal-resonance-10: extend the typed client to cover the new backend endpoints, matching the epic contract. **Client only — no UI.**

- **Types**: `EntryStatus`, `MarginaliaKind`, `MarginaliaStatus`, `Marginalia` (`essay: string | null`), `ResonanceResponse`, `MarginaliaListResponse`, `JournalEntryUpdate`; extend `JournalMessage` with optional `title`/`status`/`updated_at` (also added to the zod `journalMessageSchema` as optional/nullable so existing fixtures still validate).
- **Methods**: `journal.update(id, patch)` → PATCH; `resonance.generate(id)` → POST resonance; `resonance.list(id)` → GET marginalia; `resonance.essay(marginaliaId)` → POST essay. All reuse the existing `request()` plumbing (retry / token-refresh / error mapping); `generate` + `essay` take an optional BYOK key (`X-LLM-API-Key`) sent only when provided.
- **errorMessages**: add `marginalia_not_found` copy (`insufficient_offerings` and `llm_provider_error` already mapped).

## Test plan

`api/__tests__/resonance.test.ts` (mocked fetch): each method hits the right URL/verb and parses; `update` serializes only provided fields (drops `undefined`); `ApiError` surfaces 402 and 404.

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests). No `any`.

Closes #613
Refs #603
