### PR TITLE
fix(practice): generate slug-safe configurator keys (mindful_anchor + tallied_grounding)

### DIFF
--- a/frontend/src/features/Practice/configurator/__tests__/MindfulAnchorForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/MindfulAnchorForm.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
 import type { MindfulAnchorConfig } from '../../engine/types';
+import { OPTION_KEY_PATTERN, validateModeConfig } from '../../engine/validation';
 import MindfulAnchorForm from '../forms/MindfulAnchorForm';
 
 const base: MindfulAnchorConfig = {
@@ -57,7 +58,14 @@ describe('MindfulAnchorForm', () => {
     fireEvent.press(getByTestId('anchor-add-option'));
     const next = onChange.mock.calls[0]![0] as MindfulAnchorConfig;
     expect(next.options).toHaveLength(2);
-    expect(next.options[1]!.key).not.toBe('o1');
+    const newKey = next.options[1]!.key;
+    expect(newKey).not.toBe('o1');
+    // The generated key must satisfy the validator the same module enforces.
+    expect(OPTION_KEY_PATTERN.test(newKey)).toBe(true);
+    // The shipped bug was a *key* error (a field the form can't edit). A new
+    // row may still report an empty-label error (the user fills that in) — but
+    // never a key error.
+    expect(validateModeConfig(next).some((e) => /key/i.test(e))).toBe(false);
   });
 
   it('removes an option', () => {

--- a/frontend/src/features/Practice/configurator/__tests__/TalliedGroundingForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/TalliedGroundingForm.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
 import type { TalliedGroundingConfig } from '../../engine/types';
+import { TALLIED_KEY_PATTERN, validateModeConfig } from '../../engine/validation';
 import TalliedGroundingForm from '../forms/TalliedGroundingForm';
 
 const base: TalliedGroundingConfig = {
@@ -46,8 +47,14 @@ describe('TalliedGroundingForm', () => {
     fireEvent.press(getByTestId('tallied-add-category'));
     const next = onChange.mock.calls[0]![0] as TalliedGroundingConfig;
     expect(next.categories).toHaveLength(2);
-    expect(next.categories[1]!.key).not.toBe('c1');
+    const newKey = next.categories[1]!.key;
+    expect(newKey).not.toBe('c1');
     expect(next.categories[1]!.label).toBe('');
+    // The generated key must pass the validator the form enforces.
+    expect(TALLIED_KEY_PATTERN.test(newKey)).toBe(true);
+    // The shipped bug was a *key* error; an empty-label error may remain (the
+    // user fills it in) but a key error must not.
+    expect(validateModeConfig(next).some((e) => /key/i.test(e))).toBe(false);
   });
 
   it('removes a category', () => {

--- a/frontend/src/features/Practice/configurator/forms/MindfulAnchorForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/MindfulAnchorForm.tsx
@@ -92,7 +92,9 @@ const MindfulAnchorForm = ({ value, onChange }: Props): React.JSX.Element => {
   const removeOption = (index: number) =>
     onChange({ ...value, options: value.options.filter((_, i) => i !== index) });
   const addOption = () => {
-    const key = `option-${(nextOptionKey += 1)}`;
+    // Underscore, not hyphen: the key must match OPTION_KEY_PATTERN
+    // (^[a-z][a-z0-9_]*$) or validateModeConfig rejects the new row.
+    const key = `option_${(nextOptionKey += 1)}`;
     const next: MindfulAnchorOption = { key, label: '' };
     onChange({ ...value, options: [...value.options, next] });
   };

--- a/frontend/src/features/Practice/configurator/forms/TalliedGroundingForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/TalliedGroundingForm.tsx
@@ -69,7 +69,9 @@ const TalliedGroundingForm = ({ value, onChange }: Props): React.JSX.Element => 
   const removeCategory = (index: number) =>
     onChange({ ...value, categories: value.categories.filter((_, i) => i !== index) });
   const addCategory = () => {
-    const key = `category-${(nextCategoryKey += 1)}`;
+    // Underscore, not hyphen: the key must match TALLIED_KEY_PATTERN
+    // (^[a-z][a-z0-9_]*$) or validateModeConfig rejects the new row.
+    const key = `category_${(nextCategoryKey += 1)}`;
     const next: TalliedCategory = { key, label: '', target_count: 1 };
     onChange({ ...value, categories: [...value.categories, next] });
   };


### PR DESCRIPTION
## Summary

de-slop **High** / Family 0 (correctness): pressing **"+ Add option"** (mindful_anchor) or **"+ Add category"** (tallied_grounding) generated a **hyphenated** key (`option-1` / `category-1`) that `OPTION_KEY_PATTERN` / `TALLIED_KEY_PATTERN` (`^[a-z][a-z0-9_]*$`) **reject** — so `validateModeConfig` errored, the wizard's **Next** button disabled, and the user was blocked by an error about a "key" field the form never exposes for editing.

Fix: emit **underscores** (`option_N` / `category_N`), matching the slug pattern the same module enforces.

## Test plan

The two add-row tests now assert the generated key matches `OPTION_KEY_PATTERN` / `TALLIED_KEY_PATTERN` **and** that `validateModeConfig` reports no *key* error for the augmented row (an empty-label error may remain — the user fills that in). The previous assertion only checked `key !== 'o1'`, which is why the bug shipped. `./scripts/frontend/check-all.sh` → 4/4.

Closes #737
