### PR TITLE
docs(prompts): add journal floating-page depth epic & sub-issues

### DIFF
--- a/prompts/github-issues/README.md
+++ b/prompts/github-issues/README.md
@@ -268,3 +268,33 @@ Dependency graph:
 02 mindful-anchor-mode ───┬── 04 mindful-anchor-presets
                           └── 06 mindful-anchor-view-frontend
 ```
+
+### Journal floating-page depth & editorial polish
+
+Make the journal **feel like writing on a sheet of paper floated above a
+desk** — margins, a soft warm shadow, lifted marginalia, a floated shelf, and
+reduced-motion-safe micro-interactions — instead of the current flat surface
+where page and background share one colour. Frontend-only; tokens-driven; zero
+behaviour/contrast regressions.
+
+| # | Issue | Scope | Est. LoC |
+|---|-------|-------|----------|
+| — | [Epic tracker](journal-depth-epic.md) | — | — |
+| 01 | [Add editorial elevation tokens (desk + paper shadow)](journal-depth-01-elevation-tokens.md) | Frontend | ~120 |
+| 02 | [Float the writing surface as a paper sheet](journal-depth-02-floating-writing-sheet.md) | Frontend | ~160 |
+| 03 | [Add a ruled margin & page edge to the sheet](journal-depth-03-ruled-margins-and-texture.md) | Frontend | ~120 |
+| 04 | [Lift the marginalia notes off the page](journal-depth-04-lift-marginalia-notes.md) | Frontend | ~110 |
+| 05 | [Float the shelf entries as paper cards](journal-depth-05-floating-shelf-cards.md) | Frontend | ~170 |
+| 06 | [Add depth-reinforcing motion (reduced-motion safe)](journal-depth-06-motion-and-micro-interactions.md) | Frontend | ~140 |
+
+Dependency graph:
+
+```
+                 ┌── 02 floating-writing-sheet ──┐
+                 │                                │
+01 elevation ────┼── 03 ruled-margins-texture ───┼── 06 motion-&-micro-interactions
+   tokens        │      (also depends on 02)      │
+                 ├── 04 lift-marginalia-notes ────┤
+                 │                                │
+                 └── 05 floating-shelf-cards ─────┘
+```

--- a/prompts/github-issues/journal-depth-01-elevation-tokens.md
+++ b/prompts/github-issues/journal-depth-01-elevation-tokens.md
@@ -1,0 +1,123 @@
+# journal-depth-01: Add editorial elevation tokens (desk ground + paper shadow)
+
+**Labels:** `frontend`, `design`, `ux`
+**Epic:** [Give the Journal a floating-page depth & editorial polish](journal-depth-epic.md)
+**Depends on:** None — this is the critical-path foundation for issues 02–06
+**Estimated LoC:** ~120
+
+## Problem
+
+The journal can't *float* anything because there is no token for the surface a
+page would float **above**, and no shadow tuned to the warm paper palette.
+Today `colors.paper` (`frontend/src/design/tokens.ts:121-128`) has only the
+page ground (`background` `#faf6ef`) and a slightly warmer `backgroundAlt`
+(`#f3ecdf`); the only shadows (`tokens.ts:274-303`) are neutral-black and
+sized for grey app chrome. Issues 02–05 all need a deeper "desk" colour and a
+soft, warm, downward shadow — so those values must exist in the single source
+of truth first.
+
+## Scope
+
+Add the depth primitives — and *only* the primitives — to `tokens.ts`, with
+tests. No component changes in this issue.
+
+## Tasks
+
+### 1. Add a "desk" ground to the paper palette (TDD)
+
+In `colors.paper`, add a deeper, warmer ground the writing sheet will rest on:
+
+```ts
+paper: {
+  background: '#faf6ef',
+  backgroundAlt: '#f3ecdf',
+  // The deeper, warmer "desk" the writing sheet floats above. A step darker
+  // than `background` (relative luminance ~0.79 vs ~0.92) so the lighter sheet
+  // reads as lifted; the warm shadow below does the rest of the depth cue.
+  desk: '#e7dcc8',
+  // Faint top/side edge for the lifted sheet — slightly lighter than `hairline`
+  // so the sheet's border reads as a lit paper edge, not a divider.
+  sheetEdge: '#efe7d8',
+  ink: '#2b2620',
+  inkSoft: '#5a5046',
+  hairline: '#e3dccd',
+  anchorHighlight: '#f0e3c2',
+},
+```
+
+`colors.paper` is asserted with `arrayContaining` (`editorialTokens.test.ts:27-38`),
+so adding keys is safe. Extend that test to assert the new `desk` and
+`sheetEdge` keys are present.
+
+### 2. Add a warm "paper" elevation shadow
+
+Add an editorial shadow alongside `shadows` (do **not** mutate the existing
+neutral ones — other features depend on them). Ink-tinted, soft, downward:
+
+```ts
+/**
+ * Soft, warm, downward shadow for lifting paper surfaces (the journal sheet,
+ * shelf cards, margin notes) off the desk ground. Ink-tinted rather than pure
+ * black so the lift reads as paper-on-desk, not card-on-glass. iOS/web use the
+ * shadow* props; Android uses `elevation`.
+ */
+export const paperShadow = {
+  sheet: {
+    shadowColor: colors.paper.ink,
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.14,
+    shadowRadius: 20,
+    elevation: 8,
+  },
+  card: {
+    shadowColor: colors.paper.ink,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 6,
+    elevation: 3,
+  },
+} as const;
+```
+
+### 3. Add sheet layout metrics — without breaking the exact-keys test
+
+`editorialTokens.test.ts:60-72` asserts `Object.keys(journalLayout)` **exactly
+equals** the current four keys via `toEqual`. Adding a key to `journalLayout`
+**will fail that test.** Choose ONE and do it cleanly:
+
+- **Preferred:** add a *separate* exported object so `journalLayout` is
+  untouched:
+  ```ts
+  /** Metrics for the floated journal sheet (issue 02 consumes these). */
+  export const journalSheet = {
+    cornerRadius: radius.lg, // 16 — rounded top of the sheet
+    deskPaddingH: spacing(2), // 16 — desk visible left/right of the sheet
+    deskPaddingTop: spacing(1.5), // 12 — desk visible above the sheet
+  } as const;
+  ```
+- **Alternative:** extend `journalLayout` and update the `toEqual` list in the
+  same PR. Only do this if you also re-justify why these belong on the same
+  object.
+
+Add a test asserting `journalSheet` values are positive numbers.
+
+## Acceptance Criteria
+
+- `colors.paper.desk` and `colors.paper.sheetEdge` exist and are valid 6-digit
+  hex; `desk` is measurably darker (lower relative luminance) than
+  `colors.paper.background`.
+- `paperShadow.sheet` and `paperShadow.card` exist with both the iOS/web shadow
+  props and an Android `elevation`.
+- New sheet metrics are exported (preferably as `journalSheet`) **without**
+  breaking the existing `journalLayout` exact-keys test.
+- `editorialTokens.test.ts` is extended to cover the new keys and still asserts
+  `ink`/`inkSoft` clear AA on `colors.paper.background`.
+- `cd frontend && npm test && npm run lint && npx tsc --noEmit` all pass.
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/design/tokens.ts` | Modify — add `paper.desk`, `paper.sheetEdge`, `paperShadow`, sheet metrics |
+| `frontend/src/design/__tests__/editorialTokens.test.ts` | Modify — assert new keys; keep AA + luminance checks |
+</content>

--- a/prompts/github-issues/journal-depth-02-floating-writing-sheet.md
+++ b/prompts/github-issues/journal-depth-02-floating-writing-sheet.md
@@ -1,0 +1,123 @@
+# journal-depth-02: Float the writing surface as a paper sheet
+
+**Labels:** `frontend`, `ux`, `design`
+**Epic:** [Give the Journal a floating-page depth & editorial polish](journal-depth-epic.md)
+**Depends on:** [journal-depth-01](journal-depth-01-elevation-tokens.md) (desk + `paperShadow` + sheet metrics)
+**Estimated LoC:** ~160
+
+## Problem
+
+The writing page paints its background and its content the same colour, so it
+looks flat (see the epic's "What flat means today"). Concretely:
+
+- `frontend/src/features/Journal/JournalEntry.styles.ts:28-31` — `safeArea`
+  uses `colors.paper.background`, identical to the page content's ground.
+- `frontend/src/features/Journal/JournalEntry.styles.ts:32-41` — `page` sits
+  directly on that ground; no elevated surface, shadow, or page edge.
+
+We want the writing area to read as a **lighter sheet of paper floating above a
+deeper desk**, capped to a comfortable reading width and centred, with the
+desk visible around its edges.
+
+## Scope
+
+Restructure the `JournalPage` render tree into **desk → sheet → page**, move
+the width cap / centring onto the sheet, and recolour the desk. Pure
+presentation: no behaviour, prop, or data-flow changes. Preserve the
+`journal-page` testID and its `paddingBottom: RESONANCE_BUTTON_CLEARANCE`.
+
+## Tasks
+
+### 1. Recolour the desk and add sheet styles
+
+In `JournalEntry.styles.ts`:
+
+```ts
+safeArea: {
+  flex: 1,
+  backgroundColor: colors.paper.desk, // the deeper "desk" ground (issue 01)
+},
+/** Padded desk so the deeper ground shows as a border around the lifted sheet. */
+desk: {
+  flex: 1,
+  paddingHorizontal: journalSheet.deskPaddingH,
+  paddingTop: journalSheet.deskPaddingTop,
+},
+/** The floating paper sheet: lighter ground, soft warm shadow, rounded top. */
+sheet: {
+  flex: 1,
+  width: '100%',
+  maxWidth: journalLayout.pageMaxWidth + journalLayout.marginColumnWidth,
+  alignSelf: 'center',
+  backgroundColor: colors.paper.background,
+  borderTopLeftRadius: journalSheet.cornerRadius,
+  borderTopRightRadius: journalSheet.cornerRadius,
+  ...paperShadow.sheet,
+},
+sheetNarrow: { maxWidth: '100%' },
+```
+
+Then update `page` to **drop** `maxWidth`/`alignSelf` (now on the sheet) while
+**keeping** `flexDirection: 'row'`, `paddingHorizontal:
+journalLayout.pageHorizontalPadding`, and crucially
+`paddingBottom: RESONANCE_BUTTON_CLEARANCE`.
+
+### 2. Wrap the page tree in desk → sheet
+
+In `JournalEntryScreen.tsx`, the `JournalPage` component
+(`JournalEntryScreen.tsx:574-624`) currently returns a single
+`<View style={[styles.page, …]} testID="journal-page">`. Wrap it:
+
+```tsx
+return (
+  <View style={styles.desk}>
+    <View style={[styles.sheet, narrow && styles.sheetNarrow]}>
+      <View style={[styles.page, narrow && styles.pageNarrow]} testID="journal-page">
+        {/* …existing WritingColumn/ReadColumn + margin column, unchanged… */}
+      </View>
+    </View>
+  </View>
+);
+```
+
+`narrow` already exists in `JournalPage` via `useWindowDimensions().width <
+NARROW_BREAKPOINT`. The floating "Get Resonance" button, modal, and dialog stay
+as siblings of `JournalPage` under the `SafeAreaView` — do not move them.
+
+### 3. Verify the rounded corner doesn't clip content
+
+The sheet rounds only its **top** corners; the bottom runs under the floating
+button (that's the intended look). Do not add `overflow: 'hidden'` to the
+sheet — on iOS it would clip the shadow. Content never reaches the rounded
+corners because of the page's `pageHorizontalPadding` + the column's vertical
+padding, so no clipping is needed.
+
+## Tasks — tests
+
+- Extend `JournalEntryScreen.test.tsx`: assert a new node (e.g. `testID="journal-sheet"`,
+  add it to the sheet `View`) flattens to `backgroundColor === colors.paper.background`
+  and carries a non-zero `shadowRadius`/`elevation`.
+- Assert `safeArea` (or the screen root) uses `colors.paper.desk`.
+- **Keep the existing assertion** that `journal-page` `paddingBottom ===
+  RESONANCE_BUTTON_CLEARANCE` green — this is the regression guard.
+
+## Acceptance Criteria
+
+- The writing page renders as a lighter sheet on a visibly deeper desk ground,
+  with the desk showing as a margin on the left, right, and top.
+- The sheet has rounded top corners and the warm `paperShadow.sheet`.
+- The sheet caps width at `pageMaxWidth + marginColumnWidth` and is centred on
+  wide screens; on narrow (`< 600`) screens it goes edge-to-edge.
+- `journal-page` keeps its testID and `paddingBottom ===
+  RESONANCE_BUTTON_CLEARANCE`; all existing `JournalEntryScreen` tests pass.
+- No magic numbers — desk/sheet metrics come from issue-01 tokens.
+- `cd frontend && npm test && npm run lint && npx tsc --noEmit` pass.
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Journal/JournalEntry.styles.ts` | Modify — desk/sheet styles; trim `page` |
+| `frontend/src/features/Journal/JournalEntryScreen.tsx` | Modify — wrap `JournalPage` in desk → sheet; add `journal-sheet` testID |
+| `frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx` | Modify — assert sheet/desk styling; keep clearance test |
+</content>

