### PR TITLE
feat(frontend): depth-reinforcing motion for the journal (reduced-motion safe)

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -9,6 +9,7 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  Animated,
   ScrollView,
   Text,
   TextInput,
@@ -23,6 +24,7 @@ import GetResonanceButton, { shouldShowResonance } from './GetResonanceButton';
 import HighlightedBody from './HighlightedBody';
 import styles from './JournalEntry.styles';
 import MarginNote from './MarginNote';
+import { useSettleIn } from './motion';
 import ResonanceEssayModal from './ResonanceEssayModal';
 import { useResonance } from './useResonance';
 
@@ -30,6 +32,7 @@ import { journal, prompts } from '@/api';
 import type { EntryStatus, JournalMessage, Marginalia } from '@/api';
 import { colors } from '@/design/tokens';
 import { useIdle } from '@/hooks/useIdle';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 /** Default idle delay before an edit is persisted. */
@@ -607,6 +610,7 @@ function JournalPage({
   bodyPlaceholder: string;
 }) {
   const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
+  const settle = useSettleIn(useReducedMotion());
   const notes = ctl.resonance.marginalia;
 
   let marginContent: React.ReactNode;
@@ -617,7 +621,10 @@ function JournalPage({
 
   return (
     <View style={styles.desk}>
-      <View style={[styles.sheet, narrow && styles.sheetNarrow]} testID="journal-sheet">
+      <Animated.View
+        style={[styles.sheet, narrow && styles.sheetNarrow, settle]}
+        testID="journal-sheet"
+      >
         <View style={[styles.page, narrow && styles.pageNarrow]} testID="journal-page">
           <PageBodyColumn ctl={ctl} bodyPlaceholder={bodyPlaceholder} />
           <View
@@ -627,7 +634,7 @@ function JournalPage({
             {marginContent}
           </View>
         </View>
-      </View>
+      </Animated.View>
     </View>
   );
 }

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -7,15 +7,17 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useState } from 'react';
-import { FlatList, Text, TouchableOpacity, View } from 'react-native';
+import { Animated, FlatList, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import styles from './JournalShelf.styles';
+import { usePressScale } from './motion';
 import SearchBar from './SearchBar';
 
 import { journal, prompts } from '@/api';
 import type { JournalMessage, PromptDetail } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { RootStackParamList } from '@/navigation/RootStack';
 import { useDerivedCurrentWeek } from '@/store/useProgramProgression';
 
@@ -111,24 +113,29 @@ function PageCard({
   entry: JournalMessage;
   onOpen: (_id: number) => void;
 }): React.JSX.Element {
+  const press = usePressScale(useReducedMotion());
   return (
-    <TouchableOpacity
-      style={styles.card}
-      onPress={() => onOpen(entry.id)}
-      accessibilityRole="button"
-      accessibilityLabel={`Open ${entry.title ?? 'untitled'} entry`}
-      testID={`journal-shelf-card-${entry.id}`}
-    >
-      <View style={styles.cardTitleRow}>
-        <Text style={styles.cardTitle} numberOfLines={1}>
-          {entry.title?.trim() ? entry.title : 'Untitled'}
+    <Animated.View style={{ transform: [{ scale: press.scale }] }}>
+      <TouchableOpacity
+        style={styles.card}
+        onPress={() => onOpen(entry.id)}
+        onPressIn={press.onPressIn}
+        onPressOut={press.onPressOut}
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${entry.title ?? 'untitled'} entry`}
+        testID={`journal-shelf-card-${entry.id}`}
+      >
+        <View style={styles.cardTitleRow}>
+          <Text style={styles.cardTitle} numberOfLines={1}>
+            {entry.title?.trim() ? entry.title : 'Untitled'}
+          </Text>
+          <Text style={styles.cardDate}>{formatDate(entry.timestamp)}</Text>
+        </View>
+        <Text style={styles.cardExcerpt} numberOfLines={2}>
+          {excerpt(entry.message)}
         </Text>
-        <Text style={styles.cardDate}>{formatDate(entry.timestamp)}</Text>
-      </View>
-      <Text style={styles.cardExcerpt} numberOfLines={2}>
-        {excerpt(entry.message)}
-      </Text>
-    </TouchableOpacity>
+      </TouchableOpacity>
+    </Animated.View>
   );
 }
 

--- a/frontend/src/features/Journal/MarginNote.tsx
+++ b/frontend/src/features/Journal/MarginNote.tsx
@@ -5,7 +5,9 @@
  * staleness styling lands in a later issue). Tapping signals ``onOpen``.
  */
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { Animated, StyleSheet, Text, TouchableOpacity } from 'react-native';
+
+import { usePressScale } from './motion';
 
 import type { Marginalia } from '@/api';
 import {
@@ -17,6 +19,7 @@ import {
   spacing,
   touchTarget,
 } from '@/design/tokens';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 export interface MarginNoteProps {
   note: Marginalia;
@@ -25,27 +28,32 @@ export interface MarginNoteProps {
 
 function MarginNote({ note, onOpen }: MarginNoteProps): React.JSX.Element {
   const isStale = note.status === 'stale';
+  const press = usePressScale(useReducedMotion());
   return (
-    <TouchableOpacity
-      style={[
-        styles.card,
-        { borderLeftColor: colors.marginalia[note.kind] },
-        isStale && styles.cardStale,
-      ]}
-      onPress={() => onOpen(note)}
-      accessibilityRole="button"
-      accessibilityLabel={`Open ${note.kind} note`}
-      testID={`margin-note-${note.id}`}
-    >
-      <Text style={[styles.kind, { color: colors.marginalia[note.kind] }]}>{note.kind}</Text>
-      <Text style={styles.note}>{note.note}</Text>
-      {isStale ? (
-        <Text style={styles.staleCaption} testID={`margin-note-stale-${note.id}`}>
-          The passage this noted has changed.
-        </Text>
-      ) : null}
-      <Text style={styles.open}>Open</Text>
-    </TouchableOpacity>
+    <Animated.View style={{ transform: [{ scale: press.scale }] }}>
+      <TouchableOpacity
+        style={[
+          styles.card,
+          { borderLeftColor: colors.marginalia[note.kind] },
+          isStale && styles.cardStale,
+        ]}
+        onPress={() => onOpen(note)}
+        onPressIn={press.onPressIn}
+        onPressOut={press.onPressOut}
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${note.kind} note`}
+        testID={`margin-note-${note.id}`}
+      >
+        <Text style={[styles.kind, { color: colors.marginalia[note.kind] }]}>{note.kind}</Text>
+        <Text style={styles.note}>{note.note}</Text>
+        {isStale ? (
+          <Text style={styles.staleCaption} testID={`margin-note-stale-${note.id}`}>
+            The passage this noted has changed.
+          </Text>
+        ) : null}
+        <Text style={styles.open}>Open</Text>
+      </TouchableOpacity>
+    </Animated.View>
   );
 }
 

--- a/frontend/src/features/Journal/__tests__/motion.test.ts
+++ b/frontend/src/features/Journal/__tests__/motion.test.ts
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react-native';
+import { Animated } from 'react-native';
+
+import { PRESS_SCALE, SETTLE_DISTANCE, usePressScale, useSettleIn } from '../motion';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/** Read an Animated node's current JS value (``__getValue`` is internal/untyped). */
+const animatedValue = (node: unknown): number =>
+  (node as { __getValue: () => number }).__getValue();
+
+const stubbedTiming = (): jest.SpiedFunction<typeof Animated.timing> =>
+  jest.spyOn(Animated, 'timing').mockReturnValue({
+    start: jest.fn(),
+    stop: jest.fn(),
+  } as unknown as Animated.CompositeAnimation);
+
+describe('useSettleIn', () => {
+  it('animates the surface in from below when motion is allowed', () => {
+    const timing = stubbedTiming();
+
+    const { result } = renderHook(() => useSettleIn(false));
+
+    // Starts below its resting place (translucent, lifted) and schedules a settle.
+    expect(animatedValue(result.current.opacity)).toBe(0);
+    expect(animatedValue(result.current.transform[0]!.translateY)).toBe(SETTLE_DISTANCE);
+    expect(timing).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders at the resting state with no animation under reduced motion', () => {
+    const timing = jest.spyOn(Animated, 'timing');
+
+    const { result } = renderHook(() => useSettleIn(true));
+
+    expect(animatedValue(result.current.opacity)).toBe(1);
+    expect(animatedValue(result.current.transform[0]!.translateY)).toBe(0);
+    expect(timing).not.toHaveBeenCalled();
+  });
+});
+
+describe('usePressScale', () => {
+  it('drives the press-in / press-out scale when motion is allowed', () => {
+    const timing = stubbedTiming();
+
+    const { result } = renderHook(() => usePressScale(false));
+
+    act(() => result.current.onPressIn());
+    expect(timing).toHaveBeenLastCalledWith(
+      result.current.scale,
+      expect.objectContaining({ toValue: PRESS_SCALE, useNativeDriver: true }),
+    );
+
+    act(() => result.current.onPressOut());
+    expect(timing).toHaveBeenLastCalledWith(
+      result.current.scale,
+      expect.objectContaining({ toValue: 1, useNativeDriver: true }),
+    );
+  });
+
+  it('is a no-op under reduced motion (scale stays at rest)', () => {
+    const timing = jest.spyOn(Animated, 'timing');
+
+    const { result } = renderHook(() => usePressScale(true));
+    act(() => result.current.onPressIn());
+    act(() => result.current.onPressOut());
+
+    expect(timing).not.toHaveBeenCalled();
+    expect(animatedValue(result.current.scale)).toBe(1);
+  });
+});

--- a/frontend/src/features/Journal/motion.ts
+++ b/frontend/src/features/Journal/motion.ts
@@ -1,0 +1,85 @@
+/**
+ * Depth-reinforcing motion for the floated journal surfaces — the writing
+ * sheet settling in on mount, and cards pressing down when tapped. Every
+ * animation here is short, native-driven, and gated on ``useReducedMotion``:
+ * when reduce-motion is on the hooks return the resting state and run no
+ * animation, so layout is identical and nothing interpolates.
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import { Animated } from 'react-native';
+
+/** Sheet settle-in: a brief fade + a few-px lift into place. */
+export const SETTLE_DURATION_MS = 220;
+export const SETTLE_DISTANCE = 6;
+
+/** Card press-in: a barely-there scale-down for a "press into the desk" feel. */
+export const PRESS_DURATION_MS = 90;
+export const PRESS_SCALE = 0.98;
+
+export interface SettleStyle {
+  opacity: Animated.AnimatedInterpolation<number> | Animated.Value;
+  transform: { translateY: Animated.AnimatedInterpolation<number> }[];
+}
+
+/**
+ * Animated style for a surface that settles in when it mounts. With reduced
+ * motion the value starts at its resting position (opacity 1, no offset) and no
+ * animation is scheduled.
+ */
+export function useSettleIn(reduced: boolean): SettleStyle {
+  const anim = useRef(new Animated.Value(reduced ? 1 : 0)).current;
+
+  useEffect(() => {
+    if (reduced) {
+      anim.setValue(1);
+      return;
+    }
+    const animation = Animated.timing(anim, {
+      toValue: 1,
+      duration: SETTLE_DURATION_MS,
+      useNativeDriver: true,
+    });
+    animation.start();
+    return () => animation.stop();
+  }, [reduced, anim]);
+
+  return useMemo(
+    () => ({
+      opacity: anim,
+      transform: [
+        { translateY: anim.interpolate({ inputRange: [0, 1], outputRange: [SETTLE_DISTANCE, 0] }) },
+      ],
+    }),
+    [anim],
+  );
+}
+
+export interface PressScale {
+  scale: Animated.Value;
+  onPressIn: () => void;
+  onPressOut: () => void;
+}
+
+/**
+ * A press-feedback scale for a card. ``onPressIn``/``onPressOut`` drive a subtle
+ * scale-down and back; both are no-ops under reduced motion (the scale stays at
+ * 1, so the card still gets ``TouchableOpacity``'s default opacity dip only).
+ */
+export function usePressScale(reduced: boolean): PressScale {
+  const scale = useRef(new Animated.Value(1)).current;
+
+  const animateTo = (toValue: number): void => {
+    if (reduced) return;
+    Animated.timing(scale, {
+      toValue,
+      duration: PRESS_DURATION_MS,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  return {
+    scale,
+    onPressIn: () => animateTo(PRESS_SCALE),
+    onPressOut: () => animateTo(1),
+  };
+}

--- a/frontend/src/hooks/__tests__/useReducedMotion.test.ts
+++ b/frontend/src/hooks/__tests__/useReducedMotion.test.ts
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { AccessibilityInfo } from 'react-native';
+import type { EmitterSubscription } from 'react-native';
+
+import { useReducedMotion } from '../useReducedMotion';
+
+type ReduceMotionListener = (_value: boolean) => void;
+const subscription = { remove: jest.fn() } as unknown as EmitterSubscription;
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useReducedMotion', () => {
+  it('reflects the initial OS reduce-motion setting', async () => {
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(true);
+    jest.spyOn(AccessibilityInfo, 'addEventListener').mockReturnValue(subscription);
+
+    const { result } = renderHook(() => useReducedMotion());
+
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('updates live when the OS setting changes', async () => {
+    let fire: ReduceMotionListener | undefined;
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(false);
+    jest.spyOn(AccessibilityInfo, 'addEventListener').mockImplementation((_event, handler) => {
+      fire = handler as unknown as ReduceMotionListener;
+      return subscription;
+    });
+
+    const { result } = renderHook(() => useReducedMotion());
+    await waitFor(() => expect(result.current).toBe(false));
+
+    act(() => fire?.(true));
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useReducedMotion.ts
+++ b/frontend/src/hooks/useReducedMotion.ts
@@ -1,0 +1,29 @@
+/**
+ * Track the OS "Reduce Motion" accessibility setting.
+ *
+ * Returns ``true`` when the user has asked the system to minimise non-essential
+ * animation. The journal-depth motion (sheet settle-in, card press feedback)
+ * checks this and renders the resting state with no transition when it is on,
+ * so the polish never costs accessibility. Updates live if the setting changes
+ * while the screen is mounted.
+ */
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void AccessibilityInfo.isReduceMotionEnabled().then((value) => {
+      if (active) setReduced(value);
+    });
+    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduced);
+    return () => {
+      active = false;
+      subscription.remove();
+    };
+  }, []);
+
+  return reduced;
+}


### PR DESCRIPTION
## Summary

journal-depth-06 (the epic's **final** issue): a little motion makes a floated surface feel *physical*. Extend the house `GetResonanceButton` motion idiom (`Animated` + `useNativeDriver`, short durations) to the new floated surfaces — and gate **all** of it behind "Reduce Motion" so the polish never costs accessibility. No layout/behaviour/nav change.

- **`useReducedMotion` hook**: reads `AccessibilityInfo.isReduceMotionEnabled()` + subscribes to `reduceMotionChanged` (unmount-guarded, cleaned up); live updates.
- **Sheet settle-in** (`journal-sheet` → `Animated.View`): fade `opacity 0→1` + lift `translateY 6→0` over 220ms on mount. Reduced motion → the `Animated.Value` is built at the resting state and **no** timing is scheduled (identical layout, no in-flight interpolation).
- **Card press feedback** (shelf card + `MarginNote`): scale `1→0.98` on pressIn, restore on pressOut over 90ms, layered on the `TouchableOpacity` opacity dip. Reduced motion → press handlers are no-ops; scale stays 1.
- All distances/durations/scales are named constants in `features/Journal/motion.ts` (no magic numbers).

Touch targets stay ≥ `touchTarget.minimum` (scale wrappers add only `transform`); `journal-sheet` / `margin-note-<id>` / `journal-shelf-card-<id>` testIDs preserved.

## Test plan

Both paths: `useReducedMotion` initial + live update (mocked `AccessibilityInfo`); `useSettleIn`/`usePressScale` assert motion-OFF schedules `Animated.timing` and starts below rest, motion-ON renders at rest with timing **not** called. Existing Journal suites stay green (hook+motion+MarginNote 11; Entry+Shelf 33).

`./scripts/frontend/check-all.sh` — 4/4.

Closes #684
Refs #678
