### PR TITLE
fix(habits): unify subtractive-habit polarity so the streak matches the badge

### DIFF
--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -69,16 +69,33 @@ def _subtractive_context(habit: Habit) -> SubtractiveContext | None:
     """Return the streak context for a subtractive habit, else ``None``.
 
     ``None`` selects the additive code path in :func:`compute_habit_streak`.
-    Onboarding writes the three tiers atomically with a shared
-    ``is_additive`` value, so the first subtractive *clear*-tier goal is
-    a sufficient probe; a habit lacking that goal (older test fixtures,
-    partial migrations) falls back to additive logic to avoid
-    mis-counting against a phantom threshold.
+
+    Polarity is decided by a single rule shared with the frontend
+    (``HabitUtils.getGoalTier``): a habit is subtractive iff **any** of its
+    goals is non-additive. Probing one specific tier let the backend and the UI
+    disagree when the tiers were not perfectly consistent — the backend took the
+    additive path and a never-logged abstention habit reported a ``0`` streak
+    while the badge said "Achieved" (BUG #768). The clear threshold comes from
+    the ``clear``-tier goal's target; if that tier is absent it falls back to the
+    first non-additive goal's target so a subtractive habit never silently
+    returns ``None`` and mis-counts down the additive path.
     """
-    clear = next((g for g in habit.goals if g.tier == "clear" and not g.is_additive), None)
-    if clear is None:
+    non_additive = [g for g in habit.goals if not g.is_additive]
+    if not non_additive:
         return None
-    return SubtractiveContext(clear_threshold=clear.target, start_date=habit.start_date)
+    threshold = _subtractive_threshold(habit, non_additive[0])
+    return SubtractiveContext(clear_threshold=threshold, start_date=habit.start_date)
+
+
+def _subtractive_threshold(habit: Habit, fallback: Goal) -> float:
+    """Abstention threshold for a subtractive streak.
+
+    The ``clear``-tier goal's target is the ceiling; if that tier is absent the
+    first non-additive goal (``fallback``) stands in so the streak still
+    computes rather than mis-counting down the additive path.
+    """
+    clear = next((g for g in habit.goals if g.tier == "clear"), None)
+    return clear.target if clear is not None else fallback.target
 
 
 def _populate_streak(habit: Habit, completions: list[GoalCompletion], user_timezone: str) -> None:
