### PR TITLE
ci(deps): bridge Dependabot PRs into the Ralph loop

### DIFF
--- a/.claude/commands/ralph-tick.md
+++ b/.claude/commands/ralph-tick.md
@@ -98,6 +98,16 @@ Invoke the **`ci-debugging`** skill on the failing job. Reproduce locally, fix r
 ### 2e. PR open, Gate 3 in progress or Gate 4 not yet posted
 Go to Step 4 (arm the Monitor) and end the turn.
 
+### 2f. `dependencies` issues — the in-flight PR is Dependabot's own branch
+For a `dependencies` issue (filed by `dependabot-to-ralph-issue.yml`), the
+in-flight PR is **Dependabot's PR**, already linked via `Closes`. Push Gate-1/
+Gate-3 fixes **to the Dependabot branch** (Mode 2c/2d) — do **not** open a fresh
+branch or a second PR. A breaking major (e.g. zod 3→4) is a normal Gate-1 TDD
+adaptation: make the code changes, never pin back, suppress, or weaken a gate.
+Dependabot stops rebasing once the PR carries a non-Dependabot commit, so your
+pushes are safe. The three SDK-tied pins (styleq, expo-av, expo-notifications)
+are deferred to the Expo SDK 53 epic (#885), not lifted here.
+
 ---
 
 ## Step 3 — Pick next issue and open a PR

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,18 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    # Batch low-risk patch + minor bumps into a single PR per ecosystem so the
+    # Dependabot → Ralph bridge files one issue per batch instead of one per
+    # dependency. Major bumps stay individual (separate PRs) so they get
+    # focused review — they may carry breaking changes Ralph must adapt to.
+    groups:
+      pip-patch-minor:
+        update-types:
+          - "patch"
+          - "minor"
+    # Grouped batches can exceed the default cap; raise the limit so a weekly
+    # batch plus outstanding majors are never throttled.
+    open-pull-requests-limit: 15
 
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -13,21 +25,28 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    # Batch patch + minor into one PR per run; majors stay individual.
+    groups:
+      npm-patch-minor:
+        update-types:
+          - "patch"
+          - "minor"
+    open-pull-requests-limit: 15
     ignore:
       # react-native-web 0.19.13 requires styleq ^0.1.3; styleq 0.2.x targets
       # RNW 0.20+, so adopting it now desyncs the web style runtime. Unpin this
-      # when react-native-web is upgraded.
+      # when react-native-web is upgraded (Expo SDK 53 epic, #885).
       - dependency-name: "styleq"
         versions: [">=0.2.0"]
       # Expo SDK 52 pins expo-av to ~15.0.2 (verified by `expo install --check`);
       # expo-av 16.x targets SDK 53. Expo packages are managed by `expo install`
       # and must move together with the SDK, not piecemeal. Unpin at the SDK 53
-      # upgrade (where expo-av is also superseded by expo-audio/expo-video).
+      # upgrade (#885), where expo-av is also superseded by expo-audio/expo-video.
       - dependency-name: "expo-av"
         versions: [">=16.0.0"]
       # Expo SDK 52 pins expo-notifications to ~0.29.14 (verified by
       # `expo install --check`); later majors target SDK 53+. Same SDK-managed
-      # rule as expo-av — unpin at the SDK 53 upgrade.
+      # rule as expo-av — unpin at the SDK 53 upgrade (#885).
       - dependency-name: "expo-notifications"
         versions: [">=0.30.0"]
 
@@ -37,3 +56,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci(deps)"
+    # Batch patch + minor action bumps; majors stay individual.
+    groups:
+      actions-patch-minor:
+        update-types:
+          - "patch"
+          - "minor"
+    open-pull-requests-limit: 15

--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -1,0 +1,183 @@
+name: Dependabot → Ralph Issue Bridge
+
+# Bridges Dependabot's PR-only model into Ralph's issue-first loop. Dependabot
+# produces PRs with no GitHub issue and no `Closes #N` line, so they are
+# invisible to `scripts/ralph/pick-next.sh` and rot. This workflow, for each
+# open Dependabot PR, (a) files a Ralph-qualified `dependencies` issue and
+# (b) appends `Closes #<issue>` to the Dependabot PR body — turning the
+# Dependabot PR into Ralph's in-flight PR (Mode B), so Ralph adopts it through
+# its existing path with no duplicate PR. See issue tracker for full design.
+#
+# Two triggers, one idempotent reconciler:
+#   - pull_request_target (dependabot-only): real-time, links a PR as it opens.
+#   - workflow_dispatch + schedule: backfill / safety net; clears the existing
+#     backlog and re-links any PR whose body Dependabot later overwrites.
+#
+# SECURITY — pull_request_target runs with the base-repo token (it has
+# issues:write / pull-requests:write, which a dependabot-triggered
+# `pull_request` run does not). To stay safe we NEVER check out the PR head and
+# NEVER inline untrusted `${{ }}` event fields in a `run:` block — the PR title
+# is passed via an env var so a crafted branch/title cannot inject shell.
+
+on:
+  # Real-time: a Dependabot PR opens or reopens. pull_request_target so the run
+  # has the base-repo token (issues:write / pull-requests:write). Gated to
+  # Dependabot only below.
+  pull_request_target:
+    types: [opened, reopened]
+  # Backfill + safety net: clears the existing Dependabot backlog on first
+  # dispatch and re-links any PR whose body was overwritten. Scheduled a few
+  # hours after Dependabot's weekly Monday window so freshly-opened PRs exist.
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+# Limit the token to exactly what the bridge needs: file issues, edit PR
+# bodies, read repo metadata. No contents:write — we never push code.
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+# Serialize runs so the event-driven and scheduled paths can never race and
+# double-file for the same PR.
+concurrency:
+  group: dependabot-to-ralph-issue
+  cancel-in-progress: false
+
+jobs:
+  bridge:
+    name: File Ralph issues for Dependabot PRs and link them
+    runs-on: ubuntu-latest
+    # On pull_request_target, only act for Dependabot's own PRs. The scheduled
+    # and manual triggers have no actor PR context, so let them through.
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.actor == 'dependabot[bot]'
+    steps:
+      - name: Check out repo metadata only (no PR head)
+        # We never check out or build the PR head — only the base repo, for
+        # nothing more than a clean workspace. The bridge reads PR data via the
+        # gh API, not the checkout.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Bridge Dependabot PRs into Ralph issues
+        env:
+          # Prefer a real PAT (same convention as claude-code-review.yml and
+          # weekly-deslop.yml) so the issue/PR edits are authored by an account
+          # the mobile webhook recognizes; fall back to the run's GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.GEOFFE_GA_PAT || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          # Event-driven PR metadata, read ONLY from the trusted event payload.
+          # The title is passed as an env var (never inlined into a run: block)
+          # to foreclose script injection from a crafted branch/PR title.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # Marker linking an issue back to its Dependabot PR. Hidden HTML
+          # comment in the issue body; the dedup check greps for it so re-runs
+          # never double-file.
+          marker_for() { printf '<!-- dependabot-pr:%s -->' "$1"; }
+
+          # True if a PR body already links an issue via Closes/Fixes/Resolves.
+          body_links_issue() {
+            printf '%s' "$1" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+'
+          }
+
+          # True if an open `dependencies` issue already carries this PR's
+          # marker. Idempotency keystone: a second run finds the marker and
+          # files nothing.
+          issue_exists_for_pr() {
+            local pr="$1" marker
+            marker="$(marker_for "$pr")"
+            gh issue list --repo "$REPO" --label dependencies --state open \
+              --limit 200 --json number,body \
+              --jq '.[].body' 2>/dev/null | grep -qF "$marker"
+          }
+
+          # The working contract, stated verbatim, with a `{PR}` placeholder.
+          # Kept on one source line so it stays indented inside the YAML block
+          # scalar (a heredoc at column 1 would terminate the scalar).
+          contract='Adopt Dependabot PR #{PR} (its branch is already linked via `Closes`). Rebase on `main`, run the relevant `./scripts/<side>/check-all.sh`. **Upgrade fully — if the new major requires code changes, make them** (TDD the adaptation per `stay-green`; no pins-back, no `# type: ignore`, no weakening a gate). Push fixes **to the Dependabot branch**, drive CI + the Claude review to green, squash-merge. Merging closes this issue.'
+
+          # File a Ralph-ready `dependencies` issue for one PR and append
+          # `Closes #<issue>` to that PR's body. No-op if already linked.
+          bridge_pr() {
+            local pr="$1" title="$2" pr_body issue_body issue_num marker
+            marker="$(marker_for "$pr")"
+
+            pr_body="$(gh pr view "$pr" --repo "$REPO" --json body --jq .body)"
+
+            # Skip PRs that already link an issue (Dependabot rarely does, but
+            # a prior bridge run may have).
+            if body_links_issue "$pr_body"; then
+              echo "PR #$pr already links an issue — skipping."
+              return 0
+            fi
+
+            # Dedup against an existing open issue carrying this PR's marker.
+            if issue_exists_for_pr "$pr"; then
+              echo "Issue already exists for PR #$pr (marker present) — skipping."
+              return 0
+            fi
+
+            # Build the Ralph-ready issue body: hidden marker, the verbatim
+            # contract (with {PR} substituted), and a link to the Dependabot PR.
+            local contract_body="${contract//\{PR\}/$pr}"
+            issue_body="$(printf '%s\n\n%s\n\nDependabot PR: #%s\n' \
+              "$marker" "$contract_body" "$pr")"
+
+            # Title mirrors the Dependabot PR so the dep/from/to is legible.
+            # Labels: `dependencies` only — none of pick-next.sh's exclude set,
+            # so the picker treats it as a normal candidate.
+            issue_num="$(gh issue create --repo "$REPO" \
+              --title "chore(deps): adopt Dependabot PR #$pr — $title" \
+              --label dependencies \
+              --body "$issue_body" \
+              | grep -oE '[0-9]+$')"
+
+            echo "Filed issue #$issue_num for PR #$pr."
+
+            # Append `Closes #<issue>` so the Dependabot PR becomes Ralph's
+            # in-flight PR and auto-closes the issue on merge into main.
+            gh pr edit "$pr" --repo "$REPO" \
+              --body "$(printf '%s\n\nCloses #%s' "$pr_body" "$issue_num")"
+
+            echo "Linked PR #$pr → issue #$issue_num via Closes."
+          }
+
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            # Real-time path: bridge just this one PR. Title comes from the env
+            # var, never inlined into the command.
+            echo "Event-driven: bridging Dependabot PR #$PR_NUMBER."
+            bridge_pr "$PR_NUMBER" "$PR_TITLE"
+            exit 0
+          fi
+
+          # Reconciler path (schedule / manual): bridge every open Dependabot
+          # PR that is not yet linked. Idempotent — a re-run files/edits nothing.
+          echo "Reconciler: scanning open Dependabot PRs."
+          prs="$(gh pr list --repo "$REPO" --state open --author 'app/dependabot' \
+            --limit 200 --json number,title,body,headRefName)"
+
+          count="$(printf '%s' "$prs" | jq 'length')"
+          echo "Found $count open Dependabot PR(s)."
+
+          # Iterate without piping into a subshell so set -e propagates.
+          for i in $(seq 0 $((count - 1))); do
+            num="$(printf '%s' "$prs" | jq -r ".[$i].number")"
+            ttl="$(printf '%s' "$prs" | jq -r ".[$i].title")"
+            body="$(printf '%s' "$prs" | jq -r ".[$i].body")"
+            if body_links_issue "$body"; then
+              echo "PR #$num already links an issue — skipping."
+              continue
+            fi
+            bridge_pr "$num" "$ttl"
+          done
+
+          echo "Reconciler complete."

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -69,6 +69,10 @@ drives Gates 3–4.
 - Never write to `main` directly (except `scripts/ralph/state.json`, which the
   orchestrator handles).
 - Never force-push. Rewrite on a fresh branch if needed.
