### PR TITLE
feat(course): frontend stage-intro client + ChapterReader intro source

### DIFF
--- a/frontend/src/api/__tests__/courseIntro-api.test.ts
+++ b/frontend/src/api/__tests__/courseIntro-api.test.ts
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { course, ApiValidationError } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+const INTRO = {
+  stage: 1,
+  id: 'beige-intro',
+  slug: 'beige-introduction',
+  title: 'Welcome to Beige',
+  summary: 'What Beige is about.',
+};
+
+const INTRO_BODY = {
+  title: 'Welcome to Beige',
+  content_type: 'introduction',
+  body_markdown: '# Welcome to Beige\n\nintro body.\n',
+};
+
+describe('course stage-intro client', () => {
+  test('stageIntro GETs the stage-intro endpoint with auth', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(INTRO));
+
+    const result = await course.stageIntro(1, 'test-token');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/course/stages/1/intro');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer test-token' });
+    expect(result).toEqual(INTRO);
+  });
+
+  test('stageIntroBody GETs the stage-intro body endpoint with auth', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(INTRO_BODY));
+
+    const result = await course.stageIntroBody(2, 'test-token');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/course/stages/2/intro/body');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer test-token' });
+    expect(result).toEqual(INTRO_BODY);
+  });
+
+  test('stageIntro rejects a malformed payload with ApiValidationError', async () => {
+    // stage as a string violates the Zod schema → validated at the boundary.
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ stage: 'one', id: 'x', slug: 'x', title: 'x', summary: null }),
+    );
+
+    await expect(course.stageIntro(1, 'test-token')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -17,6 +17,7 @@ import {
   practiceSessionResponseSchema,
   practiceTagSchema,
   promptListResponseSchema,
+  stageIntroSchema,
   stageSchema,
   timezoneReadSchema,
   userPracticeSchema,
@@ -1464,6 +1465,15 @@ export interface SiteResource {
   url: string;
 }
 
+/** Metadata for a stage's course introduction (body fetched separately). */
+export interface StageIntro {
+  stage: number;
+  id: string;
+  slug: string;
+  title: string;
+  summary: string | null;
+}
+
 export const course = {
   stageContent(stageNumber: number, token?: string): Promise<ContentItem[]> {
     return request<ContentItem[]>(`/course/stages/${stageNumber}/content`, { token });
@@ -1509,6 +1519,15 @@ export const course = {
   },
   siteResourceBody(slug: string, token?: string): Promise<ContentBody> {
     return request<ContentBody>(`/course/site-resources/${slug}/body`, { token });
+  },
+  stageIntro(stageNumber: number, token?: string): Promise<StageIntro> {
+    return request<StageIntro>(`/course/stages/${stageNumber}/intro`, {
+      token,
+      schema: stageIntroSchema as unknown as z.ZodType<StageIntro>,
+    });
+  },
+  stageIntroBody(stageNumber: number, token?: string): Promise<ContentBody> {
+    return request<ContentBody>(`/course/stages/${stageNumber}/intro/body`, { token });
   },
 };
 

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -399,6 +399,18 @@ export const contentItemSchema = z.object({
 });
 
 /**
+ * Stage-introduction metadata from ``GET /course/stages/{n}/intro``. Validated
+ * at the boundary so a backend field rename/retype raises ``ApiValidationError``.
+ */
+export const stageIntroSchema = z.object({
+  stage: z.number().int(),
+  id: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  summary: z.string().nullable(),
+});
+
+/**
  * Frequency-banner payload from ``GET /user-practices/current/frequency``.
  * Validated at the boundary so a backend field rename/retype raises
  * ``ApiValidationError`` (the "Something changed on the server" path) instead of

--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -15,7 +15,8 @@ import styles, { markdownStyles } from './Course.styles';
  */
 export type ChapterReaderSource =
   | { kind: 'content'; id: number }
-  | { kind: 'resource'; slug: string };
+  | { kind: 'resource'; slug: string }
+  | { kind: 'intro'; stageNumber: number };
 
 interface ChapterReaderProps {
   source: ChapterReaderSource;
@@ -121,6 +122,17 @@ function describeError(): string {
   return 'This chapter couldn’t load right now. Please try again.';
 }
 
+function fetchBody(source: ChapterReaderSource): Promise<ContentBody> {
+  switch (source.kind) {
+    case 'content':
+      return courseApi.contentBody(source.id);
+    case 'resource':
+      return courseApi.siteResourceBody(source.slug);
+    case 'intro':
+      return courseApi.stageIntroBody(source.stageNumber);
+  }
+}
+
 function useContentBody(source: ChapterReaderSource): {
   body: ContentBody | null;
   loading: boolean;
@@ -149,10 +161,7 @@ function useContentBody(source: ChapterReaderSource): {
     // (set by ``AuthContext`` at sign-in), so the bearer header is
     // attached automatically.  Same pattern as ``stagesApi.list()``
     // and the other "no explicit token" callers in the codebase.
-    const promise =
-      source.kind === 'content'
-        ? courseApi.contentBody(source.id)
-        : courseApi.siteResourceBody(source.slug);
+    const promise = fetchBody(source);
 
     promise
       .then((result) => {

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -11,6 +11,7 @@ jest.mock('../../../api', () => ({
   course: {
     contentBody: jest.fn(),
     siteResourceBody: jest.fn(),
+    stageIntroBody: jest.fn(),
   },
 }));
 
@@ -18,10 +19,15 @@ const { course: courseApi } = jest.requireMock('../../../api') as {
   course: {
     contentBody: jest.MockedFunction<typeof Api.course.contentBody>;
     siteResourceBody: jest.MockedFunction<typeof Api.course.siteResourceBody>;
+    stageIntroBody: jest.MockedFunction<typeof Api.course.stageIntroBody>;
   };
 };
 
-const { contentBody: mockContentBody, siteResourceBody: mockSiteResourceBody } = courseApi;
+const {
+  contentBody: mockContentBody,
+  siteResourceBody: mockSiteResourceBody,
+  stageIntroBody: mockStageIntroBody,
+} = courseApi;
 
 const HAPPY_CHAPTER = {
   title: 'Chapter One',
@@ -35,11 +41,18 @@ const HAPPY_RESOURCE = {
   body_markdown: '# Philosophy\n\nphilosophy body.\n',
 };
 
+const HAPPY_INTRO = {
+  title: 'Welcome to Beige',
+  content_type: 'introduction',
+  body_markdown: '# Welcome to Beige\n\nintro body.\n',
+};
+
 describe('ChapterReader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockContentBody.mockResolvedValue(HAPPY_CHAPTER);
     mockSiteResourceBody.mockResolvedValue(HAPPY_RESOURCE);
+    mockStageIntroBody.mockResolvedValue(HAPPY_INTRO);
   });
 
   it('renders the fallback title until the live one arrives', async () => {
@@ -74,6 +87,32 @@ describe('ChapterReader', () => {
     );
     await waitFor(() => expect(mockSiteResourceBody).toHaveBeenCalledWith('philosophy'));
     expect(mockContentBody).not.toHaveBeenCalled();
+  });
+
+  it('routes intro sources to course.stageIntroBody and renders the body', async () => {
+    const { findAllByText } = render(
+      <ChapterReader
+        source={{ kind: 'intro', stageNumber: 1 }}
+        fallbackTitle="x"
+        onBack={jest.fn()}
+      />,
+    );
+    await waitFor(() => expect(mockStageIntroBody).toHaveBeenCalledWith(1));
+    expect(mockContentBody).not.toHaveBeenCalled();
+    expect(mockSiteResourceBody).not.toHaveBeenCalled();
+    await findAllByText('Welcome to Beige');
+  });
+
+  it('shows the error state when an intro body fails to load', async () => {
+    mockStageIntroBody.mockRejectedValueOnce({ detail: 'boom' });
+    const { findByTestId } = render(
+      <ChapterReader
+        source={{ kind: 'intro', stageNumber: 2 }}
+        fallbackTitle="x"
+        onBack={jest.fn()}
+      />,
+    );
+    await findByTestId('reader-error');
   });
 
   it('renders a footer when one is provided', async () => {


### PR DESCRIPTION
## Summary

course-cms-04 (epic #716): the frontend had no client for the stage-intro endpoints (#719) and `ChapterReader` had no source variant for an intro. Add both so the Course screen (#721) can open a stage intro in the existing reader. **No screen wiring yet.**

- `StageIntro` type + `stageIntroSchema` (Zod), validated at the boundary like the other validated responses.
- `course.stageIntro(stageNumber)` → `GET /course/stages/{n}/intro` (schema-checked) and `course.stageIntroBody(stageNumber)` → `GET /course/stages/{n}/intro/body`, following the existing `request()` + token-fallback pattern.
- `ChapterReaderSource` gains `{ kind: 'intro'; stageNumber }`; the fetch branches via a small exhaustive `fetchBody()` helper to `course.stageIntroBody`, reusing the existing loading/error/empty states + Markdown guards. `content`/`resource` paths unchanged.

## Test plan

`courseIntro-api`: `stageIntro`/`stageIntroBody` hit the right paths, send auth; a malformed `stageIntro` payload rejects with `ApiValidationError`. `ChapterReader`: an intro source routes to `stageIntroBody`, renders the body, and shows the error state on failure. **14 pass; `./scripts/frontend/check-all.sh` → 4/4** (zero-warning lint, no `any`/`@ts-ignore`).

Closes #720
Refs #716
