### PR TITLE
fix(ci): make the de-slopify audit read code, not just lint output

### DIFF
--- a/.claude/skills/de-slopify/SKILL.md
+++ b/.claude/skills/de-slopify/SKILL.md
@@ -33,6 +33,22 @@ autonomous implementation cycle (or worse, "fixes" correct code into broken
 code), so a finding that can't be corroborated is dropped. **A run that files
 nothing because the code is clean is a success.**
 
+## Two principles that decide whether a run is any good
+
+1. **Linters are table stakes, not the audit.** This repo already passes ruff,
+   mypy, radon, xenon, bandit, eslint, and tsc in pre-commit and CI on every
+   commit. Anything those tools gate is *already enforced* and **cannot be a
+   finding** — never report a complexity grade, a lint rule, or a type error as
+   slop. The evidence bundle from `collect-evidence.sh` is dominated by exactly
+   that output; treat it as a *map of where to look*, not as findings. Your
+   entire value is the slop linters are **blind to**.
+2. **The high-value families require reading code, not parsing tool JSON.**
+   Dead/stubbed/orphaned code, duplication, bad architecture, lying feature
+   flags, needless verbosity, comment slop, AI-generated tells, and weak/
+   coverage-theater tests do not show up in a linter report. A 5-minute,
+   single-threaded scan of tool output will conclude "clean" and miss all of
+   them. **You must do the reading pass in Step 4.**
+
 ## The three references (read them — they are the substance)
 
 | File | What it gives you |
@@ -73,7 +89,31 @@ NOT-slop list (`slop-taxonomy.md`): generated code, Alembic migrations,
 boilerplate (Pydantic/SQLModel/React Navigation), test fixtures, self-evident
 constants, deliberate repo conventions, and unmeasured "could be faster" claims.
 
-### Step 4 — Corroborate each survivor (the gate)
+### Step 4 — The reading pass (fan-out) — DO NOT SKIP
+
+This is the step that finds the slop linters cannot see, and the step the first
+audit skipped. Do not conclude "clean" without it.
+
+Fan out with the **Task tool**: spawn one subagent per feature area so the whole
+codebase is actually read in parallel, not skimmed by one thread. A good split:
+
+- one subagent per backend router (`backend/src/routers/*`),
+- one for the domain layer (`backend/src/domain/*`) and one for `services/`,
+- one for the models/schemas pair (look for frontend/backend shape drift),
+- one per frontend feature (`frontend/src/features/*`),
+- one for shared/util/config grab-bags (prime duplication + dead-code sites).
+
+Give each subagent the **full 13-family taxonomy** (`slop-taxonomy.md`) and this
+brief: *read the actual source in your area and return corroborated candidates
+for every family, with file:line evidence — focus on what linters miss: dead/
+stubbed/orphaned code, duplication (here and against the rest of the repo),
+architecture/layering violations, lying flags, verbosity, comment slop, AI-slop
+tells, and weak tests. Ignore anything ruff/mypy/radon/eslint already gates.*
+
+Use the `$EVID` bundle's churn and largest-file lists to prioritize. Collect all
+subagent candidates before corroborating.
+
+### Step 5 — Corroborate each survivor (the gate)
 
 Apply the **Two-Signal Rule** (`detection-playbook.md`): no finding survives
 without **two independent signals, at least one concrete and reproducible.**
@@ -90,7 +130,7 @@ without **two independent signals, at least one concrete and reproducible.**
 Classify each survivor by family and assign a severity (Critical/High/Medium/
 Low) from the rubric. When corroboration is shaky, **downgrade or drop.**
 
-### Step 5 — Cluster, then dedup against the backlog
+### Step 6 — Cluster, then dedup against the backlog
 
 Group corroborated findings by area/theme. A cluster needing coordinated
 multi-file change is an **epic**; standalone findings are single issues. Bundle
