### PR TITLE
feat(welcome): first-run program onboarding

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,11 +32,13 @@ import LoginScreen from './features/Auth/LoginScreen';
 import { ReauthSheet } from './features/Auth/ReauthSheet';
 import ResetPasswordScreen from './features/Auth/ResetPasswordScreen';
 import SignupScreen from './features/Auth/SignupScreen';
+import { WelcomeScreen } from './features/Welcome/WelcomeScreen';
 import type { RootTabParamList } from './navigation/BottomTabs';
 import type { RootStackParamList } from './navigation/RootStack';
 import RootStack from './navigation/RootStack';
 import { navThemeFor } from './navigation/theme';
 import { useHydrateProgramStore } from './store/useProgramStore';
+import { useFirstRun } from './store/useWelcomeStore';
 
 type AuthStackParamList = {
   Login: undefined;
@@ -130,6 +132,22 @@ function AuthNavigator() {
  * tab state, stale route params, and route state that ``CommonActions.reset``
  * would otherwise miss.
  */
+/**
+ * Program welcome gate (#836). On first run — once the persisted
+ * ``hasSeenWelcome`` flag has resolved to unset — the editorial intro shows
+ * above the app shell. Begin *or* Skip persists the flag, which flips
+ * ``isFirstRun`` to false and lands the user on the already-mounted Today hub.
+ * Returning users (flag set) never see it; before hydration ``isFirstRun`` is
+ * false, so the shell renders without a flash.
+ */
+function WelcomeGate(): React.JSX.Element {
+  const { isFirstRun, markSeen } = useFirstRun();
+  if (isFirstRun) {
+    return <WelcomeScreen onComplete={markSeen} onBegin={markSeen} />;
+  }
+  return <RootStack key="auth" />;
+}
+
 export function RootNavigator(): React.JSX.Element {
   const { authStatus } = useAuth();
 
@@ -154,7 +172,7 @@ export function RootNavigator(): React.JSX.Element {
   // back in.
   return (
     <FeatureErrorBoundary name="App">
-      <RootStack key="auth" />
+      <WelcomeGate />
       {authStatus === 'reauth-required' ? <ReauthSheet /> : null}
     </FeatureErrorBoundary>
   );

--- a/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
+++ b/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
@@ -76,12 +76,13 @@ jest.mock('@/components/FeatureErrorBoundary', () => {
   return { __esModule: true, FeatureErrorBoundary: Boundary };
 });
 
-import { render } from '@testing-library/react-native';
+import { render, act } from '@testing-library/react-native';
 import React from 'react';
 
 import { RootNavigator } from '@/App';
 import * as AuthContextModule from '@/context/AuthContext';
 import type { AuthStatus } from '@/context/AuthContext';
+import { useWelcomeStore } from '@/store/useWelcomeStore';
 
 type MockAuth = {
   token: string | null;
@@ -128,6 +129,10 @@ function mockAuthStatus(status: AuthStatus, token: string | null = null) {
 
 beforeEach(() => {
   jest.restoreAllMocks();
+  // This suite asserts the authStatus → navigator contract, not the #836
+  // first-run welcome gate. Seed the welcome flag as seen so an authenticated
+  // render lands on the shell rather than the WelcomeScreen.
+  act(() => useWelcomeStore.setState({ hasSeenWelcome: true }));
 });
 
 describe('RootNavigator gated on authStatus (BUG-NAV-001 / BUG-NAV-002)', () => {

--- a/frontend/src/__tests__/navigation/welcomeGate.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeGate.test.tsx
@@ -1,0 +1,131 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+/**
+ * Issue #836: the program welcome gates the authenticated shell on first run.
+ * Once the persisted ``hasSeenWelcome`` flag has resolved to unset, the
+ * WelcomeScreen overlays the shell; for returning users (flag set) the shell
+ * renders straight away. These tests drive ``RootNavigator`` directly, mocking
+ * the navigation tree exactly as ``authStatusNavigator.test.tsx`` does.
+ */
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+  const { mockDefaultTheme, mockDarkTheme } = require('@/test-utils/navMocks');
+  return {
+    __esModule: true,
+    NavigationContainer: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useNavigation: () => ({ navigate: jest.fn(), getParent: () => undefined }),
+    useRoute: () => ({ params: undefined }),
+    useFocusEffect: (fn: () => void) => fn(),
+    DefaultTheme: mockDefaultTheme,
+    DarkTheme: mockDarkTheme,
+  };
+});
+
+jest.mock('@/navigation/RootStack', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const RootStackMock = () => React.createElement(Text, { testID: 'root-stack' }, 'RootStack');
+  return { __esModule: true, default: RootStackMock };
+});
+
+jest.mock('@/features/Welcome/WelcomeScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const WelcomeMock = () => React.createElement(Text, { testID: 'welcome-screen' }, 'Welcome');
+  return { __esModule: true, WelcomeScreen: WelcomeMock, default: WelcomeMock };
+});
+
+jest.mock('@/features/Auth/LoginScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const LoginMock = () => React.createElement(Text, { testID: 'login-screen' }, 'Login');
+  return { __esModule: true, default: LoginMock };
+});
+
+jest.mock('@react-navigation/native-stack', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    createNativeStackNavigator: () => ({
+      Navigator: ({ children }: { children: React.ReactNode }) => {
+        const first = React.Children.toArray(children)[0] as React.ReactElement<{
+          component: React.ComponentType;
+        }>;
+        if (!first) return null;
+        const Component = first.props.component;
+        return React.createElement(Component);
+      },
+      Screen: () => null,
+    }),
+  };
+});
+
+jest.mock('@/components/FeatureErrorBoundary', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const Boundary = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(View, null, children);
+  return { __esModule: true, FeatureErrorBoundary: Boundary };
+});
+
+jest.mock('@/storage/welcomeStorage', () => ({
+  __esModule: true,
+  // A never-settling load keeps ``hasSeenWelcome`` ``null`` so the no-flash
+  // test can assert the pre-hydration paint without a stray act() update.
+  loadHasSeenWelcome: jest.fn(() => new Promise(() => undefined)),
+  saveHasSeenWelcome: jest.fn(() => Promise.resolve()),
+  clearHasSeenWelcome: jest.fn(() => Promise.resolve()),
+}));
+
+import { render, act } from '@testing-library/react-native';
+import React from 'react';
+
+import { RootNavigator } from '@/App';
+import * as AuthContextModule from '@/context/AuthContext';
+import type { AuthStatus } from '@/context/AuthContext';
+import { useWelcomeStore } from '@/store/useWelcomeStore';
+
+function mockAuthenticated() {
+  jest.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
+    token: 'jwt',
+    authStatus: 'authenticated' as AuthStatus,
+    isLoading: false,
+    userTimezone: 'UTC',
+    setUserTimezone: jest.fn(),
+    login: jest.fn(() => Promise.resolve()),
+    signup: jest.fn(() => Promise.resolve()),
+    logout: jest.fn(() => Promise.resolve()),
+    onUnauthorized: jest.fn(),
+    dismissReauth: jest.fn(() => Promise.resolve()),
+    confirmPasswordReset: jest.fn(() => Promise.resolve()),
+  } as unknown as ReturnType<typeof AuthContextModule.useAuth>);
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  mockAuthenticated();
+});
+
+describe('WelcomeGate (issue #836)', () => {
+  it('shows the WelcomeScreen on first run (flag resolved to unset)', () => {
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: false }));
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    expect(getByTestId('welcome-screen')).toBeTruthy();
+    expect(queryByTestId('root-stack')).toBeNull();
+  });
+
+  it('goes straight to the shell for a returning user (flag set)', () => {
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: true }));
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    expect(getByTestId('root-stack')).toBeTruthy();
+    expect(queryByTestId('welcome-screen')).toBeNull();
+  });
+
+  it('does not flash the welcome before the flag has hydrated', () => {
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: null }));
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    expect(getByTestId('root-stack')).toBeTruthy();
+    expect(queryByTestId('welcome-screen')).toBeNull();
+  });
+});

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -118,9 +118,14 @@ jest.mock('@/features/Journal/JournalEntryScreen', () => {
 });
 
 import App, { linking } from '@/App';
