### PR TITLE
test(api): guard journal.list() canonical URL (no 307)

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -42,6 +42,21 @@ describe('API client request composition', () => {
     );
   });
 
+  it('lists journal entries with GET /journal/ (canonical, no 307)', async () => {
+    // #791 review backfill: a 307 on list is how the journal screen fails to
+    // populate, distinct from the create path — guard the canonical slash here too.
+    // list() validates against journalListResponseSchema, so return that shape.
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [], total: 0, has_more: false }),
+    });
+    await api.journal.list({});
+    expect(fetch).toHaveBeenCalledWith(
+      `${mockBaseUrl}/journal/`,
+      expect.objectContaining(expectSignal),
+    );
+  });
+
   it('requests stage list with GET /stages', async () => {
     await api.stages.list();
     expect(fetch).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

#812: backfill the test the **#791** review (CHANGES_REQUESTED, merged before the LGTM gate was enforced) asked for. A 307 on the journal *list* is how the shelf fails to populate behind the proxy — distinct from the create path. Asserts `api.journal.list()` hits `/journal/` (trailing slash), matching the existing `create()` guard.

## Test plan

`./scripts/frontend/check-all.sh` 4/4.

Closes #812
Refs #791