### PR TITLE
ci(review): revert to GITHUB_TOKEN for posting (app token 401s)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -85,10 +85,12 @@ jobs:
         # failed/empty review), fail so the check is red and the review is
         # re-run — never a silent success with no review (#810).
         env:
-          # Prefer the action's Claude App token so the comment is authored by
-          # "claude" (consistent with the pre-#810 flow + any author-aware
-          # consumer); fall back to GITHUB_TOKEN if no Claude App is configured.
-          GH_TOKEN: ${{ steps.claude-review.outputs.github_token || secrets.GITHUB_TOKEN }}
+          # Use GITHUB_TOKEN (posts as github-actions[bot]). The action's
+          # github_token output (Claude App token) is NOT a usable gh credential
+          # for `gh pr comment` — it 401s "Bad credentials" (#839/#843), which
+          # fail-closed turned into a red check on every PR. github-actions[bot]
+          # as the author is fine: downstream consumers parse by content, not author.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           STRUCTURED: ${{ steps.claude-review.outputs.structured_output }}


### PR DESCRIPTION
## Summary

Reverts #840. The Claude App `github_token` output is **not** a usable `gh` credential — `gh pr comment` returns `HTTP 401: Bad credentials` (#843), and the fail-closed post-step turned that into a **red `claude-review` on every post-#840 PR**, breaking the gate fixed in #837.

Restore `secrets.GITHUB_TOKEN`. The verdict comment is authored by **github-actions[bot]** — acceptable, since `iteration-trigger` and the loop parse by content (`select(.body|test("Verdict"))`), not author. #838 proved this path posts reliably.

## Test plan

YAML valid. Self-skips its own PR (anti-tamper); validated on the next normal PR (which should post a verdict again instead of 401ing).

Closes #839
