### PR TITLE
feat(design): editorial screen scaffold + section rhythm (Act II foundation)

### DIFF
--- a/frontend/src/components/layout/EditorialSection.tsx
+++ b/frontend/src/components/layout/EditorialSection.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+
+import { ink, rhythm, type as typeRamp } from '@/design/tokens';
+
+interface EditorialSectionProps {
+  /** Optional serif section title. */
+  title?: string;
+  children: React.ReactNode;
+  testID?: string;
+}
+
+/**
+ * A titled editorial band (#825): a serif `type().heading` title over its
+ * children, separated from the previous section by `rhythm.sectionGap`.
+ * Token-only and AA on `surface.canvas`.
+ */
+export const EditorialSection = ({
+  title,
+  children,
+  testID,
+}: EditorialSectionProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const t = typeRamp(width);
+  return (
+    <View style={styles.section} testID={testID}>
+      {title ? (
+        <Text style={[t.heading, styles.title]} accessibilityRole="header">
+          {title}
+        </Text>
+      ) : null}
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  section: {
+    marginTop: rhythm.sectionGap,
+  },
+  title: {
+    color: ink.primary,
+    marginBottom: rhythm.blockGap,
+  },
+});
+
+export default EditorialSection;

--- a/frontend/src/components/layout/ScreenHeader.tsx
+++ b/frontend/src/components/layout/ScreenHeader.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+
+import { accent, ink, rhythm, type as typeRamp } from '@/design/tokens';
+
+interface ScreenHeaderProps {
+  /** The serif display title (rendered with `accessibilityRole="header"`). */
+  title: string;
+  /** Small-caps caption above the title. */
+  eyebrow?: string;
+  /** Optional lead paragraph beneath the title. */
+  lead?: string;
+  /** Optional right-aligned action (e.g. a button); should be ≥44dp itself. */
+  action?: React.ReactNode;
+  testID?: string;
+}
+
+const EYEBROW_LETTER_SPACING = 1.5;
+
+/**
+ * Editorial screen header (#825): eyebrow → serif `type().display` title → lead,
+ * with an optional right-aligned action slot. Responsive-scale aware via
+ * `type(width)`; token-only and AA on `surface.canvas`.
+ */
+export const ScreenHeader = ({
+  title,
+  eyebrow,
+  lead,
+  action,
+  testID,
+}: ScreenHeaderProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const t = typeRamp(width);
+  return (
+    <View style={styles.row} testID={testID}>
+      <View style={styles.text}>
+        {eyebrow ? <Text style={[t.caption, styles.eyebrow]}>{eyebrow.toUpperCase()}</Text> : null}
+        <Text style={[t.display, styles.title]} accessibilityRole="header">
+          {title}
+        </Text>
+        {lead ? <Text style={[t.body, styles.lead]}>{lead}</Text> : null}
+      </View>
+      {action ? <View style={styles.action}>{action}</View> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    paddingVertical: rhythm.heroPaddingV,
+  },
+  text: {
+    flex: 1,
+  },
+  eyebrow: {
+    color: accent.primary,
+    letterSpacing: EYEBROW_LETTER_SPACING,
+    marginBottom: rhythm.blockGap,
+  },
+  title: {
+    color: ink.primary,
+  },
+  lead: {
+    color: ink.soft,
+    marginTop: rhythm.blockGap,
+  },
+  action: {
+    marginLeft: rhythm.blockGap,
+  },
+});
+
+export default ScreenHeader;

