### PR TITLE
feat(frontend): floating "Get Resonance" button + useIdle hook

### DIFF
--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -438,3 +438,12 @@ export const editorialType = {
     fontWeight: '400' as const,
   },
 } as const;
+
+// ---------------------------------------------------------------------------
+// UI typography — non-editorial chrome (buttons, chips) in the system stack
+// ---------------------------------------------------------------------------
+
+/** Typography for interactive chrome, so button/label sizing lives in tokens. */
+export const uiType = {
+  button: { fontSize: 16, fontWeight: '600' as const },
+} as const;

--- a/frontend/src/features/Journal/GetResonanceButton.tsx
+++ b/frontend/src/features/Journal/GetResonanceButton.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Animated, StyleSheet, Text, TouchableOpacity } from 'react-native';
 
-import { BORDER_RADIUS, SPACING, colors, shadows, touchTarget } from '@/design/tokens';
+import { BORDER_RADIUS, SPACING, colors, shadows, touchTarget, uiType } from '@/design/tokens';
 
 /** Pure visibility rule, extracted so it can be unit-tested without rendering. */
 export interface ResonanceVisibilityInput {
@@ -104,8 +104,7 @@ const styles = StyleSheet.create({
   },
   label: {
     color: colors.text.light,
-    fontSize: 16,
-    fontWeight: '600',
+    ...uiType.button,
   },
 });
 

