### PR TITLE
feat(frontend): long-form journal writing surface (JournalEntryScreen)

### DIFF
--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -103,6 +103,13 @@ jest.mock('@/features/Practice/screens/PracticeCatalogScreen', () => {
   const Stub = () => <Text>PracticeCatalogScreen</Text>;
   return { PracticeCatalogScreen: Stub, default: Stub };
 });
+// journal-resonance-11: RootStack now mounts JournalEntryScreen as a pushed
+// route that reads ``route.params`` -- stub it for the same reason as above.
+jest.mock('@/features/Journal/JournalEntryScreen', () => {
+  const { Text } = require('react-native');
+  const Stub = () => <Text>JournalEntryScreen</Text>;
+  return { __esModule: true, default: Stub };
+});
 
 import App from '@/App';
 

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -28,6 +28,10 @@ const styles = StyleSheet.create({
   },
   writingColumn: {
     flex: 1,
+  },
+  /** ScrollView content: grows to fill, so an empty page is still tappable. */
+  writingColumnContent: {
+    flexGrow: 1,
     paddingVertical: spacing(3),
   },
   marginColumn: {

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -1,0 +1,67 @@
+/**
+ * Styles for the long-form journal writing surface (journal-resonance).
+ *
+ * Deliberately separate from the old chat ``Journal.styles`` — this is an
+ * editorial page (paper ground, serif body, reserved margin column), not a
+ * message list. Tokens only.
+ */
+import { StyleSheet } from 'react-native';
+
+import { colors, editorialType, journalLayout, spacing } from '@/design/tokens';
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.paper.background,
+  },
+  /** Centres the page and caps the reading measure on wide screens. */
+  page: {
+    flex: 1,
+    flexDirection: 'row',
+    width: '100%',
+    maxWidth: journalLayout.pageMaxWidth + journalLayout.marginColumnWidth,
+    alignSelf: 'center',
+    paddingHorizontal: journalLayout.pageHorizontalPadding,
+  },
+  pageNarrow: {
+    flexDirection: 'column',
+  },
+  writingColumn: {
+    flex: 1,
+    paddingVertical: spacing(3),
+  },
+  marginColumn: {
+    width: journalLayout.marginColumnWidth,
+    paddingLeft: journalLayout.marginNoteGap,
+    paddingVertical: spacing(3),
+  },
+  marginColumnNarrow: {
+    width: '100%',
+    paddingLeft: 0,
+  },
+  titleInput: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+    paddingVertical: spacing(1),
+  },
+  bodyInput: {
+    ...editorialType.body,
+    color: colors.paper.ink,
+    paddingTop: spacing(1.5),
+    // A growing multiline field; minHeight keeps the blank page inviting.
+    minHeight: 240,
+    textAlignVertical: 'top',
+  },
+  hairline: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.paper.hairline,
+    marginVertical: spacing(1),
+  },
+  savedHint: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    paddingTop: spacing(1),
+  },
+});
+
+export default styles;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -1,0 +1,212 @@
+/**
+ * ``JournalEntryScreen`` — the long-form page the user writes in.
+ *
+ * Warm editorial layout: an optional serif title and a large growing serif body
+ * on a paper ground, with a reserved right-hand margin column (a pluggable
+ * ``renderMargin`` slot the marginalia UI fills in a later issue). The page
+ * autosaves as a draft on idle — there is no send button and no chat UI.
+ */
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Text, TextInput, View, useWindowDimensions } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import styles from './JournalEntry.styles';
+
+import { journal } from '@/api';
+import type { JournalMessage } from '@/api';
+import { colors } from '@/design/tokens';
+import type { RootStackParamList } from '@/navigation/RootStack';
+
+/** Default idle delay before an edit is persisted. */
+export const AUTOSAVE_DELAY_MS = 1500;
+
+/** Below this width the margin column stacks under the writing column. */
+const NARROW_BREAKPOINT = 600;
+
+type SaveState = 'idle' | 'typing' | 'saving' | 'saved';
+
+/** Context handed to the pluggable margin slot (and exposed for the Resonance CTA). */
+export interface JournalMarginContext {
+  body: string;
+  isIdle: boolean;
+}
+
+export type JournalEntryScreenProps = NativeStackScreenProps<RootStackParamList, 'JournalEntry'> & {
+  /** Pluggable right-margin content (margin notes UI lands in a later issue). */
+  renderMargin?: (_ctx: JournalMarginContext) => React.ReactNode;
+  /** Overridable for tests; defaults to {@link AUTOSAVE_DELAY_MS}. */
+  autosaveDelayMs?: number;
+};
+
+function savedHintLabel(state: SaveState): string {
+  if (state === 'saving') return 'Saving…';
+  if (state === 'saved') return 'Saved';
+  return ' ';
+}
+
+/** Create on first save, then update; title is optional and saved separately. */
+async function writeEntry(
+  entryIdRef: React.MutableRefObject<number | null>,
+  title: string,
+  body: string,
+): Promise<void> {
+  const trimmedTitle = title.trim() ? title : null;
+  if (entryIdRef.current == null) {
+    const created = await journal.create({ message: body });
+    entryIdRef.current = created.id;
+    if (trimmedTitle != null) {
+      await journal.update(created.id, { title: trimmedTitle, status: 'draft' });
+    }
+  } else {
+    await journal.update(entryIdRef.current, { message: body, title: trimmedTitle });
+  }
+}
+
+interface AutosaveApi {
+  title: string;
+  body: string;
+  saveState: SaveState;
+  onChangeTitle: (_next: string) => void;
+  onChangeBody: (_next: string) => void;
+}
+
+/** Load an existing entry once (by route id) and hand it to ``apply``. */
+function useEntryLoadEffect(
+  routeEntryId: number | null,
+  apply: (_entry: JournalMessage) => void,
+): void {
+  useEffect(() => {
+    if (routeEntryId == null) return undefined;
+    let active = true;
+    void journal
+      .get(routeEntryId)
+      .then((entry) => {
+        if (active) apply(entry);
+      })
+      .catch(() => {
+        // Load failures surface via a toast in the host screen (later issue).
+      });
+    return () => {
+      active = false;
+    };
+  }, [routeEntryId, apply]);
+}
+
+/** Debounced create-then-update draft saver; tracks the save state. */
+function useDebouncedSave(routeEntryId: number | null, delayMs: number) {
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const entryIdRef = useRef<number | null>(routeEntryId);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  const run = useCallback(async (title: string, body: string): Promise<void> => {
+    if (!body.trim()) return; // never persist an empty draft
+    setSaveState('saving');
+    try {
+      await writeEntry(entryIdRef, title, body);
+      setSaveState('saved');
+    } catch {
+      setSaveState('idle');
+    }
+  }, []);
+
+  const save = useCallback(
+    (title: string, body: string): void => {
+      setSaveState('typing');
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => void run(title, body), delayMs);
+    },
+    [run, delayMs],
+  );
+
+  return { saveState, save };
+}
+
+/** Owns the entry's text + debounced draft autosave (create-then-update). */
+function useJournalAutosave(routeEntryId: number | null, delayMs: number): AutosaveApi {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const { saveState, save } = useDebouncedSave(routeEntryId, delayMs);
+
+  useEntryLoadEffect(
+    routeEntryId,
+    useCallback((entry: JournalMessage) => {
+      setTitle(entry.title ?? '');
+      setBody(entry.message);
+    }, []),
+  );
+
+  return {
+    title,
+    body,
+    saveState,
+    onChangeTitle: (next) => {
+      setTitle(next);
+      save(next, body);
+    },
+    onChangeBody: (next) => {
+      setBody(next);
+      save(title, next);
+    },
+  };
+}
+
+function JournalEntryScreen({
+  route,
+  renderMargin,
+  autosaveDelayMs = AUTOSAVE_DELAY_MS,
+}: JournalEntryScreenProps): React.JSX.Element {
+  const { title, body, saveState, onChangeTitle, onChangeBody } = useJournalAutosave(
+    route.params?.entryId ?? null,
+    autosaveDelayMs,
+  );
+  const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
+  const isIdle = saveState !== 'typing' && saveState !== 'saving';
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={[styles.page, narrow && styles.pageNarrow]}>
+        <View style={styles.writingColumn}>
+          <TextInput
+            style={styles.titleInput}
+            value={title}
+            onChangeText={onChangeTitle}
+            placeholder="Title"
+            placeholderTextColor={colors.paper.inkSoft}
+            accessibilityLabel="Entry title"
+            testID="journal-title-input"
+          />
+          <View style={styles.hairline} />
+          <TextInput
+            style={styles.bodyInput}
+            value={body}
+            onChangeText={onChangeBody}
+            placeholder="Begin writing…"
+            placeholderTextColor={colors.paper.inkSoft}
+            multiline
+            accessibilityLabel="Entry body"
+            testID="journal-body-input"
+          />
+          <Text style={styles.savedHint} testID="journal-save-hint">
+            {savedHintLabel(saveState)}
+          </Text>
+        </View>
+        <View
+          style={[styles.marginColumn, narrow && styles.marginColumnNarrow]}
+          testID="journal-margin-column"
+        >
+          {renderMargin?.({ body, isIdle })}
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+export default JournalEntryScreen;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -8,7 +8,7 @@
  */
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Text, TextInput, View, useWindowDimensions } from 'react-native';
+import { ScrollView, Text, TextInput, View, useWindowDimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import styles from './JournalEntry.styles';
@@ -24,7 +24,7 @@ export const AUTOSAVE_DELAY_MS = 1500;
 /** Below this width the margin column stacks under the writing column. */
 const NARROW_BREAKPOINT = 600;
 
-type SaveState = 'idle' | 'typing' | 'saving' | 'saved';
+type SaveState = 'idle' | 'typing' | 'saving' | 'saved' | 'error';
 
 /** Context handed to the pluggable margin slot (and exposed for the Resonance CTA). */
 export interface JournalMarginContext {
@@ -42,6 +42,7 @@ export type JournalEntryScreenProps = NativeStackScreenProps<RootStackParamList,
 function savedHintLabel(state: SaveState): string {
   if (state === 'saving') return 'Saving…';
   if (state === 'saved') return 'Saved';
+  if (state === 'error') return "Couldn't save — keep writing, we'll retry";
   return ' ';
 }
 
@@ -113,7 +114,8 @@ function useDebouncedSave(routeEntryId: number | null, delayMs: number) {
       await writeEntry(entryIdRef, title, body);
       setSaveState('saved');
     } catch {
-      setSaveState('idle');
+      // Surface a distinct error state so the hint isn't mistaken for "untouched".
+      setSaveState('error');
     }
   }, []);
 
