### PR TITLE
feat(safety): surface human + professional care on an acute-distress signal

### DIFF
--- a/backend/src/domain/care.py
+++ b/backend/src/domain/care.py
@@ -1,0 +1,116 @@
+"""Non-clinical care resources surfaced on an acute-distress signal.
+
+Pure, reviewable, localizable data — no FastAPI, no DB, no network, no LLM.
+When the resonance pass screens an entry as carrying an acute-distress signal
+(:func:`domain.safety.assess_distress`), the care surface must accompany — and
+never be replaced by — the AI's reflection, so a distressed person is pointed at
+**human and professional** support rather than left alone with a chatbot
+(NORTH-STAR §10).
+
+What this is, and is not
+------------------------
+These are *pointers*, not care: a warm, non-shaming invitation plus a short,
+auditable list of ways to reach a person (988, Crisis Text Line, someone you
+trust) and a professional. There is **no diagnosis, no medication guidance, no
+treatment advice** here — that belongs to a person and their prescriber, not to
+software. The copy is gathered into module constants precisely so it can be
+reviewed and localized in one place rather than scattered through a handler.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+CareKind = Literal["hotline", "text_line", "human", "professional"]
+
+
+@dataclass(frozen=True)
+class CareResource:
+    """One support pointer: a name, how to reach it, and what it is.
+
+    ``kind`` distinguishes the routing — ``hotline``/``text_line`` are immediate
+    crisis lines, ``human`` points at a trusted person, ``professional`` at
+    clinical care. Pure data: nothing here diagnoses or advises on medication.
+    """
+
+    kind: CareKind
+    name: str
+    contact: str
+    what_it_is: str
+
+
+@dataclass(frozen=True)
+class CarePayload:
+    """The full care surface: a warm message plus the structured resources.
+
+    Returned alongside (never instead of) the resonance reflection when an entry
+    screens as elevated, so the response is never *only* AI-generated text.
+    """
+
+    message: str
+    resources: tuple[CareResource, ...]
+
+
+# A warm, non-shaming invitation. It names that reaching a person matters and
+# explicitly does not frame distress as a failure (NORTH-STAR §10). No diagnosis,
+# no medication or treatment advice — only an invitation toward human contact.
+CARE_MESSAGE = (
+    "Reading this, I want to make sure you're not carrying it alone. "
+    "What you're feeling is real, and it does not make you a failure — "
+    "it makes you human. You don't have to face this moment by yourself, "
+    "and reaching out to a person is a sign of strength, not weakness. "
+    "The people below are there for exactly this, any time, and so is "
+    "someone you trust."
+)
+
+# Human + professional support pointers. Order leads with the immediate crisis
+# lines, then a trusted person, then professional care. Pure pointers — no
+# diagnosis, no medication or treatment guidance.
+CARE_RESOURCES: tuple[CareResource, ...] = (
+    CareResource(
+        kind="hotline",
+        name="988 Suicide & Crisis Lifeline",
+        contact="Call or text 988",
+        what_it_is=(
+            "Free, confidential support from a trained human counselor, "
+            "24 hours a day, 7 days a week."
+        ),
+    ),
+    CareResource(
+        kind="text_line",
+        name="Crisis Text Line",
+        contact="Text HOME to 741741",
+        what_it_is=(
+            "Text back and forth with a trained volunteer crisis counselor, any time, for free."
+        ),
+    ),
+    CareResource(
+        kind="human",
+        name="Someone you trust",
+        contact="Reach out to a friend, family member, or anyone you trust",
+        what_it_is=(
+            "You don't have to explain it perfectly — telling one person you're "
+            "struggling can make this moment less heavy."
+        ),
+    ),
+    CareResource(
+        kind="professional",
+        name="A mental-health professional",
+        contact="Contact a therapist, counselor, or your doctor",
+        what_it_is=(
+            "A professional can offer ongoing, personal support. This app builds "
+            "skill and self-knowledge alongside that care — it never replaces it."
+        ),
+    ),
+)
+
+
+def build_care_payload() -> CarePayload:
+    """Return the care surface (warm message + human and professional pointers).
+
+    Pure and deterministic: the same reviewable, localizable constants every
+    time, derived from nothing user-specific so it can never leak across users.
+    Contains no diagnosis, no medication guidance, and no treatment advice.
+    """
+    return CarePayload(message=CARE_MESSAGE, resources=CARE_RESOURCES)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Annotated, cast
 
-from fastapi import APIRouter, Depends, Header, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from sqlalchemy import ColumnElement, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -15,9 +15,11 @@ from sqlmodel import col, select
 from database import get_session
 from dependencies.ownership import require_owned_journal_entry
 from dependencies.timezone import current_user_timezone
+from domain.care import CarePayload, build_care_payload
 from domain.detection import CompletionDetected, detect_completions
 from domain.practice_resolution import effective_config
 from domain.resonance import MarginaliaAnchored, generate_essay, generate_marginalia
+from domain.safety import assess_distress
 from errors import bad_gateway, conflict, not_found, unprocessable
 from models.completion_suggestion import (
     CompletionSuggestion,
@@ -46,6 +48,8 @@ from schemas.journal import (
     JournalMessageResponse,
 )
 from schemas.marginalia import (
+    CareResourceResponse,
+    CareResponse,
     MarginaliaListResponse,
     MarginaliaResponse,
     ResonanceResponse,
@@ -62,7 +66,7 @@ from services.marginalia import (
 )
 from services.practice_session_idempotency import record_session, recorded_session_id
 from services.usage import get_monthly_cap
-from services.wallet import preflight_deduction, require_user_fresh
+from services.wallet import SpendResult, preflight_deduction, require_user_fresh
 
 
 def _sanitize_message(message: str) -> str:
@@ -421,6 +425,115 @@ async def _generate_marginalia_or_502(
         raise bad_gateway("llm_provider_error") from exc
 
 
+def _care_for(body: str) -> CarePayload | None:
+    """Screen ``body`` and return the care payload on an elevated signal, else None.
+
+    Pure and local (no network/LLM): :func:`assess_distress` cannot fail the
+    request, and the payload is built from reviewable constants — derived from
+    this entry alone, so it can never leak across users.
+    """
+    if assess_distress(body).level == "elevated":
+        return build_care_payload()
+    return None
+
+
+def _care_response(payload: CarePayload | None) -> CareResponse | None:
+    """Map a care payload to its response DTO, or ``None`` when not flagged."""
+    if payload is None:
+        return None
+    return CareResponse(
+        message=payload.message,
+        resources=[
+            CareResourceResponse(
+                kind=resource.kind,
+                name=resource.name,
+                contact=resource.contact,
+                what_it_is=resource.what_it_is,
+            )
+            for resource in payload.resources
+        ],
+    )
+
+
+async def _care_only_response(
+    session: AsyncSession, user_id: int, care: CareResponse
+) -> ResonanceResponse:
+    """Care surface with no reflection, used when an elevated entry's LLM pass fails.
+
+    The marginalia charge was already rolled back, so the wallet is unspent; we
+    surface the human + professional pointers regardless, because care must never
+    depend on the LLM succeeding (NORTH-STAR §10).
+    """
+    user = await require_user_fresh(session, user_id)
+    return ResonanceResponse(
+        marginalia=[],
+        suggestions=[],
+        remaining_messages=max(get_monthly_cap() - user.monthly_messages_used, 0),
+        remaining_balance=user.offering_balance,
+        monthly_reset_date=user.monthly_reset_date,
+        care=care,
+    )
+
+
+async def _resonance_pass_or_care(
+    message: str,
+    llm: BotmasonResonanceLLM,
+    prior: list[str],
+    session: AsyncSession,
+    care: CareResponse | None,
+) -> list[MarginaliaAnchored] | None:
+    """Run the literary pass; on an LLM failure return ``None`` iff care can stand in.
+
+    A flagged entry swallows the 502 (the charge was already rolled back) and
+    yields ``None`` so the caller can return a care-only response — care must
+    never depend on the LLM succeeding. An ordinary entry re-raises the 502,
+    preserving today's behavior exactly.
+    """
+    try:
+        return await _generate_marginalia_or_502(message, llm, prior, session)
+    except HTTPException:
+        if care is not None:
+            return None
+        raise
+
+
+async def _persist_resonance(
+    session: AsyncSession,
+    entry: JournalEntry,
+    user_id: int,
+    llm: BotmasonResonanceLLM,
+    anchored: list[MarginaliaAnchored],
+) -> tuple[list[Marginalia], list[CompletionSuggestion]]:
+    """Stage the anchored notes and best-effort completion suggestions for an entry."""
+    entry_id = cast("int", entry.id)
+    rows = _persist_marginalia(session, entry_id, user_id, anchored)
+    suggestions = await _detect_and_persist_suggestions(
+        session, entry_id, entry.message, user_id, llm
+    )
+    return rows, suggestions
+
+
+def _resonance_response(
+    rows: list[Marginalia],
+    suggestions: list[CompletionSuggestion],
+    spent: SpendResult,
+    reset_date: datetime,
+    care: CareResponse | None,
+) -> ResonanceResponse:
+    """Build the success response: notes, suggestions, refreshed balances, care."""
+    return ResonanceResponse(
+        marginalia=[MarginaliaResponse.model_validate(r, from_attributes=True) for r in rows],
+        suggestions=[
+            CompletionSuggestionResponse.model_validate(s, from_attributes=True)
+            for s in suggestions
+        ],
+        remaining_messages=max(get_monthly_cap() - spent.monthly_used, 0),
+        remaining_balance=spent.offering_balance,
+        monthly_reset_date=reset_date,
+        care=care,
+    )
+
+
 @router.post("/{entry_id}/resonance", response_model=ResonanceResponse)
 @limiter.limit("10/minute")
 async def run_resonance(
@@ -435,42 +548,36 @@ async def run_resonance(
     Wallet pre-flight deducts one message (402 when out of capacity). The LLM
     pass + persistence + the charge commit atomically; any provider error rolls
     the deduction back so a failed pass never charges (502 ``llm_provider_error``).
+
+    The entry is first screened for an acute-distress signal with a pure, local
+    check; on an elevated signal the response carries a ``care`` surface (human +
+    professional support) that accompanies — never replaces — the reflection, and
+    is returned even if the LLM pass fails, so care never depends on the LLM
+    (NORTH-STAR §10). An ordinary entry behaves exactly as before (``care`` None).
     """
     entry = await _load_user_entry(session, entry_id, current_user)
     if entry is None:
         raise not_found("journal_entry")
