### PR TITLE
chore(backend): adopt pydantic 2.13.4 (bump pydantic-core to 2.46.4)

### DIFF
--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -92,14 +92,14 @@ pluggy==1.6.0
     # via pytest
 pycparser==3.0
     # via cffi
-pydantic==2.13.2
+pydantic==2.13.4
     # via
     #   -r backend/requirements.txt
     #   anthropic
     #   fastapi
     #   openai
     #   sqlmodel
-pydantic-core==2.46.2
+pydantic-core==2.46.4
     # via pydantic
 pygments==2.20.0
     # via pytest


### PR DESCRIPTION
## Summary

Dependabot PR #252 (pydantic 2.13.2 → 2.13.4) failed CI with an unresolvable lock: `requirements-lock.txt` pinned `pydantic-core==2.46.2`, but pydantic 2.13.4 requires `pydantic-core==2.46.4`, so `uv` couldn't resolve — `backend-quality` and `migration-drift` both failed at the install step.

Fix: regenerate the lock via `uv pip compile backend/requirements.txt -o backend/requirements-lock.txt --upgrade-package pydantic --upgrade-package pydantic-core`, which bumps **only** those two pins and leaves every other dependency untouched.

```
-pydantic==2.13.2      +pydantic==2.13.4
-pydantic-core==2.46.2 +pydantic-core==2.46.4
```

## Test plan

- `uv pip install pydantic==2.13.4 pydantic-core==2.46.4` into the venv; `./scripts/backend/check-all.sh` → **7/7 green** on the new versions.
- Supersedes the blocked dependabot PR #252.

Closes #694