@@ -104,7 +144,7 @@ gh issue list --state open --search "in:title <keywords>" --json number,title
 gh search issues --repo Geoffe-Ga/adepthood "<keywords>" --state open
 ```
 
-### Step 6 — File the work (Ralph-ready)
+### Step 7 — File the work (Ralph-ready)
 
 Follow `references/issue-templates.md` exactly. The labels matter — Ralph's
 picker (`scripts/ralph/pick-next.sh`) skips `epic`/`blocked`/`needs-spec` and
@@ -121,13 +161,29 @@ works everything else lowest-number-first.
 Create any missing labels first (`gh label create ...`). Write issue bodies to
 files in the scratchpad and file with `--body-file` (never inline strings).
 
-### Step 7 — Report
+### Step 8 — Report (with a coverage ledger)
 
 Emit a concise run summary: counts by severity, what was filed (with issue
 numbers/links), what was **dropped and why** (failed corroboration / guard
-list), and what was **deduped**. If nothing met the bar, say so plainly:
-*"No corroborated slop this run — codebase is clean against the taxonomy."*
-That is a healthy outcome, not a failure.
+list), and what was **deduped**.
+
+Then add a **coverage ledger** — a table with one row per taxonomy family (all
+13) recording which areas/files you examined for it and the verdict
+(clean / candidates / filed). This is how a reader verifies the whole taxonomy
+was actually traversed in the reading pass, not assumed clean:
+
+```
+| Family | Areas examined | Verdict |
+|--------|----------------|---------|
+| 0 Correctness | routers/*, domain/energy.py | clean |
+| 3 Dispensables | services/, frontend/features/Habits | 2 filed (#812, #813) |
+| ... | ... | ... |
+```
+
+If nothing met the bar, say so plainly — *"No corroborated slop this run —
+codebase is clean against the taxonomy"* — but the ledger must still show the
+13 families were each looked at. A clean verdict with an empty ledger means the
+reading pass was skipped; that is a failed run, not a clean one.
 
 ## What this skill must never do
 
@@ -144,13 +200,15 @@ That is a healthy outcome, not a failure.
 ### Example 1 — Weekly scheduled run (the primary path)
 
 The `weekly-deslop` GitHub Action fires (or the user says "run the slop
-detector"). Collect evidence → triage → corroborate → cluster → dedup → file.
-vulture + grep prove `legacy_streak()` has zero callers → file one
-`dead-code`/`priority-medium` issue. radon grades `HabitsScreen` rendering
-logic `D` and a reading finds 4 responsibilities → file a `refactor` **epic**
-with sub-issues (via `triage-and-plan`). A suspected N+1 can't be confirmed
-without a query-count log → **dropped** and noted in the report. Net: 1 issue,
-1 epic (5 sub-issues), 3 dropped, 2 deduped.
+detector"). Collect evidence → triage → **fan-out reading pass** → corroborate →
+cluster → dedup → file → report-with-ledger. vulture + grep prove
+`legacy_streak()` has zero callers → file one `dead-code`/`priority-medium`
+issue. A reading subagent finds `HabitsScreen` mixes data-fetching, formatting,
+and 4 unrelated render responsibilities (something radon's complexity grade does
+*not* describe) → file a `refactor` **epic** with sub-issues (via
+`triage-and-plan`). A suspected N+1 can't be confirmed without a query-count
+log → **dropped** and noted in the report. Net: 1 issue, 1 epic (5 sub-issues),
+3 dropped, 2 deduped — plus a 13-row coverage ledger in the job summary.
 
 ### Example 2 — Clean run
 

--- a/.claude/skills/de-slopify/references/detection-playbook.md
+++ b/.claude/skills/de-slopify/references/detection-playbook.md
@@ -134,29 +134,61 @@ For each taxonomy family, the primary tool and the required second signal.
 
 ---
 
+## What is already enforced — never file it
+
+The repo runs ruff (`select=ALL`), mypy (strict), radon/xenon, bandit, eslint
+(sonarjs+unicorn), and tsc in pre-commit **and** CI. Anything those gate cannot
+reach `main`, so it is **not a finding**:
+
+- complexity grades (radon CC/MI, xenon) — already gated at A/B,
+- ruff/eslint lint rules and formatting,
+- mypy/tsc type errors,
+- bandit's high-confidence security rules.
+
+If the only signal for a candidate is one of these tools agreeing with itself,
+**drop it.** Those tools are the *map* (where to look), not the *findings*. The
+findings come from reading the code for what the tools are blind to. A run whose
+"findings" are all linter-shaped is a failed run — that was the failure mode of
+the first audit.
+
 ## The weekly run procedure
 
 1. **Snapshot.** Run `scripts/collect-evidence.sh` → a consolidated evidence
-   report in the scratchpad (all tool JSON + grep hits + churn).
+   report in the scratchpad (all tool JSON + grep hits + churn + reading
+   targets). Treat the linter JSON as a map, per the rule above.
 2. **Triage candidates.** Parse the report into candidate findings. Discard
    anything in the "NOT slop" guard list (`slop-taxonomy.md`) — generated code,
-   migrations, justified suppressions, framework boilerplate, test fixtures.
-3. **Corroborate each survivor** against the Two-Signal Rule. For correctness
+   migrations, justified suppressions, framework boilerplate, test fixtures —
+   and anything already enforced by the gates above.
+3. **Reading pass (fan-out) — the core of the audit.** Spawn one `Task`
+   subagent per feature area (each backend router, `domain/`, `services/`, the
+   models/schemas pair, each `frontend/src/features/*`, and the util/config
+   grab-bags). Hand each the full taxonomy and have it **read the actual
+   source** and return corroborated candidates for the linter-invisible
+   families: dead/stubbed/orphaned code, duplication (local and repo-wide),
+   architecture/layering violations, lying flags, verbosity, comment slop,
+   AI-slop tells, weak tests. Prioritize by the churn / largest-file lists in
+   the bundle. **Do not skip this for a single-threaded skim — that produces the
+   false "clean".**
+4. **Corroborate each survivor** against the Two-Signal Rule. For correctness
    candidates, *write and run the reproducing test* in a throwaway location
    (do not commit it — the implementing issue will own the real test). If it
    doesn't reproduce, drop it.
-4. **Cluster.** Group corroborated findings by area/theme. A cluster that needs
+5. **Cluster.** Group corroborated findings by area/theme. A cluster that needs
    coordinated, multi-file change becomes an **epic**; standalone findings
    become single issues. Many Low findings in one file = one tidy-up issue.
-5. **Dedup against the backlog.** For every cluster/finding, search existing
+6. **Dedup against the backlog.** For every cluster/finding, search existing
    open issues (`gh issue list`, `gh search issues`) and recent closed ones.
    If it already exists, skip (optionally add a corroborating comment). Never
    file a duplicate.
-6. **Size & file.** Apply `issue-templates.md`. Respect the ~200–300 LoC
+7. **Size & file.** Apply `issue-templates.md`. Respect the ~200–300 LoC
    sizing; split anything bigger into an epic + sub-issues in dependency order.
-7. **Report.** Emit a run summary (counts by severity, what was filed, what was
-   dropped and why, what was deduped). A run that files nothing is a success if
-   the codebase is clean — say so explicitly.
+8. **Report with a coverage ledger.** Emit a run summary (counts by severity,
+   what was filed, dropped and why, deduped) **plus a 13-row table — one per
+   taxonomy family — naming the areas examined and the verdict.** The ledger
+   proves the reading pass actually traversed the taxonomy. A clean verdict with
+   no ledger means the reading pass was skipped — that is a failed run, not a
+   clean one.
 
 ---
 

--- a/.claude/skills/de-slopify/scripts/collect-evidence.sh
+++ b/.claude/skills/de-slopify/scripts/collect-evidence.sh
@@ -134,6 +134,19 @@ if command -v git >/dev/null 2>&1; then
     || echo "(churn unavailable)" >"$OUT/churn.txt"
 fi
 
+# Reading targets: the largest source files by line count. These — together
+# with churn.txt — are where the reading pass should start, because size and
+# change-frequency are where bloaters, duplication, and god-objects accumulate.
+{
+  echo "# Largest source files (LoC) — prime reading-pass targets"
+  if [[ ${#SEARCH_PATHS[@]} -gt 0 ]]; then
+    find "${SEARCH_PATHS[@]}" -type f \
+      \( -name '*.py' -o -name '*.ts' -o -name '*.tsx' \) \
+      -not -path '*/node_modules/*' -print0 2>/dev/null \
+      | xargs -0 wc -l 2>/dev/null | sort -rn | sed '/ total$/d' | head -30
+  fi
+} >"$OUT/reading-targets.txt"
+
 # ----------------------------------------------------------------------------
 # Manifest
 # ----------------------------------------------------------------------------
@@ -148,6 +161,15 @@ fi
   echo "Each *.json / *.txt holds raw tool or grep output. Every entry is a"
   echo "CANDIDATE only — apply the Two-Signal Rule from detection-playbook.md"
   echo "before filing anything. Tool exit codes are appended as [exit N]."
+  echo
+  echo "## IMPORTANT — this bundle is a MAP, not the findings"
+  echo "The linter outputs (ruff/mypy/radon/bandit/eslint/tsc) are TABLE STAKES:"
+  echo "the repo already passes them in pre-commit and CI, so they cannot be"
+  echo "findings. Do NOT file complexity grades, lint rules, or type errors."
+  echo "Use churn.txt + reading-targets.txt to drive a Task fan-out that READS"
+  echo "the source for what linters cannot see (dead/stubbed/orphaned code,"
+  echo "duplication, architecture, lying flags, verbosity, comment slop, AI"
+  echo "tells, weak tests). That reading pass is the actual audit."
 } >"$OUT/README.txt"
 
 log "evidence collected in $OUT"

--- a/.github/workflows/weekly-deslop.yml
+++ b/.github/workflows/weekly-deslop.yml
@@ -73,12 +73,24 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Surface the agent's transcript in the run log so the audit is
+          # auditable: you can verify the skill was invoked and the whole
+          # taxonomy traversed. Safe on a private repo with read-only contents.
+          show_full_output: true
+
           # The skill files issues via gh; expose the analyzers it relies on.
           # Security boundary is the job's GITHUB_TOKEN (contents: read /
           # issues: write) — Claude cannot push code, only open issues.
+          #
+          # --model opus: this is a judgment-heavy audit (architecture,
+          #   duplication, AI-slop, verbosity) — Sonnet, the action default,
+          #   ran the first audit too leniently. Opus does the deep reading.
+          # --max-turns 240: a real reading pass fans out across every feature
+          #   area; the lean 80-turn budget bailed out after a shallow scan.
           claude_args: >-
             --allowed-tools "Bash,Read,Grep,Glob,Write,Skill,Task"
-            --max-turns 80
+            --model opus
+            --max-turns 240
 
           prompt: |
             Run a comprehensive weekly code-quality audit of this repository
@@ -86,6 +98,25 @@ jobs:
             instructions exactly.
 
             Focus area (blank means the whole repo): "${{ github.event.inputs.focus }}"
+
+            Linters are TABLE STAKES, not the audit. This repo already passes
+            ruff, mypy, radon, xenon, bandit, eslint, and tsc in pre-commit and
+            CI on every commit, so anything those tools gate is ALREADY enforced
+            and CANNOT be a finding — do not report complexity grades, lint
+            rules, or type errors as slop. Your value is the slop those tools
+            are blind to: dead/stubbed/orphaned code, duplication, bad
+            architecture and layering violations, lying feature flags, needless
+            verbosity, comment slop, AI-generated tells, and weak/coverage-
+            theater tests. Finding those requires READING THE CODE, not parsing
+            tool JSON. The evidence bundle is a starting map, not the territory.
+
+            Mandatory reading pass (this is what was skipped last time): after
+            collecting evidence, fan out with the Task tool — spawn a subagent
+            per feature area (each backend router, the domain/ modules, each
+            frontend feature) that actually READS the source against the full
+            13-family taxonomy in references/slop-taxonomy.md and reports
+            corroborated candidates. Do not conclude "clean" from a 5-minute
+            single-threaded scan of linter output.
 
             Hard requirements (the skill enforces these — do not deviate):
             - Corroborate every finding with TWO independent signals before
@@ -108,8 +139,12 @@ jobs:
             End by writing a concise run summary to the GitHub Actions job
             summary — append it to the file at $GITHUB_STEP_SUMMARY (e.g.
             `cat >> "$GITHUB_STEP_SUMMARY"`) — containing: counts by severity,
-            issues/epics filed (with numbers), findings dropped and why, and
-            findings deduped. This is the durable record, linked to the workflow
+            issues/epics filed (with numbers), findings dropped and why,
+            findings deduped, AND a coverage ledger: a table with one row per
+            taxonomy family (all 13) listing which areas/files you examined for
+            it and the verdict (clean / candidates / filed). The ledger is how
+            we verify the whole taxonomy was actually traversed rather than
+            assumed clean. This is the durable record, linked to the workflow
             run, and never touches the issue tracker. A clean run (nothing
             filed) writes "codebase is clean against the taxonomy this week" to
             the job summary and files NO issue. Only open a separate `de-slop` +


### PR DESCRIPTION
## Summary

The first scheduled de-slopify run ([run 28333472715](https://github.com/Geoffe-Ga/adepthood/actions/runs/28333472715)) came back clean but **shallow**, and its report referenced only linter-shaped concerns (e.g. radon) that the repo already gates. Reading the run log showed three concrete root causes:

1. **It ran on `claude-sonnet-4-6`** — the action's default model; no `--model` was set. This is a judgment-heavy audit (architecture, duplication, AI-slop, verbosity).
2. **It was shallow** — ~5 min / 65 turns / $1.04 for a *whole-repo, 13-family* audit. It leaned on `collect-evidence.sh`'s linter JSON and concluded "clean."
3. **Linter-anchoring** — the evidence bundle's strongest signals are things `ruff/mypy/radon/eslint` already enforce in pre-commit + CI, so they can't be findings. The real slop (dead/stubbed/orphaned code, duplication, bad architecture, lying flags, verbosity, comment slop, AI-slop, weak tests) requires **reading code**, which a single-threaded pass skipped.

## Changes

- **`weekly-deslop.yml`** — run on **Opus** (`--model opus`), raise the turn budget to **240**, enable `show_full_output` so the transcript is auditable, and reframe the prompt: *linters are table stakes* (never file what the gates already enforce), **mandate a `Task` fan-out reading pass**, and require a **13-row coverage ledger** in the job summary so taxonomy traversal is verifiable.
- **`SKILL.md`** — add two governing principles (linters are table stakes; high-value families require reading code), a new **mandatory Step 4 fan-out reading pass** (one subagent per feature area, reading source against the full taxonomy), and a coverage-ledger report step.
- **`detection-playbook.md`** — add the "already enforced — never file it" rule and fold the reading-pass fan-out into the weekly procedure.
- **`collect-evidence.sh`** — add `reading-targets.txt` (largest source files, to direct the reading pass) and reframe the bundle README as a *map, not the findings*. Verified locally: it now surfaces a 2,377-line `api/index.ts` and 1,450-line `auth.py` as prime targets the first run walked past.

## Verification of the original run

From the run log: model was `claude-sonnet-4-6`; `num_turns: 65`; `duration_ms: 290317`; the audit concluded clean with no reading pass. The coverage ledger added here makes future "clean" verdicts auditable — a clean verdict with an empty ledger now signals a *failed* run (reading pass skipped), not a clean one.

## Notes

- Context: PR #676 (the original skill) is already merged; this is a follow-up tuning pass on top of `main`.
- The unmerged `claude/de-slopify-weekly-action-uvlm52` branch (cron → Sunday) is orthogonal — it edits the `schedule:` block, not the `claude_args`/prompt touched here.
- Pre-commit hook repos can't be fetched in the sandbox (egress policy blocks `github.com` clones); shellcheck, YAML validity, and hygiene were verified manually, and `collect-evidence.sh` was smoke-tested. Full gates run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7daCzbSe7Dr5JeiZd8BA8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7daCzbSe7Dr5JeiZd8BA8)_