### PR TITLE
ci(deps): pin expo-notifications to the Expo SDK 52 range; ignore later majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,11 @@ updates:
       # upgrade (where expo-av is also superseded by expo-audio/expo-video).
       - dependency-name: "expo-av"
         versions: [">=16.0.0"]
+      # Expo SDK 52 pins expo-notifications to ~0.29.14 (verified by
+      # `expo install --check`); later majors target SDK 53+. Same SDK-managed
+      # rule as expo-av — unpin at the SDK 53 upgrade.
+      - dependency-name: "expo-notifications"
+        versions: [">=0.30.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Dependabot PR #258 (expo-notifications 0.29.14 → 56.0.12) failed CI and proposed a nonsensical cross-scheme version. `npx expo install --check` confirms `expo-notifications ~0.29.14` is correct for the pinned **Expo SDK 52** (`expo ~52.0.43`); later majors target SDK 53+. Like expo-av, this package is SDK-managed and must move with the SDK.

Discerning resolution: keep expo-notifications at `~0.29.14` and add a dependabot `ignore` for `>=0.30.0`. Unpin at the SDK 53 upgrade.

## Test plan

- `.github/dependabot.yml` validates (YAML + pre-commit).
- The incompatible dependabot PR #258 is closed.

Closes #699
