### PR TITLE
test(insights): freeze the clock in the timezone-boundary test (un-flake baseline)

### DIFF
--- a/backend/tests/test_practice_insights.py
+++ b/backend/tests/test_practice_insights.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
 from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pytest
 
+import domain.dates as dates_module
 from domain.practice_insights import (
     WEEKLY_HISTORY_WEEKS,
     WEEKLY_TARGET_SESSIONS,
@@ -14,6 +16,39 @@ from domain.practice_insights import (
     build_insights,
 )
 from models.practice_session import PracticeSession
+
+# A week after the 2026-05-11 session the boundary test uses, so both the UTC
+# (week 2026-05-11) and Pacific (week 2026-05-04) buckets of that instant fall
+# inside the 8-week window regardless of the real wall-clock date. Without this
+# freeze the test is time-coupled: as today advances the fixed session drifts to
+# the window's trailing edge and the tz shift tips the Pacific bucket out.
+_FROZEN_NOW = datetime(2026, 5, 18, 12, 0, tzinfo=UTC)
+
+
+def _zone_for(user_or_tz: object) -> ZoneInfo:
+    """Resolve an IANA zone from a tz string, UTC on failure (mirrors domain.dates)."""
+    candidate = user_or_tz if isinstance(user_or_tz, str) else getattr(user_or_tz, "timezone", None)
+    try:
+        return ZoneInfo(candidate) if candidate else ZoneInfo("UTC")
+    except (ZoneInfoNotFoundError, ValueError):
+        return ZoneInfo("UTC")
+
+
+def _frozen_now_in_tz(user_or_tz: object = None) -> datetime:
+    """Stand-in for ``domain.dates.now_in_tz`` pinned to :data:`_FROZEN_NOW`."""
+    return _FROZEN_NOW.astimezone(_zone_for(user_or_tz))
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> datetime:
+    """Pin ``domain.dates``' wall clock so the weekly window is date-independent.
+
+    ``build_insights`` windows ``weekly_counts`` against ``today_in_tz``, whose
+    single clock seam is ``now_in_tz`` (resolved through the module namespace),
+    so patching it here freezes the window for every caller.
+    """
+    monkeypatch.setattr(dates_module, "now_in_tz", _frozen_now_in_tz)
+    return _FROZEN_NOW
 
 
 def _session(
@@ -221,6 +256,7 @@ def test_last_insight_is_none_when_no_insights_logged() -> None:
 # -- Timezone-aware bucketing ----------------------------------------------
 
 
+@pytest.mark.usefixtures("frozen_clock")
 def test_bucket_uses_user_timezone_at_midnight_boundary() -> None:
     """A late-evening Pacific session stays in *its* local week, not UTC's next."""
     # 07:30 UTC on a Monday is 00:30 Pacific the *same* Monday — but the user


### PR DESCRIPTION
## Summary

`test_bucket_uses_user_timezone_at_midnight_boundary` pinned an absolute session date (2026-05-11) but `build_insights` windows `weekly_counts` against the real `today_in_tz`, so as the wall clock advances the fixed session drifts to the trailing edge of the 8-week window and the Pacific bucket falls out. It began failing **every PR's `backend-quality`** on 2026-06-29 (`assert 0 == 1`) — a RED shared baseline.

Freeze `domain.dates.now_in_tz` to `2026-05-18T12:00Z` via a `frozen_clock` fixture (the same clock seam #494 used for the streak tests) so both the UTC and Pacific buckets sit inside the window regardless of the real date.

## Test plan

Boundary test passes; `./scripts/backend/check-all.sh` 7/7 (full suite green on 2026-06-29).

Un-flakes the baseline so the other open PRs (#766/#770/#771/#775) can pass once rebased.