### PR TITLE
feat(frontend): suggestions API client + types + useResonance surfacing

### DIFF
--- a/frontend/src/api/__tests__/completionSuggestions.test.ts
+++ b/frontend/src/api/__tests__/completionSuggestions.test.ts
@@ -1,0 +1,97 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { ApiError, IDEMPOTENCY_KEY_HEADER, completionSuggestions } from '../index';
+import type { CompletionSuggestion } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function suggestion(overrides: Partial<CompletionSuggestion> = {}): CompletionSuggestion {
+  return {
+    id: 1,
+    journal_entry_id: 7,
+    target_type: 'habit',
+    goal_id: 3,
+    user_practice_id: null,
+    label: 'I went for a run',
+    anchor_start: 0,
+    anchor_end: 15,
+    anchor_text: 'I went for a run',
+    status: 'pending',
+    accepted_at: null,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const checkIn = { streak: 4, milestones: [{ threshold: 3 }], reason_code: 'streak_incremented' };
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('completionSuggestions.list', () => {
+  test('GETs the canonical /journal/{id}/suggestions URL (no 307)', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ items: [suggestion(), suggestion({ id: 2 })] }));
+    const result = await completionSuggestions.list(7, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/7/suggestions');
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(result.items).toHaveLength(2);
+  });
+
+  test('surfaces a 404 as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'journal_entry_not_found' }, 404));
+    const err = await completionSuggestions.list(7, 'tok').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(404);
+  });
+});
+
+describe('completionSuggestions.accept', () => {
+  test('POSTs the canonical accept URL with a deterministic idempotency key', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ suggestion: suggestion({ status: 'accepted' }), check_in: checkIn }),
+    );
+    const result = await completionSuggestions.accept(1, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/suggestions/1/accept');
+    expect(init.method).toBe('POST');
+    expect(init.headers[IDEMPOTENCY_KEY_HEADER]).toBe('accept-suggestion:1');
+    expect(result.suggestion.status).toBe('accepted');
+    expect(result.check_in.streak).toBe(4);
+  });
+
+  test('surfaces a 422 (practice accept) as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'practice_accept_not_supported' }, 422));
+    await expect(completionSuggestions.accept(9, 'tok')).rejects.toMatchObject({
+      status: 422,
+      detail: 'practice_accept_not_supported',
+    });
+  });
+});
+
+describe('completionSuggestions.dismiss', () => {
+  test('POSTs the canonical dismiss URL and parses the dismissed row', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(suggestion({ status: 'dismissed' })));
+    const result = await completionSuggestions.dismiss(1, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/suggestions/1/dismiss');
+    expect(init.method).toBe('POST');
+    expect(result.status).toBe('dismissed');
+  });
+});

