### PR TITLE
fix(deploy): ship backend/content in the runtime image (#773)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -43,6 +43,15 @@ ENV PYTHONPATH=/app/src
 COPY backend/alembic.ini ./
 COPY backend/migrations/ migrations/
 
+# Vendored course content (manifest + chapter markdown bodies + assets).  The
+# content repository and the startup seeder resolve this at /app/content
+# (``parents[2]/content`` from src/services); omitting it leaves the running
+# image with no manifest, so ``/health`` reports ``content_version: none`` and
+# every stage seeds empty (#773 — the prod symptom of #767).  The matching
+# ``!backend/content`` negation in Dockerfile.dockerignore keeps the .md bodies
+# from the blanket ``*.md`` exclusion.
+COPY backend/content/ content/
+
 # Create non-root user
 RUN useradd --create-home appuser
 USER appuser

--- a/backend/Dockerfile.dockerignore
+++ b/backend/Dockerfile.dockerignore
@@ -37,5 +37,12 @@ node_modules/
 *.md
 **/*.md
 
+# ...except the vendored course content: the chapter bodies under
+# backend/content/markdown are runtime data the content repository serves, not
+# docs.  Re-include the whole content tree so the blanket *.md rule above does
+# not strip it from the build context (#773).
+!backend/content
+!backend/content/**
+
 # Backend-only dev-time exclusions
 backend/tests/

--- a/backend/tests/test_dockerfile_ships_content.py
+++ b/backend/tests/test_dockerfile_ships_content.py
@@ -1,0 +1,47 @@
+"""Guard that the runtime image actually ships the vendored course content.
+
+The content repository and the startup seeder read ``backend/content`` at
+``/app/content`` inside the container.  Tests run from the repo (where the dir
+exists) so they pass regardless, which is exactly how the image-packaging gap
+behind #773 stayed green while production shipped empty (``content_version:
+none``).  These meta-tests assert the Dockerfile copies the content tree *and*
+that the ``*.md`` exclusion in the Dockerfile-scoped ignore file is negated for
+it, so the chapter bodies are not stripped from the build context.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_DOCKERFILE = _BACKEND / "Dockerfile"
+_DOCKERIGNORE = _BACKEND / "Dockerfile.dockerignore"
+
+
+def test_dockerfile_copies_the_content_dir() -> None:
+    """The runtime image must COPY backend/content so the manifest exists."""
+    text = _DOCKERFILE.read_text()
+    assert "COPY backend/content/ content/" in text, (
+        "Dockerfile must ship backend/content (manifest + chapter bodies); "
+        "without it /health reports content_version: none (#773)."
+    )
+
+
+def test_dockerignore_keeps_the_content_markdown() -> None:
+    """The blanket ``*.md`` exclusion must be negated for the content tree.
+
+    Otherwise the COPY ships ``manifest.json`` but the chapter ``.md`` bodies are
+    filtered out of the build context and never reach the image.
+    """
+    lines = _DOCKERIGNORE.read_text().splitlines()
+    assert "!backend/content/**" in lines, (
+        "Dockerfile.dockerignore must re-include backend/content/** so the "
+        "*.md rule does not strip vendored chapter bodies (#773)."
+    )
+    # The negation must come after the broad markdown exclusion, or it is a no-op.
+    assert lines.index("**/*.md") < lines.index("!backend/content/**")
+
+
+def test_vendored_manifest_is_present_to_ship() -> None:
+    """Sanity: the content the COPY relies on is actually in the repo."""
+    assert (_BACKEND / "content" / "manifest.json").is_file()


### PR DESCRIPTION
## Summary

The prod backend reports `content_version: "none"` and seeds every stage empty **even on current `main`** (Railway auto-deploys, so the code is live) — because the vendored course content never reaches the Docker image. A two-part packaging gap from when #722 vendored the content without updating the image build:

1. **`backend/Dockerfile`** copied `src/`, `alembic.ini`, `migrations/` but **not `backend/content/`**. The content repository + startup seeder resolve the manifest at `/app/content` (`parents[2]/content` from `src/services`), which didn't exist → `content_version: none`, empty seed.
2. **`backend/Dockerfile.dockerignore`** excludes `*.md` / `**/*.md` ("docs not needed at runtime") — but the chapter bodies are `backend/content/markdown/*.md`, so even with the COPY they'd be filtered out of the build context.

Tests run from the repo (where `backend/content` exists), so **CI stayed green while the shipped image was empty** — the prod symptom behind #773 / #767.

## Fix

- `Dockerfile`: `COPY backend/content/ content/` (3.7 MB — manifest + markdown + assets).
- `Dockerfile.dockerignore`: `!backend/content` + `!backend/content/**` after the `*.md` rule so chapter bodies survive.
- New `test_dockerfile_ships_content.py` guards **both** halves (COPY present; the dockerignore negation present **and ordered after** the `*.md` exclusion; manifest in repo) so this can't silently regress.

On the next deploy the image contains `/app/content`, the lifespan seeds all stages, and `/health` `content_version` flips `none → 13e167da…`, Stage 1 fills with the 17 beige chapters.

## Test plan

`./scripts/backend/check-all.sh` 7/7. The 3 new guard tests pass.

## Verify after deploy (operator)

```
curl -s https://backend-production-3ccd.up.railway.app/health
# want: "content_version":"13e167da3ec43224fb6102fcab4886c5b5c5393f" (not "none")
```

Refs #773 · Refs #767 — left open for the operator to confirm `content_version` post-deploy, then close.
