### PR TITLE
fix(deslop): mandate exhaustive whole-codebase coverage every weekly run

### DIFF
--- a/.claude/skills/de-slopify/SKILL.md
+++ b/.claude/skills/de-slopify/SKILL.md
@@ -94,14 +94,24 @@ constants, deliberate repo conventions, and unmeasured "could be faster" claims.
 This is the step that finds the slop linters cannot see, and the step the first
 audit skipped. Do not conclude "clean" without it.
 
-Fan out with the **Task tool**: spawn one subagent per feature area so the whole
-codebase is actually read in parallel, not skimmed by one thread. A good split:
+**This is an EXHAUSTIVE, WHOLE-CODEBASE reading pass on EVERY run.** Coverage is
+governed by the evidence bundle's `area-inventory.txt`, which enumerates every
+area in the repo. Fan out with the **Task tool** and spawn a reader subagent for
+**every** area in that inventory — never just the changed ones:
 
 - one subagent per backend router (`backend/src/routers/*`),
-- one for the domain layer (`backend/src/domain/*`) and one for `services/`,
+- one for each `backend/src/domain/*` and each `backend/src/services/*` module,
 - one for the models/schemas pair (look for frontend/backend shape drift),
 - one per frontend feature (`frontend/src/features/*`),
-- one for shared/util/config grab-bags (prime duplication + dead-code sites).
+- one for the shared areas (`api/`, `design/`, `components/`, `store/`) — prime
+  duplication + dead-code sites.
+
+A clean linter bundle and an unchanged file are **NOT** reasons to skip the
+reading pass for any area. **"Delta-focused", "since the last run", and "building
+on last week's baseline" scoping are FORBIDDEN** — slop in older, stable code
+must be read too. `churn.txt` / `reading-targets.txt` decide only the **order**
+areas are read first, **never** which areas are skipped (files untouched in 90
+days are absent from those lists by design).
 
 Give each subagent the **full 13-family taxonomy** (`slop-taxonomy.md`) and this
 brief: *read the actual source in your area and return corroborated candidates
@@ -110,7 +120,7 @@ stubbed/orphaned code, duplication (here and against the rest of the repo),
 architecture/layering violations, lying flags, verbosity, comment slop, AI-slop
 tells, and weak tests. Ignore anything ruff/mypy/radon/eslint already gates.*
 
-Use the `$EVID` bundle's churn and largest-file lists to prioritize. Collect all
+Use churn / largest-file lists only to prioritize the order. Collect all
 subagent candidates before corroborating.
 
 ### Step 5 — Corroborate each survivor (the gate)
@@ -167,23 +177,29 @@ Emit a concise run summary: counts by severity, what was filed (with issue
 numbers/links), what was **dropped and why** (failed corroboration / guard
 list), and what was **deduped**.
 
-Then add a **coverage ledger** — a table with one row per taxonomy family (all
-13) recording which areas/files you examined for it and the verdict
-(clean / candidates / filed). This is how a reader verifies the whole taxonomy
-was actually traversed in the reading pass, not assumed clean:
+Then add a **coverage ledger** that proves WHOLE-CODEBASE coverage two ways:
+1. one row per taxonomy family (all 13) with the verdict (clean / candidates /
+   filed), and
+2. **every area in `area-inventory.txt` marked READ this run** — no area may be
+   "unchanged → not read". This is how a reader verifies the whole taxonomy AND
+   the whole inventory were actually traversed, not assumed clean:
 
 ```
 | Family | Areas examined | Verdict |
 |--------|----------------|---------|
-| 0 Correctness | routers/*, domain/energy.py | clean |
-| 3 Dispensables | services/, frontend/features/Habits | 2 filed (#812, #813) |
+| 0 Correctness | routers/* (all 19), domain/energy.py | clean |
+| 3 Dispensables | services/* (all), frontend/features/Habits | 2 filed (#812, #813) |
 | ... | ... | ... |
+
+Inventory coverage: 19/19 routers · 16/16 domain · 12/12 services ·
+7/7 features · 4/4 shared — all READ this run.
 ```
 