+- **`dependencies` issues:** the in-flight PR is Dependabot's own branch
+  (linked via `Closes`); push fixes **there**, not a fresh branch. A breaking
+  major is a normal Gate-1 TDD adaptation — never pin back, suppress, or weaken
+  a gate. The three SDK-tied pins are deferred to the Expo SDK 53 epic (#885).
 - Never disable a CI check or pre-commit hook, and never lower a quality
   threshold to pass. No `# noqa` / `# type: ignore` / `// @ts-ignore` /
   `// eslint-disable` / `@pytest.mark.skip` without an `Issue #N`


### PR DESCRIPTION
## Summary

#884: Dependabot PRs have no issue + no `Closes #N`, so Ralph (issue → PR → gates → merge) couldn't see them and 14 piled up. Bridge them so Ralph adopts each via its existing Mode B path — no duplicate PR.

- **New `dependabot-to-ralph-issue.yml`**: `pull_request_target` (dependabot-only, real-time) + `schedule` + `workflow_dispatch` reconciler. **Hardened**: no PR-head checkout, `PR_TITLE` via env (never inlined), `permissions` = issues/PR write + contents read, pinned SHA, concurrency. Idempotent reconciler files a Ralph-ready `dependencies` issue per open Dependabot PR (dedup marker) + appends `Closes #<issue>` to the PR body.
- **`dependabot.yml`**: group patch+minor per ecosystem (majors individual), raise the limit; the 3 SDK-tied ignores preserved (→ Expo epic #885).
- **`ralph-tick.md` §2f + `PROMPT.md`**: `dependencies` issues adopt Dependabot's own branch; breaking majors are Gate-1 TDD adaptations, never pinned back.

Infra only. After merge, dispatching the reconciler backfills issues for the 14 open Dependabot PRs, which then drain through Ralph.

## Test plan

`pre-commit` (check-yaml + hygiene) clean; YAML parses; both `check-all` unaffected (no app code).

Closes #884
Refs #885
