### PR TITLE
feat(safety): medication-safety guardrail in every model-bound prompt

### DIFF
--- a/backend/src/domain/care.py
+++ b/backend/src/domain/care.py
@@ -106,6 +106,22 @@ CARE_RESOURCES: tuple[CareResource, ...] = (
 )
 
 
+# A safety instruction addressed to the *model*, embedded in every prompt that
+# sends a user's writing to an LLM. NORTH-STAR §10 ("Wellbeing and care
+# boundaries") draws a hard line: the app never advises anyone to reduce or stop
+# psychiatric medication — that decision belongs to a person and their
+# prescriber. Wording it as a single shared constant means each prompt builder
+# imports the same boundary, so it can be reviewed and revised in exactly one
+# place rather than drifting across builders.
+MEDICATION_GUARDRAIL = (
+    "Safety boundary: never advise the writer to reduce, stop, or change any "
+    "medication — including psychiatric medication — and never suggest a "
+    "specific dose. That decision belongs to the writer and their prescriber. "
+    "Affirm the writer's agency and, when medication comes up, defer it to them "
+    "and their prescriber rather than offering medical direction."
+)
+
+
 def build_care_payload() -> CarePayload:
     """Return the care surface (warm message + human and professional pointers).
 

--- a/backend/src/domain/detection.py
+++ b/backend/src/domain/detection.py
@@ -17,6 +17,7 @@ import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from domain.care import MEDICATION_GUARDRAIL
 from domain.resonance import ResonanceLLM, _quote_span
 from security import TextTooLongError, sanitize_user_text
 
@@ -70,9 +71,14 @@ def build_detection_prompt(body: str, candidates: Sequence[DetectionCandidate]) 
     Candidates are numbered by ``index``; the model returns that index plus a
     verbatim quote. The instruction excludes intentions, plans, and avoidance so
     "I want to meditate" or "I skipped sugar" is not read as a completion.
+
+    Leads with :data:`~domain.care.MEDICATION_GUARDRAIL`; the botmason adapter also
+    injects it at the system role, so it is intentionally present twice on this
+    path (defense-in-depth) — do not remove either copy.
     """
     listed = "\n".join(f"{c.index}. {c.name} ({c.target_type})" for c in candidates)
     return (
+        f"{MEDICATION_GUARDRAIL}\n\n"
         "You read a journal entry and decide which of the listed habits or "
         "practices the writer actually DID or COMPLETED in it.\n\n"
         "Rules:\n"

--- a/backend/src/domain/resonance.py
+++ b/backend/src/domain/resonance.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
+from domain.care import MEDICATION_GUARDRAIL
 from security import TextTooLongError, sanitize_user_text
 
 # Kept as literals (not imported from models.marginalia) so the domain stays
@@ -57,7 +58,13 @@ class ResonanceLLM(Protocol):
 def build_prompt(
     body: str, prior_entries: Sequence[str] | None = None, max_notes: int = _DEFAULT_MAX_NOTES
 ) -> str:
-    """Build the structured prompt asking for up to ``max_notes`` margin notes."""
+    """Build the structured prompt asking for up to ``max_notes`` margin notes.
+
+    Leads with :data:`~domain.care.MEDICATION_GUARDRAIL`. The botmason adapter
+    (:class:`services.marginalia.BotmasonResonanceLLM`) also injects the same
+    guardrail at the system role, so it is intentionally present twice on this
+    path (defense-in-depth) — do not "deduplicate" by removing either copy.
+    """
     prior_block = ""
     if prior_entries:
         capped = [entry[:_PRIOR_ENTRY_CHARS] for entry in prior_entries[:MAX_PRIOR_ENTRIES]]
@@ -67,6 +74,7 @@ def build_prompt(
             f"<prior>\n{joined}\n</prior>"
         )
     return (
+        f"{MEDICATION_GUARDRAIL}\n\n"
         "You are a thoughtful reader leaving margin notes on someone's journal "
         "page. Read the entry and surface up to "
         f"{max_notes} of the most resonant observations.\n\n"
@@ -180,8 +188,14 @@ async def generate_marginalia(
 
 
 def _build_essay_prompt(body: str, anchor_text: str, kind: str, note: str) -> str:
-    """Build the prompt expanding one margin note into a short letter-like essay."""
+    """Build the prompt expanding one margin note into a short letter-like essay.
+
+    Leads with :data:`~domain.care.MEDICATION_GUARDRAIL`; the botmason adapter also
+    injects it at the system role, so it is intentionally present twice on this
+    path (defense-in-depth) — do not remove either copy.
+    """
     return (
+        f"{MEDICATION_GUARDRAIL}\n\n"
         "You are writing a short, warm letter to the person whose journal this is, "
         f"expanding on a margin note you left. Stay grounded in the passage you "
         f"anchored to; speak in second person; never refer to yourself as an AI.\n\n"

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -20,6 +20,7 @@ from types import ModuleType
 
 from fastapi import HTTPException
 
+from domain.care import MEDICATION_GUARDRAIL
 from errors import bad_request, payment_required
 from security import sanitize_user_text
 
@@ -381,13 +382,18 @@ def _make_nonce() -> str:
 
 
 def _augment_system_prompt(system_prompt: str, nonce: str) -> str:
-    """Return ``system_prompt`` with the per-request delimiter instruction appended.
+    """Return ``system_prompt`` with the safety guardrail + delimiter instruction.
 
-    Pulled into a helper so OpenAI and Anthropic builders share the wording
-    and so tests can assert that the instruction lands inside the system role
-    (not a user turn).
+    Both builders (OpenAI and Anthropic) route their system prompt through here,
+    so this is the single seam where every authoritative instruction is added at
+    build time. Injecting the medication-safety guardrail
+    (:data:`domain.care.MEDICATION_GUARDRAIL`, NORTH-STAR §10) here — rather than
+    hard-appending it to ``_DEFAULT_SYSTEM_PROMPT`` — guarantees it travels with
+    an operator-supplied ``BOTMASON_SYSTEM_PROMPT`` too, so the boundary cannot
+    be dropped by configuration. It lands in the system role, never a user turn.
     """
-    return system_prompt + "\n\n" + _DELIMITER_INSTRUCTION_TEMPLATE.format(nonce=nonce)
+    delimiter_instruction = _DELIMITER_INSTRUCTION_TEMPLATE.format(nonce=nonce)
+    return f"{system_prompt}\n\n{MEDICATION_GUARDRAIL}\n\n{delimiter_instruction}"
 
 
 def _wrap_user_input(text: str, nonce: str) -> str:

--- a/backend/tests/domain/test_care.py
+++ b/backend/tests/domain/test_care.py
@@ -3,6 +3,11 @@
 These guard the reviewable copy: it routes to human + professional support, is
 warm and non-shaming, and carries no diagnosis or medication guidance
 (NORTH-STAR §10).
+
+The :data:`~domain.care.MEDICATION_GUARDRAIL` tests (issue #890) assert the
+single-source-of-truth constant exists and carries the load-bearing concepts
+mandated by NORTH-STAR §10: never advise reducing/stopping/changing medication,
+and defer that decision to the user and their prescriber.
 """
 
 from __future__ import annotations
@@ -10,6 +15,7 @@ from __future__ import annotations
 from domain.care import (
     CARE_MESSAGE,
     CARE_RESOURCES,
+    MEDICATION_GUARDRAIL,
     CarePayload,
     CareResource,
     build_care_payload,
@@ -49,3 +55,49 @@ def test_contains_no_diagnosis_or_medication_guidance() -> None:
     blob += " " + CARE_MESSAGE.lower()
     for banned in ("diagnos", "medication", "prescri", "dosage", "pill", "antidepressant"):
         assert banned not in blob
+
+
+# ---------------------------------------------------------------------------
+# MEDICATION_GUARDRAIL — issue #890
+# ---------------------------------------------------------------------------
+
+
+def test_medication_guardrail_is_a_non_empty_string() -> None:
+    """MEDICATION_GUARDRAIL must be a non-empty str (the constant exists and is usable)."""
+    assert isinstance(MEDICATION_GUARDRAIL, str)
+    assert len(MEDICATION_GUARDRAIL.strip()) > 0
+
+
+def test_medication_guardrail_references_medication() -> None:
+    """The guardrail must mention the word 'medication' so it is unambiguous in scope."""
+    assert "medication" in MEDICATION_GUARDRAIL.lower()
+
+
+def test_medication_guardrail_names_prescriber() -> None:
+    """The guardrail must defer medication decisions to a prescriber (NORTH-STAR §10).
+
+    NORTH-STAR §10: 'that decision belongs to a person and their prescriber'.
+    The constant must reference 'prescriber' so the boundary is explicit and
+    machine-auditable across all prompt builders that embed it.
+    """
+    assert "prescriber" in MEDICATION_GUARDRAIL.lower()
+
+
+def test_medication_guardrail_contains_never_advise_notion() -> None:
+    """The guardrail must carry a prohibition on advising medication changes.
+
+    Acceptable phrasings include 'never advise', 'do not advise', 'never
+    recommend', or equivalent.  We assert on the negative-instruction root
+    'never' or 'do not' combined with the domain concept 'reduc' (reduce/
+    reducing), 'stop', or 'chang' (change/changing).  At least one of the
+    three target verbs must appear in the guardrail so the implementer is
+    forced to address the core prohibition, not just gesture at it.
+    """
+    lowered = MEDICATION_GUARDRAIL.lower()
+    # The constant must carry a negation word paired with the prohibited action.
+    has_negation = "never" in lowered or "do not" in lowered or "not advise" in lowered
+    has_prohibited_verb = any(v in lowered for v in ("reduc", "stop", "chang"))
+    assert has_negation, "guardrail must contain a negation instruction (never / do not)"
+    assert has_prohibited_verb, (
+        "guardrail must reference the prohibited action (reduce/stop/change medication)"
+    )

--- a/backend/tests/domain/test_detection_service.py
+++ b/backend/tests/domain/test_detection_service.py
@@ -1,0 +1,67 @@
+"""Guardrail-presence tests for :mod:`domain.detection` prompt builder.
+
+Issue #890 — medication-safety guardrail in every prompt that sends user writing
+to a model.  This module asserts that :data:`~domain.care.MEDICATION_GUARDRAIL`
+is embedded in the output of :func:`~domain.detection.build_detection_prompt`.
+
+The constant does not yet exist in :mod:`domain.care`; these tests therefore
+FAIL on import (``ImportError: cannot import name 'MEDICATION_GUARDRAIL'``) until
+the implementation-specialist adds it.  That is the correct RED state.
+"""
+
+from __future__ import annotations
+
+from domain.care import MEDICATION_GUARDRAIL
+from domain.detection import DetectionCandidate, build_detection_prompt
+
+# ---------------------------------------------------------------------------
+# Fixtures shared across this module
+# ---------------------------------------------------------------------------
+
+_BODY = (
+    "This morning I meditated for twenty minutes by the window. "
+    "Later I went for a run along the river. "
+    "I planned to journal tonight but never got to it."
+)
+
+_CANDIDATES = (
+    DetectionCandidate(index=0, target_type="habit", target_id=10, name="Meditation"),
+    DetectionCandidate(index=1, target_type="practice", target_id=20, name="Run"),
+    DetectionCandidate(index=2, target_type="habit", target_id=30, name="Journal"),
+)
+
+
+# ---------------------------------------------------------------------------
+# build_detection_prompt — completion-detection prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_detection_prompt_contains_medication_guardrail() -> None:
+    """MEDICATION_GUARDRAIL must be a substring of build_detection_prompt(<body>, <candidates>).
+
+    The detection prompt embeds the journal entry body verbatim and sends it to
+    the model; the guardrail must accompany that call (NORTH-STAR §10).
+    The assertion pins the imported constant — not a copied literal — so the
+    single source of truth in :mod:`domain.care` drives all builders.
+    """
+    prompt = build_detection_prompt(_BODY, _CANDIDATES)
+    assert MEDICATION_GUARDRAIL in prompt, (
+        "build_detection_prompt must embed MEDICATION_GUARDRAIL verbatim so it "
+        "reaches the model on every completion-detection call"
+    )
+
+
+def test_build_detection_prompt_guardrail_present_with_single_candidate() -> None:
+    """Guardrail appears even when there is only one candidate (edge case)."""
+    single = (DetectionCandidate(index=0, target_type="habit", target_id=10, name="Meditation"),)
+    prompt = build_detection_prompt(_BODY, single)
+    assert MEDICATION_GUARDRAIL in prompt
+
+
+# ---------------------------------------------------------------------------
+# Non-regression: JSON / anchoring contract must not break
+# ---------------------------------------------------------------------------
+# The guardrail is appended as instruction text; it must not corrupt the
+# structured JSON contract the model returns.  The parse/anchor tests in
+# ``tests/test_detection_service.py`` exercise that contract; we defer to
+# them rather than duplicating here.

--- a/backend/tests/domain/test_resonance_service.py
+++ b/backend/tests/domain/test_resonance_service.py
@@ -1,0 +1,81 @@
+"""Guardrail-presence tests for :mod:`domain.resonance` prompt builders.
+
+Issue #890 — medication-safety guardrail in every prompt that sends user writing
+to a model.  These tests assert that :data:`~domain.care.MEDICATION_GUARDRAIL`
+is embedded in the output of every resonance prompt builder, pinning the
+single-source-of-truth constant rather than a copied literal.
+
+The constant does not yet exist in :mod:`domain.care`; these tests therefore
+FAIL on import (``ImportError: cannot import name 'MEDICATION_GUARDRAIL'``) until
+the implementation-specialist adds it.  That is the correct RED state.
+"""
+
+from __future__ import annotations
+
+from domain.care import MEDICATION_GUARDRAIL
+from domain.resonance import _build_essay_prompt, build_prompt
+
+# ---------------------------------------------------------------------------
+# Fixtures shared across this module
+# ---------------------------------------------------------------------------
+
+_BODY = (
+    "Today I walked by the river and felt the old fear rise again. "
+    "But I noticed the willow bending without breaking, and something settled."
+)
+
+_ANCHOR_TEXT = "the willow bending without breaking"
+_KIND = "symbol"
+_NOTE = "The willow holds you."
+
+
+# ---------------------------------------------------------------------------
+# build_prompt — main resonance prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_prompt_contains_medication_guardrail() -> None:
+    """MEDICATION_GUARDRAIL must be a substring of build_prompt(<body>).
+
+    The guardrail is sourced from :data:`domain.care.MEDICATION_GUARDRAIL` so
+    the constant is the single source of truth; a copied literal would not
+    satisfy this test if the constant wording changes.
+    """
+    prompt = build_prompt(_BODY)
+    assert MEDICATION_GUARDRAIL in prompt, (
+        "build_prompt must embed MEDICATION_GUARDRAIL verbatim so it reaches "
+        "the model on every resonance call"
+    )
+
+
+def test_build_prompt_with_prior_entries_contains_medication_guardrail() -> None:
+    """Guardrail must survive the prior-entries branch of build_prompt."""
+    prompt = build_prompt(_BODY, prior_entries=["An earlier entry about water."])
+    assert MEDICATION_GUARDRAIL in prompt
+
+
+# ---------------------------------------------------------------------------
+# _build_essay_prompt — expansion prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_essay_prompt_contains_medication_guardrail() -> None:
+    """MEDICATION_GUARDRAIL must be a substring of _build_essay_prompt(...).
+
+    The essay builder sends the full entry body to the model; the guardrail
+    must accompany that call too (NORTH-STAR §10).
+    """
+    prompt = _build_essay_prompt(_BODY, _ANCHOR_TEXT, _KIND, _NOTE)
+    assert MEDICATION_GUARDRAIL in prompt, (
+        "_build_essay_prompt must embed MEDICATION_GUARDRAIL verbatim"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-regression: existing parse / anchoring contract must not break
+# ---------------------------------------------------------------------------
+# The added guardrail text is instruction overhead injected into the system /
+# prompt string; it must not interfere with the JSON parsing contract.
+# The parse-and-anchor tests live in ``tests/test_resonance_service.py``
+# (the top-level module that was the original home for resonance tests).
+# We do not duplicate them here — see that file for coverage.

--- a/backend/tests/services/test_botmason_wrapping.py
+++ b/backend/tests/services/test_botmason_wrapping.py
@@ -8,6 +8,12 @@ unguessable nonce in the tag name closes that vector.
 Sanitization runs inside the wrapper so any zero-width / bidi codepoints in
 either the new user message or replayed history get stripped before the
 prompt reaches the model.
+
+Issue #890 adds :class:`TestMedicationGuardrailInSystemPrompt` which asserts
+that :data:`~domain.care.MEDICATION_GUARDRAIL` reaches the model inside the
+system role for both the OpenAI path (:func:`_build_messages`) and the
+Anthropic path (:func:`_build_anthropic_messages`), covering both the default
+system prompt and an operator-supplied ``BOTMASON_SYSTEM_PROMPT``.
 """
 
 from __future__ import annotations
@@ -16,7 +22,9 @@ import re
 
 import pytest
 
+from domain.care import MEDICATION_GUARDRAIL
 from services.botmason import (
+    _DEFAULT_SYSTEM_PROMPT,
     _augment_system_prompt,
     _build_anthropic_messages,
     _build_messages,
@@ -273,3 +281,108 @@ class TestBuildMessagesKeyErrorSafety:
         assert messages[0]["content"].endswith(">")
         # The augmented system prompt is unaffected by malformed history rows.
         assert _NONCE_RE.search(augmented) is not None
+
+
+class TestMedicationGuardrailInSystemPrompt:
+    """MEDICATION_GUARDRAIL must land in the system role for every message builder.
+
+    Issue #890: a shared safety constant must accompany every prompt that sends
+    user writing to a model.  These tests pin the import from
+    :data:`domain.care.MEDICATION_GUARDRAIL` so that the single source of truth
+    drives every builder — changing the constant wording in one place propagates
+    automatically.
+
+    Both the OpenAI path (``_build_messages``, where system is the first list
+    entry with ``role == "system"``) and the Anthropic path
+    (``_build_anthropic_messages``, where system is the second return value)
+    must carry the guardrail.
+
+    Two system-prompt cases are covered for each builder:
+
+    1. **Default system prompt** — ``_DEFAULT_SYSTEM_PROMPT`` is passed through
+       unchanged; the implementation must inject the guardrail at build time.
+    2. **Operator-supplied system prompt** — an arbitrary string is passed as
+       ``system_prompt``; the implementation must still inject the guardrail
+       even when the operator did not include it, so operators cannot
+       accidentally omit it.
+    """
+
+    # --- OpenAI path (_build_messages) ---
+
+    def test_openai_default_system_prompt_contains_guardrail(self) -> None:
+        """Guardrail is present in the system message when using the default prompt."""
+        messages = _build_messages("hello", [], _DEFAULT_SYSTEM_PROMPT)
+        system_message = messages[0]
+        assert system_message["role"] == "system"
+        assert MEDICATION_GUARDRAIL in system_message["content"], (
+            "_build_messages must embed MEDICATION_GUARDRAIL in the system role "
+            "when the default system prompt is used"
+        )
+
+    def test_openai_operator_supplied_system_prompt_contains_guardrail(self) -> None:
+        """Guardrail is present in the system message even with an operator prompt.
+
+        This is the critical regression guard: an operator could configure a
+        custom ``BOTMASON_SYSTEM_PROMPT`` that does not mention medication at
+        all.  The implementation must inject the guardrail at build time
+        regardless of what the operator provided, so the safety boundary cannot
+        be bypassed by configuration.
+        """
+        operator_prompt = "You are a helpful wellness companion. Be warm and concise."
+        messages = _build_messages("hello", [], operator_prompt)
+        system_message = messages[0]
+        assert system_message["role"] == "system"
+        assert MEDICATION_GUARDRAIL in system_message["content"], (
+            "_build_messages must embed MEDICATION_GUARDRAIL even when an "
+            "operator-supplied system prompt that lacks the guardrail is used"
+        )
+
+    def test_openai_guardrail_is_in_system_role_not_user_turn(self) -> None:
+        """The guardrail must land in the system role, not injected as a user turn."""
+        messages = _build_messages("hello", [], _DEFAULT_SYSTEM_PROMPT)
+        # The guardrail belongs in the authoritative system role...
+        assert messages[0]["role"] == "system"
+        assert MEDICATION_GUARDRAIL in messages[0]["content"], (
+            "guardrail must be present in the system role message"
+        )
+        # ...and must NOT live in a user turn (where crafted input could displace it).
+        user_turns_content = " ".join(m["content"] for m in messages if m["role"] == "user")
+        assert MEDICATION_GUARDRAIL not in user_turns_content
+
+    # --- Anthropic path (_build_anthropic_messages) ---
+
+    def test_anthropic_default_system_prompt_contains_guardrail(self) -> None:
+        """Guardrail is present in the augmented system string on the Anthropic path."""
+        _messages, augmented_system = _build_anthropic_messages("hello", [], _DEFAULT_SYSTEM_PROMPT)
+        assert MEDICATION_GUARDRAIL in augmented_system, (
+            "_build_anthropic_messages must embed MEDICATION_GUARDRAIL in the "
+            "augmented system string (passed as system= kwarg to the API)"
+        )
+
+    def test_anthropic_operator_supplied_system_prompt_contains_guardrail(self) -> None:
+        """Guardrail is injected even when the operator prompt omits it (Anthropic path).
+
+        Mirrors ``test_openai_operator_supplied_system_prompt_contains_guardrail``
+        for the Anthropic builder, which returns ``(messages, augmented_system)``
+        rather than embedding system as a leading message.
+        """
+        operator_prompt = "You are a helpful wellness companion. Be warm and concise."
+        _messages, augmented_system = _build_anthropic_messages("hello", [], operator_prompt)
+        assert MEDICATION_GUARDRAIL in augmented_system, (
+            "_build_anthropic_messages must embed MEDICATION_GUARDRAIL even when "
+            "an operator-supplied system prompt that lacks the guardrail is used"
+        )
+
+    def test_anthropic_guardrail_not_in_user_message_list(self) -> None:
+        """Guardrail must not appear only in the Anthropic user-message list.
+
+        Anthropic's API passes ``system`` separately from ``messages``.  If the
+        implementation injected the guardrail into the ``messages`` list instead
+        of the augmented system string, it would land in the wrong role and could
+        be treated as user-supplied context rather than an operator instruction.
+        """
+        _messages, augmented_system = _build_anthropic_messages("hello", [], _DEFAULT_SYSTEM_PROMPT)
+        # Guardrail must be in the augmented system string (the correct location).
+        assert MEDICATION_GUARDRAIL in augmented_system
+        # Sanity: no system role leaks into the Anthropic messages list.
+        assert all(m["role"] in {"user", "assistant"} for m in _messages)


### PR DESCRIPTION
## Summary

#890 (epic #887, NORTH-STAR §10): the system/resonance/essay/detection prompts had **no** instruction to avoid medication advice or defer to professionals — a model statement suggesting a medication change is a real harm vector.

- `domain/care.py`: one shared `MEDICATION_GUARDRAIL` constant (sibling to `CARE_MESSAGE`) — never advise reducing/stopping/changing medication, never suggest a dose; affirm agency; defer to the writer + their prescriber. No diagnosis/dosing.
- Wired (single import, no copy-drift) into **all 4** prompt builders: resonance `build_prompt` + `_build_essay_prompt`, detection `build_detection_prompt`, and botmason via `_augment_system_prompt` — so it lands in the **system/authoritative position** on both the OpenAI message and the Anthropic system kwarg, and travels with an operator-supplied `BOTMASON_SYSTEM_PROMPT`. resonance/detection also carry it in-prompt (defense-in-depth; docstrings warn against deduplicating).

Additive instruction text only — JSON/anchoring/parse contracts unchanged; no behavior change for non-medication content. **Worked under the new conductor pipeline** (architect → test → implementation → security review → Gate 2.5); security-reviewed: not user-overridable on any of the 5 model-bound paths.

## Test plan

Guardrail substring asserted in each built prompt (import the constant, not a literal) + content concepts + system-role-not-user-turn + operator-supplied case; existing parse tests stay green. `./scripts/backend/check-all.sh` 7/7, xenon A.

Closes #890
Refs #887
