### PR TITLE
refactor(frontend): extract shared duplications (storage, dialog, auth, marker)

### DIFF
--- a/frontend/src/features/Auth/ResetPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ResetPasswordScreen.tsx
@@ -3,13 +3,13 @@ import { Text, TextInput, TouchableOpacity } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
+import { validatePasswordPair } from './passwordValidation';
 
 import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
 
 const RESET_FALLBACK =
   "We couldn't apply that reset. The link may have expired -- request a new one and try again.";
-const MIN_PASSWORD_LENGTH = 8;
 const MIN_TOKEN_LENGTH = 32;
 
 interface RouteParams {
@@ -115,16 +115,6 @@ function MissingTokenView({ onRequestNew }: { onRequestNew: () => void }): React
   );
 }
 
-function _validatePasswordPair(password: string, confirmPassword: string): string | null {
-  if (password.length < MIN_PASSWORD_LENGTH) {
-    return `Pick a password that is at least ${MIN_PASSWORD_LENGTH} characters long.`;
-  }
-  if (password !== confirmPassword) {
-    return "Those passwords don't match. Re-type both fields to confirm.";
-  }
-  return null;
-}
-
 export default function ResetPasswordScreen({ navigation, route }: Props) {
   const { confirmPasswordReset } = useAuth();
   const [password, setPassword] = useState('');
@@ -140,7 +130,7 @@ export default function ResetPasswordScreen({ navigation, route }: Props) {
 
   const handleSubmit = async () => {
     setError(null);
-    const validationError = _validatePasswordPair(password, confirmPassword);
+    const validationError = validatePasswordPair(password, confirmPassword);
     if (validationError) {
       setError(validationError);
       return;

--- a/frontend/src/features/Auth/SignupScreen.tsx
+++ b/frontend/src/features/Auth/SignupScreen.tsx
@@ -4,13 +4,13 @@ import { Text, TextInput, TouchableOpacity } from 'react-native';
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { canonicalizeEmail } from './canonicalizeEmail';
+import { validatePasswordPair } from './passwordValidation';
 
 import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
 
 const SIGNUP_FALLBACK =
   "We couldn't create your account. Check your connection, then try again in a moment.";
-const MIN_PASSWORD_LENGTH = 8;
 
 interface Props {
   navigation: { navigate: (_screen: string) => void };
@@ -108,12 +108,9 @@ export default function SignupScreen({ navigation }: Props) {
   const handleSignup = async () => {
     setError(null);
 
-    if (password.length < MIN_PASSWORD_LENGTH) {
-      setError(`Pick a password that is at least ${MIN_PASSWORD_LENGTH} characters long.`);
-      return;
-    }
-    if (password !== confirmPassword) {
-      setError("Those passwords don't match. Re-type both fields to confirm.");
+    const validationError = validatePasswordPair(password, confirmPassword);
+    if (validationError) {
+      setError(validationError);
       return;
     }
 

--- a/frontend/src/features/Auth/passwordValidation.ts
+++ b/frontend/src/features/Auth/passwordValidation.ts
@@ -1,0 +1,17 @@
+/** Minimum password length enforced on signup and password reset. */
+export const MIN_PASSWORD_LENGTH = 8;
+
+/**
+ * Validate a password + confirmation pair. Returns a user-facing error string,
+ * or ``null`` when the pair is acceptable. Shared by the signup and
+ * reset-password screens so the rules and copy stay identical.
+ */
+export function validatePasswordPair(password: string, confirmPassword: string): string | null {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return `Pick a password that is at least ${MIN_PASSWORD_LENGTH} characters long.`;
+  }
+  if (password !== confirmPassword) {
+    return "Those passwords don't match. Re-type both fields to confirm.";
+  }
+  return null;
+}

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -14,6 +14,7 @@ import { colors, STAGE_COLORS, spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 import { DEFAULT_TIMEZONE } from '../../utils/dateUtils';
 
+import { TIER_LABELS, centeredTranslateX, tooltipBoxStyle, type TierType } from './goalMarker';
 import type { HabitTileProps, Goal, Habit } from './Habits.types';
 import {
   getProgressPercentage,
@@ -26,20 +27,6 @@ import {
   isEarlyUnlocked,
   calculateTodaysProgress,
 } from './HabitUtils';
-
-type TierType = 'low' | 'clear' | 'stretch';
-
-const TIER_LABELS: Record<TierType, string> = {
-  low: 'Low Grit',
-  clear: 'Clear Goal',
-  stretch: 'Stretch Goal',
-};
-
-/** Center an element of arbitrary width over its position, clamped at the bar edges. */
-const computeCenteredTranslateX = (pct: number, width: number): number => {
-  if (pct === 0) return 0;
-  return pct === 100 ? -width : -width / 2;
-};
 
 /** Marker star size: a touch larger than the bar so it reads as a sitting marker. */
 const markerStarSize = (scale: number): number => spacing(2, scale);
@@ -59,19 +46,7 @@ interface GoalTooltipProps {
 }
 
 const GoalTooltipContent = ({ goal, habit, tier, scale, tz }: GoalTooltipProps) => (
-  <View
-    testID={`tooltip-${tier}`}
-    style={{
-      position: 'absolute',
-      bottom: 16,
-      backgroundColor: '#fffdf7',
-      borderWidth: 1,
-      borderColor: getTierColor(tier),
-      borderRadius: 4,
-      paddingHorizontal: 4,
-      paddingVertical: 2,
-    }}
-  >
+  <View testID={`tooltip-${tier}`} style={tooltipBoxStyle(getTierColor(tier))}>
     <Text
       style={{
         fontSize: spacing(1.5, scale),
@@ -120,7 +95,7 @@ const GoalMarker = ({
         position: 'absolute',
         left: `${clamped}%`,
         top: (barHeight - starSize) / 2,
-        transform: [{ translateX: computeCenteredTranslateX(clamped, starSize) }],
+        transform: [{ translateX: centeredTranslateX(clamped, starSize) }],
         zIndex,
         alignItems: 'center',
       }}

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -35,6 +35,7 @@ import {
 import useResponsive from '../../../design/useResponsive';
 import { addDaysInTZ, dayKeyInTZ, todayInUserTZ } from '../../../utils/dateUtils';
 import { TARGET_UNITS, FREQUENCY_UNITS } from '../constants';
+import { TIER_LABELS, centeredTranslateX, tooltipBoxStyle } from '../goalMarker';
 import styles from '../Habits.styles';
 import type { GoalModalProps, Goal } from '../Habits.types';
 import {
@@ -50,12 +51,6 @@ import {
 /** Height of the goal progress bar; tier star markers are centered on it. */
 const MODAL_BAR_HEIGHT = 12;
 
-/** Center a star of the given size over its position, clamped at the bar edges. */
-const centeredTranslateX = (clamped: number, size: number): number => {
-  if (clamped === 0) return 0;
-  return clamped === 100 ? -size : -size / 2;
-};
-
 /** Position a tier star marker on the bar: centered on its threshold and on the bar height. */
 const markerContainerStyle = (leftPct: number, z: number, starSize: number): ViewStyle => {
   const clamped = clampPercentage(leftPct);
@@ -69,29 +64,12 @@ const markerContainerStyle = (leftPct: number, z: number, starSize: number): Vie
   };
 };
 
-const tooltipStyle = (color: string): ViewStyle => ({
-  position: 'absolute',
-  bottom: 16,
-  backgroundColor: '#fffdf7',
-  borderWidth: 1,
-  borderColor: color,
-  borderRadius: 4,
-  paddingHorizontal: 4,
-  paddingVertical: 2,
-});
-
 const tooltipTextStyle: TextStyle = {
   fontSize: 10,
   color: '#333',
   fontFamily: 'serif',
   fontStyle: 'italic',
   letterSpacing: 0.5,
-};
-
-const TIER_LABELS: Record<string, string> = {
-  low: 'Low Grit',
-  clear: 'Clear Goal',
-  stretch: 'Stretch Goal',
 };
 
 const formatGoalTooltip = (g: Goal | undefined): string => {
@@ -155,7 +133,7 @@ const GoalMarkerItem = ({
       style={markerContainerStyle(position, zIndex, starSize)}
     >
       {tooltip === tier && (
-        <View testID={`modal-tooltip-${tier}`} style={tooltipStyle(getTierColor(tier))}>
+        <View testID={`modal-tooltip-${tier}`} style={tooltipBoxStyle(getTierColor(tier))}>
           <Text style={tooltipTextStyle}>{formatGoalTooltip(goal)}</Text>
         </View>
       )}

--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -27,6 +27,9 @@ import styles from '../Habits.styles';
 import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
 import { STAGE_ORDER, calculateHabitStartDate } from '../HabitUtils';
 
+import { ConfirmDialog } from './ConfirmDialog';
+import { HABIT_NAME_MAX_LENGTH, MAX_HABITS, validateAndAddHabit } from './onboardingValidation';
+
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
 }
@@ -36,8 +39,6 @@ interface SmoothSliderProps extends SliderProps {
   animationType?: 'timing' | 'spring';
   animationConfig?: Record<string, unknown>;
 }
-
-import { HABIT_NAME_MAX_LENGTH, MAX_HABITS, validateAndAddHabit } from './onboardingValidation';
 
 const SmoothSlider = Slider as React.ComponentType<SmoothSliderProps>;
 
@@ -61,56 +62,6 @@ const assignDatesAndStages = (habits: OnboardingHabit[], startDate: Date): Onboa
     start_date: calculateHabitStartDate(startDate, index),
     stage: STAGE_ORDER[index] ?? 'Clear Light',
   }));
-
-interface ConfirmDialogProps {
-  visible: boolean;
-  title: string;
-  message?: string;
-  testID: string;
-  cancelTestID: string;
-  confirmTestID: string;
-  cancelLabel: string;
-  confirmLabel: string;
-  onCancel: () => void;
-  onConfirm: () => void;
-}
-
-const ConfirmDialog = ({
-  visible,
-  title,
-  message,
-  testID,
-  cancelTestID,
-  confirmTestID,
-  cancelLabel,
-  confirmLabel,
-  onCancel,
-  onConfirm,
-}: ConfirmDialogProps) => {
-  if (!visible) return null;
-  return (
-    <Modal transparent animationType="fade">
-      <View style={styles.modalOverlay} testID={testID}>
-        <View style={styles.discardModal}>
-          <Text style={styles.discardTitle}>{title}</Text>
-          {message && <Text style={styles.discardMessage}>{message}</Text>}
-          <View style={styles.discardActions}>
-            <TouchableOpacity onPress={onCancel} style={styles.discardButton} testID={cancelTestID}>
-              <Text style={styles.discardButtonText}>{cancelLabel}</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={onConfirm}
-              style={styles.discardButton}
-              testID={confirmTestID}
-            >
-              <Text style={styles.discardExitText}>{confirmLabel}</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </View>
-    </Modal>
-  );
-};
 
 interface HabitChipProps {
   habit: OnboardingHabit;
@@ -1107,6 +1058,7 @@ const OnboardingDialogs = ({ s }: { s: ReturnType<typeof useOnboardingState> }) 
       confirmTestID="discard-exit"
       cancelLabel="Cancel"
       confirmLabel="Exit"
+      destructive
       onCancel={() => s.setShowDiscardDialog(false)}
       onConfirm={s.handleConfirmDiscard}
     />
@@ -1118,6 +1070,7 @@ const OnboardingDialogs = ({ s }: { s: ReturnType<typeof useOnboardingState> }) 
       confirmTestID="count-warning-continue"
       cancelLabel="Keep Adding"
       confirmLabel="Continue"
+      destructive
       onCancel={() => s.setShowCountWarning(false)}
       onConfirm={() => {
         s.setShowCountWarning(false);

--- a/frontend/src/features/Habits/goalMarker.ts
+++ b/frontend/src/features/Habits/goalMarker.ts
@@ -1,0 +1,37 @@
+import type { ViewStyle } from 'react-native';
+
+/** The three goal tiers shown as star markers on a habit's progress bar. */
+export type TierType = 'low' | 'clear' | 'stretch';
+
+/** Human label per tier, shared by the habit tile and the goal modal. */
+export const TIER_LABELS: Record<TierType, string> = {
+  low: 'Low Grit',
+  clear: 'Clear Goal',
+  stretch: 'Stretch Goal',
+};
+
+/**
+ * Center a marker of the given size over its position on the bar, clamped at
+ * the edges (0% sits flush-left, 100% flush-right, everything else centered).
+ */
+export const centeredTranslateX = (clamped: number, size: number): number => {
+  if (clamped === 0) return 0;
+  return clamped === 100 ? -size : -size / 2;
+};
+
+/**
+ * The tier-tooltip bubble box (parchment fill + a tier-coloured border). The
+ * border colour is passed in so each caller can resolve it from its own palette.
+ * The tooltip *text* style is intentionally not shared — the tile scales its
+ * font with the tile scale while the modal uses a fixed size.
+ */
+export const tooltipBoxStyle = (color: string): ViewStyle => ({
+  position: 'absolute',
+  bottom: 16,
+  backgroundColor: '#fffdf7',
+  borderWidth: 1,
+  borderColor: color,
+  borderRadius: 4,
+  paddingHorizontal: 4,
+  paddingVertical: 2,
+});

--- a/frontend/src/storage/energyScaffoldingStorage.ts
+++ b/frontend/src/storage/energyScaffoldingStorage.ts
@@ -1,16 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-const ARCHIVED_KEY = '@adepthood/energy_scaffolding_archived';
+import { resetCorruptKey } from './jsonStore';
 
-// Clears poisoned storage on bad JSON so the next launch self-heals.
-async function resetCorruptKey(key: string, err: unknown): Promise<void> {
-  console.warn(`[storage] corrupt JSON in ${key}, clearing to self-heal`, err);
-  try {
-    await AsyncStorage.removeItem(key);
-  } catch (removeErr) {
-    console.warn(`[storage] failed to clear corrupt key ${key}`, removeErr);
-  }
-}
+const ARCHIVED_KEY = '@adepthood/energy_scaffolding_archived';
 
 // Device-scoped (not wiped on logout) so the dismissal survives the next login.
 export async function saveEnergyScaffoldingArchived(archived: boolean): Promise<void> {

--- a/frontend/src/storage/habitStorage.ts
+++ b/frontend/src/storage/habitStorage.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import type { Habit } from '../features/Habits/Habits.types';
 
+import { resetCorruptKey } from './jsonStore';
 import { serialize } from './serializedWrite';
 
 const STORAGE_KEY = '@adepthood/habits';
@@ -28,22 +29,6 @@ function rehydrateHabit(raw: Habit): Habit {
       timestamp: new Date(c.timestamp),
     })),
   };
-}
-
-/**
- * BUG-FRONTEND-INFRA-011 — when AsyncStorage hands us malformed JSON we used
- * to silently return ``null`` / ``[]``, masking both a parse failure and the
- * fact that future writes would keep appending to corrupt data. Now we log,
- * clear the poisoned key so subsequent launches self-heal, and let the
- * caller show a toast if the loss is user-visible.
- */
-async function resetCorruptKey(key: string, err: unknown): Promise<void> {
-  console.warn(`[storage] corrupt JSON in ${key}, clearing to self-heal`, err);
-  try {
-    await AsyncStorage.removeItem(key);
-  } catch (removeErr) {
-    console.warn(`[storage] failed to clear corrupt key ${key}`, removeErr);
-  }
 }
 
 export async function saveHabits(habits: Habit[]): Promise<void> {

--- a/frontend/src/storage/jsonStore.ts
+++ b/frontend/src/storage/jsonStore.ts
@@ -1,0 +1,15 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * Clears a poisoned AsyncStorage key on bad JSON so the next launch self-heals
+ * (BUG-FRONTEND-INFRA-011). Shared by the storage modules that read JSON —
+ * each previously carried a byte-identical copy of this helper.
+ */
+export async function resetCorruptKey(key: string, err: unknown): Promise<void> {
+  console.warn(`[storage] corrupt JSON in ${key}, clearing to self-heal`, err);
+  try {
+    await AsyncStorage.removeItem(key);
+  } catch (removeErr) {
+    console.warn(`[storage] failed to clear corrupt key ${key}`, removeErr);
+  }
+}

--- a/frontend/src/storage/notificationStorage.ts
+++ b/frontend/src/storage/notificationStorage.ts
@@ -1,6 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
+import { resetCorruptKey } from './jsonStore';
+
 const KEY_PREFIX = '@adepthood/notifications';
 // expo-secure-store only allows alphanumerics plus `.`, `-`, `_` in keys,
 // so this one cannot share the `@adepthood/...` prefix with AsyncStorage keys.
@@ -14,14 +16,6 @@ function keyFor(habitId: number): string {
 /**
  * BUG-FRONTEND-INFRA-011 — self-heal when AsyncStorage returns malformed JSON.
  */
-async function resetCorruptKey(key: string, err: unknown): Promise<void> {
-  console.warn(`[storage] corrupt JSON in ${key}, clearing to self-heal`, err);
-  try {
-    await AsyncStorage.removeItem(key);
-  } catch (removeErr) {
-    console.warn(`[storage] failed to clear corrupt key ${key}`, removeErr);
-  }
-}
 
 export async function saveNotificationIds(habitId: number, ids: string[]): Promise<void> {
   await AsyncStorage.setItem(keyFor(habitId), JSON.stringify(ids));


### PR DESCRIPTION
## Summary

de-slop **Medium** / Family 3 (duplicated code). Four **behavior-preserving** extractions (rendered output + validation semantics unchanged; tests pass unchanged):

1. **`resetCorruptKey`** — new `storage/jsonStore.ts` is the sole definition; the three byte-identical copies (`habitStorage`/`notificationStorage`/`energyScaffoldingStorage`) import it.
2. **`ConfirmDialog`** — OnboardingModal's local copy + props type deleted; it imports the shared `components/ConfirmDialog` and passes `destructive` so the confirm button stays **pixel-identical**.
3. **password-pair validation** — new `features/Auth/passwordValidation.ts` (`validatePasswordPair` + `MIN_PASSWORD_LENGTH`); both `ResetPasswordScreen` + `SignupScreen` call it; identical error strings/order preserved.
4. **goal marker/tooltip** — new `features/Habits/goalMarker.ts` (`centeredTranslateX`, `TIER_LABELS`, `tooltipBoxStyle`, `TierType`) consumed by `HabitTile` + `GoalModal`. **Left `formatGoalTooltip` + the tooltip text style per-file on purpose** — the two produce different strings/font sizes, so unifying them would change output; only the genuinely-identical helpers were shared.

## Test plan

Single-definition verified for each; no visual/behavior change. `./scripts/frontend/check-all.sh` → 4/4.

Closes #746
