### PR TITLE
refactor(map): single responsive row grid (re-architecture)

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -2,27 +2,31 @@
 
 import { StyleSheet } from 'react-native';
 
-import { colors, editorialType, radius, shadows, spacing, surface } from '../../design/tokens';
+import {
+  accent,
+  colors,
+  editorialType,
+  ink,
+  radius,
+  shadows,
+  spacing,
+  surface,
+  touchTarget,
+} from '../../design/tokens';
 
-// --- Layout constants for the three-column "spiral of becoming" table -------
-const LEFT_COLUMN_WIDTH = '40%';
-const CENTER_COLUMN_WIDTH = '40%';
-const RIGHT_COLUMN_WIDTH = '20%';
-/** The grey band starts below the two title rows (Awareness + Being). */
-const GREY_BAND_TOP = '20%';
-const HALF = '50%';
-const FULL = '100%';
-const ABSOLUTE = 'absolute';
+// --- Grid weights for the three cells of every stage row -------------------
+// One responsive row grid is the single source of vertical truth: each stage
+// row is [LeftCell | CenterCell | RightCell] with these flex weights (≈40/40/20),
+// so the three columns are siblings in the same row and cannot drift.
+const LEFT_FLEX = 2;
+const CENTER_FLEX = 2;
+const RIGHT_FLEX = 1;
 const CENTER = 'center';