--- a/frontend/src/api/__tests__/resonance.test.ts
+++ b/frontend/src/api/__tests__/resonance.test.ts
@@ -37,6 +37,7 @@ function marginalia(overrides: Partial<Marginalia> = {}): Marginalia {
 function resonancePayload(): ResonanceResponse {
   return {
     marginalia: [marginalia()],
+    suggestions: [],
     remaining_messages: 49,
     remaining_balance: 0,
     monthly_reset_date: '2026-07-01T00:00:00Z',

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -5,6 +5,9 @@ import {
   apiGoalGroupSchema,
   authResponseSchema,
   contentItemSchema,
+  acceptSuggestionResultSchema,
+  completionSuggestionListResponseSchema,
+  completionSuggestionSchema,
   frequencyResponseSchema,
   habitWithGoalsSchema,
   isTier,
@@ -21,8 +24,12 @@ import {
   stageSchema,
   timezoneReadSchema,
   userPracticeSchema,
+  type AcceptSuggestionResultT,
+  type CompletionSuggestionT,
+  type CompletionTargetTypeT,
   type Page,
   type PasswordResetAcceptedT,
+  type SuggestionStatusT,
   type Tier,
   type TimezoneReadT,
 } from './schemas';
@@ -1146,6 +1153,8 @@ export interface Marginalia {
 
 export interface ResonanceResponse {
   marginalia: Marginalia[];
+  /** Completion suggestions detected on the same pass (#817); defaults to []. */
+  suggestions: CompletionSuggestion[];
   remaining_messages: number;
   remaining_balance: number;
   monthly_reset_date: string;
@@ -1247,6 +1256,47 @@ export const resonance = {
       method: 'POST',
       token,
       headers: byokHeaders(apiKey),
+    });
+  },
+};
+
+// Completion suggestions client (habit-resonance #819)
+export type CompletionTargetType = CompletionTargetTypeT;
+export type SuggestionStatus = SuggestionStatusT;
+export type CompletionSuggestion = CompletionSuggestionT;
+export type AcceptSuggestionResult = AcceptSuggestionResultT;
+
+export interface CompletionSuggestionListResponse {
+  items: CompletionSuggestion[];
+}
+
+/**
+ * Suggestions surfaced by the resonance pass (#817/#818). URLs are the canonical
+ * non-slash sub-resource forms the backend serves directly (no 307). ``accept``
+ * carries a deterministic idempotency key so a double-tap can't double-log the
+ * underlying completion (mirrors ``goalCompletions.create``).
+ */
+export const completionSuggestions = {
+  list(entryId: number, token?: string): Promise<CompletionSuggestionListResponse> {
+    return request<CompletionSuggestionListResponse>(`/journal/${entryId}/suggestions`, {
+      token,
+      schema:
+        completionSuggestionListResponseSchema as unknown as z.ZodType<CompletionSuggestionListResponse>,
+    });
+  },
+  accept(id: number, token?: string): Promise<AcceptSuggestionResult> {
+    return request<AcceptSuggestionResult>(`/journal/suggestions/${id}/accept`, {
+      method: 'POST',
+      token,
+      headers: { [IDEMPOTENCY_KEY_HEADER]: idempotencyKey('accept-suggestion', id) },
+      schema: acceptSuggestionResultSchema as unknown as z.ZodType<AcceptSuggestionResult>,
+    });
+  },
+  dismiss(id: number, token?: string): Promise<CompletionSuggestion> {
+    return request<CompletionSuggestion>(`/journal/suggestions/${id}/dismiss`, {
+      method: 'POST',
+      token,
+      schema: completionSuggestionSchema as unknown as z.ZodType<CompletionSuggestion>,
     });
   },
 };

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -431,6 +431,51 @@ export const frequencyResponseSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Completion suggestions (habit-resonance #819) — mirror the backend
+// CompletionSuggestionResponse (no user_id) + the accept result.
+// ---------------------------------------------------------------------------
+
+export const completionTargetTypeSchema = z.enum(['habit', 'practice']);
+export const suggestionStatusSchema = z.enum(['pending', 'accepted', 'dismissed']);
+
+/** Matches the backend's CheckInResult (streak + milestones + reason). */
+export const checkInResultSchema = z.object({
+  streak: z.number().int(),
+  milestones: z.array(z.object({ threshold: z.number().int() })),
+  reason_code: z.string(),
+});
+
+export const completionSuggestionSchema = z.object({
+  id: z.number().int(),
+  journal_entry_id: z.number().int(),
+  target_type: completionTargetTypeSchema,
+  goal_id: z.number().int().nullable(),
+  user_practice_id: z.number().int().nullable(),
+  label: z.string(),
+  anchor_start: z.number().int(),
+  anchor_end: z.number().int(),
+  anchor_text: z.string(),
+  status: suggestionStatusSchema,
+  accepted_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export const completionSuggestionListResponseSchema = z.object({
+  items: z.array(completionSuggestionSchema),
+});
+
+export const acceptSuggestionResultSchema = z.object({
+  suggestion: completionSuggestionSchema,
+  check_in: checkInResultSchema,
+});
+
+export type CompletionTargetTypeT = z.infer<typeof completionTargetTypeSchema>;
+export type SuggestionStatusT = z.infer<typeof suggestionStatusSchema>;
+export type CompletionSuggestionT = z.infer<typeof completionSuggestionSchema>;
+export type AcceptSuggestionResultT = z.infer<typeof acceptSuggestionResultSchema>;
+
+// ---------------------------------------------------------------------------
 // Lenient schemas for legacy endpoints (gradually tightened)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -31,6 +31,11 @@ jest.mock('@/api', () => ({
     list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
     generate: jest.fn(),
   },
+  completionSuggestions: {
+    list: jest.fn(() => Promise.resolve({ items: [] })),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
 }));
 
 const JournalEntryScreen = require('../JournalEntryScreen').default;

--- a/frontend/src/features/Journal/__tests__/useResonance.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonance.test.tsx
@@ -2,13 +2,27 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 
-import type { Marginalia, ResonanceResponse } from '@/api';
+import type {
+  AcceptSuggestionResult,
+  CompletionSuggestion,
+  Marginalia,
+  ResonanceResponse,
+} from '@/api';
 import { ApiError } from '@/api';
 
 const mockList = jest.fn() as jest.MockedFunction<
   (_id: number) => Promise<{ items: Marginalia[] }>
 >;
 const mockGenerate = jest.fn() as jest.MockedFunction<(_id: number) => Promise<ResonanceResponse>>;
+const mockSugList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: CompletionSuggestion[] }>
+>;
+const mockAccept = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<AcceptSuggestionResult>
+>;
+const mockDismiss = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<CompletionSuggestion>
+>;
 
 jest.mock('@/api', () => {
   const actual = jest.requireActual('@/api') as Record<string, unknown>;
@@ -18,6 +32,11 @@ jest.mock('@/api', () => {
       list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
       generate: (...a: unknown[]) =>
         (mockGenerate as unknown as (...x: unknown[]) => unknown)(...a),
+    },
+    completionSuggestions: {
+      list: (...a: unknown[]) => (mockSugList as unknown as (...x: unknown[]) => unknown)(...a),
+      accept: (...a: unknown[]) => (mockAccept as unknown as (...x: unknown[]) => unknown)(...a),
+      dismiss: (...a: unknown[]) => (mockDismiss as unknown as (...x: unknown[]) => unknown)(...a),
     },
   };
 });
@@ -45,16 +64,40 @@ function note(overrides: Partial<Marginalia> = {}): Marginalia {
 function resonancePayload(notes: Marginalia[]): ResonanceResponse {
   return {
     marginalia: notes,
+    suggestions: [],
     remaining_messages: 48,
     remaining_balance: 0,
     monthly_reset_date: '2026-07-01T00:00:00Z',
   };
 }
 
+function suggestion(overrides: Partial<CompletionSuggestion> = {}): CompletionSuggestion {
+  return {
+    id: 1,
+    journal_entry_id: 7,
+    target_type: 'habit',
+    goal_id: 3,
+    user_practice_id: null,
+    label: 'I ran',
+    anchor_start: 0,
+    anchor_end: 5,
+    anchor_text: 'I ran',
+    status: 'pending',
+    accepted_at: null,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   mockList.mockReset();
   mockGenerate.mockReset();
+  mockSugList.mockReset();
+  mockAccept.mockReset();
+  mockDismiss.mockReset();
   mockList.mockResolvedValue({ items: [] });
+  mockSugList.mockResolvedValue({ items: [] });
 });
 
 describe('useResonance', () => {
@@ -118,6 +161,91 @@ describe('useResonance', () => {
       await result.current.requestResonance();
     });
     expect(mockGenerate).not.toHaveBeenCalled();
+    expect(result.current.error).toBeTruthy();
+  });
+});
+
+describe('useResonance — suggestions', () => {
+  it('loads existing suggestions on mount when the entry has an id', async () => {
+    mockSugList.mockResolvedValue({ items: [suggestion({ id: 1 }), suggestion({ id: 2 })] });
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+    await waitFor(() => expect(result.current.suggestions).toHaveLength(2));
+    expect(mockSugList).toHaveBeenCalledWith(7);
+  });
+
+  it('merges suggestions from a generate pass, deduped + sorted by anchor', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue({
+      ...resonancePayload([]),
+      suggestions: [
+        suggestion({ id: 2, anchor_start: 20 }),
+        suggestion({ id: 1, anchor_start: 0 }),
+      ],
+    });
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+    expect(result.current.suggestions.map((s: CompletionSuggestion) => s.id)).toEqual([1, 2]);
+  });
+
+  it('accept replaces the row with the accepted one and exposes the check-in', async () => {
+    mockSugList.mockResolvedValue({ items: [suggestion({ id: 1, status: 'pending' })] });
+    mockAccept.mockResolvedValue({
+      suggestion: suggestion({ id: 1, status: 'accepted', accepted_at: '2026-06-02T00:00:00Z' }),
+      check_in: { streak: 4, milestones: [{ threshold: 3 }], reason_code: 'streak_incremented' },
+    });
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+    await waitFor(() => expect(result.current.suggestions).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.acceptSuggestion(1);
+    });
+    expect(mockAccept).toHaveBeenCalledWith(1);
+    expect(result.current.suggestions[0]!.status).toBe('accepted');
+    expect(result.current.lastCheckIn?.streak).toBe(4);
+  });
+
+  it('accept leaves the row pending and surfaces a friendly error on failure', async () => {
+    mockSugList.mockResolvedValue({ items: [suggestion({ id: 1, status: 'pending' })] });
+    mockAccept.mockRejectedValue(new ApiError(409, 'already_dismissed'));
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+    await waitFor(() => expect(result.current.suggestions).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.acceptSuggestion(1);
+    });
+    expect(result.current.suggestions[0]!.status).toBe('pending');
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it('dismiss optimistically removes the row', async () => {
+    mockSugList.mockResolvedValue({ items: [suggestion({ id: 1 }), suggestion({ id: 2 })] });
+    mockDismiss.mockResolvedValue(suggestion({ id: 1, status: 'dismissed' }));
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+    await waitFor(() => expect(result.current.suggestions).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.dismissSuggestion(1);
+    });
+    expect(result.current.suggestions.map((s: CompletionSuggestion) => s.id)).toEqual([2]);
+  });
+
+  it('dismiss reverts the optimistic removal on error', async () => {
+    mockSugList.mockResolvedValue({ items: [suggestion({ id: 1 }), suggestion({ id: 2 })] });
+    mockDismiss.mockRejectedValue(new ApiError(500, 'boom'));
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+    await waitFor(() => expect(result.current.suggestions).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.dismissSuggestion(1);
+    });
+    expect(result.current.suggestions.map((s: CompletionSuggestion) => s.id)).toEqual([1, 2]); // reverted
     expect(result.current.error).toBeTruthy();
   });
 });

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -1,19 +1,29 @@
 /**
  * ``useResonance`` — drives an on-demand resonance pass for a journal entry.
  *
- * On open (entry already has an id) it loads existing marginalia. A request
- * flushes the draft save first (so we resonate against the *saved* latest body),
- * calls the generate endpoint, and merges the returned notes. One request runs
- * at a time so rapid taps can't double-charge; errors (notably 402) are mapped
- * to friendly copy and never crash the page.
+ * On open (entry already has an id) it loads existing marginalia and completion
+ * suggestions. A request flushes the draft save first (so we resonate against
+ * the *saved* latest body), calls the generate endpoint, and merges the returned
+ * notes and suggestions. One request runs at a time so rapid taps can't
+ * double-charge; errors (notably 402) are mapped to friendly copy and never
+ * crash the page. Accept/dismiss each guard against a double in-flight tap.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
 
-import { resonance } from '@/api';
-import type { Marginalia } from '@/api';
+import { completionSuggestions, resonance } from '@/api';
+import type { CheckInResult, CompletionSuggestion, Marginalia } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 
 const EMPTY_BODY_MESSAGE = 'Write a little first, then ask for its resonance.';
+
+type SetError = (_e: string) => void;
 
 export interface UseResonanceArgs {
   routeEntryId: number | null;
@@ -23,6 +33,9 @@ export interface UseResonanceArgs {
 
 export interface UseResonanceResult {
   marginalia: Marginalia[];
+  suggestions: CompletionSuggestion[];
+  /** The check-in (streak + milestones) from the most recent accept, if any. */
+  lastCheckIn: CheckInResult | null;
   loading: boolean;
   error: string | null;
   requestResonance: () => Promise<void>;