+import { useWelcomeStore } from '@/store/useWelcomeStore';
 
 beforeEach(() => {
   mockAuthState = { token: null, authStatus: 'anonymous', isLoading: false };
+  // This suite asserts the auth-status → shell contract; the #836 first-run
+  // welcome gate is exercised separately. Seed the flag as seen so an authed
+  // render reaches the shell rather than the WelcomeScreen.
+  useWelcomeStore.setState({ hasSeenWelcome: true });
 });
 
 describe('App auth flow', () => {

--- a/frontend/src/features/Welcome/Welcome.styles.ts
+++ b/frontend/src/features/Welcome/Welcome.styles.ts
@@ -1,0 +1,107 @@
+import { StyleSheet } from 'react-native';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  editorialType,
+  onShowcase,
+  rhythm,
+  showcase,
+  surface,
+  touchTarget,
+} from '@/design/tokens';
+
+/** Token-only styles for the program welcome (#836). */
+export const welcomeStyles = StyleSheet.create({
+  ground: {
+    flex: 1,
+    backgroundColor: surface.canvas,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: rhythm.screenPaddingH,
+    paddingTop: rhythm.screenPaddingTop,
+  },
+  skip: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+  },
+  skipLabel: {
+    ...editorialType.caption,
+    color: accent.primary,
+  },
+  panel: {
+    flex: 1,
+    paddingHorizontal: rhythm.screenPaddingH,
+    justifyContent: 'center',
+  },
+  hero: {
+    gap: rhythm.blockGap,
+  },
+  eyebrow: {
+    ...editorialType.caption,
+    color: onShowcase.muted,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  title: {
+    ...editorialType.display,
+    color: onShowcase.primary,
+  },
+  body: {
+    ...editorialType.body,
+    color: onShowcase.soft,
+  },
+  pillars: {
+    gap: rhythm.blockGap,
+    marginTop: rhythm.blockGap,
+  },
+  pillarRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.md,
+    minHeight: touchTarget.minimum,
+  },
+  pillarGlyph: {
+    ...editorialType.title,
+  },
+  pillarName: {
+    ...editorialType.body,
+    color: onShowcase.primary,
+  },
+  footer: {
+    paddingHorizontal: rhythm.screenPaddingH,
+    paddingBottom: rhythm.heroPaddingV,
+    gap: rhythm.blockGap,
+  },
+  dots: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: SPACING.sm,
+  },
+  dot: {
+    width: SPACING.sm,
+    height: SPACING.sm,
+    borderRadius: BORDER_RADIUS.circle,
+    backgroundColor: surface.hairline,
+  },
+  dotActive: {
+    backgroundColor: accent.primary,
+  },
+  nextButton: {
+    minHeight: touchTarget.minimum,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: showcase.canvas,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  nextLabel: {
+    ...editorialType.body,
+    color: onShowcase.primary,
+  },
+});

