### PR TITLE
feat(settings): editorial settings hub + warm adoption

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,7 +64,7 @@ type LinkedRootParamList = Omit<RootStackParamList, 'Tabs'> & {
  * password-recovery email landing page -- the parser puts ``token``
  * into ``route.params`` so ``ResetPasswordScreen`` can pick it up.
  */
-const linking: LinkingOptions<LinkedRootParamList> = {
+export const linking: LinkingOptions<LinkedRootParamList> = {
   prefixes: ['adepthood://'],
   config: {
     screens: {
@@ -77,6 +77,7 @@ const linking: LinkingOptions<LinkedRootParamList> = {
           Map: 'map',
         },
       },
+      Settings: 'settings',
       ApiKeySettings: 'api-key-settings', // pragma: allowlist secret
       // Practice share-link landing (issue #348). The recipient
       // taps ``adepthood://practices/share/<token>`` -- the parser

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -117,7 +117,7 @@ jest.mock('@/features/Journal/JournalEntryScreen', () => {
   return { __esModule: true, default: Stub };
 });
 
-import App from '@/App';
+import App, { linking } from '@/App';
 
 beforeEach(() => {
   mockAuthState = { token: null, authStatus: 'anonymous', isLoading: false };
@@ -167,5 +167,20 @@ describe('App auth flow', () => {
 
     expect(getByText('BottomTabs')).toBeTruthy();
     expect(getByText('ReauthSheet')).toBeTruthy();
+  });
+});
+
+describe('deep linking config', () => {
+  it('keeps the adepthood://api-key-settings deep link pointed at the API key screen', () => {
+    const screens = linking.config?.screens as Record<string, unknown> | undefined;
+
+    expect(linking.prefixes).toContain('adepthood://');
+    expect(screens?.ApiKeySettings).toBe('api-key-settings');
+  });
+
+  it('resolves the Settings hub deep link', () => {
+    const screens = linking.config?.screens as Record<string, unknown> | undefined;
+
+    expect(screens?.Settings).toBe('settings');
   });
 });

--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -3,7 +3,6 @@ import {
   ActivityIndicator,
   Alert,
   Linking,
-  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -13,8 +12,9 @@ import {
 
 import { BYOK_PROVIDERS, providerForKey } from './byokProviders';
 
+import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { useApiKey } from '@/context/ApiKeyContext';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import { BORDER_RADIUS, SPACING, accent, colors, ink, surface } from '@/design/tokens';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 /**
@@ -436,7 +436,7 @@ export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.
   }
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
+    <ScreenScaffold scroll testID="api-key-settings-screen">
       <ScreenBody
         apiKey={apiKey}
         draft={state.draft}
@@ -451,44 +451,52 @@ export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.
         onBack={onBack}
         onOpenTimezone={onOpenTimezone}
       />
-    </ScrollView>
+    </ScreenScaffold>
   );
 }
 
+const MENLO_MONOSPACE = 'Menlo';
+const STORED_LABEL_LETTER_SPACING = 0.5;
+const PROVIDER_HINT_MARGIN_TOP = 2;
+
 const styles = StyleSheet.create({
-  container: { padding: SPACING.xl, backgroundColor: colors.background.card, flexGrow: 1 },
-  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  title: { fontSize: 22, fontWeight: '700', marginBottom: SPACING.md },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: surface.canvas,
+  },
+  title: { fontSize: 22, fontWeight: '700', marginBottom: SPACING.md, color: ink.primary },
   body: {
     fontSize: 14,
-    color: colors.text.secondaryAccessible,
+    color: ink.soft,
     marginBottom: SPACING.xl,
     lineHeight: 20,
   },
   storedCard: {
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
     borderRadius: BORDER_RADIUS.lg,
     padding: SPACING.lg,
     marginBottom: SPACING.xl,
-    backgroundColor: colors.background.accent,
+    backgroundColor: surface.raised,
   },
   storedLabel: {
     fontSize: 12,
-    color: colors.text.secondary,
+    color: ink.muted,
     textTransform: 'uppercase',
-    letterSpacing: 0.5,
+    letterSpacing: STORED_LABEL_LETTER_SPACING,
   },
   storedValue: {
     fontSize: 18,
-    fontFamily: 'Menlo',
+    fontFamily: MENLO_MONOSPACE,
     marginTop: SPACING.sm,
     marginBottom: SPACING.lg,
-    color: colors.text.primary,
+    color: ink.primary,
   },
   hint: {
     fontSize: 14,
-    color: colors.text.secondary,
+    color: ink.muted,
     marginBottom: SPACING.xl,
     fontStyle: 'italic',
   },
@@ -496,32 +504,34 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     marginBottom: SPACING.sm,
-    color: colors.text.primary,
+    color: ink.primary,
   },
   inputRow: { flexDirection: 'row', alignItems: 'stretch', marginBottom: SPACING.md },
   input: {
     flex: 1,
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
     borderRadius: BORDER_RADIUS.md,
     padding: SPACING.md,
     fontSize: 16,
+    backgroundColor: surface.raised,
+    color: ink.primary,
   },
   revealButton: {
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
     borderLeftWidth: 0,
     borderTopRightRadius: BORDER_RADIUS.md,
     borderBottomRightRadius: BORDER_RADIUS.md,
     paddingHorizontal: SPACING.md,
     justifyContent: 'center',
-    backgroundColor: colors.background.accent,
+    backgroundColor: surface.sunken,
   },
-  revealButtonText: { fontSize: 14, color: colors.text.primary, fontWeight: '600' },
-  error: { color: colors.danger, marginBottom: SPACING.md },
+  revealButtonText: { fontSize: 14, color: ink.primary, fontWeight: '600' },
+  error: { color: colors.destructive.text, marginBottom: SPACING.md },
   success: { color: colors.successText, marginBottom: SPACING.md },
   button: { borderRadius: BORDER_RADIUS.md, padding: SPACING.md + 2, alignItems: 'center' },
-  primaryButton: { backgroundColor: colors.primary, marginTop: SPACING.xs },
+  primaryButton: { backgroundColor: accent.primary, marginTop: SPACING.xs },
   primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
   destructiveButton: {
     backgroundColor: colors.destructive.background,
@@ -530,7 +540,7 @@ const styles = StyleSheet.create({
   },
   destructiveButtonText: { color: colors.destructive.text, fontWeight: '600' },
   linkRow: { marginTop: SPACING.xl, alignItems: 'center' },
-  link: { color: colors.primary, fontWeight: '600' },
+  link: { color: accent.primary, fontWeight: '600' },
   providerSection: { marginBottom: SPACING.xl },
   providerRow: {
     flexDirection: 'row',
@@ -538,10 +548,10 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingVertical: SPACING.sm,
     borderBottomWidth: 1,
-    borderBottomColor: colors.border,
+    borderBottomColor: surface.hairline,
   },
   providerInfo: { flex: 1, paddingRight: SPACING.md },
-  providerName: { fontSize: 15, fontWeight: '600', color: colors.text.primary },
-  providerHint: { fontSize: 13, color: colors.text.secondaryAccessible, marginTop: 2 },
+  providerName: { fontSize: 15, fontWeight: '600', color: ink.primary },
+  providerHint: { fontSize: 13, color: ink.soft, marginTop: PROVIDER_HINT_MARGIN_TOP },
   detected: { color: colors.successText, marginBottom: SPACING.md, fontSize: 13 },
 });

--- a/frontend/src/features/Settings/SettingsHubScreen.tsx
+++ b/frontend/src/features/Settings/SettingsHubScreen.tsx
@@ -1,0 +1,130 @@
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { ChevronRight, Globe, KeyRound, LogOut, type LucideIcon } from 'lucide-react-native';
+import React, { useCallback } from 'react';
+import { StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+
+import { EditorialSection } from '@/components/layout/EditorialSection';
+import { ScreenHeader } from '@/components/layout/ScreenHeader';
+import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
+import { useAuth } from '@/context/AuthContext';
+import { accent, ink, rhythm, surface, touchTarget, type as typeRamp } from '@/design/tokens';
+import type { RootStackParamList } from '@/navigation/RootStack';
+
+/**
+ * Warm Settings landing hub (#835). Groups the scattered settings entries —
+ * Account (API key, time zone) and Session (log out) — as warm editorial rows
+ * on the shared scaffold. The header-right gear points here (not at a single
+ * sub-screen); logout moved off the tab header and lives in the Session group.
+ */
+
+const ICON_SIZE = 22;
+const CHEVRON_SIZE = 20;
+
+interface SettingsRowProps {
+  icon: LucideIcon;
+  label: string;
+  description: string;
+  onPress: () => void;
+  testID: string;
+  destructive?: boolean;
+}
+
+const SettingsRow = ({
+  icon: Icon,
+  label,
+  description,
+  onPress,
+  testID,
+  destructive = false,
+}: SettingsRowProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const t = typeRamp(width);
+  const tint = destructive ? accent.strong : accent.primary;
+  return (
+    <TouchableOpacity
+      style={styles.row}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={description}
+      testID={testID}
+    >
+      <Icon color={tint} size={ICON_SIZE} />
+      <View style={styles.rowText}>
+        <Text style={[t.label, styles.rowLabel]}>{label}</Text>
+        <Text style={[t.caption, styles.rowDescription]}>{description}</Text>
+      </View>
+      {destructive ? null : <ChevronRight color={ink.muted} size={CHEVRON_SIZE} />}
+    </TouchableOpacity>
+  );
+};
+
+const SettingsHubScreen = (): React.JSX.Element => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { logout } = useAuth();
+
+  const openApiKey = useCallback(() => navigation.navigate('ApiKeySettings'), [navigation]);
+  const openTimezone = useCallback(() => navigation.navigate('TimezoneSettings'), [navigation]);
+  const onLogout = useCallback(() => void logout(), [logout]);
+
+  return (
+    <ScreenScaffold scroll testID="settings-hub-screen">
+      <ScreenHeader
+        eyebrow="Your account"
+        title="Settings"
+        lead="Manage how Adepthood works for you."
+      />
+      <EditorialSection title="Account" testID="settings-group-account">
+        <SettingsRow
+          icon={KeyRound}
+          label="API key"
+          description="Bring your own BotMason API key, stored on this device."
+          onPress={openApiKey}
+          testID="settings-row-api-key"
+        />
+        <SettingsRow
+          icon={Globe}
+          label="Time zone"
+          description="Set the zone streaks and daily stats count days in."
+          onPress={openTimezone}
+          testID="settings-row-timezone"
+        />
+      </EditorialSection>
+      <EditorialSection title="Session" testID="settings-group-session">
+        <SettingsRow
+          icon={LogOut}
+          label="Log out"
+          description="Sign out of Adepthood on this device."
+          onPress={onLogout}
+          testID="settings-row-logout"
+          destructive
+        />
+      </EditorialSection>
+    </ScreenScaffold>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: touchTarget.minimum,
+    paddingVertical: rhythm.blockGap,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: surface.hairline,
+  },
+  rowText: {
+    flex: 1,
+    marginLeft: rhythm.blockGap,
+  },
+  rowLabel: {
+    color: ink.primary,
+  },
+  rowDescription: {
+    color: ink.soft,
+    marginTop: rhythm.blockGap / 3,
+  },
+});
+
+export default SettingsHubScreen;

--- a/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
+++ b/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 import { ApiError, users } from '@/api';
+import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { useAuth } from '@/context/AuthContext';
-import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import { BORDER_RADIUS, SPACING, accent, colors, ink, surface } from '@/design/tokens';
 import { detectDeviceTimezone } from '@/utils/dateUtils';
 
 /**
@@ -208,7 +209,7 @@ const ScreenBody = ({
   onSave,
   onBack,
 }: ScreenBodyProps): React.JSX.Element => (
-  <ScrollView contentContainerStyle={styles.container}>
+  <ScreenScaffold scroll testID="timezone-settings-screen">
     <Text style={styles.title}>Time zone</Text>
     <Text style={styles.body}>
       Streaks and daily stats count days in this time zone. Update it if you moved or if it was
@@ -222,7 +223,7 @@ const ScreenBody = ({
     />
     <FeedbackBanner error={state.error} status={state.status} />
     <ScreenFooter submitting={state.submitting} onSave={onSave} onBack={onBack} />
-  </ScrollView>
+  </ScreenScaffold>
 );
 
 export default function TimezoneSettingsScreen({ navigation }: Props = {}): React.JSX.Element {
@@ -264,69 +265,73 @@ export default function TimezoneSettingsScreen({ navigation }: Props = {}): Reac
   );
 }
 
+const MENLO_MONOSPACE = 'Menlo';
+const CURRENT_LABEL_LETTER_SPACING = 0.5;
+
 const styles = StyleSheet.create({
-  container: { padding: SPACING.xl, backgroundColor: colors.background.card, flexGrow: 1 },
-  title: { fontSize: 22, fontWeight: '700', marginBottom: SPACING.md },
+  title: { fontSize: 22, fontWeight: '700', marginBottom: SPACING.md, color: ink.primary },
   body: {
     fontSize: 14,
-    color: colors.text.secondaryAccessible,
+    color: ink.soft,
     marginBottom: SPACING.xl,
     lineHeight: 20,
   },
   currentCard: {
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
     borderRadius: BORDER_RADIUS.lg,
     padding: SPACING.lg,
     marginBottom: SPACING.xl,
-    backgroundColor: colors.background.accent,
+    backgroundColor: surface.raised,
   },
   currentLabel: {
     fontSize: 12,
-    color: colors.text.secondary,
+    color: ink.muted,
     textTransform: 'uppercase',
-    letterSpacing: 0.5,
+    letterSpacing: CURRENT_LABEL_LETTER_SPACING,
   },
   currentValue: {
     fontSize: 18,
-    fontFamily: 'Menlo',
+    fontFamily: MENLO_MONOSPACE,
     marginTop: SPACING.sm,
-    color: colors.text.primary,
+    color: ink.primary,
   },
   inputLabel: {
     fontSize: 14,
     fontWeight: '600',
     marginBottom: SPACING.sm,
-    color: colors.text.primary,
+    color: ink.primary,
   },
   input: {
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
     borderRadius: BORDER_RADIUS.md,
     padding: SPACING.md,
     fontSize: 16,
     marginBottom: SPACING.md,
+    backgroundColor: surface.raised,
+    color: ink.primary,
   },
   secondaryButton: {
     borderWidth: 1,
-    borderColor: colors.border,
+    borderColor: surface.hairline,
     borderRadius: BORDER_RADIUS.md,
     padding: SPACING.md,
     alignItems: 'center',
-    backgroundColor: colors.background.accent,
+    backgroundColor: surface.sunken,
     marginBottom: SPACING.md,
   },
-  secondaryButtonText: { fontSize: 14, color: colors.text.primary, fontWeight: '600' },
-  error: { color: colors.danger, marginBottom: SPACING.md },
+  secondaryButtonText: { fontSize: 14, color: ink.primary, fontWeight: '600' },
+  error: { color: colors.destructive.text, marginBottom: SPACING.md },
   success: { color: colors.successText, marginBottom: SPACING.md },
   primaryButton: {
     borderRadius: BORDER_RADIUS.md,
     padding: SAVE_BUTTON_PADDING,
     alignItems: 'center',
-    backgroundColor: colors.primary,
+    backgroundColor: accent.primary,
     marginTop: SPACING.xs,
   },
   primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
   linkRow: { marginTop: SPACING.xl, alignItems: 'center' },
-  link: { color: colors.primary, fontWeight: '600' },
+  link: { color: accent.primary, fontWeight: '600' },
 });

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -104,6 +104,12 @@ describe('provider deep links and detection', () => {
 });
 
 describe('ApiKeySettingsScreen', () => {
+  test('renders on the warm screen scaffold', () => {
+    setApiKeyState({});
+    const { getByTestId } = render(<ApiKeySettingsScreen />);
+    expect(getByTestId('api-key-settings-screen')).toBeTruthy();
+  });
+
   test('shows the loading indicator while the stored key is being read', () => {
     setApiKeyState({ isLoading: true });
     const { getByTestId, queryByTestId } = render(<ApiKeySettingsScreen />);

--- a/frontend/src/features/Settings/__tests__/SettingsHubScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/SettingsHubScreen.test.tsx
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+const mockNavigate = jest.fn();
+const mockLogout = jest.fn(() => Promise.resolve());
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ logout: mockLogout }),
+}));
+
+import SettingsHubScreen from '../SettingsHubScreen';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('SettingsHubScreen', () => {
+  test('renders the Account and Session groups with their three rows', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    expect(getByTestId('settings-group-account')).toBeTruthy();
+    expect(getByTestId('settings-group-session')).toBeTruthy();
+    expect(getByTestId('settings-row-api-key')).toBeTruthy();
+    expect(getByTestId('settings-row-timezone')).toBeTruthy();
+    expect(getByTestId('settings-row-logout')).toBeTruthy();
+  });
+
+  test('tapping the API key row navigates to ApiKeySettings', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    fireEvent.press(getByTestId('settings-row-api-key'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('ApiKeySettings');
+  });
+
+  test('tapping the time zone row navigates to TimezoneSettings', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    fireEvent.press(getByTestId('settings-row-timezone'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('TimezoneSettings');
+  });
+
+  test('tapping Log out calls the logout action', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    fireEvent.press(getByTestId('settings-row-logout'));
+
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/Settings/__tests__/TimezoneSettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/TimezoneSettingsScreen.test.tsx
@@ -48,6 +48,12 @@ beforeEach(() => {
 });
 
 describe('TimezoneSettingsScreen', () => {
+  test('renders on the warm screen scaffold', () => {
+    setAuthState('Europe/Paris');
+    const { getByTestId } = render(<TimezoneSettingsScreen />);
+    expect(getByTestId('timezone-settings-screen')).toBeTruthy();
+  });
+
   test('shows the time zone the server has on record', () => {
     setAuthState('Europe/Paris');
     const { getByTestId } = render(<TimezoneSettingsScreen />);

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -9,15 +9,16 @@ import {
   Flower2,
   Home,
   NotebookPen,
+  Settings,
   Sprout,
   type LucideIcon,
 } from 'lucide-react-native';
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 
 import type { JournalTag } from '../api';
 import { FeatureErrorBoundary } from '../components/FeatureErrorBoundary';
-import { accent, ink, SPACING, surface } from '../design/tokens';
+import { accent, ink, SPACING, surface, touchTarget } from '../design/tokens';
 import CourseScreen from '../features/Course/CourseScreen';
 import HabitsScreen from '../features/Habits/HabitsScreen';
 import JournalShelfScreen from '../features/Journal/JournalShelfScreen';
@@ -26,8 +27,6 @@ import PracticeScreen from '../features/Practice/PracticeScreen';
 import TodayScreen from '../features/Today/TodayScreen';
 
 import type { RootStackParamList } from './RootStack';
-
-import { useAuth } from '@/context/AuthContext';
 
 export type RootTabParamList = {
   Today: undefined;
@@ -76,6 +75,7 @@ const MapTab = withBoundary('Map', MapScreen);
 
 const TAB_ICON_SIZE = 24;
 const TAB_ICON_STROKE = 2;
+const SETTINGS_ICON_SIZE = 24;
 
 /** Returns a tab-bar icon renderer with shared size/stroke for every entry. */
 const makeTabIcon =
@@ -99,32 +99,21 @@ const TAB_CONFIGS: ReadonlyArray<{
 
 interface TabHeaderRightProps {
   onSettings: () => void;
-  onLogout: () => void;
 }
 
-/** Header actions (settings + logout), hoisted to a stable component so it is
- * not redefined on every ``BottomTabs`` render. */
-const TabHeaderRight = ({ onSettings, onLogout }: TabHeaderRightProps): React.JSX.Element => (
-  <View style={styles.headerRight}>
-    <TouchableOpacity
-      onPress={onSettings}
-      style={styles.headerButton}
-      accessibilityLabel="Open settings"
-      accessibilityRole="button"
-      testID="open-settings-button"
-    >
-      <Text style={styles.headerButtonText}>⚙︎</Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      onPress={onLogout}
-      style={styles.headerButton}
-      accessibilityLabel="Log out"
-      accessibilityRole="button"
-      testID="logout-button"
-    >
-      <Text style={styles.headerButtonText}>Logout</Text>
-    </TouchableOpacity>
-  </View>
+/** Header-right gear that opens the Settings hub (#835), hoisted to a stable
+ * component so it is not redefined on every ``BottomTabs`` render. Logout now
+ * lives inside the hub's Session group, not on the tab header. */
+const TabHeaderRight = ({ onSettings }: TabHeaderRightProps): React.JSX.Element => (
+  <TouchableOpacity
+    onPress={onSettings}
+    style={styles.headerButton}
+    accessibilityLabel="Open settings"
+    accessibilityRole="button"
+    testID="open-settings-button"
+  >
+    <Settings color={accent.primary} size={SETTINGS_ICON_SIZE} />
+  </TouchableOpacity>
 );
 
 /**
@@ -132,16 +121,15 @@ const TabHeaderRight = ({ onSettings, onLogout }: TabHeaderRightProps): React.JS
  * Each tab corresponds to a major feature area.
  */
 const BottomTabs = (): React.JSX.Element => {
-  const { logout } = useAuth();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const openSettings = React.useCallback(() => {
-    navigation.navigate('ApiKeySettings');
+    navigation.navigate('Settings');
   }, [navigation]);
 
   const renderHeaderRight = React.useCallback(
-    () => <TabHeaderRight onSettings={openSettings} onLogout={logout} />,
-    [openSettings, logout],
+    () => <TabHeaderRight onSettings={openSettings} />,
+    [openSettings],
   );
 
   return (
@@ -171,9 +159,13 @@ const BottomTabs = (): React.JSX.Element => {
 };
 
 const styles = StyleSheet.create({
-  headerRight: { flexDirection: 'row', alignItems: 'center', marginRight: SPACING.sm },
-  headerButton: { paddingHorizontal: SPACING.sm, paddingVertical: SPACING.xs },
-  headerButtonText: { color: accent.primary, fontSize: 14, fontWeight: '600' },
+  headerButton: {
+    minWidth: touchTarget.minimum,
+    minHeight: touchTarget.minimum,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: SPACING.sm,
+  },
 });
 
 export default BottomTabs;

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -8,6 +8,7 @@ import { PracticeCatalogScreen } from '../features/Practice/screens/PracticeCata
 import { PracticeDetailScreen } from '../features/Practice/screens/PracticeDetailScreen';
 import SharePreviewScreen from '../features/Practice/screens/SharePreviewScreen';
 import ApiKeySettingsScreen from '../features/Settings/ApiKeySettingsScreen';
+import SettingsHubScreen from '../features/Settings/SettingsHubScreen';
 import TimezoneSettingsScreen from '../features/Settings/TimezoneSettingsScreen';
 
 import type { RootTabParamList } from './BottomTabs';
@@ -39,6 +40,7 @@ export interface CreatePracticePrefill {
 
 export type RootStackParamList = {
   Tabs: NavigatorScreenParams<RootTabParamList>;
+  Settings: undefined;
   ApiKeySettings: undefined;
   TimezoneSettings: undefined;
   SharePreview: { token: string };
@@ -69,6 +71,7 @@ const RootStack = (): React.JSX.Element => (
     }}
   >
     <Stack.Screen name="Tabs" component={BottomTabs} options={{ headerShown: false }} />
+    <Stack.Screen name="Settings" component={SettingsHubScreen} options={{ title: 'Settings' }} />
     <Stack.Screen
       name="ApiKeySettings"
       component={ApiKeySettingsScreen}

--- a/frontend/src/navigation/__tests__/BottomTabs.test.tsx
+++ b/frontend/src/navigation/__tests__/BottomTabs.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
 import { NavigationContainer } from '@react-navigation/native';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import {
   BookOpen,
   Compass,
@@ -9,15 +9,10 @@ import {
   Home,
   LayoutGrid,
   NotebookPen,
+  Settings,
   Sprout,
 } from 'lucide-react-native';
 import React from 'react';
-
-const mockLogout = jest.fn(() => Promise.resolve());
-
-jest.mock('@/context/AuthContext', () => ({
-  useAuth: () => ({ logout: mockLogout }),
-}));
 
 jest.mock('expo-notifications', () => ({
   getPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
@@ -42,25 +37,25 @@ beforeEach(() => {
 });
 
 describe('BottomTabs', () => {
-  it('renders a logout button in the header', () => {
-    const { getByText } = render(
+  it('renders the settings gear in the header (logout moved to the hub)', () => {
+    const { getByTestId } = render(
       <NavigationContainer>
         <BottomTabs />
       </NavigationContainer>,
     );
 
-    expect(getByText('Logout')).toBeTruthy();
+    expect(getByTestId('open-settings-button')).toBeTruthy();
   });
 
-  it('calls logout when the logout button is pressed', () => {
-    const { getByText } = render(
+  it('renders the gear as the lucide Settings icon, not a logout text link', () => {
+    const { UNSAFE_getAllByType, queryByText } = render(
       <NavigationContainer>
         <BottomTabs />
       </NavigationContainer>,
     );
 
-    fireEvent.press(getByText('Logout'));
-    expect(mockLogout).toHaveBeenCalled();
+    expect(UNSAFE_getAllByType(Settings).length).toBeGreaterThanOrEqual(1);
+    expect(queryByText('Logout')).toBeNull();
   });
 
   it('renders a lucide icon for each of the six tabs', () => {


### PR DESCRIPTION
## Summary

#835 (epic #824): settings were scattered and grey. Organised into one warm hub.

- New `SettingsHubScreen` (`ScreenScaffold` + `ScreenHeader`): **Account** (API key, time zone) + **Session** (Log out, moved off the tab header). Warm `SettingsRow` (44dp, a11y, lucide + chevron); testIDs `settings-row-api-key/-timezone/-logout`.
- `RootStack` registers `Settings`; the gear opens the hub + renders the lucide `Settings` icon (⚙︎ emoji removed); logout text link removed from the tab header.
- Both settings screens migrated to the scaffold + warm tokens — storage/validation/reveal/BYOK/device-tz **unchanged**.

`adepthood://api-key-settings` deep link still resolves (App.tsx linking + test); logout works from the hub; testIDs preserved.

## Test plan

Hub groups + 3 rows + navigation + logout; gear is the lucide icon (logout link gone); deep-link config resolves `api-key-settings` + `settings`; both screens keep their behaviour. `./scripts/frontend/check-all.sh` 4/4 (2104); no `any`.

Closes #835
Refs #824
