### PR TITLE
style(ralph): make recap section headers stand out, with padding above

### DIFF
--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -63,6 +63,14 @@ GITHUB_API = "https://api.github.com"
 DISCORD_API = "https://discord.com/api/v10"
 # Discord embed accent — a Ralph-purple.
 EMBED_COLOR = 0x7C3AED
+# Zero-width space — a non-empty Discord field value that renders as blank, used
+# to turn a field into a header-only line.
+BLANK = "​"
+# Section headers. Discord can't size text, so uppercase + a trailing heavy rule
+# is what makes these read as section breaks rather than another bold field label.
+_RULE = "━" * 6
+THIS_PR_HEADER = f"📌  THIS PR  {_RULE}"
+LOOP_HEADER = f"📊  THE LOOP · 7D + ALL-TIME  {_RULE}"
 # The windowed stats (iterations, time-to-merge, tick cadence, busiest day) cover
 # this trailing span so they move with recent activity, not a frozen all-time average.
 RECENT_WINDOW_DAYS = 7
@@ -470,14 +478,19 @@ def _render_embed(
     footprint = f"+{latest_churn['additions']} / -{latest_churn['deletions']} across {latest_churn['files']} file(s)"
 
     fields = [
+        # A blank field is a Discord spacer; it puts a padding line above each
+        # section header so the blocks breathe instead of butting up against the
+        # field before them.
+        {"name": BLANK, "value": BLANK, "inline": False},
         {
-            "name": "📌 This PR",
+            "name": THIS_PR_HEADER,
             "value": f"*{headline}*\n[#{pr_number} — {latest.get('title', '')}]({pr_url})",
             "inline": False,
         },
         {"name": "⏱️ Time to merge", "value": _this_pr_time_line(latest_ttm_hours, latest_tick_hours), "inline": True},
         {"name": "🧮 Footprint", "value": footprint, "inline": True},
-        {"name": "​", "value": "**📊 The loop · rolling 7 days + all-time**", "inline": False},
+        {"name": BLANK, "value": BLANK, "inline": False},
+        {"name": LOOP_HEADER, "value": BLANK, "inline": False},
         {
             "name": "📦 PRs merged",
             "value": f"**{total_merged}** all-time · {int(rate['last_24h'])} in 24h · {int(rate['last_7_days'])} in 7d",


### PR DESCRIPTION
## What

Follow-up polish on the recap embed (from the Discord screenshot): the
`This PR` and `The loop` section headers didn't read as section breaks, and
needed breathing room above them.

## Changes (presentation only)

- **Headers stand out**: both `📌 THIS PR` and `📊 THE LOOP · 7D + ALL-TIME` are
  now bold field **names** (the larger Discord element), uppercased and trailed
  with a heavy rule. Previously "This PR" looked like just another metric label
  and "The loop" sat in a field *value* (smaller than a name). Pulled out as
  `THIS_PR_HEADER` / `LOOP_HEADER` constants.
- **Padding above each header**: a blank spacer field now precedes each header,
  so the two blocks get a padding line instead of butting up against the field
  above them.

## Rendered (stubbed end-to-end)

```
            ← (blank padding line)
📌  THIS PR  ━━━━━━
  *Section headers now have breathing room*  · #734 — header padding
⏱️ Time to merge   2m open → merge · 2.5h since the previous merge (full tick)
🧮 Footprint       +12 / -4 across 1 file(s)
            ← (blank padding line)
📊  THE LOOP · 7D + ALL-TIME  ━━━━━━
📦 PRs merged      478 all-time · 2 in 24h · 2 in 7d
⚡ Merge rate      0.08/hr (24h) · 0.3/day (7d)
... (rest of the loop block)
```

No metric or behavior changes. **37 tests pass**, ruff clean.

> Note: pre-commit hook repos can't be fetched in this execution environment
> (egress policy 403s `github.com`). `scripts/ralph/**` is gated by the
> `Ralph Recap Tests` (pytest) CI job; verified ruff-clean + tests green manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yeMRheRodFtDcxogsmFiH)_