### PR TITLE
feat(backend): add completion-detection domain service (LLM pass)

### DIFF
--- a/backend/src/domain/detection.py
+++ b/backend/src/domain/detection.py
@@ -24,8 +24,9 @@ from security import TextTooLongError, sanitize_user_text
 # ``resonance.VALID_KINDS``); ``test_detection_service`` guards them against
 # ``models.completion_suggestion.CompletionTargetType`` drift.
 VALID_TARGET_TYPES = frozenset({"habit", "practice"})
-# A detected label is a verbatim quote, so it shares resonance's anchor bound.
-LABEL_MAX = 280
+# Must match ``CompletionSuggestion.label``'s ``_LABEL_MAX`` (255) — a longer
+# detected label passes here but fails at DB insert in the endpoint layer.
+LABEL_MAX = 255
 MAX_HITS = 5
 
 

--- a/backend/src/domain/detection.py
+++ b/backend/src/domain/detection.py
@@ -1,0 +1,200 @@
+"""Completion detection over a journal entry.
+
+Read an entry and decide which of the user's tracked habits or practices the
+writer actually *did*.
+
+Pure, injected-LLM domain with the same trust model as :mod:`domain.resonance`:
+the model proposes a candidate **index** (into the supplied candidate list) plus
+a **verbatim quote**; the server resolves the index against the candidates it
+supplied and anchors the quote itself in the body. Model-supplied ids and
+character offsets are never trusted, and anything that doesn't resolve cleanly is
+dropped.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from domain.resonance import ResonanceLLM, _quote_span
+from security import TextTooLongError, sanitize_user_text
+
+# Domain-level literals so this module stays free of DB/model imports (mirrors
+# ``resonance.VALID_KINDS``); ``test_detection_service`` guards them against
+# ``models.completion_suggestion.CompletionTargetType`` drift.
+VALID_TARGET_TYPES = frozenset({"habit", "practice"})
+# A detected label is a verbatim quote, so it shares resonance's anchor bound.
+LABEL_MAX = 280
+MAX_HITS = 5
+
+
+@dataclass(frozen=True)
+class DetectionCandidate:
+    """One tracked habit/practice offered to the model, addressed by ``index``.
+
+    The server builds these from real rows, so ``target_type``/``target_id`` are
+    trusted; the model only ever picks an ``index`` and copies a quote.
+    """
+
+    index: int
+    target_type: str
+    target_id: int
+    name: str
+
+
+@dataclass(frozen=True)
+class _HitDraft:
+    """A model-proposed hit before resolution: a candidate index + verbatim quote."""
+
+    index: int
+    quote: str
+
+
+@dataclass(frozen=True)
+class CompletionDetected:
+    """A resolved, anchored detection: a candidate the writer attested to doing."""
+
+    target_type: str
+    target_id: int
+    label: str
+    anchor_start: int
+    anchor_end: int
+    anchor_text: str
+
+
+def build_detection_prompt(body: str, candidates: Sequence[DetectionCandidate]) -> str:
+    """Build the prompt: pick the candidates the writer actually completed.
+
+    Candidates are numbered by ``index``; the model returns that index plus a
+    verbatim quote. The instruction excludes intentions, plans, and avoidance so
+    "I want to meditate" or "I skipped sugar" is not read as a completion.
+    """
+    listed = "\n".join(f"{c.index}. {c.name} ({c.target_type})" for c in candidates)
+    return (
+        "You read a journal entry and decide which of the listed habits or "
+        "practices the writer actually DID or COMPLETED in it.\n\n"
+        "Rules:\n"
+        "- Only count things the writer actually did/completed — NOT things they "
+        "planned, intended, wanted, hoped, or AVOIDED (skipping a bad habit is "
+        "not a completion).\n"
+        '- "index" is the number of the candidate from the list below.\n'
+        '- "quote" is a VERBATIM substring copied exactly from the entry that '
+        "shows they did it.\n\n"
+        f"Candidates:\n{listed}\n\n"
+        f"Entry:\n{body}\n\n"
+        'Return JSON: {"hits": [{"index": 0, "quote": "..."}]}'
+    )
+
+
+def _hit_from_item(item: object) -> _HitDraft | None:
+    """Parse one model item into a draft, or None if it isn't well-formed."""
+    if not isinstance(item, dict):
+        return None
+    index, quote = item.get("index"), item.get("quote")
+    if isinstance(index, int) and not isinstance(index, bool) and isinstance(quote, str):
+        return _HitDraft(index=index, quote=quote)
+    return None
+
+
+def _load_hits(raw: str) -> list[object]:
+    """Defensively parse the model payload into a list of items (empty on junk)."""
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    hits = payload.get("hits") if isinstance(payload, dict) else None
+    return hits if isinstance(hits, list) else []
+
+
+def _parse_hit_drafts(raw: str) -> list[_HitDraft]:
+    """Turn the raw payload into well-formed drafts, dropping malformed items."""
+    return [draft for item in _load_hits(raw) if (draft := _hit_from_item(item)) is not None]
+
+
+def _sanitize_label(quote: str) -> str | None:
+    """Sanitize the quote into a label, or None if it can't fit after cleaning."""
+    try:
+        cleaned = sanitize_user_text(quote, max_len=LABEL_MAX)
+    except TextTooLongError:
+        return None
+    return cleaned or None
+
+
+def _anchor_hit(
+    body: str, draft: _HitDraft, by_index: dict[int, DetectionCandidate]
+) -> CompletionDetected | None:
+    """Resolve a draft against the candidates + body, or None if it can't.
+
+    The index must address a supplied candidate and the quote must occur verbatim
+    in the body — neither the model's id nor any offset it might claim is trusted.
+    """
+    candidate = by_index.get(draft.index)
+    span = _quote_span(body, draft.quote)
+    label = _sanitize_label(draft.quote)
+    if candidate is None or span is None or label is None:
+        return None
+    start, end = span
+    return CompletionDetected(
+        target_type=candidate.target_type,
+        target_id=candidate.target_id,
+        label=label,
+        anchor_start=start,
+        anchor_end=end,
+        anchor_text=body[start:end],
+    )
+
+
+def _overlaps(a: CompletionDetected, b: CompletionDetected) -> bool:
+    """True when two anchored spans intersect."""
+    return a.anchor_start < b.anchor_end and b.anchor_start < a.anchor_end
+
+
+def _is_duplicate(
+    hit: CompletionDetected, kept: list[CompletionDetected], seen_targets: set[tuple[str, int]]
+) -> bool:
+    """True when ``hit`` repeats a kept target or overlaps a kept span."""
+    if (hit.target_type, hit.target_id) in seen_targets:
+        return True
+    return any(_overlaps(hit, other) for other in kept)
+
+
+def _collect_hits(
+    body: str,
+    drafts: list[_HitDraft],
+    by_index: dict[int, DetectionCandidate],
+    max_hits: int,
+) -> list[CompletionDetected]:
+    """Resolve drafts to anchored hits, dropping dupes and capping at ``max_hits``."""
+    kept: list[CompletionDetected] = []
+    seen_targets: set[tuple[str, int]] = set()
+    for draft in drafts:
+        hit = _anchor_hit(body, draft, by_index)
+        if hit is None or _is_duplicate(hit, kept, seen_targets):
+            continue
+        kept.append(hit)
+        seen_targets.add((hit.target_type, hit.target_id))
+        if len(kept) >= max_hits:
+            break
+    return kept
+
+
+async def detect_completions(
+    body: str,
+    *,
+    candidates: Sequence[DetectionCandidate],
+    llm: ResonanceLLM,
+    max_hits: int = MAX_HITS,
+) -> list[CompletionDetected]:
+    """Detect which ``candidates`` the writer did in ``body``; anchored + deduped.
+
+    With no candidates the LLM is never called and ``[]`` is returned — a hard
+    cost guard the endpoint relies on. Otherwise hits are resolved against the
+    supplied candidates (bad index/quote dropped), de-duplicated by target and by
+    overlapping span, and capped at ``max_hits``.
+    """
+    if not candidates:
+        return []
+    raw = await llm.complete(build_detection_prompt(body, candidates))
+    by_index = {c.index: c for c in candidates}
+    return _collect_hits(body, _parse_hit_drafts(raw), by_index, max_hits)

