### PR TITLE
fix: low-severity tidy-ups (mojibake, stale docstring, form caps, map tokens)

### DIFF
--- a/backend/src/domain/weekly_prompts.py
+++ b/backend/src/domain/weekly_prompts.py
@@ -30,7 +30,7 @@ WEEKLY_PROMPTS: dict[int, str] = {
     7: ("Where in your life do you feel powerful? Where do you feel powerless?"),
     8: ("Describe a time you stood up for yourself. What did it cost you? What did it give you?"),
     9: ("What anger or frustration are you carrying? What is it trying to protect?"),
-    # Blue �� Order / Structure
+    # Blue — Order / Structure
     10: ("What rules or structures help you thrive? Which ones feel like they hold you back?"),
     11: (
         "Reflect on a commitment you have kept faithfully. "

--- a/backend/src/services/marginalia.py
+++ b/backend/src/services/marginalia.py
@@ -1,9 +1,11 @@
 """Marginalia maintenance hooks.
 
-The re-anchoring seam is intentionally a no-op here: editing a journal entry's
-body can shift or invalidate the character spans that marginalia anchor to, but
-the actual re-anchor / mark-stale logic lands in a later issue. This module
-exists so the PATCH endpoint can call a stable, documented seam now.
+When a journal entry's body changes, the character spans that marginalia anchor
+to can shift or disappear. ``reanchor_entry_marginalia`` re-anchors each active
+note by re-finding its snapshot text in the new body (via ``reanchor_one``),
+updating the anchor span when it moves and marking the note stale when the text
+can no longer be found. Notes are never deleted — a stale note stays for the
+user to resolve. The PATCH endpoint calls this after persisting a body edit.
 """
 
 from __future__ import annotations

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -69,6 +69,16 @@ export const colors = {
     default: '#dad9d4',
   },
 
+  // Medal palette for the Map goal badges — deliberately the classic
+  // bronze/silver/gold (distinct from the `tier` palette above, which is the
+  // app's literary earth-tone arc). Keyed by goal tier: low→bronze, clear→silver,
+  // stretch→gold.
+  medal: {
+    bronze: '#cd7f32',
+    silver: '#c0c0c0',
+    gold: '#ffd700',
+  },
+
   // Goal-tier star markers are tier-agnostic greyscale: a darkish-grey outline
   // while the tier is unmet, then a greyscale gradient fill with a white border
   // glow once the tier is achieved.

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -32,6 +32,8 @@ import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked } from './services/stageService';
 import type { StageData } from './stageData';
 
+import { colors } from '@/design/tokens';
+
 /** Lookup of stage number → StageData for resolving row/arrow content. */
 type StageLookup = Readonly<Record<number, StageData | undefined>>;
 
@@ -339,9 +341,9 @@ const ActionLinks = ({ stage, onNavigate }: ActionLinksProps): React.JSX.Element
 );
 
 const GOAL_TIER_COLORS: Record<string, string> = {
-  low: '#CD7F32',
-  clear: '#C0C0C0',
-  stretch: '#FFD700',
+  low: colors.medal.bronze,
+  clear: colors.medal.silver,
+  stretch: colors.medal.gold,
 };
 
 const GOAL_TIER_LABELS: Record<string, string> = {
@@ -384,7 +386,7 @@ const HabitHistoryRow = ({ item }: { item: HabitHistoryItem }): React.JSX.Elemen
             styles.goalBadge,
             {
               backgroundColor: achieved
-                ? GOAL_TIER_COLORS[tier] ?? '#888'
+                ? GOAL_TIER_COLORS[tier] ?? colors.text.tertiary
                 : 'rgba(255,255,255,0.15)',
             },
           ]}
@@ -435,7 +437,7 @@ const HistoryBody = ({
   if (loading) {
     return (
       <View style={styles.historyLoading} testID="history-loading">
-        <ActivityIndicator size="small" color="#fff" />
+        <ActivityIndicator size="small" color={colors.text.light} />
       </View>
     );
   }

--- a/frontend/src/features/Practice/configurator/forms/MindfulAnchorForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/MindfulAnchorForm.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { MindfulAnchorConfig, MindfulAnchorOption } from '../../engine/types';
+import {
+  INSTRUCTION_MAX,
+  OPTION_DESCRIPTION_MAX as DESCRIPTION_MAX,
+  OPTION_LABEL_MAX as LABEL_MAX,
+} from '../../engine/validation';
 
 import { LabeledRow, NumericField, TextField, ToggleRow } from './shared';
 
@@ -11,10 +16,6 @@ interface Props {
   value: MindfulAnchorConfig;
   onChange: (next: MindfulAnchorConfig) => void;
 }
-
-const INSTRUCTION_MAX = 280;
-const LABEL_MAX = 60;
-const DESCRIPTION_MAX = 120;
 
 // Monotonic source of new option keys — the machine id recorded in session
 // metadata, generated once and never derived from the array index (audit


### PR DESCRIPTION
## Summary

de-slop **Low** — four small independent findings bundled:

1. **`weekly_prompts.py`**: replace the two `U+FFFD` mojibake bytes in the Blue banner comment with a clean `—` (matches the sibling banners).
2. **`marginalia.py`**: rewrite the stale module docstring — the re-anchoring seam is no longer a no-op; `reanchor_entry_marginalia` fully implements re-anchor + mark-stale (PR #653). Describe the real behavior (never deletes).
3. **`MindfulAnchorForm`**: import `INSTRUCTION_MAX` / `OPTION_LABEL_MAX` / `OPTION_DESCRIPTION_MAX` from `engine/validation` instead of hand-rolled `280/60/120` that silently truncated input below the validator's `500/255/500` (matches the sibling forms).
4. **Map goal badges**: add a `colors.medal {bronze,silver,gold}` token (deliberately distinct from the `tier` palette) + reference it; move the `#888`/`#fff` fallbacks to `colors.text.tertiary` / `colors.text.light`. No raw hex left in MapScreen.

## Test plan

Backend `check-all` 7/7, frontend 4/4. (#3 widens the caps to match the validator; #4 moves literals behind tokens — both intended.)

Closes #747