-If nothing met the bar, say so plainly — *"No corroborated slop this run —
-codebase is clean against the taxonomy"* — but the ledger must still show the
-13 families were each looked at. A clean verdict with an empty ledger means the
-reading pass was skipped; that is a failed run, not a clean one.
+If nothing met the bar, say so plainly — *"Entire codebase read this run; clean
+against the taxonomy"* (never *"delta since #N"*) — but the ledger must still show
+all 13 families AND the full inventory were each read. A clean verdict with an
+empty or inventory-incomplete ledger means the reading pass was skipped or
+narrowed to changed areas; that is a failed run, not a clean one.
 
 ## What this skill must never do
 

--- a/.claude/skills/de-slopify/references/detection-playbook.md
+++ b/.claude/skills/de-slopify/references/detection-playbook.md
@@ -160,16 +160,20 @@ the first audit.
    anything in the "NOT slop" guard list (`slop-taxonomy.md`) — generated code,
    migrations, justified suppressions, framework boilerplate, test fixtures —
    and anything already enforced by the gates above.
-3. **Reading pass (fan-out) — the core of the audit.** Spawn one `Task`
-   subagent per feature area (each backend router, `domain/`, `services/`, the
-   models/schemas pair, each `frontend/src/features/*`, and the util/config
-   grab-bags). Hand each the full taxonomy and have it **read the actual
-   source** and return corroborated candidates for the linter-invisible
-   families: dead/stubbed/orphaned code, duplication (local and repo-wide),
-   architecture/layering violations, lying flags, verbosity, comment slop,
-   AI-slop tells, weak tests. Prioritize by the churn / largest-file lists in
-   the bundle. **Do not skip this for a single-threaded skim — that produces the
-   false "clean".**
+3. **Reading pass (fan-out) — the core of the audit. EXHAUSTIVE, WHOLE-CODEBASE,
+   EVERY RUN.** The bundle's `area-inventory.txt` is the authoritative coverage
+   set. Spawn one `Task` subagent for **every** area in it — every backend
+   router, every `domain/` and `services/` module, the models/schemas pair,
+   every `frontend/src/features/*`, and the shared `api/`/`design/`/`components/`/
+   `store/` — never just the changed ones. Hand each the full taxonomy and have
+   it **read the actual source** and return corroborated candidates for the
+   linter-invisible families: dead/stubbed/orphaned code, duplication (local and
+   repo-wide), architecture/layering violations, lying flags, verbosity, comment
+   slop, AI-slop tells, weak tests. **`churn.txt` / `reading-targets.txt` set the
+   ORDER only, never which areas to skip; a clean linter bundle or an unchanged
+   file is no reason to skip an area; "delta-focused" / "since last run" /
+   "building on last week's baseline" scoping is FORBIDDEN.** Do not skip this
+   for a single-threaded skim or a delta scan — both produce the false "clean".
 4. **Corroborate each survivor** against the Two-Signal Rule. For correctness
    candidates, *write and run the reproducing test* in a throwaway location
    (do not commit it — the implementing issue will own the real test). If it
@@ -184,11 +188,14 @@ the first audit.
 7. **Size & file.** Apply `issue-templates.md`. Respect the ~200–300 LoC
    sizing; split anything bigger into an epic + sub-issues in dependency order.
 8. **Report with a coverage ledger.** Emit a run summary (counts by severity,
-   what was filed, dropped and why, deduped) **plus a 13-row table — one per
-   taxonomy family — naming the areas examined and the verdict.** The ledger
-   proves the reading pass actually traversed the taxonomy. A clean verdict with
-   no ledger means the reading pass was skipped — that is a failed run, not a
-   clean one.
+   what was filed, dropped and why, deduped) **plus a coverage ledger that proves
+   WHOLE-CODEBASE coverage two ways: (a) a 13-row table — one per taxonomy family
+   — naming the areas examined and the verdict, and (b) every area in
+   `area-inventory.txt` marked READ this run (no area "unchanged → not read").**
+   A clean verdict must read *"entire codebase read this run"*, never *"delta
+   since #N"*. A clean verdict with no ledger, or a ledger that doesn't cover the
+   full inventory, means the reading pass was skipped or narrowed to changed
+   areas — that is a failed run, not a clean one.
 
 ---
 

