### PR TITLE
refactor(frontend): add a dedicated subtle-divider colour token

### DIFF
--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -35,6 +35,11 @@ describe('design tokens', () => {
       expect(colors.background.accent).toBe('#f0f0f0');
     });
 
+    it('exposes a separator token matching the legacy divider value (no visual change)', () => {
+      expect(colors.separator).toBe('#f0f0f0');
+      expect(colors.separator).toBe(colors.background.accent);
+    });
+
     it('exports text shades', () => {
       expect(colors.text.primary).toBe('#333333');
       expect(colors.text.secondary).toBe('#666666');

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -89,6 +89,10 @@ export const colors = {
   successText: '#2e7d32',
 
   border: '#ddd',
+  // Hairline separator between stacked rows/sections. Same value as
+  // ``background.accent`` (which it replaced as a divider colour) — a clearer
+  // name so a ``borderBottomColor`` reads as a divider, not a reused background.
+  separator: '#f0f0f0',
 
   /**
    * Bevel palette for recessed (sunken) controls. React Native has no

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -901,7 +901,7 @@ const styles = StyleSheet.create({
     paddingBottom: SPACING.lg,
     marginBottom: SPACING.lg,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.background.accent,
+    borderBottomColor: colors.separator,
   },
   cardHeader: {
     flexDirection: 'row',

--- a/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
+++ b/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
@@ -377,7 +377,7 @@ const styles = StyleSheet.create({
     paddingTop: SPACING.lg,
     paddingBottom: SPACING.md,
     borderBottomWidth: 1,
-    borderBottomColor: colors.background.accent,
+    borderBottomColor: colors.separator,
     gap: SPACING.sm,
   },
   headerTitle: { fontSize: 18, fontWeight: '700', color: colors.text.primary },
@@ -390,7 +390,7 @@ const styles = StyleSheet.create({
     color: colors.text.primary,
     paddingVertical: SPACING.xs,
     borderBottomWidth: 1,
-    borderBottomColor: colors.background.accent,
+    borderBottomColor: colors.separator,
   },
   aspectChip: {
     paddingHorizontal: SPACING.sm,

--- a/frontend/src/features/Practice/recipes/RecipeEditorModal.tsx
+++ b/frontend/src/features/Practice/recipes/RecipeEditorModal.tsx
@@ -709,7 +709,7 @@ const styles = StyleSheet.create({
     paddingTop: SPACING.lg,
     paddingBottom: SPACING.sm,
     borderBottomWidth: 1,
-    borderBottomColor: colors.background.accent,
+    borderBottomColor: colors.separator,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',

--- a/frontend/src/features/Practice/recipes/RecipePickerModal.tsx
+++ b/frontend/src/features/Practice/recipes/RecipePickerModal.tsx
@@ -553,7 +553,7 @@ const styles = StyleSheet.create({
     paddingTop: SPACING.lg,
     paddingBottom: SPACING.sm,
     borderBottomWidth: 1,
-    borderBottomColor: colors.background.accent,
+    borderBottomColor: colors.separator,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',


### PR DESCRIPTION
## Summary

Hairline dividers reused `colors.background.accent` (`#f0f0f0`, semantically an accent *background*) as a `borderBottomColor` — works visually but the name misleads (surfaced in the #602 review).

- Add `colors.separator` (`#f0f0f0` — **same value**, clearer name) to `design/tokens.ts`.
- Repoint the 5 divider usages (active practice card + the two recipe modals + the configurator sheet) from `background.accent` to `colors.separator`.

**No visual change** (identical value). The `borderColor` control-outline usages of `background.accent` are intentionally left — they're outlines, not dividers, and repointing them to a separator/border token would change semantics or value.

## Test plan

`tokens.test.ts` asserts `colors.separator` exists and equals the legacy divider value (`background.accent`).

`./scripts/frontend/check-all.sh` — 4/4 (lint, tsc, format, tests).

Closes #641
Refs #595
