### PR TITLE
feat(course): stage-introduction API endpoints

### DIFF
--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -28,6 +28,7 @@ from schemas.course import (
     ContentItemResponse,
     CourseProgressResponse,
     SiteResourceResponse,
+    StageIntroResponse,
 )
 from services.content_repository import (
     ContentBody,
@@ -550,3 +551,65 @@ async def get_site_resource_body(
     plain 404 via the repository's ``ContentNotFoundError``.
     """
     return _read_local_body(lambda: get_content_repository().read_resource_body(slug), slug)
+
+
+async def _require_unlocked_stage(
+    session: AsyncSession,
+    user_id: int,
+    stage_number: int,
+) -> None:
+    """Require the stage to exist and be unlocked for ``user_id``.
+
+    A nonexistent stage is a plain ``stage`` 404; a locked stage is masked as
+    ``content`` (BUG-COURSE-004) so a locked stage's intro is indistinguishable
+    from a nonexistent one over the wire.
+    """
+    await _get_stage_by_number(session, stage_number)
+    if not await _is_stage_unlocked_for_user(session, user_id, stage_number):
+        raise not_found("content")
+
+
+@router.get("/stages/{stage_number}/intro", response_model=StageIntroResponse)
+async def get_stage_introduction(
+    stage_number: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> StageIntroResponse:
+    """Return a stage's course-introduction metadata.
+
+    Ungated by ``release_day`` but gated by stage-unlock: a locked stage and a
+    stage with no intro both return ``content_not_found`` (BUG-COURSE-004) so
+    neither acts as an enumeration oracle.
+    """
+    await _require_unlocked_stage(session, current_user, stage_number)
+    intro = get_content_repository().get_stage_intro(stage_number)
+    if intro is None:
+        raise not_found("content")
+    return StageIntroResponse(
+        stage=intro.stage,
+        id=intro.id,
+        slug=intro.slug,
+        title=intro.title,
+        summary=intro.summary,
+    )
+
+
+@router.get("/stages/{stage_number}/intro/body", response_model=ContentBodyResponse)
+@limiter.limit(_CMS_PROXY_RATE_LIMIT)
+async def get_stage_intro_body(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    stage_number: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ContentBodyResponse:
+    """Return raw Markdown for a stage's course introduction.
+
+    Same gating as :func:`get_stage_introduction`. The read goes through
+    :func:`_read_local_body`, so an unknown stage keeps the 404 mask and a
+    broken repository surfaces as ``502 content_unavailable``.
+    """
+    await _require_unlocked_stage(session, current_user, stage_number)
+    return _read_local_body(
+        lambda: get_content_repository().read_intro_body(stage_number),
+        f"stage-{stage_number}-intro",
+    )

--- a/backend/src/schemas/course.py
+++ b/backend/src/schemas/course.py
@@ -67,3 +67,13 @@ class SiteResourceResponse(BaseModel):
     title: str
     description: str
     url: str
+
+
+class StageIntroResponse(BaseModel):
+    """Metadata for a stage's course introduction (body fetched separately)."""
+
+    stage: int
+    id: str
+    slug: str
+    title: str
+    summary: str | None

--- a/backend/tests/test_course_body_endpoints.py
+++ b/backend/tests/test_course_body_endpoints.py
@@ -40,7 +40,7 @@ from services.content_repository import (
 # --------------------------------------------------------------------------- #
 
 _MANIFEST: dict[str, Any] = {
-    "schema_version": "1.0.0",
+    "schema_version": "1.1.0",
     "chapters": [
         {
             "id": "beige-1",
@@ -79,6 +79,23 @@ _MANIFEST: dict[str, Any] = {
             "path": "markdown/site/aptitude-stages.md",
         },
     ],
+    "stage_intros": [
+        {
+            "stage": 1,
+            "id": "beige-intro",
+            "slug": "beige-introduction",
+            "title": "Welcome to Beige",
+            "path": "markdown/01-beige/00-introduction.md",
+            "summary": "What Beige is about.",
+        },
+        {
+            "stage": 2,
+            "id": "purple-intro",
+            "slug": "purple-introduction",
+            "title": "Welcome to Purple",
+            "path": "markdown/02-purple/00-introduction.md",
+        },
+    ],
 }
 
 
@@ -96,6 +113,10 @@ def content_dir(tmp_path: Path) -> Iterator[Path]:
         md = root / resource["path"]
         md.parent.mkdir(parents=True, exist_ok=True)
         md.write_text(f"# {resource['title']}\n")
+    for intro in _MANIFEST["stage_intros"]:
+        md = root / intro["path"]
+        md.parent.mkdir(parents=True, exist_ok=True)
+        md.write_text(f"# {intro['title']}\n\nIntro body for stage {intro['stage']}.\n")
     set_content_repository_for_tests(ContentRepository(root))
     yield root
     reset_content_repository_for_tests()
@@ -398,5 +419,107 @@ async def test_site_resource_body_502_when_markdown_file_missing(
     headers = await _signup(async_client, "rsbad")
     (content_dir / "markdown/site/aptitude-stages.md").unlink()
     resp = await async_client.get("/course/site-resources/aptitude-stages/body", headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_GATEWAY
+    assert resp.json()["detail"] == "content_unavailable"
+
+
+# --------------------------------------------------------------------------- #
+# /course/stages/{n}/intro (+ /body) — stage introductions                     #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("content_dir")
+async def test_stage_intro_metadata_and_body_for_unlocked_stage(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An unlocked stage serves its intro metadata and Markdown body."""
+    headers, user_id = await _signup_with_id(async_client, "introreader")
+    await _seed_stage_with_content(db_session, stage_number=1)
+    await _set_user_stage(db_session, user_id, stage_number=1, days_ago=1)
+
+    meta = await async_client.get("/course/stages/1/intro", headers=headers)
+    assert meta.status_code == HTTPStatus.OK
+    assert meta.json() == {
+        "stage": 1,
+        "id": "beige-intro",
+        "slug": "beige-introduction",
+        "title": "Welcome to Beige",
+        "summary": "What Beige is about.",
+    }
+
+    body = await async_client.get("/course/stages/1/intro/body", headers=headers)
+    assert body.status_code == HTTPStatus.OK
+    payload = body.json()
+    assert payload["body_markdown"].startswith("# Welcome to Beige")
+    assert payload["title"] == "Welcome to Beige"
+    assert payload["content_type"] == "introduction"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("content_dir")
+async def test_stage_intro_locked_stage_is_masked_as_not_found(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A locked stage's intro (which exists) is indistinguishable from absent."""
+    headers, user_id = await _signup_with_id(async_client, "introlocked")
+    await _seed_stage_with_content(db_session, stage_number=1)
+    await _seed_stage_with_content(db_session, stage_number=2, title="Tribal Rhythm")
+    await _set_user_stage(db_session, user_id, stage_number=1, days_ago=1)
+
+    for path in ("/course/stages/2/intro", "/course/stages/2/intro/body"):
+        resp = await async_client.get(path, headers=headers)
+        assert resp.status_code == HTTPStatus.NOT_FOUND
+        assert resp.json()["detail"] == "content_not_found"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("content_dir")
+async def test_stage_intro_unlocked_stage_without_intro_is_not_found(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An unlocked stage with no manifest intro returns content_not_found."""
+    headers, user_id = await _signup_with_id(async_client, "introless")
+    await _seed_stage_with_content(db_session, stage_number=3)
+    await _set_user_stage(db_session, user_id, stage_number=3, days_ago=1)
+
+    resp = await async_client.get("/course/stages/3/intro", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "content_not_found"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("content_dir")
+async def test_stage_intro_unknown_stage_is_not_found(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A stage with no CourseStage row is a plain stage 404."""
+    headers, user_id = await _signup_with_id(async_client, "introghost")
+    await _set_user_stage(db_session, user_id, stage_number=1, days_ago=1)
+
+    resp = await async_client.get("/course/stages/999/intro", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "stage_not_found"
+
+
+@pytest.mark.asyncio
+async def test_stage_intro_requires_auth(async_client: AsyncClient) -> None:
+    """Both intro endpoints require authentication."""
+    for path in ("/course/stages/1/intro", "/course/stages/1/intro/body"):
+        resp = await async_client.get(path)
+        assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_stage_intro_body_502_when_markdown_file_missing(
+    async_client: AsyncClient, db_session: AsyncSession, content_dir: Path
+) -> None:
+    """A manifest-listed intro whose file is gone is a server bug — 502."""
+    headers, user_id = await _signup_with_id(async_client, "introtorn")
+    await _seed_stage_with_content(db_session, stage_number=1)
+    await _set_user_stage(db_session, user_id, stage_number=1, days_ago=1)
+    (content_dir / "markdown/01-beige/00-introduction.md").unlink()
+
+    resp = await async_client.get("/course/stages/1/intro/body", headers=headers)
     assert resp.status_code == HTTPStatus.BAD_GATEWAY
     assert resp.json()["detail"] == "content_unavailable"


### PR DESCRIPTION
## Summary

course-cms-03 (epic #716): expose the stage intros `ContentRepository` can now serve (#718) over the course API, with the same auth + gating + error semantics as the chapter-body endpoint. Intros are **ungated by `release_day`** but **gated by stage-unlock**; no DB changes (intros aren't seeded).

- `StageIntroResponse` schema (`stage`, `id`, `slug`, `title`, `summary | None`).
- `GET /course/stages/{n}/intro` → `StageIntroResponse`.
- `GET /course/stages/{n}/intro/body` → `ContentBodyResponse` (rate-limited).
- `_require_unlocked_stage` helper: nonexistent stage → `stage` 404; locked stage → `content_not_found` mask (BUG-COURSE-004), reusing `_get_stage_by_number` + `_is_stage_unlocked_for_user`. Body reads via the shared `_read_local_body` so an unknown stage stays a 404 mask and a broken repository → `502 content_unavailable`.

A locked stage and a stage with no intro both return `content_not_found` (no enumeration oracle). Existing endpoints/tests unchanged; route functions stay xenon rank A.

## Test plan

6 tests (`test_course_body_endpoints.py`, manifest fixture → 1.1.0 with two intros): unlocked → 200 metadata + body (`content_type "introduction"`); locked-stage intro → 404 `content_not_found` (both endpoints); unlocked-no-intro → 404; unknown stage → `stage_not_found`; unauthenticated → 401; missing intro file → `502 content_unavailable`. `./scripts/backend/check-all.sh` → 7/7; xenon A.

Closes #719
Refs #716
