### PR TITLE
feat(course): surface the stage introduction as a card in the Course screen

### DIFF
--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { colors, radius, SPACING, shadows } from '../../design/tokens';
+import { colors, radius, SPACING, shadows, touchTarget } from '../../design/tokens';
 
 const STAGE_PILL_SIZE = 40;
 const PROGRESS_BAR_HEIGHT = 6;
@@ -89,6 +89,36 @@ const styles = StyleSheet.create({
   stageDetailValue: {
     fontSize: 12,
     color: colors.text.secondary,
+  },
+
+  // Stage introduction card
+  introCard: {
+    minHeight: touchTarget.minimum,
+    marginHorizontal: SPACING.lg,
+    marginTop: SPACING.md,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+    borderRadius: radius.md,
+    backgroundColor: colors.background.card,
+    ...shadows.small,
+  },
+  introCardLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.text.tertiary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 2,
+  },
+  introCardTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  introCardSummary: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    marginTop: 4,
   },
 
   // Progress bar

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -23,6 +23,7 @@ import ContentCard from './ContentCard';
 import ContentViewer from './ContentViewer';
 import styles from './Course.styles';
 import SiteResourcesPanel from './SiteResourcesPanel';
+import StageIntroCard from './StageIntroCard';
 import StageSelector from './StageSelector';
 
 const DEFAULT_STAGE_NUMBER = 1;
