### PR TITLE
fix(check-in): derive reason_code from the real streak transition, not update_streak

### DIFF
--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -24,6 +24,7 @@ from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from routers.auth import get_current_user
 from schemas import CheckInResult
+from schemas.checkin import CheckInReasonCode
 from services.streaks import (
     PendingCompletion,
     StreakScope,
@@ -31,7 +32,6 @@ from services.streaks import (
     check_milestones,
     compute_consecutive_streak,
     compute_streak_before_and_after,
-    update_streak,
 )
 
 
@@ -238,6 +238,22 @@ def _completion_timestamp(completed_on: date | None, user_timezone: str) -> date
     return start + (end - start) / 2
 
 
+def _reason_for_streak_transition(old_streak: int, new_streak: int) -> CheckInReasonCode:
+    """Map the actual streak change to a reason code (#782).
+
+    Derived from the real (subtractive-aware) ``new_streak`` rather than the
+    additive ``update_streak`` heuristic, so the flag never contradicts the
+    number it ships with: a subtractive transgression that zeroes the streak now
+    reads ``streak_reset``, not ``streak_incremented``. (The
+    ``already_logged_today`` case is handled before this point.)
+    """
+    if new_streak > old_streak:
+        return "streak_incremented"
+    if new_streak < old_streak:
+        return "streak_reset"
+    return "streak_held"
+
+
 async def _persist_and_build_response(session: AsyncSession, job: _CheckInJob) -> CheckInResult:
     """Persist the completion and build a CheckInResult; streak values arrive pre-computed."""
     completion = GoalCompletion(
@@ -252,12 +268,9 @@ async def _persist_and_build_response(session: AsyncSession, job: _CheckInJob) -
         await session.flush()
     await session.commit()
     # ``new_streak`` was computed alongside ``old_streak`` from one history read
-    # (issue dedup); these are pure derivations, no DB recompute.
-    _, reason = update_streak(
-        job.old_streak,
-        did_check_in=job.did_complete,
-        is_scheduled_today=job.is_scheduled,
-    )
+    # (issue dedup); these are pure derivations, no DB recompute. The reason code
+    # is derived from the actual transition so it can't contradict new_streak.
+    reason = _reason_for_streak_transition(job.old_streak, job.new_streak)
     milestones = check_milestones(job.new_streak, _DEFAULT_THRESHOLDS, job.old_streak)
     logger.info(
         "goal_completion_recorded",

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -306,6 +306,67 @@ async def test_miss_resets_streak(async_client: AsyncClient, db_session: AsyncSe
     assert data["milestones"] == []
 
 
+@pytest.mark.asyncio
+async def test_subtractive_transgression_resets_not_increments(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#782: a subtractive transgression returns streak 0 AND a reason that agrees.
+
+    Previously reason_code came from the additive update_streak heuristic, so a
+    transgression that zeroed the streak still reported "streak_incremented" —
+    the flag contradicting the number.
+    """
+    headers, user_id = await _signup(async_client, "subuser")
+    # Long abstention history so the pre-check-in streak is large.
+    habit = Habit(
+        name="No Sugar",
+        icon="🍬",
+        start_date=date(2025, 1, 1),
+        energy_cost=10,
+        energy_return=20,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    # Subtractive: clear threshold = 1 serving; logging the stretch goal's 5
+    # servings today exceeds it -> a transgression that resets the streak.
+    clear = Goal(
+        habit_id=habit.id,
+        title="Stay clean",
+        tier="clear",
+        target=1.0,
+        target_unit="servings",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=False,
+    )
+    binge = Goal(
+        habit_id=habit.id,
+        title="Hard limit",
+        tier="stretch",
+        target=5.0,
+        target_unit="servings",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=False,
+    )
+    db_session.add_all([clear, binge])
+    await db_session.commit()
+    await db_session.refresh(binge)
+
+    resp = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": binge.id, "did_complete": True},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["streak"] == 0
+    assert data["reason_code"] == "streak_reset"
+    assert data["reason_code"] != "streak_incremented"
+
+
 # ── Unknown goal returns 404 ────────────────────────────────────────────
 
 
@@ -525,7 +586,12 @@ async def test_backfill_past_date_records_completion(
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.OK
-    assert resp.json()["reason_code"] == "streak_incremented"
+    # reason_code now follows the actual streak transition (#782): backfilling
+    # yesterday extends the current streak to 1 (incremented), but backfilling an
+    # isolated day 3 back leaves the current streak at 0 — "held", not the old
+    # "incremented" lie that contradicted the zero streak.
+    expected_reason = "streak_incremented" if days_back == 1 else "streak_held"
+    assert resp.json()["reason_code"] == expected_reason
 
     result = await db_session.execute(
         select(GoalCompletion).where(GoalCompletion.goal_id == goal.id)


### PR DESCRIPTION
## Summary

#782: the check-in response computed `reason_code` from the naive additive `update_streak()` while `streak` came from the subtractive-aware `compute_streak_before_and_after`. For a subtractive transgression the streak dropped to 0 yet `reason_code` still read **"streak_incremented"** — the flag contradicting the number.

Derive `reason_code` from the actual `(old_streak, new_streak)` transition (`new > old → incremented`, `new < old → reset`, else `held`) so it can never contradict the streak it ships with. Removed the discarded `update_streak` call + import. Streak numbers unchanged.

## Test plan

- New subtractive-transgression integration test: a 5-serving log against a clear threshold of 1 returns `streak == 0` **and** `reason_code == "streak_reset"`.
- `backfill[3]` now expects `streak_held` — backfilling an isolated day 3 back leaves the current streak at 0, so the old `incremented` was the same lie this fixes.
- `./scripts/backend/check-all.sh` 7/7, xenon A.

Closes #782