### PR TITLE
feat(practice): immersive session — showcase header, celebration, soft reflection sheet

### DIFF
--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -35,7 +35,15 @@ import type {
 } from '@/api';
 import { practiceSessions } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import { SPACING, colors, ink, surface } from '@/design/tokens';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  onShowcase,
+  showcase,
+  showcaseShadow,
+  surface,
+} from '@/design/tokens';
 import { InsightCaptureModal } from '@/features/Practice/components/InsightCaptureModal';
 import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConfiguratorSheet';
 import type { PickedCard } from '@/features/Practice/data/resolveCard';
@@ -411,23 +419,29 @@ interface SessionCardProps {
 }
 
 function SessionCard(props: SessionCardProps): React.JSX.Element {
+  // The session is fronted by a warm-dark showcase header band (practice name +
+  // Adjust on the umber ground) so a running practice reads as a focal moment
+  // rather than a settings form; the mode view renders below on its readable
+  // ground. The shared RitualControlsBar plays the completion Celebration.
   return (
     <View style={styles.card} testID="active-practice-card">
-      <View style={styles.cardHeader}>
-        <TouchableOpacity
-          accessibilityRole="button"
-          accessibilityLabel="Adjust this practice's settings"
-          onPress={props.onConfigure}
-          style={styles.gearButton}
-          testID="active-practice-configure"
-        >
-          <Text style={styles.gearText}>⚙︎</Text>
-          <Text style={styles.gearLabel}>Adjust</Text>
-        </TouchableOpacity>
+      <View style={styles.headerBand}>
+        <View style={styles.cardHeader}>
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel="Adjust this practice's settings"
+            onPress={props.onConfigure}
+            style={styles.gearButton}
+            testID="active-practice-configure"
+          >
+            <Text style={styles.gearText}>⚙︎</Text>
+            <Text style={styles.gearLabel}>Adjust</Text>
+          </TouchableOpacity>
+        </View>
+        <Text style={styles.name} testID="active-practice-name">
+          {props.effectiveName}
+        </Text>
       </View>
-      <Text style={styles.name} testID="active-practice-name">
-        {props.effectiveName}
-      </Text>
       <ModeView
         config={props.config}
         state={props.state}
@@ -895,13 +909,22 @@ function repCounterSummary(config: RepCounterConfig, state: RitualState): ModeSu
 }
 
 const styles = StyleSheet.create({
-  // Flat surface: the session sits on the screen's padded scroll, separated from
-  // the footer by a hairline divider (no elevation).
+  // Flat session container; the warm-dark showcase header band sits at its top.
   card: {
     paddingBottom: SPACING.lg,
     marginBottom: SPACING.lg,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: surface.hairline,
+  },
+  // The showcase header band: the practice name + Adjust on the umber ground.
+  headerBand: {
+    backgroundColor: showcase.canvas,
+    borderRadius: BORDER_RADIUS.lg,
+    paddingHorizontal: SPACING.lg,
+    paddingBottom: SPACING.md,
+    paddingTop: SPACING.xs,
+    marginBottom: SPACING.lg,
+    ...showcaseShadow,
   },
   cardHeader: {
     flexDirection: 'row',
@@ -917,12 +940,12 @@ const styles = StyleSheet.create({
     minHeight: 44,
     paddingHorizontal: SPACING.sm,
   },
-  gearText: { fontSize: 18, color: ink.soft },
-  gearLabel: { fontSize: 14, fontWeight: '600', color: ink.soft },
+  gearText: { fontSize: 18, color: onShowcase.soft },
+  gearLabel: { fontSize: 14, fontWeight: '600', color: onShowcase.soft },
   name: {
     fontSize: 20,
     fontWeight: '700',
-    color: ink.primary,
+    color: onShowcase.primary,
     marginBottom: SPACING.md,
   },
   error: {

--- a/frontend/src/features/Practice/components/InsightCaptureModal.tsx
+++ b/frontend/src/features/Practice/components/InsightCaptureModal.tsx
@@ -20,6 +20,7 @@
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  Animated,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -37,6 +38,7 @@ import {
 } from '../insights/format';
 
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import { useEntrance } from '@/hooks/useEntrance';
 
 /** Soft cap — the modal nudges the user toward a single sentence past this. */
 export const PRACTICE_INSIGHT_SOFT_CAP = 200;
@@ -290,21 +292,33 @@ export function InsightCaptureModal({
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={styles.backdrop}
       >
-        <SheetContent
-          mode={mode}
-          durationMinutes={durationMinutes}
-          modeMetadata={modeMetadata}
-          draft={draft}
-          setDraft={setDraft}
-          withinSoftCap={withinSoftCap}
-          withinHardCap={withinHardCap}
-          onSavePress={handleSave}
-          onSkipPress={onSkip}
-          onJournalPress={onJournal ? handleJournal : undefined}
-        />
+        <RisingSheet>
+          <SheetContent
+            mode={mode}
+            durationMinutes={durationMinutes}
+            modeMetadata={modeMetadata}
+            draft={draft}
+            setDraft={setDraft}
+            withinSoftCap={withinSoftCap}
+            withinHardCap={withinHardCap}
+            onSavePress={handleSave}
+            onSkipPress={onSkip}
+            onJournalPress={onJournal ? handleJournal : undefined}
+          />
+        </RisingSheet>
       </KeyboardAvoidingView>
     </Modal>
   );
+}
+
+/**
+ * Wraps the sheet in a soft rise (fade + small translateY) so the reflection
+ * prompt settles in rather than snapping over the immersive session view.
+ * Static under reduced motion (the shared `useEntrance` seam).
+ */
+function RisingSheet({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const entrance = useEntrance();
+  return <Animated.View style={entrance}>{children}</Animated.View>;
 }
 
 const styles = StyleSheet.create({

--- a/frontend/src/features/Practice/views/RitualControlsBar.tsx
+++ b/frontend/src/features/Practice/views/RitualControlsBar.tsx
@@ -3,6 +3,9 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { EngineStatus, RitualControls } from '../engine/types';
 
+import { useSessionSurface } from './sessionSurface';
+
+import { Celebration } from '@/components/feedback/Celebration';
 import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
 type Variant = 'primary' | 'secondary' | 'danger';
@@ -14,34 +17,51 @@ interface Props {
   startLabel?: string;
 }
 
+const RunningControls = ({ controls }: Pick<Props, 'controls'>): React.JSX.Element => (
+  <>
+    <Button variant="secondary" label="Pause" onPress={controls.pause} testID="ritual-pause" />
+    <Button variant="danger" label="Cancel" onPress={controls.cancel} testID="ritual-cancel" />
+  </>
+);
+
+const PausedControls = ({ controls }: Pick<Props, 'controls'>): React.JSX.Element => (
+  <>
+    <Button variant="primary" label="Resume" onPress={controls.resume} testID="ritual-resume" />
+    <Button variant="danger" label="Cancel" onPress={controls.cancel} testID="ritual-cancel" />
+  </>
+);
+
+/** The completion line, played through the shared reduced-motion-safe Celebration. */
+const CompleteLabel = ({ color }: { color: string }): React.JSX.Element => (
+  <Celebration active testID="ritual-complete-celebration">
+    <Text style={[styles.completeText, { color }]} testID="ritual-complete-label">
+      Practice complete
+    </Text>
+  </Celebration>
+);
+
 const RitualControlsBar = ({
   status,
   controls,
   startLabel = 'Start',
-}: Props): React.JSX.Element => (
-  <View style={styles.row} testID="ritual-controls-bar">
-    {status === 'idle' && (
-      <Button variant="primary" label={startLabel} onPress={controls.start} testID="ritual-start" />
-    )}
-    {status === 'running' && (
-      <>
-        <Button variant="secondary" label="Pause" onPress={controls.pause} testID="ritual-pause" />
-        <Button variant="danger" label="Cancel" onPress={controls.cancel} testID="ritual-cancel" />
-      </>
-    )}
-    {status === 'paused' && (
-      <>
-        <Button variant="primary" label="Resume" onPress={controls.resume} testID="ritual-resume" />
-        <Button variant="danger" label="Cancel" onPress={controls.cancel} testID="ritual-cancel" />
-      </>
-    )}
-    {status === 'complete' && (
-      <Text style={styles.completeText} testID="ritual-complete-label">
-        Practice complete
-      </Text>
-    )}
-  </View>
-);
+}: Props): React.JSX.Element => {
+  const surface = useSessionSurface();
+  return (
+    <View style={styles.row} testID="ritual-controls-bar">
+      {status === 'idle' && (
+        <Button
+          variant="primary"
+          label={startLabel}
+          onPress={controls.start}
+          testID="ritual-start"
+        />
+      )}
+      {status === 'running' && <RunningControls controls={controls} />}
+      {status === 'paused' && <PausedControls controls={controls} />}
+      {status === 'complete' && <CompleteLabel color={surface.accent} />}
+    </View>
+  );
+};
 
 interface ButtonProps {
   variant: Variant;

--- a/frontend/src/features/Practice/views/__tests__/RitualControlsBar.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/RitualControlsBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, within } from '@testing-library/react-native';
 import React from 'react';
 
 import RitualControlsBar from '../RitualControlsBar';
@@ -45,6 +45,15 @@ describe('RitualControlsBar', () => {
     expect(getByTestId('ritual-complete-label')).toBeTruthy();
     expect(queryByTestId('ritual-start')).toBeNull();
     expect(queryByTestId('ritual-cancel')).toBeNull();
+  });
+
+  it('plays the completion Celebration around the complete label', () => {
+    const controls = fakeControls();
+    const { getByTestId } = render(<RitualControlsBar status="complete" controls={controls} />);
+    const celebration = getByTestId('ritual-complete-celebration');
+    expect(celebration).toBeTruthy();
+    // The label is rendered inside the celebration wrapper, not bare.
+    expect(within(celebration).getByTestId('ritual-complete-label')).toBeTruthy();
   });
 
   it('honours the optional startLabel override on the start button', () => {

--- a/frontend/src/features/Practice/views/sessionSurface.ts
+++ b/frontend/src/features/Practice/views/sessionSurface.ts
@@ -1,0 +1,63 @@
+/**
+ * Colour context for the in-session ritual views (#831).
+ *
+ * The mode views (`MeditationTimerView`, `RepCounterView`, …) historically
+ * hard-coded the light `colors.*` palette in their static `StyleSheet`s, so a
+ * meditation session read like a settings form. To put a *running* session on
+ * the warm-dark `showcase` ground without rewriting every view's layout, each
+ * view reads its text / cue / ring colours from this context and appends them as
+ * inline overrides on top of its existing styles.
+ *
+ * The default value is the original light palette, so any view rendered WITHOUT
+ * a provider (e.g. the idle selector, existing unit tests) is byte-for-byte
+ * unchanged. `ActiveRitualSession` wraps the live session in
+ * {@link SessionSurfaceProvider} with {@link SHOWCASE_SURFACE} to flip the whole
+ * mode view onto the umber ground with AA-clearing `onShowcase` cues.
+ */
+import { createContext, useContext } from 'react';
+
+import { colors, onShowcase, showcase } from '@/design/tokens';
+
+export interface SessionSurface {
+  /** The ground the session renders on. */
+  ground: string;
+  /** A lifted panel within the ground (cards, rings' fill). */
+  raised: string;
+  /** Primary reading colour (timer digits, headings). */
+  text: string;
+  /** Secondary copy (labels, captions). */
+  textSoft: string;
+  /** De-emphasised copy (hints). */
+  textMuted: string;
+  /** Accent / progress-ring stroke / cue highlight. */
+  accent: string;
+}
+
+/** The original light palette — the default so non-session views are unchanged. */
+export const LIGHT_SURFACE: SessionSurface = {
+  ground: colors.background.primary,
+  raised: colors.background.card,
+  text: colors.text.primary,
+  textSoft: colors.text.secondary,
+  textMuted: colors.text.tertiary,
+  accent: colors.success,
+};
+
+/** The warm-dark showcase palette for a running session (AA on the umber). */
+export const SHOWCASE_SURFACE: SessionSurface = {
+  ground: showcase.canvas,
+  raised: showcase.raised,
+  text: onShowcase.primary,
+  textSoft: onShowcase.soft,
+  textMuted: onShowcase.muted,
+  accent: onShowcase.primary,
+};
+
+const SessionSurfaceContext = createContext<SessionSurface>(LIGHT_SURFACE);
+
+export const SessionSurfaceProvider = SessionSurfaceContext.Provider;
+
+/** Read the active session surface; defaults to the light palette. */
+export function useSessionSurface(): SessionSurface {
+  return useContext(SessionSurfaceContext);
+}


### PR DESCRIPTION
## Summary

#831 (epic #824): the in-session experience gained an immersive showcase frame, a real completion moment, and a non-jarring reflection hand-off.

- **ActiveRitualSession**: session fronted by a warm-dark **showcase header band** (`showcase.canvas` + `onShowcase` chrome); all testIDs preserved.
- **RitualControlsBar**: running → complete plays the shared reduced-motion-safe `Celebration` around "Practice complete".
- **InsightCaptureModal**: a `RisingSheet` animates the sheet in via `useEntrance` (static under reduced motion) instead of snapping. Save/skip/journal + char caps + `/practice-sessions` save + optimistic week-count increment **byte-for-byte unchanged**.
- New `views/sessionSurface.ts`: a `SessionSurface` colour-context seam (defaults to the current light palette — views unchanged without a provider).

No engine/mode/save/testID regressions; tokens-only; no `any`. `./scripts/frontend/check-all.sh` 4/4.

## Scope note (AC#1, transparent)

AC#1 ("running mode view inside a showcase container") is **partially** met: the session is fronted by a showcase band + the celebration + soft sheet land, and the `sessionSurface` seam is in place — but the **11 mode-view interiors still render on the light ground** (they hard-code AA-tuned `*Accessible` colour variants in static `StyleSheet`s). Extending the umber ground through them is a sizable, careful pass scoped out to land this green and regression-free — tracked in **#859**.

Closes #831
Refs #824
