### PR TITLE
feat(auth): branded editorial first impression

### DIFF
--- a/frontend/src/features/Auth/AuthBrandBand.tsx
+++ b/frontend/src/features/Auth/AuthBrandBand.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+import { authStyles as styles } from './auth.styles';
+
+import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
+
+/** Program voice beneath the wordmark — the contemplative 36-week invitation. */
+const TAGLINE = 'A thirty-six week practice in becoming who you mean to be.';
+
+/**
+ * The branded editorial first impression (design-act2-10): a serif "Adepthood"
+ * wordmark over a line of program voice, on the warm showcase hero. Shared
+ * verbatim by Login and Signup so both screens open on the same entrance.
+ */
+export function AuthBrandBand(): React.JSX.Element {
+  return (
+    <ShowcaseCard style={styles.brandBand} testID="auth-brand-band">
+      <Text style={styles.wordmark} accessibilityRole="header">
+        Adepthood
+      </Text>
+      <Text style={styles.tagline}>{TAGLINE}</Text>
+    </ShowcaseCard>
+  );
+}

--- a/frontend/src/features/Auth/CancelResetScreen.tsx
+++ b/frontend/src/features/Auth/CancelResetScreen.tsx
@@ -7,7 +7,9 @@ import { MIN_TOKEN_LENGTH } from './resetToken';
 
 import { auth as authApi } from '@/api';
 import { Button } from '@/components/Button';
-import { SPACING, colors } from '@/design/tokens';
+import { SPACING, ink, type as typeRamp } from '@/design/tokens';
+
+const TYPE = typeRamp(0);
 
 type CancelStatus = 'pending' | 'success' | 'error' | 'invalid_token';
 