--- a/.claude/skills/de-slopify/scripts/collect-evidence.sh
+++ b/.claude/skills/de-slopify/scripts/collect-evidence.sh
@@ -127,6 +127,11 @@ greps grep-commented.txt    '^\s*#\s*(def |class |return |if |for |while |import
 greps grep-any.txt          ':\s*any\b|<any>|as any'
 
 # Git churn / hotspots (top 30 most-changed files in the last 90 days).
+# PRIORITIZATION SIGNAL ONLY — churn (and reading-targets below) decide which
+# area the reading pass starts with; they NEVER decide which areas are skipped.
+# Files untouched in 90 days never appear here, so a run anchored to this list
+# would never read stable code. Coverage is governed by area-inventory.txt
+# (every area must be read each run); this is just the order to read it in.
 if command -v git >/dev/null 2>&1; then
   git log --since="90 days ago" --format= --name-only 2>/dev/null \
     | grep -E '^(backend|frontend)/' \
@@ -134,11 +139,13 @@ if command -v git >/dev/null 2>&1; then
     || echo "(churn unavailable)" >"$OUT/churn.txt"
 fi
 
-# Reading targets: the largest source files by line count. These — together
-# with churn.txt — are where the reading pass should start, because size and
-# change-frequency are where bloaters, duplication, and god-objects accumulate.
+# Reading targets: the largest source files by line count. PRIORITIZATION ONLY
+# (same caveat as churn.txt) — together with churn they say where to START
+# reading, because size and change-frequency are where bloaters, duplication,
+# and god-objects accumulate. They are NOT the coverage set.
 {
-  echo "# Largest source files (LoC) — prime reading-pass targets"
+  echo "# Largest source files (LoC) — prime reading-pass START targets."
+  echo "# Prioritization order only; NOT a coverage filter (see area-inventory.txt)."
   if [[ ${#SEARCH_PATHS[@]} -gt 0 ]]; then
     find "${SEARCH_PATHS[@]}" -type f \
       \( -name '*.py' -o -name '*.ts' -o -name '*.tsx' \) \
@@ -146,6 +153,40 @@ fi
       | xargs -0 wc -l 2>/dev/null | sort -rn | sed '/ total$/d' | head -30
   fi
 } >"$OUT/reading-targets.txt"
+
+# ----------------------------------------------------------------------------
+# Area inventory — the AUTHORITATIVE coverage set for the reading pass.
+# EVERY area listed here MUST be read every run (whole-codebase audit). Churn /
+# reading-targets decide the ORDER only. The coverage ledger must enumerate
+# every area below and mark it read this run; a "0 findings" verdict is only
+# defensible when the ledger covers this entire inventory — never "delta since
+# last run". Best-effort + never-fail: missing dirs are simply skipped.
+# ----------------------------------------------------------------------------
+{
+  echo "# Area inventory — the coverage set the reading pass MUST cover in full."
+  echo "# Every area must be read each run; churn/reading-targets are order only."
+  echo
+  echo "## backend routers"
+  [[ -d "$PY_SRC/routers" ]] \
+    && find "$PY_SRC/routers" -maxdepth 1 -name '*.py' ! -name '__init__.py' 2>/dev/null | sort
+  echo
+  echo "## backend domain modules"
+  [[ -d "$PY_SRC/domain" ]] \
+    && find "$PY_SRC/domain" -maxdepth 1 -name '*.py' ! -name '__init__.py' 2>/dev/null | sort
+  echo
+  echo "## backend services modules"
+  [[ -d "$PY_SRC/services" ]] \
+    && find "$PY_SRC/services" -maxdepth 1 -name '*.py' ! -name '__init__.py' 2>/dev/null | sort
+  echo
+  echo "## frontend feature areas"
+  [[ -d "$TS_SRC/features" ]] \
+    && find "$TS_SRC/features" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort
+  echo
+  echo "## frontend shared areas"
+  for shared in api design components store; do
+    [[ -d "$TS_SRC/$shared" ]] && echo "$TS_SRC/$shared"
+  done
+} >"$OUT/area-inventory.txt"
 
 # ----------------------------------------------------------------------------
 # Manifest
@@ -166,10 +207,20 @@ fi
   echo "The linter outputs (ruff/mypy/radon/bandit/eslint/tsc) are TABLE STAKES:"
   echo "the repo already passes them in pre-commit and CI, so they cannot be"
   echo "findings. Do NOT file complexity grades, lint rules, or type errors."
-  echo "Use churn.txt + reading-targets.txt to drive a Task fan-out that READS"
-  echo "the source for what linters cannot see (dead/stubbed/orphaned code,"
-  echo "duplication, architecture, lying flags, verbosity, comment slop, AI"
-  echo "tells, weak tests). That reading pass is the actual audit."
+  echo "Drive a Task fan-out that READS the source for what linters cannot see"
+  echo "(dead/stubbed/orphaned code, duplication, architecture, lying flags,"
+  echo "verbosity, comment slop, AI tells, weak tests). That reading pass is the"
+  echo "actual audit."
+  echo
+  echo "## COVERAGE IS MANDATORY AND WHOLE-CODEBASE"
+  echo "area-inventory.txt is the AUTHORITATIVE coverage set: the reading pass"
+  echo "MUST cover EVERY area in it EVERY run. churn.txt + reading-targets.txt"
+  echo "are PRIORITIZATION ORDER ONLY — they say where to start, never which"
+  echo "areas to skip. A clean linter bundle or an unchanged file is NOT a reason"
+  echo "to skip reading an area. 'Delta-focused' / 'since last run' / 'building on"
+  echo "last week's baseline' scoping is FORBIDDEN. A '0 findings' verdict is only"
+  echo "valid when the coverage ledger enumerates this entire inventory as read"
+  echo "this run."
 } >"$OUT/README.txt"
 
 log "evidence collected in $OUT"

--- a/.github/workflows/weekly-deslop.yml
+++ b/.github/workflows/weekly-deslop.yml
@@ -110,13 +110,28 @@ jobs:
             theater tests. Finding those requires READING THE CODE, not parsing
             tool JSON. The evidence bundle is a starting map, not the territory.
 
-            Mandatory reading pass (this is what was skipped last time): after
-            collecting evidence, fan out with the Task tool — spawn a subagent
-            per feature area (each backend router, the domain/ modules, each
-            frontend feature) that actually READS the source against the full
-            13-family taxonomy in references/slop-taxonomy.md and reports
-            corroborated candidates. Do not conclude "clean" from a 5-minute
-            single-threaded scan of linter output.
+            Mandatory reading pass — EXHAUSTIVE, WHOLE-CODEBASE, EVERY RUN.
+            After collecting evidence, fan out with the Task tool and spawn a
+            reader subagent for EVERY area in the evidence bundle's
+            `area-inventory.txt`: every backend router, every backend/src/domain
+            and backend/src/services module, every frontend/src/features/* area,
+            and the shared api/ design/ components/ store/. Each reader READS the
+            source against the full 13-family taxonomy in
+            references/slop-taxonomy.md and reports corroborated candidates.
+
+            This is a whole-codebase audit on EVERY run, not a delta scan. A
+            clean linter bundle and an unchanged file are NOT reasons to skip the
+            reading pass for any area. "Delta-focused", "since the last run", and
+            "building on last week's baseline" scoping are FORBIDDEN — slop in
+            older, stable code must be read too. `churn.txt` / `reading-targets.txt`
+            decide only the ORDER areas are read, NEVER which areas are skipped.
+            Do not conclude "clean" from a single-threaded scan of linter output
+            or from reading only what changed.
+
+            Coverage ledger: maintain a ledger that lists, per area in
+            area-inventory.txt, that it was READ this run (and which families it
+            was checked against). A "0 findings" verdict is only valid when the
+            ledger covers the ENTIRE inventory this run — never "delta since #N".
 
             Hard requirements (the skill enforces these — do not deviate):
             - Corroborate every finding with TWO independent signals before
@@ -140,13 +155,15 @@ jobs:
             summary — append it to the file at $GITHUB_STEP_SUMMARY (e.g.
             `cat >> "$GITHUB_STEP_SUMMARY"`) — containing: counts by severity,
             issues/epics filed (with numbers), findings dropped and why,
-            findings deduped, AND a coverage ledger: a table with one row per
-            taxonomy family (all 13) listing which areas/files you examined for
-            it and the verdict (clean / candidates / filed). The ledger is how
-            we verify the whole taxonomy was actually traversed rather than
+            findings deduped, AND a coverage ledger that proves WHOLE-CODEBASE
+            coverage two ways: (a) one row per taxonomy family (all 13) with the
+            verdict (clean / candidates / filed), and (b) every area in
+            area-inventory.txt marked READ this run — no area may be marked
+            "unchanged → not read". The ledger is how we verify the whole
+            taxonomy AND the whole inventory were actually traversed rather than
             assumed clean. This is the durable record, linked to the workflow
-            run, and never touches the issue tracker. A clean run (nothing
-            filed) writes "codebase is clean against the taxonomy this week" to
-            the job summary and files NO issue. Only open a separate `de-slop` +
+            run, and never touches the issue tracker. A clean run (nothing filed)
+            writes "entire codebase read this run; clean against the taxonomy" to
+            the job summary (NOT "delta since #N") and files NO issue. Only open a separate `de-slop` +
             `report` issue when at least one finding was filed — never on a clean
             run (a weekly report issue every Monday would flood the tracker).


### PR DESCRIPTION
## Summary

#770: the weekly de-slop audit could silently degrade into a **delta-focused** scan (only reading source changed since the last run) and still report "clean" — a false negative. Report #762 did exactly this. Make whole-codebase coverage mandatory every run.

- **`weekly-deslop.yml` + `SKILL.md` + `detection-playbook.md`**: the reading pass is now **EXHAUSTIVE, WHOLE-CODEBASE, EVERY RUN** — fan out a reader for every area in the inventory; a clean linter bundle or an unchanged file is explicitly **not** a reason to skip an area; "delta-focused" / "since-last-run" / "building on last week's baseline" scoping is **forbidden**. Churn decides only the *order*, never which areas are skipped.
- **coverage ledger** now requires per-area proof: all 13 families AND every area in `area-inventory.txt` marked READ this run (with a tally like `19/19 routers · 16/16 domain · …`); a clean verdict asserts "entire codebase read this run", never "delta since #N".
- **`collect-evidence.sh`** emits `area-inventory.txt` — the authoritative coverage set (routers + domain/services modules + `frontend/src/features/*` + shared `api/design/components/store`; sample: 19 routers, 16 domain, 12 services, 7 features, 4 shared). Churn lists documented in-script as prioritization-only.

## Test plan

Docs/prompt/shell only. `pre-commit run --all-files`-applicable hooks pass (shellcheck clean); `collect-evidence.sh` emits a plausible inventory without erroring.

Closes #770