--- a/prompts/github-issues/journal-depth-03-ruled-margins-and-texture.md
+++ b/prompts/github-issues/journal-depth-03-ruled-margins-and-texture.md
@@ -1,0 +1,109 @@
+# journal-depth-03: Add a ruled margin & page edge to the sheet
+
+**Labels:** `frontend`, `ux`, `design`
+**Epic:** [Give the Journal a floating-page depth & editorial polish](journal-depth-epic.md)
+**Depends on:** [journal-depth-02](journal-depth-02-floating-writing-sheet.md) (the floated sheet exists)
+**Estimated LoC:** ~120
+
+## Problem
+
+Issue 02 lifts the page, but the user's ask is also to feel like "writing on a
+page **with some margins**." A floated sheet with no internal structure still
+reads as a plain panel. A faint **margin rule** between the writing column and
+the marginalia column — plus a barely-there lit edge on the sheet — is the
+classic editorial cue that turns a panel into *a page*.
+
+The two-column layout already exists: the writing column and the
+`journal-margin-column` sit side by side on wide screens and stack on narrow
+ones (`JournalEntry.styles.ts:53-61`, `JournalEntryScreen.tsx:584-621`).
+
+## Scope
+
+Add a faint vertical margin rule between the writing column and the marginalia
+(wide screens) that becomes a horizontal rule when the marginalia stacks
+underneath (narrow screens), plus a subtle lit edge on the sheet. Tokens only;
+no behaviour changes.
+
+## Tasks
+
+### 1. Margin rule via the margin column's leading edge
+
+In `JournalEntry.styles.ts`, give `marginColumn` a hairline leading rule and
+make the narrow variant move it to the top:
+
+```ts
+marginColumn: {
+  width: journalLayout.marginColumnWidth,
+  paddingLeft: journalLayout.marginNoteGap,
+  paddingVertical: spacing(3),
+  borderLeftWidth: StyleSheet.hairlineWidth,
+  borderLeftColor: colors.paper.hairline,
+},
+marginColumnNarrow: {
+  width: '100%',
+  paddingLeft: 0,
+  borderLeftWidth: 0,
+  // When the column stacks under the writing area, rule the top instead.
+  borderTopWidth: StyleSheet.hairlineWidth,
+  borderTopColor: colors.paper.hairline,
+  paddingTop: spacing(2),
+  marginTop: spacing(1),
+},
+```
+
+The rule must read as a *page margin*, not a hard divider — `colors.paper.hairline`
+at `StyleSheet.hairlineWidth` is intentionally faint. Do not darken it.
+
+### 2. A lit edge on the sheet (optional polish, keep subtle)
+
+Give the sheet from issue 02 a 1px top/side border in `colors.paper.sheetEdge`
+so the lift catches a touch of light at the edge:
+
+```ts
+sheet: {
+  /* …issue 02 props… */
+  borderTopWidth: StyleSheet.hairlineWidth,
+  borderLeftWidth: StyleSheet.hairlineWidth,
+  borderRightWidth: StyleSheet.hairlineWidth,
+  borderColor: colors.paper.sheetEdge,
+},
+```
+
+Verify the border + rounded corners + shadow still render correctly together
+(no double-border seams at the corners).
+
+### 3. Confirm read-mode parity
+
+Read mode (`ReadColumn`, `JournalEntryScreen.tsx:379-411`) uses the **same**
+`writingColumn` / `marginColumn` styles, so the rule applies to both edit and
+read modes automatically. Do not special-case it; just verify visually and in
+tests.
+
+## Tasks — tests
+
+- Extend `JournalEntryScreen.test.tsx`: flatten the `journal-margin-column`
+  style on a wide layout and assert `borderLeftWidth > 0` with
+  `borderLeftColor === colors.paper.hairline`.
+- Add a narrow-layout case (mock `useWindowDimensions` to width `< 600`) and
+  assert the rule moves to the top (`borderTopWidth > 0`, `borderLeftWidth ===
+  0`). Reuse the existing window-dimensions mocking pattern in the suite if
+  present; otherwise mock `react-native`'s `useWindowDimensions`.
+
+## Acceptance Criteria
+
+- A faint vertical hairline separates the writing column from the marginalia on
+  wide screens; it becomes a top hairline when the marginalia stacks on narrow
+  screens.
+- The sheet shows a subtle lit edge (`colors.paper.sheetEdge`) without seams or
+  a heavy "boxed" look.
+- The rule appears in both edit and read modes (shared styles).
+- All existing Journal tests pass; the rule uses only tokenised values.
+- `cd frontend && npm test && npm run lint && npx tsc --noEmit` pass.
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Journal/JournalEntry.styles.ts` | Modify — margin rule + sheet edge |
+| `frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx` | Modify — wide/narrow rule assertions |
+</content>

--- a/prompts/github-issues/journal-depth-04-lift-marginalia-notes.md
+++ b/prompts/github-issues/journal-depth-04-lift-marginalia-notes.md
@@ -1,0 +1,94 @@
+# journal-depth-04: Lift the marginalia notes off the page
+
+**Labels:** `frontend`, `ux`, `design`
+**Epic:** [Give the Journal a floating-page depth & editorial polish](journal-depth-epic.md)
+**Depends on:** [journal-depth-01](journal-depth-01-elevation-tokens.md) (`paperShadow.card`)
+**Estimated LoC:** ~110
+
+## Problem
+
+`MarginNote` cards are flat fills (`colors.paper.backgroundAlt`) with a coloured
+left bar (`MarginNote.tsx:47-55`). Once the page itself floats (issue 02), flat
+notes sitting on it look pasted-on rather than *pinned to the margin*. Giving
+each note a gentle lift makes the marginalia feel like physical slips laid on
+the page — reinforcing the epic's tactile, layered language.
+
+## Scope
+
+Add a soft shadow and a slightly more refined card treatment to `MarginNote`,
+keeping its kind accent, stale state, and `margin-note-<id>` testID intact.
+Presentation only.
+
+## Tasks
+
+### 1. Lift the card with `paperShadow.card`
+
+In `MarginNote.tsx`, apply the issue-01 card shadow and a small radius bump so
+the note reads as a lifted slip on the page:
+
+```ts
+card: {
+  minHeight: touchTarget.minimum,
+  padding: SPACING.md,
+  borderRadius: BORDER_RADIUS.md,
+  backgroundColor: colors.paper.background, // sits a touch above the page,
+                                            // lifted by the shadow (was backgroundAlt)
+  borderLeftWidth: 3,
+  borderLeftColor: colors.paper.hairline,
+  ...paperShadow.card,
+},
+```
+
+Note the ground change from `backgroundAlt` → `background`: the *shadow* now
+does the separation, so the card can match the page ground and still read as
+lifted (cleaner than a flat tinted block). Keep the 3px left bar — issue 04b
+below makes it the kind accent.
+
+### 2. Make the left bar carry the kind accent
+
+Today the kind colour is only on the `kind` label text
+(`MarginNote.tsx:35`). Tie the card's left bar to the same
+`colors.marginalia[note.kind]` so each note is colour-coded at a glance:
+
+```tsx
+<TouchableOpacity
+  style={[
+    styles.card,
+    { borderLeftColor: colors.marginalia[note.kind] },
+    isStale && styles.cardStale,
+  ]}
+  /* …unchanged… */
+>
+```
+
+`colors.marginalia` accents are all AA on the paper ground (asserted in
+`editorialTokens.test.ts:48-58`), so this is safe.
+
+### 3. Keep the stale state legible
+
+`cardStale` dims to `opacity: 0.55` (`MarginNote.tsx:56-58`). Confirm the
+shadow + dim still read correctly (a dimmed-but-lifted slip is fine). Do not
+remove the stale caption or its testID.
+
+## Tasks — tests
+
+- Extend `MarginNote.test.tsx`: flatten the card style and assert a non-zero
+  `shadowRadius`/`elevation` and `borderLeftColor === colors.marginalia[kind]`
+  for at least two kinds (e.g. `theme`, `connection`).
+- Assert the existing `margin-note-<id>` and stale testIDs/labels still render.
+
+## Acceptance Criteria
+
+- Margin notes are visibly lifted off the page with the warm `paperShadow.card`.
+- Each note's left bar is its kind accent colour (theme/connection/symbol).
+- Stale notes still dim and still show their "passage changed" caption.
+- All existing `MarginNote` tests pass; tokens only, no magic numbers.
+- `cd frontend && npm test && npm run lint && npx tsc --noEmit` pass.
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Journal/MarginNote.tsx` | Modify — card shadow + kind-accent left bar |
+| `frontend/src/features/Journal/__tests__/MarginNote.test.tsx` | Modify — assert shadow + accent |
+</content>

