### PR TITLE
refactor(practice): one configurator dispatcher + engine-owned validation bounds

### DIFF
--- a/frontend/src/features/Practice/components/ConfiguratorBody.tsx
+++ b/frontend/src/features/Practice/components/ConfiguratorBody.tsx
@@ -1,0 +1,79 @@
+/**
+ * ``ConfiguratorBody`` — the single mode→form dispatcher shared by every
+ * place that edits a :data:`ModeConfig` (the create wizard and the ritual
+ * configurator sheet).
+ *
+ * One ``MODE_FORMS`` table maps each ``ModeConfig['mode']`` to its per-mode
+ * form component. Every form honours the same ``{ value, onChange }``
+ * contract, so adding a new mode means editing this one table — not two
+ * parallel dispatchers. When a mode has no form (a future/unknown
+ * discriminator), the consumer's ``renderFallback`` decides what to show,
+ * keeping each surface's own copy and testIDs.
+ */
+
+import type React from 'react';
+
+import CardMeditationForm from '../configurator/forms/CardMeditationForm';
+import CountUpForm from '../configurator/forms/CountUpForm';
+import IntervalBellForm from '../configurator/forms/IntervalBellForm';
+import MeditationTimerForm from '../configurator/forms/MeditationTimerForm';
+import MetronomeForm from '../configurator/forms/MetronomeForm';
+import MindfulAnchorForm from '../configurator/forms/MindfulAnchorForm';
+import RandomIntervalBellForm from '../configurator/forms/RandomIntervalBellForm';
+import RepCounterForm from '../configurator/forms/RepCounterForm';
+import SenseGroundingForm from '../configurator/forms/SenseGroundingForm';
+import TalliedGroundingForm from '../configurator/forms/TalliedGroundingForm';
+import TarotForm from '../configurator/forms/TarotForm';
+import type { ModeConfig } from '../engine/types';
+
+type FormComponent<M extends ModeConfig['mode']> = React.ComponentType<{
+  value: Extract<ModeConfig, { mode: M }>;
+  onChange: (next: Extract<ModeConfig, { mode: M }>) => void;
+}>;
+
+type FormTable = { [K in ModeConfig['mode']]: FormComponent<K> | null };
+
+/** The single source of truth mapping a mode to its configurator form. */
+export const MODE_FORMS: FormTable = {
+  meditation_timer: MeditationTimerForm,
+  count_up: CountUpForm,
+  metronome: MetronomeForm,
+  interval_bell: IntervalBellForm,
+  random_interval_bell: RandomIntervalBellForm,
+  rep_counter: RepCounterForm,
+  sense_grounding: SenseGroundingForm,
+  tarot: TarotForm,
+  card_meditation: CardMeditationForm,
+  tallied_grounding: TalliedGroundingForm,
+  mindful_anchor: MindfulAnchorForm,
+};
+
+export interface ConfiguratorBodyProps {
+  config: ModeConfig;
+  onChange: (next: ModeConfig) => void;
+  /**
+   * Rendered when ``config.mode`` has no form (an unknown discriminator).
+   * Receives the raw mode string so the surface can name it in its own copy.
+   */
+  renderFallback: (mode: string) => React.JSX.Element;
+}
+
+type AnyForm = React.ComponentType<{
+  value: ModeConfig;
+  onChange: (next: ModeConfig) => void;
+}>;
+
+/** Dispatch ``config`` to its registered form, or the consumer's fallback. */
+const ConfiguratorBody = ({
+  config,
+  onChange,
+  renderFallback,
+}: ConfiguratorBodyProps): React.JSX.Element => {
+  const Form = MODE_FORMS[config.mode] as AnyForm | undefined | null;
+  if (Form === null || Form === undefined) {
+    return renderFallback(config.mode);
+  }
+  return <Form value={config} onChange={onChange} />;
+};
+
+export default ConfiguratorBody;

