### PR TITLE
fix(map): drop the placehold.co default; branded fallback for the map background

### DIFF
--- a/frontend/src/constants/__tests__/images.test.ts
+++ b/frontend/src/constants/__tests__/images.test.ts
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+import { MAP_BACKGROUND_URI } from '../images';
+
+describe('MAP_BACKGROUND_URI', () => {
+  it('never defaults to an external placeholder host (#766)', () => {
+    // With EXPO_PUBLIC_MAP_BACKGROUND_URI unset (the default build/test env) the
+    // value is null and the Map screen renders a branded in-app fallback — it
+    // must never ship the third-party "600 × 800" placehold.co image.
+    expect(MAP_BACKGROUND_URI).toBeNull();
+  });
+
+  it('is not a placehold.co URL when configured', () => {
+    if (MAP_BACKGROUND_URI) {
+      expect(MAP_BACKGROUND_URI).not.toContain('placehold');
+    }
+  });
+});

--- a/frontend/src/constants/images.ts
+++ b/frontend/src/constants/images.ts
@@ -1,2 +1,5 @@
-export const MAP_BACKGROUND_URI =
-  process.env.EXPO_PUBLIC_MAP_BACKGROUND_URI || 'https://placehold.co/600x800/png';
+// The real spiral-map art is supplied via EXPO_PUBLIC_MAP_BACKGROUND_URI (a
+// hosted image) in production. When unset, the Map screen renders a branded
+// in-app fallback rather than a third-party placeholder host — a missing env
+// var must never ship an external "600 × 800" placehold.co image (#766).
+export const MAP_BACKGROUND_URI: string | null = process.env.EXPO_PUBLIC_MAP_BACKGROUND_URI ?? null;

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -148,6 +148,11 @@ const styles = StyleSheet.create({
   arrowImage: {
     ...StyleSheet.absoluteFillObject,
   },
+  // Branded fill shown when no hosted map art is configured (#766) — keeps the
+  // map area on-brand instead of a third-party placeholder image.
+  mapBackgroundFallback: {
+    backgroundColor: colors.background.primary,
+  },
   greyBandFeminine: {
     position: ABSOLUTE,
     top: GREY_BAND_TOP,

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -248,12 +248,18 @@ const CenterColumn = ({
   <View style={styles.centerColumn}>
     <View style={styles.centerInner}>
       <GreyBands />
-      <Image
-        source={{ uri: MAP_BACKGROUND_URI }}
-        resizeMode="contain"
-        style={styles.arrowImage}
-        testID="map-background"
-      />
+      {MAP_BACKGROUND_URI ? (
+        <Image
+          source={{ uri: MAP_BACKGROUND_URI }}
+          resizeMode="contain"
+          style={styles.arrowImage}
+          testID="map-background"
+        />
+      ) : (
+        // No hosted art configured — branded in-app fallback, never an external
+        // placeholder (#766). The stage labels/bands still render on top.
+        <View style={[styles.arrowImage, styles.mapBackgroundFallback]} testID="map-background" />
+      )}
       <ConnectionLines stages={stages} />
       {stages.map((stage) => (
         <ArrowHotspot key={stage.id} stage={stage} currentStage={currentStage} onPress={onPress} />


### PR DESCRIPTION
## Summary

#766: the Map screen rendered a third-party **"600 × 800" placehold.co** placeholder because `MAP_BACKGROUND_URI` defaulted to that service when `EXPO_PUBLIC_MAP_BACKGROUND_URI` is unset — which it is in the production web build.

- `constants/images.ts`: `MAP_BACKGROUND_URI` is now the env value or `null` — **no external placeholder default**.
- `MapScreen`: render the hosted `<Image>` only when the URI is set; otherwise a **branded in-app `View` fallback** (no third-party host), keeping the `map-background` testID. Stage labels/bands still render on top.
- regression guard: a constants test asserts the default is `null` (never `placehold.co`).

## What's left (not code)

The real spiral-map art is supplied via `EXPO_PUBLIC_MAP_BACKGROUND_URI` (a hosted image) or by bundling an asset — an operator/deploy action; until then the app shows the branded fallback instead of an external placeholder.

## Test plan

`MAP_BACKGROUND_URI` defaults to `null` (no `placehold.co`); MapScreen renders the fallback when unset (exercised by existing render tests). `./scripts/frontend/check-all.sh` → 4/4.

Closes #766
