### PR TITLE
feat(frontend): weekly prompt page + practice/stage context links

### DIFF
--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -1,3 +1,5 @@
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, FlatList, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -11,7 +13,8 @@ import {
   type Stage,
 } from '../../api';
 import { STAGE_COLORS, colors } from '../../design/tokens';
-import { useAppNavigation, useAppRoute } from '../../navigation/hooks';
+import { useAppRoute } from '../../navigation/hooks';
+import type { RootStackParamList } from '../../navigation/RootStack';
 import { useProgramStore, programStage } from '../../store/useProgramStore';
 import { deriveCurrentStage } from '../Map/services/stageService';
 
@@ -252,7 +255,7 @@ const ContentArea = ({
 // --- Hook: viewer actions ---
 
 function useCourseViewer(selectedStage: number) {
-  const navigation = useAppNavigation();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [viewingItem, setViewingItem] = useState<ContentItem | null>(null);
   const [viewingResource, setViewingResource] = useState<SiteResource | null>(null);
 
@@ -271,10 +274,8 @@ function useCourseViewer(selectedStage: number) {
 
   const handleReflect = useCallback(() => {
     if (!viewingItem) return;
-    navigation.navigate('Journal', {
-      tag: 'stage_reflection',
-      stageNumber: selectedStage,
-      contentTitle: viewingItem.title,
+    navigation.navigate('JournalEntry', {
+      prefillTitle: `Stage ${selectedStage} reflection — ${viewingItem.title}`,
     });
     setViewingItem(null);
   }, [viewingItem, selectedStage, navigation]);

--- a/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
@@ -62,6 +62,9 @@ jest.mock('../../../navigation/hooks', () => ({
   useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: undefined }),
   useAppNavigation: () => ({ navigate: jest.fn() }),
 }));
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
 
 jest.mock('react-native-safe-area-context', () => {
   const ReactMod = require('react');

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -128,6 +128,10 @@ jest.mock('../../../navigation/hooks', () => ({
   useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: undefined }),
   useAppNavigation: () => ({ navigate: mockNavigate }),
 }));
+// The reflect action now pushes the root-stack JournalEntry via useNavigation.
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
 
 jest.mock('react-native-safe-area-context', () => {
   const React = require('react');
@@ -327,10 +331,9 @@ describe('CourseScreen', () => {
       fireEvent.press(getByTestId('reflect-button'));
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith('Journal', {
-      tag: 'stage_reflection',
-      stageNumber: 2,
-      contentTitle: 'Welcome Essay',
-    });
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'JournalEntry',
+      expect.objectContaining({ prefillTitle: 'Stage 2 reflection — Welcome Essay' }),
+    );
   });
 });

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -26,7 +26,7 @@ import MarginNote from './MarginNote';
 import ResonanceEssayModal from './ResonanceEssayModal';
 import { useResonance } from './useResonance';
 
-import { journal } from '@/api';
+import { journal, prompts } from '@/api';
 import type { EntryStatus, JournalMessage, Marginalia } from '@/api';
 import { colors } from '@/design/tokens';
 import { useIdle } from '@/hooks/useIdle';
@@ -60,15 +60,41 @@ function savedHintLabel(state: SaveState): string {
   return ' ';
 }
 
+/**
+ * What context this entry is being written into. A ``weekNumber`` makes it a
+ * weekly-prompt response (recorded via the prompt endpoint, which creates the
+ * journal entry server-side — so we never also ``journal.create``); the practice
+ * ids link a session/stage reflection to its source.
+ */
+export interface SaveContext {
+  weekNumber?: number;
+  practiceSessionId?: number;
+  userPracticeId?: number;
+}
+
 /** Create on first save, then update; title is optional and saved separately. */
 async function writeEntry(
   entryIdRef: React.MutableRefObject<number | null>,
   title: string,
   body: string,
+  ctx: SaveContext,
+  respondedRef: React.MutableRefObject<boolean>,
 ): Promise<void> {
+  // Weekly-prompt mode: the respond endpoint persists the entry itself, so we
+  // submit exactly once and never pair it with journal.create (no double-create).
+  if (ctx.weekNumber != null) {
+    if (respondedRef.current) return;
+    await prompts.respond(ctx.weekNumber, body);
+    respondedRef.current = true;
+    return;
+  }
   const trimmedTitle = title.trim() ? title : null;
   if (entryIdRef.current == null) {
-    const created = await journal.create({ message: body });
+    const created = await journal.create({
+      message: body,
+      practice_session_id: ctx.practiceSessionId ?? null,
+      user_practice_id: ctx.userPracticeId ?? null,
+    });
     entryIdRef.current = created.id;
     if (trimmedTitle != null) {
       await journal.update(created.id, { title: trimmedTitle, status: 'draft' });
@@ -112,29 +138,43 @@ function useEntryLoadEffect(
   }, [routeEntryId, apply]);
 }
 
-/** Debounced create-then-update draft saver; tracks the save state. */
-function useDebouncedSave(routeEntryId: number | null, delayMs: number, onSaved?: () => void) {
-  const [saveState, setSaveState] = useState<SaveState>('idle');
-  const entryIdRef = useRef<number | null>(routeEntryId);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Ref so a non-memoised callback doesn't churn the save callbacks below.
-  const onSavedRef = useRef(onSaved);
-  useEffect(() => {
-    onSavedRef.current = onSaved;
-  }, [onSaved]);
-
+/** Clear a pending timeout on unmount. */
+function useTimerCleanup(timerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>) {
   useEffect(
     () => () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     },
-    [],
+    [timerRef],
   );
+}
+
+/** Debounced create-then-update draft saver; tracks the save state. */
+function useDebouncedSave(
+  routeEntryId: number | null,
+  delayMs: number,
+  ctx: SaveContext,
+  onSaved?: () => void,
+) {
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const entryIdRef = useRef<number | null>(routeEntryId);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // A weekly-prompt response is write-once; this guards against the debounce or
+  // flush submitting it twice (the backend 409s on a duplicate week).
+  const respondedRef = useRef(false);
+  // Refs so non-memoised inputs don't churn the save callbacks below.
+  const onSavedRef = useRef(onSaved);
+  const ctxRef = useRef(ctx);
+  useEffect(() => {
+    onSavedRef.current = onSaved;
+    ctxRef.current = ctx;
+  });
+  useTimerCleanup(timerRef);
 
   const run = useCallback(async (title: string, body: string): Promise<void> => {
     if (!body.trim()) return; // never persist an empty draft
     setSaveState('saving');
     try {
-      await writeEntry(entryIdRef, title, body);
+      await writeEntry(entryIdRef, title, body, ctxRef.current, respondedRef);
       setSaveState('saved');
       onSavedRef.current?.();
     } catch {
@@ -166,20 +206,50 @@ function useDebouncedSave(routeEntryId: number | null, delayMs: number, onSaved?
   return { saveState, save, flush };
 }
 
+type StrRef = React.MutableRefObject<string>;
+
+/** Referentially-stable change handlers; each save reads the other field's ref. */
+function useFieldHandlers(
+  titleRef: StrRef,
+  bodyRef: StrRef,
+  save: (_t: string, _b: string) => void,
+  setTitle: (_v: string) => void,
+  setBody: (_v: string) => void,
+) {
+  const onChangeTitle = useCallback(
+    (next: string) => {
+      titleRef.current = next;
+      setTitle(next);
+      save(next, bodyRef.current);
+    },
+    [titleRef, bodyRef, save, setTitle],
+  );
+  const onChangeBody = useCallback(
+    (next: string) => {
+      bodyRef.current = next;
+      setBody(next);
+      save(titleRef.current, next);
+    },
+    [titleRef, bodyRef, save, setBody],
+  );
+  return { onChangeTitle, onChangeBody };
+}
+
 /** Owns the entry's text + debounced draft autosave (create-then-update). */
 function useJournalAutosave(
   routeEntryId: number | null,
   delayMs: number,
+  ctx: SaveContext,
+  initialTitle: string,
   onSaved?: () => void,
 ): AutosaveApi {
-  const [title, setTitle] = useState('');
+  const [title, setTitle] = useState(initialTitle);
   const [body, setBody] = useState('');
   const [status, setStatus] = useState<EntryStatus>('draft');
-  // Refs mirror the latest text so the change handlers can stay referentially
-  // stable (each save needs the *other* field's current value).
-  const titleRef = useRef('');
+  // Refs mirror the latest text so the change handlers stay referentially stable.
+  const titleRef = useRef(initialTitle);
   const bodyRef = useRef('');
-  const { saveState, save, flush } = useDebouncedSave(routeEntryId, delayMs, onSaved);
+  const { saveState, save, flush } = useDebouncedSave(routeEntryId, delayMs, ctx, onSaved);
 
   useEntryLoadEffect(
     routeEntryId,
@@ -192,23 +262,13 @@ function useJournalAutosave(
     }, []),
   );
 
-  const onChangeTitle = useCallback(
-    (next: string) => {
-      titleRef.current = next;
-      setTitle(next);
-      save(next, bodyRef.current);
-    },
-    [save],
+  const { onChangeTitle, onChangeBody } = useFieldHandlers(
+    titleRef,
+    bodyRef,
+    save,
+    setTitle,
+    setBody,
   );
-  const onChangeBody = useCallback(
-    (next: string) => {
-      bodyRef.current = next;
-      setBody(next);
-      save(titleRef.current, next);
-    },
-    [save],
-  );
-
   const flushNow = useCallback(() => flush(titleRef.current, bodyRef.current), [flush]);
 
   return {
@@ -230,6 +290,7 @@ interface WritingColumnProps {
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
   onFinish?: () => void;
+  bodyPlaceholder?: string;
 }
 
 /** Quiet control to mark a draft finished. */
@@ -254,6 +315,7 @@ function WritingColumn({
   onChangeTitle,
   onChangeBody,
   onFinish,
+  bodyPlaceholder = 'Begin writing…',
 }: WritingColumnProps) {
   return (
     <ScrollView
@@ -275,7 +337,7 @@ function WritingColumn({
         style={styles.bodyInput}
         value={body}
         onChangeText={onChangeBody}
-        placeholder="Begin writing…"
+        placeholder={bodyPlaceholder}
         placeholderTextColor={colors.paper.inkSoft}
         multiline
         // The outer ScrollView owns scrolling so the field grows freely and long
@@ -432,39 +494,8 @@ function useEditGate({ status, setStatus, flush, body, navigation, onConfirmEdit
   };
 }
 
-/** Compose the autosave + idle + resonance hooks into the screen's view-model. */
-function useJournalEntryController(
-  routeEntryId: number | null,
-  autosaveDelayMs: number,
-  navigation: ScreenNavigation,
-) {
-  const refreshRef = useRef<() => Promise<void>>(() => Promise.resolve());
-  const pendingRefreshRef = useRef(false);
-  // After the first save following an edit, re-read the (re-anchored/staled) notes.
-  const handleSaved = useCallback(() => {
-    if (!pendingRefreshRef.current) return;
-    pendingRefreshRef.current = false;
-    void refreshRef.current();
-  }, []);
-  const onConfirmEdit = useCallback(() => {
-    pendingRefreshRef.current = true;
-  }, []);
-
-  const autosave = useJournalAutosave(routeEntryId, autosaveDelayMs, handleSaved);
-  const { isIdle, bump } = useIdle();
-  const resonance = useResonance({ routeEntryId, flush: autosave.flush });
-  refreshRef.current = resonance.refresh;
-
-  const modal = useEssayModal(resonance.updateNote);
-  const editGate = useEditGate({
-    status: autosave.status,
-    setStatus: autosave.setStatus,
-    flush: autosave.flush,
-    body: autosave.body,
-    navigation,
-    onConfirmEdit,
-  });
-
+/** Wrap the autosave change handlers so each keystroke also bumps the idle timer. */
+function useBumpedHandlers(bump: () => void, autosave: AutosaveApi) {
   const { onChangeTitle, onChangeBody } = autosave;
   const handleTitle = useCallback(
     (t: string) => {
@@ -480,6 +511,51 @@ function useJournalEntryController(
     },
     [bump, onChangeBody],
   );
+  return { handleTitle, handleBody };
+}
+
+/** Compose the autosave + idle + resonance hooks into the screen's view-model. */
+function useJournalEntryController(
+  routeEntryId: number | null,
+  autosaveDelayMs: number,
+  navigation: ScreenNavigation,
+  ctx: SaveContext,
+  initialTitle: string,
+) {
+  const refreshRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const pendingRefreshRef = useRef(false);
+  // After the first save following an edit, re-read the (re-anchored/staled) notes.
+  const handleSaved = useCallback(() => {
+    if (!pendingRefreshRef.current) return;
+    pendingRefreshRef.current = false;
+    void refreshRef.current();
+  }, []);
+  const onConfirmEdit = useCallback(() => {
+    pendingRefreshRef.current = true;
+  }, []);
+
+  const autosave = useJournalAutosave(
+    routeEntryId,
+    autosaveDelayMs,
+    ctx,
+    initialTitle,
+    handleSaved,
+  );
+  const { isIdle, bump } = useIdle();
+  const resonance = useResonance({ routeEntryId, flush: autosave.flush });
+  refreshRef.current = resonance.refresh;
+
+  const modal = useEssayModal(resonance.updateNote);
+  const editGate = useEditGate({
+    status: autosave.status,
+    setStatus: autosave.setStatus,
+    flush: autosave.flush,
+    body: autosave.body,
+    navigation,
+    onConfirmEdit,
+  });
+
+  const { handleTitle, handleBody } = useBumpedHandlers(bump, autosave);
   const hasContent = autosave.body.trim().length > 0;
   const visible = shouldShowResonance({ isIdle, hasContent, isLoading: resonance.loading });
 
@@ -492,9 +568,11 @@ type Controller = ReturnType<typeof useJournalEntryController>;
 function JournalPage({
   ctl,
   renderMargin,
+  bodyPlaceholder,
 }: {
   ctl: Controller;
   renderMargin?: JournalEntryScreenProps['renderMargin'];
+  bodyPlaceholder: string;
 }) {
   const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
   const { title, body, saveState } = ctl.autosave;
@@ -517,6 +595,7 @@ function JournalPage({
           onChangeTitle={ctl.handleTitle}
           onChangeBody={ctl.handleBody}
           onFinish={canFinish ? markFinished : undefined}
+          bodyPlaceholder={bodyPlaceholder}
         />
       ) : (
         <ReadColumn
@@ -537,17 +616,46 @@ function JournalPage({
   );
 }
 
+interface EntryEntrypoint {
+  ctx: SaveContext;
+  initialTitle: string;
+  bodyPlaceholder: string;
+}
+
+/** Translate the route params into the save context + pre-filled title/placeholder. */
+function readEntrypoint(params: RootStackParamList['JournalEntry']): EntryEntrypoint {
+  const p = params ?? {};
+  const initialTitle =
+    p.prefillTitle ?? (p.weekNumber != null ? `Week ${p.weekNumber} Reflection` : '');
+  return {
+    ctx: {
+      weekNumber: p.weekNumber,
+      practiceSessionId: p.practiceSessionId,
+      userPracticeId: p.userPracticeId,
+    },
+    initialTitle,
+    bodyPlaceholder: p.promptQuestion ?? 'Begin writing…',
+  };
+}
+
 function JournalEntryScreen({
   route,
   navigation,
   renderMargin,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
-  const ctl = useJournalEntryController(route.params?.entryId ?? null, autosaveDelayMs, navigation);
+  const { ctx, initialTitle, bodyPlaceholder } = readEntrypoint(route.params);
+  const ctl = useJournalEntryController(
+    route.params?.entryId ?? null,
+    autosaveDelayMs,
+    navigation,
+    ctx,
+    initialTitle,
+  );
   const { editGate, modal } = ctl;
   return (
     <SafeAreaView style={styles.safeArea}>
-      <JournalPage ctl={ctl} renderMargin={renderMargin} />
+      <JournalPage ctl={ctl} renderMargin={renderMargin} bodyPlaceholder={bodyPlaceholder} />
       <GetResonanceButton
         visible={ctl.visible}
         loading={ctl.resonance.loading}

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -559,7 +559,12 @@ function useJournalEntryController(
 
   const { handleTitle, handleBody } = useBumpedHandlers(bump, autosave);
   const hasContent = autosave.body.trim().length > 0;
-  const visible = shouldShowResonance({ isIdle, hasContent, isLoading: resonance.loading });
+  // In weekly-prompt compose mode the entry is created by prompts.respond, which
+  // doesn't return a local id — so resonance can't run here. Hide the button; the
+  // reflection gains resonance normally once reopened from the shelf (with an id).
+  const isPromptCompose = ctx.weekNumber != null;
+  const visible =
+    !isPromptCompose && shouldShowResonance({ isIdle, hasContent, isLoading: resonance.loading });
 
   return { autosave, resonance, isIdle, visible, handleTitle, handleBody, modal, editGate };
 }

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -90,10 +90,12 @@ async function writeEntry(
   }
   const trimmedTitle = title.trim() ? title : null;
   if (entryIdRef.current == null) {
+    // Only attach context keys when present, so a plain entry's payload stays
+    // exactly { message } rather than carrying explicit nulls.
     const created = await journal.create({
       message: body,
-      practice_session_id: ctx.practiceSessionId ?? null,
-      user_practice_id: ctx.userPracticeId ?? null,
+      ...(ctx.practiceSessionId != null && { practice_session_id: ctx.practiceSessionId }),
+      ...(ctx.userPracticeId != null && { user_practice_id: ctx.userPracticeId }),
     });
     entryIdRef.current = created.id;
     if (trimmedTitle != null) {

--- a/frontend/src/features/Journal/JournalShelf.styles.ts
+++ b/frontend/src/features/Journal/JournalShelf.styles.ts
@@ -73,6 +73,25 @@ const styles = StyleSheet.create({
     color: colors.danger,
     textAlign: 'center',
   },
+  promptCard: {
+    marginHorizontal: SPACING.lg,
+    marginTop: SPACING.lg,
+    padding: SPACING.lg,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.paper.backgroundAlt,
+    borderLeftWidth: 3,
+    borderLeftColor: colors.marginalia.theme,
+  },
+  promptLabel: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    textTransform: 'uppercase',
+  },
+  promptQuestion: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+    paddingTop: spacing(0.5),
+  },
 });
 
 export default styles;

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -13,10 +13,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import styles from './JournalShelf.styles';
 import SearchBar from './SearchBar';
 
-import { journal } from '@/api';
-import type { JournalMessage } from '@/api';
+import { journal, prompts } from '@/api';
+import type { JournalMessage, PromptDetail } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import type { RootStackParamList } from '@/navigation/RootStack';
+import { useDerivedCurrentWeek } from '@/store/useProgramProgression';
 
 const PAGE_SIZE = 20;
 const SEARCH_MIN_LENGTH = 3;
@@ -169,15 +170,76 @@ function ShelfEmpty({ loading, error }: { loading: boolean; error: string | null
   );
 }
 
+/** The current unanswered weekly prompt, or null (answered / none / load error). */
+function usePrompt(): PromptDetail | null {
+  const [prompt, setPrompt] = useState<PromptDetail | null>(null);
+  useEffect(() => {
+    let active = true;
+    void prompts
+      .current()
+      .then((p) => {
+        if (active && !p.has_responded) setPrompt(p);
+      })
+      .catch(() => {
+        // A prompt fetch failure shouldn't block the shelf; just hide the card.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+  return prompt;
+}
+
+/** The weekly prompt surfaced as a pre-titled page (tap → the entry screen). */
+function PromptCard({
+  week,
+  question,
+  onOpen,
+}: {
+  week: number;
+  question: string;
+  onOpen: () => void;
+}) {
+  return (
+    <TouchableOpacity
+      style={styles.promptCard}
+      onPress={onOpen}
+      accessibilityRole="button"
+      accessibilityLabel={`Respond to the week ${week} prompt`}
+      testID="journal-weekly-prompt"
+    >
+      <Text style={styles.promptLabel}>Week {week}</Text>
+      <Text style={styles.promptQuestion}>{question}</Text>
+    </TouchableOpacity>
+  );
+}
+
 function JournalShelfScreen(): React.JSX.Element {
   const navigation = useNavigation<ShelfNavigation>();
   const { items, loading, error, hasMore, onSearch, loadMore } = useShelf();
+  const prompt = usePrompt();
+  const week = useDerivedCurrentWeek(prompt?.week_number ?? 1);
 
   const openEntry = useCallback(
     (entryId: number) => navigation.navigate('JournalEntry', { entryId }),
     [navigation],
   );
   const newEntry = useCallback(() => navigation.navigate('JournalEntry'), [navigation]);
+  const openPrompt = useCallback(() => {
+    if (!prompt) return;
+    navigation.navigate('JournalEntry', {
+      weekNumber: week,
+      promptQuestion: prompt.question,
+      prefillTitle: `Week ${week} Reflection`,
+    });
+  }, [navigation, prompt, week]);
+
+  const header = (
+    <>
+      {prompt ? <PromptCard week={week} question={prompt.question} onOpen={openPrompt} /> : null}
+      <ShelfHeader onSearch={onSearch} onNew={newEntry} />
+    </>
+  );
 
   return (
     <SafeAreaView style={styles.safeArea} testID="journal-shelf">
@@ -186,7 +248,7 @@ function JournalShelfScreen(): React.JSX.Element {
         data={items}
         keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => <PageCard entry={item} onOpen={openEntry} />}
-        ListHeaderComponent={<ShelfHeader onSearch={onSearch} onNew={newEntry} />}
+        ListHeaderComponent={header}
         ListEmptyComponent={<ShelfEmpty loading={loading} error={error} />}
         onEndReached={hasMore ? loadMore : undefined}
         onEndReachedThreshold={0.4}

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -4,7 +4,7 @@
  * full-text search. Tapping a page opens the entry screen by id. Replaces the
  * old chat list; categorization is the AI's marginalia now, so there are no tags.
  */
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useState } from 'react';
 import { FlatList, Text, TouchableOpacity, View } from 'react-native';
@@ -170,23 +170,30 @@ function ShelfEmpty({ loading, error }: { loading: boolean; error: string | null
   );
 }
 
-/** The current unanswered weekly prompt, or null (answered / none / load error). */
+/** The current unanswered weekly prompt, or null (answered / none / load error).
+ *
+ * Re-fetched on every focus (not just mount): the shelf stays mounted while the
+ * user pushes to the entry screen, so after responding + going back the card
+ * must clear — hence ``useFocusEffect`` and the explicit reset when answered.
+ */
 function usePrompt(): PromptDetail | null {
   const [prompt, setPrompt] = useState<PromptDetail | null>(null);
-  useEffect(() => {
-    let active = true;
-    void prompts
-      .current()
-      .then((p) => {
-        if (active && !p.has_responded) setPrompt(p);
-      })
-      .catch(() => {
-        // A prompt fetch failure shouldn't block the shelf; just hide the card.
-      });
-    return () => {
-      active = false;
-    };
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      let active = true;
+      void prompts
+        .current()
+        .then((p) => {
+          if (active) setPrompt(p.has_responded ? null : p);
+        })
+        .catch(() => {
+          // A prompt fetch failure shouldn't block the shelf; just hide the card.
+        });
+      return () => {
+        active = false;
+      };
+    }, []),
+  );
   return prompt;
 }
 

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -12,12 +12,16 @@ const mockUpdate = jest.fn() as jest.MockedFunction<
 >;
 
 const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+const mockRespond = jest.fn() as jest.MockedFunction<(_w: number, _b: string) => Promise<unknown>>;
 
 jest.mock('@/api', () => ({
   journal: {
     get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
     create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
     update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: {
+    respond: (...a: unknown[]) => (mockRespond as unknown as (...x: unknown[]) => unknown)(...a),
   },
   resonance: {
     list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
@@ -43,7 +47,16 @@ function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
   };
 }
 
-function renderScreen(params?: { entryId?: number }, extraProps: Record<string, unknown> = {}) {
+function renderScreen(
+  params?: {
+    entryId?: number;
+    weekNumber?: number;
+    promptQuestion?: string;
+    prefillTitle?: string;
+    practiceSessionId?: number;
+  },
+  extraProps: Record<string, unknown> = {},
+) {
   const route = { key: 'k', name: 'JournalEntry' as const, params };
   const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
   const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
@@ -61,9 +74,54 @@ beforeEach(() => {
   mockUpdate.mockResolvedValue(entry({ id: 42 }));
   mockList.mockReset();
   mockList.mockResolvedValue({ items: [] });
+  mockRespond.mockReset();
+  mockRespond.mockResolvedValue({});
 });
 
 describe('JournalEntryScreen', () => {
+  it('records a weekly-prompt page via respond, not a duplicate create', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(
+        {
+          weekNumber: 3,
+          promptQuestion: 'What did you notice?',
+          prefillTitle: 'Week 3 Reflection',
+        },
+        { autosaveDelayMs: 100 },
+      );
+      expect(getByTestId('journal-title-input').props.value).toBe('Week 3 Reflection');
+      fireEvent.changeText(getByTestId('journal-body-input'), 'I noticed the willow.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockRespond).toHaveBeenCalledWith(3, 'I noticed the willow.');
+      expect(mockCreate).not.toHaveBeenCalled(); // no double-create
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('pre-links a practice session on the created entry', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(
+        { practiceSessionId: 55, prefillTitle: 'After Forest grounding' },
+        { autosaveDelayMs: 100 },
+      );
+      fireEvent.changeText(getByTestId('journal-body-input'), 'That was calming.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'That was calming.', practice_session_id: 55 }),
+      );
+      expect(mockRespond).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('renders the title + body inputs and no chat UI', () => {
     const { getByTestId, queryByText } = renderScreen();
     expect(getByTestId('journal-title-input')).toBeTruthy();
@@ -94,7 +152,9 @@ describe('JournalEntryScreen', () => {
         await jest.advanceTimersByTimeAsync(1500);
       });
       expect(mockCreate).toHaveBeenCalledTimes(1);
-      expect(mockCreate).toHaveBeenCalledWith({ message: 'A new thought.' });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'A new thought.' }),
+      );
     } finally {
       jest.useRealTimers();
     }

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -82,7 +82,7 @@ describe('JournalEntryScreen', () => {
   it('records a weekly-prompt page via respond, not a duplicate create', async () => {
     jest.useFakeTimers();
     try {
-      const { getByTestId } = renderScreen(
+      const { getByTestId, queryByTestId } = renderScreen(
         {
           weekNumber: 3,
           promptQuestion: 'What did you notice?',
@@ -97,6 +97,9 @@ describe('JournalEntryScreen', () => {
       });
       expect(mockRespond).toHaveBeenCalledWith(3, 'I noticed the willow.');
       expect(mockCreate).not.toHaveBeenCalled(); // no double-create
+      // Resonance can't run on a prompt-compose entry (no local id), so the
+      // button must stay hidden even once idle with content.
+      expect(queryByTestId('get-resonance-button')).toBeNull();
     } finally {
       jest.useRealTimers();
     }

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -21,9 +21,17 @@ jest.mock('@/api', () => ({
   },
 }));
 
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ navigate: mockNavigate }),
-}));
+jest.mock('@react-navigation/native', () => {
+  const react = jest.requireActual('react') as {
+    useEffect: (_cb: () => undefined | (() => void), _deps: unknown[]) => void;
+  };
+  return {
+    useNavigation: () => ({ navigate: mockNavigate }),
+    // Run the focus callback on mount (and its cleanup on unmount) — enough to
+    // exercise the prompt re-fetch in these render-once tests.
+    useFocusEffect: (cb: () => undefined | (() => void)) => react.useEffect(cb, []),
+  };
+});
 
 // Isolate the shelf's search wiring from SearchBar's own debounce/expand UI.
 jest.mock('../SearchBar', () => {

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -3,16 +3,21 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
-import type { JournalListResponse, JournalMessage } from '@/api';
+import type { JournalListResponse, JournalMessage, PromptDetail } from '@/api';
 
 const mockList = jest.fn() as jest.MockedFunction<
   (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
 >;
+const mockPromptCurrent = jest.fn() as jest.MockedFunction<() => Promise<PromptDetail>>;
 const mockNavigate = jest.fn();
 
 jest.mock('@/api', () => ({
   journal: {
     list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: {
+    current: (...a: unknown[]) =>
+      (mockPromptCurrent as unknown as (...x: unknown[]) => unknown)(...a),
   },
 }));
 
@@ -51,10 +56,24 @@ function page(items: JournalMessage[], hasMore = false): JournalListResponse {
   return { items, total: items.length, has_more: hasMore };
 }
 
+function prompt(overrides: Partial<PromptDetail> = {}): PromptDetail {
+  return {
+    week_number: 3,
+    question: 'What did you notice this week?',
+    has_responded: false,
+    response: null,
+    timestamp: null,
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   mockList.mockReset();
   mockNavigate.mockReset();
+  mockPromptCurrent.mockReset();
   mockList.mockResolvedValue(page([]));
+  // Default: the weekly prompt is already answered, so no card surfaces.
+  mockPromptCurrent.mockResolvedValue(prompt({ has_responded: true }));
 });
 
 describe('JournalShelfScreen', () => {
@@ -136,5 +155,26 @@ describe('JournalShelfScreen', () => {
     });
     await waitFor(() => expect(getByTestId('journal-shelf-card-3')).toBeTruthy());
     expect(mockList).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 2 }));
+  });
+
+  it('surfaces an unanswered weekly prompt and opens it as a pre-titled page', async () => {
+    mockPromptCurrent.mockResolvedValue(prompt({ week_number: 3, has_responded: false }));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    fireEvent.press(await findByTestId('journal-weekly-prompt'));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'JournalEntry',
+      expect.objectContaining({
+        weekNumber: 3,
+        promptQuestion: 'What did you notice this week?',
+        prefillTitle: 'Week 3 Reflection',
+      }),
+    );
+  });
+
+  it('does not surface an already-answered weekly prompt', async () => {
+    mockPromptCurrent.mockResolvedValue(prompt({ has_responded: true }));
+    const { findByTestId, queryByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-empty');
+    expect(queryByTestId('journal-weekly-prompt')).toBeNull();
   });
 });

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -42,7 +42,7 @@ import ActiveRitualSession from '@/features/Practice/components/ActiveRitualSess
 import { FrequencyBanner } from '@/features/Practice/components/FrequencyBanner';
 import { useActivePractice } from '@/features/Practice/hooks/useActivePractice';
 import { useWeeklyProgress } from '@/features/Practice/hooks/useWeeklyProgress';
-import { useAppNavigation, useAppRoute } from '@/navigation/hooks';
+import { useAppRoute } from '@/navigation/hooks';
 import type { RootStackParamList } from '@/navigation/RootStack';
 import { useDerivedCurrentStage } from '@/store/useProgramProgression';
 import { selectCurrentStage, useStageStore } from '@/store/useStageStore';
@@ -224,21 +224,17 @@ function useWriteReflection(
   effectiveName: string | null,
   practice: ActivePracticeHook['practice'],
 ): (_args: { session: PracticeSessionResponse; insight: string | null }) => void {
-  const navigation = useAppNavigation();
-  // The captured ``insight`` is persisted on the server-side
-  // ``practice_session.insight`` column (ritual-04). A follow-up will
-  // extend `RootTabParamList.Journal` with an ``initialDraft`` field so
-  // BotMason can open with the user's just-typed sentence; until then the
-  // journal opens blank and the insight is queryable alongside the session.
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  // Opens the long-form entry screen pre-linked to this session; the captured
+  // insight still lives on the server-side ``practice_session.insight`` column
+  // (ritual-04), queryable alongside the session.
   return useCallback(
     ({ session }) => {
       const name = effectiveName ?? practice?.name ?? 'Practice';
-      navigation.navigate('Journal', {
-        tag: 'practice_note',
+      navigation.navigate('JournalEntry', {
         practiceSessionId: session.id,
         userPracticeId: session.user_practice_id,
-        practiceName: name,
-        practiceDuration: Math.round(session.duration_minutes),
+        prefillTitle: `After ${name}`,
       });
     },
     [effectiveName, practice, navigation],

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -605,13 +605,12 @@ describe('PracticeScreen', () => {
       fireEvent.press(getByTestId('insight-journal'));
     });
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        'Journal',
+      expect(mockRootNavigate).toHaveBeenCalledWith(
+        'JournalEntry',
         expect.objectContaining({
-          tag: 'practice_note',
           practiceSessionId: 100,
           userPracticeId: 10,
-          practiceName: 'Breath Awareness',
+          prefillTitle: 'After Breath Awareness',
         }),
       );
     });

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -44,7 +44,16 @@ export type RootStackParamList = {
   PracticeDetail: { practiceId: number };
   CreatePractice: { prefill?: CreatePracticePrefill } | undefined;
   Catalog: { stageNumber?: number } | undefined;
-  JournalEntry: { entryId?: number } | undefined;
+  JournalEntry:
+    | {
+        entryId?: number;
+        weekNumber?: number;
+        promptQuestion?: string;
+        practiceSessionId?: number;
+        userPracticeId?: number;
+        prefillTitle?: string;
+      }
+    | undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();


### PR DESCRIPTION
## Summary

journal-resonance-18: carry the two retained entry points onto the new journal surface.

- **Weekly prompt page**: the shelf surfaces the current *unanswered* prompt (`usePrompt` + `PromptCard`, "Week N — <question>", via `useDerivedCurrentWeek` + `has_responded`); tapping opens a pre-titled **"Week N Reflection"** page with the question as a prologue/placeholder. **No double-create**: `POST /prompts/{week}/respond` creates the entry itself, so in prompt mode `writeEntry` calls **only** `prompts.respond(weekNumber, body)` (guarded by a `respondedRef` so the debounce/flush submits exactly once); answered prompts stop surfacing.
- **Practice/stage links**: new `JournalEntry` route params (`weekNumber`, `promptQuestion`, `practiceSessionId`, `userPracticeId`, `prefillTitle`); `readEntrypoint` turns them into the `SaveContext` + pre-filled title + placeholder. `PracticeScreen`/`CourseScreen` now **push the entry screen** (not the Journal tab), threading `practice_session_id`/`user_practice_id` into `journal.create`/`update` + a title ("After <practice>" / "Stage N reflection — <title>").
- `WeeklyPromptBanner` no longer rendered on the new surface (file left for #622). No tag chips. Extracted `useTimerCleanup`/`useFieldHandlers`/`useBumpedHandlers` to stay within budgets.

## Test plan

Prompt → pre-titled page + `respond(week, body)` with **no** `create`; practice deep-link → `create` carries `practice_session_id`; shelf surfaces an unanswered prompt and hides an answered one; Practice/Course nav now targets `JournalEntry`.

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #621
Refs #603
