### PR TITLE
fix(habits): exclude zero-unit rows from stats streak (parity with GET /habits)

### DIFF
--- a/backend/src/domain/habit_stats.py
+++ b/backend/src/domain/habit_stats.py
@@ -119,6 +119,33 @@ def _subtractive_stats(
     )
 
 
+def _additive_stats(completions: list[GoalCompletion], user_timezone: str) -> HabitStats:
+    """Additive variant of :func:`compute_habit_stats`.
+
+    Additive parity (#781): a "did not complete" check-in persists a real
+    ``completed_units == 0`` row. ``GET /habits`` (services.streaks) excludes
+    those via ``completed_units > 0``; the stats path must use the same rule or
+    the two endpoints report different streaks. Filter once at the entry so the
+    day buckets, streaks, rate, and total all describe actual completions.
+    """
+    completed = [c for c in completions if c.completed_units > 0]
+    if not completed:
+        return _empty_stats()
+
+    units, counts, dates = _aggregate_by_day(completed, user_timezone)
+    sorted_dates = sorted(dates)
+    return HabitStats(
+        day_labels=list(_DAY_LABELS),
+        values=units,
+        completions_by_day=counts,
+        longest_streak=_longest_streak(sorted_dates),
+        current_streak=_current_streak(sorted_dates, user_timezone),
+        total_completions=len(completed),
+        completion_rate=_completion_rate(sorted_dates, user_timezone),
+        completion_dates=[d.isoformat() for d in sorted_dates],
+    )
+
+
 def compute_habit_stats(
     completions: list[GoalCompletion],
     user_timezone: str = "UTC",
@@ -135,19 +162,4 @@ def compute_habit_stats(
     """
     if subtractive is not None:
         return _subtractive_stats(completions, user_timezone, subtractive)
-    if not completions:
-        return _empty_stats()
-
-    units, counts, dates = _aggregate_by_day(completions, user_timezone)
-    sorted_dates = sorted(dates)
-
-    return HabitStats(
-        day_labels=list(_DAY_LABELS),
-        values=units,
-        completions_by_day=counts,
-        longest_streak=_longest_streak(sorted_dates),
-        current_streak=_current_streak(sorted_dates, user_timezone),
-        total_completions=len(completions),
-        completion_rate=_completion_rate(sorted_dates, user_timezone),
-        completion_dates=[d.isoformat() for d in sorted_dates],
-    )
+    return _additive_stats(completions, user_timezone)

--- a/backend/tests/domain/test_habit_stats.py
+++ b/backend/tests/domain/test_habit_stats.py
@@ -1,0 +1,77 @@
+"""Parity tests: habit-stats streak math must match the streak service (#781)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import pytest
+
+import domain.dates as dates_module
+from domain.habit_stats import compute_habit_stats
+from models.goal_completion import GoalCompletion
+from services.streaks import compute_habit_streak
+
+# Frozen so "yesterday/today" land deterministically (the streak walk reads
+# today_in_tz -> now_in_tz); without this the test would be time-coupled.
+_FROZEN_NOW = datetime(2026, 6, 15, 18, 0, tzinfo=UTC)
+
+
+def _zone_for(user_or_tz: object) -> ZoneInfo:
+    """Resolve an IANA zone from a tz string, UTC on failure (mirrors domain.dates)."""
+    candidate = user_or_tz if isinstance(user_or_tz, str) else getattr(user_or_tz, "timezone", None)
+    try:
+        return ZoneInfo(candidate) if candidate else ZoneInfo("UTC")
+    except (ZoneInfoNotFoundError, ValueError):
+        return ZoneInfo("UTC")
+
+
+def _frozen_now_in_tz(user_or_tz: object = None) -> datetime:
+    """Stand-in for ``domain.dates.now_in_tz`` pinned to :data:`_FROZEN_NOW`."""
+    return _FROZEN_NOW.astimezone(_zone_for(user_or_tz))
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> datetime:
+    """Pin the wall clock so the streak window is date-independent."""
+    monkeypatch.setattr(dates_module, "now_in_tz", _frozen_now_in_tz)
+    return _FROZEN_NOW
+
+
+def _completion(days_ago: int, units: float) -> GoalCompletion:
+    """An in-memory completion ``days_ago`` before the frozen now."""
+    return GoalCompletion(
+        goal_id=1,
+        user_id=1,
+        completed_units=units,
+        timestamp=_FROZEN_NOW - timedelta(days=days_ago),
+    )
+
+
+@pytest.mark.usefixtures("frozen_clock")
+def test_stats_and_streak_agree_across_zero_unit_rows() -> None:
+    """A ``completed_units == 0`` row must not inflate the stats streak (#781).
+
+    ``GET /habits`` (``compute_habit_streak``) excludes did-not-complete rows;
+    ``GET /habits/{id}/stats`` (``compute_habit_stats``) must report the same
+    ``current_streak`` rather than counting the zero-unit row as a streak day.
+    """
+    completions = [
+        _completion(days_ago=1, units=0.0),  # "did not complete" yesterday
+        _completion(days_ago=0, units=2.0),  # completed today
+    ]
+    streak = compute_habit_streak(completions, "UTC")
+    stats = compute_habit_stats(completions, "UTC")
+    assert stats.current_streak == streak == 1
+    # The zero-unit row is not a completion.
+    assert stats.total_completions == 1
+
+
+@pytest.mark.usefixtures("frozen_clock")
+def test_stats_all_zero_rows_is_empty() -> None:
+    """A habit whose only rows are did-not-complete reports a zero streak."""
+    completions = [_completion(days_ago=0, units=0.0), _completion(days_ago=1, units=0.0)]
+    stats = compute_habit_stats(completions, "UTC")
+    assert stats.current_streak == 0
+    assert stats.total_completions == 0
+    assert stats.current_streak == compute_habit_streak(completions, "UTC")


### PR DESCRIPTION
## Summary

#781: the same additive habit showed two different current-streak numbers. `GET /habits` (services.streaks) filters `completed_units > 0`, but `GET /habits/{id}/stats` (domain.habit_stats) counted every persisted completion — including the `completed_units = 0` rows written for a "did not complete" check-in — so a no-op day inflated the stats streak.

Fix the **additive** path to apply the same `completed_units > 0` rule: filter once at the entry so day buckets, streaks, completion rate/dates, and `total_completions` all describe actual completions. The **subtractive** path is untouched (it deliberately counts zero-sum abstention days). Extracted `_additive_stats` to keep xenon rank A.

**Decision** (per the issue): `total_completions` and `completions_by_day` now exclude no-op rows too — a did-not-complete is not a completion.

## Test plan

Domain parity test: `compute_habit_streak` and `compute_habit_stats(...).current_streak` agree for an interleaved `did_complete=false` row and an all-zero history (frozen clock, not time-coupled). `./scripts/backend/check-all.sh` 7/7, xenon A.

Closes #781