### PR TITLE
feat(frontend): "Check it off?" margin card for completion suggestions

### DIFF
--- a/frontend/src/features/Journal/CompletionSuggestionNote.tsx
+++ b/frontend/src/features/Journal/CompletionSuggestionNote.tsx
@@ -1,0 +1,223 @@
+/**
+ * ``CompletionSuggestionNote`` — an actionable margin card (sibling to
+ * ``MarginNote``) for a detected completion. Pressing *Get Resonance* pins it
+ * next to the sentence the writer wrote, e.g. "You wrote about **Daily run**.
+ * Check it off?", with a clear **OK** and a quiet **Not now**. OK logs the
+ * completion and the card settles into "✓ Checked off — N-day streak".
+ *
+ * Four states keyed off the suggestion status + a local in-flight flag:
+ * pending (question + actions), accepting (disabled, "Checking…"), accepted
+ * (confirmation + streak), dismissed (renders nothing). Presentational +
+ * reduced-motion-safe; tokens only.
+ */
+import React, { useState } from 'react';
+import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { usePressScale } from './motion';
+
+import type { CheckInResult, CompletionSuggestion } from '@/api';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  paperShadow,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+const QUESTION_PREFIX = 'You wrote about ';
+const QUESTION_SUFFIX = '. Check it off?';
+const OK_LABEL = 'OK';
+const DISMISS_LABEL = 'Not now';
+const CHECKING_LABEL = 'Checking…';
+const CHECKED_LABEL = '✓ Checked off';
+
+/** "N-day streak" from a check-in, or null when there is no streak to show. */
+function streakLabel(checkIn: CheckInResult | null): string | null {
+  if (!checkIn || checkIn.streak <= 0) return null;
+  return `${checkIn.streak}-day streak`;
+}
+
+export interface CompletionSuggestionNoteProps {
+  suggestion: CompletionSuggestion;
+  /** The check-in returned when this suggestion was accepted (for the streak). */
+  checkIn: CheckInResult | null;
+  onAccept: (_id: number) => void | Promise<void>;
+  onDismiss: (_id: number) => void | Promise<void>;
+}
+
+/** The settled confirmation shown once a suggestion is accepted. */
+function AcceptedCard({
+  id,
+  checkIn,
+}: {
+  id: number;
+  checkIn: CheckInResult | null;
+}): React.JSX.Element {
+  const streak = streakLabel(checkIn);
+  return (
+    <View style={styles.card} testID={`suggestion-${id}`}>
+      <Text style={styles.checked} testID={`suggestion-${id}-checked`}>
+        {CHECKED_LABEL}
+        {streak ? <Text style={styles.streak}>{`  ${streak}`}</Text> : null}
+      </Text>
+    </View>
+  );
+}
+
+/** OK / Not now buttons; OK shows "Checking…" + disables both while in-flight. */
+function SuggestionActions({
+  suggestion,
+  accepting,
+  onAccept,
+  onDismiss,
+  press,
+}: {
+  suggestion: CompletionSuggestion;
+  accepting: boolean;
+  onAccept: () => void;
+  onDismiss: () => void;
+  press: ReturnType<typeof usePressScale>;
+}): React.JSX.Element {
+  return (
+    <View style={styles.actions}>
+      <TouchableOpacity
+        style={[styles.button, styles.accept, accepting && styles.disabled]}
+        onPress={onAccept}
+        onPressIn={press.onPressIn}
+        onPressOut={press.onPressOut}
+        disabled={accepting}
+        accessibilityRole="button"
+        accessibilityLabel={`Check off ${suggestion.label}`}
+        accessibilityState={{ disabled: accepting }}
+        testID={`suggestion-${suggestion.id}-accept`}
+      >
+        <Text style={styles.acceptText}>{accepting ? CHECKING_LABEL : OK_LABEL}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[styles.button, accepting && styles.disabled]}
+        onPress={onDismiss}
+        disabled={accepting}
+        accessibilityRole="button"
+        accessibilityLabel={`Dismiss the suggestion to check off ${suggestion.label}`}
+        accessibilityState={{ disabled: accepting }}
+        testID={`suggestion-${suggestion.id}-dismiss`}
+      >
+        <Text style={styles.dismissText}>{DISMISS_LABEL}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+/** The pending question with OK / Not now (and the in-flight "Checking…"). */
+function PendingCard({
+  suggestion,
+  onAccept,
+  onDismiss,
+}: Omit<CompletionSuggestionNoteProps, 'checkIn'>): React.JSX.Element {
+  const press = usePressScale(useReducedMotion());
+  const [accepting, setAccepting] = useState(false);
+
+  const handleAccept = async (): Promise<void> => {
+    if (accepting) return; // double-tap guard
+    setAccepting(true);
+    try {
+      await onAccept(suggestion.id);
+    } finally {
+      setAccepting(false);
+    }
+  };
+
+  return (
+    <Animated.View style={{ transform: [{ scale: press.scale }] }}>
+      <View style={styles.card} testID={`suggestion-${suggestion.id}`}>
+        <Text style={styles.question}>
+          {QUESTION_PREFIX}
+          <Text style={styles.label}>{suggestion.label}</Text>
+          {QUESTION_SUFFIX}
+        </Text>
+        <SuggestionActions
+          suggestion={suggestion}
+          accepting={accepting}
+          onAccept={handleAccept}
+          onDismiss={() => onDismiss(suggestion.id)}
+          press={press}
+        />
+      </View>
+    </Animated.View>
+  );
+}
+
+function CompletionSuggestionNote({
+  suggestion,
+  checkIn,
+  onAccept,
+  onDismiss,
+}: CompletionSuggestionNoteProps): React.JSX.Element | null {
+  if (suggestion.status === 'dismissed') return null;
+  if (suggestion.status === 'accepted') {
+    return <AcceptedCard id={suggestion.id} checkIn={checkIn} />;
+  }
+  return <PendingCard suggestion={suggestion} onAccept={onAccept} onDismiss={onDismiss} />;
+}
+
+const styles = StyleSheet.create({
+  card: {
+    minHeight: touchTarget.minimum,
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.paper.background,
+    borderLeftWidth: 3,
+    borderLeftColor: colors.tier.clear,
+    ...paperShadow.card,
+  },
+  question: {
+    ...editorialType.marginNote,
+    color: colors.paper.ink,
+  },
+  label: {
+    fontWeight: '700',
+  },
+  actions: {
+    flexDirection: 'row',
+    paddingTop: spacing(1),
+  },
+  button: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: SPACING.sm,
+  },
+  accept: {
+    backgroundColor: colors.tier.clear,
+  },
+  acceptText: {
+    ...editorialType.caption,
+    color: colors.paper.background,
+    fontWeight: '600',
+  },
+  dismissText: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  checked: {
+    ...editorialType.marginNote,
+    color: colors.paper.ink,
+    fontWeight: '600',
+  },
+  streak: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+});
+
+export default CompletionSuggestionNote;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import CompletionSuggestionNote from './CompletionSuggestionNote';
 import EditConfirmDialog from './EditConfirmDialog';
 import GetResonanceButton, { shouldShowResonance } from './GetResonanceButton';
 import HighlightedBody from './HighlightedBody';
