### PR TITLE
feat(frontend): float the writing surface as a paper sheet

### DIFF
--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -12,6 +12,8 @@ import {
   colors,
   editorialType,
   journalLayout,
+  journalSheet,
+  paperShadow,
   spacing,
   touchTarget,
 } from '@/design/tokens';
@@ -27,15 +29,33 @@ export const RESONANCE_BUTTON_CLEARANCE = SPACING.xl + touchTarget.minimum + SPA
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: colors.paper.background,
+    backgroundColor: colors.paper.desk,
   },
-  /** Centres the page and caps the reading measure on wide screens. */
+  /** Padded desk so the deeper ground shows as a border around the lifted sheet. */
+  desk: {
+    flex: 1,
+    paddingHorizontal: journalSheet.deskPaddingH,
+    paddingTop: journalSheet.deskPaddingTop,
+  },
+  /** The floating paper sheet: lighter ground, soft warm shadow, rounded top. */
+  sheet: {
+    flex: 1,
+    width: '100%',
+    maxWidth: journalLayout.pageMaxWidth + journalLayout.marginColumnWidth,
+    alignSelf: 'center',
+    backgroundColor: colors.paper.background,
+    borderTopLeftRadius: journalSheet.cornerRadius,
+    borderTopRightRadius: journalSheet.cornerRadius,
+    ...paperShadow.sheet,
+  },
+  sheetNarrow: {
+    maxWidth: '100%',
+  },
+  /** The two-column page inside the sheet (width cap + centring live on the sheet). */
   page: {
     flex: 1,
     flexDirection: 'row',
     width: '100%',
-    maxWidth: journalLayout.pageMaxWidth + journalLayout.marginColumnWidth,
-    alignSelf: 'center',
     paddingHorizontal: journalLayout.pageHorizontalPadding,
     paddingBottom: RESONANCE_BUTTON_CLEARANCE,
   },

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -572,6 +572,31 @@ function useJournalEntryController(
 type Controller = ReturnType<typeof useJournalEntryController>;
 
 /** The two-column page: the body (edit or read) + the margin. */
+/** The body column: the editable writing surface, or the read-mode highlighted view. */
+function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceholder: string }) {
+  const { title, body, saveState } = ctl.autosave;
+  const { editMode, canFinish, markFinished, requestEdit } = ctl.editGate;
+  return editMode ? (
+    <WritingColumn
+      title={title}
+      body={body}
+      saveState={saveState}
+      onChangeTitle={ctl.handleTitle}
+      onChangeBody={ctl.handleBody}
+      onFinish={canFinish ? markFinished : undefined}
+      bodyPlaceholder={bodyPlaceholder}
+    />
+  ) : (
+    <ReadColumn
+      title={title}
+      body={body}
+      notes={ctl.resonance.marginalia}
+      onOpen={ctl.modal.onOpenNote}
+      onEdit={requestEdit}
+    />
+  );
+}
+
 function JournalPage({
   ctl,
   renderMargin,
@@ -582,42 +607,26 @@ function JournalPage({
   bodyPlaceholder: string;
 }) {
   const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
-  const { title, body, saveState } = ctl.autosave;
   const notes = ctl.resonance.marginalia;
-  const hasNotes = notes.length > 0;
-  const { editMode, canFinish, markFinished, requestEdit } = ctl.editGate;
 
   let marginContent: React.ReactNode;
-  if (renderMargin) marginContent = renderMargin({ body, isIdle: ctl.isIdle });
-  else if (hasNotes) marginContent = <MarginNoteList notes={notes} onOpen={ctl.modal.onOpenNote} />;
-  else marginContent = <ResonanceMargin count={0} error={ctl.resonance.error} />;
+  if (renderMargin) marginContent = renderMargin({ body: ctl.autosave.body, isIdle: ctl.isIdle });
+  else if (notes.length > 0) {
+    marginContent = <MarginNoteList notes={notes} onOpen={ctl.modal.onOpenNote} />;
+  } else marginContent = <ResonanceMargin count={0} error={ctl.resonance.error} />;
 
   return (
-    <View style={[styles.page, narrow && styles.pageNarrow]} testID="journal-page">
-      {editMode ? (
-        <WritingColumn
-          title={title}
-          body={body}
-          saveState={saveState}
-          onChangeTitle={ctl.handleTitle}
-          onChangeBody={ctl.handleBody}
-          onFinish={canFinish ? markFinished : undefined}
-          bodyPlaceholder={bodyPlaceholder}
-        />
-      ) : (
-        <ReadColumn
-          title={title}
-          body={body}
-          notes={notes}
-          onOpen={ctl.modal.onOpenNote}
-          onEdit={requestEdit}
-        />
-      )}
-      <View
-        style={[styles.marginColumn, narrow && styles.marginColumnNarrow]}
-        testID="journal-margin-column"
-      >
-        {marginContent}
+    <View style={styles.desk}>
+      <View style={[styles.sheet, narrow && styles.sheetNarrow]} testID="journal-sheet">
+        <View style={[styles.page, narrow && styles.pageNarrow]} testID="journal-page">
+          <PageBodyColumn ctl={ctl} bodyPlaceholder={bodyPlaceholder} />
+          <View
+            style={[styles.marginColumn, narrow && styles.marginColumnNarrow]}
+            testID="journal-margin-column"
+          >
+            {marginContent}
+          </View>
+        </View>
       </View>
     </View>
   );
@@ -661,7 +670,7 @@ function JournalEntryScreen({
   );
   const { editGate, modal } = ctl;
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <SafeAreaView style={styles.safeArea} testID="journal-screen">
       <JournalPage ctl={ctl} renderMargin={renderMargin} bodyPlaceholder={bodyPlaceholder} />
       <GetResonanceButton
         visible={ctl.visible}

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -7,6 +7,7 @@ import { StyleSheet } from 'react-native';
 import { RESONANCE_BUTTON_CLEARANCE } from '../JournalEntry.styles';
 
 import type { JournalMessage } from '@/api';
+import { colors } from '@/design/tokens';
 
 const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
 const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
@@ -152,6 +153,18 @@ describe('JournalEntryScreen', () => {
     const { getByTestId } = renderScreen();
     const page = StyleSheet.flatten(getByTestId('journal-page').props.style);
     expect(page.paddingBottom).toBe(RESONANCE_BUTTON_CLEARANCE);
+  });
+
+  it('floats the writing area as a lighter sheet above the deeper desk', () => {
+    const { getByTestId } = renderScreen();
+    const sheet = StyleSheet.flatten(getByTestId('journal-sheet').props.style);
+    // The sheet is the lighter paper ground, lifted by the warm paper shadow.
+    expect(sheet.backgroundColor).toBe(colors.paper.background);
+    expect(sheet.shadowRadius).toBeGreaterThan(0);
+    expect(sheet.elevation).toBeGreaterThan(0);
+    // The screen root is the deeper desk ground the sheet floats above.
+    const root = StyleSheet.flatten(getByTestId('journal-screen').props.style);
+    expect(root.backgroundColor).toBe(colors.paper.desk);
   });
 
   it('autosaves once after the debounce when the body changes', async () => {


### PR DESCRIPTION
## Summary

journal-depth-02: the writing page read flat (background == content colour). Restructure `JournalPage` into **desk → sheet → page** so the writing area reads as a lighter paper **sheet floating above a deeper desk** — pure presentation, no behaviour/prop/data change.

- **`JournalEntry.styles.ts`**: `safeArea` → `colors.paper.desk`; new `desk` (padded ground via `journalSheet.deskPaddingH/Top`), `sheet` (lighter `paper.background`, width-capped + centred, rounded top, `...paperShadow.sheet`), `sheetNarrow`. `page` drops `maxWidth`/`alignSelf` (now on the sheet) and **keeps** `flexDirection: row`, `pageHorizontalPadding`, and `paddingBottom: RESONANCE_BUTTON_CLEARANCE`.
- **`JournalEntryScreen.tsx`**: `JournalPage` renders desk → sheet (`testID journal-sheet`, `sheetNarrow` when narrow) → page (`testID journal-page`). The Get-Resonance button/modal/dialog stay siblings under the SafeAreaView; no `overflow:hidden` so the iOS shadow survives. Edit/read column selection extracted to `PageBodyColumn` for the line budget.

**Behaviour + testIDs unchanged**: `journal-page` keeps its testID and `paddingBottom === RESONANCE_BUTTON_CLEARANCE`; autosave, resonance, margin notes, read/edit toggle untouched.

## Test plan

Added "floats as a lighter sheet above the desk" (sheet uses `paper.background` + a real shadow; root uses `paper.desk`); clearance regression guard kept. **19 pass.**

`./scripts/frontend/check-all.sh` — 4/4. Tokens only.

Closes #680
Refs #678
