### PR TITLE
feat(frontend): ruled page-margin + lit sheet edge

### DIFF
--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -46,6 +46,12 @@ const styles = StyleSheet.create({
     backgroundColor: colors.paper.background,
     borderTopLeftRadius: journalSheet.cornerRadius,
     borderTopRightRadius: journalSheet.cornerRadius,
+    // A barely-there lit paper edge so the lifted sheet catches light at its
+    // border (pairs with the shadow below; not a hard box outline).
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.paper.sheetEdge,
     ...paperShadow.sheet,
   },
   sheetNarrow: {
@@ -74,10 +80,20 @@ const styles = StyleSheet.create({
     width: journalLayout.marginColumnWidth,
     paddingLeft: journalLayout.marginNoteGap,
     paddingVertical: spacing(3),
+    // Faint page-margin rule between the writing column and the marginalia —
+    // intentionally hairline-light so it reads as a margin, not a divider.
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    borderLeftColor: colors.paper.hairline,
   },
   marginColumnNarrow: {
     width: '100%',
     paddingLeft: 0,
+    // When the marginalia stacks under the writing area, rule the top instead.
+    borderLeftWidth: 0,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.paper.hairline,
+    paddingTop: spacing(2),
+    marginTop: spacing(1),
   },
   titleInput: {
     ...editorialType.title,

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -167,6 +167,29 @@ describe('JournalEntryScreen', () => {
     expect(root.backgroundColor).toBe(colors.paper.desk);
   });
 
+  it('rules a faint vertical page-margin between the columns on wide screens', () => {
+    const { getByTestId } = renderScreen();
+    const margin = StyleSheet.flatten(getByTestId('journal-margin-column').props.style);
+    expect(margin.borderLeftWidth).toBeGreaterThan(0);
+    expect(margin.borderLeftColor).toBe(colors.paper.hairline);
+  });
+
+  it('moves the margin rule to the top when the marginalia stacks on narrow screens', () => {
+    const rn = require('react-native');
+    const spy = jest
+      .spyOn(rn, 'useWindowDimensions')
+      .mockReturnValue({ width: 400, height: 800, scale: 2, fontScale: 1 });
+    try {
+      const { getByTestId } = renderScreen();
+      const margin = StyleSheet.flatten(getByTestId('journal-margin-column').props.style);
+      expect(margin.borderTopWidth).toBeGreaterThan(0);
+      expect(margin.borderLeftWidth).toBe(0);
+      expect(margin.borderTopColor).toBe(colors.paper.hairline);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('autosaves once after the debounce when the body changes', async () => {
     jest.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

journal-depth-03: a floated sheet with no internal structure still reads as a plain panel. Add the editorial cues that make it read as **a page** — tokens only, no behaviour change, shared by edit + read modes.

- **`marginColumn`**: a faint hairline leading rule (`borderLeft`, `colors.paper.hairline`) between the writing column and the marginalia on wide screens; the **narrow** variant drops the left rule and rules the **top** instead (so it reads as a margin when the marginalia stacks). Intentionally hairline-light — a margin, not a divider.
- **`sheet`**: a barely-there lit paper edge (hairline border in `colors.paper.sheetEdge`) so the lifted sheet catches light at its border alongside the shadow — no heavy boxed outline.

Both edit and read modes share `marginColumn`/`writingColumn`, so the rule applies to both automatically.

## Test plan

Wide layout asserts the margin column's left hairline (`paper.hairline`); a narrow layout (`useWindowDimensions` mocked < 600) asserts the rule moves to the top (`borderTopWidth > 0`, `borderLeftWidth === 0`). **21 pass.**

`./scripts/frontend/check-all.sh` — 4/4. Tokens only.

Closes #681
Refs #678