+    # Screen first, with a pure/local check that can't fail the request, so the
+    # care surface is decided independently of the LLM (NORTH-STAR §10).
+    care = _care_response(_care_for(entry.message))
     spent = await preflight_deduction(session, current_user)
     prior = await _recent_prior_bodies(session, current_user, entry_id)
     llm = BotmasonResonanceLLM(resolve_chat_api_key(x_llm_api_key))
-    anchored = await _generate_marginalia_or_502(entry.message, llm, prior, session)
-    rows = _persist_marginalia(session, entry_id, current_user, anchored)
-    suggestions = await _detect_and_persist_suggestions(
-        session, entry_id, entry.message, current_user, llm
-    )
-    user = await require_user_fresh(session, current_user)
-    reset_date = user.monthly_reset_date
+    anchored = await _resonance_pass_or_care(entry.message, llm, prior, session, care)
+    if anchored is None:
+        # The reflection failed but the entry is flagged: surface care regardless.
+        return await _care_only_response(session, current_user, cast("CareResponse", care))
+    rows, suggestions = await _persist_resonance(session, entry, current_user, llm, anchored)
+    spent_user = await require_user_fresh(session, current_user)
     await session.commit()
     for row in (*rows, *suggestions):
         await session.refresh(row)
     logger.info(
         "journal_resonance_generated",
-        extra={
-            "user_id": current_user,
-            "entry_id": entry_id,
-            "count": len(rows),
-            "suggestions": len(suggestions),
-        },
+        extra={"user_id": current_user, "entry_id": entry_id, "count": len(rows)},
     )
