### PR TITLE
feat(today): editorial Today hub as the home tab

### DIFF
--- a/frontend/src/features/Today/Today.styles.ts
+++ b/frontend/src/features/Today/Today.styles.ts
@@ -1,0 +1,64 @@
+import { StyleSheet } from 'react-native';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  editorialType,
+  ink,
+  onShowcase,
+  rhythm,
+  surface,
+  surfaceShadow,
+  touchTarget,
+} from '@/design/tokens';
+
+/** Token-only styles for the Today hub (#828). */
+export const todayStyles = StyleSheet.create({
+  heroEyebrow: {
+    ...editorialType.caption,
+    color: onShowcase.muted,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginBottom: SPACING.xs,
+  },
+  heroGreeting: {
+    ...editorialType.display,
+    color: onShowcase.primary,
+  },
+  heroLead: {
+    ...editorialType.note,
+    color: onShowcase.soft,
+    marginTop: SPACING.xs,
+  },
+  band: {
+    ...surfaceShadow.card,
+    backgroundColor: surface.raised,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md,
+    marginBottom: rhythm.blockGap,
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+  },
+  bandTitle: {
+    ...editorialType.note,
+    color: ink.primary,
+    fontWeight: '600',
+  },
+  bandValue: {
+    ...editorialType.title,
+    color: ink.primary,
+    marginTop: SPACING.xs,
+  },
+  bandSubtitle: {
+    ...editorialType.caption,
+    color: ink.soft,
+    marginTop: SPACING.xs,
+  },
+  bandCue: {
+    ...editorialType.caption,
+    color: accent.primary,
+    fontWeight: '600',
+    marginTop: SPACING.xs,
+  },
+});

--- a/frontend/src/features/Today/TodayScreen.tsx
+++ b/frontend/src/features/Today/TodayScreen.tsx
@@ -10,6 +10,7 @@ import { SkeletonCard } from '@/components/feedback/Skeleton';
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
 import { STAGE_ORDER } from '@/design/tokens';
+import type { Habit } from '@/features/Habits/Habits.types';
 import { useEntrance } from '@/hooks/useEntrance';
 import type { RootTabParamList } from '@/navigation/BottomTabs';
 import { useHabitStore } from '@/store/useHabitStore';
@@ -33,16 +34,18 @@ function greeting(): string {
   return 'Good evening';
 }
 
