### PR TITLE
refactor(map): remove the dead arrow-side subsystem from mapLayout

### DIFF
--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { MAP_ROWS, MAP_TITLE_LINES, STAGE_DISPLAY, arrowSide, isFeminineSide } from '../mapLayout';
+import { MAP_ROWS, MAP_TITLE_LINES, STAGE_DISPLAY } from '../mapLayout';
 import { STAGE_COUNT } from '../stageData';
 
 const HEX_COLOR = /^#[\da-f]{6}$/i;
@@ -35,12 +35,5 @@ describe('mapLayout', () => {
 
   it('exposes the EMPTINESS / UNITY title', () => {
     expect(MAP_TITLE_LINES).toEqual(['EMPTINESS', 'UNITY']);
-  });
-
-  it('puts even (Divine-Feminine) stages on the left and odd on the right', () => {
-    expect(arrowSide(8)).toBe('left');
-    expect(arrowSide(7)).toBe('right');
-    expect(isFeminineSide(8)).toBe(true);
-    expect(isFeminineSide(7)).toBe(false);
   });
 });

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -15,12 +15,6 @@
  * match the supplied spiral PNG rather than the app-wide spiral-dynamics swatches.
  */
 
-const SIDE_LEFT = 'left';
-const SIDE_RIGHT = 'right';
-
-/** Which side of the center column a stage's arrow loop sits on. */
-export type ArrowSide = typeof SIDE_LEFT | typeof SIDE_RIGHT;
-
 /** Static, design-specific copy + color for a single stage's left-column text. */
 export interface StageDisplay {
   stageNumber: number;
@@ -148,15 +142,3 @@ export const MAP_ROWS: readonly MapRow[] = [
   { rightLabel: 'Love', stageNumbers: [4, 3] },
   { rightLabel: 'Yes-And-Ness', stageNumbers: [2, 1] },
 ];
-
-/**
- * Even-numbered stages are the Divine-Feminine ("We" / "Feel") side and their
- * arrows return along the left; odd-numbered stages point right. This mirrors
- * the alternating sweep of the spiral artwork.
- */
-export const arrowSide = (stageNumber: number): ArrowSide =>
-  stageNumber % 2 === 0 ? SIDE_LEFT : SIDE_RIGHT;
-
-/** True for the Divine-Feminine side, which carries the grey background band. */
-export const isFeminineSide = (stageNumber: number): boolean =>
-  arrowSide(stageNumber) === SIDE_LEFT;


### PR DESCRIPTION
## Summary

#761 (de-slop, Families 3 + 9): the Map rebuild (#731) left an \"arrow side / feminine side\" helper subsystem in `mapLayout.ts` that no production code consumes — the rebuilt MapScreen positions grey bands via static styles and arrows via per-stage hotspot geometry, never via these helpers. Refs existed only inside `mapLayout.ts` and its own test (coverage theater on dead code).

Delete `SIDE_LEFT`/`SIDE_RIGHT`, the `ArrowSide` type, and `arrowSide`/`isFeminineSide`, plus the one test that exercised them (and its import). **Pure deletion — the Map renders identically.**

## Test plan

`grep -rn \"arrowSide|isFeminineSide|ArrowSide|SIDE_LEFT|SIDE_RIGHT\" frontend/src` returns nothing; `./scripts/frontend/check-all.sh` 4/4.

Closes #761