### PR TITLE
feat(safety): acute-distress detection domain (care guardrail seam)

### DIFF
--- a/backend/src/domain/safety.py
+++ b/backend/src/domain/safety.py
@@ -1,0 +1,139 @@
+"""Acute-distress screening over a user's free text.
+
+A pure, deterministic *screen* — not a diagnosis, not treatment, not advice. It
+reads text and returns a typed :class:`DistressSignal` saying whether the writing
+contains an **acute** distress signal (explicit suicidal intent, self-harm
+intent, medication cessation, or intent to harm another) and, if so, which
+category matched. Nothing here gives medical, medication, or treatment guidance;
+it only classifies. Later sub-issues wire the signal into a care surface — this
+module is wired into nothing.
+
+Design — deliberately conservative
+----------------------------------
+Adepthood honors ordinary darkness — grief, sadness, emptiness, the "dark night
+of the soul", existential struggle — as real developmental territory, and must
+never pathologize it (NORTH-STAR §10). So matching is intentionally narrow: each
+category fires only on phrasing that expresses *acute intent or action*, anchored
+on word boundaries and matched case-insensitively over whitespace-normalized
+text. When phrasing is ambiguous between ordinary darkness and acute distress we
+prefer **not** to flag — a false negative here is a missed prompt to surface
+human support (added later), while a false positive would shame someone in their
+darkness. The phrase lists below are explicit and auditable rather than clever;
+add to them only with a corresponding negative test guarding ordinary darkness.
+
+Purity: no FastAPI, SQLModel, or network/LLM imports — only the standard library.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+DistressLevel = Literal["none", "elevated"]
+
+
+class DistressCategory(Enum):
+    """Which acute-distress category matched, or ``NONE`` when nothing did."""
+
+    NONE = "none"
+    SUICIDAL_INTENT = "suicidal_intent"
+    SELF_HARM = "self_harm"
+    MEDICATION_CESSATION = "medication_cessation"
+    INTENT_TO_HARM = "intent_to_harm"
+
+
+@dataclass(frozen=True)
+class DistressSignal:
+    """The result of a screen: a level and the matched category.
+
+    ``level`` is ``"elevated"`` only when ``category`` is non-``NONE``; a ``"none"``
+    level always carries :attr:`DistressCategory.NONE`. This is a screen, never a
+    diagnosis.
+    """
+
+    level: DistressLevel
+    category: DistressCategory
+
+
+_NONE = DistressSignal(level="none", category=DistressCategory.NONE)
+
+# Acute-distress phrases per category. Each is matched case-insensitively, on
+# word boundaries, over whitespace-normalized text. They target explicit intent
+# or action — never ordinary sadness, grief, emptiness, or "dark night"
+# reflection, which must pass through as ``none``. Ordering matters only for
+# which category is reported first; categories are checked in list order below.
+_PATTERNS: tuple[tuple[DistressCategory, tuple[str, ...]], ...] = (
+    (
+        DistressCategory.SUICIDAL_INTENT,
+        (
+            r"kill myself",
+            r"end my life",
+            r"take my (?:own )?life",
+            r"want to die",
+            r"going to die tonight",
+            r"better off dead",
+            r"suicidal",
+            r"commit suicide",
+            r"don'?t want to (?:be alive|live) anymore",
+        ),
+    ),
+    (
+        DistressCategory.SELF_HARM,
+        (
+            r"hurt myself",
+            r"harm myself",
+            r"cut myself",
+            r"cutting myself",
+            r"self[ -]harm",
+        ),
+    ),
+    (
+        DistressCategory.INTENT_TO_HARM,
+        (
+            r"kill (?:him|her|them|someone|everyone)",
+            r"hurt (?:him|her|them|someone)",
+            r"going to hurt (?:him|her|them|someone)",
+            r"want to (?:kill|hurt) (?:him|her|them|someone)",
+        ),
+    ),
+    (
+        DistressCategory.MEDICATION_CESSATION,
+        (
+            r"stop(?:ping|ped)? (?:taking )?(?:my )?(?:meds|medication|pills|antidepressants)",
+            r"quit(?:ting)? (?:my )?(?:meds|medication|antidepressants)",
+            r"off my (?:meds|medication|antidepressants)",
+            r"flush(?:ed|ing)? my (?:meds|medication|pills)",
+        ),
+    ),
+)
+
+_COMPILED: tuple[tuple[DistressCategory, re.Pattern[str]], ...] = tuple(
+    (category, re.compile(rf"\b(?:{'|'.join(phrases)})\b", re.IGNORECASE))
+    for category, phrases in _PATTERNS
+)
+
+
+def assess_distress(text: str) -> DistressSignal:
+    """Screen ``text`` for an acute-distress signal; return a typed result.
+
+    Returns :attr:`DistressLevel` ``"elevated"`` with the matched
+    :class:`DistressCategory` when the text contains explicit acute-distress
+    phrasing (suicidal intent, self-harm intent, intent to harm another, or
+    medication cessation), and ``"none"`` otherwise. Empty or whitespace-only
+    text returns ``none``.
+
+    Matching is conservative by design (see the module docstring): it fires only
+    on explicit intent/action phrasing and lets ordinary sadness, grief,
+    emptiness, and "dark night" reflection pass through unflagged, so the app does
+    not pathologize ordinary darkness. This is a screen, not a diagnosis, and
+    introduces no medication, treatment, or medical advice.
+    """
+    normalized = re.sub(r"\s+", " ", text).strip().lower()
+    if not normalized:
+        return _NONE
+    for category, pattern in _COMPILED:
+        if pattern.search(normalized):
+            return DistressSignal(level="elevated", category=category)
+    return _NONE

--- a/backend/tests/domain/test_safety.py
+++ b/backend/tests/domain/test_safety.py
@@ -1,0 +1,81 @@
+"""Tests for the acute-distress screen in :mod:`domain.safety`.
+
+The negative cases are load-bearing: they guard against pathologizing ordinary
+darkness (grief, sadness, emptiness, the "dark night of the soul"), which the app
+honors rather than flags (NORTH-STAR §10).
+"""
+
+import pytest
+
+from domain.safety import DistressCategory, DistressSignal, assess_distress
+
+
+@pytest.mark.parametrize(
+    ("text", "category"),
+    [
+        ("I want to kill myself", DistressCategory.SUICIDAL_INTENT),
+        ("Some nights I just want to die.", DistressCategory.SUICIDAL_INTENT),
+        ("Everyone would be better off dead without me.", DistressCategory.SUICIDAL_INTENT),
+        ("I keep thinking about how to end my life.", DistressCategory.SUICIDAL_INTENT),
+        ("I've been feeling suicidal again.", DistressCategory.SUICIDAL_INTENT),
+        ("I cut myself last night.", DistressCategory.SELF_HARM),
+        ("I want to hurt myself when it gets bad.", DistressCategory.SELF_HARM),
+        ("the self-harm urges came back", DistressCategory.SELF_HARM),
+        ("I'm going to hurt him if he comes back.", DistressCategory.INTENT_TO_HARM),
+        ("I want to kill them all.", DistressCategory.INTENT_TO_HARM),
+        ("I stopped taking my meds two days ago.", DistressCategory.MEDICATION_CESSATION),
+        ("I'm quitting my antidepressants.", DistressCategory.MEDICATION_CESSATION),
+        ("I went off my medication last week.", DistressCategory.MEDICATION_CESSATION),
+        ("I flushed my pills down the toilet.", DistressCategory.MEDICATION_CESSATION),
+    ],
+)
+def test_acute_phrases_flag_elevated_with_category(text: str, category: DistressCategory) -> None:
+    signal = assess_distress(text)
+    assert signal == DistressSignal(level="elevated", category=category)
+
+
+# Curated ordinary-darkness / grief / sadness / existential-struggle phrases.
+# These MUST NOT flag — flagging them would pathologize developmental territory
+# the app deliberately honors.
+_ORDINARY_DARKNESS = [
+    "I feel so empty today.",
+    "the dark night of the soul",
+    "I'm grieving my father.",
+    "everything feels pointless lately",
+    "I'm exhausted and sad.",
+    "I've been so depressed this week.",
+    "I feel like I'm dying inside, metaphorically.",
+    "This grief is killing me, honestly.",
+    "Nothing seems to matter anymore.",
+    "I just want to disappear into the woods for a while.",
+    "I'm tired of my medication's side effects.",
+    "The loneliness has been crushing.",
+    "I cried myself to sleep again.",
+    "I feel hopeless about the future.",
+    "My heart is broken after the breakup.",
+]
+
+
+@pytest.mark.parametrize("text", _ORDINARY_DARKNESS)
+def test_ordinary_darkness_does_not_flag(text: str) -> None:
+    signal = assess_distress(text)
+    assert signal.level == "none"
+    assert signal.category is DistressCategory.NONE
+
+
+@pytest.mark.parametrize("text", ["", "   ", "\n\t  \n"])
+def test_empty_or_whitespace_returns_none(text: str) -> None:
+    assert assess_distress(text) == DistressSignal(level="none", category=DistressCategory.NONE)
+
+
+def test_matching_is_case_insensitive() -> None:
+    assert assess_distress("I WANT TO KILL MYSELF").category is (DistressCategory.SUICIDAL_INTENT)
+
+
+def test_matching_normalizes_internal_whitespace() -> None:
+    assert assess_distress("kill\n   myself").category is DistressCategory.SUICIDAL_INTENT
+
+
+def test_no_substring_false_positive_on_word_boundary() -> None:
+    # "skill" contains "kill" but must not match "kill myself".
+    assert assess_distress("I want to upskill myself professionally.").level == "none"


### PR DESCRIPTION
## Summary

#888 (epic #887, NORTH-STAR §10): no code detected acute distress before a user's writing reached an LLM / was reflected back. Add a **pure, well-tested detection seam** (wired into nothing yet — that's #889+).

- `backend/src/domain/safety.py`: `DistressSignal` (frozen: `level` none|elevated + `DistressCategory`) + `assess_distress(text)` — a conservative, word-boundary-anchored phrase screen. **Stdlib-only**; no FastAPI/SQLModel/LLM/network; **no diagnosis/treatment/medication advice** — classification only.
- **Conservative by design**: fires only on explicit acute intent/action; ordinary "dark night"/grief/sadness/emptiness returns `none` (honors darkness, doesn't pathologize). Word boundaries block substrings ("upskill myself" ≠ "kill myself").

## Test plan

35 tests: every category → `elevated`; **15 curated ordinary-darkness/grief phrases → `none`** (anti-pathologizing); empty → `none`; case/whitespace/boundary edges. `safety.py` 100% line+branch; `./scripts/backend/check-all.sh` 7/7, xenon A.

Closes #888
Refs #887