--- a/backend/tests/test_detection_service.py
+++ b/backend/tests/test_detection_service.py
@@ -1,0 +1,186 @@
+"""Tests for the completion-detection domain service (habit-resonance-02)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from domain import detection
+from domain.detection import (
+    MAX_HITS,
+    CompletionDetected,
+    DetectionCandidate,
+    build_detection_prompt,
+    detect_completions,
+)
+from models.completion_suggestion import CompletionTargetType
+
+_BODY = (
+    "This morning I meditated for twenty minutes by the window. "
+    "Later I went for a run along the river. "
+    "I planned to journal tonight but never got to it."
+)
+
+_CANDIDATES = (
+    DetectionCandidate(index=0, target_type="habit", target_id=10, name="Meditation"),
+    DetectionCandidate(index=1, target_type="practice", target_id=20, name="Run"),
+    DetectionCandidate(index=2, target_type="habit", target_id=30, name="Journal"),
+)
+
+
+class FakeLLM:
+    """Injected LLM stub: returns a fixed completion and counts calls."""
+
+    def __init__(self, completion: str) -> None:
+        """Store the canned completion this fake will return."""
+        self._completion = completion
+        self.calls = 0
+        self.prompt: str | None = None
+
+    async def complete(self, prompt: str) -> str:
+        self.calls += 1
+        self.prompt = prompt
+        return self._completion
+
+
+def _hits_json(*hits: dict[str, object]) -> str:
+    return json.dumps({"hits": list(hits)})
+
+
+def test_valid_target_types_match_the_model_enum() -> None:
+    """The domain's local target-type set must not drift from the model enum."""
+    assert {t.value for t in CompletionTargetType} == detection.VALID_TARGET_TYPES
+
+
+@pytest.mark.asyncio
+async def test_detects_and_anchors_hits() -> None:
+    """Resolved hits carry the candidate's target + a verbatim anchor span."""
+    llm = FakeLLM(
+        _hits_json(
+            {"index": 0, "quote": "I meditated for twenty minutes"},
+            {"index": 1, "quote": "I went for a run along the river"},
+        )
+    )
+    hits = await detect_completions(_BODY, candidates=_CANDIDATES, llm=llm)
+    assert [(h.target_type, h.target_id) for h in hits] == [("habit", 10), ("practice", 20)]
+    for hit in hits:
+        assert _BODY[hit.anchor_start : hit.anchor_end] == hit.anchor_text
+        assert hit.label == hit.anchor_text
+
+
+@pytest.mark.asyncio
+async def test_empty_candidates_short_circuits_without_calling_llm() -> None:
+    """No candidates ⇒ [] and the LLM is never called (the endpoint's cost guard)."""
+    llm = FakeLLM(_hits_json({"index": 0, "quote": "I meditated for twenty minutes"}))
+    hits = await detect_completions(_BODY, candidates=(), llm=llm)
+    assert hits == []
+    assert llm.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_out_of_range_index_is_dropped() -> None:
+    """An index that addresses no supplied candidate is dropped (ids untrusted)."""
+    llm = FakeLLM(_hits_json({"index": 99, "quote": "I meditated for twenty minutes"}))
+    assert await detect_completions(_BODY, candidates=_CANDIDATES, llm=llm) == []
+
+
+@pytest.mark.asyncio
+async def test_quote_not_in_body_is_dropped() -> None:
+    """A quote that doesn't occur verbatim in the body is dropped (offsets untrusted)."""
+    llm = FakeLLM(_hits_json({"index": 0, "quote": "I did not write this"}))
+    assert await detect_completions(_BODY, candidates=_CANDIDATES, llm=llm) == []
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_yields_no_hits() -> None:
+    """Junk / wrong-typed items are tolerated and produce no hits."""
+    llm = FakeLLM("not json at all")
+    assert await detect_completions(_BODY, candidates=_CANDIDATES, llm=llm) == []
+    bad = FakeLLM(_hits_json({"index": "zero", "quote": 5}, {"nope": True}))
+    assert await detect_completions(_BODY, candidates=_CANDIDATES, llm=bad) == []
+
+
+@pytest.mark.asyncio
+async def test_label_is_sanitized() -> None:
+    """The label is the sanitized quote — control characters are stripped."""
+    body = "I ran\x07 a mile today."
+    cands = (DetectionCandidate(index=0, target_type="practice", target_id=20, name="Run"),)
+    llm = FakeLLM(_hits_json({"index": 0, "quote": "ran\x07 a mile"}))
+    hits = await detect_completions(body, candidates=cands, llm=llm)
+    assert len(hits) == 1
+    assert "\x07" not in hits[0].label
+    assert "\x07" in hits[0].anchor_text
+
+
+@pytest.mark.asyncio
+async def test_same_target_is_deduped() -> None:
+    """Two hits on the same target_id collapse to the first."""
+    llm = FakeLLM(
+        _hits_json(
+            {"index": 0, "quote": "I meditated for twenty minutes"},
+            {"index": 0, "quote": "by the window"},
+        )
+    )
+    hits = await detect_completions(_BODY, candidates=_CANDIDATES, llm=llm)
+    assert len(hits) == 1
+    assert hits[0].target_id == 10
+
+
+@pytest.mark.asyncio
+async def test_overlapping_spans_are_deduped() -> None:
+    """Distinct targets whose anchors overlap collapse to the first kept."""
+    body = "I meditated and ran in one breath."
+    cands = (
+        DetectionCandidate(index=0, target_type="habit", target_id=10, name="Meditation"),
+        DetectionCandidate(index=1, target_type="practice", target_id=20, name="Run"),
+    )
+    llm = FakeLLM(
+        _hits_json(
+            {"index": 0, "quote": "meditated and ran"},
+            {"index": 1, "quote": "and ran in one breath"},
+        )
+    )
+    hits = await detect_completions(body, candidates=cands, llm=llm)
+    assert len(hits) == 1
+    assert hits[0].target_id == 10
+
+
+@pytest.mark.asyncio
+async def test_caps_at_max_hits() -> None:
+    """No more than MAX_HITS are returned even if the model proposes more."""
+    words = [f"word{i}" for i in range(MAX_HITS + 3)]
+    body = " ".join(words)
+    cands = tuple(
+        DetectionCandidate(index=i, target_type="habit", target_id=100 + i, name=f"H{i}")
+        for i in range(MAX_HITS + 3)
+    )
+    llm = FakeLLM(_hits_json(*({"index": i, "quote": words[i]} for i in range(MAX_HITS + 3))))
+    hits = await detect_completions(body, candidates=cands, llm=llm)
+    assert len(hits) == MAX_HITS
+
+
+def test_prompt_excludes_intentions_and_avoidance() -> None:
+    """The prompt forbids counting planned/avoided items, not just completed ones."""
+    prompt = build_detection_prompt(_BODY, _CANDIDATES)
+    lowered = prompt.lower()
+    assert "did" in lowered
+    assert "completed" in lowered
+    assert "planned" in lowered
+    assert "avoid" in lowered
+    # Candidates are numbered for index addressing.
+    assert "0. Meditation (habit)" in prompt
+
+
+def test_completion_detected_is_frozen() -> None:
+    """Detected hits are immutable so callers can't mutate resolved spans."""
+    hit = CompletionDetected(
+        target_type="habit",
+        target_id=10,
+        label="ran",
+        anchor_start=0,
+        anchor_end=3,
+        anchor_text="ran",
+    )
+    with pytest.raises(AttributeError):
+        hit.target_id = 99  # type: ignore[misc]

