### PR TITLE
fix(habits): use the guarded getProgressPercentage in GoalModal (no NaN width)

### DIFF
--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -41,11 +41,11 @@ import type { GoalModalProps, Goal } from '../Habits.types';
 import {
   getMarkerPositions,
   getProgressBarColor,
+  getProgressPercentage,
   clampPercentage,
   getTierColor,
   getGoalTarget,
   isGoalAchieved,
-  calculateTodaysProgress,
 } from '../HabitUtils';
 
 import ConfirmDialog from './ConfirmDialog';
@@ -78,22 +78,6 @@ const formatGoalTooltip = (g: Goal | undefined): string => {
   if (!g) return '';
   const label = TIER_LABELS[g.tier] ?? g.tier;
   return `${label}: ${g.target} ${g.target_unit} per ${g.frequency_unit.replace('_', ' ')}`;
-};
-
-const computeProgressPct = (
-  totalProgress: number,
-  lowGoal: Goal | undefined,
-  stretchGoal: Goal | undefined,
-): number => {
-  if (!stretchGoal) return 0;
-  if (lowGoal?.is_additive) {
-    return clampPercentage((totalProgress / getGoalTarget(stretchGoal)) * 100);
-  }
-  const stretchTarget = getGoalTarget(stretchGoal);
-  const lowTarget = getGoalTarget(lowGoal!);
-  return clampPercentage(
-    100 - ((totalProgress - stretchTarget) / (lowTarget - stretchTarget)) * 100,
-  );
 };
 
 interface GoalMarkerItemProps {
@@ -1175,16 +1159,26 @@ interface GoalModalBodyProps {
   onUpdateHabit: GoalModalProps['onUpdateHabit'];
 }
 
+// Reuse the canonical, zero-guarded helper the habit tile uses so the modal
+// bar can never diverge into a NaN width. The stretch goal stands in for
+// `currentGoal`: its `is_additive` flag selects the same branch the old copy
+// did, and the helper re-derives the stretch/low tiers from the habit. A
+// goal-less habit (synthetic onboarding state) has no bar to fill, so 0%.
+const modalProgressPercentage = (
+  habit: NonNullable<GoalModalProps['habit']>,
+  m: ReturnType<typeof useGoalMarkers>,
+  tz: string,
+): number => {
+  const currentGoal = m.stretchGoal ?? m.lowGoal ?? habit.goals[0];
+  return currentGoal ? getProgressPercentage(habit, currentGoal, tz) : 0;
+};
+
 const buildProgressBarProps = (
   habit: NonNullable<GoalModalProps['habit']>,
   m: ReturnType<typeof useGoalMarkers>,
   tz: string,
 ) => ({
-  progressPercentage: computeProgressPct(
-    calculateTodaysProgress(habit, tz),
-    m.lowGoal,
-    m.stretchGoal,
-  ),
+  progressPercentage: modalProgressPercentage(habit, m, tz),
   progressBarColor: getProgressBarColor(habit, tz),
   lowGoal: m.lowGoal,
   clearGoal: m.clearGoal,

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -1,6 +1,7 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
+import type { DimensionValue } from 'react-native';
 
 // EmojiSelector pulls in native bindings; render a stub.
 jest.mock('react-native-emoji-selector', () => () => null);
@@ -445,5 +446,49 @@ describe('GoalModal log-date stepper', () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
     expect(dayKeyInTZ(date, 'UTC')).toBe(dayKeyInTZ(yesterday, 'UTC'));
+  });
+});
+
+describe('GoalModal progress-bar zero/equal-target guards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const fillWidth = (habit: Habit): DimensionValue => {
+    const { getByTestId } = renderModal(habit);
+    return getByTestId('modal-progress-fill').props.style.width as DimensionValue;
+  };
+
+  // The modal once reimplemented the progress formula without the canonical
+  // helper's zero-guards, so these degenerate targets divided 0/0 -> NaN and
+  // rendered an invalid "NaN%" width. The shared helper returns 100/0 instead.
+  it('renders a valid 100% width (not NaN%) for an additive goal with stretchTarget === 0', () => {
+    const habit = makeHabit({
+      goals: [
+        makeGoal('low', { target: 0 }),
+        makeGoal('clear', { target: 0 }),
+        makeGoal('stretch', { target: 0 }),
+      ],
+      completions: [],
+    });
+    const width = fillWidth(habit);
+    expect(width).toBe('100%');
+    expect(String(width)).not.toContain('NaN');
+  });
+
+  it('renders a valid 0% width (not NaN%) for a subtractive goal with lowTarget === stretchTarget', () => {
+    const habit = makeHabit({
+      goals: [
+        makeGoal('low', { target: 5, is_additive: false }),
+        makeGoal('clear', { target: 5, is_additive: false }),
+        makeGoal('stretch', { target: 5, is_additive: false }),
+      ],
+      // Progress past the equal low/stretch boundary -> the guarded helper
+      // returns 0 (over the limit) rather than dividing by a zero range.
+      completions: [{ timestamp: new Date(), completed_units: 9 }],
+    });
+    const width = fillWidth(habit);
+    expect(width).toBe('0%');
+    expect(String(width)).not.toContain('NaN');
   });
 });


### PR DESCRIPTION
## Summary

#870 (de-slop): GoalModal reimplemented the progress-% formula as `computeProgressPct` but dropped both zero-guards of the canonical `HabitUtils.getProgressPercentage`. At `stretchTarget===0` (additive) or `lowTarget===stretchTarget` (subtractive) it evaluated `0/0 → NaN`, rendering a `width: "NaN%"`.

- Remove `computeProgressPct` (+ the now-unused `calculateTodaysProgress` import).
- `buildProgressBarProps` uses the canonical `getProgressPercentage(habit, stretchGoal ?? lowGoal ?? goals[0], tz)` — same additive/subtractive branch, no-goals → 0.
- Modal now matches the habit tile; only the two formerly-NaN cases change (→ 100/0).

## Test plan

Regression tests: additive all-zero → `100%`, subtractive `lowTarget==stretchTarget` → `0%`, each asserting no `NaN`. `./scripts/frontend/check-all.sh` 4/4 (2115).

Closes #870