-/** Habits with at least one real completion logged on today's calendar day. */
-function doneToday(): { done: number; total: number } {
-  const habits = useHabitStore.getState().habits;
+/** Count habits with a real completion on today's calendar day.
+ *
+ * Pure (takes the habits it counts) so callers subscribe to the store reactively
+ * rather than reading an imperative snapshot in a render path.
+ */
+function countDoneToday(habits: readonly Habit[]): number {
   const todayKey = dayKeyInTZ(new Date(), DEFAULT_TIMEZONE);
-  const done = habits.filter((h) =>
+  return habits.filter((h) =>
     (h.completions ?? []).some(
       (c) => c.completed_units > 0 && dayKeyInTZ(c.timestamp, DEFAULT_TIMEZONE) === todayKey,
     ),
   ).length;
-  return { done, total: habits.length };
 }
 
 /** The showcase hero: greeting + position in the 36-week journey. */
@@ -96,7 +99,8 @@ const TodayBand = ({ index, title, value, subtitle, onPress, testID }: BandProps
 /** Today's-habits band: skeleton while loading, empty state with no habits. */
 const HabitsBand = ({ index, onPress }: { index: number; onPress: () => void }) => {
   const loading = useHabitStore((state) => state.loading);
-  const total = useHabitStore((state) => state.habits.length);
+  const habits = useHabitStore((state) => state.habits);
+  const total = habits.length;
   if (loading && total === 0) return <SkeletonCard testID="today-habits-skeleton" />;
   if (total === 0) {
     return (
@@ -117,7 +121,7 @@ const HabitsBand = ({ index, onPress }: { index: number; onPress: () => void }) 
       />
     );
   }
-  const { done } = doneToday();
+  const done = countDoneToday(habits);
   return (
     <TodayBand
       index={index}

--- a/frontend/src/features/Today/TodayScreen.tsx
+++ b/frontend/src/features/Today/TodayScreen.tsx
@@ -1,0 +1,168 @@
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+import { Animated, Pressable, Text } from 'react-native';
+
+import { todayStyles as s } from './Today.styles';
+
+import { EmptyState } from '@/components/feedback/EmptyState';
+import { SkeletonCard } from '@/components/feedback/Skeleton';
+import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
+import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
+import { STAGE_ORDER } from '@/design/tokens';
+import { useEntrance } from '@/hooks/useEntrance';
+import type { RootTabParamList } from '@/navigation/BottomTabs';
+import { useHabitStore } from '@/store/useHabitStore';
+import {
+  programStage,
+  programWeek,
+  selectProgramStartDate,
+  useProgramStore,
+} from '@/store/useProgramStore';
+import { DEFAULT_TIMEZONE, dayKeyInTZ } from '@/utils/dateUtils';
+
+const TOTAL_WEEKS = 36;
+
+type TodayNav = BottomTabNavigationProp<RootTabParamList>;
+
+/** A morning/afternoon/evening greeting from the local clock. */
+function greeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return 'Good morning';
+  if (hour < 18) return 'Good afternoon';
+  return 'Good evening';
+}
+
+/** Habits with at least one real completion logged on today's calendar day. */
+function doneToday(): { done: number; total: number } {
+  const habits = useHabitStore.getState().habits;
+  const todayKey = dayKeyInTZ(new Date(), DEFAULT_TIMEZONE);
+  const done = habits.filter((h) =>
+    (h.completions ?? []).some(
+      (c) => c.completed_units > 0 && dayKeyInTZ(c.timestamp, DEFAULT_TIMEZONE) === todayKey,
+    ),
+  ).length;
+  return { done, total: habits.length };
+}
+
+/** The showcase hero: greeting + position in the 36-week journey. */
+const TodayHero = ({ week, stage }: { week: number | null; stage: number | null }) => {
+  const entrance = useEntrance(0);
+  const position = week === null ? 'Your journey awaits' : `Week ${week} of ${TOTAL_WEEKS}`;
+  const stageName = stage === null ? null : STAGE_ORDER[stage - 1] ?? null;
+  return (
+    <Animated.View style={entrance}>
+      <ShowcaseCard testID="today-hero">
+        <Text style={s.heroEyebrow}>Today</Text>
+        <Text style={s.heroGreeting} accessibilityRole="header">
+          {greeting()}
+        </Text>
+        <Text style={s.heroLead}>{stageName ? `${position} · ${stageName}` : position}</Text>
+      </ShowcaseCard>
+    </Animated.View>
+  );
+};
+
+interface BandProps {
+  index: number;
+  title: string;
+  value?: string;
+  subtitle: string;
+  onPress: () => void;
+  testID: string;
+}
+
+/** A staggered, tappable summary band that routes into a feature tab. */
+const TodayBand = ({ index, title, value, subtitle, onPress, testID }: BandProps) => {
+  const entrance = useEntrance(index);
+  return (
+    <Animated.View style={entrance}>
+      <Pressable
+        style={s.band}
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={`${title}. ${subtitle}`}
+        testID={testID}
+      >
+        <Text style={s.bandTitle}>{title}</Text>
+        {value ? <Text style={s.bandValue}>{value}</Text> : null}
+        <Text style={s.bandSubtitle}>{subtitle}</Text>
+        <Text style={s.bandCue}>Open →</Text>
+      </Pressable>
+    </Animated.View>
+  );
+};
+
+/** Today's-habits band: skeleton while loading, empty state with no habits. */
+const HabitsBand = ({ index, onPress }: { index: number; onPress: () => void }) => {
+  const loading = useHabitStore((state) => state.loading);
+  const total = useHabitStore((state) => state.habits.length);
+  if (loading && total === 0) return <SkeletonCard testID="today-habits-skeleton" />;
+  if (total === 0) {
+    return (
+      <EmptyState
+        glyph="🌱"
+        title="No habits yet"
+        body="Plant your first habit to start the daily rhythm."
+        cta={
+          <Pressable
+            style={s.band}
+            onPress={onPress}
+            accessibilityRole="button"
+            testID="today-habits-empty-cta"
+          >
+            <Text style={s.bandCue}>Add a habit →</Text>
+          </Pressable>
+        }
+      />
+    );
+  }
+  const { done } = doneToday();
+  return (
+    <TodayBand
+      index={index}
+      title="Today's habits"
+      value={`${done}/${total} done`}
+      subtitle={done >= total ? 'All caught up — beautiful.' : 'Keep the streak alive.'}
+      onPress={onPress}
+      testID="today-habits-band"
+    />
+  );
+};
+
+/** The editorial home tab: where am I in the journey, and what's next today. */
+const TodayScreen = (): React.JSX.Element => {
+  const navigation = useNavigation<TodayNav>();
+  const anchor = useProgramStore(selectProgramStartDate);
+  const week = programWeek(anchor);
+  const stage = programStage(anchor);
+  return (
+    <ScreenScaffold scroll testID="today-screen">
+      <TodayHero week={week} stage={stage} />
+      <HabitsBand index={1} onPress={() => navigation.navigate('Habits')} />
+      <TodayBand
+        index={2}
+        title="A practice to begin"
+        subtitle="Settle in with today's practice."
+        onPress={() => navigation.navigate('Practice')}
+        testID="today-practice-band"
+      />
+      <TodayBand
+        index={3}
+        title="Reflect in the journal"
+        subtitle={week === null ? 'Open your journal.' : `This week's reflection awaits.`}
+        onPress={() => navigation.navigate('Journal')}
+        testID="today-journal-band"
+      />
+      <TodayBand
+        index={4}
+        title="Continue the course"
+        subtitle="Pick up where you left off."
+        onPress={() => navigation.navigate('Course')}
+        testID="today-course-band"
+      />
+    </ScreenScaffold>
+  );
+};
+
+export default TodayScreen;

--- a/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
+++ b/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
@@ -1,0 +1,77 @@
+/* eslint-env jest */
+import { jest, beforeEach, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+import TodayScreen from '../TodayScreen';
+
+import type { Habit } from '@/features/Habits/Habits.types';
+import { useHabitStore } from '@/store/useHabitStore';
+import { useProgramStore } from '@/store/useProgramStore';
+
+const makeHabit = (id: number, completedToday: boolean): Habit =>
+  ({
+    id,
+    stage: 'beige',
+    name: `Habit ${id}`,
+    icon: '🌱',
+    streak: 0,
+    energy_cost: 1,
+    energy_return: 2,
+    start_date: new Date('2025-01-01'),
+    goals: [],
+    completions: completedToday
+      ? [{ id: `c-${id}`, timestamp: new Date(), completed_units: 1 }]
+      : [],
+  }) as Habit;
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  useProgramStore.setState({ programStartDate: new Date() });
+  useHabitStore.setState({ habits: [], loading: false });
+});
+
+describe('TodayScreen', () => {
+  it('shows the journey position in the hero', () => {
+    const { getByTestId, getByText } = render(<TodayScreen />);
+    expect(getByTestId('today-hero')).toBeTruthy();
+    expect(getByText(/Week 1 of 36/)).toBeTruthy();
+  });
+
+  it('summarises today’s habits and routes to Habits on press', () => {
+    useHabitStore.setState({ habits: [makeHabit(1, true), makeHabit(2, false)], loading: false });
+    const { getByTestId, getByText } = render(<TodayScreen />);
+    expect(getByText('1/2 done')).toBeTruthy();
+    fireEvent.press(getByTestId('today-habits-band'));
+    expect(mockNavigate).toHaveBeenCalledWith('Habits');
+  });
+
+  it('shows a habits skeleton while loading', () => {
+    useHabitStore.setState({ habits: [], loading: true });
+    const { getByTestId } = render(<TodayScreen />);
+    expect(getByTestId('today-habits-skeleton')).toBeTruthy();
+  });
+
+  it('shows the habits empty state with no habits (other bands still render)', () => {
+    const { getByTestId } = render(<TodayScreen />);
+    expect(getByTestId('today-habits-empty-cta')).toBeTruthy();
+    // One source being empty must not blank the screen — sibling bands still render.
+    expect(getByTestId('today-practice-band')).toBeTruthy();
+    expect(getByTestId('today-course-band')).toBeTruthy();
+  });
+
+  it('routes each band into its feature tab', () => {
+    const { getByTestId } = render(<TodayScreen />);
+    fireEvent.press(getByTestId('today-practice-band'));
+    fireEvent.press(getByTestId('today-journal-band'));
+    fireEvent.press(getByTestId('today-course-band'));
+    expect(mockNavigate).toHaveBeenCalledWith('Practice');
+    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(mockNavigate).toHaveBeenCalledWith('Course');
+  });
+});

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -7,6 +7,7 @@ import {
   BookOpen,
   Compass,
   Flower2,
+  Home,
   NotebookPen,
   Sprout,
   type LucideIcon,
@@ -22,12 +23,14 @@ import HabitsScreen from '../features/Habits/HabitsScreen';
 import JournalShelfScreen from '../features/Journal/JournalShelfScreen';
 import MapScreen from '../features/Map/MapScreen';
 import PracticeScreen from '../features/Practice/PracticeScreen';
+import TodayScreen from '../features/Today/TodayScreen';
 
 import type { RootStackParamList } from './RootStack';
 
 import { useAuth } from '@/context/AuthContext';
 
 export type RootTabParamList = {
+  Today: undefined;
   Habits: undefined;
   Practice: { stageNumber?: number } | undefined;
   Course: { stageNumber?: number } | undefined;
@@ -64,6 +67,7 @@ function withBoundary<P extends object>(
   return Wrapped;
 }
 
+const TodayTab = withBoundary('Today', TodayScreen);
 const HabitsTab = withBoundary('Habits', HabitsScreen);
 const PracticeTab = withBoundary('Practice', PracticeScreen);
 const CourseTab = withBoundary('Course', CourseScreen);
@@ -85,6 +89,7 @@ const TAB_CONFIGS: ReadonlyArray<{
   component: React.ComponentType<object>;
   icon: LucideIcon;
 }> = [
+  { name: 'Today', component: TodayTab, icon: Home },
   { name: 'Habits', component: HabitsTab, icon: Sprout },
   { name: 'Practice', component: PracticeTab, icon: Flower2 },
   { name: 'Course', component: CourseTab, icon: BookOpen },
@@ -141,7 +146,7 @@ const BottomTabs = (): React.JSX.Element => {
 
   return (
     <Tab.Navigator
-      initialRouteName="Habits"
+      initialRouteName="Today"
       screenOptions={{
         // Warm tab bar (#803): raised paper ground + hairline top edge; active
         // terracotta vs muted ink, both AA on the raised ground.

--- a/frontend/src/navigation/__tests__/BottomTabs.test.tsx
+++ b/frontend/src/navigation/__tests__/BottomTabs.test.tsx
@@ -2,7 +2,15 @@
 /* global describe, it, expect, beforeEach, jest */
 import { NavigationContainer } from '@react-navigation/native';
 import { render, fireEvent } from '@testing-library/react-native';
-import { BookOpen, Compass, Flower2, LayoutGrid, NotebookPen, Sprout } from 'lucide-react-native';
+import {
+  BookOpen,
+  Compass,
+  Flower2,
+  Home,
+  LayoutGrid,
+  NotebookPen,
+  Sprout,
+} from 'lucide-react-native';
 import React from 'react';
 
 const mockLogout = jest.fn(() => Promise.resolve());
@@ -55,7 +63,7 @@ describe('BottomTabs', () => {
     expect(mockLogout).toHaveBeenCalled();
   });
 
-  it('renders a lucide icon for each of the five tabs', () => {
+  it('renders a lucide icon for each of the six tabs', () => {
     const { UNSAFE_getAllByType } = render(
       <NavigationContainer>
         <BottomTabs />
@@ -66,7 +74,7 @@ describe('BottomTabs', () => {
     // animation in @react-navigation/bottom-tabs); only assert each icon
     // appears at least once, which is what makeTabIcon being invoked
     // for every TAB_CONFIGS entry guarantees.
-    for (const Icon of [Sprout, Flower2, BookOpen, NotebookPen, Compass]) {
+    for (const Icon of [Home, Sprout, Flower2, BookOpen, NotebookPen, Compass]) {
       expect(UNSAFE_getAllByType(Icon).length).toBeGreaterThanOrEqual(1);
     }
   });
@@ -78,7 +86,7 @@ describe('BottomTabs', () => {
       </NavigationContainer>,
     );
 
-    // LayoutGrid was the Catalog tab icon; it must be absent now (5 tabs).
+    // LayoutGrid was the Catalog tab icon; it must be absent now (6 tabs).
     expect(UNSAFE_queryAllByType(LayoutGrid)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

#828 (epic #824): the app had no center of gravity — it opened into Habits and the tabs were independent islands. Add a **Today hub** answering "where am I in the 36-week journey, and what should I do today?" — aggregating existing stores/clients, **no new backend**.

- **BottomTabs**: Today is the **first** tab + `initialRouteName="Today"`; `RootTabParamList` + `BottomTabs.test` updated; all other tabs/routes/testIDs intact.
- **TodayScreen** (built from the Act II primitives): `ShowcaseCard` hero (time-of-day greeting + "Week N of 36 · {stage}"), today's-habits summary, and practice/journal/course bands — each routing into its feature tab.
- **Per-band isolation**: each band shows its own `SkeletonCard`/`EmptyState`, so one failing/empty source never blanks the screen. Staggered `useEntrance` (reduced-motion-safe); tokens-only; 44dp.

## Test plan

5 tests: hero journey position; habits summary + routes; skeleton; empty-state isolation (siblings still render); per-band navigation. BottomTabs test updated; existing 2062 green. `./scripts/frontend/check-all.sh` 4/4; no `any`, no new backend.

Closes #828
Refs #824