@@ -258,6 +259,7 @@ function useCourseViewer(selectedStage: number) {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [viewingItem, setViewingItem] = useState<ContentItem | null>(null);
   const [viewingResource, setViewingResource] = useState<SiteResource | null>(null);
+  const [viewingIntro, setViewingIntro] = useState<number | null>(null);
 
   const handleContentPress = useCallback((item: ContentItem) => {
     if (!item.is_locked) setViewingItem(item);
@@ -267,9 +269,14 @@ function useCourseViewer(selectedStage: number) {
     setViewingResource(resource);
   }, []);
 
+  const handleIntroPress = useCallback((stageNumber: number) => {
+    setViewingIntro(stageNumber);
+  }, []);
+
   const handleBack = useCallback(() => {
     setViewingItem(null);
     setViewingResource(null);
+    setViewingIntro(null);
   }, []);
 
   const handleReflect = useCallback(() => {
@@ -285,8 +292,10 @@ function useCourseViewer(selectedStage: number) {
     setViewingItem,
     viewingResource,
     setViewingResource,
+    viewingIntro,
     handleContentPress,
     handleResourcePress,
+    handleIntroPress,
     handleBack,
     handleReflect,
   };
@@ -313,6 +322,15 @@ function renderOverlay(
       <ChapterReader
         source={{ kind: 'resource', slug: viewer.viewingResource.slug }}
         fallbackTitle={viewer.viewingResource.title}
+        onBack={viewer.handleBack}
+      />
+    );
+  }
+  if (viewer.viewingIntro !== null) {
+    return (
+      <ChapterReader
+        source={{ kind: 'intro', stageNumber: viewer.viewingIntro }}
+        fallbackTitle="Introduction"
         onBack={viewer.handleBack}
       />
     );
@@ -363,6 +381,7 @@ const CourseScreen = (): React.JSX.Element => {
         spiralColor={selectedStageData?.spiral_dynamics_color}
         error={stageContent.error}
       />
+      <StageIntroCard stageNumber={selectedStage} onOpen={viewer.handleIntroPress} />
       <ContentArea
         content={stageContent.content}
         loadingContent={stageContent.loadingContent}

--- a/frontend/src/features/Course/StageIntroCard.tsx
+++ b/frontend/src/features/Course/StageIntroCard.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+
+import { course as courseApi, type StageIntro } from '../../api';
+
+import styles from './Course.styles';
+
+interface StageIntroCardProps {
+  stageNumber: number;
+  onOpen: (_stageNumber: number) => void;
+}
+
+/**
+ * "Start here" card for a stage's course introduction, shown above the chapter
+ * list. Loads its own intro and refetches on stage change. A missing intro
+ * (404 — no intro authored, or the stage is locked) is a NORMAL state, not an
+ * error: the card simply renders nothing, mirroring ``SiteResourcesPanel``.
+ * Tapping opens the intro in the native ``ChapterReader`` via ``onOpen``.
+ */
+const StageIntroCard = ({ stageNumber, onOpen }: StageIntroCardProps): React.JSX.Element | null => {
+  const [intro, setIntro] = useState<StageIntro | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    // Reset immediately so a previous stage's intro never lingers while the
+    // new one loads (or while the new stage has none).
+    setIntro(null);
+    courseApi
+      .stageIntro(stageNumber)
+      .then((result) => {
+        if (active) setIntro(result);
+      })
+      .catch((err: unknown) => {
+        // No intro / locked stage is expected — keep the card hidden, no banner.
+        console.warn('No stage introduction:', err);
+      });
+    return () => {
+      active = false;
+    };
+  }, [stageNumber]);
+
+  if (!intro) return null;
+
+  return (
+    <TouchableOpacity
+      testID="stage-intro-card"
+      style={styles.introCard}
+      onPress={() => onOpen(stageNumber)}
+      accessibilityRole="button"
+      accessibilityLabel={`Open the ${intro.title} introduction`}
+    >
+      <Text style={styles.introCardLabel}>Introduction</Text>
+      <Text style={styles.introCardTitle}>{intro.title}</Text>
+      {intro.summary ? <Text style={styles.introCardSummary}>{intro.summary}</Text> : null}
+    </TouchableOpacity>
+  );
+};
+
+export default StageIntroCard;

--- a/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
@@ -55,6 +55,9 @@ jest.mock('../../../api', () => ({
     contentBody: jest.fn(),
     siteResources: () => Promise.resolve([]),
     siteResourceBody: jest.fn(),
+    // No intro in these error-state scenarios — keep the card hidden.
+    stageIntro: () => Promise.reject(new Error('content_not_found')),
+    stageIntroBody: jest.fn(),
   },
 }));
 

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -108,6 +108,14 @@ const mockSiteResourceBody = (jest.fn() as any).mockResolvedValue({
   content_type: 'resource',
   body_markdown: 'philosophy\n',
 });
+// Default: the selected stage has no intro (404) — the card stays hidden, so
+// existing tests are unaffected. Intro-specific tests override this.
+const mockStageIntro = (jest.fn() as any).mockRejectedValue({ detail: 'content_not_found' });
+const mockStageIntroBody = (jest.fn() as any).mockResolvedValue({
+  title: 'Welcome to Beige',
+  content_type: 'introduction',
+  body_markdown: '# Welcome to Beige\n\nintro\n',
+});
 
 jest.mock('../../../api', () => ({
   stages: {
@@ -120,6 +128,8 @@ jest.mock('../../../api', () => ({
     contentBody: (...args: unknown[]) => mockContentBody(...args),
     siteResources: (...args: unknown[]) => mockSiteResources(...args),
     siteResourceBody: (...args: unknown[]) => mockSiteResourceBody(...args),
+    stageIntro: (...args: unknown[]) => mockStageIntro(...args),
+    stageIntroBody: (...args: unknown[]) => mockStageIntroBody(...args),
   },
 }));
 
@@ -152,6 +162,8 @@ describe('CourseScreen', () => {
     mockStagesList.mockResolvedValue(sampleStages);
     mockStageContent.mockResolvedValue(sampleContent);
     mockStageProgress.mockResolvedValue(sampleProgress);
+    // Default: no intro for the stage — card hidden unless a test opts in.
+    mockStageIntro.mockRejectedValue({ detail: 'content_not_found' });
   });
 
   it('shows loading spinner initially', () => {
@@ -335,5 +347,65 @@ describe('CourseScreen', () => {
       'JournalEntry',
       expect.objectContaining({ prefillTitle: 'Stage 2 reflection — Welcome Essay' }),
     );
+  });
+
+  it('renders the stage intro card and opens it in the reader when an intro exists', async () => {
+    mockStageIntro.mockResolvedValue({
+      stage: 1,
+      id: 'beige-intro',
+      slug: 'beige-introduction',
+      title: 'Welcome to Beige',
+      summary: 'What Beige is about.',
+    });
+
+    const { getByTestId, getByText } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('stage-intro-card')).toBeTruthy();
+    });
+    expect(getByText('Welcome to Beige')).toBeTruthy();
+    expect(getByText('What Beige is about.')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('stage-intro-card'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('chapter-reader')).toBeTruthy();
+    });
+  });
+
+  it('shows no intro card and no error banner when the stage has no intro', async () => {
+    // Default mockStageIntro rejects with a 404 — a normal, non-error state.
+    const { getByText, queryByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Welcome Essay')).toBeTruthy();
+    });
+    expect(queryByTestId('stage-intro-card')).toBeNull();
+    expect(queryByTestId('course-error')).toBeNull();
+  });
+
+  it('refetches the intro when the stage changes', async () => {
+    mockStageIntro.mockResolvedValue({
+      stage: 1,
+      id: 'beige-intro',
+      slug: 'beige-introduction',
+      title: 'Welcome to Beige',
+      summary: null,
+    });
+
+    const { getByTestId } = render(<CourseScreen />);
+    await waitFor(() => {
+      expect(getByTestId('stage-selector')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('stage-pill-2'));
+    });
+
+    await waitFor(() => {
+      expect(mockStageIntro).toHaveBeenCalledWith(2);
+    });
   });
 });