-    return ResonanceResponse(
-        marginalia=[MarginaliaResponse.model_validate(r, from_attributes=True) for r in rows],
-        suggestions=[
-            CompletionSuggestionResponse.model_validate(s, from_attributes=True)
-            for s in suggestions
-        ],
-        remaining_messages=max(get_monthly_cap() - spent.monthly_used, 0),
-        remaining_balance=spent.offering_balance,
-        monthly_reset_date=reset_date,
-    )
+    return _resonance_response(rows, suggestions, spent, spent_user.monthly_reset_date, care)
 
 
 @router.get("/{entry_id}/marginalia", response_model=MarginaliaListResponse)

--- a/backend/src/schemas/marginalia.py
+++ b/backend/src/schemas/marginalia.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+from domain.care import CareKind
 from models.marginalia import MarginaliaKind, MarginaliaStatus
 from schemas.completion_suggestion import CompletionSuggestionResponse
 
@@ -32,11 +33,42 @@ class MarginaliaResponse(BaseModel):
     updated_at: datetime
 
 
+class CareResourceResponse(BaseModel):
+    """One non-clinical support pointer in the care surface.
+
+    Mirrors :class:`domain.care.CareResource`: a routing ``kind``, a name, how to
+    reach it, and what it is. Carries no diagnosis or medication guidance.
+    """
+
+    kind: CareKind
+    name: str
+    contact: str
+    what_it_is: str
+
+
+class CareResponse(BaseModel):
+    """The care surface returned when an entry screens as acute distress.
+
+    A warm, non-shaming message plus structured human + professional support
+    pointers (NORTH-STAR §10). Present only on an elevated signal; ``None`` on
+    every ordinary entry. It accompanies the reflection — never replaces it — so
+    a distressed person is never left alone with only AI-generated text.
+    """
+
+    message: str
+    resources: list[CareResourceResponse]
+
+
 class ResonanceResponse(BaseModel):
     """Result of a resonance pass: the new notes plus refreshed wallet balances.
 
     ``suggestions`` carries any completion suggestions detected on the same pass
     (additive, best-effort — empty when none are found or detection failed).
+
+    ``care`` is ``None`` for an ordinary entry (no behavior change); on an acute
+    -distress signal it carries the human + professional support surface, which
+    accompanies — never replaces — the reflection (NORTH-STAR §10). It is derived
+    only from the entry being processed, so it can never leak across users.
     """
 
     marginalia: list[MarginaliaResponse]
