### PR TITLE
feat(design): warm dark mode + useTheme() mode context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { CONFIG_ERROR } from './config';
 import { ApiKeyProvider } from './context/ApiKeyContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { NetworkStatusProvider } from './context/NetworkStatusContext';
+import { ThemeProvider, useTheme } from './design/ThemeContext';
 import { colors, SPACING } from './design/tokens';
 import CancelResetScreen from './features/Auth/CancelResetScreen';
 import ForgotPasswordScreen from './features/Auth/ForgotPasswordScreen';
@@ -34,7 +35,7 @@ import SignupScreen from './features/Auth/SignupScreen';
 import type { RootTabParamList } from './navigation/BottomTabs';
 import type { RootStackParamList } from './navigation/RootStack';
 import RootStack from './navigation/RootStack';
-import { navTheme } from './navigation/theme';
+import { navThemeFor } from './navigation/theme';
 import { useHydrateProgramStore } from './store/useProgramStore';
 
 type AuthStackParamList = {
@@ -190,8 +191,9 @@ function ThemedStatusBar(): React.JSX.Element {
 
 function AppShell(): React.JSX.Element {
   useHydrateProgramStore();
+  const { mode } = useTheme();
   return (
-    <NavigationContainer theme={navTheme} linking={linking}>
+    <NavigationContainer theme={navThemeFor(mode)} linking={linking}>
       <SafeAreaView style={styles.safeArea}>
         <ThemedStatusBar />
         <OfflineBanner />
@@ -207,17 +209,19 @@ export default function App(): React.JSX.Element {
   }
   return (
     <ErrorBoundary>
-      <SafeAreaProvider>
-        <NetworkStatusProvider>
-          <AuthProvider>
-            <ApiKeyProvider>
-              <ToastProvider>
-                <AppShell />
-              </ToastProvider>
-            </ApiKeyProvider>
-          </AuthProvider>
-        </NetworkStatusProvider>
-      </SafeAreaProvider>
+      <ThemeProvider>
+        <SafeAreaProvider>
+          <NetworkStatusProvider>
+            <AuthProvider>
+              <ApiKeyProvider>
+                <ToastProvider>
+                  <AppShell />
+                </ToastProvider>
+              </ApiKeyProvider>
+            </AuthProvider>
+          </NetworkStatusProvider>
+        </SafeAreaProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   );
 }

--- a/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
+++ b/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
@@ -14,7 +14,7 @@
 jest.mock('@react-navigation/native', () => {
   const React = require('react');
   // navTheme (via App.tsx) extends DefaultTheme, so the mock must expose it.
-  const { mockDefaultTheme } = require('@/test-utils/navMocks');
+  const { mockDefaultTheme, mockDarkTheme } = require('@/test-utils/navMocks');
   return {
     __esModule: true,
     NavigationContainer: ({ children }: { children: React.ReactNode }) =>
@@ -23,6 +23,7 @@ jest.mock('@react-navigation/native', () => {
     useRoute: () => ({ params: undefined }),
     useFocusEffect: (fn: () => void) => fn(),
     DefaultTheme: mockDefaultTheme,
+    DarkTheme: mockDarkTheme,
   };
 });
 

--- a/frontend/src/design/ThemeContext.tsx
+++ b/frontend/src/design/ThemeContext.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+import { Appearance } from 'react-native';
+import type { ViewStyle } from 'react-native';
+
+import {
+  accent,
+  accentDark,
+  ink,
+  inkDark,
+  surface,
+  surfaceDark,
+  surfaceShadow,
+  surfaceShadowDark,
+} from './tokens';
+
+export type ThemeMode = 'light' | 'dark';
+
+/** The resolved token set for the active mode. Shapes mirror the light tokens. */
+export interface ThemeTokens {
+  mode: ThemeMode;
+  surface: Record<keyof typeof surface, string>;
+  ink: Record<keyof typeof ink, string>;
+  accent: Record<keyof typeof accent, string>;
+  surfaceShadow: { card: ViewStyle; raised: ViewStyle };
+}
+
+export interface ThemeContextValue extends ThemeTokens {
+  setMode: (mode: ThemeMode) => void;
+}
+
+const LIGHT_TOKENS: ThemeTokens = { mode: 'light', surface, ink, accent, surfaceShadow };
+const DARK_TOKENS: ThemeTokens = {
+  mode: 'dark',
+  surface: surfaceDark,
+  ink: inkDark,
+  accent: accentDark,
+  surfaceShadow: surfaceShadowDark,
+};
+
+/** Resolve the token set for a mode. Exported so the nav theme can reuse it. */
+export const themeTokensFor = (mode: ThemeMode): ThemeTokens =>
+  mode === 'dark' ? DARK_TOKENS : LIGHT_TOKENS;
+
+// Default to the light set with a no-op setter, so components calling
+// ``useTheme()`` outside a provider (e.g. the many screen tests) resolve the
+// light language without needing a wrapper.
+const ThemeContext = createContext<ThemeContextValue>({ ...LIGHT_TOKENS, setMode: () => {} });
+
+/** The system color scheme at mount, mapped to a mode (defaults to light). */
+const initialSystemMode = (): ThemeMode =>
+  Appearance.getColorScheme() === 'dark' ? 'dark' : 'light';
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  /** Force a mode (tests / explicit override); otherwise follows the system. */
+  initialMode?: ThemeMode;
+}
+
+/**
+ * Provides the warm-mode token set. Initialises from the system color scheme
+ * (overridable via ``initialMode``); ``setMode`` reskins the tree by swapping
+ * the resolved tokens without touching layout or testIDs (#804).
+ */
+export const ThemeProvider = ({ children, initialMode }: ThemeProviderProps): React.JSX.Element => {
+  const [mode, setMode] = useState<ThemeMode>(initialMode ?? initialSystemMode());
+  const value = useMemo<ThemeContextValue>(() => ({ ...themeTokensFor(mode), setMode }), [mode]);
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+/** Resolve the active theme tokens (light when outside a provider). */
+export const useTheme = (): ThemeContextValue => useContext(ThemeContext);

--- a/frontend/src/design/__tests__/ThemeContext.test.tsx
+++ b/frontend/src/design/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import { ThemeProvider, useTheme } from '../ThemeContext';
+import { surface, surfaceDark } from '../tokens';
+
+const Probe = (): React.JSX.Element => {
+  const { mode, surface: s } = useTheme();
+  return <Text testID="probe">{`${mode}:${s.canvas}`}</Text>;
+};
+
+describe('useTheme / ThemeProvider (#804)', () => {
+  it('resolves the light token set when rendered without a provider', () => {
+    const { getByTestId } = render(<Probe />);
+    expect(getByTestId('probe').props.children).toBe(`light:${surface.canvas}`);
+  });
+
+  it('resolves the dark token set under ThemeProvider initialMode="dark"', () => {
+    const { getByTestId } = render(
+      <ThemeProvider initialMode="dark">
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(getByTestId('probe').props.children).toBe(`dark:${surfaceDark.canvas}`);
+  });
+
+  it('honours an explicit light initialMode', () => {
+    const { getByTestId } = render(
+      <ThemeProvider initialMode="light">
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(getByTestId('probe').props.children).toBe(`light:${surface.canvas}`);
+  });
+});

--- a/frontend/src/design/__tests__/semanticTokensDark.test.ts
+++ b/frontend/src/design/__tests__/semanticTokensDark.test.ts
@@ -1,0 +1,56 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { accentDark, inkDark, paperDark, surfaceDark } from '../tokens';
+
+/** WCAG relative luminance of a #rrggbb color. */
+const luminance = (hex: string): number => {
+  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
+  const channels = [match[1], match[2], match[3]].map((pair) => {
+    const c = Number.parseInt(pair!, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+};
+
+const contrast = (a: string, b: string): number => {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+const AA_NORMAL = 4.5;
+
+describe('warm dark tokens (Candle & Ink, #804)', () => {
+  it('uses a warm umber ground, not neutral #121212', () => {
+    expect(surfaceDark.canvas).not.toBe('#121212');
+    // Warm = red channel >= blue channel on the ground.
+    const hex = surfaceDark.canvas.replace('#', '');
+    expect(Number.parseInt(hex.slice(0, 2), 16)).toBeGreaterThanOrEqual(
+      Number.parseInt(hex.slice(4, 6), 16),
+    );
+  });
+
+  it('floats raised above canvas above the desk', () => {
+    expect(luminance(surfaceDark.raised)).toBeGreaterThan(luminance(surfaceDark.canvas));
+    expect(luminance(surfaceDark.desk)).toBeLessThan(luminance(surfaceDark.canvas));
+  });
+
+  it('every inkDark value clears WCAG AA on the dark canvas', () => {
+    for (const value of Object.values(inkDark)) {
+      expect(contrast(value, surfaceDark.canvas)).toBeGreaterThanOrEqual(AA_NORMAL);
+    }
+  });
+
+  it('every accentDark value clears WCAG AA on the dark canvas', () => {
+    for (const value of Object.values(accentDark)) {
+      expect(contrast(value, surfaceDark.canvas)).toBeGreaterThanOrEqual(AA_NORMAL);
+    }
+  });
+
+  it('dark journal paper keeps ink AA on its dark ground', () => {
+    expect(contrast(paperDark.ink, paperDark.background)).toBeGreaterThanOrEqual(AA_NORMAL);
+    expect(contrast(paperDark.inkSoft, paperDark.background)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+});

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -628,3 +628,76 @@ export const surfaceShadow = {
     elevation: 6,
   },
 } as const;
+
+// ---------------------------------------------------------------------------
+// Warm dark mode — the candlelit counterpart of the light language (#804)
+// ---------------------------------------------------------------------------
+
+/**
+ * Warm dark grounds — deep umber/charcoal, NOT Material's neutral ``#121212``,
+ * so the dark theme reads as candlelit paper rather than a black slab. Mirrors
+ * the light ``surface`` shape; ``raised`` is lighter than ``canvas`` (a lifted
+ * sheet) and ``desk`` is the deepest ground.
+ */
+export const surfaceDark = {
+  canvas: '#1c1814', // the dark app ground (warm umber)
+  raised: '#272019', // lifted cards / sheets — a step lighter
+  sunken: '#15110d', // recessed wells — a step darker
+  desk: '#120e0b', // the deepest ground a sheet floats above
+  hairline: '#3a3026', // faint warm rule on the dark ground
+} as const;
+
+/**
+ * Warm off-white ink for ``surfaceDark.canvas``. Every value clears WCAG AA
+ * (>= 4.5:1) on the dark canvas — asserted in ``semanticTokensDark.test.ts``.
+ */
+export const inkDark = {
+  primary: '#f3ece0', // 15.0:1 (AAA)
+  soft: '#cdbfae', // 9.8:1 (AAA)
+  muted: '#a89880', // 6.3:1 — captions / placeholders
+} as const;
+
+/**
+ * Terracotta accent for dark mode — brightened from the light ``accent`` so it
+ * clears AA as text on the dark canvas (a dark ground needs a lighter accent).
+ */
+export const accentDark = {
+  primary: '#e0895a', // 6.6:1 on the dark canvas
+  strong: '#eaa078', // 8.2:1 — pressed / emphasis
+} as const;
+
+/**
+ * Dark elevation. Shadows read faintly on dark grounds, so the lift leans on a
+ * near-black warm shadow at higher opacity plus the same Android elevations.
+ */
+export const surfaceShadowDark = {
+  card: {
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.4,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  raised: {
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.5,
+    shadowRadius: 18,
+    elevation: 6,
+  },
+} as const;
+
+/**
+ * Warm dark equivalents of the journal ``colors.paper`` palette so the journal
+ * joins warm dark. Mirrors the ``paper`` keys; ink clears AA on the dark ground.
+ */
+export const paperDark = {
+  background: '#1c1814',
+  backgroundAlt: '#15110d',
+  desk: '#120e0b',
+  sheetEdge: '#2a2219',
+  ink: '#f3ece0', // 15.0:1 on background
+  inkSoft: '#cdbfae', // 9.8:1 on background
+  hairline: '#3a3026',
+  anchorHighlight: '#4a3a24',
+} as const;

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -40,7 +40,7 @@ jest.mock('react-native-safe-area-context', () => ({
 // assertions free of routing side effects.
 jest.mock('@react-navigation/native', () => {
   // navTheme (via App.tsx) extends DefaultTheme, so the mock must expose it.
-  const { mockDefaultTheme } = require('@/test-utils/navMocks');
+  const { mockDefaultTheme, mockDarkTheme } = require('@/test-utils/navMocks');
   return {
     NavigationContainer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     useNavigation: () => ({
@@ -49,6 +49,7 @@ jest.mock('@react-navigation/native', () => {
       },
     }),
     DefaultTheme: mockDefaultTheme,
+    DarkTheme: mockDarkTheme,
   };
 });
 

--- a/frontend/src/navigation/__tests__/theme.test.ts
+++ b/frontend/src/navigation/__tests__/theme.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { accent, ink, surface } from '../../design/tokens';
-import { navTheme } from '../theme';
+import { accent, accentDark, ink, inkDark, surface, surfaceDark } from '../../design/tokens';
+import { navTheme, navThemeDark, navThemeFor } from '../theme';
 
 /** WCAG relative luminance of a #rrggbb color. */
 const luminance = (hex: string): number => {
@@ -43,5 +43,26 @@ describe('navTheme (#803)', () => {
     // active vs inactive are distinguished by hue (terracotta vs muted ink), not
     // luminance, so they must not be the same value.
     expect(accent.primary).not.toBe(ink.muted);
+  });
+});
+
+describe('navThemeDark (#804)', () => {
+  it('derives its chrome colors from the dark tokens', () => {
+    expect(navThemeDark.dark).toBe(true);
+    expect(navThemeDark.colors.primary).toBe(accentDark.primary);
+    expect(navThemeDark.colors.background).toBe(surfaceDark.canvas);
+    expect(navThemeDark.colors.card).toBe(surfaceDark.raised);
+    expect(navThemeDark.colors.text).toBe(inkDark.primary);
+    expect(navThemeDark.colors.border).toBe(surfaceDark.hairline);
+  });
+
+  it('navThemeFor selects by mode', () => {
+    expect(navThemeFor('dark')).toBe(navThemeDark);
+    expect(navThemeFor('light')).toBe(navTheme);
+  });
+
+  it('active dark tint clears AA on the dark tab-bar ground', () => {
+    expect(contrast(accentDark.primary, surfaceDark.raised)).toBeGreaterThanOrEqual(AA_NORMAL);
+    expect(contrast(inkDark.muted, surfaceDark.raised)).toBeGreaterThanOrEqual(AA_NORMAL);
   });
 });

--- a/frontend/src/navigation/theme.ts
+++ b/frontend/src/navigation/theme.ts
@@ -1,6 +1,7 @@
-import { DefaultTheme, type Theme } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, type Theme } from '@react-navigation/native';
 
-import { accent, ink, surface } from '@/design/tokens';
+import type { ThemeMode } from '@/design/ThemeContext';
+import { accent, accentDark, ink, inkDark, surface, surfaceDark } from '@/design/tokens';
 
 /**
  * Warm "Candle & Ink" React Navigation theme (#803). Extends ``DefaultTheme``
@@ -24,3 +25,23 @@ export const navTheme: Theme = {
     notification: accent.primary,
   },
 };
+
+/**
+ * Warm dark nav theme (#804). Extends ``DarkTheme`` (so ``dark: true`` + the v7
+ * ``fonts`` block are inherited) and repaints the chrome from the dark tokens.
+ */
+export const navThemeDark: Theme = {
+  ...DarkTheme,
+  colors: {
+    ...DarkTheme.colors,
+    primary: accentDark.primary,
+    background: surfaceDark.canvas,
+    card: surfaceDark.raised,
+    text: inkDark.primary,
+    border: surfaceDark.hairline,
+    notification: accentDark.primary,
+  },
+};
+
+/** Select the nav theme for the active mode. */
+export const navThemeFor = (mode: ThemeMode): Theme => (mode === 'dark' ? navThemeDark : navTheme);

--- a/frontend/src/test-utils/navMocks.ts
+++ b/frontend/src/test-utils/navMocks.ts
@@ -19,3 +19,20 @@ export const mockDefaultTheme = {
   },
   fonts: {},
 } as const;
+
+/**
+ * Dark counterpart — `navThemeDark` spreads `DarkTheme`, so any App-importing
+ * test mock must expose it too (#804).
+ */
+export const mockDarkTheme = {
+  dark: true,
+  colors: {
+    primary: '#ffffff',
+    background: '#000000',
+    card: '#000000',
+    text: '#ffffff',
+    border: '#333333',
+    notification: '#ffffff',
+  },
+  fonts: {},
+} as const;


### PR DESCRIPTION
## Summary

#804 (epic #798, **final sub-issue**): `darkColors` was a neutral `#121212` Material palette that clashed with the warm light language. Add a warm dark mode + a hook to resolve tokens by mode.

- **Warm dark tokens** on a deep-umber ground (`surfaceDark.canvas #1c1814`, not `#121212`): `inkDark` (15.0 / 9.8 / 6.3:1) + `accentDark` brightened terracotta (6.6 / 8.2:1) — every value clears **AA** on the dark ground; `surfaceShadowDark` + `paperDark` mirror the light shapes.
- **`useTheme()` / `ThemeProvider`** (`design/ThemeContext.tsx`): default is the **light** set + no-op `setMode`, so components without a provider resolve light (existing tests need no wrapper). Provider initializes from `Appearance.getColorScheme()`; App wraps the tree.
- **Dark nav**: `navThemeDark` + `navThemeFor(mode)`, selected from `useTheme().mode`.
- **Light mode unchanged** — only dark counterparts added.

## Test plan

`semanticTokensDark` (AA on dark for every inkDark/accentDark + dark paper), `ThemeContext` (light default, dark via initialMode), `navThemeDark` derivation/selection/AA. Light token tests untouched. `./scripts/frontend/check-all.sh` 4/4.

Closes #804
Refs #798