### PR TITLE
feat(frontend): make practice sharing real — wire the ShareSheet into detail

### DIFF
--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -24,6 +24,7 @@ import type { ModeConfig } from '../engine/types';
 import { type PracticeItem, practices, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import ShareSheet from '@/features/Practice/components/ShareSheet';
 import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import type { RootStackParamList } from '@/navigation/RootStack';
@@ -63,6 +64,56 @@ function initialState(): ScreenState {
  * ``userPractices.create``; "Customize a copy" replays the wizard with
  * this practice's mode_config pre-filled.
  */
+/** The loaded detail view (practice guaranteed non-null); owns the share sheet. */
+function LoadedDetail({
+  props,
+  state,
+  practice,
+  currentStage,
+}: {
+  props: PracticeDetailScreenProps;
+  state: PracticeDetailHook;
+  practice: PracticeItem;
+  currentStage: number;
+}): React.JSX.Element {
+  const [shareOpen, setShareOpen] = useState(false);
+  return (
+    <ScrollView contentContainerStyle={styles.body} testID="practice-detail-screen">
+      <DetailHeader practice={practice} />
+      <DetailBody practice={practice} />
+      {state.actionError !== null && (
+        <Text style={styles.errorText} testID="practice-detail-action-error">
+          {state.actionError}
+        </Text>
+      )}
+      {state.assignedStage !== null && (
+        <View style={styles.banner} testID="practice-detail-assigned-banner">
+          <Text style={styles.bannerText}>Set as your stage {state.assignedStage} practice.</Text>
+        </View>
+      )}
+      <ActionRow
+        practice={practice}
+        onUseForCurrentStage={() => void state.assign(currentStage)}
+        onUseForStage={state.openPicker}
+        onCustomizeCopy={() => navigateToCopy(props, practice)}
+        onShare={() => setShareOpen(true)}
+      />
+      {state.pickerOpen && (
+        <StagePicker
+          assigning={state.assigning}
+          onPick={state.assign}
+          onClose={state.closePicker}
+        />
+      )}
+      <ShareSheet
+        visible={shareOpen}
+        practiceId={practice.id}
+        onClose={() => setShareOpen(false)}
+      />
+    </ScrollView>
+  );
+}
+
 export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JSX.Element {
   const { practiceId } = props.route.params;
   const state = usePracticeDetail(practiceId);
@@ -80,33 +131,12 @@ export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JS
     );
   }
   return (
-    <ScrollView contentContainerStyle={styles.body} testID="practice-detail-screen">
-      <DetailHeader practice={state.practice} />
-      <DetailBody practice={state.practice} />
-      {state.actionError !== null && (
-        <Text style={styles.errorText} testID="practice-detail-action-error">
-          {state.actionError}
-        </Text>
-      )}
-      {state.assignedStage !== null && (
-        <View style={styles.banner} testID="practice-detail-assigned-banner">
-          <Text style={styles.bannerText}>Set as your stage {state.assignedStage} practice.</Text>
-        </View>
-      )}
-      <ActionRow
-        practice={state.practice}
-        onUseForCurrentStage={() => void state.assign(currentStage)}
-        onUseForStage={state.openPicker}
-        onCustomizeCopy={() => navigateToCopy(props, state.practice!)}
-      />
-      {state.pickerOpen && (
-        <StagePicker
-          assigning={state.assigning}
-          onPick={state.assign}
-          onClose={state.closePicker}
-        />
-      )}
-    </ScrollView>
+    <LoadedDetail
+      props={props}
+      state={state}
+      practice={state.practice}
+      currentStage={currentStage}
+    />
   );
 }
 
@@ -313,6 +343,7 @@ interface ActionRowProps {
   onUseForCurrentStage: () => void;
   onUseForStage: () => void;
   onCustomizeCopy: () => void;
+  onShare: () => void;
 }
 
 const ActionRow = ({
@@ -320,6 +351,7 @@ const ActionRow = ({
   onUseForCurrentStage,
   onUseForStage,
   onCustomizeCopy,
+  onShare,
 }: ActionRowProps): React.JSX.Element => (
   // ``Edit`` / ``Delete`` are owner-only per the issue spec, but the
   // ``GET /practices/{id}`` response intentionally drops the submitter id
@@ -347,6 +379,12 @@ const ActionRow = ({
       testID="practice-detail-customize-copy"
       accessibilityLabel="Duplicate this practice into a new, editable copy"
       disabled={practice.mode_config === undefined}
+    />
+    <ActionButton
+      label="Share"
+      onPress={onShare}
+      testID="practice-detail-share"
+      accessibilityLabel="Share this practice with a link"
     />
   </View>
 );

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -49,6 +49,15 @@ jest.mock('@/api', () => ({
   },
 }));
 
+// Stub the ShareSheet — its mint/revoke behaviour is covered by its own test;
+// here we only assert the Share action mounts it (visible).
+jest.mock('@/features/Practice/components/ShareSheet', () => {
+  const { Text } = require('react-native');
+  const Stub = ({ visible }: { visible: boolean }) =>
+    visible ? <Text testID="share-sheet">share-sheet</Text> : null;
+  return { __esModule: true, default: Stub };
+});
+
 const { PracticeDetailScreen } = require('../PracticeDetailScreen');
 
 interface NavMock {
@@ -162,6 +171,15 @@ describe('PracticeDetailScreen — Use for stage', () => {
       stage_number: 4,
     });
     expect(view.getByTestId('practice-detail-assigned-banner')).toBeTruthy();
+  });
+
+  it('opens the share sheet from the Share action', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.queryByTestId('share-sheet')).toBeNull();
+    fireEvent.press(view.getByTestId('practice-detail-share'));
+    expect(view.getByTestId('share-sheet')).toBeTruthy();
   });
 
   it('surfaces an action error if assignment fails', async () => {


### PR DESCRIPTION
## Summary

practice-redesign-10: `ShareSheet` was fully built (mints/revokes links via the `practiceShare` client) but **had no caller** — sharing was dead code with no entry point. Decision gate: the `practiceShare` client + backend share endpoints both exist on this branch, so this takes the **wire path** (not deletion).

- Add a discoverable **Share** action to `PracticeDetailScreen`'s action row (`testID practice-detail-share`), alongside the #600 Use/Customize/Duplicate verbs, wired to a `shareOpen` state that renders `<ShareSheet visible practiceId={practice.id} onClose=… />`.
- Extracted the loaded view into a `LoadedDetail` sub-component (owns `shareOpen`) so the screen stays within the line/complexity budget.

`ShareSheet` itself was already built to the #602 language and fully token-based (drag-handle sheet, calm header, grouped mint form, links list with a quiet **Copy/Revoke** pair), so it needed no cosmetic churn — the missing piece was the entry point. Its `practiceShare.list`/`create`/`revoke` calls are unchanged. **No dead, unreferenced share code remains.**

## Test plan

`PracticeDetailScreen.test.tsx` — the Share action opens the sheet; `ShareSheet`'s own mint/revoke/copy behaviour stays covered by its suite (31 tests across the two).

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #626
Refs #595