--- a/frontend/src/features/Practice/components/__tests__/ConfiguratorBody.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ConfiguratorBody.test.tsx
@@ -1,0 +1,39 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import ConfiguratorBody from '../ConfiguratorBody';
+
+import { defaultConfigFor } from '@/features/Practice/configurator/defaults';
+import type { ModeConfig } from '@/features/Practice/engine/types';
+
+const noop = (): void => {};
+const fallback = (mode: string): React.JSX.Element => <Text testID="fallback">{mode}</Text>;
+
+describe('ConfiguratorBody dispatcher', () => {
+  it('renders the meditation-timer form for a timer-family mode', () => {
+    const config = defaultConfigFor('meditation_timer');
+    const { getByTestId } = render(
+      <ConfiguratorBody config={config} onChange={noop} renderFallback={fallback} />,
+    );
+    expect(getByTestId('meditation-timer-form')).toBeTruthy();
+  });
+
+  it('renders the tallied-grounding form for a grounding-family mode', () => {
+    const config = defaultConfigFor('tallied_grounding');
+    const { getByTestId } = render(
+      <ConfiguratorBody config={config} onChange={noop} renderFallback={fallback} />,
+    );
+    expect(getByTestId('tallied-grounding-form')).toBeTruthy();
+  });
+
+  it('renders the consumer fallback (with the mode name) for an unknown mode', () => {
+    const unknown = { mode: 'mystery' } as unknown as ModeConfig;
+    const { getByTestId } = render(
+      <ConfiguratorBody config={unknown} onChange={noop} renderFallback={fallback} />,
+    );
+    expect(getByTestId('fallback').props.children).toBe('mystery');
+  });
+});

--- a/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
+++ b/frontend/src/features/Practice/configurator/RitualConfiguratorSheet.tsx
@@ -15,22 +15,12 @@ import type { ModeConfig } from '../engine/types';
 import { CUSTOM_NAME_MAX, validateCustomName, validateModeConfig } from '../engine/validation';
 import RecipePickerModal from '../recipes/RecipePickerModal';
 
-import CardMeditationForm from './forms/CardMeditationForm';
-import CountUpForm from './forms/CountUpForm';
-import IntervalBellForm from './forms/IntervalBellForm';
-import MeditationTimerForm from './forms/MeditationTimerForm';
-import MetronomeForm from './forms/MetronomeForm';
-import MindfulAnchorForm from './forms/MindfulAnchorForm';
-import RandomIntervalBellForm from './forms/RandomIntervalBellForm';
-import RepCounterForm from './forms/RepCounterForm';
-import SenseGroundingForm from './forms/SenseGroundingForm';
 import { ErrorList } from './forms/shared';