--- a/backend/tests/test_detection_service.py
+++ b/backend/tests/test_detection_service.py
@@ -14,7 +14,7 @@ from domain.detection import (
     build_detection_prompt,
     detect_completions,
 )
-from models.completion_suggestion import CompletionTargetType
+from models.completion_suggestion import _LABEL_MAX, CompletionTargetType
 
 _BODY = (
     "This morning I meditated for twenty minutes by the window. "
@@ -51,6 +51,15 @@ def _hits_json(*hits: dict[str, object]) -> str:
 def test_valid_target_types_match_the_model_enum() -> None:
     """The domain's local target-type set must not drift from the model enum."""
     assert {t.value for t in CompletionTargetType} == detection.VALID_TARGET_TYPES
+
+
+def test_label_max_matches_the_db_column() -> None:
+    """LABEL_MAX must equal the CompletionSuggestion.label column cap (#843 review).
+
+    A larger domain cap would let a detected label pass here and then fail at DB
+    insert in the endpoint layer.
+    """
+    assert detection.LABEL_MAX == _LABEL_MAX
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

#815 (epic #822): a pure, injected-LLM domain function that reads a journal entry and decides which of the user's tracked habits/practices the writer actually **did** — same trust model as `domain/resonance.py`: the model proposes a candidate **index** + **verbatim quote**; the server resolves the index against the supplied list and anchors the quote itself, **never trusting model ids/offsets**.

- `domain/detection.py`: `DetectionCandidate` + `CompletionDetected`; `build_detection_prompt` ("did/completed, **not** planned/avoided"); defensive JSON parse; index-range + verbatim-quote resolution; label sanitize; overlap + same-target dedupe; cap at `MAX_HITS=5`.
- `detect_completions(body, *, candidates, llm, max_hits=MAX_HITS)` — **empty candidates short-circuit to `[]` with no LLM call** (the endpoint's cost guard).
- Reuses the `ResonanceLLM` seam + quote-span/overlap helpers — no second provider.

Pure module (no DB/FastAPI).

## Test plan

Fake-LLM tests: anchoring, the empty-candidate short-circuit (LLM never called), out-of-range index + quote-not-found drops, sanitize, dedupe, the cap, and the prompt forbidding intentions/avoidance. `./scripts/backend/check-all.sh` 7/7, xenon A.

Closes #815
Refs #822
