### PR TITLE
feat(backend): accept/dismiss endpoints for completion suggestions

### DIFF
--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -3,69 +3,26 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy.exc import IntegrityError, MultipleResultsFound
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import log_ownership_denied
 from dependencies.timezone import current_user_timezone
-from domain.dates import day_bounds_in_tz, today_in_tz
-from domain.streaks import is_scheduled_on
-from errors import bad_request, not_found
+from errors import not_found
 from models.goal import Goal
-from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from routers.auth import get_current_user
 from schemas import CheckInResult
-from schemas.checkin import CheckInReasonCode
-from services.streaks import (
-    PendingCompletion,
-    StreakScope,
-    SubtractiveContext,
-    check_milestones,
-    compute_consecutive_streak,
-    compute_streak_before_and_after,
-)
-
-
-@dataclass(frozen=True)
-class _CheckInJob:
-    """Inputs to ``_persist_and_build_response`` / ``_try_persist_or_idempotent``."""
-
-    goal_id: int
-    target: float
-    user_id: int
-    user_timezone: str
-    did_complete: bool
-    is_scheduled: bool
-    old_streak: int
-    new_streak: int
-    # Explicit completion time for a backfilled past day; ``None`` lets the
-    # ``GoalCompletion`` model default (``datetime.now(UTC)``) stand.
-    timestamp: datetime | None
-    # Subtractive-habit context for the streak computation: a no-log day
-    # on an "abstain from sugar" habit is success, not a chain break.
-    # ``None`` selects the additive code path.
-    subtractive: SubtractiveContext | None
-
+from services.checkin import CheckInContext, record_goal_completion
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/goal_completions", tags=["goals"])
-
-_DEFAULT_THRESHOLDS = [1, 3, 7, 14, 30]
-
-# A completion may be backfilled at most this many days into the past.
-# Beyond this window a user could manufacture an arbitrarily long streak
-# by logging one consecutive past day at a time.
-_MAX_BACKFILL_DAYS = 30
 
 
 class GoalCompletionRequest(BaseModel):