--- a/frontend/src/features/Course/__tests__/StageIntroCard.test.tsx
+++ b/frontend/src/features/Course/__tests__/StageIntroCard.test.tsx
@@ -1,0 +1,63 @@
+/* eslint-env jest */
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import type * as Api from '../../../api';
+import StageIntroCard from '../StageIntroCard';
+
+jest.mock('../../../api', () => ({
+  course: {
+    stageIntro: jest.fn(),
+  },
+}));
+
+const { course: courseApi } = jest.requireMock('../../../api') as {
+  course: { stageIntro: jest.MockedFunction<typeof Api.course.stageIntro> };
+};
+const mockStageIntro = courseApi.stageIntro;
+
+const INTRO = {
+  stage: 1,
+  id: 'beige-intro',
+  slug: 'beige-introduction',
+  title: 'Welcome to Beige',
+  summary: 'What Beige is about.',
+};
+
+describe('StageIntroCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the intro title + summary and fires onOpen with the stage on press', async () => {
+    mockStageIntro.mockResolvedValue(INTRO);
+    const onOpen = jest.fn();
+    const { getByTestId, getByText } = render(<StageIntroCard stageNumber={1} onOpen={onOpen} />);
+
+    await waitFor(() => expect(getByTestId('stage-intro-card')).toBeTruthy());
+    expect(getByText('Welcome to Beige')).toBeTruthy();
+    expect(getByText('What Beige is about.')).toBeTruthy();
+
+    fireEvent.press(getByTestId('stage-intro-card'));
+    expect(onOpen).toHaveBeenCalledWith(1);
+  });
+
+  it('renders nothing when the stage has no intro (404)', async () => {
+    mockStageIntro.mockRejectedValue({ detail: 'content_not_found' });
+    const { queryByTestId } = render(<StageIntroCard stageNumber={2} onOpen={jest.fn()} />);
+
+    await waitFor(() => expect(mockStageIntro).toHaveBeenCalledWith(2));
+    expect(queryByTestId('stage-intro-card')).toBeNull();
+  });
+
+  it('renders without a summary when none is provided', async () => {
+    mockStageIntro.mockResolvedValue({ ...INTRO, summary: null });
+    const { getByTestId, queryByText } = render(
+      <StageIntroCard stageNumber={1} onOpen={jest.fn()} />,
+    );
+
+    await waitFor(() => expect(getByTestId('stage-intro-card')).toBeTruthy());
+    expect(queryByText('What Beige is about.')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

course-cms-05 (epic #716): nothing surfaced the stage introduction. Add a `StageIntroCard` at the top of the stage (below progress, above the chapter list) that opens the intro in the native-Markdown `ChapterReader` (#720). **A missing/locked intro is a normal state — never an error surface.**

- `StageIntroCard`: self-contained like `SiteResourcesPanel` — fetches `course.stageIntro(stageNumber)` in an effect keyed on the stage (resets to `null`, refetches on change, cancels stale resolves); a 404/failure is caught → `intro` stays `null` → renders nothing. Shows an "Introduction" label + title + optional summary; `testID="stage-intro-card"`, `role="button"`, `accessibilityLabel`, `minHeight: touchTarget.minimum`. Tokens only.
- `useCourseViewer`: + `viewingIntro` + `handleIntroPress`, cleared in `handleBack`; `renderOverlay` opens `<ChapterReader source={{ kind: 'intro', stageNumber }} />` (no footer — intros aren't tracked). Item/resource overlay paths unchanged.

Missing intro → no card, no error banner, chapters still render; metadata/progress/site-resources/drip-feed and all Course `testID`s unchanged.

## Test plan

18 tests across the Course suites: card renders title/summary + opens the reader; no card/no error when absent (chapters still render); refetches on stage change; renders without a summary; error-state suites keep the card hidden. `./scripts/frontend/check-all.sh` → 4/4 (zero-warning lint, no `any`).

Closes #721
Refs #716