@@ -30,6 +43,10 @@ export interface UseResonanceResult {
   updateNote: (_note: Marginalia) => void;
   /** Re-read the persisted marginalia (after an edit re-anchors/stales them). */
   refresh: () => Promise<void>;
+  /** Accept a suggestion: logs the completion, flips the row to accepted. */
+  acceptSuggestion: (_id: number) => Promise<void>;
+  /** Dismiss a suggestion: optimistically removes it, reverts on error. */
+  dismissSuggestion: (_id: number) => Promise<void>;
 }
 
 /** Union of two note lists, keyed by id (incoming wins on conflict). */
@@ -40,18 +57,29 @@ function mergeById(existing: Marginalia[], incoming: Marginalia[]): Marginalia[]
   return [...byId.values()].sort((a, b) => a.anchor_start - b.anchor_start);
 }
 
-/** Load the entry's existing marginalia once on open (id only). */
-function useInitialMarginalia(
+/** Union of two suggestion lists, keyed by id, sorted by anchor span. */
+function mergeSuggestionsById(
+  existing: CompletionSuggestion[],
+  incoming: CompletionSuggestion[],
+): CompletionSuggestion[] {
+  const byId = new Map<number, CompletionSuggestion>();
+  for (const s of existing) byId.set(s.id, s);
+  for (const s of incoming) byId.set(s.id, s);
+  return [...byId.values()].sort((a, b) => a.anchor_start - b.anchor_start);
+}
+
+/** Load a list-shaped resource once on open; silent on failure (id only). */
+function useLoadOnOpen<T>(
   routeEntryId: number | null,
-  setMarginalia: (_notes: Marginalia[]) => void,
+  load: (_id: number) => Promise<{ items: T[] }>,
+  apply: (_items: T[]) => void,
 ): void {
   useEffect(() => {
     if (routeEntryId == null) return undefined;
     let active = true;
-    void resonance
-      .list(routeEntryId)
+    void load(routeEntryId)
       .then((res) => {
-        if (active) setMarginalia(res.items);
+        if (active) apply(res.items);
       })
       .catch(() => {
         // A failed initial load shouldn't block writing; stay silent here.
@@ -59,16 +87,81 @@ function useInitialMarginalia(
     return () => {
       active = false;
     };
-  }, [routeEntryId, setMarginalia]);
+  }, [routeEntryId, load, apply]);
 }
 
-export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseResonanceResult {
-  const [marginalia, setMarginalia] = useState<Marginalia[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const inFlightRef = useRef(false);
+interface SuggestionsApi {
+  suggestions: CompletionSuggestion[];
+  lastCheckIn: CheckInResult | null;
+  mergeFromGenerate: (_incoming: CompletionSuggestion[]) => void;
+  acceptSuggestion: (_id: number) => Promise<void>;
+  dismissSuggestion: (_id: number) => Promise<void>;
+}
 
-  useInitialMarginalia(routeEntryId, setMarginalia);
+/** Owns suggestion state: load-on-open, merge, and accept/dismiss with guards. */
+function useSuggestions(routeEntryId: number | null, setError: SetError): SuggestionsApi {
+  const [suggestions, setSuggestions] = useState<CompletionSuggestion[]>([]);
+  const [lastCheckIn, setLastCheckIn] = useState<CheckInResult | null>(null);
+  const pendingIdsRef = useRef<Set<number>>(new Set());
+
+  useLoadOnOpen(routeEntryId, completionSuggestions.list, setSuggestions);
+
+  const mergeFromGenerate = useCallback((incoming: CompletionSuggestion[]) => {
+    setSuggestions((prev) => mergeSuggestionsById(prev, incoming));
+  }, []);
+
+  const acceptSuggestion = useCallback(
+    async (id: number): Promise<void> => {
+      if (pendingIdsRef.current.has(id)) return; // per-id guard — no double-log
+      pendingIdsRef.current.add(id);
+      try {
+        const result = await completionSuggestions.accept(id);
+        setSuggestions((prev) => mergeSuggestionsById(prev, [result.suggestion]));
+        setLastCheckIn(result.check_in);
+      } catch (err) {
+        setError(formatApiError(err)); // row stays pending; user can retry
+      } finally {
+        pendingIdsRef.current.delete(id);
+      }
+    },
+    [setError],
+  );
+
+  const dismissSuggestion = useCallback(
+    async (id: number): Promise<void> => {
+      if (pendingIdsRef.current.has(id)) return;
+      pendingIdsRef.current.add(id);
+      const snapshot = suggestions;
+      setSuggestions(snapshot.filter((s) => s.id !== id)); // optimistic
+      try {
+        await completionSuggestions.dismiss(id);
+      } catch (err) {
+        setSuggestions(snapshot); // revert
+        setError(formatApiError(err));
+      } finally {
+        pendingIdsRef.current.delete(id);
+      }
+    },
+    [suggestions, setError],
+  );
+
+  return { suggestions, lastCheckIn, mergeFromGenerate, acceptSuggestion, dismissSuggestion };
+}
+
+interface GeneratePass {
+  loading: boolean;
+  requestResonance: () => Promise<void>;
+}
+
+/** The charged "generate" pass: flush, generate, merge notes + suggestions. */
+function useGeneratePass(
+  flush: () => Promise<number | null>,
+  setMarginalia: Dispatch<SetStateAction<Marginalia[]>>,
+  mergeFromGenerate: (_incoming: CompletionSuggestion[]) => void,
+  setError: Dispatch<SetStateAction<string | null>>,
+): GeneratePass {
+  const [loading, setLoading] = useState(false);
+  const inFlightRef = useRef(false);
 
   const requestResonance = useCallback(async (): Promise<void> => {
     if (inFlightRef.current) return; // one pass at a time — no double-charge
@@ -83,13 +176,30 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
       }
       const result = await resonance.generate(entryId);
       setMarginalia((prev) => mergeById(prev, result.marginalia));
+      mergeFromGenerate(result.suggestions);
     } catch (err) {
       setError(formatApiError(err));
     } finally {
       inFlightRef.current = false;
       setLoading(false);
     }
-  }, [flush]);
+  }, [flush, setMarginalia, mergeFromGenerate, setError]);
+
+  return { loading, requestResonance };
+}
+
+export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseResonanceResult {
+  const [marginalia, setMarginalia] = useState<Marginalia[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useLoadOnOpen(routeEntryId, resonance.list, setMarginalia);
+  const sug = useSuggestions(routeEntryId, setError);
+  const { loading, requestResonance } = useGeneratePass(
+    flush,
+    setMarginalia,
+    sug.mergeFromGenerate,
+    setError,
+  );
 
   const updateNote = useCallback((updated: Marginalia) => {
     setMarginalia((prev) => mergeById(prev, [updated]));
@@ -105,5 +215,16 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     }
   }, [routeEntryId]);
 
-  return { marginalia, loading, error, requestResonance, updateNote, refresh };
+  return {
+    marginalia,
+    suggestions: sug.suggestions,
+    lastCheckIn: sug.lastCheckIn,
+    loading,
+    error,
+    requestResonance,
+    updateNote,
+    refresh,
+    acceptSuggestion: sug.acceptSuggestion,
+    dismissSuggestion: sug.dismissSuggestion,
+  };
 }


