### PR TITLE
chore(deps): adopt eslint-plugin-react-hooks 7.1.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -64,7 +64,7 @@
         "eslint-import-resolver-typescript": "^3.10.1",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-sonarjs": "^4.0.2",
         "eslint-plugin-unicorn": "^55.0.0",
         "globals": "^17.5.0",
@@ -9199,16 +9199,40 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks/node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react-hooks/node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -19872,6 +19896,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -64,7 +64,7 @@
         "eslint-import-resolver-typescript": "^3.10.1",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "7.1.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-sonarjs": "^4.0.2",
         "eslint-plugin-unicorn": "^55.0.0",
         "globals": "^17.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "7.1.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-sonarjs": "^4.0.2",
     "eslint-plugin-unicorn": "^55.0.0",
     "globals": "^17.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-sonarjs": "^4.0.2",
     "eslint-plugin-unicorn": "^55.0.0",
     "globals": "^17.5.0",


### PR DESCRIPTION
## Summary

Dependabot PR #255 (eslint-plugin-react-hooks 5.2.0 → 7.1.1, major) was blocked. The major is **peer-compatible with the project's ESLint 9**, and the flat config (`eslint.config.cjs`) wires only the two stable rules — `react-hooks/rules-of-hooks` (error) and `react-hooks/exhaustive-deps` (warn) — both of which still pass on v7. No new violations surface, so the bump is clean with **no code changes**.

The original dependabot failure was stale/behind-main; on current `main` the bump resolves and lints clean.

## Test plan

- `npm run lint --max-warnings=0` → exit 0
- `./scripts/frontend/check-all.sh` → 4/4
- Closed the superseded dependabot PR #255.

Closes #696
