### PR TITLE
fix(ralph): make recap metrics move — true total, rolling windows, real cycle time

### DIFF
--- a/scripts/ralph/RECAP.md
+++ b/scripts/ralph/RECAP.md
@@ -76,22 +76,35 @@ once manually — handy for backfilling after enabling the bot mid-campaign.
 
 All math is pure and unit-tested in `stats.py`; all I/O is in `recap.py`.
 
-- **PRs merged** — closed PRs with a non-null `merged_at`, capped at `--max-prs`
-  (default 200). "last 7d" counts merges within the trailing 7 days of now.
-- **Merge rate** — `total_merges / span_days`, where `span_days` runs from the
-  **first** merge to **now** (not to the last merge). Anchoring to now makes a
-  stalled loop show a *decaying* rate instead of a frozen one.
-- **Review iterations before LGTM** — per merged PR, issue comments are read
-  oldest-first and a comment counts as a verdict only if it contains `VERDICT`
-  (case-insensitive), matching `iteration-trigger.yml`. The count is the number
-  of non-LGTM verdicts preceding the first LGTM. PRs that never reached an LGTM
-  verdict are excluded. The embed shows avg rounds, first-try-clean %, worst,
-  and the sample size `n`.
-- **Time to merge** — `merged_at - created_at` per PR; median, fastest, slowest.
+The headline **PRs merged** total is all-time; the activity and quality stats
+below cover a trailing **7-day window** (`RECENT_WINDOW_DAYS`) so they move with
+recent work instead of being diluted by a frozen lifetime average. The window is
+fetched via the search API (`is:pr is:merged merged:>=<date>`), capped at
+`--max-prs` (default 200) as a safety bound on a burst day.
+
+- **PRs merged** — the true cumulative count of merged PRs from the search API
+  (`total_count`), independent of any per-run fetch cap, plus "in 24h" and
+  "in 7d" counts from the window.
+- **Merge rate** — rolling windows: merges in the last 24h as **per-hour**, and
+  merges in the last 7 days as **per-day**. Fixed-width windows move every recap
+  and decay toward zero when the loop idles. The 7-day per-day figure (steadier
+  than the 24h one) is what the backlog ETA is built on.
+- **Review iterations before LGTM** (7d) — per merged PR in the window, issue
+  comments are read oldest-first and a comment counts as a verdict only if it
+  contains `VERDICT` (case-insensitive), matching `iteration-trigger.yml`. The
+  count is the number of non-LGTM verdicts preceding the first LGTM. PRs that
+  never reached an LGTM verdict are excluded. The embed shows avg rounds,
+  first-try-clean %, worst, and the sample size `n`.
+- **Cycle time** (7d) — `merged_at - first_commit_at` per PR: from the PR's
+  first commit (the work-beginning proxy, via the pull-request commits endpoint)
+  to merge, so it captures coding time rather than just the review window. Falls
+  back to `created_at` when no commit timestamp is available, and clamps to zero
+  so a rebased commit dated after the merge can't go negative. Median, fastest,
+  slowest.
 - **Backlog remaining and ETA** — `open_items / per_day` as days and a date.
   When the rate is zero the ETA reads "unknown (stalled)"; an empty backlog
   reads "backlog clear".
-- **Busiest day** — the UTC calendar day with the most merges.
+- **Busiest day** (7d) — the UTC calendar day in the window with the most merges.
 - **This PR's footprint** — additions/deletions/changed-files for the most
   recently merged PR (the list endpoint omits diff stats, so it's fetched via
   the single-PR detail endpoint).

--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -37,6 +37,7 @@ import json
 import os
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, cast
 
@@ -62,7 +63,11 @@ GITHUB_API = "https://api.github.com"
 DISCORD_API = "https://discord.com/api/v10"
 # Discord embed accent — a Ralph-purple.
 EMBED_COLOR = 0x7C3AED
-# Cap per-PR comment fetches so a giant campaign doesn't make thousands of calls.
+# The windowed stats (iterations, cycle time, busiest day) cover this trailing
+# span so they move with recent activity instead of a frozen all-time average.
+RECENT_WINDOW_DAYS = 7
+# Safety cap on PRs analyzed per run: each window PR costs two extra API calls
+# (verdicts + first commit), so bound a burst day rather than fan out unbounded.
 DEFAULT_MAX_PRS = 200
 HEADLINE_MODEL = "claude-opus-4-8"
 
