### PR TITLE
refactor: remove dead API client methods + orphaned single-stage endpoint

### DIFF
--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -154,30 +154,6 @@ async def get_program_calendar(
     )
 
 
-@router.get("/{stage_number}", response_model=StageResponse)
-async def get_stage(
-    stage_number: int,
-    current_user: Annotated[int, Depends(get_current_user)],
-    session: Annotated[AsyncSession, Depends(get_session)],
-) -> StageResponse:
-    """Get a single stage with full metadata and progress."""
-    result = await session.execute(
-        select(CourseStage).where(CourseStage.stage_number == stage_number)
-    )
-    stage = result.scalars().first()
-    if stage is None:
-        raise not_found("stage")
-
-    progress = await get_user_progress(session, current_user)
-    # Single-stage view carries no progress overlay (the list view computes it in
-    # a batched pass); StageResponse.progress defaults to 0.0, so pass that.
-    return _build_stage_response(
-        stage,
-        0.0,
-        unlocked=is_stage_unlocked(stage.stage_number, progress),
-    )
-
-
 @router.get("/{stage_number}/progress", response_model=StageProgressResponse)
 async def get_stage_progress(
     stage_number: int,

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -78,12 +78,6 @@ async def test_list_stages_requires_auth(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_stage_requires_auth(async_client: AsyncClient) -> None:
-    resp = await async_client.get("/stages/1")
-    assert resp.status_code == HTTPStatus.UNAUTHORIZED
-
-
-@pytest.mark.asyncio
 async def test_get_stage_progress_requires_auth(async_client: AsyncClient) -> None:
     resp = await async_client.get("/stages/1/progress")
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
@@ -201,34 +195,6 @@ async def test_list_stages_populates_progress_field(
     # Stage 1 is always unlocked, and the user has a practice session,
     # so progress should be > 0.
     assert data[0]["progress"] > 0.0
-
-
-# ── GET /stages/{stage_number} ──────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_get_stage_detail(
-    async_client: AsyncClient,
-    db_session: AsyncSession,
-) -> None:
-    headers, _user_id = await _signup(async_client)
-    await _seed_stages(db_session, count=2)
-    resp = await async_client.get("/stages/1", headers=headers)
-    assert resp.status_code == HTTPStatus.OK
-    data = resp.json()
-    assert data["stage_number"] == 1
-    assert data["title"] == "Stage 1"
-    assert data["spiral_dynamics_color"] == "beige"
-    assert "is_unlocked" in data
-
-
-@pytest.mark.asyncio
-async def test_get_stage_not_found(
-    async_client: AsyncClient,
-) -> None:
-    headers, _user_id = await _signup(async_client)
-    resp = await async_client.get("/stages/99", headers=headers)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
 # ── GET /stages/{stage_number}/progress ─────────────────────────────────

--- a/frontend/src/api/__tests__/goalGroups-api.test.ts
+++ b/frontend/src/api/__tests__/goalGroups-api.test.ts
@@ -43,43 +43,6 @@ describe('goalGroups API client', () => {
     expect(result).toEqual(group);
   });
 
-  test('goalGroups.create sends POST with payload', async () => {
-    const created = { id: 2, name: 'Custom', shared_template: false, goals: [] };
-    mockFetch.mockReturnValueOnce(jsonResponse(created, 201));
-
-    const result = await goalGroups.create({ name: 'Custom', icon: '🎯' }, 'test-token');
-
-    const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/goal-groups/');
-    expect(init.method).toBe('POST');
-    expect(JSON.parse(init.body)).toMatchObject({ name: 'Custom', icon: '🎯' });
-    expect(result).toEqual(created);
-  });
-
-  test('goalGroups.update sends PUT with payload', async () => {
-    const updated = { id: 1, name: 'Updated', shared_template: false, goals: [] };
-    mockFetch.mockReturnValueOnce(jsonResponse(updated));
-
-    const result = await goalGroups.update(1, { name: 'Updated' }, 'test-token');
-
-    const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/goal-groups/1');
-    expect(init.method).toBe('PUT');
-    expect(result).toEqual(updated);
-  });
-
-  test('goalGroups.delete sends DELETE request', async () => {
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(null) }),
-    );
-
-    await goalGroups.delete(1, 'test-token');
-
-    const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/goal-groups/1');
-    expect(init.method).toBe('DELETE');
-  });
-
   test('goalGroups.list throws ApiError on failure', async () => {
     mockFetch.mockReturnValueOnce(
       Promise.resolve({

--- a/frontend/src/api/__tests__/pagination-api.test.ts
+++ b/frontend/src/api/__tests__/pagination-api.test.ts
@@ -1,16 +1,6 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
-import {
-  fetchAllPages,
-  habits,
-  practices,
-  practiceSessions,
-  goalGroups,
-  stages,
-  userPractices,
-  course,
-  ApiValidationError,
-} from '../index';
+import { fetchAllPages, habits, practices, stages, course, ApiValidationError } from '../index';
 
 // Mock global fetch
 const mockFetch = jest.fn() as jest.Mock;
@@ -73,35 +63,6 @@ const validPractice = (over: Record<string, unknown> = {}) => ({
   approved: true,
   ...over,
 });
-const validUserPractice = (over: Record<string, unknown> = {}) => ({
-  id: 1,
-  user_id: 1,
-  practice_id: 2,
-  stage_number: 1,
-  start_date: '2026-01-01',
-  end_date: null,
-  ...over,
-});
-const validSession = (over: Record<string, unknown> = {}) => ({
-  id: 9,
-  user_id: 1,
-  user_practice_id: 5,
-  duration_minutes: 10,
-  timestamp: '2026-03-01T10:30:00Z',
-  reflection: null,
-  ...over,
-});
-const validGoalGroup = (over: Record<string, unknown> = {}) => ({
-  id: 1,
-  name: 'Morning',
-  icon: null,
-  description: null,
-  user_id: null,
-  shared_template: true,
-  source: null,
-  goals: [],
-  ...over,
-});
 const validContentItem = (over: Record<string, unknown> = {}) => ({
   id: 1,
   title: 'Intro',
@@ -136,26 +97,6 @@ describe('paginated list endpoints (issue #221 — Page envelope)', () => {
     expect(url).toBe('http://test/practices/?paginate=true&stage_number=2&limit=50&offset=50');
   });
 
-  test('practiceSessions.listPaginated forwards user_practice_id', async () => {
-    const envelope = page([validSession()]);
-    mockFetch.mockReturnValueOnce(jsonResponse(envelope));
-
-    const result = await practiceSessions.listPaginated({ userPracticeId: 5 }, 'tok');
-
-    const [url] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/practice-sessions/?paginate=true&user_practice_id=5');
-    expect(result.items).toHaveLength(1);
-  });
-
-  test('goalGroups.listPaginated hits /goal-groups/ with the envelope flag', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse(page([validGoalGroup()])));
-
-    await goalGroups.listPaginated({ limit: 10 }, 'tok');
-
-    const [url] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/goal-groups/?paginate=true&limit=10');
-  });
-
   test('stages.listPaginated hits /stages (no trailing slash) with the envelope flag', async () => {
     mockFetch.mockReturnValueOnce(jsonResponse(page([validStage()])));
 
@@ -163,15 +104,6 @@ describe('paginated list endpoints (issue #221 — Page envelope)', () => {
 
     const [url] = mockFetch.mock.calls[0];
     expect(url).toBe('http://test/stages?paginate=true');
-  });
-
-  test('userPractices.listPaginated hits /user-practices/ with the envelope flag', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse(page([validUserPractice()])));
-
-    await userPractices.listPaginated({ offset: 0 }, 'tok');
-
-    const [url] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/user-practices/?paginate=true&offset=0');
   });
 
   test('course.stageContentPaginated targets the stage content path with the envelope flag', async () => {
@@ -202,7 +134,7 @@ describe('paginated list endpoints (issue #221 — Page envelope)', () => {
       jsonResponse({ items: 'nope', total: 0, limit: 50, offset: 0, has_more: false }),
     );
 
-    await expect(goalGroups.listPaginated({}, 'tok')).rejects.toThrow(ApiValidationError);
+    await expect(stages.listPaginated({}, 'tok')).rejects.toThrow(ApiValidationError);
   });
 });
 

--- a/frontend/src/api/__tests__/practiceRecipes-api.test.ts
+++ b/frontend/src/api/__tests__/practiceRecipes-api.test.ts
@@ -73,14 +73,6 @@ describe('practiceRecipes.list', () => {
   });
 });
 
-describe('practiceRecipes.get drift', () => {
-  test('raises ApiValidationError when a required field is renamed', async () => {
-    const drifted = { ...recipeFixture, owner_user_id: undefined, ownerUserId: null };
-    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
-    await expect(practiceRecipes.get(7)).rejects.toThrow(ApiValidationError);
-  });
-});
-
 describe('practiceRecipes.create', () => {
   test('POSTs the payload and parses the response', async () => {
     mockFetch.mockReturnValueOnce(jsonResponse(recipeFixture, 201));

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 import { flattenGoalCompletions } from './flattenGoalCompletions';
 import {
-  apiGoalGroupSchema,
   authResponseSchema,
   contentItemSchema,
   acceptSuggestionResultSchema,
@@ -17,13 +16,11 @@ import {
   passwordResetAcceptedSchema,
   practiceItemSchema,
   practiceRecipeSchema,
-  practiceSessionResponseSchema,
   practiceTagSchema,
   promptListResponseSchema,
   stageIntroSchema,
   stageSchema,
   timezoneReadSchema,
-  userPracticeSchema,
   type AcceptSuggestionResultT,
   type CompletionSuggestionT,
   type CompletionTargetTypeT,
@@ -759,14 +756,6 @@ export interface ApiGoalGroup {
   goals: ApiGoal[];
 }
 
-export interface GoalGroupCreatePayload {
-  name: string;
-  icon?: string | null;
-  description?: string | null;
-  shared_template?: boolean;
-  source?: string | null;
-}
-
 export interface ApiHabit {
   id: number;
   // ``user_id`` is intentionally absent — see ``habitSchema`` in ``schemas.ts``.
@@ -959,12 +948,6 @@ export const habits = {
   listAll(token?: string): Promise<ApiHabitWithGoals[]> {
     return fetchAllPages((params) => habits.listPaginated(params, token));
   },
-  get(habitId: number, token?: string): Promise<ApiHabitWithGoals> {
-    return request<ApiHabitWithGoals>(`/habits/${habitId}`, {
-      token,
-      schema: habitWithGoalsSchema as unknown as z.ZodType<ApiHabitWithGoals>,
-    });
-  },
   create(payload: HabitCreatePayload, token?: string): Promise<ApiHabit> {
     return request<ApiHabit>('/habits/', { method: 'POST', body: payload, token });
   },
@@ -1067,32 +1050,8 @@ export const goalGroups = {
   list(token?: string): Promise<ApiGoalGroup[]> {
     return request<ApiGoalGroup[]>('/goal-groups/', { token });
   },
-  /**
-   * Paginated goal-groups list (BUG-INFRA-015). Opts into the ``Page``
-   * envelope; prefer this over the bare-list variant when ``total`` /
-   * ``has_more`` are needed for a "load more" control.
-   */
-  listPaginated(params: PaginationParams = {}, token?: string): Promise<Page<ApiGoalGroup>> {
-    return request<Page<ApiGoalGroup>>(`/goal-groups/?${pageQuery({}, params)}`, {
-      token,
-      schema: pageSchema(apiGoalGroupSchema) as unknown as z.ZodType<Page<ApiGoalGroup>>,
-    });
-  },
   get(groupId: number, token?: string): Promise<ApiGoalGroup> {
     return request<ApiGoalGroup>(`/goal-groups/${groupId}`, { token });
-  },
-  create(payload: GoalGroupCreatePayload, token?: string): Promise<ApiGoalGroup> {
-    return request<ApiGoalGroup>('/goal-groups/', { method: 'POST', body: payload, token });
-  },
-  update(groupId: number, payload: GoalGroupCreatePayload, token?: string): Promise<ApiGoalGroup> {
-    return request<ApiGoalGroup>(`/goal-groups/${groupId}`, {
-      method: 'PUT',
-      body: payload,
-      token,
-    });
-  },
-  delete(groupId: number, token?: string): Promise<void> {
-    return request<void>(`/goal-groups/${groupId}`, { method: 'DELETE', token });
   },
 };
 
@@ -1362,13 +1321,6 @@ export interface Stage {
   progress: number;
 }
 
-export interface StageProgressDetail {
-  habits_progress: number;
-  practice_sessions_completed: number;
-  course_items_completed: number;
-  overall_progress: number;
-}
-
 export interface PracticeHistoryItem {
   name: string;
   sessions_completed: number;
@@ -1407,12 +1359,6 @@ export const stages = {
   /** Whole stages list via the ``Page`` envelope (issue #408). */
   listAll(token?: string): Promise<Stage[]> {
     return fetchAllPages((params) => stages.listPaginated(params, token));
-  },
-  get(stageNumber: number, token?: string): Promise<Stage> {
-    return request<Stage>(`/stages/${stageNumber}`, { token });
-  },
-  progress(stageNumber: number, token?: string): Promise<StageProgressDetail> {
-    return request<StageProgressDetail>(`/stages/${stageNumber}/progress`, { token });
   },
   history(stageNumber: number, token?: string): Promise<StageHistoryResponse> {
     return request<StageHistoryResponse>(`/stages/${stageNumber}/history`, { token });
@@ -1469,9 +1415,6 @@ export interface StageIntro {
 }
 
 export const course = {
-  stageContent(stageNumber: number, token?: string): Promise<ContentItem[]> {
-    return request<ContentItem[]>(`/course/stages/${stageNumber}/content`, { token });
-  },
   /**
    * Paginated stage content (BUG-INFRA-018). Opts into the ``Page`` envelope.
    *
@@ -1836,17 +1779,6 @@ export const userPractices = {
     return request<UserPractice[]>('/user-practices/', { token });
   },
   /**
-   * Paginated user-practices list (BUG-INFRA-017). Opts into the ``Page``
-   * envelope; prefer this over the bare-list variant when ``total`` /
-   * ``has_more`` are needed.
-   */
-  listPaginated(params: PaginationParams = {}, token?: string): Promise<Page<UserPractice>> {
-    return request<Page<UserPractice>>(`/user-practices/?${pageQuery({}, params)}`, {
-      token,
-      schema: pageSchema(userPracticeSchema) as unknown as z.ZodType<Page<UserPractice>>,
-    });
-  },
-  /**
    * PATCH the per-user overrides (custom name + mode_config_override).
    *
    * Passing ``mode_config_override: null`` resets to the catalog default;
@@ -1988,12 +1920,6 @@ export const practiceRecipes = {
       schema: recipeArraySchema,
     });
   },
-  get(recipeId: number, token?: string): Promise<PracticeRecipe> {
-    return request<PracticeRecipe>(`/practice-recipes/${recipeId}`, {
-      token,
-      schema: recipeSchema,
-    });
-  },
   create(payload: PracticeRecipeCreate, token?: string): Promise<PracticeRecipe> {
     return request<PracticeRecipe>('/practice-recipes/', {
       method: 'POST',
@@ -2073,26 +1999,6 @@ export const practiceSessions = {
       body: payload,
       token,
     });
-  },
-  /**
-   * Paginated session history for one user-practice (BUG-INFRA-014). Opts into
-   * the ``Page`` envelope; ``userPracticeId`` is required (the backend route
-   * scopes sessions to a single user-practice).
-   */
-  listPaginated(
-    params: { userPracticeId: number } & PaginationParams,
-    token?: string,
-  ): Promise<Page<PracticeSessionResponse>> {
-    const { userPracticeId, ...page } = params;
-    return request<Page<PracticeSessionResponse>>(
-      `/practice-sessions/?${pageQuery({ user_practice_id: userPracticeId }, page)}`,
-      {
-        token,
-        schema: pageSchema(practiceSessionResponseSchema) as unknown as z.ZodType<
-          Page<PracticeSessionResponse>
-        >,
-      },
-    );
   },
   weekCount(token?: string): Promise<WeekCountResponse> {
     return request<WeekCountResponse>('/practice-sessions/week-count', { token });


### PR DESCRIPTION
## Summary

#866 (de-slop): the shared API client exposed CRUD/pagination surfaces no screen calls, and backend `GET /stages/{stage_number}` (hardcoded `progress=0.0`) had no production client.

**Each deletion grep-confirmed zero production callers** (alias-aware, multiline). Removed: `goalGroups.create/update/delete/listPaginated`; `stages.get/progress` + `StageProgressDetail`; `userPractices.listPaginated`; `practiceSessions.listPaginated`; `habits.get`; `practiceRecipes.get`; non-paginated `course.stageContent`; unused schema imports + `GoalGroupCreatePayload`; dead-surface tests.

**RETAINED after re-audit** (the issue's grep was alias-naive): `goalGroups.get` (GoalModal), `goalGroups.list`, `journal.get`, `practiceRecipes.list`, `stages.listPaginated` (feeds `listAll`), `userPractices.list`, `practiceSessions.create/weekCount/insights`.

Backend: deleted `GET /stages/{stage_number}`; kept the list + `/progress` + `/history` routes.

## Test plan

`./scripts/frontend/check-all.sh` 4/4 (2121); `./scripts/backend/check-all.sh` 7/7 (95.9% cov), xenon A. Only dead-surface tests removed.

Closes #866
