### PR TITLE
fix(habits): persist backfillMissedDays / setNewStartDate (silent lost write)

### DIFF
--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -1158,6 +1158,8 @@ describe('habitManager', () => {
       const habit = useHabitStore.getState().habits[0]!;
       expect(habit.streak).toBe(4);
       expect(habit.completions).toHaveLength(2);
+      // #783: must persist or the backfill is lost on the next cold rehydrate.
+      expect(saveHabits).toHaveBeenLastCalledWith([expect.objectContaining({ streak: 4 })]);
     });
   });
 
@@ -1176,6 +1178,10 @@ describe('habitManager', () => {
       expect(updated.streak).toBe(0);
       expect(updated.completions).toEqual([]);
       expect(updated.start_date).toEqual(newDate);
+      // #783: must persist or the reset start date is lost on the next rehydrate.
+      expect(saveHabits).toHaveBeenLastCalledWith([
+        expect.objectContaining({ start_date: newDate }),
+      ]);
     });
   });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -1021,11 +1021,18 @@ export const habitManager = {
   },
 
   backfillMissedDays: (habitId: number, days: Date[]): void => {
-    setHabits(getHabits().map((h) => (h.id === habitId ? backfillHabit(h, days) : h)));
+    // Persist like every sibling mutation — without this the backfill lives only
+    // in the Zustand store and is silently lost on the next cold rehydrate (#783).
+    const next = getHabits().map((h) => (h.id === habitId ? backfillHabit(h, days) : h));
+    setHabits(next);
+    void persistHabits(next);
   },
 
   setNewStartDate: (habitId: number, newDate: Date): void => {
-    setHabits(getHabits().map((h) => (h.id === habitId ? resetHabitStart(h, newDate) : h)));
+    // Persist so the reset start date survives a rehydrate (#783).
+    const next = getHabits().map((h) => (h.id === habitId ? resetHabitStart(h, newDate) : h));
+    setHabits(next);
+    void persistHabits(next);
   },
 
   onboardingSave: async (newHabits: OnboardingHabit[], showToast?: ShowToast): Promise<void> => {


### PR DESCRIPTION
## Summary

#783: `backfillMissedDays` and `setNewStartDate` mutated only the in-memory Zustand store and **never called `persistHabits`** — unlike every sibling mutation — so a user's backfilled days / reset start date were **silently lost on the next cold rehydrate**. Both are wired to live UI in `MissedDaysModal`.

Persist the new state in both (`void persistHabits(next)`), matching `updateGoal`. The streak/start-date math is unchanged.

## Test plan

The backfill/setNewStartDate tests now also assert `saveHabits` is called with the updated habits (reproduces the old lost-write). `./scripts/frontend/check-all.sh` 4/4.

Closes #783