### PR TITLE
feat(frontend): editorial elevation tokens (desk ground + paper shadow)

### DIFF
--- a/frontend/src/design/__tests__/editorialTokens.test.ts
+++ b/frontend/src/design/__tests__/editorialTokens.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { colors, editorialType, journalLayout } from '../tokens';
+import { colors, editorialType, journalLayout, journalSheet, paperShadow } from '../tokens';
 
 /** WCAG relative luminance of a #rrggbb color. */
 const luminance = (hex: string): number => {
@@ -29,6 +29,8 @@ describe('editorial tokens', () => {
         expect.arrayContaining([
           'background',
           'backgroundAlt',
+          'desk',
+          'sheetEdge',
           'ink',
           'inkSoft',
           'hairline',
@@ -42,6 +44,33 @@ describe('editorial tokens', () => {
       expect(contrast(colors.paper.inkSoft, colors.paper.background)).toBeGreaterThanOrEqual(
         AA_NORMAL,
       );
+    });
+
+    it('has a desk ground darker than the page (so the sheet reads as lifted)', () => {
+      expect(colors.paper.desk).toMatch(/^#[\da-f]{6}$/i);
+      expect(colors.paper.sheetEdge).toMatch(/^#[\da-f]{6}$/i);
+      expect(luminance(colors.paper.desk)).toBeLessThan(luminance(colors.paper.background));
+    });
+  });
+
+  describe('paperShadow', () => {
+    it('exports sheet + card lifts with shadow props and an Android elevation', () => {
+      for (const lift of [paperShadow.sheet, paperShadow.card]) {
+        expect(lift.shadowColor).toBe(colors.paper.ink);
+        expect(lift.shadowOffset.height).toBeGreaterThan(0);
+        expect(lift.shadowOpacity).toBeGreaterThan(0);
+        expect(lift.elevation).toBeGreaterThan(0);
+      }
+      // The sheet sits higher off the desk than a card.
+      expect(paperShadow.sheet.elevation).toBeGreaterThan(paperShadow.card.elevation);
+    });
+  });
+
+  describe('journalSheet', () => {
+    it('exports positive sheet metrics without touching journalLayout', () => {
+      for (const value of Object.values(journalSheet)) {
+        expect(value).toBeGreaterThan(0);
+      }
     });
   });
 

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -121,6 +121,13 @@ export const colors = {
   paper: {
     background: '#faf6ef',
     backgroundAlt: '#f3ecdf',
+    // The deeper, warmer "desk" the writing sheet floats above — a step darker
+    // than `background` so the lighter sheet reads as lifted (the warm
+    // `paperShadow` below carries the rest of the depth cue).
+    desk: '#e7dcc8',
+    // Faint lit edge for the lifted sheet — slightly lighter than `hairline` so
+    // the sheet border reads as a paper edge, not a divider.
+    sheetEdge: '#efe7d8',
     ink: '#2b2620',
     inkSoft: '#5a5046',
     hairline: '#e3dccd',
@@ -450,4 +457,38 @@ export const editorialType = {
 /** Typography for interactive chrome, so button/label sizing lives in tokens. */
 export const uiType = {
   button: { fontSize: 16, fontWeight: '600' as const },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Editorial elevation — depth primitives for the floating journal page
+// ---------------------------------------------------------------------------
+
+/**
+ * Soft, warm, downward shadows for lifting paper surfaces (the journal sheet,
+ * shelf cards, margin notes) off the desk ground. Ink-tinted rather than pure
+ * black so the lift reads as paper-on-desk, not card-on-glass. iOS/web use the
+ * shadow* props; Android uses `elevation`.
+ */
+export const paperShadow = {
+  sheet: {
+    shadowColor: colors.paper.ink,
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.14,
+    shadowRadius: 18,
+    elevation: 6,
+  },
+  card: {
+    shadowColor: colors.paper.ink,
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+} as const;
+
+/** Metrics for the floated journal sheet (the depth issues consume these). */
+export const journalSheet = {
+  cornerRadius: radius.lg, // rounded top of the lifted sheet
+  deskPaddingH: spacing(2), // desk visible left/right of the sheet
+  deskPaddingTop: spacing(1.5), // desk visible above the sheet
 } as const;


### PR DESCRIPTION
## Summary

journal-depth-01: add the depth primitives the floating-page work (issues #680–#684) needs — **primitives only, no component changes**.

- **`colors.paper.desk`** (`#e7dcc8`): the deeper, warmer ground the writing sheet floats above — measurably darker (lower luminance) than `background` so the lighter sheet reads as lifted. Plus **`colors.paper.sheetEdge`** (`#efe7d8`): a faint lit paper edge.
- **`paperShadow`**: warm, ink-tinted, downward lifts (`sheet` + `card`) with iOS/web shadow props **and** an Android `elevation`; kept separate from the neutral `shadows` other chrome depends on.
- **`journalSheet`**: sheet layout metrics (corner radius, desk padding) as a *separate* export so `journalLayout`'s exact-keys test stays untouched.

## Test plan

`editorialTokens.test.ts` extended: desk/sheetEdge are valid hex with `desk` darker than the page; `paperShadow.sheet`/`.card` carry shadow props + elevation (sheet lifts higher than card); `journalSheet` values positive; `ink`/`inkSoft` still clear AA on the paper ground.

`./scripts/frontend/check-all.sh` — 4/4.

Closes #679
Refs #678
