### PR TITLE
fix(ralph): honest recap times — split this-PR vs loop, add tick cadence

### DIFF
--- a/scripts/ralph/RECAP.md
+++ b/scripts/ralph/RECAP.md
@@ -95,17 +95,29 @@ fetched via the search API (`is:pr is:merged merged:>=<date>`), capped at
   count is the number of non-LGTM verdicts preceding the first LGTM. PRs that
   never reached an LGTM verdict are excluded. The embed shows avg rounds,
   first-try-clean %, worst, and the sample size `n`.
-- **Cycle time** (7d) — `merged_at - first_commit_at` per PR: from the PR's
-  first commit (the work-beginning proxy, via the pull-request commits endpoint)
-  to merge, so it captures coding time rather than just the review window. Falls
-  back to `created_at` when no commit timestamp is available, and clamps to zero
-  so a rebased commit dated after the merge can't go negative. Median, fastest,
-  slowest.
+- **Time to merge · opened → merged** (7d) — `merged_at - created_at` per PR:
+  the review/merge window. Clamped to zero so clock skew can't go negative.
+  Median, fastest, slowest. (A PR's first-commit timestamp is deliberately not
+  used: for single-commit squash PRs the commit is authored seconds before the
+  PR opens, so "first commit → merge" collapses to this same window.)
+- **Tick cadence · merge → merge** (7d) — the gap between consecutive merges
+  (`stats.merge_intervals_hours`). For a sequential loop this is the closest
+  proxy for how long each tick actually took end to end (pick → code → review →
+  merge), since commit timestamps only mark when work was committed, not begun.
+  Median, fastest, slowest; reads "not enough merges in the window yet" below two
+  merges.
 - **Backlog remaining and ETA** — `open_items / per_day` as days and a date.
   When the rate is zero the ETA reads "unknown (stalled)"; an empty backlog
   reads "backlog clear".
 - **Busiest day** (7d) — the UTC calendar day in the window with the most merges.
-- **This PR's footprint** — additions/deletions/changed-files for the most
+
+The embed groups fields into two labelled blocks so a single merge's numbers are
+never confused with the dataset-wide ones:
+
+- **This PR · time to merge** — the just-merged PR's own `opened → merged`
+  window, plus `since the previous merge (full tick)` — the gap from the prior
+  merge, the per-PR analogue of the tick cadence. Both move on every recap.
+- **This PR · footprint** — additions/deletions/changed-files for the most
   recently merged PR (the list endpoint omits diff stats, so it's fetched via
   the single-PR detail endpoint).
 - **The ten-word headline** — `generate_headline` asks `claude-opus-4-8`

--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -63,11 +63,11 @@ GITHUB_API = "https://api.github.com"
 DISCORD_API = "https://discord.com/api/v10"
 # Discord embed accent — a Ralph-purple.
 EMBED_COLOR = 0x7C3AED
-# The windowed stats (iterations, cycle time, busiest day) cover this trailing
-# span so they move with recent activity instead of a frozen all-time average.
+# The windowed stats (iterations, time-to-merge, tick cadence, busiest day) cover
+# this trailing span so they move with recent activity, not a frozen all-time average.
 RECENT_WINDOW_DAYS = 7
-# Safety cap on PRs analyzed per run: each window PR costs two extra API calls
-# (verdicts + first commit), so bound a burst day rather than fan out unbounded.
+# Safety cap on PRs analyzed per run: each window PR costs one extra API call
+# (its verdicts), so bound a burst day rather than fan out unbounded.
 DEFAULT_MAX_PRS = 200
 HEADLINE_MODEL = "claude-opus-4-8"
 
