### PR TITLE
feat(ralph): restructure recap embed headers, fields, and windows

### DIFF
--- a/scripts/ralph/RECAP.md
+++ b/scripts/ralph/RECAP.md
@@ -1,10 +1,11 @@
 # Ralph Discord Recap
 
-Whenever a PR merges, this posts a clean Discord embed summarizing how
-adepthood's Ralph tick loop is doing: PRs merged, merge rate, average review
-iterations before LGTM, estimated time remaining on the backlog, the busiest
-day, the latest PR's footprint, and a ten-word headline for what the latest
-merge unlocked.
+Whenever a PR merges, this posts a clean Discord embed in two blocks —
+`————THIS PR————` (the just-merged PR: its unlock headline, link, footprint,
+review iterations, review time, and tick length) and `————THE LOOP————` (the
+rolling/all-time figures: busiest day, PRs merged, lines of code, merge rate,
+review iterations, review time, tick length, and backlog remaining). Within each
+block, multi-window stats run smallest window first (24h → 7d → all-time).
 
 A "Ralph tick loop" is the autonomous loop driven by `/loop /ralph-tick` (see
 `.claude/commands/ralph-tick.md`): each tick opens a PR, iterates against the
@@ -82,9 +83,15 @@ recent work instead of being diluted by a frozen lifetime average. The window is
 fetched via the search API (`is:pr is:merged merged:>=<date>`), capped at
 `--max-prs` (default 200) as a safety bound on a burst day.
 
