### PR TITLE
feat(frontend): hovering resonance essay modal

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -15,6 +15,7 @@ import GetResonanceButton, { shouldShowResonance } from './GetResonanceButton';
 import HighlightedBody from './HighlightedBody';
 import styles from './JournalEntry.styles';
 import MarginNote from './MarginNote';
+import ResonanceEssayModal from './ResonanceEssayModal';
 import { useResonance } from './useResonance';
 
 import { journal } from '@/api';
@@ -313,10 +314,19 @@ function useJournalEntryController(routeEntryId: number | null, autosaveDelayMs:
   const { isIdle, bump } = useIdle();
   const resonance = useResonance({ routeEntryId, flush: autosave.flush });
   const { onChangeTitle, onChangeBody } = autosave;
-  // Selected note is consumed by the essay modal in a later issue; here we only
-  // need to record the open intent so the highlight/note taps have a sink.
-  const [, setSelectedNote] = useState<Marginalia | null>(null);
-  const onOpenNote = useCallback((note: Marginalia) => setSelectedNote(note), []);
+  const { updateNote } = resonance;
+  const [openNote, setOpenNote] = useState<Marginalia | null>(null);
+  const onOpenNote = useCallback((note: Marginalia) => setOpenNote(note), []);
+  const onCloseNote = useCallback(() => setOpenNote(null), []);
+  // Cache the freshly-loaded essay back onto the note (instant re-open) and keep
+  // the open modal showing the updated note.
+  const onEssayLoaded = useCallback(
+    (updated: Marginalia) => {
+      updateNote(updated);
+      setOpenNote(updated);
+    },
+    [updateNote],
+  );
 
   const handleTitle = useCallback(
     (t: string) => {
@@ -335,7 +345,61 @@ function useJournalEntryController(routeEntryId: number | null, autosaveDelayMs:
   const hasContent = autosave.body.trim().length > 0;
   const visible = shouldShowResonance({ isIdle, hasContent, isLoading: resonance.loading });
 
-  return { autosave, resonance, isIdle, visible, handleTitle, handleBody, onOpenNote };
+  return {
+    autosave,
+    resonance,
+    isIdle,
+    visible,
+    handleTitle,
+    handleBody,
+    onOpenNote,
+    openNote,
+    onCloseNote,
+    onEssayLoaded,
+  };
+}
+
+type Controller = ReturnType<typeof useJournalEntryController>;
+
+/** The two-column page: the body (edit or read) + the margin. */
+function JournalPage({
+  ctl,
+  renderMargin,
+}: {
+  ctl: Controller;
+  renderMargin?: JournalEntryScreenProps['renderMargin'];
+}) {
+  const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
+  const { title, body, saveState } = ctl.autosave;
+  const notes = ctl.resonance.marginalia;
+  const hasNotes = notes.length > 0;
+
+  let marginContent: React.ReactNode;
+  if (renderMargin) marginContent = renderMargin({ body, isIdle: ctl.isIdle });
+  else if (hasNotes) marginContent = <MarginNoteList notes={notes} onOpen={ctl.onOpenNote} />;
+  else marginContent = <ResonanceMargin count={0} error={ctl.resonance.error} />;
+
+  return (
+    <View style={[styles.page, narrow && styles.pageNarrow]}>
+      {hasNotes ? (
+        <ReadColumn title={title} body={body} notes={notes} onOpen={ctl.onOpenNote} />
+      ) : (
+        <WritingColumn
+          title={title}
+          body={body}
+          saveState={saveState}
+          onChangeTitle={ctl.handleTitle}
+          onChangeBody={ctl.handleBody}
+        />
+      )}
+      <View
+        style={[styles.marginColumn, narrow && styles.marginColumnNarrow]}
+        testID="journal-margin-column"
+      >
+        {marginContent}
+      </View>
+    </View>
+  );
 }
 
 function JournalEntryScreen({
@@ -343,45 +407,19 @@ function JournalEntryScreen({
   renderMargin,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
-  const { autosave, resonance, isIdle, visible, handleTitle, handleBody, onOpenNote } =
-    useJournalEntryController(route.params?.entryId ?? null, autosaveDelayMs);
-  const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
-  const { title, body, saveState } = autosave;
-  const notes = resonance.marginalia;
-  // Once notes exist the body switches to a highlighted read view; the
-  // deliberate edit-vs-read toggle lands in a later issue.
-  const hasNotes = notes.length > 0;
-
-  let marginContent: React.ReactNode;
-  if (renderMargin) marginContent = renderMargin({ body, isIdle });
-  else if (hasNotes) marginContent = <MarginNoteList notes={notes} onOpen={onOpenNote} />;
-  else marginContent = <ResonanceMargin count={0} error={resonance.error} />;
-
+  const ctl = useJournalEntryController(route.params?.entryId ?? null, autosaveDelayMs);
   return (
     <SafeAreaView style={styles.safeArea}>
-      <View style={[styles.page, narrow && styles.pageNarrow]}>
-        {hasNotes ? (
-          <ReadColumn title={title} body={body} notes={notes} onOpen={onOpenNote} />
-        ) : (
-          <WritingColumn
-            title={title}
-            body={body}
-            saveState={saveState}
-            onChangeTitle={handleTitle}
-            onChangeBody={handleBody}
-          />
-        )}
-        <View
-          style={[styles.marginColumn, narrow && styles.marginColumnNarrow]}
-          testID="journal-margin-column"
-        >
-          {marginContent}
-        </View>
-      </View>
+      <JournalPage ctl={ctl} renderMargin={renderMargin} />
       <GetResonanceButton
-        visible={visible}
-        loading={resonance.loading}
-        onPress={resonance.requestResonance}
+        visible={ctl.visible}
+        loading={ctl.resonance.loading}
+        onPress={ctl.resonance.requestResonance}
+      />
+      <ResonanceEssayModal
+        note={ctl.openNote}
+        onClose={ctl.onCloseNote}
+        onEssayLoaded={ctl.onEssayLoaded}
       />
     </SafeAreaView>
   );

--- a/frontend/src/features/Journal/ResonanceEssayModal.tsx
+++ b/frontend/src/features/Journal/ResonanceEssayModal.tsx
@@ -1,0 +1,202 @@
+/**
+ * ``ResonanceEssayModal`` — a margin note expanded into its letter-like essay,
+ * hovering over the (still-visible, dimmed) page. Lazily fetches the essay the
+ * first time a note is opened and caches it back to the note via
+ * ``onEssayLoaded`` so re-opening is instant. A warm editorial reading card, not
+ * a chat reply.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { resonance } from '@/api';
+import type { Marginalia } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
+
+export interface ResonanceEssayModalProps {
+  note: Marginalia | null;
+  onClose: () => void;
+  onEssayLoaded?: (_note: Marginalia) => void;
+}
+
+interface EssayState {
+  essay: string | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/** Lazily load the note's essay (unless it already carries one). */
+function useEssay(
+  note: Marginalia | null,
+  onEssayLoaded?: (_n: Marginalia) => void,
+): EssayState & {
+  retry: () => void;
+} {
+  const [state, setState] = useState<EssayState>({ essay: null, loading: false, error: null });
+  const [attempt, setAttempt] = useState(0);
+  const retry = useCallback(() => setAttempt((a) => a + 1), []);
+
+  useEffect(() => {
+    if (note == null) return undefined;
+    if (note.essay != null) {
+      setState({ essay: note.essay, loading: false, error: null });
+      return undefined;
+    }
+    let active = true;
+    setState({ essay: null, loading: true, error: null });
+    resonance
+      .essay(note.id)
+      .then((updated) => {
+        if (!active) return;
+        setState({ essay: updated.essay, loading: false, error: null });
+        onEssayLoaded?.(updated);
+      })
+      .catch((err: unknown) => {
+        if (active) setState({ essay: null, loading: false, error: formatApiError(err) });
+      });
+    return () => {
+      active = false;
+    };
+  }, [note, attempt, onEssayLoaded]);
+
+  return { ...state, retry };
+}
+
+/** The body region: spinner, the essay, or a friendly error with retry. */
+function EssayBody({ essay, loading, error, retry }: EssayState & { retry: () => void }) {
+  if (loading) {
+    return <ActivityIndicator testID="essay-loading" color={colors.paper.ink} />;
+  }
+  if (error != null) {
+    return (
+      <TouchableOpacity onPress={retry} accessibilityRole="button" testID="essay-retry">
+        <Text style={styles.error}>{error}</Text>
+        <Text style={styles.retry}>Tap to try again</Text>
+      </TouchableOpacity>
+    );
+  }
+  return (
+    <Text style={styles.essay} testID="essay-text">
+      {essay}
+    </Text>
+  );
+}
+
+function ResonanceEssayModal({
+  note,
+  onClose,
+  onEssayLoaded,
+}: ResonanceEssayModalProps): React.JSX.Element {
+  const { essay, loading, error, retry } = useEssay(note, onEssayLoaded);
+
+  return (
+    <Modal
+      visible={note != null}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      testID="essay-modal"
+    >
+      <Pressable
+        style={styles.scrim}
+        onPress={onClose}
+        testID="essay-scrim"
+        accessibilityLabel="Dismiss essay"
+      >
+        {/* Stop taps on the card from dismissing. */}
+        <Pressable style={styles.card} onPress={() => {}}>
+          <View style={styles.header}>
+            <Text style={[styles.kind, { color: note ? colors.marginalia[note.kind] : undefined }]}>
+              {note?.kind}
+            </Text>
+            <TouchableOpacity
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+              testID="essay-close"
+            >
+              <Text style={styles.close}>×</Text>
+            </TouchableOpacity>
+          </View>
+          <Text style={styles.quote} testID="essay-quote">
+            “{note?.anchor_text}”
+          </Text>
+          <ScrollView contentContainerStyle={styles.bodyScroll}>
+            <EssayBody essay={essay} loading={loading} error={error} retry={retry} />
+          </ScrollView>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrim: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.xl,
+  },
+  card: {
+    maxHeight: '80%',
+    padding: SPACING.xl,
+    borderRadius: BORDER_RADIUS.lg,
+    backgroundColor: colors.paper.background,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  kind: {
+    ...editorialType.caption,
+    textTransform: 'capitalize',
+    fontWeight: '600',
+  },
+  close: {
+    fontSize: 28,
+    lineHeight: 28,
+    minWidth: touchTarget.minimum,
+    textAlign: 'right',
+    color: colors.paper.inkSoft,
+  },
+  quote: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+    paddingVertical: spacing(1.5),
+  },
+  bodyScroll: {
+    paddingTop: spacing(1),
+  },
+  essay: {
+    ...editorialType.body,
+    color: colors.paper.ink,
+  },
+  error: {
+    ...editorialType.body,
+    color: colors.danger,
+  },
+  retry: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    paddingTop: spacing(1),
+  },
+});
+
+export default ResonanceEssayModal;

--- a/frontend/src/features/Journal/ResonanceEssayModal.tsx
+++ b/frontend/src/features/Journal/ResonanceEssayModal.tsx
@@ -5,7 +5,7 @@
  * ``onEssayLoaded`` so re-opening is instant. A warm editorial reading card, not
  * a chat reply.
  */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Modal,
@@ -35,6 +35,9 @@ export interface ResonanceEssayModalProps {
   onEssayLoaded?: (_note: Marginalia) => void;
 }
 
+/** Stable no-op so the card's press-capture doesn't allocate a fn per render. */
+const NOOP = (): void => {};
+
 interface EssayState {
   essay: string | null;
   loading: boolean;
@@ -51,10 +54,17 @@ function useEssay(
   const [state, setState] = useState<EssayState>({ essay: null, loading: false, error: null });
   const [attempt, setAttempt] = useState(0);
   const retry = useCallback(() => setAttempt((a) => a + 1), []);
+  // Hold the callback in a ref so a non-memoised caller can't retrigger fetches:
+  // the fetch effect depends only on the note + retry attempt.
+  const onLoadedRef = useRef(onEssayLoaded);
+  useEffect(() => {
+    onLoadedRef.current = onEssayLoaded;
+  }, [onEssayLoaded]);
 
   useEffect(() => {
     if (note == null) return undefined;
-    if (note.essay != null) {
+    if (note.essay) {
+      // Treat a blank essay the same as missing (don't render an empty body).
       setState({ essay: note.essay, loading: false, error: null });
       return undefined;
     }
@@ -65,7 +75,7 @@ function useEssay(
       .then((updated) => {
         if (!active) return;
         setState({ essay: updated.essay, loading: false, error: null });
-        onEssayLoaded?.(updated);
+        onLoadedRef.current?.(updated);
       })
       .catch((err: unknown) => {
         if (active) setState({ essay: null, loading: false, error: formatApiError(err) });
@@ -73,7 +83,7 @@ function useEssay(
     return () => {
       active = false;
     };
-  }, [note, attempt, onEssayLoaded]);
+  }, [note, attempt]);
 
   return { ...state, retry };
 }
@@ -119,8 +129,8 @@ function ResonanceEssayModal({
         testID="essay-scrim"
         accessibilityLabel="Dismiss essay"
       >
-        {/* Stop taps on the card from dismissing. */}
-        <Pressable style={styles.card} onPress={() => {}}>
+        {/* Capture taps on the card so they don't bubble to the dismiss scrim. */}
+        <Pressable style={styles.card} onPress={NOOP}>
           <View style={styles.header}>
             <Text style={[styles.kind, { color: note ? colors.marginalia[note.kind] : undefined }]}>
               {note?.kind}

--- a/frontend/src/features/Journal/__tests__/ResonanceEssayModal.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ResonanceEssayModal.test.tsx
@@ -1,0 +1,99 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import type { Marginalia } from '@/api';
+
+const mockEssay = jest.fn() as jest.MockedFunction<(_id: number) => Promise<Marginalia>>;
+
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api') as Record<string, unknown>;
+  return {
+    ...actual,
+    resonance: {
+      essay: (...a: unknown[]) => (mockEssay as unknown as (...x: unknown[]) => unknown)(...a),
+    },
+  };
+});
+
+const ResonanceEssayModal = require('../ResonanceEssayModal').default;
+
+function note(overrides: Partial<Marginalia> = {}): Marginalia {
+  return {
+    id: 4,
+    journal_entry_id: 1,
+    kind: 'connection',
+    anchor_start: 0,
+    anchor_end: 6,
+    anchor_text: 'willow',
+    note: 'It bends.',
+    essay: null,
+    essay_generated_at: null,
+    status: 'active',
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockEssay.mockReset();
+});
+
+describe('ResonanceEssayModal', () => {
+  it('lazily fetches the essay once when the note has none, then renders it', async () => {
+    mockEssay.mockResolvedValue(note({ id: 4, essay: 'A warm letter about bending.' }));
+    const onEssayLoaded = jest.fn();
+    const { findByTestId } = render(
+      <ResonanceEssayModal note={note()} onClose={jest.fn()} onEssayLoaded={onEssayLoaded} />,
+    );
+    const text = await findByTestId('essay-text');
+    expect(text.props.children).toBe('A warm letter about bending.');
+    expect(mockEssay).toHaveBeenCalledTimes(1);
+    expect(onEssayLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a cached essay without calling the API', async () => {
+    const { getByTestId } = render(
+      <ResonanceEssayModal note={note({ essay: 'Already here.' })} onClose={jest.fn()} />,
+    );
+    await waitFor(() => expect(getByTestId('essay-text').props.children).toBe('Already here.'));
+    expect(mockEssay).not.toHaveBeenCalled();
+  });
+
+  it('shows the kind and the anchored passage as a pulled quote', () => {
+    const { getByTestId } = render(
+      <ResonanceEssayModal
+        note={note({ essay: 'x', anchor_text: 'the willow' })}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(getByTestId('essay-quote').props.children.join('')).toContain('the willow');
+  });
+
+  it('dismisses via the scrim and the close control', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <ResonanceEssayModal note={note({ essay: 'x' })} onClose={onClose} />,
+    );
+    fireEvent.press(getByTestId('essay-scrim'));
+    fireEvent.press(getByTestId('essay-close'));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows a friendly error with retry, and retry refetches', async () => {
+    mockEssay
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(note({ id: 4, essay: 'Recovered essay.' }));
+    const { findByTestId } = render(
+      <ResonanceEssayModal note={note()} onClose={jest.fn()} onEssayLoaded={jest.fn()} />,
+    );
+    const retry = await findByTestId('essay-retry');
+    await act(async () => {
+      fireEvent.press(retry);
+    });
+    expect((await findByTestId('essay-text')).props.children).toBe('Recovered essay.');
+    expect(mockEssay).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -28,6 +28,8 @@ export interface UseResonanceResult {
   error: string | null;
   remaining: number | null;
   requestResonance: () => Promise<void>;
+  /** Merge an updated note (e.g. one that just gained a cached essay) by id. */
+  updateNote: (_note: Marginalia) => void;
 }
 
 /** Union of two note lists, keyed by id (incoming wins on conflict). */
@@ -83,5 +85,9 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     }
   }, [flush]);
 
-  return { marginalia, loading, error, remaining, requestResonance };
+  const updateNote = useCallback((updated: Marginalia) => {
+    setMarginalia((prev) => mergeById(prev, [updated]));
+  }, []);
+
+  return { marginalia, loading, error, remaining, requestResonance, updateNote };
 }


### PR DESCRIPTION
## Summary

journal-resonance-15: tapping a margin note (or its highlight) opens a modal that **hovers over the still-visible, dimmed page**, shows the anchored passage as a pulled quote, **lazily** fetches the essay, and renders it in warm editorial type — a letter, not a chat reply.

- **`ResonanceEssayModal.tsx`**: visible when a note is set; a reading card over a dimmed scrim (`colors.mystical.overlay`), not full-screen. Header = kind + `anchor_text` quote. Body shows a **cached** essay immediately, else loads via `resonance.essay(note.id)`, renders it, and bubbles the updated note through `onEssayLoaded` so re-open is instant; errors map to friendly copy with tap-to-retry. **Dismiss 3 ways**: scrim, close control, Android back. Lazy-fetch/retry in a `useEssay` hook; body in an `EssayBody` helper.
- **`useResonance.updateNote(note)`**: caches a freshly-loaded essay by id.
- **`JournalEntryScreen`**: tracks the open note; #617's `onOpen` sets it; `onEssayLoaded` caches + keeps the modal current; closing clears it. Page composition extracted into a `JournalPage` component.

## Test plan

`ResonanceEssayModal.test.tsx` (mock API): no cached essay → fetch once + render + `onEssayLoaded`; cached essay → **no API call**; header shows passage + kind; scrim and close both dismiss; error → friendly retry that refetches.

`./scripts/frontend/check-all.sh` — 4/4. Editorial tokens, a11y labels, no colour literals.

Closes #618
Refs #603
