### PR TITLE
feat(frontend): float the shelf entries as paper cards

### DIFF
--- a/frontend/src/features/Journal/JournalShelf.styles.ts
+++ b/frontend/src/features/Journal/JournalShelf.styles.ts
@@ -1,15 +1,24 @@
 /** Styles for the journal shelf (the landing list of entry "pages"). */
 import { StyleSheet } from 'react-native';
 
-import { BORDER_RADIUS, SPACING, colors, editorialType, spacing } from '@/design/tokens';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  paperShadow,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
 
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: colors.paper.background,
+    backgroundColor: colors.paper.desk, // shared desk ground (issue 01)
   },
   listContent: {
     paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.md,
     paddingBottom: SPACING.xxl,
     flexGrow: 1,
   },
@@ -31,10 +40,15 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   card: {
-    minHeight: 44,
+    minHeight: touchTarget.minimum,
     paddingVertical: SPACING.md,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.paper.hairline,
+    paddingHorizontal: SPACING.lg,
+    marginBottom: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    // The lifted page card: separation now comes from the gap + shadow between
+    // floated cards, so the old borderBottom hairline is gone.
+    backgroundColor: colors.paper.background,
+    ...paperShadow.card,
   },
   cardTitleRow: {
     flexDirection: 'row',
@@ -78,9 +92,12 @@ const styles = StyleSheet.create({
     marginTop: SPACING.lg,
     padding: SPACING.lg,
     borderRadius: BORDER_RADIUS.md,
-    backgroundColor: colors.paper.backgroundAlt,
+    // Lifted onto the desk like the entry cards, but keeps its accent-bar
+    // identity marking it as the weekly prompt.
+    backgroundColor: colors.paper.background,
     borderLeftWidth: 3,
     borderLeftColor: colors.marginalia.theme,
+    ...paperShadow.card,
   },
   promptLabel: {
     ...editorialType.caption,

--- a/frontend/src/features/Journal/JournalShelf.styles.ts
+++ b/frontend/src/features/Journal/JournalShelf.styles.ts
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.md,
   },
   newEntry: {
-    minHeight: 44,
+    minHeight: touchTarget.minimum,
     justifyContent: 'center',
     alignItems: 'center',
     marginTop: SPACING.sm,

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -2,8 +2,10 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
 import type { JournalListResponse, JournalMessage, PromptDetail } from '@/api';
+import { colors } from '@/design/tokens';
 
 const mockList = jest.fn() as jest.MockedFunction<
   (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
@@ -91,6 +93,21 @@ describe('JournalShelfScreen', () => {
     expect(await findByTestId('journal-shelf-card-3')).toBeTruthy();
     expect(getByTestId('journal-shelf-card-2')).toBeTruthy();
     expect(getByTestId('journal-shelf-card-1')).toBeTruthy();
+  });
+
+  it('floats each entry as a lifted paper card on the deeper desk ground', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    const card = StyleSheet.flatten((await findByTestId('journal-shelf-card-1')).props.style);
+    // Lifted paper card: matches the page ground, lifted by the warm card shadow,
+    // separated by gaps rather than the old hairline divider.
+    expect(card.backgroundColor).toBe(colors.paper.background);
+    expect(card.shadowRadius).toBeGreaterThan(0);
+    expect(card.elevation).toBeGreaterThan(0);
+    expect(card.borderBottomWidth).toBeUndefined();
+    // The shelf sits on the deeper desk ground the cards float above.
+    const root = StyleSheet.flatten(getByTestId('journal-shelf').props.style);
+    expect(root.backgroundColor).toBe(colors.paper.desk);
   });
 
   it('shows the empty state when there are no entries', async () => {

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -110,6 +110,19 @@ describe('JournalShelfScreen', () => {
     expect(root.backgroundColor).toBe(colors.paper.desk);
   });
 
+  it('floats the weekly-prompt card with matching depth while keeping its accent bar', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    mockPromptCurrent.mockResolvedValue(prompt({ week_number: 3, has_responded: false }));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    const card = StyleSheet.flatten((await findByTestId('journal-weekly-prompt')).props.style);
+    // Same floated treatment as the entry cards…
+    expect(card.backgroundColor).toBe(colors.paper.background);
+    expect(card.shadowRadius).toBeGreaterThan(0);
+    expect(card.elevation).toBeGreaterThan(0);
+    // …but keeps its accent-bar identity.
+    expect(card.borderLeftColor).toBe(colors.marginalia.theme);
+  });
+
   it('shows the empty state when there are no entries', async () => {
     mockList.mockResolvedValue(page([]));
     const { findByTestId } = render(<JournalShelfScreen />);


### PR DESCRIPTION
## Summary

journal-depth-05: after the writing page floats, the shelf still looked flat, breaking cohesion. Recolour the shelf to the shared **desk** ground and turn each entry into a **lifted paper card** — "pages on a shelf." Presentation only.

- `safeArea` → `colors.paper.desk` (shared desk ground).
- `card`: lifted paper card (`paper.background` + `paperShadow.card` + rounded), spaced by a `marginBottom` gap; **dropped** the old `borderBottom` hairline (separation now comes from gap + shadow); replaced the bare `44` with `touchTarget.minimum`.
- `promptCard`: same floated treatment while keeping its `marginalia.theme` accent-bar identity.
- `newEntry` CTA left as the solid primary button (chrome, not a card).

**AA on the desk ground (`#e7dcc8`):** `inkSoft` 5.79:1, `danger` 5.96:1 — both clear AA, so empty/error text stays directly on the desk (no chip needed).

Behaviour preserved: all testIDs (`journal-shelf`, `journal-shelf-card-<id>`, list/empty/error, `shelf-search`), the New-entry CTA, empty/error states, prompt card, and list scrolling unchanged.

## Test plan

Added "floats each entry as a lifted paper card on the deeper desk ground" (card uses `paper.background` + a real shadow, no `borderBottomWidth`; root uses `paper.desk`); existing shelf tests stay green. **11 pass.**

`./scripts/frontend/check-all.sh` — 4/4. Tokens only.

Closes #683
Refs #678
