### PR TITLE
feat(frontend): wire the resonance request flow

### DIFF
--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -66,6 +66,15 @@ const styles = StyleSheet.create({
     color: colors.paper.inkSoft,
     paddingTop: spacing(1),
   },
+  marginCount: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+  marginError: {
+    ...editorialType.caption,
+    color: colors.danger,
+    paddingTop: spacing(1),
+  },
 });
 
 export default styles;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -11,11 +11,14 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ScrollView, Text, TextInput, View, useWindowDimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import GetResonanceButton, { shouldShowResonance } from './GetResonanceButton';
 import styles from './JournalEntry.styles';
+import { useResonance } from './useResonance';
 
 import { journal } from '@/api';
 import type { JournalMessage } from '@/api';
 import { colors } from '@/design/tokens';
+import { useIdle } from '@/hooks/useIdle';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 /** Default idle delay before an edit is persisted. */
@@ -70,6 +73,8 @@ interface AutosaveApi {
   saveState: SaveState;
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
+  /** Persist the latest text immediately and resolve to the entry id (or null). */
+  flush: () => Promise<number | null>;
 }
 
 /** Load an existing entry once (by route id) and hand it to ``apply``. */
@@ -128,7 +133,18 @@ function useDebouncedSave(routeEntryId: number | null, delayMs: number) {
     [run, delayMs],
   );
 
-  return { saveState, save };
+  // Cancel any pending debounce and persist now; resolves to the entry id so a
+  // caller (e.g. resonance) can act on the just-saved entry.
+  const flush = useCallback(
+    async (title: string, body: string): Promise<number | null> => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (body.trim()) await run(title, body);
+      return entryIdRef.current;
+    },
+    [run],
+  );
+
+  return { saveState, save, flush };
 }
 
 /** Owns the entry's text + debounced draft autosave (create-then-update). */
@@ -139,7 +155,7 @@ function useJournalAutosave(routeEntryId: number | null, delayMs: number): Autos
   // stable (each save needs the *other* field's current value).
   const titleRef = useRef('');
   const bodyRef = useRef('');
-  const { saveState, save } = useDebouncedSave(routeEntryId, delayMs);
+  const { saveState, save, flush } = useDebouncedSave(routeEntryId, delayMs);
 
   useEntryLoadEffect(
     routeEntryId,
@@ -168,11 +184,27 @@ function useJournalAutosave(routeEntryId: number | null, delayMs: number): Autos
     [save],
   );
 
-  return { title, body, saveState, onChangeTitle, onChangeBody };
+  const flushNow = useCallback(() => flush(titleRef.current, bodyRef.current), [flush]);
+
+  return { title, body, saveState, onChangeTitle, onChangeBody, flush: flushNow };
+}
+
+interface WritingColumnProps {
+  title: string;
+  body: string;
+  saveState: SaveState;
+  onChangeTitle: (_next: string) => void;
+  onChangeBody: (_next: string) => void;
 }
 
 /** The scrollable writing column (title + growing body + save hint). */