--- a/frontend/src/features/Welcome/WelcomeScreen.tsx
+++ b/frontend/src/features/Welcome/WelcomeScreen.tsx
@@ -1,0 +1,183 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { Pressable, ScrollView, Text, View, useWindowDimensions } from 'react-native';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { welcomeStyles as s } from './Welcome.styles';
+import { WELCOME_PANELS, type WelcomePanel } from './welcomeContent';
+
+import { CalloutBand } from '@/components/layout/CalloutBand';
+import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+interface PanelProps {
+  panel: WelcomePanel;
+  index: number;
+  width: number;
+}
+
+/** A single editorial panel rendered as a ShowcaseCard hero. */
+const WelcomePanelView = ({ panel, index, width }: PanelProps): React.JSX.Element => (
+  <View style={[s.panel, { width }]} testID={`welcome-panel-${index}`}>
+    <ShowcaseCard>
+      <View style={s.hero}>
+        <Text style={s.eyebrow}>{panel.eyebrow}</Text>
+        <Text style={s.title} accessibilityRole="header">
+          {panel.title}
+        </Text>
+        <Text style={s.body}>{panel.body}</Text>
+        {panel.pillars ? (
+          <View style={s.pillars}>
+            {panel.pillars.map((pillar) => (
+              <View key={pillar.name} style={s.pillarRow}>
+                <Text style={s.pillarGlyph}>{pillar.glyph}</Text>
+                <Text style={s.pillarName}>{pillar.name}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+      </View>
+    </ShowcaseCard>
+  </View>
+);
+
+interface DotsProps {
+  count: number;
+  active: number;
+}
+
+/** Page-position indicator; non-interactive so paging stays the single seam. */
+const PagerDots = ({ count, active }: DotsProps): React.JSX.Element => (
+  <View style={s.dots} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+    {Array.from({ length: count }, (_, i) => (
+      <View key={i} style={[s.dot, i === active ? s.dotActive : undefined]} />
+    ))}
+  </View>
+);
+
+/** Persistent Skip affordance shown on every panel. */
+const SkipButton = ({ onSkip }: { onSkip: () => void }): React.JSX.Element => (
+  <View style={s.header}>
+    <Pressable
+      onPress={onSkip}
+      style={s.skip}
+      accessibilityRole="button"
+      accessibilityLabel="Skip the welcome"
+      testID="welcome-skip"
+    >
+      <Text style={s.skipLabel}>Skip</Text>
+    </Pressable>
+  </View>
+);
+
+interface FooterProps {
+  page: number;
+  isLast: boolean;
+  onNext: () => void;
+  onBegin: () => void;
+}
+
+/** Page dots plus the contextual Next / Begin control. */
+const WelcomeFooter = ({ page, isLast, onNext, onBegin }: FooterProps): React.JSX.Element => (
+  <View style={s.footer}>
+    <PagerDots count={WELCOME_PANELS.length} active={page} />
+    {isLast ? (
+      <CalloutBand
+        label="Begin"
+        onPress={onBegin}
+        accessibilityLabel="Begin the journey"
+        testID="welcome-begin"
+      />
+    ) : (
+      <Pressable
+        onPress={onNext}
+        style={s.nextButton}
+        accessibilityRole="button"
+        accessibilityLabel="Next panel"
+        testID="welcome-next"
+      >
+        <Text style={s.nextLabel}>Next</Text>
+      </Pressable>
+    )}
+  </View>
+);
+
+interface Pager {
+  page: number;
+  width: number;
+  scrollRef: React.RefObject<ScrollView>;
+  onScroll: (_e: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  goNext: () => void;
+}
+
+/** Reduced-motion-safe horizontal paging state for the welcome panels. */
+const useWelcomePager = (): Pager => {
+  const { width } = useWindowDimensions();
+  const reduced = useReducedMotion();
+  const scrollRef = useRef<ScrollView>(null);
+  const [page, setPage] = useState(0);
+  const lastIndex = WELCOME_PANELS.length - 1;
+
+  const onScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      setPage(Math.round(e.nativeEvent.contentOffset.x / Math.max(width, 1)));
+    },
+    [width],
+  );
+
+  const goNext = useCallback(() => {
+    const next = Math.min(page + 1, lastIndex);
+    setPage(next);
+    scrollRef.current?.scrollTo({ x: next * width, animated: !reduced });
+  }, [page, lastIndex, width, reduced]);
+
+  return { page, width, scrollRef, onScroll, goNext };
+};
+
+export interface WelcomeScreenProps {
+  /** Persist the flag and dismiss the welcome (called on Begin and Skip). */
+  onComplete: () => void;
+  /** Land on the Today hub, optionally opening the first-habits step. */
+  onBegin: () => void;
+}
+
+/**
+ * The program welcome (#836): a swipeable editorial intro to the 36-week
+ * journey. Paging works with or without animation (reduced-motion-safe), a
+ * persistent Skip sits on every panel, and the final panel's Begin CTA lands
+ * the user on Today.
+ */
+export const WelcomeScreen = ({ onComplete, onBegin }: WelcomeScreenProps): React.JSX.Element => {
+  const { page, width, scrollRef, onScroll, goNext } = useWelcomePager();
+  const begin = useCallback(() => {
+    onComplete();
+    onBegin();
+  }, [onComplete, onBegin]);
+
+  return (
+    <SafeAreaView style={s.ground} testID="welcome-screen">
+      <SkipButton onSkip={onComplete} />
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={onScroll}
+        scrollEventThrottle={16}
+        testID="welcome-pager"
+      >
+        {WELCOME_PANELS.map((panel, index) => (
+          <WelcomePanelView key={panel.title} panel={panel} index={index} width={width} />
+        ))}
+      </ScrollView>
+      <WelcomeFooter
+        page={page}
+        isLast={page === WELCOME_PANELS.length - 1}
+        onNext={goNext}
+        onBegin={begin}
+      />
+    </SafeAreaView>
+  );
+};
+
+export default WelcomeScreen;

--- a/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
+++ b/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
@@ -1,0 +1,88 @@
+/* eslint-env jest */
+import { jest, beforeEach, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+let mockReduced = false;
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockReduced,
+}));
+
+const TEST_WIDTH = 400;
+jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
+  __esModule: true,
+  default: () => ({ width: TEST_WIDTH, height: 800, scale: 1, fontScale: 1 }),
+}));
+
+import { WELCOME_PANELS, WELCOME_PILLARS } from '../welcomeContent';
+import { WelcomeScreen } from '../WelcomeScreen';
+
+beforeEach(() => {
+  mockReduced = false;
+});
+
+const setup = () => {
+  const onComplete = jest.fn();
+  const onBegin = jest.fn();
+  const utils = render(<WelcomeScreen onComplete={onComplete} onBegin={onBegin} />);
+  return { onComplete, onBegin, ...utils };
+};
+
+describe('WelcomeScreen', () => {
+  it('renders every editorial panel with the five pillars', () => {
+    const { getByTestId, getByText } = setup();
+    expect(getByTestId('welcome-screen')).toBeTruthy();
+    WELCOME_PANELS.forEach((_, i) => {
+      expect(getByTestId(`welcome-panel-${i}`)).toBeTruthy();
+    });
+    WELCOME_PILLARS.forEach((pillar) => {
+      expect(getByText(pillar.name)).toBeTruthy();
+    });
+  });
+
+  it('keeps a persistent Skip on the screen', () => {
+    const { getByTestId } = setup();
+    expect(getByTestId('welcome-skip')).toBeTruthy();
+  });
+
+  it('shows Begin on the final panel and Next before it', () => {
+    const { getByTestId, queryByTestId } = setup();
+    // First render is the first panel: Next visible, Begin not yet.
+    expect(getByTestId('welcome-next')).toBeTruthy();
+    expect(queryByTestId('welcome-begin')).toBeNull();
+  });
+
+  it('Begin completes (sets flag) and navigates to Today', () => {
+    const { getByTestId, onComplete, onBegin } = setup();
+    // Page to the last panel via the pager scroll handler.
+    const lastIndex = WELCOME_PANELS.length - 1;
+    fireEvent(getByTestId('welcome-pager'), 'momentumScrollEnd', {
+      nativeEvent: { contentOffset: { x: lastIndex * 400 }, layoutMeasurement: { width: 400 } },
+    });
+    fireEvent.press(getByTestId('welcome-begin'));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onBegin).toHaveBeenCalledTimes(1);
+  });
+
+  it('Skip completes (sets flag) without beginning', () => {
+    const { getByTestId, onComplete, onBegin } = setup();
+    fireEvent.press(getByTestId('welcome-skip'));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onBegin).not.toHaveBeenCalled();
+  });
+
+  it('advances pages under reduced motion (paging works without animation)', () => {
+    mockReduced = true;
+    const { getByTestId } = setup();
+    fireEvent.press(getByTestId('welcome-next'));
+    // After advancing past the first panel the Next control is still present
+    // until the final panel — the page state changed without animation.
+    fireEvent(getByTestId('welcome-pager'), 'momentumScrollEnd', {
+      nativeEvent: {
+        contentOffset: { x: (WELCOME_PANELS.length - 1) * 400 },
+        layoutMeasurement: { width: 400 },
+      },
+    });
+    expect(getByTestId('welcome-begin')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Welcome/welcomeContent.ts
+++ b/frontend/src/features/Welcome/welcomeContent.ts
@@ -1,0 +1,48 @@
+// Editorial copy for the program welcome (issue #836). Kept as data so the
+// WelcomeScreen stays a thin composition of ShowcaseCard heroes.
+
+export interface WelcomePillar {
+  glyph: string;
+  name: string;
+}
+
+export interface WelcomePanel {
+  eyebrow: string;
+  title: string;
+  body: string;
+  pillars?: readonly WelcomePillar[];
+}
+
+/** The five APTITUDE pillars introduced on the second panel. */
+export const WELCOME_PILLARS: readonly WelcomePillar[] = [
+  { glyph: '🌱', name: 'Habits' },
+  { glyph: '🪷', name: 'Practice' },
+  { glyph: '📖', name: 'Course' },
+  { glyph: '✒️', name: 'Journal' },
+  { glyph: '🧭', name: 'Map' },
+];
+
+/** The 3–4 swipeable editorial panels, in order. */
+export const WELCOME_PANELS: readonly WelcomePanel[] = [
+  {
+    eyebrow: 'Welcome',
+    title: 'Begin the 36-week journey',
+    body: 'APTITUDE is a slow, deliberate path of becoming. Take a breath — there is no rushing this work, and nothing here expires.',
+  },
+  {
+    eyebrow: 'Five pillars',
+    title: 'How the work holds together',
+    body: 'Each week weaves the same five threads. Lean on whichever the day asks for.',
+    pillars: WELCOME_PILLARS,
+  },
+  {
+    eyebrow: 'A week, lived',
+    title: 'How a week works',
+    body: 'Plant a small habit, sit with a practice, read the week’s course, and reflect in your journal. The map shows how far you have come.',
+  },
+  {
+    eyebrow: 'Ready',
+    title: 'Let’s begin',
+    body: 'Press Begin to land on Today, your daily home. From the Habits tab you can plant your first habits whenever you’re ready.',
+  },
+] as const;

--- a/frontend/src/storage/__tests__/welcomeStorage.test.ts
+++ b/frontend/src/storage/__tests__/welcomeStorage.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { clearHasSeenWelcome, loadHasSeenWelcome, saveHasSeenWelcome } from '../welcomeStorage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const KEY = '@adepthood/has_seen_welcome';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('welcomeStorage', () => {
+  test('saveHasSeenWelcome writes the true flag', async () => {
+    await saveHasSeenWelcome();
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(KEY, 'true');
+  });
+
+  test('loadHasSeenWelcome returns false when unset', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+    expect(await loadHasSeenWelcome()).toBe(false);
+  });
+
+  test('loadHasSeenWelcome returns true once set', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce('true');
+    expect(await loadHasSeenWelcome()).toBe(true);
+  });
+
+  test('loadHasSeenWelcome swallows storage errors as false', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('boom'));
+    expect(await loadHasSeenWelcome()).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  test('clearHasSeenWelcome removes the key', async () => {
+    await clearHasSeenWelcome();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(KEY);
+  });
+});

