### PR TITLE
refactor(backend): move SubtractiveContext + streak walk into the domain layer

### DIFF
--- a/backend/src/domain/habit_stats.py
+++ b/backend/src/domain/habit_stats.py
@@ -6,8 +6,13 @@ from datetime import UTC, date, timedelta
 from typing import TYPE_CHECKING
 
 from domain.dates import to_user_date, today_in_tz
+from domain.streaks import (
+    SubtractiveContext,
+    subtractive_current_streak,
+    subtractive_day_totals,
+    subtractive_longest_streak,
+)
 from schemas.habit_stats import HabitStats
-from services.streaks import SubtractiveContext
 
 if TYPE_CHECKING:
     from models.goal_completion import GoalCompletion
@@ -86,71 +91,6 @@ def _completion_rate(sorted_dates: list[date], user_timezone: str) -> float:
     return len(sorted_dates) / span if span > 0 else 0.0
 
 
-def _subtractive_day_totals(
-    completions: list[GoalCompletion],
-    user_timezone: str,
-) -> dict[date, float]:
-    """Sum completion units per user-local day, including zero-sum days.
-
-    Mirrors :func:`services.streaks._bucket_day_totals` so the abstention
-    walks here line up with the streak helpers; a key with no row at all
-    is reads as 0 (perfect abstention).
-    """
-    day_totals: dict[date, float] = {}
-    for c in completions:
-        moment = c.timestamp if c.timestamp.tzinfo is not None else c.timestamp.replace(tzinfo=UTC)
-        day = to_user_date(user_timezone, moment)
-        day_totals[day] = day_totals.get(day, 0.0) + c.completed_units
-    return day_totals
-
-
-def _subtractive_current_streak(
-    day_totals: dict[date, float],
-    user_timezone: str,
-    ctx: SubtractiveContext,
-) -> int:
-    """Walk backwards from today counting abstention days, bounded by ``start_date``."""
-    today = today_in_tz(user_timezone)
-    if ctx.start_date > today:
-        return 0
-    streak = 0
-    cursor = today
-    while cursor >= ctx.start_date:
-        if day_totals.get(cursor, 0.0) > ctx.clear_threshold:
-            break
-        streak += 1
-        cursor -= timedelta(days=1)
-    return streak
-
-
-def _subtractive_longest_streak(
-    day_totals: dict[date, float],
-    user_timezone: str,
-    ctx: SubtractiveContext,
-) -> int:
-    """Longest no-transgression run across ``[start_date, today]``.
-
-    Without this the API's ``longest_streak`` for a subtractive habit
-    falls through to the additive helper, which sorts logged days --
-    producing 0 for the no-log case and a contradictory display
-    (``current=N, longest=0``) for any user mid-abstention.
-    """
-    today = today_in_tz(user_timezone)
-    if ctx.start_date > today:
-        return 0
-    longest = 0
-    run = 0
-    cursor = ctx.start_date
-    while cursor <= today:
-        if day_totals.get(cursor, 0.0) > ctx.clear_threshold:
-            run = 0
-        else:
-            run += 1
-            longest = max(longest, run)
-        cursor += timedelta(days=1)
-    return longest
-
-
 def _subtractive_stats(
     completions: list[GoalCompletion],
     user_timezone: str,
@@ -166,13 +106,13 @@ def _subtractive_stats(
     """
     units, presence, dates = _aggregate_by_day(completions, user_timezone)
     sorted_dates = sorted(dates)
-    day_totals = _subtractive_day_totals(completions, user_timezone)
+    day_totals = subtractive_day_totals(completions, user_timezone)
     return HabitStats(
         day_labels=list(_DAY_LABELS),
         values=units,
         completions_by_day=presence,
-        longest_streak=_subtractive_longest_streak(day_totals, user_timezone, ctx),
-        current_streak=_subtractive_current_streak(day_totals, user_timezone, ctx),
+        longest_streak=subtractive_longest_streak(day_totals, user_timezone, ctx),
+        current_streak=subtractive_current_streak(day_totals, user_timezone, ctx),
         total_completions=len(completions),
         completion_rate=_completion_rate(sorted_dates, user_timezone),
         completion_dates=[d.isoformat() for d in sorted_dates],

--- a/backend/src/domain/streaks.py
+++ b/backend/src/domain/streaks.py
@@ -2,6 +2,17 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from domain.dates import to_user_date, today_in_tz
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from models.goal_completion import GoalCompletion
+
 # Canonical weekday names accepted in ``Habit.notification_days``,
 # mirroring ``date.strftime("%a")``.
 WEEKDAY_ABBREVIATIONS: tuple[str, ...] = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
@@ -31,3 +42,104 @@ def update_streak(
     if not is_scheduled_today:
         return current_streak, "streak_held"
     return 0, "streak_reset"
+
+
+@dataclass(frozen=True)
+class SubtractiveContext:
+    """Habit-level context required to compute a subtractive streak.
+
+    Bundles the two values a subtractive-habit streak walk needs into a single
+    kwarg so streak functions stay under the project's ``PLR0913`` (max-5-args)
+    bar even after picking up the abstention code path.  ``clear_threshold`` is
+    the day's failure cutoff (sum > threshold = transgression); ``start_date``
+    is the habit's birth so the walk cannot accrue streak days before the habit
+    existed.
+    """
+
+    clear_threshold: float
+    start_date: date
+
+
+def _subtractive_user_date(ts: datetime | str, user_timezone: str) -> date:
+    """Bucket a stored timestamp into the user's local calendar day.
+
+    Accepts a :class:`datetime` (the Postgres ``timestamptz`` path) or an
+    ISO-8601 string (SQLite returns these for tz-aware columns).  Naive values
+    are treated as UTC — acceptable here because the source column is declared
+    timezone-aware and SQLite merely lies about its storage.
+    """
+    if isinstance(ts, datetime):
+        moment = ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
+    else:
+        parsed = datetime.fromisoformat(ts)
+        moment = parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+    return to_user_date(user_timezone, moment)
+
+
+def subtractive_day_totals(
+    completions: Sequence[GoalCompletion],
+    user_timezone: str,
+) -> dict[date, float]:
+    """Sum completion units per user-local day, *without* the >0 filter.
+
+    For subtractive habits the absence of a row means perfect abstention, so the
+    bucketing keeps zero-sum days addressable too.  Callers treat
+    ``get(day, 0.0)`` as the "did the user stay under their limit" probe.
+    """
+    day_totals: dict[date, float] = {}
+    for c in completions:
+        day = _subtractive_user_date(c.timestamp, user_timezone)
+        day_totals[day] = day_totals.get(day, 0.0) + c.completed_units
+    return day_totals
+
+
+def subtractive_current_streak(
+    day_totals: dict[date, float],
+    user_timezone: str,
+    ctx: SubtractiveContext,
+) -> int:
+    """Count consecutive abstention days for a subtractive habit.
+
+    Walks backwards from today; a day counts when its total is at most
+    ``ctx.clear_threshold`` (trivially true for a day with no row).  Stops on a
+    transgression (total above the threshold) or when the cursor crosses
+    ``ctx.start_date``.  Returns 0 when the habit has not begun yet.
+    """
+    today = today_in_tz(user_timezone)
+    if ctx.start_date > today:
+        return 0
+    streak = 0
+    cursor = today
+    while cursor >= ctx.start_date:
+        if day_totals.get(cursor, 0.0) > ctx.clear_threshold:
+            break
+        streak += 1
+        cursor -= timedelta(days=1)
+    return streak
+
+
+def subtractive_longest_streak(
+    day_totals: dict[date, float],
+    user_timezone: str,
+    ctx: SubtractiveContext,
+) -> int:
+    """Longest no-transgression run across ``[start_date, today]``.
+
+    Walks forwards from ``start_date``; each abstention day extends the current
+    run (tracking the maximum), and a transgression resets it.  Returns 0 when
+    the habit has not begun yet.
+    """
+    today = today_in_tz(user_timezone)
+    if ctx.start_date > today:
+        return 0
+    longest = 0
+    run = 0
+    cursor = ctx.start_date
+    while cursor <= today:
+        if day_totals.get(cursor, 0.0) > ctx.clear_threshold:
+            run = 0
+        else:
+            run += 1
+            longest = max(longest, run)
+        cursor += timedelta(days=1)
+    return longest

--- a/backend/src/services/streaks.py
+++ b/backend/src/services/streaks.py
@@ -25,7 +25,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from domain.dates import to_user_date, today_in_tz
-from domain.streaks import update_streak
+from domain.streaks import (
+    SubtractiveContext,
+    subtractive_current_streak,
+    subtractive_day_totals,
+    update_streak,
+)
 from models.goal_completion import GoalCompletion
 from schemas.milestone import Milestone
 
@@ -39,22 +44,6 @@ __all__ = [
     "compute_streak_before_and_after",
     "update_streak",
 ]
-
-
-@dataclass(frozen=True)
-class SubtractiveContext:
-    """Habit-level context required to compute a subtractive streak.
-
-    Bundles the two values a subtractive-habit streak walk needs into a
-    single kwarg so streak functions stay under the project's
-    ``PLR0913`` (max-5-args) bar even after picking up the abstention
-    code path.  ``clear_threshold`` is the day's failure cutoff (sum >
-    threshold = transgression); ``start_date`` is the habit's birth so
-    the walk cannot accrue streak days before the habit existed.
-    """
-
-    clear_threshold: float
-    start_date: date
 
 
 def _to_user_date(ts: datetime | str, user_timezone: str) -> date:
@@ -173,7 +162,7 @@ def _streak_from_day_totals(
 ) -> int:
     """Count the consecutive-day streak from pre-bucketed day totals."""
     if subtractive is not None:
-        return _compute_subtractive_streak(day_totals, user_timezone, subtractive)
+        return subtractive_current_streak(day_totals, user_timezone, subtractive)
 
     sorted_days = sorted(day_totals, reverse=True)
     # Mirror the frontend's recency gate so a stale chain reports 0 here
@@ -237,60 +226,6 @@ def _completed_user_dates(
     return {_to_user_date(c.timestamp, user_timezone) for c in completions if c.completed_units > 0}
 
 
-def _bucket_day_totals(
-    completions: Sequence[GoalCompletion],
-    user_timezone: str,
-) -> dict[date, float]:
-    """Sum completion units per user-local day, *without* the >0 filter.
-
-    The additive path uses :func:`_completed_user_dates` because absence
-    of a row is the failure signal there.  For subtractive habits the
-    opposite is true (no row = perfect abstention), so the bucketing
-    must keep zero-sum days addressable too.  Returns ``{day: total}``;
-    callers treat ``get(day, 0.0)`` as the canonical "did the user stay
-    under their limit" probe.
-    """
-    day_totals: dict[date, float] = {}
-    for c in completions:
-        day = _to_user_date(c.timestamp, user_timezone)
-        day_totals[day] = day_totals.get(day, 0.0) + c.completed_units
-    return day_totals
-
-
-def _compute_subtractive_streak(
-    day_totals: dict[date, float],
-    user_timezone: str,
-    ctx: SubtractiveContext,
-) -> int:
-    """Count consecutive abstention days for a subtractive habit.
-
-    Walks backwards from today.  A day counts toward the streak when
-    the user's total for that day is at most ``ctx.clear_threshold`` —
-    which is trivially true for a day that has no row at all (no log =
-    didn't slip).  The walk stops when:
-
-    * the user logged *above* the clear threshold on that day
-      (a "transgression" breaks the chain), or
-    * the cursor crosses ``ctx.start_date`` going backwards (you
-      cannot accrue streak before the habit existed).
-
-    Returns 0 when the habit's start_date is in the future relative to
-    the user's "today" — the habit hasn't begun yet, so there is no
-    abstention to count.
-    """
-    today = today_in_tz(user_timezone)
-    if ctx.start_date > today:
-        return 0
-    streak = 0
-    cursor = today
-    while cursor >= ctx.start_date:
-        if day_totals.get(cursor, 0.0) > ctx.clear_threshold:
-            break
-        streak += 1
-        cursor -= timedelta(days=1)
-    return streak
-
-
 def compute_habit_streak(
     completions: Sequence[GoalCompletion],
     user_timezone: str = "UTC",
@@ -317,8 +252,8 @@ def compute_habit_streak(
     ``start_date`` to walk backwards counting abstention days instead.
     """
     if subtractive is not None:
-        day_totals = _bucket_day_totals(completions, user_timezone)
-        return _compute_subtractive_streak(day_totals, user_timezone, subtractive)
+        day_totals = subtractive_day_totals(completions, user_timezone)
+        return subtractive_current_streak(day_totals, user_timezone, subtractive)
     dates = _completed_user_dates(completions, user_timezone)
     if not dates:
         return 0


### PR DESCRIPTION
## Summary

de-slop **Medium** / Family 5 (layering violation) + Family 3 (duplicated code). `domain/habit_stats.py` imported `SubtractiveContext` from `services/streaks.py` — the only `domain → services` (uphill) import — and the subtractive-streak walk was implemented **byte-identically** on both sides of the boundary, free to silently diverge (displayed streak vs stats streak for the same habit).

**Pure dedup + relayer, ZERO behavior change:**
- `domain/streaks.py` is now the canonical home: `SubtractiveContext` + `subtractive_day_totals` / `subtractive_current_streak` / `subtractive_longest_streak` (loop bodies preserved verbatim) + the SQLite-string-aware date coercion.
- `services/streaks.py` + `domain/habit_stats.py` delete their copies and import the single domain implementation. `services` **re-exports** `SubtractiveContext`, so existing `from services.streaks import SubtractiveContext` importers (routers, tests) are unchanged.
- `domain/habit_stats.py` now imports from `domain.streaks` — the uphill import is gone.

## Test plan

`grep -rn "from services" backend/src/domain/` → **empty**. The streak/stats suite passes **unchanged** (no expectations edited — behavior is identical). `./scripts/backend/check-all.sh` → 7/7; xenon A.

Closes #740