@@ -133,29 +135,79 @@ function useDebouncedSave(routeEntryId: number | null, delayMs: number) {
 function useJournalAutosave(routeEntryId: number | null, delayMs: number): AutosaveApi {
   const [title, setTitle] = useState('');
   const [body, setBody] = useState('');
+  // Refs mirror the latest text so the change handlers can stay referentially
+  // stable (each save needs the *other* field's current value).
+  const titleRef = useRef('');
+  const bodyRef = useRef('');
   const { saveState, save } = useDebouncedSave(routeEntryId, delayMs);
 
   useEntryLoadEffect(
     routeEntryId,
     useCallback((entry: JournalMessage) => {
-      setTitle(entry.title ?? '');
-      setBody(entry.message);
+      titleRef.current = entry.title ?? '';
+      bodyRef.current = entry.message;
+      setTitle(titleRef.current);
+      setBody(bodyRef.current);
     }, []),
   );
 
-  return {
-    title,
-    body,
-    saveState,
-    onChangeTitle: (next) => {
+  const onChangeTitle = useCallback(
+    (next: string) => {
+      titleRef.current = next;
       setTitle(next);
-      save(next, body);
+      save(next, bodyRef.current);
     },
-    onChangeBody: (next) => {
+    [save],
+  );
+  const onChangeBody = useCallback(
+    (next: string) => {
+      bodyRef.current = next;
       setBody(next);
-      save(title, next);
+      save(titleRef.current, next);
     },
-  };
+    [save],
+  );
+
+  return { title, body, saveState, onChangeTitle, onChangeBody };
+}
+
+/** The scrollable writing column (title + growing body + save hint). */
+function WritingColumn({ title, body, saveState, onChangeTitle, onChangeBody }: AutosaveApi) {
+  return (
+    <ScrollView
+      style={styles.writingColumn}
+      contentContainerStyle={styles.writingColumnContent}
+      keyboardShouldPersistTaps="handled"
+    >
+      <TextInput
+        style={styles.titleInput}
+        value={title}
+        onChangeText={onChangeTitle}
+        placeholder="Title"
+        placeholderTextColor={colors.paper.inkSoft}
+        accessibilityLabel="Entry title"
+        testID="journal-title-input"
+      />
+      <View style={styles.hairline} />
+      <TextInput
+        style={styles.bodyInput}
+        value={body}
+        onChangeText={onChangeBody}
+        placeholder="Begin writing…"
+        placeholderTextColor={colors.paper.inkSoft}
+        multiline
+        // The outer ScrollView owns scrolling so the field grows freely and long
+        // entries stay reachable (iOS multiline TextInput won't scroll its own
+        // content inside a flex parent).
+        scrollEnabled={false}
+        accessibilityLabel="Entry body"
+        testID="journal-body-input"
+      />
+      <Text style={styles.savedHint} testID="journal-save-hint">
+        {savedHintLabel(saveState)}
+      </Text>
+    </ScrollView>
+  );
 }
 
 function JournalEntryScreen({
@@ -163,46 +215,19 @@ function JournalEntryScreen({
   renderMargin,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
-  const { title, body, saveState, onChangeTitle, onChangeBody } = useJournalAutosave(
-    route.params?.entryId ?? null,
-    autosaveDelayMs,
-  );
+  const autosave = useJournalAutosave(route.params?.entryId ?? null, autosaveDelayMs);
   const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
-  const isIdle = saveState !== 'typing' && saveState !== 'saving';
+  const isIdle = autosave.saveState !== 'typing' && autosave.saveState !== 'saving';
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={[styles.page, narrow && styles.pageNarrow]}>
-        <View style={styles.writingColumn}>
-          <TextInput
-            style={styles.titleInput}
-            value={title}
-            onChangeText={onChangeTitle}
-            placeholder="Title"
-            placeholderTextColor={colors.paper.inkSoft}
-            accessibilityLabel="Entry title"
-            testID="journal-title-input"
-          />
-          <View style={styles.hairline} />
-          <TextInput
-            style={styles.bodyInput}
-            value={body}
-            onChangeText={onChangeBody}
-            placeholder="Begin writing…"
-            placeholderTextColor={colors.paper.inkSoft}
-            multiline
-            accessibilityLabel="Entry body"
-            testID="journal-body-input"
-          />
-          <Text style={styles.savedHint} testID="journal-save-hint">
-            {savedHintLabel(saveState)}
-          </Text>
-        </View>
+        <WritingColumn {...autosave} />
         <View
           style={[styles.marginColumn, narrow && styles.marginColumnNarrow]}
           testID="journal-margin-column"
         >
-          {renderMargin?.({ body, isIdle })}
+          {renderMargin?.({ body: autosave.body, isIdle })}
         </View>
       </View>
     </SafeAreaView>

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -1,0 +1,110 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import type { JournalMessage } from '@/api';
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 7,
+    message: 'An existing page about rivers.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'reflection' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'Rivers',
+    status: 'draft',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderScreen(params?: { entryId?: number }, extraProps: Record<string, unknown> = {}) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn() };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return render(<Screen navigation={navigation} route={route} {...extraProps} />);
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+});
+
+describe('JournalEntryScreen', () => {
+  it('renders the title + body inputs and no chat UI', () => {
+    const { getByTestId, queryByText } = renderScreen();
+    expect(getByTestId('journal-title-input')).toBeTruthy();
+    expect(getByTestId('journal-body-input')).toBeTruthy();
+    // No chat affordances on the writing surface.
+    expect(queryByText('Send')).toBeNull();
+  });
+
+  it('reserves a margin column and renders the renderMargin slot', () => {
+    const renderMargin = jest.fn(() => null);
+    const { getByTestId } = renderScreen(undefined, { renderMargin });
+    expect(getByTestId('journal-margin-column')).toBeTruthy();
+    expect(renderMargin).toHaveBeenCalled();
+  });
+
+  it('autosaves once after the debounce when the body changes', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 1500 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A new thought.');
+      expect(mockCreate).not.toHaveBeenCalled(); // still within the debounce window
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1500);
+      });
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockCreate).toHaveBeenCalledWith({ message: 'A new thought.' });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not persist an empty draft', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 1500 });
+      fireEvent.changeText(getByTestId('journal-body-input'), '   ');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1500);
+      });
+      expect(mockCreate).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('loads an existing entry by id', async () => {
+    mockGet.mockResolvedValue(entry({ id: 7, title: 'Rivers', message: 'An existing page.' }));
+    const { getByTestId } = renderScreen({ entryId: 7 });
+    await waitFor(() => {
+      expect(getByTestId('journal-title-input').props.value).toBe('Rivers');
+    });
+    expect(mockGet).toHaveBeenCalledWith(7);
+    expect(getByTestId('journal-body-input').props.value).toBe('An existing page.');
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -108,6 +108,21 @@ describe('JournalEntryScreen', () => {
     }
   });
 
+  it('shows a distinct error hint when a save fails', async () => {
+    mockCreate.mockRejectedValue(new Error('network'));
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A thought.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(getByTestId('journal-save-hint').props.children).toMatch(/save/i);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('does not persist an empty draft', async () => {
     jest.useFakeTimers();
     try {

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -84,6 +84,30 @@ describe('JournalEntryScreen', () => {
     }
   });
 
+  it('updates (not creates again) on the second save after the initial create', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'First save.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'Second save.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockCreate).toHaveBeenCalledTimes(1); // create not repeated
+      expect(mockUpdate).toHaveBeenCalledWith(
+        42,
+        expect.objectContaining({ message: 'Second save.' }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('does not persist an empty draft', async () => {
     jest.useFakeTimers();
     try {

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -2,6 +2,7 @@ import type { NavigatorScreenParams } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 
+import JournalEntryScreen from '../features/Journal/JournalEntryScreen';
 import { CreatePracticeWizard } from '../features/Practice/screens/CreatePracticeWizard';
 import { PracticeCatalogScreen } from '../features/Practice/screens/PracticeCatalogScreen';
 import { PracticeDetailScreen } from '../features/Practice/screens/PracticeDetailScreen';
@@ -43,6 +44,7 @@ export type RootStackParamList = {
   PracticeDetail: { practiceId: number };
   CreatePractice: { prefill?: CreatePracticePrefill } | undefined;
   Catalog: { stageNumber?: number } | undefined;
+  JournalEntry: { entryId?: number } | undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -79,6 +81,11 @@ const RootStack = (): React.JSX.Element => (
       name="Catalog"
       component={PracticeCatalogScreen}
       options={{ title: 'Practices' }}
+    />
+    <Stack.Screen
+      name="JournalEntry"
+      component={JournalEntryScreen}
+      options={{ title: 'Journal' }}
     />
   </Stack.Navigator>
 );


### PR DESCRIPTION
## Summary

journal-resonance-11: **`JournalEntryScreen`** — the long-form page the user writes in. Warm editorial layout, **no chat UI**.

- Paper ground, serif title + growing multiline serif body, a **reserved right-hand margin column** (`journalLayout.marginColumnWidth`; stacks under the body on narrow phones) exposed as a pluggable **`renderMargin`** slot that receives the current body + idle signal (for the Resonance CTA + margin-notes UI in later issues). Loads by route `entryId` via `journal.get`, or starts blank.
- **Autosave**: ~1.5s idle debounce → `journal.create` on first save, `journal.update` thereafter; tracks a save state (typing/saving/saved) and never persists an empty draft. Logic lives in small composable hooks (`useDebouncedSave` + `useEntryLoadEffect`).
- `JournalEntry.styles.ts`: new, separate from the old chat styles; tokens only.
- Registers the `JournalEntry` route on the root stack (open with or without an id).

## Test plan

`JournalEntryScreen.test.tsx`: renders title + body and no chat affordance; one debounced save fires after the idle window (fake timers); an empty draft is never saved; an existing entry loads by id; the `renderMargin` slot renders. `AppAuthFlow` stubs the new route-param screen (same pattern as the other pushed screens).

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #614
Refs #603
