### PR TITLE
feat(frontend): deliberate edit confirm + stale-note rendering

### DIFF
--- a/frontend/src/features/Journal/EditConfirmDialog.tsx
+++ b/frontend/src/features/Journal/EditConfirmDialog.tsx
@@ -1,0 +1,137 @@
+/**
+ * ``EditConfirmDialog`` — makes editing a *finished* (resonated) entry a
+ * deliberate act. Editing can shift the passages the margin notes anchor to, so
+ * we ask first: keep editing this one, start a fresh page, or cancel. A small
+ * card over the dimmed, still-visible page.
+ */
+import React from 'react';
+import { Modal, Pressable, StyleSheet, Text, TouchableOpacity } from 'react-native';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
+
+export interface EditConfirmDialogProps {
+  visible: boolean;
+  onEdit: () => void;
+  onStartNew: () => void;
+  onCancel: () => void;
+}
+
+/** No-op so the card's tap-capture doesn't allocate a function per render. */
+const NOOP = (): void => {};
+
+interface ChoiceProps {
+  label: string;
+  onPress: () => void;
+  a11y: string;
+  testID: string;
+  primary?: boolean;
+}
+
+function Choice({ label, onPress, a11y, testID, primary = false }: ChoiceProps) {
+  return (
+    <TouchableOpacity
+      style={primary ? styles.primary : styles.secondary}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={a11y}
+      testID={testID}
+    >
+      <Text style={primary ? styles.primaryLabel : styles.secondaryLabel}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+function EditConfirmDialog({
+  visible,
+  onEdit,
+  onStartNew,
+  onCancel,
+}: EditConfirmDialogProps): React.JSX.Element {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
+      <Pressable
+        style={styles.scrim}
+        onPress={onCancel}
+        testID="edit-confirm-scrim"
+        accessibilityLabel="Dismiss"
+      >
+        <Pressable style={styles.card} onPress={NOOP} testID="edit-confirm-dialog">
+          <Text style={styles.title}>Edit finished entry?</Text>
+          <Text style={styles.body}>
+            This entry has its resonance. Editing it may move or unsettle the margin notes — they’ll
+            re-anchor where they still fit and dim where they no longer do.
+          </Text>
+          <Choice
+            label="Edit"
+            onPress={onEdit}
+            a11y="Edit this entry"
+            testID="edit-confirm-edit"
+            primary
+          />
+          <Choice
+            label="Start new"
+            onPress={onStartNew}
+            a11y="Start a new entry"
+            testID="edit-confirm-start-new"
+          />
+          <Choice label="Cancel" onPress={onCancel} a11y="Cancel" testID="edit-confirm-cancel" />
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrim: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.xl,
+  },
+  card: {
+    padding: SPACING.xl,
+    borderRadius: BORDER_RADIUS.lg,
+    backgroundColor: colors.paper.background,
+  },
+  title: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+  },
+  body: {
+    ...editorialType.note,
+    color: colors.paper.inkSoft,
+    paddingVertical: spacing(1.5),
+  },
+  primary: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.primary,
+    marginTop: spacing(1),
+  },
+  primaryLabel: {
+    ...editorialType.note,
+    color: colors.text.light,
+    fontWeight: '600',
+  },
+  secondary: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: spacing(0.5),
+  },
+  secondaryLabel: {
+    ...editorialType.note,
+    color: colors.paper.inkSoft,
+  },
+});
+
+export default EditConfirmDialog;

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -78,6 +78,11 @@ const styles = StyleSheet.create({
   marginNoteSlot: {
     marginBottom: journalLayout.marginNoteGap,
   },
+  controlLink: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    paddingTop: spacing(2),
+  },
 });
 
 export default styles;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -8,9 +8,17 @@
  */
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ScrollView, Text, TextInput, View, useWindowDimensions } from 'react-native';
+import {
+  ScrollView,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import EditConfirmDialog from './EditConfirmDialog';
 import GetResonanceButton, { shouldShowResonance } from './GetResonanceButton';
 import HighlightedBody from './HighlightedBody';
 import styles from './JournalEntry.styles';
@@ -19,7 +27,7 @@ import ResonanceEssayModal from './ResonanceEssayModal';
 import { useResonance } from './useResonance';
 
 import { journal } from '@/api';
-import type { JournalMessage, Marginalia } from '@/api';
+import type { EntryStatus, JournalMessage, Marginalia } from '@/api';
 import { colors } from '@/design/tokens';
 import { useIdle } from '@/hooks/useIdle';
 import type { RootStackParamList } from '@/navigation/RootStack';
@@ -73,6 +81,8 @@ async function writeEntry(
 interface AutosaveApi {
   title: string;
   body: string;
+  status: EntryStatus;
+  setStatus: (_status: EntryStatus) => void;
   saveState: SaveState;
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
@@ -103,10 +113,15 @@ function useEntryLoadEffect(
 }
 
 /** Debounced create-then-update draft saver; tracks the save state. */
-function useDebouncedSave(routeEntryId: number | null, delayMs: number) {
+function useDebouncedSave(routeEntryId: number | null, delayMs: number, onSaved?: () => void) {
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const entryIdRef = useRef<number | null>(routeEntryId);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Ref so a non-memoised callback doesn't churn the save callbacks below.
+  const onSavedRef = useRef(onSaved);
+  useEffect(() => {
+    onSavedRef.current = onSaved;
+  }, [onSaved]);
 
   useEffect(
     () => () => {
@@ -121,6 +136,7 @@ function useDebouncedSave(routeEntryId: number | null, delayMs: number) {
     try {
       await writeEntry(entryIdRef, title, body);
       setSaveState('saved');
+      onSavedRef.current?.();
     } catch {
       // Surface a distinct error state so the hint isn't mistaken for "untouched".
       setSaveState('error');
@@ -151,14 +167,19 @@ function useDebouncedSave(routeEntryId: number | null, delayMs: number) {
 }
 
 /** Owns the entry's text + debounced draft autosave (create-then-update). */
-function useJournalAutosave(routeEntryId: number | null, delayMs: number): AutosaveApi {
+function useJournalAutosave(
+  routeEntryId: number | null,
+  delayMs: number,
+  onSaved?: () => void,
+): AutosaveApi {
   const [title, setTitle] = useState('');
   const [body, setBody] = useState('');
+  const [status, setStatus] = useState<EntryStatus>('draft');
   // Refs mirror the latest text so the change handlers can stay referentially
   // stable (each save needs the *other* field's current value).
   const titleRef = useRef('');
   const bodyRef = useRef('');
-  const { saveState, save, flush } = useDebouncedSave(routeEntryId, delayMs);
+  const { saveState, save, flush } = useDebouncedSave(routeEntryId, delayMs, onSaved);
 
   useEntryLoadEffect(
     routeEntryId,
@@ -167,6 +188,7 @@ function useJournalAutosave(routeEntryId: number | null, delayMs: number): Autos
       bodyRef.current = entry.message;
       setTitle(titleRef.current);
       setBody(bodyRef.current);
+      setStatus(entry.status ?? 'draft');
     }, []),
   );
 
@@ -189,7 +211,16 @@ function useJournalAutosave(routeEntryId: number | null, delayMs: number): Autos
 
   const flushNow = useCallback(() => flush(titleRef.current, bodyRef.current), [flush]);
 
-  return { title, body, saveState, onChangeTitle, onChangeBody, flush: flushNow };
+  return {
+    title,
+    body,
+    status,
+    setStatus,
+    saveState,
+    onChangeTitle,
+    onChangeBody,
+    flush: flushNow,
+  };
 }
 
 interface WritingColumnProps {
@@ -198,6 +229,21 @@ interface WritingColumnProps {
   saveState: SaveState;
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
+  onFinish?: () => void;
+}
+
+/** Quiet control to mark a draft finished. */
+function FinishControl({ onFinish }: { onFinish: () => void }) {
+  return (
+    <TouchableOpacity
+      onPress={onFinish}
+      accessibilityRole="button"
+      accessibilityLabel="Mark this entry finished"
+      testID="journal-finish-button"
+    >
+      <Text style={styles.controlLink}>Finish</Text>
+    </TouchableOpacity>
+  );
 }
 
 /** The scrollable writing column (title + growing body + save hint). */
@@ -207,6 +253,7 @@ function WritingColumn({
   saveState,
   onChangeTitle,
   onChangeBody,
+  onFinish,
 }: WritingColumnProps) {
   return (
     <ScrollView
@@ -241,6 +288,7 @@ function WritingColumn({
       <Text style={styles.savedHint} testID="journal-save-hint">
         {savedHintLabel(saveState)}
       </Text>
+      {onFinish ? <FinishControl onFinish={onFinish} /> : null}
     </ScrollView>
   );
 }
@@ -263,17 +311,19 @@ function ResonanceMargin({ count, error }: { count: number; error: string | null
   );
 }
 
-/** Read-mode body: the title + the highlighted passage tree (shown once notes exist). */
+/** Read-mode body: the title + the highlighted passage tree + an Edit affordance. */
 function ReadColumn({
   title,
   body,
   notes,
   onOpen,
+  onEdit,
 }: {
   title: string;
   body: string;
   notes: Marginalia[];
   onOpen: (_note: Marginalia) => void;
+  onEdit: () => void;
 }) {
   return (
     <ScrollView
@@ -284,6 +334,14 @@ function ReadColumn({
       {title ? <Text style={styles.titleInput}>{title}</Text> : null}
       <View style={styles.hairline} />
       <HighlightedBody body={body} notes={notes} onOpen={onOpen} />
+      <TouchableOpacity
+        onPress={onEdit}
+        accessibilityRole="button"
+        accessibilityLabel="Edit this entry"
+        testID="journal-edit-button"
+      >
+        <Text style={styles.controlLink}>Edit</Text>
+      </TouchableOpacity>
     </ScrollView>
   );
 }
@@ -308,18 +366,14 @@ function MarginNoteList({
   );
 }
 
-/** Compose the autosave + idle + resonance hooks into the screen's view-model. */
-function useJournalEntryController(routeEntryId: number | null, autosaveDelayMs: number) {
-  const autosave = useJournalAutosave(routeEntryId, autosaveDelayMs);
-  const { isIdle, bump } = useIdle();
-  const resonance = useResonance({ routeEntryId, flush: autosave.flush });
-  const { onChangeTitle, onChangeBody } = autosave;
-  const { updateNote } = resonance;
+type ScreenNavigation = JournalEntryScreenProps['navigation'];
+
+/** The essay-modal open/close state + essay caching. */
+function useEssayModal(updateNote: (_note: Marginalia) => void) {
   const [openNote, setOpenNote] = useState<Marginalia | null>(null);
   const onOpenNote = useCallback((note: Marginalia) => setOpenNote(note), []);
   const onCloseNote = useCallback(() => setOpenNote(null), []);
-  // Cache the freshly-loaded essay back onto the note (instant re-open) and keep
-  // the open modal showing the updated note.
+  // Cache the freshly-loaded essay back onto the note and keep the modal current.
   const onEssayLoaded = useCallback(
     (updated: Marginalia) => {
       updateNote(updated);
@@ -327,7 +381,91 @@ function useJournalEntryController(routeEntryId: number | null, autosaveDelayMs:
     },
     [updateNote],
   );
+  return { openNote, onOpenNote, onCloseNote, onEssayLoaded };
+}
 
+interface EditGateArgs {
+  status: EntryStatus;
+  setStatus: (_status: EntryStatus) => void;
+  flush: () => Promise<number | null>;
+  body: string;
+  navigation: ScreenNavigation;
+  onConfirmEdit: () => void;
+}
+
+/** The deliberate edit gate for finished entries + the draft "Finish" action. */
+function useEditGate({ status, setStatus, flush, body, navigation, onConfirmEdit }: EditGateArgs) {
+  const [editing, setEditing] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  // A finished entry is read-only until the user deliberately chooses to edit.
+  const editMode = editing || status !== 'finished';
+
+  const requestEdit = useCallback(() => setConfirmOpen(true), []);
+  const cancelEdit = useCallback(() => setConfirmOpen(false), []);
+  const confirmEdit = useCallback(() => {
+    setConfirmOpen(false);
+    setEditing(true);
+    onConfirmEdit();
+  }, [onConfirmEdit]);
+  const startNew = useCallback(() => {
+    setConfirmOpen(false);
+    navigation.push('JournalEntry');
+  }, [navigation]);
+  const markFinished = useCallback(async () => {
+    const id = await flush();
+    if (id == null) return;
+    await journal.update(id, { status: 'finished' });
+    setStatus('finished');
+    setEditing(false);
+  }, [flush, setStatus]);
+
+  const canFinish = status === 'draft' && body.trim().length > 0;
+  return {
+    editMode,
+    confirmOpen,
+    requestEdit,
+    cancelEdit,
+    confirmEdit,
+    startNew,
+    markFinished,
+    canFinish,
+  };
+}
+
+/** Compose the autosave + idle + resonance hooks into the screen's view-model. */
+function useJournalEntryController(
+  routeEntryId: number | null,
+  autosaveDelayMs: number,
+  navigation: ScreenNavigation,
+) {
+  const refreshRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const pendingRefreshRef = useRef(false);
+  // After the first save following an edit, re-read the (re-anchored/staled) notes.
+  const handleSaved = useCallback(() => {
+    if (!pendingRefreshRef.current) return;
+    pendingRefreshRef.current = false;
+    void refreshRef.current();
+  }, []);
+  const onConfirmEdit = useCallback(() => {
+    pendingRefreshRef.current = true;
+  }, []);
+
+  const autosave = useJournalAutosave(routeEntryId, autosaveDelayMs, handleSaved);
+  const { isIdle, bump } = useIdle();
+  const resonance = useResonance({ routeEntryId, flush: autosave.flush });
+  refreshRef.current = resonance.refresh;
+
+  const modal = useEssayModal(resonance.updateNote);
+  const editGate = useEditGate({
+    status: autosave.status,
+    setStatus: autosave.setStatus,
+    flush: autosave.flush,
+    body: autosave.body,
+    navigation,
+    onConfirmEdit,
+  });
+
+  const { onChangeTitle, onChangeBody } = autosave;
   const handleTitle = useCallback(
     (t: string) => {
       bump();
@@ -345,18 +483,7 @@ function useJournalEntryController(routeEntryId: number | null, autosaveDelayMs:
   const hasContent = autosave.body.trim().length > 0;
   const visible = shouldShowResonance({ isIdle, hasContent, isLoading: resonance.loading });
 
-  return {
-    autosave,
-    resonance,
-    isIdle,
-    visible,
-    handleTitle,
-    handleBody,
-    onOpenNote,
-    openNote,
-    onCloseNote,
-    onEssayLoaded,
-  };
+  return { autosave, resonance, isIdle, visible, handleTitle, handleBody, modal, editGate };
 }
 
 type Controller = ReturnType<typeof useJournalEntryController>;
@@ -373,23 +500,31 @@ function JournalPage({
   const { title, body, saveState } = ctl.autosave;
   const notes = ctl.resonance.marginalia;
   const hasNotes = notes.length > 0;
+  const { editMode, canFinish, markFinished, requestEdit } = ctl.editGate;
 
   let marginContent: React.ReactNode;
   if (renderMargin) marginContent = renderMargin({ body, isIdle: ctl.isIdle });
-  else if (hasNotes) marginContent = <MarginNoteList notes={notes} onOpen={ctl.onOpenNote} />;
+  else if (hasNotes) marginContent = <MarginNoteList notes={notes} onOpen={ctl.modal.onOpenNote} />;
   else marginContent = <ResonanceMargin count={0} error={ctl.resonance.error} />;
 
   return (
     <View style={[styles.page, narrow && styles.pageNarrow]}>
-      {hasNotes ? (
-        <ReadColumn title={title} body={body} notes={notes} onOpen={ctl.onOpenNote} />
-      ) : (
+      {editMode ? (
         <WritingColumn
           title={title}
           body={body}
           saveState={saveState}
           onChangeTitle={ctl.handleTitle}
           onChangeBody={ctl.handleBody}
+          onFinish={canFinish ? markFinished : undefined}
+        />
+      ) : (
+        <ReadColumn
+          title={title}
+          body={body}
+          notes={notes}
+          onOpen={ctl.modal.onOpenNote}
+          onEdit={requestEdit}
         />
       )}
       <View
@@ -404,10 +539,12 @@ function JournalPage({
 
 function JournalEntryScreen({
   route,
+  navigation,
   renderMargin,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
-  const ctl = useJournalEntryController(route.params?.entryId ?? null, autosaveDelayMs);
+  const ctl = useJournalEntryController(route.params?.entryId ?? null, autosaveDelayMs, navigation);
+  const { editGate, modal } = ctl;
   return (
     <SafeAreaView style={styles.safeArea}>
       <JournalPage ctl={ctl} renderMargin={renderMargin} />
@@ -417,9 +554,15 @@ function JournalEntryScreen({
         onPress={ctl.resonance.requestResonance}
       />
       <ResonanceEssayModal
-        note={ctl.openNote}
-        onClose={ctl.onCloseNote}
-        onEssayLoaded={ctl.onEssayLoaded}
+        note={modal.openNote}
+        onClose={modal.onCloseNote}
+        onEssayLoaded={modal.onEssayLoaded}
+      />
+      <EditConfirmDialog
+        visible={editGate.confirmOpen}
+        onEdit={editGate.confirmEdit}
+        onStartNew={editGate.startNew}
+        onCancel={editGate.cancelEdit}
       />
     </SafeAreaView>
   );

--- a/frontend/src/features/Journal/MarginNote.tsx
+++ b/frontend/src/features/Journal/MarginNote.tsx
@@ -34,7 +34,12 @@ function MarginNote({ note, onOpen }: MarginNoteProps): React.JSX.Element {
     >
       <Text style={[styles.kind, { color: colors.marginalia[note.kind] }]}>{note.kind}</Text>
       <Text style={styles.note}>{note.note}</Text>
-      <Text style={styles.open}>{isStale ? 'Anchor moved · Open' : 'Open'}</Text>
+      {isStale ? (
+        <Text style={styles.staleCaption} testID={`margin-note-stale-${note.id}`}>
+          The passage this noted has changed.
+        </Text>
+      ) : null}
+      <Text style={styles.open}>Open</Text>
     </TouchableOpacity>
   );
 }
@@ -59,6 +64,12 @@ const styles = StyleSheet.create({
   note: {
     ...editorialType.marginNote,
     color: colors.paper.ink,
+    paddingTop: spacing(0.5),
+  },
+  staleCaption: {
+    ...editorialType.caption,
+    fontStyle: 'italic',
+    color: colors.paper.inkSoft,
     paddingTop: spacing(0.5),
   },
   open: {

--- a/frontend/src/features/Journal/__tests__/EditConfirmDialog.test.tsx
+++ b/frontend/src/features/Journal/__tests__/EditConfirmDialog.test.tsx
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import EditConfirmDialog from '../EditConfirmDialog';
+
+function renderDialog(overrides: Record<string, unknown> = {}) {
+  const props = {
+    visible: true,
+    onEdit: jest.fn(),
+    onStartNew: jest.fn(),
+    onCancel: jest.fn(),
+    ...overrides,
+  };
+  return { ...render(<EditConfirmDialog {...props} />), props };
+}
+
+describe('EditConfirmDialog', () => {
+  it('shows the three choices with warm copy', () => {
+    const { getByTestId, getByText } = renderDialog();
+    expect(getByText('Edit finished entry?')).toBeTruthy();
+    expect(getByTestId('edit-confirm-edit')).toBeTruthy();
+    expect(getByTestId('edit-confirm-start-new')).toBeTruthy();
+    expect(getByTestId('edit-confirm-cancel')).toBeTruthy();
+  });
+
+  it('fires the matching callback for each choice', () => {
+    const { getByTestId, props } = renderDialog();
+    fireEvent.press(getByTestId('edit-confirm-edit'));
+    fireEvent.press(getByTestId('edit-confirm-start-new'));
+    fireEvent.press(getByTestId('edit-confirm-cancel'));
+    expect(props.onEdit).toHaveBeenCalledTimes(1);
+    expect(props.onStartNew).toHaveBeenCalledTimes(1);
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels when the scrim is tapped', () => {
+    const { getByTestId, props } = renderDialog();
+    fireEvent.press(getByTestId('edit-confirm-scrim'));
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -45,9 +45,12 @@ function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
 
 function renderScreen(params?: { entryId?: number }, extraProps: Record<string, unknown> = {}) {
   const route = { key: 'k', name: 'JournalEntry' as const, params };
-  const navigation = { navigate: jest.fn(), goBack: jest.fn() };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
   const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
-  return render(<Screen navigation={navigation} route={route} {...extraProps} />);
+  return {
+    ...render(<Screen navigation={navigation} route={route} {...extraProps} />),
+    navigation,
+  };
 }
 
 beforeEach(() => {
@@ -150,26 +153,29 @@ describe('JournalEntryScreen', () => {
     }
   });
 
-  it('renders read-mode highlights + margin notes once an entry has notes', async () => {
-    mockGet.mockResolvedValue(entry({ id: 7, message: 'I walked by the river.' }));
-    mockList.mockResolvedValue({
-      items: [
-        {
-          id: 50,
-          journal_entry_id: 7,
-          kind: 'theme',
-          anchor_start: 2,
-          anchor_end: 8,
-          anchor_text: 'walked',
-          note: 'You keep moving.',
-          essay: null,
-          essay_generated_at: null,
-          status: 'active',
-          created_at: '',
-          updated_at: '',
-        },
-      ],
-    });
+  function noteRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 50,
+      journal_entry_id: 7,
+      kind: 'theme',
+      anchor_start: 2,
+      anchor_end: 8,
+      anchor_text: 'walked',
+      note: 'You keep moving.',
+      essay: null,
+      essay_generated_at: null,
+      status: 'active',
+      created_at: '',
+      updated_at: '',
+      ...overrides,
+    };
+  }
+
+  it('renders read-mode highlights + margin notes for a finished entry', async () => {
+    mockGet.mockResolvedValue(
+      entry({ id: 7, message: 'I walked by the river.', status: 'finished' }),
+    );
+    mockList.mockResolvedValue({ items: [noteRow()] });
     const { findByTestId, queryByTestId } = renderScreen({ entryId: 7 });
     expect(await findByTestId('margin-note-50')).toBeTruthy();
     expect(queryByTestId('journal-body-read')).not.toBeNull();
@@ -178,7 +184,7 @@ describe('JournalEntryScreen', () => {
     expect(queryByTestId('journal-body-input')).toBeNull();
   });
 
-  it('loads an existing entry by id', async () => {
+  it('loads an existing draft by id (editable)', async () => {
     mockGet.mockResolvedValue(entry({ id: 7, title: 'Rivers', message: 'An existing page.' }));
     const { getByTestId } = renderScreen({ entryId: 7 });
     await waitFor(() => {
@@ -186,5 +192,96 @@ describe('JournalEntryScreen', () => {
     });
     expect(mockGet).toHaveBeenCalledWith(7);
     expect(getByTestId('journal-body-input').props.value).toBe('An existing page.');
+  });
+
+  describe('edit gate (finished entries)', () => {
+    async function renderFinished() {
+      mockGet.mockResolvedValue(entry({ id: 7, message: 'I walked.', status: 'finished' }));
+      mockList.mockResolvedValue({ items: [] });
+      const view = renderScreen({ entryId: 7 });
+      await waitFor(() => expect(view.queryByTestId('journal-edit-button')).not.toBeNull());
+      return view;
+    }
+
+    it('opens the confirm dialog when editing a finished entry', async () => {
+      const { getByTestId, queryByTestId } = await renderFinished();
+      fireEvent.press(getByTestId('journal-edit-button'));
+      expect(queryByTestId('edit-confirm-dialog')).not.toBeNull();
+      // Still locked — body not editable yet.
+      expect(queryByTestId('journal-body-input')).toBeNull();
+    });
+
+    it('Edit unlocks the editable body', async () => {
+      const { getByTestId, findByTestId } = await renderFinished();
+      fireEvent.press(getByTestId('journal-edit-button'));
+      fireEvent.press(getByTestId('edit-confirm-edit'));
+      expect(await findByTestId('journal-body-input')).toBeTruthy();
+    });
+
+    it('Start new navigates to a blank JournalEntry', async () => {
+      const { getByTestId, navigation } = await renderFinished();
+      fireEvent.press(getByTestId('journal-edit-button'));
+      fireEvent.press(getByTestId('edit-confirm-start-new'));
+      expect(navigation.push).toHaveBeenCalledWith('JournalEntry');
+    });
+
+    it('Cancel keeps the entry locked', async () => {
+      const { getByTestId, queryByTestId } = await renderFinished();
+      fireEvent.press(getByTestId('journal-edit-button'));
+      fireEvent.press(getByTestId('edit-confirm-cancel'));
+      expect(queryByTestId('journal-body-input')).toBeNull();
+      expect(queryByTestId('edit-confirm-dialog')).toBeNull();
+    });
+
+    it('re-fetches marginalia after the first save following an edit', async () => {
+      jest.useFakeTimers();
+      try {
+        mockGet.mockResolvedValue(entry({ id: 7, message: 'I walked.', status: 'finished' }));
+        mockList.mockResolvedValue({ items: [] });
+        const { getByTestId, findByTestId } = renderScreen(
+          { entryId: 7 },
+          { autosaveDelayMs: 100 },
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        fireEvent.press(getByTestId('journal-edit-button'));
+        fireEvent.press(getByTestId('edit-confirm-edit'));
+        const input = await findByTestId('journal-body-input');
+        mockList.mockClear();
+        fireEvent.changeText(input, 'I strolled instead.');
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(100);
+        });
+        expect(mockUpdate).toHaveBeenCalledWith(
+          7,
+          expect.objectContaining({ message: 'I strolled instead.' }),
+        );
+        expect(mockList).toHaveBeenCalledWith(7); // re-read after the edit-save
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  it('marks a draft finished via the Finish control', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId, findByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A finished thought.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      mockUpdate.mockClear();
+      fireEvent.press(getByTestId('journal-finish-button'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockUpdate).toHaveBeenCalledWith(42, { status: 'finished' });
+      // Returns to read mode.
+      expect(await findByTestId('journal-edit-button')).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/frontend/src/features/Journal/__tests__/MarginNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/MarginNote.test.tsx
@@ -49,6 +49,14 @@ describe('MarginNote', () => {
       ? Object.assign({}, ...card.props.style)
       : card.props.style;
     expect(flattened.opacity).toBeLessThan(1);
-    expect(getByText(/Anchor moved/)).toBeTruthy();
+    expect(getByText(/The passage this noted has changed/)).toBeTruthy();
+  });
+
+  it('a stale note is still openable', () => {
+    const onOpen = jest.fn();
+    const n = note({ id: 13, status: 'stale' });
+    const { getByTestId } = render(<MarginNote note={n} onOpen={onOpen} />);
+    fireEvent.press(getByTestId('margin-note-13'));
+    expect(onOpen).toHaveBeenCalledWith(n);
   });
 });

--- a/frontend/src/features/Journal/__tests__/highlightSegments.test.ts
+++ b/frontend/src/features/Journal/__tests__/highlightSegments.test.ts
@@ -66,4 +66,16 @@ describe('buildHighlightSegments', () => {
     const segments = buildHighlightSegments(BODY, [n]);
     expect(segments.every((s) => s.note == null)).toBe(true);
   });
+
+  it('does not draw stale anchors inline', () => {
+    const start = BODY.indexOf('the willow');
+    const stale = note({
+      id: 8,
+      anchor_start: start,
+      anchor_end: start + 'the willow'.length,
+      status: 'stale',
+    });
+    const segments = buildHighlightSegments(BODY, [stale]);
+    expect(segments.every((s) => s.note == null)).toBe(true);
+  });
 });

--- a/frontend/src/features/Journal/highlightSegments.ts
+++ b/frontend/src/features/Journal/highlightSegments.ts
@@ -17,7 +17,13 @@ export interface HighlightSegment {
 function usableNotes(body: string, notes: Marginalia[]): Marginalia[] {
   return notes
     .filter(
-      (n) => n.anchor_start >= 0 && n.anchor_end <= body.length && n.anchor_start < n.anchor_end,
+      (n) =>
+        // Stale anchors no longer point at a trustworthy span, so they are not
+        // drawn inline (the note itself stays openable in the margin).
+        n.status !== 'stale' &&
+        n.anchor_start >= 0 &&
+        n.anchor_end <= body.length &&
+        n.anchor_start < n.anchor_end,
     )
     .sort((a, b) => a.anchor_start - b.anchor_start);
 }

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -30,6 +30,8 @@ export interface UseResonanceResult {
   requestResonance: () => Promise<void>;
   /** Merge an updated note (e.g. one that just gained a cached essay) by id. */
   updateNote: (_note: Marginalia) => void;
+  /** Re-read the persisted marginalia (after an edit re-anchors/stales them). */
+  refresh: () => Promise<void>;
 }
 
 /** Union of two note lists, keyed by id (incoming wins on conflict). */
@@ -40,13 +42,11 @@ function mergeById(existing: Marginalia[], incoming: Marginalia[]): Marginalia[]
   return [...byId.values()].sort((a, b) => a.anchor_start - b.anchor_start);
 }
 
-export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseResonanceResult {
-  const [marginalia, setMarginalia] = useState<Marginalia[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [remaining, setRemaining] = useState<number | null>(null);
-  const inFlightRef = useRef(false);
-
+/** Load the entry's existing marginalia once on open (id only). */
+function useInitialMarginalia(
+  routeEntryId: number | null,
+  setMarginalia: (_notes: Marginalia[]) => void,
+): void {
   useEffect(() => {
     if (routeEntryId == null) return undefined;
     let active = true;
@@ -61,7 +61,17 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     return () => {
       active = false;
     };
-  }, [routeEntryId]);
+  }, [routeEntryId, setMarginalia]);
+}
+
+export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseResonanceResult {
+  const [marginalia, setMarginalia] = useState<Marginalia[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const inFlightRef = useRef(false);
+
+  useInitialMarginalia(routeEntryId, setMarginalia);
 
   const requestResonance = useCallback(async (): Promise<void> => {
     if (inFlightRef.current) return; // one pass at a time — no double-charge
@@ -89,5 +99,15 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     setMarginalia((prev) => mergeById(prev, [updated]));
   }, []);
 
-  return { marginalia, loading, error, remaining, requestResonance, updateNote };
+  const refresh = useCallback(async (): Promise<void> => {
+    if (routeEntryId == null) return;
+    try {
+      const res = await resonance.list(routeEntryId);
+      setMarginalia(res.items);
+    } catch {
+      // A failed refresh leaves the current notes in place; nothing to surface.
+    }
+  }, [routeEntryId]);
+
+  return { marginalia, loading, error, remaining, requestResonance, updateNote, refresh };
 }


### PR DESCRIPTION
## Summary

journal-resonance-16: make editing a **finished** (resonated) entry deliberate, and give **stale** notes a gentle treatment that stays openable.

- **`EditConfirmDialog.tsx`**: accessible "Edit finished entry?" modal over a dimmed scrim (scrim + Android back → cancel) with three choices — **Edit / Start new / Cancel** — warm copy, editorial tokens, no colour literals.
- **Edit gate** in `JournalEntryScreen`: read mode is now driven by `status === 'finished'` (not "has notes"). Drafts and new entries are editable immediately; a finished entry opens **read-only** (highlighted body + margin notes) with an Edit affordance. Edit → editable; Start new → a blank `JournalEntry` route; Cancel → stays locked. A quiet **Finish** control marks a draft finished via `journal.update` (resonance leaves status as-is) and returns to read mode.
- **Re-fetch on edit-save (exactly once)**: editing a previously-finished entry sets a pending-refresh flag; after the next successful save the autosave's `onSaved` hook calls `resonance.refresh()` so re-anchored/stale marginalia are re-read.
- **Stale rendering**: stale anchors are not drawn inline (highlight filter); stale margin notes stay dimmed with a caption ("The passage this noted has changed.") and remain tappable to open their essay — never hidden/deleted client-side.

Hooks/subcomponents extracted (`useEditGate`, `useEssayModal`, `useInitialMarginalia`, `FinishControl`, `Choice`) to stay within the line/complexity budgets.

## Test plan

Finished entry → dialog; Edit unlocks; Start new navigates blank; Cancel keeps locked; edit-save re-fetches marginalia; draft → Finish → finished/read; stale note dimmed + caption + openable; stale highlight not drawn inline. 139 Journal tests across 14 suites.

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #619
Refs #603