-- **PRs merged** — the true cumulative count of merged PRs from the search API
-  (`total_count`), independent of any per-run fetch cap, plus "in 24h" and
-  "in 7d" counts from the window.
+- **PRs merged** — "in 24h" and "in 7d" counts from the window, then the true
+  cumulative all-time count from the search API (`total_count`), which is
+  independent of any per-run fetch cap (smallest window first).
+- **LoC** — lines-of-code churn as `+additions / -deletions` over the trailing
+  24h and 7d windows (summed from each window PR's detail call), then the
+  **full-repo net** from GitHub's code-frequency stats API
+  (`/stats/code_frequency`, additions − deletions across all history). The stats
+  endpoint warms asynchronously and answers 202 on a cold cache, so the full-repo
+  figure retries a few times and falls back to "—" if still unavailable.
 - **Merge rate** — rolling windows: merges in the last 24h as **per-hour**, and
   merges in the last 7 days as **per-day**. Fixed-width windows move every recap
   and decay toward zero when the loop idles. The 7-day per-day figure (steadier
@@ -112,14 +119,19 @@ fetched via the search API (`is:pr is:merged merged:>=<date>`), capped at
 - **Busiest day** (7d) — the UTC calendar day in the window with the most merges.
 
 The embed groups fields into two labelled blocks so a single merge's numbers are
-never confused with the dataset-wide ones:
+never confused with the dataset-wide ones. The `————THIS PR————` block holds:
 
-- **This PR · time to merge** — the just-merged PR's own `opened → merged`
-  window, plus `since the previous merge (full tick)` — the gap from the prior
-  merge, the per-PR analogue of the tick cadence. Both move on every recap.
-- **This PR · footprint** — additions/deletions/changed-files for the most
-  recently merged PR (the list endpoint omits diff stats, so it's fetched via
-  the single-PR detail endpoint).
+- **Unlock** — the ten-word "what this merge unlocked" headline (see below).
+- **Link** — the PR number, title, and URL.
+- **Footprint** — additions/deletions/changed-files for the just-merged PR (the
+  list endpoint omits diff stats, so it's fetched via the single-PR detail
+  endpoint).
+- **Review iterations** — this PR's own rounds before its first LGTM verdict
+  (`0` reads "clean first try"; a PR merged without an LGTM verdict says so).
+- **Time for review** — this PR's own `opened → merged` window.
+- **Tick length** — the gap from the previous merge, the per-PR analogue of the
+  tick cadence (`first tracked merge` when there is no prior merge in the window).
+
 - **The ten-word headline** — `generate_headline` asks `claude-opus-4-8`
   (effort `low`) for a plain-language headline of what the latest merge
   unlocked, and degrades to the cleaned PR title on any SDK/API absence or

--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -66,11 +66,12 @@ EMBED_COLOR = 0x7C3AED
 # Zero-width space — a non-empty Discord field value that renders as blank, used
 # to turn a field into a header-only line.
 BLANK = "​"
-# Section headers. Discord can't size text, so uppercase + a trailing heavy rule
-# is what makes these read as section breaks rather than another bold field label.
-_RULE = "━" * 6
-THIS_PR_HEADER = f"📌  THIS PR  {_RULE}"
-LOOP_HEADER = f"📊  THE LOOP · 7D + ALL-TIME  {_RULE}"
+# Section headers. Discord can't size text, so uppercase flanked by four em-dashes
+# on each side is what makes these read as section breaks rather than another bold
+# field label. No emoji, no window qualifier — just the section name.
+_RULE = "—" * 4
+THIS_PR_HEADER = f"{_RULE}THIS PR{_RULE}"
+LOOP_HEADER = f"{_RULE}THE LOOP{_RULE}"
 # The windowed stats (iterations, time-to-merge, tick cadence, busiest day) cover
 # this trailing span so they move with recent activity, not a frozen all-time average.
 RECENT_WINDOW_DAYS = 7
@@ -204,6 +205,24 @@ def fetch_pr_detail(repo: str, number: int, *, token: str) -> dict[str, Any]:
     return cast("dict[str, Any]", _request_json(url, headers=_gh_headers(token)))
 
 
+def _pr_churn(repo: str, number: int, *, token: str) -> tuple[int, int, int]:
+    """Return one PR's (additions, deletions, changed_files) from its detail.
+
+    The search/list endpoints omit diff stats, so each PR needs its own detail
+    call. A transport failure on a single PR degrades to a zero tuple rather than
+    failing the whole recap — the LoC sums simply skip that PR's churn.
+    """
+    try:
+        detail = fetch_pr_detail(repo, number, token=token)
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        return (0, 0, 0)
+    return (
+        int(detail.get("additions", 0)),
+        int(detail.get("deletions", 0)),
+        int(detail.get("changed_files", 0)),
+    )
+
+
 def fetch_pr_verdicts(repo: str, number: int, *, token: str) -> list[str]:
     """Return the ordered list of normalized Claude verdicts on one PR."""
     comments = _gh_get_paged(
@@ -218,6 +237,25 @@ def fetch_pr_verdicts(repo: str, number: int, *, token: str) -> list[str]:
         if verdict is not None:
             verdicts.append(verdict)
     return verdicts
+
+
+def fetch_repo_net_lines(repo: str, *, token: str, attempts: int = 3) -> int | None:
+    """Return net lines of code across the whole repo via the code-frequency stats API.
+
+    GitHub computes the per-week additions/deletions stats asynchronously and
+    answers 202 with an empty body on a cold cache, so retry a few times. Any
+    failure (still warming, or an HTTP/transport error) returns None so the recap
+    shows a placeholder for the full-repo figure instead of failing outright.
+    """
+    url = f"{GITHUB_API}/repos/{repo}/stats/code_frequency"
+    for _ in range(attempts):
+        try:
+            data = _request_json(url, headers=_gh_headers(token))
+        except (urllib.error.HTTPError, urllib.error.URLError):
+            return None
+        if data:
+            return stats.net_lines_from_code_frequency(cast("list[list[int]]", data))
+    return None
 
 
 def _excluded_labels() -> set[str]:
@@ -368,25 +406,25 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
 
     merged_at = [_pr_merged_at(pr) for pr in window]
 
+    # One pass over the window collects both review rounds (from verdicts) and
+    # churn (from PR detail) per PR. window[0] is the just-merged PR, so its own
+    # figures fall out of index 0 without a second fetch.
     iterations: list[int] = []
-    for pr in window:
+    churn: list[tuple[int, int, int]] = []
+    latest_iterations: int | None = None
+    for index, pr in enumerate(window):
         verdicts = fetch_pr_verdicts(repo, int(pr["number"]), token=token)
         rounds = stats.iterations_before_lgtm(verdicts)
         if rounds is not None:
             iterations.append(rounds)
+        if index == 0:
+            latest_iterations = rounds
+        churn.append(_pr_churn(repo, int(pr["number"]), token=token))
 
     open_to_merge = [_open_to_merge_hours(pr) for pr in window]
     intervals = stats.merge_intervals_hours(merged_at)
 
     latest = window[0]
-    latest_detail = fetch_pr_detail(repo, int(latest["number"]), token=token)
-    churn = [
-        (
-            int(latest_detail.get("additions", 0)),
-            int(latest_detail.get("deletions", 0)),
-            int(latest_detail.get("changed_files", 0)),
-        )
-    ]
 
     rate = stats.merge_rate(merged_at, now=now)
     ttm = stats.time_to_merge_stats(open_to_merge)
@@ -394,8 +432,15 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
     iters = stats.iteration_stats(iterations)
     open_items = count_open_backlog(repo, token=token)
     estimate = stats.estimate_remaining(open_items, rate["per_day"], now=now)
-    totals = stats.churn_totals(churn)
     busy = stats.busiest_day(merged_at)
+
+    # Footprint is the just-merged PR; the loop's LoC sums the 7d window (the whole
+    # fetched set) and the 24h slice of it, with the full-repo net from the stats API.
+    day_ago = now - dt.timedelta(hours=stats.HOURS_PER_DAY)
+    latest_churn = stats.churn_totals(churn[:1])
+    loc_7d = stats.churn_totals(churn)
+    loc_24h = stats.churn_totals([c for c, ts in zip(churn, merged_at) if ts >= day_ago])
+    repo_net = fetch_repo_net_lines(repo, token=token)
 
     headline = generate_headline(str(latest.get("title", "")), str(latest.get("body") or ""))
 
@@ -413,8 +458,12 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
         tick=tick,
         iters=iters,
         estimate=estimate,
-        latest_churn=totals,
+        latest_churn=latest_churn,
+        loc_24h=loc_24h,
+        loc_7d=loc_7d,
+        repo_net=repo_net,
         busy=busy,
+        latest_iterations=latest_iterations,
         latest_ttm_hours=latest_ttm_hours,
         latest_tick_hours=latest_tick_hours,
         now=now,
@@ -431,12 +480,36 @@ def _stat_line(summary: dict[str, float]) -> str:
     )
 
 
-def _this_pr_time_line(latest_ttm_hours: float, latest_tick_hours: float | None) -> str:
-    """One-line time summary for the just-merged PR: review window + full tick."""
-    line = f"**{_fmt_hours(latest_ttm_hours)}** open → merge"
-    if latest_tick_hours is not None:
-        line += f"\n{_fmt_hours(latest_tick_hours)} since the previous merge (full tick)"
-    return line
+def _this_pr_review_line(latest_ttm_hours: float) -> str:
+    """The just-merged PR's own open → merge review window."""
+    return f"**{_fmt_hours(latest_ttm_hours)}** open → merge"
+
+
+def _this_pr_tick_line(latest_tick_hours: float | None) -> str:
+    """The just-merged PR's full tick — the gap since the previous merge."""
+    if latest_tick_hours is None:
+        return "first tracked merge"
+    return f"**{_fmt_hours(latest_tick_hours)}** since the previous merge"
+
+
+def _this_pr_iter_line(latest_iterations: int | None) -> str:
+    """Review rounds the just-merged PR took before its first LGTM verdict."""
+    if latest_iterations is None:
+        return "merged without an LGTM verdict"
+    if latest_iterations == 0:
+        return "**0** rounds · clean first try"
+    plural = "round" if latest_iterations == 1 else "rounds"
+    return f"**{latest_iterations}** {plural} to LGTM"
+
+
+def _loc_line(loc_24h: dict[str, int], loc_7d: dict[str, int], repo_net: int | None) -> str:
+    """Lines-of-code churn over the 24h and 7d windows, plus the full-repo net."""
+
+    def churn(totals: dict[str, int]) -> str:
+        return f"+{totals['additions']:,} / -{totals['deletions']:,}"
+
+    full_repo = f"{repo_net:,} net" if repo_net is not None else "—"
+    return f"{churn(loc_24h)} (24h) · {churn(loc_7d)} (7d) · {full_repo} (full repo)"
 
 
 def _render_embed(
@@ -451,7 +524,11 @@ def _render_embed(
     iters: dict[str, float],
     estimate: dict[str, object],
     latest_churn: dict[str, int],
+    loc_24h: dict[str, int],
+    loc_7d: dict[str, int],
+    repo_net: int | None,
     busy: tuple[str, int] | None,
+    latest_iterations: int | None,
     latest_ttm_hours: float,
     latest_tick_hours: float | None,
     now: dt.datetime,
@@ -460,7 +537,8 @@ def _render_embed(
 
     Fields are split into two labelled blocks: the just-merged PR ("This PR")
     and the rolling/all-time loop figures ("The loop"), so a single merge's
-    numbers are never confused with the dataset-wide ones.
+    numbers are never confused with the dataset-wide ones. Within each block,
+    multi-window stats run smallest window first (24h → 7d → all-time).
     """
     pr_number = int(latest["number"])
     pr_url = str(latest.get("html_url", f"https://github.com/{repo}/pull/{pr_number}"))
@@ -482,34 +560,35 @@ def _render_embed(
         # section header so the blocks breathe instead of butting up against the
         # field before them.
         {"name": BLANK, "value": BLANK, "inline": False},
-        {
-            "name": THIS_PR_HEADER,
-            "value": f"*{headline}*\n[#{pr_number} — {latest.get('title', '')}]({pr_url})",
-            "inline": False,
-        },
-        {"name": "⏱️ Time to merge", "value": _this_pr_time_line(latest_ttm_hours, latest_tick_hours), "inline": True},
+        {"name": THIS_PR_HEADER, "value": BLANK, "inline": False},
+        {"name": "🔓 Unlock", "value": f"*{headline}*", "inline": False},
+        {"name": "🔗 Link", "value": f"[#{pr_number} — {latest.get('title', '')}]({pr_url})", "inline": False},
         {"name": "🧮 Footprint", "value": footprint, "inline": True},
+        {"name": "🔁 Review iterations", "value": _this_pr_iter_line(latest_iterations), "inline": True},
+        {"name": "⏱️ Time for review", "value": _this_pr_review_line(latest_ttm_hours), "inline": True},
+        {"name": "🔄 Tick length", "value": _this_pr_tick_line(latest_tick_hours), "inline": True},
         {"name": BLANK, "value": BLANK, "inline": False},
         {"name": LOOP_HEADER, "value": BLANK, "inline": False},
+        {"name": "🔥 Busiest day (7d)", "value": busy_line, "inline": True},
         {
             "name": "📦 PRs merged",
-            "value": f"**{total_merged}** all-time · {int(rate['last_24h'])} in 24h · {int(rate['last_7_days'])} in 7d",
+            "value": f"{int(rate['last_24h'])} in 24h · {int(rate['last_7_days'])} in 7d · **{total_merged}** all-time",
             "inline": True,
         },
+        {"name": "📈 LoC", "value": _loc_line(loc_24h, loc_7d, repo_net), "inline": False},
         {
             "name": "⚡ Merge rate",
             "value": f"**{rate['per_hour']:.2f}**/hr (24h) · {rate['per_day']:.1f}/day (7d)",
             "inline": True,
         },
         {"name": "🔁 Review iterations (7d)", "value": iter_line, "inline": False},
-        {"name": "⏱️ Time to merge · opened → merged (7d)", "value": _stat_line(ttm), "inline": False},
-        {"name": "🔄 Tick cadence · merge → merge (7d)", "value": _stat_line(tick), "inline": False},
+        {"name": "⏱️ Time for review (7d)", "value": _stat_line(ttm), "inline": False},
+        {"name": "🔄 Tick length (7d)", "value": _stat_line(tick), "inline": False},
         {
             "name": "🗺️ Backlog remaining",
             "value": f"**{estimate['open_items']}** open · ETA {_fmt_eta(estimate)}",
             "inline": True,
         },
-        {"name": "🔥 Busiest day (7d)", "value": busy_line, "inline": True},
     ]
 
     embed = {

--- a/scripts/ralph/stats.py
+++ b/scripts/ralph/stats.py
@@ -196,6 +196,16 @@ def churn_totals(churn: list[tuple[int, int, int]]) -> dict[str, int]:
     }
 
 
+def net_lines_from_code_frequency(weeks: list[list[int]]) -> int:
+    """Sum GitHub's weekly code-frequency rows into the repo's net lines of code.
+
+    Each row is `[unix_week, additions, deletions]` and GitHub reports deletions
+    as a negative number, so the running net is just additions and deletions added
+    straight across every week. Returns 0 for an empty history.
+    """
+    return sum(int(week[1]) + int(week[2]) for week in weeks)
+
+
 def busiest_day(merged_at: list[dt.datetime]) -> tuple[str, int] | None:
     """Return the (ISO date, count) of the day with the most merges, or None."""
     if not merged_at:

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -177,6 +177,19 @@ def test_churn_totals_sums_and_nets() -> None:
     assert out["files"] == 3
 
 
+# ---------- net_lines_from_code_frequency ----------
+
+
+def test_net_lines_from_code_frequency_sums_signed_weeks() -> None:
+    # GitHub reports deletions as negatives: (100-30) + (50-10) = 110.
+    weeks = [[1_700_000_000, 100, -30], [1_700_600_000, 50, -10]]
+    assert rs.net_lines_from_code_frequency(weeks) == 110
+
+
+def test_net_lines_from_code_frequency_empty_is_zero() -> None:
+    assert rs.net_lines_from_code_frequency([]) == 0
+
+
 # ---------- busiest_day ----------
 
 
@@ -266,6 +279,80 @@ def test_open_to_merge_hours_clamps_negative_to_zero() -> None:
     # Clock skew (merge stamped before open) must not produce a negative window.
     pr = _hit(1, merged="2026-06-27T10:00:00Z", created="2026-06-27T12:00:00Z")
     assert recap._open_to_merge_hours(pr) == 0.0
+
+
+# ---------- _pr_churn ----------
+
+
+def test_pr_churn_reads_detail_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "fetch_pr_detail", lambda *a, **k: {"additions": 12, "deletions": 4, "changed_files": 3})
+    assert recap._pr_churn("owner/repo", 1, token="t") == (12, 4, 3)
+
+
+def test_pr_churn_degrades_to_zero_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    def _boom(*_a: Any, **_k: Any) -> dict[str, Any]:
+        raise urllib.error.URLError("network down")
+
+    monkeypatch.setattr(recap, "fetch_pr_detail", _boom)
+    assert recap._pr_churn("owner/repo", 1, token="t") == (0, 0, 0)
+
+
+# ---------- fetch_repo_net_lines ----------
+
+
+def test_fetch_repo_net_lines_sums_code_frequency(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: [[1, 100, -40], [2, 20, -5]])
+    assert recap.fetch_repo_net_lines("owner/repo", token="t") == 75
+
+
+def test_fetch_repo_net_lines_none_when_stats_still_warming(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A 202 from GitHub yields an empty body (None); retries exhaust to None.
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: None)
+    assert recap.fetch_repo_net_lines("owner/repo", token="t", attempts=2) is None
+
+
+def test_fetch_repo_net_lines_none_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    def _boom(*_a: Any, **_k: Any) -> object:
+        raise urllib.error.HTTPError("u", 500, "err", {}, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(recap, "_request_json", _boom)
+    assert recap.fetch_repo_net_lines("owner/repo", token="t") is None
+
+
+# ---------- this-PR display lines ----------
+
+
+def test_this_pr_iter_line_variants() -> None:
+    assert recap._this_pr_iter_line(None) == "merged without an LGTM verdict"
+    assert recap._this_pr_iter_line(0) == "**0** rounds · clean first try"
+    assert recap._this_pr_iter_line(1) == "**1** round to LGTM"
+    assert recap._this_pr_iter_line(3) == "**3** rounds to LGTM"
+
+
+def test_this_pr_tick_line_handles_first_merge() -> None:
+    assert recap._this_pr_tick_line(None) == "first tracked merge"
+    assert recap._this_pr_tick_line(0.5) == "**30m** since the previous merge"
+
+
+def test_this_pr_review_line_formats_window() -> None:
+    assert recap._this_pr_review_line(2.0) == "**2.0h** open → merge"
+
+
+def test_loc_line_renders_three_windows() -> None:
+    loc_24h = {"additions": 1200, "deletions": 300, "net": 900, "files": 5}
+    loc_7d = {"additions": 8400, "deletions": 1600, "net": 6800, "files": 40}
+    line = recap._loc_line(loc_24h, loc_7d, 124_500)
+    assert line == "+1,200 / -300 (24h) · +8,400 / -1,600 (7d) · 124,500 net (full repo)"
+
+
+def test_loc_line_placeholder_when_repo_net_unavailable() -> None:
+    totals = {"additions": 0, "deletions": 0, "net": 0, "files": 0}
+    line = recap._loc_line(totals, totals, None)
+    assert line.endswith("— (full repo)")
 
 
 # ---------- _heuristic_headline ----------


### PR DESCRIPTION
Reformat the Ralph Discord recap to match the requested layout.

Headers now read "————THIS PR————" and "————THE LOOP————" — four em-dashes
on each side, no leading emoji, and no window qualifier on the loop header.

Re-order the stats so every multi-window figure runs smallest window first
(24h → 7d → all-time), and split/rename fields:

THIS PR: Unlock, Link, Footprint, Review iterations (this PR's own rounds),
Time for review, Tick length — each now its own field.

THE LOOP: Busiest day, PRs merged (24h → 7d → all-time), LoC (24h / 7d churn
plus full-repo net from the code-frequency stats API), Merge rate, Review
iterations, Time for review, Tick length, Backlog remaining.

LoC needs per-PR diff stats, so the window pass now also fetches each PR's
churn (degrading to zero on a single-PR transport error); the full-repo net
comes from /stats/code_frequency and falls back to "—" while the stats cache
is still warming.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015ipNY2Rd4FcsYrRnRu7wfN