### PR TITLE
fix(ci): skip Ralph recap post when Discord config is unset

### DIFF
--- a/.github/workflows/ralph-recap.yml
+++ b/.github/workflows/ralph-recap.yml
@@ -2,7 +2,8 @@ name: Ralph Recap
 
 # Posts a Ralph tick-loop recap to Discord every time a pull request is merged.
 #
-# Required configuration in the repo:
+# Configuration in the repo (delivery is skipped, not failed, when unset — see
+# the --skip-if-unconfigured flag below):
 #   secret   DISCORD_BOT_TOKEN  - bot token with Send Messages on the channel
 #   variable RALPH_CHANNEL_ID   - target Discord channel ID (all digits)
 #   secret   ANTHROPIC_API_KEY  - optional; enables the Claude-written headline
@@ -44,4 +45,4 @@ jobs:
           RALPH_CHANNEL_ID: ${{ vars.RALPH_CHANNEL_ID }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          python scripts/ralph/recap.py --repo "${{ github.repository }}"
+          python scripts/ralph/recap.py --repo "${{ github.repository }}" --skip-if-unconfigured

--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -19,6 +19,9 @@ This is meant to run from a GitHub Actions workflow keyed on
         python scripts/ralph/recap.py --repo Geoffe-Ga/adepthood --dry-run
 
 `--dry-run` prints the rendered embed as JSON instead of posting it.
+`--skip-if-unconfigured` exits 0 (rather than erroring) when the Discord channel
+ID or bot token is unset, so the merge-triggered workflow stays green on repos
+that haven't wired up Discord delivery.
 
 The backlog count mirrors `scripts/ralph/pick-next.sh`: open issues bearing any
 of the picker's exclude labels (epics, blocked, etc.) are not part of Ralph's
@@ -462,19 +465,33 @@ def _gather(repo: str, gh_token: str, max_prs: int) -> dict[str, Any] | None:
         raise RecapError(f"network failure talking to GitHub: {exc.reason}") from exc
 
 
-def _deliver(channel_id: str | None, payload: dict[str, Any]) -> None:
-    """Post the payload to Discord, mapping failures to RecapError."""
-    if not channel_id:
-        raise RecapError("RALPH_CHANNEL_ID (or --channel-id) is required to post", code=2)
+def _deliver(channel_id: str | None, payload: dict[str, Any], *, skip_if_unconfigured: bool = False) -> bool:
+    """Post the payload to Discord, mapping failures to RecapError.
+
+    Returns ``True`` when the recap was posted and ``False`` when delivery was
+    skipped because the Discord configuration is absent and
+    ``skip_if_unconfigured`` is set. Without that flag a missing channel ID or
+    bot token is a hard error (exit code 2), as before.
+    """
     discord_token = os.environ.get("DISCORD_BOT_TOKEN")
-    if not discord_token:
-        raise RecapError("DISCORD_BOT_TOKEN is required to post", code=2)
+    missing = [
+        name
+        for name, value in (("RALPH_CHANNEL_ID (or --channel-id)", channel_id), ("DISCORD_BOT_TOKEN", discord_token))
+        if not value
+    ]
+    if missing or channel_id is None or discord_token is None:
+        detail = " and ".join(missing)
+        if skip_if_unconfigured:
+            print(f"Discord delivery not configured ({detail} unset) — skipping recap post.")
+            return False
+        raise RecapError(f"{detail} is required to post", code=2)
     try:
         post_to_discord(channel_id, discord_token, payload)
     except urllib.error.HTTPError as exc:
         raise RecapError(f"Discord API request failed: {exc.code} {exc.reason}") from exc
     except urllib.error.URLError as exc:
         raise RecapError(f"network failure talking to Discord: {exc.reason}") from exc
+    return True
 
 
 def _run(args: argparse.Namespace) -> int:
@@ -492,8 +509,8 @@ def _run(args: argparse.Namespace) -> int:
         print(json.dumps(payload, indent=2))
         return 0
 
-    _deliver(args.channel_id, payload)
-    print(f"Posted Ralph recap to channel {args.channel_id}.")
+    if _deliver(args.channel_id, payload, skip_if_unconfigured=args.skip_if_unconfigured):
+        print(f"Posted Ralph recap to channel {args.channel_id}.")
     return 0
 
 
@@ -503,6 +520,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--channel-id", default=os.environ.get("RALPH_CHANNEL_ID"))
     parser.add_argument("--max-prs", type=int, default=DEFAULT_MAX_PRS)
     parser.add_argument("--dry-run", action="store_true", help="print the embed instead of posting")
+    parser.add_argument(
+        "--skip-if-unconfigured",
+        action="store_true",
+        help="exit 0 (instead of erroring) when the Discord channel ID or bot token is unset",
+    )
     args = parser.parse_args(argv)
     try:
         return _run(args)

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -287,3 +287,45 @@ def test_generate_headline_falls_back_on_sdk_error(monkeypatch: pytest.MonkeyPat
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
 
     assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"
+
+
+def test_deliver_skips_when_unconfigured_and_flag_set(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+
+    posted = recap._deliver(None, {"embeds": []}, skip_if_unconfigured=True)
+
+    assert posted is False
+    assert "skipping recap post" in capsys.readouterr().out
+
+
+def test_deliver_skips_when_only_token_missing_and_flag_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+
+    assert recap._deliver("123", {"embeds": []}, skip_if_unconfigured=True) is False
+
+
+def test_deliver_errors_with_code_2_when_unconfigured_and_flag_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+
+    with pytest.raises(recap.RecapError) as excinfo:
+        recap._deliver(None, {"embeds": []})
+
+    assert excinfo.value.code == 2
+    assert "required to post" in str(excinfo.value)
+
+
+def test_deliver_posts_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "bot-token")  # pragma: allowlist secret
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        recap,
+        "post_to_discord",
+        lambda channel_id, token, payload: calls.append((channel_id, token, payload)),
+    )
+
+    posted = recap._deliver("123", {"embeds": []}, skip_if_unconfigured=True)
+
+    assert posted is True
+    assert calls == [("123", "bot-token", {"embeds": []})]


### PR DESCRIPTION
## Problem

The merge-triggered **Ralph Recap** workflow has been failing on every merged PR:

```
error: RALPH_CHANNEL_ID (or --channel-id) is required to post
Error: Process completed with exit code 2
```

`recap.py` exits with code **2** when the Discord delivery config
(`RALPH_CHANNEL_ID` repo variable + `DISCORD_BOT_TOKEN` secret) is absent. This
repo hasn't wired up Discord, so the optional recap notification was hard-failing
the job on every merge.

## Fix

Posting a Discord recap is an optional, best-effort notification — a missing
channel ID or bot token should **skip the post, not fail CI**.

- Add a `--skip-if-unconfigured` flag to `scripts/ralph/recap.py`. When set, a
  missing channel ID or bot token prints a clear message and exits **0**;
  without the flag the original hard-error (exit 2) behavior is preserved for
  explicit local posting.
- `_deliver(...)` now returns a bool (posted vs. skipped) and reports *all*
  missing credentials in one message.
- The `ralph-recap.yml` workflow passes `--skip-if-unconfigured`, so it stays
  green whether or not Discord is configured. When Discord *is* configured, the
  recap posts exactly as before.

## Tests

Added four cases to `scripts/ralph/test_recap_stats.py` covering: skip when
unconfigured + flag set, skip when only the token is missing, the preserved
exit-code-2 error when the flag is unset, and a successful post when fully
configured. Full suite: **33 passed**.

> Note: pre-commit's hook repos could not be fetched in the execution
> environment (egress policy returns 403 for `github.com`), so the local
> pre-commit/pre-push hooks could not initialize. The backend-scoped ruff/mypy
> hooks do not cover the changed files (`scripts/ralph/**` + the workflow), and
> the `Ralph Recap Tests` CI job (pytest) is the authoritative gate for these
> files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yeMRheRodFtDcxogsmFiH)_