### PR TITLE
feat(design): shared motion vocabulary + editorial empty/loading/celebration states

### DIFF
--- a/frontend/src/components/feedback/Celebration.tsx
+++ b/frontend/src/components/feedback/Celebration.tsx
@@ -1,0 +1,57 @@
+/**
+ * A small arrival celebration: when `active` flips true the children pulse once
+ * (a gentle scale up-and-back) to mark the moment — e.g. a weekly goal reached.
+ * Under reduced motion there is no pulse (children render at rest). If `onDismiss`
+ * is given it fires after the celebration window, for transient/auto-dismissing
+ * uses; persistent callers (a goal-reached label) simply omit it.
+ */
+import React, { useEffect, useRef } from 'react';
+import { Animated } from 'react-native';
+
+import { motion } from '@/design/tokens';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+const PULSE_SCALE = 1.06;
+const DISMISS_MS = 2400;
+
+interface CelebrationProps {
+  children: React.ReactNode;
+  /** Play the pulse / start the auto-dismiss timer when this is true. */
+  active: boolean;
+  /** Optional auto-dismiss callback, fired ~DISMISS_MS after activation. */
+  onDismiss?: () => void;
+  testID?: string;
+}
+
+export function Celebration({
+  children,
+  active,
+  onDismiss,
+  testID = 'celebration',
+}: CelebrationProps): React.JSX.Element {
+  const reduced = useReducedMotion();
+  const scale = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (!active) return undefined;
+    if (!reduced) {
+      Animated.sequence([
+        Animated.timing(scale, {
+          toValue: PULSE_SCALE,
+          duration: motion.fast,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scale, { toValue: 1, duration: motion.base, useNativeDriver: true }),
+      ]).start();
+    }
+    if (!onDismiss) return undefined;
+    const timer = setTimeout(onDismiss, DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [active, reduced, scale, onDismiss]);
+
+  return (
+    <Animated.View testID={testID} style={{ transform: [{ scale }] }}>
+      {children}
+    </Animated.View>
+  );
+}

--- a/frontend/src/components/feedback/EmptyState.tsx
+++ b/frontend/src/components/feedback/EmptyState.tsx
@@ -1,0 +1,71 @@
+/**
+ * Editorial empty state: a warm centred glyph, a serif title, a lead body, and
+ * an optional call-to-action slot. Replaces the bare one-line "nothing here yet"
+ * text the Practice / Journal / Course screens each rolled by hand. Fades in via
+ * ``useEntrance`` (static under reduced motion); token-only, AA on the canvas.
+ */
+import React from 'react';
+import {
+  Animated,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+import { ink, rhythm, SPACING, surface, type } from '@/design/tokens';
+import { useEntrance } from '@/hooks/useEntrance';
+
+const GLYPH_SIZE = 48;
+
+interface EmptyStateProps {
+  glyph: string;
+  title: string;
+  body: string;
+  /** Optional action (e.g. a Button) rendered under the body. */
+  cta?: React.ReactNode;
+  /** Extra container style — e.g. safe-area insets from the host screen. */
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export function EmptyState({
+  glyph,
+  title,
+  body,
+  cta,
+  style,
+  testID = 'empty-state',
+}: EmptyStateProps): React.JSX.Element {
+  const t = type(useWindowDimensions().width);
+  const entrance = useEntrance();
+  return (
+    <Animated.View style={[styles.container, style, entrance]} testID={testID}>
+      <Text style={styles.glyph} accessibilityElementsHidden importantForAccessibility="no">
+        {glyph}
+      </Text>
+      <Text style={[t.title, styles.title]} accessibilityRole="header">
+        {title}
+      </Text>
+      <Text style={[t.body, styles.body]}>{body}</Text>
+      {cta ? <View style={styles.cta}>{cta}</View> : null}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: rhythm.screenPaddingH,
+    gap: rhythm.blockGap,
+    backgroundColor: surface.canvas,
+  },
+  glyph: { fontSize: GLYPH_SIZE },
+  title: { color: ink.primary, textAlign: 'center' },
+  body: { color: ink.soft, textAlign: 'center' },
+  cta: { marginTop: SPACING.sm },
+});

--- a/frontend/src/components/feedback/Skeleton.tsx
+++ b/frontend/src/components/feedback/Skeleton.tsx
@@ -1,0 +1,96 @@
+/**
+ * Loading placeholders that replace raw full-screen spinners. A `Skeleton` is a
+ * rounded block that gently shimmers (opacity loop); `SkeletonCard` stacks a few
+ * into a card silhouette. Under reduced motion the shimmer is omitted entirely —
+ * a plain static block at the resting opacity — so nothing animates.
+ */
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  StyleSheet,
+  View,
+  type DimensionValue,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+import { BORDER_RADIUS, SPACING, surface, surfaceShadow } from '@/design/tokens';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+const SHIMMER_MIN = 0.4;
+const SHIMMER_MAX = 0.75;
+const SHIMMER_MS = 900;
+
+interface SkeletonProps {
+  width?: DimensionValue;
+  height?: number;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+/** The animated branch — only mounted when motion is allowed, so the loop hook
+ * is never scheduled under reduced motion. */
+function ShimmerBlock({
+  width,
+  height,
+  style,
+  testID,
+}: Required<Pick<SkeletonProps, 'width' | 'height'>> &
+  Pick<SkeletonProps, 'style' | 'testID'>): React.JSX.Element {
+  const opacity = useRef(new Animated.Value(SHIMMER_MIN)).current;
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: SHIMMER_MAX,
+          duration: SHIMMER_MS,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: SHIMMER_MIN,
+          duration: SHIMMER_MS,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [opacity]);
+  return <Animated.View testID={testID} style={[styles.base, { width, height, opacity }, style]} />;
+}
+
+export function Skeleton({
+  width = '100%',
+  height = 16,
+  style,
+  testID = 'skeleton',
+}: SkeletonProps): React.JSX.Element {
+  const reduced = useReducedMotion();
+  if (reduced) {
+    return (
+      <View testID={testID} style={[styles.base, { width, height, opacity: SHIMMER_MIN }, style]} />
+    );
+  }
+  return <ShimmerBlock width={width} height={height} style={style} testID={testID} />;
+}
+
+export function SkeletonCard({ testID = 'skeleton-card' }: { testID?: string }): React.JSX.Element {
+  return (
+    <View testID={testID} style={styles.card}>
+      <Skeleton width="55%" height={20} testID="skeleton-card-title" />
+      <Skeleton width="100%" height={14} />
+      <Skeleton width="80%" height={14} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: { backgroundColor: surface.sunken, borderRadius: BORDER_RADIUS.sm },
+  card: {
+    gap: SPACING.sm,
+    padding: SPACING.md,
+    backgroundColor: surface.raised,
+    borderRadius: BORDER_RADIUS.md,
+    ...surfaceShadow.card,
+  },
+});

--- a/frontend/src/components/feedback/__tests__/Celebration.test.tsx
+++ b/frontend/src/components/feedback/__tests__/Celebration.test.tsx
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import { Celebration } from '@/components/feedback/Celebration';
+import * as reducedMotion from '@/hooks/useReducedMotion';
+
+const DISMISS_MS = 2400;
+
+describe('Celebration', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('renders its children', () => {
+    const { getByText } = render(
+      <Celebration active={false}>
+        <Text>Goal reached</Text>
+      </Celebration>,
+    );
+    expect(getByText('Goal reached')).toBeTruthy();
+  });
+
+  it('auto-dismisses after the window when active', () => {
+    jest.useFakeTimers();
+    const onDismiss = jest.fn();
+    render(
+      <Celebration active onDismiss={onDismiss}>
+        <Text>Done</Text>
+      </Celebration>,
+    );
+    expect(onDismiss).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(DISMISS_MS);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('is static + still auto-dismisses under reduced motion', () => {
+    jest.spyOn(reducedMotion, 'useReducedMotion').mockReturnValue(true);
+    jest.useFakeTimers();
+    const onDismiss = jest.fn();
+    const { getByText } = render(
+      <Celebration active onDismiss={onDismiss}>
+        <Text>Quiet win</Text>
+      </Celebration>,
+    );
+    expect(getByText('Quiet win')).toBeTruthy();
+    jest.advanceTimersByTime(DISMISS_MS);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/feedback/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/feedback/__tests__/EmptyState.test.tsx
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import { Button } from '@/components/Button';
+import { EmptyState } from '@/components/feedback/EmptyState';
+
+describe('EmptyState', () => {
+  it('renders the glyph, a header-role title, and the body', () => {
+    const { getByText, getByRole } = render(
+      <EmptyState glyph="🧘" title="Nothing yet" body="Add your first one." />,
+    );
+    // The glyph is decorative and hidden from accessibility.
+    expect(getByText('🧘', { includeHiddenElements: true })).toBeTruthy();
+    expect(getByText('Add your first one.')).toBeTruthy();
+    expect(getByRole('header').props.children).toBe('Nothing yet');
+  });
+
+  it('renders an optional CTA slot and fires it', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <EmptyState
+        glyph="📓"
+        title="Empty"
+        body="None."
+        cta={<Button label="Add" onPress={onPress} testID="empty-cta" />}
+      />,
+    );
+    fireEvent.press(getByTestId('empty-cta'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('merges a style override (e.g. safe-area insets) onto the container', () => {
+    const { getByTestId } = render(
+      <EmptyState glyph="x" title="t" body="b" style={{ paddingTop: 47 }} testID="es" />,
+    );
+    expect(getByTestId('es')).toHaveStyle({ paddingTop: 47 });
+  });
+});

--- a/frontend/src/components/feedback/__tests__/Skeleton.test.tsx
+++ b/frontend/src/components/feedback/__tests__/Skeleton.test.tsx
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { Animated, StyleSheet } from 'react-native';
+
+import { Skeleton, SkeletonCard } from '@/components/feedback/Skeleton';
+import * as reducedMotion from '@/hooks/useReducedMotion';
+
+const STATIC_OPACITY = 0.4;
+
+describe('Skeleton', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('runs a shimmer loop when motion is allowed', () => {
+    jest.spyOn(reducedMotion, 'useReducedMotion').mockReturnValue(false);
+    const loop = jest.spyOn(Animated, 'loop');
+    const { getByTestId } = render(<Skeleton />);
+    expect(getByTestId('skeleton')).toBeTruthy();
+    expect(loop).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the shimmer loop under reduced motion (static block)', () => {
+    jest.spyOn(reducedMotion, 'useReducedMotion').mockReturnValue(true);
+    const loop = jest.spyOn(Animated, 'loop');
+    const { getByTestId } = render(<Skeleton />);
+    expect(loop).not.toHaveBeenCalled();
+    expect(StyleSheet.flatten(getByTestId('skeleton').props.style).opacity).toBe(STATIC_OPACITY);
+  });
+
+  it('SkeletonCard stacks placeholder lines', () => {
+    const { getByTestId } = render(<SkeletonCard />);
+    expect(getByTestId('skeleton-card')).toBeTruthy();
+    expect(getByTestId('skeleton-card-title')).toBeTruthy();
+  });
+});

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -277,6 +277,18 @@ export const rhythm = {
 } as const;
 
 // ---------------------------------------------------------------------------
+// Motion — shared durations + distance for the app-wide entrance/feedback
+// vocabulary. Every consumer gates on ``useReducedMotion`` and falls back to the
+// resting state, so this polish never costs accessibility.
+// ---------------------------------------------------------------------------
+
+export const motion = {
+  fast: 90, // ms — press / quick feedback
+  base: 220, // ms — entrance fade + settle, celebration pulse
+  settleY: 6, // px — the small upward translate an element settles from
+} as const;
+
+// ---------------------------------------------------------------------------
 // Border radius
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -35,6 +35,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import WeeklyProgress from './WeeklyProgress';
 
 import type { PracticeSessionResponse } from '@/api';
+import { EmptyState } from '@/components/feedback/EmptyState';
 import { useAuth } from '@/context/AuthContext';
 import { BORDER_RADIUS, SPACING, colors, touchTarget } from '@/design/tokens';
 import { stageService } from '@/features/Map/services/stageService';
@@ -222,17 +223,20 @@ interface EmptyStateViewProps {
 const EmptyStateView = ({ stageNumber }: EmptyStateViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
   return (
-    <View
-      style={[styles.empty, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
+    <EmptyState
+      glyph="🧘"
+      title="No practice yet"
+      body="No practice set for this stage yet."
+      cta={
+        <CatalogButton
+          stageNumber={stageNumber}
+          label="Browse practices"
+          testID="browse-catalog-button"
+        />
+      }
+      style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
       testID="practice-empty-state"
-    >
-      <Text style={styles.emptyText}>No practice set for this stage yet.</Text>
-      <CatalogButton
-        stageNumber={stageNumber}
-        label="Browse practices"
-        testID="browse-catalog-button"
-      />
-    </View>
+    />
   );
 };
 
@@ -319,19 +323,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: SPACING.xxl,
     backgroundColor: colors.background.primary,
-  },
-  empty: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: SPACING.lg,
-    padding: SPACING.xxl,
-    backgroundColor: colors.background.primary,
-  },
-  emptyText: {
-    fontSize: 16,
-    color: colors.text.secondary,
-    textAlign: 'center',
   },
   errorText: {
     color: colors.danger,

--- a/frontend/src/features/Practice/WeeklyProgress.tsx
+++ b/frontend/src/features/Practice/WeeklyProgress.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { Celebration } from '@/components/feedback/Celebration';
 import { colors, SPACING, BORDER_RADIUS } from '@/design/tokens';
 
 const WEEKLY_TARGET = 4;
@@ -52,12 +53,14 @@ const WeeklyProgress: React.FC<WeeklyProgressProps> = ({ count }) => {
           );
         })}
       </View>
-      <Text
-        style={[styles.helper, isComplete && styles.helperComplete]}
-        testID={isComplete ? 'weekly-complete-message' : 'weekly-helper'}
-      >
-        {helperText(completed)}
-      </Text>
+      <Celebration active={isComplete} testID="weekly-celebration">
+        <Text
+          style={[styles.helper, isComplete && styles.helperComplete]}
+          testID={isComplete ? 'weekly-complete-message' : 'weekly-helper'}
+        >
+          {helperText(completed)}
+        </Text>
+      </Celebration>
     </View>
   );
 };

--- a/frontend/src/hooks/__tests__/useEntrance.test.tsx
+++ b/frontend/src/hooks/__tests__/useEntrance.test.tsx
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { Animated } from 'react-native';
+
+import { useEntrance } from '@/hooks/useEntrance';
+import * as reducedMotion from '@/hooks/useReducedMotion';
+
+function Probe({ index }: { index?: number }): React.JSX.Element {
+  const style = useEntrance(index);
+  return <Animated.View testID="probe" style={style} />;
+}
+
+describe('useEntrance', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('schedules a fade/settle entrance when motion is allowed', () => {
+    jest.spyOn(reducedMotion, 'useReducedMotion').mockReturnValue(false);
+    const timing = jest.spyOn(Animated, 'timing');
+    render(<Probe />);
+    expect(timing).toHaveBeenCalledTimes(1);
+  });
+
+  it('schedules no animation under reduced motion', () => {
+    jest.spyOn(reducedMotion, 'useReducedMotion').mockReturnValue(true);
+    const timing = jest.spyOn(Animated, 'timing');
+    render(<Probe />);
+    expect(timing).not.toHaveBeenCalled();
+  });
+
+  it('exposes an opacity + translateY transform style', () => {
+    const { getByTestId } = render(<Probe />);
+    const style = getByTestId('probe').props.style;
+    expect(style.opacity).toBeDefined();
+    expect(style.transform[0].translateY).toBeDefined();
+  });
+});

--- a/frontend/src/hooks/useEntrance.ts
+++ b/frontend/src/hooks/useEntrance.ts
@@ -1,0 +1,52 @@
+/**
+ * App-wide entrance motion: a brief fade + small upward settle when an element
+ * mounts, staggerable by index. Mirrors the journal's ``useSettleIn`` but lives
+ * in the shared layer so any screen can adopt the same vocabulary.
+ *
+ * Fully disabled under reduced motion — the value starts at its resting state
+ * (opacity 1, no offset) and no animation is scheduled, so layout is identical.
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import { Animated } from 'react-native';
+
+import { useReducedMotion } from './useReducedMotion';
+
+import { motion } from '@/design/tokens';
+
+/** Per-index delay so a list can cascade in rather than appearing at once. */
+const STAGGER_MS = 40;
+
+export interface EntranceStyle {
+  opacity: Animated.Value;
+  transform: { translateY: Animated.AnimatedInterpolation<number> }[];
+}
+
+export function useEntrance(index = 0): EntranceStyle {
+  const reduced = useReducedMotion();
+  const anim = useRef(new Animated.Value(reduced ? 1 : 0)).current;
+
+  useEffect(() => {
+    if (reduced) {
+      anim.setValue(1);
+      return;
+    }
+    const animation = Animated.timing(anim, {
+      toValue: 1,
+      duration: motion.base,
+      delay: index * STAGGER_MS,
+      useNativeDriver: true,
+    });
+    animation.start();
+    return () => animation.stop();
+  }, [reduced, anim, index]);
+
+  return useMemo(
+    () => ({
+      opacity: anim,
+      transform: [
+        { translateY: anim.interpolate({ inputRange: [0, 1], outputRange: [motion.settleY, 0] }) },
+      ],
+    }),
+    [anim],
+  );
+}


### PR DESCRIPTION
## Summary

#827 (epic #824): polish lived in the journal's local motion only; empty states were bare text, loading a raw `ActivityIndicator`, arrivals didn't celebrate. Add a shared, **reduced-motion-safe** set.

- `motion` tokens (fast 90, base 220ms, settleY 6px).
- `useEntrance(index)`: fade + small translateY, staggered; under reduced motion inits at rest, schedules nothing.
- `components/feedback`: `EmptyState` (glyph + serif title + body + CTA), `Skeleton`/`SkeletonCard` (shimmer → static 0.4 under reduced motion), `Celebration` (pulse on active, static under reduced motion, optional auto-dismiss).
- Reference adoptions: Practice empty state → `EmptyState` (testIDs + copy preserved); weekly-goal-reached → `Celebration` (testIDs intact).

## Test plan

Animated-vs-reduced-motion branch tested for `useEntrance`/`Skeleton`/`Celebration`; `EmptyState` glyph/title/body/CTA; Practice + WeeklyProgress adoptions keep testIDs. `./scripts/frontend/check-all.sh` green (2057 tests); no `any`, no inline hex/durations.

Closes #827
Refs #824
