### PR TITLE
fix(cors): document the live origin + guard it (false offline on app.aptitude.guru)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -145,10 +145,12 @@ JWT tokens — keep it secret, keep it safe.
 This controls CORS (which origins can call your API). Set it to the URL where
 your frontend will live. Comma-separated if you have multiple:
 ```
-https://app.adepthood.com,https://www.adepthood.com
+https://app.aptitude.guru
 ```
 All entries **must** use `https://`. The backend will refuse to start if they
-don't — this is intentional.
+don't — this is intentional. **Every** live frontend origin must be listed: a
+missing one makes the browser block all responses and the app falsely report
+"offline" (#765).
 
 > You can come back and update `PROD_DOMAIN` after you deploy the frontend and
 > know its URL. The backend will need a redeploy to pick up the change.
@@ -245,7 +247,7 @@ requests from the frontend's URL.
 
 **If you add a custom domain later**, update `PROD_DOMAIN` to include it:
 ```
-https://app.adepthood.com,https://adepthood-frontend.up.railway.app
+https://app.aptitude.guru,https://adepthood-frontend.up.railway.app
 ```
 
 ---

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,8 +7,10 @@ ENV=development  # Valid values: development, staging, production
 # JWT Authentication
 SECRET_KEY=replace-me  # REQUIRED: set to a cryptographically random string for JWT signing
 
-# CORS (required in staging/production, comma-separated HTTPS URLs)
-# PROD_DOMAIN=https://app.adepthood.com,https://www.adepthood.com
+# CORS (required in staging/production, comma-separated HTTPS URLs).
+# Must list every live frontend origin or the browser blocks all responses and
+# the app falsely reports "offline" (#765). The production web app is:
+# PROD_DOMAIN=https://app.aptitude.guru
 
 # Server
 PORT=8000

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -45,6 +45,18 @@ def test_production_with_valid_domain() -> None:
     assert origins == ["https://app.adepthood.com"]
 
 
+@patch.dict("os.environ", {"PROD_DOMAIN": "https://app.aptitude.guru"})
+def test_production_allows_the_live_frontend_origin() -> None:
+    """Regression guard (#765): the live web origin is a valid production origin.
+
+    A deploy whose PROD_DOMAIN omits app.aptitude.guru makes the browser block
+    every cross-origin response, so the whole app falsely reports "offline".
+    The origin must pass validation and be applied verbatim.
+    """
+    _validate_prod_origin("https://app.aptitude.guru")  # must not raise
+    assert get_cors_origins("production") == ["https://app.aptitude.guru"]
+
+
 @patch.dict(
     "os.environ",
     {"PROD_DOMAIN": "https://app.adepthood.com, https://www.adepthood.com"},


### PR DESCRIPTION
## Summary

#765: the production web app (`app.aptitude.guru`) showed a false **"You appear to be offline"** on every screen — the browser blocked all cross-origin responses because the backend's CORS allow-list (`PROD_DOMAIN`) doesn't include `app.aptitude.guru`. A blocked response rejects with no HTTP status → the frontend maps it to `ApiError(0, 'network_error')` → the offline copy.

Production CORS is **env-driven** (`_parse_prod_origins` reads `PROD_DOMAIN`), so the live fix is a deploy env-var. The preventable root cause: the deploy template still documented the stale `adepthood.com` domain. Code side:
- correct `.env.example` + `DEPLOYMENT.md` `PROD_DOMAIN` samples to the real origin (`https://app.aptitude.guru`) and call out that a missing origin breaks the whole app;
- **regression guard** in `test_cors.py`: assert `https://app.aptitude.guru` passes `_validate_prod_origin` and is applied verbatim by `get_cors_origins`.

## What's left (not code)

Set `PROD_DOMAIN=https://app.aptitude.guru` on the deployed backend + redeploy — operator action, tracked in the deploy issue (#773).

## Test plan

`test_production_allows_the_live_frontend_origin` (test_cors.py). `./scripts/backend/check-all.sh` → 7/7.

Refs #765
