### PR TITLE
refactor(frontend): minimalist recipe-library modals pass

### DIFF
--- a/frontend/src/features/Practice/recipes/RecipeEditorModal.tsx
+++ b/frontend/src/features/Practice/recipes/RecipeEditorModal.tsx
@@ -773,23 +773,33 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
   },
-  actionsRow: { flexDirection: 'row', gap: SPACING.xs, marginTop: SPACING.xs },
-  smallButton: {
-    paddingVertical: SPACING.xs,
-    paddingHorizontal: SPACING.sm,
-    borderRadius: BORDER_RADIUS.sm,
-    backgroundColor: colors.background.accent,
-    minHeight: 32,
+  // Reorder + remove are de-emphasised quiet controls, right-aligned, so the
+  // step content reads first; "+ Add step" is the one prominent add affordance.
+  actionsRow: {
+    flexDirection: 'row',
+    gap: SPACING.md,
+    marginTop: SPACING.xs,
+    justifyContent: 'flex-end',
   },
-  smallButtonText: { color: colors.text.primary, fontSize: 13, fontWeight: '500' },
-  addButton: {
-    paddingVertical: SPACING.sm,
-    borderRadius: BORDER_RADIUS.sm,
-    backgroundColor: colors.background.accent,
+  smallButton: {
+    minHeight: 44,
+    paddingHorizontal: SPACING.xs,
+    backgroundColor: 'transparent',
     alignItems: 'center',
+    justifyContent: 'center',
+  },
+  smallButtonText: { color: colors.text.secondaryAccessible, fontSize: 13, fontWeight: '500' },
+  addButton: {
+    minHeight: 44,
+    paddingVertical: SPACING.sm,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    borderColor: colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
     marginTop: SPACING.sm,
   },
-  addButtonText: { color: colors.text.primary, fontWeight: '600', fontSize: 14 },
+  addButtonText: { color: colors.primary, fontWeight: '600', fontSize: 14 },
   errors: {
     backgroundColor: colors.background.card,
     borderLeftColor: colors.danger,

--- a/frontend/src/features/Practice/recipes/RecipePickerModal.tsx
+++ b/frontend/src/features/Practice/recipes/RecipePickerModal.tsx
@@ -358,14 +358,15 @@ const RecipeRow = (props: RecipeRowProps): React.JSX.Element => {
   return (
     <View style={styles.card} testID={`recipe-row-${props.recipe.id}`}>
       <RecipeRowHeader recipe={props.recipe} isSystem={isSystem} summary={stepSummary} />
-      <View style={styles.rowActions}>
-        <RowButton
-          label="Use this"
-          variant="primary"
-          disabled={props.disableActions}
-          onPress={props.onApply}
-          testID={`recipe-row-${props.recipe.id}-apply`}
-        />
+      <RowButton
+        label="Use this"
+        variant="primary"
+        block
+        disabled={props.disableActions}
+        onPress={props.onApply}
+        testID={`recipe-row-${props.recipe.id}-apply`}
+      />
+      <View style={styles.secondaryActions}>
         <RecipeRowMutationButtons
           recipeId={props.recipe.id}
           isSystem={isSystem}
@@ -416,6 +417,7 @@ const RecipeRowMutationButtons = (props: RecipeRowMutationButtonsProps): React.J
     return (
       <RowButton
         label="Edit a copy"
+        variant="quiet"
         disabled={props.disableActions}
         onPress={props.onFork}
         testID={`recipe-row-${props.recipeId}-fork`}
@@ -426,13 +428,14 @@ const RecipeRowMutationButtons = (props: RecipeRowMutationButtonsProps): React.J
     <>
       <RowButton
         label="Edit"
+        variant="quiet"
         disabled={props.disableActions}
         onPress={props.onEdit}
         testID={`recipe-row-${props.recipeId}-edit`}
       />
       <RowButton
         label="Delete"
-        variant="danger"
+        variant="quietDanger"
         disabled={props.disableActions}
         onPress={props.onDelete}
         testID={`recipe-row-${props.recipeId}-delete`}
@@ -441,9 +444,13 @@ const RecipeRowMutationButtons = (props: RecipeRowMutationButtonsProps): React.J
   );
 };
 
+type RowButtonVariant = 'primary' | 'default' | 'quiet' | 'quietDanger';
+
 interface RowButtonProps {
   label: string;
-  variant?: 'primary' | 'danger' | 'default';
+  variant?: RowButtonVariant;
+  /** Stretch to fill the row — used for the primary "Use this" action. */
+  block?: boolean;
   disabled: boolean;
   onPress: () => void;
   testID: string;
@@ -452,28 +459,33 @@ interface RowButtonProps {
 const RowButton = ({
   label,
   variant = 'default',
+  block = false,
   disabled,
   onPress,
   testID,
 }: RowButtonProps): React.JSX.Element => {
-  const variantStyle =
-    variant === 'primary'
-      ? styles.primaryButton
-      : variant === 'danger'
-        ? styles.dangerButton
-        : styles.defaultButton;
-  const variantText =
-    variant === 'primary' || variant === 'danger' ? styles.lightText : styles.defaultText;
+  const bg = {
+    primary: styles.primaryButton,
+    default: styles.defaultButton,
+    quiet: styles.quietButton,
+    quietDanger: styles.quietButton,
+  }[variant];
+  const text = {
+    primary: styles.lightText,
+    default: styles.defaultText,
+    quiet: styles.quietText,
+    quietDanger: styles.quietDangerText,
+  }[variant];
   return (
     <TouchableOpacity
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityState={{ disabled }}
       onPress={disabled ? undefined : onPress}
-      style={[styles.smallButton, variantStyle, disabled && styles.disabled]}
+      style={[styles.smallButton, bg, block && styles.blockButton, disabled && styles.disabled]}
       testID={testID}
     >
-      <Text style={[styles.smallButtonText, variantText]}>{label}</Text>
+      <Text style={[styles.smallButtonText, text]}>{label}</Text>
     </TouchableOpacity>
   );
 };
@@ -591,20 +603,28 @@ const styles = StyleSheet.create({
   systemBadgeText: { fontSize: 11, color: colors.text.secondaryAccessible, fontWeight: '500' },
   description: { color: colors.text.secondaryAccessible, fontSize: 13, lineHeight: 18 },
   summary: { color: colors.text.secondaryAccessible, fontSize: 12, fontStyle: 'italic' },
-  rowActions: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs, marginTop: SPACING.xs },
+  // One primary "Use this" per row; the rest are quiet text-links beneath it.
+  secondaryActions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: SPACING.md,
+    marginTop: SPACING.xs,
+  },
   smallButton: {
-    paddingVertical: SPACING.xs,
+    minHeight: 44,
     paddingHorizontal: SPACING.sm,
     borderRadius: BORDER_RADIUS.sm,
-    minHeight: 32,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  defaultButton: { backgroundColor: colors.background.accent },
-  primaryButton: { backgroundColor: colors.primary },
-  dangerButton: { backgroundColor: colors.danger },
+  blockButton: { alignSelf: 'stretch', marginTop: SPACING.xs },
+  defaultButton: { backgroundColor: colors.background.accent, paddingHorizontal: SPACING.md },
+  primaryButton: { backgroundColor: colors.primary, paddingHorizontal: SPACING.md },
+  quietButton: { backgroundColor: 'transparent', paddingHorizontal: 0 },
   defaultText: { color: colors.text.primary, fontSize: 13, fontWeight: '500' },
-  lightText: { color: colors.text.light, fontSize: 13, fontWeight: '600' },
+  lightText: { color: colors.text.light, fontSize: 14, fontWeight: '600' },
+  quietText: { color: colors.text.secondaryAccessible, fontSize: 13, fontWeight: '500' },
+  quietDangerText: { color: colors.danger, fontSize: 13, fontWeight: '500' },
   smallButtonText: {},
   disabled: { opacity: 0.4 },
 });

--- a/frontend/src/features/Practice/recipes/__tests__/RecipePickerModal.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/RecipePickerModal.test.tsx
@@ -101,6 +101,21 @@ describe('RecipePickerModal', () => {
     expect(utils.queryByTestId('recipe-row-2-fork')).toBeNull();
   });
 
+  it('keeps an accessible role + label on the primary and secondary row actions', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.getByTestId('recipe-row-2')).toBeTruthy());
+    for (const [testID, label] of [
+      ['recipe-row-2-apply', 'Use this'],
+      ['recipe-row-2-edit', 'Edit'],
+      ['recipe-row-2-delete', 'Delete'],
+      ['recipe-row-1-fork', 'Edit a copy'],
+    ] as const) {
+      const node = utils.getByTestId(testID);
+      expect(node.props.accessibilityRole).toBe('button');
+      expect(node.props.accessibilityLabel).toBe(label);
+    }
+  });
+
   it('applies a recipe and closes the picker', async () => {
     const utils = mountPicker();
     await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());


### PR DESCRIPTION
## Summary

practice-redesign-09: a minimalist visual + interaction pass over the two recipe modals to match the #602 language — **layout/affordance/spacing only, no behaviour change**.

- **Picker rows** (`RecipePickerModal`): each row leads with one prominent full-width **"Use this"**; the secondary actions (Edit / Edit a copy / Delete) drop to a **quiet de-emphasised text-link cluster** instead of four equal buttons (`RowButton` gained `quiet`/`quietDanger` + `block` variants). System badge + summary line unchanged; tap targets ≥44dp.
- **Editor** (`RecipeEditorModal`): metadata (name/description/rounds) grouped above the steps; each step card's reorder ↑/↓ + remove are **de-emphasised** (quiet, right-aligned), and **"+ Add step"** is the single prominent (outlined-primary) add.
- Tokens only throughout.

**No behaviour change**: `apply(recipe.id, userPracticeId)`, `remove(recipe.id)`, `create(payload)`, `update(recipeId, payload)` fire from the same handlers; `moveStep`/`removeStep`/`appendStep`, `TagPicker`, `SearchableDropdown`, and the recipe data model are untouched; all testIDs + `accessibilityRole`/`Label` preserved.

## Test plan

Picker + editor behaviour assertions retained (apply/remove/create/update, append/move/remove steps); added an assertion that the new row actions keep their roles/labels. **33 recipe tests pass.**

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #625
Refs #595
