### PR TITLE
feat(backend): run completion detection on the resonance press

### DIFF
--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -14,12 +14,22 @@ from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import require_owned_journal_entry
+from domain.detection import CompletionDetected, detect_completions
 from domain.resonance import MarginaliaAnchored, generate_essay, generate_marginalia
 from errors import not_found, unprocessable
+from models.completion_suggestion import (
+    CompletionSuggestion,
+    CompletionTargetType,
+    SuggestionStatus,
+)
 from models.journal_entry import JournalEntry, JournalTag
 from models.marginalia import Marginalia, MarginaliaStatus
 from rate_limit import limiter
 from routers.auth import get_current_user
+from schemas.completion_suggestion import (
+    CompletionSuggestionListResponse,
+    CompletionSuggestionResponse,
+)
 from schemas.journal import (
     JOURNAL_MESSAGE_MAX_LENGTH,
     JournalEntryUpdate,
@@ -35,7 +45,12 @@ from schemas.marginalia import (
 from security import TextTooLongError, sanitize_user_text
 from services import journal_encryption
 from services.botmason import LLMProviderError, resolve_chat_api_key
-from services.marginalia import BotmasonResonanceLLM, reanchor_entry_marginalia
+from services.completion_candidates import gather_candidates
+from services.marginalia import (
+    BotmasonResonanceLLM,
+    reanchor_entry_marginalia,
+    reanchor_entry_suggestions,
+)
 from services.usage import get_monthly_cap
 from services.wallet import preflight_deduction, require_user_fresh
 
@@ -240,6 +255,7 @@ async def _apply_entry_update(
         if new_message != old_message:
             entry.message = new_message
             await reanchor_entry_marginalia(entry, old_message, new_message, session)
+            await reanchor_entry_suggestions(entry, new_message, session)
     if payload.title is not None:
         entry.title = payload.title
     if payload.status is not None:
@@ -334,6 +350,69 @@ def _persist_marginalia(
     return rows
 
 
+def _suggestion_from_hit(
+    entry_id: int, user_id: int, hit: CompletionDetected
+) -> CompletionSuggestion:
+    """Map a detection hit to a PENDING CompletionSuggestion row.
+
+    The polymorphic FK is selected by ``target_type`` to satisfy the model's
+    target-fk-matches CHECK (habit → goal_id, practice → user_practice_id).
+    """
+    is_habit = hit.target_type == CompletionTargetType.HABIT
+    return CompletionSuggestion(
+        journal_entry_id=entry_id,
+        user_id=user_id,
+        target_type=hit.target_type,
+        goal_id=hit.target_id if is_habit else None,
+        user_practice_id=None if is_habit else hit.target_id,
+        label=hit.label,
+        anchor_start=hit.anchor_start,
+        anchor_end=hit.anchor_end,
+        anchor_text=hit.anchor_text,
+        status=SuggestionStatus.PENDING,
+    )
+
+
+async def _detect_and_persist_suggestions(
+    session: AsyncSession, entry_id: int, message: str, user_id: int, llm: BotmasonResonanceLLM
+) -> list[CompletionSuggestion]:
+    """Best-effort completion detection on the same pass; stage PENDING rows.
+
+    Empty candidates short-circuit with no LLM call (cost guard). A provider error
+    is swallowed (returns ``[]``) so the literary pass, the wallet charge, and the
+    commit are never rolled back — detection is strictly additive.
+    """
+    candidates = await gather_candidates(session, user_id)
+    if not candidates:
+        return []
+    try:
+        hits = await detect_completions(message, candidates=candidates, llm=llm)
+    except LLMProviderError:
+        logger.warning("journal_detection_failed", extra={"user_id": user_id, "entry_id": entry_id})
+        return []
+    rows = [_suggestion_from_hit(entry_id, user_id, hit) for hit in hits]
+    session.add_all(rows)
+    return rows
+
+
+async def _generate_marginalia_or_502(
+    message: str, llm: BotmasonResonanceLLM, prior: list[str], session: AsyncSession
+) -> list[MarginaliaAnchored]:
+    """Run the literary pass; a provider error rolls back the charge and 502s.
+
+    This is the only charged LLM call — a failure here must un-deduct the wallet
+    so a failed pass never charges (the detection pass that follows is best-effort
+    and never triggers a rollback).
+    """
+    try:
+        return await generate_marginalia(message, llm=llm, prior_entries=prior)
+    except LLMProviderError as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY, detail="llm_provider_error"
+        ) from exc
+
+
 @router.post("/{entry_id}/resonance", response_model=ResonanceResponse)
 @limiter.limit("10/minute")
 async def run_resonance(
@@ -355,25 +434,31 @@ async def run_resonance(
     spent = await preflight_deduction(session, current_user)
     prior = await _recent_prior_bodies(session, current_user, entry_id)
     llm = BotmasonResonanceLLM(resolve_chat_api_key(x_llm_api_key))
-    try:
-        anchored = await generate_marginalia(entry.message, llm=llm, prior_entries=prior)
-    except LLMProviderError as exc:
-        await session.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY, detail="llm_provider_error"
-        ) from exc
+    anchored = await _generate_marginalia_or_502(entry.message, llm, prior, session)
     rows = _persist_marginalia(session, entry_id, current_user, anchored)
+    suggestions = await _detect_and_persist_suggestions(
+        session, entry_id, entry.message, current_user, llm
+    )
     user = await require_user_fresh(session, current_user)
     reset_date = user.monthly_reset_date
     await session.commit()
-    for row in rows:
+    for row in (*rows, *suggestions):
         await session.refresh(row)
     logger.info(
         "journal_resonance_generated",
-        extra={"user_id": current_user, "entry_id": entry_id, "count": len(rows)},
+        extra={
+            "user_id": current_user,
+            "entry_id": entry_id,
+            "count": len(rows),
+            "suggestions": len(suggestions),
+        },
     )
     return ResonanceResponse(
         marginalia=[MarginaliaResponse.model_validate(r, from_attributes=True) for r in rows],
+        suggestions=[
+            CompletionSuggestionResponse.model_validate(s, from_attributes=True)
+            for s in suggestions
+        ],
         remaining_messages=max(get_monthly_cap() - spent.monthly_used, 0),
         remaining_balance=spent.offering_balance,
         monthly_reset_date=reset_date,
@@ -401,6 +486,35 @@ async def list_marginalia(
     rows = result.scalars().all()
     return MarginaliaListResponse(
         items=[MarginaliaResponse.model_validate(r, from_attributes=True) for r in rows]
+    )
+
+
+@router.get("/{entry_id}/suggestions", response_model=CompletionSuggestionListResponse)
+async def list_suggestions(
+    entry_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> CompletionSuggestionListResponse:
+    """List the caller's completion suggestions for an entry, ordered by anchor.
+
+    Ownership-scoped: a missing, soft-deleted, or foreign entry resolves to 404
+    (enumeration-safe, matching the marginalia list). ``user_id`` is never
+    returned.
+    """
+    entry = await _load_user_entry(session, entry_id, current_user)
+    if entry is None:
+        raise not_found("journal_entry")
+    result = await session.execute(
+        select(CompletionSuggestion)
+        .where(
+            CompletionSuggestion.journal_entry_id == entry_id,
+            CompletionSuggestion.user_id == current_user,  # defense-in-depth
+        )
+        .order_by(col(CompletionSuggestion.anchor_start))
+    )
+    rows = result.scalars().all()
+    return CompletionSuggestionListResponse(
+        items=[CompletionSuggestionResponse.model_validate(r, from_attributes=True) for r in rows]
     )
 
 

--- a/backend/src/schemas/completion_suggestion.py
+++ b/backend/src/schemas/completion_suggestion.py
@@ -1,0 +1,38 @@
+"""Response schemas for completion-suggestion endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from models.completion_suggestion import CompletionTargetType, SuggestionStatus
+
+
+class CompletionSuggestionResponse(BaseModel):
+    """A single completion suggestion returned to clients.
+
+    ``user_id`` is intentionally excluded — the client knows its own identity and
+    exposing surrogate keys aids enumeration (mirrors ``MarginaliaResponse`` and
+    the journal-entry response).
+    """
+
+    id: int
+    journal_entry_id: int
+    target_type: CompletionTargetType
+    goal_id: int | None
+    user_practice_id: int | None
+    label: str
+    anchor_start: int
+    anchor_end: int
+    anchor_text: str
+    status: SuggestionStatus
+    accepted_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class CompletionSuggestionListResponse(BaseModel):
+    """All completion suggestions for an entry (any status)."""
+
+    items: list[CompletionSuggestionResponse]

--- a/backend/src/schemas/marginalia.py
+++ b/backend/src/schemas/marginalia.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pydantic import BaseModel
 
 from models.marginalia import MarginaliaKind, MarginaliaStatus
+from schemas.completion_suggestion import CompletionSuggestionResponse
 
 
 class MarginaliaResponse(BaseModel):
@@ -32,9 +33,14 @@ class MarginaliaResponse(BaseModel):
 
 
 class ResonanceResponse(BaseModel):
-    """Result of a resonance pass: the new notes plus refreshed wallet balances."""
+    """Result of a resonance pass: the new notes plus refreshed wallet balances.
+
+    ``suggestions`` carries any completion suggestions detected on the same pass
+    (additive, best-effort — empty when none are found or detection failed).
+    """
 
     marginalia: list[MarginaliaResponse]
+    suggestions: list[CompletionSuggestionResponse] = []
     remaining_messages: int
     remaining_balance: int
     monthly_reset_date: datetime

--- a/backend/src/services/marginalia.py
+++ b/backend/src/services/marginalia.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from domain.marginalia_anchoring import reanchor_one
+from models.completion_suggestion import CompletionSuggestion, SuggestionStatus
 from models.journal_entry import JournalEntry
 from models.marginalia import Marginalia, MarginaliaStatus
 from services.botmason import generate_response
@@ -64,3 +65,31 @@ async def reanchor_entry_marginalia(
         else:
             note.anchor_start = outcome.anchor_start
             note.anchor_end = outcome.anchor_end
+
+
+async def reanchor_entry_suggestions(
+    entry: JournalEntry,
+    new_message: str,
+    session: AsyncSession,
+) -> None:
+    """Re-anchor (or auto-dismiss) the entry's PENDING completion suggestions.
+
+    Mirrors :func:`reanchor_entry_marginalia`: each pending suggestion re-anchors
+    to its span if its ``anchor_text`` still occurs in ``new_message``; if the
+    mention was deleted the suggestion auto-flips to ``dismissed`` (the user never
+    attested to a completion the edited entry no longer claims). Accepted and
+    already-dismissed suggestions are left untouched.
+    """
+    result = await session.execute(
+        select(CompletionSuggestion).where(
+            CompletionSuggestion.journal_entry_id == entry.id,
+            CompletionSuggestion.status == SuggestionStatus.PENDING,
+        )
+    )
+    for suggestion in result.scalars().all():
+        outcome = reanchor_one(suggestion.anchor_text, suggestion.anchor_start, new_message)
+        if outcome.stale:
+            suggestion.status = SuggestionStatus.DISMISSED
+        else:
+            suggestion.anchor_start = outcome.anchor_start
+            suggestion.anchor_end = outcome.anchor_end

--- a/backend/tests/test_completion_detection_endpoint.py
+++ b/backend/tests/test_completion_detection_endpoint.py
@@ -1,0 +1,256 @@
+"""Completion detection wired into the resonance endpoint + list + re-anchor (#817)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from http import HTTPStatus
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from models.completion_suggestion import CompletionSuggestion, SuggestionStatus
+from models.goal import Goal
+from models.habit import Habit
+from models.marginalia import Marginalia
+from models.user import User
+from services import marginalia as marginalia_service
+from services.botmason import LLMProviderError
+
+_BODY = "I meditated by the river and the willow bent without breaking."
+_NOTE = {"kind": "theme", "quote": "the willow bent without breaking", "note": "It holds."}
+
+
+async def _signup(client: AsyncClient, username: str = "det") -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _user_id(session: AsyncSession, username: str = "det") -> int:
+    user = (
+        await session.execute(select(User).where(col(User.email) == f"{username}@example.com"))
+    ).scalar_one()
+    assert user.id is not None
+    return user.id
+
+
+async def _create_entry(client: AsyncClient, headers: dict[str, str], body: str = _BODY) -> int:
+    resp = await client.post("/journal/", json={"message": body}, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+async def _seed_habit(session: AsyncSession, user_id: int, name: str = "Meditation") -> None:
+    habit = Habit(
+        name=name,
+        icon="🧘",
+        start_date=date(2025, 1, 1),
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    session.add(
+        Goal(
+            habit_id=habit.id,
+            title="clear",
+            tier="clear",
+            target=1.0,
+            target_unit="x",
+            frequency=1.0,
+            frequency_unit="per_day",
+            is_additive=True,
+        )
+    )
+    await session.commit()
+
+
+def _fake(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    hits: list[dict[str, Any]],
+    detection_calls: list[str] | None = None,
+    detection_raises: bool = False,
+) -> None:
+    """Patch the shared LLM seam: marginalia JSON for the literary prompt, hits for detection."""
+    notes_payload = json.dumps({"notes": [_NOTE]})
+    hits_payload = json.dumps({"hits": hits})
+
+    async def _complete(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> SimpleNamespace:
+        del history, system_prompt, api_key
+        if '"hits"' in prompt or "COMPLETED" in prompt:  # the detection prompt
+            if detection_calls is not None:
+                detection_calls.append(prompt)
+            if detection_raises:
+                raise LLMProviderError("detector down")
+            return SimpleNamespace(text=hits_payload)
+        return SimpleNamespace(text=notes_payload)
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _complete)
+
+
+@pytest.mark.asyncio
+async def test_one_press_returns_marginalia_and_suggestions_on_one_charge(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake(monkeypatch, hits=[{"index": 0, "quote": "I meditated"}])
+    headers = await _signup(async_client)
+    await _seed_habit(db_session, await _user_id(db_session))
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert len(body["marginalia"]) == 1
+    assert len(body["suggestions"]) == 1
+    s = body["suggestions"][0]
+    assert s["status"] == SuggestionStatus.PENDING.value
+    assert s["label"] == "I meditated"
+    assert s["target_type"] == "habit"
+    assert s["goal_id"] is not None
+    assert "user_id" not in s  # enumeration-safe
+    assert body["remaining_messages"] == 49  # exactly one charge (50 cap - 1)
+    persisted = (
+        await db_session.execute(select(func.count()).select_from(CompletionSuggestion))
+    ).scalar_one()
+    assert persisted == 1
+
+
+@pytest.mark.asyncio
+async def test_no_candidates_skips_detection_llm(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+    _fake(monkeypatch, hits=[{"index": 0, "quote": "I meditated"}], detection_calls=calls)
+    headers = await _signup(async_client, "nohab")  # no habit seeded → no candidates
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["suggestions"] == []
+    assert len(resp.json()["marginalia"]) == 1  # literary pass still ran
+    assert calls == []  # the detection LLM was never called (cost guard)
+
+
+@pytest.mark.asyncio
+async def test_detection_failure_is_best_effort(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake(monkeypatch, hits=[], detection_raises=True)
+    headers = await _signup(async_client, "detfail")
+    await _seed_habit(db_session, await _user_id(db_session, "detfail"))
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK  # NOT 502 — detection is additive
+    body = resp.json()
+    assert body["suggestions"] == []
+    assert len(body["marginalia"]) == 1  # literary notes intact
+    assert body["remaining_messages"] == 49  # charged; no rollback
+    marg = (await db_session.execute(select(func.count()).select_from(Marginalia))).scalar_one()
+    assert marg == 1  # the resonance pass was not rolled back
+
+
+@pytest.mark.asyncio
+async def test_list_suggestions_scoped_ordered_no_user_id(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Two habits → two candidates; two hits whose quotes sit at different offsets.
+    _fake(
+        monkeypatch,
+        hits=[
+            {"index": 0, "quote": "willow bent"},  # later in the body
+            {"index": 1, "quote": "I meditated"},  # earlier in the body
+        ],
+    )
+    headers = await _signup(async_client)
+    uid = await _user_id(db_session)
+    await _seed_habit(db_session, uid, "Meditation")
+    await _seed_habit(db_session, uid, "Stillness")
+    entry_id = await _create_entry(async_client, headers)
+    await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+
+    resp = await async_client.get(f"/journal/{entry_id}/suggestions", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()["items"]
+    assert len(items) == 2
+    starts = [i["anchor_start"] for i in items]
+    assert starts == sorted(starts)  # ordered by anchor position
+    assert all("user_id" not in i for i in items)
+
+
+@pytest.mark.asyncio
+async def test_list_suggestions_foreign_entry_is_404(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake(monkeypatch, hits=[{"index": 0, "quote": "I meditated"}])
+    alice = await _signup(async_client, "alice")
+    await _seed_habit(db_session, await _user_id(db_session, "alice"))
+    entry_id = await _create_entry(async_client, alice)
+    await async_client.post(f"/journal/{entry_id}/resonance", headers=alice)
+
+    bob = await _signup(async_client, "bob")
+    resp = await async_client.get(f"/journal/{entry_id}/suggestions", headers=bob)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_edit_reanchors_pending_and_auto_dismisses_deleted_mention(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake(monkeypatch, hits=[{"index": 0, "quote": "I meditated"}])
+    headers = await _signup(async_client, "editor")
+    await _seed_habit(db_session, await _user_id(db_session, "editor"))
+    entry_id = await _create_entry(async_client, headers)
+    await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+
+    # Edit the body so the "I meditated" mention is gone → auto-dismiss the pending suggestion.
+    patched = await async_client.patch(
+        f"/journal/{entry_id}",
+        json={"message": "I rested quietly by the river today."},
+        headers=headers,
+    )
+    assert patched.status_code == HTTPStatus.OK
+    row = (await db_session.execute(select(CompletionSuggestion))).scalars().one()
+    await db_session.refresh(row)
+    assert row.status == SuggestionStatus.DISMISSED
+
+
+@pytest.mark.asyncio
+async def test_edit_keeping_mention_reanchors_without_dismiss(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake(monkeypatch, hits=[{"index": 0, "quote": "I meditated"}])
+    headers = await _signup(async_client, "keeper")
+    await _seed_habit(db_session, await _user_id(db_session, "keeper"))
+    entry_id = await _create_entry(async_client, headers)
+    await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+
+    # Prepend text so "I meditated" survives but shifts position → re-anchored, still pending.
+    patched = await async_client.patch(
+        f"/journal/{entry_id}",
+        json={"message": "Today, after a long walk, I meditated by the river."},
+        headers=headers,
+    )
+    assert patched.status_code == HTTPStatus.OK
+    row = (await db_session.execute(select(CompletionSuggestion))).scalars().one()
+    await db_session.refresh(row)
+    assert row.status == SuggestionStatus.PENDING
+    assert row.anchor_text == "I meditated"
+    assert row.anchor_start > 0  # shifted to the new offset


### PR DESCRIPTION
## Summary

#817 (epic #822): the same "Get Resonance" press now also detects completions, persists PENDING `CompletionSuggestion` rows, and returns them — additively, **best-effort, on the same single charge** — plus a list endpoint and re-anchoring.

- `schemas/completion_suggestion.py`: `CompletionSuggestionResponse` (**no `user_id`** — enumeration-safe) + list response; `ResonanceResponse.suggestions: [] = []` (additive).
- `run_resonance`: after the (only-charged) literary pass, reuse the **same `llm`** to gather candidates + `detect_completions`, staging PENDING rows in the same commit. Empty candidates ⇒ no LLM call. Detection/`LLMProviderError` ⇒ `suggestions=[]` with literary notes, the single wallet charge, and the commit intact (**no rollback, no second debit**).
- `GET /journal/{id}/suggestions`: ownership-scoped (foreign/absent → 404), ordered by anchor, never returns `user_id`.
- `reanchor_entry_suggestions`: on edit, re-anchor pending suggestions; a deleted mention auto-flips to `dismissed`.

## Test plan

7 async tests (prompt-aware FakeLLM): one press → marginalia AND suggestions with `remaining_messages==49` (**single charge**) + PENDING persisted + no `user_id`; no-candidates ⇒ no detection call; **detection failure ⇒ `suggestions=[]`, 200 not 502, charge + marginalia intact**; list scoped/ordered/no-`user_id`; foreign → 404; edit auto-dismisses a deleted mention + re-anchors a surviving one. `./scripts/backend/check-all.sh` 7/7, xenon A.

Closes #817
Refs #822
