### PR TITLE
perf(backend): index CompletionSuggestion target FKs

### DIFF
--- a/backend/migrations/versions/c5d6e7f8a9b0_index_completion_suggestion_target_fks.py
+++ b/backend/migrations/versions/c5d6e7f8a9b0_index_completion_suggestion_target_fks.py
@@ -1,0 +1,48 @@
+"""index completion_suggestion target FKs (goal_id, user_practice_id).
+
+Revision ID: c5d6e7f8a9b0
+Revises: a3b4c5d6e7f9
+Create Date: 2026-06-30 00:00:00.000000
+
+Purely additive: ``upgrade`` creates B-tree indexes on the polymorphic target
+FK columns ``goal_id`` and ``user_practice_id`` so reverse lookups ("pending
+suggestions for goal X" / "for user-practice Y") are range scans rather than
+full table scans (Postgres does not auto-index FK columns). ``downgrade`` drops
+them. No ``ALTER`` / ``DROP`` against existing columns or data.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c5d6e7f8a9b0"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "a3b4c5d6e7f9"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create FK indexes on ``goal_id`` and ``user_practice_id``."""
+    op.create_index(
+        "ix_completion_suggestion_goal_id",
+        "completionsuggestion",
+        ["goal_id"],
+    )
+    op.create_index(
+        "ix_completion_suggestion_user_practice_id",
+        "completionsuggestion",
+        ["user_practice_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the FK indexes on ``goal_id`` and ``user_practice_id``."""
+    op.drop_index(
+        "ix_completion_suggestion_user_practice_id",
+        table_name="completionsuggestion",
+    )
+    op.drop_index(
+        "ix_completion_suggestion_goal_id",
+        table_name="completionsuggestion",
+    )

--- a/backend/src/models/completion_suggestion.py
+++ b/backend/src/models/completion_suggestion.py
@@ -87,11 +87,16 @@ class CompletionSuggestion(SQLModel, table=True):
 
     # The hot read is "all suggestions for an entry", so index that FK; the
     # denormalized owner FK is indexed so "all suggestions for a user" is a range
-    # scan. CHECKs keep the enum columns, anchor bounds, and the polymorphic
-    # target honest at the DB level (matching the Marginalia precedent).
+    # scan. The polymorphic target FKs are indexed too so reverse lookups
+    # ("pending suggestions for goal X" / "for user-practice Y") are range scans
+    # rather than full table scans (Postgres does not auto-index FK columns).
+    # CHECKs keep the enum columns, anchor bounds, and the polymorphic target
+    # honest at the DB level (matching the Marginalia precedent).
     __table_args__ = (
         Index("ix_completion_suggestion_journal_entry_id", "journal_entry_id"),
         Index("ix_completion_suggestion_user_id", "user_id"),
+        Index("ix_completion_suggestion_goal_id", "goal_id"),
+        Index("ix_completion_suggestion_user_practice_id", "user_practice_id"),
         _target_type_check(),
         _status_check(),
         CheckConstraint("anchor_start >= 0", name="ck_completion_suggestion_anchor_start_nonneg"),

--- a/backend/tests/test_completion_suggestion_model.py
+++ b/backend/tests/test_completion_suggestion_model.py
@@ -98,7 +98,7 @@ def _habit_suggestion(
         "goal_id": goal_id,
         "label": "Run",
         "anchor_start": 0,
-        "anchor_end": 19,
+        "anchor_end": 22,
         "anchor_text": "I went for a run today",
     }
     base.update(over)


### PR DESCRIPTION
## Summary

#841 (follow-up to #814/#838): Postgres doesn't auto-index FK columns, so reverse lookups (the #817/#818 query layer) would full-scan as counts grow.

- Index `completion_suggestion.goal_id` + `user_practice_id` in the model `__table_args__` (matching the existing `journal_entry_id`/`user_id` indexes): `ix_completion_suggestion_goal_id`, `ix_completion_suggestion_user_practice_id`.
- Migration `c5d6e7f8a9b0` (down_revision `a3b4c5d6e7f9`, single head) creates both in `upgrade()`, drops in `downgrade()`.
- Test tidy: `_habit_suggestion` `anchor_end` 19 → 22 to match the 22-char `anchor_text`.

## Test plan

`./scripts/backend/check-all.sh` 7/7 (96% cov), xenon A; `alembic heads` → single head `c5d6e7f8a9b0`; existing CompletionSuggestion model tests green.

Closes #841
