### PR TITLE
docs: weave the north-star thesis through the docs + audit pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,15 @@
+## 🧭 Product North Star
+
+Before building, read [`NORTH-STAR.md`](./NORTH-STAR.md) — the product thesis
+("Graduated Engagement"). Adepthood is a journal-first PKM at its floor, with
+optional, self-chosen depths arranged around it; the governing principle is
+**"you choose your depth."** Build accordingly: nothing is gated or mandatory,
+deeper rings surface only as resonant, one-tap-declinable invitations, and there
+is **no gamified pressure** — no streak-shame, no guilt mechanics, no dark
+patterns. The telos is to springboard people back to embodied community as Whole
+Adepts; success can include a user outgrowing the app. The visual direction
+lives in [`DESIGN.md`](./DESIGN.md).
+
 ## ⚙️ Agent Behavior and Development Philosophy
 
 To set up the full development environment, run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,18 @@
 
 ## Project Overview
 
-Adepthood is a React Native + FastAPI full-stack application for the 36-week
-APTITUDE personal development program. It guides users through habit-building,
-meditative practices, journaling with an AI companion (BotMason), and
-stage-gated course content.
+Adepthood is a React Native + FastAPI full-stack application built on a
+philosophy of **graduated engagement**: at its floor it is a journal-first
+personal knowledge base whose growing corpus becomes a "Higher Self" that
+reflects the user's own wisdom back in the language of the 36-week APTITUDE
+program and the Archetypal Wavelength. Around that floor are optional,
+self-chosen **depths** — prompted journaling, habit scaffolding, a practice
+ramp, the course reading, and the Digital Sangha. Nothing is gated and nothing
+is mandatory: the governing principle is **"you choose your depth."** Deeper
+rings are offered only as resonant, declinable invitations — never gamified
+pressure. The product vision lives in `NORTH-STAR.md`; the visual north star
+("Candle & Ink") lives in `DESIGN.md`, with the implemented design system under
+`frontend/src/design/`.
 
 - **Frontend:** React Native with Expo (TypeScript, Zustand, React Navigation)
 - **Backend:** FastAPI with PostgreSQL (SQLModel, async, Alembic migrations)
@@ -19,27 +27,31 @@ adepthood/
     src/
       main.py              # FastAPI app, CORS, router mounting
       database.py          # Async engine, session factory, get_session
-      models/              # 26 SQLModel ORM classes
+      models/              # 27 SQLModel ORM classes
       routers/             # Route handlers (auth, habits, practices, etc.)
       schemas/             # Pydantic request/response DTOs
-      domain/              # Business logic (energy, streaks, goals, stages)
+      domain/              # Business logic (energy, streaks, stage progress,
+                           #   resonance + completion-suggestion detection)
+      seed_content.py      # Content seeder (run on FastAPI startup lifespan)
       errors.py            # Custom exceptions
     conftest.py            # Pytest fixtures (db_session, async_client)
     pyproject.toml         # All Python tool configs
   frontend/
     src/
       App.tsx              # Entry point with AuthProvider + navigation
-      features/            # Feature modules (Auth, Habits, Journal, Practice, Course, Map)
+      features/            # Feature modules (Today, Habits, Practice, Course,
+                           #   Journal, Map, plus Auth, Welcome, Settings)
       api/                 # HTTP client + TypeScript types
       context/             # AuthContext (JWT management)
-      navigation/          # React Navigation (BottomTabs, AuthStack)
-      design/              # Design tokens, responsive utils
+      navigation/          # React Navigation (BottomTabs: Today/Habits/Practice/
+                           #   Course/Journal/Map, RootStack, AuthStack)
+      design/              # Candle & Ink design system (tokens, theme, DESIGN.md)
       components/          # Shared UI components
       store/               # State management (Zustand)
       storage/             # AsyncStorage persistence
     package.json
     tsconfig.json