-function WritingColumn({ title, body, saveState, onChangeTitle, onChangeBody }: AutosaveApi) {
+function WritingColumn({
+  title,
+  body,
+  saveState,
+  onChangeTitle,
+  onChangeBody,
+}: WritingColumnProps) {
   return (
     <ScrollView
       style={styles.writingColumn}
@@ -210,26 +242,85 @@ function WritingColumn({ title, body, saveState, onChangeTitle, onChangeBody }: 
   );
 }
 
+/** Quiet placeholder margin content until the notes UI lands (#617). */
+function ResonanceMargin({ count, error }: { count: number; error: string | null }) {
+  return (
+    <>
+      <Text style={styles.marginCount} testID="journal-margin-count">
+        {count === 1 ? '1 note in the margin' : `${count} notes in the margin`}
+      </Text>
+      {error ? (
+        <Text style={styles.marginError} testID="journal-resonance-error">
+          {error}
+        </Text>
+      ) : null}
+    </>
+  );
+}
+
+/** Compose the autosave + idle + resonance hooks into the screen's view-model. */
+function useJournalEntryController(routeEntryId: number | null, autosaveDelayMs: number) {
+  const autosave = useJournalAutosave(routeEntryId, autosaveDelayMs);
+  const { isIdle, bump } = useIdle();
+  const resonance = useResonance({ routeEntryId, flush: autosave.flush });
+  const { onChangeTitle, onChangeBody } = autosave;
+
+  const handleTitle = useCallback(
+    (t: string) => {
+      bump();
+      onChangeTitle(t);
+    },
+    [bump, onChangeTitle],
+  );
+  const handleBody = useCallback(
+    (t: string) => {
+      bump();
+      onChangeBody(t);
+    },
+    [bump, onChangeBody],
+  );
+  const hasContent = autosave.body.trim().length > 0;
+  const visible = shouldShowResonance({ isIdle, hasContent, isLoading: resonance.loading });
+
+  return { autosave, resonance, isIdle, visible, handleTitle, handleBody };
+}
+
 function JournalEntryScreen({
   route,
   renderMargin,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
-  const autosave = useJournalAutosave(route.params?.entryId ?? null, autosaveDelayMs);
+  const { autosave, resonance, isIdle, visible, handleTitle, handleBody } =
+    useJournalEntryController(route.params?.entryId ?? null, autosaveDelayMs);
   const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
-  const isIdle = autosave.saveState !== 'typing' && autosave.saveState !== 'saving';
+  const { title, body, saveState } = autosave;
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={[styles.page, narrow && styles.pageNarrow]}>
-        <WritingColumn {...autosave} />
+        <WritingColumn
+          title={title}
+          body={body}
+          saveState={saveState}
+          onChangeTitle={handleTitle}
+          onChangeBody={handleBody}
+        />
         <View
           style={[styles.marginColumn, narrow && styles.marginColumnNarrow]}
           testID="journal-margin-column"
         >
-          {renderMargin?.({ body: autosave.body, isIdle })}
+          {renderMargin ? (
+            renderMargin({ body, isIdle })
+          ) : (
+            <ResonanceMargin count={resonance.marginalia.length} error={resonance.error} />
+          )}
         </View>
       </View>
+      <GetResonanceButton
+        visible={visible}
+        loading={resonance.loading}
+        onPress={resonance.requestResonance}
+      />
     </SafeAreaView>
   );
 }

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -246,9 +246,11 @@ function WritingColumn({
 function ResonanceMargin({ count, error }: { count: number; error: string | null }) {
   return (
     <>
-      <Text style={styles.marginCount} testID="journal-margin-count">
-        {count === 1 ? '1 note in the margin' : `${count} notes in the margin`}
-      </Text>
+      {count > 0 ? (
+        <Text style={styles.marginCount} testID="journal-margin-count">
+          {count === 1 ? '1 note in the margin' : `${count} notes in the margin`}
+        </Text>
+      ) : null}
       {error ? (
         <Text style={styles.marginError} testID="journal-resonance-error">
           {error}

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -11,11 +11,17 @@ const mockUpdate = jest.fn() as jest.MockedFunction<
   (_id: number, _p: unknown) => Promise<JournalMessage>
 >;
 
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+
 jest.mock('@/api', () => ({
   journal: {
     get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
     create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
     update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: jest.fn(),
   },
 }));
 
@@ -50,6 +56,8 @@ beforeEach(() => {
   mockUpdate.mockReset();
   mockCreate.mockResolvedValue(entry({ id: 42 }));
   mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
 });
 
 describe('JournalEntryScreen', () => {

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -69,6 +69,11 @@ describe('JournalEntryScreen', () => {
     expect(queryByText('Send')).toBeNull();
   });
 
+  it('shows no count indicator on a fresh entry with no notes', () => {
+    const { queryByTestId } = renderScreen();
+    expect(queryByTestId('journal-margin-count')).toBeNull();
+  });
+
   it('reserves a margin column and renders the renderMargin slot', () => {
     const renderMargin = jest.fn(() => null);
     const { getByTestId } = renderScreen(undefined, { renderMargin });

--- a/frontend/src/features/Journal/__tests__/useResonance.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonance.test.tsx
@@ -1,0 +1,124 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { Marginalia, ResonanceResponse } from '@/api';
+import { ApiError } from '@/api';
+
+const mockList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: Marginalia[] }>
+>;
+const mockGenerate = jest.fn() as jest.MockedFunction<(_id: number) => Promise<ResonanceResponse>>;
+
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api') as Record<string, unknown>;
+  return {
+    ...actual,
+    resonance: {
+      list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+      generate: (...a: unknown[]) =>
+        (mockGenerate as unknown as (...x: unknown[]) => unknown)(...a),
+    },
+  };
+});
+
+const { useResonance } = require('../useResonance');
+
+function note(overrides: Partial<Marginalia> = {}): Marginalia {
+  return {
+    id: 1,
+    journal_entry_id: 7,
+    kind: 'theme',
+    anchor_start: 0,
+    anchor_end: 4,
+    anchor_text: 'walk',
+    note: 'A beginning.',
+    essay: null,
+    essay_generated_at: null,
+    status: 'active',
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function resonancePayload(notes: Marginalia[]): ResonanceResponse {
+  return {
+    marginalia: notes,
+    remaining_messages: 48,
+    remaining_balance: 0,
+    monthly_reset_date: '2026-07-01T00:00:00Z',
+  };
+}
+
+beforeEach(() => {
+  mockList.mockReset();
+  mockGenerate.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+});
+
+describe('useResonance', () => {
+  it('loads existing marginalia on mount when the entry has an id', async () => {
+    mockList.mockResolvedValue({ items: [note({ id: 1 }), note({ id: 2, anchor_start: 10 })] });
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+    await waitFor(() => expect(result.current.marginalia).toHaveLength(2));
+    expect(mockList).toHaveBeenCalledWith(7);
+  });
+
+  it('flushes the save, then generates and stores notes + remaining', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue(resonancePayload([note({ id: 5, journal_entry_id: 42 })]));
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(mockGenerate).toHaveBeenCalledWith(42);
+    expect(result.current.marginalia).toHaveLength(1);
+    expect(result.current.remaining).toBe(48);
+  });
+
+  it('maps a 402 to a friendly error and leaves the page usable', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockRejectedValue(new ApiError(402, 'insufficient_offerings'));
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.error).not.toContain('insufficient_offerings'); // friendly, not raw
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('guards against concurrent generates (no double-charge on rapid taps)', async () => {
+    const flush = jest.fn(async () => 42);
+    let resolveGen: (_v: ResonanceResponse) => void = () => {};
+    mockGenerate.mockReturnValue(
+      new Promise<ResonanceResponse>((resolve) => {
+        resolveGen = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      void result.current.requestResonance();
+      void result.current.requestResonance(); // second tap while first is in flight
+      resolveGen(resonancePayload([note({ id: 9 })]));
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a gentle message when there is nothing to save', async () => {
+    const flush = jest.fn(async () => null);
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+    expect(mockGenerate).not.toHaveBeenCalled();
+    expect(result.current.error).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -1,0 +1,87 @@
+/**
+ * ``useResonance`` — drives an on-demand resonance pass for a journal entry.
+ *
+ * On open (entry already has an id) it loads existing marginalia. A request
+ * flushes the draft save first (so we resonate against the *saved* latest body),
+ * calls the generate endpoint, merges the returned notes, and refreshes the
+ * remaining-pass balance. One request runs at a time so rapid taps can't
+ * double-charge; errors (notably 402) are mapped to friendly copy and never
+ * crash the page.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { resonance } from '@/api';
+import type { Marginalia } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+
+const EMPTY_BODY_MESSAGE = 'Write a little first, then ask for its resonance.';
+
+export interface UseResonanceArgs {
+  routeEntryId: number | null;
+  /** Persist the latest text and resolve to the entry id (from the writing surface). */
+  flush: () => Promise<number | null>;
+}
+
+export interface UseResonanceResult {
+  marginalia: Marginalia[];
+  loading: boolean;
+  error: string | null;
+  remaining: number | null;
+  requestResonance: () => Promise<void>;
+}
+
+/** Union of two note lists, keyed by id (incoming wins on conflict). */
+function mergeById(existing: Marginalia[], incoming: Marginalia[]): Marginalia[] {
+  const byId = new Map<number, Marginalia>();
+  for (const note of existing) byId.set(note.id, note);
+  for (const note of incoming) byId.set(note.id, note);
+  return [...byId.values()].sort((a, b) => a.anchor_start - b.anchor_start);
+}
+
+export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseResonanceResult {
+  const [marginalia, setMarginalia] = useState<Marginalia[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (routeEntryId == null) return undefined;
+    let active = true;
+    void resonance
+      .list(routeEntryId)
+      .then((res) => {
+        if (active) setMarginalia(res.items);
+      })
+      .catch(() => {
+        // A failed initial load shouldn't block writing; stay silent here.
+      });
+    return () => {
+      active = false;
+    };
+  }, [routeEntryId]);
+
+  const requestResonance = useCallback(async (): Promise<void> => {
+    if (inFlightRef.current) return; // one pass at a time — no double-charge
+    inFlightRef.current = true;
+    setLoading(true);
+    setError(null);
+    try {
+      const entryId = await flush();
+      if (entryId == null) {
+        setError(EMPTY_BODY_MESSAGE);
+        return;
+      }
+      const result = await resonance.generate(entryId);
+      setMarginalia((prev) => mergeById(prev, result.marginalia));
+      setRemaining(result.remaining_messages);
+    } catch (err) {
+      setError(formatApiError(err));
+    } finally {
+      inFlightRef.current = false;
+      setLoading(false);
+    }
+  }, [flush]);
+
+  return { marginalia, loading, error, remaining, requestResonance };
+}


### PR DESCRIPTION
## Summary

journal-resonance-13: connect the writing surface, idle signal, API client, and Get-Resonance button so a tap generates resonance for the saved entry. Notes aren't drawn in the margin yet (#617) — just state + a quiet count indicator.

- **`useResonance({routeEntryId, flush})`**: loads existing marginalia on open (`resonance.list`); `requestResonance()` **flushes the draft save first** (so we resonate against the saved latest body), calls `resonance.generate`, merges returned notes by id, and updates the remaining-pass balance. **One pass in flight at a time** (ref guard) so rapid taps can't double-charge; errors map via `formatApiError` (402 → the friendly insufficient-offerings copy) and never crash; errored requests stay retryable.
- **`useJournalAutosave.flush()`**: cancels the debounce, persists now, and resolves to the entry id (create-on-first, update-after).
- **`JournalEntryScreen`** wires `useIdle` (bumped per keystroke) + `useResonance`; button visibility is `shouldShowResonance({isIdle, hasContent, isLoading})`; a quiet "N notes in the margin" indicator + gentle error line fill the reserved column until #617. Hook wiring lives in a small controller hook.

## Test plan

`useResonance.test.tsx` (mock API): saves-then-generates and stores notes + remaining; existing notes load on mount; 402 → friendly error, page usable; in-flight guard prevents concurrent generates; empty body → gentle prompt, no call. `JournalEntryScreen.test.tsx` updated for the new `resonance` dependency.

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #616
Refs #603
