### PR TITLE
feat(content): add optional stage_intros[] tier to the manifest (schema 1.1.0)

### DIFF
--- a/backend/content/manifest.example.json
+++ b/backend/content/manifest.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "chapters": [
     {
       "id": "beige-1",
@@ -32,6 +32,16 @@
       "title": "Getting Started",
       "description": "Orientation guide for new practitioners.",
       "path": "markdown/site/getting-started.md"
+    }
+  ],
+  "stage_intros": [
+    {
+      "stage": 1,
+      "id": "beige-intro",
+      "slug": "beige-introduction",
+      "title": "Welcome to Beige",
+      "path": "markdown/01-beige/00-introduction.md",
+      "summary": "What the Beige stage is about and how to move through it."
     }
   ]
 }

--- a/backend/content/manifest.schema.json
+++ b/backend/content/manifest.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/Geoffe-Ga/adepthood/backend/content/manifest.schema.json",
   "title": "APTITUDE content manifest",
-  "description": "Frozen contract between the aptitude-course content repo (which generates this manifest from per-file YAML frontmatter) and the adepthood backend (which vendors and reads it). Changing this schema post-merge requires a schema_version bump and a note in docs/adr/0001-git-content-pipeline.md (issue #389).",
+  "description": "Frozen contract between the aptitude-course content repo (which generates this manifest from per-file YAML frontmatter) and the adepthood backend (which vendors and reads it). Changing this schema post-merge requires a schema_version bump and a note in docs/adr/0001-git-content-pipeline.md (issue #389). schema_version 1.1.0 adds the optional, additive 'stage_intros[]' tier (per-stage course introductions); a 1.0.0 manifest with no 'stage_intros' stays valid.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -27,6 +27,13 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/site_resource"
+      }
+    },
+    "stage_intros": {
+      "description": "Optional per-stage course introductions (added in schema_version 1.1.0). Ungated and not seeded; the reader serves them straight from the manifest. Omitting this key keeps a 1.0.0 manifest valid.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/stage_intro"
       }
     }
   },
@@ -131,6 +138,47 @@
         "path": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "stage_intro": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stage",
+        "id",
+        "slug",
+        "title",
+        "path"
+      ],
+      "properties": {
+        "stage": {
+          "description": "Curriculum stage 1..10 this introduction belongs to (same numbering as chapters).",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "id": {
+          "description": "Stable identifier, unique repo-wide, e.g. 'beige-intro'. Never reused or renumbered.",
+          "type": "string",
+          "minLength": 1
+        },
+        "slug": {
+          "description": "URL-safe slug for the introduction.",
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "description": "Markdown path relative to the content repo root, e.g. 'markdown/01-beige/00-introduction.md'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string"
         }
       }
     }

