### PR TITLE
feat(design): warm editorial navigation theme (headers + bottom tab bar)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ import SignupScreen from './features/Auth/SignupScreen';
 import type { RootTabParamList } from './navigation/BottomTabs';
 import type { RootStackParamList } from './navigation/RootStack';
 import RootStack from './navigation/RootStack';
+import { navTheme } from './navigation/theme';
 import { useHydrateProgramStore } from './store/useProgramStore';
 
 type AuthStackParamList = {
@@ -190,7 +191,7 @@ function ThemedStatusBar(): React.JSX.Element {
 function AppShell(): React.JSX.Element {
   useHydrateProgramStore();
   return (
-    <NavigationContainer linking={linking}>
+    <NavigationContainer theme={navTheme} linking={linking}>
       <SafeAreaView style={styles.safeArea}>
         <ThemedStatusBar />
         <OfflineBanner />

--- a/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
+++ b/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
@@ -13,6 +13,8 @@
  */
 jest.mock('@react-navigation/native', () => {
   const React = require('react');
+  // navTheme (via App.tsx) extends DefaultTheme, so the mock must expose it.
+  const { mockDefaultTheme } = require('@/test-utils/navMocks');
   return {
     __esModule: true,
     NavigationContainer: ({ children }: { children: React.ReactNode }) =>
@@ -20,19 +22,7 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({ navigate: jest.fn(), getParent: () => undefined }),
     useRoute: () => ({ params: undefined }),
     useFocusEffect: (fn: () => void) => fn(),
-    // navTheme (via App.tsx) extends DefaultTheme, so the mock must expose it.
-    DefaultTheme: {
-      dark: false,
-      colors: {
-        primary: '#000000',
-        background: '#ffffff',
-        card: '#ffffff',
-        text: '#000000',
-        border: '#cccccc',
-        notification: '#000000',
-      },
-      fonts: {},
-    },
+    DefaultTheme: mockDefaultTheme,
   };
 });
 

--- a/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
+++ b/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
@@ -20,6 +20,19 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({ navigate: jest.fn(), getParent: () => undefined }),
     useRoute: () => ({ params: undefined }),
     useFocusEffect: (fn: () => void) => fn(),
+    // navTheme (via App.tsx) extends DefaultTheme, so the mock must expose it.
+    DefaultTheme: {
+      dark: false,
+      colors: {
+        primary: '#000000',
+        background: '#ffffff',
+        card: '#ffffff',
+        text: '#000000',
+        border: '#cccccc',
+        notification: '#000000',
+      },
+      fonts: {},
+    },
   };
 });
 

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -38,27 +38,19 @@ jest.mock('react-native-safe-area-context', () => ({
 // route-focus auto-reset (BUG-FE-UI-102); returning a stub navigation
 // object that no-ops on ``addListener`` keeps the unrelated auth-flow
 // assertions free of routing side effects.
-jest.mock('@react-navigation/native', () => ({
-  NavigationContainer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useNavigation: () => ({
-    addListener: () => () => {
-      /* unused in this test */
-    },
-  }),
+jest.mock('@react-navigation/native', () => {
   // navTheme (via App.tsx) extends DefaultTheme, so the mock must expose it.
-  DefaultTheme: {
-    dark: false,
-    colors: {
-      primary: '#000000',
-      background: '#ffffff',
-      card: '#ffffff',
-      text: '#000000',
-      border: '#cccccc',
-      notification: '#000000',
-    },
-    fonts: {},
-  },
-}));
+  const { mockDefaultTheme } = require('@/test-utils/navMocks');
+  return {
+    NavigationContainer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useNavigation: () => ({
+      addListener: () => () => {
+        /* unused in this test */
+      },
+    }),
+    DefaultTheme: mockDefaultTheme,
+  };
+});
 
 jest.mock('@react-navigation/native-stack', () => ({
   createNativeStackNavigator: () => ({

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -45,6 +45,19 @@ jest.mock('@react-navigation/native', () => ({
       /* unused in this test */
     },
   }),
+  // navTheme (via App.tsx) extends DefaultTheme, so the mock must expose it.
+  DefaultTheme: {
+    dark: false,
+    colors: {
+      primary: '#000000',
+      background: '#ffffff',
+      card: '#ffffff',
+      text: '#000000',
+      border: '#cccccc',
+      notification: '#000000',
+    },
+    fonts: {},
+  },
 }));
 
 jest.mock('@react-navigation/native-stack', () => ({

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -147,6 +147,8 @@ const BottomTabs = (): React.JSX.Element => {
         // terracotta vs muted ink, both AA on the raised ground.
         tabBarActiveTintColor: accent.primary,
         tabBarInactiveTintColor: ink.muted,
+        // borderTopWidth is intentionally omitted — RN Navigation defaults it to
+        // StyleSheet.hairlineWidth; we only retint the existing edge.
         tabBarStyle: { backgroundColor: surface.raised, borderTopColor: surface.hairline },
         headerRight: renderHeaderRight,
       }}

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -16,7 +16,7 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { JournalTag } from '../api';
 import { FeatureErrorBoundary } from '../components/FeatureErrorBoundary';
-import { colors, SPACING } from '../design/tokens';
+import { accent, ink, SPACING, surface } from '../design/tokens';
 import CourseScreen from '../features/Course/CourseScreen';
 import HabitsScreen from '../features/Habits/HabitsScreen';
 import JournalShelfScreen from '../features/Journal/JournalShelfScreen';
@@ -143,8 +143,11 @@ const BottomTabs = (): React.JSX.Element => {
     <Tab.Navigator
       initialRouteName="Habits"
       screenOptions={{
-        tabBarActiveTintColor: colors.primary,
-        tabBarInactiveTintColor: colors.text.tertiaryAccessible,
+        // Warm tab bar (#803): raised paper ground + hairline top edge; active
+        // terracotta vs muted ink, both AA on the raised ground.
+        tabBarActiveTintColor: accent.primary,
+        tabBarInactiveTintColor: ink.muted,
+        tabBarStyle: { backgroundColor: surface.raised, borderTopColor: surface.hairline },
         headerRight: renderHeaderRight,
       }}
     >
@@ -163,7 +166,7 @@ const BottomTabs = (): React.JSX.Element => {
 const styles = StyleSheet.create({
   headerRight: { flexDirection: 'row', alignItems: 'center', marginRight: SPACING.sm },
   headerButton: { paddingHorizontal: SPACING.sm, paddingVertical: SPACING.xs },
-  headerButtonText: { color: colors.primary, fontSize: 14, fontWeight: '600' },
+  headerButtonText: { color: accent.primary, fontSize: 14, fontWeight: '600' },
 });
 
 export default BottomTabs;

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -13,6 +13,7 @@ import TimezoneSettingsScreen from '../features/Settings/TimezoneSettingsScreen'
 import type { RootTabParamList } from './BottomTabs';
 import BottomTabs from './BottomTabs';
 
+import { accent, fonts, ink } from '@/design/tokens';
 import type { ModeConfig } from '@/features/Practice/engine/types';
 
 /**
@@ -59,7 +60,14 @@ export type RootStackParamList = {
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 const RootStack = (): React.JSX.Element => (
-  <Stack.Navigator>
+  // Header background/border come from the warm navTheme; here we add the
+  // editorial serif title + terracotta back/tint (#803).
+  <Stack.Navigator
+    screenOptions={{
+      headerTintColor: accent.primary,
+      headerTitleStyle: { fontFamily: fonts.serif, color: ink.primary },
+    }}
+  >
     <Stack.Screen name="Tabs" component={BottomTabs} options={{ headerShown: false }} />
     <Stack.Screen
       name="ApiKeySettings"

--- a/frontend/src/navigation/__tests__/theme.test.ts
+++ b/frontend/src/navigation/__tests__/theme.test.ts
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { accent, ink, surface } from '../../design/tokens';
+import { navTheme } from '../theme';
+
+/** WCAG relative luminance of a #rrggbb color. */
+const luminance = (hex: string): number => {
+  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
+  const channels = [match[1], match[2], match[3]].map((pair) => {
+    const c = Number.parseInt(pair!, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+};
+
+const contrast = (a: string, b: string): number => {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+const AA_NORMAL = 4.5;
+
+describe('navTheme (#803)', () => {
+  it('derives its chrome colors from the warm semantic tokens', () => {
+    expect(navTheme.colors.primary).toBe(accent.primary);
+    expect(navTheme.colors.background).toBe(surface.canvas);
+    expect(navTheme.colors.card).toBe(surface.raised);
+    expect(navTheme.colors.text).toBe(ink.primary);
+    expect(navTheme.colors.border).toBe(surface.hairline);
+  });
+
+  it('keeps a fonts block (v7 Theme contract inherited from DefaultTheme)', () => {
+    expect(navTheme.fonts).toBeDefined();
+  });
+
+  it('active + inactive tab tints clear AA on the raised tab-bar ground', () => {
+    // active = accent.primary, inactive = ink.muted, ground = surface.raised
+    expect(contrast(accent.primary, surface.raised)).toBeGreaterThanOrEqual(AA_NORMAL);
+    expect(contrast(ink.muted, surface.raised)).toBeGreaterThanOrEqual(AA_NORMAL);
+    // active vs inactive are distinguished by hue (terracotta vs muted ink), not
+    // luminance, so they must not be the same value.
+    expect(accent.primary).not.toBe(ink.muted);
+  });
+});

--- a/frontend/src/navigation/theme.ts
+++ b/frontend/src/navigation/theme.ts
@@ -12,9 +12,13 @@ export const navTheme: Theme = {
   ...DefaultTheme,
   colors: {
     ...DefaultTheme.colors,
-    primary: accent.primary, // back/tint + active affordances
-    background: surface.canvas, // screen ground behind navigators
-    card: surface.raised, // headers + tab bar ground
+    // React Navigation's color keys are opaque, so the only non-obvious part is
+    // the mapping: primary drives the back arrow / header tint + active
+    // affordances, card is the header + tab-bar ground, background is the screen
+    // ground.
+    primary: accent.primary,
+    background: surface.canvas,
+    card: surface.raised,
     text: ink.primary,
     border: surface.hairline,
     notification: accent.primary,

--- a/frontend/src/navigation/theme.ts
+++ b/frontend/src/navigation/theme.ts
@@ -1,0 +1,22 @@
+import { DefaultTheme, type Theme } from '@react-navigation/native';
+
+import { accent, ink, surface } from '@/design/tokens';
+
+/**
+ * Warm "Candle & Ink" React Navigation theme (#803). Extends ``DefaultTheme``
+ * (so v7's ``fonts`` block is inherited) and repaints the chrome colors from the
+ * semantic tokens, so the persistent nav frame matches the warmed screens
+ * instead of staying cold grey. Passed to ``NavigationContainer``.
+ */
+export const navTheme: Theme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    primary: accent.primary, // back/tint + active affordances
+    background: surface.canvas, // screen ground behind navigators
+    card: surface.raised, // headers + tab bar ground
+    text: ink.primary,
+    border: surface.hairline,
+    notification: accent.primary,
+  },
+};

--- a/frontend/src/test-utils/navMocks.ts
+++ b/frontend/src/test-utils/navMocks.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared React Navigation test doubles.
+ *
+ * App.tsx builds `navTheme` by spreading `DefaultTheme`, so any test that mounts
+ * App must expose `DefaultTheme` from its `@react-navigation/native` mock or the
+ * theme module throws at load. This is the single source for that stub so a
+ * future RN-Navigation shape change is a one-line update (was duplicated inline
+ * across App-importing test mocks — #803 review).
+ */
+export const mockDefaultTheme = {
+  dark: false,
+  colors: {
+    primary: '#000000',
+    background: '#ffffff',
+    card: '#ffffff',
+    text: '#000000',
+    border: '#cccccc',
+    notification: '#000000',
+  },
+  fonts: {},
+} as const;


### PR DESCRIPTION
## Summary

#803 (epic #798): the persistent nav chrome (stack headers + bottom tab bar) used default grey React Navigation styling, framing every screen cold.

- `navigation/theme.ts` — a single warm `Theme` extending `DefaultTheme` (inherits v7 `fonts`), colors from `surface`/`ink`/`accent`; passed to `NavigationContainer`.
- **Tab bar**: `surface.raised` ground + `surface.hairline` top border, active `accent.primary` vs inactive `ink.muted` (both AA on the ground).
- **Headers**: warm bg/title/tint from the theme + editorial serif `headerTitleStyle` + terracotta tint.
- Two App-importing nav mocks (authStatusNavigator, AppAuthFlow) now expose `DefaultTheme` so `navTheme` loads.

## Test plan

`theme.test.ts` asserts token derivation, a v7 `fonts` block, and active/inactive AA on the tab-bar ground. Routes/deep-links/testIDs unchanged. `./scripts/frontend/check-all.sh` 4/4.

Closes #803
Refs #798