### PR TITLE
fix(backend): align journal GET/DELETE to 404 for other-user (match PATCH)

### DIFF
--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -87,10 +87,8 @@ async def require_owned_journal_entry(
 
     BUG-JOURNAL-007: soft-deleted rows are treated as non-existent (404)
     so a user cannot GET or DELETE an entry they already deleted.
-    BUG-JOURNAL-006: the ownership check uses the identity-map result from
-    the primary-key lookup; a future refactor should push the ``user_id``
-    filter into the WHERE clause, but the existing pattern is preserved here
-    to avoid touching more files than Prompt 12B owns.
+    Another user's entry is also collapsed to 404 (not 403) so GET/DELETE match
+    PATCH's enumeration-safe contract — the cross-user probe is still audited.
     """
     result = await session.execute(
         select(JournalEntry).where(
@@ -103,7 +101,7 @@ async def require_owned_journal_entry(
         raise not_found("journal_entry")
     if entry.user_id != current_user:
         log_ownership_denied("journal_entry", entry_id, current_user)
-        raise forbidden("forbidden")
+        raise not_found("journal_entry")
     return entry
 
 

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -223,8 +223,9 @@ async def get_journal_entry(
 ) -> JournalEntry:
     """Return a single journal entry by ID, scoped to the authenticated user.
 
-    Ownership is verified by ``require_owned_journal_entry``: 404 when the
-    row does not exist, 403 when it exists but belongs to another user.
+    Ownership is verified by ``require_owned_journal_entry``: 404 when the row
+    does not exist *or* belongs to another user (enumeration-safe, matching
+    PATCH and DELETE).
     """
     return entry
 

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -10,7 +10,9 @@ Per the BUG-T7 remediation (prompt ``07-normalize-idor-ordering``):
 
 - Genuinely missing rows still 404 (sibling tests in each
   ``test_<resource>_api.py``).
-- Rows that exist but belong to another user 403, never 404.
+- Rows that exist but belong to another user 403, never 404 — EXCEPT the
+  enumeration-safe resources (goals, marginalia, and journal entries) which
+  deliberately collapse the cross-user branch to 404 on every method.
 - Course content is a shared catalog rather than a per-user resource;
   its enumeration oracle (BUG-COURSE-004) is closed by masking the
   locked branch as 404 instead.  That mask is asserted in
@@ -203,8 +205,11 @@ async def test_idor_habit_stats_returns_403(async_client: AsyncClient) -> None:
     assert resp.status_code == HTTPStatus.FORBIDDEN
 
 
+# Journal entries are the deliberate exception to the 403-everywhere rule: GET,
+# DELETE, and PATCH all collapse a cross-user probe to 404 (enumeration-safe),
+# matching the goal/marginalia contract.
 @pytest.mark.asyncio
-async def test_idor_journal_entry_get_returns_403(async_client: AsyncClient) -> None:
+async def test_idor_journal_entry_get_returns_404(async_client: AsyncClient) -> None:
     alice_headers, _ = await _signup(async_client, "alice_j_get")
     bob_headers, _ = await _signup(async_client, "bob_j_get")
 
@@ -214,11 +219,11 @@ async def test_idor_journal_entry_get_returns_403(async_client: AsyncClient) -> 
     entry_id = create.json()["id"]
 
     resp = await async_client.get(f"/journal/{entry_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
 @pytest.mark.asyncio
-async def test_idor_journal_entry_delete_returns_403(async_client: AsyncClient) -> None:
+async def test_idor_journal_entry_delete_returns_404(async_client: AsyncClient) -> None:
     alice_headers, _ = await _signup(async_client, "alice_j_del")
     bob_headers, _ = await _signup(async_client, "bob_j_del")
 
@@ -228,7 +233,7 @@ async def test_idor_journal_entry_delete_returns_403(async_client: AsyncClient) 
     entry_id = create.json()["id"]
 
     resp = await async_client.delete(f"/journal/{entry_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -352,7 +352,7 @@ async def test_user_cannot_see_other_users_entries(async_client: AsyncClient) ->
 
 @pytest.mark.asyncio
 async def test_user_cannot_get_other_users_entry(async_client: AsyncClient) -> None:
-    """BUG-T7: cross-user GET returns 403 (was 404).  See ``tests/security/test_idor.py``."""
+    """Cross-user GET returns 404 (enumeration-safe), matching PATCH."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
 
@@ -362,12 +362,12 @@ async def test_user_cannot_get_other_users_entry(async_client: AsyncClient) -> N
     entry_id = create_resp.json()["id"]
 
     resp = await async_client.get(f"/journal/{entry_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
 @pytest.mark.asyncio
 async def test_user_cannot_delete_other_users_entry(async_client: AsyncClient) -> None:
-    """BUG-T7: cross-user DELETE returns 403 (was 404)."""
+    """Cross-user DELETE returns 404 (enumeration-safe), matching PATCH."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
 
@@ -377,7 +377,7 @@ async def test_user_cannot_delete_other_users_entry(async_client: AsyncClient) -
     entry_id = create_resp.json()["id"]
 
     resp = await async_client.delete(f"/journal/{entry_id}", headers=bob_headers)
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
 # ── Length and search bounds ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

journal-resonance follow-up (#646). `PATCH /journal/{id}` returns **404** for another user's entry (enumeration-safe), but `GET`/`DELETE` returned **403** via `require_owned_journal_entry` — same resource, inconsistent contract.

Collapse the ownership mismatch in `require_owned_journal_entry` to **404** (the cross-user probe is still audited via `log_ownership_denied`), matching the **goal/marginalia precedent already in this module**. Both GET and DELETE go through that dependency, so they align at once; PATCH already 404s.

- `ownership.py`: ownership mismatch raises `not_found` (was `forbidden`); docstring updated. `forbidden` stays imported (other resource deps still 403).
- journal GET docstring notes 404 for missing-or-other-user.
- Tests: the IDOR matrix journal cases now expect 404 (header updated to note goals/marginalia/journal as the deliberate enumeration-safe exceptions to the 403 rule); the `journal_api` cross-user GET/DELETE tests assert 404.

## Test plan

GET/DELETE/PATCH on another user's entry all return 404 (`test_idor.py`, `test_journal_api.py`, `test_journal_patch.py`).

`./scripts/backend/check-all.sh` — 7/7 (incl. coverage); mypy clean.

Closes #646
Refs #603
Refs #606
