### PR TITLE
ci(deps): pin expo-av to the Expo SDK 52 range; ignore 16.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,12 @@ updates:
       # when react-native-web is upgraded.
       - dependency-name: "styleq"
         versions: [">=0.2.0"]
+      # Expo SDK 52 pins expo-av to ~15.0.2 (verified by `expo install --check`);
+      # expo-av 16.x targets SDK 53. Expo packages are managed by `expo install`
+      # and must move together with the SDK, not piecemeal. Unpin at the SDK 53
+      # upgrade (where expo-av is also superseded by expo-audio/expo-video).
+      - dependency-name: "expo-av"
+        versions: [">=16.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Dependabot PR #257 (expo-av 15.0.2 → 16.0.8, major) failed CI because it's **incompatible with the pinned Expo SDK 52** (`expo ~52.0.43`). `npx expo install --check` confirms `expo-av ~15.0.2` is the correct version for SDK 52; expo-av 16.x targets SDK 53. Expo packages are SDK-managed (via `expo install`) and must move **together with the SDK**, not piecemeal.

Discerning resolution: keep expo-av at `~15.0.2` and add a dependabot `ignore` for `expo-av >=16.0.0`. Unpin at the SDK 53 upgrade (where expo-av is also superseded by expo-audio/expo-video).

## Test plan

- `.github/dependabot.yml` validates (YAML + pre-commit).
- Closed the incompatible dependabot PR #257.

Closes #698
