### PR TITLE
feat(design): app-wide editorial type ramp on free/system fonts

### DIFF
--- a/frontend/src/design/ATTRIBUTION
+++ b/frontend/src/design/ATTRIBUTION
@@ -21,8 +21,12 @@ Clean-room stance
 - Marks: no Anthropic (or any other company's) name, logo, wordmark, or brand
   swatch is presented as Adepthood's own. "Candle & Ink" is an internal name
   for this language.
-- Fonts: no proprietary fonts. Editorial type uses a free/system serif stack
-  only (see `editorialType.serif`; enforced under design-language-02 / #800).
+- Fonts: no proprietary/commercial font files are bundled, self-hosted, or
+  embedded (#800). Both faces are platform-system stacks — serif
+  (`fonts.serif`: Georgia / system serif) and sans (`fonts.sans`: system UI /
+  sans-serif). No commercial face is pulled off the user's machine via fallback
+  stacks for brand parity. If an OFL/Apache face is ever bundled, its license
+  file must be committed and listed here.
 
 Summary: original palette, no proprietary fonts, no third-party marks; the only
 external input is the MIT-licensed reference doc, used for format guidance only.

--- a/frontend/src/design/DESIGN.md
+++ b/frontend/src/design/DESIGN.md
@@ -36,10 +36,24 @@ The accent is an **original** terracotta/sienna derived from the app's own
 clears AA as text. It is **not** copied from any product or brand. See
 [`ATTRIBUTION`](./ATTRIBUTION).
 
+## Type system (`type(width)`, #800)
+
+A cohesive serif-display + clean-sans ramp, responsive on the same breakpoint
+base as `typography()`:
+
+- **Faces** — `fonts.serif` (display/title/heading) + `fonts.sans` (body/label/
+  caption). Both are **platform-system stacks**; no bundled font files. The
+  journal keeps its all-serif `editorialType` for long-form reading and now
+  shares `fonts.serif` as its source.
+- **Ramp** — `type(width)` → `{ display, title, heading, body, label, caption }`,
+  each `{ fontFamily, fontSize, lineHeight, fontWeight }`; sizes descend and
+  scale up from phone → tablet.
+
 ## Constraints (carried from the epic)
 
-- **No proprietary fonts** — editorial type uses a free/system serif stack
-  (see `editorialType.serif`); see #800.
+- **No proprietary fonts** — both serif and sans are free/system stacks
+  (`fonts.serif` / `fonts.sans`); any bundled OFL/Apache face must commit its
+  license. See #800 and `ATTRIBUTION`.
 - **No third-party brand marks or swatches** presented as our own.
 - **Additive, not destructive** — the legacy grey `colors.background` /
   `colors.surface` remain for un-migrated screens; this layer is the new

--- a/frontend/src/design/__tests__/typeSystem.test.ts
+++ b/frontend/src/design/__tests__/typeSystem.test.ts
@@ -1,0 +1,56 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { breakpoints, editorialType, fonts, type } from '../tokens';
+
+describe('app type system (Candle & Ink, #800)', () => {
+  describe('fonts', () => {
+    it('exposes non-empty serif + sans system stacks', () => {
+      expect(typeof fonts.serif).toBe('string');
+      expect(fonts.serif.length).toBeGreaterThan(0);
+      expect(typeof fonts.sans).toBe('string');
+      expect(fonts.sans.length).toBeGreaterThan(0);
+    });
+
+    it('shares its serif with the journal editorialType (single source)', () => {
+      expect(editorialType.serif).toBe(fonts.serif);
+    });
+  });
+
+  describe('type(width) ramp', () => {
+    const ramp = type(breakpoints.md);
+
+    it('exports the full ramp', () => {
+      expect(Object.keys(ramp)).toEqual([
+        'display',
+        'title',
+        'heading',
+        'body',
+        'label',
+        'caption',
+      ]);
+    });
+
+    it('uses serif for display/heading and clean sans for body/labels', () => {
+      for (const key of ['display', 'title', 'heading'] as const) {
+        expect(ramp[key].fontFamily).toBe(fonts.serif);
+      }
+      for (const key of ['body', 'label', 'caption'] as const) {
+        expect(ramp[key].fontFamily).toBe(fonts.sans);
+      }
+    });
+
+    it('descends in size and keeps lineHeight above fontSize', () => {
+      const order = ['display', 'title', 'heading', 'body', 'label', 'caption'] as const;
+      for (let i = 1; i < order.length; i += 1) {
+        expect(ramp[order[i]!].fontSize).toBeLessThan(ramp[order[i - 1]!].fontSize);
+      }
+      for (const key of order) {
+        expect(ramp[key].lineHeight).toBeGreaterThan(ramp[key].fontSize);
+      }
+    });
+
+    it('is responsive — a tablet reads larger than a phone', () => {
+      expect(type(breakpoints.xl).body.fontSize).toBeGreaterThan(type(0).body.fontSize);
+    });
+  });
+});

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -444,6 +444,28 @@ const serifByPlatform: Record<string, string> = {
 };
 const serifStack = serifByPlatform[Platform.OS] ?? 'Georgia, "Times New Roman", serif';
 
+// Clean system sans for chrome/body — no bundled font asset (same IP stance as
+// the serif): the platform UI face on iOS, ``sans-serif`` on Android, a CSS
+// stack on web. Resolved from ``Platform.OS`` to stay loadable under the repo's
+// hand-rolled react-native mocks (see serif note above).
+const sansByPlatform: Record<string, string> = {
+  ios: 'System',
+  android: 'sans-serif',
+};
+const sansStack =
+  sansByPlatform[Platform.OS] ?? '-apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif';
+
+/**
+ * Shared font stacks — the single source of truth for the app's faces. Only
+ * platform-system fonts are used; no proprietary/commercial font files are
+ * bundled, self-hosted, or embedded (see ``ATTRIBUTION``). ``editorialType``
+ * (journal) and the app ``type`` ramp both draw their serif from ``serif``.
+ */
+export const fonts = {
+  serif: serifStack,
+  sans: sansStack,
+} as const;
+
 export const editorialType = {
   serif: serifStack,
   display: { fontFamily: serifStack, fontSize: 34, lineHeight: 42, fontWeight: '700' as const },
@@ -459,6 +481,50 @@ export const editorialType = {
     fontWeight: '400' as const,
   },
 } as const;
+
+// ---------------------------------------------------------------------------
+// App-wide editorial type ramp — serif display + clean-sans body (#800)
+// ---------------------------------------------------------------------------
+
+/**
+ * The cohesive app type system: a serif display/heading face paired with a
+ * clean system sans for body/labels (the journal keeps its all-serif
+ * ``editorialType`` for long-form reading). Responsive-aware — sizes scale on
+ * the same breakpoint base as :func:`typography`, so a phone reads tighter than
+ * a tablet. Every face comes from :data:`fonts` (system only — no bundled font).
+ */
+export const type = (width: number) => {
+  const base =
+    width < breakpoints.sm
+      ? 15
+      : width < breakpoints.md
+        ? 16
+        : width < breakpoints.lg
+          ? 17
+          : width < breakpoints.xl
+            ? 18
+            : 19;
+  const serif = (size: number, weight: '600' | '700') => ({
+    fontFamily: fonts.serif,
+    fontSize: size,
+    lineHeight: Math.round(size * 1.25),
+    fontWeight: weight,
+  });
+  const sans = (size: number, weight: '400' | '600') => ({
+    fontFamily: fonts.sans,
+    fontSize: size,
+    lineHeight: Math.round(size * 1.5),
+    fontWeight: weight,
+  });
+  return {
+    display: serif(Math.round(base * 2.1), '700'),
+    title: serif(Math.round(base * 1.6), '600'),
+    heading: serif(Math.round(base * 1.25), '600'),
+    body: sans(base, '400'),
+    label: sans(Math.round(base * 0.9), '600'),
+    caption: sans(Math.round(base * 0.8), '400'),
+  } as const;
+};
 
 // ---------------------------------------------------------------------------
 // UI typography — non-editorial chrome (buttons, chips) in the system stack


### PR DESCRIPTION
## Summary

#800 (epic #798): editorial serif type was journal-only and the rest of the app used bare system sans with no ramp. Add a cohesive **serif-display + clean-sans** type system app-wide — using only **platform-system fonts** (no proprietary/commercial font files bundled, self-hosted, or embedded).

- `fonts = { serif, sans }` — single source of truth for the app's faces (both system stacks, resolved from `Platform.OS`).
- `type(width)` ramp → `{ display, title, heading, body, label, caption }`: serif for display/title/heading, clean sans for body/label/caption; sizes descend + scale on the same breakpoint base as `typography()` (responsive).
- `editorialType` keys unchanged; it now shares `fonts.serif` as its source.
- `DESIGN.md` documents the type system; `ATTRIBUTION` records the no-proprietary-fonts stance for serif + sans.

## Test plan

`typeSystem.test.ts` asserts ramp keys, serif/sans assignment, size descent + lineHeight, responsiveness, and `editorialType.serif === fonts.serif`. Journal `editorialTokens` contracts green. `./scripts/frontend/check-all.sh` 4/4.

Closes #800
Refs #798