### PR TITLE
feat(design): shared warm Button + TextField primitives, adopted across controls

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+import { accent, BORDER_RADIUS, SPACING, surface, touchTarget, uiType } from '@/design/tokens';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'tertiary';
+
+interface ButtonProps {
+  label: string;
+  onPress: () => void;
+  variant?: ButtonVariant;
+  disabled?: boolean;
+  busy?: boolean;
+  testID?: string;
+  accessibilityLabel?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Shared button primitive in the warm "Candle & Ink" language (#801).
+ * primary = terracotta fill (white label, 5.2:1 AA); secondary = warm outline;
+ * tertiary = text-only accent. 44dp min height; press feedback is suppressed
+ * under prefers-reduced-motion.
+ */
+export function Button({
+  label,
+  onPress,
+  variant = 'primary',
+  disabled = false,
+  busy = false,
+  testID,
+  accessibilityLabel,
+  style,
+}: ButtonProps): React.JSX.Element {
+  const reducedMotion = useReducedMotion();
+  const isDisabled = disabled || busy;
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityState={{ disabled: isDisabled, busy }}
+      activeOpacity={reducedMotion ? 1 : 0.7}
+      onPress={onPress}
+      disabled={isDisabled}
+      testID={testID}
+      style={[styles.base, styles[variant], isDisabled && styles.disabled, style]}
+    >
+      <Text style={[styles.label, labelStyles[variant]]}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    minHeight: touchTarget.minimum,
+    borderRadius: BORDER_RADIUS.lg,
+    paddingVertical: SPACING.buttonV,
+    paddingHorizontal: SPACING.xl,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primary: { backgroundColor: accent.primary },
+  secondary: { backgroundColor: surface.raised, borderWidth: 1, borderColor: accent.primary },
+  tertiary: { backgroundColor: 'transparent' },
+  disabled: { opacity: 0.5 },
+  label: { fontSize: uiType.button.fontSize, fontWeight: uiType.button.fontWeight },
+});
+
+const labelStyles = StyleSheet.create({
+  primary: { color: surface.raised }, // white on terracotta — 5.2:1 AA
+  secondary: { color: accent.primary },
+  tertiary: { color: accent.primary },
+});

--- a/frontend/src/components/TextField.tsx
+++ b/frontend/src/components/TextField.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { StyleSheet, TextInput } from 'react-native';
+import type { NativeSyntheticEvent, TextInputFocusEventData, TextInputProps } from 'react-native';
+
+import {
+  accent,
+  BORDER_RADIUS,
+  colors,
+  ink,
+  SPACING,
+  surface,
+  touchTarget,
+  uiType,
+} from '@/design/tokens';
+
+interface TextFieldProps extends TextInputProps {
+  /** Recessed (sunken) variant using the warm bevel tokens. */
+  recessed?: boolean;
+}
+
+/**
+ * Shared text input in the warm "Candle & Ink" language (#801): warm ground,
+ * hairline border, ink text, ink.muted placeholder, terracotta focus border.
+ * Forwards all standard TextInput props (value, onChangeText, secureTextEntry,
+ * testID, …) and composes focus/blur so the focus ring works alongside callers.
+ */
+export function TextField({
+  recessed = false,
+  style,
+  onFocus,
+  onBlur,
+  ...rest
+}: TextFieldProps): React.JSX.Element {
+  const [focused, setFocused] = useState(false);
+  const handleFocus = (event: NativeSyntheticEvent<TextInputFocusEventData>): void => {
+    setFocused(true);
+    onFocus?.(event);
+  };
+  const handleBlur = (event: NativeSyntheticEvent<TextInputFocusEventData>): void => {
+    setFocused(false);
+    onBlur?.(event);
+  };
+  return (
+    <TextInput
+      {...rest}
+      placeholderTextColor={ink.muted}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      style={[
+        styles.base,
+        recessed ? styles.recessed : styles.raised,
+        focused && styles.focused,
+        style,
+      ]}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    minHeight: touchTarget.minimum,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    color: ink.primary,
+    fontSize: uiType.button.fontSize,
+  },
+  raised: { backgroundColor: surface.raised, borderColor: surface.hairline },
+  recessed: { backgroundColor: colors.bevel.recessedSurface, borderColor: colors.bevel.edgeDark },
+  focused: { borderColor: accent.primary },
+});

