### PR TITLE
feat(frontend): rebuild Map as three-column spiral table

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -2,7 +2,22 @@
 
 import { StyleSheet } from 'react-native';
 
-import { colors, radius, shadows, spacing } from '../../design/tokens';
+import { colors, editorialType, radius, shadows, spacing } from '../../design/tokens';
+
+// --- Layout constants for the three-column "spiral of becoming" table -------
+const LEFT_COLUMN_WIDTH = '40%';
+const CENTER_COLUMN_WIDTH = '40%';
+const RIGHT_COLUMN_WIDTH = '20%';
+/** The grey band starts below the two title rows (Awareness + Being). */
+const GREY_BAND_TOP = '20%';
+const HALF = '50%';
+const FULL = '100%';
+const ABSOLUTE = 'absolute';
+const CENTER = 'center';
+const TABLE_BORDER_COLOR = '#111111';
+const FEMININE_BAND_COLOR = '#d9d9d9';
+const MASCULINE_BAND_COLOR = '#efefef';
+const ARROW_LABEL_COLOR = '#262626';
 
 /**
  * Mystical-aesthetic styles for the Map screen.
@@ -12,19 +27,18 @@ import { colors, radius, shadows, spacing } from '../../design/tokens';
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.primary,
+    backgroundColor: colors.background.primary,
   },
 
   // Loading / error states
   centered: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: CENTER,
+    justifyContent: CENTER,
+    backgroundColor: colors.background.primary,
   },
   loadingText: {
-    color: colors.text.light,
+    color: colors.text.primary,
     fontSize: 14,
     marginTop: spacing(1),
   },
@@ -72,9 +86,112 @@ const styles = StyleSheet.create({
 
   // Stage connection lines between stages
   connectionLine: {
-    position: 'absolute',
+    position: ABSOLUTE,
     width: 2,
-    backgroundColor: 'rgba(255,255,255,0.15)',
+    backgroundColor: 'rgba(0,0,0,0.10)',
+  },
+
+  // --- Three-column spiral table -------------------------------------------
+  table: {
+    flex: 1,
+    flexDirection: 'row',
+    borderWidth: 2,
+    borderColor: TABLE_BORDER_COLOR,
+  },
+  leftColumn: {
+    width: LEFT_COLUMN_WIDTH,
+  },
+  centerColumn: {
+    width: CENTER_COLUMN_WIDTH,
+  },
+  rightColumn: {
+    width: RIGHT_COLUMN_WIDTH,
+  },
+  rowCell: {
+    borderBottomWidth: 2,
+    borderBottomColor: TABLE_BORDER_COLOR,
+    justifyContent: CENTER,
+  },
+  rowCellLast: {
+    borderBottomWidth: 0,
+  },
+
+  // Left-column stage text block (also the tap target -0)
+  stageBlock: {
+    flex: 1,
+    justifyContent: CENTER,
+    paddingHorizontal: spacing(1),
+    paddingVertical: spacing(0.5),
+  },
+  personaText: {
+    fontWeight: '700',
+    fontSize: 14,
+    textAlign: 'right',
+  },
+  lineText: {
+    fontSize: 12,
+    textAlign: 'right',
+  },
+
+  // Right-column aspect label
+  rightLabelText: {
+    fontSize: 16,
+    color: colors.text.primary,
+    paddingLeft: spacing(1),
+  },
+
+  // Center column — artwork, bands, overlays
+  centerInner: {
+    flex: 1,
+    position: 'relative',
+  },
+  arrowImage: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  greyBandFeminine: {
+    position: ABSOLUTE,
+    top: GREY_BAND_TOP,
+    left: 0,
+    width: HALF,
+    bottom: 0,
+    backgroundColor: FEMININE_BAND_COLOR,
+  },
+  greyBandMasculine: {
+    position: ABSOLUTE,
+    top: GREY_BAND_TOP,
+    left: HALF,
+    width: HALF,
+    bottom: 0,
+    backgroundColor: MASCULINE_BAND_COLOR,
+  },
+  arrowLabelWrap: {
+    position: ABSOLUTE,
+    left: 0,
+    width: FULL,
+    alignItems: CENTER,
+    justifyContent: CENTER,
+  },
+  arrowLabelText: {
+    fontWeight: '700',
+    fontSize: 12,
+    color: ARROW_LABEL_COLOR,
+    textAlign: CENTER,
+  },
+  titleOverlay: {
+    position: ABSOLUTE,
+    top: 0,
+    left: 0,
+    width: FULL,
+    height: GREY_BAND_TOP,
+    alignItems: CENTER,
+    justifyContent: CENTER,
+  },
+  titleText: {
+    fontFamily: editorialType.serif,
+    fontWeight: '700',
+    fontSize: 40,
+    color: TABLE_BORDER_COLOR,
+    letterSpacing: 2,
   },
 
   // Modal overlay and content

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -1,10 +1,9 @@
 // frontend/features/Map/MapScreen.tsx
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
-  ImageBackground,
   InteractionManager,
   Modal,
   Pressable,
@@ -12,7 +11,6 @@ import {
   Text,
   TouchableOpacity,
   View,
-  useWindowDimensions,
 } from 'react-native';
 
 import type { HabitHistoryItem, PracticeHistoryItem, StageHistoryResponse } from '../../api';
@@ -29,8 +27,13 @@ import {
 } from '../../store/useStageStore';
 
 import styles from './Map.styles';
+import { MAP_ROWS, MAP_TITLE_LINES, STAGE_DISPLAY } from './mapLayout';
+import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked } from './services/stageService';
 import type { StageData } from './stageData';
+
+/** Lookup of stage number → StageData for resolving row/arrow content. */
+type StageLookup = Readonly<Record<number, StageData | undefined>>;
 
 const FULL_PROGRESS = 1;
 