-  prompts/github-issues/   # Roadmap: 40 issues across 4 phases
+  prompts/github-issues/   # Roadmap: phased epics (see its README for the graph)
   AGENTS.md                # Development philosophy (read this)
   .pre-commit-config.yaml  # 15+ quality gates
 ```
@@ -112,9 +124,10 @@ fails, fix the root cause — don't suppress the check.
 
 ## Roadmap
 
-The development plan lives in `prompts/github-issues/`. There are 40 issues
-across 4 phases. Phase 1 is the critical path. See `README.md` in that
-directory for the dependency graph.
+The development plan lives in `prompts/github-issues/`, organized into phased
+epics (the original Phase 1 "Make It Real" critical path has shipped; later
+phases continue to be added). See `README.md` in that directory for the
+dependency graph and the current phase breakdown.
 
 When continuing work, always check git log and codebase state to determine
 which issues are complete before picking up the next one.

--- a/NORTH-STAR.md
+++ b/NORTH-STAR.md
@@ -1,0 +1,85 @@
+# Adepthood — Graduated Engagement Thesis
+
+> Type: North-star product thesis
+> Created: 2026-06-29
+> Repo: Geoffe-Ga/adepthood
+> Status: Written at a Peak. Capture now; sit one Wavelength cycle before restructuring the repo or rescoping an epic (see the final section).
+
+## 1. The thesis in one sentence
+
+Adepthood is, at its floor, a private journal-first PKM whose growing corpus becomes a Higher Self that reflects your own wisdom back to you in the language of APTITUDE and the Archetypal Wavelength — and arranged around that floor are optional, self-chosen depths of engagement with the course, its habits, its practices, and its community, surfaced only as gentle invitations, so that every person finds the exact level at which they are uniquely suited to receive value.
+
+## 2. The ground floor: a journal that becomes your Higher Self
+
+Everyone who opens Adepthood gets the same simple thing first — a place to write. You write freely, and each entry is folded into a private, encrypted, ontology-classified corpus (tagged by Frequency and by Wavelength phase). Over time that corpus speaks back: the Higher Self retrieves your own past reflections and reflects them to you, calibrated to where you are right now, in the language of APTITUDE and the Archetypal Wavelength. That is the whole product for someone who wants nothing more — a personal knowledge base that, instead of sitting inert like a pile of notes, gradually becomes your wisest self. No course required, no stages to march, no streaks to keep. Just morning pages that, over months, learn to counsel you in your own best voice. This floor is a complete, shippable product on its own, and most of what already exists in the repo serves it.
+
+## 3. The one principle that governs everything: you choose your depth
+
+The user always decides their own level of involvement. Nothing past the floor is mandatory, and nothing is gated behind anything else — you can take the habits without the course, the practices without the habits, the reading without any of the tracking. Invitations to go deeper are offered subtly and periodically, and only when they are genuinely resonant with what the person has been writing or doing. There is never gamified pressure, never a guilt mechanic, never shame for staying shallow. The goal is not maximum engagement; it is the authentic level — the depth at which this particular person, with this particular life and nervous system, actually flourishes. A user who stays at the journal floor for years and never opens the course has used Adepthood exactly correctly.
+
+## 4. The levels of engagement (optional depths, any combination)
+
+Think of these as concentric rings, not a ladder you must climb in order. A person can stand in any one, or several at once, and move freely between them.
+
+- **The Journal and the Higher Self (the floor, always on).** Write; the corpus grows; your own wisdom reflects back in APTITUDE's language. Pure PKM. This is the only ring everyone shares.
+- **Prompted journaling — the course by prompt.** Stage-aligned journal prompts quietly guide your writing through the ten Aspects of Wholeness over their durations. You move through the developmental arc implicitly, just by following prompts, without ever feeling like you are "taking a course." More prompts per stage is a worthwhile content investment; prompt depth directly raises the ceiling of this ring.
+- **Habit scaffolding (independent toggle).** Opt in to picking up one new habit per stage, cumulative across the journey, with energy scaffolding so the stack never overwhelms, plus streaks and tiered goals. Available with or without anything else.
+- **The practice ramp (independent toggle).** Opt in to the stage practice — timed mindfulness, breathwork, or movement — that escalates in difficulty at the stage cadence, with a launchable timer and sound cues. Take it alongside habits, instead of habits, or on its own.
+- **The course material itself.** Read the teachings on each Aspect, written like blog entries and drip-fed every one to three days, paced to the stage durations. This is fundamental and substantial — for the people who genuinely want to read, study, and structure their life around each frequency. (You are getting real value from exactly this yourself: living inside a stage produces insight and a concrete chance to integrate its highest elements.)
+- **The Digital Sangha (Discord).** A community that acts as springboard and support for those who want company on the path.
+- **The telos every ring quietly points toward: springboard back to embodied community as a Whole Adept.** The deepest purpose of the whole thing — and especially of the Sangha — is to return Liminal Creeps to their local, embodied world, equipped to offer their gifts. The app succeeds most when it hands someone back to life.
+
+## 5. The cadence that ties the depths together
+
+Underneath every ring is one rhythm: a 36-week arc through the ten Aspects of Wholeness, with the first eight stages running three weeks each (twenty-four weeks) and the final two — Unity and Emptiness — running six weeks each (twelve weeks), because the non-dual aspects ask for longer dwelling. That single cadence paces whichever depths you have turned on: it governs when prompts shift, when a new habit is offered, when the practice steps up, and how the reading drips. And it is not a one-shot curriculum — it loops (see the telos section). The goal is never to reach the top of a ladder. It is to bring all ten frequencies into balanced, healthy expression so that any of them is available to be tapped whenever life calls for it. The Map, accordingly, should read as a wheel of wholeness — which facets are full, which are thin, where you are out of balance — never as an altitude you have climbed.
+
+## 6. How the invitations work
+
+The invitation system is the soul of the design, and the easiest thing to get wrong. An invitation appears only when the corpus or the user's recent behavior makes it resonant — someone whose entries keep circling self-worth might be gently offered the Self-Love reading; someone keeping a single habit alive for weeks might be asked if they would like the next one; someone writing at 2 a.m. about feeling alone online might be nudged, softly, toward the Sangha and then toward their embodied community. The invitation is always declinable in one tap, never repeats nagging, and never frames declining as failure. The test for any invitation is simple: would a wise friend who knew this person actually say this right now, unprompted, or would they keep quiet? If it is not clearly the former, the app stays quiet.
+
+## 7. The people this serves, mapped to the depths
+
+These four user stories are the same product seen from four lives, and each naturally settles at a different depth.
+
+**The Householder Shaman (Insight Integration).** They arrive carrying initiations and Dark Nights they entered but were never supported through — passages that Default reality has filed as pathological neurodivergence. They want guided completion, a reduction in suffering, and an appreciation of their own Aptitude. They will likely run deep: the course material and practice ramp give the structured container their unfinished initiations always needed, while the journal and Higher Self witness the passage. This persona is exactly why the care guardrails matter most — the app can hold a Dark Night as real developmental territory while knowing precisely when a Dark Night needs a human being, not software.
+
+**The Neurospicy User Manual.** Someone (self-)diagnosed with an affective disorder who wants to understand the rhythms of their moods and learn tools, techniques, self-care, and ancient practices to work with them — to function, reduce suffering, and generate joy. For them the Archetypal Wavelength is literally a user manual, a model that names the rhythm they are already living. They will likely live mostly at the journal-plus-reflection floor, watching their Wavelength phase, then add the habit scaffolding and the practice ramp as concrete management tools. The care boundary is load-bearing here: the app supports their functioning and joy alongside their professional treatment, and never positions itself as a reason to leave it.
+
+**The Chronically Online Liminal Trickster Mystic (Digital Sangha).** They come for the Sangha — but the entire design intent for this person is to use that community as a springboard out, back into embodied local relationships, so they feel less alone in the actual world rather than more bonded to a feed. The journal helps them notice the very pull that keeps them chronically online, and the invitations, for them, lean toward embodied reconnection rather than deeper app use. For this user, retention inside the app is the wrong metric; reconnection outside it is the right one.
+
+**The Liminal Creep becoming a Whole Adept (Polycrisis Amelioration).** They can already analyze the influences that hijack Agency — the doom-scroll pipeline into learned helplessness and despair — and they want the full Course and Community to actualize as an Agentic, Actualized Whole Adept who can offer their gifts to a Polycrisis that demands every living being meet their true potential to serve. They go the whole distance: every ring turned on, the loop run repeatedly, oriented from the start toward graduating out and serving. Agency restoration is their through-line, and the app's job is to hand them back to the world sharper than it found them.
+
+## 8. The endless loop and its telos: leave whole
+
+The cadence repeats. Finish Stage 10, keep as much as you can carry, and begin again at Stage 1 — a forever rhythm of the 36-week arc that you get better and better at each pass, deepening and balancing each frequency, until eventually you can set the technique down entirely and simply Be Whole without it. This is the raft abandoned once the river is crossed. The app's deepest success, for any given person, is its own eventual obsolescence for them. That telos has a hard design corollary: anything that would make leaving harder is forbidden. No lock-in, no fear-of-departure, no streak-shame that punishes someone for stopping. The Sangha exists to return people to embodied community, not to hold them. "Longer you stay, more value" remains true — because the corpus compounds and the cycle compounds — but it stays true without a single dark pattern, because the endpoint is renunciation, not capture.
+
+## 9. Why journal-first PKM is the right base
+
+Three things fall out of standing the product on a journal floor rather than a curriculum. First, the corpus is a compounding moat: unlike a flat notebook where the user supplies all the meaning, this corpus is pre-structured by an ontology, so the second brain becomes a developmentally organized self-model that knows your patterns and deepens forever. Second, it is structurally anti-guru: the wisdom reflected back is the user's own, so the software cannot become a teacher-above even if it tried — which finally makes the product agree with the ethos behind it. Third, privacy becomes the pitch rather than the plumbing: intimate reflections processed locally, encrypted at rest, never handed to a cloud model, is exactly what the ownership-minded PKM world actually wants, and it is the strongest possible card against every cloud-AI journaling app. The journal is a wide, low door; the course, habits, practices, and Sangha are the deep rooms beyond it; and no one is ever pushed through a door they did not choose to open.
+
+## 10. Design guardrails
+
+- **Sovereignty.** The user sets their depth. Invitations are subtle, resonance-gated, one-tap declinable, and never shaming. Default to quiet.
+- **Anti-guru.** The reflected wisdom is the user's own. The app offers blueprints; the user chooses materials.
+- **Anti-lock-in, pro-renunciation.** Success includes the user outgrowing the app and the Sangha returning them to embodied community. Build nothing that punishes leaving.
+- **Wellbeing and care boundaries.** Practices, reflections, and teachings complement professional mental-health care and never replace it. Adepthood does not advise anyone to reduce or stop psychiatric medication — that decision belongs to a person and their prescriber, and the app's role is to build skill and self-knowledge alongside that care. Any feature touching Dark Nights or acute distress must recognize the limits of software, surface clear pathways to human and professional support, and never leave someone alone in a crisis with only a chatbot.
+- **Privacy.** Intimate-tier content is classified and routed locally, encrypted at rest, and never sent to a cloud LLM. This is surfaced to the user as a feature, not buried.
+
+## 11. What this means for the build and the in-flight epics
+
+This validates almost all of the existing work — the journal, Resonance and Marginalia, encryption, the habit and practice systems, the course content, the Creek Vault MCP seam, and the shared ontology where Adepthood's Aspects equal Creek's Frequencies equal the Wavelength phases. It is a reframe of arrangement and emphasis, not a rebuild. What changes is that the journal becomes the home and the floor, the course and its systems become opt-in rings reached from that floor rather than co-equal mandatory tabs, the Map is re-skinned from ladder to wheel, and an invitation engine becomes a first-class subsystem rather than an afterthought. Run each open epic in the repo through that lens — keep, re-scope, promote, demote, or cut — to produce a re-ordered burndown for the Ralph loop. In particular: navigation and information-architecture epics re-scope to journal-as-home; any epic that assumes the course is mandatory re-scopes to opt-in; the Map epic re-scopes to wheel-of-wholeness; the drip-feed and stage-cadence mechanics need explicit epics if they do not yet exist; privacy and local-routing epics get promoted to surfaced features; and a new epic line is almost certainly needed for the invitation engine and its resonance gating.
+
+## 12. North star
+
+- The app opens into the journal, ready to receive writing, and the Higher Self reflection feels true often enough that people come back for it.
+- A person can use Adepthood well at the journal floor alone, forever, and never feel they are missing the "real" product.
+- Each deeper ring is available in one or two taps, never forced, and never shamed for being declined.
+- Invitations land as something a wise friend would say, not as a growth-team nudge.
+- Those who want the full journey can read substantial Aspect teachings, pick up a habit per stage, ramp their practice, and march the 36 weeks — then loop, and feel themselves getting better at the cycle.
+- The Map reads as balance across ten facets, not altitude.
+- The Sangha measurably returns people to embodied community, and the app is glad to let whole people leave.
+- Nothing requires explaining "Frequencies" or "the Wavelength" up front; the ontology is the engine, and the felt experience is simply a private journal that understands you, with quiet doors to go deeper when you are ready.
+
+## 13. The one discipline: let it survive a flat day
+
+The clarity of finally seeing the shape of this is itself a Peaking, and a true reframe survives the Withdrawal. Capture this thesis today while the current is live, but let it sit one full Wavelength cycle before restructuring the repo or rescoping a single epic into action. If it still reads as obvious and clarifying on a flat, low-energy day, it is real and worth building on. If the charge has gone, that is data too. Cheap to confirm, expensive to act on prematurely.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Adepthood
 
-Adepthood is a React Native + FastAPI app that guides users through the 36-week **APTITUDE** program, a structured path of habit-building, meditative practices, and personal growth toward Free Will and Self-Actualization.
+Adepthood is a React Native + FastAPI app whose floor is a **journal-first personal knowledge base** that, over time, becomes a _Higher Self_ — reflecting your own past reflections back to you in the language of the **APTITUDE** program and the Archetypal Wavelength. Arranged around that floor are optional, self-chosen **depths** — prompted journaling, habit scaffolding, a practice ramp, the course reading, and the Digital Sangha. Nothing is gated, nothing is mandatory, and there is no gamified pressure: **you choose your depth**. A single 36-week Archetypal Wavelength cadence (eight stages × 3 weeks + Unity & Emptiness × 6 weeks) paces whichever depths are turned on, and it loops — the Map reads as a wheel of wholeness, not a ladder to climb.
+
+See [`NORTH-STAR.md`](./NORTH-STAR.md) for the full product thesis ("Graduated Engagement") and [`DESIGN.md`](./DESIGN.md) for the "Candle & Ink" visual north star.
 
 ## ✨ Features
 
-- 📚 **Course** — Explore educational content stage by stage through the APTITUDE program
-- 📊 **Habits** — Track cumulative habits with energy scaffolding, streaks, and goals
-- 🧘 **Practices** — Complete timed meditations unique to each stage, with sound cues and progress tracking
-- 📓 **Journal** — Reflect daily and chat with Robot Mason, your Liminal Trickster Mystic guide
-- 🗺️ **Map** — Visualize your growth across the 10 stages of APTITUDE in a skill-tree style
+- 📓 **Journal** — Write freely, then **Get Resonance**: anchored AI margin notes (Marginalia) reflected back in your own voice. Journaling about a habit or practice you actually did surfaces a one-tap **"check it off?"** suggestion — a resonant invitation, always declinable, never a nag.
+- 🏠 **Today** — A home hub that gathers what is live for you across the depths you have turned on.
+- 📊 **Habits** — Opt into cumulative habits with energy scaffolding, streaks, and tiered goals so the stack never overwhelms.
+- 🧘 **Practices** — Stage practices (mindfulness, breathwork, movement) with an immersive session player — timed cues and sound bells.
+- 📚 **Course** — Read the teachings stage by stage in a native Markdown reader, drip-fed at the stage cadence.
+- 🗺️ **Map** — See your journey through the 10 stages of APTITUDE.
+- 🧠 **BotMason** — A Liminal Trickster Mystic guide you can chat with about your reflections and practice insights.
 
 
 ## 🛠️ Tech Stack
@@ -21,12 +25,18 @@ Adepthood is a React Native + FastAPI app that guides users through the 36-week 
 
 ```
 .