-const TABLE_BORDER_COLOR = '#111111';
-const FEMININE_BAND_COLOR = '#d9d9d9';
-const MASCULINE_BAND_COLOR = '#efefef';
-const ARROW_LABEL_COLOR = '#262626';
 
 /**
- * Mystical-aesthetic styles for the Map screen.
- * Supports hotspot overlays, rich stage detail modal, glow effects,
- * and visual states for locked/current/completed stages.
+ * Styles for the Map's spiral-of-becoming grid + the rich stage-detail modal.
+ * The grid is token-only and laid out purely with flex; the modal keeps the
+ * existing mystical treatment.
  */
 const styles = StyleSheet.create({
   container: {
@@ -38,82 +42,36 @@ const styles = StyleSheet.create({
     backgroundColor: surface.canvas,
   },
   loadingText: {
-    color: colors.text.primary,
+    color: ink.primary,
     fontSize: 14,
     marginTop: spacing(1),
   },
   errorText: {
     color: colors.danger,
     fontSize: 14,
-    textAlign: 'center',
+    textAlign: CENTER,
     paddingHorizontal: spacing(2),
   },
 
-  // Hotspot touch targets (transparent overlays on the background image)
-  hotspot: {
-    position: 'absolute',
-    backgroundColor: 'rgba(255,255,255,0.01)',
-  },
-  hotspotLocked: {
-    opacity: 0.4,
-  },
-  hotspotCurrent: {
-    borderWidth: 2,
-    borderColor: colors.mystical.glowLight,
-    borderRadius: radius.sm,
-  },
-  hotspotCompleted: {
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.3)',
-    borderRadius: radius.sm,
-  },
-
-  // Lock icon overlay for locked stages
-  lockOverlay: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  lockText: {
-    fontSize: 14,
-    color: colors.text.light,
-    opacity: 0.7,
-  },
-
-  // Stage connection lines between stages
-  connectionLine: {
-    position: ABSOLUTE,
-    width: 2,
-    backgroundColor: 'rgba(0,0,0,0.10)',
-  },
-
-  // --- Three-column spiral table -------------------------------------------
-  table: {
+  // --- The single responsive row grid --------------------------------------
+  grid: {
     flex: 1,
+  },
+  // One stage row; flex weight set inline to stageNumbers.length so a paired
+  // row is twice the height of a single-stage row.
+  groupRow: {
     flexDirection: 'row',
-    borderWidth: 2,
-    borderColor: TABLE_BORDER_COLOR,
   },
-  leftColumn: {
-    width: LEFT_COLUMN_WIDTH,
+  leftCell: {
+    flex: LEFT_FLEX,
   },
-  centerColumn: {
-    width: CENTER_COLUMN_WIDTH,
+  centerCell: {
+    flex: CENTER_FLEX,
   },
-  rightColumn: {
-    width: RIGHT_COLUMN_WIDTH,
-  },
-  rowCell: {
-    borderBottomWidth: 2,
-    borderBottomColor: TABLE_BORDER_COLOR,
+  rightCell: {
+    flex: RIGHT_FLEX,
     justifyContent: CENTER,
-  },
-  rowCellLast: {
-    borderBottomWidth: 0,
+    paddingLeft: spacing(1),
   },
 
   // Left-column stage text block (also the tap target -0)
@@ -133,78 +91,115 @@ const styles = StyleSheet.create({
     textAlign: 'right',
   },
 
-  // Right-column aspect label
+  // Right-column aspect label (wraps to fit — never clipped)
   rightLabelText: {
-    fontSize: 16,
-    color: colors.text.primary,
-    paddingLeft: spacing(1),
+    fontFamily: editorialType.serif,
+    fontSize: 15,
+    color: ink.primary,
   },
 
-  // Center column — artwork, bands, overlays
-  centerInner: {
+  // --- Center column: per-stage arrow cell (tap target -1) ------------------
+  centerStageCell: {
     flex: 1,
-    position: 'relative',
-  },
-  arrowImage: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  // Branded fill shown when no hosted map art is configured (#766) — keeps the
-  // map area on-brand instead of a third-party placeholder image.
-  mapBackgroundFallback: {
-    backgroundColor: surface.canvas,
-  },
-  greyBandFeminine: {
-    position: ABSOLUTE,
-    top: GREY_BAND_TOP,
-    left: 0,
-    width: HALF,
-    bottom: 0,
-    backgroundColor: FEMININE_BAND_COLOR,
-  },
-  greyBandMasculine: {
-    position: ABSOLUTE,
-    top: GREY_BAND_TOP,
-    left: HALF,
-    width: HALF,
-    bottom: 0,
-    backgroundColor: MASCULINE_BAND_COLOR,
-  },
-  arrowLabelWrap: {
-    position: ABSOLUTE,
-    left: 0,
-    width: FULL,
+    minHeight: touchTarget.minimum,
     alignItems: CENTER,
     justifyContent: CENTER,
+    paddingHorizontal: spacing(0.5),
+  },
+  // Gentle alternating band (replaces the old absolute grey half-bands): even
+  // (Divine-Feminine) stages get a recessed tint, odd stages stay on canvas.
+  cellFeminine: {
+    backgroundColor: surface.sunken,
+  },
+  cellMasculine: {
+    backgroundColor: surface.canvas,
+  },
+  // Legible current-stage marker (replaces the faint hotspot border).
+  cellCurrent: {
+    borderWidth: 2,
+    borderColor: accent.primary,
+    borderRadius: radius.sm,
+  },
+  arrowGlyph: {
+    fontSize: 22,
+    fontWeight: '700',
+    lineHeight: 26,
+  },
+  centerLabelRow: {
+    flexDirection: 'row',
+    alignItems: CENTER,
+    justifyContent: CENTER,
+    gap: spacing(0.5),
   },
   arrowLabelText: {
     fontWeight: '700',
     fontSize: 12,
-    color: ARROW_LABEL_COLOR,
+    color: ink.soft,
+    textAlign: CENTER,
+    flexShrink: 1,
+  },
+  // Responsive title carried in the top stage rows' own grid cells (no fixed
+  // 40px overlay): the serif ramp scales rather than overflowing the column.
+  titleText: {
+    ...editorialType.title,
+    color: ink.primary,
+    letterSpacing: 1,
     textAlign: CENTER,
   },
-  titleOverlay: {
-    position: ABSOLUTE,
-    top: 0,
-    left: 0,
-    width: FULL,
-    height: GREY_BAND_TOP,
+  // Thin connector between a stage and the one below it (replaces the old
+  // percentage-positioned connection line).
+  connector: {
+    width: 2,
+    height: spacing(1),
+    marginTop: spacing(0.25),
+    backgroundColor: surface.hairline,
+  },
+
+  // Lock icon overlay for locked stages
+  lockOverlay: {
+    ...StyleSheet.absoluteFillObject,
     alignItems: CENTER,
     justifyContent: CENTER,
   },
-  titleText: {
-    fontFamily: editorialType.serif,
+  lockText: {
+    fontSize: 14,
+    color: ink.muted,
+  },
+  // Locked stages read recessed
+  locked: {
+    opacity: 0.4,
+  },
+
+  // Completed stage checkmark
+  completedBadge: {
+    position: 'absolute',
+    top: spacing(0.25),
+    right: spacing(0.25),
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: colors.success,
+    alignItems: CENTER,
+    justifyContent: CENTER,
+  },
+  completedBadgeText: {
+    fontSize: 11,
+    color: colors.text.light,
     fontWeight: '700',
-    fontSize: 40,
-    color: TABLE_BORDER_COLOR,
-    letterSpacing: 2,
+  },
+
+  // Optional decorative backdrop behind the grid (only when art is configured)
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    opacity: 0.12,
   },
 
   // Modal overlay and content
   modalOverlay: {
     flex: 1,
     backgroundColor: colors.mystical.overlay,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: CENTER,
+    alignItems: CENTER,
   },
   modalContent: {
     width: '85%',
@@ -239,7 +234,7 @@ const styles = StyleSheet.create({
   },
   titleRow: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: CENTER,
     marginBottom: spacing(0.5),
     paddingRight: spacing(3),
   },
@@ -323,7 +318,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing(1),
     paddingHorizontal: spacing(1.5),
     borderRadius: radius.md,
-    alignItems: 'center',
+    alignItems: CENTER,
   },
   actionText: {
     fontSize: 13,
@@ -338,7 +333,7 @@ const styles = StyleSheet.create({
   historyHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center',
+    alignItems: CENTER,
     paddingVertical: spacing(1),
   },
   historyTitle: {
@@ -352,23 +347,23 @@ const styles = StyleSheet.create({
   },
   historyLoading: {
     paddingVertical: spacing(1.5),
-    alignItems: 'center',
+    alignItems: CENTER,
   },
   historyEmpty: {
     fontSize: 12,
     color: colors.mystical.transparentLight,
     fontStyle: 'italic',
     paddingVertical: spacing(1),
-    textAlign: 'center',
+    textAlign: CENTER,
   },
   historyError: {
     paddingVertical: spacing(1.5),
-    alignItems: 'center',
+    alignItems: CENTER,
   },
   historyErrorText: {
     fontSize: 12,
     color: colors.danger,
-    textAlign: 'center',
+    textAlign: CENTER,
     marginBottom: spacing(1),
   },
   historyRetry: {
@@ -383,10 +378,10 @@ const styles = StyleSheet.create({
   refreshBanner: {
     position: 'absolute',
     top: spacing(2),
-    alignSelf: 'center',
+    alignSelf: CENTER,
     maxWidth: '90%',
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: CENTER,
     backgroundColor: colors.mystical.overlay,
     paddingVertical: spacing(1),
     paddingHorizontal: spacing(2),
@@ -419,7 +414,7 @@ const styles = StyleSheet.create({
   },
   historyItem: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: CENTER,
     paddingVertical: spacing(0.5),
   },
   historyItemIcon: {
@@ -444,31 +439,13 @@ const styles = StyleSheet.create({
     width: 14,
     height: 14,
     borderRadius: 7,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: CENTER,
+    justifyContent: CENTER,
   },
   goalBadgeText: {
     fontSize: 8,
     fontWeight: '700',
     color: colors.text.light,
-  },
-
-  // Completed stage checkmark
-  completedBadge: {
-    position: 'absolute',
-    top: -4,
-    right: -4,
-    width: 18,
-    height: 18,
-    borderRadius: 9,
-    backgroundColor: colors.success,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  completedBadgeText: {
-    fontSize: 11,
-    color: colors.text.light,
-    fontWeight: '700',
   },
 });
 

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -27,10 +27,10 @@ import {
 } from '../../store/useStageStore';
 
 import styles from './Map.styles';
-import { MAP_ROWS, MAP_TITLE_LINES, STAGE_DISPLAY } from './mapLayout';
+import { MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked } from './services/stageService';
-import type { StageData } from './stageData';
+import { isLeftReturning, type StageData } from './stageData';
 
 import { colors } from '@/design/tokens';
 
@@ -38,40 +38,16 @@ import { colors } from '@/design/tokens';
 type StageLookup = Readonly<Record<number, StageData | undefined>>;
 
 const FULL_PROGRESS = 1;
+/** Directional spiral glyphs — the Map reads with no background PNG (#766). */
+const ARROW_GLYPH_LEFT = '↩';
+const ARROW_GLYPH_RIGHT = '↪';
 
 // --- Sub-components ---
-
-const ConnectionLines = ({ stages }: { stages: StageData[] }): React.JSX.Element => (
-  <>
-    {stages.slice(0, -1).map((stage, idx) => {
-      const next = stages[idx + 1];
-      if (!next) return null;
-      const topPct = stage.hotspots[0]?.top ?? 0;
-      const nextTop = next.hotspots[0]?.top ?? 0;
-      return (
-        <View
-          key={`conn-${stage.stageNumber}`}
-          testID={`stage-connection-${stage.stageNumber}`}
-          style={[
-            styles.connectionLine,
-            {
-              top: `${topPct + 6}%`,
-              left: '50%',
-              height: `${nextTop - topPct - 6}%`,
-            },
-          ]}
-        />
-      );
-    })}
-  </>
-);
-
-const getHotspotStyle = (stage: StageData, currentStage: number | null) => {
-  if (!isStageUnlocked(stage, currentStage)) return styles.hotspotLocked;
-  if (stage.stageNumber === currentStage) return styles.hotspotCurrent;
-  if (stage.progress >= FULL_PROGRESS) return styles.hotspotCompleted;
-  return null;
-};
+//
+// One responsive row grid is the single source of vertical truth. Each stage is
+// a flex row [LeftCell | CenterCell | RightCell]; the three columns are siblings
+// in the same row, so they cannot drift the way the old content-driven flex
+// table + absolute-percentage center overlay did. The Map reads with no PNG.
 
 const LockOverlay = (): React.JSX.Element => (
   <View style={styles.lockOverlay}>
@@ -79,19 +55,20 @@ const LockOverlay = (): React.JSX.Element => (
   </View>
 );
 
-interface StageTapProps {
+interface StageCellProps {
   stage: StageData;
   display: StageDisplay;
   locked: boolean;
+  isCurrent: boolean;
   onPress: (_stage: StageData) => void;
 }
 
-// --- Left column: colored stage text (also the -0 tap target) -------------
+// --- Left cell: colored stage text (the -0 tap target) --------------------
 
-const StageTextBlock = ({ stage, display, locked, onPress }: StageTapProps): React.JSX.Element => (
+const StageTextBlock = ({ stage, display, locked, onPress }: StageCellProps): React.JSX.Element => (
   <TouchableOpacity
     testID={`stage-hotspot-${display.stageNumber}-0`}
-    style={[styles.stageBlock, locked ? styles.hotspotLocked : null]}
+    style={[styles.stageBlock, locked ? styles.locked : null]}
     onPress={() => onPress(stage)}
     accessibilityRole="button"
     accessibilityLabel={`${display.persona} - ${display.descriptor}`}
@@ -103,174 +80,102 @@ const StageTextBlock = ({ stage, display, locked, onPress }: StageTapProps): Rea
   </TouchableOpacity>
 );
 
-interface RowProps {
-  row: MapRow;
-  isLast: boolean;
-  lookup: StageLookup;
-  currentStage: number | null;
-  onPress: (_stage: StageData) => void;
-}
+// --- Center cell: directional glyph + label/title, lock, badge (the -1 tap) -
 
-const cellStyle = (row: MapRow, isLast: boolean) => [
-  styles.rowCell,
-  { flex: row.stageNumbers.length },
-  isLast ? styles.rowCellLast : null,
-];
-
-const LeftRow = ({ row, isLast, lookup, currentStage, onPress }: RowProps): React.JSX.Element => (
-  <View style={cellStyle(row, isLast)}>
-    {row.stageNumbers.map((stageNumber) => {
-      const stage = lookup[stageNumber];
-      const display = STAGE_DISPLAY[stageNumber];
-      return stage && display ? (
-        <StageTextBlock
-          key={stageNumber}
-          stage={stage}
-          display={display}
-          locked={!isStageUnlocked(stage, currentStage)}
-          onPress={onPress}
-        />
-      ) : null;
-    })}
-  </View>
-);
-
-interface ColumnProps {
-  lookup: StageLookup;
-  currentStage: number | null;
-  onPress: (_stage: StageData) => void;
-}
-
-const LeftTextColumn = ({ lookup, currentStage, onPress }: ColumnProps): React.JSX.Element => (
-  <View style={styles.leftColumn}>
-    {MAP_ROWS.map((row, idx) => (
-      <LeftRow
-        key={row.rightLabel}
-        row={row}
-        isLast={idx === MAP_ROWS.length - 1}
-        lookup={lookup}
-        currentStage={currentStage}
-        onPress={onPress}
-      />
-    ))}
-  </View>
-);
-
-// --- Right column: aspect-of-wholeness labels -----------------------------
-
-const RightLabelColumn = (): React.JSX.Element => (
-  <View style={styles.rightColumn}>
-    {MAP_ROWS.map((row, idx) => (
-      <View key={row.rightLabel} style={cellStyle(row, idx === MAP_ROWS.length - 1)}>
-        <Text style={styles.rightLabelText}>{row.rightLabel}</Text>
-      </View>
-    ))}
-  </View>
-);
-
-// --- Center column: arrow artwork, grey bands, tap targets, labels --------
-
-const bandPosition = (stage: StageData) => {
-  const hs = stage.hotspots[0];
-  return { top: `${hs?.top ?? 0}%` as const, height: `${hs?.height ?? 0}%` as const };
-};
-
-const ArrowHotspot = ({
-  stage,
-  currentStage,
-  onPress,
-}: {
-  stage: StageData;
-  currentStage: number | null;
-  onPress: (_stage: StageData) => void;
-}): React.JSX.Element | null => {
-  const hs = stage.hotspots[0];
-  if (!hs) return null;
-  const locked = !isStageUnlocked(stage, currentStage);
+const CenterContent = ({ display }: { display: StageDisplay }): React.JSX.Element => {
+  const glyph = isLeftReturning(display.stageNumber) ? ARROW_GLYPH_LEFT : ARROW_GLYPH_RIGHT;
+  const title = TITLE_BY_STAGE[display.stageNumber];
   return (
-    <TouchableOpacity
-      testID={`stage-hotspot-${stage.stageNumber}-1`}
-      style={[
-        styles.hotspot,
-        { top: `${hs.top}%`, left: `${hs.left}%`, width: `${hs.width}%`, height: `${hs.height}%` },
-        getHotspotStyle(stage, currentStage),
-      ]}
-      onPress={() => onPress(stage)}
-      accessibilityRole="button"
-      accessibilityLabel={`${stage.title} - ${stage.subtitle}`}
-    >
-      {locked ? <LockOverlay /> : null}
-      {stage.progress >= FULL_PROGRESS ? (
-        <View style={styles.completedBadge} testID={`stage-complete-${stage.stageNumber}`}>
-          <Text style={styles.completedBadgeText}>✓</Text>
+    <>
+      <Text style={[styles.arrowGlyph, { color: display.textColor }]}>{glyph}</Text>
+      {title ? (
+        <Text style={styles.titleText}>{title}</Text>
+      ) : display.arrowLabel ? (
+        <View style={styles.centerLabelRow}>
+          <Text style={styles.arrowLabelText}>{display.arrowLabel}</Text>
         </View>
       ) : null}
-    </TouchableOpacity>
+    </>
   );
 };
 
-const ArrowLabel = ({ stage }: { stage: StageData }): React.JSX.Element | null => {
-  const display = STAGE_DISPLAY[stage.stageNumber];
-  if (!display?.arrowLabel) return null;
-  return (
-    <View pointerEvents="none" style={[styles.arrowLabelWrap, bandPosition(stage)]}>
-      <Text style={styles.arrowLabelText}>{display.arrowLabel}</Text>
-    </View>
-  );
-};
-
-const SpiralTitle = (): React.JSX.Element => (
-  <View pointerEvents="none" style={styles.titleOverlay}>
-    {MAP_TITLE_LINES.map((line) => (
-      <Text key={line} style={styles.titleText}>
-        {line}
-      </Text>
-    ))}
-  </View>
-);
-
-const GreyBands = (): React.JSX.Element => (
-  <>
-    <View pointerEvents="none" style={styles.greyBandFeminine} />
-    <View pointerEvents="none" style={styles.greyBandMasculine} />
-  </>
-);
-
-const CenterColumn = ({
-  stages,
-  currentStage,
+const StageCenterCell = ({
+  stage,
+  display,
+  locked,
+  isCurrent,
   onPress,
-}: {
-  stages: StageData[];
+}: StageCellProps): React.JSX.Element => (
+  <TouchableOpacity
+    testID={`stage-hotspot-${display.stageNumber}-1`}
+    style={[
+      styles.centerStageCell,
+      isLeftReturning(display.stageNumber) ? styles.cellFeminine : styles.cellMasculine,
+      locked ? styles.locked : null,
+      isCurrent ? styles.cellCurrent : null,
+    ]}
+    onPress={() => onPress(stage)}
+    accessibilityRole="button"
+    accessibilityLabel={`${stage.title} - ${stage.subtitle}`}
+  >
+    <CenterContent display={display} />
+    {locked ? <LockOverlay /> : null}
+    {stage.progress >= FULL_PROGRESS ? (
+      <View style={styles.completedBadge} testID={`stage-complete-${stage.stageNumber}`}>
+        <Text style={styles.completedBadgeText}>✓</Text>
+      </View>
+    ) : null}
+    {/* Connector to the stage below (replaces the old %-positioned line). */}
+    {display.stageNumber > 1 ? (
+      <View style={styles.connector} testID={`stage-connection-${stage.stageNumber}`} />
+    ) : null}
+  </TouchableOpacity>
+);
+
+interface MapRowProps {
+  row: MapRow;
+  lookup: StageLookup;
   currentStage: number | null;
   onPress: (_stage: StageData) => void;
-}): React.JSX.Element => (
-  <View style={styles.centerColumn}>
-    <View style={styles.centerInner}>
-      <GreyBands />
-      {MAP_BACKGROUND_URI ? (
-        <Image
-          source={{ uri: MAP_BACKGROUND_URI }}
-          resizeMode="contain"
-          style={styles.arrowImage}
-          testID="map-background"
-        />
-      ) : (
-        // No hosted art configured — branded in-app fallback, never an external
-        // placeholder (#766). The stage labels/bands still render on top.
-        <View style={[styles.arrowImage, styles.mapBackgroundFallback]} testID="map-background" />
-      )}
-      <ConnectionLines stages={stages} />
-      {stages.map((stage) => (
-        <ArrowHotspot key={stage.id} stage={stage} currentStage={currentStage} onPress={onPress} />
-      ))}
-      {stages.map((stage) => (
-        <ArrowLabel key={stage.id} stage={stage} />
-      ))}
-      <SpiralTitle />
+}
+
+/** One grid row: left text + center glyph stacked per stage, one aspect label. */
+const MapRowView = ({ row, lookup, currentStage, onPress }: MapRowProps): React.JSX.Element => {
+  const resolved = row.stageNumbers
+    .map((n) => ({ stage: lookup[n], display: STAGE_DISPLAY[n] }))
+    .filter((r): r is { stage: StageData; display: StageDisplay } => !!r.stage && !!r.display);
+  return (
+    <View style={[styles.groupRow, { flex: row.stageNumbers.length }]}>
+      <View style={styles.leftCell}>
+        {resolved.map(({ stage, display }) => (
+          <StageTextBlock
+            key={stage.stageNumber}
+            stage={stage}
+            display={display}
+            locked={!isStageUnlocked(stage, currentStage)}
+            isCurrent={stage.stageNumber === currentStage}
+            onPress={onPress}
+          />
+        ))}
+      </View>
+      <View style={styles.centerCell}>
+        {resolved.map(({ stage, display }) => (
+          <StageCenterCell
+            key={stage.stageNumber}
+            stage={stage}
+            display={display}
+            locked={!isStageUnlocked(stage, currentStage)}
+            isCurrent={stage.stageNumber === currentStage}
+            onPress={onPress}
+          />
+        ))}
+      </View>
+      <View style={styles.rightCell}>
+        <Text style={styles.rightLabelText}>{row.rightLabel}</Text>
+      </View>
     </View>
-  </View>
-);
+  );
+};
 
 const StageMetadataSection = ({ stage }: { stage: StageData }): React.JSX.Element => (
   <View style={styles.metadataSection} testID="stage-metadata">
@@ -607,23 +512,37 @@ const MapRefreshErrorBanner = ({ onRetry }: { onRetry: () => void }): React.JSX.
   </View>
 );
 
-interface SpiralTableProps {
-  stages: StageData[];
+interface MapGridProps {
   lookup: StageLookup;
   currentStage: number | null;
   onSelectStage: (_stage: StageData) => void;
 }
 
-const SpiralTable = ({
-  stages,
-  lookup,
-  currentStage,
-  onSelectStage,
-}: SpiralTableProps): React.JSX.Element => (
-  <View style={styles.table}>
-    <LeftTextColumn lookup={lookup} currentStage={currentStage} onPress={onSelectStage} />
-    <CenterColumn stages={stages} currentStage={currentStage} onPress={onSelectStage} />
-    <RightLabelColumn />
+// Optional decorative backdrop. The grid is fully legible without it (#766), so
+// a missing PNG is a faint no-op rather than a third-party placeholder.
+const MapBackdrop = (): React.JSX.Element =>
+  MAP_BACKGROUND_URI ? (
+    <Image
+      source={{ uri: MAP_BACKGROUND_URI }}
+      resizeMode="contain"
+      style={styles.backdrop}
+      testID="map-background"
+    />
+  ) : (
+    <View style={styles.backdrop} testID="map-background" pointerEvents="none" />
+  );
+
+const MapGrid = ({ lookup, currentStage, onSelectStage }: MapGridProps): React.JSX.Element => (
+  <View style={styles.grid}>
+    {MAP_ROWS.map((row) => (
+      <MapRowView
+        key={row.rightLabel}
+        row={row}
+        lookup={lookup}
+        currentStage={currentStage}
+        onPress={onSelectStage}
+      />
+    ))}
   </View>
 );
 
@@ -691,12 +610,8 @@ const MapScreen = (): React.JSX.Element => {
 
   return (
     <View style={styles.container}>
-      <SpiralTable
-        stages={stages}
-        lookup={lookup}
-        currentStage={currentStage}
-        onSelectStage={setActiveStage}
-      />
+      <MapBackdrop />
+      <MapGrid lookup={lookup} currentStage={currentStage} onSelectStage={setActiveStage} />
       {error && stages.length > 0 && <MapRefreshErrorBanner onRetry={handleRefresh} />}
       <StageDetailModal
         activeStage={activeStage}

--- a/frontend/src/features/Map/__tests__/stageData.test.ts
+++ b/frontend/src/features/Map/__tests__/stageData.test.ts
@@ -1,40 +1,17 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { HOTSPOTS, STAGE_COUNT } from '../stageData';
-
-const SIDE_SPLIT = 40;
+import { isLeftReturning, STAGE_COUNT } from '../stageData';
 
 describe('stageData', () => {
-  it('provides one arrow hotspot for every stage', () => {
-    expect(HOTSPOTS).toHaveLength(STAGE_COUNT);
-    HOTSPOTS.forEach((spots) => expect(spots).toHaveLength(1));
-  });
-
-  it('has non-overlapping vertical hotspot ranges', () => {
-    for (let i = 0; i < HOTSPOTS.length - 1; i++) {
-      const current = HOTSPOTS[i]!;
-      const next = HOTSPOTS[i + 1]!;
-      const currentBottom = Math.max(...current.map((h) => h.top + h.height));
-      const nextTop = Math.min(...next.map((h) => h.top));
-      expect(currentBottom).toBeLessThanOrEqual(nextTop);
-    }
-  });
-
-  it('positions arrow hotspots on alternating sides of the spiral', () => {
-    // HOTSPOTS are indexed 0–9 where 0 = stage 10, 9 = stage 1. Even
-    // (Divine-Feminine) stages return along the left; odd stages point right.
-    HOTSPOTS.forEach((spots, index) => {
-      const stageNumber = STAGE_COUNT - index;
-      const arrow = spots[0]!;
-      if (stageNumber % 2 === 0) {
-        expect(arrow.left).toBeLessThan(SIDE_SPLIT);
-      } else {
-        expect(arrow.left).toBeGreaterThan(SIDE_SPLIT);
-      }
-    });
-  });
-
   it('exports STAGE_COUNT as 10', () => {
     expect(STAGE_COUNT).toBe(10);
+  });
+
+  it('winds even (Divine-Feminine) stages left and odd stages right', () => {
+    // The spiral's meaning, read directly by the arrow glyph so the Map is
+    // legible with no background PNG (#766).
+    for (let stage = 1; stage <= STAGE_COUNT; stage++) {
+      expect(isLeftReturning(stage)).toBe(stage % 2 === 0);
+    }
   });
 });

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -38,8 +38,17 @@ export interface MapRow {
   stageNumbers: readonly number[];
 }
 
-/** The serif title overlaid across the top of the spiral (top → bottom). */
+/** The serif title across the top of the spiral (top → bottom). */
 export const MAP_TITLE_LINES = ['EMPTINESS', 'UNITY'] as const;
+
+/**
+ * The title line each top stage carries in its own grid row (no absolute
+ * overlay): stage 10 reads EMPTINESS, stage 9 reads UNITY. Stages 1–8 have none.
+ */
+export const TITLE_BY_STAGE: Readonly<Record<number, string>> = {
+  10: MAP_TITLE_LINES[0],
+  9: MAP_TITLE_LINES[1],
+};
 
 /**
  * Per-stage left-column copy and color, keyed by ``stage_number`` (1–10).
@@ -108,7 +117,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     persona: 'Dominator',
     descriptor: 'Power',
     practice: 'Confidence Meditation',
-    arrowLabel: 'Self-',
+    arrowLabel: 'Self-Interest',
     textColor: '#b14a3a',
   },
   2: {

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -11,7 +11,7 @@ import { stages as stagesApi } from '../../../api';
 import type { Stage } from '../../../api';
 import { STAGE_COLORS, STAGE_ORDER } from '../../../design/tokens';
 import { useStageStore } from '../../../store/useStageStore';
-import { HOTSPOTS, STAGE_COUNT } from '../stageData';
+import { STAGE_COUNT } from '../stageData';
 import type { StageData } from '../stageData';
 
 /**
@@ -28,7 +28,6 @@ export const clampProgress = (raw: number | null | undefined): number => {
 
 /** Convert a backend Stage response into a frontend StageData with layout. */
 export const toStageData = (apiStage: Stage): StageData => {
-  const index = STAGE_COUNT - apiStage.stage_number; // stage 10 → index 0
   const colorName = STAGE_ORDER[apiStage.stage_number - 1] ?? 'Beige';
   return {
     id: apiStage.id,
@@ -49,7 +48,6 @@ export const toStageData = (apiStage: Stage): StageData => {
     relationshipToFreeWill: apiStage.relationship_to_free_will,
     freeWillDescription: apiStage.free_will_description,
     overviewUrl: apiStage.overview_url,
-    hotspots: [...(HOTSPOTS[index] ?? [])],
   };
 };
 

--- a/frontend/src/features/Map/stageData.ts
+++ b/frontend/src/features/Map/stageData.ts
@@ -1,17 +1,12 @@
 // frontend/features/Map/stageData.ts
 
 /**
- * Type definitions and static hotspot layout for the Map screen.
- * Stage content is fetched from the backend API — only tap-target
- * geometry remains hardcoded since it maps to the background artwork.
+ * Type definitions and shared geometry helpers for the Map screen.
+ *
+ * The Map is laid out by a single responsive row grid (see ``MapGrid`` in
+ * ``MapScreen``); there is no longer any absolute-percentage coordinate system
+ * here. Stage *content* is fetched from the backend API.
  */
-
-export interface Hotspot {
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-}
 
 export interface StageData {
   id: number;
@@ -30,45 +25,14 @@ export interface StageData {
   relationshipToFreeWill: string;
   freeWillDescription: string;
   overviewUrl: string;
-  hotspots: Hotspot[]; // areas that respond to taps
 }
 
 /** Total number of APTITUDE stages. */
 export const STAGE_COUNT = 10;
 
-// --- Arrow tap-target geometry ---------------------------------------------
-// The center column shows the colored-arrow spiral PNG. Each stage gets one
-// tappable band over its arrow loop, expressed as a percentage of the *center
-// column* (not the whole screen). The ten loops are evenly stacked top→bottom,
-// alternating sides as the spiral winds: even (Divine-Feminine) stages return
-// along the left, odd stages point right. Tune these against the final artwork.
-
-/** Height of one arrow band as a % of the column (ten evenly-spaced loops). */
-const ARROW_BAND_HEIGHT = 100 / STAGE_COUNT;
-/** Vertical inset so adjacent bands never touch / overlap. */
-const ARROW_BAND_INSET = 1;
-/** Horizontal extent of an arrow loop, as a % of the column width. */
-const ARROW_WIDTH = 46;
-/** Left edge of a left-returning (Divine-Feminine) arrow loop. */
-const ARROW_LEFT_X = 4;
-/** Left edge of a right-pointing arrow loop. */
-const ARROW_RIGHT_X = 50;
-
-const isLeftReturning = (stageNumber: number): boolean => stageNumber % 2 === 0;
-
 /**
- * Percentage-based arrow hotspots, one band per stage. Indexed 0–9 where
- * index 0 = stage 10 (top) and index 9 = stage 1 (bottom), matching the
- * descending sort applied to the backend stage list.
+ * Which way a stage's spiral arrow winds. Even (Divine-Feminine) stages return
+ * along the left; odd stages point right. This is the spiral's *meaning* — the
+ * arrow glyph reads from it directly, so the Map is legible with no PNG (#766).
  */
-export const HOTSPOTS: readonly Hotspot[][] = Array.from({ length: STAGE_COUNT }, (_, index) => {
-  const stageNumber = STAGE_COUNT - index;
-  return [
-    {
-      top: index * ARROW_BAND_HEIGHT + ARROW_BAND_INSET,
-      left: isLeftReturning(stageNumber) ? ARROW_LEFT_X : ARROW_RIGHT_X,
-      width: ARROW_WIDTH,
-      height: ARROW_BAND_HEIGHT - ARROW_BAND_INSET * 2,
-    },
-  ];
-});
+export const isLeftReturning = (stageNumber: number): boolean => stageNumber % 2 === 0;

--- a/frontend/src/store/__tests__/useStageStore.test.ts
+++ b/frontend/src/store/__tests__/useStageStore.test.ts
@@ -19,7 +19,6 @@ const makeStage = (stageNumber: number, overrides: Partial<StageData> = {}): Sta
   relationshipToFreeWill: '',
   freeWillDescription: '',
   overviewUrl: '',
-  hotspots: [],
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary

#842 (epic #824): the Map computed its 10-stage grid **twice** with two engines that drift (content-driven flex table + absolute-% center). Every render defect — title bleeding across rows, label clipping, label/lock overlap, the `'Self-'` truncation, the stray current border, dependence on an often-missing spiral PNG (**#766**) — fell out of that. Replaced with one grid.

- `MAP_ROWS` → `MapRowView` (flex row) → `[leftCell | centerCell | rightCell]`; a stage's cells are **siblings in one row and cannot drift**. Deleted `HOTSPOTS`, `ARROW_*` positioning, `bandPosition`, and every absolute-% style.
- **PNG non-authoritative (#766)**: a per-stage directional glyph (↩/↪) in the stage `textColor` via `isLeftReturning` — legible with no art; `MAP_BACKGROUND_URI` is now a faint optional backdrop.
- Responsive title (no fixed 40px), aspect labels wrap ("Understanding"), `'Self-'` → `'Self-Interest'`, per-cell tints, legible accent-halo current marker.

Spiral meaning + tap/lock/complete + every testID preserved; renders with or without a PNG.

## Test plan

`stageData.test` rewritten off the deleted `HOTSPOTS` (parity + count); all Map behaviour tests (20 hotspots, ≥9 connections, locks, modal, nav, history, retry) pass unchanged. `./scripts/frontend/check-all.sh` 4/4 (2073); token-only, AA, no magic numbers.

Closes #842
Refs #824
