### PR TITLE
test(content): guard that Stage 1 seeds from the vendored manifest

### DIFF
--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -33,6 +33,10 @@ from services.content_repository import (
 # Placeholders kept for stages 2 and 3 (3 each) until the manifest covers them.
 _PLACEHOLDER_COUNT = 6
 
+# Resolved once at import (not inside async tests — pathlib in an async def trips
+# ASYNC240) so the real vendored content dir is reusable across tests.
+_VENDORED_CONTENT_DIR = Path(__file__).resolve().parent.parent / "content"
+
 
 def _chapter(
     chapter_id: str,
@@ -143,12 +147,46 @@ def test_vendored_content_pin_lists_real_chapters_and_resources() -> None:
     Guards the activation: an empty ``backend/content`` (the pre-vendor state)
     would seed zero StageContent rows and leave the Course screen blank.
     """
-    repo = ContentRepository(Path(__file__).resolve().parent.parent / "content")
+    repo = ContentRepository(_VENDORED_CONTENT_DIR)
     chapters = repo.list_chapters()
     resources = repo.list_resources()
     assert chapters, "vendored manifest should list chapters"
     assert {c.stage for c in chapters}, "chapters should cover at least one stage"
     assert resources, "vendored manifest should list site resources"
+
+
+@pytest.mark.asyncio
+async def test_seed_content_populates_stage_one_from_vendored_manifest(
+    db_session: AsyncSession,
+) -> None:
+    """Regression guard (#767): seeding the vendored manifest fills Stage 1.
+
+    Before the content pin shipped, Stage 1 had neither placeholder rows nor
+    manifest content, so the Course screen showed "No Content Yet" / "0/0". The
+    vendored manifest now covers Stage 1; seeding must produce non-zero
+    StageContent for it so the entry stage is never silently empty again.
+    """
+    set_content_repository_for_tests(ContentRepository(_VENDORED_CONTENT_DIR))
+    try:
+        await _seed_stages(db_session, count=10)
+        await seed_content(db_session)
+        stage_one = (
+            (await db_session.execute(select(CourseStage).where(CourseStage.stage_number == 1)))
+            .scalars()
+            .one()
+        )
+        rows = (
+            (
+                await db_session.execute(
+                    select(StageContent).where(StageContent.course_stage_id == stage_one.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert rows, "Stage 1 must seed real course content from the vendored manifest"
+    finally:
+        reset_content_repository_for_tests()
 
 
 def test_content_ref_format() -> None:


### PR DESCRIPTION
## Summary

#767: the Course screen showed "No Content Yet" / "0/0" for Stage 1 because the stage had **neither placeholder rows nor vendored content**. Investigated as a code/seed bug per request — and the **root cause is already fixed in code**: #722 vendored the content (the manifest now ships **17 Stage-1 / beige chapters**), and `seed_content` runs on the startup lifespan hook (`main.py:_seed_startup_data`) and seeds **every stage the manifest ships** (suppressing placeholders once a stage is covered). So no seed-path code gap remains.

This PR adds a **regression guard**: seed the real vendored manifest and assert Stage 1 gets non-zero `StageContent` rows — so the entry stage can never silently re-empty.

## What's left (not code)

Production (`app.aptitude.guru`) needs a **deploy + startup seed** to populate its DB from the now-vendored manifest. That's an ops action tracked in a separate issue (I can't reach the prod DB).

## Test plan

`test_seed_content_populates_stage_one_from_vendored_manifest` seeds the real `backend/content` manifest and asserts Stage 1 `StageContent` rows exist. `./scripts/backend/check-all.sh` → 7/7.

Refs #767
