### PR TITLE
ci(review): author the verdict comment as claude, not github-actions[bot]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -85,7 +85,10 @@ jobs:
         # failed/empty review), fail so the check is red and the review is
         # re-run — never a silent success with no review (#810).
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer the action's Claude App token so the comment is authored by
+          # "claude" (consistent with the pre-#810 flow + any author-aware
+          # consumer); fall back to GITHUB_TOKEN if no Claude App is configured.
+          GH_TOKEN: ${{ steps.claude-review.outputs.github_token || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           STRUCTURED: ${{ steps.claude-review.outputs.structured_output }}


### PR DESCRIPTION
## Summary

#839: the deterministic post-step (#810) used `GITHUB_TOKEN`, so the verdict comment was authored by **github-actions[bot]** (#838). Use the action's `github_token` output (the Claude App token) for `gh pr comment`, falling back to `GITHUB_TOKEN`, so reviews keep the **claude** author.

Content-based consumers (iteration-trigger, the loop) were unaffected; this just restores author consistency for author-aware consumers.

## Test plan

YAML valid. Like all review-workflow edits, this PR self-skips the action (anti-tamper) and is validated on the next normal PR.

Closes #839