--- a/frontend/src/components/layout/ScreenScaffold.tsx
+++ b/frontend/src/components/layout/ScreenScaffold.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+import { rhythm, surface } from '@/design/tokens';
+
+interface ScreenScaffoldProps {
+  children: React.ReactNode;
+  /** Wrap the content in a vertical ScrollView (for long screens). */
+  scroll?: boolean;
+  /** Extra style merged onto the padded content container. */
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+/**
+ * The "this is an Adepthood screen" container (#825): a warm `surface.canvas`
+ * ground with the shared `rhythm` horizontal/top padding, optionally scrollable.
+ * Token-only so every screen inherits the same editorial rhythm.
+ */
+export const ScreenScaffold = ({
+  children,
+  scroll = false,
+  style,
+  testID,
+}: ScreenScaffoldProps): React.JSX.Element => {
+  if (scroll) {
+    return (
+      <ScrollView
+        style={styles.ground}
+        contentContainerStyle={[styles.content, style]}
+        testID={testID}
+      >
+        {children}
+      </ScrollView>
+    );
+  }
+  return (
+    <View style={[styles.ground, styles.content, style]} testID={testID}>
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  ground: {
+    flex: 1,
+    backgroundColor: surface.canvas,
+  },
+  content: {
+    paddingHorizontal: rhythm.screenPaddingH,
+    paddingTop: rhythm.screenPaddingTop,
+  },
+});
+
+export default ScreenScaffold;

--- a/frontend/src/components/layout/__tests__/EditorialSection.test.tsx
+++ b/frontend/src/components/layout/__tests__/EditorialSection.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import { EditorialSection } from '../EditorialSection';
+
+import { rhythm } from '@/design/tokens';
+
+describe('EditorialSection', () => {
+  it('renders its title + children separated by the section gap', () => {
+    const { getByText, getByTestId } = render(
+      <EditorialSection title="Recent" testID="section">
+        <Text>item</Text>
+      </EditorialSection>,
+    );
+    expect(getByText('Recent')).toBeTruthy();
+    expect(getByText('item')).toBeTruthy();
+    const flat = StyleSheet.flatten(getByTestId('section').props.style);
+    expect(flat.marginTop).toBe(rhythm.sectionGap);
+  });
+
+  it('renders untitled with just children', () => {
+    const { getByText, queryByText } = render(
+      <EditorialSection>
+        <Text>only</Text>
+      </EditorialSection>,
+    );
+    expect(getByText('only')).toBeTruthy();
+    expect(queryByText('Recent')).toBeNull();
+  });
+});

--- a/frontend/src/components/layout/__tests__/ScreenHeader.test.tsx
+++ b/frontend/src/components/layout/__tests__/ScreenHeader.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import { ScreenHeader } from '../ScreenHeader';
+
+describe('ScreenHeader', () => {
+  it('renders the eyebrow (uppercased), a header-role title, and a lead', () => {
+    const { getByText } = render(
+      <ScreenHeader eyebrow="Aptitude Program" title="The Course" lead="A guided path." />,
+    );
+    expect(getByText('APTITUDE PROGRAM')).toBeTruthy();
+    const title = getByText('The Course');
+    expect(title.props.accessibilityRole).toBe('header');
+    expect(getByText('A guided path.')).toBeTruthy();
+  });
+
+  it('renders an optional action slot', () => {
+    const { getByText } = render(<ScreenHeader title="Today" action={<Text>Action</Text>} />);
+    expect(getByText('Action')).toBeTruthy();
+  });
+
+  it('omits the eyebrow + lead when not provided', () => {
+    const { queryByText, getByText } = render(<ScreenHeader title="Map" />);
+    expect(getByText('Map')).toBeTruthy();
+    expect(queryByText('APTITUDE PROGRAM')).toBeNull();
+  });
+});

--- a/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
+++ b/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import { ScreenScaffold } from '../ScreenScaffold';
+
+import { surface } from '@/design/tokens';
+
+describe('ScreenScaffold', () => {
+  it('renders children on the warm canvas ground', () => {
+    const { getByText, getByTestId } = render(
+      <ScreenScaffold testID="scaffold">
+        <Text>hello</Text>
+      </ScreenScaffold>,
+    );
+    expect(getByText('hello')).toBeTruthy();
+    const flat = StyleSheet.flatten(getByTestId('scaffold').props.style);
+    expect(flat.backgroundColor).toBe(surface.canvas);
+  });
+
+  it('renders a scroll variant', () => {
+    const { getByText } = render(
+      <ScreenScaffold scroll>
+        <Text>scrolled</Text>
+      </ScreenScaffold>,
+    );
+    expect(getByText('scrolled')).toBeTruthy();
+  });
+});

--- a/frontend/src/design/__tests__/rhythmTokens.test.ts
+++ b/frontend/src/design/__tests__/rhythmTokens.test.ts
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+import { describe, expect, it } from '@jest/globals';
+
+import { rhythm, spacing } from '../tokens';
+
+describe('rhythm tokens (#825)', () => {
+  it('exposes the screen-rhythm keys as positive numbers', () => {
+    for (const value of Object.values(rhythm)) {
+      expect(typeof value).toBe('number');
+      expect(value).toBeGreaterThan(0);
+    }
+    expect(Object.keys(rhythm)).toEqual([
+      'screenPaddingH',
+      'screenPaddingTop',
+      'sectionGap',
+      'blockGap',
+      'heroPaddingV',
+    ]);
+  });
+
+  it('derives from the spacing scale (not magic numbers)', () => {
+    expect(rhythm.screenPaddingH).toBe(spacing(2));
+    expect(rhythm.sectionGap).toBe(spacing(3));
+    expect(rhythm.blockGap).toBe(spacing(1.5));
+  });
+
+  it('orders section gaps wider than block gaps', () => {
+    expect(rhythm.sectionGap).toBeGreaterThan(rhythm.blockGap);
+  });
+});

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -262,6 +262,20 @@ export const SPACING = {
   buttonV: 14,
 } as const;
 
+/**
+ * Editorial screen rhythm (#825) — the single source of screen padding + section
+ * gaps so every screen inherits Habits' composed feel. Derived from ``spacing``
+ * (8px base); consumed by the layout primitives (ScreenScaffold / ScreenHeader /
+ * EditorialSection).
+ */
+export const rhythm = {
+  screenPaddingH: spacing(2), // 16 — horizontal page gutter
+  screenPaddingTop: spacing(2), // 16 — top padding under the safe area
+  sectionGap: spacing(3), // 24 — between editorial sections
+  blockGap: spacing(1.5), // 12 — between blocks within a section
+  heroPaddingV: spacing(3), // 24 — vertical breathing room around a screen header
+} as const;
+
 // ---------------------------------------------------------------------------
 // Border radius
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -1,6 +1,14 @@
 import { StyleSheet } from 'react-native';
 
-import { colors, radius, SPACING, shadows, surface, touchTarget } from '../../design/tokens';
+import {
+  colors,
+  radius,
+  rhythm,
+  SPACING,
+  shadows,
+  surface,
+  touchTarget,
+} from '../../design/tokens';
 
 const STAGE_PILL_SIZE = 40;
 const PROGRESS_BAR_HEIGHT = 6;
@@ -9,6 +17,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: surface.canvas,
+  },
+
+  // Editorial header band (#825): aligns ScreenHeader to the screen gutter.
+  headerBand: {
+    paddingHorizontal: rhythm.screenPaddingH,
   },
 
   // Stage selector

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -12,6 +12,7 @@ import {
   type SiteResource,
   type Stage,
 } from '../../api';
