### PR TITLE
feat(practice): warm catalog, detail, and begin-a-session hero (#830)

### DIFF
--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -21,6 +21,7 @@
  */
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RefreshCw } from 'lucide-react-native';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -36,8 +37,18 @@ import WeeklyProgress from './WeeklyProgress';
 
 import type { PracticeSessionResponse } from '@/api';
 import { EmptyState } from '@/components/feedback/EmptyState';
+import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
 import { useAuth } from '@/context/AuthContext';
-import { BORDER_RADIUS, SPACING, colors, touchTarget } from '@/design/tokens';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  colors,
+  editorialType,
+  onShowcase,
+  surface,
+  touchTarget,
+} from '@/design/tokens';
 import { stageService } from '@/features/Map/services/stageService';
 import ActiveRitualSession from '@/features/Practice/components/ActiveRitualSession';
 import { FrequencyBanner } from '@/features/Practice/components/FrequencyBanner';
@@ -128,6 +139,8 @@ interface CatalogButtonProps {
   stageNumber: number;
   label: string;
   testID: string;
+  /** Optional leading icon (e.g. the RefreshCw glyph on "Change practice"). */
+  icon?: React.ReactNode;
 }
 
 /**
@@ -135,7 +148,12 @@ interface CatalogButtonProps {
  * user's resolved stage. Used as "Change practice" in the active state and
  * "Browse all practices" in the selection state — both open the same catalog.
  */
-const CatalogButton = ({ stageNumber, label, testID }: CatalogButtonProps): React.JSX.Element => {
+const CatalogButton = ({
+  stageNumber,
+  label,
+  testID,
+  icon,
+}: CatalogButtonProps): React.JSX.Element => {
   // Catalog is a pushed RootStack screen (not a tab), so navigate with the
   // stack-typed navigation rather than the tab-scoped useAppNavigation.
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -147,10 +165,27 @@ const CatalogButton = ({ stageNumber, label, testID }: CatalogButtonProps): Reac
       accessibilityLabel={label}
       testID={testID}
     >
+      {icon}
       <Text style={styles.browseCatalogText}>{label}</Text>
     </TouchableOpacity>
   );
 };