@@ -44,6 +76,7 @@ class ResonanceResponse(BaseModel):
     remaining_messages: int
     remaining_balance: int
     monthly_reset_date: datetime
+    care: CareResponse | None = None
 
 
 class MarginaliaListResponse(BaseModel):

--- a/backend/tests/domain/test_care.py
+++ b/backend/tests/domain/test_care.py
@@ -1,0 +1,51 @@
+"""Tests for the non-clinical care resources in :mod:`domain.care`.
+
+These guard the reviewable copy: it routes to human + professional support, is
+warm and non-shaming, and carries no diagnosis or medication guidance
+(NORTH-STAR §10).
+"""
+
+from __future__ import annotations
+
+from domain.care import (
+    CARE_MESSAGE,
+    CARE_RESOURCES,
+    CarePayload,
+    CareResource,
+    build_care_payload,
+)
+
+
+def test_payload_carries_the_message_and_all_resources() -> None:
+    payload = build_care_payload()
+    assert isinstance(payload, CarePayload)
+    assert payload.message == CARE_MESSAGE
+    assert payload.resources == CARE_RESOURCES
+    assert all(isinstance(resource, CareResource) for resource in payload.resources)
+
+
+def test_routes_to_human_and_professional_support() -> None:
+    kinds = {resource.kind for resource in CARE_RESOURCES}
+    # Immediate human lines, a trusted person, and a professional.
+    assert {"hotline", "text_line", "human", "professional"} <= kinds
+
+
+def test_includes_the_expected_crisis_pointers() -> None:
+    blob = " ".join(f"{r.name} {r.contact} {r.what_it_is}" for r in CARE_RESOURCES)
+    assert "988" in blob
+    assert "741741" in blob
+    assert "trust" in blob.lower()
+
+
+def test_message_is_warm_and_non_shaming() -> None:
+    lowered = CARE_MESSAGE.lower()
+    # Explicitly reframes distress as not a failure; never shaming.
+    assert "failure" in lowered
+    assert "alone" in lowered
+
+
+def test_contains_no_diagnosis_or_medication_guidance() -> None:
+    blob = " ".join(f"{r.name} {r.contact} {r.what_it_is}" for r in (*CARE_RESOURCES,)).lower()
+    blob += " " + CARE_MESSAGE.lower()
+    for banned in ("diagnos", "medication", "prescri", "dosage", "pill", "antidepressant"):
+        assert banned not in blob