--- a/backend/tests/test_manifest_schema.py
+++ b/backend/tests/test_manifest_schema.py
@@ -48,13 +48,26 @@ def test_example_manifest_validates(schema: dict[str, Any], example: dict[str, A
 
 
 def test_example_covers_the_contract_surface(example: dict[str, Any]) -> None:
-    """Per the issue: one stage, two chapters, one site resource."""
+    """Per the issue: one stage, two chapters, one site resource, one intro."""
     assert len(example["chapters"]) == 2
     assert len({c["stage"] for c in example["chapters"]}) == 1
     assert len(example["site_resources"]) == 1
-    # Semver, the contract's change-control handle.
+    # schema_version 1.1.0 ships the additive stage_intros[] tier.
+    assert example["schema_version"] == "1.1.0"
+    assert len(example["stage_intros"]) == 1
     major, minor, patch = example["schema_version"].split(".")
     assert all(part.isdigit() for part in (major, minor, patch))
+
+
+def test_stage_intros_are_optional_for_backwards_compatibility(
+    schema: dict[str, Any],
+    example: dict[str, Any],
+) -> None:
+    """A 1.0.0-shaped manifest with no stage_intros must still validate."""
+    legacy = json.loads(json.dumps(example))
+    legacy.pop("stage_intros")
+    legacy["schema_version"] = "1.0.0"
+    Draft202012Validator(schema).validate(legacy)
 
 
 @pytest.mark.parametrize(
@@ -79,6 +92,20 @@ def test_example_covers_the_contract_surface(example: dict[str, Any]) -> None:
         pytest.param(
             lambda m: m["site_resources"][0].update(extra=True),
             id="site resource unknown field",
+        ),
+        pytest.param(lambda m: m["stage_intros"][0].pop("path"), id="stage_intro missing path"),
+        pytest.param(lambda m: m["stage_intros"][0].pop("stage"), id="stage_intro missing stage"),
+        pytest.param(
+            lambda m: m["stage_intros"][0].update(stage=0),
+            id="stage_intro stage below 1",
+        ),
+        pytest.param(
+            lambda m: m["stage_intros"][0].update(stage=11),
+            id="stage_intro stage above the 10-stage curriculum",
+        ),
+        pytest.param(
+            lambda m: m["stage_intros"][0].update(extra=True),
+            id="stage_intro unknown field",
         ),
     ],
 )

--- a/docs/adr/0001-git-content-pipeline.md
+++ b/docs/adr/0001-git-content-pipeline.md
@@ -88,6 +88,15 @@ an existing reader bumps the major version, and readers must reject a
 manifest whose major version differs from theirs. Every bump gets a
 dated note appended to this ADR.
 
+**2026-06-28 — `schema_version 1.1.0` (additive).** Added an optional
+top-level `stage_intros[]` tier (`$defs/stage_intro`: required
+`stage`/`id`/`slug`/`title`/`path`, optional `summary`) to carry per-stage
+course introductions. Purely additive and backwards-compatible — a `1.0.0`
+manifest with no `stage_intros` still validates, and the reader (which only
+rejects a differing *major*) already accepts `1.1.0`. Coordinated with the
+`aptitude-course` content repo (spec CR-B mirrors this tier). Intros are
+ungated and not seeded into the database.
+
 ## Consequences
 
 - Issues #390–#399 implement against this contract without

--- a/docs/content.md
+++ b/docs/content.md
@@ -32,7 +32,9 @@ contract — changing it requires a `schema_version` bump and an ADR
 note) every time the app constructs its `ContentRepository` and every
 time the sync script runs.
 
-Two collections:
+Three collections (`stage_intros[]` added in `schema_version 1.1.0`, an
+additive minor bump — a `1.0.0` manifest with no `stage_intros` stays
+valid):
 
 * `chapters[]` — stage-locked, drip-fed reading. Each entry carries
   `id`, `stage` (1–10, identical numbering in both repos), `chapter`,
@@ -41,6 +43,10 @@ Two collections:
 * `site_resources[]` — free evergreen pages (philosophy, about, …),
   each with `slug`, `title`, `description`, `path`. Served
   authenticated but never stage-gated.
+* `stage_intros[]` — optional per-stage course introductions, each with
+  `stage`, `id`, `slug`, `title`, `path`, and optional `summary`. Unlike
+  chapters, intros are **ungated and not seeded** into the database — the
+  reader serves them straight from the manifest.
 
 ## How releases are timed
 


### PR DESCRIPTION
## Summary

course-cms-01 (epic #716): the manifest contract had `chapters[]` and `site_resources[]` but no way to represent per-stage course introductions. Add an **additive, optional `stage_intros[]` tier** so both repos agree on the shape before any code reads it. **Contract + docs only — no reader/router/UI changes.**

- **Schema** (`manifest.schema.json`): optional top-level `stage_intros[]` (not in `required`) + `$defs/stage_intro` (`additionalProperties:false`; required `stage`/`id`/`slug`/`title`/`path`, optional `summary`; `stage` 1..10). Description notes the 1.1.0 additive change.
- **Example** (`manifest.example.json`): `schema_version` → `1.1.0` + a `beige-intro` entry.
- **Docs**: ADR 0001 change-control note for 1.1.0; `docs/content.md` documents the tier (ungated, not seeded).

Backwards-compatible: a `1.0.0` manifest with no `stage_intros` stays valid, and the reader (rejects only a differing *major*) already accepts `1.1.0`. Coordinates with `aptitude-course` spec CR-B.

## Test plan

`test_manifest_schema.py`: valid `stage_intros` validates; a `stage_intros`-free 1.0.0 manifest still validates (back-compat); missing `path`/`stage`, `stage` out of range (0/11), and unknown fields are rejected; example is 1.1.0. `./scripts/backend/check-all.sh` → 7/7.

Closes #717
Refs #716
