### PR TITLE
fix(journal): stop the 307 https->http downgrade that breaks save behind Railway

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,4 +52,11 @@ EXPOSE 8000
 # Run migrations then start the server.  We import `main:app` (not
 # `src.main:app`) because PYTHONPATH is set to /app/src; this matches the
 # module layout used in tests.
-CMD ["sh", "-c", "python -m alembic upgrade head && python -m uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${WEB_CONCURRENCY:-2}"]
+#
+# --proxy-headers + --forwarded-allow-ips="*": the app runs behind Railway's
+# TLS-terminating proxy, so it must trust X-Forwarded-Proto to know it is on
+# https.  Without this, redirects (e.g. the trailing-slash 307) and any absolute
+# URL the app builds downgrade to http://, which browsers refuse to follow on a
+# cross-origin request — saving/loading then fails (#790).  Railway's only
+# ingress is its proxy, so trusting all forwarding peers is safe here.
+CMD ["sh", "-c", "python -m alembic upgrade head && python -m uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${WEB_CONCURRENCY:-2} --proxy-headers --forwarded-allow-ips=*"]

--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -28,11 +28,11 @@ describe('API client request composition', () => {
     );
   });
 
-  it('creates journal entry with POST /journal', async () => {
+  it('creates journal entry with POST /journal/ (canonical, no 307)', async () => {
     const entry = { content: 'hi' };
     await api.journal.create(entry);
     expect(fetch).toHaveBeenCalledWith(
-      `${mockBaseUrl}/journal`,
+      `${mockBaseUrl}/journal/`,
       expect.objectContaining({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1186,7 +1186,10 @@ export const journal = {
     if (params.limit != null) query.set('limit', String(params.limit));
     if (params.offset != null) query.set('offset', String(params.offset));
     const qs = query.toString();
-    return request<JournalListResponse>(`/journal${qs ? `?${qs}` : ''}`, {
+    // Canonical trailing slash: the collection route is `/journal/`; calling
+    // `/journal` triggers a 307 redirect that downgrades https->http behind the
+    // proxy and breaks the cross-origin request (#790).
+    return request<JournalListResponse>(`/journal/${qs ? `?${qs}` : ''}`, {
       token,
       schema: journalListResponseSchema as unknown as z.ZodType<JournalListResponse>,
     });
@@ -1195,7 +1198,8 @@ export const journal = {
     return request<JournalMessage>(`/journal/${entryId}`, { token });
   },
   create(entry: JournalMessageCreate, token?: string): Promise<JournalMessage> {
-    return request<JournalMessage>('/journal', {
+    // Trailing slash — the collection POST route is `/journal/` (#790).
+    return request<JournalMessage>('/journal/', {
       method: 'POST',
       body: entry,
       token,


### PR DESCRIPTION
## Summary

#790: \`POST /journal\` returned **307 → Location: http://…/journal/** — a trailing-slash redirect that also **downgraded https→http**. Browsers refuse to follow a protocol-downgrading cross-origin redirect, so journal save + list failed with a false "offline".

Two root causes, both fixed:
- **Proxy scheme:** the app runs behind Railway’s TLS-terminating proxy but uvicorn didn’t trust \`X-Forwarded-Proto\`, so it built \`http://\` URLs. Start it with \`--proxy-headers --forwarded-allow-ips=\"*\"\` so redirects/absolute URLs use https (Railway’s only ingress is its proxy). Fixes **every** redirect, not just journal.
- **Trailing slash:** the collection routes are \`/journal/\`; the frontend called \`/journal\` (create POST + list GET), triggering the redirect. Call the canonical \`/journal/\` so no redirect happens.

## Test plan

`./scripts/frontend/check-all.sh` 4/4; api test asserts the canonical `/journal/` path. Dockerfile CMD change verified by inspection (deploy config).

Closes #790