### PR TITLE
fix(practice): make tallied_grounding + mindful_anchor editable in the configurator

### DIFF
--- a/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
+++ b/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
@@ -20,10 +20,12 @@ import CountUpForm from './forms/CountUpForm';
 import IntervalBellForm from './forms/IntervalBellForm';
 import MeditationTimerForm from './forms/MeditationTimerForm';
 import MetronomeForm from './forms/MetronomeForm';
+import MindfulAnchorForm from './forms/MindfulAnchorForm';
 import RandomIntervalBellForm from './forms/RandomIntervalBellForm';
 import RepCounterForm from './forms/RepCounterForm';
 import SenseGroundingForm from './forms/SenseGroundingForm';
 import { ErrorList } from './forms/shared';
+import TalliedGroundingForm from './forms/TalliedGroundingForm';
 import TarotForm from './forms/TarotForm';
 
 import { type UserPractice, type UserPracticeCustomize, userPractices } from '@/api';
@@ -261,7 +263,12 @@ interface BodyProps {
   onChange: (next: ModeConfig) => void;
 }
 
-const ConfiguratorBody = ({ config, onChange }: BodyProps): React.JSX.Element => {
+// The dispatch is split into two helpers so each stays within the complexity
+// budget as modes accumulate: timer-family forms vs the card/grounding family.
+const timerBody = (
+  config: ModeConfig,
+  onChange: BodyProps['onChange'],
+): React.JSX.Element | null => {
   switch (config.mode) {
     case 'meditation_timer':
       return <MeditationTimerForm value={config} onChange={onChange} />;
@@ -275,8 +282,22 @@ const ConfiguratorBody = ({ config, onChange }: BodyProps): React.JSX.Element =>
       return <RandomIntervalBellForm value={config} onChange={onChange} />;
     case 'rep_counter':
       return <RepCounterForm value={config} onChange={onChange} />;
+    default:
+      return null;
+  }
+};
+
+const cardAndGroundingBody = (
+  config: ModeConfig,
+  onChange: BodyProps['onChange'],
+): React.JSX.Element => {
+  switch (config.mode) {
     case 'sense_grounding':
       return <SenseGroundingForm value={config} onChange={onChange} />;
+    case 'tallied_grounding':
+      return <TalliedGroundingForm value={config} onChange={onChange} />;
+    case 'mindful_anchor':
+      return <MindfulAnchorForm value={config} onChange={onChange} />;
     case 'tarot':
       return <TarotForm value={config} onChange={onChange} />;
     case 'card_meditation':
@@ -285,6 +306,9 @@ const ConfiguratorBody = ({ config, onChange }: BodyProps): React.JSX.Element =>
       return <UnknownModeNotice />;
   }
 };
+
+const ConfiguratorBody = ({ config, onChange }: BodyProps): React.JSX.Element =>
+  timerBody(config, onChange) ?? cardAndGroundingBody(config, onChange);
 
 const UnknownModeNotice = (): React.JSX.Element => (
   <View testID="ritual-configurator-unknown">

--- a/frontend/src/features/Practice/configurator/__tests__/RitualConfiguratorSheet.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/RitualConfiguratorSheet.test.tsx
@@ -50,6 +50,30 @@ describe('RitualConfiguratorSheet', () => {
     expect(getByTestId('ritual-configurator-aspect')).toBeTruthy();
   });
 
+  it('renders the tallied_grounding form (editable, not the unknown-mode notice)', () => {
+    const config: ModeConfig = {
+      mode: 'tallied_grounding',
+      rounds: 2,
+      categories: [{ key: 'c1', label: 'Red things', target_count: 3 }],
+    };
+    const { getByTestId, queryByTestId } = renderSheet({ initialConfig: config });
+    expect(getByTestId('tallied-grounding-form')).toBeTruthy();
+    expect(queryByTestId('ritual-configurator-unknown')).toBeNull();
+  });
+
+  it('renders the mindful_anchor form (editable, not the unknown-mode notice)', () => {
+    const config: ModeConfig = {
+      mode: 'mindful_anchor',
+      instruction: 'Stand on grass',
+      min_duration_seconds: 60,
+      options: [{ key: 'o1', label: 'Bare feet' }],
+      require_option_choice: false,
+    };
+    const { getByTestId, queryByTestId } = renderSheet({ initialConfig: config });
+    expect(getByTestId('mindful-anchor-form')).toBeTruthy();
+    expect(queryByTestId('ritual-configurator-unknown')).toBeNull();
+  });
+
   it('header makes the per-user-override scope explicit', () => {
     const { getByTestId } = renderSheet();
     expect(getByTestId('ritual-configurator-title').props.children).toBe('Adjust your practice');


### PR DESCRIPTION
## Summary

de-slop **Medium** / Family 3 (stubbed capability) + Family 12. `tallied_grounding` + `mindful_anchor` can be **created** (forms wired into the Create wizard) but the configurator's `ConfiguratorBody` had no `case` for them — routing them to the "Configuration not yet available" notice. For `tallied_grounding` it also rendered a "Browse recipe library" button *above* that notice (self-contradictory, since it's in `RECIPE_LIBRARY_MODES`).

- Add the two missing cases so the existing `TalliedGroundingForm` / `MindfulAnchorForm` render in the Adjust sheet.
- Split the now-11-mode dispatch into `timerBody` + `cardAndGroundingBody` helpers so `ConfiguratorBody` stays within the complexity budget (the single switch had hit 12 > 10).

## Test plan

Render each mode in the sheet and assert its real form (`tallied-grounding-form` / `mindful-anchor-form`) appears and `ritual-configurator-unknown` does **not**. `./scripts/frontend/check-all.sh` → 4/4.

Closes #742
