### PR TITLE
refactor(backend): de-slop tidy-up — stage-gap helper, true 30d window, dedup

### DIFF
--- a/backend/src/domain/dates.py
+++ b/backend/src/domain/dates.py
@@ -142,3 +142,22 @@ def to_user_date(
         msg = "to_user_date refuses naive datetimes; pass tzinfo-aware values"
         raise ValueError(msg)
     return moment.astimezone(_resolve_zone(user_or_tz)).date()
+
+
+def to_user_date_bucket(ts: datetime | str, user_or_tz: _HasTimezone | str | None) -> date:
+    """Bucket a *stored* timestamp into the user's local calendar day.
+
+    Unlike :func:`to_user_date` (which demands a tz-aware datetime), this is the
+    storage-boundary helper: it accepts either a :class:`datetime` (the Postgres
+    ``timestamptz`` path) or an ISO-8601 string (SQLite returns these for tz-aware
+    columns), and coerces a naive value to UTC — acceptable here because the
+    source column is declared timezone-aware and SQLite merely lies about its
+    storage. The single canonical owner of this coercion (was duplicated in the
+    streak service and the subtractive domain).
+    """
+    if isinstance(ts, datetime):
+        moment = ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
+    else:
+        parsed = datetime.fromisoformat(ts)
+        moment = parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+    return to_user_date(user_or_tz, moment)

--- a/backend/src/domain/practice_insights.py
+++ b/backend/src/domain/practice_insights.py
@@ -133,9 +133,13 @@ def _streak_weeks(
 
 
 def _is_in_30d_window(session: PracticeSession, today: date, tz: str | None) -> bool:
-    """``True`` if the session's local date is within the rolling 30-day window."""
+    """``True`` if the session's local date is within the rolling 30-day window.
+
+    Strict lower bound so the span is exactly ``ROLLING_30D_WINDOW_DAYS`` distinct
+    calendar days (today-29 .. today); an inclusive lower bound would count 31.
+    """
     local_day = to_user_date(tz, _as_utc_aware(session.timestamp))
-    return today - timedelta(days=ROLLING_30D_WINDOW_DAYS) <= local_day <= today
+    return today - timedelta(days=ROLLING_30D_WINDOW_DAYS) < local_day <= today
 
 
 def _rolling_30d_stats(

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -98,6 +98,27 @@ async def ensure_user_progress(session: AsyncSession, user_id: int) -> StageProg
     return progress
 
 
+def expected_completed_stages(current_stage: int) -> set[int]:
+    """Return the stages a row at ``current_stage`` must have completed.
+
+    The invariant set is ``{1 .. current_stage - 1}``.
+    """
+    return set(range(1, current_stage))
+
+
+def completed_stage_gap(completed: set[int], current_stage: int) -> tuple[set[int], set[int]]:
+    """Return ``(missing, extra)`` for a stage-progress row.
+
+    The invariant every stage mutation must preserve is
+    ``set(completed) == {1..current_stage-1}``. ``missing`` are stages that
+    should be marked complete but aren't; ``extra`` are stages credited beyond
+    the expected range. Both empty means the row is contiguous. This is the
+    canonical owner of the gap math the admin router used to inline twice.
+    """
+    expected = expected_completed_stages(current_stage)
+    return expected - completed, completed - expected
+
+
 def is_stage_unlocked(
     stage_number: int, progress: StageProgress | None, now: datetime | None = None
 ) -> bool:

--- a/backend/src/domain/streaks.py
+++ b/backend/src/domain/streaks.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
-from domain.dates import to_user_date, today_in_tz
+from domain.dates import to_user_date_bucket, today_in_tz
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -60,22 +60,6 @@ class SubtractiveContext:
     start_date: date
 
 
-def _subtractive_user_date(ts: datetime | str, user_timezone: str) -> date:
-    """Bucket a stored timestamp into the user's local calendar day.
-
-    Accepts a :class:`datetime` (the Postgres ``timestamptz`` path) or an
-    ISO-8601 string (SQLite returns these for tz-aware columns).  Naive values
-    are treated as UTC — acceptable here because the source column is declared
-    timezone-aware and SQLite merely lies about its storage.
-    """
-    if isinstance(ts, datetime):
-        moment = ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
-    else:
-        parsed = datetime.fromisoformat(ts)
-        moment = parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
-    return to_user_date(user_timezone, moment)
-
-
 def subtractive_day_totals(
     completions: Sequence[GoalCompletion],
     user_timezone: str,
@@ -88,7 +72,7 @@ def subtractive_day_totals(
     """
     day_totals: dict[date, float] = {}
     for c in completions:
-        day = _subtractive_user_date(c.timestamp, user_timezone)
+        day = to_user_date_bucket(c.timestamp, user_timezone)
         day_totals[day] = day_totals.get(day, 0.0) + c.completed_units
     return day_totals
 

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -48,9 +48,7 @@ class JournalEntry(SQLModel, table=True):
     BUG-JOURNAL-007: hard delete is replaced with a soft-delete ``deleted_at``
     column so deleted rows can be recovered within the retention window and the
     ``LLMUsageLog.journal_entry_id`` FK is never orphaned.  All read endpoints
-    filter ``deleted_at IS NULL``; a separate nightly purge job can hard-delete
-    rows older than the retention window (not implemented here — follow-up
-    GitHub issue).
+    filter ``deleted_at IS NULL``; soft-deleted rows are retained indefinitely.
     """
 
     # ``ix_journalentry_deleted_at`` is created by migration ``a0b1c2d3e4f5``

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -17,6 +17,7 @@ from sqlmodel import col
 
 from database import get_session
 from dependencies.auth import require_admin
+from domain.stage_progress import completed_stage_gap, expected_completed_stages
 from errors import bad_request, not_found
 from models.llm_usage_log import LLMUsageLog
 from models.stage_progress import StageProgress
@@ -193,15 +194,15 @@ def _detect_gap(progress: StageProgress) -> StageProgressGap | None:
     endpoint's loop trivial.
     """
     completed = set(progress.completed_stages or [])
-    expected = set(range(1, progress.current_stage))
-    if completed == expected:
+    missing, extra = completed_stage_gap(completed, progress.current_stage)
+    if not missing and not extra:
         return None
     return StageProgressGap(
         user_id=progress.user_id,
         current_stage=progress.current_stage,
         completed_stages=sorted(completed),
-        missing_stages=sorted(expected - completed),
-        extra_stages=sorted(completed - expected),
+        missing_stages=sorted(missing),
+        extra_stages=sorted(extra),
     )
 
 
@@ -277,10 +278,10 @@ async def repair_stage_progress(
         raise not_found("stage_progress")
 
     before = set(progress.completed_stages or [])
-    expected = set(range(1, progress.current_stage))
-    stages_added = sorted(expected - before)
-    stages_removed = sorted(before - expected)
-    progress.completed_stages = sorted(expected)
+    missing, extra = completed_stage_gap(before, progress.current_stage)
+    stages_added = sorted(missing)
+    stages_removed = sorted(extra)
+    progress.completed_stages = sorted(expected_completed_stages(progress.current_stage))
     await session.commit()
     await session.refresh(progress)
 
@@ -298,7 +299,7 @@ async def repair_stage_progress(
     return StageProgressRepairResult(
         user_id=user_id,
         current_stage=progress.current_stage,
-        completed_stages=sorted(expected),
+        completed_stages=progress.completed_stages,
         stages_added=stages_added,
         stages_removed=stages_removed,
     )

--- a/backend/src/services/streaks.py
+++ b/backend/src/services/streaks.py
@@ -18,12 +18,12 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
-from domain.dates import to_user_date, today_in_tz
+from domain.dates import to_user_date_bucket, today_in_tz
 from domain.streaks import (
     SubtractiveContext,
     subtractive_current_streak,
@@ -43,35 +43,6 @@ __all__ = [
     "compute_streak_before_and_after",
     "update_streak",
 ]
-
-
-def _to_user_date(ts: datetime | str, user_timezone: str) -> date:
-    """Bucket a stored timestamp into the user's local calendar day.
-
-    Accepts either a :class:`datetime` (the production path through
-    Postgres ``timestamptz`` columns) or an ISO-8601 string (SQLite test
-    DB returns these for ``DateTime(timezone=True)`` columns since
-    SQLite has no native tz type).  Naive datetimes are treated as UTC
-    so SQLite-stored values still convert correctly; this is the one
-    place where naive coercion is acceptable because the source column
-    is declared timezone-aware and SQLite is just lying about its
-    storage.
-
-    Narrowing the type to ``datetime | str`` (rather than ``object``)
-    lets mypy reject bad call sites at the boundary; an unexpected
-    ``None`` from an ORM-column edge case used to fall through to
-    ``str()`` and raise an obscure ``ValueError`` from
-    ``fromisoformat``.
-    """
-    if isinstance(ts, datetime):
-        moment = ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
-    else:
-        # ISO-8601 string from SQLite; the column is timezone-aware so
-        # the format is always "YYYY-MM-DD HH:MM:SS[.fff][+HH:MM]".
-        # ``fromisoformat`` accepts that since Python 3.11.
-        parsed = datetime.fromisoformat(ts)
-        moment = parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
-    return to_user_date(user_timezone, moment)
 
 
 def _count_consecutive_days(sorted_days: list[date], day_ok: dict[date, bool]) -> int:
@@ -149,7 +120,7 @@ async def _fetch_day_totals(
     )
     day_totals: dict[date, float] = {}
     for ts, units in rows:
-        day = _to_user_date(ts, user_timezone)
+        day = to_user_date_bucket(ts, user_timezone)
         day_totals[day] = day_totals.get(day, 0.0) + units
     return day_totals
 
@@ -222,7 +193,11 @@ def _completed_user_dates(
     Split out so :func:`compute_habit_streak` stays at xenon rank A; the
     inner generator + filter pushed the parent block over the threshold.
     """
-    return {_to_user_date(c.timestamp, user_timezone) for c in completions if c.completed_units > 0}
+    return {
+        to_user_date_bucket(c.timestamp, user_timezone)
+        for c in completions
+        if c.completed_units > 0
+    }
 
 
 def compute_habit_streak(

--- a/backend/tests/domain/test_stage_gap.py
+++ b/backend/tests/domain/test_stage_gap.py
@@ -1,0 +1,34 @@
+"""Unit tests for the stage-gap invariant helpers (#785)."""
+
+from __future__ import annotations
+
+from domain.stage_progress import completed_stage_gap, expected_completed_stages
+
+
+def test_expected_completed_stages_is_one_to_current_minus_one() -> None:
+    assert expected_completed_stages(1) == set()
+    assert expected_completed_stages(4) == {1, 2, 3}
+
+
+def test_gap_contiguous_is_empty() -> None:
+    missing, extra = completed_stage_gap({1, 2}, 3)
+    assert missing == set()
+    assert extra == set()
+
+
+def test_gap_reports_missing_stage() -> None:
+    missing, extra = completed_stage_gap({1}, 3)
+    assert missing == {2}
+    assert extra == set()
+
+
+def test_gap_reports_extra_stage() -> None:
+    missing, extra = completed_stage_gap({1, 2, 3}, 3)
+    assert missing == set()
+    assert extra == {3}
+
+
+def test_gap_reports_missing_and_extra_together() -> None:
+    missing, extra = completed_stage_gap({1, 3}, 3)
+    assert missing == {2}
+    assert extra == {3}

--- a/backend/tests/test_practice_insights.py
+++ b/backend/tests/test_practice_insights.py
@@ -192,6 +192,27 @@ def test_avg_is_none_when_no_sessions_in_30d() -> None:
     assert insights.total_minutes_30d == 0.0
 
 
+@pytest.mark.usefixtures("frozen_clock")
+def test_30d_window_includes_day_29_boundary() -> None:
+    """A session 29 days back is inside the true 30-day window (today-29..today)."""
+    session = _session(timestamp=_FROZEN_NOW - timedelta(days=29), duration_minutes=15.0)
+    insights = build_insights([session], tz="UTC")
+    assert insights.total_minutes_30d == pytest.approx(15.0)
+
+
+@pytest.mark.usefixtures("frozen_clock")
+def test_30d_window_excludes_day_30_boundary() -> None:
+    """A session exactly 30 days back is outside a true 30-day window (#785).
+
+    An inclusive lower bound counted 31 distinct days; the strict bound makes the
+    span match the ``ROLLING_30D_WINDOW_DAYS`` name.
+    """
+    session = _session(timestamp=_FROZEN_NOW - timedelta(days=30), duration_minutes=15.0)
+    insights = build_insights([session], tz="UTC")
+    assert insights.total_minutes_30d == pytest.approx(0.0)
+    assert insights.avg_duration_minutes_30d is None
+
+
 def test_per_mode_counts_30d() -> None:
     now = _now_utc()
     sessions = [


### PR DESCRIPTION
## Summary

#785: four small, independent maintainability items from the weekly audit.

1. **Stage-gap invariant** lifted into `domain/stage_progress.py` (`expected_completed_stages` + `completed_stage_gap(completed, current_stage) -> (missing, extra)`); both `admin.py` sites call it instead of duplicating `set(range(...))` + delta math. New domain test.
2. **True 30-day window**: `_is_in_30d_window` was inclusive both ends (31 days); now a strict lower bound (`today-30 < local_day <= today`) = exactly 30 days. Constant/fields/docstring stay at 30. Frozen-clock boundary tests: `today-29` included, `today-30` excluded.
3. **Dedup date-bucket helper**: one canonical `to_user_date_bucket` in `domain/dates.py`; deleted the identical `_to_user_date`/`_subtractive_user_date`.
4. **Journal docstring** no longer promises an unfiled purge job.

## Test plan

`./scripts/backend/check-all.sh` 7/7, xenon rank A on all six touched files.

Closes #785