### PR TITLE
ci: skip claude-review on dependabot PRs (unblock the required check)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs: GitHub does not expose Actions secrets (incl.
+    # CLAUDE_CODE_OAUTH_TOKEN) to dependabot-triggered runs, so the action would
+    # hard-fail before reviewing and block the PR's required check. Dependency
+    # bumps merge on green CI + human judgment instead.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

GitHub doesn't expose Actions secrets (incl. `CLAUDE_CODE_OAUTH_TOKEN`) to dependabot-triggered workflows, so the `claude-review` action hard-failed (`Environment variable validation failed`) before reviewing — turning the **required** check red on every dependabot PR and blocking merge.

**Option B** from the issue: guard the `claude-review` job with `if: github.event.pull_request.user.login != 'dependabot[bot]'` so it **skips** on dependabot PRs (a skipped required check passes branch protection). Dependency bumps now clear on green CI + human judgment.

Option A (mirror the secret into the Dependabot secrets store) needs repo-settings access and may still fail on the read-only dependabot `GITHUB_TOKEN`, so the guard is the reliable, code-only fix.

## Test plan

- YAML validates; pre-commit hooks pass.
- This human-authored PR still runs `claude-review` normally (the guard only excludes `dependabot[bot]`).
- After merge, the 15 blocked dependabot PRs (#248–#258, #382, #649–#651) clear their checks on a `@dependabot rebase`.

Closes #411
