### PR TITLE
ci(review): post the verdict with GEOFFE_GA_PAT (real author)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -85,12 +85,12 @@ jobs:
         # failed/empty review), fail so the check is red and the review is
         # re-run — never a silent success with no review (#810).
         env:
-          # Use GITHUB_TOKEN (posts as github-actions[bot]). The action's
-          # github_token output (Claude App token) is NOT a usable gh credential
-          # for `gh pr comment` — it 401s "Bad credentials" (#839/#843), which
-          # fail-closed turned into a red check on every PR. github-actions[bot]
-          # as the author is fine: downstream consumers parse by content, not author.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer GEOFFE_GA_PAT (a real PAT with pull-requests:write, the same
+          # one iteration-trigger uses) so the verdict comment is authored by a
+          # real account the mobile webhook recognizes; fall back to GITHUB_TOKEN
+          # (github-actions[bot]) if the PAT secret is absent. NOT the action's
+          # Claude App github_token output — that 401s with gh (#839/#843).
+          GH_TOKEN: ${{ secrets.GEOFFE_GA_PAT || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           STRUCTURED: ${{ steps.claude-review.outputs.structured_output }}


### PR DESCRIPTION
## Summary

The verdict comment was authored by `github-actions[bot]` (after #844 restored `GITHUB_TOKEN`). Per maintainer request, prefer **`GEOFFE_GA_PAT`** — a real PAT with `pull-requests:write` (the same secret `iteration-trigger` uses), so the comment is authored by a real account the mobile webhook recognizes — falling back to `GITHUB_TOKEN` if the PAT secret is absent.

This is a usable `gh` credential, unlike the action's Claude App `github_token` output that 401'd (#839/#843).

## Test plan

YAML valid. Self-skips its own PR (anti-tamper); validated on the next normal PR (#843's re-review), which should post a verdict authored by `Geoffe-Ga`.

Refs #810
