### PR TITLE
test(backend): cover the marginalia owner invariant at the write layer

### DIFF
--- a/backend/tests/test_resonance_endpoints.py
+++ b/backend/tests/test_resonance_endpoints.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
+from models.journal_entry import JournalEntry
 from models.marginalia import Marginalia
 from models.user import User
 from services import marginalia as marginalia_service
@@ -59,6 +60,41 @@ def _raise_llm(monkeypatch: pytest.MonkeyPatch) -> None:
         raise LLMProviderError("provider down")
 
     monkeypatch.setattr(marginalia_service, "generate_response", _boom)
+
+
+@pytest.mark.asyncio
+async def test_persisted_marginalia_user_id_matches_entry_owner(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Owner invariant: a note's user_id is derived from the entry owner server-side.
+
+    The client never supplies it, so every persisted marginalia.user_id equals the
+    entry's user_id.
+    """
+    _fake_llm(
+        monkeypatch,
+        {"kind": "theme", "quote": "I walked by the river", "note": "You return to water."},
+    )
+    headers = await _signup(async_client, "owner")
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+    entry = (
+        await db_session.execute(select(JournalEntry).where(col(JournalEntry.id) == entry_id))
+    ).scalar_one()
+    rows = (
+        (
+            await db_session.execute(
+                select(Marginalia).where(col(Marginalia.journal_entry_id) == entry_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows
+    assert all(note.user_id == entry.user_id for note in rows)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

journal-resonance follow-up (#643). The enforcement this issue asked for **already landed** across prior PRs:
- **Anchor bounds** — the `Marginalia` model carries DB CHECKs (`anchor_start >= 0`, `anchor_end > anchor_start`), with rejection tests in `test_marginalia_model.py` (`test_negative_anchor_start_is_rejected`, `test_inverted_anchor_span_is_rejected`).
- **Owner derivation** — the resonance endpoint sets `user_id` from the authenticated owner of the loaded entry; another user's entry → 404 with no rows (`test_resonance_other_users_entry_is_404`).

The one acceptance criterion without explicit coverage was the **owner invariant itself**. This adds a test that, after a successful resonance pass, every persisted `marginalia.user_id` equals the entry's `user_id` — proving `user_id` is derived server-side from the owner, never the client.

(There is no client-supplied-anchor write path — anchors come from the server-side `generate_marginalia`, located verbatim in the entry body — so the "reject invalid spans with 422" path has no client entry point; the DB CHECKs are the defense-in-depth guard.)

## Test plan

`test_persisted_marginalia_user_id_matches_entry_owner` — asserts `marginalia.user_id == entry.user_id` for all persisted notes.

`./scripts/backend/check-all.sh` — 7/7 (incl. coverage); mypy clean (tests too).

Closes #643
Refs #603
Refs #604
