### PR TITLE
refactor(frontend): tidy-up bundle — reinvented helpers, dead slots, constant drift

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -4,7 +4,7 @@ import { Animated, Easing, Text, TouchableOpacity, View, type DimensionValue } f
 import { TierStar } from '../../components/TierStar';
 import { colors, STAGE_COLORS, spacing, surface } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
-import { DEFAULT_TIMEZONE } from '../../utils/dateUtils';
+import { DEFAULT_TIMEZONE, MS_PER_DAY } from '../../utils/dateUtils';
 
 import ConfirmDialog from './components/ConfirmDialog';
 import { TIER_LABELS, centeredTranslateX, tooltipBoxStyle, type TierType } from './goalMarker';
@@ -452,7 +452,6 @@ const useHabitTileData = (habit: Habit, tz: string, stageColor: string) => {
 
 const LOCKED_BACKGROUND = '#e8e8e8';
 const LOCKED_OPACITY = 0.4;
-const MS_PER_DAY = 86_400_000;
 
 const calculateDaysUntilUnlock = (startDate: Date): number => {
   const now = new Date();

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -5,6 +5,7 @@ import { STAGE_DURATIONS_DAYS } from '../../constants/program';
 import { brightenColor, colors, STAGE_COLORS, STAGE_ORDER } from '../../design/tokens';
 import {
   DEFAULT_TIMEZONE,
+  MS_PER_DAY,
   dayKeyInTZ,
   streakFromCompletions,
   subtractiveLongestStreakFromCompletions,
@@ -17,8 +18,6 @@ import type { Goal, Habit, Completion, HabitStatsData } from './Habits.types';
 export { STAGE_ORDER };
 // Re-export so existing call sites stay valid; canonical definition lives in src/constants/program.ts.
 export { STAGE_DURATIONS_DAYS };
-
-const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 /**
  * Calculate the start date for a habit based on its order in the onboarding

--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -25,7 +25,7 @@ import DatePicker, { parseISODate, toISODate } from '../../../components/DatePic
 import { colors, STAGE_COLORS } from '../../../design/tokens';
 import styles from '../Habits.styles';
 import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
-import { STAGE_ORDER, calculateHabitStartDate } from '../HabitUtils';
+import { STAGE_ORDER, calculateHabitStartDate, calculateNetEnergy } from '../HabitUtils';
 
 import { ConfirmDialog } from './ConfirmDialog';
 import { HABIT_NAME_MAX_LENGTH, MAX_HABITS, validateAndAddHabit } from './onboardingValidation';
@@ -49,8 +49,8 @@ type RevealPhase = 'idle' | 'showing-scores' | 'sorting' | 'complete';
 
 const sortByNetEnergy = (habits: OnboardingHabit[]): OnboardingHabit[] =>
   [...habits].sort((a, b) => {
-    const netA = a.energy_return - a.energy_cost;
-    const netB = b.energy_return - b.energy_cost;
+    const netA = calculateNetEnergy(a.energy_cost, a.energy_return);
+    const netB = calculateNetEnergy(b.energy_cost, b.energy_return);
     if (netA !== netB) return netB - netA;
     if (a.energy_cost !== b.energy_cost) return a.energy_cost - b.energy_cost;
     return b.energy_return - a.energy_return;
@@ -161,7 +161,7 @@ const ReorderItem = ({ item, index, drag, isActive, onEditIcon }: ReorderItemPro
         <View style={styles.habitEnergyInfo}>
           <Text style={styles.habitEnergyText}>
             Cost: {item.energy_cost} | Return: {item.energy_return} | Net:{' '}
-            {item.energy_return - item.energy_cost}
+            {calculateNetEnergy(item.energy_cost, item.energy_return)}
           </Text>
         </View>
       </Animated.View>
@@ -446,7 +446,7 @@ const RevealStep = ({ habits, revealedScoreCount, revealPhase }: RevealStepProps
             </Text>
             {index < revealedScoreCount && (
               <Text testID="reveal-score" style={revealStyles.score}>
-                Net: {habit.energy_return - habit.energy_cost}
+                Net: {calculateNetEnergy(habit.energy_cost, habit.energy_return)}
               </Text>
             )}
           </View>

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -993,7 +993,7 @@ describe('habitManager', () => {
       expect(ctx).not.toBeNull();
       habitManager.applyLogUnitContext(ctx!);
 
-      expect(ctx!.updated.completions).toHaveLength(1);
+      expect(ctx!.next[0]!.completions).toHaveLength(1);
       expect(useHabitStore.getState().habits[0]!.completions).toHaveLength(1);
     });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -368,7 +368,6 @@ const applyLogUnit = (
 export interface LogUnitContext {
   prev: Habit[];
   next: Habit[];
-  updated: Habit;
   habitName: string;
   /** Amount of units the caller logged in this operation. */
   amount: number;
@@ -956,7 +955,6 @@ export const habitManager = {
     return {
       prev,
       next,
-      updated,
       habitName,
       amount,
       oldProgress,

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -2,9 +2,9 @@
  * ``JournalEntryScreen`` — the long-form page the user writes in.
  *
  * Warm editorial layout: an optional serif title and a large growing serif body
- * on a paper ground, with a reserved right-hand margin column (a pluggable
- * ``renderMargin`` slot the marginalia UI fills in a later issue). The page
- * autosaves as a draft on idle — there is no send button and no chat UI.
+ * on a paper ground, with a reserved right-hand margin column that the
+ * marginalia UI (``MarginStream``) fills inline. The page autosaves as a draft
+ * on idle — there is no send button and no chat UI.
  */
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -51,15 +51,7 @@ const NARROW_BREAKPOINT = 600;
 
 type SaveState = 'idle' | 'typing' | 'saving' | 'saved' | 'error';
 
-/** Context handed to the pluggable margin slot (and exposed for the Resonance CTA). */
-export interface JournalMarginContext {
-  body: string;
-  isIdle: boolean;
-}
-
 export type JournalEntryScreenProps = NativeStackScreenProps<RootStackParamList, 'JournalEntry'> & {
-  /** Pluggable right-margin content (margin notes UI lands in a later issue). */
-  renderMargin?: (_ctx: JournalMarginContext) => React.ReactNode;
   /** Overridable for tests; defaults to {@link AUTOSAVE_DELAY_MS}. */
   autosaveDelayMs?: number;
 };
@@ -630,15 +622,7 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
   );
 }
 
-function JournalPage({
-  ctl,
-  renderMargin,
-  bodyPlaceholder,
-}: {
-  ctl: Controller;
-  renderMargin?: JournalEntryScreenProps['renderMargin'];
-  bodyPlaceholder: string;
-}) {
+function JournalPage({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceholder: string }) {
   const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
   const settle = useSettleIn(useReducedMotion());
   const notes = ctl.resonance.marginalia;
@@ -646,8 +630,7 @@ function JournalPage({
   const hasVisibleSuggestions = suggestions.some((s) => s.status !== 'dismissed');
 
   let marginContent: React.ReactNode;
-  if (renderMargin) marginContent = renderMargin({ body: ctl.autosave.body, isIdle: ctl.isIdle });
-  else if (notes.length > 0 || hasVisibleSuggestions) {
+  if (notes.length > 0 || hasVisibleSuggestions) {
     marginContent = (
       <MarginStream
         notes={notes}
@@ -705,7 +688,6 @@ function readEntrypoint(params: RootStackParamList['JournalEntry']): EntryEntryp
 function JournalEntryScreen({
   route,
   navigation,
-  renderMargin,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
   const { ctx, initialTitle, bodyPlaceholder } = readEntrypoint(route.params);
@@ -719,7 +701,7 @@ function JournalEntryScreen({
   const { editGate, modal } = ctl;
   return (
     <SafeAreaView style={styles.safeArea} testID="journal-screen">
-      <JournalPage ctl={ctl} renderMargin={renderMargin} bodyPlaceholder={bodyPlaceholder} />
+      <JournalPage ctl={ctl} bodyPlaceholder={bodyPlaceholder} />
       <GetResonanceButton
         visible={ctl.visible}
         loading={ctl.resonance.loading}

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -26,12 +26,12 @@ import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { RootStackParamList } from '@/navigation/RootStack';
 import { useDerivedCurrentWeek } from '@/store/useProgramProgression';
+import { MS_PER_DAY } from '@/utils/dateUtils';
 
 const PAGE_SIZE = 20;
 const SEARCH_MIN_LENGTH = 3;
 const SEARCH_MAX_LENGTH = 64; // mirrors the backend JOURNAL_SEARCH_MAX_LENGTH guard
 const EXCERPT_MAX = 140;
-const MS_PER_DAY = 86_400_000;
 const WEEK_DAYS = 7;
 const MONTH_DAYS = 30;
 const WORDS_PER_MINUTE = 200;

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -147,11 +147,9 @@ describe('JournalEntryScreen', () => {
     expect(queryByTestId('journal-margin-count')).toBeNull();
   });
 
-  it('reserves a margin column and renders the renderMargin slot', () => {
-    const renderMargin = jest.fn(() => null);
-    const { getByTestId } = renderScreen(undefined, { renderMargin });
+  it('reserves a margin column for the inline marginalia UI', () => {
+    const { getByTestId } = renderScreen();
     expect(getByTestId('journal-margin-column')).toBeTruthy();
-    expect(renderMargin).toHaveBeenCalled();
   });
 
   it('reserves bottom clearance so the floating Get Resonance button never overlaps content', () => {

--- a/frontend/src/features/Journal/__tests__/useResonance.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonance.test.tsx
@@ -205,7 +205,7 @@ describe('useResonance — suggestions', () => {
     });
     expect(mockAccept).toHaveBeenCalledWith(1);
     expect(result.current.suggestions[0]!.status).toBe('accepted');
-    expect(result.current.lastCheckIn?.streak).toBe(4);
+    expect(result.current.acceptedCheckIns[1]?.streak).toBe(4);
   });
 
   it('accept leaves the row pending and surfaces a friendly error on failure', async () => {

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -35,8 +35,6 @@ export interface UseResonanceArgs {
 export interface UseResonanceResult {
   marginalia: Marginalia[];
   suggestions: CompletionSuggestion[];
-  /** The check-in (streak + milestones) from the most recent accept, if any. */
-  lastCheckIn: CheckInResult | null;
   /** Check-in (streak) per accepted suggestion id, for the confirmed card. */
   acceptedCheckIns: Record<number, CheckInResult | null>;
   loading: boolean;
@@ -95,7 +93,6 @@ function useLoadOnOpen<T>(
 
 interface SuggestionsApi {
   suggestions: CompletionSuggestion[];
-  lastCheckIn: CheckInResult | null;
   /** Check-in (streak) per accepted suggestion id, for the confirmed card. */
   acceptedCheckIns: Record<number, CheckInResult | null>;
   mergeFromGenerate: (_incoming: CompletionSuggestion[]) => void;
@@ -106,7 +103,6 @@ interface SuggestionsApi {
 /** Owns suggestion state: load-on-open, merge, and accept/dismiss with guards. */
 function useSuggestions(routeEntryId: number | null, setError: SetError): SuggestionsApi {
   const [suggestions, setSuggestions] = useState<CompletionSuggestion[]>([]);
-  const [lastCheckIn, setLastCheckIn] = useState<CheckInResult | null>(null);
   const [acceptedCheckIns, setAcceptedCheckIns] = useState<Record<number, CheckInResult | null>>(
     {},
   );
@@ -123,7 +119,6 @@ function useSuggestions(routeEntryId: number | null, setError: SetError): Sugges
       runAccept(id, {
         pendingIdsRef,
         setSuggestions,
-        setLastCheckIn,
         setAcceptedCheckIns,
         setError,
       }),
@@ -137,7 +132,6 @@ function useSuggestions(routeEntryId: number | null, setError: SetError): Sugges
 
   return {
     suggestions,
-    lastCheckIn,
     acceptedCheckIns,
     mergeFromGenerate,
     acceptSuggestion,
@@ -148,7 +142,6 @@ function useSuggestions(routeEntryId: number | null, setError: SetError): Sugges
 interface AcceptDeps {
   pendingIdsRef: MutableRefObject<Set<number>>;
   setSuggestions: Dispatch<SetStateAction<CompletionSuggestion[]>>;
-  setLastCheckIn: Dispatch<SetStateAction<CheckInResult | null>>;
   setAcceptedCheckIns: Dispatch<SetStateAction<Record<number, CheckInResult | null>>>;
   setError: SetError;
 }
@@ -160,7 +153,6 @@ async function runAccept(id: number, deps: AcceptDeps): Promise<void> {
   try {
     const result = await completionSuggestions.accept(id);
     deps.setSuggestions((prev) => mergeSuggestionsById(prev, [result.suggestion]));
-    deps.setLastCheckIn(result.check_in);
     deps.setAcceptedCheckIns((prev) => ({ ...prev, [id]: result.check_in }));
   } catch (err) {
     deps.setError(formatApiError(err)); // row stays pending; user can retry
@@ -264,7 +256,6 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
   return {
     marginalia,
     suggestions: sug.suggestions,
-    lastCheckIn: sug.lastCheckIn,
     acceptedCheckIns: sug.acceptedCheckIns,
     loading,
     error,

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -79,8 +79,8 @@ import { SHOWCASE_SURFACE, SessionSurfaceProvider } from '@/features/Practice/vi
 import TalliedGroundingView from '@/features/Practice/views/TalliedGroundingView';
 import TarotMeditationView from '@/features/Practice/views/TarotMeditationView';
 import { useOptimisticMutation } from '@/hooks/useOptimisticMutation';
+import { MS_PER_DAY } from '@/utils/dateUtils';
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const MS_PER_MINUTE = 60_000;
 const TAROT_DECK_SIZE = 22;
 const KEEP_AWAKE_TAG = 'ritual-engine';

--- a/frontend/src/features/Today/TodayScreen.tsx
+++ b/frontend/src/features/Today/TodayScreen.tsx
@@ -15,14 +15,13 @@ import { useEntrance } from '@/hooks/useEntrance';
 import type { RootTabParamList } from '@/navigation/BottomTabs';
 import { useHabitStore } from '@/store/useHabitStore';
 import {
+  TOTAL_PROGRAM_WEEKS,
   programStage,
   programWeek,
   selectProgramStartDate,
   useProgramStore,
 } from '@/store/useProgramStore';
 import { DEFAULT_TIMEZONE, dayKeyInTZ } from '@/utils/dateUtils';
-
-const TOTAL_WEEKS = 36;
 
 type TodayNav = BottomTabNavigationProp<RootTabParamList>;
 
@@ -51,7 +50,7 @@ function countDoneToday(habits: readonly Habit[]): number {
 /** The showcase hero: greeting + position in the 36-week journey. */
 const TodayHero = ({ week, stage }: { week: number | null; stage: number | null }) => {
   const entrance = useEntrance(0);
-  const position = week === null ? 'Your journey awaits' : `Week ${week} of ${TOTAL_WEEKS}`;
+  const position = week === null ? 'Your journey awaits' : `Week ${week} of ${TOTAL_PROGRAM_WEEKS}`;
   const stageName = stage === null ? null : STAGE_ORDER[stage - 1] ?? null;
   return (
     <Animated.View style={entrance}>

--- a/frontend/src/store/useProgramStore.ts
+++ b/frontend/src/store/useProgramStore.ts
@@ -8,15 +8,15 @@ import {
   loadProgramStartDate,
   saveProgramStartDate,
 } from '../storage/programStorage';
+import { MS_PER_DAY } from '../utils/dateUtils';
 
 import { registerStoreReset } from './registry';
 
-const MS_PER_DAY = 1000 * 60 * 60 * 24;
 const DAYS_PER_WEEK = 7;
 const STAGE_COUNT = STAGE_DURATIONS_DAYS.length;
 const TOTAL_PROGRAM_DAYS = STAGE_DURATIONS_DAYS.reduce((sum, d) => sum + d, 0);
 // Integer-pinned so a future non-7-multiple change to STAGE_DURATIONS_DAYS can't silently leak fractional weeks.
-const TOTAL_PROGRAM_WEEKS = Math.floor(TOTAL_PROGRAM_DAYS / DAYS_PER_WEEK);
+export const TOTAL_PROGRAM_WEEKS = Math.floor(TOTAL_PROGRAM_DAYS / DAYS_PER_WEEK);
 
 export interface ProgramStoreState {
   programStartDate: Date | null;

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -27,6 +27,9 @@
  */
 export const DEFAULT_TIMEZONE = 'UTC';
 
+/** Milliseconds in one calendar day — the single source for day-span math. */
+export const MS_PER_DAY = 86_400_000;
+
 /**
  * Resolve a likely-valid IANA zone, falling back to UTC on error.
  *


### PR DESCRIPTION
## Summary

#874 (de-slop): six corroborated frontend tidy-ups, each grep-verified before change. Pure refactor.

1. OnboardingModal uses `calculateNetEnergy` at its 3 inline sites.
2. Removed dead `LogUnitContext.updated` (test-only reader).
3. Removed dead `useResonance.lastCheckIn` (prod uses `acceptedCheckIns`).
4. Removed dead `JournalEntryScreen.renderMargin` slot (nav-mounted; inline `MarginStream` is real).
5. `TodayScreen` derives the week denominator from the store's `TOTAL_PROGRAM_WEEKS` (not a hardcoded 36).
6. Hoisted one `MS_PER_DAY` into `utils/dateUtils.ts`; replaced the 5 copies.

## Test plan

Grep: no inline net-energy, dead `updated`/`lastCheckIn`/`renderMargin`, or redeclared `MS_PER_DAY`. `./scripts/frontend/check-all.sh` 4/4 (2122).

Closes #874
