### PR TITLE
fix(security): collapse cross-user goal access to 404 in goal_completions

### DIFF
--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -18,7 +18,7 @@ from dependencies.ownership import log_ownership_denied
 from dependencies.timezone import current_user_timezone
 from domain.dates import day_bounds_in_tz, today_in_tz
 from domain.streaks import is_scheduled_on
-from errors import bad_request, forbidden, not_found
+from errors import bad_request, not_found
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
@@ -95,10 +95,20 @@ async def _get_owned_goal_and_habit(
 
     habit = await session.get(Habit, goal.habit_id)
     if habit is None:
-        raise forbidden("not_owner")
+        # Orphaned FK (goal exists, parent habit gone) — a distinct integrity
+        # signal, but collapsed to 404 like a missing goal so it never acts as
+        # an enumeration oracle (matches dependencies.ownership.require_owned_goal).
+        logger.warning(
+            "orphaned_goal_fk",
+            extra={"goal_id": goal_id, "habit_id": goal.habit_id, "user_id": user_id},
+        )
+        raise not_found("goal")
     if habit.user_id != user_id:
+        # Cross-tenant access is collapsed to 404 (not 403) so a prober cannot
+        # tell "exists but not yours" from "absent" — the enumeration-safe
+        # contract the goals router already enforces.
         log_ownership_denied("goal", goal_id, user_id)
-        raise forbidden("not_owner")
+        raise not_found("goal")
 
     return goal, habit, resolved_id
 

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -324,7 +324,7 @@ async def test_unknown_goal_returns_404(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_other_users_goal_returns_403(
+async def test_other_users_goal_returns_404(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
     _alice_headers, alice_id = await _signup(async_client, "alice")
@@ -332,13 +332,14 @@ async def test_other_users_goal_returns_403(
 
     goal = await _seed_goal(db_session, alice_id)
 
-    # Bob tries to complete Alice's goal
+    # Bob tries to complete Alice's goal — collapsed to 404 (not 403) so the
+    # endpoint can't be used to enumerate other users' goals.
     resp = await async_client.post(
         "/goal_completions/",
         json={"goal_id": goal.id, "did_complete": True},
         headers=bob_headers,
     )
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
 @pytest.mark.asyncio
@@ -358,7 +359,7 @@ async def test_cross_tenant_goal_completion_emits_audit_log(
             json={"goal_id": goal.id, "did_complete": True},
             headers=bob_headers,
         )
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.status_code == HTTPStatus.NOT_FOUND
     deny_logs = [r for r in caplog.records if r.message == "resource_access_denied"]
     assert deny_logs, "expected a resource_access_denied audit log entry"
     assert getattr(deny_logs[0], "resource", None) == "goal"

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -102,7 +102,7 @@ async def test_update_goal_404_when_goal_missing(async_client: AsyncClient) -> N
 
 
 @pytest.mark.asyncio
-async def test_update_goal_403_when_caller_not_owner(
+async def test_update_goal_404_when_caller_not_owner(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
     """Cross-tenant probe: alice's goal cannot be updated by bob.


### PR DESCRIPTION
## Summary

de-slop **High** / Family 5 + 10 (inconsistent error contract + enumeration leak). `POST /goal_completions` raised **403 `not_owner`** for a goal owned by another user, while `PUT /goals/{id}` (`require_owned_goal`) returns **404** for the byte-identical case — so the completions endpoint **leaked goal existence** (403 = "exists but not yours" vs 404 = "absent") to a cross-tenant prober. Same IDOR class fixed for journal in #646.

Route the completions helper through the same enumeration-safe **404** contract:
- cross-user goal → `not_found("goal")` (still audited via `log_ownership_denied`);
- orphaned goal→habit FK → log `orphaned_goal_fk` + `not_found("goal")`, matching `require_owned_goal` exactly.

`forbidden` is no longer used here; dropped the import.

## Test plan

- Cross-user completion now asserts **404** (test renamed to `..._404`); the audit-log test asserts 404 while still expecting the `resource_access_denied` row.
- Fixed the mislabelled `test_update_goal_403_when_caller_not_owner` (always asserted 404) → `..._404_...`.
- `./scripts/backend/check-all.sh` → 7/7; xenon A.

Closes #738