@@ -138,17 +143,67 @@ def _gh_get_paged(path: str, *, token: str, params: dict[str, str], max_items: i
 # --------------------------------------------------------------------------- #
 
 
-def fetch_merged_prs(repo: str, *, token: str, max_prs: int) -> list[dict[str, Any]]:
-    """Return merged PRs (newest merge first), capped at max_prs."""
-    closed = _gh_get_paged(
-        f"/repos/{repo}/pulls",
-        token=token,
-        params={"state": "closed", "sort": "updated", "direction": "desc"},
-        max_items=max_prs * 2,
-    )
-    merged = [pr for pr in closed if pr.get("merged_at")]
-    merged.sort(key=lambda pr: cast("str", pr["merged_at"]), reverse=True)
-    return merged[:max_prs]
+def _gh_search_issues(query: str, *, token: str, max_items: int) -> list[dict[str, Any]]:
+    """Run a GitHub issue/PR search, paging up to max_items results.
+
+    Search responses wrap the hits in an `items` array (unlike the list
+    endpoints used by `_gh_get_paged`), so this has its own pager.
+    """
+    headers = _gh_headers(token)
+    out: list[dict[str, Any]] = []
+    page = 1
+    while len(out) < max_items:
+        qs = urllib.parse.urlencode({"q": query, "per_page": "100", "page": str(page)})
+        url = f"{GITHUB_API}/search/issues?{qs}"
+        data = cast("dict[str, Any]", _request_json(url, headers=headers))
+        items = cast("list[dict[str, Any]]", data.get("items", []))
+        if not items:
+            break
+        out.extend(items)
+        if len(items) < 100:
+            break
+        page += 1
+    return out[:max_items]
+
+
+def count_merged_total(repo: str, *, token: str) -> int:
+    """Return the true all-time count of merged PRs via the search API.
+
+    Independent of any per-run fetch cap, so the headline total keeps climbing
+    instead of pinning at the number of PRs we happened to pull this run.
+    """
+    qs = urllib.parse.urlencode({"q": f"repo:{repo} is:pr is:merged", "per_page": "1"})
+    data = cast("dict[str, Any]", _request_json(f"{GITHUB_API}/search/issues?{qs}", headers=_gh_headers(token)))
+    return int(data.get("total_count", 0))
+
+
+def fetch_recent_merged_prs(repo: str, *, token: str, since: dt.date, max_prs: int) -> list[dict[str, Any]]:
+    """Return PRs merged on/after `since` (newest merge first), capped at max_prs.
+
+    Uses search so the window is filtered server-side; each hit carries its
+    `pull_request.merged_at` and `created_at`, which is all the windowed stats
+    need without a per-PR detail call.
+    """
+    query = f"repo:{repo} is:pr is:merged merged:>={since.isoformat()}"
+    items = _gh_search_issues(query, token=token, max_items=max_prs)
+    items.sort(key=lambda it: cast("str", it["pull_request"]["merged_at"]), reverse=True)
+    return items
+
+
+def fetch_pr_first_commit_at(repo: str, number: int, *, token: str) -> dt.datetime | None:
+    """Return the authored time of a PR's first commit, or None if unavailable.
+
+    The pull-request commits endpoint returns commits oldest-first, so the first
+    element is where work on the branch began — the closest cheap proxy for
+    "work started" behind the cycle-time metric.
+    """
+    url = f"{GITHUB_API}/repos/{repo}/pulls/{number}/commits?per_page=1"
+    commits = cast("list[dict[str, Any]]", _request_json(url, headers=_gh_headers(token)))
+    if not commits:
+        return None
+    commit = cast("dict[str, Any]", commits[0].get("commit", {}))
+    authored = commit.get("author", {}).get("date") or commit.get("committer", {}).get("date")
+    return stats.parse_iso(str(authored)) if authored else None
 
 
 def fetch_pr_detail(repo: str, number: int, *, token: str) -> dict[str, Any]:
@@ -285,30 +340,52 @@ def _fmt_eta(estimate: dict[str, object]) -> str:
     return f"~{days:.1f} days (≈ {eta.date().isoformat()})"
 
 
+def _pr_merged_at(pr: dict[str, Any]) -> dt.datetime:
+    """Parse a search hit's merge timestamp from its `pull_request` block."""
+    return stats.parse_iso(cast("str", pr["pull_request"]["merged_at"]))
+
+
+def _cycle_hours(repo: str, pr: dict[str, Any], *, token: str) -> float:
+    """Hours from a PR's first commit (or PR open, as fallback) to its merge.
+
+    Measures real cycle time — work-beginning to merge — rather than just the
+    review window. Falls back to the PR's open time when no commit timestamp is
+    available, and clamps to zero so a rebased commit dated after the merge can
+    never produce a negative duration.
+    """
+    merged = _pr_merged_at(pr)
+    started = fetch_pr_first_commit_at(repo, int(pr["number"]), token=token)
+    if started is None:
+        started = stats.parse_iso(cast("str", pr["created_at"]))
+    return max((merged - started).total_seconds() / 3600.0, 0.0)
+
+
 def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dict[str, Any] | None:
     """Gather data and assemble the Discord embed payload.
 
-    Returns None when there are no merged PRs yet (nothing to recap).
+    The headline total is the true all-time merged count; the activity and
+    quality stats (rate, iterations, cycle time, busiest day) cover the trailing
+    `RECENT_WINDOW_DAYS` so they move with recent work. Returns None when there
+    are no merged PRs yet (nothing to recap).
     """
-    merged = fetch_merged_prs(repo, token=token, max_prs=max_prs)
-    if not merged:
+    total_merged = count_merged_total(repo, token=token)
+    since = (now - dt.timedelta(days=RECENT_WINDOW_DAYS)).date()
+    window = fetch_recent_merged_prs(repo, token=token, since=since, max_prs=max_prs)
+    if not window:
         return None
 
-    merged_at = [stats.parse_iso(cast("str", pr["merged_at"])) for pr in merged]
-    durations = [
-        (stats.parse_iso(cast("str", pr["merged_at"])) - stats.parse_iso(cast("str", pr["created_at"]))).total_seconds()
-        / 3600.0
-        for pr in merged
-    ]
+    merged_at = [_pr_merged_at(pr) for pr in window]
 
     iterations: list[int] = []
-    for pr in merged:
+    cycle_hours: list[float] = []
+    for pr in window:
         verdicts = fetch_pr_verdicts(repo, int(pr["number"]), token=token)
         rounds = stats.iterations_before_lgtm(verdicts)
         if rounds is not None:
             iterations.append(rounds)
+        cycle_hours.append(_cycle_hours(repo, pr, token=token))
 
-    latest = merged[0]
+    latest = window[0]
     latest_detail = fetch_pr_detail(repo, int(latest["number"]), token=token)
     churn = [
         (
@@ -319,7 +396,7 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
     ]
 
     rate = stats.merge_rate(merged_at, now=now)
-    ttm = stats.time_to_merge_stats(durations)
+    cycle = stats.time_to_merge_stats(cycle_hours)
     iters = stats.iteration_stats(iterations)
     open_items = count_open_backlog(repo, token=token)
     estimate = stats.estimate_remaining(open_items, rate["per_day"], now=now)
@@ -332,8 +409,9 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
         repo=repo,
         latest=latest,
         headline=headline,
+        total_merged=total_merged,
         rate=rate,
-        ttm=ttm,
+        cycle=cycle,
         iters=iters,
         estimate=estimate,
         latest_churn=totals,
@@ -347,8 +425,9 @@ def _render_embed(
     repo: str,
     latest: dict[str, Any],
     headline: str,
+    total_merged: int,
     rate: dict[str, float],
-    ttm: dict[str, float],
+    cycle: dict[str, float],
     iters: dict[str, float],
     estimate: dict[str, object],
     latest_churn: dict[str, int],
@@ -365,7 +444,7 @@ def _render_embed(
         f"**{clean_pct}%** first-try clean · "
         f"worst **{int(iters['max'])}** (n={int(iters['sample'])})"
         if iters["sample"]
-        else "no LGTM verdicts found yet"
+        else "no LGTM verdicts in the last 7d"
     )
 
     busy_line = f"{busy[1]} merges on {busy[0]}" if busy else "—"
@@ -378,24 +457,24 @@ def _render_embed(
         },
         {
             "name": "📦 PRs merged",
-            "value": f"**{int(rate['total'])}** total · {int(rate['last_7_days'])} in last 7d",
+            "value": f"**{total_merged}** all-time · {int(rate['last_24h'])} in 24h · {int(rate['last_7_days'])} in 7d",
             "inline": True,
         },
         {
             "name": "⚡ Merge rate",
-            "value": f"**{rate['per_day']:.2f}**/day over {rate['span_days']:.1f}d",
+            "value": f"**{rate['per_hour']:.2f}**/hr (24h) · {rate['per_day']:.1f}/day (7d)",
             "inline": True,
         },
         {
-            "name": "🔁 Review iterations",
+            "name": "🔁 Review iterations (7d)",
             "value": iter_line,
             "inline": False,
         },
         {
-            "name": "⏱️ Time to merge",
+            "name": "⏱️ Cycle time · first commit → merge (7d)",
             "value": (
-                f"median **{_fmt_hours(ttm['median'])}** · "
-                f"fastest {_fmt_hours(ttm['fastest'])} · slowest {_fmt_hours(ttm['slowest'])}"
+                f"median **{_fmt_hours(cycle['median'])}** · "
+                f"fastest {_fmt_hours(cycle['fastest'])} · slowest {_fmt_hours(cycle['slowest'])}"
             ),
             "inline": False,
         },
@@ -405,7 +484,7 @@ def _render_embed(
             "inline": True,
         },
         {
-            "name": "🔥 Busiest day",
+            "name": "🔥 Busiest day (7d)",
             "value": busy_line,
             "inline": True,
         },

--- a/scripts/ralph/stats.py
+++ b/scripts/ralph/stats.py
@@ -84,28 +84,33 @@ def _median(values: list[float]) -> float:
     return (ordered[mid - 1] + ordered[mid]) / 2
 
 
+HOURS_PER_DAY = 24.0
+DAYS_PER_WEEK = 7.0
+
+
 def merge_rate(merged_at: list[dt.datetime], *, now: dt.datetime) -> dict[str, float]:
-    """Compute merge throughput from a list of merge timestamps.
+    """Compute merge throughput over fixed rolling windows.
 
-    Returns merges-per-day over the whole campaign, merges over the trailing 7
-    days, and the span in days. The campaign span runs from the first merge to
-    `now` (not to the last merge) so a stalled loop shows a decaying rate rather
-    than a frozen one.
+    Reports activity over the trailing 24 hours (as merges-per-hour) and the
+    trailing 7 days (as merges-per-day). Fixed-width windows mean every recap
+    moves with the latest data instead of being diluted by a frozen all-time
+    span, and an idle loop decays toward zero rather than showing a stale
+    average. The 7-day per-day figure (steadier than the 24h one) is what the
+    backlog ETA is built on.
     """
-    count = len(merged_at)
-    if count == 0:
-        return {"total": 0.0, "per_day": 0.0, "last_7_days": 0.0, "span_days": 0.0}
+    if not merged_at:
+        return {"last_24h": 0.0, "per_hour": 0.0, "last_7_days": 0.0, "per_day": 0.0}
 
-    first = min(merged_at)
-    span_days = max((now - first).total_seconds() / 86400.0, 1e-9)
-    week_ago = now - dt.timedelta(days=7)
+    day_ago = now - dt.timedelta(hours=HOURS_PER_DAY)
+    week_ago = now - dt.timedelta(days=DAYS_PER_WEEK)
+    last_24h = sum(1 for ts in merged_at if ts >= day_ago)
     last_7 = sum(1 for ts in merged_at if ts >= week_ago)
 
     return {
-        "total": float(count),
-        "per_day": count / span_days,
+        "last_24h": float(last_24h),
+        "per_hour": last_24h / HOURS_PER_DAY,
         "last_7_days": float(last_7),
-        "span_days": span_days,
+        "per_day": last_7 / DAYS_PER_WEEK,
     }
 
 

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -75,22 +75,29 @@ def test_iterations_before_lgtm_none_when_never_lgtm() -> None:
 
 def test_merge_rate_empty() -> None:
     rate = rs.merge_rate([], now=_at(27))
-    assert rate["total"] == 0.0
-    assert rate["per_day"] == 0.0
+    assert rate == {"last_24h": 0.0, "per_hour": 0.0, "last_7_days": 0.0, "per_day": 0.0}
 
 
-def test_merge_rate_spans_first_merge_to_now() -> None:
-    merged = [_at(20), _at(22), _at(24)]
-    rate = rs.merge_rate(merged, now=_at(30))
-    assert rate["total"] == 3.0
-    assert rate["span_days"] == 10.0
-    assert rate["per_day"] == 0.3
+def test_merge_rate_last_24h_per_hour() -> None:
+    # Two merges within 24h of `now` (27th 06:00 and 12:00); one is older.
+    merged = [_at(26, 5), _at(27, 6), _at(27, 12)]
+    rate = rs.merge_rate(merged, now=_at(27, 12))
+    assert rate["last_24h"] == 2.0
+    assert rate["per_hour"] == 2.0 / 24.0
 
 
-def test_merge_rate_last_7_days_window() -> None:
+def test_merge_rate_last_7_days_per_day() -> None:
+    # Two merges within 7 days of the 28th; the 1st is outside the window.
     merged = [_at(1), _at(25), _at(27)]
     rate = rs.merge_rate(merged, now=_at(28))
     assert rate["last_7_days"] == 2.0
+    assert rate["per_day"] == 2.0 / 7.0
+
+
+def test_merge_rate_drops_stale_all_time_keys() -> None:
+    rate = rs.merge_rate([_at(27)], now=_at(27))
+    assert "total" not in rate
+    assert "span_days" not in rate
 
 
 # ---------- time_to_merge_stats ----------
@@ -201,6 +208,75 @@ def test_count_open_backlog_respects_env_override(monkeypatch: pytest.MonkeyPatc
     ]
     _patch_issues(monkeypatch, issues)
     assert recap.count_open_backlog("owner/repo", token="t") == 2
+
+
+# ---------- count_merged_total ----------
+
+
+def test_count_merged_total_reads_search_total_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: {"total_count": 723, "items": []})
+    assert recap.count_merged_total("owner/repo", token="t") == 723
+
+
+# ---------- fetch_pr_first_commit_at ----------
+
+
+def test_fetch_pr_first_commit_at_returns_author_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    commits = [{"commit": {"author": {"date": "2026-06-20T08:00:00Z"}}}]
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: commits)
+    assert recap.fetch_pr_first_commit_at("owner/repo", 7, token="t") == _at(20, 8)
+
+
+def test_fetch_pr_first_commit_at_falls_back_to_committer_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    commits = [{"commit": {"committer": {"date": "2026-06-21T09:00:00Z"}}}]
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: commits)
+    assert recap.fetch_pr_first_commit_at("owner/repo", 7, token="t") == _at(21, 9)
+
+
+def test_fetch_pr_first_commit_at_none_when_no_commits(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: [])
+    assert recap.fetch_pr_first_commit_at("owner/repo", 7, token="t") is None
+
+
+# ---------- fetch_recent_merged_prs ----------
+
+
+def _hit(number: int, *, merged: str, created: str) -> dict[str, Any]:
+    return {"number": number, "created_at": created, "pull_request": {"merged_at": merged}}
+
+
+def test_fetch_recent_merged_prs_sorts_newest_merge_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    hits = [
+        _hit(1, merged="2026-06-25T00:00:00Z", created="2026-06-24T00:00:00Z"),
+        _hit(2, merged="2026-06-27T00:00:00Z", created="2026-06-26T00:00:00Z"),
+        _hit(3, merged="2026-06-26T00:00:00Z", created="2026-06-25T00:00:00Z"),
+    ]
+    monkeypatch.setattr(recap, "_gh_search_issues", lambda *a, **k: hits)
+    out = recap.fetch_recent_merged_prs("owner/repo", token="t", since=_at(20).date(), max_prs=200)
+    assert [pr["number"] for pr in out] == [2, 3, 1]
+
+
+# ---------- _cycle_hours ----------
+
+
+def test_cycle_hours_uses_first_commit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "fetch_pr_first_commit_at", lambda *a, **k: _at(27, 9))
+    pr = _hit(1, merged="2026-06-27T12:00:00Z", created="2026-06-27T11:00:00Z")
+    # 09:00 first commit -> 12:00 merge = 3h, ignoring the later PR-open time.
+    assert recap._cycle_hours("owner/repo", pr, token="t") == 3.0
+
+
+def test_cycle_hours_falls_back_to_created_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "fetch_pr_first_commit_at", lambda *a, **k: None)
+    pr = _hit(1, merged="2026-06-27T12:00:00Z", created="2026-06-27T10:00:00Z")
+    assert recap._cycle_hours("owner/repo", pr, token="t") == 2.0
+
+
+def test_cycle_hours_clamps_negative_to_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A rebased first commit dated after the merge must not go negative.
+    monkeypatch.setattr(recap, "fetch_pr_first_commit_at", lambda *a, **k: _at(27, 14))
+    pr = _hit(1, merged="2026-06-27T12:00:00Z", created="2026-06-27T11:00:00Z")
+    assert recap._cycle_hours("owner/repo", pr, token="t") == 0.0
 
 
 # ---------- _heuristic_headline ----------


### PR DESCRIPTION
## Problem

Scrolling the Ralph channel, almost none of the recap metrics moved PR-to-PR:

- **"PRs merged: 200 total"** was frozen — that's literally the `DEFAULT_MAX_PRS = 200` fetch cap (`merge_rate["total"] = len(fetched)`), so past 200 merges it pins forever.
- **Merge rate 4.7/day**, **review iterations**, **time-to-merge**, **busiest day** were all computed over that same fixed ~200-PR / ~42-day window, so one new PR was a ~0.5% nudge — invisible. Only "last 7d" and the per-PR footprint moved.
- **Time-to-merge (18m median)** measured `created_at → merged_at` — the *review* window only, **not** from when work began, so it excluded coding time.

## Fix

Each metric now reflects recent reality (decisions confirmed with the maintainer):

| Metric | Before | After |
|---|---|---|
| PRs merged | capped at 200 | **true all-time** count (search `total_count`) + 24h + 7d |
| Merge rate | `200 / 42d` ≈ frozen | **per-hour over 24h** · per-day over 7d |
| Time to merge | `created_at→merge` (~18m) | **Cycle time: first commit → merge** (real work-start→merge) |
| Iterations / busiest day | ~200-PR lifetime | trailing **7-day window** |

- **True total** via the search API (`is:pr is:merged` → `total_count`), independent of any fetch cap — climbs every merge.
- **Rolling rate**: merges/hour over the last 24h (live, as requested) and merges/day over the last 7d (the steadier figure that drives the backlog ETA). Idle loops decay toward zero instead of showing a stale average.
- **Cycle time**: `merged_at − first_commit_at` per PR (first commit via the PR commits endpoint = work-beginning proxy). Falls back to `created_at` when no commit timestamp exists, and clamps negatives (rebased commits dated after merge) to zero.
- **7-day window** (`RECENT_WINDOW_DAYS`) for iterations / cycle time / busiest day, fetched server-side via search (each hit carries `pull_request.merged_at` + `created_at`), capped at `--max-prs` as a burst-day safety bound.

## Example render (stubbed end-to-end)

```
📦 PRs merged          | 731 all-time · 2 in 24h · 5 in 7d
⚡ Merge rate          | 0.08/hr (24h) · 0.7/day (7d)
🔁 Review iterations (7d) | 0.6 avg rounds to LGTM · 40% first-try clean · worst 1 (n=5)
⏱️ Cycle time · first commit → merge (7d) | median 24.0h · fastest 2.0h · slowest 2.0d
🔥 Busiest day (7d)    | 2 merges on 2026-06-28
```

## Tests

`stats.merge_rate` reworked to the windowed shape (24h per-hour + 7d per-day). New tests cover the windowed rate, the search-based true total, first-commit fetch (author/committer date + empty fallback), recent-merge sort order, and cycle-time first-commit/created_at/clamp paths. **38 passed.**

> Note: pre-commit hook repos can't be fetched in this execution environment (egress policy returns 403 for `github.com`), so local hooks can't initialize. `scripts/ralph/**` is gated only by the `Ralph Recap Tests` (pytest) CI job — the backend-scoped ruff/mypy/complexity hooks don't cover it — and I verified ruff-clean + tests green manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yeMRheRodFtDcxogsmFiH)_