### PR TITLE
fix(contracts): drop required user_id from userPractice + practiceSession schemas

### DIFF
--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -374,16 +374,17 @@ describe('per-item paginated schemas', () => {
     expect(parsed.name).toBe('Breath');
   });
 
+  // No user_id: the backend omits it from user-scoped responses (BUG-T7), so the
+  // live shape this validator parses never carries it.
   const userPractice = {
     id: 3,
-    user_id: 1,
     practice_id: 7,
     stage_number: 2,
     start_date: '2026-01-01',
     end_date: null,
   };
 
-  it('userPracticeSchema accepts valid (optional overrides) and rejects drift', () => {
+  it('userPracticeSchema accepts the live shape without user_id and rejects drift', () => {
     expect(userPracticeSchema.parse(userPractice).end_date).toBeNull();
     expect(() =>
       userPracticeSchema.parse({ ...userPractice, effective_name: 'My Breath' }),
@@ -391,16 +392,16 @@ describe('per-item paginated schemas', () => {
     expect(() => userPracticeSchema.parse({ ...userPractice, start_date: undefined })).toThrow();
   });
 
+  // No user_id — same OwnedResourcePublic (BUG-T7) contract as userPractice.
   const session = {
     id: 9,
-    user_id: 1,
     user_practice_id: 3,
     duration_minutes: 10,
     timestamp: '2026-03-01T10:30:00Z',
     reflection: null,
   };
 
-  it('practiceSessionResponseSchema accepts valid and rejects a non-ISO timestamp', () => {
+  it('practiceSessionResponseSchema accepts the live shape (no user_id) and rejects a non-ISO timestamp', () => {
     expect(practiceSessionResponseSchema.parse(session).reflection).toBeNull();
     expect(() => practiceSessionResponseSchema.parse({ ...session, timestamp: 'oops' })).toThrow();
     expect(() =>

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1554,7 +1554,8 @@ export interface PracticeItem {
 
 export interface UserPractice {
   id: number;
-  user_id: number;
+  /** Omitted by the backend's user-scoped responses (OwnedResourcePublic / BUG-T7). */
+  user_id?: number | null;
   practice_id: number;
   stage_number: number;
   start_date: string;
@@ -1699,7 +1700,8 @@ export interface PracticeSessionCreate {
 
 export interface PracticeSessionResponse {
   id: number;
-  user_id: number;
+  /** Omitted by the backend's user-scoped responses (OwnedResourcePublic / BUG-T7). */
+  user_id?: number | null;
   user_practice_id: number;
   duration_minutes: number;
   timestamp: string;

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -341,7 +341,9 @@ export const practiceRecipeSchema = z.object({
 /** A user's selected practice (mirrors ``UserPractice``). */
 export const userPracticeSchema = z.object({
   id: z.number().int(),
-  user_id: z.number().int(),
+  // Backend omits user_id from user-scoped responses (OwnedResourcePublic /
+  // BUG-T7); nullish so a well-formed payload without it still validates.
+  user_id: z.number().int().nullish(),
   practice_id: z.number().int(),
   stage_number: z.number().int(),
   start_date: isoDate,
@@ -355,7 +357,9 @@ export const userPracticeSchema = z.object({
 /** A logged practice session (mirrors ``PracticeSessionResponse``). */
 export const practiceSessionResponseSchema = z.object({
   id: z.number().int(),
-  user_id: z.number().int(),
+  // Backend omits user_id from user-scoped responses (OwnedResourcePublic /
+  // BUG-T7); nullish so a well-formed payload without it still validates.
+  user_id: z.number().int().nullish(),
   user_practice_id: z.number().int(),
   duration_minutes: z.number(),
   timestamp: isoDateTime,


### PR DESCRIPTION
## Summary

de-slop **High** / Family 8 (frontend/backend shape drift). The backend removed `user_id` from every user-scoped response (`OwnedResourcePublic` / BUG-T7), and the habit/goal-group Zod validators were updated to tolerate its absence — but `userPracticeSchema` and `practiceSessionResponseSchema` still **hard-required** it. Both are wired as **live response validators** (`pageSchema(...)`), so a paginated fetch threw `ApiValidationError` on a well-formed, `user_id`-less backend payload.

- `schemas.ts`: `user_id` → `z.number().int().nullish()` on both schemas.
- `index.ts`: `user_id` optional (`number | null`) on the `UserPractice` + `PracticeSessionResponse` interfaces.
- `schemas.test.ts`: dropped the masking `user_id: 1` from both fixtures (which hid the drift) so the tests now parse the real no-`user_id` shape.

## Test plan

Both fixtures now omit `user_id`; the schema tests parse them without throwing (proving the live contract). `./scripts/frontend/check-all.sh` → 4/4.

Closes #739
