### PR TITLE
feat(ralph): post Discord recap to a channel on every PR merge

### DIFF
--- a/.github/workflows/ralph-recap-tests.yml
+++ b/.github/workflows/ralph-recap-tests.yml
@@ -1,0 +1,35 @@
+name: Ralph Recap Tests
+
+# Unit tests for the Ralph recap tooling (scripts/ralph/). The recap scripts
+# live outside backend/, so the backend-scoped lint/coverage gates don't cover
+# them — this workflow keeps the pure stats math and the backlog filter honest.
+
+on:
+  push:
+    paths:
+      - "scripts/ralph/**"
+      - ".github/workflows/ralph-recap-tests.yml"
+  pull_request:
+    paths:
+      - "scripts/ralph/**"
+      - ".github/workflows/ralph-recap-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  recap-tests:
+    name: Recap unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run recap tests
+        run: python -m pytest scripts/ralph -q

--- a/.github/workflows/ralph-recap.yml
+++ b/.github/workflows/ralph-recap.yml
@@ -1,0 +1,44 @@
+name: Ralph Recap
+
+# Posts a Ralph tick-loop recap to Discord every time a pull request is merged.
+#
+# Required configuration in the repo:
+#   secret   DISCORD_BOT_TOKEN  - bot token with Send Messages on the channel
+#   variable RALPH_CHANNEL_ID   - target Discord channel ID (all digits)
+#   secret   ANTHROPIC_API_KEY  - optional; enables the Claude-written headline
+#
+# The built-in GITHUB_TOKEN supplies the merge history (read-only). See
+# scripts/ralph/RECAP.md for setup, the metric definitions, and tuning.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  recap:
+    name: Post merge recap
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Anthropic SDK (for the headline)
+        run: pip install anthropic
+
+      - name: Post Ralph recap to Discord
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          RALPH_CHANNEL_ID: ${{ vars.RALPH_CHANNEL_ID }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python scripts/ralph/recap.py --repo "${{ github.repository }}"

--- a/.github/workflows/ralph-recap.yml
+++ b/.github/workflows/ralph-recap.yml
@@ -32,7 +32,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install Anthropic SDK (for the headline)
-        run: pip install anthropic
+        # Pinned floor guarantees the installed SDK supports output_config /
+        # effort (used by generate_headline); a fresh install resolves to the
+        # newest release in range.
+        run: pip install 'anthropic>=0.69,<1'
 
       - name: Post Ralph recap to Discord
         env:

--- a/scripts/ralph/RECAP.md
+++ b/scripts/ralph/RECAP.md
@@ -1,0 +1,137 @@
+# Ralph Discord Recap
+
+Whenever a PR merges, this posts a clean Discord embed summarizing how
+adepthood's Ralph tick loop is doing: PRs merged, merge rate, average review
+iterations before LGTM, estimated time remaining on the backlog, the busiest
+day, the latest PR's footprint, and a ten-word headline for what the latest
+merge unlocked.
+
+A "Ralph tick loop" is the autonomous loop driven by `/loop /ralph-tick` (see
+`.claude/commands/ralph-tick.md`): each tick opens a PR, iterates against the
+Claude reviewer's `Verdict:` comment until LGTM, merges, and moves to the next
+backlog issue. This tool turns that merge history into a recap.
+
+Adapted from the `discord-ralph-recap` skill in
+[`Geoffe-Ga/well-worn-tools` PR #14](https://github.com/Geoffe-Ga/well-worn-tools/pull/14).
+
+## Files
+
+```
+scripts/ralph/
+├── recap.py             # I/O shell: fetch GitHub data, generate headline, post embed
+├── stats.py             # pure, unit-tested statistics math
+├── test_recap_stats.py  # tests for stats.py + the backlog filter
+└── RECAP.md             # this file
+.github/workflows/
+├── ralph-recap.yml        # fires on every merged PR → posts the recap
+└── ralph-recap-tests.yml  # runs the unit tests on changes under scripts/ralph/
+```
+
+## What you need
+
+- `DISCORD_BOT_TOKEN` (repo **secret**) — a Discord bot token. The bot must be
+  in the server with **View Channel** + **Send Messages** on the target channel.
+- `RALPH_CHANNEL_ID` (repo **variable**) — the target channel's numeric ID
+  (Developer Mode → right-click channel → Copy Channel ID).
+- A GitHub token — in Actions the built-in `GITHUB_TOKEN` is enough
+  (`contents: read`, `pull-requests: read`, `issues: read`).
+- `ANTHROPIC_API_KEY` (repo **secret**, optional) — enables the Claude-written
+  ten-word headline. Without it the headline falls back to a cleaned PR title
+  and nothing else changes.
+
+## Setup
+
+The workflow is keyed on `pull_request: types: [closed]`, gated to merges with
+`if: github.event.pull_request.merged == true`. (`closed` fires on both merge
+and plain close; the guard keeps it to real merges. A `push: branches: [main]`
+trigger would wrongly fire on hotfixes and reverts too.)
+
+Wire the secrets/variable once:
+
+```bash
+gh secret set DISCORD_BOT_TOKEN
+gh variable set RALPH_CHANNEL_ID --body "123456789012345678"
+gh secret set ANTHROPIC_API_KEY   # optional, for the headline
+```
+
+The next merged PR triggers the first recap. Each post is self-contained — no
+state is stored between runs; every recap is recomputed from the live history.
+
+## Dry-run / one-off from the terminal
+
+`--dry-run` prints the embed JSON instead of posting it:
+
+```bash
+DISCORD_BOT_TOKEN=unused RALPH_CHANNEL_ID=unused \
+GITHUB_TOKEN="$(gh auth token)" \
+python scripts/ralph/recap.py --repo Geoffe-Ga/adepthood --dry-run
+```
+
+Drop `--dry-run` (with a real `DISCORD_BOT_TOKEN` / `RALPH_CHANNEL_ID`) to post
+once manually — handy for backfilling after enabling the bot mid-campaign.
+
+## Metric definitions
+
+All math is pure and unit-tested in `stats.py`; all I/O is in `recap.py`.
+
+- **PRs merged** — closed PRs with a non-null `merged_at`, capped at `--max-prs`
+  (default 200). "last 7d" counts merges within the trailing 7 days of now.
+- **Merge rate** — `total_merges / span_days`, where `span_days` runs from the
+  **first** merge to **now** (not to the last merge). Anchoring to now makes a
+  stalled loop show a *decaying* rate instead of a frozen one.
+- **Review iterations before LGTM** — per merged PR, issue comments are read
+  oldest-first and a comment counts as a verdict only if it contains `VERDICT`
+  (case-insensitive), matching `iteration-trigger.yml`. The count is the number
+  of non-LGTM verdicts preceding the first LGTM. PRs that never reached an LGTM
+  verdict are excluded. The embed shows avg rounds, first-try-clean %, worst,
+  and the sample size `n`.
+- **Time to merge** — `merged_at - created_at` per PR; median, fastest, slowest.
+- **Backlog remaining and ETA** — `open_items / per_day` as days and a date.
+  When the rate is zero the ETA reads "unknown (stalled)"; an empty backlog
+  reads "backlog clear".
+- **Busiest day** — the UTC calendar day with the most merges.
+- **This PR's footprint** — additions/deletions/changed-files for the most
+  recently merged PR (the list endpoint omits diff stats, so it's fetched via
+  the single-PR detail endpoint).
+- **The ten-word headline** — `generate_headline` asks `claude-opus-4-8`
+  (effort `low`) for a plain-language headline of what the latest merge
+  unlocked, and degrades to the cleaned PR title on any SDK/API absence or
+  error, so the recap never fails on the headline.
+
+## adepthood-specific tuning
+
+The **backlog count is the metric most worth checking**, and this port already
+adapts it. `count_open_backlog` counts open issues (PRs excluded) minus any
+issue bearing one of the picker's exclude labels — epics, `blocked`,
+`needs-spec`, `do-not-auto-merge`, etc. — so the ETA reflects what
+`scripts/ralph/pick-next.sh` would actually pick up, not every open card. The
+exclude set defaults to the same list as the picker and honors the same
+`RALPH_EXCLUDE_LABELS` env var; set it (space-separated) to override, or to an
+empty string to count every open issue.
+
+If the reviewer ever phrases verdicts differently from the `Verdict:` line that
+`claude-code-review.yml` posts, update `normalize_verdict` in `stats.py`.
+
+## Tests
+
+```bash
+python -m pytest scripts/ralph -q
+```
+
+CI runs the same suite via `.github/workflows/ralph-recap-tests.yml` on any
+change under `scripts/ralph/`.
+
+## Troubleshooting
+
+- **Discord 401 Unauthorized** — wrong/revoked token. Use the **bot** token
+  (Bot tab), and don't prefix it with `Bot ` (the script adds that).
+- **Discord 403 Forbidden** — the bot isn't in the server, or lacks View
+  Channel / Send Messages on `RALPH_CHANNEL_ID`.
+- **Discord 404 Not Found** — `RALPH_CHANNEL_ID` is wrong. It's an all-digits
+  snowflake (Copy Channel ID), not the channel name.
+- **Headline is just the PR title** — `ANTHROPIC_API_KEY` is unset or the SDK
+  isn't installed (the workflow installs it).
+- **"no LGTM verdicts found yet"** — no merged PR has a Claude review comment
+  containing a `Verdict` line yet.
+- **ETA "unknown (stalled)"** — no merges in the window, so no rate to
+  extrapolate; resolves once merges resume.

--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Post a Ralph tick-loop recap to Discord whenever a PR is merged.
+
+Reads two environment variables for delivery:
+
+    DISCORD_BOT_TOKEN   Bot token (sent as `Authorization: Bot <token>`).
+    RALPH_CHANNEL_ID    Snowflake ID of the channel to post the recap into.
+
+and uses a GitHub token (GITHUB_TOKEN / GH_TOKEN) plus the repo slug
+(--repo or $GITHUB_REPOSITORY) to gather the merge history. If ANTHROPIC_API_KEY
+is present, the most-recently-merged PR gets a ten-word "what this unlocked"
+headline from Claude; otherwise a plain heuristic headline is used.
+
+This is meant to run from a GitHub Actions workflow keyed on
+`pull_request: closed` (filtered to merged PRs) — see
+`.github/workflows/ralph-recap.yml` — but it runs fine locally too:
+
+    DISCORD_BOT_TOKEN=... RALPH_CHANNEL_ID=... GITHUB_TOKEN=... \
+        python scripts/ralph/recap.py --repo Geoffe-Ga/adepthood --dry-run
+
+`--dry-run` prints the rendered embed as JSON instead of posting it.
+
+The backlog count mirrors `scripts/ralph/pick-next.sh`: open issues bearing any
+of the picker's exclude labels (epics, blocked, etc.) are not part of Ralph's
+real workload, so they are dropped from the ETA. Override the label set with the
+same `RALPH_EXCLUDE_LABELS` env var the picker uses.
+
+The statistics math lives in stats.py (pure, unit-tested); this module is the
+I/O shell around it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, cast
+
+import stats
+
+# Optional dependency: only needed for the Claude-written headline. Imported at
+# module top level so the rest of the recap works even when it is absent.
+try:
+    import anthropic as _anthropic_mod
+except ImportError:
+    _anthropic_mod = None
+
+
+class RecapError(Exception):
+    """A user-facing failure with an associated process exit code."""
+
+    def __init__(self, message: str, code: int = 1) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+GITHUB_API = "https://api.github.com"
+DISCORD_API = "https://discord.com/api/v10"
+# Discord embed accent — a Ralph-purple.
+EMBED_COLOR = 0x7C3AED
+# Cap per-PR comment fetches so a giant campaign doesn't make thousands of calls.
+DEFAULT_MAX_PRS = 200
+HEADLINE_MODEL = "claude-opus-4-8"
+
+# Issues carrying any of these labels are not part of Ralph's real backlog, so
+# they are excluded from the open-issue count behind the ETA. Kept in sync with
+# the default exclude set in `scripts/ralph/pick-next.sh`.
+DEFAULT_EXCLUDE_LABELS = (
+    "epic",
+    "wontfix",
+    "duplicate",
+    "invalid",
+    "question",
+    "blocked",
+    "needs-spec",
+    "future-work",
+    "do-not-auto-merge",
+    "in-progress",
+)
+
+
+# --------------------------------------------------------------------------- #
+# HTTP helpers
+# --------------------------------------------------------------------------- #
+
+
+def _request_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    method: str = "GET",
+    body: bytes | None = None,
+) -> object:
+    """Perform an HTTP request and parse a JSON response body.
+
+    Returns the parsed JSON (typed as `object`; callers cast). Raises
+    urllib.error.HTTPError / URLError on transport or HTTP failures.
+    """
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    with urllib.request.urlopen(request) as response:
+        raw = response.read().decode("utf-8")
+    return json.loads(raw) if raw else None
+
+
+def _gh_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "ralph-recap",
+    }
+
+
+def _gh_get_paged(path: str, *, token: str, params: dict[str, str], max_items: int) -> list[dict[str, Any]]:
+    """GET a paginated GitHub list endpoint, stopping at max_items."""
+    headers = _gh_headers(token)
+    out: list[dict[str, Any]] = []
+    page = 1
+    while len(out) < max_items:
+        query = "&".join(f"{k}={v}" for k, v in {**params, "per_page": "100", "page": str(page)}.items())
+        url = f"{GITHUB_API}{path}?{query}"
+        chunk = cast("list[dict[str, Any]]", _request_json(url, headers=headers))
+        if not chunk:
+            break
+        out.extend(chunk)
+        if len(chunk) < 100:
+            break
+        page += 1
+    return out[:max_items]
+
+
+# --------------------------------------------------------------------------- #
+# GitHub data gathering
+# --------------------------------------------------------------------------- #
+
+
+def fetch_merged_prs(repo: str, *, token: str, max_prs: int) -> list[dict[str, Any]]:
+    """Return merged PRs (newest merge first), capped at max_prs."""
+    closed = _gh_get_paged(
+        f"/repos/{repo}/pulls",
+        token=token,
+        params={"state": "closed", "sort": "updated", "direction": "desc"},
+        max_items=max_prs * 2,
+    )
+    merged = [pr for pr in closed if pr.get("merged_at")]
+    merged.sort(key=lambda pr: cast("str", pr["merged_at"]), reverse=True)
+    return merged[:max_prs]
+
+
+def fetch_pr_detail(repo: str, number: int, *, token: str) -> dict[str, Any]:
+    """Fetch a single PR (carries additions/deletions/changed_files)."""
+    url = f"{GITHUB_API}/repos/{repo}/pulls/{number}"
+    return cast("dict[str, Any]", _request_json(url, headers=_gh_headers(token)))
+
+
+def fetch_pr_verdicts(repo: str, number: int, *, token: str) -> list[str]:
+    """Return the ordered list of normalized Claude verdicts on one PR."""
+    comments = _gh_get_paged(
+        f"/repos/{repo}/issues/{number}/comments",
+        token=token,
+        params={"sort": "created", "direction": "asc"},
+        max_items=100,
+    )
+    verdicts: list[str] = []
+    for comment in comments:
+        verdict = stats.normalize_verdict(str(comment.get("body", "")))
+        if verdict is not None:
+            verdicts.append(verdict)
+    return verdicts
+
+
+def _excluded_labels() -> set[str]:
+    """Return the label set that disqualifies an issue from the backlog count.
+
+    Mirrors `scripts/ralph/pick-next.sh`: defaults to the housekeeping/deferred
+    markers, overridable via the same `RALPH_EXCLUDE_LABELS` env var (a
+    space-separated list). An empty override counts every open issue.
+    """
+    raw = os.environ.get("RALPH_EXCLUDE_LABELS")
+    if raw is None:
+        return set(DEFAULT_EXCLUDE_LABELS)
+    return {label for label in raw.split() if label}
+
+
+def count_open_backlog(repo: str, *, token: str, max_items: int = 1000) -> int:
+    """Count open issues that are real, unblocked Ralph work — the backlog.
+
+    Excludes pull requests (which the issues endpoint returns too) and any issue
+    bearing an excluded label, so the ETA reflects what the picker would
+    actually pick up rather than every open card.
+    """
+    issues = _gh_get_paged(
+        f"/repos/{repo}/issues",
+        token=token,
+        params={"state": "open"},
+        max_items=max_items,
+    )
+    excluded = _excluded_labels()
+    backlog = 0
+    for issue in issues:
+        if "pull_request" in issue:
+            continue
+        names = {str(label.get("name", "")) for label in issue.get("labels", [])}
+        if names & excluded:
+            continue
+        backlog += 1
+    return backlog
+
+
+# --------------------------------------------------------------------------- #
+# Headline generation
+# --------------------------------------------------------------------------- #
+
+
+def _heuristic_headline(title: str) -> str:
+    """Fallback ten-word headline: the cleaned PR title, clipped to ten words."""
+    cleaned = title.strip()
+    for prefix in ("feat:", "feat(", "fix:", "chore:", "refactor:", "docs:"):
+        if cleaned.lower().startswith(prefix):
+            cleaned = cleaned.split(":", 1)[-1].strip() if ":" in cleaned else cleaned
+            break
+    words = cleaned.split()
+    return " ".join(words[:10]) if words else "Latest change merged into the tick loop"
+
+
+def generate_headline(title: str, body: str) -> str:
+    """Ask Claude for a ten-word "what this unlocked" headline.
+
+    Falls back to a heuristic if the Anthropic SDK or API key is unavailable, so
+    the recap never fails just because the headline can't be generated.
+    """
+    if _anthropic_mod is None or not os.environ.get("ANTHROPIC_API_KEY"):
+        return _heuristic_headline(title)
+
+    prompt = (
+        "A pull request was just merged into an autonomous coding loop. "
+        "Write a single headline of at most ten words describing what merging "
+        "this PR has unlocked or newly made possible for the project. Lead with "
+        "the capability or outcome, not the implementation. Plain language only: "
+        "no buzzwords, no 'leverage'/'robust'/'seamless'/'synergy', no jargon "
+        "soup, no trailing punctuation. Return only the headline.\n\n"
+        f"PR title: {title}\n\n"
+        f"PR description:\n{body[:4000]}"
+    )
+    try:
+        client = _anthropic_mod.Anthropic()
+        response = client.messages.create(
+            model=HEADLINE_MODEL,
+            max_tokens=256,
+            output_config={"effort": "low"},
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = "".join(block.text for block in response.content if block.type == "text").strip()
+    except Exception:  # any SDK/API failure degrades to the heuristic, never fails the recap
+        return _heuristic_headline(title)
+    return text or _heuristic_headline(title)
+
+
+# --------------------------------------------------------------------------- #
+# Recap assembly
+# --------------------------------------------------------------------------- #
+
+
+def _fmt_hours(hours: float) -> str:
+    if hours < 1:
+        return f"{round(hours * 60)}m"
+    if hours < 48:
+        return f"{hours:.1f}h"
+    return f"{hours / 24:.1f}d"
+
+
+def _fmt_eta(estimate: dict[str, object]) -> str:
+    if not estimate["known"]:
+        return "unknown (loop is stalled — no recent merges)"
+    days = cast("float | None", estimate["days_remaining"])
+    if days is None or days <= 0:
+        return "backlog clear 🎉"
+    eta = cast("dt.datetime", estimate["eta"])
+    return f"~{days:.1f} days (≈ {eta.date().isoformat()})"
+
+
+def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dict[str, Any] | None:
+    """Gather data and assemble the Discord embed payload.
+
+    Returns None when there are no merged PRs yet (nothing to recap).
+    """
+    merged = fetch_merged_prs(repo, token=token, max_prs=max_prs)
+    if not merged:
+        return None
+
+    merged_at = [stats.parse_iso(cast("str", pr["merged_at"])) for pr in merged]
+    durations = [
+        (stats.parse_iso(cast("str", pr["merged_at"])) - stats.parse_iso(cast("str", pr["created_at"]))).total_seconds()
+        / 3600.0
+        for pr in merged
+    ]
+
+    iterations: list[int] = []
+    for pr in merged:
+        verdicts = fetch_pr_verdicts(repo, int(pr["number"]), token=token)
+        rounds = stats.iterations_before_lgtm(verdicts)
+        if rounds is not None:
+            iterations.append(rounds)
+
+    latest = merged[0]
+    latest_detail = fetch_pr_detail(repo, int(latest["number"]), token=token)
+    churn = [
+        (
+            int(latest_detail.get("additions", 0)),
+            int(latest_detail.get("deletions", 0)),
+            int(latest_detail.get("changed_files", 0)),
+        )
+    ]
+
+    rate = stats.merge_rate(merged_at, now=now)
+    ttm = stats.time_to_merge_stats(durations)
+    iters = stats.iteration_stats(iterations)
+    open_items = count_open_backlog(repo, token=token)
+    estimate = stats.estimate_remaining(open_items, rate["per_day"], now=now)
+    totals = stats.churn_totals(churn)
+    busy = stats.busiest_day(merged_at)
+
+    headline = generate_headline(str(latest.get("title", "")), str(latest.get("body") or ""))
+
+    return _render_embed(
+        repo=repo,
+        latest=latest,
+        headline=headline,
+        rate=rate,
+        ttm=ttm,
+        iters=iters,
+        estimate=estimate,
+        latest_churn=totals,
+        busy=busy,
+        now=now,
+    )
+
+
+def _render_embed(
+    *,
+    repo: str,
+    latest: dict[str, Any],
+    headline: str,
+    rate: dict[str, float],
+    ttm: dict[str, float],
+    iters: dict[str, float],
+    estimate: dict[str, object],
+    latest_churn: dict[str, int],
+    busy: tuple[str, int] | None,
+    now: dt.datetime,
+) -> dict[str, Any]:
+    """Turn computed stats into a Discord embed payload (one message)."""
+    pr_number = int(latest["number"])
+    pr_url = str(latest.get("html_url", f"https://github.com/{repo}/pull/{pr_number}"))
+
+    clean_pct = round(iters["clean_merge_rate"] * 100)
+    iter_line = (
+        f"**{iters['mean']:.1f}** avg rounds to LGTM · "
+        f"**{clean_pct}%** first-try clean · "
+        f"worst **{int(iters['max'])}** (n={int(iters['sample'])})"
+        if iters["sample"]
+        else "no LGTM verdicts found yet"
+    )
+
+    busy_line = f"{busy[1]} merges on {busy[0]}" if busy else "—"
+
+    fields = [
+        {
+            "name": "🚀 Latest unlock",
+            "value": f"*{headline}*\n[#{pr_number} — {latest.get('title', '')}]({pr_url})",
+            "inline": False,
+        },
+        {
+            "name": "📦 PRs merged",
+            "value": f"**{int(rate['total'])}** total · {int(rate['last_7_days'])} in last 7d",
+            "inline": True,
+        },
+        {
+            "name": "⚡ Merge rate",
+            "value": f"**{rate['per_day']:.2f}**/day over {rate['span_days']:.1f}d",
+            "inline": True,
+        },
+        {
+            "name": "🔁 Review iterations",
+            "value": iter_line,
+            "inline": False,
+        },
+        {
+            "name": "⏱️ Time to merge",
+            "value": (
+                f"median **{_fmt_hours(ttm['median'])}** · "
+                f"fastest {_fmt_hours(ttm['fastest'])} · slowest {_fmt_hours(ttm['slowest'])}"
+            ),
+            "inline": False,
+        },
+        {
+            "name": "🗺️ Backlog remaining",
+            "value": f"**{estimate['open_items']}** open · ETA {_fmt_eta(estimate)}",
+            "inline": True,
+        },
+        {
+            "name": "🔥 Busiest day",
+            "value": busy_line,
+            "inline": True,
+        },
+        {
+            "name": "🧮 This PR's footprint",
+            "value": (
+                f"+{latest_churn['additions']} / -{latest_churn['deletions']} across {latest_churn['files']} file(s)"
+            ),
+            "inline": False,
+        },
+    ]
+
+    embed = {
+        "title": f"🤖 Ralph Recap — {repo}",
+        "url": f"https://github.com/{repo}/pulls?q=is%3Apr+is%3Amerged",
+        "description": f"Another tick landed. Here's where the loop stands as of <t:{int(now.timestamp())}:R>.",
+        "color": EMBED_COLOR,
+        "fields": fields,
+        "footer": {"text": "Ralph tick loop · recap fires on every merge"},
+        "timestamp": now.isoformat(),
+    }
+    return {"embeds": [embed]}
+
+
+# --------------------------------------------------------------------------- #
+# Discord delivery
+# --------------------------------------------------------------------------- #
+
+
+def post_to_discord(channel_id: str, token: str, payload: dict[str, Any]) -> None:
+    """Post the recap payload to a Discord channel as a bot."""
+    url = f"{DISCORD_API}/channels/{channel_id}/messages"
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+        "User-Agent": "DiscordBot (ralph-recap, 1.0)",
+    }
+    _request_json(url, headers=headers, method="POST", body=json.dumps(payload).encode("utf-8"))
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+
+
+def _gather(repo: str, gh_token: str, max_prs: int) -> dict[str, Any] | None:
+    """Build the recap payload, mapping network failures to RecapError."""
+    now = dt.datetime.now(dt.timezone.utc)
+    try:
+        return build_recap(repo, token=gh_token, max_prs=max_prs, now=now)
+    except urllib.error.HTTPError as exc:
+        raise RecapError(f"GitHub API request failed: {exc.code} {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise RecapError(f"network failure talking to GitHub: {exc.reason}") from exc
+
+
+def _deliver(channel_id: str | None, payload: dict[str, Any]) -> None:
+    """Post the payload to Discord, mapping failures to RecapError."""
+    if not channel_id:
+        raise RecapError("RALPH_CHANNEL_ID (or --channel-id) is required to post", code=2)
+    discord_token = os.environ.get("DISCORD_BOT_TOKEN")
+    if not discord_token:
+        raise RecapError("DISCORD_BOT_TOKEN is required to post", code=2)
+    try:
+        post_to_discord(channel_id, discord_token, payload)
+    except urllib.error.HTTPError as exc:
+        raise RecapError(f"Discord API request failed: {exc.code} {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise RecapError(f"network failure talking to Discord: {exc.reason}") from exc
+
+
+def _run(args: argparse.Namespace) -> int:
+    if not args.repo:
+        raise RecapError("--repo or $GITHUB_REPOSITORY is required", code=2)
+    gh_token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not gh_token:
+        raise RecapError("GITHUB_TOKEN (or GH_TOKEN) is required", code=2)
+
+    payload = _gather(str(args.repo), gh_token, int(args.max_prs))
+    if payload is None:
+        print("No merged PRs yet — nothing to recap.")
+        return 0
+    if args.dry_run:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    _deliver(args.channel_id, payload)
+    print(f"Posted Ralph recap to channel {args.channel_id}.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="owner/repo slug")
+    parser.add_argument("--channel-id", default=os.environ.get("RALPH_CHANNEL_ID"))
+    parser.add_argument("--max-prs", type=int, default=DEFAULT_MAX_PRS)
+    parser.add_argument("--dry-run", action="store_true", help="print the embed instead of posting")
+    args = parser.parse_args(argv)
+    try:
+        return _run(args)
+    except RecapError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return exc.code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -221,7 +221,9 @@ def _heuristic_headline(title: str) -> str:
     cleaned = title.strip()
     for prefix in ("feat:", "feat(", "fix:", "chore:", "refactor:", "docs:"):
         if cleaned.lower().startswith(prefix):
-            cleaned = cleaned.split(":", 1)[-1].strip() if ":" in cleaned else cleaned
+            # split on the first ":" if present; a prefix with no colon (rare)
+            # leaves the title unchanged since split returns the whole string.
+            cleaned = cleaned.split(":", 1)[-1].strip()
             break
     words = cleaned.split()
     return " ".join(words[:10]) if words else "Latest change merged into the tick loop"

--- a/scripts/ralph/stats.py
+++ b/scripts/ralph/stats.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Pure statistics helpers for the Ralph tick-loop recap.
+
+Everything in this module is side-effect free: it takes already-fetched data
+(lists of timestamps, verdict sequences, churn tuples) and returns plain
+dicts/numbers. `recap.py` does all the GitHub / Discord / Anthropic I/O and
+hands the data here. Keeping the math pure makes it unit-testable without a
+network.
+
+A "Ralph tick loop" is an autonomous agent that grinds a backlog one issue at
+a time: each tick opens a PR, iterates against the Claude reviewer's verdict
+until LGTM, merges, and moves to the next backlog item. These helpers turn the
+merge history into the numbers a human wants to see in a recap.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections import Counter
+
+# A Claude reviewer verdict, normalized. The reviewer posts a comment ending in
+# a `Verdict:` line; we collapse it to one of these three tokens.
+LGTM = "LGTM"
+CHANGES_REQUESTED = "CHANGES_REQUESTED"
+COMMENTS = "COMMENTS"
+
+ISO_NO_TZ = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def parse_iso(timestamp: str) -> dt.datetime:
+    """Parse a GitHub ISO-8601 timestamp into an aware UTC datetime.
+
+    GitHub stamps end in `Z`; `datetime.fromisoformat` only learned to accept
+    that in 3.11, so normalize it for 3.10 support.
+    """
+    return dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+
+
+def normalize_verdict(raw: str) -> str | None:
+    """Collapse a Claude review comment body to a single verdict token.
+
+    Returns None when the body carries no recognizable verdict line, so callers
+    can ignore non-review comments. The check mirrors the grep ladder in
+    `iteration-trigger.yml`: CHANGES_REQUESTED wins over a bare LGTM mention so
+    a comment that says "this is not yet LGTM, changes requested" is counted as
+    a change request.
+    """
+    upper = raw.upper()
+    if "VERDICT" not in upper:
+        return None
+    if "CHANGES_REQUESTED" in upper or "CHANGES REQUESTED" in upper:
+        return CHANGES_REQUESTED
+    if "LGTM" in upper:
+        return LGTM
+    return COMMENTS
+
+
+def iterations_before_lgtm(verdicts: list[str]) -> int | None:
+    """Count review rounds a PR took before its first LGTM.
+
+    `verdicts` is the ordered list of normalized verdicts for one PR. The result
+    is the number of non-LGTM verdicts that preceded the first LGTM — i.e. how
+    many times the loop had to go back and address feedback. Returns None if the
+    PR never reached an LGTM verdict (it was merged on human judgment, or the
+    reviewer only left COMMENTS), so it can be excluded from the average.
+    """
+    for index, verdict in enumerate(verdicts):
+        if verdict == LGTM:
+            return index
+    return None
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _median(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+def merge_rate(merged_at: list[dt.datetime], *, now: dt.datetime) -> dict[str, float]:
+    """Compute merge throughput from a list of merge timestamps.
+
+    Returns merges-per-day over the whole campaign, merges over the trailing 7
+    days, and the span in days. The campaign span runs from the first merge to
+    `now` (not to the last merge) so a stalled loop shows a decaying rate rather
+    than a frozen one.
+    """
+    count = len(merged_at)
+    if count == 0:
+        return {"total": 0.0, "per_day": 0.0, "last_7_days": 0.0, "span_days": 0.0}
+
+    first = min(merged_at)
+    span_days = max((now - first).total_seconds() / 86400.0, 1e-9)
+    week_ago = now - dt.timedelta(days=7)
+    last_7 = sum(1 for ts in merged_at if ts >= week_ago)
+
+    return {
+        "total": float(count),
+        "per_day": count / span_days,
+        "last_7_days": float(last_7),
+        "span_days": span_days,
+    }
+
+
+def time_to_merge_stats(durations_hours: list[float]) -> dict[str, float]:
+    """Summarize how long PRs sat open before merging, in hours."""
+    if not durations_hours:
+        return {"mean": 0.0, "median": 0.0, "fastest": 0.0, "slowest": 0.0}
+    return {
+        "mean": _mean(durations_hours),
+        "median": _median(durations_hours),
+        "fastest": min(durations_hours),
+        "slowest": max(durations_hours),
+    }
+
+
+def iteration_stats(per_pr: list[int]) -> dict[str, float]:
+    """Summarize iteration counts across PRs that reached LGTM.
+
+    `per_pr` is the list of `iterations_before_lgtm` results (Nones already
+    filtered out). `clean_merge_rate` is the share of PRs that landed LGTM with
+    zero feedback rounds — a proxy for how often the loop nails it first try.
+    """
+    if not per_pr:
+        return {"mean": 0.0, "median": 0.0, "max": 0.0, "clean_merge_rate": 0.0, "sample": 0.0}
+    floats = [float(n) for n in per_pr]
+    clean = sum(1 for n in per_pr if n == 0)
+    return {
+        "mean": _mean(floats),
+        "median": _median(floats),
+        "max": float(max(per_pr)),
+        "clean_merge_rate": clean / len(per_pr),
+        "sample": float(len(per_pr)),
+    }
+
+
+def estimate_remaining(open_items: int, per_day: float, *, now: dt.datetime) -> dict[str, object]:
+    """Project how long the backlog will take at the current merge rate.
+
+    Returns the remaining-item count, estimated days left, and an ETA date.
+    When the rate is zero (no merges yet, or a fully stalled loop) the estimate
+    is unknown rather than infinite.
+    """
+    if open_items <= 0:
+        return {"open_items": 0, "days_remaining": 0.0, "eta": now, "known": True}
+    if per_day <= 0:
+        return {"open_items": open_items, "days_remaining": None, "eta": None, "known": False}
+
+    days_remaining = open_items / per_day
+    eta = now + dt.timedelta(days=days_remaining)
+    return {"open_items": open_items, "days_remaining": days_remaining, "eta": eta, "known": True}
+
+
+def churn_totals(churn: list[tuple[int, int, int]]) -> dict[str, int]:
+    """Sum (additions, deletions, changed_files) tuples across merged PRs."""
+    additions = sum(c[0] for c in churn)
+    deletions = sum(c[1] for c in churn)
+    files = sum(c[2] for c in churn)
+    return {
+        "additions": additions,
+        "deletions": deletions,
+        "net": additions - deletions,
+        "files": files,
+    }
+
+
+def busiest_day(merged_at: list[dt.datetime]) -> tuple[str, int] | None:
+    """Return the (ISO date, count) of the day with the most merges, or None."""
+    if not merged_at:
+        return None
+    counter: Counter[str] = Counter(ts.date().isoformat() for ts in merged_at)
+    day, count = counter.most_common(1)[0]
+    return day, count

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -1,0 +1,203 @@
+"""Tests for the Ralph recap: pure stats helpers and the backlog count.
+
+Run from the repo root with:
+
+    python -m pytest scripts/ralph -q
+
+`stats.py` is pure and tested directly. `recap.py` is the I/O shell; only its
+adepthood-specific backlog filtering is unit-tested here (network calls are
+monkeypatched), since everything else is a thin wrapper over `stats`.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import pytest
+
+import recap
+import stats as rs
+
+UTC = dt.timezone.utc
+
+
+def _at(day: int, hour: int = 12) -> dt.datetime:
+    return dt.datetime(2026, 6, day, hour, tzinfo=UTC)
+
+
+# ---------- parse_iso ----------
+
+
+def test_parse_iso_handles_trailing_z() -> None:
+    parsed = rs.parse_iso("2026-06-27T08:30:00Z")
+    assert parsed == dt.datetime(2026, 6, 27, 8, 30, tzinfo=UTC)
+
+
+# ---------- normalize_verdict ----------
+
+
+def test_normalize_verdict_returns_none_without_verdict_line() -> None:
+    assert rs.normalize_verdict("Looks great, merging!") is None
+
+
+def test_normalize_verdict_detects_lgtm() -> None:
+    assert rs.normalize_verdict("Nice work.\nVerdict: LGTM") == rs.LGTM
+
+
+def test_normalize_verdict_changes_requested_beats_lgtm_mention() -> None:
+    body = "This is not yet LGTM.\nVerdict: CHANGES_REQUESTED"
+    assert rs.normalize_verdict(body) == rs.CHANGES_REQUESTED
+
+
+def test_normalize_verdict_defaults_to_comments() -> None:
+    assert rs.normalize_verdict("Some notes.\nVerdict: COMMENTS") == rs.COMMENTS
+
+
+# ---------- iterations_before_lgtm ----------
+
+
+def test_iterations_before_lgtm_counts_rounds() -> None:
+    verdicts = [rs.CHANGES_REQUESTED, rs.COMMENTS, rs.LGTM]
+    assert rs.iterations_before_lgtm(verdicts) == 2
+
+
+def test_iterations_before_lgtm_zero_for_clean_merge() -> None:
+    assert rs.iterations_before_lgtm([rs.LGTM]) == 0
+
+
+def test_iterations_before_lgtm_none_when_never_lgtm() -> None:
+    assert rs.iterations_before_lgtm([rs.CHANGES_REQUESTED, rs.COMMENTS]) is None
+
+
+# ---------- merge_rate ----------
+
+
+def test_merge_rate_empty() -> None:
+    rate = rs.merge_rate([], now=_at(27))
+    assert rate["total"] == 0.0
+    assert rate["per_day"] == 0.0
+
+
+def test_merge_rate_spans_first_merge_to_now() -> None:
+    merged = [_at(20), _at(22), _at(24)]
+    rate = rs.merge_rate(merged, now=_at(30))
+    assert rate["total"] == 3.0
+    assert rate["span_days"] == 10.0
+    assert rate["per_day"] == 0.3
+
+
+def test_merge_rate_last_7_days_window() -> None:
+    merged = [_at(1), _at(25), _at(27)]
+    rate = rs.merge_rate(merged, now=_at(28))
+    assert rate["last_7_days"] == 2.0
+
+
+# ---------- time_to_merge_stats ----------
+
+
+def test_time_to_merge_stats() -> None:
+    out = rs.time_to_merge_stats([1.0, 3.0, 5.0])
+    assert out["median"] == 3.0
+    assert out["fastest"] == 1.0
+    assert out["slowest"] == 5.0
+    assert out["mean"] == 3.0
+
+
+# ---------- iteration_stats ----------
+
+
+def test_iteration_stats_clean_merge_rate() -> None:
+    out = rs.iteration_stats([0, 0, 2, 4])
+    assert out["clean_merge_rate"] == 0.5
+    assert out["max"] == 4.0
+    assert out["sample"] == 4.0
+
+
+def test_iteration_stats_empty() -> None:
+    out = rs.iteration_stats([])
+    assert out["sample"] == 0.0
+
+
+# ---------- estimate_remaining ----------
+
+
+def test_estimate_remaining_projects_eta() -> None:
+    est = rs.estimate_remaining(10, 2.0, now=_at(1))
+    assert est["known"] is True
+    assert est["days_remaining"] == 5.0
+    assert est["eta"] == _at(6)
+
+
+def test_estimate_remaining_unknown_when_rate_zero() -> None:
+    est = rs.estimate_remaining(10, 0.0, now=_at(1))
+    assert est["known"] is False
+    assert est["days_remaining"] is None
+
+
+def test_estimate_remaining_clear_backlog() -> None:
+    est = rs.estimate_remaining(0, 2.0, now=_at(1))
+    assert est["open_items"] == 0
+    assert est["days_remaining"] == 0.0
+
+
+# ---------- churn_totals ----------
+
+
+def test_churn_totals_sums_and_nets() -> None:
+    out = rs.churn_totals([(10, 3, 2), (5, 5, 1)])
+    assert out["additions"] == 15
+    assert out["deletions"] == 8
+    assert out["net"] == 7
+    assert out["files"] == 3
+
+
+# ---------- busiest_day ----------
+
+
+def test_busiest_day_picks_max() -> None:
+    merged = [_at(20), _at(20), _at(21)]
+    result = rs.busiest_day(merged)
+    assert result == ("2026-06-20", 2)
+
+
+def test_busiest_day_none_when_empty() -> None:
+    assert rs.busiest_day([]) is None
+
+
+# ---------- count_open_backlog (adepthood adaptation) ----------
+
+
+def _issue(number: int, *, labels: list[str], is_pr: bool = False) -> dict[str, Any]:
+    issue: dict[str, Any] = {"number": number, "labels": [{"name": name} for name in labels]}
+    if is_pr:
+        issue["pull_request"] = {"url": f"https://example/{number}"}
+    return issue
+
+
+def _patch_issues(monkeypatch: pytest.MonkeyPatch, issues: list[dict[str, Any]]) -> None:
+    monkeypatch.setattr(recap, "_gh_get_paged", lambda *a, **k: issues)
+
+
+def test_count_open_backlog_excludes_prs_and_labelled_issues(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RALPH_EXCLUDE_LABELS", raising=False)
+    issues = [
+        _issue(1, labels=[]),  # counted
+        _issue(2, labels=["enhancement"]),  # counted
+        _issue(3, labels=["epic"]),  # excluded by label
+        _issue(4, labels=["blocked", "enhancement"]),  # excluded by label
+        _issue(5, labels=[], is_pr=True),  # excluded as a PR
+    ]
+    _patch_issues(monkeypatch, issues)
+    assert recap.count_open_backlog("owner/repo", token="t") == 2
+
+
+def test_count_open_backlog_respects_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RALPH_EXCLUDE_LABELS", "deferred")
+    issues = [
+        _issue(1, labels=["epic"]),  # no longer excluded (override drops "epic")
+        _issue(2, labels=["deferred"]),  # excluded by override
+        _issue(3, labels=[]),  # counted
+    ]
+    _patch_issues(monkeypatch, issues)
+    assert recap.count_open_backlog("owner/repo", token="t") == 2

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -201,3 +201,89 @@ def test_count_open_backlog_respects_env_override(monkeypatch: pytest.MonkeyPatc
     ]
     _patch_issues(monkeypatch, issues)
     assert recap.count_open_backlog("owner/repo", token="t") == 2
+
+
+# ---------- _heuristic_headline ----------
+
+
+def test_heuristic_headline_strips_conventional_prefix() -> None:
+    assert recap._heuristic_headline("feat(backend): add the energy ledger") == "add the energy ledger"
+
+
+def test_heuristic_headline_clips_to_ten_words() -> None:
+    headline = recap._heuristic_headline("one two three four five six seven eight nine ten eleven")
+    assert headline == "one two three four five six seven eight nine ten"
+
+
+def test_heuristic_headline_blank_title_falls_back() -> None:
+    assert recap._heuristic_headline("   ") == "Latest change merged into the tick loop"
+
+
+# ---------- generate_headline ----------
+
+
+class _Block:
+    def __init__(self, text: str, kind: str = "text") -> None:
+        self.text = text
+        self.type = kind
+
+
+class _Response:
+    def __init__(self, blocks: list[_Block]) -> None:
+        self.content = blocks
+
+
+class _FakeAnthropic:
+    """Minimal stand-in for the anthropic SDK that records create() kwargs."""
+
+    last_kwargs: dict[str, Any] = {}
+
+    class _Client:
+        def __init__(self) -> None:
+            self.messages = _FakeAnthropic._Messages()
+
+    class _Messages:
+        def create(self, **kwargs: Any) -> _Response:
+            _FakeAnthropic.last_kwargs = kwargs
+            return _Response([_Block("Energy ledger now powers daily streaks")])
+
+    def Anthropic(self) -> "_FakeAnthropic._Client":  # noqa: N802 - mirrors the SDK's class name
+        return _FakeAnthropic._Client()
+
+
+def test_generate_headline_uses_sdk_and_passes_low_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeAnthropic()
+    _FakeAnthropic.last_kwargs = {}
+    monkeypatch.setattr(recap, "_anthropic_mod", fake)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
+
+    headline = recap.generate_headline("feat: add energy ledger", "Body text")
+
+    assert headline == "Energy ledger now powers daily streaks"
+    assert _FakeAnthropic.last_kwargs["model"] == recap.HEADLINE_MODEL
+    assert _FakeAnthropic.last_kwargs["output_config"] == {"effort": "low"}
+
+
+def test_generate_headline_falls_back_when_no_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "_anthropic_mod", _FakeAnthropic())
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"
+
+
+def test_generate_headline_falls_back_when_sdk_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "_anthropic_mod", None)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
+
+    assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"
+
+
+def test_generate_headline_falls_back_on_sdk_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Boom:
+        def Anthropic(self) -> object:  # noqa: N802 - mirrors the SDK's class name
+            raise RuntimeError("api down")
+
+    monkeypatch.setattr(recap, "_anthropic_mod", _Boom())
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
+
+    assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"


### PR DESCRIPTION
## Summary

Brings the **Ralph Discord check-in** online for adepthood, adapted from the
`discord-ralph-recap` skill in
[`Geoffe-Ga/well-worn-tools` PR #14](https://github.com/Geoffe-Ga/well-worn-tools/pull/14).

Whenever a PR merges, a GitHub Actions workflow posts a clean Discord embed
recapping the Ralph tick loop:

- 🚀 a ten-word "what this unlocked" headline for the latest merge (Claude
  `claude-opus-4-8`, with a heuristic PR-title fallback when `ANTHROPIC_API_KEY`
  is absent — the recap never fails on the headline)
- 📦 PRs merged (total + last 7 days), ⚡ merge rate (decaying — anchored to
  *now*, not the last merge)
- 🔁 average review iterations before LGTM + first-try-clean %, parsed from the
  Claude reviewer's `Verdict:` comments (same convention as `iteration-trigger.yml`)
- ⏱️ time-to-merge (median/fastest/slowest), 🗺️ backlog ETA, 🔥 busiest day,
  🧮 the latest PR's footprint

### Adapted for adepthood
- **Location:** the tooling lives in `scripts/ralph/` alongside the existing
  Ralph loop (`PROMPT.md`, `pick-next.sh`, `ralph-tick`), not as a `.claude`
  skill — adepthood is an app monorepo, not a skills collection.
- **Backlog count → real Ralph workload:** `count_open_backlog` now mirrors
  `scripts/ralph/pick-next.sh` — it excludes PRs and any issue carrying the
  picker's exclude labels (`epic`, `blocked`, `needs-spec`,
  `do-not-auto-merge`, …) and honors the same `RALPH_EXCLUDE_LABELS` override,
  so the ETA reflects what the picker would actually pick up rather than every
  open card. (`metrics.md` in the source flags this as the metric most worth
  adapting.)
- **Workflow path** points at `scripts/ralph/recap.py` and pins actions to the
  same SHAs the repo's other workflows use.

## Files

| Path | What |
| --- | --- |
| `scripts/ralph/stats.py` | Pure, unit-tested statistics math (no I/O) |
| `scripts/ralph/recap.py` | I/O shell: fetch GitHub data, generate headline, post the Discord embed |
| `scripts/ralph/test_recap_stats.py` | Unit tests for the stats + the adapted backlog filter |
| `scripts/ralph/RECAP.md` | Setup, secrets, metric definitions, and adepthood tuning notes |
| `.github/workflows/ralph-recap.yml` | Poster — fires on `pull_request: closed`, gated to merges |
| `.github/workflows/ralph-recap-tests.yml` | Runs the unit tests on changes under `scripts/ralph/` |

## Configuration required to go live

Set these on the repo (the workflow reads them as env of the same name):

```bash
gh secret   set DISCORD_BOT_TOKEN          # bot token; needs View Channel + Send Messages
gh variable set RALPH_CHANNEL_ID --body 123456789012345678
gh secret   set ANTHROPIC_API_KEY          # optional — enables the Claude headline
```

The built-in `GITHUB_TOKEN` supplies the read-only merge history. The poster
workflow lands on `main` with this PR, so it begins firing on the **next**
merge after this one.

## Test plan

- `python -m pytest scripts/ralph -q` → **22 passed** (stats helpers + the
  PR/label-aware backlog count, incl. the `RALPH_EXCLUDE_LABELS` override).
- End-to-end `build_recap` → `_render_embed` exercised offline with stubbed
  GitHub responses: produces a valid Discord embed payload (verified the JSON).
- Verified the `pull_request: closed` + `merged == true` trigger model and that
  both workflow YAMLs parse; Python modules compile; hygiene (final newline,
  no trailing whitespace) checked on all new files.
- CI: `Ralph Recap Tests` runs the suite on this PR.

> **Note on local pre-commit:** the sandbox's egress policy blocks cloning the
> pre-commit hook repos (proxy returns 403 for `github.com/pre-commit/*`), so
> the full `pre-commit` framework could not bootstrap locally. All new files
> sit **outside** every backend-/frontend-scoped hook (`ruff`/`mypy`/`isort`/
> `bandit`/`eslint` all filter on `^backend/` or `^frontend/`); the generic
> hooks that *would* apply (AST, YAML, whitespace, EOF) were verified by hand.
> CI enforces the real gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjSYodTnoCMVSHwJ6cajfa)_