--- a/backend/tests/test_resonance_endpoints.py
+++ b/backend/tests/test_resonance_endpoints.py
@@ -194,6 +194,110 @@ async def test_list_marginalia_is_ordered_and_hides_user_id(
     assert all("user_id" not in i for i in items)
 
 
+# An entry body the acute-distress screen flags (see domain.safety) — used to
+# exercise the care surface without depending on resonance LLM output.
+_DISTRESS_BODY = "I keep thinking I want to kill myself and end my life tonight."
+
+
+def _assert_care_routes_to_human_and_professional(care: dict[str, object]) -> None:
+    """Assert the care payload carries the human + professional pointers + a warm note."""
+    assert isinstance(care["message"], str)
+    lowered = care["message"].lower()
+    # Warm and non-shaming: names that distress is not a failure.
+    assert "failure" in lowered
+    blob = json.dumps(care).lower()
+    assert "988" in blob  # immediate crisis line (human counselor)
+    assert "741741" in blob  # crisis text line
+    assert "trust" in blob  # someone you trust (human)
+    assert "professional" in blob  # professional support
+    resources = care["resources"]
+    assert isinstance(resources, list)
+    kinds = {r["kind"] for r in resources if isinstance(r, dict)}
+    assert {"hotline", "text_line", "human", "professional"} <= kinds
+
+
+@pytest.mark.asyncio
+async def test_normal_entry_returns_no_care(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-distress entry is unchanged: care is None, marginalia intact."""
+    _fake_llm(
+        monkeypatch,
+        {"kind": "theme", "quote": "I walked by the river", "note": "You return to water."},
+    )
+    headers = await _signup(async_client, "calm")
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["care"] is None
+    assert len(body["marginalia"]) == 1
+    assert body["remaining_messages"] == 49
+
+
+@pytest.mark.asyncio
+async def test_distress_entry_returns_care_alongside_reflection(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A flagged entry returns the care surface AND the reflection (never only AI)."""
+    _fake_llm(
+        monkeypatch,
+        {"kind": "theme", "quote": "kill myself", "note": "You are not alone in this."},
+    )
+    headers = await _signup(async_client, "flagged")
+    entry_id = await _create_entry(async_client, headers, body=_DISTRESS_BODY)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["care"] is not None
+    _assert_care_routes_to_human_and_professional(body["care"])
+    # Care accompanies the reflection — it is additive, not a replacement.
+    assert len(body["marginalia"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_distress_entry_returns_care_even_when_llm_fails(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Care must not depend on the LLM: a flagged entry surfaces care on an LLM error.
+
+    The reflection is absent (marginalia empty) and the charge is rolled back, but
+    the human + professional pointers are returned regardless (NORTH-STAR §10).
+    """
+    _raise_llm(monkeypatch)
+    headers = await _signup(async_client, "flagged_err")
+    entry_id = await _create_entry(async_client, headers, body=_DISTRESS_BODY)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["care"] is not None
+    _assert_care_routes_to_human_and_professional(body["care"])
+    assert body["marginalia"] == []
+    # No reflection persisted, and the charge was rolled back.
+    rows = (await db_session.execute(select(func.count()).select_from(Marginalia))).scalar_one()
+    assert rows == 0
+    user = (
+        await db_session.execute(select(User).where(col(User.email) == "flagged_err@example.com"))
+    ).scalar_one()
+    assert user.monthly_messages_used == 0
+
+
+@pytest.mark.asyncio
+async def test_normal_entry_llm_error_is_502_no_care(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-flagged entry keeps today's behavior on an LLM error: 502, no care."""
+    _raise_llm(monkeypatch)
+    headers = await _signup(async_client, "calm_err")
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_GATEWAY
+
+
 @pytest.mark.asyncio
 async def test_list_marginalia_other_users_entry_is_404(
     async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

#889 (epic #887, NORTH-STAR §10): a distressed entry returned only AI margin notes. Now an `elevated` distress signal surfaces **human + professional** support, and AI reflection is never the only response.

- New `domain/care.py` (pure data): warm non-shaming `CARE_MESSAGE` + `CARE_RESOURCES` (988, Crisis Text Line 741741, someone you trust, a professional). **No diagnosis/medication/treatment guidance**; deterministic from constants; no FastAPI/DB/LLM imports.
- `ResonanceResponse.care` optional field (None on ordinary entries).
- `run_resonance`: `assess_distress` runs **first** (pure/local); care computed **before** the LLM and **independent** of it — a flagged entry whose marginalia 502s returns care-only (charge rolled back); a non-flagged entry re-raises 502. Success → care accompanies reflection.

**No regression**: non-distress entries return `care=None`, everything else unchanged.

## Test plan

Care alongside reflection; care even when the LLM errors; normal `care=None` unchanged; normal LLM error still 502; resources route to human+professional, no diagnosis/medication terms. `care.py`/schema 100%; `./scripts/backend/check-all.sh` 7/7, xenon A.

Closes #889
Refs #887
