### PR TITLE
feat(backend): add completion-suggestion model + migration

### DIFF
--- a/backend/migrations/versions/a3b4c5d6e7f9_add_completion_suggestion.py
+++ b/backend/migrations/versions/a3b4c5d6e7f9_add_completion_suggestion.py
@@ -1,0 +1,87 @@
+"""add completion_suggestion table for journal-attested completions.
+
+Revision ID: a3b4c5d6e7f9
+Revises: f1e2d3c4b5a6
+Create Date: 2026-06-30 00:00:00.000000
+
+Purely additive: ``upgrade`` creates the ``completionsuggestion`` table (a
+resonance-pass proposal that a journal span attests to completing a habit goal
+or a user-practice) plus its FK indexes; ``downgrade`` drops them. No ``ALTER`` /
+``DROP`` against existing tables. The FKs cascade so deleting the journal entry,
+owner, goal, or user-practice removes the suggestion.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3b4c5d6e7f9"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "f1e2d3c4b5a6"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``completionsuggestion`` table and its FK indexes."""
+    op.create_table(
+        "completionsuggestion",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("journal_entry_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("target_type", sa.String(length=20), nullable=False),
+        sa.Column("goal_id", sa.Integer(), nullable=True),
+        sa.Column("user_practice_id", sa.Integer(), nullable=True),
+        sa.Column("label", sa.String(length=255), nullable=False),
+        sa.Column("anchor_start", sa.Integer(), nullable=False),
+        sa.Column("anchor_end", sa.Integer(), nullable=False),
+        sa.Column("anchor_text", sa.String(length=280), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("accepted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journalentry.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["goal_id"], ["goal.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_practice_id"], ["userpractice.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "target_type IN ('habit', 'practice')",
+            name="ck_completion_suggestion_target_type_valid",
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'accepted', 'dismissed')",
+            name="ck_completion_suggestion_status_valid",
+        ),
+        sa.CheckConstraint(
+            "anchor_start >= 0",
+            name="ck_completion_suggestion_anchor_start_nonneg",
+        ),
+        sa.CheckConstraint(
+            "anchor_end > anchor_start",
+            name="ck_completion_suggestion_anchor_span_positive",
+        ),
+        sa.CheckConstraint(
+            "(target_type = 'habit' AND goal_id IS NOT NULL AND user_practice_id IS NULL)"
+            " OR (target_type = 'practice' AND user_practice_id IS NOT NULL AND goal_id IS NULL)",
+            name="ck_completion_suggestion_target_fk_matches",
+        ),
+    )
+    op.create_index(
+        "ix_completion_suggestion_journal_entry_id",
+        "completionsuggestion",
+        ["journal_entry_id"],
+    )
+    op.create_index(
+        "ix_completion_suggestion_user_id",
+        "completionsuggestion",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``completionsuggestion`` table and its indexes."""
+    op.drop_index("ix_completion_suggestion_user_id", table_name="completionsuggestion")
+    op.drop_index("ix_completion_suggestion_journal_entry_id", table_name="completionsuggestion")
+    op.drop_table("completionsuggestion")

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,5 +1,6 @@
 """Database models package."""
 
+from .completion_suggestion import CompletionSuggestion
 from .content_completion import ContentCompletion
 from .course_stage import CourseStage
 from .energy_plan import EnergyPlan
@@ -27,6 +28,7 @@ from .user_practice import UserPractice
 from .wallet_audit import WalletAudit
 
 __all__ = [
+    "CompletionSuggestion",
     "ContentCompletion",
     "CourseStage",
     "EnergyPlan",

--- a/backend/src/models/completion_suggestion.py
+++ b/backend/src/models/completion_suggestion.py
@@ -1,0 +1,142 @@
+"""Completion suggestions anchored to a journal span (habit-resonance-01).
+
+A ``CompletionSuggestion`` is the resonance pass's proposal that a span of a
+journal entry attests to completing a habit goal or a user-practice. Like
+:class:`~models.marginalia.Marginalia` it anchors to a character span, but
+instead of carrying a note it links to exactly one target (a goal *or* a
+user-practice) and carries an accept→dismiss lifecycle. Data-layer only —
+endpoints and the LLM detection pass live in later issues.
+"""
+
+import enum
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, Index
+from sqlmodel import Field, Relationship, SQLModel
+
+if TYPE_CHECKING:
+    from .journal_entry import JournalEntry
+
+_ANCHOR_TEXT_MAX = 280
+_LABEL_MAX = 255
+_ENUM_MAX = 20
+
+
+class CompletionTargetType(enum.StrEnum):
+    """What a suggestion proposes the journal span attests to completing."""
+
+    HABIT = "habit"
+    PRACTICE = "practice"
+
+
+class SuggestionStatus(enum.StrEnum):
+    """The accept→dismiss lifecycle of a suggestion.
+
+    ``pending`` is undecided; ``accepted`` logged the completion; ``dismissed``
+    was declined by the user. A decided suggestion is terminal.
+    """
+
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    DISMISSED = "dismissed"
+
+
+def _target_type_check() -> CheckConstraint:
+    """CHECK derived from ``CompletionTargetType`` so the DB set can't drift."""
+    quoted = ", ".join(f"'{t.value}'" for t in CompletionTargetType)
+    return CheckConstraint(
+        f"target_type IN ({quoted})",
+        name="ck_completion_suggestion_target_type_valid",
+    )
+
+
+def _status_check() -> CheckConstraint:
+    """CHECK derived from ``SuggestionStatus`` so the DB set can't drift."""
+    quoted = ", ".join(f"'{s.value}'" for s in SuggestionStatus)
+    return CheckConstraint(
+        f"status IN ({quoted})",
+        name="ck_completion_suggestion_status_valid",
+    )
+
+
+def _target_fk_matches_check() -> CheckConstraint:
+    """Exactly the FK matching ``target_type`` is set, the other is NULL.
+
+    A ``habit`` suggestion sets ``goal_id`` (and leaves ``user_practice_id``
+    NULL); a ``practice`` suggestion sets ``user_practice_id`` (and leaves
+    ``goal_id`` NULL). Keeps the polymorphic target honest at the DB level so a
+    non-ORM writer cannot persist a habit suggestion pointing at a practice.
+    """
+    return CheckConstraint(
+        "(target_type = 'habit' AND goal_id IS NOT NULL AND user_practice_id IS NULL)"
+        " OR (target_type = 'practice' AND user_practice_id IS NOT NULL AND goal_id IS NULL)",
+        name="ck_completion_suggestion_target_fk_matches",
+    )
+
+
+class CompletionSuggestion(SQLModel, table=True):
+    """A single anchored completion proposal on a journal entry.
+
+    ``anchor_start`` / ``anchor_end`` are character offsets into the entry's
+    text and ``anchor_text`` snapshots the spanned substring, mirroring
+    :class:`~models.marginalia.Marginalia`. Exactly one of ``goal_id`` /
+    ``user_practice_id`` is set, selected by ``target_type`` and enforced by the
+    ``ck_completion_suggestion_target_fk_matches`` CHECK.
+    """
+
+    # The hot read is "all suggestions for an entry", so index that FK; the
+    # denormalized owner FK is indexed so "all suggestions for a user" is a range
+    # scan. CHECKs keep the enum columns, anchor bounds, and the polymorphic
+    # target honest at the DB level (matching the Marginalia precedent).
+    __table_args__ = (
+        Index("ix_completion_suggestion_journal_entry_id", "journal_entry_id"),
+        Index("ix_completion_suggestion_user_id", "user_id"),
+        _target_type_check(),
+        _status_check(),
+        CheckConstraint("anchor_start >= 0", name="ck_completion_suggestion_anchor_start_nonneg"),
+        CheckConstraint(
+            "anchor_end > anchor_start",
+            name="ck_completion_suggestion_anchor_span_positive",
+        ),
+        _target_fk_matches_check(),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    journal_entry_id: int = Field(foreign_key="journalentry.id", ondelete="CASCADE")
+    # Denormalized owner FK (also reachable via the entry) so "all suggestions
+    # for a user" reads need no JOIN; writers set it to the entry's owner.
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
+    target_type: str = Field(max_length=_ENUM_MAX)
+    # Exactly one of these is set, per ``target_type`` (see the FK-matches CHECK).
+    goal_id: int | None = Field(
+        default=None,
+        sa_column=Column(ForeignKey("goal.id", ondelete="CASCADE"), nullable=True),
+    )
+    user_practice_id: int | None = Field(
+        default=None,
+        sa_column=Column(ForeignKey("userpractice.id", ondelete="CASCADE"), nullable=True),
+    )
+    label: str = Field(max_length=_LABEL_MAX)
+    anchor_start: int = Field(ge=0)
+    anchor_end: int = Field(ge=1)  # DB CHECK also enforces anchor_end > anchor_start
+    anchor_text: str = Field(max_length=_ANCHOR_TEXT_MAX)
+    status: str = Field(default=SuggestionStatus.PENDING, max_length=_ENUM_MAX)
+    accepted_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            onupdate=lambda: datetime.now(UTC),
+        ),
+    )
+
+    entry: "JournalEntry" = Relationship(back_populates="suggestions")

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -8,6 +8,7 @@ from sqlmodel import Field, Relationship, SQLModel
 from services.journal_encryption import EncryptedString
 
 if TYPE_CHECKING:
+    from .completion_suggestion import CompletionSuggestion
     from .marginalia import Marginalia
     from .user import User
 
@@ -98,6 +99,10 @@ class JournalEntry(SQLModel, table=True):
     )
     user: "User" = Relationship(back_populates="journals")
     marginalia: list["Marginalia"] = Relationship(
+        back_populates="entry",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
+    suggestions: list["CompletionSuggestion"] = Relationship(
         back_populates="entry",
         sa_relationship_kwargs={"cascade": "all, delete-orphan"},
     )

--- a/backend/tests/test_completion_suggestion_model.py
+++ b/backend/tests/test_completion_suggestion_model.py
@@ -1,0 +1,285 @@
+"""Data-layer tests for the CompletionSuggestion model (habit-resonance-01)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.completion_suggestion import (
+    CompletionSuggestion,
+    CompletionTargetType,
+    SuggestionStatus,
+)
+from models.goal import Goal
+from models.habit import Habit
+from models.journal_entry import JournalEntry
+from models.practice import Practice
+from models.user import User
+from models.user_practice import UserPractice
+
+
+async def _user(session: AsyncSession, email: str = "cs@example.com") -> int:
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.flush()
+    assert user.id is not None
+    return user.id
+
+
+async def _entry(session: AsyncSession, user_id: int) -> int:
+    entry = JournalEntry(sender="user", user_id=user_id, message="I went for a run today")
+    session.add(entry)
+    await session.flush()
+    assert entry.id is not None
+    return entry.id
+
+
+async def _goal(session: AsyncSession, user_id: int) -> int:
+    habit = Habit(
+        name="Run",
+        icon="🏃",
+        start_date=date(2025, 1, 1),
+        energy_cost=10,
+        energy_return=20,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.flush()
+    goal = Goal(
+        habit_id=habit.id,
+        title="Daily run",
+        tier="clear",
+        target=1.0,
+        target_unit="run",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    session.add(goal)
+    await session.flush()
+    assert goal.id is not None
+    return goal.id
+
+
+async def _user_practice(session: AsyncSession, user_id: int) -> int:
+    practice = Practice(
+        stage_number=1,
+        name="Meditation",
+        description="Sit quietly",
+        instructions="Close your eyes and breathe",
+        default_duration_minutes=10,
+        approved=True,
+    )
+    session.add(practice)
+    await session.flush()
+    up = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=1,
+        start_date=date(2025, 1, 1),
+    )
+    session.add(up)
+    await session.flush()
+    assert up.id is not None
+    return up.id
+
+
+def _habit_suggestion(
+    entry_id: int, user_id: int, goal_id: int | None, **over: object
+) -> CompletionSuggestion:
+    base: dict[str, object] = {
+        "journal_entry_id": entry_id,
+        "user_id": user_id,
+        "target_type": CompletionTargetType.HABIT,
+        "goal_id": goal_id,
+        "label": "Run",
+        "anchor_start": 0,
+        "anchor_end": 19,
+        "anchor_text": "I went for a run today",
+    }
+    base.update(over)
+    return CompletionSuggestion(**base)
+
+
+@pytest.mark.asyncio
+async def test_insert_habit_suggestion_and_read(db_session: AsyncSession) -> None:
+    """A habit suggestion persists and reads back with its defaults."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    goal_id = await _goal(db_session, user_id)
+    db_session.add(_habit_suggestion(entry_id, user_id, goal_id))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(CompletionSuggestion))).scalar_one()
+    assert row.journal_entry_id == entry_id
+    assert row.target_type == CompletionTargetType.HABIT
+    assert row.goal_id == goal_id
+    assert row.user_practice_id is None
+    # status defaults to pending; accepted_at is unset until accepted.
+    assert row.status == SuggestionStatus.PENDING
+    assert row.accepted_at is None
+    assert row.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_insert_practice_suggestion(db_session: AsyncSession) -> None:
+    """A practice suggestion sets user_practice_id and leaves goal_id NULL."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    up_id = await _user_practice(db_session, user_id)
+    db_session.add(
+        CompletionSuggestion(
+            journal_entry_id=entry_id,
+            user_id=user_id,
+            target_type=CompletionTargetType.PRACTICE,
+            user_practice_id=up_id,
+            label="Meditation",
+            anchor_start=0,
+            anchor_end=10,
+            anchor_text="meditation",
+            status=SuggestionStatus.ACCEPTED,
+            accepted_at=datetime.now(UTC),
+        ),
+    )
+    await db_session.commit()
+
+    row = (await db_session.execute(select(CompletionSuggestion))).scalar_one()
+    assert row.target_type == CompletionTargetType.PRACTICE
+    assert row.user_practice_id == up_id
+    assert row.goal_id is None
+    assert row.status == SuggestionStatus.ACCEPTED
+    assert row.accepted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_parent_delete_cascades(db_session: AsyncSession) -> None:
+    """Deleting the journal entry removes its suggestions (delete-orphan)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    goal_id = await _goal(db_session, user_id)
+    db_session.add(_habit_suggestion(entry_id, user_id, goal_id))
+    await db_session.commit()
+
+    loaded = await db_session.get(JournalEntry, entry_id)
+    assert loaded is not None
+    await db_session.delete(loaded)
+    await db_session.commit()
+
+    remaining = (
+        await db_session.execute(select(func.count()).select_from(CompletionSuggestion))
+    ).scalar_one()
+    assert remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_updated_at_advances_on_mutate(db_session: AsyncSession) -> None:
+    """updated_at advances when the row is flushed after a mutation (onupdate)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    goal_id = await _goal(db_session, user_id)
+    row = _habit_suggestion(entry_id, user_id, goal_id)
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+    original = row.updated_at
+
+    row.status = SuggestionStatus.DISMISSED
+    await db_session.commit()
+    await db_session.refresh(row)
+    assert row.updated_at > original
+
+
+@pytest.mark.asyncio
+async def test_invalid_status_is_rejected(db_session: AsyncSession) -> None:
+    """A status outside the enum set violates the CHECK constraint."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    goal_id = await _goal(db_session, user_id)
+    db_session.add(_habit_suggestion(entry_id, user_id, goal_id, status="bogus"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_invalid_target_type_is_rejected(db_session: AsyncSession) -> None:
+    """A target_type outside the enum set violates the CHECK constraint."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    goal_id = await _goal(db_session, user_id)
+    db_session.add(_habit_suggestion(entry_id, user_id, goal_id, target_type="bogus"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_negative_anchor_start_is_rejected(db_session: AsyncSession) -> None:
+    """anchor_start must be non-negative (CHECK constraint)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    goal_id = await _goal(db_session, user_id)
+    db_session.add(_habit_suggestion(entry_id, user_id, goal_id, anchor_start=-1, anchor_end=4))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_inverted_anchor_span_is_rejected(db_session: AsyncSession) -> None:
+    """anchor_end must be greater than anchor_start (CHECK constraint)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    goal_id = await _goal(db_session, user_id)
+    db_session.add(_habit_suggestion(entry_id, user_id, goal_id, anchor_start=5, anchor_end=3))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_habit_target_without_goal_is_rejected(db_session: AsyncSession) -> None:
+    """A habit suggestion must set goal_id (target_fk_matches CHECK)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    db_session.add(_habit_suggestion(entry_id, user_id, goal_id=None))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_habit_target_with_practice_fk_is_rejected(db_session: AsyncSession) -> None:
+    """A habit suggestion must not also set user_practice_id (target_fk_matches)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    goal_id = await _goal(db_session, user_id)
+    up_id = await _user_practice(db_session, user_id)
+    db_session.add(_habit_suggestion(entry_id, user_id, goal_id, user_practice_id=up_id))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_practice_target_without_user_practice_is_rejected(db_session: AsyncSession) -> None:
+    """A practice suggestion must set user_practice_id (target_fk_matches CHECK)."""
+    user_id = await _user(db_session)
+    entry_id = await _entry(db_session, user_id)
+    db_session.add(
+        CompletionSuggestion(
+            journal_entry_id=entry_id,
+            user_id=user_id,
+            target_type=CompletionTargetType.PRACTICE,
+            label="Meditation",
+            anchor_start=0,
+            anchor_end=10,
+            anchor_text="meditation",
+        ),
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+def test_enum_values() -> None:
+    """The enum value sets match the contract."""
+    assert {t.value for t in CompletionTargetType} == {"habit", "practice"}
+    assert {s.value for s in SuggestionStatus} == {"pending", "accepted", "dismissed"}


### PR DESCRIPTION
## Summary

#814 (epic #822): data layer for journal-attested completion suggestions — anchored to a journal span like marginalia, linking to a habit goal or a user-practice with an accept→dismiss lifecycle. No endpoints/LLM yet.

- `models/completion_suggestion.py`: `CompletionTargetType` (habit|practice) + `SuggestionStatus` (pending|accepted|dismissed); the table with CASCADE FKs, label, anchor span + anchor_text, status, accepted_at, tz-aware timestamps. CHECKs for the enums, anchor bounds, and `ck_..._target_fk_matches` (exactly the FK matching `target_type` is set); indexes + `JournalEntry.suggestions` back-ref.
- Additive migration `a3b4c5d6e7f9` chained from `f1e2d3c4b5a6` (single head); `alembic check` clean.

Mirrors `models/marginalia.py` + its migration.

## Test plan

12 constraint + cascade tests; `./scripts/backend/check-all.sh` 7/7, xenon A, single alembic head.

Closes #814
Refs #822