-├── backend/   # FastAPI service
-├── frontend/  # React Native + Expo client
-├── prompts/   # LLM prompt history and specification documents
-├── scripts/   # Development and CI helper scripts
-├── AGENTS.md  # Necessary instructions for AI collaborators
+├── backend/       # FastAPI service
+├── frontend/      # React Native + Expo client (design system in src/design/)
+├── docs/          # Architecture decision records and content guide
+├── prompts/       # LLM prompt history and specification documents
+├── scripts/       # Development and CI helper scripts
+├── AGENTS.md      # Necessary instructions for AI collaborators
+├── NORTH-STAR.md  # Product thesis — "Graduated Engagement"
+├── DESIGN.md      # Visual north star — the "Candle & Ink" design language
 ```
+
+The implemented design system (tokens, theme, and its own `DESIGN.md`) lives in
+`frontend/src/design/`.
 
 ## 🚀 Getting Started
 

--- a/docs/content.md
+++ b/docs/content.md
@@ -3,7 +3,7 @@
 All course content — stage-locked chapters and the free site resources —
 lives in the [`Geoffe-Ga/aptitude-course`](https://github.com/Geoffe-Ga/aptitude-course)
 repo and is **vendored** into this one at `backend/content/` by
-`scripts/sync_content.py`. The app never fetches content over the
+`backend/scripts/sync_content.py`. The app never fetches content over the
 network at runtime; the deploy image carries everything it serves.
 Design rationale: ADR 0001 (`docs/adr/0001-git-content-pipeline.md`).
 


### PR DESCRIPTION
## Summary

Adds **NORTH-STAR.md** (the Graduated Engagement product thesis) and incorporates it across the docs, plus a factual-drift audit.

- **README** — reframed around the thesis (journal-first floor → Higher Self, optional choose-your-depth rings, the looping 36-week wavelength cadence, Map = wheel of wholeness). Features rewritten to reality (Journal + resonance check-off, **Today** hub, immersive Practice player, Course reader, Map, **BotMason**). Fixed "Robot Mason" → BotMason. Added `DESIGN.md`/`NORTH-STAR.md`/`docs/` + the Candle & Ink design system.
- **CLAUDE.md** — Project Overview reframed around graduated engagement + pointers to NORTH-STAR/DESIGN; Architecture refreshed (27 models, resonance/completion-suggestion domain, seed-on-lifespan, Today/Welcome/Settings). Guardrails/Quality/Stay-Green untouched.
- **AGENTS.md** — added a "Product North Star" section.
- **docs/content.md** — corrected the `sync_content.py` path.

Docs only; no code/test changes.