@@ -109,201 +66,6 @@ async def _get_owned_goal_and_habit(
     return goal, habit
 
 
-async def _already_logged_on(
-    session: AsyncSession,
-    goal_id: int,
-    user_id: int,
-    user_timezone: str,
-    day: date,
-) -> bool:
-    """Return True if a completion exists for this goal on ``day`` (user-local)."""
-    start, end = day_bounds_in_tz(user_timezone, day)
-    result = await session.execute(
-        select(GoalCompletion.id)
-        .where(
-            GoalCompletion.goal_id == goal_id,
-            GoalCompletion.user_id == user_id,
-            GoalCompletion.timestamp >= start,
-            GoalCompletion.timestamp < end,
-        )
-        .limit(1)
-    )
-    return result.scalar_one_or_none() is not None
-
-
-async def _idempotent_already_logged_response(
-    session: AsyncSession,
-    goal_id: int,
-    user_id: int,
-    user_timezone: str,
-    subtractive: SubtractiveContext | None = None,
-) -> CheckInResult:
-    """Build the ``already_logged_today`` response shape used by both fast + race paths."""
-    streak = await compute_consecutive_streak(session, goal_id, user_id, user_timezone, subtractive)
-    return CheckInResult(
-        streak=streak,
-        milestones=[],
-        reason_code="already_logged_today",
-    )
-
-
-async def _subtractive_context_for_goal(
-    session: AsyncSession, habit: Habit, posted_goal: Goal
-) -> SubtractiveContext | None:
-    """Build the subtractive-streak context for the habit, else ``None``.
-
-    The check-in payload identifies a single goal (any tier), but the
-    "transgression" line the user thinks in terms of is always the
-    clear-tier sibling.  ``None`` selects the additive code path so
-    additive habits behave exactly as before.
-
-    Queries the sibling directly rather than walking ``habit.goals``
-    because the habit row is fetched with ``session.get`` (no eager
-    relationship load), and touching the lazy-loaded relationship in an
-    async context raises ``MissingGreenlet``.
-
-    Filters on ``is_additive == False`` to mirror the in-memory
-    ``_subtractive_context`` helper in ``routers/habits.py``: if a
-    mixed-polarity fixture or partial migration ever co-locates an
-    additive clear goal under the same habit, this filter rejects it
-    before it builds a wrong-shape context.
-
-    Uses ``scalar_one_or_none`` rather than ``scalar`` so duplicate
-    ``clear``-tier siblings (no DB-level ``UniqueConstraint`` on
-    ``(habit_id, tier)`` today -- PR #379 review) surface as a
-    ``MultipleResultsFound``, which is re-raised as a stable 500
-    so clients see a predictable error code instead of an opaque
-    server error.
-    """
-    if posted_goal.is_additive:
-        return None
-    result = await session.execute(
-        select(Goal.target).where(
-            Goal.habit_id == habit.id,
-            Goal.tier == "clear",
-            col(Goal.is_additive).is_(False),
-        )
-    )
-    try:
-        clear_target = result.scalar_one_or_none()
-    except MultipleResultsFound as exc:
-        logger.exception(
-            "subtractive_check_in_duplicate_clear_goal",
-            extra={"habit_id": habit.id, "user_id": habit.user_id},
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="duplicate_clear_tier_goals",
-        ) from exc
-    if clear_target is None:
-        return None
-    return SubtractiveContext(clear_threshold=clear_target, start_date=habit.start_date)
-
-
-def _held_response(current_user: int, goal_id: int, old_streak: int) -> CheckInResult:
-    """Return ``streak_held`` without inserting a row -- naturally idempotent on retry."""
-    logger.info(
-        "goal_completion_held",
-        extra={"user_id": current_user, "goal_id": goal_id, "streak": old_streak},
-    )
-    return CheckInResult(streak=old_streak, milestones=[], reason_code="streak_held")
-
-
-def _resolve_target_day(completed_on: date | None, user_timezone: str) -> date:
-    """Return the calendar day to log against.
-
-    Defaults to the user's today when ``completed_on`` is omitted. Rejects
-    a future date, and a backfill older than ``_MAX_BACKFILL_DAYS`` days.
-    """
-    today = today_in_tz(user_timezone)
-    target_day = completed_on or today
-    if target_day > today:
-        raise bad_request("completion_date_in_future")
-    if target_day < today - timedelta(days=_MAX_BACKFILL_DAYS):
-        raise bad_request("completion_date_too_old")
-    return target_day
-
-
-def _completion_timestamp(completed_on: date | None, user_timezone: str) -> datetime | None:
-    """Stored timestamp for the completion row.
-
-    ``None`` lets the model default (now) stand for a same-day log. For a
-    backfilled day, anchors mid-day in the user's TZ so the value lands
-    unambiguously inside that local calendar day regardless of DST
-    shoulder days, and buckets on it under the unique-per-day index.
-    """
-    if completed_on is None:
-        return None
-    start, end = day_bounds_in_tz(user_timezone, completed_on)
-    return start + (end - start) / 2
-
-
-def _reason_for_streak_transition(old_streak: int, new_streak: int) -> CheckInReasonCode:
-    """Map the actual streak change to a reason code (#782).
-
-    Derived from the real (subtractive-aware) ``new_streak`` rather than the
-    additive ``update_streak`` heuristic, so the flag never contradicts the
-    number it ships with: a subtractive transgression that zeroes the streak now
-    reads ``streak_reset``, not ``streak_incremented``. (The
-    ``already_logged_today`` case is handled before this point.)
-    """
-    if new_streak > old_streak:
-        return "streak_incremented"
-    if new_streak < old_streak:
-        return "streak_reset"
-    return "streak_held"
-
-
-async def _persist_and_build_response(session: AsyncSession, job: _CheckInJob) -> CheckInResult:
-    """Persist the completion and build a CheckInResult; streak values arrive pre-computed."""
-    completion = GoalCompletion(
-        goal_id=job.goal_id,
-        user_id=job.user_id,
-        completed_units=job.target if job.did_complete else 0,
-    )
-    if job.timestamp is not None:
-        completion.timestamp = job.timestamp
-    async with session.begin_nested():
-        session.add(completion)
-        await session.flush()
-    await session.commit()
-    # ``new_streak`` was computed alongside ``old_streak`` from one history read
-    # (issue dedup); these are pure derivations, no DB recompute. The reason code
-    # is derived from the actual transition so it can't contradict new_streak.
-    reason = _reason_for_streak_transition(job.old_streak, job.new_streak)
-    milestones = check_milestones(job.new_streak, _DEFAULT_THRESHOLDS, job.old_streak)
-    logger.info(
-        "goal_completion_recorded",
-        extra={
-            "user_id": job.user_id,
-            "goal_id": job.goal_id,
-            "did_complete": job.did_complete,
-            "streak": job.new_streak,
-        },
-    )
-    return CheckInResult(streak=job.new_streak, milestones=milestones, reason_code=reason)
-
-
-async def _try_persist_or_idempotent(session: AsyncSession, job: _CheckInJob) -> CheckInResult:
-    """Persist + commit, falling back to the idempotent response on a unique-index race."""
-    try:
-        return await _persist_and_build_response(session, job)
-    except IntegrityError:
-        # Rollback before the follow-up SELECT in case the integrity error
-        # surfaced from the outer commit() rather than the savepoint flush
-        # -- SQLAlchemy marks the session as ``PendingRollbackError`` until
-        # rollback() is called and any subsequent query would otherwise
-        # raise on a clean-looking happy path.
-        await session.rollback()
-        return await _idempotent_already_logged_response(
-            session,
-            job.goal_id,
-            job.user_id,
-            job.user_timezone,
-            job.subtractive,
-        )
-
-
 @router.post("/", response_model=CheckInResult)
 async def create_goal_completion(
     payload: GoalCompletionRequest,
@@ -313,51 +75,16 @@ async def create_goal_completion(
 ) -> CheckInResult:
     """Record a check-in and return updated streak and milestones.
 
-    Logs against today by default; ``payload.completed_on`` backfills a
-    past calendar day (a future date is rejected). Idempotent on the
-    same (user, goal, day) -- the cheap day-pre-check runs before the
-    expensive streak query so duplicate retries fail fast.
+    Logs against today by default; ``payload.completed_on`` backfills a past
+    calendar day (a future date is rejected). Idempotent on the same
+    (user, goal, day). The recording itself lives in ``services.checkin`` so the
+    journal accept flow (#818) records through the identical path.
     """
     goal, habit = await _get_owned_goal_and_habit(session, payload.goal_id, current_user)
-    goal_id = payload.goal_id
-    target_day = _resolve_target_day(payload.completed_on, user_tz)
-    subtractive = await _subtractive_context_for_goal(session, habit, goal)
-
-    if await _already_logged_on(session, goal_id, current_user, user_tz, target_day):
-        return await _idempotent_already_logged_response(
-            session, goal_id, current_user, user_tz, subtractive
-        )
-
-    is_scheduled = is_scheduled_on(habit.notification_days, target_day.strftime("%a"))
-
-    # Unscheduled miss holds the current streak without inserting — only the
-    # pre-insert streak is needed, so compute it once here.
-    if not payload.did_complete and not is_scheduled:
-        old_streak = await compute_consecutive_streak(
-            session, goal_id, current_user, user_tz, subtractive
-        )
-        return _held_response(current_user, goal_id, old_streak)
-
-    # Persist path: derive the pre- and post-insert streak from ONE history
-    # read instead of recomputing on each branch (the day is fresh — the
-    # idempotency check above ruled out an existing log for it).
-    pending_units = goal.target if payload.did_complete else 0.0
-    old_streak, new_streak = await compute_streak_before_and_after(
+    ctx = CheckInContext(goal=goal, habit=habit, user_id=current_user, user_timezone=user_tz)
+    return await record_goal_completion(
         session,
-        StreakScope(goal_id, current_user, user_tz, subtractive),
-        PendingCompletion(target_day, pending_units),
-    )
-
-    job = _CheckInJob(
-        goal_id=goal_id,
-        target=goal.target,
-        user_id=current_user,
-        user_timezone=user_tz,
+        ctx,
         did_complete=payload.did_complete,
-        is_scheduled=is_scheduled,
-        old_streak=old_streak,
-        new_streak=new_streak,
-        timestamp=_completion_timestamp(payload.completed_on, user_tz),
-        subtractive=subtractive,
+        completed_on=payload.completed_on,
     )
-    return await _try_persist_or_idempotent(session, job)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -14,19 +14,23 @@ from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import require_owned_journal_entry
+from dependencies.timezone import current_user_timezone
 from domain.detection import CompletionDetected, detect_completions
 from domain.resonance import MarginaliaAnchored, generate_essay, generate_marginalia
-from errors import not_found, unprocessable
+from errors import conflict, not_found, unprocessable
 from models.completion_suggestion import (
     CompletionSuggestion,
     CompletionTargetType,
     SuggestionStatus,
 )
+from models.goal import Goal
+from models.habit import Habit
 from models.journal_entry import JournalEntry, JournalTag
 from models.marginalia import Marginalia, MarginaliaStatus
 from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.completion_suggestion import (
+    AcceptSuggestionResponse,
     CompletionSuggestionListResponse,
     CompletionSuggestionResponse,
 )
@@ -45,6 +49,7 @@ from schemas.marginalia import (
 from security import TextTooLongError, sanitize_user_text
 from services import journal_encryption
 from services.botmason import LLMProviderError, resolve_chat_api_key
+from services.checkin import CheckInContext, current_check_in, record_goal_completion
 from services.completion_candidates import gather_candidates
 from services.marginalia import (
     BotmasonResonanceLLM,
@@ -516,6 +521,107 @@ async def list_suggestions(
     return CompletionSuggestionListResponse(
         items=[CompletionSuggestionResponse.model_validate(r, from_attributes=True) for r in rows]
     )
+
+
+async def _load_user_suggestion(
+    session: AsyncSession, suggestion_id: int, user_id: int
+) -> CompletionSuggestion | None:
+    """Load the caller's own suggestion, or None (404-scoped, enumeration-safe)."""
+    result = await session.execute(
+        select(CompletionSuggestion).where(
+            CompletionSuggestion.id == suggestion_id,
+            CompletionSuggestion.user_id == user_id,
+        )
+    )
+    return result.scalars().first()
+
+
+async def _resolve_suggestion_goal(
+    session: AsyncSession, suggestion: CompletionSuggestion, user_id: int
+) -> tuple[Goal, Habit]:
+    """Resolve a habit suggestion's goal + parent habit, ownership-checked (404-mask)."""
+    goal = await session.get(Goal, suggestion.goal_id) if suggestion.goal_id is not None else None
+    if goal is None:
+        raise not_found("goal")
+    habit = await session.get(Habit, goal.habit_id)
+    if habit is None or habit.user_id != user_id:
+        raise not_found("goal")
+    return goal, habit
+
+
+def _suggestion_response(suggestion: CompletionSuggestion) -> CompletionSuggestionResponse:
+    """Map a suggestion row to its user_id-free response model."""
+    return CompletionSuggestionResponse.model_validate(suggestion, from_attributes=True)
+
+
+async def _accept_pending_habit(
+    session: AsyncSession,
+    suggestion: CompletionSuggestion,
+    current_user: int,
+    user_tz: str,
+) -> AcceptSuggestionResponse:
+    """Log today's completion for a pending habit suggestion and flip it to accepted."""
+    goal, habit = await _resolve_suggestion_goal(session, suggestion, current_user)
+    ctx = CheckInContext(goal=goal, habit=habit, user_id=current_user, user_timezone=user_tz)
+    check_in = await record_goal_completion(session, ctx, did_complete=True)
+    suggestion.status = SuggestionStatus.ACCEPTED
+    suggestion.accepted_at = datetime.now(UTC)
+    session.add(suggestion)
+    await session.commit()
+    await session.refresh(suggestion)
+    return AcceptSuggestionResponse(suggestion=_suggestion_response(suggestion), check_in=check_in)
+
+
+@router.post("/suggestions/{suggestion_id}/accept", response_model=AcceptSuggestionResponse)
+async def accept_suggestion(
+    suggestion_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
+) -> AcceptSuggestionResponse:
+    """Accept a pending habit suggestion: log today's completion + flip to accepted.
+
+    Ownership-scoped (404). Practice targets are an explicit 422 until #821.
+    Re-accepting an already-accepted suggestion is an idempotent no-op (no second
+    completion); accepting a dismissed one is a 409 illegal transition. The
+    check-in goes through the shared ``record_goal_completion`` (idempotent per
+    goal/day, so a same-day manual check-in is not double-counted).
+    """
+    suggestion = await _load_user_suggestion(session, suggestion_id, current_user)
+    if suggestion is None:
+        raise not_found("completion_suggestion")
+    if suggestion.target_type == CompletionTargetType.PRACTICE:
+        raise unprocessable("practice_accept_not_supported")
+    if suggestion.status == SuggestionStatus.DISMISSED:
+        raise conflict("suggestion_dismissed")
+    if suggestion.status == SuggestionStatus.ACCEPTED:
+        goal, habit = await _resolve_suggestion_goal(session, suggestion, current_user)
+        ctx = CheckInContext(goal=goal, habit=habit, user_id=current_user, user_timezone=user_tz)
+        check_in = await current_check_in(session, ctx)
+        return AcceptSuggestionResponse(
+            suggestion=_suggestion_response(suggestion), check_in=check_in
+        )
+    return await _accept_pending_habit(session, suggestion, current_user, user_tz)
+
+
+@router.post("/suggestions/{suggestion_id}/dismiss", response_model=CompletionSuggestionResponse)
+async def dismiss_suggestion(
+    suggestion_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> CompletionSuggestionResponse:
+    """Dismiss a pending suggestion (idempotent). Dismissing an accepted one is 409."""
+    suggestion = await _load_user_suggestion(session, suggestion_id, current_user)
+    if suggestion is None:
+        raise not_found("completion_suggestion")
+    if suggestion.status == SuggestionStatus.ACCEPTED:
+        raise conflict("suggestion_accepted")
+    if suggestion.status == SuggestionStatus.PENDING:
+        suggestion.status = SuggestionStatus.DISMISSED
+        session.add(suggestion)
+        await session.commit()
+        await session.refresh(suggestion)
+    return _suggestion_response(suggestion)
 
 
 # Economy seam: essay expansion is free by default. A future pricing pass would

--- a/backend/src/schemas/completion_suggestion.py
+++ b/backend/src/schemas/completion_suggestion.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pydantic import BaseModel
 
 from models.completion_suggestion import CompletionTargetType, SuggestionStatus
+from schemas.checkin import CheckInResult
 
 
 class CompletionSuggestionResponse(BaseModel):
@@ -36,3 +37,10 @@ class CompletionSuggestionListResponse(BaseModel):
     """All completion suggestions for an entry (any status)."""
 
     items: list[CompletionSuggestionResponse]
+
+
+class AcceptSuggestionResponse(BaseModel):
+    """The accepted suggestion plus the check-in it logged (streak + milestones)."""
+
+    suggestion: CompletionSuggestionResponse
+    check_in: CheckInResult

--- a/backend/src/services/checkin.py
+++ b/backend/src/services/checkin.py
@@ -1,0 +1,336 @@
+"""Shared goal check-in recording.
+
+The streak / idempotency / milestone logic that backs ``POST /goal_completions/``
+lives here so other callers (the journal resonance accept flow, #818) record a
+completion through the EXACT same path — one completion per goal/day, identical
+streak + milestone math — rather than reimplementing it.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import cast
+
+from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError, MultipleResultsFound
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.dates import day_bounds_in_tz, today_in_tz
+from domain.streaks import is_scheduled_on
+from errors import bad_request
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from schemas import CheckInResult
+from schemas.checkin import CheckInReasonCode
+from services.streaks import (
+    PendingCompletion,
+    StreakScope,
+    SubtractiveContext,
+    check_milestones,
+    compute_consecutive_streak,
+    compute_streak_before_and_after,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_THRESHOLDS = [1, 3, 7, 14, 30]
+
+# A completion may be backfilled at most this many days into the past.
+# Beyond this window a user could manufacture an arbitrarily long streak
+# by logging one consecutive past day at a time.
+_MAX_BACKFILL_DAYS = 30
+
+
+@dataclass(frozen=True)
+class _CheckInJob:
+    """Inputs to ``_persist_and_build_response`` / ``_try_persist_or_idempotent``."""
+
+    goal_id: int
+    target: float
+    user_id: int
+    user_timezone: str
+    did_complete: bool
+    is_scheduled: bool
+    old_streak: int
+    new_streak: int
+    # Explicit completion time for a backfilled past day; ``None`` lets the
+    # ``GoalCompletion`` model default (``datetime.now(UTC)``) stand.
+    timestamp: datetime | None
+    # Subtractive-habit context for the streak computation: a no-log day
+    # on an "abstain from sugar" habit is success, not a chain break.
+    # ``None`` selects the additive code path.
+    subtractive: SubtractiveContext | None
+
+
+async def _already_logged_on(
+    session: AsyncSession,
+    goal_id: int,
+    user_id: int,
+    user_timezone: str,
+    day: date,
+) -> bool:
+    """Return True if a completion exists for this goal on ``day`` (user-local)."""
+    start, end = day_bounds_in_tz(user_timezone, day)
+    result = await session.execute(
+        select(GoalCompletion.id)
+        .where(
+            GoalCompletion.goal_id == goal_id,
+            GoalCompletion.user_id == user_id,
+            GoalCompletion.timestamp >= start,
+            GoalCompletion.timestamp < end,
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _idempotent_already_logged_response(
+    session: AsyncSession,
+    goal_id: int,
+    user_id: int,
+    user_timezone: str,
+    subtractive: SubtractiveContext | None = None,
+) -> CheckInResult:
+    """Build the ``already_logged_today`` response shape used by both fast + race paths."""
+    streak = await compute_consecutive_streak(session, goal_id, user_id, user_timezone, subtractive)
+    return CheckInResult(
+        streak=streak,
+        milestones=[],
+        reason_code="already_logged_today",
+    )
+
+
+async def _subtractive_context_for_goal(
+    session: AsyncSession, habit: Habit, posted_goal: Goal
+) -> SubtractiveContext | None:
+    """Build the subtractive-streak context for the habit, else ``None``.
+
+    The check-in identifies a single goal (any tier), but the "transgression"
+    line the user thinks in terms of is always the clear-tier sibling. ``None``
+    selects the additive code path so additive habits behave exactly as before.
+
+    Queries the sibling directly rather than walking ``habit.goals`` because the
+    habit row is fetched with ``session.get`` (no eager relationship load), and
+    touching the lazy-loaded relationship in an async context raises
+    ``MissingGreenlet``.
+
+    Filters on ``is_additive == False`` so a mixed-polarity fixture or partial
+    migration that co-locates an additive clear goal under the same habit is
+    rejected before it builds a wrong-shape context. ``scalar_one_or_none``
+    surfaces duplicate ``clear``-tier siblings as a ``MultipleResultsFound``,
+    re-raised as a stable 500.
+    """
+    if posted_goal.is_additive:
+        return None
+    result = await session.execute(
+        select(Goal.target).where(
+            Goal.habit_id == habit.id,
+            Goal.tier == "clear",
+            col(Goal.is_additive).is_(False),
+        )
+    )
+    try:
+        clear_target = result.scalar_one_or_none()
+    except MultipleResultsFound as exc:
+        logger.exception(
+            "subtractive_check_in_duplicate_clear_goal",
+            extra={"habit_id": habit.id, "user_id": habit.user_id},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="duplicate_clear_tier_goals",
+        ) from exc
+    if clear_target is None:
+        return None
+    return SubtractiveContext(clear_threshold=clear_target, start_date=habit.start_date)
+
+
+def _held_response(current_user: int, goal_id: int, old_streak: int) -> CheckInResult:
+    """Return ``streak_held`` without inserting a row -- naturally idempotent on retry."""
+    logger.info(
+        "goal_completion_held",
+        extra={"user_id": current_user, "goal_id": goal_id, "streak": old_streak},
+    )
+    return CheckInResult(streak=old_streak, milestones=[], reason_code="streak_held")
+
+
+def _resolve_target_day(completed_on: date | None, user_timezone: str) -> date:
+    """Return the calendar day to log against.
+
+    Defaults to the user's today when ``completed_on`` is omitted. Rejects a
+    future date, and a backfill older than ``_MAX_BACKFILL_DAYS`` days.
+    """
+    today = today_in_tz(user_timezone)
+    target_day = completed_on or today
+    if target_day > today:
+        raise bad_request("completion_date_in_future")
+    if target_day < today - timedelta(days=_MAX_BACKFILL_DAYS):
+        raise bad_request("completion_date_too_old")
+    return target_day
+
+
+def _completion_timestamp(completed_on: date | None, user_timezone: str) -> datetime | None:
+    """Stored timestamp for the completion row.
+
+    ``None`` lets the model default (now) stand for a same-day log. For a
+    backfilled day, anchors mid-day in the user's TZ so the value lands
+    unambiguously inside that local calendar day regardless of DST shoulder
+    days, and buckets on it under the unique-per-day index.
+    """
+    if completed_on is None:
+        return None
+    start, end = day_bounds_in_tz(user_timezone, completed_on)
+    return start + (end - start) / 2
+
+
+def _reason_for_streak_transition(old_streak: int, new_streak: int) -> CheckInReasonCode:
+    """Map the actual streak change to a reason code (#782).
+
+    Derived from the real (subtractive-aware) ``new_streak`` rather than the
+    additive ``update_streak`` heuristic, so the flag never contradicts the
+    number it ships with: a subtractive transgression that zeroes the streak
+    reads ``streak_reset``, not ``streak_incremented``. (The
+    ``already_logged_today`` case is handled before this point.)
+    """
+    if new_streak > old_streak:
+        return "streak_incremented"
+    if new_streak < old_streak:
+        return "streak_reset"
+    return "streak_held"
+
+
+async def _persist_and_build_response(session: AsyncSession, job: _CheckInJob) -> CheckInResult:
+    """Persist the completion and build a CheckInResult; streak values arrive pre-computed."""
+    completion = GoalCompletion(
+        goal_id=job.goal_id,
+        user_id=job.user_id,
+        completed_units=job.target if job.did_complete else 0,
+    )
+    if job.timestamp is not None:
+        completion.timestamp = job.timestamp
+    async with session.begin_nested():
+        session.add(completion)
+        await session.flush()
+    await session.commit()
+    # ``new_streak`` was computed alongside ``old_streak`` from one history read
+    # (issue dedup); these are pure derivations, no DB recompute. The reason code
+    # is derived from the actual transition so it can't contradict new_streak.
+    reason = _reason_for_streak_transition(job.old_streak, job.new_streak)
+    milestones = check_milestones(job.new_streak, _DEFAULT_THRESHOLDS, job.old_streak)
+    logger.info(
+        "goal_completion_recorded",
+        extra={
+            "user_id": job.user_id,
+            "goal_id": job.goal_id,
+            "did_complete": job.did_complete,
+            "streak": job.new_streak,
+        },
+    )
+    return CheckInResult(streak=job.new_streak, milestones=milestones, reason_code=reason)
+
+
+async def _try_persist_or_idempotent(session: AsyncSession, job: _CheckInJob) -> CheckInResult:
+    """Persist + commit, falling back to the idempotent response on a unique-index race."""
+    try:
+        return await _persist_and_build_response(session, job)
+    except IntegrityError:
+        # Rollback before the follow-up SELECT in case the integrity error
+        # surfaced from the outer commit() rather than the savepoint flush --
+        # SQLAlchemy marks the session as ``PendingRollbackError`` until
+        # rollback() is called and any subsequent query would otherwise raise.
+        await session.rollback()
+        return await _idempotent_already_logged_response(
+            session,
+            job.goal_id,
+            job.user_id,
+            job.user_timezone,
+            job.subtractive,
+        )
+
+
+@dataclass(frozen=True)
+class CheckInContext:
+    """An owned, loaded goal + the actor recording against it.
+
+    Bundles the (goal, habit, user, timezone) tuple the recording helpers share
+    so callers pass one context instead of four positional arguments.
+    """
+
+    goal: Goal
+    habit: Habit
+    user_id: int
+    user_timezone: str
+
+
+async def current_check_in(session: AsyncSession, ctx: CheckInContext) -> CheckInResult:
+    """Current streak for an already-recorded goal, WITHOUT writing a row.
+
+    Used for the idempotent no-op view (e.g. re-accepting an already-accepted
+    suggestion) so it never logs a fresh completion.
+    """
+    goal_id = cast("int", ctx.goal.id)
+    subtractive = await _subtractive_context_for_goal(session, ctx.habit, ctx.goal)
+    streak = await compute_consecutive_streak(
+        session, goal_id, ctx.user_id, ctx.user_timezone, subtractive
+    )
+    return CheckInResult(streak=streak, milestones=[], reason_code="already_logged_today")
+
+
+async def record_goal_completion(
+    session: AsyncSession,
+    ctx: CheckInContext,
+    *,
+    did_complete: bool = True,
+    completed_on: date | None = None,
+) -> CheckInResult:
+    """Record a check-in for an already-owned goal and return streak + milestones.
+
+    The single source of truth for check-in recording: idempotent on the same
+    (user, goal, day), with identical streak/milestone math for the
+    ``POST /goal_completions/`` route and the journal accept flow (#818). The
+    caller is responsible for ownership; ``ctx.goal``/``ctx.habit`` must be loaded.
+    """
+    # An already-owned, persisted goal always carries a PK.
+    goal_id = cast("int", ctx.goal.id)
+    target_day = _resolve_target_day(completed_on, ctx.user_timezone)
+    subtractive = await _subtractive_context_for_goal(session, ctx.habit, ctx.goal)
+
+    if await _already_logged_on(session, goal_id, ctx.user_id, ctx.user_timezone, target_day):
+        return await _idempotent_already_logged_response(
+            session, goal_id, ctx.user_id, ctx.user_timezone, subtractive
+        )
+
+    is_scheduled = is_scheduled_on(ctx.habit.notification_days, target_day.strftime("%a"))
+
+    # Unscheduled miss holds the current streak without inserting — only the
+    # pre-insert streak is needed, so compute it once here.
+    if not did_complete and not is_scheduled:
+        old_streak = await compute_consecutive_streak(
+            session, goal_id, ctx.user_id, ctx.user_timezone, subtractive
+        )
+        return _held_response(ctx.user_id, goal_id, old_streak)
+
+    # Persist path: derive pre- and post-insert streak from ONE history read.
+    pending_units = ctx.goal.target if did_complete else 0.0
+    old_streak, new_streak = await compute_streak_before_and_after(
+        session,
+        StreakScope(goal_id, ctx.user_id, ctx.user_timezone, subtractive),
+        PendingCompletion(target_day, pending_units),
+    )
+    job = _CheckInJob(
+        goal_id=goal_id,
+        target=ctx.goal.target,
+        user_id=ctx.user_id,
+        user_timezone=ctx.user_timezone,
+        did_complete=did_complete,
+        is_scheduled=is_scheduled,
+        old_streak=old_streak,
+        new_streak=new_streak,
+        timestamp=_completion_timestamp(completed_on, ctx.user_timezone),
+        subtractive=subtractive,
+    )
+    return await _try_persist_or_idempotent(session, job)

--- a/backend/tests/routers/test_goal_completions_streak_dedup.py
+++ b/backend/tests/routers/test_goal_completions_streak_dedup.py
@@ -16,7 +16,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import routers.goal_completions as gc_module
+import services.checkin as checkin_module
 from domain.dates import today_in_tz
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
@@ -89,8 +89,8 @@ def _spy_streak_calls(monkeypatch: pytest.MonkeyPatch) -> tuple[list[int], list[
     """
     consecutive = [0]
     before_after = [0]
-    real_consecutive = gc_module.compute_consecutive_streak
-    real_before_after = gc_module.compute_streak_before_and_after
+    real_consecutive = checkin_module.compute_consecutive_streak
+    real_before_after = checkin_module.compute_streak_before_and_after
 
     async def _count_consecutive(
         session: AsyncSession,
@@ -108,8 +108,8 @@ def _spy_streak_calls(monkeypatch: pytest.MonkeyPatch) -> tuple[list[int], list[
         before_after[0] += 1
         return await real_before_after(session, scope, pending)
 
-    monkeypatch.setattr(gc_module, "compute_consecutive_streak", _count_consecutive)
-    monkeypatch.setattr(gc_module, "compute_streak_before_and_after", _count_before_after)
+    monkeypatch.setattr(checkin_module, "compute_consecutive_streak", _count_consecutive)
+    monkeypatch.setattr(checkin_module, "compute_streak_before_and_after", _count_before_after)
     return consecutive, before_after
 
 

--- a/backend/tests/test_completion_accept_dismiss.py
+++ b/backend/tests/test_completion_accept_dismiss.py
@@ -1,0 +1,333 @@
+"""Accept / dismiss endpoints for completion suggestions (#818)."""
+
+from __future__ import annotations
+
+from datetime import date
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from models.completion_suggestion import (
+    CompletionSuggestion,
+    CompletionTargetType,
+    SuggestionStatus,
+)
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.practice import Practice
+from models.user import User
+from models.user_practice import UserPractice
+
+_BODY = "I went for a run today and it felt good."
+
+
+async def _signup(client: AsyncClient, username: str = "acc") -> dict[str, str]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _user_id(session: AsyncSession, username: str = "acc") -> int:
+    user = (
+        await session.execute(select(User).where(col(User.email) == f"{username}@example.com"))
+    ).scalar_one()
+    assert user.id is not None
+    return user.id
+
+
+async def _create_entry(client: AsyncClient, headers: dict[str, str]) -> int:
+    resp = await client.post("/journal/", json={"message": _BODY}, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+async def _seed_goal(session: AsyncSession, user_id: int, target: float = 5.0) -> int:
+    """Seed a habit + clear-tier goal; return the goal id."""
+    habit = Habit(
+        name="Run",
+        icon="🏃",
+        start_date=date(2025, 1, 1),
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    goal = Goal(
+        habit_id=habit.id,
+        title="clear",
+        tier="clear",
+        target=target,
+        target_unit="miles",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    assert goal.id is not None
+    return goal.id
+
+
+async def _seed_user_practice(session: AsyncSession, user_id: int) -> int:
+    """Seed a Practice + UserPractice; return the user_practice id."""
+    practice = Practice(
+        stage_number=1,
+        name="Sit",
+        description="A sit.",
+        instructions="Sit and breathe.",
+        default_duration_minutes=10.0,
+        mode="meditation_timer",
+        mode_config={"mode": "meditation_timer", "duration_minutes": 10},
+    )
+    session.add(practice)
+    await session.commit()
+    await session.refresh(practice)
+    user_practice = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=1,
+        start_date=date(2025, 1, 1),
+    )
+    session.add(user_practice)
+    await session.commit()
+    await session.refresh(user_practice)
+    assert user_practice.id is not None
+    return user_practice.id
+
+
+async def _seed_suggestion(
+    session: AsyncSession,
+    *,
+    entry_id: int,
+    user_id: int,
+    goal_id: int,
+    status: SuggestionStatus = SuggestionStatus.PENDING,
+) -> int:
+    """Seed a pending (default) HABIT suggestion; return its id."""
+    suggestion = CompletionSuggestion(
+        journal_entry_id=entry_id,
+        user_id=user_id,
+        target_type=CompletionTargetType.HABIT,
+        goal_id=goal_id,
+        user_practice_id=None,
+        label="went for a run",
+        anchor_start=2,
+        anchor_end=22,
+        anchor_text="went for a run today",
+        status=status,
+    )
+    session.add(suggestion)
+    await session.commit()
+    await session.refresh(suggestion)
+    assert suggestion.id is not None
+    return suggestion.id
+
+
+async def _completion_count(session: AsyncSession, goal_id: int) -> int:
+    result = await session.execute(
+        select(func.count())
+        .select_from(GoalCompletion)
+        .where(col(GoalCompletion.goal_id) == goal_id)
+    )
+    return int(result.scalar_one())
+
+
+@pytest.mark.asyncio
+async def test_accept_logs_completion_and_flips_to_accepted(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Accept a pending habit suggestion → logs a completion + accepted + streak."""
+    headers = await _signup(async_client)
+    user_id = await _user_id(db_session)
+    goal_id = await _seed_goal(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers)
+    sug_id = await _seed_suggestion(db_session, entry_id=entry_id, user_id=user_id, goal_id=goal_id)
+
+    resp = await async_client.post(f"/journal/suggestions/{sug_id}/accept", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["suggestion"]["status"] == "accepted"
+    assert data["suggestion"]["accepted_at"] is not None
+    assert "user_id" not in data["suggestion"]
+    assert data["check_in"]["streak"] == 1
+    assert await _completion_count(db_session, goal_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_accept_is_idempotent_per_goal_day(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A same-day manual check-in then accept does NOT double-count the completion."""
+    headers = await _signup(async_client)
+    user_id = await _user_id(db_session)
+    goal_id = await _seed_goal(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers)
+    sug_id = await _seed_suggestion(db_session, entry_id=entry_id, user_id=user_id, goal_id=goal_id)
+
+    # Manual check-in first, then accept the suggestion the same day.
+    first = await async_client.post(
+        "/goal_completions/", json={"goal_id": goal_id, "did_complete": True}, headers=headers
+    )
+    assert first.status_code == HTTPStatus.OK
+    resp = await async_client.post(f"/journal/suggestions/{sug_id}/accept", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["suggestion"]["status"] == "accepted"
+    assert await _completion_count(db_session, goal_id) == 1  # not 2
+
+
+@pytest.mark.asyncio
+async def test_accept_already_accepted_is_noop(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Re-accepting an accepted suggestion is a no-op (no second completion)."""
+    headers = await _signup(async_client)
+    user_id = await _user_id(db_session)
+    goal_id = await _seed_goal(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers)
+    sug_id = await _seed_suggestion(db_session, entry_id=entry_id, user_id=user_id, goal_id=goal_id)
+
+    await async_client.post(f"/journal/suggestions/{sug_id}/accept", headers=headers)
+    resp = await async_client.post(f"/journal/suggestions/{sug_id}/accept", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["suggestion"]["status"] == "accepted"
+    assert await _completion_count(db_session, goal_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_accept_dismissed_is_conflict(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Accepting a dismissed suggestion is a 409 illegal transition."""
+    headers = await _signup(async_client)
+    user_id = await _user_id(db_session)
+    goal_id = await _seed_goal(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers)
+    sug_id = await _seed_suggestion(
+        db_session,
+        entry_id=entry_id,
+        user_id=user_id,
+        goal_id=goal_id,
+        status=SuggestionStatus.DISMISSED,
+    )
+
+    resp = await async_client.post(f"/journal/suggestions/{sug_id}/accept", headers=headers)
+
+    assert resp.status_code == HTTPStatus.CONFLICT
+
+
+@pytest.mark.asyncio
+async def test_accept_practice_is_unsupported(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Accepting a practice suggestion is an explicit 422 placeholder for #821."""
+    headers = await _signup(async_client)
+    user_id = await _user_id(db_session)
+    entry_id = await _create_entry(async_client, headers)
+    user_practice_id = await _seed_user_practice(db_session, user_id)
+    practice_suggestion = CompletionSuggestion(
+        journal_entry_id=entry_id,
+        user_id=user_id,
+        target_type=CompletionTargetType.PRACTICE,
+        goal_id=None,
+        user_practice_id=user_practice_id,
+        label="a sit",
+        anchor_start=0,
+        anchor_end=5,
+        anchor_text="I sat",
+        status=SuggestionStatus.PENDING,
+    )
+    db_session.add(practice_suggestion)
+    await db_session.commit()
+    await db_session.refresh(practice_suggestion)
+
+    resp = await async_client.post(
+        f"/journal/suggestions/{practice_suggestion.id}/accept", headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert resp.json()["detail"] == "practice_accept_not_supported"
+
+
+@pytest.mark.asyncio
+async def test_dismiss_pending_then_idempotent(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Dismiss flips pending → dismissed and is idempotent on repeat."""
+    headers = await _signup(async_client)
+    user_id = await _user_id(db_session)
+    goal_id = await _seed_goal(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers)
+    sug_id = await _seed_suggestion(db_session, entry_id=entry_id, user_id=user_id, goal_id=goal_id)
+
+    first = await async_client.post(f"/journal/suggestions/{sug_id}/dismiss", headers=headers)
+    assert first.status_code == HTTPStatus.OK
+    assert first.json()["status"] == "dismissed"
+    assert "user_id" not in first.json()
+
+    again = await async_client.post(f"/journal/suggestions/{sug_id}/dismiss", headers=headers)
+    assert again.status_code == HTTPStatus.OK
+    assert again.json()["status"] == "dismissed"
+
+
+@pytest.mark.asyncio
+async def test_dismiss_accepted_is_conflict(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Dismissing an accepted suggestion is a 409 illegal transition."""
+    headers = await _signup(async_client)
+    user_id = await _user_id(db_session)
+    goal_id = await _seed_goal(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers)
+    sug_id = await _seed_suggestion(
+        db_session,
+        entry_id=entry_id,
+        user_id=user_id,
+        goal_id=goal_id,
+        status=SuggestionStatus.ACCEPTED,
+    )
+
+    resp = await async_client.post(f"/journal/suggestions/{sug_id}/dismiss", headers=headers)
+
+    assert resp.status_code == HTTPStatus.CONFLICT
+
+
+@pytest.mark.asyncio
+async def test_accept_foreign_suggestion_is_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Another user's suggestion is 404 (enumeration-safe) on both verbs."""
+    owner_headers = await _signup(async_client, "owner")
+    owner_id = await _user_id(db_session, "owner")
+    goal_id = await _seed_goal(db_session, owner_id)
+    entry_id = await _create_entry(async_client, owner_headers)
+    sug_id = await _seed_suggestion(
+        db_session, entry_id=entry_id, user_id=owner_id, goal_id=goal_id
+    )
+
+    attacker_headers = await _signup(async_client, "attacker")
+    accept = await async_client.post(
+        f"/journal/suggestions/{sug_id}/accept", headers=attacker_headers
+    )
+    dismiss = await async_client.post(
+        f"/journal/suggestions/{sug_id}/dismiss", headers=attacker_headers
+    )
+
+    assert accept.status_code == HTTPStatus.NOT_FOUND
+    assert dismiss.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
## Summary

#818 (epic #822): a pending suggestion gets two verbs. **Accept** logs today's completion exactly as the check-in screen does (same idempotency/streak/milestone math) and flips to `accepted`; **dismiss** retires it.

- **Extract** the check-in recording into `services/checkin.py` (`CheckInContext` + `record_goal_completion` + `current_check_in`); `/goal_completions/` delegates — **behavior-preserving**, `test_goal_completions.py` passes untouched (the dedup spy only retargets to the moved symbol).
- `POST /journal/suggestions/{id}/accept` (ownership-scoped 404, no `user_id`): pending habit ⇒ log a `GoalCompletion` at `goal.target` via the **shared** path (idempotent per goal/day) → `accepted`; already-accepted ⇒ no-op; dismissed ⇒ 409; practice ⇒ **422 `practice_accept_not_supported`**.
- `POST /journal/suggestions/{id}/dismiss`: pending ⇒ dismissed; idempotent; accepted ⇒ 409.

## Test plan

8 tests: accept logs+flips+streak; **accept idempotent per goal/day**; already-accepted no-op; dismissed→409; practice→422; dismiss + idempotent; accepted→409; foreign→404 on both; no `user_id`. `test_goal_completions.py` unchanged + green. `./scripts/backend/check-all.sh` 7/7, xenon A.

Closes #818
Refs #822