--- a/frontend/src/storage/welcomeStorage.ts
+++ b/frontend/src/storage/welcomeStorage.ts
@@ -1,0 +1,24 @@
+// Persists the one-time "has seen the program welcome" flag (issue #836) so the
+// editorial first-run intro shows exactly once across launches.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const HAS_SEEN_WELCOME_KEY = '@adepthood/has_seen_welcome';
+const FLAG_TRUE = 'true';
+
+export async function saveHasSeenWelcome(): Promise<void> {
+  await AsyncStorage.setItem(HAS_SEEN_WELCOME_KEY, FLAG_TRUE);
+}
+
+export async function loadHasSeenWelcome(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(HAS_SEEN_WELCOME_KEY);
+    return raw === FLAG_TRUE;
+  } catch (err) {
+    console.warn('[welcomeStorage] failed to load welcome flag', err);
+    return false;
+  }
+}
+
+export async function clearHasSeenWelcome(): Promise<void> {
+  await AsyncStorage.removeItem(HAS_SEEN_WELCOME_KEY);
+}

--- a/frontend/src/store/__tests__/useWelcomeStore.test.tsx
+++ b/frontend/src/store/__tests__/useWelcomeStore.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const mockAsyncStorage = jest.requireMock('@react-native-async-storage/async-storage') as {
+  setItem: jest.Mock<(_key: string, _value: string) => Promise<void>>;
+  getItem: jest.Mock<(_key: string) => Promise<string | null>>;
+  removeItem: jest.Mock<(_key: string) => Promise<void>>;
+};
+
+import { useFirstRun, useWelcomeStore } from '../useWelcomeStore';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAsyncStorage.getItem.mockResolvedValue(null);
+  act(() => {
+    useWelcomeStore.setState({ hasSeenWelcome: null });
+  });
+});
+
+describe('useFirstRun', () => {
+  it('returns isFirstRun true once the flag hydrates to unset', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+    const { result } = renderHook(() => useFirstRun());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.isFirstRun).toBe(true);
+  });
+
+  it('returns isFirstRun false once the flag is set (returning user)', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce('true');
+    const { result } = renderHook(() => useFirstRun());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.isFirstRun).toBe(false);
+  });
+
+  it('markSeen persists the flag and flips isFirstRun to false', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+    const { result } = renderHook(() => useFirstRun());
+    await waitFor(() => expect(result.current.isFirstRun).toBe(true));
+    act(() => result.current.markSeen());
+    expect(result.current.isFirstRun).toBe(false);
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith('@adepthood/has_seen_welcome', 'true');
+  });
+});
+
+describe('useWelcomeStore.reset', () => {
+  it('clears the flag in memory and storage', () => {
+    act(() => {
+      useWelcomeStore.getState().hydrateHasSeenWelcome(true);
+      useWelcomeStore.getState().reset();
+    });
+    expect(useWelcomeStore.getState().hasSeenWelcome).toBeNull();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/has_seen_welcome');
+  });
+});

