### PR TITLE
refactor(backend): consolidate additive-streak + day-bucket math

### DIFF
--- a/backend/src/domain/habit_stats.py
+++ b/backend/src/domain/habit_stats.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, timedelta
+from datetime import date
 from typing import TYPE_CHECKING
 
-from domain.dates import to_user_date, today_in_tz
+from domain.dates import to_user_date_bucket, today_in_tz
 from domain.streaks import (
     SubtractiveContext,
+    current_consecutive_streak,
     subtractive_current_streak,
-    subtractive_day_totals,
     subtractive_longest_streak,
+    sum_units_by_user_day,
 )
 from schemas.habit_stats import HabitStats
 
@@ -43,8 +44,7 @@ def _aggregate_by_day(
     counts = [0] * _DAYS_IN_WEEK
     dates: set[date] = set()
     for c in completions:
-        moment = c.timestamp if c.timestamp.tzinfo is not None else c.timestamp.replace(tzinfo=UTC)
-        local_date = to_user_date(user_timezone, moment)
+        local_date = to_user_date_bucket(c.timestamp, user_timezone)
         js_idx = (local_date.weekday() + 1) % _DAYS_IN_WEEK
         units[js_idx] += c.completed_units
         counts[js_idx] += 1
@@ -53,6 +53,13 @@ def _aggregate_by_day(
 
 
 def _longest_streak(sorted_dates: list[date]) -> int:
+    """Longest run of consecutive completion *days* (additive history).
+
+    Distinct from :func:`domain.streaks.subtractive_longest_streak`, which scans
+    every calendar day in ``[start_date, today]`` and counts absent days as
+    abstention wins; this additive walk only ever sees days the user actually
+    logged, so the two cannot share an implementation.
+    """
     longest = 0
     run = 0
     prev: date | None = None
@@ -61,24 +68,6 @@ def _longest_streak(sorted_dates: list[date]) -> int:
         longest = max(longest, run)
         prev = d
     return longest
-
-
-def _current_streak(sorted_dates: list[date], user_timezone: str) -> int:
-    """Return the current consecutive-day streak with a one-day grace at midnight."""
-    if not sorted_dates:
-        return 0
-    most_recent = sorted_dates[-1]
-    today = today_in_tz(user_timezone)
-    yesterday = today - timedelta(days=1)
-    if most_recent < yesterday:
-        return 0
-    streak = 1
-    for i in range(len(sorted_dates) - 2, -1, -1):
-        if (sorted_dates[i + 1] - sorted_dates[i]).days == 1:
-            streak += 1
-        else:
-            break
-    return streak
 
 
 def _completion_rate(sorted_dates: list[date], user_timezone: str) -> float:
@@ -106,7 +95,7 @@ def _subtractive_stats(
     """
     units, presence, dates = _aggregate_by_day(completions, user_timezone)
     sorted_dates = sorted(dates)
-    day_totals = subtractive_day_totals(completions, user_timezone)
+    day_totals = sum_units_by_user_day(completions, user_timezone)
     return HabitStats(
         day_labels=list(_DAY_LABELS),
         values=units,
@@ -139,7 +128,9 @@ def _additive_stats(completions: list[GoalCompletion], user_timezone: str) -> Ha
         values=units,
         completions_by_day=counts,
         longest_streak=_longest_streak(sorted_dates),
-        current_streak=_current_streak(sorted_dates, user_timezone),
+        current_streak=current_consecutive_streak(
+            sorted(dates, reverse=True), today_in_tz(user_timezone)
+        ),
         total_completions=len(completed),
         completion_rate=_completion_rate(sorted_dates, user_timezone),
         completion_dates=[d.isoformat() for d in sorted_dates],

--- a/backend/src/domain/streaks.py
+++ b/backend/src/domain/streaks.py
@@ -60,21 +60,58 @@ class SubtractiveContext:
     start_date: date
 
 
-def subtractive_day_totals(
+def sum_units_by_user_day(
     completions: Sequence[GoalCompletion],
     user_timezone: str,
 ) -> dict[date, float]:
-    """Sum completion units per user-local day, *without* the >0 filter.
+    """Sum completion units per user-local calendar day.
 
-    For subtractive habits the absence of a row means perfect abstention, so the
-    bucketing keeps zero-sum days addressable too.  Callers treat
-    ``get(day, 0.0)`` as the "did the user stay under their limit" probe.
+    The single owner of the ``day_totals[day] = get(day, 0.0) + units`` bucketing
+    loop keyed on :func:`domain.dates.to_user_date_bucket`.  Used by both the
+    in-memory streak path (``GET /habits``) and the per-goal stats/streak paths,
+    which must agree or the same goal would report two different streaks.  No
+    ``> 0`` filter is applied: subtractive habits treat the absence of a row as
+    perfect abstention, so zero-sum days stay addressable via ``get(day, 0.0)``.
     """
     day_totals: dict[date, float] = {}
     for c in completions:
         day = to_user_date_bucket(c.timestamp, user_timezone)
         day_totals[day] = day_totals.get(day, 0.0) + c.completed_units
     return day_totals
+
+
+def current_consecutive_streak(sorted_days_desc: Sequence[date], today: date) -> int:
+    """Count the current additive consecutive-day streak (the single owner).
+
+    The one canonical implementation of the additive streak the frontend
+    ``streakFromCompletions`` helper mirrors; both ``GET /habits``
+    (``services.streaks``) and ``GET /habits/{id}/stats`` (``domain.habit_stats``)
+    delegate here so the same goal can never report two different streak counts.
+
+    ``sorted_days_desc`` must be the distinct user-local completion days sorted
+    *descending* (most recent first).  Two rules apply:
+
+    * **Recency grace gate** — if the most recent day is older than yesterday
+      (``most_recent < today - 1``) the chain is stale and the streak is 0.  The
+      one-day grace prevents the UI flashing "streak lost" between local midnight
+      and the user's first completion of the day; one stale day is forgiven, two
+      is not.
+    * **Backward walk** — starting from the most recent day, count days while
+      each step back is exactly one calendar day; the first gap > 1 day ends the
+      streak.
+
+    Returns 0 for an empty sequence.
+    """
+    if not sorted_days_desc:
+        return 0
+    if sorted_days_desc[0] < today - timedelta(days=1):
+        return 0
+    streak = 1
+    for i in range(1, len(sorted_days_desc)):
+        if (sorted_days_desc[i - 1] - sorted_days_desc[i]).days != 1:
+            break
+        streak += 1
+    return streak
 
 
 def subtractive_current_streak(

--- a/backend/src/services/streaks.py
+++ b/backend/src/services/streaks.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -26,8 +26,9 @@ from sqlmodel import col, select
 from domain.dates import to_user_date_bucket, today_in_tz
 from domain.streaks import (
     SubtractiveContext,
+    current_consecutive_streak,
     subtractive_current_streak,
-    subtractive_day_totals,
+    sum_units_by_user_day,
     update_streak,
 )
 from models.goal_completion import GoalCompletion
@@ -43,43 +44,6 @@ __all__ = [
     "compute_streak_before_and_after",
     "update_streak",
 ]
-
-
-def _count_consecutive_days(sorted_days: list[date], day_ok: dict[date, bool]) -> int:
-    """Count consecutive days from most recent where ``day_ok`` is True.
-
-    ``sorted_days`` MUST be sorted descending (most recent first); the
-    consecutive-day check ``(sorted_days[i - 1] - day).days == 1`` only
-    holds for that ordering, and a future caller passing ascending
-    dates would silently return the wrong streak length without this
-    invariant being documented.
-    """
-    streak = 0
-    for i, day in enumerate(sorted_days):
-        if not day_ok[day]:
-            break
-        if i > 0 and (sorted_days[i - 1] - day).days != 1:
-            break
-        streak += 1
-    return streak
-
-
-def _is_chain_stale(sorted_days_desc: list[date], user_timezone: str) -> bool:
-    """Return True when the most-recent completion day is older than yesterday.
-
-    Mirrors the frontend ``streakFromCompletions`` recency gate so both
-    sides of the wire agree: if the user has not completed today *or*
-    yesterday, the chain is considered broken and the streak is 0.
-
-    The "yesterday" grace window prevents the UI from briefly flashing
-    "streak lost" between local midnight and the user's first
-    completion of the day; one stale day is forgiven, two is not.
-    """
-    if not sorted_days_desc:
-        return True
-    today = today_in_tz(user_timezone)
-    yesterday = today - timedelta(days=1)
-    return sorted_days_desc[0] < yesterday
 
 
 async def compute_consecutive_streak(
@@ -114,15 +78,29 @@ async def _fetch_day_totals(
 ) -> dict[date, float]:
     """Sum a goal's completion units per user-local calendar day (one query)."""
     rows = await session.execute(
-        select(GoalCompletion.timestamp, GoalCompletion.completed_units)
+        select(GoalCompletion)
         .where(GoalCompletion.goal_id == goal_id, GoalCompletion.user_id == user_id)
         .order_by(col(GoalCompletion.timestamp).desc())
     )
-    day_totals: dict[date, float] = {}
-    for ts, units in rows:
-        day = to_user_date_bucket(ts, user_timezone)
-        day_totals[day] = day_totals.get(day, 0.0) + units
-    return day_totals
+    return sum_units_by_user_day(rows.scalars().all(), user_timezone)
+
+
+def _additive_streak_from_day_totals(day_totals: dict[date, float], user_timezone: str) -> int:
+    """Additive consecutive-day streak from bucketed totals (incl. zero days).
+
+    A most-recent *logged* day that wasn't a completion (a persisted
+    ``completed_units == 0`` "did not complete" row) breaks the chain
+    immediately, so the streak is 0 even though earlier days completed.  The
+    leading completed days then go to the shared
+    :func:`domain.streaks.current_consecutive_streak`, which owns the recency
+    grace gate + backward walk that the frontend ``streakFromCompletions``
+    mirrors — keeping GET /habits and GET /habits/{id}/stats in lockstep.
+    """
+    sorted_days = sorted(day_totals, reverse=True)
+    completed_days = [d for d in sorted_days if day_totals[d] > 0]
+    if not completed_days or completed_days[0] != sorted_days[0]:
+        return 0
+    return current_consecutive_streak(completed_days, today_in_tz(user_timezone))
 
 
 def _streak_from_day_totals(
@@ -133,17 +111,7 @@ def _streak_from_day_totals(
     """Count the consecutive-day streak from pre-bucketed day totals."""
     if subtractive is not None:
         return subtractive_current_streak(day_totals, user_timezone, subtractive)
-
-    sorted_days = sorted(day_totals, reverse=True)
-    # Mirror the frontend's recency gate so a stale chain reports 0 here
-    # too.  ``compute_consecutive_streak`` is also called from the
-    # check-in path which inserts today's completion before reading,
-    # so the gate is a no-op there; the win is preventing surprise
-    # divergence from any future caller.
-    if _is_chain_stale(sorted_days, user_timezone):
-        return 0
-    day_ok = {d: day_totals[d] > 0 for d in sorted_days}
-    return _count_consecutive_days(sorted_days, day_ok)
+    return _additive_streak_from_day_totals(day_totals, user_timezone)
 
 
 @dataclass(frozen=True)
@@ -226,16 +194,10 @@ def compute_habit_streak(
     ``start_date`` to walk backwards counting abstention days instead.
     """
     if subtractive is not None:
-        day_totals = subtractive_day_totals(completions, user_timezone)
+        day_totals = sum_units_by_user_day(completions, user_timezone)
         return subtractive_current_streak(day_totals, user_timezone, subtractive)
-    dates = _completed_user_dates(completions, user_timezone)
-    if not dates:
-        return 0
-    sorted_dates = sorted(dates, reverse=True)
-    if _is_chain_stale(sorted_dates, user_timezone):
-        return 0
-    day_ok = dict.fromkeys(sorted_dates, True)
-    return _count_consecutive_days(sorted_dates, day_ok)
+    sorted_dates = sorted(_completed_user_dates(completions, user_timezone), reverse=True)
+    return current_consecutive_streak(sorted_dates, today_in_tz(user_timezone))
 
 
 def check_milestones(

--- a/backend/tests/domain/test_streaks.py
+++ b/backend/tests/domain/test_streaks.py
@@ -1,6 +1,42 @@
+from datetime import date, timedelta
+
 import pytest
 
-from domain.streaks import is_scheduled_on, update_streak
+from domain.streaks import current_consecutive_streak, is_scheduled_on, update_streak
+
+_TODAY = date(2026, 6, 30)
+_YESTERDAY = _TODAY - timedelta(days=1)
+
+
+def test_current_consecutive_streak_empty_is_zero() -> None:
+    assert current_consecutive_streak([], _TODAY) == 0
+
+
+def test_current_consecutive_streak_today_counts() -> None:
+    """A completion today grace-gates open and starts the chain at 1."""
+    assert current_consecutive_streak([_TODAY], _TODAY) == 1
+
+
+def test_current_consecutive_streak_yesterday_grace_window() -> None:
+    """Most-recent day == yesterday is still inside the one-day grace gate."""
+    assert current_consecutive_streak([_YESTERDAY], _TODAY) == 1
+
+
+def test_current_consecutive_streak_two_days_stale_breaks() -> None:
+    """Most-recent day older than yesterday is stale; the streak is 0."""
+    two_days_ago = _TODAY - timedelta(days=2)
+    assert current_consecutive_streak([two_days_ago], _TODAY) == 0
+
+
+def test_current_consecutive_streak_counts_consecutive_run() -> None:
+    days_desc = [_TODAY - timedelta(days=i) for i in range(3)]
+    assert current_consecutive_streak(days_desc, _TODAY) == 3
+
+
+def test_current_consecutive_streak_gap_breaks_chain() -> None:
+    """A gap > 1 day ends the walk; only the leading run counts."""
+    days_desc = [_TODAY, _YESTERDAY, _TODAY - timedelta(days=3)]
+    assert current_consecutive_streak(days_desc, _TODAY) == 2
 
 
 def test_streak_increment() -> None:


### PR DESCRIPTION
## Summary

#869 (de-slop): the additive streak walk + per-user-day bucket-sum loop were hand-copied across `domain/habit_stats`, `services/streaks`, `domain/streaks` — the modules behind the GET /habits vs /stats parity contract. **Pure refactor, no behavior change.**

- `domain/streaks.py`: single owners — `current_consecutive_streak(sorted_days_desc, today)` (grace gate + backward walk) and `sum_units_by_user_day` (the bucket loop on `to_user_date_bucket`).
- `habit_stats.py`: `_current_streak` → calls the shared helper; inline tz coercion replaced by `to_user_date_bucket`; `_longest_streak` kept separate (different semantics, documented).
- `services/streaks.py`: `_count_consecutive_days`/`_is_chain_stale` → delegate to the shared helper (most-recent-miss→0 quirk preserved); `_fetch_day_totals` folds onto `sum_units_by_user_day`.

## Test plan

Existing streak/stats/parity tests pass **unmodified** (the behavior oracle); +6 unit tests for `current_consecutive_streak`. No duplicated math remains (grep). `./scripts/backend/check-all.sh` 7/7 (96% cov), xenon A.

Closes #869