### PR DESCRIPTION
## Summary

#819 (epic #822): typed access to completion suggestions; no UI yet (#820).

- `schemas.ts`/`index.ts`: `CompletionSuggestion`, `SuggestionStatus`, `CompletionTargetType`, `AcceptSuggestionResult{suggestion, check_in}` (all **no `user_id`**); `ResonanceResponse.suggestions` extended.
- `completionSuggestions.{list,accept,dismiss}` mirroring the resonance client, each `request(…, {schema})`; **canonical URLs** (no 307); accept sends `Idempotency-Key: accept-suggestion:{id}` like `goalCompletions.create`.
- `useResonance`: loads suggestions on open + merges from a generate pass (dedupe + sorted by anchor); `acceptSuggestion(id)` (per-id in-flight guard, replaces row + exposes `lastCheckIn`, stays pending on error); `dismissSuggestion(id)` (optimistic, reverts on error). **Marginalia untouched.**

## Test plan

`completionSuggestions` canonical URLs + accept idempotency header + 404/422 mapping; `useResonance` load-on-open, merge dedupe+sort, accept replace+check_in+guard+error-stays-pending, dismiss optimistic+revert; marginalia tests green. `./scripts/frontend/check-all.sh` 4/4; no `any`.

Closes #819
Refs #822
