### PR TITLE
feat(map): journey narrative with achievement

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -7,8 +7,11 @@ import {
   colors,
   editorialType,
   ink,
+  onShowcase,
   radius,
   shadows,
+  showcase,
+  showcaseShadow,
   spacing,
   surface,
   touchTarget,
@@ -114,11 +117,30 @@ const styles = StyleSheet.create({
   cellMasculine: {
     backgroundColor: surface.canvas,
   },
-  // Legible current-stage marker (replaces the faint hotspot border).
+  // Brighter "you are here" current-stage marker: a thicker accent halo +
+  // recessed warm fill so the live stage reads at a glance.
   cellCurrent: {
-    borderWidth: 2,
-    borderColor: accent.primary,
+    borderWidth: 3,
+    borderColor: accent.strong,
+    borderRadius: radius.md,
+    backgroundColor: surface.desk,
+    ...shadows.medium,
+  },
+  // "You are here" pill anchored to the current stage's center cell.
+  youAreHere: {
+    position: 'absolute',
+    top: spacing(0.25),
+    left: spacing(0.25),
+    paddingVertical: spacing(0.25),
+    paddingHorizontal: spacing(0.5),
     borderRadius: radius.sm,
+    backgroundColor: accent.strong,
+  },
+  youAreHereText: {
+    fontSize: 9,
+    fontWeight: '700',
+    color: colors.text.light,
+    letterSpacing: 0.5,
   },
   arrowGlyph: {
     fontSize: 22,
@@ -169,6 +191,56 @@ const styles = StyleSheet.create({
   locked: {
     opacity: 0.4,
   },
+  // Unlock timeline beneath the lock glyph ("Unlocks in N days").
+  unlockTimeline: {
+    position: 'absolute',
+    bottom: spacing(0.25),
+    left: 0,
+    right: 0,
+    fontSize: 9,
+    color: ink.muted,
+    textAlign: CENTER,
+    paddingHorizontal: spacing(0.25),
+  },
+
+  // --- Stage-completion celebration banner ----------------------------------
+  celebrationBanner: {
+    position: 'absolute',
+    top: spacing(2),
+    alignSelf: CENTER,
+    maxWidth: '90%',
+    backgroundColor: showcase.canvas,
+    borderRadius: radius.md,
+    paddingVertical: spacing(1.25),
+    paddingHorizontal: spacing(2.5),
+    borderLeftWidth: 4,
+    borderLeftColor: accent.primary,
+    ...showcaseShadow,
+  },
+  celebrationText: {
+    fontFamily: editorialType.serif,
+    fontSize: 15,
+    fontWeight: '700',
+    color: onShowcase.primary,
+    textAlign: CENTER,
+  },
+
+  // --- Journey read header --------------------------------------------------
+  journeyHeader: {
+    paddingVertical: spacing(1),
+    paddingHorizontal: spacing(2),
+    alignItems: CENTER,
+    backgroundColor: surface.sunken,
+    borderBottomWidth: 1,
+    borderBottomColor: surface.hairline,
+  },
+  journeyReadText: {
+    fontFamily: editorialType.serif,
+    fontSize: 16,
+    fontWeight: '700',
+    color: ink.primary,
+    letterSpacing: 0.5,
+  },
 
   // Completed stage checkmark
   completedBadge: {
@@ -201,14 +273,17 @@ const styles = StyleSheet.create({
     justifyContent: CENTER,
     alignItems: CENTER,
   },
+  // Re-grounded on the showcase umber band; the per-stage colour is
+  // applied inline as a left accent rail so each stage tints its own modal.
   modalContent: {
     width: '85%',
     maxHeight: '80%',
-    backgroundColor: colors.secondary,
+    backgroundColor: showcase.canvas,
     padding: spacing(2.5),
     borderRadius: radius.lg,
+    borderLeftWidth: 4,
     position: 'relative',
-    ...shadows.large,
+    ...showcaseShadow,
   },
 
   // Close button
@@ -216,13 +291,16 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: spacing(1),
     right: spacing(1),
-    padding: spacing(0.5),
+    minWidth: touchTarget.minimum,
+    minHeight: touchTarget.minimum,
+    alignItems: CENTER,
+    justifyContent: CENTER,
     zIndex: 1,
   },
   closeText: {
-    fontSize: 20,
+    fontSize: 22,
     fontWeight: '600',
-    color: colors.text.light,
+    color: onShowcase.soft,
   },
 
   // Stage color indicator dot
@@ -241,15 +319,50 @@ const styles = StyleSheet.create({
 
   // Title and subtitle
   modalTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: colors.text.light,
+    ...editorialType.title,
+    fontSize: 22,
+    color: onShowcase.primary,
   },
   modalSubtitle: {
     fontSize: 14,
-    color: colors.mystical.transparentLight,
+    color: onShowcase.soft,
     marginBottom: spacing(1.5),
     fontStyle: 'italic',
+  },
+
+  // One-sentence progression read (replaces the disparate count list).
+  progressionSentence: {
+    fontFamily: editorialType.serif,
+    fontSize: 15,
+    lineHeight: 22,
+    color: onShowcase.primary,
+    marginBottom: spacing(1.5),
+  },
+
+  // Ranked headline stats row
+  rankedStatsRow: {
+    flexDirection: 'row',
+    gap: spacing(1),
+    marginBottom: spacing(1.5),
+  },
+  rankedStat: {
+    flex: 1,
+    backgroundColor: showcase.raised,
+    borderRadius: radius.md,
+    paddingVertical: spacing(1),
+    paddingHorizontal: spacing(0.5),
+    alignItems: CENTER,
+  },
+  rankedStatValue: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: onShowcase.primary,
+  },
+  rankedStatLabel: {
+    fontSize: 10,
+    color: onShowcase.muted,
+    textAlign: CENTER,
+    marginTop: spacing(0.25),
   },
 
   // Progress bar
@@ -258,12 +371,12 @@ const styles = StyleSheet.create({
   },
   progressLabel: {
     fontSize: 12,
-    color: colors.mystical.transparentLight,
+    color: onShowcase.soft,
     marginBottom: spacing(0.5),
   },
   progressBar: {
     height: 8,
-    backgroundColor: 'rgba(255,255,255,0.15)',
+    backgroundColor: showcase.raised,
     borderRadius: radius.sm,
     overflow: 'hidden',
   },
@@ -282,18 +395,18 @@ const styles = StyleSheet.create({
   },
   metadataLabel: {
     fontSize: 12,
-    color: colors.mystical.transparentLight,
+    color: onShowcase.soft,
     width: 100,
     fontWeight: '600',
   },
   metadataValue: {
     fontSize: 12,
-    color: colors.text.light,
+    color: onShowcase.primary,
     flex: 1,
   },
   freeWillDescription: {
     fontSize: 12,
-    color: colors.mystical.transparentLight,
+    color: onShowcase.soft,
     marginTop: spacing(0.5),
     lineHeight: 18,
     fontStyle: 'italic',
@@ -302,27 +415,46 @@ const styles = StyleSheet.create({
   // Separator
   separator: {
     height: 1,
-    backgroundColor: 'rgba(255,255,255,0.1)',
+    backgroundColor: showcase.raised,
     marginVertical: spacing(1.5),
   },
 
-  // Quick action buttons
+  // Ranked actions: a full-width primary "Continue" stacked above two
+  // secondary actions (visual hierarchy only — all three keep their handlers).
   actions: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
     gap: spacing(1),
   },
-  actionButton: {
+  primaryAction: {
+    minHeight: touchTarget.minimum,
+    paddingVertical: spacing(1.25),
+    paddingHorizontal: spacing(1.5),
+    borderRadius: radius.md,
+    alignItems: CENTER,
+    justifyContent: CENTER,
+    backgroundColor: accent.primary,
+  },
+  primaryActionText: {
+    fontSize: 15,
+    color: colors.text.light,
+    fontWeight: '700',
+  },
+  secondaryActionsRow: {
+    flexDirection: 'row',
+    gap: spacing(1),
+  },
+  secondaryAction: {
     flex: 1,
-    backgroundColor: 'rgba(255,255,255,0.1)',
+    minHeight: touchTarget.minimum,
+    backgroundColor: showcase.raised,
     paddingVertical: spacing(1),
     paddingHorizontal: spacing(1.5),
     borderRadius: radius.md,
     alignItems: CENTER,
+    justifyContent: CENTER,
   },
-  actionText: {
+  secondaryActionText: {
     fontSize: 13,
-    color: colors.text.light,
+    color: onShowcase.primary,
     fontWeight: '600',
   },
 
@@ -339,11 +471,11 @@ const styles = StyleSheet.create({
   historyTitle: {
     fontSize: 14,
     fontWeight: '700',
-    color: colors.text.light,
+    color: onShowcase.primary,
   },
   historyToggle: {
     fontSize: 12,
-    color: colors.mystical.transparentLight,
+    color: onShowcase.soft,
   },
   historyLoading: {
     paddingVertical: spacing(1.5),
@@ -351,7 +483,7 @@ const styles = StyleSheet.create({
   },
   historyEmpty: {
     fontSize: 12,
-    color: colors.mystical.transparentLight,
+    color: onShowcase.soft,
     fontStyle: 'italic',
     paddingVertical: spacing(1),
     textAlign: CENTER,
@@ -373,7 +505,7 @@ const styles = StyleSheet.create({
   historyRetryText: {
     fontSize: 12,
     fontWeight: '600',
-    color: colors.text.light,
+    color: onShowcase.primary,
   },
   refreshBanner: {
     position: 'absolute',
@@ -408,7 +540,7 @@ const styles = StyleSheet.create({
   historySubheading: {
     fontSize: 12,
     fontWeight: '600',
-    color: colors.mystical.transparentLight,
+    color: onShowcase.soft,
     marginTop: spacing(1),
     marginBottom: spacing(0.5),
   },
@@ -423,12 +555,12 @@ const styles = StyleSheet.create({
   },
   historyItemName: {
     fontSize: 12,
-    color: colors.text.light,
+    color: onShowcase.primary,
     flex: 1,
   },
   historyItemDetail: {
     fontSize: 11,
-    color: colors.mystical.transparentLight,
+    color: onShowcase.soft,
   },
   goalBadges: {
     flexDirection: 'row',

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -17,7 +17,11 @@ import type { HabitHistoryItem, PracticeHistoryItem, StageHistoryResponse } from
 import { stages as stagesApi } from '../../api';
 import { MAP_BACKGROUND_URI } from '../../constants/images';
 import { useAppNavigation } from '../../navigation/hooks';
-import { useDerivedCurrentStage } from '../../store/useProgramProgression';
+import {
+  useDaysUntilStage,
+  useDerivedCurrentStage,
+  useDerivedCurrentWeek,
+} from '../../store/useProgramProgression';
 import {
   selectCurrentStage,
   selectStages,
@@ -26,12 +30,14 @@ import {
   useStageStore,
 } from '../../store/useStageStore';
 
+import { journeyRead, progressionSentence, rankedStats, unlockTimeline } from './journeyNarrative';
 import styles from './Map.styles';
 import { MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked } from './services/stageService';
-import { isLeftReturning, type StageData } from './stageData';
+import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
 
+import { Celebration } from '@/components/feedback/Celebration';
 import { colors } from '@/design/tokens';
 
 /** Lookup of stage number → StageData for resolving row/arrow content. */
@@ -52,6 +58,26 @@ const ARROW_GLYPH_RIGHT = '↪';
 const LockOverlay = (): React.JSX.Element => (
   <View style={styles.lockOverlay}>
     <Text style={styles.lockText}>🔒</Text>
+  </View>
+);
+
+/**
+ * "Unlocks in N days" / unlock-condition copy for a locked stage, computed from
+ * the existing calendar drip (no new backend). Falls back to the condition when
+ * no program anchor is set.
+ */
+const UnlockTimeline = ({ stageNumber }: { stageNumber: number }): React.JSX.Element => {
+  const daysUntil = useDaysUntilStage(stageNumber);
+  return (
+    <Text style={styles.unlockTimeline} testID={`stage-unlock-${stageNumber}`}>
+      {unlockTimeline(daysUntil)}
+    </Text>
+  );
+};
+
+const YouAreHereMarker = (): React.JSX.Element => (
+  <View style={styles.youAreHere} testID="you-are-here">
+    <Text style={styles.youAreHereText}>YOU ARE HERE</Text>
   </View>
 );
 
@@ -120,6 +146,8 @@ const StageCenterCell = ({
   >
     <CenterContent display={display} />
     {locked ? <LockOverlay /> : null}
+    {locked ? <UnlockTimeline stageNumber={display.stageNumber} /> : null}
+    {isCurrent ? <YouAreHereMarker /> : null}
     {stage.progress >= FULL_PROGRESS ? (
       <View style={styles.completedBadge} testID={`stage-complete-${stage.stageNumber}`}>
         <Text style={styles.completedBadgeText}>✓</Text>
@@ -225,29 +253,36 @@ interface ActionLinksProps {
   onNavigate: (_screen: 'Practice' | 'Course' | 'Journal', _stage: StageData) => void;
 }
 
+// Ranked actions: the primary "Continue" (the stage's Practice) sits full-width
+// above two secondary links. Visual hierarchy only — every handler + testID is
+// unchanged, so Practice/Course/Journal still route exactly as before.
 const ActionLinks = ({ stage, onNavigate }: ActionLinksProps): React.JSX.Element => (
   <View style={styles.actions}>
     <TouchableOpacity
       testID="practice-link"
-      style={styles.actionButton}
+      style={styles.primaryAction}
       onPress={() => onNavigate('Practice', stage)}
+      accessibilityRole="button"
+      accessibilityLabel="Continue this stage"
     >
-      <Text style={styles.actionText}>Practice</Text>
+      <Text style={styles.primaryActionText}>Continue</Text>
     </TouchableOpacity>
-    <TouchableOpacity
-      testID="course-link"
-      style={styles.actionButton}
-      onPress={() => onNavigate('Course', stage)}
-    >
-      <Text style={styles.actionText}>Course</Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      testID="journal-link"
-      style={styles.actionButton}
-      onPress={() => onNavigate('Journal', stage)}
-    >
-      <Text style={styles.actionText}>Journal</Text>
-    </TouchableOpacity>
+    <View style={styles.secondaryActionsRow}>
+      <TouchableOpacity
+        testID="course-link"
+        style={styles.secondaryAction}
+        onPress={() => onNavigate('Course', stage)}
+      >
+        <Text style={styles.secondaryActionText}>Course</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        testID="journal-link"
+        style={styles.secondaryAction}
+        onPress={() => onNavigate('Journal', stage)}
+      >
+        <Text style={styles.secondaryActionText}>Journal</Text>
+      </TouchableOpacity>
+    </View>
   </View>
 );
 
@@ -310,8 +345,42 @@ const HabitHistoryRow = ({ item }: { item: HabitHistoryItem }): React.JSX.Elemen
   </View>
 );
 
+const RankedStatsRow = ({
+  history,
+}: {
+  history: StageHistoryResponse;
+}): React.JSX.Element | null => {
+  const stats = rankedStats(history);
+  if (stats.length === 0) return null;
+  return (
+    <View style={styles.rankedStatsRow} testID="ranked-stats">
+      {stats.map((stat) => (
+        <View key={stat.key} style={styles.rankedStat} testID={`ranked-stat-${stat.key}`}>
+          <Text style={styles.rankedStatValue}>{stat.value}</Text>
+          <Text style={styles.rankedStatLabel}>{stat.label}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+/** One progression sentence + the ranked headline stats for the stage. */
+const JourneyNarrativeBlock = ({
+  history,
+}: {
+  history: StageHistoryResponse;
+}): React.JSX.Element => (
+  <View testID="journey-narrative">
+    <Text style={styles.progressionSentence} testID="progression-sentence">
+      {progressionSentence(history)}
+    </Text>
+    <RankedStatsRow history={history} />
+  </View>
+);
+
 const HistoryContent = ({ history }: { history: StageHistoryResponse }): React.JSX.Element => (
   <View testID="history-content">
+    <JourneyNarrativeBlock history={history} />
     {history.practices.length > 0 && (
       <>
         <Text style={styles.historySubheading}>Practices</Text>
@@ -472,7 +541,11 @@ const StageDetailModal = ({
 }: StageDetailModalProps): React.JSX.Element => (
   <Modal visible={!!activeStage} transparent animationType="slide" onRequestClose={onClose}>
     <Pressable style={styles.modalOverlay} onPress={onClose} testID="modal-overlay">
-      <Pressable style={styles.modalContent} onPress={() => {}} testID="stage-modal">
+      <Pressable
+        style={[styles.modalContent, activeStage ? { borderLeftColor: activeStage.color } : null]}
+        onPress={() => {}}
+        testID="stage-modal"
+      >
         {activeStage && <ModalBody stage={activeStage} onClose={onClose} onNavigate={onNavigate} />}
       </Pressable>
     </Pressable>
@@ -532,6 +605,16 @@ const MapBackdrop = (): React.JSX.Element =>
     <View style={styles.backdrop} testID="map-background" pointerEvents="none" />
   );
 
+/** Compact momentum read at the top of the Map: "Stage N of 10 · Week W". */
+const JourneyHeader = ({ currentStage }: { currentStage: number }): React.JSX.Element => {
+  const week = useDerivedCurrentWeek(1);
+  return (
+    <View style={styles.journeyHeader} testID="journey-read">
+      <Text style={styles.journeyReadText}>{journeyRead(currentStage, week, STAGE_COUNT)}</Text>
+    </View>
+  );
+};
+
 const MapGrid = ({ lookup, currentStage, onSelectStage }: MapGridProps): React.JSX.Element => (
   <View style={styles.grid}>
     {MAP_ROWS.map((row) => (
@@ -578,6 +661,63 @@ const useStageNavigation = (onBeforeNavigate: () => void) => {
   );
 };
 
+/** Highest stage number whose progress has reached 100%, or 0 when none. */
+const highestCompletedStage = (stages: readonly StageData[]): number =>
+  stages.reduce((max, s) => (s.progress >= FULL_PROGRESS ? Math.max(max, s.stageNumber) : max), 0);
+
+interface CompletionCelebration {
+  active: boolean;
+  message: string;
+  dismiss: () => void;
+}
+
+/**
+ * Watch for a newly-completed stage and surface a celebration naming the stage
+ * that just unlocked. The first render seeds the baseline (no celebration on
+ * mount); thereafter a rise in the highest-completed stage fires once.
+ */
+const useStageCompletionCelebration = (
+  stages: readonly StageData[],
+  lookup: StageLookup,
+): CompletionCelebration => {
+  const completed = highestCompletedStage(stages);
+  const prevCompletedRef = useRef<number | null>(null);
+  const [active, setActive] = useState(false);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const prev = prevCompletedRef.current;
+    prevCompletedRef.current = completed;
+    if (prev === null || completed <= prev) return;
+    const next = lookup[completed + 1];
+    const nextName = next ? next.title : 'The next stage';
+    setMessage(`${nextName} unlocked`);
+    setActive(true);
+  }, [completed, lookup]);
+
+  const dismiss = useCallback(() => setActive(false), []);
+  return { active, message, dismiss };
+};
+
+const CelebrationBanner = ({
+  active,
+  message,
+  onDismiss,
+}: {
+  active: boolean;
+  message: string;
+  onDismiss: () => void;
+}): React.JSX.Element | null => {
+  if (!active) return null;
+  return (
+    <Celebration active={active} onDismiss={onDismiss} testID="stage-celebration">
+      <View style={styles.celebrationBanner}>
+        <Text style={styles.celebrationText}>{message}</Text>
+      </View>
+    </Celebration>
+  );
+};
+
 const MapScreen = (): React.JSX.Element => {
   const stages = useStageStore(selectStages);
   const loading = useStageStore(selectStagesLoading);
@@ -604,6 +744,7 @@ const MapScreen = (): React.JSX.Element => {
   const handleRefresh = useCallback(() => void stageService.loadStages(), []);
   const handleCloseModal = useCallback(() => setActiveStage(null), []);
   const handleNavigate = useStageNavigation(handleCloseModal);
+  const celebration = useStageCompletionCelebration(stages, lookup);
 
   if (loading && stages.length === 0) return <MapLoading />;
   if (error && stages.length === 0) return <MapError message={error} />;
@@ -611,8 +752,14 @@ const MapScreen = (): React.JSX.Element => {
   return (
     <View style={styles.container}>
       <MapBackdrop />
+      <JourneyHeader currentStage={currentStage} />
       <MapGrid lookup={lookup} currentStage={currentStage} onSelectStage={setActiveStage} />
       {error && stages.length > 0 && <MapRefreshErrorBanner onRetry={handleRefresh} />}
+      <CelebrationBanner
+        active={celebration.active}
+        message={celebration.message}
+        onDismiss={celebration.dismiss}
+      />
       <StageDetailModal
         activeStage={activeStage}
         onClose={handleCloseModal}

--- a/frontend/src/features/Map/__tests__/MapJourney.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapJourney.test.tsx
@@ -1,0 +1,268 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+import React from 'react';
+import { Image } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
+  runAfterInteractions: (cb: () => void) => {
+    cb();
+    return { then: () => {}, done: () => {}, cancel: () => {} };
+  },
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('../../../navigation/hooks', () => ({
+  useAppNavigation: () => ({ navigate: mockNavigate }),
+}));
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: () => 0,
+}));
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// Reduced-motion-safe path: no Animated pulse (Animated trips the test
+// renderer's InteractionManager). Asserts the celebration still renders at rest.
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => true,
+}));
+
+let mockDerivedStage = 1;
+let mockDerivedWeek = 1;
+let mockDaysUntilStage: number | null = null;
+jest.mock('../../../store/useProgramProgression', () => ({
+  useDerivedCurrentStage: (fallback: number) => mockDerivedStage ?? fallback,
+  useDerivedCurrentWeek: (fallback: number) => mockDerivedWeek ?? fallback,
+  useDaysUntilStage: () => mockDaysUntilStage,
+}));
+
+interface StageHistoryData {
+  stage_number: number;
+  practices: Array<{
+    name: string;
+    sessions_completed: number;
+    total_minutes: number;
+    last_session: string | null;
+  }>;
+  habits: Array<{
+    name: string;
+    icon: string;
+    goals_achieved: Record<string, boolean>;
+    best_streak: number;
+    total_completions: number;
+  }>;
+}
+
+const mockHistoryFn = jest.fn<Promise<StageHistoryData>, [number, string?]>();
+jest.mock('../../../api', () => ({
+  stages: {
+    history: (...args: [number, string?]) => mockHistoryFn(...args),
+  },
+}));
+
+function mockMakeStage(stageNumber: number, progress = 0) {
+  return {
+    id: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    stageNumber,
+    progress,
+    color: '#abcdef',
+    isUnlocked: stageNumber <= 2,
+    category: 'Test',
+    aspect: 'Aspect',
+    spiralDynamicsColor: 'Beige',
+    growingUpStage: 'Growing',
+    divineGenderPolarity: 'Polarity',
+    relationshipToFreeWill: 'Free Will',
+    freeWillDescription: 'Description of free will.',
+    overviewUrl: '',
+  };
+}
+
+let mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+
+const mockLoadStages = jest.fn();
+jest.mock('../services/stageService', () => ({
+  stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+  isStageUnlocked: (
+    stage: { isUnlocked: boolean; stageNumber: number },
+    currentStage: number | null,
+  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
+}));
+
+const buildMockStageState = () => ({
+  stages: mockStages,
+  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
+  stageOrder: mockStages.map((s) => s.stageNumber),
+  currentStage: 1,
+  loading: false,
+  error: null,
+  setStages: jest.fn(),
+  setCurrentStage: jest.fn(),
+  setLoading: jest.fn(),
+  setError: jest.fn(),
+  updateStageProgress: jest.fn(),
+});
+
+jest.mock('../../../store/useStageStore', () => ({
+  useStageStore: jest.fn((selector) => {
+    const mockState = buildMockStageState();
+    return selector ? selector(mockState) : mockState;
+  }),
+  selectStages: (s: { stages: unknown }) => s.stages,
+  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
+  selectStagesLoading: (s: { loading: unknown }) => s.loading,
+  selectStagesError: (s: { error: unknown }) => s.error,
+}));
+
+import MapScreen from '../MapScreen';
+
+import { showcase } from '@/design/tokens';
+
+const findText = (tree: ReturnType<typeof create>, fragment: string): boolean =>
+  tree.root.findAll(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (node: any) =>
+      typeof node.props.children === 'string' && node.props.children.includes(fragment),
+  ).length > 0;
+
+const openStage = (tree: ReturnType<typeof create>, stageNumber: number): void => {
+  act(() => {
+    tree.root.findByProps({ testID: `stage-hotspot-${stageNumber}-0` }).props.onPress();
+  });
+};
+
+describe('MapScreen — journey narrative', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockLoadStages.mockClear();
+    mockHistoryFn.mockReset();
+    mockDerivedStage = 5;
+    mockDerivedWeek = 12;
+    mockDaysUntilStage = null;
+    mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('renders the compact journey read "Stage N of 10 · Week W"', () => {
+    const tree = create(<MapScreen />);
+    const read = tree.root.findByProps({ testID: 'journey-read' });
+    expect(read).toBeTruthy();
+    expect(findText(tree, 'Stage 5 of 10 · Week 12')).toBe(true);
+  });
+
+  it('marks the current stage with a "you are here" marker + halo', () => {
+    const tree = create(<MapScreen />);
+    const markers = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) => node.props.testID === 'you-are-here',
+    );
+    expect(markers.length).toBeGreaterThanOrEqual(1);
+    expect(findText(tree, 'YOU ARE HERE')).toBe(true);
+  });
+
+  it('shows an "Unlocks in N days" timeline on a locked stage', () => {
+    // Calendar at stage 5, so stage 8 is locked.
+    mockDaysUntilStage = 9;
+    const tree = create(<MapScreen />);
+    const unlock = tree.root.findByProps({ testID: 'stage-unlock-8' });
+    expect(unlock).toBeTruthy();
+    expect(findText(tree, 'Unlocks in 9 days')).toBe(true);
+  });
+
+  it('grounds the detail modal on the showcase surface tinted with the stage colour', () => {
+    const tree = create(<MapScreen />);
+    openStage(tree, 1);
+    const modal = tree.root.findByProps({ testID: 'stage-modal' });
+    const flat = Array.isArray(modal.props.style)
+      ? Object.assign({}, ...modal.props.style.filter(Boolean))
+      : modal.props.style;
+    expect(flat.backgroundColor).toBe(showcase.canvas);
+    expect(flat.borderLeftColor).toBe('#abcdef');
+  });
+
+  it('renders a one-sentence history + ranked stats + retained medals', async () => {
+    mockHistoryFn.mockResolvedValueOnce({
+      stage_number: 1,
+      practices: [
+        { name: 'Breath', sessions_completed: 12, total_minutes: 180, last_session: null },
+      ],
+      habits: [
+        {
+          name: 'Exercise',
+          icon: '🏃',
+          goals_achieved: { low: true, clear: true, stretch: false },
+          best_streak: 14,
+          total_completions: 45,
+        },
+      ],
+    });
+    const tree = create(<MapScreen />);
+    openStage(tree, 1);
+    await act(async () => {
+      tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
+    });
+
+    expect(tree.root.findByProps({ testID: 'progression-sentence' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'ranked-stats' })).toBeTruthy();
+    // One progression sentence.
+    expect(findText(tree, 'You logged 12 sessions')).toBe(true);
+    // Medals retained.
+    const badges = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) =>
+        typeof node.props.testID === 'string' && node.props.testID.startsWith('goal-badge-'),
+    );
+    expect(badges.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('ranks the modal actions into a primary Continue + two secondary, all wired', () => {
+    const tree = create(<MapScreen />);
+    openStage(tree, 1);
+
+    // Primary action keeps the practice-link handler but reads "Continue".
+    expect(findText(tree, 'Continue')).toBe(true);
+    act(() => tree.root.findByProps({ testID: 'practice-link' }).props.onPress());
+    expect(mockNavigate).toHaveBeenCalledWith('Practice', { stageNumber: 1 });
+
+    // Each action closes the modal on navigate, so reopen between presses; the
+    // two secondary actions remain wired to Course / Journal.
+    openStage(tree, 1);
+    act(() => tree.root.findByProps({ testID: 'course-link' }).props.onPress());
+    expect(mockNavigate).toHaveBeenCalledWith('Course', { stageNumber: 1 });
+
+    openStage(tree, 1);
+    act(() => tree.root.findByProps({ testID: 'journal-link' }).props.onPress());
+    expect(mockNavigate).toHaveBeenCalledWith('Journal', {
+      tag: 'stage_reflection',
+      stageNumber: 1,
+    });
+  });
+
+  it('plays the Celebration when a stage newly completes', () => {
+    let tree!: ReturnType<typeof create>;
+    act(() => {
+      tree = create(<MapScreen />);
+    });
+    // No celebration on first paint (baseline seeded).
+    const celebrations = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (n: any) => n.props.testID === 'stage-celebration',
+    );
+    expect(celebrations.length).toBe(0);
+
+    // Stage 3 completes → re-render with the new progress.
+    mockStages = mockStages.map((s) => (s.stageNumber === 3 ? { ...s, progress: 1 } : s));
+    act(() => {
+      tree.update(<MapScreen />);
+    });
+
+    const celebration = tree.root.findByProps({ testID: 'stage-celebration' });
+    expect(celebration).toBeTruthy();
+    // Names the next stage that unlocked.
+    expect(findText(tree, 'Stage 4 unlocked')).toBe(true);
+    act(() => tree.unmount());
+  });
+});

--- a/frontend/src/features/Map/__tests__/MapRetry.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapRetry.test.tsx
@@ -26,6 +26,8 @@ jest.mock('react-native-safe-area-context', () => ({
 }));
 jest.mock('../../../store/useProgramProgression', () => ({
   useDerivedCurrentStage: (fallback: number) => fallback,
+  useDerivedCurrentWeek: (fallback: number) => fallback,
+  useDaysUntilStage: () => null,
 }));
 
 interface StageHistoryData {

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -29,8 +29,12 @@ jest.mock('react-native-safe-area-context', () => ({
 // consumes ``useDerivedCurrentStage`` directly, so mocking it here drives both
 // the "current" highlight and the calendar-based unlock.
 let mockDerivedStage = 1;
+let mockDerivedWeek = 1;
+let mockDaysUntilStage: number | null = null;
 jest.mock('../../../store/useProgramProgression', () => ({
   useDerivedCurrentStage: (fallback: number) => mockDerivedStage ?? fallback,
+  useDerivedCurrentWeek: (fallback: number) => mockDerivedWeek ?? fallback,
+  useDaysUntilStage: () => mockDaysUntilStage,
 }));
 
 /** Build a realistic StageData for testing (must be prefixed with mock). */
@@ -118,6 +122,8 @@ describe('MapScreen', () => {
     mockNavigate.mockClear();
     mockLoadStages.mockClear();
     mockDerivedStage = 1;
+    mockDerivedWeek = 1;
+    mockDaysUntilStage = null;
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 

--- a/frontend/src/features/Map/__tests__/journeyNarrative.test.ts
+++ b/frontend/src/features/Map/__tests__/journeyNarrative.test.ts
@@ -1,0 +1,70 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { journeyRead, progressionSentence, rankedStats, unlockTimeline } from '../journeyNarrative';
+
+import type { StageHistoryResponse } from '@/api';
+
+const HISTORY: StageHistoryResponse = {
+  stage_number: 1,
+  practices: [
+    { name: 'Breath of Fire', sessions_completed: 12, total_minutes: 180, last_session: null },
+    { name: 'Box Breath', sessions_completed: 3, total_minutes: 30, last_session: null },
+  ],
+  habits: [
+    {
+      name: 'Morning Exercise',
+      icon: '🏃',
+      goals_achieved: { low: true, clear: true, stretch: false },
+      best_streak: 14,
+      total_completions: 45,
+    },
+  ],
+};
+
+const EMPTY: StageHistoryResponse = { stage_number: 1, practices: [], habits: [] };
+
+describe('journeyRead', () => {
+  it('renders "Stage N of 10 · Week W"', () => {
+    expect(journeyRead(5, 12, 10)).toBe('Stage 5 of 10 · Week 12');
+  });
+});
+
+describe('unlockTimeline', () => {
+  it('pluralises day counts', () => {
+    expect(unlockTimeline(3)).toBe('Unlocks in 3 days');
+    expect(unlockTimeline(1)).toBe('Unlocks in 1 day');
+  });
+
+  it('treats zero / negative as unlocking now', () => {
+    expect(unlockTimeline(0)).toBe('Unlocking now');
+    expect(unlockTimeline(-2)).toBe('Unlocking now');
+  });
+
+  it('falls back to the condition when no anchor is set', () => {
+    expect(unlockTimeline(null)).toContain('reaches it');
+  });
+});
+
+describe('progressionSentence', () => {
+  it('reads as one sentence with sessions and a streak', () => {
+    const sentence = progressionSentence(HISTORY);
+    expect(sentence).toBe('You logged 15 sessions across 2 practices and held a 14-day streak.');
+  });
+
+  it('falls back to a beginning-of-story line when empty', () => {
+    expect(progressionSentence(EMPTY)).toContain('just beginning');
+  });
+});
+
+describe('rankedStats', () => {
+  it('ranks headline stats largest-first and drops zeros', () => {
+    const stats = rankedStats(HISTORY);
+    // 15 sessions, 3 hours (210 min → 4 rounded), 14-day streak; all > 0.
+    expect(stats.map((s) => s.key)).toEqual(['sessions', 'streak', 'minutes']);
+    expect(stats[0]).toEqual({ key: 'sessions', label: 'Sessions', value: 15 });
+  });
+
+  it('returns nothing for an empty history', () => {
+    expect(rankedStats(EMPTY)).toEqual([]);
+  });
+});

--- a/frontend/src/features/Map/journeyNarrative.ts
+++ b/frontend/src/features/Map/journeyNarrative.ts
@@ -1,0 +1,96 @@
+// frontend/features/Map/journeyNarrative.ts
+
+/**
+ * Narrative helpers for the Map's journey read + stage-detail modal.
+ *
+ * These turn the raw stage-history payload into a single progression sentence
+ * and a ranked list of headline stats, so the modal reads as a story rather
+ * than a pile of disparate counts. Pure functions — no React, no I/O.
+ */
+
+import type { StageHistoryResponse } from '../../api';
+
+/** Compact "Stage N of 10 · Week W" read for the journey header. */
+export const journeyRead = (
+  currentStage: number,
+  currentWeek: number,
+  stageCount: number,
+): string => `Stage ${currentStage} of ${stageCount} · Week ${currentWeek}`;
+
+/** "Unlocks in N days" / already-reached copy for a locked stage. */
+export const unlockTimeline = (daysUntil: number | null): string => {
+  if (daysUntil === null) return 'Unlocks as your journey reaches it';
+  if (daysUntil <= 0) return 'Unlocking now';
+  return `Unlocks in ${daysUntil} day${daysUntil === 1 ? '' : 's'}`;
+};
+
+/** A single ranked headline stat (largest contribution first). */
+export interface RankedStat {
+  key: string;
+  label: string;
+  value: number;
+}
+
+const MINUTES_PER_HOUR = 60;
+
+/** Total sessions + total minutes + best habit streak, derived once. */
+interface JourneyTotals {
+  sessions: number;
+  minutes: number;
+  bestStreak: number;
+  practiceCount: number;
+  habitCount: number;
+}
+
+const totalsFor = (history: StageHistoryResponse): JourneyTotals => {
+  const sessions = history.practices.reduce((sum, p) => sum + p.sessions_completed, 0);
+  const minutes = history.practices.reduce((sum, p) => sum + p.total_minutes, 0);
+  const bestStreak = history.habits.reduce((max, h) => Math.max(max, h.best_streak), 0);
+  return {
+    sessions,
+    minutes,
+    bestStreak,
+    practiceCount: history.practices.length,
+    habitCount: history.habits.length,
+  };
+};
+
+/**
+ * One progression sentence summarising the stage's activity. Reads as a story
+ * ("You logged 12 sessions across 1 practice and held a 14-day streak.") rather
+ * than a bare count list.
+ */
+export const progressionSentence = (history: StageHistoryResponse): string => {
+  const { sessions, bestStreak, practiceCount, habitCount } = totalsFor(history);
+  const clauses: string[] = [];
+  if (sessions > 0) {
+    clauses.push(
+      `logged ${sessions} session${sessions === 1 ? '' : 's'} across ${practiceCount} practice${
+        practiceCount === 1 ? '' : 's'
+      }`,
+    );
+  }
+  if (bestStreak > 0) {
+    clauses.push(`held a ${bestStreak}-day streak`);
+  } else if (habitCount > 0) {
+    clauses.push(`began building ${habitCount} habit${habitCount === 1 ? '' : 's'}`);
+  }
+  if (clauses.length === 0) return 'Your story for this stage is just beginning.';
+  return `You ${clauses.join(' and ')}.`;
+};
+
+/** Headline stats ranked largest-first, dropping zero-value rows. */
+export const rankedStats = (history: StageHistoryResponse): RankedStat[] => {
+  const { sessions, minutes, bestStreak } = totalsFor(history);
+  const hours = Math.round(minutes / MINUTES_PER_HOUR);
+  return [
+    { key: 'sessions', label: 'Sessions', value: sessions },
+    { key: 'minutes', label: minutes >= MINUTES_PER_HOUR ? 'Hours' : 'Minutes', value: minutes },
+    { key: 'streak', label: 'Best streak (days)', value: bestStreak },
+  ]
+    .map((stat) =>
+      stat.key === 'minutes' && minutes >= MINUTES_PER_HOUR ? { ...stat, value: hours } : stat,
+    )
+    .filter((stat) => stat.value > 0)
+    .sort((a, b) => b.value - a.value);
+};

--- a/frontend/src/store/__tests__/useProgramStore.test.ts
+++ b/frontend/src/store/__tests__/useProgramStore.test.ts
@@ -144,3 +144,26 @@ describe('programDayOffset / programWeek / programStage', () => {
     expect(programStage(anchor, today)).toBe(10);
   });
 });
+
+describe('daysUntilStage', () => {
+  const { daysUntilStage } = require('../useProgramStore');
+
+  it('returns null when no anchor is set', () => {
+    expect(daysUntilStage(3, null)).toBeNull();
+  });
+
+  it('counts whole days until a future stage begins', () => {
+    const anchor = new Date(2026, 0, 1);
+    // Stage 3 begins on day 42 (two 21-day stages). On day 0 that is 42 days out.
+    expect(daysUntilStage(3, anchor, anchor)).toBe(42);
+    // Ten days in, 32 remain.
+    expect(daysUntilStage(3, anchor, new Date(2026, 0, 11))).toBe(32);
+  });
+
+  it('returns <= 0 once the stage has been reached', () => {
+    const anchor = new Date(2026, 0, 1);
+    // Stage 1 begins at day 0, so it is always already reached.
+    expect(daysUntilStage(1, anchor, anchor)).toBe(0);
+    expect(daysUntilStage(1, anchor, new Date(2026, 0, 11))).toBeLessThan(0);
+  });
+});

--- a/frontend/src/store/useProgramProgression.ts
+++ b/frontend/src/store/useProgramProgression.ts
@@ -1,5 +1,5 @@
 // React hooks layered on useProgramStore so consumers get a single render-friendly value plus a server-derived fallback.
-import { useProgramStore, programStage, programWeek } from './useProgramStore';
+import { useProgramStore, daysUntilStage, programStage, programWeek } from './useProgramStore';
 
 export const useDerivedCurrentStage = (fallback: number, today: Date = new Date()): number => {
   const anchor = useProgramStore((s) => s.programStartDate);
@@ -9,4 +9,10 @@ export const useDerivedCurrentStage = (fallback: number, today: Date = new Date(
 export const useDerivedCurrentWeek = (fallback: number, today: Date = new Date()): number => {
   const anchor = useProgramStore((s) => s.programStartDate);
   return programWeek(anchor, today) ?? fallback;
+};
+
+// Whole days until ``stageNumber`` unlocks on the calendar, or null when no anchor is set.
+export const useDaysUntilStage = (stageNumber: number, today: Date = new Date()): number | null => {
+  const anchor = useProgramStore((s) => s.programStartDate);
+  return daysUntilStage(stageNumber, anchor, today);
 };

--- a/frontend/src/store/useProgramStore.ts
+++ b/frontend/src/store/useProgramStore.ts
@@ -87,6 +87,27 @@ export const programWeek = (anchor: Date | null, today: Date = new Date()): numb
   return week;
 };
 
+// Cumulative day offset at which a 1-based stage *begins* (stage 1 starts at day 0).
+const stageStartDay = (stageNumber: number): number => {
+  let start = 0;
+  for (let i = 0; i < stageNumber - 1 && i < STAGE_COUNT; i += 1) {
+    start += STAGE_DURATIONS_DAYS[i]!;
+  }
+  return start;
+};
+
+// Whole days until ``stageNumber`` unlocks on the calendar, or null when no anchor.
+// 0 (or negative) means the stage has already been reached — callers treat <= 0 as unlocked.
+export const daysUntilStage = (
+  stageNumber: number,
+  anchor: Date | null,
+  today: Date = new Date(),
+): number | null => {
+  const offset = programDayOffset(anchor, today);
+  if (offset === null) return null;
+  return stageStartDay(stageNumber) - offset;
+};
+
 // Current stage (1-10) walking STAGE_DURATIONS_DAYS so the 21/42-day split is honoured.
 export const programStage = (anchor: Date | null, today: Date = new Date()): number | null => {
   const offset = programDayOffset(anchor, today);


### PR DESCRIPTION
## Summary

#833 (epic #824): the Map had a rich spiral but a weak journey narrative. Layered the narrative onto #842's rebuilt grid.

- Strengthened current marker: thicker `accent.strong` halo + a **YOU ARE HERE** pill on the live stage; a `JourneyHeader` reads "Stage N of 10 · Week W".
- Locked stages show "Unlocks in N days" / the condition, computed from the existing calendar drip (`daysUntilStage`) — **no new backend**.
- Detail modal re-grounded on `showcase.canvas` tinted with the stage's colour (`onShowcase`, AA); history → one progression sentence + ranked stats (medals retained); actions ranked into a primary **Continue** + two secondary (handlers/testIDs intact).
- Stage completion → shared `Celebration` ("{next} unlocked").

#842's grid + all tap/lock/complete/badge behaviour + every testID preserved.

## Test plan

`MapJourney.test` (7) + `journeyNarrative.test` (8) + `daysUntilStage` (3); existing Map tests green. `./scripts/frontend/check-all.sh` 4/4 (2091); tokens-only, AA, no `any`.

Closes #833
Refs #824