+
+/**
+ * The arrival hero for the active practice — a focal warm-umber showcase band
+ * that frames the session as a "begin a session" moment. Presentation only:
+ * the large Begin control lives in the engine's mode view below (its
+ * `idle → running` wiring is unchanged).
+ */
+const BeginHero = ({ practiceName }: { practiceName: string }): React.JSX.Element => (
+  <ShowcaseCard style={styles.hero} testID="practice-begin-hero">
+    <Text style={styles.heroEyebrow}>PRACTICE</Text>
+    <Text style={styles.heroTitle} accessibilityRole="header">
+      Begin a session
+    </Text>
+    <Text style={styles.heroLead}>Settle in with {practiceName} when you’re ready.</Text>
+  </ShowcaseCard>
+);
 
 interface ActiveSessionViewProps {
   userPractice: NonNullable<ActivePracticeHook['activeUserPractice']>;
@@ -189,12 +224,14 @@ const ActiveSessionView = ({
         testID="practice-screen"
       >
         {banner}
+        <BeginHero practiceName={effectiveName ?? practiceName} />
         {/* The primary switch affordance, in the scroll header (not over the
             timer, so it doesn't intercept mid-session taps). */}
         <CatalogButton
           stageNumber={stageNumber}
           label="Change practice"
           testID="change-practice-button"
+          icon={<RefreshCw size={16} color={accent.primary} style={styles.browseCatalogIcon} />}
         />
         <ActiveRitualSession
           key={`practice-${userPractice.id}`}
@@ -283,7 +320,7 @@ const LoadingView = (): React.JSX.Element => {
       style={[styles.centered, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
       testID="practice-loading"
     >
-      <ActivityIndicator size="large" color={colors.primary} />
+      <ActivityIndicator size="large" color={accent.primary} />
     </View>
   );
 };
@@ -314,7 +351,7 @@ const ErrorView = ({
 };
 
 const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: colors.background.primary },
+  screen: { flex: 1, backgroundColor: surface.canvas },
   fill: { flex: 1 },
   scrollContent: { padding: SPACING.md, paddingBottom: SPACING.xxl },
   centered: {
@@ -322,7 +359,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: SPACING.xxl,
-    backgroundColor: colors.background.primary,
+    backgroundColor: surface.canvas,
   },
   errorText: {
     color: colors.danger,
@@ -331,27 +368,39 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.lg,
   },
   retryButton: {
-    backgroundColor: colors.primary,
+    backgroundColor: accent.primary,
     borderRadius: BORDER_RADIUS.md,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.xl,
   },
-  retryButtonText: { color: colors.text.light, fontWeight: '600' },
+  retryButtonText: { color: surface.raised, fontWeight: '600' },
+  hero: { marginHorizontal: SPACING.md, marginBottom: SPACING.md },
+  heroEyebrow: {
+    ...editorialType.caption,
+    color: onShowcase.muted,
+    letterSpacing: 1.5,
+    marginBottom: SPACING.xs,
+  },
+  heroTitle: { ...editorialType.display, color: onShowcase.primary, marginBottom: SPACING.xs },
+  heroLead: { ...editorialType.note, color: onShowcase.soft },
   browseCatalog: {
+    flexDirection: 'row',
+    gap: SPACING.xs,
     marginHorizontal: SPACING.md,
     marginBottom: SPACING.md,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.lg,
     borderRadius: BORDER_RADIUS.md,
     borderWidth: 1,
-    borderColor: colors.primary,
+    borderColor: accent.primary,
     alignItems: 'center',
     justifyContent: 'center',
     minHeight: touchTarget.minimum,
   },
+  browseCatalogIcon: { marginRight: SPACING.xs },
   // fontSize 16 mirrors retryButtonText above (the app has no static type token;
   // typography() is viewport-responsive) so the two buttons stay visually aligned.
-  browseCatalogText: { color: colors.primary, fontWeight: '600', fontSize: 16 },
+  browseCatalogText: { color: accent.primary, fontWeight: '600', fontSize: 16 },
 });
 
 export default PracticeScreen;

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -357,6 +357,31 @@ describe('PracticeScreen', () => {
     expect(queryByTestId('practice-empty-state')).toBeNull();
   });
 
+  it('frames the active practice with a focal "Begin a session" showcase hero', async () => {
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId, getByText } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+    // The warm showcase hero presents the arrival moment; the engine's own
+    // Begin control (ritual-start) still drives idle → running unchanged.
+    expect(getByTestId('practice-begin-hero')).toBeTruthy();
+    expect(getByText('Begin a session')).toBeTruthy();
+    expect(getByTestId('ritual-start')).toBeTruthy();
+  });
+
+  it('begins the session from the unchanged engine start control', async () => {
+    jest.useFakeTimers();
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId, queryByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('practice-begin-hero')).toBeTruthy());
+    // Pressing Begin (ritual-start) transitions the engine into a running
+    // session — the meditation timer view exposes its running cancel control.
+    await act(async () => {
+      fireEvent.press(getByTestId('ritual-start'));
+    });
+    expect(queryByTestId('ritual-cancel')).toBeTruthy();
+    jest.useRealTimers();
+  });
+
   it('change-practice opens the Catalog seeded to the current stage', async () => {
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId } = render(<PracticeScreen />);

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -35,7 +35,7 @@ import type {
 } from '@/api';
 import { practiceSessions } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import { SPACING, colors } from '@/design/tokens';
+import { SPACING, colors, ink, surface } from '@/design/tokens';
 import { InsightCaptureModal } from '@/features/Practice/components/InsightCaptureModal';
 import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConfiguratorSheet';
 import type { PickedCard } from '@/features/Practice/data/resolveCard';
@@ -901,7 +901,7 @@ const styles = StyleSheet.create({
     paddingBottom: SPACING.lg,
     marginBottom: SPACING.lg,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.separator,
+    borderBottomColor: surface.hairline,
   },
   cardHeader: {
     flexDirection: 'row',
@@ -917,12 +917,12 @@ const styles = StyleSheet.create({
     minHeight: 44,
     paddingHorizontal: SPACING.sm,
   },
-  gearText: { fontSize: 18, color: colors.text.secondary },
-  gearLabel: { fontSize: 14, fontWeight: '600', color: colors.text.secondary },
+  gearText: { fontSize: 18, color: ink.soft },
+  gearLabel: { fontSize: 14, fontWeight: '600', color: ink.soft },
   name: {
     fontSize: 20,
     fontWeight: '700',
-    color: colors.text.primary,
+    color: ink.primary,
     marginBottom: SPACING.md,
   },
   error: {

--- a/frontend/src/features/Practice/hooks/useRecentPractices.ts
+++ b/frontend/src/features/Practice/hooks/useRecentPractices.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  MAX_RECENT_PRACTICES,
+  loadRecentPractices,
+  recordRecentPractice,
+  type RecentPractice,
+} from '@/storage/recentPracticesStorage';
+
+interface RecentPracticesHook {
+  recents: RecentPractice[];
+  /** Record a freshly-begun practice — updates state optimistically, then persists. */
+  record: (_entry: RecentPractice) => void;
+}
+
+/**
+ * Reads (and records into) the persisted "recently begun practices" list. The
+ * catalog uses it to surface a quick shortcut row above the full sections.
+ */
+export function useRecentPractices(): RecentPracticesHook {
+  const [recents, setRecents] = useState<RecentPractice[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    void loadRecentPractices().then((list) => {
+      if (active) setRecents(list);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const record = useCallback((entry: RecentPractice) => {
+    setRecents((prev) => mergeRecent(prev, entry));
+    void recordRecentPractice(entry);
+  }, []);
+
+  return { recents, record };
+}
+
+/** Move ``entry`` to the front of ``prev`` (deduped by id), capped to the max. */
+function mergeRecent(prev: readonly RecentPractice[], entry: RecentPractice): RecentPractice[] {
+  const deduped = prev.filter((item) => item.id !== entry.id);
+  return [entry, ...deduped].slice(0, MAX_RECENT_PRACTICES);
+}

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -34,11 +34,25 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { type PracticeItem, practices, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import { BORDER_RADIUS, SPACING, colors, shadows, touchTarget } from '@/design/tokens';
+import { Button } from '@/components/Button';
+import { EmptyState } from '@/components/feedback/EmptyState';
+import { ScreenHeader } from '@/components/layout/ScreenHeader';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  colors,
+  ink,
+  surface,
+  surfaceShadow,
+  touchTarget,
+} from '@/design/tokens';
 import { MODE_CATEGORIES, type PickableMode } from '@/features/Practice/components/ModePicker';
 import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
+import { useRecentPractices } from '@/features/Practice/hooks/useRecentPractices';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import type { RootStackParamList } from '@/navigation/RootStack';
+import type { RecentPractice } from '@/storage/recentPracticesStorage';
 
 type Section = 'presets' | 'drafts' | 'imported';
 
@@ -82,8 +96,9 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
     navigateToDetail,
     navigateToCreate,
   );
-  const onUse = useCatalogSetActive(stageNumber, navigation, setActive);
-
+  const setActivePractice = useCatalogSetActive(stageNumber, navigation, setActive);
+  const { recents, record } = useRecentPractices();
+  const onUse = useRecordedUse(setActivePractice, record);
   const { sections, renderItem } = useCatalogList(state, query, modeCategory, onDetail, onUse);
   const insets = useSafeAreaInsets();
   const containerStyle = [styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom }];
@@ -96,7 +111,7 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
         keyExtractor={catalogKeyExtractor}
         renderItem={renderItem}
         renderSectionHeader={renderSectionHeader}
-        renderSectionFooter={renderSectionFooter}
+        renderSectionFooter={makeSectionFooter(onCreate)}
         ListHeaderComponent={
           <CatalogHeader
             query={query}
@@ -106,6 +121,8 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
             modeCategory={modeCategory}
             onMode={setModeCategory}
             onCreate={onCreate}
+            recents={recents}
+            onDetail={onDetail}
           />
         }
         ListFooterComponent={<CatalogStatus state={state} onRetry={reload} />}
@@ -115,6 +132,30 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
       />
     </View>
   );
+}
+
+/** "Use this practice" — snapshot it into the recents list, then set it active. */
+function useRecordedUse(
+  setActivePractice: (id: number) => void,
+  record: (_entry: RecentPractice) => void,
+): (practice: PracticeItem) => void {
+  return useCallback(
+    (practice: PracticeItem) => {
+      record(toRecentPractice(practice));
+      setActivePractice(practice.id);
+    },
+    [record, setActivePractice],
+  );
+}
+
+/** Snapshot a catalog item into the persisted recent-practice shape. */
+function toRecentPractice(practice: PracticeItem): RecentPractice {
+  return {
+    id: practice.id,
+    name: practice.name,
+    mode: practice.mode ?? null,
+    durationMinutes: practice.default_duration_minutes,
+  };
 }
 
 /** Seed the stage chip: an explicit prop (tests) wins, else the ``Catalog``
@@ -134,7 +175,7 @@ function useCatalogList(
   query: string,
   modeCategory: string | null,
   onDetail: (id: number) => void,
-  onUse: (id: number) => void,
+  onUse: (practice: PracticeItem) => void,
 ): { sections: CatalogSection[]; renderItem: (info: { item: PracticeItem }) => React.JSX.Element } {
   const sections = useMemo(
     () => buildSections(state.practices, query, modeCategory),
@@ -202,18 +243,58 @@ interface CatalogSection {
 
 const catalogKeyExtractor = (item: PracticeItem): string => `practice-${item.id}`;
 
-const renderSectionHeader = ({ section }: { section: CatalogSection }): React.JSX.Element => (
-  <View style={styles.section} testID={`practice-catalog-section-${section.section}`}>
-    <Text style={styles.sectionTitle}>{section.title}</Text>
-  </View>
-);
+const renderSectionHeader = ({ section }: { section: CatalogSection }): React.JSX.Element | null =>
+  section.data.length === 0 ? null : (
+    <View style={styles.section} testID={`practice-catalog-section-${section.section}`}>
+      <Text style={styles.sectionTitle}>{section.title}</Text>
+    </View>
+  );
 
-const renderSectionFooter = ({ section }: { section: CatalogSection }): React.JSX.Element | null =>
-  section.data.length === 0 ? (
-    <Text style={styles.emptyText} testID={`practice-catalog-section-${section.section}-empty`}>
-      Nothing here yet.
-    </Text>
-  ) : null;
+interface SectionFooterProps {
+  section: Section;
+  onCreate: () => void;
+}
+
+const SECTION_EMPTY_COPY: Readonly<Record<Section, { title: string; body: string }>> = {
+  presets: { title: 'No presets here', body: 'No curated practices match this filter yet.' },
+  drafts: { title: 'No drafts yet', body: 'Author a practice and it lands here.' },
+  imported: { title: 'Nothing imported', body: 'Practices shared with you will appear here.' },
+};
+
+/**
+ * An empty catalog section reads as an editorial empty state that points to the
+ * create wizard, rather than the old passive "Nothing here yet." line.
+ */
+/** A SectionList footer renderer that shows the empty state only for empty sections. */
+function makeSectionFooter(
+  onCreate: () => void,
+): (info: { section: CatalogSection }) => React.JSX.Element | null {
+  return ({ section }) =>
+    section.data.length === 0 ? (
+      <SectionFooter section={section.section} onCreate={onCreate} />
+    ) : null;
+}
+
+const SectionFooter = ({ section, onCreate }: SectionFooterProps): React.JSX.Element | null => {
+  const copy = SECTION_EMPTY_COPY[section];
+  return (
+    <EmptyState
+      glyph="🪶"
+      title={copy.title}
+      body={copy.body}
+      style={styles.sectionEmpty}
+      testID={`practice-catalog-section-${section}-empty`}
+      cta={
+        <Button
+          variant="secondary"
+          label="Create a practice"
+          onPress={onCreate}
+          testID={`practice-catalog-section-${section}-create`}
+        />
+      }
+    />
+  );
+};
 
 /** Build the three catalog sections (always present, even when empty). */
 function buildSections(
@@ -237,6 +318,8 @@ interface CatalogHeaderProps {
   modeCategory: string | null;
   onMode: (category: string | null) => void;
   onCreate: () => void;
+  recents: readonly RecentPractice[];
+  onDetail: (id: number) => void;
 }
 
 /** Non-scrolling-away header for the SectionList (kept as an element so the
@@ -247,8 +330,55 @@ const CatalogHeader = (props: CatalogHeaderProps): React.JSX.Element => (
     <SearchBar value={props.query} onChange={props.onQueryChange} />
     <StageChips selected={props.stageNumber} onSelect={props.onStage} />
     <ModeChips selected={props.modeCategory} onSelect={props.onMode} />
+    <RecentlyUsed recents={props.recents} onDetail={props.onDetail} />
   </View>
 );
+
+interface RecentlyUsedProps {
+  recents: readonly RecentPractice[];
+  onDetail: (id: number) => void;
+}
+
+/** A quick "Recently used" shortcut above the full catalog; hidden when empty. */
+const RecentlyUsed = ({ recents, onDetail }: RecentlyUsedProps): React.JSX.Element | null => {
+  if (recents.length === 0) return null;
+  return (
+    <View style={styles.section} testID="practice-catalog-recently-used">
+      <Text style={styles.sectionTitle}>Recently used</Text>
+      {recents.map((recent) => (
+        <RecentRow key={`recent-${recent.id}`} recent={recent} onDetail={onDetail} />
+      ))}
+    </View>
+  );
+};
+
+interface RecentRowProps {
+  recent: RecentPractice;
+  onDetail: (id: number) => void;
+}
+
+const RecentRow = ({ recent, onDetail }: RecentRowProps): React.JSX.Element => {
+  const mode = (recent.mode ?? 'meditation_timer') as PickableMode;
+  const { label, icon } = MODE_PRESENTATION[mode] ?? FALLBACK_PRESENTATION;
+  const rounded = Math.round(recent.durationMinutes);
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={`${recent.name}. ${label}, ${rounded} minutes.`}
+      onPress={() => onDetail(recent.id)}
+      style={[styles.row, styles.recentRow]}
+      testID={`practice-catalog-recent-row-${recent.id}`}
+    >
+      <Text style={styles.rowIcon}>{icon}</Text>
+      <View style={styles.rowText}>
+        <Text style={styles.rowName} numberOfLines={1}>
+          {recent.name}
+        </Text>
+        <Text style={styles.rowSubtitle}>{`${label} · ${formatDuration(rounded)}`}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
 
 interface CatalogStatusProps {
   state: CatalogState;
@@ -260,7 +390,7 @@ const CatalogStatus = ({ state, onRetry }: CatalogStatusProps): React.JSX.Elemen
   if (state.loading) {
     return (
       <View style={styles.loadingBlock} testID="practice-catalog-loading">
-        <ActivityIndicator color={colors.primary} />
+        <ActivityIndicator color={accent.primary} />
       </View>
     );
   }
@@ -325,21 +455,19 @@ interface HeaderProps {
 }
 
 const Header = ({ onCreate }: HeaderProps): React.JSX.Element => (
-  <View style={styles.header}>
-    <View>
-      <Text style={styles.heading}>Practice catalog</Text>
-      <Text style={styles.subheading}>Browse every practice, or author your own.</Text>
-    </View>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessibilityLabel="Create a new practice"
-      onPress={onCreate}
-      style={styles.createButton}
-      testID="practice-catalog-create"
-    >
-      <Text style={styles.createButtonText}>+ Create</Text>
-    </TouchableOpacity>
-  </View>
+  <ScreenHeader
+    eyebrow="Practice"
+    title="Catalog"
+    lead="Browse every practice, or author your own."
+    action={
+      <Button
+        label="+ Create"
+        accessibilityLabel="Create a new practice"
+        onPress={onCreate}
+        testID="practice-catalog-create"
+      />
+    }
+  />
 );
 
 interface SearchBarProps {
@@ -352,7 +480,7 @@ const SearchBar = ({ value, onChange }: SearchBarProps): React.JSX.Element => (
     accessibilityLabel="Search practices by name or description"
     style={styles.search}
     placeholder="Search by name or description"
-    placeholderTextColor={colors.text.tertiaryAccessible}
+    placeholderTextColor={ink.muted}
     value={value}
     onChangeText={onChange}
     testID="practice-catalog-search"
@@ -429,7 +557,7 @@ const FilterChip = ({ label, selected, onPress, testID }: FilterChipProps): Reac
 interface PracticeRowProps {
   practice: PracticeItem;
   onDetail: (id: number) => void;
-  onUse: (id: number) => void;
+  onUse: (practice: PracticeItem) => void;
 }
 
 // Derived from MODE_CATEGORIES so adding a mode propagates here automatically.
@@ -477,7 +605,7 @@ const PracticeRowComponent = ({
       <TouchableOpacity
         accessibilityRole="button"
         accessibilityLabel={`Use ${practice.name}`}
-        onPress={() => onUse(practice.id)}
+        onPress={() => onUse(practice)}
         style={styles.rowUse}
         testID={`practice-catalog-row-${practice.id}-use`}
       >
@@ -548,36 +676,17 @@ function bucketSections(items: readonly PracticeItem[]): SectionBuckets {
 }
 
 const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: colors.background.primary },
+  screen: { flex: 1, backgroundColor: surface.canvas },
   body: { padding: SPACING.md, paddingBottom: SPACING.xl },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: SPACING.md,
-  },
-  heading: { fontSize: 22, fontWeight: '700', color: colors.text.primary },
-  subheading: {
-    fontSize: 13,
-    color: colors.text.secondaryAccessible,
-    marginTop: 2,
-  },
-  createButton: {
-    backgroundColor: colors.primary,
-    paddingVertical: SPACING.sm,
-    paddingHorizontal: SPACING.md,
-    borderRadius: BORDER_RADIUS.sm,
-  },
-  createButtonText: { color: colors.text.light, fontWeight: '700', fontSize: 13 },
   search: {
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
     borderRadius: BORDER_RADIUS.sm,
     paddingHorizontal: SPACING.sm,
     paddingVertical: SPACING.sm,
     fontSize: 14,
-    color: colors.text.primary,
-    backgroundColor: colors.background.card,
+    color: ink.primary,
+    backgroundColor: surface.raised,
     marginBottom: SPACING.sm,
   },
   chipRow: {
@@ -591,12 +700,12 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.xs,
     borderRadius: BORDER_RADIUS.lg,
     borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.background.card,
+    borderColor: surface.hairline,
+    backgroundColor: surface.raised,
   },
-  chipSelected: { backgroundColor: colors.primary, borderColor: colors.primary },
-  chipText: { fontSize: 12, color: colors.text.primary, fontWeight: '600' },
-  chipTextSelected: { color: colors.text.light },
+  chipSelected: { backgroundColor: accent.primary, borderColor: accent.primary },
+  chipText: { fontSize: 12, color: ink.primary, fontWeight: '600' },
+  chipTextSelected: { color: surface.raised },
   loadingBlock: { padding: SPACING.lg, alignItems: 'center' },
   errorBlock: { padding: SPACING.lg, alignItems: 'center', gap: SPACING.sm },
   errorText: { color: colors.destructive.text, fontSize: 13 },
@@ -604,20 +713,20 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.md,
     borderRadius: BORDER_RADIUS.sm,
-    backgroundColor: colors.background.card,
+    backgroundColor: surface.raised,
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
   },
-  retryButtonText: { color: colors.text.primary, fontWeight: '600' },
+  retryButtonText: { color: ink.primary, fontWeight: '600' },
   section: { marginTop: SPACING.md },
   sectionTitle: {
     fontSize: 14,
     fontWeight: '700',
-    color: colors.text.secondaryAccessible,
+    color: ink.soft,
     textTransform: 'uppercase',
     marginBottom: SPACING.sm,
   },
-  emptyText: { color: colors.text.tertiaryAccessible, fontSize: 13 },
+  sectionEmpty: { flex: 0, alignItems: 'stretch', paddingVertical: SPACING.md, gap: SPACING.sm },
   rowContainer: {
     flexDirection: 'row',
     alignItems: 'stretch',
@@ -629,28 +738,29 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: SPACING.md,
-    backgroundColor: colors.background.card,
+    backgroundColor: surface.raised,
     borderRadius: BORDER_RADIUS.lg,
     padding: SPACING.md,
-    ...shadows.small,
+    ...surfaceShadow.card,
   },
+  recentRow: { marginBottom: SPACING.sm },
   rowUse: {
     justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: SPACING.md,
     minWidth: touchTarget.minimum,
     minHeight: touchTarget.minimum,
-    backgroundColor: colors.primary,
+    backgroundColor: accent.primary,
     borderRadius: BORDER_RADIUS.lg,
-    ...shadows.small,
+    ...surfaceShadow.card,
   },
-  rowUseText: { color: colors.text.light, fontWeight: '700', fontSize: 14 },
+  rowUseText: { color: surface.raised, fontWeight: '700', fontSize: 14 },
   rowIcon: { fontSize: 24, width: 32, textAlign: 'center' },
   rowText: { flex: 1 },
-  rowName: { fontSize: 15, fontWeight: '700', color: colors.text.primary },
+  rowName: { fontSize: 15, fontWeight: '700', color: ink.primary },
   rowSubtitle: {
     fontSize: 13,
-    color: colors.text.secondaryAccessible,
+    color: ink.soft,
     marginTop: 2,
   },
 });

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -10,20 +10,23 @@
 
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  ActivityIndicator,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { ModeConfig } from '../engine/types';
 
 import { type PracticeItem, practices, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  colors,
+  editorialType,
+  ink,
+  surface,
+  surfaceShadow,
+} from '@/design/tokens';
 import ShareSheet from '@/features/Practice/components/ShareSheet';
 import { MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
@@ -75,7 +78,7 @@ function LoadedDetail({
 }): React.JSX.Element {
   const [shareOpen, setShareOpen] = useState(false);
   return (
-    <ScrollView contentContainerStyle={styles.body} testID="practice-detail-screen">
+    <ScreenScaffold scroll style={styles.scaffold} testID="practice-detail-screen">
       <DetailHeader practice={practice} />
       <DetailBody practice={practice} />
       {state.actionError !== null && (
@@ -112,7 +115,7 @@ function LoadedDetail({
         practiceId={practice.id}
         onClose={() => setShareOpen(false)}
       />
-    </ScrollView>
+    </ScreenScaffold>
   );
 }
 
@@ -128,7 +131,7 @@ export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JS
   if (state.loading) {
     return (
       <View style={styles.loading} testID="practice-detail-loading">
-        <ActivityIndicator color={colors.primary} size="large" />
+        <ActivityIndicator color={accent.primary} size="large" />
       </View>
     );
   }
@@ -233,7 +236,8 @@ interface DetailHeaderProps {
 
 const DetailHeader = ({ practice }: DetailHeaderProps): React.JSX.Element => (
   <View style={styles.headerBlock}>
-    <Text style={styles.heading} testID="practice-detail-name">
+    <Text style={styles.eyebrow}>PRACTICE</Text>
+    <Text style={styles.heading} accessibilityRole="header" testID="practice-detail-name">
       {practice.name}
     </Text>
     <View style={styles.metaRow}>
@@ -498,10 +502,21 @@ const ErrorView = ({ message, onRetry }: ErrorViewProps): React.JSX.Element => (
 );
 
 const styles = StyleSheet.create({
-  loading: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  body: { padding: SPACING.md, paddingBottom: SPACING.xl },
+  loading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: surface.canvas,
+  },
+  scaffold: { paddingBottom: SPACING.xl },
   headerBlock: { marginBottom: SPACING.md },
-  heading: { fontSize: 22, fontWeight: '700', color: colors.text.primary },
+  eyebrow: {
+    ...editorialType.caption,
+    color: accent.primary,
+    letterSpacing: 1.5,
+    marginBottom: SPACING.xs,
+  },
+  heading: { ...editorialType.display, color: ink.primary },
   metaRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
@@ -509,53 +524,53 @@ const styles = StyleSheet.create({
     marginTop: SPACING.xs,
   },
   badge: {
-    backgroundColor: colors.background.accent,
+    backgroundColor: surface.sunken,
     paddingVertical: SPACING.xs,
     paddingHorizontal: SPACING.sm,
     borderRadius: BORDER_RADIUS.sm,
   },
-  badgeText: { color: colors.text.primary, fontSize: 12, fontWeight: '600' },
+  badgeText: { color: ink.primary, fontSize: 12, fontWeight: '600' },
   bodyBlock: {
-    backgroundColor: colors.background.card,
+    backgroundColor: surface.raised,
     borderRadius: BORDER_RADIUS.lg,
     padding: SPACING.md,
     marginBottom: SPACING.md,
-    ...shadows.small,
+    ...surfaceShadow.card,
   },
   section: { marginBottom: SPACING.sm },
   sectionLabel: {
     fontSize: 12,
     fontWeight: '700',
-    color: colors.text.secondaryAccessible,
+    color: ink.soft,
     textTransform: 'uppercase',
     marginBottom: SPACING.xs,
   },
-  sectionText: { fontSize: 14, color: colors.text.primary, lineHeight: 20 },
-  bullet: { fontSize: 13, color: colors.text.primary, marginVertical: 1 },
+  sectionText: { fontSize: 14, color: ink.primary, lineHeight: 20 },
+  bullet: { fontSize: 13, color: ink.primary, marginVertical: 1 },
   actionRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.sm },
   actionButton: {
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.md,
     borderRadius: BORDER_RADIUS.sm,
-    backgroundColor: colors.background.card,
+    backgroundColor: surface.raised,
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
   },
-  actionButtonPrimary: { backgroundColor: colors.primary, borderColor: colors.primary },
-  actionButtonText: { color: colors.text.primary, fontWeight: '600', fontSize: 13 },
-  actionButtonTextPrimary: { color: colors.text.light },
+  actionButtonPrimary: { backgroundColor: accent.primary, borderColor: accent.primary },
+  actionButtonText: { color: ink.primary, fontWeight: '600', fontSize: 13 },
+  actionButtonTextPrimary: { color: surface.raised },
   disabledButton: { opacity: 0.5 },
   pickerCard: {
-    backgroundColor: colors.background.card,
+    backgroundColor: surface.raised,
     borderRadius: BORDER_RADIUS.lg,
     padding: SPACING.md,
     marginTop: SPACING.md,
-    ...shadows.small,
+    ...surfaceShadow.card,
   },
   pickerHeading: {
     fontSize: 14,
     fontWeight: '700',
-    color: colors.text.primary,
+    color: ink.primary,
     marginBottom: SPACING.sm,
   },
   pickerRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
@@ -564,20 +579,27 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.xs,
     paddingHorizontal: SPACING.sm,
     borderRadius: BORDER_RADIUS.sm,
-    backgroundColor: colors.background.accent,
+    backgroundColor: surface.sunken,
     alignItems: 'center',
   },
-  stageBoxText: { color: colors.text.primary, fontWeight: '700' },
+  stageBoxText: { color: ink.primary, fontWeight: '700' },
   pickerCancel: { marginTop: SPACING.sm, alignSelf: 'flex-end' },
-  pickerCancelText: { color: colors.primary, fontWeight: '600', fontSize: 13 },
+  pickerCancelText: { color: accent.primary, fontWeight: '600', fontSize: 13 },
   banner: {
-    backgroundColor: colors.background.accent,
+    backgroundColor: surface.sunken,
     padding: SPACING.sm,
     borderRadius: BORDER_RADIUS.sm,
     marginBottom: SPACING.sm,
   },
   bannerText: { color: colors.successText, fontSize: 13, fontWeight: '600' },
-  errorBlock: { padding: SPACING.lg, alignItems: 'center', gap: SPACING.md },
+  errorBlock: {
+    flex: 1,
+    padding: SPACING.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: SPACING.md,
+    backgroundColor: surface.canvas,
+  },
   errorText: { color: colors.destructive.text, fontSize: 13, marginBottom: SPACING.sm },
 });
 

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 import { Alert } from 'react-native';
@@ -343,6 +344,66 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
     // Filtering by Timers should keep this row visible — the fallback maps it to meditation_timer.
     fireEvent.press(view.getByTestId('practice-catalog-mode-timers'));
     expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
+  });
+});
+
+describe('PracticeCatalogScreen — empty sections', () => {
+  it('renders an editorial empty state with a Create CTA into the wizard', async () => {
+    const { view, navigateToCreate } = renderScreen();
+    await waitForLoad();
+    // The Imported section is always empty today — it shows the warm empty state
+    // (replacing the old passive "Nothing here yet." line) with a create CTA.
+    expect(view.getByTestId('practice-catalog-section-imported-empty')).toBeTruthy();
+    expect(view.queryByText('Nothing here yet.')).toBeNull();
+    fireEvent.press(view.getByTestId('practice-catalog-section-imported-create'));
+    expect(navigateToCreate).toHaveBeenCalled();
+  });
+});
+
+describe('PracticeCatalogScreen — recently used', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('hides the Recently-used shortcut when there is no history', async () => {
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.queryByTestId('practice-catalog-recently-used')).toBeNull();
+  });
+
+  it('surfaces a recorded practice in the Recently-used shortcut and opens its detail', async () => {
+    await AsyncStorage.setItem(
+      '@adepthood/recent_practices',
+      JSON.stringify([
+        {
+          id: 2,
+          name: 'Awareness bells preset',
+          mode: 'random_interval_bell',
+          durationMinutes: 20,
+        },
+      ]),
+    );
+    const { view, navigateToDetail } = renderScreen();
+    await waitForLoad();
+    expect(view.getByTestId('practice-catalog-recently-used')).toBeTruthy();
+    const recentRow = view.getByTestId('practice-catalog-recent-row-2');
+    expect(recentRow).toBeTruthy();
+    fireEvent.press(recentRow);
+    expect(navigateToDetail).toHaveBeenCalledWith(2);
+  });
+
+  it('records a practice when its Use button is tapped', async () => {
+    const setActive = jest.fn(async () => undefined) as jest.MockedFunction<
+      (id: number, stage: number) => Promise<void>
+    >;
+    const { view } = renderScreen({ setActive });
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
+    await waitFor(async () => {
+      const raw = await AsyncStorage.getItem('@adepthood/recent_practices');
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw as string)[0].id).toBe(1);
+    });
   });
 });
 

--- a/frontend/src/storage/recentPracticesStorage.ts
+++ b/frontend/src/storage/recentPracticesStorage.ts
@@ -1,0 +1,56 @@
+// Remembers the handful of practices a user has most recently begun, so the
+// catalog can offer a "Recently used" shortcut. Snapshots the display fields
+// (not just the id) so a recent entry renders even when it belongs to another
+// stage than the one the catalog is currently paging.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { resetCorruptKey } from './jsonStore';
+
+const RECENT_PRACTICES_KEY = '@adepthood/recent_practices';
+
+/** How many recent practices the shortcut keeps (most-recent-first). */
+export const MAX_RECENT_PRACTICES = 6;
+
+/** A lightweight snapshot of a practice the user recently began. */
+export interface RecentPractice {
+  id: number;
+  name: string;
+  mode: string | null;
+  durationMinutes: number;
+}
+
+function isRecentPractice(value: unknown): value is RecentPractice {
+  if (typeof value !== 'object' || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.id === 'number' &&
+    typeof entry.name === 'string' &&
+    (entry.mode === null || typeof entry.mode === 'string') &&
+    typeof entry.durationMinutes === 'number'
+  );
+}
+
+function sanitize(value: unknown): RecentPractice[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isRecentPractice).slice(0, MAX_RECENT_PRACTICES);
+}
+
+/** Read the recent-practice list; self-heals (returns []) on missing/corrupt data. */
+export async function loadRecentPractices(): Promise<RecentPractice[]> {
+  try {
+    const raw = await AsyncStorage.getItem(RECENT_PRACTICES_KEY);
+    if (raw === null) return [];
+    return sanitize(JSON.parse(raw));
+  } catch (err) {
+    await resetCorruptKey(RECENT_PRACTICES_KEY, err);
+    return [];
+  }
+}
+
+/** Move ``entry`` to the front of the recent list (deduped by id), then persist. */
+export async function recordRecentPractice(entry: RecentPractice): Promise<void> {
+  const existing = await loadRecentPractices();
+  const deduped = existing.filter((item) => item.id !== entry.id);
+  const next = [entry, ...deduped].slice(0, MAX_RECENT_PRACTICES);
+  await AsyncStorage.setItem(RECENT_PRACTICES_KEY, JSON.stringify(next));
+}


### PR DESCRIPTION
Closes #830 (design-act2-06: Practice catalog + "begin a session" + warm adoption).

## What changed
- **Warm migration** — `PracticeScreen`, `PracticeCatalogScreen`, and `PracticeDetailScreen` move off the legacy grey/brown tokens (`colors.background.*`, `colors.text.secondary`, `colors.text.primary`, `colors.primary`, `colors.border`) onto the Candle & Ink `surface`/`ink`/`accent` language. `ActiveRitualSession`'s Adjust gear, name, and divider come along too.
- **Scaffold + editorial header** — catalog header and the detail screen adopt `ScreenHeader`/`ScreenScaffold`; the detail name keeps its `practice-detail-name` testID with a serif display treatment.
- **Begin-a-session hero** — the active landing now opens with a focal warm-umber `ShowcaseCard` ("Begin a session"). The engine `idle → running` wiring is unchanged — the large Begin control is still the engine's `ritual-start`, and Adjust still opens the configurator.
- **Change practice** gains a `RefreshCw` icon.
- **Recently used** — a persisted shortcut (new `recentPracticesStorage` + `useRecentPractices`) surfaces the practices a user recently began, above the full sections; hidden when empty.
- **Empty sections** — the passive "Nothing here yet." line becomes an editorial `EmptyState` with a "Create a practice" CTA into the wizard.

## Invariants preserved
- Practice engine state machine, session start/stop, configurator, and **all** Practice navigation + testIDs unchanged — only chrome/presentation moved.
- No legacy grey grounds remain on the three screens (verified by grep).

## Tests
- New: showcase Begin hero renders + Begin still drives the engine into a running session; catalog Recently-used shortcut surfaces a recorded practice and opens its detail; "Use" records a recent; empty section shows the EmptyState → wizard CTA.
- `./scripts/frontend/check-all.sh` green (eslint, prettier, tsc, 2072 jest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)