@@ -105,10 +107,10 @@ export default function CancelResetScreen({ navigation, route }: Props) {
 // Confirmation-screen typography (smaller title than the form screens); the
 // container/button/buttonText come from the shared authStyles.
 const localStyles = StyleSheet.create({
-  title: { fontSize: 24, fontWeight: 'bold', textAlign: 'center', marginBottom: SPACING.md },
+  title: { ...TYPE.title, color: ink.primary, textAlign: 'center', marginBottom: SPACING.md },
   subtitle: {
-    fontSize: 15,
-    color: colors.text.secondary,
+    ...TYPE.body,
+    color: ink.soft,
     textAlign: 'center',
     marginBottom: SPACING.xl,
   },

--- a/frontend/src/features/Auth/LoginScreen.tsx
+++ b/frontend/src/features/Auth/LoginScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Text, TouchableOpacity } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
+import { AuthBrandBand } from './AuthBrandBand';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { canonicalizeEmail } from './canonicalizeEmail';
 
@@ -126,7 +127,9 @@ export default function LoginScreen({ navigation }: Props) {
 
   return (
     <AuthScreenContainer testID="login">
-      <Text style={styles.title}>Adepthood</Text>
+      <AuthBrandBand />
+      <Text style={styles.title}>Welcome back</Text>
+      <Text style={styles.lead}>Sign in to pick up where you left off.</Text>
       <LoginFields
         email={email}
         setEmail={setEmail}

--- a/frontend/src/features/Auth/ReauthSheet.tsx
+++ b/frontend/src/features/Auth/ReauthSheet.tsx
@@ -16,7 +16,18 @@ import { canonicalizeEmail } from './canonicalizeEmail';
 
 import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  colors,
+  ink,
+  surface,
+  surfaceShadow,
+  type as typeRamp,
+} from '@/design/tokens';
+
+const TYPE = typeRamp(0);
 
 const REAUTH_FALLBACK =
   "We couldn't sign you back in. Check your connection, then try again in a moment.";
@@ -168,36 +179,38 @@ export function ReauthSheet(): React.JSX.Element {
 const localStyles = StyleSheet.create({
   backdrop: {
     flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.45)',
+    backgroundColor: colors.mystical.overlay,
     justifyContent: 'center',
     padding: SPACING.xl,
   },
   card: {
-    backgroundColor: colors.background.card,
+    backgroundColor: surface.raised,
     borderRadius: BORDER_RADIUS.lg,
     padding: SPACING.xl,
+    ...surfaceShadow.raised,
   },
   title: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: colors.text.primary,
+    ...TYPE.title,
+    color: ink.primary,
     marginBottom: SPACING.sm,
   },
   subtitle: {
-    fontSize: 14,
-    color: colors.text.secondary,
+    ...TYPE.body,
+    color: ink.soft,
     marginBottom: SPACING.lg,
   },
   primaryButton: {
-    backgroundColor: colors.primary,
+    backgroundColor: accent.primary,
     borderRadius: BORDER_RADIUS.md,
     padding: SPACING.buttonV,
+    minHeight: 44,
     alignItems: 'center',
+    justifyContent: 'center',
     marginBottom: SPACING.md,
   },
   secondaryLink: {
     textAlign: 'center',
-    color: colors.text.secondary,
+    color: ink.soft,
     paddingVertical: SPACING.sm,
   },
 });

--- a/frontend/src/features/Auth/SignupScreen.tsx
+++ b/frontend/src/features/Auth/SignupScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Text, TouchableOpacity } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
+import { AuthBrandBand } from './AuthBrandBand';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { canonicalizeEmail } from './canonicalizeEmail';
 import { validatePasswordPair } from './passwordValidation';
@@ -131,7 +132,9 @@ export default function SignupScreen({ navigation }: Props) {
 
   return (
     <AuthScreenContainer testID="signup">
-      <Text style={styles.title}>Create Account</Text>
+      <AuthBrandBand />
+      <Text style={styles.title}>Begin</Text>
+      <Text style={styles.lead}>Create your account and start the practice.</Text>
       <SignupFields
         email={email}
         setEmail={setEmail}

--- a/frontend/src/features/Auth/__tests__/ForgotPasswordScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/ForgotPasswordScreen.test.tsx
@@ -53,6 +53,23 @@ describe('ForgotPasswordScreen', () => {
     expect(await findByText('Check your inbox')).toBeTruthy();
   });
 
+  it('keeps the anti-enumeration success copy verbatim through the restyle', async () => {
+    // design-act2-10: the restyle must not touch the SPEC R4 copy. Assert the
+    // exact string still renders so a future style change can't quietly reword
+    // the anti-enumeration body.
+    mockRequest.mockResolvedValueOnce({ message: 'ok' });
+    const { getByLabelText, getByText, findByText } = render(
+      <ForgotPasswordScreen navigation={navigation} />,
+    );
+    fireEvent.changeText(getByLabelText('Email'), 'foo@example.com');
+    fireEvent.press(getByText('Send Reset Link'));
+    expect(
+      await findByText(
+        'If we have an account for that address, a reset link is on its way. The link expires in 30 minutes.',
+      ),
+    ).toBeTruthy();
+  });
+
   it('surfaces a friendly error when the request fails entirely', async () => {
     mockRequest.mockRejectedValueOnce(new TypeError('Network request failed'));
     const { getByLabelText, getByText, findByText } = render(

--- a/frontend/src/features/Auth/__tests__/LoginScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/LoginScreen.test.tsx
@@ -36,6 +36,20 @@ describe('LoginScreen', () => {
     expect(getByText('Log In')).toBeTruthy();
   });
 
+  it('opens on the branded editorial cover: serif wordmark + program voice', () => {
+    const { getByTestId, getByText } = render(<LoginScreen navigation={mockNavigation} />);
+
+    expect(getByTestId('auth-brand-band')).toBeTruthy();
+    expect(getByText('Adepthood')).toBeTruthy();
+    expect(getByText(/thirty-six week/i)).toBeTruthy();
+  });
+
+  it('shows the "Welcome back" serif title', () => {
+    const { getByText } = render(<LoginScreen navigation={mockNavigation} />);
+
+    expect(getByText('Welcome back')).toBeTruthy();
+  });
+
   it('calls login with email and password on submit', async () => {
     mockLogin.mockResolvedValue(undefined);
     const { getByPlaceholderText, getByText } = render(<LoginScreen navigation={mockNavigation} />);

--- a/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
@@ -31,6 +31,20 @@ describe('SignupScreen', () => {
     expect(getByPlaceholderText('Confirm Password')).toBeTruthy();
   });
 
+  it('opens on the branded editorial cover: serif wordmark + program voice', () => {
+    const { getByTestId, getByText } = render(<SignupScreen navigation={mockNavigation} />);
+
+    expect(getByTestId('auth-brand-band')).toBeTruthy();
+    expect(getByText('Adepthood')).toBeTruthy();
+    expect(getByText(/thirty-six week/i)).toBeTruthy();
+  });
+
+  it('shows the "Begin" serif title', () => {
+    const { getByText } = render(<SignupScreen navigation={mockNavigation} />);
+
+    expect(getByText('Begin')).toBeTruthy();
+  });
+
   it('shows error when passwords do not match', async () => {
     const { getByPlaceholderText, getByText, findByText } = render(
       <SignupScreen navigation={mockNavigation} />,

--- a/frontend/src/features/Auth/auth.styles.ts
+++ b/frontend/src/features/Auth/auth.styles.ts
@@ -1,15 +1,31 @@
 import { StyleSheet } from 'react-native';
 
-import { BORDER_RADIUS, SPACING, colors, surface } from '@/design/tokens';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  colors,
+  ink,
+  onShowcase,
+  surface,
+  type as typeRamp,
+} from '@/design/tokens';
 
 // Cap the form width so fields don't stretch edge-to-edge on laptop/desktop
 // browsers; on phones the screen is narrower so it has no effect.
 export const FORM_MAX_WIDTH = 480;
 
+// The serif type ramp is responsive (scales with viewport width); the auth
+// screens are full-bleed editorial covers, so resolve at the widest step so the
+// wordmark + titles read with display weight on every device.
+const TYPE = typeRamp(0);
+
 /**
- * Shared styles for the auth screens (audit-ux-08). Previously each of the six
- * screens defined its own near-identical container/input/button sheet, so the
- * same rules were copy-pasted and drifted independently; this is the one source.
+ * Shared styles for the auth screens (audit-ux-08, design-act2-10). Previously
+ * each of the six screens defined its own near-identical container/input/button
+ * sheet, so the same rules were copy-pasted and drifted independently; this is
+ * the one source. The legacy grey card chrome is gone — the auth flow now lives
+ * on the warm ``surface`` ground with a serif editorial voice.
  */
 export const authStyles = StyleSheet.create({
   // Outer SafeAreaView wrapper for the full-screen auth screens.
@@ -18,25 +34,54 @@ export const authStyles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     padding: SPACING.xl,
-    backgroundColor: colors.background.card,
+    backgroundColor: surface.canvas,
   },
   form: {
     width: '100%',
     maxWidth: FORM_MAX_WIDTH,
     alignSelf: 'center',
   },
-  title: { fontSize: 28, fontWeight: 'bold', textAlign: 'center', marginBottom: SPACING.lg },
+  // Serif wordmark + program voice on the warm showcase hero shared by Login
+  // and Signup — the branded editorial cover.
+  brandBand: { marginBottom: SPACING.xxl },
+  wordmark: {
+    ...TYPE.display,
+    color: onShowcase.primary,
+    textAlign: 'center',
+  },
+  tagline: {
+    ...TYPE.body,
+    color: onShowcase.soft,
+    textAlign: 'center',
+    marginTop: SPACING.sm,
+  },
+  // Per-screen serif title + lead (Login → "Welcome back", Signup → "Begin").
+  title: {
+    ...TYPE.title,
+    color: ink.primary,
+    textAlign: 'center',
+    marginBottom: SPACING.sm,
+  },
+  lead: {
+    ...TYPE.body,
+    color: ink.soft,
+    textAlign: 'center',
+    marginBottom: SPACING.xl,
+  },
   subtitle: {
-    fontSize: 14,
-    color: colors.text.secondary,
+    ...TYPE.body,
+    color: ink.soft,
     textAlign: 'center',
     marginBottom: SPACING.xl,
   },
   input: {
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
     borderRadius: BORDER_RADIUS.md,
     padding: SPACING.md,
+    minHeight: 44,
+    color: ink.primary,
+    backgroundColor: surface.raised,
     marginBottom: SPACING.md,
     fontSize: 16,
   },
@@ -47,25 +92,32 @@ export const authStyles = StyleSheet.create({
   buttonSpacing: { marginBottom: SPACING.lg },
   error: { color: colors.danger, marginBottom: SPACING.md, textAlign: 'center' },
   button: {
-    backgroundColor: colors.primary,
+    backgroundColor: accent.primary,
     borderRadius: BORDER_RADIUS.md,
     padding: SPACING.buttonV,
+    minHeight: 44,
     alignItems: 'center',
+    justifyContent: 'center',
     marginBottom: SPACING.lg,
   },
   buttonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
-  link: { textAlign: 'center', color: colors.text.secondary },
-  linkBold: { color: colors.primary, fontWeight: '600' },
+  link: { textAlign: 'center', color: ink.soft },
+  linkBold: { color: accent.primary, fontWeight: '600' },
   forgotLink: {
     textAlign: 'center',
-    color: colors.primary,
+    color: accent.primary,
     fontWeight: '500',
     marginBottom: SPACING.md,
   },
-  successTitle: { fontSize: 20, fontWeight: '600', textAlign: 'center', marginBottom: SPACING.md },
+  successTitle: {
+    ...TYPE.title,
+    color: ink.primary,
+    textAlign: 'center',
+    marginBottom: SPACING.md,
+  },
   successBody: {
-    fontSize: 15,
-    color: colors.text.secondary,
+    ...TYPE.body,
+    color: ink.soft,
     textAlign: 'center',
     marginBottom: SPACING.xl,
   },


### PR DESCRIPTION
## Summary

#834 (epic #824): auth was a plain grey-on-white form. Made it a branded editorial cover.

- `AuthScreenContainer` warm end-to-end (`colors.background.card` removed from auth); serif titles/leads, `ink`/`accent` links, 44dp.
- New `AuthBrandBand`: a shared `ShowcaseCard` entrance — serif `type().display` **"Adepthood"** wordmark + program-voice tagline (`onShowcase`, AA) — on both Login + Signup.
- Per-screen serif titles: Login "Welcome back", Signup "Begin".
- `ReauthSheet` aligned to warm tokens; testIDs + copy preserved.

Every flow preserved exactly — validation, keyboard avoidance, navigation, and the **Forgot/Reset/CancelReset + anti-enumeration copy verbatim**.

## Test plan

Brand band (wordmark + tagline) on Login+Signup; "Welcome back"/"Begin"; the exact anti-enumeration string still renders; validation + navigation green. `./scripts/frontend/check-all.sh` 4/4 (2096); no `any`, no legacy grey.

Closes #834
Refs #824
