### PR TITLE
feat(frontend): margin notes + inline anchor highlighting

### DIFF
--- a/frontend/src/features/Journal/HighlightedBody.tsx
+++ b/frontend/src/features/Journal/HighlightedBody.tsx
@@ -1,0 +1,57 @@
+/**
+ * Read-mode rendering of an entry body with each anchored span softly
+ * highlighted and tappable. The offset math lives in {@link buildHighlightSegments};
+ * this only maps segments to a composed ``<Text>`` tree.
+ */
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import { buildHighlightSegments } from './highlightSegments';
+
+import type { Marginalia } from '@/api';
+import { colors, editorialType } from '@/design/tokens';
+
+export interface HighlightedBodyProps {
+  body: string;
+  notes: Marginalia[];
+  onOpen: (_note: Marginalia) => void;
+}
+
+function HighlightedBody({ body, notes, onOpen }: HighlightedBodyProps): React.JSX.Element {
+  const segments = buildHighlightSegments(body, notes);
+  return (
+    <Text style={styles.body} testID="journal-body-read">
+      {segments.map((segment) => {
+        const { note } = segment;
+        if (note == null) return segment.text;
+        return (
+          <Text
+            key={segment.start}
+            style={[styles.highlight, { color: colors.marginalia[note.kind] }]}
+            onPress={() => onOpen(note)}
+            accessibilityRole="link"
+            accessibilityLabel={`Highlighted ${note.kind} passage`}
+            testID={`highlight-${note.id}`}
+          >
+            {segment.text}
+          </Text>
+        );
+      })}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    ...editorialType.body,
+    color: colors.paper.ink,
+  },
+  highlight: {
+    // Soft paper-toned wash; the kind colour comes from the inline text colour so
+    // there are no colour literals here.
+    backgroundColor: colors.paper.anchorHighlight,
+    fontWeight: '600',
+  },
+});
+
+export default HighlightedBody;

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -75,6 +75,9 @@ const styles = StyleSheet.create({
     color: colors.danger,
     paddingTop: spacing(1),
   },
+  marginNoteSlot: {
+    marginBottom: journalLayout.marginNoteGap,
+  },
 });
 
 export default styles;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -12,11 +12,13 @@ import { ScrollView, Text, TextInput, View, useWindowDimensions } from 'react-na
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import GetResonanceButton, { shouldShowResonance } from './GetResonanceButton';
+import HighlightedBody from './HighlightedBody';
 import styles from './JournalEntry.styles';
+import MarginNote from './MarginNote';
 import { useResonance } from './useResonance';
 
 import { journal } from '@/api';
-import type { JournalMessage } from '@/api';
+import type { JournalMessage, Marginalia } from '@/api';
 import { colors } from '@/design/tokens';
 import { useIdle } from '@/hooks/useIdle';
 import type { RootStackParamList } from '@/navigation/RootStack';
@@ -260,12 +262,61 @@ function ResonanceMargin({ count, error }: { count: number; error: string | null
   );
 }
 