@@ -68,51 +71,197 @@ const getHotspotStyle = (stage: StageData, currentStage: number | null) => {
   return null;
 };
 
-interface StageHotspotsProps {
-  stages: StageData[];
+const LockOverlay = (): React.JSX.Element => (
+  <View style={styles.lockOverlay}>
+    <Text style={styles.lockText}>🔒</Text>
+  </View>
+);
+
+interface StageTapProps {
+  stage: StageData;
+  display: StageDisplay;
+  locked: boolean;
+  onPress: (_stage: StageData) => void;
+}
+
+// --- Left column: colored stage text (also the -0 tap target) -------------
+
+const StageTextBlock = ({ stage, display, locked, onPress }: StageTapProps): React.JSX.Element => (
+  <TouchableOpacity
+    testID={`stage-hotspot-${display.stageNumber}-0`}
+    style={[styles.stageBlock, locked ? styles.hotspotLocked : null]}
+    onPress={() => onPress(stage)}
+    accessibilityRole="button"
+    accessibilityLabel={`${display.persona} - ${display.descriptor}`}
+  >
+    <Text style={[styles.personaText, { color: display.textColor }]}>{display.persona}</Text>
+    <Text style={[styles.lineText, { color: display.textColor }]}>{display.descriptor}</Text>
+    <Text style={[styles.lineText, { color: display.textColor }]}>{display.practice}</Text>
+    {locked ? <LockOverlay /> : null}
+  </TouchableOpacity>
+);
+
+interface RowProps {
+  row: MapRow;
+  isLast: boolean;
+  lookup: StageLookup;
   currentStage: number | null;
   onPress: (_stage: StageData) => void;
 }
 
-const StageHotspots = ({
+const cellStyle = (row: MapRow, isLast: boolean) => [
+  styles.rowCell,
+  { flex: row.stageNumbers.length },
+  isLast ? styles.rowCellLast : null,
+];
+
+const LeftRow = ({ row, isLast, lookup, currentStage, onPress }: RowProps): React.JSX.Element => (
+  <View style={cellStyle(row, isLast)}>
+    {row.stageNumbers.map((stageNumber) => {
+      const stage = lookup[stageNumber];
+      const display = STAGE_DISPLAY[stageNumber];
+      return stage && display ? (
+        <StageTextBlock
+          key={stageNumber}
+          stage={stage}
+          display={display}
+          locked={!isStageUnlocked(stage, currentStage)}
+          onPress={onPress}
+        />
+      ) : null;
+    })}
+  </View>
+);
+
+interface ColumnProps {
+  lookup: StageLookup;
+  currentStage: number | null;
+  onPress: (_stage: StageData) => void;
+}
+
+const LeftTextColumn = ({ lookup, currentStage, onPress }: ColumnProps): React.JSX.Element => (
+  <View style={styles.leftColumn}>
+    {MAP_ROWS.map((row, idx) => (
+      <LeftRow
+        key={row.rightLabel}
+        row={row}
+        isLast={idx === MAP_ROWS.length - 1}
+        lookup={lookup}
+        currentStage={currentStage}
+        onPress={onPress}
+      />
+    ))}
+  </View>
+);
+
+// --- Right column: aspect-of-wholeness labels -----------------------------
+
+const RightLabelColumn = (): React.JSX.Element => (
+  <View style={styles.rightColumn}>
+    {MAP_ROWS.map((row, idx) => (
+      <View key={row.rightLabel} style={cellStyle(row, idx === MAP_ROWS.length - 1)}>
+        <Text style={styles.rightLabelText}>{row.rightLabel}</Text>
+      </View>
+    ))}
+  </View>
+);
+
+// --- Center column: arrow artwork, grey bands, tap targets, labels --------
+
+const bandPosition = (stage: StageData) => {
+  const hs = stage.hotspots[0];
+  return { top: `${hs?.top ?? 0}%` as const, height: `${hs?.height ?? 0}%` as const };
+};
+
+const ArrowHotspot = ({
+  stage,
+  currentStage,
+  onPress,
+}: {
+  stage: StageData;
+  currentStage: number | null;
+  onPress: (_stage: StageData) => void;
+}): React.JSX.Element | null => {
+  const hs = stage.hotspots[0];
+  if (!hs) return null;
+  const locked = !isStageUnlocked(stage, currentStage);
+  return (
+    <TouchableOpacity
+      testID={`stage-hotspot-${stage.stageNumber}-1`}
+      style={[
+        styles.hotspot,
+        { top: `${hs.top}%`, left: `${hs.left}%`, width: `${hs.width}%`, height: `${hs.height}%` },
+        getHotspotStyle(stage, currentStage),
+      ]}
+      onPress={() => onPress(stage)}
+      accessibilityRole="button"
+      accessibilityLabel={`${stage.title} - ${stage.subtitle}`}
+    >
+      {locked ? <LockOverlay /> : null}
+      {stage.progress >= FULL_PROGRESS ? (
+        <View style={styles.completedBadge} testID={`stage-complete-${stage.stageNumber}`}>
+          <Text style={styles.completedBadgeText}>✓</Text>
+        </View>
+      ) : null}
+    </TouchableOpacity>
+  );
+};
+
+const ArrowLabel = ({ stage }: { stage: StageData }): React.JSX.Element | null => {
+  const display = STAGE_DISPLAY[stage.stageNumber];
+  if (!display?.arrowLabel) return null;
+  return (
+    <View pointerEvents="none" style={[styles.arrowLabelWrap, bandPosition(stage)]}>
+      <Text style={styles.arrowLabelText}>{display.arrowLabel}</Text>
+    </View>
+  );
+};
+
+const SpiralTitle = (): React.JSX.Element => (
+  <View pointerEvents="none" style={styles.titleOverlay}>
+    {MAP_TITLE_LINES.map((line) => (
+      <Text key={line} style={styles.titleText}>
+        {line}
+      </Text>
+    ))}
+  </View>
+);
+
+const GreyBands = (): React.JSX.Element => (
+  <>
+    <View pointerEvents="none" style={styles.greyBandFeminine} />
+    <View pointerEvents="none" style={styles.greyBandMasculine} />
+  </>
+);
+
+const CenterColumn = ({
   stages,
   currentStage,
   onPress,
-}: StageHotspotsProps): React.JSX.Element => (
-  <>
-    {stages.flatMap((stage) =>
-      stage.hotspots.map((hs, index) => (
-        <TouchableOpacity
-          key={`${stage.id}-${index}`}
-          testID={`stage-hotspot-${stage.stageNumber}-${index}`}
-          style={[
-            styles.hotspot,
-            {
-              top: `${hs.top}%`,
-              left: `${hs.left}%`,
-              width: `${hs.width}%`,
-              height: `${hs.height}%`,
-            },
-            getHotspotStyle(stage, currentStage),
-          ]}
-          onPress={() => onPress(stage)}
-          accessibilityLabel={`${stage.title} - ${stage.subtitle}`}
-          accessibilityRole="button"
-        >
-          {!isStageUnlocked(stage, currentStage) && (
-            <View style={styles.lockOverlay}>
-              <Text style={styles.lockText}>🔒</Text>
-            </View>
-          )}
-          {stage.progress >= FULL_PROGRESS && index === 0 && (
-            <View style={styles.completedBadge} testID={`stage-complete-${stage.stageNumber}`}>
-              <Text style={styles.completedBadgeText}>✓</Text>
-            </View>
-          )}
-        </TouchableOpacity>
-      )),
-    )}
-  </>
+}: {
+  stages: StageData[];
+  currentStage: number | null;
+  onPress: (_stage: StageData) => void;
+}): React.JSX.Element => (
+  <View style={styles.centerColumn}>
+    <View style={styles.centerInner}>
+      <GreyBands />
+      <Image
+        source={{ uri: MAP_BACKGROUND_URI }}
+        resizeMode="contain"
+        style={styles.arrowImage}
+        testID="map-background"
+      />
+      <ConnectionLines stages={stages} />
+      {stages.map((stage) => (
+        <ArrowHotspot key={stage.id} stage={stage} currentStage={currentStage} onPress={onPress} />
+      ))}
+      {stages.map((stage) => (
+        <ArrowLabel key={stage.id} stage={stage} />
+      ))}
+      <SpiralTitle />
+    </View>
+  </View>
 );
 
 const StageMetadataSection = ({ stage }: { stage: StageData }): React.JSX.Element => (
@@ -419,7 +568,7 @@ const StageDetailModal = ({
 
 const MapLoading = (): React.JSX.Element => (
   <View style={styles.centered} testID="map-loading">
-    <ActivityIndicator size="large" color="#fff" />
+    <ActivityIndicator size="large" color={styles.loadingText.color} />
     <Text style={styles.loadingText}>Loading stages...</Text>
   </View>
 );
@@ -450,74 +599,42 @@ const MapRefreshErrorBanner = ({ onRetry }: { onRetry: () => void }): React.JSX.
   </View>
 );
 
-function useBackgroundSize() {
-  const { width, height } = useWindowDimensions();
-  const [aspectRatio, setAspectRatio] = useState(1);
-
-  useEffect(() => {
-    Image.getSize(MAP_BACKGROUND_URI, (w, h) => setAspectRatio(w / h));
-  }, []);
-
-  const isPortrait = height >= width;
-  return isPortrait
-    ? { width, height: width / aspectRatio }
-    : { height, width: height * aspectRatio };
-}
-
-interface MapBackgroundProps {
+interface SpiralTableProps {
   stages: StageData[];
+  lookup: StageLookup;
   currentStage: number | null;
   onSelectStage: (_stage: StageData) => void;
 }
 
-const MapBackground = ({
+const SpiralTable = ({
   stages,
+  lookup,
   currentStage,
   onSelectStage,
-}: MapBackgroundProps): React.JSX.Element => {
-  const backgroundStyle = useBackgroundSize();
-
-  return (
-    <ImageBackground
-      source={{ uri: MAP_BACKGROUND_URI }}
-      style={backgroundStyle}
-      resizeMode="contain"
-      testID="map-background"
-    >
-      <ConnectionLines stages={stages} />
-      <StageHotspots stages={stages} currentStage={currentStage} onPress={onSelectStage} />
-    </ImageBackground>
-  );
-};
+}: SpiralTableProps): React.JSX.Element => (
+  <View style={styles.table}>
+    <LeftTextColumn lookup={lookup} currentStage={currentStage} onPress={onSelectStage} />
+    <CenterColumn stages={stages} currentStage={currentStage} onPress={onSelectStage} />
+    <RightLabelColumn />
+  </View>
+);
 
 // --- Main component ---
 
-const MapScreen = (): React.JSX.Element => {
+type NavTarget = 'Practice' | 'Course' | 'Journal';
+
+/**
+ * Build the stage-detail action navigator. Closes the modal first, then routes
+ * after interactions settle; a ref guards against double-taps mid-transition.
+ */
+const useStageNavigation = (onBeforeNavigate: () => void) => {
   const navigation = useAppNavigation();
-  const stages = useStageStore(selectStages);
-  const loading = useStageStore(selectStagesLoading);
-  const error = useStageStore(selectStagesError);
-  const storeCurrentStage = useStageStore(selectCurrentStage);
-  // Prefer the date-driven stage when the master anchor is set; the
-  // server's count-based ``currentStage`` is the fallback for users who
-  // haven't picked an anchor yet.
-  const currentStage = useDerivedCurrentStage(storeCurrentStage);
-  const [activeStage, setActiveStage] = useState<StageData | null>(null);
   const navigatingRef = useRef(false);
-
-  useEffect(() => {
-    if (stages.length === 0 && !loading) {
-      void stageService.loadStages();
-    }
-  }, [stages.length, loading]);
-
-  const handleRefresh = useCallback(() => void stageService.loadStages(), []);
-
-  const handleNavigate = useCallback(
-    (screen: 'Practice' | 'Course' | 'Journal', stage: StageData) => {
+  return useCallback(
+    (screen: NavTarget, stage: StageData) => {
       if (navigatingRef.current) return;
       navigatingRef.current = true;
-      setActiveStage(null);
+      onBeforeNavigate();
       InteractionManager.runAfterInteractions(() => {
         if (screen === 'Journal') {
           navigation.navigate('Journal', {
@@ -530,17 +647,48 @@ const MapScreen = (): React.JSX.Element => {
         navigatingRef.current = false;
       });
     },
-    [navigation],
+    [navigation, onBeforeNavigate],
+  );
+};
+
+const MapScreen = (): React.JSX.Element => {
+  const stages = useStageStore(selectStages);
+  const loading = useStageStore(selectStagesLoading);
+  const error = useStageStore(selectStagesError);
+  const storeCurrentStage = useStageStore(selectCurrentStage);
+  // Prefer the date-driven stage when the master anchor is set; the
+  // server's count-based ``currentStage`` is the fallback for users who
+  // haven't picked an anchor yet.
+  const currentStage = useDerivedCurrentStage(storeCurrentStage);
+  const [activeStage, setActiveStage] = useState<StageData | null>(null);
+
+  // Resolve each row's stage numbers to their loaded StageData once per change.
+  const lookup = useMemo<StageLookup>(
+    () => Object.fromEntries(stages.map((stage) => [stage.stageNumber, stage])),
+    [stages],
   );
 
+  useEffect(() => {
+    if (stages.length === 0 && !loading) {
+      void stageService.loadStages();
+    }
+  }, [stages.length, loading]);
+
+  const handleRefresh = useCallback(() => void stageService.loadStages(), []);
   const handleCloseModal = useCallback(() => setActiveStage(null), []);
+  const handleNavigate = useStageNavigation(handleCloseModal);
 
   if (loading && stages.length === 0) return <MapLoading />;
   if (error && stages.length === 0) return <MapError message={error} />;
 
   return (
     <View style={styles.container}>
-      <MapBackground stages={stages} currentStage={currentStage} onSelectStage={setActiveStage} />
+      <SpiralTable
+        stages={stages}
+        lookup={lookup}
+        currentStage={currentStage}
+        onSelectStage={setActiveStage}
+      />
       {error && stages.length > 0 && <MapRefreshErrorBanner onRetry={handleRefresh} />}
       <StageDetailModal
         activeStage={activeStage}

--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { MAP_ROWS, MAP_TITLE_LINES, STAGE_DISPLAY, arrowSide, isFeminineSide } from '../mapLayout';
+import { STAGE_COUNT } from '../stageData';
+
+const HEX_COLOR = /^#[\da-f]{6}$/i;
+const ALL_STAGES = Array.from({ length: STAGE_COUNT }, (_, i) => STAGE_COUNT - i);
+
+describe('mapLayout', () => {
+  it('defines display copy for every stage', () => {
+    ALL_STAGES.forEach((stageNumber) => {
+      const display = STAGE_DISPLAY[stageNumber];
+      expect(display).toBeDefined();
+      expect(display?.stageNumber).toBe(stageNumber);
+      expect(display?.persona).toBeTruthy();
+      expect(display?.descriptor).toBeTruthy();
+      expect(display?.practice).toBeTruthy();
+      expect(display?.textColor).toMatch(HEX_COLOR);
+    });
+  });
+
+  it('omits the arrow label only on the two title stages (9 and 10)', () => {
+    const labelled = ALL_STAGES.filter((n) => STAGE_DISPLAY[n]?.arrowLabel !== '');
+    const titleStages = ALL_STAGES.filter((n) => STAGE_DISPLAY[n]?.arrowLabel === '');
+    expect(titleStages.sort((a, b) => a - b)).toEqual([9, 10]);
+    expect(labelled).toHaveLength(STAGE_COUNT - 2);
+  });
+
+  it('covers all ten stages across six rows, top → bottom', () => {
+    expect(MAP_ROWS).toHaveLength(6);
+    const ordered = MAP_ROWS.flatMap((row) => row.stageNumbers);
+    expect(ordered).toEqual([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    MAP_ROWS.forEach((row) => expect(row.rightLabel).toBeTruthy());
+  });
+
+  it('exposes the EMPTINESS / UNITY title', () => {
+    expect(MAP_TITLE_LINES).toEqual(['EMPTINESS', 'UNITY']);
+  });
+
+  it('puts even (Divine-Feminine) stages on the left and odd on the right', () => {
+    expect(arrowSide(8)).toBe('left');
+    expect(arrowSide(7)).toBe('right');
+    expect(isFeminineSide(8)).toBe(true);
+    expect(isFeminineSide(7)).toBe(false);
+  });
+});

--- a/frontend/src/features/Map/__tests__/stageData.test.ts
+++ b/frontend/src/features/Map/__tests__/stageData.test.ts
@@ -2,9 +2,12 @@
 /* global describe, it, expect */
 import { HOTSPOTS, STAGE_COUNT } from '../stageData';
 
+const SIDE_SPLIT = 40;
+
 describe('stageData', () => {
-  it('provides hotspots for all stages', () => {
+  it('provides one arrow hotspot for every stage', () => {
     expect(HOTSPOTS).toHaveLength(STAGE_COUNT);
+    HOTSPOTS.forEach((spots) => expect(spots).toHaveLength(1));
   });
 
   it('has non-overlapping vertical hotspot ranges', () => {
@@ -18,20 +21,15 @@ describe('stageData', () => {
   });
 
   it('positions arrow hotspots on alternating sides of the spiral', () => {
-    // HOTSPOTS are indexed 0–9 where 0 = stage 10, 9 = stage 1
+    // HOTSPOTS are indexed 0–9 where 0 = stage 10, 9 = stage 1. Even
+    // (Divine-Feminine) stages return along the left; odd stages point right.
     HOTSPOTS.forEach((spots, index) => {
       const stageNumber = STAGE_COUNT - index;
-      const arrowSpots = spots.slice(1);
-      if (stageNumber === 9) {
-        expect(arrowSpots).toHaveLength(2);
+      const arrow = spots[0]!;
+      if (stageNumber % 2 === 0) {
+        expect(arrow.left).toBeLessThan(SIDE_SPLIT);
       } else {
-        expect(arrowSpots).toHaveLength(1);
-        const arrow = arrowSpots[0]!;
-        if (stageNumber % 2 === 0) {
-          expect(arrow.left).toBeLessThan(40);
-        } else {
-          expect(arrow.left).toBeGreaterThan(40);
-        }
+        expect(arrow.left).toBeGreaterThan(SIDE_SPLIT);
       }
     });
   });

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -1,0 +1,162 @@
+// frontend/features/Map/mapLayout.ts
+
+/**
+ * Presentation data for the Map screen's "spiral of becoming" layout.
+ *
+ * The Map is a three-column table:
+ *   - left column   — the colored stage text (persona / descriptor / practice)
+ *   - center column — the colored-arrow spiral artwork with tap targets
+ *   - right column  — the aspect-of-wholeness label for each row
+ *
+ * Stage *content* (title, subtitle, progress, lock state) still comes from the
+ * backend via ``useStageStore``; this module only holds the static, design-
+ * specific copy and per-stage colors that mirror the arrow artwork. Colors are
+ * intentionally kept here (not in ``design/tokens``) because they are tuned to
+ * match the supplied spiral PNG rather than the app-wide spiral-dynamics swatches.
+ */
+
+const SIDE_LEFT = 'left';
+const SIDE_RIGHT = 'right';
+
+/** Which side of the center column a stage's arrow loop sits on. */
+export type ArrowSide = typeof SIDE_LEFT | typeof SIDE_RIGHT;
+
+/** Static, design-specific copy + color for a single stage's left-column text. */
+export interface StageDisplay {
+  stageNumber: number;
+  /** Bold first line — the egoic/identity "character" of the stage. */
+  persona: string;
+  /** Second line — the stage's mode of knowing. */
+  descriptor: string;
+  /** Third line — the practice cultivated at this stage. */
+  practice: string;
+  /** Short label overlaid on the arrow loop ('' for the title rows 9–10). */
+  arrowLabel: string;
+  /** Text color matching this stage's arrow in the artwork. */
+  textColor: string;
+}
+
+/** A horizontal band of the table: one aspect label over one or two stages. */
+export interface MapRow {
+  /** Aspect-of-wholeness label shown in the right column. */
+  rightLabel: string;
+  /** Stage numbers contained in this row, ordered top → bottom. */
+  stageNumbers: readonly number[];
+}
+
+/** The serif title overlaid across the top of the spiral (top → bottom). */
+export const MAP_TITLE_LINES = ['EMPTINESS', 'UNITY'] as const;
+
+/**
+ * Per-stage left-column copy and color, keyed by ``stage_number`` (1–10).
+ * Stage 10 is the top of the spiral (Whole Adept) and stage 1 the bottom
+ * (Biological Machine).
+ */
+export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
+  10: {
+    stageNumber: 10,
+    persona: 'Whole Adept',
+    descriptor: 'Pure Awareness',
+    practice: 'Cultivate Vipassana',
+    arrowLabel: '',
+    textColor: '#1a1a1a',
+  },
+  9: {
+    stageNumber: 9,
+    persona: 'Blissy Adept',
+    descriptor: 'Effortless Being',
+    practice: 'Cultivate Samatha Jhanas',
+    arrowLabel: '',
+    textColor: '#9a5a78',
+  },
+  8: {
+    stageNumber: 8,
+    persona: 'Adept',
+    descriptor: 'Nonduality',
+    practice: 'Deep Intuition',
+    arrowLabel: 'Nondual',
+    textColor: '#6d92a6',
+  },
+  7: {
+    stageNumber: 7,
+    persona: 'Despairing Analyst',
+    descriptor: 'Integrative',
+    practice: 'Blissy Meditation',
+    arrowLabel: 'Systems',
+    textColor: '#c9a43c',
+  },
+  6: {
+    stageNumber: 6,
+    persona: 'Shadow Glorifier',
+    descriptor: 'Pluralistic',
+    practice: 'Shadow Work',
+    arrowLabel: 'Embodied',
+    textColor: '#7cb273',
+  },
+  5: {
+    stageNumber: 5,
+    persona: 'Status Seeker',
+    descriptor: 'Achievest',
+    practice: 'Wim Hof Method',
+    arrowLabel: 'Intellectual',
+    textColor: '#dc9a5b',
+  },
+  4: {
+    stageNumber: 4,
+    persona: 'Victim',
+    descriptor: 'Conformity',
+    practice: 'Metta Meditation',
+    arrowLabel: 'Community',
+    textColor: '#6f9bd4',
+  },
+  3: {
+    stageNumber: 3,
+    persona: 'Dominator',
+    descriptor: 'Power',
+    practice: 'Confidence Meditation',
+    arrowLabel: 'Self-',
+    textColor: '#b14a3a',
+  },
+  2: {
+    stageNumber: 2,
+    persona: 'Pleasure Seeker',
+    descriptor: 'Magic',
+    practice: 'Divination',
+    arrowLabel: 'Receptivity',
+    textColor: '#5d4e9e',
+  },
+  1: {
+    stageNumber: 1,
+    persona: 'Biological Machine',
+    descriptor: 'Survival',
+    practice: '5-4-3-2-1 Technique',
+    arrowLabel: 'Agency',
+    textColor: '#cdb079',
+  },
+};
+
+/**
+ * The six table rows, top → bottom. The top two rows hold a single stage each
+ * (under the EMPTINESS / UNITY title); the lower four each pair a cool-color
+ * "feminine" stage above a warm-color "masculine" stage.
+ */
+export const MAP_ROWS: readonly MapRow[] = [
+  { rightLabel: 'Awareness', stageNumbers: [10] },
+  { rightLabel: 'Being', stageNumbers: [9] },
+  { rightLabel: 'Wisdom', stageNumbers: [8, 7] },
+  { rightLabel: 'Understanding', stageNumbers: [6, 5] },
+  { rightLabel: 'Love', stageNumbers: [4, 3] },
+  { rightLabel: 'Yes-And-Ness', stageNumbers: [2, 1] },
+];
+
+/**
+ * Even-numbered stages are the Divine-Feminine ("We" / "Feel") side and their
+ * arrows return along the left; odd-numbered stages point right. This mirrors
+ * the alternating sweep of the spiral artwork.
+ */
+export const arrowSide = (stageNumber: number): ArrowSide =>
+  stageNumber % 2 === 0 ? SIDE_LEFT : SIDE_RIGHT;
+
+/** True for the Divine-Feminine side, which carries the grey background band. */
+export const isFeminineSide = (stageNumber: number): boolean =>
+  arrowSide(stageNumber) === SIDE_LEFT;

--- a/frontend/src/features/Map/stageData.ts
+++ b/frontend/src/features/Map/stageData.ts
@@ -33,53 +33,42 @@ export interface StageData {
   hotspots: Hotspot[]; // areas that respond to taps
 }
 
-// Percentage-based hotspot layout matching the spiral image. Each stage has a
-// tappable region over the colored text on the left and another over its spiral
-// arrow. Arrows alternate sides as the spiral winds; stage 9 has two arrows.
-// Indexed 0–9 where index 0 = stage 10 (top) and index 9 = stage 1 (bottom).
-export const HOTSPOTS: readonly Hotspot[][] = [
-  [
-    { top: 4, left: 4, width: 32, height: 6 },
-    { top: 4, left: 34, width: 40, height: 6 },
-  ],
-  [
-    { top: 12, left: 4, width: 32, height: 6 },
-    { top: 12, left: 34, width: 40, height: 6 },
-    { top: 12, left: 50, width: 40, height: 6 },
-  ],
-  [
-    { top: 20, left: 4, width: 32, height: 6 },
-    { top: 20, left: 34, width: 40, height: 6 },
-  ],
-  [
-    { top: 28, left: 4, width: 32, height: 6 },
-    { top: 28, left: 50, width: 40, height: 6 },
-  ],
-  [
-    { top: 36, left: 4, width: 32, height: 6 },
-    { top: 36, left: 34, width: 40, height: 6 },
-  ],
-  [
-    { top: 44, left: 4, width: 32, height: 6 },
-    { top: 44, left: 50, width: 40, height: 6 },
-  ],
-  [
-    { top: 52, left: 4, width: 32, height: 6 },
-    { top: 52, left: 34, width: 40, height: 6 },
-  ],
-  [
-    { top: 60, left: 4, width: 32, height: 6 },
-    { top: 60, left: 50, width: 40, height: 6 },
-  ],
-  [
-    { top: 68, left: 4, width: 32, height: 6 },
-    { top: 68, left: 34, width: 40, height: 6 },
-  ],
-  [
-    { top: 76, left: 4, width: 32, height: 6 },
-    { top: 76, left: 50, width: 40, height: 6 },
-  ],
-] as const;
-
 /** Total number of APTITUDE stages. */
 export const STAGE_COUNT = 10;
+
+// --- Arrow tap-target geometry ---------------------------------------------
+// The center column shows the colored-arrow spiral PNG. Each stage gets one
+// tappable band over its arrow loop, expressed as a percentage of the *center
+// column* (not the whole screen). The ten loops are evenly stacked top→bottom,
+// alternating sides as the spiral winds: even (Divine-Feminine) stages return
+// along the left, odd stages point right. Tune these against the final artwork.
+
+/** Height of one arrow band as a % of the column (ten evenly-spaced loops). */
+const ARROW_BAND_HEIGHT = 100 / STAGE_COUNT;
+/** Vertical inset so adjacent bands never touch / overlap. */
+const ARROW_BAND_INSET = 1;
+/** Horizontal extent of an arrow loop, as a % of the column width. */
+const ARROW_WIDTH = 46;
+/** Left edge of a left-returning (Divine-Feminine) arrow loop. */
+const ARROW_LEFT_X = 4;
+/** Left edge of a right-pointing arrow loop. */
+const ARROW_RIGHT_X = 50;
+
+const isLeftReturning = (stageNumber: number): boolean => stageNumber % 2 === 0;
+
+/**
+ * Percentage-based arrow hotspots, one band per stage. Indexed 0–9 where
+ * index 0 = stage 10 (top) and index 9 = stage 1 (bottom), matching the
+ * descending sort applied to the backend stage list.
+ */
+export const HOTSPOTS: readonly Hotspot[][] = Array.from({ length: STAGE_COUNT }, (_, index) => {
+  const stageNumber = STAGE_COUNT - index;
+  return [
+    {
+      top: index * ARROW_BAND_HEIGHT + ARROW_BAND_INSET,
+      left: isLeftReturning(stageNumber) ? ARROW_LEFT_X : ARROW_RIGHT_X,
+      width: ARROW_WIDTH,
+      height: ARROW_BAND_HEIGHT - ARROW_BAND_INSET * 2,
+    },
+  ];
+});


### PR DESCRIPTION
Restructure the Map screen to match the "spiral of becoming" design:
left column renders the stage text natively (persona / descriptor /
practice) in per-stage colors that mirror the arrow artwork; the center
column hosts the colored-arrow spiral PNG (via EXPO_PUBLIC_MAP_BACKGROUND_URI)
with one tap target per arrow loop, the EMPTINESS / UNITY title, per-arrow
labels, and a two-tone grey band over the Divine-Feminine ("We"/"Feel")
half that stops before Ultraviolet; the right column shows the aspect
labels (Awareness, Being, Wisdom, Understanding, Love, Yes-And-Ness).

- add mapLayout.ts holding the static, design-specific copy + colors
- redefine HOTSPOTS as one arrow band per stage, alternating sides
- preserve the stage-detail modal, history, navigation, lock and
  refresh-banner behaviors and their testIDs

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013QMurBJvEkeWMAf5MyDVKA