### PR TITLE
chore(deps): adopt eslint-config-prettier 10.1.8

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,7 +60,7 @@
         "@types/react": "~18.3.12",
         "@types/uuid": "^10.0.0",
         "eslint": "^9.33.0",
-        "eslint-config-prettier": "^9.1.2",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^3.10.1",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.5",
@@ -9024,13 +9024,16 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
-      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
     "@types/react": "~18.3.12",
     "@types/uuid": "^10.0.0",
     "eslint": "^9.33.0",
-    "eslint-config-prettier": "^9.1.2",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",


### PR DESCRIPTION
## Summary

Dependabot PR #256 (eslint-config-prettier 9.1.2 → 10.1.8, major) was blocked. The major is **peer-compatible** (`eslint >=7`) and the flat config consumes the main export spread as a config entry (`eslint.config.cjs:194`), which still exposes the same rules-disabling shape in v10 — so the bump is **clean, no config changes**. Pinned as `^10.1.8` for caret consistency with the other eslint-* deps.

## Test plan

- `./scripts/frontend/check-all.sh` → 4/4 (lint/tsc/format/tests)
- Closed the superseded dependabot PR #256.

Closes #697