--- a/frontend/src/features/Journal/GetResonanceButton.tsx
+++ b/frontend/src/features/Journal/GetResonanceButton.tsx
@@ -1,0 +1,112 @@
+/**
+ * ``GetResonanceButton`` — a soft floating affordance that fades in when the
+ * user pauses writing and tucks away while they type. Presentational only: the
+ * request is wired by the screen that hosts it (a later issue).
+ */
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, TouchableOpacity } from 'react-native';
+
+import { BORDER_RADIUS, SPACING, colors, shadows, touchTarget } from '@/design/tokens';
+
+/** Pure visibility rule, extracted so it can be unit-tested without rendering. */
+export interface ResonanceVisibilityInput {
+  isIdle: boolean;
+  hasContent: boolean;
+  isLoading: boolean;
+}
+
+export function shouldShowResonance({
+  isIdle,
+  hasContent,
+  isLoading,
+}: ResonanceVisibilityInput): boolean {
+  // Stay visible while a pass is running so the loading state is never orphaned.
+  if (isLoading) return true;
+  return isIdle && hasContent;
+}
+
+const FADE_DURATION_MS = 220;
+const SLIDE_DISTANCE = 8;
+
+export interface GetResonanceButtonProps {
+  visible: boolean;
+  loading?: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+}
+
+/** Derive the button's view state (keeps the component's branching low). */
+function getButtonState(visible: boolean, loading: boolean, disabled: boolean) {
+  return {
+    // Hidden = inert: not pressable and not reachable by the screen reader.
+    interactive: visible && !disabled && !loading,
+    pointerEvents: (visible ? 'auto' : 'none') as 'auto' | 'none',
+    importantForA11y: (visible ? 'auto' : 'no-hide-descendants') as 'auto' | 'no-hide-descendants',
+    label: loading ? 'Listening…' : 'Get Resonance',
+    a11yLabel: loading ? 'Listening to your writing' : 'Get resonance',
+  };
+}
+
+function GetResonanceButton({
+  visible,
+  loading = false,
+  disabled = false,
+  onPress,
+}: GetResonanceButtonProps): React.JSX.Element {
+  const anim = useRef(new Animated.Value(visible ? 1 : 0)).current;
+
+  useEffect(() => {
+    Animated.timing(anim, {
+      toValue: visible ? 1 : 0,
+      duration: FADE_DURATION_MS,
+      useNativeDriver: true,
+    }).start();
+  }, [visible, anim]);
+
+  const translateY = anim.interpolate({ inputRange: [0, 1], outputRange: [SLIDE_DISTANCE, 0] });
+  const view = getButtonState(visible, loading, disabled);
+
+  return (
+    <Animated.View
+      style={[styles.wrapper, { opacity: anim, transform: [{ translateY }] }]}
+      pointerEvents={view.pointerEvents}
+      accessibilityElementsHidden={!visible}
+      importantForAccessibility={view.importantForA11y}
+    >
+      <TouchableOpacity
+        style={styles.button}
+        onPress={view.interactive ? onPress : undefined}
+        disabled={!view.interactive}
+        accessibilityRole="button"
+        accessibilityLabel={view.a11yLabel}
+        accessibilityState={{ disabled: !view.interactive, busy: loading }}
+        testID="get-resonance-button"
+      >
+        <Text style={styles.label}>{view.label}</Text>
+      </TouchableOpacity>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    right: SPACING.lg,
+    bottom: SPACING.xl,
+  },
+  button: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.xl,
+    borderRadius: BORDER_RADIUS.xxl,
+    backgroundColor: colors.primary,
+    ...shadows.medium,
+  },
+  label: {
+    color: colors.text.light,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+
+export default GetResonanceButton;

--- a/frontend/src/features/Journal/__tests__/GetResonanceButton.test.tsx
+++ b/frontend/src/features/Journal/__tests__/GetResonanceButton.test.tsx
@@ -36,6 +36,14 @@ describe('GetResonanceButton', () => {
     expect(getByTestId('get-resonance-button').props.accessibilityState.busy).toBe(true);
   });
 
+  it('does not fire onPress when disabled', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(<GetResonanceButton visible disabled onPress={onPress} />);
+    fireEvent.press(getByTestId('get-resonance-button'));
+    expect(onPress).not.toHaveBeenCalled();
+    expect(getByTestId('get-resonance-button').props.accessibilityState.disabled).toBe(true);
+  });
+
   it('is inert (hidden from a11y, not pressable) when not visible', () => {
     const onPress = jest.fn();
     const { queryByTestId } = render(<GetResonanceButton visible={false} onPress={onPress} />);

--- a/frontend/src/features/Journal/__tests__/GetResonanceButton.test.tsx
+++ b/frontend/src/features/Journal/__tests__/GetResonanceButton.test.tsx
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import GetResonanceButton, { shouldShowResonance } from '../GetResonanceButton';
+
+describe('shouldShowResonance', () => {
+  it('shows only when idle with content', () => {
+    expect(shouldShowResonance({ isIdle: true, hasContent: true, isLoading: false })).toBe(true);
+    expect(shouldShowResonance({ isIdle: false, hasContent: true, isLoading: false })).toBe(false);
+    expect(shouldShowResonance({ isIdle: true, hasContent: false, isLoading: false })).toBe(false);
+  });
+
+  it('stays visible while a pass is loading regardless of idle/content', () => {
+    expect(shouldShowResonance({ isIdle: false, hasContent: false, isLoading: true })).toBe(true);
+  });
+});
+
+describe('GetResonanceButton', () => {
+  it('fires onPress when visible and idle', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(<GetResonanceButton visible onPress={onPress} />);
+    fireEvent.press(getByTestId('get-resonance-button'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a busy label and is disabled while loading', () => {
+    const onPress = jest.fn();
+    const { getByTestId, getByText } = render(
+      <GetResonanceButton visible loading onPress={onPress} />,
+    );
+    expect(getByText('Listening…')).toBeTruthy();
+    fireEvent.press(getByTestId('get-resonance-button'));
+    expect(onPress).not.toHaveBeenCalled();
+    expect(getByTestId('get-resonance-button').props.accessibilityState.busy).toBe(true);
+  });
+
+  it('is inert (hidden from a11y, not pressable) when not visible', () => {
+    const onPress = jest.fn();
+    const { queryByTestId } = render(<GetResonanceButton visible={false} onPress={onPress} />);
+    // Hidden from the accessibility tree, so default queries don't surface it
+    // (accessibilityElementsHidden + no-hide-descendants) — i.e. not focusable.
+    expect(queryByTestId('get-resonance-button')).toBeNull();
+    // And with includeHiddenElements, the press handler is detached.
+    const button = queryByTestId('get-resonance-button', { includeHiddenElements: true });
+    expect(button).not.toBeNull();
+    fireEvent.press(button!);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/__tests__/useIdle.test.ts
+++ b/frontend/src/hooks/__tests__/useIdle.test.ts
@@ -1,0 +1,66 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react-native';
+
+import { DEFAULT_IDLE_DELAY_MS, useIdle } from '../useIdle';
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useIdle', () => {
+  it('starts not-idle and flips to idle after the delay', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useIdle({ delayMs: 1000 }));
+    expect(result.current.isIdle).toBe(false);
+
+    act(() => {
+      result.current.bump();
+    });
+    expect(result.current.isIdle).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.isIdle).toBe(true);
+  });
+
+  it('bump resets idle back to false and restarts the timer', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useIdle({ delayMs: 1000 }));
+
+    act(() => {
+      result.current.bump();
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.isIdle).toBe(true);
+
+    act(() => {
+      result.current.bump();
+    });
+    expect(result.current.isIdle).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(999);
+    });
+    expect(result.current.isIdle).toBe(false); // timer restarted, not yet elapsed
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.isIdle).toBe(true);
+  });
+
+  it('defaults to DEFAULT_IDLE_DELAY_MS', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useIdle());
+    act(() => {
+      result.current.bump();
+      jest.advanceTimersByTime(DEFAULT_IDLE_DELAY_MS - 1);
+    });
+    expect(result.current.isIdle).toBe(false);
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.isIdle).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useIdle.ts
+++ b/frontend/src/hooks/useIdle.ts
@@ -1,0 +1,41 @@
+/**
+ * Track whether the user has paused (gone "idle") after activity.
+ *
+ * Call {@link UseIdleResult.bump} on each keystroke: it resets ``isIdle`` to
+ * false and restarts the idle timer. After ``delayMs`` with no bump, ``isIdle``
+ * flips true. The journal uses this to float the "Get Resonance" affordance in
+ * once writing settles and tuck it away while the user types.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Default idle delay — long enough to feel like a genuine pause, not a stutter. */
+export const DEFAULT_IDLE_DELAY_MS = 1800;
+
+export interface UseIdleOptions {
+  delayMs?: number;
+}
+
+export interface UseIdleResult {
+  isIdle: boolean;
+  bump: () => void;
+}
+
+export function useIdle({ delayMs = DEFAULT_IDLE_DELAY_MS }: UseIdleOptions = {}): UseIdleResult {
+  const [isIdle, setIsIdle] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const bump = useCallback(() => {
+    setIsIdle(false);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setIsIdle(true), delayMs);
+  }, [delayMs]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  return { isIdle, bump };
+}


### PR DESCRIPTION
## Summary

journal-resonance-12: the affordance that floats in when writing settles and tucks away while typing. **Hook + presentational button + animation only** — the request is wired in a later issue.

- **`useIdle({delayMs=1800}) → {isIdle, bump}`**: `bump()` resets to not-idle and restarts the timer; idle flips true after the delay; timers cleaned up on unmount. Delay is a named constant (`DEFAULT_IDLE_DELAY_MS`).
- **`shouldShowResonance({isIdle, hasContent, isLoading})`**: pure, tested visibility rule — show on idle-with-content, and stay visible while a pass is loading.
- **`GetResonanceButton`** (presentational): soft opacity + translateY fade on `visible`, a friendly **"Listening…"** busy state that disables press, honors `touchTarget.minimum`, and is fully **inert when hidden** (pointerEvents none + hidden from the a11y tree + detached press handler).

No reduce-motion handling — the app has no such convention yet, so there's nothing to honor.

## Test plan

`useIdle.test.ts` (fake timers): flip / reset / default delay. `GetResonanceButton.test.tsx`: `shouldShowResonance` truth table; press fires `onPress`; loading shows the busy label + blocks press; hidden is non-pressable and absent from the accessibility tree.

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #615
Refs #603
