### PR TITLE
fix(frontend): journal load failures + Get Resonance overlap

### DIFF
--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -189,4 +189,21 @@ describe('formatApiError', () => {
     const err = new Error('SecureStore is not available on this device.');
     expect(formatApiError(err)).toBe('SecureStore is not available on this device.');
   });
+
+  // A failed ``fetch`` rejects with a TypeError whose message differs by engine:
+  // "Load failed" (iOS Safari/WebKit), "Failed to fetch" (Chrome/Blink),
+  // "NetworkError when attempting to fetch resource." (Firefox), "Network
+  // request failed" (React Native). These are cryptic — surface the friendly
+  // offline copy instead of leaking the raw engine string to users.
+  it.each([
+    ['Load failed'],
+    ['Failed to fetch'],
+    ['NetworkError when attempting to fetch resource.'],
+    ['Network request failed'],
+    ['The network connection was lost.'],
+  ])('maps the fetch network TypeError %p to friendly offline copy', (message) => {
+    const result = formatApiError(new TypeError(message));
+    expect(result).not.toBe(message); // never leak the raw engine string
+    expect(result).toMatch(/offline/i);
+  });
 });

--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -201,6 +201,7 @@ describe('formatApiError', () => {
     ['NetworkError when attempting to fetch resource.'],
     ['Network request failed'],
     ['The network connection was lost.'],
+    ['The Internet connection appears to be offline.'],
   ])('maps the fetch network TypeError %p to friendly offline copy', (message) => {
     const result = formatApiError(new TypeError(message));
     expect(result).not.toBe(message); // never leak the raw engine string

--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -270,6 +270,19 @@ describe('journalListResponseSchema validation', () => {
     expect(() => journalListResponseSchema.parse({ items: [message], total: 1 })).toThrow();
   });
 
+  it('accepts a weekly_prompt-tagged entry (created by prompts.respond)', () => {
+    // Regression: responding to a weekly prompt creates a journal entry tagged
+    // ``weekly_prompt`` server-side (routers/prompts.py). The shelf list then
+    // includes that row, so the tag enum must accept it — otherwise the whole
+    // page fails Zod validation and the user sees "Load failed".
+    const parsed = journalListResponseSchema.parse({
+      items: [{ ...message, tag: 'weekly_prompt' }],
+      total: 1,
+      has_more: false,
+    });
+    expect(parsed.items[0]?.tag).toBe('weekly_prompt');
+  });
+
   it('rejects an unknown sender', () => {
     expect(() =>
       journalListResponseSchema.parse({

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -225,6 +225,29 @@ function isValidation(err: unknown): boolean {
 }
 
 /**
+ * A failed ``fetch`` rejects with a ``TypeError`` whose message differs by
+ * engine: "Load failed" (iOS Safari/WebKit), "Failed to fetch" (Chrome/Blink),
+ * "NetworkError when attempting to fetch resource." (Firefox), "Network request
+ * failed" (React Native), "The network connection was lost." (iOS). These are
+ * cryptic engine strings that must never reach the user verbatim — most often a
+ * dropped connection mid-response (e.g. a large journal list on weak signal).
+ */
+const FETCH_NETWORK_MESSAGE_FRAGMENTS = [
+  'load failed',
+  'failed to fetch',
+  'networkerror',
+  'network request failed',
+  'network connection was lost',
+  'connection appears to be offline',
+] as const;
+
+function isFetchNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error) || err.name !== 'TypeError') return false;
+  const message = err.message.toLowerCase();
+  return FETCH_NETWORK_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment));
+}
+
+/**
  * Universal ``unknown`` → user-facing-string converter. Handles:
  *
  *  - ``ApiTimeoutError`` — timeout-specific copy before status/detail mapping
@@ -247,6 +270,9 @@ function isValidation(err: unknown): boolean {
 function classifyNetworkError(err: unknown): string | undefined {
   if (isTimeout(err)) return TIMEOUT_MESSAGE;
   if (isValidation(err)) return VALIDATION_MESSAGE;
+  // A raw fetch failure (TypeError) — show the same friendly offline copy as an
+  // explicit ``network_error`` rather than leaking the engine's debug string.
+  if (isFetchNetworkError(err)) return USER_FACING_ERROR_MESSAGES.network_error;
   return undefined;
 }
 

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -233,6 +233,11 @@ export const journalTagSchema = z.enum([
   'stage_reflection',
   'practice_note',
   'habit_note',
+  // Responding to a weekly prompt creates a journal entry tagged
+  // ``weekly_prompt`` (backend ``JournalTag.WEEKLY_PROMPT``). The shelf list
+  // includes that row, so the enum must accept it — otherwise the whole page
+  // fails Zod validation and the user sees "Load failed".
+  'weekly_prompt',
 ]);
 
 /** One journal message (mirrors the backend ``JournalMessage`` response). */

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -7,7 +7,22 @@
  */
 import { StyleSheet } from 'react-native';
 
-import { colors, editorialType, journalLayout, spacing } from '@/design/tokens';
+import {
+  SPACING,
+  colors,
+  editorialType,
+  journalLayout,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
+
+/**
+ * Bottom inset reserving room for the floating "Get Resonance" button so page
+ * content (the save hint, Finish link, and the stacked margin column on narrow
+ * screens) never renders underneath it. Mirrors the button's own offset
+ * (``bottom: SPACING.xl``) plus its height plus a small breathing gap.
+ */
+export const RESONANCE_BUTTON_CLEARANCE = SPACING.xl + touchTarget.minimum + SPACING.md;
 
 const styles = StyleSheet.create({
   safeArea: {
@@ -22,6 +37,8 @@ const styles = StyleSheet.create({
     maxWidth: journalLayout.pageMaxWidth + journalLayout.marginColumnWidth,
     alignSelf: 'center',
     paddingHorizontal: journalLayout.pageHorizontalPadding,
+    // Keep content clear of the floating Get Resonance button (overlap fix).
+    paddingBottom: RESONANCE_BUTTON_CLEARANCE,
   },
   pageNarrow: {
     flexDirection: 'column',

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -37,7 +37,6 @@ const styles = StyleSheet.create({
     maxWidth: journalLayout.pageMaxWidth + journalLayout.marginColumnWidth,
     alignSelf: 'center',
     paddingHorizontal: journalLayout.pageHorizontalPadding,
-    // Keep content clear of the floating Get Resonance button (overlap fix).
     paddingBottom: RESONANCE_BUTTON_CLEARANCE,
   },
   pageNarrow: {

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -593,7 +593,7 @@ function JournalPage({
   else marginContent = <ResonanceMargin count={0} error={ctl.resonance.error} />;
 
   return (
-    <View style={[styles.page, narrow && styles.pageNarrow]}>
+    <View style={[styles.page, narrow && styles.pageNarrow]} testID="journal-page">
       {editMode ? (
         <WritingColumn
           title={title}

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -2,6 +2,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { RESONANCE_BUTTON_CLEARANCE } from '../JournalEntry.styles';
 
 import type { JournalMessage } from '@/api';
 
@@ -143,6 +146,12 @@ describe('JournalEntryScreen', () => {
     const { getByTestId } = renderScreen(undefined, { renderMargin });
     expect(getByTestId('journal-margin-column')).toBeTruthy();
     expect(renderMargin).toHaveBeenCalled();
+  });
+
+  it('reserves bottom clearance so the floating Get Resonance button never overlaps content', () => {
+    const { getByTestId } = renderScreen();
+    const page = StyleSheet.flatten(getByTestId('journal-page').props.style);
+    expect(page.paddingBottom).toBe(RESONANCE_BUTTON_CLEARANCE);
   });
 
   it('autosaves once after the debounce when the body changes', async () => {


### PR DESCRIPTION
## Summary

Reported: "Lots of load fails on the journal feature. It's also messed up with things overlapping one another." Following the bug-squashing methodology (RCA → reproduce → TDD → verify), the two screenshots traced to **three distinct root causes**, each fixed in its own atomic commit with a failing-test-first cycle.

### 1. "Load failed" on the shelf — cryptic raw fetch error leaked to users
The weekly-prompt card loaded on the same screen, so it wasn't a total outage. **"Load failed" is iOS Safari's raw `fetch` `TypeError` message** when a connection drops mid-response — and the journal list is the largest response on that screen, so it's the most likely to be cut on weak signal. `formatApiError` fell through to `readableMessage` and surfaced that engine string verbatim.

**Fix:** classify fetch `TypeError`s (`Load failed` / `Failed to fetch` / `NetworkError…` / `Network request failed` / `The network connection was lost.`) as network errors and reuse the existing *"You appear to be offline. Check your connection and try again."* copy already used for the explicit `network_error` code.

### 2. Latent shelf-validation bug — `weekly_prompt` tag rejected
The backend tags weekly-prompt responses `weekly_prompt` (`JournalTag.WEEKLY_PROMPT`, `routers/prompts.py`), but the frontend Zod `journalTagSchema` only allowed `freeform` / `stage_reflection` / `practice_note` / `habit_note`. Once a user answers **any** weekly prompt, `journal.list` fails Zod validation and the whole shelf errors instead of rendering entries. A week-7 user (six prior prompts) is squarely in this case.

**Fix:** add `weekly_prompt` to the enum so these entries round-trip.

### 3. Overlapping UI — floating button on top of content
The "Get Resonance" button is absolutely positioned bottom-right, but the page reserved no space for it. On a narrow phone the margin column (carrying the *"Write a little first, then ask for its resonance"* hint) stacks under the writing column at the bottom of the screen, so the floating button rendered directly on top of it.

**Fix:** reserve a bottom inset (`RESONANCE_BUTTON_CLEARANCE` = button offset + height + gap) so the save hint, Finish link, and stacked margin column all clear the button.

> Note on "Couldn't save" in the editor screenshot: that's the autosave's own hardcoded copy (*"…we'll retry"*), triggered by the same kind of dropped request — it already retries on the next keystroke, so no separate change was warranted.

## Testing
TDD throughout (failing test first, then green):
- **jest:** 272 passing across `src/api` + `src/features/Journal`, including new cases for each fix
- **tsc** `--noEmit`, **eslint**, **prettier** — all clean

Pre-commit/pre-push hooks could not initialize in the web session (GitHub hook-repo fetches return 403 under the egress policy — not routed around per the proxy README); the equivalent gates were run manually as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3oQBetaYmJ1v2Yw73dX87)_