### PR TITLE
feat(design): promote warm-editorial semantic tokens app-wide + provenance

### DIFF
--- a/frontend/src/design/ATTRIBUTION
+++ b/frontend/src/design/ATTRIBUTION
@@ -1,0 +1,28 @@
+ATTRIBUTION — Adepthood "Candle & Ink" design language
+=======================================================
+
+This file records the provenance of Adepthood's design language so the IP
+position is auditable in-repo (epic #798 / design-language-01).
+
+Reference material (inspiration only, not copied)
+-------------------------------------------------
+- awesome-design-md — the "Claude" design-language Markdown entry was read as a
+  reference for *how to structure* a token-and-provenance doc. License: MIT.
+  No code, tokens, color values, type scale, or prose were copied from it; it
+  informed the format of DESIGN.md only.
+
+Clean-room stance
+-----------------
+- Palette: the warm grounds (`surface.*`, `ink.*`) are derived from Adepthood's
+  own pre-existing `colors.paper` journal palette. The terracotta `accent.*` is
+  derived from Adepthood's own `colors.tier.clear` (#be6e46), darkened to clear
+  WCAG AA as text. No swatch is taken from any third-party product or brand
+  palette.
+- Marks: no Anthropic (or any other company's) name, logo, wordmark, or brand
+  swatch is presented as Adepthood's own. "Candle & Ink" is an internal name
+  for this language.
+- Fonts: no proprietary fonts. Editorial type uses a free/system serif stack
+  only (see `editorialType.serif`; enforced under design-language-02 / #800).
+
+Summary: original palette, no proprietary fonts, no third-party marks; the only
+external input is the MIT-licensed reference doc, used for format guidance only.

--- a/frontend/src/design/DESIGN.md
+++ b/frontend/src/design/DESIGN.md
@@ -1,0 +1,57 @@
+# Candle & Ink — Adepthood's warm-editorial design language
+
+The canonical reference for Adepthood's visual language (epic #798). Where the
+code and this doc disagree, `tokens.ts` wins — update this doc to match.
+
+## Intent
+
+A warm, literary, paper-on-desk feel — the opposite of flat grey SaaS chrome.
+The language began on the journal-resonance surface (`colors.paper`,
+`editorialType`, `paperShadow`) and is now promoted app-wide through a semantic
+`surface` / `ink` / `accent` layer.
+
+## Semantic layer (`tokens.ts`)
+
+| Token                         | Value      | Role                                          |
+| ----------------------------- | ---------- | --------------------------------------------- |
+| `surface.canvas`              | `#faf6ef`  | the app ground (warm off-white paper)         |
+| `surface.raised`              | `#ffffff`  | lifted cards / sheets                         |
+| `surface.sunken`              | `#f3ecdf`  | recessed wells                                |
+| `surface.desk`                | `#e7dcc8`  | the deeper ground a sheet floats above        |
+| `surface.hairline`            | `#e3dccd`  | faint warm rule                               |
+| `ink.primary`                 | `#2b2620`  | body text — 13.9:1 on canvas (AAA)            |
+| `ink.soft`                    | `#5a5046`  | secondary text — 7.3:1 (AAA)                  |
+| `ink.muted`                   | `#6b6055`  | captions / placeholders — 5.7:1               |
+| `accent.primary`              | `#a5572f`  | terracotta accent — 4.9:1 (clears AA as text) |
+| `accent.strong`               | `#8f4a28`  | pressed / emphasis — 6.1:1                    |
+| `surfaceShadow.{card,raised}` | ink-tinted | warm downward elevation (iOS/web + Android)   |
+
+**Contrast contract:** every `ink.*` and `accent.*` value clears WCAG AA
+(≥ 4.5:1) on `surface.canvas`. Enforced by `__tests__/semanticTokens.test.ts`.
+
+## Palette provenance
+
+The accent is an **original** terracotta/sienna derived from the app's own
+`colors.tier.clear` (`#be6e46`, a graphical-only ~3:1 swatch), darkened so it
+clears AA as text. It is **not** copied from any product or brand. See
+[`ATTRIBUTION`](./ATTRIBUTION).
+
+## Constraints (carried from the epic)
+
+- **No proprietary fonts** — editorial type uses a free/system serif stack
+  (see `editorialType.serif`); see #800.
+- **No third-party brand marks or swatches** presented as our own.
+- **Additive, not destructive** — the legacy grey `colors.background` /
+  `colors.surface` remain for un-migrated screens; this layer is the new
+  default, adopted screen-by-screen across the #798 sub-issues.
+- **Reuse the existing warm values** — `surface`/`ink` are derived from
+  `colors.paper`, not a parallel palette.
+
+## Adoption map (epic #798)
+
+- #799 — this token layer + provenance (critical path)
+- #800 — editorial type system on free/system fonts
+- #801 — shared buttons, controls & inputs
+- #802 — warm grounds & soft elevation for cards/surfaces
+- #803 — editorial navigation (headers + bottom tab bar)
+- #804 — warm dark mode matching the light language

--- a/frontend/src/design/__tests__/semanticTokens.test.ts
+++ b/frontend/src/design/__tests__/semanticTokens.test.ts
@@ -1,0 +1,78 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { StyleSheet } from 'react-native';
+
+import { accent, colors, ink, surface, surfaceShadow } from '../tokens';
+
+/** WCAG relative luminance of a #rrggbb color. */
+const luminance = (hex: string): number => {
+  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
+  const channels = [match[1], match[2], match[3]].map((pair) => {
+    const c = Number.parseInt(pair!, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+};
+
+const contrast = (a: string, b: string): number => {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+const AA_NORMAL = 4.5;
+
+describe('semantic tokens (Candle & Ink)', () => {
+  describe('surface', () => {
+    it('derives its grounds from the warm paper palette', () => {
+      expect(surface.canvas).toBe(colors.paper.background);
+      expect(surface.sunken).toBe(colors.paper.backgroundAlt);
+      expect(surface.desk).toBe(colors.paper.desk);
+      expect(surface.hairline).toBe(colors.paper.hairline);
+      expect(surface.raised).toMatch(/^#[\da-f]{6}$/i);
+    });
+
+    it('floats raised above canvas above the desk', () => {
+      expect(luminance(surface.raised)).toBeGreaterThan(luminance(surface.canvas));
+      expect(luminance(surface.desk)).toBeLessThan(luminance(surface.canvas));
+    });
+  });
+
+  describe('ink + accent contrast', () => {
+    it('every ink value clears WCAG AA on the canvas', () => {
+      for (const value of Object.values(ink)) {
+        expect(contrast(value, surface.canvas)).toBeGreaterThanOrEqual(AA_NORMAL);
+      }
+    });
+
+    it('every accent value clears WCAG AA on the canvas', () => {
+      for (const value of Object.values(accent)) {
+        expect(contrast(value, surface.canvas)).toBeGreaterThanOrEqual(AA_NORMAL);
+      }
+    });
+
+    it('keeps an original terracotta accent (not the graphical-only tier swatch)', () => {
+      // The accent is derived from — but distinct from — the 3:1 graphical
+      // tier.clear swatch, darkened so it clears AA as text.
+      expect(accent.primary).not.toBe(colors.tier.clear);
+      expect(luminance(accent.primary)).toBeLessThan(luminance(colors.tier.clear));
+    });
+  });
+
+  describe('surfaceShadow', () => {
+    it('flattens to warm, ink-tinted lifts with iOS/web + Android props', () => {
+      for (const lift of [surfaceShadow.card, surfaceShadow.raised]) {
+        const flat = StyleSheet.flatten(lift);
+        expect(flat.shadowColor).toBe(colors.paper.ink);
+        expect(flat.shadowOffset?.height).toBeGreaterThan(0);
+        expect(flat.shadowOpacity).toBeGreaterThan(0);
+        expect(flat.shadowRadius).toBeGreaterThan(0);
+        expect(flat.elevation).toBeGreaterThan(0);
+      }
+      // A raised sheet sits higher off the desk than a card.
+      expect(surfaceShadow.raised.elevation).toBeGreaterThan(surfaceShadow.card.elevation);
+    });
+  });
+});

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -502,3 +502,63 @@ export const journalSheet = {
   deskPaddingH: spacing(2), // desk visible left/right of the sheet
   deskPaddingTop: spacing(1.5), // desk visible above the sheet
 } as const;
+
+// ---------------------------------------------------------------------------
+// Semantic app-wide layer — the "Candle & Ink" warm-editorial language (#798)
+// ---------------------------------------------------------------------------
+
+/**
+ * App-wide warm grounds. Derived from the existing paper palette so the whole
+ * app reads as paper-on-desk rather than flat grey chrome. The legacy
+ * ``background``/``surface`` greys remain for un-migrated screens but are no
+ * longer the design default.
+ */
+export const surface = {
+  canvas: colors.paper.background, // #faf6ef — the app ground
+  raised: '#ffffff', // lifted cards / sheets
+  sunken: colors.paper.backgroundAlt, // #f3ecdf — recessed wells
+  desk: colors.paper.desk, // #e7dcc8 — the deeper ground a sheet floats above
+  hairline: colors.paper.hairline, // #e3dccd — faint warm rule
+} as const;
+
+/**
+ * Ink scale for text on ``surface.canvas``. Every value clears WCAG AA
+ * (>= 4.5:1) on the canvas ground — asserted in ``semanticTokens.test.ts``.
+ */
+export const ink = {
+  primary: colors.paper.ink, // #2b2620 — 13.9:1 (AAA)
+  soft: colors.paper.inkSoft, // #5a5046 — 7.3:1 (AAA)
+  muted: '#6b6055', // 5.7:1 — captions / placeholders
+} as const;
+
+/**
+ * Original terracotta / sienna accent, darkened from ``colors.tier.clear``
+ * (#be6e46, a graphical-only ~3:1 swatch) so the accent clears AA as text on
+ * the canvas. Not any brand's swatch — see ``ATTRIBUTION``.
+ */
+export const accent = {
+  primary: '#a5572f', // 4.9:1 on canvas
+  strong: '#8f4a28', // 6.1:1 — pressed / emphasis
+} as const;
+
+/**
+ * App-wide warm elevation — the generalisation of ``paperShadow`` beyond the
+ * journal. Ink-tinted, downward; iOS/web use the shadow* props, Android uses
+ * ``elevation``. ``paperShadow`` stays as-is for the journal's contracts.
+ */
+export const surfaceShadow = {
+  card: {
+    shadowColor: colors.paper.ink,
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  raised: {
+    shadowColor: colors.paper.ink,
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.14,
+    shadowRadius: 18,
+    elevation: 6,
+  },
+} as const;


### PR DESCRIPTION
## Summary

#799 (epic #798, **critical path** — every other sub-issue depends on this): the warm-editorial language was fenced to the journal. Add an app-wide semantic `surface`/`ink`/`accent` layer so the rest of the app can move off flat grey chrome.

- `surface.{canvas,raised,sunken,desk,hairline}` derived from `colors.paper`.
- `ink.{primary,soft,muted}` — every value clears WCAG **AA** (≥4.5:1) on `surface.canvas` (13.9 / 7.3 / 5.7:1).
- `accent.{primary,strong}` — an **original** terracotta/sienna darkened from `colors.tier.clear` (#be6e46, a graphical-only 3:1 swatch) so it clears AA as text (4.9 / 6.1:1).
- `surfaceShadow.{card,raised}` — app-wide generalisation of `paperShadow` (ink-tinted; iOS/web shadow* + Android elevation). `paperShadow` left intact for the journal.
- `DESIGN.md` (canonical doc) + `ATTRIBUTION` (MIT reference used for format only; clean-room palette; no proprietary fonts; no third-party marks).

## Test plan

`semanticTokens.test.ts` asserts AA-on-canvas for every `ink`/`accent` value + a `StyleSheet.flatten` check on `surfaceShadow`; existing journal token contracts stay green (48/48). `./scripts/frontend/check-all.sh` 4/4.

Closes #799
Refs #798