### PR TITLE
refactor(backend): tidy-up bundle — stale docstring, dead code, bad_gateway helper

### DIFF
--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -24,6 +24,17 @@ from routers.auth import get_current_user
 logger = logging.getLogger(__name__)
 
 
+def visible_to_user(owner_col: Mapped[int | None], user_id: int) -> ColumnElement[bool]:
+    """WHERE predicate matching system (``owner_user_id IS NULL``) or caller-owned rows.
+
+    The shared read-visibility predicate for the personal-library resources
+    (practice recipes + tags): the caller sees every system row plus their own.
+    List endpoints use it directly; :func:`system_or_owned_clause` ANDs it with
+    an id filter for the single-row lookup.  Pass ``col(Model.owner_user_id)``.
+    """
+    return or_(owner_col.is_(None), owner_col == user_id)
+
+
 def system_or_owned_clause(
     id_col: Mapped[int | None],
     owner_col: Mapped[int | None],
@@ -32,11 +43,11 @@ def system_or_owned_clause(
 ) -> ColumnElement[bool]:
     """WHERE clause for a system (``owner_user_id IS NULL``) or caller-owned row.
 
-    The shared read-visibility predicate for the personal-library resources
-    (practice recipes + tags): the caller sees every system row plus their own.
-    Pass the model's ``col(Model.id)`` / ``col(Model.owner_user_id)``.
+    The single-row variant of :func:`visible_to_user`: ANDs the visibility
+    predicate with an id filter.  Pass the model's ``col(Model.id)`` /
+    ``col(Model.owner_user_id)``.
     """
-    return and_(id_col == obj_id, or_(owner_col.is_(None), owner_col == user_id))
+    return and_(id_col == obj_id, visible_to_user(owner_col, user_id))
 
 
 def require_personal_row(owner_user_id: int | None, *, system_detail: str) -> None:

--- a/backend/src/domain/streaks.py
+++ b/backend/src/domain/streaks.py
@@ -30,20 +30,6 @@ def is_scheduled_on(notification_days: list[str] | None, weekday_name: str) -> b
     return any(day.lower() == target for day in notification_days)
 
 
-def update_streak(
-    current_streak: int,
-    *,
-    did_check_in: bool,
-    is_scheduled_today: bool = True,
-) -> tuple[int, str]:
-    """Increment on check-in, hold on unscheduled miss, reset on scheduled miss."""
-    if did_check_in:
-        return current_streak + 1, "streak_incremented"
-    if not is_scheduled_today:
-        return current_streak, "streak_held"
-    return 0, "streak_reset"
-
-
 @dataclass(frozen=True)
 class SubtractiveContext:
     """Habit-level context required to compute a subtractive streak.

--- a/backend/src/errors.py
+++ b/backend/src/errors.py
@@ -68,6 +68,16 @@ def unprocessable(reason: str) -> HTTPException:
     return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=reason)
 
 
+def bad_gateway(reason: str) -> HTTPException:
+    """Return a 502 HTTPException for an upstream-dependency failure.
+
+    Use this when a downstream provider the request relies on (the LLM
+    provider, the content repository) errors out, so the caller sees a
+    stable snake_case token rather than the raw upstream error.
+    """
+    return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=reason)
+
+
 async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Catch-all handler — log, report to Sentry, return a sanitised envelope.
 

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -15,7 +15,7 @@ from content_config import CONTENT_REF_SCHEME, content_ref
 from database import get_session
 from domain.course import compute_days_elapsed, filter_content_for_user, next_unlock_day
 from domain.stage_progress import ensure_user_progress, get_user_progress, is_stage_unlocked
-from errors import forbidden, not_found
+from errors import bad_gateway, forbidden, not_found
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
@@ -398,10 +398,7 @@ def _read_local_body(read: Callable[[], ContentBody], reference: str) -> Content
         raise not_found("content") from None
     except ContentRepositoryError as exc:
         logger.exception("content_read_failed", extra={"reference": reference})
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=_CONTENT_UNAVAILABLE_DETAIL,
-        ) from exc
+        raise bad_gateway(_CONTENT_UNAVAILABLE_DETAIL) from exc
     return ContentBodyResponse(
         title=body.title,
         content_type=body.content_type,

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Annotated, cast
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Header, Query, Request, Response, status
 from sqlalchemy import ColumnElement, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -18,7 +18,7 @@ from dependencies.timezone import current_user_timezone
 from domain.detection import CompletionDetected, detect_completions
 from domain.practice_resolution import effective_config
 from domain.resonance import MarginaliaAnchored, generate_essay, generate_marginalia
-from errors import conflict, not_found, unprocessable
+from errors import bad_gateway, conflict, not_found, unprocessable
 from models.completion_suggestion import (
     CompletionSuggestion,
     CompletionTargetType,
@@ -418,9 +418,7 @@ async def _generate_marginalia_or_502(
         return await generate_marginalia(message, llm=llm, prior_entries=prior)
     except LLMProviderError as exc:
         await session.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY, detail="llm_provider_error"
-        ) from exc
+        raise bad_gateway("llm_provider_error") from exc
 
 
 @router.post("/{entry_id}/resonance", response_model=ResonanceResponse)
@@ -757,9 +755,7 @@ async def expand_marginalia_essay(
             note=note.note,
         )
     except LLMProviderError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY, detail="llm_provider_error"
-        ) from exc
+        raise bad_gateway("llm_provider_error") from exc
     note.essay = essay
     note.essay_generated_at = datetime.now(UTC)
     await session.commit()

--- a/backend/src/routers/practice_recipes.py
+++ b/backend/src/routers/practice_recipes.py
@@ -31,13 +31,14 @@ from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Select
-from sqlmodel import col, or_, select
+from sqlmodel import col, select
 
 from database import get_session
 from dependencies.ownership import (
     require_owned_user_practice,
     require_personal_row,
     system_or_owned_clause,
+    visible_to_user,
 )
 from domain.practice_resolution import effective_config, effective_name
 from errors import bad_request, conflict, not_found
@@ -165,10 +166,7 @@ def _build_recipe_list_query(user_id: int, mode: str | None) -> Select[tuple[Pra
     complexity that inlining them pushes the endpoint to rank B.
     """
     query = select(PracticeRecipe).where(
-        or_(
-            col(PracticeRecipe.owner_user_id).is_(None),
-            PracticeRecipe.owner_user_id == user_id,
-        )
+        visible_to_user(col(PracticeRecipe.owner_user_id), user_id)
     )
     if mode is not None:
         query = query.where(PracticeRecipe.mode == mode)

--- a/backend/src/routers/practice_tags.py
+++ b/backend/src/routers/practice_tags.py
@@ -25,10 +25,14 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col, or_, select
+from sqlmodel import col, select
 
 from database import get_session
-from dependencies.ownership import require_personal_row, system_or_owned_clause
+from dependencies.ownership import (
+    require_personal_row,
+    system_or_owned_clause,
+    visible_to_user,
+)
 from errors import conflict, not_found
 from models.practice_tag import PracticeTag
 from routers.auth import get_current_user
@@ -74,12 +78,7 @@ async def list_practice_tags(
     """
     query = (
         select(PracticeTag)
-        .where(
-            or_(
-                col(PracticeTag.owner_user_id).is_(None),
-                PracticeTag.owner_user_id == user_id,
-            )
-        )
+        .where(visible_to_user(col(PracticeTag.owner_user_id), user_id))
         .order_by(col(PracticeTag.owner_user_id).nulls_first(), PracticeTag.label)
     )
     items, total = await paginate_query(session, query, pagination)

--- a/backend/src/services/checkin.py
+++ b/backend/src/services/checkin.py
@@ -54,7 +54,6 @@ class _CheckInJob:
     user_id: int
     user_timezone: str
     did_complete: bool
-    is_scheduled: bool
     old_streak: int
     new_streak: int
     # Explicit completion time for a backfilled past day; ``None`` lets the
@@ -327,7 +326,6 @@ async def record_goal_completion(
         user_id=ctx.user_id,
         user_timezone=ctx.user_timezone,
         did_complete=did_complete,
-        is_scheduled=is_scheduled,
         old_streak=old_streak,
         new_streak=new_streak,
         timestamp=_completion_timestamp(completed_on, ctx.user_timezone),

--- a/backend/src/services/streaks.py
+++ b/backend/src/services/streaks.py
@@ -29,7 +29,6 @@ from domain.streaks import (
     current_consecutive_streak,
     subtractive_current_streak,
     sum_units_by_user_day,
-    update_streak,
 )
 from models.goal_completion import GoalCompletion
 from schemas.milestone import Milestone
@@ -42,7 +41,6 @@ __all__ = [
     "compute_consecutive_streak",
     "compute_habit_streak",
     "compute_streak_before_and_after",
-    "update_streak",
 ]
 
 

--- a/backend/src/services/wallet.py
+++ b/backend/src/services/wallet.py
@@ -292,7 +292,8 @@ async def require_user_fresh(session: AsyncSession, user_id: int) -> User:
 async def preflight_deduction(session: AsyncSession, user_id: int) -> SpendResult:
     """Roll over the monthly counter and deduct one BotMason message.
 
-    Shared pre-flight for the streaming and non-streaming chat endpoints.
+    Pre-flight for the BotMason reflection write path (the ``/resonance``
+    endpoint in :mod:`routers.journal`), its sole caller.
     Raises ``400 user_not_found`` if the authenticated user disappeared
     between auth and spend and ``402 insufficient_offerings`` when neither
     wallet has capacity.  Returns the post-deduction :class:`SpendResult`

--- a/backend/tests/domain/test_streaks.py
+++ b/backend/tests/domain/test_streaks.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 
 import pytest
 
-from domain.streaks import current_consecutive_streak, is_scheduled_on, update_streak
+from domain.streaks import current_consecutive_streak, is_scheduled_on
 
 _TODAY = date(2026, 6, 30)
 _YESTERDAY = _TODAY - timedelta(days=1)
@@ -37,32 +37,6 @@ def test_current_consecutive_streak_gap_breaks_chain() -> None:
     """A gap > 1 day ends the walk; only the leading run counts."""
     days_desc = [_TODAY, _YESTERDAY, _TODAY - timedelta(days=3)]
     assert current_consecutive_streak(days_desc, _TODAY) == 2
-
-
-def test_streak_increment() -> None:
-    new_streak, code = update_streak(3, did_check_in=True)
-    assert new_streak == 4
-    assert code == "streak_incremented"
-
-
-def test_streak_reset() -> None:
-    new_streak, code = update_streak(5, did_check_in=False)
-    assert new_streak == 0
-    assert code == "streak_reset"
-
-
-def test_streak_held_when_not_scheduled() -> None:
-    """A miss on a non-scheduled day holds the streak."""
-    new_streak, code = update_streak(5, did_check_in=False, is_scheduled_today=False)
-    assert new_streak == 5
-    assert code == "streak_held"
-
-
-def test_streak_increments_on_unscheduled_day_when_user_checks_in() -> None:
-    """An opportunistic check-in on a non-scheduled day still increments."""
-    new_streak, code = update_streak(2, did_check_in=True, is_scheduled_today=False)
-    assert new_streak == 3
-    assert code == "streak_incremented"
 
 
 def test_is_scheduled_on_none_means_every_day() -> None:

--- a/backend/tests/services/test_streaks.py
+++ b/backend/tests/services/test_streaks.py
@@ -20,7 +20,6 @@ from services.streaks import (
     check_milestones,
     compute_consecutive_streak,
     compute_habit_streak,
-    update_streak,
 )
 
 # ── Frozen clock for date-coupled tests (§5.4 un-flake) ────────────────────
@@ -132,12 +131,6 @@ def test_check_milestones_all_new_when_old_is_zero() -> None:
 
 def test_check_milestones_returns_empty_when_none_reached() -> None:
     assert check_milestones(0, [1, 3, 7]) == []
-
-
-def test_update_streak_is_re_exported_from_service() -> None:
-    """``update_streak`` should stay importable from the service layer too."""
-    assert update_streak(2, did_check_in=True) == (3, "streak_incremented")
-    assert update_streak(99, did_check_in=False) == (0, "streak_reset")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_errors.py
+++ b/backend/tests/test_errors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastapi import HTTPException, status
 
-from errors import bad_request, forbidden, not_found
+from errors import bad_gateway, bad_request, forbidden, not_found
 
 
 def test_not_found_returns_404_with_resource_detail() -> None:
@@ -33,3 +33,10 @@ def test_bad_request_returns_400_with_reason() -> None:
     assert isinstance(exc, HTTPException)
     assert exc.status_code == status.HTTP_400_BAD_REQUEST
     assert exc.detail == "user_already_exists"
+
+
+def test_bad_gateway_returns_502_with_reason() -> None:
+    exc = bad_gateway("llm_provider_error")
+    assert isinstance(exc, HTTPException)
+    assert exc.status_code == status.HTTP_502_BAD_GATEWAY
+    assert exc.detail == "llm_provider_error"


### PR DESCRIPTION
## Summary

#873 (de-slop): five corroborated tidy-ups, each grep-verified dead before removal. No behavior change except the corrected docstring + 502-helper indirection (identical status/detail).

1. `wallet.preflight_deduction` docstring — dropped the deleted "streaming chat" reference; names its real caller (BotMason reflection path).
2. Deleted dead `domain/streaks.update_streak` + its re-export/`__all__` + the re-export test + the 4 domain tests that called it (migrated to `_reason_for_streak_transition` in #782).
3. Deleted dead `_CheckInJob.is_scheduled` field + kwarg (written, never read).
4. Added `errors.bad_gateway(reason)`; routed the 3 inline 502 raises through it (journal 2×, course) + dropped unused imports.
5. Extracted `dependencies/ownership.visible_to_user`; both list endpoints use it instead of the duplicated `or_(owner is None | owner==user)`.

## Test plan

`./scripts/backend/check-all.sh` 7/7 (96% cov), xenon A on all changed modules. Final greps: no `update_streak`/`is_scheduled` refs remain (bar the docstring); no inline 502 literal. Added a `bad_gateway` test.

Closes #873
