### PR TITLE
feat(content): index and serve stage_intros through ContentRepository

### DIFF
--- a/backend/src/services/content_repository.py
+++ b/backend/src/services/content_repository.py
@@ -36,6 +36,11 @@ _SUPPORTED_SCHEMA_MAJOR = 1
 # chapter enum (chapter|essay|prompt|video) — deliberately distinct.
 _RESOURCE_CONTENT_TYPE: Final[str] = "resource"
 
+# Per-stage course introductions (manifest schema 1.1.0, issue #717) are
+# neither chapters nor resources, so they carry their own content_type —
+# distinct from the chapter enum and from ``_RESOURCE_CONTENT_TYPE``.
+_INTRO_CONTENT_TYPE: Final[str] = "introduction"
+
 #: Audit-trail stamp written by ``scripts/sync_content.py`` (issue #391).
 _CONTENT_VERSION_FILE: Final[str] = "CONTENT_VERSION"
 
@@ -76,6 +81,22 @@ class SiteResourceMeta:
     slug: str
     title: str
     description: str
+
+
+@dataclass(frozen=True)
+class StageIntroMeta:
+    """One per-stage course introduction's manifest metadata (issue #718).
+
+    Like :class:`SiteResourceMeta`, deliberately omits the manifest ``path`` —
+    body reads go through :meth:`ContentRepository.read_intro_body`, which
+    resolves the path internally with the traversal guard.
+    """
+
+    stage: int
+    id: str
+    slug: str
+    title: str
+    summary: str | None = None
 
 
 @dataclass(frozen=True)
