### PR TITLE
refactor(auth): shared EmailField / PasswordField across the auth screens

### DIFF
--- a/frontend/src/features/Auth/ForgotPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ForgotPasswordScreen.tsx
@@ -4,11 +4,11 @@ import { Text, TouchableOpacity, View } from 'react-native';
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { canonicalizeEmail } from './canonicalizeEmail';
+import { EmailField } from './components/EmailField';
 
 import { auth as authApi } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
-import { TextField } from '@/components/TextField';
 
 const FORGOT_FALLBACK =
   "We couldn't reach the server. Check your connection, then try again in a moment.";
@@ -24,14 +24,11 @@ interface ForgotFieldsProps {
 
 function ForgotFields({ email, setEmail }: ForgotFieldsProps): React.JSX.Element {
   return (
-    <TextField
+    <EmailField
       accessibilityLabel="Email"
       style={styles.inputSpacing}
-      placeholder="Email"
       value={email}
       onChangeText={setEmail}
-      autoCapitalize="none"
-      keyboardType="email-address"
     />
   );
 }

--- a/frontend/src/features/Auth/LoginScreen.tsx
+++ b/frontend/src/features/Auth/LoginScreen.tsx
@@ -5,10 +5,11 @@ import { authStyles as styles } from './auth.styles';
 import { AuthBrandBand } from './AuthBrandBand';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { canonicalizeEmail } from './canonicalizeEmail';
+import { EmailField } from './components/EmailField';
+import { PasswordField } from './components/PasswordField';
 
 import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
-import { TextField } from '@/components/TextField';
 import { useAuth } from '@/context/AuthContext';
 
 const LOGIN_FALLBACK =
@@ -33,22 +34,17 @@ function LoginFields({
 }: LoginFieldsProps): React.JSX.Element {
   return (
     <>
-      <TextField
+      <EmailField
         accessibilityLabel="Email"
         style={styles.inputSpacing}
-        placeholder="Email"
         value={email}
         onChangeText={setEmail}
-        autoCapitalize="none"
-        keyboardType="email-address"
       />
-      <TextField
+      <PasswordField
         accessibilityLabel="Password"
         style={styles.inputSpacing}
-        placeholder="Password"
         value={password}
         onChangeText={setPassword}
-        secureTextEntry
       />
     </>
   );

--- a/frontend/src/features/Auth/ReauthSheet.tsx
+++ b/frontend/src/features/Auth/ReauthSheet.tsx
@@ -6,13 +6,14 @@ import {
   Platform,
   StyleSheet,
   Text,
-  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
 
 import { authStyles } from './auth.styles';
 import { canonicalizeEmail } from './canonicalizeEmail';
+import { EmailField } from './components/EmailField';
+import { PasswordField } from './components/PasswordField';
 
 import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
@@ -92,23 +93,18 @@ function ReauthForm(props: ReauthFormProps): React.JSX.Element {
       <Text style={localStyles.subtitle}>
         Your session expired. Enter your credentials to keep going where you left off.
       </Text>
-      <TextInput
+      <EmailField
         accessibilityLabel="Email"
-        style={authStyles.input}
-        placeholder="Email"
+        style={authStyles.inputSpacing}
         value={email}
         onChangeText={onEmailChange}
-        autoCapitalize="none"
-        keyboardType="email-address"
         testID="reauth-email"
       />
-      <TextInput
+      <PasswordField
         accessibilityLabel="Password"
-        style={authStyles.input}
-        placeholder="Password"
+        style={authStyles.inputSpacing}
         value={password}
         onChangeText={onPasswordChange}
-        secureTextEntry
         testID="reauth-password"
       />
       {error ? <Text style={authStyles.error}>{error}</Text> : null}

--- a/frontend/src/features/Auth/ResetPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ResetPasswordScreen.tsx
@@ -3,12 +3,12 @@ import { Text, TouchableOpacity } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
+import { PasswordField } from './components/PasswordField';
 import { validatePasswordPair } from './passwordValidation';
 import { MIN_TOKEN_LENGTH } from './resetToken';
 
 import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
-import { TextField } from '@/components/TextField';
 import { useAuth } from '@/context/AuthContext';
 
 const RESET_FALLBACK =
@@ -38,22 +38,20 @@ function ResetFields({
 }: ResetFieldsProps): React.JSX.Element {
   return (
     <>
-      <TextField
+      <PasswordField
         accessibilityLabel="New password"
         style={styles.inputSpacing}
         placeholder="New Password"
         value={password}
         onChangeText={setPassword}
-        secureTextEntry
         textContentType="newPassword"
       />
-      <TextField
+      <PasswordField
         accessibilityLabel="Confirm new password"
         style={styles.inputSpacing}
         placeholder="Confirm New Password"
         value={confirmPassword}
         onChangeText={setConfirmPassword}
-        secureTextEntry
         textContentType="newPassword"
       />
     </>

--- a/frontend/src/features/Auth/SignupScreen.tsx
+++ b/frontend/src/features/Auth/SignupScreen.tsx
@@ -5,11 +5,12 @@ import { authStyles as styles } from './auth.styles';
 import { AuthBrandBand } from './AuthBrandBand';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { canonicalizeEmail } from './canonicalizeEmail';
+import { EmailField } from './components/EmailField';
+import { PasswordField } from './components/PasswordField';
 import { validatePasswordPair } from './passwordValidation';
 
 import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
-import { TextField } from '@/components/TextField';
 import { useAuth } from '@/context/AuthContext';
 
 const SIGNUP_FALLBACK =
@@ -38,30 +39,24 @@ function SignupFields({
 }: SignupFieldsProps) {
   return (
     <>
-      <TextField
+      <EmailField
         accessibilityLabel="Email"
         style={styles.inputSpacing}
-        placeholder="Email"
         value={email}
         onChangeText={setEmail}
-        autoCapitalize="none"
-        keyboardType="email-address"
       />
-      <TextField
+      <PasswordField
         accessibilityLabel="Password"
         style={styles.inputSpacing}
-        placeholder="Password"
         value={password}
         onChangeText={setPassword}
-        secureTextEntry
       />
-      <TextField
+      <PasswordField
         accessibilityLabel="Confirm password"
         style={styles.inputSpacing}
         placeholder="Confirm Password"
         value={confirmPassword}
         onChangeText={setConfirmPassword}
-        secureTextEntry
       />
     </>
   );

--- a/frontend/src/features/Auth/__tests__/credentialFields.test.tsx
+++ b/frontend/src/features/Auth/__tests__/credentialFields.test.tsx
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+/* global describe, it, expect, jest */
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import { EmailField } from '@/features/Auth/components/EmailField';
+import { PasswordField } from '@/features/Auth/components/PasswordField';
+
+describe('EmailField', () => {
+  it('renders with the email keyboard/capitalisation props', () => {
+    const { getByTestId } = render(<EmailField testID="email" value="" onChangeText={jest.fn()} />);
+    const input = getByTestId('email');
+    expect(input.props.placeholder).toBe('Email');
+    expect(input.props.keyboardType).toBe('email-address');
+    expect(input.props.autoCapitalize).toBe('none');
+  });
+
+  it('forwards onChangeText', () => {
+    const onChangeText = jest.fn();
+    const { getByTestId } = render(
+      <EmailField testID="email" value="" onChangeText={onChangeText} />,
+    );
+    fireEvent.changeText(getByTestId('email'), 'user@test.com');
+    expect(onChangeText).toHaveBeenCalledWith('user@test.com');
+  });
+});
+
+describe('PasswordField', () => {
+  it('renders masked with the password props', () => {
+    const { getByTestId } = render(<PasswordField testID="pw" value="" onChangeText={jest.fn()} />);
+    const input = getByTestId('pw');
+    expect(input.props.secureTextEntry).toBe(true);
+    expect(input.props.placeholder).toBe('Password');
+  });
+
+  it('lets callers override the placeholder and forwards onChangeText', () => {
+    const onChangeText = jest.fn();
+    const { getByTestId } = render(
+      <PasswordField
+        testID="pw"
+        placeholder="Confirm Password"
+        value=""
+        onChangeText={onChangeText}
+      />,
+    );
+    const input = getByTestId('pw');
+    expect(input.props.placeholder).toBe('Confirm Password');
+    fireEvent.changeText(input, 'secret'); // pragma: allowlist secret
+    expect(onChangeText).toHaveBeenCalledWith('secret'); // pragma: allowlist secret
+  });
+});

--- a/frontend/src/features/Auth/auth.styles.ts
+++ b/frontend/src/features/Auth/auth.styles.ts
@@ -74,17 +74,6 @@ export const authStyles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: SPACING.xl,
   },
-  input: {
-    borderWidth: 1,
-    borderColor: surface.hairline,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.md,
-    minHeight: 44,
-    color: ink.primary,
-    backgroundColor: surface.raised,
-    marginBottom: SPACING.md,
-    fontSize: 16,
-  },
   // Layout-only spacing for the warm `TextField`/`Button` primitives (#801),
   // which own their own ground/border/colour. Keeps field/button rhythm without
   // re-imposing the legacy grey chrome.

--- a/frontend/src/features/Auth/components/EmailField.tsx
+++ b/frontend/src/features/Auth/components/EmailField.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import type { TextInputProps } from 'react-native';
+
+import { TextField } from '@/components/TextField';
+
+/**
+ * Shared email input for the Auth screens. Wraps the warm {@link TextField}
+ * with the email-specific keyboard/capitalisation props that were previously
+ * copy-pasted across Login, Signup, Forgot Password and the re-auth sheet
+ * (#871). Callers still own value/onChangeText/testID/accessibilityLabel/style,
+ * so per-screen labels and ids are preserved unchanged.
+ */
+export function EmailField(props: TextInputProps): React.JSX.Element {
+  return (
+    <TextField placeholder="Email" autoCapitalize="none" keyboardType="email-address" {...props} />
+  );
+}

--- a/frontend/src/features/Auth/components/PasswordField.tsx
+++ b/frontend/src/features/Auth/components/PasswordField.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { TextInputProps } from 'react-native';
+
+import { TextField } from '@/components/TextField';
+
+/**
+ * Shared password input for the Auth screens. Wraps the warm {@link TextField}
+ * with ``secureTextEntry`` so the masking that was duplicated across Login,
+ * Signup, Reset Password and the re-auth sheet (#871) lives in one place.
+ * Callers still own value/onChangeText/testID/accessibilityLabel/style/
+ * placeholder/textContentType, so per-screen labels and ids are preserved.
+ */
+export function PasswordField(props: TextInputProps): React.JSX.Element {
+  return <TextField secureTextEntry placeholder="Password" {...props} />;
+}


### PR DESCRIPTION
## Summary

#871 (de-slop): email/password markup was copy-pasted across every Auth screen, and ReauthSheet had drifted to a raw `TextInput`.

- New `features/Auth/components/EmailField.tsx` + `PasswordField.tsx` — thin wrappers over the shared `TextField` (email/password props before `{...props}`, so callers override freely).
- Adopted in Login/Signup/Forgot/Reset + ReauthSheet (raw `TextInput` → shared component; removed the dead `input` style). **No raw `TextInput` email/password field remains.**

No auth-flow behavior change; every label/testID preserved.

## Test plan

Existing Auth suites pass unchanged (the oracle) + a new `credentialFields` unit test. `./scripts/frontend/check-all.sh` 4/4 (2119).

Closes #871