-import TalliedGroundingForm from './forms/TalliedGroundingForm';
-import TarotForm from './forms/TarotForm';
 
 import { type UserPractice, type UserPracticeCustomize, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import ConfiguratorBody from '@/features/Practice/components/ConfiguratorBody';
 
 /** Modes that have a recipe library backing them; see backend `RECIPE_MODES`. */
 const RECIPE_LIBRARY_MODES = new Set(['sense_grounding', 'tallied_grounding']);
@@ -116,7 +106,11 @@ const ConfiguratorSheetBody = (props: ConfiguratorSheetBodyProps): React.JSX.Ele
       />
       <ScrollView style={styles.body} keyboardShouldPersistTaps="handled">
         {props.recipeLibraryAvailable && <RecipeLibraryButton onPress={props.onOpenRecipePicker} />}
-        <ConfiguratorBody config={props.edit.config} onChange={props.edit.setConfig} />
+        <ConfiguratorBody
+          config={props.edit.config}
+          onChange={props.edit.setConfig}
+          renderFallback={renderUnknownModeNotice}
+        />
         <ErrorList errors={props.edit.errors} />
         {props.state.apiError !== null && (
           <Text style={styles.apiError} testID="ritual-configurator-api-error">
@@ -258,59 +252,7 @@ const ConfiguratorHeader = ({
   </View>
 );
 
-interface BodyProps {
-  config: ModeConfig;
-  onChange: (next: ModeConfig) => void;
-}
-
-// The dispatch is split into two helpers so each stays within the complexity
-// budget as modes accumulate: timer-family forms vs the card/grounding family.
-const timerBody = (
-  config: ModeConfig,
-  onChange: BodyProps['onChange'],
-): React.JSX.Element | null => {
-  switch (config.mode) {
-    case 'meditation_timer':
-      return <MeditationTimerForm value={config} onChange={onChange} />;
-    case 'count_up':
-      return <CountUpForm value={config} onChange={onChange} />;
-    case 'metronome':
-      return <MetronomeForm value={config} onChange={onChange} />;
-    case 'interval_bell':
-      return <IntervalBellForm value={config} onChange={onChange} />;
-    case 'random_interval_bell':
-      return <RandomIntervalBellForm value={config} onChange={onChange} />;
-    case 'rep_counter':
-      return <RepCounterForm value={config} onChange={onChange} />;
-    default:
-      return null;
-  }
-};
-
-const cardAndGroundingBody = (
-  config: ModeConfig,
-  onChange: BodyProps['onChange'],
-): React.JSX.Element => {
-  switch (config.mode) {
-    case 'sense_grounding':
-      return <SenseGroundingForm value={config} onChange={onChange} />;
-    case 'tallied_grounding':
-      return <TalliedGroundingForm value={config} onChange={onChange} />;
-    case 'mindful_anchor':
-      return <MindfulAnchorForm value={config} onChange={onChange} />;
-    case 'tarot':
-      return <TarotForm value={config} onChange={onChange} />;
-    case 'card_meditation':
-      return <CardMeditationForm value={config} onChange={onChange} />;
-    default:
-      return <UnknownModeNotice />;
-  }
-};
-
-const ConfiguratorBody = ({ config, onChange }: BodyProps): React.JSX.Element =>
-  timerBody(config, onChange) ?? cardAndGroundingBody(config, onChange);
-
-const UnknownModeNotice = (): React.JSX.Element => (
+const renderUnknownModeNotice = (): React.JSX.Element => (
   <View testID="ritual-configurator-unknown">
     <Text style={styles.unknownText}>
       Configuration not yet available — long-press to replace this practice.

--- a/frontend/src/features/Practice/recipes/RecipeEditorModal.tsx
+++ b/frontend/src/features/Practice/recipes/RecipeEditorModal.tsx
@@ -27,6 +27,13 @@ import type {
 import { practiceRecipes, practiceTags } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import {
+  CUSTOM_NAME_MAX,
+  PROMPT_LABEL_MAX,
+  TALLIED_CATEGORIES_MAX,
+  TALLIED_ROUNDS_MAX,
+  TALLIED_TARGET_MAX,
+} from '@/features/Practice/engine/validation';
 
 export interface RecipeEditorModalProps {
   visible: boolean;
@@ -43,12 +50,15 @@ export interface RecipeEditorModalProps {
   createTag?: typeof practiceTags.create;
 }
 
-const NAME_MAX = 255;
+// Bounds that mirror the backend recipe schema are owned by ``engine/validation``;
+// alias them to the names this draft editor uses so the contract stays single-sourced.
+const NAME_MAX = CUSTOM_NAME_MAX;
+const PROMPT_MAX = PROMPT_LABEL_MAX;
+const ROUNDS_MAX = TALLIED_ROUNDS_MAX;
+const TARGET_COUNT_MAX = TALLIED_TARGET_MAX;
+const STEPS_MAX = TALLIED_CATEGORIES_MAX;
+// Recipe description cap has no engine-owned constant (no mode config mirrors it).
 const DESCRIPTION_MAX = 2_000;
-const PROMPT_MAX = 255;
-const ROUNDS_MAX = 10;
-const TARGET_COUNT_MAX = 20;
-const STEPS_MAX = 12;
 
 const RecipeEditorModal = (props: RecipeEditorModalProps): React.JSX.Element => {
   const deps = resolveDeps(props);

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -32,24 +32,14 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { defaultConfigFor, suggestedDurationFor } from '../configurator/defaults';
-import CardMeditationForm from '../configurator/forms/CardMeditationForm';
-import CountUpForm from '../configurator/forms/CountUpForm';
-import IntervalBellForm from '../configurator/forms/IntervalBellForm';
-import MeditationTimerForm from '../configurator/forms/MeditationTimerForm';
-import MetronomeForm from '../configurator/forms/MetronomeForm';
-import MindfulAnchorForm from '../configurator/forms/MindfulAnchorForm';
-import RandomIntervalBellForm from '../configurator/forms/RandomIntervalBellForm';
-import RepCounterForm from '../configurator/forms/RepCounterForm';
-import SenseGroundingForm from '../configurator/forms/SenseGroundingForm';
 import { ErrorList } from '../configurator/forms/shared';
-import TalliedGroundingForm from '../configurator/forms/TalliedGroundingForm';
-import TarotForm from '../configurator/forms/TarotForm';
 import type { ModeConfig } from '../engine/types';
 import { validateModeConfig } from '../engine/validation';
 
 import { practices, userPractices } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import ConfiguratorBody from '@/features/Practice/components/ConfiguratorBody';
 import ModePicker, { type PickableMode } from '@/features/Practice/components/ModePicker';
 import { FALLBACK_STAGE, MAX_STAGE, MIN_STAGE } from '@/features/Practice/constants';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
@@ -326,7 +316,11 @@ const ConfigureStep = (props: ConfigureStepProps): React.JSX.Element => {
   return (
     <View testID="create-practice-step-configure">
       <Text style={styles.bodyLead}>Defaults are filled in — tweak or continue.</Text>
-      <ConfiguratorBody config={config} onChange={props.onChange} />
+      <ConfiguratorBody
+        config={config}
+        onChange={props.onChange}
+        renderFallback={renderWizardFallback}
+      />
       <ErrorList errors={errors} />
       <NavRow
         onBack={props.onBack}
@@ -339,56 +333,20 @@ const ConfigureStep = (props: ConfigureStepProps): React.JSX.Element => {
   );
 };
 
-interface ConfiguratorBodyProps {
-  config: ModeConfig;
-  onChange: (next: ModeConfig) => void;
-}
-
-type FormComponent<M extends ModeConfig['mode']> = React.ComponentType<{
-  value: Extract<ModeConfig, { mode: M }>;
-  onChange: (next: Extract<ModeConfig, { mode: M }>) => void;
-}>;
-
-type FormTable = { [K in ModeConfig['mode']]: FormComponent<K> | null };
-
-const MODE_FORMS: FormTable = {
-  meditation_timer: MeditationTimerForm,
-  count_up: CountUpForm,
-  metronome: MetronomeForm,
-  interval_bell: IntervalBellForm,
-  random_interval_bell: RandomIntervalBellForm,
-  rep_counter: RepCounterForm,
-  sense_grounding: SenseGroundingForm,
-  tarot: TarotForm,
-  card_meditation: CardMeditationForm,
-  tallied_grounding: TalliedGroundingForm,
-  mindful_anchor: MindfulAnchorForm,
-};
-
 /** Title-case a mode key for user-facing copy (e.g. ``mindful_anchor`` → "Mindful anchor"). */
 const humanizeMode = (mode: string): string => {
   const spaced = mode.replace(/_/g, ' ');
   return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 };
 
-const ConfiguratorBody = ({ config, onChange }: ConfiguratorBodyProps): React.JSX.Element => {
-  type AnyForm = React.ComponentType<{
-    value: ModeConfig;
-    onChange: (next: ModeConfig) => void;
-  }>;
-  const Form = MODE_FORMS[config.mode] as AnyForm | null;
-  if (Form === null) {
-    // Defensive: every current mode has a form, but if a future mode maps to
-    // null the notice must name *that* mode, not a hardcoded one.
-    return (
-      <NoticeView
-        testID="create-practice-configure-fallback"
-        message={`${humanizeMode(config.mode)} will ship with a configurator soon. The defaults below will be saved as-is.`}
-      />
-    );
-  }
-  return <Form value={config} onChange={onChange} />;
-};
+// Defensive: every current mode has a form, but if a future mode maps to null
+// the notice must name *that* mode, not a hardcoded one.
+const renderWizardFallback = (mode: string): React.JSX.Element => (
+  <NoticeView
+    testID="create-practice-configure-fallback"
+    message={`${humanizeMode(mode)} will ship with a configurator soon. The defaults below will be saved as-is.`}
+  />
+);
 
 interface MetadataStepProps {
   state: WizardState;


### PR DESCRIPTION
## Summary

#872 (de-slop): two parallel mode→form dispatchers imported the same 11 per-mode forms, and `RecipeEditorModal` re-hardcoded bounds `engine/validation.ts` already owns.

- New `components/ConfiguratorBody.tsx`: one `MODE_FORMS` table (all 11 modes) + a `renderFallback` seam, consumed by **both** `CreatePracticeWizard` and `RitualConfiguratorSheet` (local dispatchers + 11 form imports removed). Adding a mode is now one edit.
- `RecipeEditorModal` imports the bounds from `engine/validation.ts` (aliased to canonical names); `DESCRIPTION_MAX` stays local (no engine mirror). `validateDraft` logic unchanged.

Pure refactor — same behavior, copy, testIDs.

## Test plan

Existing Practice suites pass unchanged + a new `ConfiguratorBody` test. Grep: one dispatcher, no duplicated bound literals in `RecipeEditorModal`. `./scripts/frontend/check-all.sh` 4/4 (2122).

Closes #872