@@ -173,6 +194,32 @@ def _index_resources(raw_resources: list[dict[str, Any]]) -> dict[str, dict[str,
     return resources
 
 
+def _index_intros(raw_intros: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    """Index stage introductions by stage, rejecting duplicates (the schema cannot).
+
+    At most one introduction per stage; a second one is a manifest error the
+    JSON Schema cannot express.
+    """
+    intros: dict[int, dict[str, Any]] = {}
+    for intro in raw_intros:
+        if intro["stage"] in intros:
+            msg = f"duplicate stage introduction in manifest for stage {intro['stage']}"
+            raise ContentRepositoryError(msg)
+        intros[intro["stage"]] = intro
+    return intros
+
+
+def _intro_meta(raw: dict[str, Any]) -> StageIntroMeta:
+    """Build a :class:`StageIntroMeta` from a validated manifest entry."""
+    return StageIntroMeta(
+        stage=raw["stage"],
+        id=raw["id"],
+        slug=raw["slug"],
+        title=raw["title"],
+        summary=raw.get("summary"),
+    )
+
+
 class ContentRepository:
     """Parse-once reader over the vendored content directory.
 
@@ -187,6 +234,9 @@ class ContentRepository:
         manifest = self._load_and_validate_manifest()
         self._chapters = _index_chapters(manifest["chapters"])
         self._resources = _index_resources(manifest["site_resources"])
+        # ``stage_intros`` is optional (manifest schema 1.1.0); a 1.0.0 pin
+        # without the key degrades to an empty index.
+        self._intros = _index_intros(manifest.get("stage_intros", []))
 
     def _load_and_validate_manifest(self) -> dict[str, Any]:
         """Load ``manifest.json`` and enforce the issue #389 contract."""
@@ -278,6 +328,34 @@ class ContentRepository:
             body=self._read_markdown(resource["path"]),
             title=resource["title"],
             content_type=_RESOURCE_CONTENT_TYPE,
+        )
+
+    def list_stage_intros(self) -> list[StageIntroMeta]:
+        """Every per-stage introduction, ordered by stage.
+
+        Empty when the manifest carries no ``stage_intros`` (a 1.0.0 pin).
+        """
+        return [_intro_meta(self._intros[stage]) for stage in sorted(self._intros)]
+
+    def get_stage_intro(self, stage: int) -> StageIntroMeta | None:
+        """The introduction for ``stage``, or ``None`` when unknown.
+
+        Optional lookup — returns ``None`` rather than raising, mirroring
+        :meth:`get_chapter`.
+        """
+        raw = self._intros.get(stage)
+        return _intro_meta(raw) if raw is not None else None
+
+    def read_intro_body(self, stage: int) -> ContentBody:
+        """Raw Markdown + title for a stage introduction, by stage."""
+        intro = self._intros.get(stage)
+        if intro is None:
+            msg = f"no stage introduction for stage {stage}"
+            raise ContentNotFoundError(msg)
+        return ContentBody(
+            body=self._read_markdown(intro["path"]),
+            title=intro["title"],
+            content_type=_INTRO_CONTENT_TYPE,
         )
 
 

--- a/backend/tests/fixtures/content/manifest.json
+++ b/backend/tests/fixtures/content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "chapters": [
     {
       "id": "beige-1",
@@ -63,6 +63,23 @@
       "title": "Getting Started",
       "description": "Orientation for new adepts.",
       "path": "markdown/site/getting-started.md"
+    }
+  ],
+  "stage_intros": [
+    {
+      "stage": 1,
+      "id": "beige-intro",
+      "slug": "beige-introduction",
+      "title": "Welcome to Beige",
+      "path": "markdown/01-beige/00-introduction.md",
+      "summary": "What Beige is about."
+    },
+    {
+      "stage": 2,
+      "id": "purple-intro",
+      "slug": "purple-introduction",
+      "title": "Welcome to Purple",
+      "path": "markdown/02-purple/00-introduction.md"
     }
   ]
 }

--- a/backend/tests/fixtures/content/markdown/01-beige/00-introduction.md
+++ b/backend/tests/fixtures/content/markdown/01-beige/00-introduction.md
@@ -1,0 +1,3 @@
+# Welcome to Beige
+
+The survival stage introduction.

--- a/backend/tests/fixtures/content/markdown/02-purple/00-introduction.md
+++ b/backend/tests/fixtures/content/markdown/02-purple/00-introduction.md
@@ -1,0 +1,3 @@
+# Welcome to Purple
+
+The tribal stage introduction.

--- a/backend/tests/test_content_repository.py
+++ b/backend/tests/test_content_repository.py
@@ -20,6 +20,7 @@ from services.content_repository import (
     ContentNotFoundError,
     ContentRepository,
     ContentRepositoryError,
+    StageIntroMeta,
     content_version_info,
     get_content_repository,
     reset_content_repository_for_tests,
@@ -27,7 +28,7 @@ from services.content_repository import (
 )
 
 _VALID_MANIFEST: dict[str, Any] = {
-    "schema_version": "1.0.0",
+    "schema_version": "1.1.0",
     "chapters": [
         {
             "id": "beige-1",
@@ -60,6 +61,23 @@ _VALID_MANIFEST: dict[str, Any] = {
             "path": "markdown/site/getting-started.md",
         }
     ],
+    "stage_intros": [
+        {
+            "stage": 2,
+            "id": "purple-intro",
+            "slug": "purple-introduction",
+            "title": "Welcome to Purple",
+            "path": "markdown/02-purple/00-introduction.md",
+        },
+        {
+            "stage": 1,
+            "id": "beige-intro",
+            "slug": "beige-introduction",
+            "title": "Welcome to Beige",
+            "path": "markdown/01-beige/00-introduction.md",
+            "summary": "What Beige is about.",
+        },
+    ],
 }
 
 
@@ -75,6 +93,10 @@ def _write_content_dir(root: Path, manifest: dict[str, Any]) -> Path:
         md = root / resource["path"]
         md.parent.mkdir(parents=True, exist_ok=True)
         md.write_text(f"# {resource['title']}\n")
+    for intro in manifest.get("stage_intros", []):
+        md = root / intro["path"]
+        md.parent.mkdir(parents=True, exist_ok=True)
+        md.write_text(f"# {intro['title']}\n\nIntro for stage {intro['stage']}.\n")
     return root
 
 
@@ -245,6 +267,82 @@ def test_resource_missing_description_is_rejected_at_construction(tmp_path: Path
     root = _write_content_dir(tmp_path / "content", sparse)
     with pytest.raises(ContentRepositoryError):
         ContentRepository(root)
+
+
+# ── Stage introductions (issue #718) ────────────────────────────────────
+
+
+def test_lists_stage_intros_in_stage_order(content_dir: Path) -> None:
+    """Intros sort by stage even though the manifest lists stage 2 first."""
+    repo = ContentRepository(content_dir)
+    intros = repo.list_stage_intros()
+    assert [i.stage for i in intros] == [1, 2]
+    assert isinstance(intros[0], StageIntroMeta)
+    assert intros[0].id == "beige-intro"
+    assert intros[0].slug == "beige-introduction"
+    assert intros[0].title == "Welcome to Beige"
+    assert intros[0].summary == "What Beige is about."
+    assert intros[1].summary is None  # optional field omitted in the manifest
+
+
+def test_get_stage_intro_returns_meta(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    intro = repo.get_stage_intro(1)
+    assert intro is not None
+    assert intro.id == "beige-intro"
+
+
+def test_get_stage_intro_returns_none_for_unseeded_stage(content_dir: Path) -> None:
+    """Optional lookup mirrors ``get_chapter`` — no intro for stage 3."""
+    repo = ContentRepository(content_dir)
+    assert repo.get_stage_intro(3) is None
+
+
+def test_read_intro_body_returns_markdown_with_metadata(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    body = repo.read_intro_body(1)
+    assert body.title == "Welcome to Beige"
+    assert body.content_type == "introduction"
+    assert "Intro for stage 1." in body.body
+
+
+def test_unknown_stage_intro_raises_not_found(content_dir: Path) -> None:
+    repo = ContentRepository(content_dir)
+    with pytest.raises(ContentNotFoundError):
+        repo.read_intro_body(99)
+
+
+def test_stage_intros_absent_yields_empty_list(tmp_path: Path) -> None:
+    """A 1.0.0 pin with no ``stage_intros`` key degrades to an empty index."""
+    manifest: dict[str, Any] = {"schema_version": "1.0.0", "chapters": [], "site_resources": []}
+    root = _write_content_dir(tmp_path / "content", manifest)
+    assert ContentRepository(root).list_stage_intros() == []
+
+
+def test_duplicate_stage_intro_raises_repository_error(tmp_path: Path) -> None:
+    doubled = copy.deepcopy(_VALID_MANIFEST)
+    doubled["stage_intros"].append(
+        {
+            "stage": 1,
+            "id": "beige-intro-2",
+            "slug": "beige-introduction-2",
+            "title": "Another Beige Intro",
+            "path": "markdown/01-beige/00-introduction.md",
+        }
+    )
+    root = _write_content_dir(tmp_path / "content", doubled)
+    with pytest.raises(ContentRepositoryError):
+        ContentRepository(root)
+
+
+def test_intro_path_traversal_is_rejected(tmp_path: Path) -> None:
+    evil = copy.deepcopy(_VALID_MANIFEST)
+    evil["stage_intros"][0]["path"] = "../secret.md"
+    root = _write_content_dir(tmp_path / "content", evil)
+    (tmp_path / "secret.md").write_text("classified")
+    repo = ContentRepository(root)
+    with pytest.raises(ContentRepositoryError):
+        repo.read_intro_body(2)  # stage 2 is the first entry, with the evil path
 
 
 def test_content_version_info_parses_stamp(content_dir: Path) -> None:


### PR DESCRIPTION
## Summary

course-cms-02 (epic #716): `ContentRepository` indexed `chapters` + `site_resources` but ignored the new `stage_intros[]` tier (#717). Mirror the `site_resources` handling so the course router (#719) can read intro metadata + bodies with the same parse-once + traversal-guard guarantees. **Intros are not seeded and not read-tracked** — served straight from the manifest, keyed by `stage`.

- `StageIntroMeta(stage, id, slug, title, summary | None)` — frozen dataclass omitting `path` (resolved internally), like `SiteResourceMeta`.
- `_index_intros` keyed by `stage`; duplicate stage → `ContentRepositoryError`; reads `manifest.get("stage_intros", [])` so a 1.0.0 pin degrades to an empty index.
- `list_stage_intros()` (stage order), `get_stage_intro(stage) -> meta | None`, `read_intro_body(stage) -> ContentBody` (`ContentNotFoundError` on unknown stage; body via existing `_read_markdown` guard; `content_type "introduction"`).

Repository-only; never writes the content dir; parse-once. Chapter/resource behaviour + tests unchanged.

## Test plan

8 new tests: stage-order listing; `get_stage_intro` meta + `None`; `read_intro_body` markdown/title/type; unknown stage → `ContentNotFoundError`; absent `stage_intros` → empty (back-compat); duplicate stage + path-traversal → `ContentRepositoryError`. Fixtures bumped to schema 1.1.0 with two intros. `./scripts/backend/check-all.sh` → 7/7; xenon A.

Closes #718
Refs #716