+import { ScreenHeader } from '../../components/layout/ScreenHeader';
 import { STAGE_COLORS, colors } from '../../design/tokens';
 import { useAppRoute } from '../../navigation/hooks';
 import type { RootStackParamList } from '../../navigation/RootStack';
@@ -338,6 +339,9 @@ function renderOverlay(
   return null;
 }
 
+const COURSE_EYEBROW = 'Aptitude Program';
+const COURSE_TITLE = 'The Course';
+
 const CourseScreen = (): React.JSX.Element => {
   const { allStages, selectedStage, setSelectedStage, loading, error, retry } = useStagesLoader();
   const stageContent = useStageContent(selectedStage, allStages.length > 0);
@@ -369,6 +373,9 @@ const CourseScreen = (): React.JSX.Element => {
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
+      <View style={styles.headerBand}>
+        <ScreenHeader eyebrow={COURSE_EYEBROW} title={COURSE_TITLE} />
+      </View>
       <StageSelector
         stages={allStages}
         selectedStage={selectedStage}


### PR DESCRIPTION
## Summary

#825 (epic #824, **critical-path foundation**): every screen re-invented its own header/padding/section spacing. Add the shared editorial scaffold the rest of Act II builds on.

- **`rhythm` tokens** (derived from `spacing()`): `screenPaddingH/Top`, `sectionGap`, `blockGap`, `heroPaddingV` — single source for screen padding + section gaps.
- **`components/layout/`** primitives (token-only, AA on `surface.canvas`, responsive via `type(width)`): `ScreenScaffold` (warm ground + responsive padding + optional scroll), `ScreenHeader` (eyebrow → serif `type().display` title with `accessibilityRole="header"` + optional lead + action slot), `EditorialSection` (titled band, `sectionGap`).
- **Reference adoption**: Course header band renders through `ScreenHeader`; content list untouched (#832); every Course route/testID preserved.

## Test plan

`ScreenScaffold`/`ScreenHeader`/`EditorialSection`/`rhythmTokens` tests; CourseScreen tests pass unchanged. `./scripts/frontend/check-all.sh` 4/4; no `any`, no inline hex.

Closes #825
Refs #824
