### PR TITLE
feat(design): warm screen grounds + soft elevation for cards/surfaces

### DIFF
--- a/frontend/src/design/__tests__/semanticTokens.test.ts
+++ b/frontend/src/design/__tests__/semanticTokens.test.ts
@@ -61,6 +61,18 @@ describe('semantic tokens (Candle & Ink)', () => {
     });
   });
 
+  describe('legacy text on the warm canvas (#802 migration safety)', () => {
+    it('keeps the chrome text tokens AA-legible after grounds moved to canvas', () => {
+      for (const value of [
+        colors.text.primary,
+        colors.text.secondary,
+        colors.text.secondaryAccessible,
+      ]) {
+        expect(contrast(value, surface.canvas)).toBeGreaterThanOrEqual(AA_NORMAL);
+      }
+    });
+  });
+
   describe('surfaceShadow', () => {
     it('flattens to warm, ink-tinted lifts with iOS/web + Android props', () => {
       for (const lift of [surfaceShadow.card, surfaceShadow.raised]) {

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -290,28 +290,28 @@ export const BORDER_RADIUS = {
 
 export const shadows = {
   small: {
-    shadowColor: '#000000',
+    shadowColor: colors.paper.ink,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.1,
     shadowRadius: 2,
     elevation: 2,
   },
   medium: {
-    shadowColor: '#000000',
+    shadowColor: colors.paper.ink,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.15,
     shadowRadius: 3,
     elevation: 3,
   },
   large: {
-    shadowColor: '#000000',
+    shadowColor: colors.paper.ink,
     shadowOffset: { width: 0, height: 3 },
     shadowOpacity: 0.2,
     shadowRadius: 4,
     elevation: 5,
   },
   glow: {
-    shadowColor: '#000000',
+    shadowColor: colors.paper.ink,
     shadowOffset: { width: 0, height: 3 },
     shadowOpacity: 0.2,
     shadowRadius: 4,

--- a/frontend/src/features/Auth/auth.styles.ts
+++ b/frontend/src/features/Auth/auth.styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import { BORDER_RADIUS, SPACING, colors, surface } from '@/design/tokens';
 
 // Cap the form width so fields don't stretch edge-to-edge on laptop/desktop
 // browsers; on phones the screen is narrower so it has no effect.
@@ -13,7 +13,7 @@ export const FORM_MAX_WIDTH = 480;
  */
 export const authStyles = StyleSheet.create({
   // Outer SafeAreaView wrapper for the full-screen auth screens.
-  safeArea: { flex: 1, backgroundColor: colors.background.card },
+  safeArea: { flex: 1, backgroundColor: surface.canvas },
   container: {
     flex: 1,
     justifyContent: 'center',

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { colors, radius, SPACING, shadows, touchTarget } from '../../design/tokens';
+import { colors, radius, SPACING, shadows, surface, touchTarget } from '../../design/tokens';
 
 const STAGE_PILL_SIZE = 40;
 const PROGRESS_BAR_HEIGHT = 6;
@@ -8,7 +8,7 @@ const PROGRESS_BAR_HEIGHT = 6;
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.background.primary,
+    backgroundColor: surface.canvas,
   },
 
   // Stage selector
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
   // Content viewer
   viewerContainer: {
     flex: 1,
-    backgroundColor: colors.background.primary,
+    backgroundColor: surface.canvas,
   },
   viewerHeader: {
     flexDirection: 'row',
@@ -299,7 +299,7 @@ const styles = StyleSheet.create({
   // Native Markdown reader body
   readerScroll: {
     flex: 1,
-    backgroundColor: colors.background.primary,
+    backgroundColor: surface.canvas,
     paddingHorizontal: SPACING.lg,
   },
   readerError: {

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Animated, Easing, Text, TouchableOpacity, View, type DimensionValue } from 'react-native';
 
 import { TierStar } from '../../components/TierStar';
-import { colors, STAGE_COLORS, spacing } from '../../design/tokens';
+import { colors, STAGE_COLORS, spacing, surface } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 import { DEFAULT_TIMEZONE } from '../../utils/dateUtils';
 
@@ -580,7 +580,7 @@ const buildUnlockedTileStyle = (
   margin: gridGutter / 2,
   minHeight: tileMinHeight,
   borderRadius: spacing(1, scale),
-  backgroundColor: '#f8f8f8',
+  backgroundColor: surface.canvas,
 });
 
 const UnlockedTile = ({

--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -1,6 +1,12 @@
 import { Platform, StyleSheet, type ViewStyle } from 'react-native';
 
-import { colors as COLORS, shadows as SHADOWS, SPACING, BORDER_RADIUS } from '../../design/tokens';
+import {
+  colors as COLORS,
+  shadows as SHADOWS,
+  SPACING,
+  BORDER_RADIUS,
+  surface,
+} from '../../design/tokens';
 
 export { colors as COLORS } from '../../design/tokens';
 
@@ -17,7 +23,7 @@ export const styles = StyleSheet.create({
   // ===== Layout containers =====
   container: {
     flex: 1,
-    backgroundColor: COLORS.background.primary,
+    backgroundColor: surface.canvas,
     padding: SPACING.md,
   },
   habitsGrid: {
@@ -475,7 +481,7 @@ export const styles = StyleSheet.create({
     borderColor: '#ddd',
     borderRadius: BORDER_RADIUS.md,
     overflow: 'hidden',
-    backgroundColor: '#fff',
+    backgroundColor: surface.raised,
   },
 
   // ===== Reorder Button =====
@@ -697,7 +703,7 @@ export const styles = StyleSheet.create({
   },
   statsInfoContainer: {
     marginTop: SPACING.lg,
-    backgroundColor: COLORS.background.primary,
+    backgroundColor: surface.canvas,
     borderRadius: BORDER_RADIUS.md,
     padding: SPACING.md,
   },
@@ -1019,7 +1025,7 @@ export const styles = StyleSheet.create({
 
   // ===== Energy Rating =====
   energyTile: {
-    backgroundColor: COLORS.background.primary,
+    backgroundColor: surface.canvas,
     padding: SPACING.sm,
     borderRadius: BORDER_RADIUS.md,
     marginBottom: SPACING.sm,
@@ -1099,7 +1105,7 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: JUSTIFY_SPACE_BETWEEN,
-    backgroundColor: COLORS.background.primary,
+    backgroundColor: surface.canvas,
     paddingVertical: SPACING.md,
     paddingHorizontal: SPACING.lg,
     borderRadius: BORDER_RADIUS.lg,
@@ -1139,7 +1145,7 @@ export const styles = StyleSheet.create({
   habitChip: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: COLORS.background.primary,
+    backgroundColor: surface.canvas,
     borderRadius: BORDER_RADIUS.lg,
     paddingVertical: SPACING.xs,
     paddingHorizontal: SPACING.md,
@@ -1177,7 +1183,7 @@ export const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-    backgroundColor: '#fff',
+    backgroundColor: surface.raised,
     height: 280,
     borderTopLeftRadius: BORDER_RADIUS.xl,
     borderTopRightRadius: BORDER_RADIUS.xl,
@@ -1353,7 +1359,7 @@ export const styles = StyleSheet.create({
   // Enhanced progress bar styles
   goalProgressBar: {
     height: 12,
-    backgroundColor: COLORS.background.primary,
+    backgroundColor: surface.canvas,
     borderRadius: 6,
     overflow: 'hidden',
     position: 'relative',
@@ -1402,11 +1408,11 @@ export const styles = StyleSheet.create({
     position: 'absolute',
     top: 36,
     right: 8,
-    backgroundColor: '#fff',
+    backgroundColor: surface.raised,
     borderRadius: 8,
     padding: 8,
     zIndex: 1002,
-    shadowColor: '#000',
+    shadowColor: COLORS.paper.ink,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.2,
     shadowRadius: 4,

--- a/frontend/src/features/Habits/__tests__/HabitTileLocked.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileLocked.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals
 import React from 'react';
 import renderer from 'react-test-renderer';
 
+import { surface } from '../../../design/tokens';
 import type { Habit } from '../Habits.types';
 import { HabitTile } from '../HabitTile';
 
@@ -159,7 +160,7 @@ describe('HabitTile locked state', () => {
     const tile = component.root.findByProps({ testID: 'habit-tile' });
 
     // Should have normal background
-    expect(tile.props.style.backgroundColor).toBe('#f8f8f8');
+    expect(tile.props.style.backgroundColor).toBe(surface.canvas);
 
     // Should have progress bar
     const progressFills = component.root.findAllByProps({ testID: 'progress-fill' });

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import React from 'react';
 import { StyleSheet } from 'react-native';
 
-import { BORDER_RADIUS, SPACING, colors as COLORS } from '../../../../design/tokens';
+import { BORDER_RADIUS, SPACING, colors as COLORS, surface } from '../../../../design/tokens';
 
 const OnboardingModal = require('../OnboardingModal').default;
 
@@ -54,7 +54,7 @@ describe('OnboardingModal cost step', () => {
     expect(style.padding).toBe(SPACING.sm);
     expect(style.marginBottom).toBe(SPACING.sm);
     expect(style.borderRadius).toBe(BORDER_RADIUS.md);
-    expect(style.backgroundColor).toBe(COLORS.background.primary);
+    expect(style.backgroundColor).toBe(surface.canvas);
   });
 
   it('applies mystical slider styling', () => {

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -2,7 +2,7 @@
 
 import { StyleSheet } from 'react-native';
 
-import { colors, editorialType, radius, shadows, spacing } from '../../design/tokens';
+import { colors, editorialType, radius, shadows, spacing, surface } from '../../design/tokens';
 
 // --- Layout constants for the three-column "spiral of becoming" table -------
 const LEFT_COLUMN_WIDTH = '40%';
@@ -27,7 +27,7 @@ const ARROW_LABEL_COLOR = '#262626';
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.background.primary,
+    backgroundColor: surface.canvas,
   },
 
   // Loading / error states
@@ -35,7 +35,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: CENTER,
     justifyContent: CENTER,
-    backgroundColor: colors.background.primary,
+    backgroundColor: surface.canvas,
   },
   loadingText: {
     color: colors.text.primary,
@@ -151,7 +151,7 @@ const styles = StyleSheet.create({
   // Branded fill shown when no hosted map art is configured (#766) — keeps the
   // map area on-brand instead of a third-party placeholder image.
   mapBackgroundFallback: {
-    backgroundColor: colors.background.primary,
+    backgroundColor: surface.canvas,
   },
   greyBandFeminine: {
     position: ABSOLUTE,

--- a/frontend/src/features/Practice/views/__tests__/__snapshots__/MindfulAnchorView.test.tsx.snap
+++ b/frontend/src/features/Practice/views/__tests__/__snapshots__/MindfulAnchorView.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`MindfulAnchorView matches the option-chooser snapshot 1`] = `
         "marginBottom": 20,
         "maxWidth": 340,
         "padding": 20,
-        "shadowColor": "#000000",
+        "shadowColor": "#2b2620",
         "shadowOffset": {
           "height": 1,
           "width": 0,
@@ -225,7 +225,7 @@ exports[`MindfulAnchorView matches the option-chooser snapshot 1`] = `
           "minWidth": 220,
           "paddingHorizontal": 30,
           "paddingVertical": 14,
-          "shadowColor": "#000000",
+          "shadowColor": "#2b2620",
           "shadowOffset": {
             "height": 1,
             "width": 0,


### PR DESCRIPTION
## Summary

#802 (epic #798): screens and cards across Habits/Course/Map/Auth sat on flat grey (`#f8f8f8`/`#fff`) with neutral-black shadows. Migrate to the warm surfaces from #799.

- `tokens.ts`: warm every `shadows.*` tint (`#000000` → `colors.paper.ink`) so all elevation reads as paper-on-desk app-wide; legacy grey `colors.background.primary` kept but no longer a ground.
- Screen grounds → `surface.canvas` (Habits/Course/Map/Auth); raw `#fff` cards → `surface.raised`; warmed the Habits menu shadow.
- `STAGE_COLORS`/`MAP_STAGE_COLORS`/`colors.mystical.*` preserved.

## Test plan

Color-assertion tests repointed to `surface.canvas`; MindfulAnchorView snapshot refreshed (shadow tint only); a `semanticTokens` guard asserts `colors.text.*` still clear AA on the warm canvas (11.7 / 5.3 / 6.9:1). `./scripts/frontend/check-all.sh` 4/4.

Closes #802
Refs #798