### PR TITLE
fix(frontend): center Get Resonance button horizontally

### DIFF
--- a/frontend/src/features/Journal/GetResonanceButton.tsx
+++ b/frontend/src/features/Journal/GetResonanceButton.tsx
@@ -91,8 +91,10 @@ function GetResonanceButton({
 const styles = StyleSheet.create({
   wrapper: {
     position: 'absolute',
-    right: SPACING.lg,
+    left: 0,
+    right: 0,
     bottom: SPACING.xl,
+    alignItems: 'center',
   },
   button: {
     minHeight: touchTarget.minimum,


### PR DESCRIPTION
Stretch the floating wrapper full-width and center its child instead of
pinning it to the right edge, so the button sits in the middle of the screen.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01McuHvMemP6Sk2zUSPVZcWV