### PR TITLE
feat(design): warm-dark showcase surface + accent callout band

### DIFF
--- a/frontend/src/components/layout/CalloutBand.tsx
+++ b/frontend/src/components/layout/CalloutBand.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+
+import { accent, BORDER_RADIUS, rhythm, surface, touchTarget, uiType } from '@/design/tokens';
+
+interface CalloutBandProps {
+  /** The CTA label, rendered in inverted cream on the terracotta band. */
+  label: string;
+  onPress: () => void;
+  accessibilityLabel?: string;
+  testID?: string;
+}
+
+/**
+ * A full-bleed terracotta (`accent.primary`) callout band with an inverted cream
+ * CTA (#826) — the app's single loudest accent moment, used scarcely. The cream
+ * label (`surface.canvas`) clears WCAG AA on the accent ground. 44dp hit target;
+ * no press animation, so it is reduced-motion-safe by construction.
+ */
+export const CalloutBand = ({
+  label,
+  onPress,
+  accessibilityLabel,
+  testID,
+}: CalloutBandProps): React.JSX.Element => (
+  <Pressable
+    onPress={onPress}
+    accessibilityRole="button"
+    accessibilityLabel={accessibilityLabel ?? label}
+    testID={testID}
+    style={styles.band}
+  >
+    <Text style={styles.label}>{label}</Text>
+  </Pressable>
+);
+
+const styles = StyleSheet.create({
+  band: {
+    minHeight: touchTarget.minimum,
+    backgroundColor: accent.primary,
+    borderRadius: BORDER_RADIUS.md,
+    paddingVertical: rhythm.blockGap,
+    paddingHorizontal: rhythm.screenPaddingH,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    color: surface.canvas, // cream on terracotta — 4.9:1 AA
+    fontSize: uiType.button.fontSize,
+    fontWeight: uiType.button.fontWeight,
+  },
+});

--- a/frontend/src/components/layout/ShowcaseCard.tsx
+++ b/frontend/src/components/layout/ShowcaseCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+import { BORDER_RADIUS, rhythm, showcase, showcaseShadow } from '@/design/tokens';
+
+interface ShowcaseCardProps {
+  children: React.ReactNode;
+  /** Extra style merged onto the umber band. */
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+/**
+ * A rounded warm-umber showcase band (#826) — the "designed product" hero
+ * moment on an otherwise light screen. Establishes the on-showcase surface;
+ * text inside should use the `onShowcase` ink tokens (which clear AA on this
+ * ground). Token-only, portable `showcaseShadow`.
+ */
+export const ShowcaseCard = ({ children, style, testID }: ShowcaseCardProps): React.JSX.Element => (
+  <View style={[styles.band, style]} testID={testID}>
+    {children}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  band: {
+    backgroundColor: showcase.canvas,
+    borderRadius: BORDER_RADIUS.lg,
+    paddingVertical: rhythm.heroPaddingV,
+    paddingHorizontal: rhythm.screenPaddingH,
+    ...showcaseShadow,
+  },
+});

