### PR TITLE
fix: re-sync program anchor from habits on every load

### DIFF
--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -497,6 +497,66 @@ describe('habitManager', () => {
       expect(saveHabits).toHaveBeenCalled();
     });
 
+    it('re-anchors the universal program calendar to the earliest loaded habit start_date', async () => {
+      // Returning user: cache empty, the master anchor was wiped on logout,
+      // but the server still has the user's habits. The Habits screen derives
+      // each tile from its own ``start_date`` so it keeps progressing, but
+      // Map/Practice/Course/Journal read the program anchor — which only
+      // ``onboardingSave`` ever set. Without a reload-time re-sync the anchor
+      // stays null and those screens silently fall back to divergent values.
+      useProgramStore.getState().hydrateProgramStartDate(null);
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 1,
+          name: 'Survive',
+          icon: '\u{1F9D8}',
+          start_date: '2026-01-08',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [],
+        },
+        {
+          id: 2,
+          name: 'Belong',
+          icon: '\u{1F49C}',
+          start_date: '2026-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Purple',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      const anchor = useProgramStore.getState().programStartDate;
+      expect(anchor).not.toBeNull();
+      expect(anchor!.getFullYear()).toBe(2026);
+      expect(anchor!.getMonth()).toBe(0);
+      expect(anchor!.getDate()).toBe(1);
+    });
+
+    it('does NOT anchor the program calendar to the demo FALLBACK habits', async () => {
+      // Truly-fresh user: no cache, empty server. ``loadHabits`` seeds the
+      // hard-coded demo tiles (2025 dates) so the screen is not blank — but
+      // those are placeholders, not a real program start, so the master
+      // anchor must stay null and let every screen use its server fallback.
+      useProgramStore.getState().hydrateProgramStartDate(null);
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never);
+
+      await habitManager.loadHabits();
+
+      expect(useHabitStore.getState().habits.length).toBeGreaterThan(0);
+      expect(useProgramStore.getState().programStartDate).toBeNull();
+    });
+
     it('records an error message when the API fails and no cache exists', async () => {
       (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
       (habitsApi.listAll as jest.Mock).mockRejectedValueOnce(new Error('boom') as never);

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -296,7 +296,7 @@ const buildAddedHabit = (input: AddHabitInput, existingCount: number): Habit => 
 };
 
 /** Earliest habit start date (the program start); takes the min, not index 0, in case the list is unsorted. */
-const earliestStartDate = (habits: OnboardingHabit[]): Date | null => {
+const earliestStartDate = (habits: ReadonlyArray<{ start_date: Date }>): Date | null => {
   let earliest: number | null = null;
   for (const habit of habits) {
     const time = new Date(habit.start_date).getTime();
@@ -304,6 +304,31 @@ const earliestStartDate = (habits: OnboardingHabit[]): Date | null => {
     if (earliest === null || time < earliest) earliest = time;
   }
   return earliest === null ? null : new Date(earliest);
+};
+
+/** Same calendar day, ignoring time — the store normalises anchors to local midnight. */
+const sameCalendarDay = (a: Date, b: Date): boolean =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+/**
+ * Re-derive the universal program anchor from the live habits' earliest
+ * ``start_date``. Map, Practice, Course and Journal all read this anchor to
+ * compute the current week/stage; it is written at ``onboardingSave`` but only
+ * ``loadHabits`` runs on every session. Without this re-sync a returning user
+ * — whose persisted anchor was wiped on logout, or who onboarded before the
+ * anchor existed — keeps a calendar-correct Habits screen while every other
+ * screen falls back to a divergent server value. Recomputing on load keeps all
+ * screens in lockstep and self-heals a missing anchor. Skipped for the demo
+ * FALLBACK seed, whose placeholder dates are not a real program start.
+ */
+const syncProgramAnchorFromHabits = (): void => {
+  const anchor = earliestStartDate(getHabits());
+  if (anchor === null) return;
+  const current = useProgramStore.getState().programStartDate;
+  if (current !== null && sameCalendarDay(current, anchor)) return;
+  useProgramStore.getState().setProgramStartDate(anchor);
 };
 
 const syncOnboardingHabits = async (fullHabits: ReturnType<typeof buildOnboardingHabits>) => {
@@ -417,42 +442,49 @@ const rescheduleAndPersist = (habit: Habit): Promise<void> => {
 const handleApiSuccess = async (
   apiHabits: Awaited<ReturnType<typeof habitsApi.list>>,
   hasCachedData: boolean,
-): Promise<void> => {
+): Promise<boolean> => {
   // Only seed FALLBACK when the user is truly fresh: no cache, no live store, no API.
   if (apiHabits.length === 0 && !hasCachedData && getHabits().length === 0) {
     setHabits(FALLBACK_HABITS);
-    return;
+    return true;
   }
   if (apiHabits.length > 0) {
     const mapped = mapApiHabits(apiHabits);
     setHabits(mapped);
     await persistHabits(mapped);
   }
+  return false;
 };
 
-const handleApiError = (err: unknown, hasCachedData: boolean): void => {
+const handleApiError = (err: unknown, hasCachedData: boolean): boolean => {
   console.error('Failed to load habits:', err);
   // Mirrors the live-store guard in ``handleApiSuccess`` for the error path.
-  if (hasCachedData || getHabits().length > 0) return;
+  if (hasCachedData || getHabits().length > 0) return false;
   setError(
     formatApiError(err, {
       fallback: "We couldn't load your habits. Check your connection, then pull down to try again.",
     }),
   );
   setHabits(FALLBACK_HABITS);
+  return true;
 };
 
-type FetchResult = { kind: 'ok'; count: number } | { kind: 'error' };
+// ``seededFallback`` is true only when the store now holds the demo FALLBACK
+// tiles — the caller skips the program-anchor sync so placeholder dates never
+// become a real program start.
+type FetchResult =
+  | { kind: 'ok'; count: number; seededFallback: boolean }
+  | { kind: 'error'; seededFallback: boolean };
 
 const fetchFromApi = async (hasCachedData: boolean): Promise<FetchResult> => {
   try {
     const apiHabits = await habitsApi.listAll();
-    await handleApiSuccess(apiHabits, hasCachedData);
+    const seededFallback = await handleApiSuccess(apiHabits, hasCachedData);
     setError(null);
-    return { kind: 'ok', count: apiHabits.length };
+    return { kind: 'ok', count: apiHabits.length, seededFallback };
   } catch (err) {
-    handleApiError(err, hasCachedData);
-    return { kind: 'error' };
+    const seededFallback = handleApiError(err, hasCachedData);
+    return { kind: 'error', seededFallback };
   }
 };
 
@@ -691,11 +723,13 @@ const loadHabits = async (tz?: string): Promise<void> => {
     setLoading(false);
   }
   const result = await fetchFromApi(hasCachedData);
+  let seededFallback = result.seededFallback;
   // Stuck-user recovery: cache has habits, server returned an empty list.
   // Push the cache back, then re-fetch so the store gets the server's ids.
   if (result.kind === 'ok' && result.count === 0 && hasCachedData) {
     await recoverStuckHabits(cached!);
     const refetch = await fetchFromApi(true);
+    seededFallback = refetch.seededFallback;
     // #286: the recovery push seeded default goal targets — replay any
     // cached customizations onto the fresh server goals.
     if (refetch.kind === 'ok') {
@@ -703,6 +737,10 @@ const loadHabits = async (tz?: string): Promise<void> => {
     }
   }
   setLoading(false);
+
+  // Keep Map/Practice/Course/Journal aligned with the now-current habits by
+  // re-deriving the shared program anchor from the real (non-demo) tiles.
+  if (!seededFallback) syncProgramAnchorFromHabits();
 
   // BUG-HABITS-007 + BUG-FE-HABIT-205 partial-success fix: replay pending
   // check-ins queued during offline, and when one fails mid-batch only re-


### PR DESCRIPTION
## Summary

Fixes a calendar synchronization bug where returning users or those who onboarded before the program anchor feature existed would see divergent dates across screens. The Habits screen would progress correctly (using each habit's `start_date`), but Map, Practice, Course, and Journal screens would fall back to a server value because the shared program anchor was null or stale.

## Changes

- **Added `syncProgramAnchorFromHabits()`**: Re-derives the universal program anchor from the earliest `start_date` across all loaded habits on every `loadHabits()` call. This keeps all screens in lockstep and self-heals a missing or stale anchor.

- **Added `sameCalendarDay()` helper**: Compares two dates at the calendar day level (ignoring time), matching the store's normalization to local midnight. Prevents unnecessary updates when the anchor is already correct.

- **Updated `handleApiSuccess()` and `handleApiError()`**: Now return a boolean flag (`seededFallback`) indicating whether the store was populated with demo FALLBACK tiles. This allows the caller to skip anchor sync for placeholder data.

- **Updated `FetchResult` type**: Added `seededFallback` field to both success and error variants, propagated through the fetch/recovery flow.

- **Conditional anchor sync in `loadHabits()`**: Only calls `syncProgramAnchorFromHabits()` when real habits are loaded, never for the demo FALLBACK seed. This prevents placeholder 2025 dates from becoming a real program start.

- **Added comprehensive test coverage**: Two new tests verify that:
  1. The anchor is correctly re-derived from the earliest habit `start_date` on load
  2. The anchor remains null when only demo FALLBACK habits are seeded

## Implementation Details

- The anchor sync is skipped entirely if the store already holds the correct calendar day, avoiding unnecessary writes.
- The logic respects the existing "truly fresh user" guard: only seeds FALLBACK when cache is empty, live store is empty, and API returns nothing.
- Recovery path (stuck-user re-fetch) also tracks `seededFallback` to ensure anchor sync is only applied to real data.

https://claude.ai/code/session_01TcyRphhpXzFjMnmP6x7zsi