### PR TITLE
fix(cors): allow PATCH so browser preflight for save endpoints succeeds

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -69,9 +69,12 @@ DEV_ORIGINS = [
 ]
 
 # CORS — only the methods the API actually serves are allowed.  Listing them
-# explicitly (BUG-INFRA-008) keeps the preflight surface tight; if a new
-# method is added (PATCH, etc.) the test suite will surface the omission.
-ALLOWED_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+# explicitly (BUG-INFRA-008) keeps the preflight surface tight.  PATCH is
+# required: several endpoints (user-practices customize, journal, practice tags
+# and recipes) are PATCH, and omitting it 400s their browser preflight so every
+# save fails on the web app.  ``test_allowed_methods_cover_all_routes`` guards
+# that this list stays a superset of the verbs the routers actually serve.
+ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
 # ``X-Request-ID`` is included so browser clients on a different origin
 # can SET the header on outbound requests (otherwise the preflight
 # strips it).  It is also exposed via ``EXPOSED_HEADERS`` below so the

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from main import (
+    ALLOWED_METHODS,
     DEV_ORIGINS,
     _assert_credentials_safe,
     _validate_prod_origin,
@@ -257,14 +258,45 @@ def test_forbidden_origin_no_cors_headers() -> None:
     assert "access-control-allow-origin" not in response.headers
 
 
-def test_preflight_disallowed_method() -> None:
-    """Preflight request for a disallowed method should return 400."""
+def test_preflight_patch_allowed() -> None:
+    """A PATCH preflight succeeds (#788): the API serves PATCH endpoints.
+
+    Omitting PATCH from the allow-list 400s the browser preflight for every
+    PATCH route (user-practices customize, journal, practice tags/recipes), so
+    saves fail with a false "offline" on the web app.
+    """
     headers = {
         "Origin": ALLOWED_ORIGIN,
         "Access-Control-Request-Method": "PATCH",
     }
     response = client.options("/auth/login", headers=headers)
+    assert response.status_code == HTTPStatus.OK
+    assert "PATCH" in response.headers.get("access-control-allow-methods", "")
+
+
+def test_preflight_disallowed_method() -> None:
+    """Preflight for a method the API never serves returns 400."""
+    headers = {
+        "Origin": ALLOWED_ORIGIN,
+        "Access-Control-Request-Method": "TRACE",
+    }
+    response = client.options("/auth/login", headers=headers)
     assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_allowed_methods_cover_all_routes() -> None:
+    """Every HTTP verb the routers serve must be in the CORS allow-list (#788).
+
+    A PATCH endpoint with PATCH missing from ALLOWED_METHODS 400s its browser
+    preflight. HEAD/OPTIONS are auto-handled by Starlette (not served by the
+    routers), so they are excluded from the comparison.
+    """
+    served: set[str] = set()
+    for route in app.routes:
+        served |= getattr(route, "methods", None) or set()
+    served -= {"HEAD", "OPTIONS"}
+    missing = served - set(ALLOWED_METHODS)
+    assert not missing, f"router methods missing from CORS allow-list: {missing}"
 
 
 # ── BUG-APP-003: PROD_DOMAIN URL-validation hardening ─────────────────────


### PR DESCRIPTION
## Summary

#788: every save on the web app failed because the CORS preflight for **PATCH returned 400** — \`ALLOWED_METHODS\` omitted PATCH while the API serves four PATCH endpoints (user-practices customize, journal, practice tags, practice recipes). DevTools confirmed: `access-control-allow-origin` present (origin fine) but `access-control-allow-methods: GET, POST, PUT, DELETE, OPTIONS` — no PATCH.

Add PATCH to `ALLOWED_METHODS`; flip the test that wrongly asserted PATCH→400 to assert it succeeds; add `test_allowed_methods_cover_all_routes` which introspects every route and asserts each served verb is in the allow-list (so this cannot recur).

## Test plan

4 CORS tests pass; `./scripts/backend/check-all.sh` 7/7.

Closes #788