### PR TITLE
feat(frontend): journal shelf landing surface + editorial search

### DIFF
--- a/frontend/src/features/Journal/JournalShelf.styles.ts
+++ b/frontend/src/features/Journal/JournalShelf.styles.ts
@@ -1,0 +1,73 @@
+/** Styles for the journal shelf (the landing list of entry "pages"). */
+import { StyleSheet } from 'react-native';
+
+import { BORDER_RADIUS, SPACING, colors, editorialType, spacing } from '@/design/tokens';
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.paper.background,
+  },
+  listContent: {
+    paddingHorizontal: SPACING.lg,
+    paddingBottom: SPACING.xxl,
+    flexGrow: 1,
+  },
+  header: {
+    paddingVertical: SPACING.md,
+  },
+  newEntry: {
+    minHeight: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: SPACING.sm,
+    paddingVertical: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.primary,
+  },
+  newEntryLabel: {
+    color: colors.text.light,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  card: {
+    minHeight: 44,
+    paddingVertical: SPACING.md,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.paper.hairline,
+  },
+  cardTitleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+  },
+  cardTitle: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+    flexShrink: 1,
+  },
+  cardDate: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    paddingLeft: SPACING.sm,
+  },
+  cardExcerpt: {
+    ...editorialType.note,
+    color: colors.paper.inkSoft,
+    paddingTop: spacing(0.5),
+  },
+  emptyWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.xl,
+    paddingTop: SPACING.xxl,
+  },
+  emptyText: {
+    ...editorialType.body,
+    color: colors.paper.inkSoft,
+    textAlign: 'center',
+  },
+});
+
+export default styles;

