### PR TITLE
fix(ralph-recap): warm the code-frequency cache with backoff; render 0 net

### DIFF
--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -36,9 +36,11 @@ import datetime as dt
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
 from typing import Any, cast
 
 import stats
@@ -239,22 +241,34 @@ def fetch_pr_verdicts(repo: str, number: int, *, token: str) -> list[str]:
     return verdicts
 
 
-def fetch_repo_net_lines(repo: str, *, token: str, attempts: int = 3) -> int | None:
+def fetch_repo_net_lines(
+    repo: str,
+    *,
+    token: str,
+    attempts: int = 4,
+    sleep: Callable[[float], None] = time.sleep,
+) -> int | None:
     """Return net lines of code across the whole repo via the code-frequency stats API.
 
     GitHub computes the per-week additions/deletions stats asynchronously and
-    answers 202 with an empty body on a cold cache, so retry a few times. Any
-    failure (still warming, or an HTTP/transport error) returns None so the recap
-    shows a placeholder for the full-repo figure instead of failing outright.
+    answers 202 with an empty body on a cold cache; ``_request_json`` surfaces
+    that as ``None``. The recap runs right after a merge, so the cache is almost
+    always cold — wait with exponential backoff (2s, 4s, 8s) between attempts to
+    let it warm rather than firing all retries back-to-back. A genuine ``200 []``
+    (parsed as an empty list, not ``None``) is a real "no history" answer and
+    yields ``0 net``. Only a still-cold cache after every attempt, or an
+    HTTP/transport error, returns ``None`` so the recap shows the ``—`` placeholder.
     """
     url = f"{GITHUB_API}/repos/{repo}/stats/code_frequency"
-    for _ in range(attempts):
+    for attempt in range(attempts):
         try:
             data = _request_json(url, headers=_gh_headers(token))
         except (urllib.error.HTTPError, urllib.error.URLError):
             return None
-        if data:
+        if data is not None:  # 200 with rows, or a valid empty [] → 0 net
             return stats.net_lines_from_code_frequency(cast("list[list[int]]", data))
+        if attempt < attempts - 1:  # cold 202 — give the async cache time to warm
+            sleep(2.0 * (2**attempt))
     return None
 
 

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -309,8 +309,42 @@ def test_fetch_repo_net_lines_sums_code_frequency(monkeypatch: pytest.MonkeyPatc
 
 def test_fetch_repo_net_lines_none_when_stats_still_warming(monkeypatch: pytest.MonkeyPatch) -> None:
     # A 202 from GitHub yields an empty body (None); retries exhaust to None.
+    # Inject a no-op sleep so the backoff doesn't actually wait.
     monkeypatch.setattr(recap, "_request_json", lambda *a, **k: None)
-    assert recap.fetch_repo_net_lines("owner/repo", token="t", attempts=2) is None
+    assert (
+        recap.fetch_repo_net_lines("owner/repo", token="t", attempts=2, sleep=lambda _s: None)
+        is None
+    )
+
+
+def test_fetch_repo_net_lines_warms_to_data_after_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Cold 202 (None) twice, then the warmed stats land — backoff between tries.
+    responses: list[object] = [None, None, [[0, 100, -40]]]
+    calls = {"n": 0}
+
+    def _req(*_a: Any, **_k: Any) -> object:
+        out = responses[calls["n"]]
+        calls["n"] += 1
+        return out
+
+    monkeypatch.setattr(recap, "_request_json", _req)
+    slept: list[float] = []
+    result = recap.fetch_repo_net_lines("owner/repo", token="t", attempts=4, sleep=slept.append)
+    assert result == 60  # 100 + (-40)
+    assert calls["n"] == 3
+    assert slept == [2.0, 4.0]  # exponential backoff before the 2nd and 3rd attempts
+
+
+def test_fetch_repo_net_lines_empty_list_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A valid 200 [] (no history) is 0 net, not the "—" placeholder.
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: [])
+    assert recap.fetch_repo_net_lines("owner/repo", token="t", sleep=lambda _s: None) == 0
+
+
+def test_loc_line_renders_zero_net_not_dash() -> None:
+    line = recap._loc_line({"additions": 0, "deletions": 0}, {"additions": 0, "deletions": 0}, 0)
+    assert "0 net" in line
+    assert "—" not in line
 
 
 def test_fetch_repo_net_lines_none_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

#771: the Discord recap's "📈 LoC … (full repo)" segment rendered a blank `—` because `fetch_repo_net_lines` always returned `None`. Two compounding bugs:

1. **No backoff between retries.** GitHub's `/stats/code_frequency` computes asynchronously and answers `202` (empty body → `None`) until the cache warms; the recap runs right after a merge (cold cache) and fired all retries back-to-back with zero wait → every attempt saw the cold 202 → `None` → `—`. Add exponential backoff (2s, 4s, 8s) via an injectable `sleep` seam and bump attempts to 4.
2. **Empty list treated as falsy.** A valid `200 []` (no history) hit `if data:` == False → `None` → `—`. Guard on `data is not None` so `[]` → `net_lines_from_code_frequency([]) == 0` → `0 net` (which `_loc_line` already renders). `—` now only shows for transport errors or a still-cold cache after every attempt.

## Test plan

New tests: a cold 202 that warms on a later attempt returns the net (asserts the backoff sleeps `[2.0, 4.0]`); empty `[]` → `0`; `_loc_line(0)` → `0 net` not `—`; the still-warming test injects a no-op sleep. `scripts/ralph/test_recap_stats.py` (8 relevant) + `pre-commit` green.

Closes #771