+/** Read-mode body: the title + the highlighted passage tree (shown once notes exist). */
+function ReadColumn({
+  title,
+  body,
+  notes,
+  onOpen,
+}: {
+  title: string;
+  body: string;
+  notes: Marginalia[];
+  onOpen: (_note: Marginalia) => void;
+}) {
+  return (
+    <ScrollView
+      style={styles.writingColumn}
+      contentContainerStyle={styles.writingColumnContent}
+      keyboardShouldPersistTaps="handled"
+    >
+      {title ? <Text style={styles.titleInput}>{title}</Text> : null}
+      <View style={styles.hairline} />
+      <HighlightedBody body={body} notes={notes} onOpen={onOpen} />
+    </ScrollView>
+  );
+}
+
+/** The stack of margin notes, ordered by anchor position. */
+function MarginNoteList({
+  notes,
+  onOpen,
+}: {
+  notes: Marginalia[];
+  onOpen: (_note: Marginalia) => void;
+}) {
+  const ordered = [...notes].sort((a, b) => a.anchor_start - b.anchor_start);
+  return (
+    <>
+      {ordered.map((note) => (
+        <View key={note.id} style={styles.marginNoteSlot}>
+          <MarginNote note={note} onOpen={onOpen} />
+        </View>
+      ))}
+    </>
+  );
+}
+
 /** Compose the autosave + idle + resonance hooks into the screen's view-model. */
 function useJournalEntryController(routeEntryId: number | null, autosaveDelayMs: number) {
   const autosave = useJournalAutosave(routeEntryId, autosaveDelayMs);
   const { isIdle, bump } = useIdle();
   const resonance = useResonance({ routeEntryId, flush: autosave.flush });
   const { onChangeTitle, onChangeBody } = autosave;
+  // Selected note is consumed by the essay modal in a later issue; here we only
+  // need to record the open intent so the highlight/note taps have a sink.
+  const [, setSelectedNote] = useState<Marginalia | null>(null);
+  const onOpenNote = useCallback((note: Marginalia) => setSelectedNote(note), []);
 
   const handleTitle = useCallback(
     (t: string) => {
@@ -284,7 +335,7 @@ function useJournalEntryController(routeEntryId: number | null, autosaveDelayMs:
   const hasContent = autosave.body.trim().length > 0;
   const visible = shouldShowResonance({ isIdle, hasContent, isLoading: resonance.loading });
 
-  return { autosave, resonance, isIdle, visible, handleTitle, handleBody };
+  return { autosave, resonance, isIdle, visible, handleTitle, handleBody, onOpenNote };
 }
 
 function JournalEntryScreen({
@@ -292,30 +343,39 @@ function JournalEntryScreen({
   renderMargin,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
-  const { autosave, resonance, isIdle, visible, handleTitle, handleBody } =
+  const { autosave, resonance, isIdle, visible, handleTitle, handleBody, onOpenNote } =
     useJournalEntryController(route.params?.entryId ?? null, autosaveDelayMs);
   const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
   const { title, body, saveState } = autosave;
+  const notes = resonance.marginalia;
+  // Once notes exist the body switches to a highlighted read view; the
+  // deliberate edit-vs-read toggle lands in a later issue.
+  const hasNotes = notes.length > 0;
+
+  let marginContent: React.ReactNode;
+  if (renderMargin) marginContent = renderMargin({ body, isIdle });
+  else if (hasNotes) marginContent = <MarginNoteList notes={notes} onOpen={onOpenNote} />;
+  else marginContent = <ResonanceMargin count={0} error={resonance.error} />;
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={[styles.page, narrow && styles.pageNarrow]}>
-        <WritingColumn
-          title={title}
-          body={body}
-          saveState={saveState}
-          onChangeTitle={handleTitle}
-          onChangeBody={handleBody}
-        />
+        {hasNotes ? (
+          <ReadColumn title={title} body={body} notes={notes} onOpen={onOpenNote} />
+        ) : (
+          <WritingColumn
+            title={title}
+            body={body}
+            saveState={saveState}
+            onChangeTitle={handleTitle}
+            onChangeBody={handleBody}
+          />
+        )}
         <View
           style={[styles.marginColumn, narrow && styles.marginColumnNarrow]}
           testID="journal-margin-column"
         >
-          {renderMargin ? (
-            renderMargin({ body, isIdle })
-          ) : (
-            <ResonanceMargin count={resonance.marginalia.length} error={resonance.error} />
-          )}
+          {marginContent}
         </View>
       </View>
       <GetResonanceButton

--- a/frontend/src/features/Journal/MarginNote.tsx
+++ b/frontend/src/features/Journal/MarginNote.tsx
@@ -1,0 +1,71 @@
+/**
+ * ``MarginNote`` — one of the AI's margin notes, pinned beside the passage it
+ * refers to. Presentational: a serif card with a kind pin (in the kind accent),
+ * the note text, and a subtle open affordance. Stale notes render dimmed (full
+ * staleness styling lands in a later issue). Tapping signals ``onOpen``.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+
+import type { Marginalia } from '@/api';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
+
+export interface MarginNoteProps {
+  note: Marginalia;
+  onOpen: (_note: Marginalia) => void;
+}
+
+function MarginNote({ note, onOpen }: MarginNoteProps): React.JSX.Element {
+  const isStale = note.status === 'stale';
+  return (
+    <TouchableOpacity
+      style={[styles.card, isStale && styles.cardStale]}
+      onPress={() => onOpen(note)}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${note.kind} note`}
+      testID={`margin-note-${note.id}`}
+    >
+      <Text style={[styles.kind, { color: colors.marginalia[note.kind] }]}>{note.kind}</Text>
+      <Text style={styles.note}>{note.note}</Text>
+      <Text style={styles.open}>{isStale ? 'Anchor moved · Open' : 'Open'}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    minHeight: touchTarget.minimum,
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.paper.backgroundAlt,
+    borderLeftWidth: 3,
+    borderLeftColor: colors.paper.hairline,
+  },
+  cardStale: {
+    opacity: 0.55,
+  },
+  kind: {
+    ...editorialType.caption,
+    textTransform: 'capitalize',
+    fontWeight: '600',
+  },
+  note: {
+    ...editorialType.marginNote,
+    color: colors.paper.ink,
+    paddingTop: spacing(0.5),
+  },
+  open: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    paddingTop: spacing(1),
+  },
+});
+
+export default MarginNote;

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -150,6 +150,34 @@ describe('JournalEntryScreen', () => {
     }
   });
 
+  it('renders read-mode highlights + margin notes once an entry has notes', async () => {
+    mockGet.mockResolvedValue(entry({ id: 7, message: 'I walked by the river.' }));
+    mockList.mockResolvedValue({
+      items: [
+        {
+          id: 50,
+          journal_entry_id: 7,
+          kind: 'theme',
+          anchor_start: 2,
+          anchor_end: 8,
+          anchor_text: 'walked',
+          note: 'You keep moving.',
+          essay: null,
+          essay_generated_at: null,
+          status: 'active',
+          created_at: '',
+          updated_at: '',
+        },
+      ],
+    });
+    const { findByTestId, queryByTestId } = renderScreen({ entryId: 7 });
+    expect(await findByTestId('margin-note-50')).toBeTruthy();
+    expect(queryByTestId('journal-body-read')).not.toBeNull();
+    expect(queryByTestId('highlight-50')).not.toBeNull();
+    // Read mode replaces the editable body.
+    expect(queryByTestId('journal-body-input')).toBeNull();
+  });
+
   it('loads an existing entry by id', async () => {
     mockGet.mockResolvedValue(entry({ id: 7, title: 'Rivers', message: 'An existing page.' }));
     const { getByTestId } = renderScreen({ entryId: 7 });

--- a/frontend/src/features/Journal/__tests__/MarginNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/MarginNote.test.tsx
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import MarginNote from '../MarginNote';
+
+import type { Marginalia } from '@/api';
+
+function note(overrides: Partial<Marginalia> = {}): Marginalia {
+  return {
+    id: 3,
+    journal_entry_id: 1,
+    kind: 'symbol',
+    anchor_start: 0,
+    anchor_end: 4,
+    anchor_text: 'walk',
+    note: 'The willow bends without breaking.',
+    essay: null,
+    essay_generated_at: null,
+    status: 'active',
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+describe('MarginNote', () => {
+  it('shows the kind label and the note text', () => {
+    const { getByText } = render(<MarginNote note={note()} onOpen={jest.fn()} />);
+    expect(getByText('symbol')).toBeTruthy();
+    expect(getByText('The willow bends without breaking.')).toBeTruthy();
+  });
+
+  it('fires onOpen with the note when pressed', () => {
+    const onOpen = jest.fn();
+    const n = note({ id: 11 });
+    const { getByTestId } = render(<MarginNote note={n} onOpen={onOpen} />);
+    fireEvent.press(getByTestId('margin-note-11'));
+    expect(onOpen).toHaveBeenCalledWith(n);
+  });
+
+  it('renders the dimmed stale variant', () => {
+    const { getByTestId, getByText } = render(
+      <MarginNote note={note({ id: 12, status: 'stale' })} onOpen={jest.fn()} />,
+    );
+    const card = getByTestId('margin-note-12');
+    const flattened = Array.isArray(card.props.style)
+      ? Object.assign({}, ...card.props.style)
+      : card.props.style;
+    expect(flattened.opacity).toBeLessThan(1);
+    expect(getByText(/Anchor moved/)).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/highlightSegments.test.ts
+++ b/frontend/src/features/Journal/__tests__/highlightSegments.test.ts
@@ -1,0 +1,69 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+import { buildHighlightSegments } from '../highlightSegments';
+
+import type { Marginalia } from '@/api';
+
+const BODY = 'I walked by the river and the willow bent.';
+
+function note(overrides: Partial<Marginalia>): Marginalia {
+  return {
+    id: 1,
+    journal_entry_id: 1,
+    kind: 'theme',
+    anchor_start: 0,
+    anchor_end: 1,
+    anchor_text: 'x',
+    note: 'n',
+    essay: null,
+    essay_generated_at: null,
+    status: 'active',
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+describe('buildHighlightSegments', () => {
+  it('returns the whole body as one plain segment when there are no notes', () => {
+    const segments = buildHighlightSegments(BODY, []);
+    expect(segments).toEqual([{ start: 0, text: BODY, note: null }]);
+  });
+
+  it('splits the body at anchor boundaries', () => {
+    const start = BODY.indexOf('the willow');
+    const n = note({ id: 7, anchor_start: start, anchor_end: start + 'the willow'.length });
+    const segments = buildHighlightSegments(BODY, [n]);
+
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toEqual({ start: 0, text: BODY.slice(0, start), note: null });
+    expect(segments[1]).toMatchObject({ start, text: 'the willow' });
+    expect(segments[1]!.note?.id).toBe(7);
+    expect(segments[2]!.note).toBeNull();
+    // Reassembling the segments reproduces the body exactly.
+    expect(segments.map((s) => s.text).join('')).toBe(BODY);
+  });
+
+  it('handles an anchor at the very start (no leading plain segment)', () => {
+    const n = note({ id: 2, anchor_start: 0, anchor_end: 8 }); // "I walked"
+    const segments = buildHighlightSegments(BODY, [n]);
+    expect(segments[0]!.note?.id).toBe(2);
+    expect(segments[0]!.text).toBe('I walked');
+  });
+
+  it('keeps the earliest of two overlapping anchors, deterministically', () => {
+    const a = note({ id: 1, anchor_start: 2, anchor_end: 10 });
+    const b = note({ id: 2, anchor_start: 5, anchor_end: 15 }); // overlaps a
+    const segments = buildHighlightSegments(BODY, [b, a]); // unsorted input
+    const highlighted = segments.filter((s) => s.note != null);
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0]!.note?.id).toBe(1); // earliest start wins
+  });
+
+  it('drops anchors that fall outside the body', () => {
+    const n = note({ id: 9, anchor_start: 100, anchor_end: 120 });
+    const segments = buildHighlightSegments(BODY, [n]);
+    expect(segments.every((s) => s.note == null)).toBe(true);
+  });
+});

--- a/frontend/src/features/Journal/highlightSegments.ts
+++ b/frontend/src/features/Journal/highlightSegments.ts
@@ -1,0 +1,47 @@
+/**
+ * Split an entry body into render segments, tagging each anchored range with its
+ * note. Pure offset math — no React — so the highlight logic is unit-testable
+ * apart from the ``<Text>`` tree that consumes it.
+ */
+import type { Marginalia } from '@/api';
+
+export interface HighlightSegment {
+  /** Character offset of this segment in the body (stable, unique → React key). */
+  start: number;
+  text: string;
+  /** The note whose anchor this segment is, or null for plain text. */
+  note: Marginalia | null;
+}
+
+/** Anchors that fall inside the body and are non-empty, earliest first. */
+function usableNotes(body: string, notes: Marginalia[]): Marginalia[] {
+  return notes
+    .filter(
+      (n) => n.anchor_start >= 0 && n.anchor_end <= body.length && n.anchor_start < n.anchor_end,
+    )
+    .sort((a, b) => a.anchor_start - b.anchor_start);
+}
+
+export function buildHighlightSegments(body: string, notes: Marginalia[]): HighlightSegment[] {
+  const segments: HighlightSegment[] = [];
+  let cursor = 0;
+  for (const note of usableNotes(body, notes)) {
+    // Skip any anchor that overlaps a range we've already committed to — first
+    // (earliest-start) wins, deterministically.
+    if (note.anchor_start < cursor) continue;
+    if (note.anchor_start > cursor) {
+      segments.push({ start: cursor, text: body.slice(cursor, note.anchor_start), note: null });
+    }
+    segments.push({
+      start: note.anchor_start,
+      text: body.slice(note.anchor_start, note.anchor_end),
+      note,
+    });
+    cursor = note.anchor_end;
+  }
+  if (cursor < body.length) {
+    segments.push({ start: cursor, text: body.slice(cursor), note: null });
+  }
+  if (segments.length === 0) segments.push({ start: 0, text: body, note: null });
+  return segments;
+}


### PR DESCRIPTION
## Summary

journal-resonance-14: render each marginalia as a note pinned in the reserved margin and softly highlight its anchored span inline. Tapping a note or its highlight fires `onOpen(note)`; the essay modal is a later issue.

- **`highlightSegments.ts`**: pure `buildHighlightSegments(body, notes) → Segment[]`. Sorts anchors, splits the body at boundaries, **skips overlaps deterministically** (earliest start wins), drops out-of-range anchors; each segment carries a stable `start` offset (used as the React key).
- **`HighlightedBody.tsx`**: composes the segments into a `<Text>` tree; each anchor range is a tappable, **kind-tinted** highlight (paper-toned wash + kind text colour from `colors.marginalia` — no colour literals).
- **`MarginNote.tsx`** (presentational): serif card with a kind pin in the kind accent, the note text, an open affordance; **stale** notes render dimmed.
- **`JournalEntryScreen`**: once an entry has notes it switches the body to the highlighted **read view** and fills the margin with the ordered `MarginNote` stack (the deliberate edit-vs-read toggle is #619); a blank entry stays in the editable writing surface. `onOpen` records the selected note for the modal.

## Test plan

`highlightSegments.test.ts` (split / start-anchor / overlap resolution / out-of-range); `MarginNote.test.tsx` (kind + text, fires `onOpen`, dims when stale); `JournalEntryScreen.test.tsx` renders read-mode highlights + margin notes once notes load.

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests). No colour literals; highlight math is a pure function.

Closes #617
Refs #603