--- a/prompts/github-issues/journal-depth-05-floating-shelf-cards.md
+++ b/prompts/github-issues/journal-depth-05-floating-shelf-cards.md
@@ -1,0 +1,115 @@
+# journal-depth-05: Float the shelf entries as paper cards
+
+**Labels:** `frontend`, `ux`, `design`
+**Epic:** [Give the Journal a floating-page depth & editorial polish](journal-depth-epic.md)
+**Depends on:** [journal-depth-01](journal-depth-01-elevation-tokens.md) (desk + `paperShadow`)
+**Estimated LoC:** ~170
+
+## Problem
+
+The shelf — the journal's landing list — is as flat as the writing page was.
+`JournalShelf.styles.ts` paints `safeArea` with `colors.paper.background`
+(`:7-10`) and renders each entry as a hairline-separated **row**
+(`card`, `:33-38`) on that single flat ground. After issues 02–04 the writing
+page floats but the shelf still looks flat, breaking the feature's cohesion.
+The shelf entries are conceptually "pages on a shelf" — they should read as
+**lifted paper cards on the same desk ground.**
+
+## Scope
+
+Recolour the shelf to the desk ground and turn each entry row into a floated
+paper card; give the weekly-prompt card matching depth. Preserve the shelf's
+testIDs, the `new entry` CTA behaviour, the empty/error states, and list
+scrolling. Presentation only.
+
+## Tasks
+
+### 1. Desk ground + lifted entry cards
+
+In `JournalShelf.styles.ts`:
+
+```ts
+safeArea: {
+  flex: 1,
+  backgroundColor: colors.paper.desk, // shared desk ground (issue 01)
+},
+listContent: {
+  paddingHorizontal: SPACING.lg,
+  paddingTop: SPACING.md,
+  paddingBottom: SPACING.xxl,
+  flexGrow: 1,
+},
+card: {
+  minHeight: touchTarget.minimum, // import touchTarget; was a bare 44
+  paddingVertical: SPACING.md,
+  paddingHorizontal: SPACING.lg,
+  marginBottom: SPACING.md,
+  borderRadius: BORDER_RADIUS.md,
+  backgroundColor: colors.paper.background, // the lifted page card
+  ...paperShadow.card,
+  // Remove the old borderBottom hairline — separation now comes from the
+  // gap + shadow between floated cards.
+},
+```
+
+Drop `card`'s `borderBottomWidth`/`borderBottomColor`. Verify `cardTitleRow`,
+`cardTitle`, `cardDate`, `cardExcerpt` still lay out correctly inside the padded
+card (`:39-58`).
+
+### 2. Give the weekly-prompt card matching depth
+
+`promptCard` (`:76-84`) is a flat `backgroundAlt` block with a coloured left
+bar. Keep its identity (the accent bar marks it as the prompt) but lift it onto
+the desk consistently:
+
+```ts
+promptCard: {
+  marginHorizontal: SPACING.lg,
+  marginTop: SPACING.lg,
+  padding: SPACING.lg,
+  borderRadius: BORDER_RADIUS.md,
+  backgroundColor: colors.paper.background,
+  borderLeftWidth: 3,
+  borderLeftColor: colors.marginalia.theme,
+  ...paperShadow.card,
+},
+```
+
+### 3. Keep the CTA and states intact
+
+`newEntry` (`:19-27`) stays the solid primary button — it's chrome, not a
+paper card; leave its fill. Confirm the empty (`emptyWrap`/`emptyText`) and
+error (`emptyError`) states still centre correctly on the new desk ground and
+remain AA (`inkSoft`/`danger` on `colors.paper.desk` — verify >= 4.5:1; if
+`danger` on `desk` is borderline, keep error text on a small `background`
+chip rather than darkening the desk).
+
+## Tasks — tests
+
+- Extend `JournalShelfScreen.test.tsx`: flatten an entry card's style and
+  assert `backgroundColor === colors.paper.background`, a non-zero
+  `shadowRadius`/`elevation`, and **no** `borderBottomWidth`.
+- Assert `safeArea`/root uses `colors.paper.desk`.
+- Confirm existing shelf tests (entry list render, tap → navigate, empty/error,
+  prompt card) still pass.
+
+## Acceptance Criteria
+
+- Shelf entries render as lifted paper cards on the deeper desk ground, spaced
+  by gaps rather than hairline dividers.
+- The weekly-prompt card shares the floated treatment while keeping its accent
+  bar identity.
+- The "New entry" CTA, empty state, and error state are unchanged in behaviour
+  and remain AA-legible on the desk ground.
+- All existing shelf tests pass; tokens only, no magic numbers (replace the
+  bare `44` with `touchTarget.minimum`).
+- `cd frontend && npm test && npm run lint && npx tsc --noEmit` pass.
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/features/Journal/JournalShelf.styles.ts` | Modify — desk ground + floated cards |
+| `frontend/src/features/Journal/JournalShelfScreen.tsx` | Modify only if markup changes are needed for spacing |
+| `frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx` | Modify — assert card depth + desk ground |
+</content>

--- a/prompts/github-issues/journal-depth-06-motion-and-micro-interactions.md
+++ b/prompts/github-issues/journal-depth-06-motion-and-micro-interactions.md
@@ -1,0 +1,111 @@
+# journal-depth-06: Add depth-reinforcing motion (reduced-motion safe)
+
+**Labels:** `frontend`, `ux`, `design`, `a11y`
+**Epic:** [Give the Journal a floating-page depth & editorial polish](journal-depth-epic.md)
+**Depends on:** [journal-depth-02](journal-depth-02-floating-writing-sheet.md), [journal-depth-04](journal-depth-04-lift-marginalia-notes.md), [journal-depth-05](journal-depth-05-floating-shelf-cards.md)
+**Estimated LoC:** ~140
+
+## Problem
+
+Static depth (shadows, layering) is convincing, but a little motion makes a
+floated surface feel *physical*: a sheet that settles in as it appears, cards
+that press down slightly when tapped. The `GetResonanceButton` already
+demonstrates the house motion idiom — `Animated` with `useNativeDriver: true`,
+short durations, subtle slide (`GetResonanceButton.tsx:56-75`). This issue
+extends that idiom to the new floated surfaces — **and gates all of it behind
+"Reduce Motion"** so the polish never costs accessibility.
+
+## Scope
+
+Add subtle, tasteful, reduced-motion-aware motion to the floated journal
+surfaces. Keep every animation short (<= ~250ms), native-driven, and skippable.
+No layout or behaviour changes when motion is disabled.
+
+## Tasks
+
+### 1. A reusable reduced-motion hook
+
+Add `frontend/src/hooks/useReducedMotion.ts` (check first whether one already
+exists — there is a `useIdle` hook in `frontend/src/hooks/`; follow its style):
+
+```ts
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+/** True when the OS "Reduce Motion" setting is on; updates live. */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    let active = true;
+    void AccessibilityInfo.isReduceMotionEnabled().then((v) => {
+      if (active) setReduced(v);
+    });
+    const sub = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduced);
+    return () => {
+      active = false;
+      sub.remove();
+    };
+  }, []);
+  return reduced;
+}
+```
+
+Unit-test it by mocking `AccessibilityInfo`.
+
+### 2. Sheet "settle in" on mount (writing page)
+
+In `JournalEntryScreen.tsx`, when the sheet (issue 02) mounts, fade + lift it a
+few px into place (`opacity 0→1`, `translateY 6→0`, ~220ms,
+`useNativeDriver: true`). When `useReducedMotion()` is true, start at the final
+values and run no animation. Use a token for the slide distance (reuse the
+`SLIDE_DISTANCE` idiom from `GetResonanceButton`, or add a small motion token).
+
+### 3. Press feedback on cards (shelf + margin notes)
+
+For shelf entry cards (`JournalShelfScreen.tsx`) and `MarginNote`, add a subtle
+press-in: scale to ~0.98 and/or reduce shadow on `pressIn`, restore on
+`pressOut`. `TouchableOpacity` already gives an opacity dip; layer a small
+`Animated` scale for a "press down into the desk" feel. Skip entirely under
+reduced motion (fall back to the default opacity press).
+
+Keep hit areas >= `touchTarget.minimum`; the scale is visual only and must not
+shrink the touch target.
+
+### 4. Respect reduced motion everywhere
+
+Every animation added here must check `useReducedMotion()` and, when true,
+render the final state with no transition. Add a test asserting that with
+reduce-motion mocked **on**, the animated value is at its resting value
+immediately (no in-flight interpolation).
+
+## Tasks — tests
+
+- `useReducedMotion` test: returns the mocked initial value and updates on the
+  `reduceMotionChanged` event.
+- Sheet mount: with reduced motion **off**, the sheet's animated style starts
+  below final and settles; with it **on**, it renders at final immediately.
+- Card press: `pressIn`/`pressOut` adjust the animated scale when motion is on;
+  no-op when off. Use fake timers + `act` consistent with the existing suite.
+
+## Acceptance Criteria
+
+- The writing sheet gently settles in on mount; shelf cards and margin notes
+  give subtle press feedback — all short, native-driven, and tasteful.
+- With OS "Reduce Motion" enabled, **no** journal animation runs; surfaces
+  render directly at their resting state with identical layout.
+- Touch targets remain >= 44dp; no behaviour or navigation changes.
+- New tests cover both the motion-on and motion-off paths; coverage stays at
+  thresholds.
+- `cd frontend && npm test && npm run lint && npx tsc --noEmit` pass.
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| `frontend/src/hooks/useReducedMotion.ts` | Create (if absent) — reduced-motion hook |
+| `frontend/src/hooks/__tests__/useReducedMotion.test.ts` | Create — hook tests |
+| `frontend/src/features/Journal/JournalEntryScreen.tsx` | Modify — sheet settle-in |
+| `frontend/src/features/Journal/MarginNote.tsx` | Modify — press feedback |
+| `frontend/src/features/Journal/JournalShelfScreen.tsx` | Modify — card press feedback |
+| `frontend/src/features/Journal/__tests__/*` | Modify — motion on/off assertions |
+</content>

--- a/prompts/github-issues/journal-depth-epic.md
+++ b/prompts/github-issues/journal-depth-epic.md
@@ -1,0 +1,167 @@
+# Epic: Give the Journal a floating-page depth & editorial polish
+
+**Labels:** `epic`, `frontend`, `ux`, `design`
+**Scope:** Frontend only (journal-resonance surface + shared design tokens)
+**Estimated total LoC:** ~800
+
+## Role
+
+You are a senior React Native / front-end engineer with a strong visual
+design sense, working inside Adepthood's existing **editorial / "paper"**
+design language (`colors.paper.*`, `editorialType`, `journalLayout` in
+`frontend/src/design/tokens.ts`). You make surfaces beautiful **through the
+token system** — never with one-off magic numbers — and you treat
+accessibility (WCAG 2.1 AA contrast, 44dp touch targets, reduced-motion)
+as a non-negotiable part of "beautiful," not an afterthought.
+
+## Goal
+
+Make the journal **feel like writing on a real sheet of paper that floats a
+little above a desk** — with margins, a soft warm shadow, and gentle motion —
+instead of the current flat surface where the writing area and its background
+are the same colour. After this epic ships, the journal writing page, the
+marginalia, and the shelf all read as one cohesive, tactile, *floated*
+editorial space, with **zero regressions** to existing behaviour, testIDs, or
+contrast guarantees.
+
+### What "flat" means today (the problem)
+
+`JournalEntryScreen` paints its `SafeAreaView` and its page content with the
+**same** colour — `colors.paper.background` (`#faf6ef`):
+
+- `frontend/src/features/Journal/JournalEntry.styles.ts:28-31` — `safeArea`
+  background is `colors.paper.background`.
+- `frontend/src/features/Journal/JournalEntry.styles.ts:32-41` — the `page`
+  sits directly on that same ground with only horizontal padding; there is no
+  elevated surface, no shadow, no visible page edge, and no margin rule.
+
+Because foreground and background are identical, the eye has nothing to
+separate "the page" from "everything else." The shelf
+(`JournalShelf.styles.ts`) has the same problem: entries are hairline-
+separated rows on a single flat ground, and `MarginNote` cards are flat
+fills with a coloured left bar. Nothing is *lifted*.
+
+## Context
+
+The journal already has a deliberate, well-tokenised editorial palette and
+type scale — the raw materials for depth are mostly present:
+
+- **Palette** — `colors.paper` (`tokens.ts:121-128`): `background` `#faf6ef`,
+  `backgroundAlt` `#f3ecdf`, `ink` `#2b2620`, `inkSoft` `#5a5046`, `hairline`
+  `#e3dccd`, `anchorHighlight`. Contrast of `ink`/`inkSoft` on the ground is
+  AAA and is **asserted by tests** (see below) — do not break it.
+- **Shadows** — `shadows` (`tokens.ts:274-303`) exist but are neutral-black
+  and tuned for the grey app chrome, not the warm paper surface.
+- **Layout metrics** — `journalLayout` (`tokens.ts:406-411`):
+  `marginColumnWidth` 220, `pageHorizontalPadding` 24, `pageMaxWidth` 680,
+  `marginNoteGap` 16.
+- **Type** — `editorialType` (`tokens.ts:430-444`): a platform serif stack
+  with display/title/body/note/caption/marginNote scales.
+
+**Surfaces in scope:**
+
+| File | Role |
+|------|------|
+| `frontend/src/design/tokens.ts` | Source of truth for every colour/shadow/metric |
+| `frontend/src/features/Journal/JournalEntry.styles.ts` | Writing-page styles |
+| `frontend/src/features/Journal/JournalEntryScreen.tsx` | Writing-page structure (`JournalPage`) |
+| `frontend/src/features/Journal/MarginNote.tsx` | One margin note card |
+| `frontend/src/features/Journal/JournalShelf.styles.ts` | Shelf list styles |
+| `frontend/src/features/Journal/JournalShelfScreen.tsx` | Shelf structure |
+
+**Hard contracts the epic must preserve (verified by existing tests):**
+
+1. `JournalEntryScreen.test.tsx:151-155` flattens the `journal-page` style and
+   asserts `paddingBottom === RESONANCE_BUTTON_CLEARANCE`. The `journal-page`
+   testID and that exact `paddingBottom` value must remain on the page node.
+2. `JournalEntryScreen.test.tsx:144-149` asserts the `journal-margin-column`
+   testID exists and the `renderMargin` slot is invoked.
+3. Read-mode testIDs `journal-body-read`, `highlight-<id>`, `margin-note-<id>`,
+   and edit/finish testIDs must keep working.
+4. `editorialTokens.test.ts:60-72` asserts `Object.keys(journalLayout)`
+   **exactly equals** `['marginColumnWidth','pageHorizontalPadding',
+   'pageMaxWidth','marginNoteGap']` via `toEqual`. **Adding a key to
+   `journalLayout` will fail this test** — either extend the test in the same
+   PR or put new metrics in a separate exported object (issue 01 decides this).
+5. `editorialTokens.test.ts:27-45` asserts `colors.paper` *contains* its keys
+   (`arrayContaining`) and that `ink`/`inkSoft` clear AA on the ground — adding
+   `colors.paper` keys is safe; lowering contrast is not.
+
+## Output Format
+
+Six independently-shippable sub-issues. **Issue 01 (tokens) is the critical
+path** — every other issue imports the elevation tokens it adds. After 01
+lands, 02–05 can proceed in parallel; 06 (motion) lands last because it
+animates the surfaces 02/04/05 build.
+
+```
+                 ┌── 02 floating-writing-sheet ──┐
+                 │                                │
+01 elevation ────┼── 03 ruled-margins-texture ───┼── 06 motion-&-micro-interactions
+   tokens        │      (also depends on 02)      │
+                 ├── 04 lift-marginalia-notes ────┤
+                 │                                │
+                 └── 05 floating-shelf-cards ─────┘
+```
+
+## Sub-issues
+
+| # | Title | Scope | Est. LoC |
+|---|-------|-------|----------|
+| 01 | [Add editorial elevation tokens (desk + paper shadow)](journal-depth-01-elevation-tokens.md) | Frontend | ~120 |
+| 02 | [Float the writing surface as a paper sheet](journal-depth-02-floating-writing-sheet.md) | Frontend | ~160 |
+| 03 | [Add a ruled margin & page edge to the sheet](journal-depth-03-ruled-margins-and-texture.md) | Frontend | ~120 |
+| 04 | [Lift the marginalia notes off the page](journal-depth-04-lift-marginalia-notes.md) | Frontend | ~110 |
+| 05 | [Float the shelf entries as paper cards](journal-depth-05-floating-shelf-cards.md) | Frontend | ~170 |
+| 06 | [Add depth-reinforcing motion (reduced-motion safe)](journal-depth-06-motion-and-micro-interactions.md) | Frontend | ~140 |
+
+## Acceptance Criteria (epic-level)
+
+- [ ] The journal writing page reads as a **lighter sheet floating on a deeper
+      "desk" ground**, with a soft warm shadow and visible margins.
+- [ ] The shelf and the marginalia share the same floated, layered language —
+      the whole journal feature feels cohesive and tactile.
+- [ ] Motion reinforces depth subtly and is fully disabled under
+      "Reduce Motion."
+- [ ] **No regressions:** every existing Journal test passes unchanged
+      (testIDs, `RESONANCE_BUTTON_CLEARANCE`, read/edit/finish flows).
+- [ ] **No contrast regressions:** all text keeps WCAG 2.1 AA (>= 4.5:1) on
+      whatever ground it sits on; the token contrast tests stay green.
+- [ ] All new styling flows from `tokens.ts` — no magic numbers in components
+      or style files (CLAUDE.md guardrail).
+- [ ] `cd frontend && npm test && npm run lint && npx tsc --noEmit` green; the
+      backend is untouched. `pre-commit run --all-files` green on each PR.
+
+## Constraints
+
+- **Tokens only.** Every colour, radius, shadow, and spacing value comes from
+  `tokens.ts`. No inline hex, no bare pixel constants in components.
+- **Editorial palette only** for these surfaces — extend `colors.paper`, do
+  not reach for the grey app-chrome palette (`colors.background.*`).
+- **Preserve every testID and the `RESONANCE_BUTTON_CLEARANCE` contract.**
+  Add depth by *wrapping* the existing `journal-page` node, not by moving the
+  clearance padding off it.
+- **Accessibility is part of the deliverable:** AA contrast, 44dp touch
+  targets (`touchTarget.minimum`), and `prefers-reduced-motion` honoured.
+- **React Native shadow portability:** specify both the iOS/web shadow props
+  (`shadowColor/Offset/Opacity/Radius`) *and* Android `elevation`; assert via
+  `StyleSheet.flatten` in tests rather than snapshotting.
+- **TDD:** write/extend the failing test first, then implement. Keep coverage
+  at or above the repo thresholds (90% line / 80% branch).
+- One logical change per PR; conventional commit messages
+  (`feat(frontend): …`, `style(frontend): …`, `test(frontend): …`).
+
+## References
+
+- `frontend/src/design/tokens.ts:121-128` — `colors.paper` palette
+- `frontend/src/design/tokens.ts:274-303` — `shadows` (neutral; for contrast)
+- `frontend/src/design/tokens.ts:406-411` — `journalLayout` metrics
+- `frontend/src/design/tokens.ts:430-444` — `editorialType` scale
+- `frontend/src/design/__tests__/editorialTokens.test.ts` — token contracts
+- `frontend/src/features/Journal/JournalEntry.styles.ts` — writing-page styles
+- `frontend/src/features/Journal/JournalEntryScreen.tsx:574-624` — `JournalPage`
+- `frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx:144-155` — layout contracts
+- `frontend/src/features/Journal/MarginNote.tsx` — note card
+- `frontend/src/features/Journal/JournalShelf.styles.ts` — shelf styles
+</content>
+</invoke>


### PR DESCRIPTION
## Summary

Add a comprehensive epic and six sub-issues to the roadmap for implementing floating-page depth and editorial polish in the journal feature. This epic transforms the journal from a flat surface into a tactile, layered experience where the writing page, marginalia, and shelf all read as paper surfaces floating above a desk ground.

## Changes

- **Epic tracker** (`journal-depth-epic.md`): Defines the overall goal, role, context, hard contracts (testID/contrast preservation), and dependency graph for six sub-issues. Establishes that this is frontend-only, tokens-driven, with zero behaviour or contrast regressions.

- **Issue 01** (`journal-depth-01-elevation-tokens.md`): Critical-path foundation. Adds `colors.paper.desk` and `colors.paper.sheetEdge` to the palette, introduces `paperShadow` (sheet + card variants with iOS/web + Android props), and sheet layout metrics. No component changes.

- **Issue 02** (`journal-depth-02-floating-writing-sheet.md`): Restructures `JournalPage` into desk → sheet → page, recolours the safe area to the desk ground, and applies the sheet shadow and rounded corners. Preserves `journal-page` testID and `RESONANCE_BUTTON_CLEARANCE`.

- **Issue 03** (`journal-depth-03-ruled-margins-and-texture.md`): Adds a faint hairline margin rule between writing and marginalia columns (vertical on wide screens, horizontal on narrow), plus a subtle lit edge on the sheet via `colors.paper.sheetEdge`.

- **Issue 04** (`journal-depth-04-lift-marginalia-notes.md`): Lifts `MarginNote` cards with `paperShadow.card`, changes the background from `backgroundAlt` to `background` (shadow does the separation), and ties the left bar to the kind accent colour.

- **Issue 05** (`journal-depth-05-floating-shelf-cards.md`): Recolours the shelf to the desk ground, turns each entry row into a floated card with `paperShadow.card`, and gives the weekly-prompt card matching depth. Removes hairline dividers in favour of gap + shadow separation.

- **Issue 06** (`journal-depth-06-motion-and-micro-interactions.md`): Adds reduced-motion-aware micro-interactions: sheet settle-in on mount (fade + lift), and subtle press feedback on cards (scale). Introduces `useReducedMotion` hook that gates all motion behind OS accessibility settings.

- **README.md**: Updated roadmap index with the new epic and dependency graph.

## Implementation Notes

- **Dependency graph**: Issue 01 is the critical path; issues 02–05 can proceed in parallel after 01 lands; issue 06 depends on 02/04/05.
- **Hard contracts preserved**: All sub-issues explicitly preserve existing testIDs (`journal-page`, `journal-margin-column`, `margin-note-<id>`, etc.), the `RESONANCE_BUTTON_CLEARANCE` padding, and WCAG 2.1 AA contrast guarantees.
- **Tokens-only approach**: Every colour, shadow, radius, and spacing value flows from `tokens.ts`; no magic numbers in components.
- **TDD discipline**: Each sub-issue specifies failing tests first, then implementation.
- **Accessibility**: Reduced-motion support, 44dp touch targets, and AA contrast are non-negotiable parts of the deliverable, not afterthoughts.

These issues are ready for implementation and follow the project's conventional commit and quality-gate standards.

https://claude.ai/code/session_018kiTYPkyzTda35BrNcrYWk