### PR TITLE
feat(journal): editorial library shelf

### DIFF
--- a/frontend/src/features/Journal/JournalShelf.styles.ts
+++ b/frontend/src/features/Journal/JournalShelf.styles.ts
@@ -1,43 +1,37 @@
-/** Styles for the journal shelf (the landing list of entry "pages"). */
+/** Styles for the journal shelf (the editorial library of entry "pages"). */
 import { StyleSheet } from 'react-native';
 
 import {
   BORDER_RADIUS,
   SPACING,
+  accent,
   colors,
   editorialType,
-  paperShadow,
+  ink,
   spacing,
+  surface,
+  surfaceShadow,
   touchTarget,
 } from '@/design/tokens';
 
+const PROMPT_ACCENT_BAR = 3; // the weekly prompt's identifying left rule
+const HEADING_TRACKING = 1; // small-caps letter-spacing for recency headings
+
 const styles = StyleSheet.create({
-  safeArea: {
+  list: {
     flex: 1,
-    backgroundColor: colors.paper.desk, // shared desk ground (issue 01)
   },
   listContent: {
-    paddingHorizontal: SPACING.lg,
-    paddingTop: SPACING.md,
     paddingBottom: SPACING.xxl,
     flexGrow: 1,
   },
-  header: {
-    paddingVertical: SPACING.md,
-  },
-  newEntry: {
-    minHeight: touchTarget.minimum,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginTop: SPACING.sm,
-    paddingVertical: SPACING.md,
-    borderRadius: BORDER_RADIUS.md,
-    backgroundColor: colors.primary,
-  },
-  newEntryLabel: {
-    color: colors.text.light,
-    fontSize: 16,
-    fontWeight: '600',
+  sectionHeading: {
+    ...editorialType.caption,
+    color: ink.muted,
+    textTransform: 'uppercase',
+    letterSpacing: HEADING_TRACKING,
+    marginTop: SPACING.lg,
+    marginBottom: SPACING.sm,
   },
   card: {
     minHeight: touchTarget.minimum,
@@ -45,10 +39,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.lg,
     marginBottom: SPACING.md,
     borderRadius: BORDER_RADIUS.md,
-    // The lifted page card: separation now comes from the gap + shadow between
-    // floated cards, so the old borderBottom hairline is gone.
-    backgroundColor: colors.paper.background,
-    ...paperShadow.card,
+    // A warm paper tile lifted off the canvas by the shared card shadow;
+    // separation comes from the gap + shadow, not a hairline divider.
+    backgroundColor: surface.desk,
+    ...surfaceShadow.card,
   },
   cardTitleRow: {
     flexDirection: 'row',
@@ -57,18 +51,26 @@ const styles = StyleSheet.create({
   },
   cardTitle: {
     ...editorialType.title,
-    color: colors.paper.ink,
+    color: ink.primary,
     flexShrink: 1,
   },
   cardDate: {
     ...editorialType.caption,
-    color: colors.paper.inkSoft,
+    color: ink.soft,
     paddingLeft: SPACING.sm,
   },
   cardExcerpt: {
     ...editorialType.note,
-    color: colors.paper.inkSoft,
+    color: ink.soft,
     paddingTop: spacing(0.5),
+  },
+  cardCaption: {
+    ...editorialType.caption,
+    color: ink.muted,
+    paddingTop: spacing(0.5),
+  },
+  searchRow: {
+    marginBottom: SPACING.sm,
   },
   emptyWrap: {
     flex: 1,
@@ -79,7 +81,7 @@ const styles = StyleSheet.create({
   },
   emptyText: {
     ...editorialType.body,
-    color: colors.paper.inkSoft,
+    color: ink.soft,
     textAlign: 'center',
   },
   emptyError: {
@@ -88,25 +90,23 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   promptCard: {
-    marginHorizontal: SPACING.lg,
     marginTop: SPACING.lg,
     padding: SPACING.lg,
     borderRadius: BORDER_RADIUS.md,
-    // Lifted onto the desk like the entry cards, but keeps its accent-bar
-    // identity marking it as the weekly prompt.
-    backgroundColor: colors.paper.background,
-    borderLeftWidth: 3,
-    borderLeftColor: colors.marginalia.theme,
-    ...paperShadow.card,
+    // Lifted onto a raised sheet, but keeps an accent bar marking it the prompt.
+    backgroundColor: surface.raised,
+    borderLeftWidth: PROMPT_ACCENT_BAR,
+    borderLeftColor: accent.primary,
+    ...surfaceShadow.card,
   },
   promptLabel: {
     ...editorialType.caption,
-    color: colors.paper.inkSoft,
+    color: ink.muted,
     textTransform: 'uppercase',
   },
   promptQuestion: {
     ...editorialType.title,
-    color: colors.paper.ink,
+    color: ink.primary,
     paddingTop: spacing(0.5),
   },
 });

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -1,14 +1,16 @@
 /**
- * ``JournalShelfScreen`` — the journal's landing surface: a shelf of entries as
- * dated pages (title + excerpt + date), a "New entry" action, and editorial
- * full-text search. Tapping a page opens the entry screen by id. Replaces the
- * old chat list; categorization is the AI's marginalia now, so there are no tags.
+ * ``JournalShelfScreen`` — the journal's landing surface, restyled as an
+ * editorial library (#829): a warm ``ScreenScaffold`` + serif ``ScreenHeader``,
+ * search on the warm palette, entries grouped by recency (This week / This month
+ * / Earlier) as lifted paper tiles with a reading-time + "saved … ago" caption,
+ * the weekly prompt promoted to its own band, and an inviting empty state with a
+ * call to action. Tapping a page opens the entry screen by id.
  */
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Animated, FlatList, Text, TouchableOpacity, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Animated, SectionList, Text, TouchableOpacity, View } from 'react-native';
+import type { SectionListData, SectionListRenderItemInfo } from 'react-native';
 
 import styles from './JournalShelf.styles';
 import { usePressScale } from './motion';
@@ -17,6 +19,10 @@ import SearchBar from './SearchBar';
 import { journal, prompts } from '@/api';
 import type { JournalMessage, PromptDetail } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
+import { Button } from '@/components/Button';
+import { EmptyState } from '@/components/feedback/EmptyState';
+import { ScreenHeader } from '@/components/layout/ScreenHeader';
+import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { RootStackParamList } from '@/navigation/RootStack';
 import { useDerivedCurrentWeek } from '@/store/useProgramProgression';
@@ -25,8 +31,17 @@ const PAGE_SIZE = 20;
 const SEARCH_MIN_LENGTH = 3;
 const SEARCH_MAX_LENGTH = 64; // mirrors the backend JOURNAL_SEARCH_MAX_LENGTH guard
 const EXCERPT_MAX = 140;
+const MS_PER_DAY = 86_400_000;
+const WEEK_DAYS = 7;
+const MONTH_DAYS = 30;
+const WORDS_PER_MINUTE = 200;
 
 type ShelfNavigation = NativeStackNavigationProp<RootStackParamList>;
+
+interface ShelfSection {
+  title: string;
+  data: JournalMessage[];
+}
 
 function formatDate(timestamp: string): string {
   const date = new Date(timestamp);
@@ -37,6 +52,49 @@ function formatDate(timestamp: string): string {
 function excerpt(body: string): string {
   const flat = body.replace(/\s+/g, ' ').trim();
   return flat.length > EXCERPT_MAX ? `${flat.slice(0, EXCERPT_MAX).trimEnd()}…` : flat;
+}
+
+const RECENCY_ORDER = ['This week', 'This month', 'Earlier'] as const;
+
+/** Bucket name for an entry's age relative to ``now`` (epoch ms). */
+function bucketFor(timestamp: string, now: number): string {
+  const age = (now - new Date(timestamp).getTime()) / MS_PER_DAY;
+  if (age < WEEK_DAYS) return 'This week';
+  if (age < MONTH_DAYS) return 'This month';
+  return 'Earlier';
+}
+
+/** Group entries into recency sections, dropping any section with no entries. */
+function groupByRecency(items: JournalMessage[], now: number): ShelfSection[] {
+  return RECENCY_ORDER.map((title) => ({
+    title,
+    data: items.filter((item) => bucketFor(item.timestamp, now) === title),
+  })).filter((section) => section.data.length > 0);
+}
+
+/** Estimated reading time in whole minutes (≥1). */
+function readingMinutes(body: string): number {
+  const trimmed = body.trim();
+  const words = trimmed ? trimmed.split(/\s+/).length : 0;
+  return Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
+}
+
+/** A relative "saved …" phrase, falling back to the absolute date when old. */
+function savedAgo(timestamp: string, now: number): string {
+  const ms = new Date(timestamp).getTime();
+  if (Number.isNaN(ms)) return '';
+  const age = Math.floor((now - ms) / MS_PER_DAY);
+  if (age <= 0) return 'saved today';
+  if (age === 1) return 'saved 1 day ago';
+  if (age < MONTH_DAYS) return `saved ${age} days ago`;
+  return `saved ${formatDate(timestamp)}`;
+}
+
+/** Reading-time + "saved … ago" caption for a page card. */
+function pageCaption(entry: JournalMessage, now: number): string {
+  const read = `${readingMinutes(entry.message)} min read`;
+  const ago = savedAgo(entry.timestamp, now);
+  return ago ? `${read} · ${ago}` : read;
 }
 
 /** A search query only hits the API once it clears the backend's min length. */
@@ -109,9 +167,11 @@ function useShelf(): ShelfState {
 function PageCard({
   entry,
   onOpen,
+  now,
 }: {
   entry: JournalMessage;
   onOpen: (_id: number) => void;
+  now: number;
 }): React.JSX.Element {
   const press = usePressScale(useReducedMotion());
   return (
@@ -134,30 +194,36 @@ function PageCard({
         <Text style={styles.cardExcerpt} numberOfLines={2}>
           {excerpt(entry.message)}
         </Text>
+        <Text style={styles.cardCaption}>{pageCaption(entry, now)}</Text>
       </TouchableOpacity>
     </Animated.View>
   );
 }
 
-function ShelfHeader({ onSearch, onNew }: { onSearch: (_q: string) => void; onNew: () => void }) {
+/** A serif recency band heading (This week / This month / Earlier). */
+function SectionHeading({ title }: { title: string }): React.JSX.Element {
   return (
-    <View style={styles.header}>
-      <SearchBar onSearch={onSearch} />
-      <TouchableOpacity
-        style={styles.newEntry}
-        onPress={onNew}
-        accessibilityRole="button"
-        accessibilityLabel="New entry"
-        testID="journal-new-entry"
-      >
-        <Text style={styles.newEntryLabel}>New entry</Text>
-      </TouchableOpacity>
-    </View>
+    <Text style={styles.sectionHeading} accessibilityRole="header">
+      {title}
+    </Text>
   );
 }
 
-/** Empty-list state: nothing while loading, the load error, else the empty copy. */
-function ShelfEmpty({ loading, error }: { loading: boolean; error: string | null }) {
+interface ShelfEmptyProps {
+  loading: boolean;
+  error: string | null;
+  searching: boolean;
+  onNew: () => void;
+}
+
+/** Empty list: nothing while loading, the load error, a no-results line for an
+ * active search, else the inviting empty state with a CTA into a blank page. */
+function ShelfEmpty({
+  loading,
+  error,
+  searching,
+  onNew,
+}: ShelfEmptyProps): React.JSX.Element | null {
   if (loading) return null;
   if (error != null) {
     return (
@@ -168,12 +234,23 @@ function ShelfEmpty({ loading, error }: { loading: boolean; error: string | null
       </View>
     );
   }
+  if (searching) {
+    return (
+      <View style={styles.emptyWrap}>
+        <Text style={styles.emptyText} testID="journal-shelf-no-results">
+          No pages match your search.
+        </Text>
+      </View>
+    );
+  }
   return (
-    <View style={styles.emptyWrap}>
-      <Text style={styles.emptyText} testID="journal-shelf-empty">
-        Your shelf is empty — start a page.
-      </Text>
-    </View>
+    <EmptyState
+      glyph="📖"
+      title="Your shelf is empty"
+      body="Start your first page — a quiet place to think out loud."
+      cta={<Button label="Start a page" onPress={onNew} testID="journal-empty-cta" />}
+      testID="journal-shelf-empty"
+    />
   );
 }
 
@@ -204,7 +281,7 @@ function usePrompt(): PromptDetail | null {
   return prompt;
 }
 
-/** The weekly prompt surfaced as a pre-titled page (tap → the entry screen). */
+/** The weekly prompt surfaced as its own pre-titled band (tap → the entry screen). */
 function PromptCard({
   week,
   question,
@@ -213,7 +290,7 @@ function PromptCard({
   week: number;
   question: string;
   onOpen: () => void;
-}) {
+}): React.JSX.Element {
   return (
     <TouchableOpacity
       style={styles.promptCard}
@@ -228,12 +305,53 @@ function PromptCard({
   );
 }
 
-function JournalShelfScreen(): React.JSX.Element {
-  const navigation = useNavigation<ShelfNavigation>();
-  const { items, loading, error, hasMore, onSearch, loadMore } = useShelf();
-  const prompt = usePrompt();
-  const week = useDerivedCurrentWeek(prompt?.week_number ?? 1);
+interface TopMatterProps {
+  prompt: PromptDetail | null;
+  week: number;
+  onPrompt: () => void;
+  onNew: () => void;
+  onSearch: (_query: string) => void;
+  query: string;
+  resultCount?: number;
+}
 
+/** The scrolling head of the shelf: title + New entry, the prompt band, search. */
+function ShelfTopMatter({
+  prompt,
+  week,
+  onPrompt,
+  onNew,
+  onSearch,
+  query,
+  resultCount,
+}: TopMatterProps): React.JSX.Element {
+  return (
+    <View>
+      <ScreenHeader
+        title="Your shelf"
+        eyebrow="Journal"
+        action={<Button label="New entry" onPress={onNew} testID="journal-new-entry" />}
+      />
+      {prompt ? <PromptCard week={week} question={prompt.question} onOpen={onPrompt} /> : null}
+      <View style={styles.searchRow}>
+        <SearchBar onSearch={onSearch} searchQuery={query || undefined} resultCount={resultCount} />
+      </View>
+    </View>
+  );
+}
+
+interface ShelfNav {
+  openEntry: (_id: number) => void;
+  newEntry: () => void;
+  openPrompt: () => void;
+}
+
+/** Memoized navigation callbacks for the shelf's three destinations. */
+function useShelfNavigation(
+  navigation: ShelfNavigation,
+  prompt: PromptDetail | null,
+  week: number,
+): ShelfNav {
   const openEntry = useCallback(
     (entryId: number) => navigation.navigate('JournalEntry', { entryId }),
     [navigation],
@@ -247,28 +365,58 @@ function JournalShelfScreen(): React.JSX.Element {
       prefillTitle: `Week ${week} Reflection`,
     });
   }, [navigation, prompt, week]);
+  return { openEntry, newEntry, openPrompt };
+}
 
-  const header = (
-    <>
-      {prompt ? <PromptCard week={week} question={prompt.question} onOpen={openPrompt} /> : null}
-      <ShelfHeader onSearch={onSearch} onNew={newEntry} />
-    </>
+function JournalShelfScreen(): React.JSX.Element {
+  const navigation = useNavigation<ShelfNavigation>();
+  const { items, loading, error, query, hasMore, onSearch, loadMore } = useShelf();
+  const prompt = usePrompt();
+  const week = useDerivedCurrentWeek(prompt?.week_number ?? 1);
+  const nav = useShelfNavigation(navigation, prompt, week);
+  const now = Date.now();
+  const sections = groupByRecency(items, now);
+  const searching = query.length >= SEARCH_MIN_LENGTH;
+  const resultCount = searching ? items.length : undefined;
+
+  const renderItem = ({ item }: SectionListRenderItemInfo<JournalMessage, ShelfSection>) => (
+    <PageCard entry={item} onOpen={nav.openEntry} now={now} />
   );
+  const renderSectionHeader = ({
+    section,
+  }: {
+    section: SectionListData<JournalMessage, ShelfSection>;
+  }) => <SectionHeading title={section.title} />;
 
   return (
-    <SafeAreaView style={styles.safeArea} testID="journal-shelf">
-      <FlatList
+    <ScreenScaffold testID="journal-shelf">
+      <SectionList
+        style={styles.list}
         testID="journal-shelf-list"
-        data={items}
+        sections={sections}
         keyExtractor={(item) => String(item.id)}
-        renderItem={({ item }) => <PageCard entry={item} onOpen={openEntry} />}
-        ListHeaderComponent={header}
-        ListEmptyComponent={<ShelfEmpty loading={loading} error={error} />}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        stickySectionHeadersEnabled={false}
+        ListHeaderComponent={
+          <ShelfTopMatter
+            prompt={prompt}
+            week={week}
+            onPrompt={nav.openPrompt}
+            onNew={nav.newEntry}
+            onSearch={onSearch}
+            query={query}
+            resultCount={resultCount}
+          />
+        }
+        ListEmptyComponent={
+          <ShelfEmpty loading={loading} error={error} searching={searching} onNew={nav.newEntry} />
+        }
         onEndReached={hasMore ? loadMore : undefined}
         onEndReachedThreshold={0.4}
         contentContainerStyle={styles.listContent}
       />
-    </SafeAreaView>
+    </ScreenScaffold>
   );
 }
 

--- a/frontend/src/features/Journal/SearchBar.tsx
+++ b/frontend/src/features/Journal/SearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
-import { colors, radius, SPACING } from '../../design/tokens';
+import { accent, ink, radius, SPACING, surface } from '../../design/tokens';
 
 const DEBOUNCE_DELAY_MS = 300;
 
@@ -34,6 +34,52 @@ interface ExpandedSearchBarProps {
   resultCount?: number;
 }
 
+/** The result line: "No results …" when a query came back empty, else the count. */
+function resultLine(searchQuery: string, resultCount: number): string {
+  return resultCount === 0
+    ? `No results for '${searchQuery}'`
+    : `${resultCount} results for '${searchQuery}'`;
+}
+
+/** The warm-palette text field; owns its own accent-on-focus border. */
+const SearchTextInput = ({
+  text,
+  onChangeText,
+}: {
+  text: string;
+  onChangeText: (_value: string) => void;
+}): React.JSX.Element => {
+  const [focused, setFocused] = useState(false);
+  return (
+    <TextInput
+      testID="search-input"
+      accessibilityLabel="Search journal"
+      style={[styles.searchTextInput, focused && styles.searchTextInputFocused]}
+      value={text}
+      onChangeText={onChangeText}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
+      placeholder="Search journal..."
+      placeholderTextColor={ink.muted}
+      autoFocus
+    />
+  );
+};
+
+/** The count / "no results" caption, shown only for an active query. */
+const SearchResultLine = ({
+  searchQuery,
+  resultCount,
+}: {
+  searchQuery?: string;
+  resultCount?: number;
+}): React.JSX.Element | null =>
+  searchQuery && resultCount != null ? (
+    <Text style={styles.searchResultCount} testID="search-result-count">
+      {resultLine(searchQuery, resultCount)}
+    </Text>
+  ) : null;
+
 const ExpandedSearchBarContent = ({
   text,
   onChangeText,
@@ -53,16 +99,7 @@ const ExpandedSearchBarContent = ({
       >
         <Text style={styles.searchIcon}>🔍</Text>
       </TouchableOpacity>
-      <TextInput
-        testID="search-input"
-        accessibilityLabel="Search journal"
-        style={styles.searchTextInput}
-        value={text}
-        onChangeText={onChangeText}
-        placeholder="Search journal..."
-        placeholderTextColor={colors.text.tertiary}
-        autoFocus
-      />
+      <SearchTextInput text={text} onChangeText={onChangeText} />
       <TouchableOpacity
         testID="search-clear"
         onPress={onClear}
@@ -73,11 +110,7 @@ const ExpandedSearchBarContent = ({
         <Text style={styles.searchClearText}>×</Text>
       </TouchableOpacity>
     </View>
-    {searchQuery && resultCount != null && (
-      <Text style={styles.searchResultCount}>
-        {resultCount} results for &apos;{searchQuery}&apos;
-      </Text>
-    )}
+    <SearchResultLine searchQuery={searchQuery} resultCount={resultCount} />
   </View>
 );
 
@@ -158,13 +191,13 @@ const styles = StyleSheet.create({
     width: 36,
     height: 36,
     borderRadius: 18,
-    backgroundColor: colors.background.accent,
+    backgroundColor: surface.sunken,
     alignItems: 'center',
     justifyContent: 'center',
   },
   searchIcon: {
     fontSize: 16,
-    color: colors.text.secondary,
+    color: ink.soft,
     fontWeight: '600',
   },
   searchTextInput: {
@@ -174,27 +207,30 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.md,
     borderRadius: radius.lg,
     borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.background.card,
+    borderColor: surface.hairline,
+    backgroundColor: surface.raised,
     fontSize: 14,
-    color: colors.text.primary,
+    color: ink.primary,
+  },
+  searchTextInputFocused: {
+    borderColor: accent.primary,
   },
   searchClear: {
     width: 36,
     height: 36,
     borderRadius: 18,
-    backgroundColor: colors.background.accent,
+    backgroundColor: surface.sunken,
     alignItems: 'center',
     justifyContent: 'center',
   },
   searchClearText: {
     fontSize: 14,
-    color: colors.text.secondary,
+    color: ink.soft,
     fontWeight: '600',
   },
   searchResultCount: {
     fontSize: 12,
-    color: colors.text.tertiary,
+    color: ink.muted,
     marginTop: SPACING.xs,
     marginLeft: 44,
   },

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 
 import type { JournalListResponse, JournalMessage, PromptDetail } from '@/api';
-import { colors } from '@/design/tokens';
+import { accent, surface } from '@/design/tokens';
 
 const mockList = jest.fn() as jest.MockedFunction<
   (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
@@ -95,38 +95,77 @@ describe('JournalShelfScreen', () => {
     expect(getByTestId('journal-shelf-card-1')).toBeTruthy();
   });
 
-  it('floats each entry as a lifted paper card on the deeper desk ground', async () => {
+  it('floats each entry as a warm paper tile lifted off the canvas ground', async () => {
     mockList.mockResolvedValue(page([entry(1)]));
     const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
     const card = StyleSheet.flatten((await findByTestId('journal-shelf-card-1')).props.style);
-    // Lifted paper card: matches the page ground, lifted by the warm card shadow,
+    // Lifted warm paper tile (surface.desk) raised by the shared card shadow,
     // separated by gaps rather than the old hairline divider.
-    expect(card.backgroundColor).toBe(colors.paper.background);
+    expect(card.backgroundColor).toBe(surface.desk);
     expect(card.shadowRadius).toBeGreaterThan(0);
     expect(card.elevation).toBeGreaterThan(0);
     expect(card.borderBottomWidth).toBeUndefined();
-    // The shelf sits on the deeper desk ground the cards float above.
+    // The shelf now sits on the warm scaffold canvas.
     const root = StyleSheet.flatten(getByTestId('journal-shelf').props.style);
-    expect(root.backgroundColor).toBe(colors.paper.desk);
+    expect(root.backgroundColor).toBe(surface.canvas);
   });
 
-  it('floats the weekly-prompt card with matching depth while keeping its accent bar', async () => {
+  it('floats the weekly-prompt band with matching depth while keeping its accent bar', async () => {
     mockList.mockResolvedValue(page([entry(1)]));
     mockPromptCurrent.mockResolvedValue(prompt({ week_number: 3, has_responded: false }));
     const { findByTestId } = render(<JournalShelfScreen />);
     const card = StyleSheet.flatten((await findByTestId('journal-weekly-prompt')).props.style);
-    // Same floated treatment as the entry cards…
-    expect(card.backgroundColor).toBe(colors.paper.background);
+    // Lifted onto a raised sheet…
+    expect(card.backgroundColor).toBe(surface.raised);
     expect(card.shadowRadius).toBeGreaterThan(0);
     expect(card.elevation).toBeGreaterThan(0);
     // …but keeps its accent-bar identity.
-    expect(card.borderLeftColor).toBe(colors.marginalia.theme);
+    expect(card.borderLeftColor).toBe(accent.primary);
   });
 
   it('shows the empty state when there are no entries', async () => {
     mockList.mockResolvedValue(page([]));
     const { findByTestId } = render(<JournalShelfScreen />);
     expect(await findByTestId('journal-shelf-empty')).toBeTruthy();
+  });
+
+  it('groups entries into recency sections (This week / This month / Earlier)', async () => {
+    const DAY_MS = 86_400_000;
+    const ago = (days: number) => new Date(Date.now() - days * DAY_MS).toISOString();
+    mockList.mockResolvedValue(
+      page([
+        entry(1, { timestamp: ago(1) }), // This week
+        entry(2, { timestamp: ago(10) }), // This month
+        entry(3, { timestamp: ago(60) }), // Earlier
+      ]),
+    );
+    const { findByText, getByText, getByTestId } = render(<JournalShelfScreen />);
+    expect(await findByText('This week')).toBeTruthy();
+    expect(getByText('This month')).toBeTruthy();
+    expect(getByText('Earlier')).toBeTruthy();
+    expect(getByTestId('journal-shelf-card-1')).toBeTruthy();
+    expect(getByTestId('journal-shelf-card-3')).toBeTruthy();
+  });
+
+  it('starts a blank page from the empty-state call to action', async () => {
+    mockList.mockResolvedValue(page([]));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    fireEvent.press(await findByTestId('journal-empty-cta'));
+    expect(mockNavigate).toHaveBeenCalledWith('JournalEntry');
+  });
+
+  it('shows a no-results line when a search returns nothing', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { findByTestId, getByTestId, queryByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-card-1');
+
+    mockList.mockResolvedValue(page([])); // the search comes back empty
+    await act(async () => {
+      fireEvent.changeText(getByTestId('shelf-search'), 'zzz');
+    });
+    expect(await findByTestId('journal-shelf-no-results')).toBeTruthy();
+    // The inviting empty state is suppressed during an active search.
+    expect(queryByTestId('journal-shelf-empty')).toBeNull();
   });
 
   it('opens a fresh entry from "New entry"', async () => {

--- a/frontend/src/features/Journal/__tests__/SearchBar.test.tsx
+++ b/frontend/src/features/Journal/__tests__/SearchBar.test.tsx
@@ -91,4 +91,12 @@ describe('SearchBar', () => {
     fireEvent.press(getByTestId('search-toggle'));
     expect(getByText("5 results for 'test'")).toBeTruthy();
   });
+
+  it('shows a "No results" line when a query comes back empty', () => {
+    const { getByTestId, getByText } = render(
+      <SearchBar onSearch={onSearch} resultCount={0} searchQuery="willow" />,
+    );
+    fireEvent.press(getByTestId('search-toggle'));
+    expect(getByText("No results for 'willow'")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

#829 (epic #824): the journal writing surface is the flagship but the shelf read as a different product. Re-make it as a warm grouped library.

- `ScreenScaffold` + serif `ScreenHeader` ("Your shelf"); "New entry" → header action slot as the warm `Button`.
- `SearchBar` repaletted onto warm tokens (surface grounds, `ink` text, `ink.muted` placeholder, `accent` focus) — **debounce/min-char unchanged**; "No results for '…'" line.
- Flat `FlatList` → `SectionList` grouped **This week / This month / Earlier**; `PageCard`s on `surface.desk` + `surfaceShadow.card` with an "N min read · saved … ago" caption; weekly-prompt promoted to its own band.
- Inviting `EmptyState` + "Start a page" CTA.

## Test plan

Grouping-into-sections, empty-state CTA → new entry, search "No results"; all nav/pagination/search + testIDs preserved (no legacy `colors.background.*`). `./scripts/frontend/check-all.sh` 4/4; no `any`.

Closes #829
Refs #824