--- a/frontend/src/store/useWelcomeStore.ts
+++ b/frontend/src/store/useWelcomeStore.ts
@@ -1,0 +1,95 @@
+// First-run state for the program welcome (issue #836). Backed by AsyncStorage
+// so the editorial intro shows exactly once; returning users are never gated.
+import { useEffect } from 'react';
+import { create } from 'zustand';
+
+import {
+  clearHasSeenWelcome,
+  loadHasSeenWelcome,
+  saveHasSeenWelcome,
+} from '../storage/welcomeStorage';
+
+import { registerStoreReset } from './registry';
+
+export interface WelcomeStoreState {
+  // ``null`` while the persisted flag has not yet been read from storage; the
+  // welcome gate stays closed until hydration resolves so returning users never
+  // see a flash of the intro on cold start.
+  hasSeenWelcome: boolean | null;
+  // Seed from storage on boot without re-writing it.
+  hydrateHasSeenWelcome: (_seen: boolean) => void;
+  // Mark the welcome complete (Begin or Skip) and persist it.
+  markWelcomeSeen: () => void;
+  // BUG-FE-STATE-001: wipe on logout. Also clears persisted storage.
+  reset: () => void;
+}
+
+const INITIAL_STATE = {
+  hasSeenWelcome: null as boolean | null,
+};
+
+const persistAsync = (seen: boolean): void => {
+  const op = seen ? saveHasSeenWelcome() : clearHasSeenWelcome();
+  op.catch((err) => {
+    console.warn('[useWelcomeStore] failed to persist welcome flag', err);
+  });
+};
+
+export const useWelcomeStore = create<WelcomeStoreState>((set) => ({
+  ...INITIAL_STATE,
+
+  hydrateHasSeenWelcome: (seen) => {
+    set({ hasSeenWelcome: seen });
+  },
+  markWelcomeSeen: () => {
+    set({ hasSeenWelcome: true });
+    persistAsync(true);
+  },
+  reset: () => {
+    set({ ...INITIAL_STATE });
+    persistAsync(false);
+  },
+}));
+
+registerStoreReset(() => {
+  useWelcomeStore.getState().reset();
+});
+
+export interface FirstRun {
+  // ``true`` only once storage has resolved and the flag is unset; ``false``
+  // before hydration and for returning users.
+  isFirstRun: boolean;
+  // ``true`` once the persisted flag has been read (regardless of its value).
+  hydrated: boolean;
+  // Persist the flag and close the welcome gate (Begin or Skip).
+  markSeen: () => void;
+}
+
+/**
+ * First-run gate for the program welcome. Hydrates the persisted flag on mount,
+ * then reports whether the editorial intro should show. ``isFirstRun`` is
+ * ``true`` exactly when the flag has resolved to unset; it flips to ``false``
+ * the moment ``markSeen`` runs, so the welcome shows once and never again.
+ */
+export function useFirstRun(): FirstRun {
+  const hasSeenWelcome = useWelcomeStore((s) => s.hasSeenWelcome);
+  const hydrate = useWelcomeStore((s) => s.hydrateHasSeenWelcome);
+  const markSeen = useWelcomeStore((s) => s.markWelcomeSeen);
+
+  useEffect(() => {
+    if (hasSeenWelcome !== null) return;
+    let cancelled = false;
+    void loadHasSeenWelcome().then((seen) => {
+      if (!cancelled) hydrate(seen);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [hasSeenWelcome, hydrate]);
+
+  return {
+    isFirstRun: hasSeenWelcome === false,
+    hydrated: hasSeenWelcome !== null,
+    markSeen,
+  };
+}


### PR DESCRIPTION
## Summary

#836 (epic #824, **final sub-issue**): a new user was dropped straight from signup into the app shell with no welcome into the 36-week journey. Add a skippable, show-once editorial welcome.

- `features/Welcome/WelcomeScreen`: a 4-panel swipeable intro of `ShowcaseCard` heroes (serif welcome → five pillars → how a week works → Begin), **reduced-motion-safe**, a persistent **Skip** on every panel, a `CalloutBand` Begin on the last. Tokens-only, 44dp, AA; full testIDs.
- `welcomeStorage` + `useWelcomeStore` (`hasSeenWelcome` + logout-reset) + `useFirstRun()`: `App.tsx` `WelcomeGate` routes first-run → Welcome, else → shell. **Begin AND Skip** persist the flag → land on Today. No flash pre-hydration; returning users unaffected.

No backend (AsyncStorage only).

## Test plan

WelcomeScreen panels + pillars + Begin/Skip; `useFirstRun` true→false transitions; `WelcomeGate` first-run vs returning-user routing; reduced-motion paging. `./scripts/frontend/check-all.sh` 4/4 (2122); no `any`, no backend.

Closes #836
Refs #824
