### PR TITLE
feat(frontend): lift the marginalia notes off the page

### DIFF
--- a/frontend/src/features/Journal/MarginNote.tsx
+++ b/frontend/src/features/Journal/MarginNote.tsx
@@ -13,6 +13,7 @@ import {
   SPACING,
   colors,
   editorialType,
+  paperShadow,
   spacing,
   touchTarget,
 } from '@/design/tokens';
@@ -26,7 +27,11 @@ function MarginNote({ note, onOpen }: MarginNoteProps): React.JSX.Element {
   const isStale = note.status === 'stale';
   return (
     <TouchableOpacity
-      style={[styles.card, isStale && styles.cardStale]}
+      style={[
+        styles.card,
+        { borderLeftColor: colors.marginalia[note.kind] },
+        isStale && styles.cardStale,
+      ]}
       onPress={() => onOpen(note)}
       accessibilityRole="button"
       accessibilityLabel={`Open ${note.kind} note`}
@@ -49,9 +54,13 @@ const styles = StyleSheet.create({
     minHeight: touchTarget.minimum,
     padding: SPACING.md,
     borderRadius: BORDER_RADIUS.md,
-    backgroundColor: colors.paper.backgroundAlt,
+    // Sits a touch above the page, lifted by paperShadow.card — the shadow does
+    // the separation, so the slip can match the page ground (was backgroundAlt)
+    // and still read as a lifted note pinned to the margin.
+    backgroundColor: colors.paper.background,
     borderLeftWidth: 3,
-    borderLeftColor: colors.paper.hairline,
+    borderLeftColor: colors.paper.hairline, // default; overridden per kind inline
+    ...paperShadow.card,
   },
   cardStale: {
     opacity: 0.55,

--- a/frontend/src/features/Journal/__tests__/MarginNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/MarginNote.test.tsx
@@ -2,10 +2,12 @@
 import { jest, describe, it, expect } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
 import MarginNote from '../MarginNote';
 
 import type { Marginalia } from '@/api';
+import { colors } from '@/design/tokens';
 
 function note(overrides: Partial<Marginalia> = {}): Marginalia {
   return {
@@ -50,6 +52,20 @@ describe('MarginNote', () => {
       : card.props.style;
     expect(flattened.opacity).toBeLessThan(1);
     expect(getByText(/The passage this noted has changed/)).toBeTruthy();
+  });
+
+  it('lifts the card off the page and colour-codes the left bar by kind', () => {
+    for (const kind of ['theme', 'connection'] as const) {
+      const { getByTestId } = render(
+        <MarginNote note={note({ id: 20, kind })} onOpen={jest.fn()} />,
+      );
+      const card = StyleSheet.flatten(getByTestId('margin-note-20').props.style);
+      // Lifted by the warm paper card shadow (iOS/web shadow + Android elevation).
+      expect(card.shadowRadius).toBeGreaterThan(0);
+      expect(card.elevation).toBeGreaterThan(0);
+      // The left bar carries the note's kind accent.
+      expect(card.borderLeftColor).toBe(colors.marginalia[kind]);
+    }
   });
 
   it('a stale note is still openable', () => {


### PR DESCRIPTION
## Summary

journal-depth-04: once the page floats, flat `MarginNote` cards look pasted-on rather than pinned to the margin. Give each note a gentle lift so the marginalia feel like physical slips laid on the page. **Presentation only.**

- Apply **`paperShadow.card`** and switch the card ground from `paper.backgroundAlt` → `paper.background` — the shadow now does the separation, so the slip matches the page ground and still reads as lifted (cleaner than a flat tinted block).
- Tie the 3px left bar to **`colors.marginalia[note.kind]`** so each note is colour-coded at a glance (theme / connection / symbol), matching its kind label.

Kind accent, stale dimming + "passage changed" caption, and the `margin-note-<id>` / stale testIDs are all unchanged.

## Test plan

Asserts the card carries a real shadow (`shadowRadius` + `elevation`) and the left bar is the kind accent for `theme` + `connection`; existing kind/text, `onOpen`, and stale cases still pass. **5 pass.**

`./scripts/frontend/check-all.sh` — 4/4. Tokens only.

Closes #682
Refs #678