@@ -29,7 +30,13 @@ import ResonanceEssayModal from './ResonanceEssayModal';
 import { useResonance } from './useResonance';
 
 import { journal, prompts } from '@/api';
-import type { EntryStatus, JournalMessage, Marginalia } from '@/api';
+import type {
+  CheckInResult,
+  CompletionSuggestion,
+  EntryStatus,
+  JournalMessage,
+  Marginalia,
+} from '@/api';
 import { Button } from '@/components/Button';
 import { colors } from '@/design/tokens';
 import { useIdle } from '@/hooks/useIdle';
@@ -404,20 +411,52 @@ function ReadColumn({
   );
 }
 
-/** The stack of margin notes, ordered by anchor position. */
-function MarginNoteList({
-  notes,
-  onOpen,
-}: {
+type MarginItem =
+  | { key: string; anchor: number; note: Marginalia }
+  | { key: string; anchor: number; suggestion: CompletionSuggestion };
+
+/** Literary notes + actionable suggestions interleaved by anchor position. */
+interface MarginStreamProps {
   notes: Marginalia[];
+  suggestions: CompletionSuggestion[];
+  acceptedCheckIns: Record<number, CheckInResult>;
   onOpen: (_note: Marginalia) => void;
-}) {
-  const ordered = [...notes].sort((a, b) => a.anchor_start - b.anchor_start);
+  onAccept: (_id: number) => void | Promise<void>;
+  onDismiss: (_id: number) => void | Promise<void>;
+}
+
+function buildMarginItems(notes: Marginalia[], suggestions: CompletionSuggestion[]): MarginItem[] {
+  const items: MarginItem[] = [
+    ...notes.map((note) => ({ key: `note-${note.id}`, anchor: note.anchor_start, note })),
+    ...suggestions
+      .filter((s) => s.status !== 'dismissed')
+      .map((s) => ({ key: `suggestion-${s.id}`, anchor: s.anchor_start, suggestion: s })),
+  ];
+  return items.sort((a, b) => a.anchor - b.anchor);
+}
+
+function MarginStream({
+  notes,
+  suggestions,
+  acceptedCheckIns,
+  onOpen,
+  onAccept,
+  onDismiss,
+}: MarginStreamProps) {
   return (
     <>
-      {ordered.map((note) => (
-        <View key={note.id} style={styles.marginNoteSlot}>
-          <MarginNote note={note} onOpen={onOpen} />
+      {buildMarginItems(notes, suggestions).map((item) => (
+        <View key={item.key} style={styles.marginNoteSlot}>
+          {'note' in item ? (
+            <MarginNote note={item.note} onOpen={onOpen} />
+          ) : (
+            <CompletionSuggestionNote
+              suggestion={item.suggestion}
+              checkIn={acceptedCheckIns[item.suggestion.id] ?? null}
+              onAccept={onAccept}
+              onDismiss={onDismiss}
+            />
+          )}
         </View>
       ))}
     </>
@@ -603,11 +642,22 @@ function JournalPage({
   const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
   const settle = useSettleIn(useReducedMotion());
   const notes = ctl.resonance.marginalia;
+  const suggestions = ctl.resonance.suggestions;
+  const hasVisibleSuggestions = suggestions.some((s) => s.status !== 'dismissed');
 
   let marginContent: React.ReactNode;
   if (renderMargin) marginContent = renderMargin({ body: ctl.autosave.body, isIdle: ctl.isIdle });
-  else if (notes.length > 0) {
-    marginContent = <MarginNoteList notes={notes} onOpen={ctl.modal.onOpenNote} />;
+  else if (notes.length > 0 || hasVisibleSuggestions) {
+    marginContent = (
+      <MarginStream
+        notes={notes}
+        suggestions={suggestions}
+        acceptedCheckIns={ctl.resonance.acceptedCheckIns}
+        onOpen={ctl.modal.onOpenNote}
+        onAccept={ctl.resonance.acceptSuggestion}
+        onDismiss={ctl.resonance.dismissSuggestion}
+      />
+    );
   } else marginContent = <ResonanceMargin error={ctl.resonance.error} />;
 
   return (

--- a/frontend/src/features/Journal/__tests__/CompletionSuggestionNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/CompletionSuggestionNote.test.tsx
@@ -1,0 +1,126 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import CompletionSuggestionNote from '../CompletionSuggestionNote';
+
+import type { CheckInResult, CompletionSuggestion } from '@/api';
+import { touchTarget } from '@/design/tokens';
+
+function suggestion(overrides: Partial<CompletionSuggestion> = {}): CompletionSuggestion {
+  return {
+    id: 7,
+    journal_entry_id: 1,
+    target_type: 'habit',
+    goal_id: 42,
+    user_practice_id: null,
+    label: 'Daily run',
+    anchor_start: 0,
+    anchor_end: 9,
+    anchor_text: 'Daily run',
+    status: 'pending',
+    accepted_at: null,
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+const checkIn = (streak: number): CheckInResult => ({
+  streak,
+  milestones: [],
+  reason_code: 'streak_incremented',
+});
+
+const noop = () => Promise.resolve();
+
+describe('CompletionSuggestionNote', () => {
+  it('pending: renders the label question + OK / Not now with 44dp targets', () => {
+    const { getByTestId, getByText } = render(
+      <CompletionSuggestionNote
+        suggestion={suggestion()}
+        checkIn={null}
+        onAccept={noop}
+        onDismiss={noop}
+      />,
+    );
+    expect(getByText('Daily run')).toBeTruthy();
+    const ok = getByTestId('suggestion-7-accept');
+    const not = getByTestId('suggestion-7-dismiss');
+    expect(getByText('OK')).toBeTruthy();
+    expect(getByText('Not now')).toBeTruthy();
+    for (const btn of [ok, not]) {
+      expect(StyleSheetMin(btn)).toBeGreaterThanOrEqual(touchTarget.minimum);
+    }
+  });
+
+  it('OK calls onAccept(id), shows "Checking…", and guards double-tap', async () => {
+    let resolve: (() => void) | undefined;
+    const onAccept = jest.fn(() => new Promise<void>((r) => (resolve = () => r())));
+    const { getByTestId, getByText } = render(
+      <CompletionSuggestionNote
+        suggestion={suggestion({ id: 9 })}
+        checkIn={null}
+        onAccept={onAccept}
+        onDismiss={noop}
+      />,
+    );
+    fireEvent.press(getByTestId('suggestion-9-accept'));
+    expect(onAccept).toHaveBeenCalledWith(9);
+    expect(getByText('Checking…')).toBeTruthy();
+    // Second tap while in-flight is ignored (disabled).
+    fireEvent.press(getByTestId('suggestion-9-accept'));
+    expect(onAccept).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolve?.();
+    });
+  });
+
+  it('accepted: renders the confirmation + streak from check_in', () => {
+    const { getByTestId, getByText } = render(
+      <CompletionSuggestionNote
+        suggestion={suggestion({ status: 'accepted' })}
+        checkIn={checkIn(4)}
+        onAccept={noop}
+        onDismiss={noop}
+      />,
+    );
+    expect(getByTestId('suggestion-7-checked')).toBeTruthy();
+    expect(getByText(/Checked off/)).toBeTruthy();
+    expect(getByText(/4-day streak/)).toBeTruthy();
+  });
+
+  it('Not now calls onDismiss(id)', () => {
+    const onDismiss = jest.fn(() => Promise.resolve());
+    const { getByTestId } = render(
+      <CompletionSuggestionNote
+        suggestion={suggestion({ id: 12 })}
+        checkIn={null}
+        onAccept={noop}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.press(getByTestId('suggestion-12-dismiss'));
+    expect(onDismiss).toHaveBeenCalledWith(12);
+  });
+
+  it('dismissed: renders nothing', () => {
+    const { queryByTestId } = render(
+      <CompletionSuggestionNote
+        suggestion={suggestion({ status: 'dismissed' })}
+        checkIn={null}
+        onAccept={noop}
+        onDismiss={noop}
+      />,
+    );
+    expect(queryByTestId('suggestion-7')).toBeNull();
+  });
+});
+
+/** Smallest of the flattened minHeight/minWidth on a pressable, for 44dp checks. */
+function StyleSheetMin(node: { props: { style: unknown } }): number {
+  const { StyleSheet } = require('react-native');
+  const flat = StyleSheet.flatten(node.props.style) as { minHeight?: number; minWidth?: number };
+  return Math.min(flat.minHeight ?? 0, flat.minWidth ?? 0);
+}

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -14,6 +14,7 @@ import {
   useRef,
   useState,
   type Dispatch,
+  type MutableRefObject,
   type SetStateAction,
 } from 'react';
 
@@ -36,6 +37,8 @@ export interface UseResonanceResult {
   suggestions: CompletionSuggestion[];
   /** The check-in (streak + milestones) from the most recent accept, if any. */
   lastCheckIn: CheckInResult | null;
+  /** Check-in (streak) per accepted suggestion id, for the confirmed card. */
+  acceptedCheckIns: Record<number, CheckInResult>;
   loading: boolean;
   error: string | null;
   requestResonance: () => Promise<void>;
@@ -93,6 +96,8 @@ function useLoadOnOpen<T>(
 interface SuggestionsApi {
   suggestions: CompletionSuggestion[];
   lastCheckIn: CheckInResult | null;
+  /** Check-in (streak) per accepted suggestion id, for the confirmed card. */
+  acceptedCheckIns: Record<number, CheckInResult>;
   mergeFromGenerate: (_incoming: CompletionSuggestion[]) => void;
   acceptSuggestion: (_id: number) => Promise<void>;
   dismissSuggestion: (_id: number) => Promise<void>;
@@ -102,6 +107,7 @@ interface SuggestionsApi {
 function useSuggestions(routeEntryId: number | null, setError: SetError): SuggestionsApi {
   const [suggestions, setSuggestions] = useState<CompletionSuggestion[]>([]);
   const [lastCheckIn, setLastCheckIn] = useState<CheckInResult | null>(null);
+  const [acceptedCheckIns, setAcceptedCheckIns] = useState<Record<number, CheckInResult>>({});
   const pendingIdsRef = useRef<Set<number>>(new Set());
 
   useLoadOnOpen(routeEntryId, completionSuggestions.list, setSuggestions);
@@ -111,41 +117,79 @@ function useSuggestions(routeEntryId: number | null, setError: SetError): Sugges
   }, []);
 
   const acceptSuggestion = useCallback(
-    async (id: number): Promise<void> => {
-      if (pendingIdsRef.current.has(id)) return; // per-id guard — no double-log
-      pendingIdsRef.current.add(id);
-      try {
-        const result = await completionSuggestions.accept(id);
-        setSuggestions((prev) => mergeSuggestionsById(prev, [result.suggestion]));
-        setLastCheckIn(result.check_in);
-      } catch (err) {
-        setError(formatApiError(err)); // row stays pending; user can retry
-      } finally {
-        pendingIdsRef.current.delete(id);
-      }
-    },
+    (id: number) =>
+      runAccept(id, {
+        pendingIdsRef,
+        setSuggestions,
+        setLastCheckIn,
+        setAcceptedCheckIns,
+        setError,
+      }),
     [setError],
   );
 
   const dismissSuggestion = useCallback(
-    async (id: number): Promise<void> => {
-      if (pendingIdsRef.current.has(id)) return;
-      pendingIdsRef.current.add(id);
-      const snapshot = suggestions;
-      setSuggestions(snapshot.filter((s) => s.id !== id)); // optimistic
-      try {
-        await completionSuggestions.dismiss(id);
-      } catch (err) {
-        setSuggestions(snapshot); // revert
-        setError(formatApiError(err));
-      } finally {
-        pendingIdsRef.current.delete(id);
-      }
-    },
+    (id: number) => runDismiss(id, suggestions, { pendingIdsRef, setSuggestions, setError }),
     [suggestions, setError],
   );
 
-  return { suggestions, lastCheckIn, mergeFromGenerate, acceptSuggestion, dismissSuggestion };
+  return {
+    suggestions,
+    lastCheckIn,
+    acceptedCheckIns,
+    mergeFromGenerate,
+    acceptSuggestion,
+    dismissSuggestion,
+  };
+}
+
+interface AcceptDeps {
+  pendingIdsRef: MutableRefObject<Set<number>>;
+  setSuggestions: Dispatch<SetStateAction<CompletionSuggestion[]>>;
+  setLastCheckIn: Dispatch<SetStateAction<CheckInResult | null>>;
+  setAcceptedCheckIns: Dispatch<SetStateAction<Record<number, CheckInResult>>>;
+  setError: SetError;
+}
+
+/** Accept a suggestion: per-id guarded; logs the completion, flips to accepted. */
+async function runAccept(id: number, deps: AcceptDeps): Promise<void> {
+  if (deps.pendingIdsRef.current.has(id)) return; // per-id guard — no double-log
+  deps.pendingIdsRef.current.add(id);
+  try {
+    const result = await completionSuggestions.accept(id);
+    deps.setSuggestions((prev) => mergeSuggestionsById(prev, [result.suggestion]));
+    deps.setLastCheckIn(result.check_in);
+    deps.setAcceptedCheckIns((prev) => ({ ...prev, [id]: result.check_in }));
+  } catch (err) {
+    deps.setError(formatApiError(err)); // row stays pending; user can retry
+  } finally {
+    deps.pendingIdsRef.current.delete(id);
+  }
+}
+
+interface DismissDeps {
+  pendingIdsRef: MutableRefObject<Set<number>>;
+  setSuggestions: Dispatch<SetStateAction<CompletionSuggestion[]>>;
+  setError: SetError;
+}
+
+/** Dismiss a suggestion: per-id guarded; optimistic remove, revert on error. */
+async function runDismiss(
+  id: number,
+  snapshot: CompletionSuggestion[],
+  deps: DismissDeps,
+): Promise<void> {
+  if (deps.pendingIdsRef.current.has(id)) return;
+  deps.pendingIdsRef.current.add(id);
+  deps.setSuggestions(snapshot.filter((s) => s.id !== id)); // optimistic
+  try {
+    await completionSuggestions.dismiss(id);
+  } catch (err) {
+    deps.setSuggestions(snapshot); // revert
+    deps.setError(formatApiError(err));
+  } finally {
+    deps.pendingIdsRef.current.delete(id);
+  }
 }
 
 interface GeneratePass {
@@ -219,6 +263,7 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     marginalia,
     suggestions: sug.suggestions,
     lastCheckIn: sug.lastCheckIn,
+    acceptedCheckIns: sug.acceptedCheckIns,
     loading,
     error,
     requestResonance,


### PR DESCRIPTION
## Summary

#820 (epic #822): pressing **Get Resonance** now pops an actionable card into the margin next to the sentence — *"You wrote about **{label}**. Check it off?"* — with **OK** and a quiet **Not now**, rendered as marginalia **interleaved by anchor**.

- `CompletionSuggestionNote.tsx` (sibling to `MarginNote`, **tokens-only**, reduced-motion-safe): pending (question + OK + Not now, ≥44dp, a11y, `suggestion-*` testIDs), accepting (disabled + "Checking…"), accepted ("✓ Checked off" + N-day streak from `check_in`), dismissed (renders nothing).
- `JournalEntryScreen`: `buildMarginItems` merges literary notes + non-dismissed suggestions **sorted by `anchor_start`**; wires `onAccept`/`onDismiss`; `marginNoteSlot` + `RESONANCE_BUTTON_CLEARANCE` untouched.
- `useResonance`: `acceptedCheckIns` per-id (additive; `lastCheckIn` kept for #819 tests).

## Test plan

5 tests: pending label + OK/Not-now + 44dp; OK → onAccept + "Checking…" + **double-tap guard**; accepted confirmation + streak; Not now → onDismiss; dismissed renders nothing. Existing Journal/MarginNote/useResonance tests green. `./scripts/frontend/check-all.sh` 4/4; no `any`, no inline hex.

Closes #820
Refs #822
