### PR TITLE
Refresh Practice screen on focus after catalog selection

### DIFF
--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -19,9 +19,9 @@
  * The screen itself stays small by keeping all state inside the extracted hooks
  * and the inner session component.
  */
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   ScrollView,
@@ -55,9 +55,39 @@ type WeeklyProgressHook = ReturnType<typeof useWeeklyProgress>;
  * stage changes). The chip is display-only — switching practices is the
  * explicit "Change practice" button, which routes through the catalog.
  */
-function usePracticeChrome(stageNumber: number): { banner: React.JSX.Element } {
-  const banner = useMemo(() => <FrequencyBanner stageNumber={stageNumber} />, [stageNumber]);
+function usePracticeChrome(
+  stageNumber: number,
+  refreshSignal: number,
+): { banner: React.JSX.Element } {
+  const banner = useMemo(
+    () => <FrequencyBanner stageNumber={stageNumber} refreshSignal={refreshSignal} />,
+    [stageNumber, refreshSignal],
+  );
   return { banner };
+}
+
+/**
+ * Re-fetch the active practice + frequency banner whenever the screen regains
+ * focus. The Practice tab stays mounted while the user pushes to the catalog /
+ * detail screen to choose a practice; without this, returning would show the
+ * stale selection (the selection saved fine — it just wasn't re-read). The
+ * first focus is skipped because the hooks already fetch on mount, and the
+ * refresh is silent so the current practice stays on screen while it reloads.
+ */
+function useFocusRefresh(refresh: (_opts?: { silent?: boolean }) => Promise<void>): number {
+  const [refreshSignal, setRefreshSignal] = useState(0);
+  const firstFocus = useRef(true);
+  useFocusEffect(
+    useCallback(() => {
+      if (firstFocus.current) {
+        firstFocus.current = false;
+        return;
+      }
+      void refresh({ silent: true });
+      setRefreshSignal((n) => n + 1);
+    }, [refresh]),
+  );
+  return refreshSignal;
 }
 
 const PracticeScreen = (): React.JSX.Element => {
@@ -66,7 +96,8 @@ const PracticeScreen = (): React.JSX.Element => {
   const active = useActivePractice(stageNumber);
   const weekly = useWeeklyProgress();
   const handleWriteReflection = useWriteReflection(active.effectiveName, active.practice);
-  const { banner } = usePracticeChrome(stageNumber);
+  const refreshSignal = useFocusRefresh(active.refresh);
+  const { banner } = usePracticeChrome(stageNumber, refreshSignal);
 
   if (active.isLoading) return <LoadingView />;
   if (active.error && !active.activeUserPractice) {

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -102,12 +102,33 @@ jest.mock('../../../navigation/hooks', () => ({
   useAppRoute: () => ({ key: 'Practice-test', name: 'Practice', params: mockRouteParams }),
 }));
 
+// Captured focus callbacks so tests can simulate the screen regaining focus
+// (e.g. returning from the catalog after picking a practice).
+const mockFocusCallbacks: Array<() => void | (() => void)> = [];
+
 // The "Browse all practices" button navigates via the stack-typed useNavigation
-// (Catalog is a pushed RootStack route, not a tab).
-jest.mock('@react-navigation/native', () => ({
-  ...(jest.requireActual('@react-navigation/native') as object),
-  useNavigation: () => ({ navigate: mockRootNavigate }),
-}));
+// (Catalog is a pushed RootStack route, not a tab). ``useFocusEffect`` is stubbed
+// to run the callback on mount and to expose it for manual re-triggering.
+jest.mock('@react-navigation/native', () => {
+  const reactMod = jest.requireActual('react') as {
+    useEffect: (_cb: () => undefined | (() => void), _deps: unknown[]) => void;
+  };
+  return {
+    ...(jest.requireActual('@react-navigation/native') as object),
+    useNavigation: () => ({ navigate: mockRootNavigate }),
+    useFocusEffect: (cb: () => void | (() => void)) => {
+      reactMod.useEffect(() => {
+        mockFocusCallbacks.push(cb);
+        const cleanup = cb();
+        return () => {
+          const index = mockFocusCallbacks.indexOf(cb);
+          if (index >= 0) mockFocusCallbacks.splice(index, 1);
+          if (typeof cleanup === 'function') cleanup();
+        };
+      }, [cb]);
+    },
+  };
+});
 
 jest.mock('expo-av', () => ({
   Audio: {
@@ -249,6 +270,7 @@ const modeFixtures: ModeFixture[] = [
 describe('PracticeScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFocusCallbacks.length = 0;
     mockPracticesList.mockResolvedValue([samplePractice()]);
     mockUserPracticesList.mockResolvedValue([]);
     mockWeekCount.mockResolvedValue({ count: 2 });
@@ -314,6 +336,25 @@ describe('PracticeScreen', () => {
     expect(getByTestId('active-practice-configure').props.accessibilityLabel).toBe(
       "Adjust this practice's settings",
     );
+  });
+
+  it('reflects a practice selected elsewhere once the screen regains focus', async () => {
+    // The Practice tab stays mounted while the user pushes to the catalog to
+    // pick a practice. The selection saves there; on returning, a silent
+    // focus-refresh must re-read it so the screen stops showing the empty state.
+    mockUserPracticesList
+      .mockResolvedValueOnce([]) // initial mount: nothing selected yet
+      .mockResolvedValue([sampleUserPractice()]); // after focus: now selected
+    const { getByTestId, queryByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('practice-empty-state')).toBeTruthy());
+
+    await act(async () => {
+      mockFocusCallbacks.forEach((cb) => cb());
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+    expect(queryByTestId('practice-empty-state')).toBeNull();
   });
 
   it('change-practice opens the Catalog seeded to the current stage', async () => {

--- a/frontend/src/features/Practice/components/FrequencyBanner.tsx
+++ b/frontend/src/features/Practice/components/FrequencyBanner.tsx
@@ -4,7 +4,7 @@
  * sourced from `GET /user-practices/current/frequency`. It is intentionally not
  * interactive — switching practices is a separate, explicit control.
  */
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { FrequencyResponse } from '@/api';
@@ -28,6 +28,13 @@ export interface FrequencyBannerProps {
    * resolves keeps the chip and the card in lockstep on every render.
    */
   stageNumber?: number | null;
+  /**
+   * Monotonic counter the parent bumps to force a background refetch (e.g. when
+   * the Practice screen regains focus after a selection made elsewhere). The
+   * initial value is ignored; only changes after mount trigger a refetch, and
+   * the refetch keeps the previous chip visible while it revalidates.
+   */
+  refreshSignal?: number;
 }
 
 function BannerSkeleton() {
@@ -79,8 +86,24 @@ function FrequencyChip({ data, swatch }: { data: FrequencyResponse; swatch: Colo
   );
 }
 
-export function FrequencyBanner({ data: injected, stageNumber }: FrequencyBannerProps) {
+export function FrequencyBanner({
+  data: injected,
+  stageNumber,
+  refreshSignal,
+}: FrequencyBannerProps) {
   const hook = useFrequency(stageNumber);
+  // Refetch when the parent bumps ``refreshSignal`` after mount. The injected
+  // (storybook / test) path owns its data, so it never hits the network; the
+  // initial value is recorded without fetching since ``useFrequency`` already
+  // loads on mount.
+  const { refetch } = hook;
+  const seenSignal = useRef(refreshSignal);
+  useEffect(() => {
+    if (injected !== undefined) return;
+    if (seenSignal.current === refreshSignal) return;
+    seenSignal.current = refreshSignal;
+    void refetch();
+  }, [refreshSignal, refetch, injected]);
   // Injected data wins for storybook / tests; otherwise consume the hook.
   const data = injected ?? hook.data;
   const isLoading = injected ? false : hook.isLoading;

--- a/frontend/src/features/Practice/components/__tests__/FrequencyBanner.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/FrequencyBanner.test.tsx
@@ -113,6 +113,35 @@ describe('FrequencyBanner', () => {
     expect(getByTestId('frequency-banner-content').props.accessibilityRole).toBe('text');
   });
 
+  it('refetches when refreshSignal changes after mount, but not on the initial value', () => {
+    const refetch = jest.fn();
+    mockUseFrequency.mockReturnValue({
+      data: samplePayload,
+      isLoading: false,
+      error: null,
+      refetch,
+    });
+    const { rerender } = render(<FrequencyBanner refreshSignal={0} />);
+    // The initial signal value is recorded without fetching (the hook already
+    // loaded on mount); only a subsequent change triggers a refetch.
+    expect(refetch).not.toHaveBeenCalled();
+    rerender(<FrequencyBanner refreshSignal={1} />);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores refreshSignal when data is injected (no network for storybook / tests)', () => {
+    const refetch = jest.fn();
+    mockUseFrequency.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+      refetch,
+    });
+    const { rerender } = render(<FrequencyBanner data={samplePayload} refreshSignal={0} />);
+    rerender(<FrequencyBanner data={samplePayload} refreshSignal={1} />);
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
   it('accepts an injected data prop for storybook / testing — overrides the hook', () => {
     // When `data` is passed explicitly it wins, mirroring the dependency
     // injection escape hatch used by the mode views.

--- a/frontend/src/features/Practice/hooks/useActivePractice.ts
+++ b/frontend/src/features/Practice/hooks/useActivePractice.ts
@@ -95,39 +95,46 @@ function useRefreshAction(
   setState: Dispatch<SetStateAction<State>>,
   mountedRef: RefObject<boolean>,
 ): (_opts?: { silent?: boolean }) => Promise<void> {
-  return useCallback(async (opts?: { silent?: boolean }) => {
-    // A silent refresh keeps the current view (no spinner) while it revalidates
-    // in the background; a normal refresh shows the loading state.
-    setState((prev) => ({ ...prev, isLoading: opts?.silent ? prev.isLoading : true, error: null }));
-    try {
-      const [practiceList, userPracticeList] = await Promise.all([
-        practices.listAll(stageNumber),
-        userPractices.list(),
-      ]);
-      if (!mountedRef.current) return;
-      // Strict `=== null` matches the backend contract: a closed row gets
-      // an ISO date string in `end_date`, an open row gets JSON `null`.
-      // The OpenAPI schema is `string | null`, so an empty string would be
-      // a schema violation — flag it loudly if a future migration ever
-      // emits one rather than silently filtering past it.
-      const active =
-        userPracticeList.find((up) => up.stage_number === stageNumber && up.end_date === null) ??
-        null;
-      setState({
-        availablePractices: practiceList,
-        activeUserPractice: active,
-        isLoading: false,
-        error: null,
-      });
-    } catch (err) {
-      if (!mountedRef.current) return;
+  return useCallback(
+    async (opts?: { silent?: boolean }) => {
+      // A silent refresh keeps the current view (no spinner) while it revalidates
+      // in the background; a normal refresh shows the loading state.
       setState((prev) => ({
         ...prev,
-        isLoading: false,
-        error: formatApiError(err, { fallback: LOAD_FALLBACK }),
+        isLoading: opts?.silent ? prev.isLoading : true,
+        error: null,
       }));
-    }
-  }, [stageNumber, setState, mountedRef]);
+      try {
+        const [practiceList, userPracticeList] = await Promise.all([
+          practices.listAll(stageNumber),
+          userPractices.list(),
+        ]);
+        if (!mountedRef.current) return;
+        // Strict `=== null` matches the backend contract: a closed row gets
+        // an ISO date string in `end_date`, an open row gets JSON `null`.
+        // The OpenAPI schema is `string | null`, so an empty string would be
+        // a schema violation — flag it loudly if a future migration ever
+        // emits one rather than silently filtering past it.
+        const active =
+          userPracticeList.find((up) => up.stage_number === stageNumber && up.end_date === null) ??
+          null;
+        setState({
+          availablePractices: practiceList,
+          activeUserPractice: active,
+          isLoading: false,
+          error: null,
+        });
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+          error: formatApiError(err, { fallback: LOAD_FALLBACK }),
+        }));
+      }
+    },
+    [stageNumber, setState, mountedRef],
+  );
 }
 
 function useSelectAction(

--- a/frontend/src/features/Practice/hooks/useActivePractice.ts
+++ b/frontend/src/features/Practice/hooks/useActivePractice.ts
@@ -41,7 +41,13 @@ export interface UseActivePracticeResult {
   effectiveConfig: ModeConfig | null;
   isLoading: boolean;
   error: string | null;
-  refresh: () => Promise<void>;
+  /**
+   * Re-fetch the stage catalogue + active row. Pass ``{ silent: true }`` to
+   * refresh in the background without flipping ``isLoading`` (so the screen
+   * keeps showing the current practice instead of flashing a spinner) — used
+   * when the screen regains focus after a selection made elsewhere.
+   */
+  refresh: (_opts?: { silent?: boolean }) => Promise<void>;
   /** Create/replace the active practice for the stage. */
   selectPractice: (_practiceId: number) => Promise<void>;
   /** Replace the in-memory active `UserPractice` after a child mutation. */
@@ -88,9 +94,11 @@ function useRefreshAction(
   stageNumber: number,
   setState: Dispatch<SetStateAction<State>>,
   mountedRef: RefObject<boolean>,
-): () => Promise<void> {
-  return useCallback(async () => {
-    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+): (_opts?: { silent?: boolean }) => Promise<void> {
+  return useCallback(async (opts?: { silent?: boolean }) => {
+    // A silent refresh keeps the current view (no spinner) while it revalidates
+    // in the background; a normal refresh shows the loading state.
+    setState((prev) => ({ ...prev, isLoading: opts?.silent ? prev.isLoading : true, error: null }));
     try {
       const [practiceList, userPracticeList] = await Promise.all([
         practices.listAll(stageNumber),

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -28,7 +28,6 @@ import ShareSheet from '@/features/Practice/components/ShareSheet';
 import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import type { RootStackParamList } from '@/navigation/RootStack';
-import { selectCurrentStage, useStageStore } from '@/store/useStageStore';
 
 export type PracticeDetailScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -69,12 +68,10 @@ function LoadedDetail({
   props,
   state,
   practice,
-  currentStage,
 }: {
   props: PracticeDetailScreenProps;
   state: PracticeDetailHook;
   practice: PracticeItem;
-  currentStage: number;
 }): React.JSX.Element {
   const [shareOpen, setShareOpen] = useState(false);
   return (
@@ -93,7 +90,12 @@ function LoadedDetail({
       )}
       <ActionRow
         practice={practice}
-        onUseForCurrentStage={() => void state.assign(currentStage)}
+        // A practice is catalogued for exactly one stage and the backend
+        // rejects assigning it anywhere else (BUG-PRACTICE-004), so the
+        // one-tap path targets the practice's own stage rather than the
+        // store's ``currentStage`` (which is derived differently from the
+        // stage the catalog filtered by and could mismatch -> silent 400).
+        onUseForCurrentStage={() => void state.assign(practice.stage_number)}
         onUseForStage={state.openPicker}
         onCustomizeCopy={() => navigateToCopy(props, practice)}
         onShare={() => setShareOpen(true)}
@@ -116,8 +118,13 @@ function LoadedDetail({
 
 export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JSX.Element {
   const { practiceId } = props.route.params;
-  const state = usePracticeDetail(practiceId);
-  const currentStage = useStageStore(selectCurrentStage);
+  const { navigation } = props;
+  // After a successful selection, pop back to the Practice screen (the tab is
+  // the first route under the root stack; the catalog + this detail screen are
+  // pushed on top), matching the catalog's one-tap "Use" which also returns the
+  // user to where they can see the active practice.
+  const onAssigned = useCallback(() => navigation.popToTop(), [navigation]);
+  const state = usePracticeDetail(practiceId, onAssigned);
   if (state.loading) {
     return (
       <View style={styles.loading} testID="practice-detail-loading">
@@ -130,14 +137,7 @@ export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JS
       <ErrorView message={state.loadError ?? 'Could not load practice.'} onRetry={state.reload} />
     );
   }
-  return (
-    <LoadedDetail
-      props={props}
-      state={state}
-      practice={state.practice}
-      currentStage={currentStage}
-    />
-  );
+  return <LoadedDetail props={props} state={state} practice={state.practice} />;
 }
 
 interface PracticeDetailHook {
@@ -154,7 +154,7 @@ interface PracticeDetailHook {
   assign: (stageNumber: number) => Promise<void>;
 }
 
-function usePracticeDetail(practiceId: number): PracticeDetailHook {
+function usePracticeDetail(practiceId: number, onAssigned?: () => void): PracticeDetailHook {
   const [state, setState] = useState<ScreenState>(initialState);
 
   const runReload = useCallback(async () => {
@@ -196,6 +196,9 @@ function usePracticeDetail(practiceId: number): PracticeDetailHook {
           pickerOpen: false,
           assignedStage: stageNumber,
         }));
+        // Confirmation banner is set above for the brief moment before the
+        // screen pops; the callback returns the user to the Practice screen.
+        onAssigned?.();
       } catch (err) {
         setState((prev) => ({
           ...prev,
@@ -204,7 +207,7 @@ function usePracticeDetail(practiceId: number): PracticeDetailHook {
         }));
       }
     },
-    [practiceId],
+    [practiceId, onAssigned],
   );
 
   return { ...state, reload, openPicker, closePicker, assign };

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -142,7 +142,7 @@ describe('PracticeDetailScreen — Use for stage', () => {
     mockUserPracticesCreate.mockReset();
   });
 
-  it('uses the practice\'s own stage in one tap and returns to the Practice screen', async () => {
+  it("uses the practice's own stage in one tap and returns to the Practice screen", async () => {
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
     mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
     const nav = makeNav();

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -64,6 +64,7 @@ interface NavMock {
   goBack: jest.Mock<() => void>;
   replace: jest.Mock<(...args: unknown[]) => void>;
   navigate: jest.Mock<(...args: unknown[]) => void>;
+  popToTop: jest.Mock<() => void>;
 }
 
 function makeNav(): NavMock {
@@ -71,6 +72,7 @@ function makeNav(): NavMock {
     goBack: jest.fn() as jest.Mock<() => void>,
     replace: jest.fn() as jest.Mock<(...args: unknown[]) => void>,
     navigate: jest.fn() as jest.Mock<(...args: unknown[]) => void>,
+    popToTop: jest.fn() as jest.Mock<() => void>,
   };
 }
 
@@ -140,25 +142,29 @@ describe('PracticeDetailScreen — Use for stage', () => {
     mockUserPracticesCreate.mockReset();
   });
 
-  it('sets the practice active for the current stage in one tap (no picker)', async () => {
+  it('uses the practice\'s own stage in one tap and returns to the Practice screen', async () => {
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
     mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
-    const { view } = renderScreen();
+    const nav = makeNav();
+    const { view } = renderScreen(77, nav);
     await waitForLoad();
     await act(async () => {
       fireEvent.press(view.getByTestId('practice-detail-use-current-stage'));
       await flushPromises();
     });
-    // Store default current stage is 1; no stage picker is opened.
-    expect(mockUserPracticesCreate).toHaveBeenCalledWith({ practice_id: 77, stage_number: 1 });
+    // The practice is catalogued for stage 4, so the one-tap path targets that
+    // stage (the backend rejects any other) rather than the store's current
+    // stage. No picker is opened, and the screen pops back to Practice.
+    expect(mockUserPracticesCreate).toHaveBeenCalledWith({ practice_id: 77, stage_number: 4 });
     expect(view.queryByTestId('practice-detail-stage-picker')).toBeNull();
-    expect(view.getByTestId('practice-detail-assigned-banner')).toBeTruthy();
+    expect(nav.popToTop).toHaveBeenCalledTimes(1);
   });
 
-  it('opens the stage picker and writes via userPractices.create on pick', async () => {
+  it('opens the stage picker, writes via userPractices.create, and returns on pick', async () => {
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
     mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
-    const { view } = renderScreen();
+    const nav = makeNav();
+    const { view } = renderScreen(77, nav);
     await waitForLoad();
     fireEvent.press(view.getByTestId('practice-detail-use-for-stage'));
     expect(view.getByTestId('practice-detail-stage-picker')).toBeTruthy();
@@ -170,7 +176,7 @@ describe('PracticeDetailScreen — Use for stage', () => {
       practice_id: 77,
       stage_number: 4,
     });
-    expect(view.getByTestId('practice-detail-assigned-banner')).toBeTruthy();
+    expect(nav.popToTop).toHaveBeenCalledTimes(1);
   });
 
   it('opens the share sheet from the Share action', async () => {
@@ -182,10 +188,11 @@ describe('PracticeDetailScreen — Use for stage', () => {
     expect(view.getByTestId('share-sheet')).toBeTruthy();
   });
 
-  it('surfaces an action error if assignment fails', async () => {
+  it('surfaces an action error and stays put if assignment fails', async () => {
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
     mockUserPracticesCreate.mockRejectedValueOnce(new Error('nope'));
-    const { view } = renderScreen();
+    const nav = makeNav();
+    const { view } = renderScreen(77, nav);
     await waitForLoad();
     fireEvent.press(view.getByTestId('practice-detail-use-for-stage'));
     await act(async () => {
@@ -193,6 +200,8 @@ describe('PracticeDetailScreen — Use for stage', () => {
       await flushPromises();
     });
     expect(view.getByTestId('practice-detail-action-error')).toBeTruthy();
+    // A failed assignment must not navigate away — the user stays to see the error.
+    expect(nav.popToTop).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
When a user selects a practice in the Catalog and returns to the Practice screen, the screen now silently refetches the active practice to reflect the selection. Previously, the screen would remain mounted with stale data, requiring a manual refresh or navigation away and back.

## Changes

### Practice Screen Focus Refresh
- Added `useFocusRefresh` hook to detect when the Practice screen regains focus (after returning from the Catalog)
- Skips the initial focus to avoid redundant fetches (hooks already load on mount)
- Performs a silent refresh (`{ silent: true }`) that revalidates data in the background without showing a loading spinner, keeping the current practice visible during the refetch
- Passes a `refreshSignal` counter to `FrequencyBanner` to trigger its refetch when the screen refocuses

### Frequency Banner Refetch
- Added `refreshSignal` prop to `FrequencyBanner` to support background refetches
- Tracks the signal value with `useRef` and only refetches when it changes after mount
- Skips refetch when data is injected (storybook/test mode) since those don't use the network

### Practice Detail Screen Navigation
- Changed one-tap "Use for current stage" to use the practice's own `stage_number` instead of the store's `currentStage`
  - The backend rejects assignments to stages other than the practice's catalogued stage (BUG-PRACTICE-004)
  - Using the store's `currentStage` could mismatch and cause silent 400 errors
- Added `onAssigned` callback that pops the navigation stack back to the Practice screen after successful assignment
- Removed dependency on `useStageStore` in the detail screen

### Test Coverage
- Updated `PracticeScreen.test.tsx` to mock `useFocusEffect` and expose focus callbacks for manual triggering
- Added test verifying the screen reflects a practice selected elsewhere once it regains focus
- Updated `PracticeDetailScreen.test.tsx` to verify the one-tap path uses the practice's stage and navigates back on success
- Added tests for `FrequencyBanner` refetch behavior on signal changes and with injected data

## Implementation Details
- The `useFocusRefresh` hook uses `useRef` to track whether it's the first focus (which is skipped) to avoid double-fetching
- Silent refresh preserves the current UI state while revalidating in the background, providing a seamless experience
- The focus callback cleanup properly removes callbacks from the mock array to prevent memory leaks in tests

https://claude.ai/code/session_017ae8ekv3dg9mLPNz2fCYyE