### PR TITLE
ci(deps): pin styleq to react-native-web's range; ignore 0.2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # react-native-web 0.19.13 requires styleq ^0.1.3; styleq 0.2.x targets
+      # RNW 0.20+, so adopting it now desyncs the web style runtime. Unpin this
+      # when react-native-web is upgraded.
+      - dependency-name: "styleq"
+        versions: [">=0.2.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Dependabot PR #254 (styleq 0.1.3 → 0.2.1) failed CI because it's **incompatible with the pinned `react-native-web@0.19.13`**, which requires `styleq ^0.1.3`. styleq 0.2.x targets RNW 0.20+, and **nothing in the app imports styleq directly** (it's a web-deploy dedup pin for RNW's transitive copy) — so forcing 0.2.1 would only desync the web style runtime and risk silent styling breakage.

Discerning resolution: keep styleq at 0.1.3 (matching RNW) and add a dependabot `ignore` for `styleq >=0.2.0` so the incompatible bump stops being re-proposed every week. Unpin when react-native-web is upgraded.

## Test plan

- `.github/dependabot.yml` validates (YAML + pre-commit).
- Closed the incompatible dependabot PR #254.

Closes #695
