### PR TITLE
feat: check off practices from the journal resonance pass

### DIFF
--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from sqlalchemy import ColumnElement, func
@@ -16,6 +16,7 @@ from database import get_session
 from dependencies.ownership import require_owned_journal_entry
 from dependencies.timezone import current_user_timezone
 from domain.detection import CompletionDetected, detect_completions
+from domain.practice_resolution import effective_config
 from domain.resonance import MarginaliaAnchored, generate_essay, generate_marginalia
 from errors import conflict, not_found, unprocessable
 from models.completion_suggestion import (
@@ -27,6 +28,9 @@ from models.goal import Goal
 from models.habit import Habit
 from models.journal_entry import JournalEntry, JournalTag
 from models.marginalia import Marginalia, MarginaliaStatus
+from models.practice import Practice
+from models.practice_session import PracticeSession
+from models.user_practice import UserPractice
 from rate_limit import limiter
 from routers.auth import get_current_user
 from schemas.completion_suggestion import (
@@ -56,6 +60,7 @@ from services.marginalia import (
     reanchor_entry_marginalia,
     reanchor_entry_suggestions,
 )
+from services.practice_session_idempotency import record_session, recorded_session_id
 from services.usage import get_monthly_cap
 from services.wallet import preflight_deduction, require_user_fresh
 
@@ -387,7 +392,7 @@ async def _detect_and_persist_suggestions(
     is swallowed (returns ``[]``) so the literary pass, the wallet charge, and the
     commit are never rolled back — detection is strictly additive.
     """
-    candidates = await gather_candidates(session, user_id)
+    candidates = await gather_candidates(session, user_id, include_practices=True)
     if not candidates:
         return []
     try:
@@ -572,6 +577,79 @@ async def _accept_pending_habit(
     return AcceptSuggestionResponse(suggestion=_suggestion_response(suggestion), check_in=check_in)
 
 
+# Positive fallback so a journal-attested session (no recorded duration) still
+# counts toward weekly totals when the resolved config carries no duration.
+_JOURNAL_ATTESTED_FALLBACK_MINUTES = 1.0
+
+
+async def _resolve_suggestion_practice(
+    session: AsyncSession, suggestion: CompletionSuggestion, current_user: int
+) -> tuple[UserPractice, Practice]:
+    """Load the suggestion's UserPractice (ownership-scoped) + its catalog Practice."""
+    user_practice = await session.get(UserPractice, suggestion.user_practice_id)
+    if user_practice is None or user_practice.user_id != current_user:
+        raise not_found("completion_suggestion")
+    practice = await session.get(Practice, user_practice.practice_id)
+    if practice is None:
+        raise not_found("completion_suggestion")
+    return user_practice, practice
+
+
+def _attested_duration(practice: Practice, user_practice: UserPractice) -> float:
+    """Resolved-config duration if positive, else a positive fallback."""
+    duration = getattr(effective_config(practice, user_practice), "duration_minutes", None)
+    if isinstance(duration, (int, float)) and duration > 0:
+        return float(duration)
+    return _JOURNAL_ATTESTED_FALLBACK_MINUTES
+
+
+async def _accept_pending_practice(
+    session: AsyncSession, suggestion: CompletionSuggestion, current_user: int
+) -> AcceptSuggestionResponse:
+    """Log a journal-attested PracticeSession for a pending practice suggestion.
+
+    Idempotent via the practice-session spend layer keyed
+    ``accept-suggestion:practice:{id}`` (already recorded ⇒ no second session),
+    backstopping the suggestion-status guard. Practices carry no streak, so
+    ``check_in`` is ``None``.
+    """
+    user_practice, practice = await _resolve_suggestion_practice(session, suggestion, current_user)
+    key = f"accept-suggestion:practice:{suggestion.id}"
+    if await recorded_session_id(session, current_user, key) is None:
+        practice_session = PracticeSession(
+            user_id=current_user,
+            user_practice_id=cast("int", user_practice.id),
+            duration_minutes=_attested_duration(practice, user_practice),
+            mode=practice.mode,
+            mode_metadata={"attested_via": "journal", "mode": practice.mode},
+            completed=True,
+        )
+        session.add(practice_session)
+        await session.flush()
+        await record_session(session, current_user, key, cast("int", practice_session.id))
+    suggestion.status = SuggestionStatus.ACCEPTED
+    suggestion.accepted_at = datetime.now(UTC)
+    session.add(suggestion)
+    await session.commit()
+    await session.refresh(suggestion)
+    return AcceptSuggestionResponse(suggestion=_suggestion_response(suggestion), check_in=None)
+
+
+async def _already_accepted_response(
+    session: AsyncSession, suggestion: CompletionSuggestion, current_user: int, user_tz: str
+) -> AcceptSuggestionResponse:
+    """Idempotent response for an already-accepted suggestion (no new write).
+
+    Habits re-derive the current streak; practices have none (``check_in=None``).
+    """
+    if suggestion.target_type == CompletionTargetType.PRACTICE:
+        return AcceptSuggestionResponse(suggestion=_suggestion_response(suggestion), check_in=None)
+    goal, habit = await _resolve_suggestion_goal(session, suggestion, current_user)
+    ctx = CheckInContext(goal=goal, habit=habit, user_id=current_user, user_timezone=user_tz)
+    check_in = await current_check_in(session, ctx)
+    return AcceptSuggestionResponse(suggestion=_suggestion_response(suggestion), check_in=check_in)
+
+
 @router.post("/suggestions/{suggestion_id}/accept", response_model=AcceptSuggestionResponse)
 async def accept_suggestion(
     suggestion_id: int,
@@ -579,28 +657,23 @@ async def accept_suggestion(
     session: Annotated[AsyncSession, Depends(get_session)],
     user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> AcceptSuggestionResponse:
-    """Accept a pending habit suggestion: log today's completion + flip to accepted.
+    """Accept a pending suggestion: log the completion + flip to accepted.
 
-    Ownership-scoped (404). Practice targets are an explicit 422 until #821.
-    Re-accepting an already-accepted suggestion is an idempotent no-op (no second
-    completion); accepting a dismissed one is a 409 illegal transition. The
-    check-in goes through the shared ``record_goal_completion`` (idempotent per
-    goal/day, so a same-day manual check-in is not double-counted).
+    Ownership-scoped (404). A habit logs today's completion via the shared
+    ``record_goal_completion`` (idempotent per goal/day) and returns its streak; a
+    practice logs a journal-attested ``PracticeSession`` (idempotent, no streak).
+    Re-accepting an accepted one is an idempotent no-op; accepting a dismissed one
+    is a 409 illegal transition.
     """
     suggestion = await _load_user_suggestion(session, suggestion_id, current_user)
     if suggestion is None:
         raise not_found("completion_suggestion")
-    if suggestion.target_type == CompletionTargetType.PRACTICE:
-        raise unprocessable("practice_accept_not_supported")
     if suggestion.status == SuggestionStatus.DISMISSED:
         raise conflict("suggestion_dismissed")
     if suggestion.status == SuggestionStatus.ACCEPTED:
-        goal, habit = await _resolve_suggestion_goal(session, suggestion, current_user)
-        ctx = CheckInContext(goal=goal, habit=habit, user_id=current_user, user_timezone=user_tz)
-        check_in = await current_check_in(session, ctx)
-        return AcceptSuggestionResponse(
-            suggestion=_suggestion_response(suggestion), check_in=check_in
-        )
+        return await _already_accepted_response(session, suggestion, current_user, user_tz)
+    if suggestion.target_type == CompletionTargetType.PRACTICE:
+        return await _accept_pending_practice(session, suggestion, current_user)
     return await _accept_pending_habit(session, suggestion, current_user, user_tz)
 
 

--- a/backend/src/schemas/completion_suggestion.py
+++ b/backend/src/schemas/completion_suggestion.py
@@ -40,7 +40,11 @@ class CompletionSuggestionListResponse(BaseModel):
 
 
 class AcceptSuggestionResponse(BaseModel):
-    """The accepted suggestion plus the check-in it logged (streak + milestones)."""
+    """The accepted suggestion plus the check-in it logged (streak + milestones).
+
+    ``check_in`` is ``None`` for practice targets — a journal-attested
+    ``PracticeSession`` carries no streak (#821).
+    """
 
     suggestion: CompletionSuggestionResponse
-    check_in: CheckInResult
+    check_in: CheckInResult | None = None

--- a/backend/src/services/completion_candidates.py
+++ b/backend/src/services/completion_candidates.py
@@ -2,8 +2,8 @@
 
 Turns the caller's current habits into the ``DetectionCandidate`` list that
 :func:`domain.detection.detect_completions` consumes, so the check-off endpoint
-(#817) stays thin. Habits only for now; practices ride a dormant
-``include_practices`` flag that issue #821 fills in.
+(#817) stays thin. Covers habits and, with ``include_practices``, the user's
+active practices too (#821) — sharing one candidate budget.
 """
 
 from __future__ import annotations
@@ -14,17 +14,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from domain.detection import DetectionCandidate
+from domain.practice_resolution import effective_name
 from load_options import HABIT_WITH_GOALS
 from models.goal import Goal, GoalTier
 from models.habit import Habit
+from models.practice import Practice
+from models.user_practice import UserPractice
 
 logger = logging.getLogger(__name__)
 
 # Upper bound on the candidate list handed to the LLM, to keep the prompt (and
-# its cost) bounded for users with many habits.
+# its cost) bounded for users with many habits + practices (shared budget).
 MAX_CANDIDATES = 25
 
 _HABIT_TARGET = "habit"
+_PRACTICE_TARGET = "practice"
 
 
 def _pick_representative(goals: list[Goal]) -> Goal | None:
@@ -77,6 +81,37 @@ def _habit_candidates(habits: list[Habit]) -> list[DetectionCandidate]:
     return candidates
 
 
+async def _practice_candidates(
+    session: AsyncSession, user_id: int, *, start_index: int
+) -> list[DetectionCandidate]:
+    """The user's active practices as candidates, dense-indexed after the habits.
+
+    A practice is active while ``end_date IS NULL``; its display name is the
+    user's custom name or the catalog name (:func:`effective_name`). The target
+    is the ``UserPractice`` row, so accept logs a journal-attested
+    ``PracticeSession`` against it (#821).
+    """
+    result = await session.execute(
+        select(UserPractice, Practice)
+        .join(Practice, col(Practice.id) == UserPractice.practice_id)
+        .where(UserPractice.user_id == user_id, col(UserPractice.end_date).is_(None))
+        .order_by(col(UserPractice.id)),
+    )
+    candidates: list[DetectionCandidate] = []
+    for user_practice, practice in result.all():
+        if user_practice.id is None:
+            continue
+        candidates.append(
+            DetectionCandidate(
+                index=start_index + len(candidates),
+                target_type=_PRACTICE_TARGET,
+                target_id=user_practice.id,
+                name=effective_name(practice, user_practice),
+            ),
+        )
+    return candidates
+
+
 def _capped(candidates: list[DetectionCandidate], user_id: int) -> list[DetectionCandidate]:
     """Truncate to :data:`MAX_CANDIDATES`, warning when habits are dropped."""
     if len(candidates) <= MAX_CANDIDATES:
@@ -100,9 +135,10 @@ async def gather_candidates(
     per habit (clear-tier, else first), skips goal-less habits, stamps dense
     0-based indices in habit-id order, and truncates to :data:`MAX_CANDIDATES`.
 
-    ``include_practices`` is a dormant seam (default off) wired up by issue #821:
-    journal-attested PracticeSessions will become candidates here. It is a no-op
-    today so the endpoint (#817) can already pass the flag through.
+    With ``include_practices`` (default off), the user's active practices are
+    appended after the habits, sharing the same :data:`MAX_CANDIDATES` budget and
+    continuing the dense index, so accept can log a journal-attested
+    PracticeSession against the resolved UserPractice (#821).
     """
     result = await session.execute(
         select(Habit)
@@ -111,5 +147,7 @@ async def gather_candidates(
         .order_by(col(Habit.id)),
     )
     habits = list(result.scalars().all())
-    _ = include_practices  # dormant until #821
-    return _capped(_habit_candidates(habits), user_id)
+    candidates = _habit_candidates(habits)
+    if include_practices:
+        candidates += await _practice_candidates(session, user_id, start_index=len(candidates))
+    return _capped(candidates, user_id)

--- a/backend/tests/services/test_completion_candidates.py
+++ b/backend/tests/services/test_completion_candidates.py
@@ -15,7 +15,9 @@ from sqlmodel import select
 from conftest import test_engine
 from models.goal import Goal
 from models.habit import Habit
+from models.practice import Practice
 from models.user import User
+from models.user_practice import UserPractice
 from services.completion_candidates import (
     MAX_CANDIDATES,
     gather_candidates,
@@ -175,15 +177,44 @@ async def test_caps_at_max_candidates_and_warns(
     assert any("truncated" in r.message for r in caplog.records)
 
 
+async def _active_practice(session: AsyncSession, user_id: int, name: str) -> int:
+    """Seed a Practice + active UserPractice; return the user_practice id."""
+    practice = Practice(
+        stage_number=1,
+        name=name,
+        description="x",
+        instructions="x",
+        default_duration_minutes=10.0,
+        mode="meditation_timer",
+        mode_config={"mode": "meditation_timer", "duration_minutes": 10},
+    )
+    session.add(practice)
+    await session.commit()
+    await session.refresh(practice)
+    user_practice = UserPractice(
+        user_id=user_id, practice_id=practice.id, stage_number=1, start_date=date(2025, 1, 1)
+    )
+    session.add(user_practice)
+    await session.commit()
+    await session.refresh(user_practice)
+    assert user_practice.id is not None
+    return user_practice.id
+
+
 @pytest.mark.asyncio
-async def test_include_practices_is_dormant(db_session: AsyncSession) -> None:
+async def test_include_practices_adds_active_practices(db_session: AsyncSession) -> None:
     user_id = await _user(db_session)
     await _habit(db_session, user_id, "Only habit", tiers=("clear",))
+    up_id = await _active_practice(db_session, user_id, "Morning sit")
 
     off = await gather_candidates(db_session, user_id, include_practices=False)
     on = await gather_candidates(db_session, user_id, include_practices=True)
 
-    assert [c.name for c in on] == [c.name for c in off] == ["Only habit"]
+    assert [c.name for c in off] == ["Only habit"]  # practices excluded by default
+    assert [c.name for c in on] == ["Only habit", "Morning sit"]  # appended, shared budget
+    practice = next(c for c in on if c.target_type == "practice")
+    assert practice.target_id == up_id
+    assert practice.index == 1  # dense index continues after the habit
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_completion_accept_dismiss.py
+++ b/backend/tests/test_completion_accept_dismiss.py
@@ -20,6 +20,7 @@ from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from models.practice import Practice
+from models.practice_session import PracticeSession
 from models.user import User
 from models.user_practice import UserPractice
 
@@ -232,16 +233,11 @@ async def test_accept_dismissed_is_conflict(
     assert resp.status_code == HTTPStatus.CONFLICT
 
 
-@pytest.mark.asyncio
-async def test_accept_practice_is_unsupported(
-    async_client: AsyncClient, db_session: AsyncSession
-) -> None:
-    """Accepting a practice suggestion is an explicit 422 placeholder for #821."""
-    headers = await _signup(async_client)
-    user_id = await _user_id(db_session)
-    entry_id = await _create_entry(async_client, headers)
-    user_practice_id = await _seed_user_practice(db_session, user_id)
-    practice_suggestion = CompletionSuggestion(
+async def _seed_practice_suggestion(
+    session: AsyncSession, *, entry_id: int, user_id: int, user_practice_id: int
+) -> int:
+    """Seed a pending PRACTICE suggestion targeting ``user_practice_id``."""
+    suggestion = CompletionSuggestion(
         journal_entry_id=entry_id,
         user_id=user_id,
         target_type=CompletionTargetType.PRACTICE,
@@ -253,16 +249,72 @@ async def test_accept_practice_is_unsupported(
         anchor_text="I sat",
         status=SuggestionStatus.PENDING,
     )
-    db_session.add(practice_suggestion)
-    await db_session.commit()
-    await db_session.refresh(practice_suggestion)
+    session.add(suggestion)
+    await session.commit()
+    await session.refresh(suggestion)
+    assert suggestion.id is not None
+    return suggestion.id
 
-    resp = await async_client.post(
-        f"/journal/suggestions/{practice_suggestion.id}/accept", headers=headers
+
+async def _practice_session_count(session: AsyncSession, user_practice_id: int) -> int:
+    result = await session.execute(
+        select(func.count())
+        .select_from(PracticeSession)
+        .where(col(PracticeSession.user_practice_id) == user_practice_id)
+    )
+    return int(result.scalar_one())
+
+
+@pytest.mark.asyncio
+async def test_accept_practice_logs_journal_attested_session(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Accepting a practice logs a completed, journal-attested PracticeSession (#821)."""
+    headers = await _signup(async_client)
+    user_id = await _user_id(db_session)
+    entry_id = await _create_entry(async_client, headers)
+    up_id = await _seed_user_practice(db_session, user_id)
+    sug_id = await _seed_practice_suggestion(
+        db_session, entry_id=entry_id, user_id=user_id, user_practice_id=up_id
     )
 
-    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    assert resp.json()["detail"] == "practice_accept_not_supported"
+    resp = await async_client.post(f"/journal/suggestions/{sug_id}/accept", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["suggestion"]["status"] == "accepted"
+    assert body["check_in"] is None  # practices carry no streak
+    assert "user_id" not in body["suggestion"]
+    ps = (
+        await db_session.execute(
+            select(PracticeSession).where(col(PracticeSession.user_practice_id) == up_id)
+        )
+    ).scalar_one()
+    assert ps.completed is True
+    assert ps.mode_metadata is not None
+    assert ps.mode_metadata["attested_via"] == "journal"
+
+
+@pytest.mark.asyncio
+async def test_accept_practice_is_idempotent(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Re-accepting a practice suggestion does not log a second session (#821)."""
+    headers = await _signup(async_client)
+    user_id = await _user_id(db_session)
+    entry_id = await _create_entry(async_client, headers)
+    up_id = await _seed_user_practice(db_session, user_id)
+    sug_id = await _seed_practice_suggestion(
+        db_session, entry_id=entry_id, user_id=user_id, user_practice_id=up_id
+    )
+
+    first = await async_client.post(f"/journal/suggestions/{sug_id}/accept", headers=headers)
+    second = await async_client.post(f"/journal/suggestions/{sug_id}/accept", headers=headers)
+
+    assert first.status_code == HTTPStatus.OK
+    assert second.status_code == HTTPStatus.OK
+    assert second.json()["check_in"] is None
+    assert await _practice_session_count(db_session, up_id) == 1
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/__tests__/completionSuggestions.test.ts
+++ b/frontend/src/api/__tests__/completionSuggestions.test.ts
@@ -72,7 +72,7 @@ describe('completionSuggestions.accept', () => {
     expect(init.method).toBe('POST');
     expect(init.headers[IDEMPOTENCY_KEY_HEADER]).toBe('accept-suggestion:1');
     expect(result.suggestion.status).toBe('accepted');
-    expect(result.check_in.streak).toBe(4);
+    expect(result.check_in?.streak).toBe(4);
   });
 
   test('surfaces a 422 (practice accept) as an ApiError', async () => {

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -467,7 +467,8 @@ export const completionSuggestionListResponseSchema = z.object({
 
 export const acceptSuggestionResultSchema = z.object({
   suggestion: completionSuggestionSchema,
-  check_in: checkInResultSchema,
+  // null for practice targets — a journal-attested PracticeSession has no streak (#821).
+  check_in: checkInResultSchema.nullable(),
 });
 
 export type CompletionTargetTypeT = z.infer<typeof completionTargetTypeSchema>;

--- a/frontend/src/features/Journal/CompletionSuggestionNote.tsx
+++ b/frontend/src/features/Journal/CompletionSuggestionNote.tsx
@@ -33,6 +33,7 @@ const OK_LABEL = 'OK';
 const DISMISS_LABEL = 'Not now';
 const CHECKING_LABEL = 'Checking…';
 const CHECKED_LABEL = '✓ Checked off';
+const LOGGED_LABEL = '✓ Logged';
 
 /** "N-day streak" from a check-in, or null when there is no streak to show. */
 function streakLabel(checkIn: CheckInResult | null): string | null {
@@ -48,19 +49,26 @@ export interface CompletionSuggestionNoteProps {
   onDismiss: (_id: number) => void | Promise<void>;
 }
 
-/** The settled confirmation shown once a suggestion is accepted. */
+/** The settled confirmation shown once a suggestion is accepted.
+ *
+ * Habits read "✓ Checked off" + an optional streak; practices read "✓ Logged"
+ * with no streak line (a journal-attested session has none).
+ */
 function AcceptedCard({
   id,
+  targetType,
   checkIn,
 }: {
   id: number;
+  targetType: CompletionSuggestion['target_type'];
   checkIn: CheckInResult | null;
 }): React.JSX.Element {
   const streak = streakLabel(checkIn);
+  const label = targetType === 'practice' ? LOGGED_LABEL : CHECKED_LABEL;
   return (
     <View style={styles.card} testID={`suggestion-${id}`}>
       <Text style={styles.checked} testID={`suggestion-${id}-checked`}>
-        {CHECKED_LABEL}
+        {label}
         {streak ? <Text style={styles.streak}>{`  ${streak}`}</Text> : null}
       </Text>
     </View>
@@ -158,7 +166,9 @@ function CompletionSuggestionNote({
 }: CompletionSuggestionNoteProps): React.JSX.Element | null {
   if (suggestion.status === 'dismissed') return null;
   if (suggestion.status === 'accepted') {
-    return <AcceptedCard id={suggestion.id} checkIn={checkIn} />;
+    return (
+      <AcceptedCard id={suggestion.id} targetType={suggestion.target_type} checkIn={checkIn} />
+    );
   }
   return <PendingCard suggestion={suggestion} onAccept={onAccept} onDismiss={onDismiss} />;
 }

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -419,7 +419,7 @@ type MarginItem =
 interface MarginStreamProps {
   notes: Marginalia[];
   suggestions: CompletionSuggestion[];
-  acceptedCheckIns: Record<number, CheckInResult>;
+  acceptedCheckIns: Record<number, CheckInResult | null>;
   onOpen: (_note: Marginalia) => void;
   onAccept: (_id: number) => void | Promise<void>;
   onDismiss: (_id: number) => void | Promise<void>;

--- a/frontend/src/features/Journal/__tests__/CompletionSuggestionNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/CompletionSuggestionNote.test.tsx
@@ -91,6 +91,21 @@ describe('CompletionSuggestionNote', () => {
     expect(getByText(/4-day streak/)).toBeTruthy();
   });
 
+  it('accepted practice: renders "Logged" with no streak when check_in is null (#821)', () => {
+    const { getByTestId, getByText, queryByText } = render(
+      <CompletionSuggestionNote
+        suggestion={suggestion({ status: 'accepted', target_type: 'practice' })}
+        checkIn={null}
+        onAccept={noop}
+        onDismiss={noop}
+      />,
+    );
+    expect(getByTestId('suggestion-7-checked')).toBeTruthy();
+    expect(getByText(/Logged/)).toBeTruthy();
+    expect(queryByText(/Checked off/)).toBeNull();
+    expect(queryByText(/streak/)).toBeNull();
+  });
+
   it('Not now calls onDismiss(id)', () => {
     const onDismiss = jest.fn(() => Promise.resolve());
     const { getByTestId } = render(

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -38,7 +38,7 @@ export interface UseResonanceResult {
   /** The check-in (streak + milestones) from the most recent accept, if any. */
   lastCheckIn: CheckInResult | null;
   /** Check-in (streak) per accepted suggestion id, for the confirmed card. */
-  acceptedCheckIns: Record<number, CheckInResult>;
+  acceptedCheckIns: Record<number, CheckInResult | null>;
   loading: boolean;
   error: string | null;
   requestResonance: () => Promise<void>;
@@ -97,7 +97,7 @@ interface SuggestionsApi {
   suggestions: CompletionSuggestion[];
   lastCheckIn: CheckInResult | null;
   /** Check-in (streak) per accepted suggestion id, for the confirmed card. */
-  acceptedCheckIns: Record<number, CheckInResult>;
+  acceptedCheckIns: Record<number, CheckInResult | null>;
   mergeFromGenerate: (_incoming: CompletionSuggestion[]) => void;
   acceptSuggestion: (_id: number) => Promise<void>;
   dismissSuggestion: (_id: number) => Promise<void>;
@@ -107,7 +107,9 @@ interface SuggestionsApi {
 function useSuggestions(routeEntryId: number | null, setError: SetError): SuggestionsApi {
   const [suggestions, setSuggestions] = useState<CompletionSuggestion[]>([]);
   const [lastCheckIn, setLastCheckIn] = useState<CheckInResult | null>(null);
-  const [acceptedCheckIns, setAcceptedCheckIns] = useState<Record<number, CheckInResult>>({});
+  const [acceptedCheckIns, setAcceptedCheckIns] = useState<Record<number, CheckInResult | null>>(
+    {},
+  );
   const pendingIdsRef = useRef<Set<number>>(new Set());
 
   useLoadOnOpen(routeEntryId, completionSuggestions.list, setSuggestions);
@@ -147,7 +149,7 @@ interface AcceptDeps {
   pendingIdsRef: MutableRefObject<Set<number>>;
   setSuggestions: Dispatch<SetStateAction<CompletionSuggestion[]>>;
   setLastCheckIn: Dispatch<SetStateAction<CheckInResult | null>>;
-  setAcceptedCheckIns: Dispatch<SetStateAction<Record<number, CheckInResult>>>;
+  setAcceptedCheckIns: Dispatch<SetStateAction<Record<number, CheckInResult | null>>>;
   setError: SetError;
 }
 


### PR DESCRIPTION
## Summary

#821 (epic #822, **final sub-issue**): turn on the practice target type — detect when the writer describes doing one of their practices and let **OK** log a journal-attested `PracticeSession`. Fills the dormant candidate + accept seams.

- `gather_candidates(..., include_practices=True)`: active `UserPractice`s become practice candidates after habits, sharing the `MAX_CANDIDATES=25` budget; name via `effective_name`. `run_resonance` passes `include_practices=True`.
- **Practice accept** (replaces the 422 placeholder): journal-attested `PracticeSession` (`completed=True`, `mode_metadata={"attested_via":"journal",…}`, resolved/fallback `duration_minutes`), **idempotent** via the practice-session spend layer keyed `accept-suggestion:practice:{id}`; flip to accepted. No streak ⇒ `check_in` optional/null end-to-end.
- Card: habit "✓ Checked off" + streak; practice **"✓ Logged"**, no streak line.

## Test plan

Existing practice-session + #818 habit-accept + #820 card tests stay green (check_in-nullable is additive). New: practice accept logs an attested completed session + `check_in` null + idempotent; `include_practices` candidate gathering; card "✓ Logged". `./scripts/backend/check-all.sh` 7/7 + xenon A; `./scripts/frontend/check-all.sh` 4/4.

Closes #821
Refs #822