--- a/frontend/src/components/__tests__/Button.test.tsx
+++ b/frontend/src/components/__tests__/Button.test.tsx
@@ -1,0 +1,49 @@
+/* eslint-env jest */
+/* global describe, it, expect, jest */
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { Button } from '../Button';
+
+import { accent, surface, touchTarget } from '@/design/tokens';
+
+describe('Button', () => {
+  it('renders the label and fires onPress', () => {
+    const onPress = jest.fn();
+    const { getByTestId, getByText } = render(<Button label="Save" onPress={onPress} testID="b" />);
+    expect(getByText('Save')).toBeTruthy();
+    fireEvent.press(getByTestId('b'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onPress when disabled or busy', () => {
+    const onPress = jest.fn();
+    const { getByTestId, rerender } = render(
+      <Button label="Save" onPress={onPress} disabled testID="b" />,
+    );
+    fireEvent.press(getByTestId('b'));
+    rerender(<Button label="Save" onPress={onPress} busy testID="b" />);
+    fireEvent.press(getByTestId('b'));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('renders each variant with its warm fill/outline', () => {
+    const onPress = jest.fn();
+    const flat = (variant: 'primary' | 'secondary' | 'tertiary') => {
+      const { getByTestId } = render(
+        <Button label="X" onPress={onPress} variant={variant} testID={variant} />,
+      );
+      return StyleSheet.flatten(getByTestId(variant).props.style);
+    };
+    expect(flat('primary').backgroundColor).toBe(accent.primary);
+    expect(flat('secondary').borderColor).toBe(accent.primary);
+    expect(flat('secondary').backgroundColor).toBe(surface.raised);
+    expect(flat('tertiary').backgroundColor).toBe('transparent');
+  });
+
+  it('meets the 44dp minimum touch target', () => {
+    const { getByTestId } = render(<Button label="X" onPress={jest.fn()} testID="b" />);
+    expect(StyleSheet.flatten(getByTestId('b').props.style).minHeight).toBe(touchTarget.minimum);
+  });
+});

--- a/frontend/src/components/__tests__/TextField.test.tsx
+++ b/frontend/src/components/__tests__/TextField.test.tsx
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+/* global describe, it, expect, jest */
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { TextField } from '../TextField';
+
+import { accent, colors, ink, surface, touchTarget } from '@/design/tokens';
+
+describe('TextField', () => {
+  it('forwards onChangeText and renders the value', () => {
+    const onChangeText = jest.fn();
+    const { getByTestId } = render(
+      <TextField testID="f" value="hi" onChangeText={onChangeText} placeholder="Email" />,
+    );
+    fireEvent.changeText(getByTestId('f'), 'there');
+    expect(onChangeText).toHaveBeenCalledWith('there');
+  });
+
+  it('uses the warm ground, ink text, and ink.muted placeholder at 44dp', () => {
+    const { getByTestId } = render(<TextField testID="f" placeholder="Email" />);
+    const field = getByTestId('f');
+    expect(field.props.placeholderTextColor).toBe(ink.muted);
+    const flat = StyleSheet.flatten(field.props.style);
+    expect(flat.color).toBe(ink.primary);
+    expect(flat.backgroundColor).toBe(surface.raised);
+    expect(flat.minHeight).toBe(touchTarget.minimum);
+  });
+
+  it('uses the bevel ground for the recessed variant', () => {
+    const { getByTestId } = render(<TextField testID="f" recessed />);
+    expect(StyleSheet.flatten(getByTestId('f').props.style).backgroundColor).toBe(
+      colors.bevel.recessedSurface,
+    );
+  });
+
+  it('shows a terracotta focus border on focus', () => {
+    const { getByTestId } = render(<TextField testID="f" />);
+    fireEvent(getByTestId('f'), 'focus');
+    expect(StyleSheet.flatten(getByTestId('f').props.style).borderColor).toBe(accent.primary);
+  });
+});

--- a/frontend/src/features/Auth/CancelResetScreen.tsx
+++ b/frontend/src/features/Auth/CancelResetScreen.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { ActivityIndicator, StyleSheet, Text } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { MIN_TOKEN_LENGTH } from './resetToken';
 
 import { auth as authApi } from '@/api';
+import { Button } from '@/components/Button';
 import { SPACING, colors } from '@/design/tokens';
 
 type CancelStatus = 'pending' | 'success' | 'error' | 'invalid_token';
@@ -30,15 +31,14 @@ function TerminalView({ title, body, onBackToLogin }: TerminalViewProps): React.
     <AuthScreenContainer testID="cancel-reset">
       <Text style={localStyles.title}>{title}</Text>
       <Text style={localStyles.subtitle}>{body}</Text>
-      <TouchableOpacity
+      <Button
         accessibilityLabel="Back to log in"
-        accessibilityRole="button"
-        style={styles.button}
+        variant="secondary"
+        style={styles.buttonSpacing}
         onPress={onBackToLogin}
         testID="cancel-reset-back-to-login"
-      >
-        <Text style={styles.buttonText}>Back to Log In</Text>
-      </TouchableOpacity>
+        label="Back to Log In"
+      />
     </AuthScreenContainer>
   );
 }

--- a/frontend/src/features/Auth/ForgotPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ForgotPasswordScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
@@ -7,6 +7,8 @@ import { canonicalizeEmail } from './canonicalizeEmail';
 
 import { auth as authApi } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
+import { Button } from '@/components/Button';
+import { TextField } from '@/components/TextField';
 
 const FORGOT_FALLBACK =
   "We couldn't reach the server. Check your connection, then try again in a moment.";
@@ -22,9 +24,9 @@ interface ForgotFieldsProps {
 
 function ForgotFields({ email, setEmail }: ForgotFieldsProps): React.JSX.Element {
   return (
-    <TextInput
+    <TextField
       accessibilityLabel="Email"
-      style={styles.input}
+      style={styles.inputSpacing}
       placeholder="Email"
       value={email}
       onChangeText={setEmail}
@@ -47,17 +49,15 @@ function ForgotActions({
 }: ForgotActionsProps): React.JSX.Element {
   return (
     <>
-      <TouchableOpacity
+      <Button
         accessibilityLabel="Send reset link"
-        accessibilityRole="button"
-        accessibilityState={{ disabled: submitting, busy: submitting }}
-        style={styles.button}
+        style={styles.buttonSpacing}
         onPress={onSubmit}
         disabled={submitting}
+        busy={submitting}
         testID="forgot-submit"
-      >
-        <Text style={styles.buttonText}>{submitting ? 'Sending...' : 'Send Reset Link'}</Text>
-      </TouchableOpacity>
+        label={submitting ? 'Sending...' : 'Send Reset Link'}
+      />
       <TouchableOpacity
         accessibilityLabel="Back to log in"
         accessibilityRole="link"
@@ -85,15 +85,14 @@ function SuccessNotice({ onBackToLogin }: { onBackToLogin: () => void }): React.
         If we have an account for that address, a reset link is on its way. The link expires in 30
         minutes.
       </Text>
-      <TouchableOpacity
+      <Button
         accessibilityLabel="Back to log in"
-        accessibilityRole="button"
-        style={styles.button}
+        variant="secondary"
+        style={styles.buttonSpacing}
         onPress={onBackToLogin}
         testID="forgot-back-to-login"
-      >
-        <Text style={styles.buttonText}>Back to Log In</Text>
-      </TouchableOpacity>
+        label="Back to Log In"
+      />
     </View>
   );
 }

--- a/frontend/src/features/Auth/LoginScreen.tsx
+++ b/frontend/src/features/Auth/LoginScreen.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
-import { Text, TextInput, TouchableOpacity } from 'react-native';
+import { Text, TouchableOpacity } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { canonicalizeEmail } from './canonicalizeEmail';
 
 import { formatApiError } from '@/api/errorMessages';
+import { Button } from '@/components/Button';
+import { TextField } from '@/components/TextField';
 import { useAuth } from '@/context/AuthContext';
 
 const LOGIN_FALLBACK =
@@ -30,18 +32,18 @@ function LoginFields({
 }: LoginFieldsProps): React.JSX.Element {
   return (
     <>
-      <TextInput
+      <TextField
         accessibilityLabel="Email"
-        style={styles.input}
+        style={styles.inputSpacing}
         placeholder="Email"
         value={email}
         onChangeText={setEmail}
         autoCapitalize="none"
         keyboardType="email-address"
       />
-      <TextInput
+      <TextField
         accessibilityLabel="Password"
-        style={styles.input}
+        style={styles.inputSpacing}
         placeholder="Password"
         value={password}
         onChangeText={setPassword}
@@ -66,17 +68,15 @@ function LoginActions({
 }: LoginActionsProps): React.JSX.Element {
   return (
     <>
-      <TouchableOpacity
+      <Button
         accessibilityLabel="Log in"
-        accessibilityRole="button"
-        accessibilityState={{ disabled: submitting, busy: submitting }}
-        style={styles.button}
+        style={styles.buttonSpacing}
         onPress={onLogin}
         disabled={submitting}
+        busy={submitting}
         testID="login-submit"
-      >
-        <Text style={styles.buttonText}>{submitting ? 'Logging in...' : 'Log In'}</Text>
-      </TouchableOpacity>
+        label={submitting ? 'Logging in...' : 'Log In'}
+      />
       <TouchableOpacity
         accessibilityLabel="Forgot password"
         accessibilityRole="link"

--- a/frontend/src/features/Auth/ResetPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ResetPasswordScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Text, TextInput, TouchableOpacity } from 'react-native';
+import { Text, TouchableOpacity } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
@@ -7,6 +7,8 @@ import { validatePasswordPair } from './passwordValidation';
 import { MIN_TOKEN_LENGTH } from './resetToken';
 
 import { formatApiError } from '@/api/errorMessages';
+import { Button } from '@/components/Button';
+import { TextField } from '@/components/TextField';
 import { useAuth } from '@/context/AuthContext';
 
 const RESET_FALLBACK =
@@ -36,18 +38,18 @@ function ResetFields({
 }: ResetFieldsProps): React.JSX.Element {
   return (
     <>
-      <TextInput
+      <TextField
         accessibilityLabel="New password"
-        style={styles.input}
+        style={styles.inputSpacing}
         placeholder="New Password"
         value={password}
         onChangeText={setPassword}
         secureTextEntry
         textContentType="newPassword"
       />
-      <TextInput
+      <TextField
         accessibilityLabel="Confirm new password"
-        style={styles.input}
+        style={styles.inputSpacing}
         placeholder="Confirm New Password"
         value={confirmPassword}
         onChangeText={setConfirmPassword}
@@ -71,17 +73,15 @@ function ResetActions({
 }: ResetActionsProps): React.JSX.Element {
   return (
     <>
-      <TouchableOpacity
+      <Button
         accessibilityLabel="Set new password"
-        accessibilityRole="button"
-        accessibilityState={{ disabled: submitting, busy: submitting }}
-        style={styles.button}
+        style={styles.buttonSpacing}
         onPress={onSubmit}
         disabled={submitting}
+        busy={submitting}
         testID="reset-submit"
-      >
-        <Text style={styles.buttonText}>{submitting ? 'Setting password...' : 'Set Password'}</Text>
-      </TouchableOpacity>
+        label={submitting ? 'Setting password...' : 'Set Password'}
+      />
       <TouchableOpacity
         accessibilityLabel="Back to log in"
         accessibilityRole="link"
@@ -102,15 +102,14 @@ function MissingTokenView({ onRequestNew }: { onRequestNew: () => void }): React
       <Text style={styles.subtitle}>
         That link is missing or malformed. Request a fresh one to continue.
       </Text>
-      <TouchableOpacity
+      <Button
         accessibilityLabel="Request a new reset link"
-        accessibilityRole="button"
-        style={styles.button}
+        variant="secondary"
+        style={styles.buttonSpacing}
         onPress={onRequestNew}
         testID="reset-request-new"
-      >
-        <Text style={styles.buttonText}>Request New Link</Text>
-      </TouchableOpacity>
+        label="Request New Link"
+      />
     </AuthScreenContainer>
   );
 }

--- a/frontend/src/features/Auth/SignupScreen.tsx
+++ b/frontend/src/features/Auth/SignupScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Text, TextInput, TouchableOpacity } from 'react-native';
+import { Text, TouchableOpacity } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
@@ -7,6 +7,8 @@ import { canonicalizeEmail } from './canonicalizeEmail';
 import { validatePasswordPair } from './passwordValidation';
 
 import { formatApiError } from '@/api/errorMessages';
+import { Button } from '@/components/Button';
+import { TextField } from '@/components/TextField';
 import { useAuth } from '@/context/AuthContext';
 
 const SIGNUP_FALLBACK =
@@ -35,26 +37,26 @@ function SignupFields({
 }: SignupFieldsProps) {
   return (
     <>
-      <TextInput
+      <TextField
         accessibilityLabel="Email"
-        style={styles.input}
+        style={styles.inputSpacing}
         placeholder="Email"
         value={email}
         onChangeText={setEmail}
         autoCapitalize="none"
         keyboardType="email-address"
       />
-      <TextInput
+      <TextField
         accessibilityLabel="Password"
-        style={styles.input}
+        style={styles.inputSpacing}
         placeholder="Password"
         value={password}
         onChangeText={setPassword}
         secureTextEntry
       />
-      <TextInput
+      <TextField
         accessibilityLabel="Confirm password"
-        style={styles.input}
+        style={styles.inputSpacing}
         placeholder="Confirm Password"
         value={confirmPassword}
         onChangeText={setConfirmPassword}
@@ -73,17 +75,15 @@ interface SignupActionsProps {
 function SignupActions({ onSignup, onNavigateLogin, submitting }: SignupActionsProps) {
   return (
     <>
-      <TouchableOpacity
+      <Button
         accessibilityLabel="Create account"
-        accessibilityRole="button"
-        accessibilityState={{ disabled: submitting, busy: submitting }}
-        style={styles.button}
+        style={styles.buttonSpacing}
         onPress={onSignup}
         disabled={submitting}
+        busy={submitting}
         testID="signup-submit"
-      >
-        <Text style={styles.buttonText}>{submitting ? 'Creating account...' : 'Sign Up'}</Text>
-      </TouchableOpacity>
+        label={submitting ? 'Creating account...' : 'Sign Up'}
+      />
       <TouchableOpacity
         accessibilityLabel="Go to log-in screen"
         accessibilityRole="link"

--- a/frontend/src/features/Auth/auth.styles.ts
+++ b/frontend/src/features/Auth/auth.styles.ts
@@ -40,6 +40,11 @@ export const authStyles = StyleSheet.create({
     marginBottom: SPACING.md,
     fontSize: 16,
   },
+  // Layout-only spacing for the warm `TextField`/`Button` primitives (#801),
+  // which own their own ground/border/colour. Keeps field/button rhythm without
+  // re-imposing the legacy grey chrome.
+  inputSpacing: { marginBottom: SPACING.md },
+  buttonSpacing: { marginBottom: SPACING.lg },
   error: { color: colors.danger, marginBottom: SPACING.md, textAlign: 'center' },
   button: {
     backgroundColor: colors.primary,

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -21,6 +21,7 @@ import type {
 import EmojiSelector from 'react-native-emoji-selector';
 
 import { goalGroups as goalGroupsApi, type ApiGoalGroup } from '../../../api';
+import { Button } from '../../../components/Button';
 import { TierStar } from '../../../components/TierStar';
 import { useAuth } from '../../../context/AuthContext';
 import {
@@ -410,9 +411,7 @@ const LogUnitSection = ({
         onChangeText={setLogAmount}
         keyboardType="numeric"
       />
-      <TouchableOpacity style={styles.logUnitButton} onPress={onLog}>
-        <Text style={styles.logUnitButtonText}>Log Units</Text>
-      </TouchableOpacity>
+      <Button label="Log Units" onPress={onLog} testID="goal-log-units" />
     </View>
   </View>
 );

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -30,6 +30,7 @@ import { useResonance } from './useResonance';
 
 import { journal, prompts } from '@/api';
 import type { EntryStatus, JournalMessage, Marginalia } from '@/api';
+import { Button } from '@/components/Button';
 import { colors } from '@/design/tokens';
 import { useIdle } from '@/hooks/useIdle';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
@@ -301,14 +302,13 @@ interface WritingColumnProps {
 /** Quiet control to mark a draft finished. */
 function FinishControl({ onFinish }: { onFinish: () => void }) {
   return (
-    <TouchableOpacity
+    <Button
+      variant="tertiary"
       onPress={onFinish}
-      accessibilityRole="button"
       accessibilityLabel="Mark this entry finished"
       testID="journal-finish-button"
-    >
-      <Text style={styles.controlLink}>Finish</Text>
-    </TouchableOpacity>
+      label="Finish"
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

#801 (epic #798): interactive chrome was styled per-feature against the cold grey palette with no shared primitive. Introduce warm-language `Button` + `TextField` built on the #799/#800 tokens and adopt them in high-traffic controls.

- **`Button`** — primary (terracotta `accent.primary` fill, white label — **5.24:1** AA) / secondary (warm outline) / tertiary (text-only); pressed + disabled + busy; label via the type ramp; 44dp; press feedback suppressed under `useReducedMotion`. Tokens-only.
- **`TextField`** — warm ground, hairline border, `ink.primary` text, enforced `ink.muted` placeholder, terracotta focus border, `bevel` recessed variant; 44dp; forwards `TextInput` props.
- Adopted across **Auth** (Login/Signup/Forgot/Reset/CancelReset), **Habits** (GoalModal), **Journal** (entry finish). All testIDs/placeholders/labels + press/submit behaviour preserved.

Icon-buttons + micro-controls left as a clear seam.

## Test plan

`Button.test.tsx` (variants/press/disabled/44dp) + `TextField.test.tsx` (onChange/warm ground/`ink.muted` placeholder/bevel/focus); migrated screens' tests green. `./scripts/frontend/check-all.sh` 4/4.

Closes #801
Refs #798