--- a/frontend/src/features/Journal/JournalShelf.styles.ts
+++ b/frontend/src/features/Journal/JournalShelf.styles.ts
@@ -68,6 +68,11 @@ const styles = StyleSheet.create({
     color: colors.paper.inkSoft,
     textAlign: 'center',
   },
+  emptyError: {
+    ...editorialType.body,
+    color: colors.danger,
+    textAlign: 'center',
+  },
 });
 
 export default styles;

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -1,0 +1,172 @@
+/**
+ * ``JournalShelfScreen`` — the journal's landing surface: a shelf of entries as
+ * dated pages (title + excerpt + date), a "New entry" action, and editorial
+ * full-text search. Tapping a page opens the entry screen by id. Replaces the
+ * old chat list; categorization is the AI's marginalia now, so there are no tags.
+ */
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useState } from 'react';
+import { FlatList, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import styles from './JournalShelf.styles';
+import SearchBar from './SearchBar';
+
+import { journal } from '@/api';
+import type { JournalMessage } from '@/api';
+import type { RootStackParamList } from '@/navigation/RootStack';
+
+const PAGE_SIZE = 20;
+const SEARCH_MIN_LENGTH = 3;
+const EXCERPT_MAX = 140;
+
+type ShelfNavigation = NativeStackNavigationProp<RootStackParamList>;
+
+function formatDate(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+function excerpt(body: string): string {
+  const flat = body.replace(/\s+/g, ' ').trim();
+  return flat.length > EXCERPT_MAX ? `${flat.slice(0, EXCERPT_MAX).trimEnd()}…` : flat;
+}
+
+/** A search query only hits the API once it clears the backend's min length. */
+function searchParam(query: string): string | undefined {
+  return query.length >= SEARCH_MIN_LENGTH ? query : undefined;
+}
+
+interface ShelfState {
+  items: JournalMessage[];
+  loading: boolean;
+  query: string;
+  hasMore: boolean;
+  onSearch: (_query: string) => void;
+  loadMore: () => void;
+}
+
+/** Loads the shelf with offset paging + debounced search (via SearchBar). */
+function useShelf(): ShelfState {
+  const [items, setItems] = useState<JournalMessage[]>([]);
+  const [query, setQuery] = useState('');
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async (search: string | undefined, offset: number) => {
+    setLoading(true);
+    try {
+      const page = await journal.list({ search, limit: PAGE_SIZE, offset });
+      setItems((prev) => (offset === 0 ? page.items : [...prev, ...page.items]));
+      setHasMore(page.has_more);
+    } catch {
+      // A failed load leaves the current shelf in place; the user can retry.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(undefined, 0);
+  }, [load]);
+
+  const onSearch = useCallback(
+    (next: string) => {
+      // 1-2 chars: hold the current view rather than 422 on the backend guard.
+      if (next.length > 0 && next.length < SEARCH_MIN_LENGTH) return;
+      setQuery(next);
+      void load(searchParam(next), 0);
+    },
+    [load],
+  );
+
+  const loadMore = useCallback(() => {
+    if (hasMore && !loading) void load(searchParam(query), items.length);
+  }, [hasMore, loading, load, query, items.length]);
+
+  return { items, loading, query, hasMore, onSearch, loadMore };
+}
+
+function PageCard({
+  entry,
+  onOpen,
+}: {
+  entry: JournalMessage;
+  onOpen: (_id: number) => void;
+}): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={styles.card}
+      onPress={() => onOpen(entry.id)}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${entry.title ?? 'untitled'} entry`}
+      testID={`journal-shelf-card-${entry.id}`}
+    >
+      <View style={styles.cardTitleRow}>
+        <Text style={styles.cardTitle} numberOfLines={1}>
+          {entry.title?.trim() ? entry.title : 'Untitled'}
+        </Text>
+        <Text style={styles.cardDate}>{formatDate(entry.timestamp)}</Text>
+      </View>
+      <Text style={styles.cardExcerpt} numberOfLines={2}>
+        {excerpt(entry.message)}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+function ShelfHeader({ onSearch, onNew }: { onSearch: (_q: string) => void; onNew: () => void }) {
+  return (
+    <View style={styles.header}>
+      <SearchBar onSearch={onSearch} />
+      <TouchableOpacity
+        style={styles.newEntry}
+        onPress={onNew}
+        accessibilityRole="button"
+        accessibilityLabel="New entry"
+        testID="journal-new-entry"
+      >
+        <Text style={styles.newEntryLabel}>New entry</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function JournalShelfScreen(): React.JSX.Element {
+  const navigation = useNavigation<ShelfNavigation>();
+  const { items, loading, hasMore, onSearch, loadMore } = useShelf();
+
+  const openEntry = useCallback(
+    (entryId: number) => navigation.navigate('JournalEntry', { entryId }),
+    [navigation],
+  );
+  const newEntry = useCallback(() => navigation.navigate('JournalEntry'), [navigation]);
+
+  return (
+    <SafeAreaView style={styles.safeArea} testID="journal-shelf">
+      <FlatList
+        testID="journal-shelf-list"
+        data={items}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => <PageCard entry={item} onOpen={openEntry} />}
+        ListHeaderComponent={<ShelfHeader onSearch={onSearch} onNew={newEntry} />}
+        ListEmptyComponent={
+          loading ? null : (
+            <View style={styles.emptyWrap}>
+              <Text style={styles.emptyText} testID="journal-shelf-empty">
+                Your shelf is empty — start a page.
+              </Text>
+            </View>
+          )
+        }
+        onEndReached={hasMore ? loadMore : undefined}
+        onEndReachedThreshold={0.4}
+        contentContainerStyle={styles.listContent}
+      />
+    </SafeAreaView>
+  );
+}
+
+export default JournalShelfScreen;

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -15,10 +15,12 @@ import SearchBar from './SearchBar';
 
 import { journal } from '@/api';
 import type { JournalMessage } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 const PAGE_SIZE = 20;
 const SEARCH_MIN_LENGTH = 3;
+const SEARCH_MAX_LENGTH = 64; // mirrors the backend JOURNAL_SEARCH_MAX_LENGTH guard
 const EXCERPT_MAX = 140;
 
 type ShelfNavigation = NativeStackNavigationProp<RootStackParamList>;
@@ -42,10 +44,18 @@ function searchParam(query: string): string | undefined {
 interface ShelfState {
   items: JournalMessage[];
   loading: boolean;
+  error: string | null;
   query: string;
   hasMore: boolean;
   onSearch: (_query: string) => void;
   loadMore: () => void;
+}
+
+/** Out-of-range queries are dropped before hitting the API (avoids a 422). */
+function isSearchable(next: string): boolean {
+  return (
+    next.length === 0 || (next.length >= SEARCH_MIN_LENGTH && next.length <= SEARCH_MAX_LENGTH)
+  );
 }
 
 /** Loads the shelf with offset paging + debounced search (via SearchBar). */
@@ -54,15 +64,19 @@ function useShelf(): ShelfState {
   const [query, setQuery] = useState('');
   const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async (search: string | undefined, offset: number) => {
     setLoading(true);
+    setError(null);
     try {
       const page = await journal.list({ search, limit: PAGE_SIZE, offset });
       setItems((prev) => (offset === 0 ? page.items : [...prev, ...page.items]));
       setHasMore(page.has_more);
-    } catch {
-      // A failed load leaves the current shelf in place; the user can retry.
+    } catch (err) {
+      // Surface the failure so a cold-start network error isn't mistaken for an
+      // empty shelf; the current items (if any) stay in place for retry.
+      setError(formatApiError(err));
     } finally {
       setLoading(false);
     }
@@ -74,8 +88,8 @@ function useShelf(): ShelfState {
 
   const onSearch = useCallback(
     (next: string) => {
-      // 1-2 chars: hold the current view rather than 422 on the backend guard.
-      if (next.length > 0 && next.length < SEARCH_MIN_LENGTH) return;
+      // 1-2 chars (or >64) hold the current view rather than 422 on the guard.
+      if (!isSearchable(next)) return;
       setQuery(next);
       void load(searchParam(next), 0);
     },
@@ -86,7 +100,7 @@ function useShelf(): ShelfState {
     if (hasMore && !loading) void load(searchParam(query), items.length);
   }, [hasMore, loading, load, query, items.length]);
 
-  return { items, loading, query, hasMore, onSearch, loadMore };
+  return { items, loading, error, query, hasMore, onSearch, loadMore };
 }
 
 function PageCard({
@@ -134,9 +148,30 @@ function ShelfHeader({ onSearch, onNew }: { onSearch: (_q: string) => void; onNe
   );
 }
 
+/** Empty-list state: nothing while loading, the load error, else the empty copy. */
+function ShelfEmpty({ loading, error }: { loading: boolean; error: string | null }) {
+  if (loading) return null;
+  if (error != null) {
+    return (
+      <View style={styles.emptyWrap}>
+        <Text style={styles.emptyError} testID="journal-shelf-error">
+          {error}
+        </Text>
+      </View>
+    );
+  }
+  return (
+    <View style={styles.emptyWrap}>
+      <Text style={styles.emptyText} testID="journal-shelf-empty">
+        Your shelf is empty — start a page.
+      </Text>
+    </View>
+  );
+}
+
 function JournalShelfScreen(): React.JSX.Element {
   const navigation = useNavigation<ShelfNavigation>();
-  const { items, loading, hasMore, onSearch, loadMore } = useShelf();
+  const { items, loading, error, hasMore, onSearch, loadMore } = useShelf();
 
   const openEntry = useCallback(
     (entryId: number) => navigation.navigate('JournalEntry', { entryId }),
@@ -152,15 +187,7 @@ function JournalShelfScreen(): React.JSX.Element {
         keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => <PageCard entry={item} onOpen={openEntry} />}
         ListHeaderComponent={<ShelfHeader onSearch={onSearch} onNew={newEntry} />}
-        ListEmptyComponent={
-          loading ? null : (
-            <View style={styles.emptyWrap}>
-              <Text style={styles.emptyText} testID="journal-shelf-empty">
-                Your shelf is empty — start a page.
-              </Text>
-            </View>
-          )
-        }
+        ListEmptyComponent={<ShelfEmpty loading={loading} error={error} />}
         onEndReached={hasMore ? loadMore : undefined}
         onEndReachedThreshold={0.4}
         contentContainerStyle={styles.listContent}

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -108,6 +108,23 @@ describe('JournalShelfScreen', () => {
     );
   });
 
+  it('does not search when the query exceeds the 64-char maximum', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-card-1');
+    mockList.mockClear();
+
+    fireEvent.changeText(getByTestId('shelf-search'), 'x'.repeat(65)); // > 64: no call
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a load error instead of the empty state on a cold-start failure', async () => {
+    mockList.mockRejectedValue(new Error('network down'));
+    const { findByTestId, queryByTestId } = render(<JournalShelfScreen />);
+    expect(await findByTestId('journal-shelf-error')).toBeTruthy();
+    expect(queryByTestId('journal-shelf-empty')).toBeNull();
+  });
+
   it('appends the next page when more are available', async () => {
     mockList.mockResolvedValueOnce(page([entry(1), entry(2)], true));
     const { findByTestId, getByTestId } = render(<JournalShelfScreen />);

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -1,0 +1,123 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import type { JournalListResponse, JournalMessage } from '@/api';
+
+const mockList = jest.fn() as jest.MockedFunction<
+  (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
+>;
+const mockNavigate = jest.fn();
+
+jest.mock('@/api', () => ({
+  journal: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+// Isolate the shelf's search wiring from SearchBar's own debounce/expand UI.
+jest.mock('../SearchBar', () => {
+  const { TextInput } = require('react-native');
+  const Stub = ({ onSearch }: { onSearch: (_q: string) => void }) => (
+    <TextInput testID="shelf-search" onChangeText={onSearch} />
+  );
+  return { __esModule: true, default: Stub };
+});
+
+const JournalShelfScreen = require('../JournalShelfScreen').default;
+
+function entry(id: number, overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id,
+    message: `Body of entry ${id}.`,
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'reflection' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: `Entry ${id}`,
+    status: 'finished',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function page(items: JournalMessage[], hasMore = false): JournalListResponse {
+  return { items, total: items.length, has_more: hasMore };
+}
+
+beforeEach(() => {
+  mockList.mockReset();
+  mockNavigate.mockReset();
+  mockList.mockResolvedValue(page([]));
+});
+
+describe('JournalShelfScreen', () => {
+  it('renders page cards from the shelf (newest-first order as returned)', async () => {
+    mockList.mockResolvedValue(page([entry(3), entry(2), entry(1)]));
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    expect(await findByTestId('journal-shelf-card-3')).toBeTruthy();
+    expect(getByTestId('journal-shelf-card-2')).toBeTruthy();
+    expect(getByTestId('journal-shelf-card-1')).toBeTruthy();
+  });
+
+  it('shows the empty state when there are no entries', async () => {
+    mockList.mockResolvedValue(page([]));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    expect(await findByTestId('journal-shelf-empty')).toBeTruthy();
+  });
+
+  it('opens a fresh entry from "New entry"', async () => {
+    const { findByTestId } = render(<JournalShelfScreen />);
+    fireEvent.press(await findByTestId('journal-new-entry'));
+    expect(mockNavigate).toHaveBeenCalledWith('JournalEntry');
+  });
+
+  it('opens the tapped entry by id', async () => {
+    mockList.mockResolvedValue(page([entry(7)]));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    fireEvent.press(await findByTestId('journal-shelf-card-7'));
+    expect(mockNavigate).toHaveBeenCalledWith('JournalEntry', { entryId: 7 });
+  });
+
+  it('searches only at >= 3 chars and clears back to the full shelf', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-card-1');
+    mockList.mockClear();
+
+    fireEvent.changeText(getByTestId('shelf-search'), 'wi'); // < 3 chars: no call
+    expect(mockList).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.changeText(getByTestId('shelf-search'), 'willow');
+    });
+    expect(mockList).toHaveBeenCalledWith(expect.objectContaining({ search: 'willow', offset: 0 }));
+
+    mockList.mockClear();
+    await act(async () => {
+      fireEvent.changeText(getByTestId('shelf-search'), '');
+    });
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({ search: undefined, offset: 0 }),
+    );
+  });
+
+  it('appends the next page when more are available', async () => {
+    mockList.mockResolvedValueOnce(page([entry(1), entry(2)], true));
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-card-2');
+
+    mockList.mockResolvedValueOnce(page([entry(3)], false));
+    await act(async () => {
+      fireEvent(getByTestId('journal-shelf-list'), 'onEndReached');
+    });
+    await waitFor(() => expect(getByTestId('journal-shelf-card-3')).toBeTruthy());
+    expect(mockList).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 2 }));
+  });
+});

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -19,7 +19,7 @@ import { FeatureErrorBoundary } from '../components/FeatureErrorBoundary';
 import { colors, SPACING } from '../design/tokens';
 import CourseScreen from '../features/Course/CourseScreen';
 import HabitsScreen from '../features/Habits/HabitsScreen';
-import JournalScreen from '../features/Journal/JournalScreen';
+import JournalShelfScreen from '../features/Journal/JournalShelfScreen';
 import MapScreen from '../features/Map/MapScreen';
 import PracticeScreen from '../features/Practice/PracticeScreen';
 
@@ -67,7 +67,7 @@ function withBoundary<P extends object>(
 const HabitsTab = withBoundary('Habits', HabitsScreen);
 const PracticeTab = withBoundary('Practice', PracticeScreen);
 const CourseTab = withBoundary('Course', CourseScreen);
-const JournalTab = withBoundary('Journal', JournalScreen);
+const JournalTab = withBoundary('Journal', JournalShelfScreen);
 const MapTab = withBoundary('Map', MapScreen);
 
 const TAB_ICON_SIZE = 24;


### PR DESCRIPTION
## Summary

journal-resonance-17: the journal now opens to a **shelf of pages** instead of a chat list.

- **`JournalShelfScreen`**: a `FlatList` of dated page cards (serif title or "Untitled" + date + a 1–2 line excerpt), newest-first, with offset paging (load-more on `has_more`) and a paper-toned empty state. **New entry** → blank `JournalEntry`; tapping a card → `JournalEntry` with its `entryId`. Pushes the root-stack entry route via `NativeStackNavigationProp` (same pattern `PracticeScreen` uses for `Catalog`). Logic in a `useShelf` hook; `PageCard`/`ShelfHeader` extracted to stay within budgets. Tokens only; `touchTarget.minimum`.
- **Editorial search**: `journal.list({search})` debounced, firing only at **3–64 chars** (1–2 chars hold the view to avoid the backend 422); clearing returns to the full shelf. **No tag filter** — categorization is the AI's marginalia now.
- **`BottomTabs`**: the Journal tab renders the shelf (was the chat `JournalScreen`); the entry screen stays a pushed route. The old chat screen is left in place for **#622** to remove; the tab keeps its params since `PracticeScreen` still navigates to Journal with a practice context (the shelf ignores them).

## Test plan

`JournalShelfScreen.test.tsx` (mock API + nav, fake timers): cards render newest-first; empty state; New entry → blank entry; tap → correct `entryId`; search fires only ≥3 chars and clears to full; load-more appends the next page.

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #620
Refs #603
