### PR TITLE
Add de-slopify skill: comprehensive code-quality auditor

### DIFF
--- a/.claude/skills/de-slopify/SKILL.md
+++ b/.claude/skills/de-slopify/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: de-slopify
+description: >-
+  Audit the codebase for sloppy, amateurish, or AI-generated low-quality code —
+  bugs, code smells, dead/stubbed/orphaned code, duplication, poor architecture,
+  needless verbosity, comment slop, type-safety erosion, and weak tests — then
+  file corroborated findings as Ralph-ready GitHub issues (and decomposed epics
+  for big work). Use when the user says "de-slop", "deslopify", "run the slop
+  detector", "find code smells", "audit code quality", "find dead code", "weekly
+  code quality scan", "bullshit detector", or when the weekly de-slop GitHub
+  Action runs. Findings must be corroborated by two independent signals before
+  filing — null findings are a valid result. Do NOT use for implementing fixes
+  (Ralph / continue-epic does that), for reviewing a specific PR diff (use
+  comprehensive-pr-review), for fixing CI failures (use ci-debugging), or for
+  triaging a backlog of existing issues (use backlog-grooming).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# De-Slopify — The Comprehensive Bullshit Detector
+
+A reusable, scheduled code-quality auditor. It hunts the whole codebase for
+**evidence** of slop — bugs, code smell, dead/stubbed/orphaned code,
+duplication, poor architecture, verbosity, comment noise, type erosion, weak
+tests, security candidates — **corroborates** each finding against two
+independent signals, and files only the survivors as GitHub issues that the
+local **Ralph** loop picks up autonomously. Big problems become **epics** with
+decomposed sub-issues.
+
+Its prime directive: **precision over recall.** A false positive wastes an
+autonomous implementation cycle (or worse, "fixes" correct code into broken
+code), so a finding that can't be corroborated is dropped. **A run that files
+nothing because the code is clean is a success.**
+
+## The three references (read them — they are the substance)
+
+| File | What it gives you |
+|------|-------------------|
+| `references/slop-taxonomy.md` | The exhaustive field guide: 13 families of slop (Correctness, Bloaters, OO-abusers, Change-preventers, Dispensables, Couplers/Architecture, Naming/Comments, Verbosity, Type-safety, Testing, Security, Deps/Config, **AI-slop-specific**), each with tells, corroboration hints, a severity rubric, and an explicit NOT-slop guard list. |
+| `references/detection-playbook.md` | The Two-Signal Rule, the toolbox→category map, grep recipes, the weekly run procedure, and the precision calibration. |
+| `references/issue-templates.md` | Standalone-finding and epic templates, the exact labels Ralph's picker honors, `gh` filing recipes, and the pre-file checklist. |
+
+`scripts/collect-evidence.sh` runs the read-only toolbox and writes a complete
+evidence bundle to the scratchpad.
+
+## Instructions
+
+### Step 1 — Orient
+
+Read the house rules so findings respect intent, not a generic ideal:
+`CLAUDE.md`, `AGENTS.md`, and skim `prompts/github-issues/README.md` for what's
+already planned. Then read all three references above (at minimum the taxonomy
+and playbook). Understand the NOT-slop guard list before you flag anything.
+
+### Step 2 — Collect evidence (read-only)
+
+```bash
+EVID=$(bash .claude/skills/de-slopify/scripts/collect-evidence.sh | tail -1)
+```
+
+This runs ruff, vulture, radon, mypy, bandit, interrogate, pip-audit (backend);
+eslint, tsc (frontend); the grep heuristics; and git churn — capturing each
+into `$EVID`. It never modifies files and never aborts on a tool error. Read
+`$EVID/README.txt`, then work through every output file. Supplement with
+targeted `Grep`/`Read` as candidates emerge.
+
+### Step 3 — Triage candidates against the guard list
+
+For each candidate from the evidence bundle, **first discard** anything in the
+NOT-slop list (`slop-taxonomy.md`): generated code, Alembic migrations,
+`package-lock.json`, justified suppressions (with a linked issue), framework
+boilerplate (Pydantic/SQLModel/React Navigation), test fixtures, self-evident
+constants, deliberate repo conventions, and unmeasured "could be faster" claims.
+
+### Step 4 — Corroborate each survivor (the gate)
+
+Apply the **Two-Signal Rule** (`detection-playbook.md`): no finding survives
+without **two independent signals, at least one concrete and reproducible.**
+
+- For any **correctness/bug** claim (taxonomy Family 0, and Family 12 "confident
+  wrongness"): **write and run a reproducing test** in a throwaway location. If
+  it does not reproduce, **drop it.** Never file a bug on reasoning alone.
+- For dead code: a tool hit (vulture/eslint) **and** a grep proving zero inbound
+  references *including* dynamic dispatch, FastAPI routes, DI, and pytest
+  fixtures. vulture alone is not enough — it false-positives on dynamic use.
+- For everything else: tool/static signal + structural proof or a reading that
+  explains the defect in terms of intent.
+
+Classify each survivor by family and assign a severity (Critical/High/Medium/
+Low) from the rubric. When corroboration is shaky, **downgrade or drop.**
+
+### Step 5 — Cluster, then dedup against the backlog
+
+Group corroborated findings by area/theme. A cluster needing coordinated
+multi-file change is an **epic**; standalone findings are single issues. Bundle
+many Low findings in one file into a single tidy-up issue — don't flood the
+backlog.
+
+Then, for every cluster/finding, search existing issues and skip duplicates:
+
+```bash
+gh issue list --state open --search "in:title <keywords>" --json number,title
+gh search issues --repo Geoffe-Ga/adepthood "<keywords>" --state open
+```
+
+### Step 6 — File the work (Ralph-ready)
+
+Follow `references/issue-templates.md` exactly. The labels matter — Ralph's
+picker (`scripts/ralph/pick-next.sh`) skips `epic`/`blocked`/`needs-spec` and
+works everything else lowest-number-first.
+
+- **Standalone finding** → Template A, normal labels (no excluded label), sized
+  ≤ ~300 net LoC / ≤ 5 files. Paste the corroborating evidence into the body.
+- **Epic** → Template B with the `epic` label (Ralph skips the umbrella), plus
+  sub-issues via Template A in dependency order. If the decomposition needs more
+  than ~3 sub-issues, **invoke the `triage-and-plan` skill** to do it properly —
+  don't hand-roll a sprawling epic. Mark dependent sub-issues `blocked` and note
+  `Depends on #N`.
+
+Create any missing labels first (`gh label create ...`). Write issue bodies to
+files in the scratchpad and file with `--body-file` (never inline strings).
+
+### Step 7 — Report
+
+Emit a concise run summary: counts by severity, what was filed (with issue
+numbers/links), what was **dropped and why** (failed corroboration / guard
+list), and what was **deduped**. If nothing met the bar, say so plainly:
+*"No corroborated slop this run — codebase is clean against the taxonomy."*
+That is a healthy outcome, not a failure.
+
+## What this skill must never do
+
+- File a finding it could not corroborate with two independent signals.
+- File a correctness/bug claim without a reproducing test.
+- Implement fixes itself — it only files work; Ralph/`continue-epic` implements.
+- Modify tracked files, weaken a quality gate, or commit anything.
+- Touch generated code, migrations, lockfiles, or justified suppressions.
+- Create duplicate issues, or flood the backlog with low-value nits.
+- File a stylistic opinion that contradicts CLAUDE.md/AGENTS.md conventions.
+
+## Examples
+
+### Example 1 — Weekly scheduled run (the primary path)
+
+The `weekly-deslop` GitHub Action fires (or the user says "run the slop
+detector"). Collect evidence → triage → corroborate → cluster → dedup → file.
+vulture + grep prove `legacy_streak()` has zero callers → file one
+`dead-code`/`priority-medium` issue. radon grades `HabitsScreen` rendering
+logic `D` and a reading finds 4 responsibilities → file a `refactor` **epic**
+with sub-issues (via `triage-and-plan`). A suspected N+1 can't be confirmed
+without a query-count log → **dropped** and noted in the report. Net: 1 issue,
+1 epic (5 sub-issues), 3 dropped, 2 deduped.
+
+### Example 2 — Clean run
+
+Evidence bundle yields only candidates that fail the guard list (a `# noqa`
+with a linked issue, framework boilerplate, deliberate test-fixture
+duplication). Nothing corroborates into a real finding. Report:
+*"No corroborated slop this run."* File nothing.
+
+### Example 3 — A "lying" feature flag (high-value find)
+
+grep finds an `ENCRYPTION_AT_REST_ENABLED` flag and a docstring promising
+encryption (signal 1); reading the model layer shows the column is written as
+plaintext with no encrypt hook (signal 2). Corroborated and high-severity — the
+code advertises a guarantee it doesn't deliver. File an `audit-destub`-style
+epic to make it real (encrypt-on-write, key rotation, migration), mirroring the
+existing `prompts/github-issues/audit-destub-05b-*.md` precedent.
+
+## Troubleshooting
+
+### A tool is missing in CI / locally
+`collect-evidence.sh` skips absent tools and notes it. Install the dev deps
+(`pip install -r backend/requirements-dev.txt`, `cd frontend && npm ci`) for the
+full toolbox; proceed with whatever is available otherwise.
+
+### Worried about false positives
+Re-read the Two-Signal Rule and the NOT-slop guard list. When unsure, drop the
+finding. Precision is the whole point — a missed smell costs nothing this week;
+a bogus issue costs an autonomous implementation cycle.
+
+### The backlog is filling with too many issues
+Bundle Low-severity findings per file/area into single tidy-up issues, raise the
+corroboration bar, and prefer a few ironclad high-value issues over many maybes.
+
+### Ralph isn't picking up a filed issue
+Check labels against `scripts/ralph/pick-next.sh`: an excluded label
+(`epic`/`blocked`/`needs-spec`/etc.) or an open PR already referencing it will
+make the picker skip it. Epics are skipped by design; their sub-issues are not.

--- a/.claude/skills/de-slopify/references/detection-playbook.md
+++ b/.claude/skills/de-slopify/references/detection-playbook.md
@@ -1,0 +1,175 @@
+# Detection Playbook — Evidence, Corroboration, and the No-False-Positive Gate
+
+The taxonomy (`slop-taxonomy.md`) says *what* to look for. This playbook says
+*how to find it with evidence* and — critically — *how to prove a finding is
+real before it becomes work*. The entire value of this skill collapses if it
+files plausible-but-wrong findings, because Ralph will autonomously implement
+them. **A false positive is worse than a missed finding.**
+
+---
+
+## The Two-Signal Rule (the core discipline)
+
+> **No finding is filed unless it is corroborated by at least two independent
+> signals, at least one of which is concrete and reproducible.**
+
+The signal classes, strongest first:
+
+1. **Reproducing artifact** — a failing test, a stack trace, a query-count log,
+   a `tsc`/`mypy` error, an import that doesn't resolve. *Strongest.* For any
+   **correctness/bug** claim (Family 0, Family 12 "confident wrongness"), a
+   reproducing artifact is **mandatory** — never file a bug on reasoning alone.
+2. **Static-analysis hit** — a tool flags the exact line(s): ruff, mypy,
+   vulture, radon/xenon, bandit, eslint, detect-secrets, pip-audit, an
+   import-cycle scan, a duplication scan.
+3. **Structural proof** — a grep/graph result showing the claim: zero inbound
+   references (dead code), N identical token-runs across files (duplication),
+   a recurring field triple (data clump), a flag whose claim has no
+   implementing code path.
+4. **Reviewer reading** — an agent reads the code and explains the defect in
+   terms of intent. *Never sufficient alone* — it must confirm a 1–3 signal,
+   and for bugs it must be backed by signal #1.
+
+**Examples of valid corroboration:**
+
+- *Dead function:* vulture flags it (signal 2) **and** grep finds zero callers
+  including dynamic/string/route references (signal 3). ✅
+- *God function:* radon grades it `D` (signal 2) **and** a reading shows ≥3
+  distinct responsibilities (signal 4). ✅
+- *Off-by-one:* a written test fails at the boundary (signal 1) **and** the
+  reading explains why (signal 4). ✅
+- *Duplicated block:* duplication scan finds it (signal 2/3) **and** the diff
+  shows the blocks are semantically identical (signal 4). ✅
+
+**Examples that DO NOT clear the gate (drop them):**
+
+- "This function looks too long." — one soft signal, no tool, no responsibility
+  analysis. ❌
+- "This is probably an N+1." — no query-count artifact. ❌
+- "This might be a race condition." — no reproducing test or rigorous argument
+  plus a concrete interleaving. ❌
+- vulture flags a symbol that is actually a FastAPI route handler / pytest
+  fixture / dynamically dispatched — the grep refutes it. ❌ (This is why
+  vulture alone is never enough.)
+
+When in doubt, **don't file it.** Null findings are a valid, healthy outcome.
+
+---
+
+## The toolbox (already in this repo)
+
+Everything below is already installed via `backend/requirements-dev.txt`,
+`.pre-commit-config.yaml`, and `frontend/package.json`. `collect-evidence.sh`
+runs the read-only subset and writes a report to the scratchpad.
+
+### Backend (Python)
+
+| Tool | Finds | Invocation (from `backend/`) |
+|------|-------|------------------------------|
+| **ruff** (`select=ALL`) | bugs (`B`,`BLE`,`RUF`), simplifications (`SIM`), complexity (`PLR`), datetimes (`DTZ`), dead imports (`F401`) | `ruff check src --output-format=json` |
+| **vulture** | dead code: unused funcs/classes/vars/imports | `vulture src --min-confidence 80` |
+| **radon** | cyclomatic complexity + maintainability index | `radon cc src -s -n C` / `radon mi src -s` |
+| **xenon** | complexity grade gate | `xenon src --max-absolute B --max-average A` |
+| **mypy** (strict) | type holes, `Any` creep, unreachable code | `mypy src` |
+| **bandit** | security smells (injection, weak crypto, asserts) | `bandit -r src -f json` |
+| **interrogate** | docstring coverage gaps | `interrogate src -v` |
+| **pip-audit** | vulnerable dependencies | `pip-audit -r requirements.txt` |
+| **detect-secrets** | hardcoded secrets | `detect-secrets scan` |
+| **git** | churn / hotspots / commented-out code | `git log --format= --name-only \| sort \| uniq -c \| sort -rn` |
+
+### Frontend (TypeScript / React Native)
+
+| Tool | Finds | Invocation (from `frontend/`) |
+|------|-------|-------------------------------|
+| **eslint** (sonarjs + unicorn) | cognitive complexity, duplication, dead code, footguns | `npx eslint . -f json` |
+| **tsc** (strict) | type holes, `any`, unreachable, hallucinated APIs | `npx tsc --noEmit` |
+| **jest --coverage** | coverage gaps (then judge assertion quality) | `npx jest --coverage` |
+| **grep/ripgrep** | `@ts-ignore`, `any`, `TODO`, commented code, AI-tells | see grep recipes below |
+
+### Cross-cutting grep recipes
+
+Run these read-only; each hit is a *candidate* needing a second signal.
+
+```bash
+# Stubs / hollow implementations
+rg -n "NotImplementedError|not implemented|return None\s*#\s*TODO|throw new Error\(['\"]not implemented" backend/src frontend/src
+# AI-tell comments
+rg -n "In a real implementation|placeholder|for now|as an AI|should probably|FIXME|HACK|XXX" backend/src frontend/src
+# Debt markers
+rg -n "TODO|FIXME|HACK" backend/src frontend/src
+# Escape hatches without an issue reference
+rg -n "type: ignore|@ts-ignore|eslint-disable|# noqa" backend/src frontend/src
+# Swallowed exceptions
+rg -n "except (Exception|BaseException)?:\s*$" -U backend/src
+rg -n "catch\s*\([^)]*\)\s*\{\s*\}" frontend/src
+# Commented-out code (heuristic: lines that are commented statements)
+rg -n "^\s*#\s*(def |class |return |if |for |import )" backend/src
+# Magic numbers (review, don't auto-file)
+rg -n "[^_a-zA-Z0-9.]\d{3,}" backend/src
+```
+
+---
+
+## Category → detection → corroboration map
+
+For each taxonomy family, the primary tool and the required second signal.
+
+| Family | Primary signal | Required second signal |
+|--------|----------------|------------------------|
+| 0. Correctness/bugs | ruff `B`/`BLE`/`RUF`, eslint, reading | **a failing test that reproduces it** (mandatory) |
+| 1. Bloaters | radon CC / eslint cognitive-complexity | reading confirms multiple responsibilities |
+| 2. OO abusers | reading / grep `isinstance` ladders | confirm a cleaner construct fits |
+| 3. Dispensables — dead | vulture / eslint no-unused | grep proves zero inbound refs (incl. dynamic) |
+| 3. Dispensables — dup | duplication scan (`jscpd`-style / eslint sonar) | diff confirms semantic identity, ≥2 sites |
+| 3. Dispensables — stub | grep stub markers | confirm callers depend on it (else it's dead) |
+| 4. Change-preventers | git churn / shotgun trace | confirm scatter across files for one change |
+| 5. Couplers/arch | import-cycle scan / layering grep | confirm the edge crosses a layer wrongly |
+| 6. Naming/comments | comment-density / grep | reading confirms zero added information |
+| 7. Verbosity | ruff `SIM`, reading | confirm an idiomatic shorter form exists |
+| 8. Type safety | mypy / tsc / grep escape-hatches | confirm a real type is knowable / no issue ref |
+| 9. Testing | jest/pytest coverage + mutation reasoning | confirm a logic flip would survive |
+| 10. Security | bandit / detect-secrets / pip-audit | confirm input reaches sink / secret is live |
+| 11. Deps/config | grep imports vs manifest | confirm zero use / real conflict |
+| 12. AI-slop | grep AI-tells / dup vs existing helper | reproducing artifact (bugs) or grep of the real helper |
+
+---
+
+## The weekly run procedure
+
+1. **Snapshot.** Run `scripts/collect-evidence.sh` → a consolidated evidence
+   report in the scratchpad (all tool JSON + grep hits + churn).
+2. **Triage candidates.** Parse the report into candidate findings. Discard
+   anything in the "NOT slop" guard list (`slop-taxonomy.md`) — generated code,
+   migrations, justified suppressions, framework boilerplate, test fixtures.
+3. **Corroborate each survivor** against the Two-Signal Rule. For correctness
+   candidates, *write and run the reproducing test* in a throwaway location
+   (do not commit it — the implementing issue will own the real test). If it
+   doesn't reproduce, drop it.
+4. **Cluster.** Group corroborated findings by area/theme. A cluster that needs
+   coordinated, multi-file change becomes an **epic**; standalone findings
+   become single issues. Many Low findings in one file = one tidy-up issue.
+5. **Dedup against the backlog.** For every cluster/finding, search existing
+   open issues (`gh issue list`, `gh search issues`) and recent closed ones.
+   If it already exists, skip (optionally add a corroborating comment). Never
+   file a duplicate.
+6. **Size & file.** Apply `issue-templates.md`. Respect the ~200–300 LoC
+   sizing; split anything bigger into an epic + sub-issues in dependency order.
+7. **Report.** Emit a run summary (counts by severity, what was filed, what was
+   dropped and why, what was deduped). A run that files nothing is a success if
+   the codebase is clean — say so explicitly.
+
+---
+
+## Calibration: precision over recall
+
+This detector is tuned for **precision**. It is acceptable — expected, even —
+to miss real slop in a given week. It is **not** acceptable to file a finding
+that wastes an autonomous implementation cycle on a non-problem or, worse,
+"fixes" correct code into broken code.
+
+- If a finding's corroboration is shaky, **downgrade or drop it**.
+- If a "fix" would be opinionated/stylistic against repo convention, **drop it**.
+- If the evidence is a single tool hit with a known false-positive profile
+  (vulture on dynamic dispatch, magic-number grep on HTTP codes), **drop it**
+  unless a second signal confirms.
+- Prefer **few, ironclad, high-value** issues over a long list of maybes.

--- a/.claude/skills/de-slopify/references/issue-templates.md
+++ b/.claude/skills/de-slopify/references/issue-templates.md
@@ -1,0 +1,195 @@
+# Issue & Epic Templates — Filing De-Slop Work the Backlog Can Consume
+
+Findings become GitHub issues that **Ralph** picks up autonomously
+(`scripts/ralph/pick-next.sh`). To be picked up correctly, issues must follow
+the label and shape conventions below. Get this wrong and Ralph either ignores
+real work or tries to implement an epic as a single PR.
+
+---
+
+## How the Ralph picker treats labels (must-know)
+
+From `scripts/ralph/pick-next.sh`:
+
+- **Picks** the lowest-numbered open issue with **none** of these labels:
+  `epic wontfix duplicate invalid question blocked needs-spec future-work
+  do-not-auto-merge in-progress`.
+- An issue already referenced by an open PR's `Closes/Fixes/Resolves #N` is
+  treated as in-flight and skipped.
+
+**Consequences for de-slop filing:**
+
+- A **standalone finding** = a normal issue with **no** excluded label → Ralph
+  works it. ✅
+- An **epic** must carry the `epic` label → Ralph skips the umbrella and works
+  its decomposed sub-issues instead. ✅
+- A sub-issue that depends on an unbuilt predecessor should carry `blocked` (or
+  `needs-spec`) until its predecessor merges, so Ralph doesn't start it out of
+  order. The 10-tick `backlog-grooming` pass (or you, next run) removes the
+  label once the predecessor is done. Note the dependency as `Depends on #N` in
+  the body regardless.
+
+---
+
+## Standard labels this skill uses
+
+Create any that don't exist (`gh label create <name> --color <hex> --description ...`).
+
+| Label | Meaning | Color |
+|-------|---------|-------|
+| `de-slop` | Filed by the weekly de-slopify detector | `#5319e7` |
+| `epic` | Umbrella issue; Ralph skips, works sub-issues | `#3e4b9e` |
+| `priority-critical` / `priority-high` / `priority-medium` / `priority-low` | Severity from the rubric | red→grey |
+| `backend` / `frontend` / `full-stack` | Scope | tool-matched |
+| `bug` | Family 0 / 12 correctness finding (has a reproducing test) | `#d73a4a` |
+| `dead-code` | Family 3 dispensable | `#cfd3d7` |
+| `refactor` | Bloaters / couplers / verbosity | `#fbca04` |
+| `tech-debt` | Architecture / change-preventers | `#e99695` |
+| `security` | Family 10 (work itself defers to the `security` skill) | `#b60205` |
+| `tests` | Family 9 testing slop | `#0e8a16` |
+| `blocked` / `needs-spec` | Not ready for autonomous pickup | `#000000` |
+
+Keep labels minimal per issue: one severity + one scope + one category + `de-slop`.
+
+---
+
+## Template A — Standalone finding (single, atomic, Ralph-ready)
+
+Mirror the established `prompts/github-issues/*.md` shape so it's actionable
+without a single clarifying question. Title is imperative and specific.
+
+```markdown
+# <imperative title> (e.g. "Remove dead `legacy_streak()` and its orphaned test")
+
+**Labels:** `de-slop`, `<scope>`, `<category>`, `priority-<level>`
+**Detected by:** weekly de-slopify run <YYYY-MM-DD>
+**Severity:** <Critical|High|Medium|Low>
+
+## Problem
+<2-3 sentences. What's wrong, where. Cite file:line. State the taxonomy family.>
+**Current state:** <concrete observation>
+
+## Evidence (corroboration)
+- Signal 1: <reproducing artifact — test output / tsc error / query count / tool JSON>
+- Signal 2: <independent signal — grep result / second tool / reading>
+<Paste the minimal proof. This is what makes the finding trustworthy.>
+
+## Scope
+<1-2 sentences bounding what this covers and explicitly what it does NOT.>
+
+## Tasks
+1. <specific, actionable step with file paths>
+2. <...>
+
+## Acceptance Criteria
+- [ ] <testable, binary criterion tied to the evidence above>
+- [ ] No existing tests break; coverage stays ≥ 90%.
+- [ ] All pre-commit hooks pass (`pre-commit run --all-files`).
+
+## Files to Create/Modify
+| File | Action |
+|------|--------|
+| `path/to/file.py` | Modify / Delete / Create |
+```
+
+**Rule:** a standalone issue should be ~50–300 net LoC and touch ≤ ~5 files. If
+it's bigger, it's an epic.
+
+---
+
+## Template B — Epic (umbrella for coordinated, multi-issue work)
+
+Use when a corroborated problem needs more than one PR's worth of change
+(e.g. "decompose the 600-line `HabitsScreen`", "unify three divergent error
+contracts", "destub the aspirational encryption feature"). Mirrors the existing
+`prompts/github-issues/phase-*-epic.md` and `audit-destub` shape.
+
+```markdown
+# <Epic title> (e.g. "De-Slop: Decompose the HabitsScreen god-component")
+
+**Labels:** `de-slop`, `epic`, `<scope>`, `priority-<level>`
+**Detected by:** weekly de-slopify run <YYYY-MM-DD>
+
+## Why this is an epic
+<The corroborated problem and why it can't be one atomic PR. Cite evidence.>
+
+## Evidence (corroboration)
+<The tool output / metrics / reading that proves the problem is real.>
+
+## Target end state
+<What "done" looks like across all sub-issues — the architecture after.>
+
+## Decomposition (sub-issues, in dependency order)
+1. #<n> — <sub-issue title> — ~<LoC> — depends on: none
+2. #<n> — <sub-issue title> — ~<LoC> — depends on: #<prev>
+...
+
+## Dependency graph
+```
+sub-1 ──▶ sub-2 ──▶ sub-4
+   └────▶ sub-3 ────┘
+```
+
+## Non-goals
+<What this epic explicitly does not attempt.>
+```
+
+Then create each sub-issue with **Template A**, link them to the epic body, and
+(if GitHub sub-issues are available) attach them via `gh sub-issue` / the REST
+sub-issues API. Mark dependents `blocked` per the picker rule above.
+
+> The `triage-and-plan` skill is the heavy machinery for decomposing a large
+> area into a well-ordered epic of ~300-LoC issues. **Invoke it** when an epic
+> needs more than ~3 sub-issues — don't hand-roll a sprawling decomposition.
+
+---
+
+## `gh` filing recipes (file-based bodies, never inline strings)
+
+Write the body to a temp file in the scratchpad, then file it. This avoids shell
+quoting bugs and matches the repo's `git-workflow` convention.
+
+```bash
+SCRATCH="${SCRATCHPAD:-/tmp}"; BODY="$SCRATCH/deslop-issue.md"
+
+# Standalone finding
+cat > "$BODY" <<'EOF'
+## Problem
+...
+EOF
+gh issue create \
+  --title "Remove dead legacy_streak() and its orphaned test" \
+  --label de-slop --label backend --label dead-code --label priority-medium \
+  --body-file "$BODY"
+
+# Epic (capture its number to link sub-issues)
+EPIC_URL=$(gh issue create --title "De-Slop: Decompose HabitsScreen" \
+  --label de-slop --label epic --label frontend --label priority-high \
+  --body-file "$SCRATCH/deslop-epic.md")
+EPIC_NUM="${EPIC_URL##*/}"
+
+# Sub-issue referencing the epic
+gh issue create --title "Extract useHabits hook from HabitsScreen" \
+  --label de-slop --label frontend --label refactor --label priority-high \
+  --body-file "$SCRATCH/deslop-sub-1.md"   # body contains "Refs #$EPIC_NUM"
+```
+
+Dedup before every create:
+
+```bash
+gh issue list --state open --search "in:title <keywords>" --json number,title
+gh search issues --repo Geoffe-Ga/adepthood "<keywords>" --state open
+```
+
+---
+
+## Filing checklist (every issue, before `gh issue create`)
+
+- [ ] Corroborated by ≥2 signals; evidence pasted into the body.
+- [ ] Not a duplicate of an open or recently-closed issue.
+- [ ] Not in the "NOT slop" guard list.
+- [ ] Correct labels: severity + scope + category + `de-slop` (+ `epic` if umbrella).
+- [ ] Title is imperative and specific; body is actionable without questions.
+- [ ] Sized right (standalone ≤ ~300 LoC / ≤ 5 files; else epic + sub-issues).
+- [ ] Dependencies noted (`Depends on #N`) and dependents labeled `blocked`.
+- [ ] Acceptance criteria are testable and tie back to the evidence.

--- a/.claude/skills/de-slopify/references/slop-taxonomy.md
+++ b/.claude/skills/de-slopify/references/slop-taxonomy.md
@@ -1,0 +1,270 @@
+# The Slop Taxonomy — An Exhaustive Field Guide to Sloppy and Amateurish Code
+
+This is the reference catalog the `de-slopify` skill scans against. It is the
+distilled answer to the question *"what does sloppy, amateurish, AI-generated,
+or otherwise low-quality code actually look like?"* — organized so a reviewer
+(human or agent) can systematically hunt for each species.
+
+It synthesizes several established sources and adapts them to Adepthood's
+FastAPI + React Native stack:
+
+- **Fowler & Beck**, *Refactoring* (2nd ed., 2018) — the canonical 22 smells,
+  grouped into Bloaters, OO-Abusers, Change-Preventers, Dispensables, Couplers.
+- **Mäntylä & Lassenius**, *Bad Code Smells Taxonomy* — the academic expansion.
+- **Robert C. Martin**, *Clean Code* — the heuristics (G1–G36, N1–N7, etc.).
+- **SonarSource / SonarQube** rule families — reliability, maintainability,
+  security-hotspot, cognitive-complexity.
+- **AI-slop literature (2024–2026)** — the failure modes specific to
+  LLM/agent-generated code (architectural drift, duplicated blocks, confident
+  wrongness, ceremonial comments, hallucinated APIs).
+
+> **How to use it.** Each entry has: a *name*, a *tell* (how it presents), and a
+> *corroboration hint* (what second signal makes it real vs. a false alarm).
+> Nothing here is filed as work on its own — see `detection-playbook.md` for the
+> evidence-and-corroboration gate every finding must pass.
+
+---
+
+## Family 0 — Correctness & Latent Bugs (the highest-value class)
+
+Slop that is not merely ugly but *wrong*. These get the highest severity because
+they cause incidents, not just friction.
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Off-by-one / boundary error** | `<=` vs `<`, `range(n)` vs `range(n+1)`, slice fence-posts | Write the failing test at the boundary value; if it fails, real. |
+| **Swallowed exception** | `except Exception: pass`, `catch {}`, `.catch(() => {})` with no rethrow/log | grep for bare excepts; confirm the error path is reachable and silently lost. |
+| **Broad except clause** | `except Exception:` / `except:` masking specific failures | ruff `BLE001`; confirm a narrower type exists. |
+| **Mutable default argument** | `def f(x=[])`, `def f(x={})` | ruff `B006`; trivially real. |
+| **Resource leak** | file/socket/session opened without `with`/`finally`/`close()` | trace the handle; confirm no context manager. |
+| **Async footgun** | un-awaited coroutine, blocking call in async path, `asyncio.run` in a running loop | ruff `RUF006`, `ASYNC*`; confirm with a runtime trace or test. |
+| **Race / shared-state mutation** | module-level mutable state mutated per-request; non-atomic check-then-act | concurrency reasoning + a stress test; corroborate, don't guess. |
+| **Floating-point / money in float** | currency or energy points stored as `float` | confirm rounding drift is observable. |
+| **Timezone-naive datetime** | `datetime.now()` without tz, naïve/aware mixing | ruff `DTZ*`; confirm comparison across tz. |
+| **TOCTOU / idempotency hole** | check-then-act without a lock or unique constraint; missing idempotency key TTL | reproduce the double-submit. |
+| **Unvalidated boundary input** | request body trusted without schema/length/range checks | confirm no Pydantic validator / no zod-equivalent. |
+| **Incorrect null/undefined handling** | `if (x)` truthiness bugs (`0`, `""`, `false`), `Optional` deref without guard | type-narrowing analysis + test. |
+| **SQL/ORM N+1 or missing filter** | query in a loop; `.all()` then filter in Python; missing tenant/user filter | log query count; the missing-filter case is also a security bug. |
+| **Wrong comparison** | `==` on objects/NaN, `is` on small ints/strings by luck, `assert` for control flow | confirm semantics differ from intent. |
+| **Silent type coercion** | implicit `str`↔`int`, JS `==`, truthy coercion | eslint `eqeqeq`; confirm a coercion path. |
+
+---
+
+## Family 1 — Bloaters (code that grew too big to reason about)
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Long Method / Function** | 50+ lines, scrolls past a screen, many responsibilities | radon CC grade ≥ C **and** a reviewer reading confirms multiple jobs. |
+| **Large Class / God Object** | a class/module that knows or does everything | LoC + fan-in/fan-out; confirm distinct responsibilities. |
+| **Long Parameter List** | 4+ positional params, especially booleans | ruff `PLR0913`; confirm a param object is natural. |
+| **Data Clumps** | the same 3+ fields travel together everywhere | grep the recurring tuple; confirm ≥3 call sites. |
+| **Primitive Obsession** | strings/ints where a value object belongs (ids, money, enums-as-strings) | confirm invariants are re-checked everywhere. |
+| **Long message chain / Train wreck** | `a.b().c().d().e()` | confirm Law-of-Demeter violation, not a fluent builder. |
+| **Combinatorial flag explosion** | functions whose behavior forks on many boolean params | count branches; confirm callers pass varied combos. |
+| **Deeply nested code** | 4+ levels of indentation, arrow-shaped code | cognitive-complexity / radon; confirm guard clauses would flatten it. |
+
+---
+
+## Family 2 — OO / Structure Abusers
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Switch/if-elif on type** | repeated `isinstance`/`type ==` ladders | confirm polymorphism or a dispatch table fits. |
+| **Refused Bequest** | subclass ignores/overrides most of parent | confirm the inheritance is wrong, not partial. |
+| **Temporary Field** | object field only set in some flows, null otherwise | trace lifecycle; confirm it's conditional state. |
+| **Alternative Classes, Different Interfaces** | two classes do the same job with different method names | confirm interchangeability. |
+| **Inappropriate Intimacy** | two modules reach into each other's privates | confirm tight coupling across a boundary. |
+| **Feature Envy** | a method uses another object's data more than its own | confirm the method belongs elsewhere. |
+| **Middle Man** | a class that only delegates | confirm it adds no value. |
+| **Hub-and-spoke god module** | everything imports one util grab-bag | import graph fan-in; confirm it should be split. |
+
+---
+
+## Family 3 — Dispensables (code that should not exist)
+
+This family is the heart of "de-slopping." It is where dead, stubbed, orphaned,
+and duplicated code lives.
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Dead code** | unreachable branches, unused functions/classes/vars, unused imports | **vulture** (Python) / **eslint+ts** (frontend) **and** a grep proving zero references (incl. dynamic/string refs, routers, DI). |
+| **Commented-out code** | blocks of `# old impl ...` / `// ...` left in | grep; trivially real — delete, git remembers. |
+| **Stubbed / hollow implementation** | `raise NotImplementedError`, `pass`, `return None  # TODO`, `return []` placeholder, `throw new Error('not implemented')`, a function whose body is a single `...` | grep + confirm it's referenced as if real (a stub nobody calls is dead code; a stub callers depend on is a **lie** — higher severity). |
+| **Fake/aspirational feature flag** | a flag/docstring/comment claiming a guarantee the code doesn't deliver (e.g. "encrypted at rest" with plaintext writes) | trace the claim to the implementation; confirm the gap. This is the `audit-destub` pattern — see that epic. |
+| **Orphaned code** | files/modules nothing imports; routes never mounted; assets never referenced; tests for deleted features | dependency graph + grep; confirm zero inbound edges. |
+| **Duplicated code** | copy-pasted blocks, parallel near-identical functions | structural duplication scan + diff the blocks; confirm ≥ N tokens identical across ≥2 sites. |
+| **Speculative generality** | abstractions/params/hooks "for the future" with one caller | confirm a single implementation/caller; YAGNI. |
+| **Lazy class** | a class/module that doesn't pull its weight | confirm it can be inlined. |
+| **Data class (anemic)** | a bag of fields with no behavior where behavior belongs | confirm logic is scattered across users. |
+| **Dead config / deps** | declared dependencies never imported; env vars never read; settings never used | grep usage of each; confirm zero references. |
+| **Redundant test** | tests asserting framework behavior, tautologies, `assert True`, snapshot-only with no logic | confirm it would survive a logic mutation (see mutation-testing). |
+
+---
+
+## Family 4 — Change-Preventers (code that makes change expensive)
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Divergent Change** | one module changed for many unrelated reasons | git churn + confirm distinct change-reasons in history. |
+| **Shotgun Surgery** | one logical change forces edits in many files | trace a representative change; confirm scatter. |
+| **Parallel inheritance hierarchies** | adding a subclass here forces one there | confirm the lock-step. |
+| **Implicit cross-layer coupling** | frontend type silently depends on backend shape with no shared contract | confirm a schema mismatch is possible. |
+
+---
+
+## Family 5 — Couplers & Architecture
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Circular dependency** | module A imports B imports A | import-graph cycle detection; trivially real once found. |
+| **Layering violation** | router does DB access directly; domain imports web framework; model imports a router | confirm the dependency crosses a layer the wrong way. |
+| **Business logic in the wrong tier** | validation/energy/streak math inside a route handler or a React component | confirm it belongs in `domain/`. |
+| **Leaky abstraction** | callers must know internal details to use a thing safely | confirm the contract is insufficient. |
+| **Global mutable singleton** | module-level caches/state mutated across requests | confirm request-to-request bleed. |
+| **Missing seam / untestable design** | logic that can't be tested without network/clock/db because it hard-codes them | confirm no injection point exists. |
+| **Inconsistent error contract** | endpoints return errors in different shapes/status codes | diff error responses across routers. |
+| **Architectural drift (AI-era)** | the same concept implemented 3 ways because each was generated fresh | find the divergent implementations; confirm they should be one. |
+
+---
+
+## Family 6 — Naming, Readability & Comment Slop
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Meaningless names** | `data`, `data2`, `tmp`, `obj`, `foo`, `handleStuff`, `x1` | confirm the name doesn't reveal intent. |
+| **Misleading names** | name says one thing, code does another; `get_*` that mutates | confirm semantic mismatch (a real bug risk). |
+| **Inconsistent vocabulary** | `fetch`/`get`/`load`/`retrieve` for the same concept | confirm same operation, different words. |
+| **Ceremonial / restating comments** | `# increment i by 1` above `i += 1`; `// constructor`; docstrings that restate the signature | grep comment-to-code ratio; confirm zero added information. |
+| **Stale / lying comments** | comment describes behavior the code no longer has | confirm divergence from code. |
+| **Banner / ASCII-art noise** | `#########` dividers, decorative boxes | cosmetic; bundle, don't file alone. |
+| **Over-explaining the obvious** | paragraph docstring on a one-line getter | confirm verbosity without value. |
+| **AI-tell comments** | "Note: this is a placeholder", "In a real implementation...", "This should probably...", "As an AI..." | grep; these flag unfinished/uncertain code — pair with the code they describe. |
+| **Commented apologies / TODO/FIXME/HACK/XXX** | debt markers left in tree | grep; triage each — actionable now ⇒ file it. |
+
+---
+
+## Family 7 — Verbosity & Needless Complexity
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Reinventing the stdlib** | hand-rolled `groupby`, manual `dict.get` chains, custom date math | confirm a standard/idiomatic one-liner exists. |
+| **Yoda / redundant conditionals** | `if x == True`, `if len(xs) > 0`, `return True if c else False`, `x if x else y` | ruff `SIM*`; trivially real. |
+| **Unnecessary intermediate variables / indirection** | single-use vars, wrapper functions that only call one thing | confirm inlining clarifies. |
+| **Defensive over-checking** | re-validating invariants already guaranteed; double null-checks | confirm the guard is unreachable. |
+| **Premature / cargo-cult optimization** | micro-opts that obscure intent with no measured need | confirm no profiling justified it. |
+| **Verbose boilerplate that a helper would kill** | the same 6-line try/except/log repeated everywhere | confirm a decorator/util fits. |
+| **Wall-of-code config** | giant literal dicts/objects that should be data files | confirm it belongs in config/fixtures. |
+| **Over-abstraction** | factories-of-factories, 5 layers to do one thing | confirm fewer layers suffice. |
+
+---
+
+## Family 8 — Type-Safety & Contract Erosion
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Escape hatches** | `# type: ignore`, `// @ts-ignore`, `// eslint-disable`, `# noqa`, `cast(Any, ...)` without justification | grep; confirm no linked issue justifies it (CLAUDE.md bans unjustified ones). |
+| **`Any` / `unknown` creep** | `Any` params/returns, `as any`, untyped dicts crossing boundaries | mypy/tsc; confirm a real type is knowable. |
+| **Loose assertions** | `as Foo` casts that bypass checks, non-null `!` operator overuse | confirm the cast can be wrong at runtime. |
+| **Frontend/backend shape drift** | TS type and Pydantic schema for the same payload disagree | diff the two; confirm a field/optionality mismatch. |
+| **Missing annotations** | public functions without signatures (where strict mode allows) | mypy/tsc strict gaps. |
+
+---
+
+## Family 9 — Testing Slop
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Coverage theater** | high % but assertions are weak/absent | mutation testing — does a logic flip survive? |
+| **Tests that never fail** | `assert True`, asserting mocks were called but not outcomes, snapshot-only | confirm no behavioral assertion. |
+| **Over-mocking** | mocking the unit under test; testing the mock | confirm the real behavior isn't exercised. |
+| **Missing edge/error-path tests** | only happy path covered | coverage of error branches; confirm gaps. |
+| **Flaky tests** | time/order/network dependent | confirm nondeterminism source. |
+| **Commented-out / skipped tests** | `@pytest.mark.skip`, `xit`, `it.skip` without an issue ref | grep; CLAUDE.md requires a justification. |
+
+---
+
+## Family 10 — Security & Safety Slop
+
+(Defer deep work to the `security` skill; this catalog only flags candidates.)
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Hardcoded secret/credential** | API keys, tokens, passwords in source | detect-secrets / gitleaks; confirm it's a live secret shape. |
+| **Injection vector** | string-built SQL, `eval`, `exec`, shell with user input, `dangerouslySetInnerHTML` | bandit / eslint; confirm user input reaches the sink. |
+| **Missing authz check** | endpoint mutates another user's data without ownership check | trace the handler; confirm no guard. |
+| **Permissive CORS / wildcard** | `allow_origins=["*"]` with credentials | confirm config. |
+| **Weak crypto / homemade auth** | md5/sha1 for passwords, custom token signing | confirm the primitive. |
+| **Sensitive data in logs** | logging tokens, PII, journal contents | grep log calls near sensitive fields. |
+| **Vulnerable dependency** | pinned dep with a known CVE | pip-audit / npm audit (defer fix to `cve-remediation`). |
+
+---
+
+## Family 11 — Dependency, Build & Config Hygiene
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Unused dependency** | declared in requirements/package.json, never imported | grep imports; confirm zero use. |
+| **Phantom dependency** | imported but not declared | confirm import without a manifest entry. |
+| **Duplicate / conflicting config** | two tools configured for the same job, contradicting | confirm overlap. |
+| **Magic numbers / strings** | unexplained literals (`* 86400`, `0.7`, status codes) | confirm a named constant adds meaning. |
+| **Environment-coupled code** | hard-coded localhost/paths/ports | confirm it breaks outside dev. |
+| **Copy-pasted config drift** | the same setting set differently in N places | diff the values. |
+
+---
+
+## Family 12 — AI-Slop-Specific Patterns (2024–2026)
+
+LLM/agent-generated code has characteristic failure modes worth hunting
+explicitly. (Sources: AI-slop research catalogs; SpecDetect4AI; empirical
+studies of LLM-generated code.)
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Confident wrongness** | plausible code that compiles and reads well but is subtly incorrect | only filed with a reproducing test — never on vibes. |
+| **Hallucinated API / import** | calls to functions/params/endpoints that don't exist | tsc/mypy/import error; trivially real if it doesn't resolve. |
+| **Reinvented existing helper** | a fresh utility duplicating one already in the repo | grep for the existing helper; confirm overlap. |
+| **Ceremonial scaffolding** | elaborate structure (interfaces, abstract bases) around trivial logic | confirm the ceremony exceeds the need. |
+| **Explanatory-comment spam** | every line narrated; docstrings restating types | comment density metric. |
+| **"In a real implementation" stubs** | placeholder bodies with apologetic comments | grep AI-tell phrases. |
+| **Inconsistent-with-house-style** | code that ignores the repo's established patterns (e.g. not using `Depends(get_session)`) | compare to the canonical pattern in CLAUDE.md. |
+| **Defensive sludge** | redundant try/except, re-checking guaranteed invariants, belt-and-suspenders nobody asked for | confirm unreachable defenses. |
+| **Over-broad error handling that hides bugs** | catch-all that turns a crash into a wrong-but-silent result | confirm a real failure is masked. |
+
+---
+
+## Severity rubric
+
+Assign each corroborated finding a severity. This maps to issue labels and to
+how aggressively Ralph should pick it up.
+
+| Severity | Definition | Examples |
+|----------|------------|----------|
+| **Critical** | Causes data loss, security breach, or user-facing breakage now | live secret, missing authz, injection, swallowed error on a write path, a stub callers depend on |
+| **High** | Latent correctness bug, architectural debt that compounds, lying feature flag | off-by-one behind a flag, N+1 on a hot path, circular dep, frontend/backend shape drift |
+| **Medium** | Maintainability tax, real dead/duplicated code, weak tests | god function, duplicated block, coverage theater, dead module |
+| **Low** | Readability, naming, comment slop, cosmetic verbosity | ceremonial comments, meaningless names, redundant conditionals |
+
+**Bundling rule:** many Low findings in one file/area = one tidy-up issue, not
+twenty. Don't death-by-a-thousand-issues the backlog.
+
+---
+
+## What is explicitly NOT slop (false-positive guards)
+
+The detector must *not* file these. Treating them as findings is itself slop.
+
+- **Intentional, documented simplicity** — a small function is not a "lazy class."
+- **Justified suppressions** — a `# type: ignore[...]` or `// eslint-disable`
+  with a linked issue and a real reason is allowed by CLAUDE.md. Leave it.
+- **Test fixtures and factories** — duplication and "magic" values in tests are
+  often deliberate and readable.
+- **Generated code / vendored files / migrations** — Alembic migrations,
+  `package-lock.json`, build output. Out of scope.
+- **Framework-required boilerplate** — Pydantic models, SQLModel tables, React
+  Navigation config have irreducible shape.
+- **Domain constants that are self-explanatory** — `status_code=404`, `HTTP_200`.
+- **Style the repo has deliberately chosen** — match CLAUDE.md/AGENTS.md, not a
+  generic ideal.
+- **Speculative "could be faster"** without a measurement — premature.
+- **Anything you can't corroborate** — if the second signal isn't there, it's a
+  hypothesis, not a finding. Drop it.

--- a/.claude/skills/de-slopify/scripts/collect-evidence.sh
+++ b/.claude/skills/de-slopify/scripts/collect-evidence.sh
@@ -82,6 +82,7 @@ if [[ -d "$PY_SRC" ]]; then
   run bandit.json          bandit -r "$PY_SRC" -f json -c "$BACKEND/.bandit"
   run interrogate.txt      interrogate "$PY_SRC" -v
   run pip-audit.txt        pip-audit -r "$BACKEND/requirements.txt"
+  run detect-secrets.txt   detect-secrets scan "$PY_SRC"
 fi
 
 # ----------------------------------------------------------------------------

--- a/.claude/skills/de-slopify/scripts/collect-evidence.sh
+++ b/.claude/skills/de-slopify/scripts/collect-evidence.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# collect-evidence.sh — read-only slop-evidence collector for the de-slopify skill.
+#
+# Runs the repo's existing static-analysis toolbox plus grep heuristics and
+# writes every raw result into an output directory. It NEVER modifies tracked
+# files and NEVER fails the run because a single tool is missing or unhappy —
+# each tool's exit status is captured, not propagated, so the agent always gets
+# a complete evidence bundle to corroborate against.
+#
+# Usage:
+#   scripts/collect-evidence.sh [OUTPUT_DIR]
+#
+# OUTPUT_DIR defaults to "$SCRATCHPAD/deslop-evidence" if SCRATCHPAD is set,
+# else a mktemp dir. The chosen directory is printed on the last line so a
+# caller can capture it:  EVID=$(scripts/collect-evidence.sh | tail -1)
+#
+# Exit codes: 0 always (collection is best-effort). 2 only on a setup error
+# (no git repo / cannot create output dir).
+
+set -uo pipefail
+
+# --- locate the repo root (this script lives in .claude/skills/de-slopify/scripts) ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+if [[ ! -d "$REPO_ROOT/.git" ]]; then
+  echo "collect-evidence: not a git repo at $REPO_ROOT" >&2
+  exit 2
+fi
+cd "$REPO_ROOT" || exit 2
+
+# --- output dir ---
+OUT="${1:-${SCRATCHPAD:+$SCRATCHPAD/deslop-evidence}}"
+if [[ -z "$OUT" ]]; then
+  OUT="$(mktemp -d)"
+fi
+if ! mkdir -p "$OUT"; then
+  echo "collect-evidence: cannot create output dir $OUT" >&2
+  exit 2
+fi
+
+BACKEND="backend"
+FRONTEND="frontend"
+PY_SRC="$BACKEND/src"
+TS_SRC="$FRONTEND/src"
+
+log() { echo ">>> $*" >&2; }
+
+# Activate the project venv if present (so backend tools resolve).
+if [[ -f .venv/bin/activate ]]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+fi
+
+# run <outfile> <cmd...> — run a tool, capture stdout+stderr and exit code,
+# never abort the script. Skips gracefully if the binary is absent.
+run() {
+  local out="$1"; shift
+  local bin="$1"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "SKIPPED: $bin not installed" >"$OUT/$out"
+    log "skip $bin (not installed)"
+    return 0
+  fi
+  log "run $*"
+  if "$@" >"$OUT/$out" 2>&1; then
+    echo "[exit 0]" >>"$OUT/$out"
+  else
+    echo "[exit $?]" >>"$OUT/$out"
+  fi
+  return 0
+}
+
+# ----------------------------------------------------------------------------
+# Backend (Python) — read-only analysis
+# ----------------------------------------------------------------------------
+if [[ -d "$PY_SRC" ]]; then
+  run ruff.json            ruff check "$PY_SRC" --config="$BACKEND/pyproject.toml" --output-format=json
+  run vulture.txt          vulture "$PY_SRC" --min-confidence 80
+  run radon-cc.txt         radon cc "$PY_SRC" -s -n C
+  run radon-mi.txt         radon mi "$PY_SRC" -s
+  run mypy.txt             mypy "$PY_SRC" --config-file="$BACKEND/pyproject.toml"
+  run bandit.json          bandit -r "$PY_SRC" -f json -c "$BACKEND/.bandit"
+  run interrogate.txt      interrogate "$PY_SRC" -v
+  run pip-audit.txt        pip-audit -r "$BACKEND/requirements.txt"
+fi
+
+# ----------------------------------------------------------------------------
+# Frontend (TypeScript) — read-only analysis
+# ----------------------------------------------------------------------------
+if [[ -d "$TS_SRC" ]]; then
+  # eslint and tsc are run via the frontend dir; capture but never abort.
+  ( cd "$FRONTEND" && command -v npx >/dev/null 2>&1 \
+      && npx --no-install eslint . -f json ) >"$OUT/eslint.json" 2>&1 \
+      || echo "[eslint unavailable or reported issues — inspect output]" >>"$OUT/eslint.json"
+  ( cd "$FRONTEND" && command -v npx >/dev/null 2>&1 \
+      && npx --no-install tsc -p tsconfig.json --noEmit ) >"$OUT/tsc.txt" 2>&1 \
+      || echo "[tsc reported issues — inspect output]" >>"$OUT/tsc.txt"
+fi
+
+# ----------------------------------------------------------------------------
+# Cross-cutting grep heuristics (candidates only — need a 2nd signal)
+# ----------------------------------------------------------------------------
+GREP_BIN="grep"
+GREP_FLAGS=(-rnE)
+if command -v rg >/dev/null 2>&1; then
+  GREP_BIN="rg"
+  GREP_FLAGS=(-n)
+fi
+SEARCH_PATHS=()
+[[ -d "$PY_SRC" ]] && SEARCH_PATHS+=("$PY_SRC")
+[[ -d "$TS_SRC" ]] && SEARCH_PATHS+=("$TS_SRC")
+
+greps() {
+  local out="$1" pat="$2"
+  if [[ ${#SEARCH_PATHS[@]} -eq 0 ]]; then return 0; fi
+  "$GREP_BIN" "${GREP_FLAGS[@]}" "$pat" "${SEARCH_PATHS[@]}" >"$OUT/$out" 2>/dev/null \
+    || echo "(no matches)" >"$OUT/$out"
+}
+
+greps grep-stubs.txt        'NotImplementedError|not implemented|throw new Error\(.?not implemented|return None\s*#\s*TODO|\bpass\s*#\s*(stub|placeholder)'
+greps grep-ai-tells.txt     'In a real implementation|real implementation|placeholder|for now|as an AI|should probably'
+greps grep-debt.txt         'TODO|FIXME|HACK|XXX'
+greps grep-escape-hatch.txt 'type: ?ignore|@ts-ignore|@ts-nocheck|eslint-disable|# ?noqa|cast\(Any'
+greps grep-swallow.txt      'except (Exception|BaseException)?\s*:|catch\s*\([^)]*\)\s*\{\s*\}|\.catch\(\(\)\s*=>\s*\{?\s*\}?\)'
+greps grep-commented.txt    '^\s*#\s*(def |class |return |if |for |while |import |from )'
+greps grep-any.txt          ':\s*any\b|<any>|as any'
+
+# Git churn / hotspots (top 30 most-changed files in the last 90 days).
+if command -v git >/dev/null 2>&1; then
+  git log --since="90 days ago" --format= --name-only 2>/dev/null \
+    | grep -E '^(backend|frontend)/' \
+    | sort | uniq -c | sort -rn | head -30 >"$OUT/churn.txt" 2>/dev/null \
+    || echo "(churn unavailable)" >"$OUT/churn.txt"
+fi
+
+# ----------------------------------------------------------------------------
+# Manifest
+# ----------------------------------------------------------------------------
+{
+  echo "# De-Slop Evidence Bundle"
+  echo "Repo:    $REPO_ROOT"
+  echo "Out:     $OUT"
+  echo
+  echo "## Files"
+  ls -1 "$OUT" | sed 's/^/  - /'
+  echo
+  echo "Each *.json / *.txt holds raw tool or grep output. Every entry is a"
+  echo "CANDIDATE only — apply the Two-Signal Rule from detection-playbook.md"
+  echo "before filing anything. Tool exit codes are appended as [exit N]."
+} >"$OUT/README.txt"
+
+log "evidence collected in $OUT"
+echo "$OUT"

--- a/.github/workflows/weekly-deslop.yml
+++ b/.github/workflows/weekly-deslop.yml
@@ -105,9 +105,13 @@ jobs:
             - A run that files NOTHING because the code is clean is a SUCCESS.
               Do not invent work to look productive.
 
-            End by posting a concise run summary as a single GitHub issue
-            labeled `de-slop` + `report` titled
-            "De-Slop weekly report — <date>" containing: counts by severity,
+            End by writing a concise run summary to the GitHub Actions job
+            summary — append it to the file at $GITHUB_STEP_SUMMARY (e.g.
+            `cat >> "$GITHUB_STEP_SUMMARY"`) — containing: counts by severity,
             issues/epics filed (with numbers), findings dropped and why, and
-            findings deduped. If nothing was filed, the report still goes out
-            and says the codebase is clean against the taxonomy this week.
+            findings deduped. This is the durable record, linked to the workflow
+            run, and never touches the issue tracker. A clean run (nothing
+            filed) writes "codebase is clean against the taxonomy this week" to
+            the job summary and files NO issue. Only open a separate `de-slop` +
+            `report` issue when at least one finding was filed — never on a clean
+            run (a weekly report issue every Monday would flood the tracker).

--- a/.github/workflows/weekly-deslop.yml
+++ b/.github/workflows/weekly-deslop.yml
@@ -1,0 +1,113 @@
+name: Weekly De-Slop
+
+# Runs the `de-slopify` skill on a schedule: a comprehensive, evidence-based
+# code-quality audit that files corroborated findings as Ralph-ready GitHub
+# issues (and decomposed epics for large work). It NEVER writes to the repo —
+# the job's GITHUB_TOKEN is `contents: read` / `issues: write`, so the only
+# durable output is new issues. False positives are the enemy: the skill files
+# nothing it cannot corroborate with two independent signals, and a clean run
+# (zero issues) is a valid, expected outcome.
+#
+# Trigger: every Monday 08:00 UTC, or manually via the Actions tab.
+#
+# Required configuration:
+#   secret  CLAUDE_CODE_OAUTH_TOKEN  - same token the other Claude workflows use.
+
+on:
+  schedule:
+    # Mondays at 08:00 UTC. (cron is UTC; GitHub may delay under load.)
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+    inputs:
+      focus:
+        description: "Optional area to focus the audit on (e.g. 'backend', 'frontend/src/features/Habits'). Blank = whole repo."
+        required: false
+        default: ""
+
+# Avoid overlapping audits.
+concurrency:
+  group: weekly-deslop
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  # OIDC token for the claude action's auth exchange (mirrors claude.yml).
+  id-token: write
+
+jobs:
+  deslop:
+    name: Detect slop and file backlog issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository (full history for churn analysis)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history so git-churn / hotspot detection has signal.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version-file: "frontend/.nvmrc"
+
+      - name: Install backend toolbox (read-only analyzers)
+        run: |
+          python -m venv .venv
+          # shellcheck disable=SC1091
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+
+      - name: Install frontend toolbox
+        run: |
+          cd frontend && npm ci
+
+      - name: Run de-slopify audit
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0  # v1.0.158
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # The skill files issues via gh; expose the analyzers it relies on.
+          # Security boundary is the job's GITHUB_TOKEN (contents: read /
+          # issues: write) — Claude cannot push code, only open issues.
+          claude_args: >-
+            --allowed-tools "Bash,Read,Grep,Glob,Write,Skill,Task"
+            --max-turns 80
+
+          prompt: |
+            Run a comprehensive weekly code-quality audit of this repository
+            using the `de-slopify` skill. Invoke the skill and follow its
+            instructions exactly.
+
+            Focus area (blank means the whole repo): "${{ github.event.inputs.focus }}"
+
+            Hard requirements (the skill enforces these — do not deviate):
+            - Corroborate every finding with TWO independent signals before
+              filing. For any correctness/bug claim, write and run a reproducing
+              test first; if it does not reproduce, DROP the finding.
+            - Discard everything in the skill's NOT-slop guard list (generated
+              code, migrations, lockfiles, justified suppressions, framework
+              boilerplate, test fixtures, deliberate conventions).
+            - Dedup against existing open and recently-closed issues before
+              filing anything (`gh issue list`, `gh search issues`).
+            - File standalone findings as Ralph-ready issues (Template A) and
+              large coordinated work as an `epic`-labeled umbrella with
+              decomposed sub-issues (Template B); use the `triage-and-plan`
+              skill when an epic needs more than ~3 sub-issues.
+            - Create any missing labels first. Write issue bodies to files and
+              file with `gh issue create --body-file`.
+            - A run that files NOTHING because the code is clean is a SUCCESS.
+              Do not invent work to look productive.
+
+            End by posting a concise run summary as a single GitHub issue
+            labeled `de-slop` + `report` titled
+            "De-Slop weekly report — <date>" containing: counts by severity,
+            issues/epics filed (with numbers), findings dropped and why, and
+            findings deduped. If nothing was filed, the report still goes out
+            and says the codebase is clean against the taxonomy this week.


### PR DESCRIPTION
## Summary

Introduces the `de-slopify` skill — a reusable, scheduled code-quality auditor that hunts the codebase for evidence of slop (bugs, code smells, dead/stubbed/orphaned code, duplication, poor architecture, verbosity, comment noise, type erosion, weak tests, security candidates) and files only corroborated findings as Ralph-ready GitHub issues. Big problems become epics with decomposed sub-issues.

The skill's prime directive is **precision over recall**: a finding that cannot be corroborated with two independent signals is dropped. A run that files nothing because the code is clean is a success.

## Key Changes

- **`SKILL.md`** — The skill definition, instructions (7 steps), and examples. Covers orientation, evidence collection, triage, corroboration, clustering, filing, and reporting.

- **`references/slop-taxonomy.md`** — An exhaustive field guide to 13 families of slop (Correctness & Latent Bugs, Bloaters, OO-Abusers, Dispensables, Change-Preventers, Couplers/Architecture, Naming/Comments, Verbosity, Type-Safety, Testing, Security, Deps/Config, AI-Slop-Specific). Each entry has a tell, corroboration hint, severity rubric, and a NOT-slop guard list to avoid false positives.

- **`references/detection-playbook.md`** — The Two-Signal Rule (the core discipline), the toolbox (ruff, vulture, radon, mypy, bandit, eslint, tsc, grep heuristics), category→detection→corroboration map, and the weekly run procedure.

- **`references/issue-templates.md`** — Standalone-finding and epic templates, the exact labels Ralph's picker honors, `gh` filing recipes, and the pre-file checklist.

- **`scripts/collect-evidence.sh`** — A read-only evidence collector that runs the repo's static-analysis toolbox (backend: ruff, vulture, radon, mypy, bandit, interrogate, pip-audit; frontend: eslint, tsc) plus grep heuristics, capturing all results into a scratchpad directory. Never modifies files, never aborts on tool errors.

- **`.github/workflows/weekly-deslop.yml`** — A scheduled GitHub Action (Mondays 08:00 UTC, or manual dispatch) that invokes the skill via the Claude Code action. Permissions are `contents: read` / `issues: write` — the only durable output is new issues.

## Notable Implementation Details

- **Two-Signal Rule enforced**: No finding is filed without at least two independent signals, at least one concrete and reproducible. For correctness/bug claims, a reproducing test is mandatory.
- **Guard list prevents false positives**: Generated code, migrations, lockfiles, justified suppressions, framework boilerplate, test fixtures, and deliberate conventions are explicitly excluded.
- **Ralph integration**: Labels and issue shape follow `scripts/ralph/pick-next.sh` conventions so findings are picked up autonomously. Epics carry the `epic` label (Ralph skips them and works sub-issues instead); dependents are marked `blocked`.
- **Graceful degradation**: `collect-evidence.sh` never fails the run because a tool is missing or unhappy — each tool's exit status is captured, not propagated, so the agent always gets a complete evidence bundle.
- **Dedup before filing**: The skill searches existing issues and skips duplicates.
- **Null findings are valid**: A run that files nothing is a healthy outcome, not a failure.

## Workflow Integration

The skill is invoked by:
1. The weekly GitHub Action (automatic Mondays, or manual dispatch)
2. The user saying "de-slop", "deslopify", "run the slop detector", "find code smells", "audit code quality", "find dead code", "weekly code quality scan", or "bullshit detector"

It is **not** used for implementing fixes (Ralph / `continue-epic` does that), reviewing a specific PR diff (`comprehensive-pr-review`), fixing CI failures (`ci-debugging`), or triaging existing issues (`backlog-grooming`).

https://claude.ai/code/session_01Y7daCzbSe7Dr5JeiZd8BA8