--- a/frontend/src/components/layout/__tests__/CalloutBand.test.tsx
+++ b/frontend/src/components/layout/__tests__/CalloutBand.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { CalloutBand } from '../CalloutBand';
+
+import { accent, surface, touchTarget } from '@/design/tokens';
+
+describe('CalloutBand', () => {
+  it('renders the label on the accent band and fires onPress', () => {
+    const onPress = jest.fn();
+    const { getByText, getByTestId } = render(
+      <CalloutBand label="Begin" onPress={onPress} testID="callout" />,
+    );
+    fireEvent.press(getByText('Begin'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+    const flat = StyleSheet.flatten(getByTestId('callout').props.style);
+    expect(flat.backgroundColor).toBe(accent.primary);
+    expect(flat.minHeight).toBeGreaterThanOrEqual(touchTarget.minimum);
+  });
+
+  it('renders the CTA label in inverted cream', () => {
+    const { getByText } = render(<CalloutBand label="Begin" onPress={jest.fn()} />);
+    const flat = StyleSheet.flatten(getByText('Begin').props.style);
+    expect(flat.color).toBe(surface.canvas);
+  });
+});

--- a/frontend/src/components/layout/__tests__/ShowcaseCard.test.tsx
+++ b/frontend/src/components/layout/__tests__/ShowcaseCard.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import { ShowcaseCard } from '../ShowcaseCard';
+
+import { showcase } from '@/design/tokens';
+
+describe('ShowcaseCard', () => {
+  it('renders children on the umber showcase band', () => {
+    const { getByText, getByTestId } = render(
+      <ShowcaseCard testID="showcase">
+        <Text>hero</Text>
+      </ShowcaseCard>,
+    );
+    expect(getByText('hero')).toBeTruthy();
+    const flat = StyleSheet.flatten(getByTestId('showcase').props.style);
+    expect(flat.backgroundColor).toBe(showcase.canvas);
+    expect(flat.elevation).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/design/ATTRIBUTION
+++ b/frontend/src/design/ATTRIBUTION
@@ -18,6 +18,9 @@ Clean-room stance
   derived from Adepthood's own `colors.tier.clear` (#be6e46), darkened to clear
   WCAG AA as text. No swatch is taken from any third-party product or brand
   palette.
+- Showcase palette (#826): `showcase.*`/`onShowcase.*` are an original warm-umber
+  derivation of Adepthood's own warm ink (`colors.paper.ink`) — a brown umber,
+  not navy and not Material's `#121212`. No third-party product/brand swatch.
 - Marks: no Anthropic (or any other company's) name, logo, wordmark, or brand
   swatch is presented as Adepthood's own. "Candle & Ink" is an internal name
   for this language.

--- a/frontend/src/design/DESIGN.md
+++ b/frontend/src/design/DESIGN.md
@@ -69,3 +69,19 @@ base as `typography()`:
 - #802 — warm grounds & soft elevation for cards/surfaces
 - #803 — editorial navigation (headers + bottom tab bar)
 - #804 — warm dark mode matching the light language
+
+## Showcase surfaces (Act II, #826)
+
+A warm-dark "designed product" band on an otherwise light screen — the hero
+moment for Today, the Practice player, the Course cover, and the Map celebration.
+
+- `showcase.canvas` `#2a211a` / `showcase.raised` `#352a20` — deep warm **umber**
+  (red channel above blue; not navy, not `#121212`), an original derivation of
+  the app's own warm ink.
+- `onShowcase.{primary,soft,muted}` (`#f3ece0` / `#cdbfae` / `#a8967c`) — every
+  value clears WCAG AA on the umber (13.4 / 8.8 / 5.5:1); enforced by
+  `showcaseTokens.test.ts`.
+- `showcaseShadow` — ink-tinted portable elevation (iOS/web shadow\* + Android).
+- Primitives (`components/layout/`): `ShowcaseCard` (rounded umber band) and
+  `CalloutBand` (full-bleed `accent.primary` band with an inverted cream CTA —
+  `surface.canvas` at 4.9:1 AA on the accent; used scarcely).

--- a/frontend/src/design/__tests__/showcaseTokens.test.ts
+++ b/frontend/src/design/__tests__/showcaseTokens.test.ts
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { StyleSheet } from 'react-native';
+
+import { accent, onShowcase, showcase, showcaseShadow, surface } from '../tokens';
+
+/** WCAG relative luminance of a #rrggbb color. */
+const luminance = (hex: string): number => {
+  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
+  const channels = [match[1], match[2], match[3]].map((pair) => {
+    const c = Number.parseInt(pair!, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+};
+
+const contrast = (a: string, b: string): number => {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+const AA_NORMAL = 4.5;
+const channels = (hex: string): [number, number, number] => {
+  const h = hex.replace('#', '');
+  return [
+    Number.parseInt(h.slice(0, 2), 16),
+    Number.parseInt(h.slice(2, 4), 16),
+    Number.parseInt(h.slice(4, 6), 16),
+  ];
+};
+
+describe('showcase tokens (#826)', () => {
+  it('is a warm umber — not navy, not Material #121212', () => {
+    const [r, , b] = channels(showcase.canvas);
+    expect(r).toBeGreaterThanOrEqual(b); // warm: red channel >= blue (not navy)
+    expect(showcase.canvas).not.toBe('#121212');
+    // raised is a lifted step above the canvas
+    expect(luminance(showcase.raised)).toBeGreaterThan(luminance(showcase.canvas));
+  });
+
+  it('every onShowcase ink value clears WCAG AA on the umber ground', () => {
+    for (const value of Object.values(onShowcase)) {
+      expect(contrast(value, showcase.canvas)).toBeGreaterThanOrEqual(AA_NORMAL);
+    }
+  });
+
+  it('the CalloutBand cream CTA clears AA on the accent ground', () => {
+    expect(contrast(surface.canvas, accent.primary)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+
+  it('showcaseShadow flattens to portable shadow* + Android elevation', () => {
+    const flat = StyleSheet.flatten(showcaseShadow);
+    expect(flat.shadowOffset?.height).toBeGreaterThan(0);
+    expect(flat.shadowOpacity).toBeGreaterThan(0);
+    expect(flat.shadowRadius).toBeGreaterThan(0);
+    expect(flat.elevation).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -701,6 +701,44 @@ export const surfaceShadowDark = {
   },
 } as const;
 
+// ---------------------------------------------------------------------------
+// Showcase surfaces — a warm-dark "designed product" band on a light screen
+// ---------------------------------------------------------------------------
+
+/**
+ * Deep warm-umber showcase ground for hero moments on an otherwise light screen
+ * (Today #828, the Practice player #831, the Course cover #832, the Map
+ * celebration #833). An original derivation of the app's own warm ink — a brown
+ * umber (red channel above blue), NOT navy and NOT Material's ``#121212``. See
+ * ``ATTRIBUTION``.
+ */
+export const showcase = {
+  canvas: '#2a211a', // the umber band ground
+  raised: '#352a20', // a lifted step within the band
+} as const;
+
+/**
+ * Ink for text on ``showcase.canvas``. Every value clears WCAG AA (>= 4.5:1) on
+ * the umber ground — asserted in ``showcaseTokens.test.ts``.
+ */
+export const onShowcase = {
+  primary: '#f3ece0', // 13.4:1 — warm off-white
+  soft: '#cdbfae', // 8.8:1
+  muted: '#a8967c', // 5.5:1 — captions
+} as const;
+
+/**
+ * Elevation for a showcase band lifting off a light screen — ink-tinted,
+ * downward; iOS/web shadow* props + Android ``elevation``.
+ */
+export const showcaseShadow = {
+  shadowColor: colors.paper.ink,
+  shadowOffset: { width: 0, height: 10 },
+  shadowOpacity: 0.18,
+  shadowRadius: 22,
+  elevation: 8,
+} as const;
+
 /**
  * Warm dark equivalents of the journal ``colors.paper`` palette so the journal
  * joins warm dark. Mirrors the ``paper`` keys; ink clears AA on the dark ground.


### PR DESCRIPTION
## Summary

#826 (epic #824): Act II needs a warm-dark hero surface + a full-bleed accent moment (Today/Practice/Course/Map). The app only had light grounds + a neutral Material `darkColors`.

- `tokens.ts`: `showcase.canvas` `#2a211a` (warm **umber**, r>b — not navy/not `#121212`) + `raised`; `onShowcase` ink (13.4 / 8.8 / 5.5:1 on umber); `showcaseShadow` (portable).
- `components/layout`: `ShowcaseCard` (umber band) + `CalloutBand` (full-bleed `accent.primary`, inverted cream CTA at **4.9:1**, 44dp). Token-derived so #804 themes by mode.
- `DESIGN.md` + `ATTRIBUTION` record the clean-room provenance.

## Test plan

`showcaseTokens` (onShowcase AA on umber; umber warm + not `#121212`; CTA AA on accent; shadow flatten), `ShowcaseCard`, `CalloutBand` (label + onPress + 44dp). `./scripts/frontend/check-all.sh` 4/4; no `any`, no inline hex.

Closes #826
Refs #824
