### PR TITLE
refactor(frontend): de-slop tidy-up — ConfirmDialog on web + dead/dup cleanup

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -41,13 +41,6 @@ export type { Page } from './schemas';
 /** Default per-request timeout. Tuned long enough to cover slow 3G + warm-up. */
 export const FETCH_TIMEOUT_MS = 30_000;
 
-/**
- * Longer timeout applied to BotMason SSE streams. The server keeps the
- * connection open until the model finishes; a 30-second cap would kill the
- * tail of every reply.
- */
-export const STREAM_TIMEOUT_MS = 5 * 60_000;
-
 /** Maximum retry attempts **after** the initial request. */
 const MAX_RETRIES = 2;
 const BASE_BACKOFF_MS = 500;
@@ -1991,10 +1984,6 @@ export const practiceRecipes = {
  * `banner_text` is the fully formatted English string — the client
  * renders it verbatim, never assembling the copy from the structured
  * fields. The structured fields are still exposed for chips and tests.
- *
- * TODO(ritual-05): once #310 (frequency-copy endpoint) merges, align this
- * hand-written shape with the backend response (e.g. via a shared Zod schema)
- * for end-to-end type safety.
  */
 export interface FrequencyResponse {
   stage_number: number;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -208,6 +208,7 @@ async function saveTokenThenApply(
   newTimezone: string | undefined,
   mutators: AuthMutators,
   tokenRef: React.MutableRefObject<string | null>,
+  warnLabel: string,
 ): Promise<void> {
   if (tokenRef.current === null) {
     // Logout won the race — drop the late refresh response on the floor.
@@ -216,7 +217,7 @@ async function saveTokenThenApply(
   try {
     await saveToken(newToken);
   } catch (err: unknown) {
-    console.warn('saveToken failed in onTokenRefreshed', err);
+    console.warn(`saveToken failed in ${warnLabel}`, err);
     return;
   }
   if (tokenRef.current === null) return;
@@ -246,7 +247,7 @@ function useApiCallbacks(
       void clearTokenForReauth(mutators, reason);
     });
     setOnTokenRefreshed((t: string, tz: string | undefined) => {
-      void saveTokenThenApply(t, tz, mutators, tokenRef);
+      void saveTokenThenApply(t, tz, mutators, tokenRef, 'onTokenRefreshed');
     });
     return () => {
       setTokenGetter(null);
@@ -434,19 +435,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // ``saveTokenThenApply`` so a logout that wins the race against a
   // proactive refresh does NOT silently resurrect the session by
   // re-applying a stale token after the user explicitly signed out.
-  const applyNewToken = useCallback(async (newToken: string, newTimezone: string | undefined) => {
-    if (tokenRef.current === null) return;
-    try {
-      await saveToken(newToken);
-    } catch (err: unknown) {
-      console.warn('saveToken failed in applyNewToken', err);
-      return;
-    }
-    if (tokenRef.current === null) return;
-    setToken(newToken);
-    setUserTimezone(newTimezone ?? 'UTC');
-    setAuthStatus('authenticated');
-  }, []);
+  const applyNewToken = useCallback(
+    async (newToken: string, newTimezone: string | undefined) => {
+      await saveTokenThenApply(newToken, newTimezone, mutators, tokenRef, 'applyNewToken');
+    },
+    [mutators],
+  );
 
   useApiCallbacks(tokenRef, mutators);
   useProactiveRefresh(token, tokenRef, applyNewToken);

--- a/frontend/src/features/Auth/CancelResetScreen.tsx
+++ b/frontend/src/features/Auth/CancelResetScreen.tsx
@@ -3,11 +3,10 @@ import { ActivityIndicator, StyleSheet, Text, TouchableOpacity } from 'react-nat
 
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
+import { MIN_TOKEN_LENGTH } from './resetToken';
 
 import { auth as authApi } from '@/api';
 import { SPACING, colors } from '@/design/tokens';
-
-const MIN_TOKEN_LENGTH = 32;
 
 type CancelStatus = 'pending' | 'success' | 'error' | 'invalid_token';
 

--- a/frontend/src/features/Auth/ResetPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ResetPasswordScreen.tsx
@@ -4,13 +4,13 @@ import { Text, TextInput, TouchableOpacity } from 'react-native';
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { validatePasswordPair } from './passwordValidation';
+import { MIN_TOKEN_LENGTH } from './resetToken';
 
 import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
 
 const RESET_FALLBACK =
   "We couldn't apply that reset. The link may have expired -- request a new one and try again.";
-const MIN_TOKEN_LENGTH = 32;
 
 interface RouteParams {
   token?: string;

--- a/frontend/src/features/Auth/resetToken.ts
+++ b/frontend/src/features/Auth/resetToken.ts
@@ -1,0 +1,6 @@
+/**
+ * Minimum length of a backend-issued password-reset token (matches the server's
+ * token generator). Shared by the reset-password and cancel-reset screens so the
+ * client-side "looks valid" guard stays identical on both.
+ */
+export const MIN_TOKEN_LENGTH = 32;

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -1,19 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
-import {
-  Alert,
-  Animated,
-  Easing,
-  Text,
-  TouchableOpacity,
-  View,
-  type DimensionValue,
-} from 'react-native';
+import { Animated, Easing, Text, TouchableOpacity, View, type DimensionValue } from 'react-native';
 
 import { TierStar } from '../../components/TierStar';
 import { colors, STAGE_COLORS, spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 import { DEFAULT_TIMEZONE } from '../../utils/dateUtils';
 
+import ConfirmDialog from './components/ConfirmDialog';
 import { TIER_LABELS, centeredTranslateX, tooltipBoxStyle, type TierType } from './goalMarker';
 import type { HabitTileProps, Goal, Habit } from './Habits.types';
 import {
@@ -457,18 +450,6 @@ const useHabitTileData = (habit: Habit, tz: string, stageColor: string) => {
   return { progressPercentage, progressBarColor, hasCompletedGoal, markers };
 };
 
-const showUnlockConfirmation = (habit: Habit, onUnlock: (_id: number) => void) => {
-  const dateStr = new Date(habit.start_date).toLocaleDateString();
-  Alert.alert(
-    'Unlock Early?',
-    `Unlock "${habit.name}" early? The recommended start date is ${dateStr}.`,
-    [
-      { text: 'Cancel', style: 'cancel' },
-      { text: 'Unlock', onPress: () => onUnlock(habit.id) },
-    ],
-  );
-};
-
 const LOCKED_BACKGROUND = '#e8e8e8';
 const LOCKED_OPACITY = 0.4;
 const MS_PER_DAY = 86_400_000;
@@ -518,40 +499,60 @@ const LOCKED_NAME_STYLE = {
   color: '#999',
 };
 
-const LockedTile = ({
+const LockedTileButton = ({
   habit,
   stageColor,
   scale,
   gridGutter,
   tileMinHeight,
-  onUnlockHabit,
-}: LockedTileProps) => {
-  const handleLongPress = onUnlockHabit
-    ? () => showUnlockConfirmation(habit, onUnlockHabit)
-    : undefined;
-  return (
-    <TouchableOpacity
-      testID="habit-tile"
-      accessibilityLabel={`${habit.name} locked`}
-      onLongPress={handleLongPress}
-      style={getLockedTileStyle(stageColor, scale, gridGutter, tileMinHeight)}
+  onLongPress,
+}: Omit<LockedTileProps, 'onUnlockHabit'> & { onLongPress?: () => void }) => (
+  <TouchableOpacity
+    testID="habit-tile"
+    accessibilityLabel={`${habit.name} locked`}
+    onLongPress={onLongPress}
+    style={getLockedTileStyle(stageColor, scale, gridGutter, tileMinHeight)}
+  >
+    <View testID="habit-header" style={{ flexDirection: 'row', alignItems: 'center' }}>
+      <Text style={{ fontSize: spacing(2, scale), marginRight: spacing(1, scale) }}>🔒</Text>
+      <Text style={{ ...LOCKED_NAME_STYLE, fontSize: spacing(2, scale) }}>{habit.name}</Text>
+    </View>
+    <Text
+      testID="unlock-label"
+      style={{
+        fontSize: spacing(1.5, scale),
+        color: '#999',
+        marginTop: spacing(0.5, scale),
+        fontStyle: 'italic',
+      }}
     >
-      <View testID="habit-header" style={{ flexDirection: 'row', alignItems: 'center' }}>
-        <Text style={{ fontSize: spacing(2, scale), marginRight: spacing(1, scale) }}>🔒</Text>
-        <Text style={{ ...LOCKED_NAME_STYLE, fontSize: spacing(2, scale) }}>{habit.name}</Text>
-      </View>
-      <Text
-        testID="unlock-label"
-        style={{
-          fontSize: spacing(1.5, scale),
-          color: '#999',
-          marginTop: spacing(0.5, scale),
-          fontStyle: 'italic',
+      {getUnlockLabel(habit)}
+    </Text>
+  </TouchableOpacity>
+);
+
+const LockedTile = ({ onUnlockHabit, ...rest }: LockedTileProps) => {
+  const [showUnlockConfirm, setShowUnlockConfirm] = useState(false);
+  const handleLongPress = onUnlockHabit ? () => setShowUnlockConfirm(true) : undefined;
+  const dateStr = new Date(rest.habit.start_date).toLocaleDateString();
+  return (
+    <>
+      <LockedTileButton {...rest} onLongPress={handleLongPress} />
+      <ConfirmDialog
+        visible={showUnlockConfirm}
+        title="Unlock Early?"
+        message={`Unlock "${rest.habit.name}" early? The recommended start date is ${dateStr}.`}
+        testID="unlock-habit-confirm"
+        cancelTestID="unlock-habit-cancel"
+        confirmTestID="unlock-habit-confirm-button"
+        confirmLabel="Unlock"
+        onCancel={() => setShowUnlockConfirm(false)}
+        onConfirm={() => {
+          setShowUnlockConfirm(false);
+          onUnlockHabit?.(rest.habit.id);
         }}
-      >
-        {getUnlockLabel(habit)}
-      </Text>
-    </TouchableOpacity>
+      />
+    </>
   );
 };
 

--- a/frontend/src/features/Habits/__tests__/ManualUnlock.test.tsx
+++ b/frontend/src/features/Habits/__tests__/ManualUnlock.test.tsx
@@ -1,7 +1,6 @@
 /* eslint-env jest */
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import React from 'react';
-import { Alert } from 'react-native';
 import renderer from 'react-test-renderer';
 
 import type { Habit } from '../Habits.types';
@@ -105,10 +104,12 @@ describe('HabitTile early-unlock visual indicator', () => {
 });
 
 describe('HabitTile locked tile long-press', () => {
-  beforeEach(() => {
-    jest.restoreAllMocks();
-    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
-  });
+  // ConfirmDialog (#786) replaces Alert.alert, which is a no-op on RN Web mobile.
+  const mentionsHabit = (component: ReturnType<typeof renderer.create>, name: string): boolean =>
+    component.root.findAll(
+      (n: { props: { children?: unknown } }) =>
+        typeof n.props.children === 'string' && n.props.children.includes(name),
+    ).length > 0;
 
   it('shows unlock confirmation on long-press of a locked (unrevealed) tile', () => {
     const onUnlockHabit = jest.fn();
@@ -120,14 +121,10 @@ describe('HabitTile locked tile long-press', () => {
     renderer.act(() => {
       tile.props.onLongPress();
     });
-    expect(Alert.alert).toHaveBeenCalledWith(
-      'Unlock Early?',
-      expect.stringContaining('Future Habit'),
-      expect.arrayContaining([
-        expect.objectContaining({ text: 'Cancel' }),
-        expect.objectContaining({ text: 'Unlock' }),
-      ]),
-    );
+    // The rendered dialog appears (not a silently-dropped Alert) and names the habit.
+    expect(component.root.findByProps({ testID: 'unlock-habit-confirm' })).toBeTruthy();
+    expect(component.root.findByProps({ testID: 'unlock-habit-confirm-button' })).toBeTruthy();
+    expect(mentionsHabit(component, 'Future Habit')).toBe(true);
   });
 
   it('calls onUnlockHabit when unlock is confirmed', () => {
@@ -140,14 +137,9 @@ describe('HabitTile locked tile long-press', () => {
     renderer.act(() => {
       tile.props.onLongPress();
     });
-
-    // Get the Unlock button callback from the Alert.alert call
-    const alertCalls = (Alert.alert as jest.Mock).mock.calls;
-    const firstCall = alertCalls[0] as unknown[];
-    const buttons = firstCall[2] as Array<{ text: string; onPress?: () => void }>;
-    const unlockButton = buttons.find((b) => b.text === 'Unlock');
+    const confirmButton = component.root.findByProps({ testID: 'unlock-habit-confirm-button' });
     renderer.act(() => {
-      unlockButton?.onPress?.();
+      confirmButton.props.onPress();
     });
     expect(onUnlockHabit).toHaveBeenCalledWith(habit.id);
   });
@@ -162,7 +154,7 @@ describe('HabitTile locked tile long-press', () => {
     renderer.act(() => {
       tile.props.onLongPress();
     });
-    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(component.root.findAllByProps({ testID: 'unlock-habit-confirm' })).toHaveLength(0);
     expect(onLongPress).toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -1,7 +1,6 @@
 import { Check, ChevronLeft, ChevronRight, Pencil } from 'lucide-react-native';
 import React, { useState, useRef, useEffect } from 'react';
 import {
-  Alert,
   Modal,
   Pressable,
   ScrollView,
@@ -47,6 +46,8 @@ import {
   isGoalAchieved,
   calculateTodaysProgress,
 } from '../HabitUtils';
+
+import ConfirmDialog from './ConfirmDialog';
 
 /** Height of the goal progress bar; tier star markers are centered on it. */
 const MODAL_BAR_HEIGHT = 12;
@@ -937,38 +938,37 @@ const useGoalGroup = (habit: GoalModalProps['habit']) => {
   return goalGroup;
 };
 
-const confirmGoalUpdate = (
+interface PendingGoalEdit {
+  tier: 'low' | 'clear';
+  goal: Goal;
+  newTarget: number;
+  title: string;
+  message: string;
+}
+
+/**
+ * Build the pending goal-edit confirmation for a marker drop, or ``null`` when
+ * the drop is a no-op. Rendered via ``ConfirmDialog`` rather than ``Alert.alert``
+ * because the latter is a no-op on React Native Web mobile (#786).
+ */
+const buildPendingGoalEdit = (
   tier: 'low' | 'clear',
   percent: number,
-  lowGoal: Goal | undefined,
-  clearGoal: Goal | undefined,
-  stretchGoal: Goal | undefined,
+  tiers: ReturnType<typeof useGoalTiers>,
   habitId: number | undefined,
-  markers: { low: number; clear: number },
-  setLowMarker: (_v: number) => void,
-  setClearMarker: (_v: number) => void,
-  onUpdateGoal: GoalModalProps['onUpdateGoal'],
-) => {
-  const goal = tier === 'low' ? lowGoal : clearGoal;
-  if (!goal || !habitId) return;
-  const stretchTarget = stretchGoal ? getGoalTarget(stretchGoal) : goal.target;
+): PendingGoalEdit | null => {
+  const goal = tier === 'low' ? tiers.lowGoal : tiers.clearGoal;
+  if (!goal || !habitId) return null;
+  const stretchTarget = tiers.stretchGoal ? getGoalTarget(tiers.stretchGoal) : goal.target;
   const newTarget = Math.max(1, Math.round((percent / 100) * stretchTarget));
   const tierLabel = tier === 'low' ? 'Low Grit' : 'Clear Goal';
-  Alert.alert(
-    `Edit ${tierLabel.split(' ')[0]} Goal`,
-    `Edit the ${tierLabel} to be ${newTarget} ${goal.target_unit} ${goal.frequency_unit.replace('_', ' ')}?`,
-    [
-      {
-        text: 'No',
-        style: 'cancel',
-        onPress: () => {
-          if (tier === 'low') setLowMarker(markers.low);
-          else setClearMarker(markers.clear);
-        },
-      },
-      { text: 'Yes', onPress: () => onUpdateGoal(habitId, { ...goal, target: newTarget }) },
-    ],
-  );
+  return {
+    tier,
+    goal,
+    newTarget,
+    title: `Edit ${tierLabel.split(' ')[0]} Goal`,
+    message: `Edit the ${tierLabel} to be ${newTarget} ${goal.target_unit} ${goal.frequency_unit.replace('_', ' ')}?`,
+  };
 };
 
 function useGoalTiers(habit: GoalModalProps['habit']) {
@@ -1018,20 +1018,21 @@ function useGoalConfirm(
   setClearMarker: (_v: number) => void,
   onUpdateGoal: GoalModalProps['onUpdateGoal'],
 ) {
-  return (tier: 'low' | 'clear', percent: number) => {
-    confirmGoalUpdate(
-      tier,
-      percent,
-      tiers.lowGoal,
-      tiers.clearGoal,
-      tiers.stretchGoal,
-      habitId,
-      tiers.markers,
-      setLowMarker,
-      setClearMarker,
-      onUpdateGoal,
-    );
+  const [pending, setPending] = useState<PendingGoalEdit | null>(null);
+  const onConfirm = (tier: 'low' | 'clear', percent: number) => {
+    const edit = buildPendingGoalEdit(tier, percent, tiers, habitId);
+    if (edit) setPending(edit);
   };
+  const cancelPending = () => {
+    if (pending?.tier === 'low') setLowMarker(tiers.markers.low);
+    else if (pending?.tier === 'clear') setClearMarker(tiers.markers.clear);
+    setPending(null);
+  };
+  const applyPending = () => {
+    if (pending && habitId) onUpdateGoal(habitId, { ...pending.goal, target: pending.newTarget });
+    setPending(null);
+  };
+  return { onConfirm, pending, cancelPending, applyPending };
 }
 
 const useGoalMarkers = (
@@ -1053,7 +1054,13 @@ const useGoalMarkers = (
     barWidth.current = e.nativeEvent.layout.width;
   };
 
-  const onConfirm = useGoalConfirm(tiers, habit?.id, setLowMarker, setClearMarker, onUpdateGoal);
+  const { onConfirm, pending, cancelPending, applyPending } = useGoalConfirm(
+    tiers,
+    habit?.id,
+    setLowMarker,
+    setClearMarker,
+    onUpdateGoal,
+  );
   const { lowPan, clearPan } = useMarkerPanResponders(
     tiers,
     barWidth,
@@ -1075,6 +1082,9 @@ const useGoalMarkers = (
     lowPan,
     clearPan,
     handleBarLayout,
+    pendingGoalEdit: pending,
+    cancelGoalEdit: cancelPending,
+    applyGoalEdit: applyPending,
   };
 };
 
@@ -1211,6 +1221,25 @@ const useLogState = (
   return { logAmount, setLogAmount, logDate, setLogDate, handleLogUnit };
 };
 
+const GoalEditConfirmDialog = ({
+  m,
+}: {
+  m: ReturnType<typeof useGoalMarkers>;
+}): React.JSX.Element => (
+  <ConfirmDialog
+    visible={!!m.pendingGoalEdit}
+    title={m.pendingGoalEdit?.title ?? ''}
+    message={m.pendingGoalEdit?.message}
+    confirmLabel="Yes"
+    cancelLabel="No"
+    testID="goal-edit-confirm"
+    confirmTestID="goal-edit-confirm-button"
+    cancelTestID="goal-edit-cancel"
+    onCancel={m.cancelGoalEdit}
+    onConfirm={m.applyGoalEdit}
+  />
+);
+
 const GoalModalBody = ({
   habit,
   onClose,
@@ -1257,6 +1286,7 @@ const GoalModalBody = ({
         tz={userTimezone}
         onLog={log.handleLogUnit}
       />
+      <GoalEditConfirmDialog m={m} />
     </View>
   );
 };

--- a/frontend/src/features/Journal/SearchBar.tsx
+++ b/frontend/src/features/Journal/SearchBar.tsx
@@ -20,7 +20,7 @@ const CollapsedSearchBar = ({ onToggle }: { onToggle: () => void }): React.JSX.E
       accessibilityLabel="Open journal search"
       accessibilityRole="button"
     >
-      <Text style={styles.searchIcon}>?</Text>
+      <Text style={styles.searchIcon}>🔍</Text>
     </TouchableOpacity>
   </View>
 );
@@ -51,7 +51,7 @@ const ExpandedSearchBarContent = ({
         accessibilityLabel="Focus journal search"
         accessibilityRole="button"
       >
-        <Text style={styles.searchIcon}>?</Text>
+        <Text style={styles.searchIcon}>🔍</Text>
       </TouchableOpacity>
       <TextInput
         testID="search-input"
@@ -70,7 +70,7 @@ const ExpandedSearchBarContent = ({
         accessibilityLabel="Clear search"
         accessibilityRole="button"
       >
-        <Text style={styles.searchClearText}>X</Text>
+        <Text style={styles.searchClearText}>×</Text>
       </TouchableOpacity>
     </View>
     {searchQuery && resultCount != null && (

--- a/frontend/src/features/Journal/__tests__/SearchBar.test.tsx
+++ b/frontend/src/features/Journal/__tests__/SearchBar.test.tsx
@@ -18,9 +18,11 @@ describe('SearchBar', () => {
   });
 
   it('renders search icon button when collapsed', () => {
-    const { getByTestId, queryByTestId } = render(<SearchBar onSearch={onSearch} />);
+    const { getByTestId, queryByTestId, getByText } = render(<SearchBar onSearch={onSearch} />);
     expect(getByTestId('search-toggle')).toBeTruthy();
     expect(queryByTestId('search-input')).toBeNull();
+    // Real magnifier glyph, not the old literal "?" placeholder.
+    expect(getByText('🔍')).toBeTruthy();
   });
 
   it('expands to show text input on toggle press', () => {

--- a/frontend/src/features/Journal/__tests__/useResonance.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonance.test.tsx
@@ -66,7 +66,7 @@ describe('useResonance', () => {
     expect(mockList).toHaveBeenCalledWith(7);
   });
 
-  it('flushes the save, then generates and stores notes + remaining', async () => {
+  it('flushes the save, then generates and stores notes', async () => {
     const flush = jest.fn(async () => 42);
     mockGenerate.mockResolvedValue(resonancePayload([note({ id: 5, journal_entry_id: 42 })]));
     const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
@@ -77,7 +77,6 @@ describe('useResonance', () => {
     expect(flush).toHaveBeenCalledTimes(1);
     expect(mockGenerate).toHaveBeenCalledWith(42);
     expect(result.current.marginalia).toHaveLength(1);
-    expect(result.current.remaining).toBe(48);
   });
 
   it('maps a 402 to a friendly error and leaves the page usable', async () => {

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -3,10 +3,9 @@
  *
  * On open (entry already has an id) it loads existing marginalia. A request
  * flushes the draft save first (so we resonate against the *saved* latest body),
- * calls the generate endpoint, merges the returned notes, and refreshes the
- * remaining-pass balance. One request runs at a time so rapid taps can't
- * double-charge; errors (notably 402) are mapped to friendly copy and never
- * crash the page.
+ * calls the generate endpoint, and merges the returned notes. One request runs
+ * at a time so rapid taps can't double-charge; errors (notably 402) are mapped
+ * to friendly copy and never crash the page.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -26,7 +25,6 @@ export interface UseResonanceResult {
   marginalia: Marginalia[];
   loading: boolean;
   error: string | null;
-  remaining: number | null;
   requestResonance: () => Promise<void>;
   /** Merge an updated note (e.g. one that just gained a cached essay) by id. */
   updateNote: (_note: Marginalia) => void;
@@ -68,7 +66,6 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
   const [marginalia, setMarginalia] = useState<Marginalia[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [remaining, setRemaining] = useState<number | null>(null);
   const inFlightRef = useRef(false);
 
   useInitialMarginalia(routeEntryId, setMarginalia);
@@ -86,7 +83,6 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
       }
       const result = await resonance.generate(entryId);
       setMarginalia((prev) => mergeById(prev, result.marginalia));
-      setRemaining(result.remaining_messages);
     } catch (err) {
       setError(formatApiError(err));
     } finally {
@@ -109,5 +105,5 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     }
   }, [routeEntryId]);
 
-  return { marginalia, loading, error, remaining, requestResonance, updateNote, refresh };
+  return { marginalia, loading, error, requestResonance, updateNote, refresh };
 }

--- a/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { resolveCardImage } from '../../data/assetResolver';
@@ -14,7 +14,7 @@ import {
 } from '../../engine/types';
 import { pickCardPhoto } from '../../utils/pickCardPhoto';
 
-import { Chip, LabeledRow, NumericField, TextField, ToggleRow } from './shared';
+import { Chip, CollapsibleSection, LabeledRow, NumericField, TextField, ToggleRow } from './shared';
 
 import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
@@ -43,7 +43,9 @@ const CardMeditationForm = ({ value, onChange }: Props): React.JSX.Element => {
       ) : (
         <DeckSummary deckId={value.deck_id} />
       )}
-      <AdvancedSection value={value} onChange={onChange} />
+      <CollapsibleSection testIDBase="card-meditation-advanced">
+        <AdvancedFields value={value} onChange={onChange} />
+      </CollapsibleSection>
     </View>
   );
 };
@@ -260,25 +262,6 @@ const CardPhotoField = ({ index, card, onUpdate }: CardPhotoFieldProps): React.J
   );
 };
 
-const AdvancedSection = ({ value, onChange }: Props): React.JSX.Element => {
-  const [open, setOpen] = useState(false);
-  return (
-    <View testID="card-meditation-advanced">
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessibilityLabel="Advanced settings"
-        accessibilityState={{ expanded: open }}
-        onPress={() => setOpen((prev) => !prev)}
-        style={styles.advancedToggle}
-        testID="card-meditation-advanced-toggle"
-      >
-        <Text style={styles.advancedToggleText}>{`${open ? '▾' : '▸'} Advanced`}</Text>
-      </TouchableOpacity>
-      {open && <AdvancedFields value={value} onChange={onChange} />}
-    </View>
-  );
-};
-
 const AdvancedFields = ({ value, onChange }: Props): React.JSX.Element => (
   <View testID="card-meditation-advanced-fields">
     <LabeledRow label="Minutes with the card">
@@ -393,8 +376,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background.accent,
   },
   addButtonText: { fontSize: 14, fontWeight: '600', color: colors.text.primary },
-  advancedToggle: { paddingVertical: SPACING.md, marginTop: SPACING.sm },
-  advancedToggleText: { fontSize: 14, fontWeight: '600', color: colors.text.primary },
 });
 
 export default CardMeditationForm;

--- a/frontend/src/features/Practice/configurator/forms/IntervalBellForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/IntervalBellForm.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import type { IntervalBellConfig, IntervalBellTone } from '../../engine/types';
+import type { IntervalBellConfig } from '../../engine/types';
 
-import { Chip, LabeledRow, NumericField } from './shared';
+import { BellToneRow, Chip, LabeledRow, NumericField } from './shared';
 
 import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
-
-const TONES: readonly IntervalBellTone[] = ['bowl', 'chime', 'gong'];
 
 interface Props {
   value: IntervalBellConfig;
@@ -30,7 +28,7 @@ const IntervalBellForm = ({ value, onChange }: Props): React.JSX.Element => {
       ) : (
         <CustomOffsetControls value={value} onChange={onChange} />
       )}
-      <BellToneRow value={value} onChange={onChange} />
+      <BellToneRow value={value} onChange={onChange} testIDPrefix="interval-bell" />
     </View>
   );
 };
@@ -77,22 +75,6 @@ const SpacingRow = ({ kind, value, onChange }: SpacingRowProps): React.JSX.Eleme
     </LabeledRow>
   );
 };
-
-const BellToneRow = ({ value, onChange }: Props): React.JSX.Element => (
-  <LabeledRow label="Bell tone">
-    <View style={localStyles.kindRow}>
-      {TONES.map((tone) => (
-        <Chip
-          key={tone}
-          label={tone}
-          active={value.bell_tone === tone}
-          onPress={() => onChange({ ...value, bell_tone: tone })}
-          testID={`interval-bell-tone-${tone}`}
-        />
-      ))}
-    </View>
-  </LabeledRow>
-);
 
 const EvenIntervalControls = ({ value, onChange }: Props): React.JSX.Element => (
   <LabeledRow label="Interval (minutes)">

--- a/frontend/src/features/Practice/configurator/forms/RandomIntervalBellForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/RandomIntervalBellForm.tsx
@@ -1,13 +1,9 @@
-import React, { useState } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React from 'react';
+import { View } from 'react-native';
 
-import type { IntervalBellTone, RandomIntervalBellConfig } from '../../engine/types';
+import type { RandomIntervalBellConfig } from '../../engine/types';
 
-import { Chip, LabeledRow, NumericField, ToggleRow } from './shared';
-
-import { SPACING, colors } from '@/design/tokens';
-
-const TONES: readonly IntervalBellTone[] = ['bowl', 'chime', 'gong'];
+import { BellToneRow, CollapsibleSection, LabeledRow, NumericField, ToggleRow } from './shared';
 
 interface Props {
   value: RandomIntervalBellConfig;
@@ -42,45 +38,12 @@ const RandomIntervalBellForm = ({ value, onChange }: Props): React.JSX.Element =
         testID="random-interval-bell-max"
       />
     </LabeledRow>
-    <BellToneRow value={value} onChange={onChange} />
-    <AdvancedSection value={value} onChange={onChange} />
+    <BellToneRow value={value} onChange={onChange} testIDPrefix="random-interval-bell" />
+    <CollapsibleSection testIDBase="random-interval-bell-advanced">
+      <AdvancedFields value={value} onChange={onChange} />
+    </CollapsibleSection>
   </View>
 );
-
-const BellToneRow = ({ value, onChange }: Props): React.JSX.Element => (
-  <LabeledRow label="Bell tone">
-    <View style={styles.toneRow}>
-      {TONES.map((tone) => (
-        <Chip
-          key={tone}
-          label={tone}
-          active={value.bell_tone === tone}
-          onPress={() => onChange({ ...value, bell_tone: tone })}
-          testID={`random-interval-bell-tone-${tone}`}
-        />
-      ))}
-    </View>
-  </LabeledRow>
-);
-
-const AdvancedSection = ({ value, onChange }: Props): React.JSX.Element => {
-  const [open, setOpen] = useState(false);
-  return (
-    <View testID="random-interval-bell-advanced">
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessibilityLabel="Advanced settings"
-        accessibilityState={{ expanded: open }}
-        onPress={() => setOpen((prev) => !prev)}
-        style={styles.advancedToggle}
-        testID="random-interval-bell-advanced-toggle"
-      >
-        <Text style={styles.advancedToggleText}>{`${open ? '▾' : '▸'} Advanced`}</Text>
-      </TouchableOpacity>
-      {open && <AdvancedFields value={value} onChange={onChange} />}
-    </View>
-  );
-};
 
 const AdvancedFields = ({ value, onChange }: Props): React.JSX.Element => (
   <View testID="random-interval-bell-advanced-fields">
@@ -107,11 +70,5 @@ const AdvancedFields = ({ value, onChange }: Props): React.JSX.Element => (
     />
   </View>
 );
-
-const styles = StyleSheet.create({
-  toneRow: { flexDirection: 'row', gap: SPACING.xs, flexWrap: 'wrap' },
-  advancedToggle: { paddingVertical: SPACING.md, marginTop: SPACING.sm },
-  advancedToggleText: { fontSize: 14, fontWeight: '600', color: colors.text.primary },
-});
 
 export default RandomIntervalBellForm;

--- a/frontend/src/features/Practice/configurator/forms/shared.tsx
+++ b/frontend/src/features/Practice/configurator/forms/shared.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { StyleSheet, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+import type { IntervalBellTone } from '../../engine/types';
 
 import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
@@ -190,7 +192,72 @@ export const ErrorList = ({ errors }: { errors: readonly string[] }): React.JSX.
   );
 };
 
+/** The bell tones every interval-bell mode offers. */
+export const BELL_TONES: readonly IntervalBellTone[] = ['bowl', 'chime', 'gong'];
+
+interface BellToneRowProps<T extends { bell_tone: IntervalBellTone }> {
+  value: T;
+  onChange: (_next: T) => void;
+  /** testID stem, e.g. ``interval-bell`` → ``interval-bell-tone-bowl``. */
+  testIDPrefix: string;
+}
+
+/** Tone picker shared by the interval-bell and random-interval-bell forms. */
+export const BellToneRow = <T extends { bell_tone: IntervalBellTone }>({
+  value,
+  onChange,
+  testIDPrefix,
+}: BellToneRowProps<T>): React.JSX.Element => (
+  <LabeledRow label="Bell tone">
+    <View style={formStyles.toneRow}>
+      {BELL_TONES.map((tone) => (
+        <Chip
+          key={tone}
+          label={tone}
+          active={value.bell_tone === tone}
+          onPress={() => onChange({ ...value, bell_tone: tone })}
+          testID={`${testIDPrefix}-tone-${tone}`}
+        />
+      ))}
+    </View>
+  </LabeledRow>
+);
+
+interface CollapsibleSectionProps {
+  /** testID stem, e.g. ``card-meditation-advanced`` → ``…-advanced-toggle``. */
+  testIDBase: string;
+  label?: string;
+  children: React.ReactNode;
+}
+
+/** "Advanced" disclosure shared across configurator forms. */
+export const CollapsibleSection = ({
+  testIDBase,
+  label = 'Advanced',
+  children,
+}: CollapsibleSectionProps): React.JSX.Element => {
+  const [open, setOpen] = useState(false);
+  return (
+    <View testID={testIDBase}>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={`${label} settings`}
+        accessibilityState={{ expanded: open }}
+        onPress={() => setOpen((prev) => !prev)}
+        style={formStyles.advancedToggle}
+        testID={`${testIDBase}-toggle`}
+      >
+        <Text style={formStyles.advancedToggleText}>{`${open ? '▾' : '▸'} ${label}`}</Text>
+      </TouchableOpacity>
+      {open && children}
+    </View>
+  );
+};
+
 const formStyles = StyleSheet.create({
+  toneRow: { flexDirection: 'row', gap: SPACING.xs, flexWrap: 'wrap' },
+  advancedToggle: { paddingVertical: SPACING.md, marginTop: SPACING.sm },
+  advancedToggleText: { fontSize: 14, fontWeight: '600', color: colors.text.primary },
   row: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/frontend/src/features/Practice/data/__tests__/colorPalette.test.ts
+++ b/frontend/src/features/Practice/data/__tests__/colorPalette.test.ts
@@ -4,47 +4,9 @@ import { describe, it, expect } from '@jest/globals';
 import {
   COLOR_PALETTE,
   SPIRAL_DYNAMICS_COLORS,
-  contrastRatio,
   isSpiralDynamicsColor,
-  relativeLuminance,
   swatchFor,
 } from '../colorPalette';
-
-const WCAG_AA_BODY = 4.5;
-
-describe('relativeLuminance', () => {
-  it('returns 0 for black and 1 for white', () => {
-    expect(relativeLuminance('#000000')).toBeCloseTo(0, 5);
-    expect(relativeLuminance('#ffffff')).toBeCloseTo(1, 5);
-  });
-
-  it('matches the WCAG reference for mid-grey #777777', () => {
-    // #777 has a published relative luminance of ~0.1845.
-    expect(relativeLuminance('#777777')).toBeCloseTo(0.1845, 3);
-  });
-
-  it('accepts uppercase hex and the leading "#" is optional', () => {
-    expect(relativeLuminance('FFFFFF')).toBeCloseTo(1, 5);
-    expect(relativeLuminance('#FFFFFF')).toBeCloseTo(1, 5);
-  });
-
-  it('throws on a malformed hex string instead of returning NaN', () => {
-    expect(() => relativeLuminance('not-a-color')).toThrow(/hex/i);
-    expect(() => relativeLuminance('#12345')).toThrow(/hex/i);
-  });
-});
-
-describe('contrastRatio', () => {
-  it('is 21:1 for black on white', () => {
-    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 0);
-  });
-
-  it('is symmetric — order of arguments does not change the ratio', () => {
-    const a = contrastRatio('#1a1a1a', '#d8cbb8');
-    const b = contrastRatio('#d8cbb8', '#1a1a1a');
-    expect(a).toBeCloseTo(b, 5);
-  });
-});
 
 describe('COLOR_PALETTE', () => {
   it('maps every spiral-dynamics colour exactly once', () => {
@@ -69,16 +31,6 @@ describe('COLOR_PALETTE', () => {
       'Clear Light',
     ]);
   });
-
-  it.each(SPIRAL_DYNAMICS_COLORS)(
-    '%s swatch hits WCAG AA body-text contrast (>= 4.5:1)',
-    (colour) => {
-      const swatch = COLOR_PALETTE[colour];
-      const ratio = contrastRatio(swatch.text, swatch.bg);
-      // Fail message helps designers tweak palette safely.
-      expect(ratio).toBeGreaterThanOrEqual(WCAG_AA_BODY);
-    },
-  );
 });
 
 describe('isSpiralDynamicsColor', () => {

--- a/frontend/src/features/Practice/data/colorPalette.ts
+++ b/frontend/src/features/Practice/data/colorPalette.ts
@@ -43,43 +43,6 @@ export const COLOR_PALETTE: Readonly<Record<SpiralDynamicsColor, ColorSwatch>> =
   'Clear Light': { bg: '#ffffff', text: '#000000' },
 });
 
-const HEX_PATTERN = /^#?[0-9a-f]{6}$/i;
-
-function parseChannel(hex: string, offset: number): number {
-  return Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
-}
-
-function srgbToLinear(channel: number): number {
-  // sRGB → linear-light per WCAG 2.1 §1.4.3 definition of relative luminance.
-  return channel <= 0.039_28 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
-}
-
-/**
- * Relative luminance of an sRGB hex colour per WCAG 2.1.
- *
- * Throws on malformed input so a typo in the palette surfaces as a loud
- * test failure rather than a silent `NaN` contrast ratio.
- */
-export function relativeLuminance(hex: string): number {
-  if (!HEX_PATTERN.test(hex)) {
-    throw new Error(`Expected 6-digit hex colour, got ${JSON.stringify(hex)}`);
-  }
-  const raw = hex.startsWith('#') ? hex.slice(1) : hex;
-  const r = srgbToLinear(parseChannel(raw, 0));
-  const g = srgbToLinear(parseChannel(raw, 2));
-  const b = srgbToLinear(parseChannel(raw, 4));
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
-}
-
-/** WCAG contrast ratio between two sRGB hex colours. Order-independent. */
-export function contrastRatio(a: string, b: string): number {
-  const la = relativeLuminance(a);
-  const lb = relativeLuminance(b);
-  const lighter = Math.max(la, lb);
-  const darker = Math.min(la, lb);
-  return (lighter + 0.05) / (darker + 0.05);
-}
-
 export function isSpiralDynamicsColor(value: string): value is SpiralDynamicsColor {
   return (SPIRAL_DYNAMICS_COLORS as readonly string[]).includes(value);
 }

--- a/frontend/src/features/Practice/recipes/RecipePickerModal.tsx
+++ b/frontend/src/features/Practice/recipes/RecipePickerModal.tsx
@@ -444,11 +444,11 @@ const RecipeRowMutationButtons = (props: RecipeRowMutationButtonsProps): React.J
   );
 };
 
-type RowButtonVariant = 'primary' | 'default' | 'quiet' | 'quietDanger';
+type RowButtonVariant = 'primary' | 'quiet' | 'quietDanger';
 
 interface RowButtonProps {
   label: string;
-  variant?: RowButtonVariant;
+  variant: RowButtonVariant;
   /** Stretch to fill the row — used for the primary "Use this" action. */
   block?: boolean;
   disabled: boolean;
@@ -458,7 +458,7 @@ interface RowButtonProps {
 
 const RowButton = ({
   label,
-  variant = 'default',
+  variant,
   block = false,
   disabled,
   onPress,
@@ -466,13 +466,11 @@ const RowButton = ({
 }: RowButtonProps): React.JSX.Element => {
   const bg = {
     primary: styles.primaryButton,
-    default: styles.defaultButton,
     quiet: styles.quietButton,
     quietDanger: styles.quietButton,
   }[variant];
   const text = {
     primary: styles.lightText,
-    default: styles.defaultText,
     quiet: styles.quietText,
     quietDanger: styles.quietDangerText,
   }[variant];
@@ -618,10 +616,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   blockButton: { alignSelf: 'stretch', marginTop: SPACING.xs },
-  defaultButton: { backgroundColor: colors.background.accent, paddingHorizontal: SPACING.md },
   primaryButton: { backgroundColor: colors.primary, paddingHorizontal: SPACING.md },
   quietButton: { backgroundColor: 'transparent', paddingHorizontal: 0 },
-  defaultText: { color: colors.text.primary, fontSize: 13, fontWeight: '500' },
   lightText: { color: colors.text.light, fontSize: 14, fontWeight: '600' },
   quietText: { color: colors.text.secondaryAccessible, fontSize: 13, fontWeight: '500' },
   quietDangerText: { color: colors.danger, fontSize: 13, fontWeight: '500' },


### PR DESCRIPTION
## Summary

#786: a bundle of linter-invisible frontend items from the weekly audit — one behavioral bug plus dead-code/dup/stale-comment cleanup (mirrors #747).

1. **(behavioral)** HabitTile unlock confirm + GoalModal drag-to-edit confirm routed through `ConfirmDialog` instead of `Alert.alert`, which is a **no-op on RN Web mobile** — the confirms silently did nothing on the web app. Tests now drive the rendered dialog.
2. Delete dead `relativeLuminance`/`contrastRatio` (+ helpers + tests) in colorPalette.
3. Extract shared `BellToneRow`/`BELL_TONES` + `CollapsibleSection` into `forms/shared.tsx`.
4. Drop dead `RowButton` `default` variant; make `variant` required.
5. Remove dead `useResonance.remaining` + trim docstring/test.
6. Delete dead `STREAM_TIMEOUT_MS` export + false docstring.
7. Remove stale `#310` TODO (already shipped).
8. Dedup AuthContext token-apply into one helper.
9. Hoist `MIN_TOKEN_LENGTH` to shared `Auth/resetToken.ts`.
10. SearchBar real glyphs (🔍 + ×); test asserts the rendered icon.

No coverage-theater tests remain for deleted code.

## Test plan

`./scripts/frontend/check-all.sh` 4/4.

Closes #786