@@ -188,22 +188,6 @@ def fetch_recent_merged_prs(repo: str, *, token: str, since: dt.date, max_prs: i
     items = _gh_search_issues(query, token=token, max_items=max_prs)
     items.sort(key=lambda it: cast("str", it["pull_request"]["merged_at"]), reverse=True)
     return items
-
-
-def fetch_pr_first_commit_at(repo: str, number: int, *, token: str) -> dt.datetime | None:
-    """Return the authored time of a PR's first commit, or None if unavailable.
-
-    The pull-request commits endpoint returns commits oldest-first, so the first
-    element is where work on the branch began — the closest cheap proxy for
-    "work started" behind the cycle-time metric.
-    """
-    url = f"{GITHUB_API}/repos/{repo}/pulls/{number}/commits?per_page=1"
-    commits = cast("list[dict[str, Any]]", _request_json(url, headers=_gh_headers(token)))
-    if not commits:
-        return None
-    commit = cast("dict[str, Any]", commits[0].get("commit", {}))
-    authored = commit.get("author", {}).get("date") or commit.get("committer", {}).get("date")
-    return stats.parse_iso(str(authored)) if authored else None
 
 
 def fetch_pr_detail(repo: str, number: int, *, token: str) -> dict[str, Any]:
@@ -345,28 +329,28 @@ def _pr_merged_at(pr: dict[str, Any]) -> dt.datetime:
     return stats.parse_iso(cast("str", pr["pull_request"]["merged_at"]))
 
 
-def _cycle_hours(repo: str, pr: dict[str, Any], *, token: str) -> float:
-    """Hours from a PR's first commit (or PR open, as fallback) to its merge.
+def _open_to_merge_hours(pr: dict[str, Any]) -> float:
+    """Hours from a PR opening to its merge — the review/merge window.
 
-    Measures real cycle time — work-beginning to merge — rather than just the
-    review window. Falls back to the PR's open time when no commit timestamp is
-    available, and clamps to zero so a rebased commit dated after the merge can
-    never produce a negative duration.
+    Clamped to zero so clock skew can never produce a negative duration. A PR's
+    commit timestamps are deliberately not used here: for single-commit squash
+    PRs the commit is authored seconds before the PR opens, so "first commit ->
+    merge" collapses to this same window. The genuine end-to-end work duration is
+    captured by the merge-to-merge tick cadence instead (see
+    `stats.merge_intervals_hours`).
     """
     merged = _pr_merged_at(pr)
-    started = fetch_pr_first_commit_at(repo, int(pr["number"]), token=token)
-    if started is None:
-        started = stats.parse_iso(cast("str", pr["created_at"]))
-    return max((merged - started).total_seconds() / 3600.0, 0.0)
+    opened = stats.parse_iso(cast("str", pr["created_at"]))
+    return max((merged - opened).total_seconds() / 3600.0, 0.0)
 
 
 def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dict[str, Any] | None:
     """Gather data and assemble the Discord embed payload.
 
     The headline total is the true all-time merged count; the activity and
-    quality stats (rate, iterations, cycle time, busiest day) cover the trailing
-    `RECENT_WINDOW_DAYS` so they move with recent work. Returns None when there
-    are no merged PRs yet (nothing to recap).
+    quality stats (rate, iterations, time-to-merge, tick cadence, busiest day)
+    cover the trailing `RECENT_WINDOW_DAYS` so they move with recent work. Returns
+    None when there are no merged PRs yet (nothing to recap).
     """
     total_merged = count_merged_total(repo, token=token)
     since = (now - dt.timedelta(days=RECENT_WINDOW_DAYS)).date()
@@ -377,13 +361,14 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
     merged_at = [_pr_merged_at(pr) for pr in window]
 
     iterations: list[int] = []
-    cycle_hours: list[float] = []
     for pr in window:
         verdicts = fetch_pr_verdicts(repo, int(pr["number"]), token=token)
         rounds = stats.iterations_before_lgtm(verdicts)
         if rounds is not None:
             iterations.append(rounds)
-        cycle_hours.append(_cycle_hours(repo, pr, token=token))
+
+    open_to_merge = [_open_to_merge_hours(pr) for pr in window]
+    intervals = stats.merge_intervals_hours(merged_at)
 
     latest = window[0]
     latest_detail = fetch_pr_detail(repo, int(latest["number"]), token=token)
@@ -396,7 +381,8 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
     ]
 
     rate = stats.merge_rate(merged_at, now=now)
-    cycle = stats.time_to_merge_stats(cycle_hours)
+    ttm = stats.time_to_merge_stats(open_to_merge)
+    tick = stats.time_to_merge_stats(intervals)
     iters = stats.iteration_stats(iterations)
     open_items = count_open_backlog(repo, token=token)
     estimate = stats.estimate_remaining(open_items, rate["per_day"], now=now)
@@ -405,19 +391,44 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
 
     headline = generate_headline(str(latest.get("title", "")), str(latest.get("body") or ""))
 
+    # Per-PR (this-merge) figures, kept distinct from the windowed dataset above.
+    latest_ttm_hours = _open_to_merge_hours(latest)
+    latest_tick_hours = (merged_at[0] - merged_at[1]).total_seconds() / 3600.0 if len(merged_at) >= 2 else None
+
     return _render_embed(
         repo=repo,
         latest=latest,
         headline=headline,
         total_merged=total_merged,
         rate=rate,
-        cycle=cycle,
+        ttm=ttm,
+        tick=tick,
         iters=iters,
         estimate=estimate,
         latest_churn=totals,
         busy=busy,
+        latest_ttm_hours=latest_ttm_hours,
+        latest_tick_hours=latest_tick_hours,
         now=now,
     )
+
+
+def _stat_line(summary: dict[str, float]) -> str:
+    """Render a median/fastest/slowest duration summary, or a gap-data notice."""
+    if summary["slowest"] <= 0:
+        return "not enough merges in the window yet"
+    return (
+        f"median **{_fmt_hours(summary['median'])}** · "
+        f"fastest {_fmt_hours(summary['fastest'])} · slowest {_fmt_hours(summary['slowest'])}"
+    )
+
+
+def _this_pr_time_line(latest_ttm_hours: float, latest_tick_hours: float | None) -> str:
+    """One-line time summary for the just-merged PR: review window + full tick."""
+    line = f"**{_fmt_hours(latest_ttm_hours)}** open → merge"
+    if latest_tick_hours is not None:
+        line += f"\n{_fmt_hours(latest_tick_hours)} since the previous merge (full tick)"
+    return line
 
 
 def _render_embed(
@@ -427,14 +438,22 @@ def _render_embed(
     headline: str,
     total_merged: int,
     rate: dict[str, float],
-    cycle: dict[str, float],
+    ttm: dict[str, float],
+    tick: dict[str, float],
     iters: dict[str, float],
     estimate: dict[str, object],
     latest_churn: dict[str, int],
     busy: tuple[str, int] | None,
+    latest_ttm_hours: float,
+    latest_tick_hours: float | None,
     now: dt.datetime,
 ) -> dict[str, Any]:
-    """Turn computed stats into a Discord embed payload (one message)."""
+    """Turn computed stats into a Discord embed payload (one message).
+
+    Fields are split into two labelled blocks: the just-merged PR ("This PR")
+    and the rolling/all-time loop figures ("The loop"), so a single merge's
+    numbers are never confused with the dataset-wide ones.
+    """
     pr_number = int(latest["number"])
     pr_url = str(latest.get("html_url", f"https://github.com/{repo}/pull/{pr_number}"))
 
@@ -448,13 +467,17 @@ def _render_embed(
     )
 
     busy_line = f"{busy[1]} merges on {busy[0]}" if busy else "—"
+    footprint = f"+{latest_churn['additions']} / -{latest_churn['deletions']} across {latest_churn['files']} file(s)"
 
     fields = [
         {
-            "name": "🚀 Latest unlock",
+            "name": "📌 This PR",
             "value": f"*{headline}*\n[#{pr_number} — {latest.get('title', '')}]({pr_url})",
             "inline": False,
         },
+        {"name": "⏱️ Time to merge", "value": _this_pr_time_line(latest_ttm_hours, latest_tick_hours), "inline": True},
+        {"name": "🧮 Footprint", "value": footprint, "inline": True},
+        {"name": "​", "value": "**📊 The loop · rolling 7 days + all-time**", "inline": False},
         {
             "name": "📦 PRs merged",
             "value": f"**{total_merged}** all-time · {int(rate['last_24h'])} in 24h · {int(rate['last_7_days'])} in 7d",
@@ -465,36 +488,15 @@ def _render_embed(
             "value": f"**{rate['per_hour']:.2f}**/hr (24h) · {rate['per_day']:.1f}/day (7d)",
             "inline": True,
         },
-        {
-            "name": "🔁 Review iterations (7d)",
-            "value": iter_line,
-            "inline": False,
-        },
-        {
-            "name": "⏱️ Cycle time · first commit → merge (7d)",
-            "value": (
-                f"median **{_fmt_hours(cycle['median'])}** · "
-                f"fastest {_fmt_hours(cycle['fastest'])} · slowest {_fmt_hours(cycle['slowest'])}"
-            ),
-            "inline": False,
-        },
+        {"name": "🔁 Review iterations (7d)", "value": iter_line, "inline": False},
+        {"name": "⏱️ Time to merge · opened → merged (7d)", "value": _stat_line(ttm), "inline": False},
+        {"name": "🔄 Tick cadence · merge → merge (7d)", "value": _stat_line(tick), "inline": False},
         {
             "name": "🗺️ Backlog remaining",
             "value": f"**{estimate['open_items']}** open · ETA {_fmt_eta(estimate)}",
             "inline": True,
         },
-        {
-            "name": "🔥 Busiest day (7d)",
-            "value": busy_line,
-            "inline": True,
-        },
-        {
-            "name": "🧮 This PR's footprint",
-            "value": (
-                f"+{latest_churn['additions']} / -{latest_churn['deletions']} across {latest_churn['files']} file(s)"
-            ),
-            "inline": False,
-        },
+        {"name": "🔥 Busiest day (7d)", "value": busy_line, "inline": True},
     ]
 
     embed = {

--- a/scripts/ralph/stats.py
+++ b/scripts/ralph/stats.py
@@ -115,7 +115,11 @@ def merge_rate(merged_at: list[dt.datetime], *, now: dt.datetime) -> dict[str, f
 
 
 def time_to_merge_stats(durations_hours: list[float]) -> dict[str, float]:
-    """Summarize how long PRs sat open before merging, in hours."""
+    """Summarize a list of PR durations (hours) as mean/median/fastest/slowest.
+
+    Used for both the open-to-merge window and the merge-to-merge tick cadence —
+    it is just a five-number summary over whatever durations it is handed.
+    """
     if not durations_hours:
         return {"mean": 0.0, "median": 0.0, "fastest": 0.0, "slowest": 0.0}
     return {
@@ -124,6 +128,22 @@ def time_to_merge_stats(durations_hours: list[float]) -> dict[str, float]:
         "fastest": min(durations_hours),
         "slowest": max(durations_hours),
     }
+
+
+def merge_intervals_hours(merged_at: list[dt.datetime]) -> list[float]:
+    """Hours between each consecutive pair of merges — the per-tick cadence.
+
+    Sorts the merge timestamps ascending and returns the gap, in hours, between
+    each merge and the one before it (so n merges yield n-1 intervals; fewer than
+    two merges yield an empty list). For a sequential loop this is the closest
+    available proxy for how long each tick actually took end to end — pick, code,
+    review, merge — because a PR's own commit timestamps only mark when work was
+    committed, not when it began.
+    """
+    if len(merged_at) < 2:
+        return []
+    ordered = sorted(merged_at)
+    return [(ordered[i] - ordered[i - 1]).total_seconds() / 3600.0 for i in range(1, len(ordered))]
 
 
 def iteration_stats(per_pr: list[int]) -> dict[str, float]:

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -111,6 +111,24 @@ def test_time_to_merge_stats() -> None:
     assert out["mean"] == 3.0
 
 
+# ---------- merge_intervals_hours ----------
+
+
+def test_merge_intervals_hours_returns_consecutive_gaps() -> None:
+    # 09:00, 12:00, 15:00 -> two 3-hour gaps.
+    assert rs.merge_intervals_hours([_at(27, 9), _at(27, 12), _at(27, 15)]) == [3.0, 3.0]
+
+
+def test_merge_intervals_hours_sorts_before_diffing() -> None:
+    # Newest-first input (as the recap holds it) still yields positive gaps.
+    assert rs.merge_intervals_hours([_at(27, 15), _at(27, 9), _at(27, 12)]) == [3.0, 3.0]
+
+
+def test_merge_intervals_hours_empty_below_two_merges() -> None:
+    assert rs.merge_intervals_hours([]) == []
+    assert rs.merge_intervals_hours([_at(27, 9)]) == []
+
+
 # ---------- iteration_stats ----------
 
 
@@ -218,26 +236,6 @@ def test_count_merged_total_reads_search_total_count(monkeypatch: pytest.MonkeyP
     assert recap.count_merged_total("owner/repo", token="t") == 723
 
 
-# ---------- fetch_pr_first_commit_at ----------
-
-
-def test_fetch_pr_first_commit_at_returns_author_date(monkeypatch: pytest.MonkeyPatch) -> None:
-    commits = [{"commit": {"author": {"date": "2026-06-20T08:00:00Z"}}}]
-    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: commits)
-    assert recap.fetch_pr_first_commit_at("owner/repo", 7, token="t") == _at(20, 8)
-
-
-def test_fetch_pr_first_commit_at_falls_back_to_committer_date(monkeypatch: pytest.MonkeyPatch) -> None:
-    commits = [{"commit": {"committer": {"date": "2026-06-21T09:00:00Z"}}}]
-    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: commits)
-    assert recap.fetch_pr_first_commit_at("owner/repo", 7, token="t") == _at(21, 9)
-
-
-def test_fetch_pr_first_commit_at_none_when_no_commits(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: [])
-    assert recap.fetch_pr_first_commit_at("owner/repo", 7, token="t") is None
-
-
 # ---------- fetch_recent_merged_prs ----------
 
 
@@ -256,27 +254,18 @@ def test_fetch_recent_merged_prs_sorts_newest_merge_first(monkeypatch: pytest.Mo
     assert [pr["number"] for pr in out] == [2, 3, 1]
 
 
-# ---------- _cycle_hours ----------
+# ---------- _open_to_merge_hours ----------
 
 
-def test_cycle_hours_uses_first_commit(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(recap, "fetch_pr_first_commit_at", lambda *a, **k: _at(27, 9))
-    pr = _hit(1, merged="2026-06-27T12:00:00Z", created="2026-06-27T11:00:00Z")
-    # 09:00 first commit -> 12:00 merge = 3h, ignoring the later PR-open time.
-    assert recap._cycle_hours("owner/repo", pr, token="t") == 3.0
-
-
-def test_cycle_hours_falls_back_to_created_at(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(recap, "fetch_pr_first_commit_at", lambda *a, **k: None)
+def test_open_to_merge_hours_measures_open_to_merge_window() -> None:
     pr = _hit(1, merged="2026-06-27T12:00:00Z", created="2026-06-27T10:00:00Z")
-    assert recap._cycle_hours("owner/repo", pr, token="t") == 2.0
+    assert recap._open_to_merge_hours(pr) == 2.0
 
 
-def test_cycle_hours_clamps_negative_to_zero(monkeypatch: pytest.MonkeyPatch) -> None:
-    # A rebased first commit dated after the merge must not go negative.
-    monkeypatch.setattr(recap, "fetch_pr_first_commit_at", lambda *a, **k: _at(27, 14))
-    pr = _hit(1, merged="2026-06-27T12:00:00Z", created="2026-06-27T11:00:00Z")
-    assert recap._cycle_hours("owner/repo", pr, token="t") == 0.0
+def test_open_to_merge_hours_clamps_negative_to_zero() -> None:
+    # Clock skew (merge stamped before open) must not produce a negative window.
+    pr = _hit(1, merged="2026-06-27T10:00:00Z", created="2026-06-27T12:00:00Z")
+    assert recap._open_to_merge_hours(pr) == 0.0
 
 
 # ---------- _heuristic_headline ----------


### PR DESCRIPTION
## Problem

Three issues with the recap's timing, raised from the Discord screenshots:

1. **Time to merge still showed ~18m and never moved** — and #701's rename to
   "cycle time · first commit → merge" didn't fix it.
2. No per-PR time-to-merge for the just-merged PR.
3. This-PR fields and dataset-wide fields were visually mixed together.

## Double-check of the times (point 3)

I pulled real data. These PRs are **single-commit squashes**, and the commit is
authored *seconds* before the PR opens, so "first commit → merge" collapses onto
the open→merge window:

| PR | first commit | opened | merged | commit→merge | open→merge |
|----|----|----|----|----|----|
| #730 | 17:48:55 | 17:49:29 | 17:51:45 | 2m50s | 2m16s |
| #725 | 17:32:02 | 17:32:19 | 17:43:41 | 11m39s | 11m22s |

A ~17–34s difference. The 18m is the genuine open→merge window; the commit
timestamp marks the **end** of coding, not the start, so it can't surface work
time. The fix is to stop pretending otherwise and add a metric that *can*.

## Fix

- **Honest dataset label**: `⏱️ Time to merge · opened → merged (7d)` —
  `merged_at − created_at`, clamped ≥0. Drops the misleading first-commit framing
  (and its per-PR API call).
- **New `🔄 Tick cadence · merge → merge (7d)`** (`stats.merge_intervals_hours`):
  the gap between consecutive merges — the closest available proxy for full
  end-to-end per-tick duration (pick → code → review → merge) for a sequential
  loop. Reads "not enough merges in the window yet" below two merges.
- **Per-PR time-to-merge** for the just-merged PR: its own `opened → merged`
  plus `since the previous merge (full tick)`.
- **Two labelled blocks** so a single merge's numbers never read as dataset-wide:
  - `📌 This PR` — headline + link, time to merge, footprint
  - `📊 The loop · rolling 7 days + all-time` — totals, rate, iterations, time to
    merge, tick cadence, backlog, busiest day
- Removed now-dead `fetch_pr_first_commit_at` / `_cycle_hours`; updated `RECAP.md`.

## Rendered (stubbed end-to-end)

```
📌 This PR
  *The thing now works end to end*  · #731 — feat: do the thing
⏱️ Time to merge    2m open → merge · 2.5h since the previous merge (full tick)
🧮 Footprint        +290 / -40 across 7 file(s)
── 📊 The loop · rolling 7 days + all-time ──
📦 PRs merged       731 all-time · 3 in 24h · 3 in 7d
⚡ Merge rate       0.12/hr (24h) · 0.4/day (7d)
🔁 Review iterations (7d)  0.0 avg rounds to LGTM · 100% first-try clean · worst 0 (n=3)
⏱️ Time to merge · opened → merged (7d)   median 10m · fastest 2m · slowest 11m
🔄 Tick cadence · merge → merge (7d)      median 1.4h · fastest 18m · slowest 2.5h
🗺️ Backlog remaining  2 open · ETA ~4.7 days
🔥 Busiest day (7d)   3 merges on 2026-06-28
```

## Tests

Dropped the first-commit/cycle-time cases; added `merge_intervals_hours` (gaps,
sort-first, <2-merge empty) and `_open_to_merge_hours` (window, negative clamp).
Verified the full embed renders end-to-end with stubbed network calls and every
number checks out by hand. **37 passed**, ruff clean.

> Note: pre-commit hook repos can't be fetched in this execution environment
> (egress policy 403s `github.com`), so local hooks can't initialize.
> `scripts/ralph/**` is gated by the `Ralph Recap Tests` (pytest) CI job — the
> backend-scoped ruff/mypy hooks don't cover it — verified ruff-clean + tests
> green manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yeMRheRodFtDcxogsmFiH)_