@@ -206,6 +223,7 @@ async def create_habit(
     payload: HabitCreate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> Habit:
     """Create a habit + three default goals; 409 over-quota or duplicate name."""
     await _ensure_under_quota(session, current_user)
@@ -213,6 +231,10 @@ async def create_habit(
     habit = Habit(user_id=current_user, **payload.model_dump())
     new_id = await _persist_habit_with_default_goals(session, habit)
     refreshed = await _refetch_with_goals(session, new_id, current_user)
+    # Recompute the streak like the list/detail paths so POST mirrors GET instead
+    # of returning the model default (0); a subtractive habit can already have a
+    # non-zero abstention streak from its start_date with no completions (#768).
+    await _populate_streaks_for(session, [refreshed], current_user, user_tz)
     logger.info("habit_created", extra={"user_id": current_user, "habit_id": refreshed.id})
     return refreshed
 

--- a/backend/tests/test_habits_api.py
+++ b/backend/tests/test_habits_api.py
@@ -10,6 +10,7 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from domain.dates import today_in_tz
 from models.goal import Goal
@@ -752,3 +753,39 @@ async def test_cross_tenant_completions_survive_a_commit_after_get(
     assert persisted is not None, "cross-tenant completion row was lost by a post-GET commit"
     assert persisted.goal_id == goal_id
     assert persisted.user_id == 999_999
+
+
+@pytest.mark.asyncio
+async def test_subtractive_habit_no_logs_streaks_from_start_date_via_list(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#768 wiring guard: a subtractive habit with zero logs streaks via GET /habits.
+
+    The list path (``_populate_streaks_for``) must take the subtractive streak
+    path for an any-non-additive habit and report the consecutive abstention
+    day-count, not 0 — the production symptom where the badge said "Achieved"
+    while the streak read 0.
+    """
+    headers = await _signup(async_client, "abstainer")
+    created = await async_client.post(
+        "/habits/", json=sample_payload(name="No Sugar"), headers=headers
+    )
+    assert created.status_code == HTTPStatus.OK
+    habit_id = created.json()["id"]
+
+    # POST creates additive defaults; flip them subtractive + backdate the start
+    # so the abstention chain is today + the five prior days = 6.
+    habit = await db_session.get(Habit, habit_id)
+    assert habit is not None
+    habit.start_date = today_in_tz("UTC") - timedelta(days=5)
+    goals = (
+        (await db_session.execute(select(Goal).where(Goal.habit_id == habit_id))).scalars().all()
+    )
+    for goal in goals:
+        goal.is_additive = False
+    await db_session.commit()
+
+    resp = await async_client.get("/habits/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    row = next(h for h in resp.json() if h["id"] == habit_id)
+    assert row["streak"] == 6

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -231,9 +231,14 @@ export const getGoalTier = (habit: Habit, tz: string = DEFAULT_TIMEZONE): GoalTi
   }
 
   const todayProgress = calculateTodaysProgress(habit, tz);
-  return lowGoal.is_additive
-    ? resolveAdditiveTier(todayProgress, lowGoal, clearGoal, stretchGoal)
-    : resolveSubtractiveTier(todayProgress, lowGoal, clearGoal, stretchGoal);
+  // A habit is subtractive iff ANY of its goals is non-additive — the same rule
+  // the backend's _subtractive_context uses, so the "Achieved" badge and the
+  // server-computed streak can never disagree (#768). Probing a single tier let
+  // them diverge when the tiers were not perfectly consistent.
+  const isSubtractive = habit.goals.some((g) => !g.is_additive);
+  return isSubtractive
+    ? resolveSubtractiveTier(todayProgress, lowGoal, clearGoal, stretchGoal)
+    : resolveAdditiveTier(todayProgress, lowGoal, clearGoal, stretchGoal);
 };
 
 /** Progress on the unified 0-100 scale shared with :func:`getMarkerPositions`. */
@@ -374,19 +379,22 @@ const computeCompletionRate = (sortedDays: Date[], totalUniqueDays: number): num
  * is additive or lacks the clear-tier sibling to read the threshold
  * from, falling back to the additive code path.
  *
- * Probes ``tier === 'clear' && !is_additive`` together so a partial
- * fixture (or future migration that lets per-tier ``is_additive`` drift)
- * cannot misclassify an additive habit as subtractive.  Mirrors the
- * backend ``_subtractive_context`` helper in ``routers/habits.py``.
+ * Subtractive iff **any** goal is non-additive — the single polarity rule
+ * shared with ``getGoalTier`` (the badge) and the backend
+ * ``_subtractive_context`` (BUG #768): probing one specific tier let the two
+ * disagree, so a never-logged abstention habit reported a ``0`` streak while
+ * the badge said "Achieved". The threshold comes from the ``clear``-tier goal,
+ * or the first non-additive goal if the clear tier is absent.
  */
 const subtractiveStreakInputs = (
   habit: Habit,
   tz: string,
 ): { clearThreshold: number; startDate: string } | null => {
-  const clearGoal = habit.goals.find((g) => g.tier === 'clear' && !g.is_additive);
-  if (!clearGoal) return null;
+  const nonAdditive = habit.goals.filter((g) => !g.is_additive);
+  if (nonAdditive.length === 0) return null;
+  const thresholdGoal = habit.goals.find((g) => g.tier === 'clear') ?? nonAdditive[0]!;
   return {
-    clearThreshold: getGoalTarget(clearGoal),
+    clearThreshold: getGoalTarget(thresholdGoal),
     startDate: dayKeyInTZ(habit.start_date, tz),
   };
 };

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -114,6 +114,49 @@ describe('HabitUtils', () => {
     expect(Math.round(pct)).toBe(50);
   });
 
+  test('getGoalTier treats an any-non-additive habit as subtractive (#768)', () => {
+    // Inconsistent tiers: low is additive but clear/stretch are not. The old
+    // rule probed the low tier and resolved ADDITIVE, disagreeing with the
+    // backend (subtractive) so the badge said "Achieved" while the streak read 0.
+    // The new any-non-additive rule resolves subtractive on both sides.
+    const goals: Goal[] = [
+      {
+        id: 1,
+        tier: 'low',
+        title: 'low',
+        target: 10,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 2,
+        tier: 'clear',
+        title: 'clear',
+        target: 5,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 3,
+        tier: 'stretch',
+        title: 'stretch',
+        target: 2,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+    ];
+    // No units logged today → a subtractive habit is fully achieved (abstained);
+    // an additive one would not be. So `completedAllGoals` proves the polarity.
+    const habit: Habit = { ...baseHabit, goals, completions: [] };
+    expect(getGoalTier(habit).completedAllGoals).toBe(true);
+  });
+
   // Pins the missing-stretch fallback: ``stretchGoal ?? currentGoal``.
   test('getProgressPercentage falls back to currentGoal when stretch is missing (additive)', () => {
     const lowOnly: Goal = {


### PR DESCRIPTION
## Summary

#768: a subtractive habit ("No Sugar") with zero logs showed **`0 DAYS — ACHIEVED TODAY!`** — the badge said achieved (subtractive) but the streak was `0`. The domain math is correct; the bug was a **polarity-detection asymmetry** — the backend probed the *clear*-tier `is_additive`, the frontend the *low*-tier — so when tiers weren't perfectly consistent they disagreed and the backend took the additive path → `0` for a never-logged habit.

**Unify all three probes on one rule — subtractive iff ANY goal is non-additive** — so the badge and the streak can never disagree:
- backend `_subtractive_context`: any-non-additive → subtractive; threshold from the clear-tier target, else the first non-additive goal (extracted `_subtractive_threshold`, keeps xenon rank A).
- frontend `getGoalTier` (badge) **and** `subtractiveStreakInputs` (frontend streak): both use `habit.goals.some(g => !g.is_additive)` with the same clear-or-fallback threshold.

No model/migration change; the domain streak math is untouched.

## Test plan

- Backend: `GET /habits` list path returns a non-zero streak for a subtractive habit with zero completions (covers the wiring, not just the domain fn).
- Frontend: `getGoalTier`/tile renders the subtractive "N DAYS — ACHIEVED" path for an any-non-additive habit.
- `./scripts/backend/check-all.sh` 7/7, `./scripts/frontend/check-all.sh` 4/4, xenon A.

Closes #768
