### PR TITLE
feat(safety): frontend care-support surface on a distress flag

### DIFF
--- a/frontend/src/api/__tests__/careSchemas.test.ts
+++ b/frontend/src/api/__tests__/careSchemas.test.ts
@@ -1,0 +1,238 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+
+/**
+ * RED tests for ``careResourceSchema`` / ``careResponseSchema`` /
+ * ``resonanceResponseSchema`` (issue #891).
+ *
+ * These tests import symbols that do not exist yet — they will fail with
+ * ``SyntaxError`` / ``Cannot find module`` / ``is not a function`` until the
+ * implementation-specialist adds the schemas to ``@/api/schemas``.
+ */
+import { careResourceSchema, careResponseSchema, resonanceResponseSchema } from '../schemas';
+
+/** Return a shallow copy of ``obj`` without ``key`` (avoids unused rest-sibling bindings). */
+function omitKey<T extends Record<string, unknown>>(obj: T, key: string): Record<string, unknown> {
+  const copy: Record<string, unknown> = { ...obj };
+  delete copy[key];
+  return copy;
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const HOTLINE_RESOURCE = {
+  kind: 'hotline' as const,
+  name: '988 Suicide & Crisis Lifeline',
+  contact: '988',
+  what_it_is: 'Free, confidential crisis support — call or text anytime.',
+};
+
+const TEXT_LINE_RESOURCE = {
+  kind: 'text_line' as const,
+  name: 'Crisis Text Line',
+  contact: 'Text HOME to 741741',
+  what_it_is: 'Text-based crisis counselling, 24/7.',
+};
+
+const HUMAN_RESOURCE = {
+  kind: 'human' as const,
+  name: 'Trusted person in your life',
+  contact: 'Call, text, or visit',
+  what_it_is: 'Someone who knows you — no professional training required.',
+};
+
+const PROFESSIONAL_RESOURCE = {
+  kind: 'professional' as const,
+  name: 'Licensed therapist',
+  contact: 'Psychology Today directory',
+  what_it_is: 'An ongoing therapeutic relationship with a credentialed clinician.',
+};
+
+const FULL_CARE_RESPONSE = {
+  message: 'What you shared sounds heavy. Here are some people who can help right now.',
+  resources: [HOTLINE_RESOURCE, TEXT_LINE_RESOURCE, HUMAN_RESOURCE, PROFESSIONAL_RESOURCE],
+};
+
+const BASE_RESONANCE_PAYLOAD = {
+  marginalia: [],
+  suggestions: [],
+  remaining_messages: 48,
+  remaining_balance: 0,
+  monthly_reset_date: '2026-07-01T00:00:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// careResourceSchema
+// ---------------------------------------------------------------------------
+
+describe('careResourceSchema — valid kinds', () => {
+  it('accepts kind "hotline" with all required fields', () => {
+    expect(() => careResourceSchema.parse(HOTLINE_RESOURCE)).not.toThrow();
+  });
+
+  it('accepts kind "text_line" with all required fields', () => {
+    expect(() => careResourceSchema.parse(TEXT_LINE_RESOURCE)).not.toThrow();
+  });
+
+  it('accepts kind "human" with all required fields', () => {
+    expect(() => careResourceSchema.parse(HUMAN_RESOURCE)).not.toThrow();
+  });
+
+  it('accepts kind "professional" with all required fields', () => {
+    expect(() => careResourceSchema.parse(PROFESSIONAL_RESOURCE)).not.toThrow();
+  });
+});
+
+describe('careResourceSchema — field contract', () => {
+  it('round-trips every scalar field exactly', () => {
+    const parsed = careResourceSchema.parse(HOTLINE_RESOURCE);
+    expect(parsed.kind).toBe('hotline');
+    expect(parsed.name).toBe('988 Suicide & Crisis Lifeline');
+    expect(parsed.contact).toBe('988');
+    expect(parsed.what_it_is).toBe('Free, confidential crisis support — call or text anytime.');
+  });
+
+  it('rejects an unknown kind value', () => {
+    expect(() => careResourceSchema.parse({ ...HOTLINE_RESOURCE, kind: 'chatbot' })).toThrow();
+  });
+
+  it('rejects a missing kind field', () => {
+    expect(() => careResourceSchema.parse(omitKey(HOTLINE_RESOURCE, 'kind'))).toThrow();
+  });
+
+  it('rejects a missing name field', () => {
+    expect(() => careResourceSchema.parse(omitKey(HOTLINE_RESOURCE, 'name'))).toThrow();
+  });
+
+  it('rejects a missing contact field', () => {
+    expect(() => careResourceSchema.parse(omitKey(HOTLINE_RESOURCE, 'contact'))).toThrow();
+  });
+
+  it('rejects a missing what_it_is field', () => {
+    expect(() => careResourceSchema.parse(omitKey(HOTLINE_RESOURCE, 'what_it_is'))).toThrow();
+  });
+
+  it('rejects a numeric kind (type drift)', () => {
+    expect(() => careResourceSchema.parse({ ...HOTLINE_RESOURCE, kind: 42 })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// careResponseSchema
+// ---------------------------------------------------------------------------
+
+describe('careResponseSchema', () => {
+  it('accepts a full payload with all four resource kinds', () => {
+    expect(() => careResponseSchema.parse(FULL_CARE_RESPONSE)).not.toThrow();
+  });
+
+  it('round-trips the message string', () => {
+    const parsed = careResponseSchema.parse(FULL_CARE_RESPONSE);
+    expect(parsed.message).toBe(FULL_CARE_RESPONSE.message);
+  });
+
+  it('round-trips all four resources in order', () => {
+    const parsed = careResponseSchema.parse(FULL_CARE_RESPONSE);
+    expect(parsed.resources).toHaveLength(4);
+    expect(parsed.resources[0]!.kind).toBe('hotline');
+    expect(parsed.resources[1]!.kind).toBe('text_line');
+    expect(parsed.resources[2]!.kind).toBe('human');
+    expect(parsed.resources[3]!.kind).toBe('professional');
+  });
+
+  it('accepts an empty resources array (degenerate backend response)', () => {
+    expect(() => careResponseSchema.parse({ message: 'Reach out.', resources: [] })).not.toThrow();
+  });
+
+  it('rejects when resources contains an invalid kind', () => {
+    expect(() =>
+      careResponseSchema.parse({
+        ...FULL_CARE_RESPONSE,
+        resources: [{ ...HOTLINE_RESOURCE, kind: 'emergency_dispatch' }],
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a missing message field', () => {
+    expect(() => careResponseSchema.parse(omitKey(FULL_CARE_RESPONSE, 'message'))).toThrow();
+  });
+
+  it('rejects a missing resources field', () => {
+    expect(() => careResponseSchema.parse({ message: 'Reach out.' })).toThrow();
+  });
+
+  it('rejects a non-array resources field (type drift)', () => {
+    expect(() => careResponseSchema.parse({ message: 'Reach out.', resources: null })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resonanceResponseSchema — care field integration
+// ---------------------------------------------------------------------------
+
+describe('resonanceResponseSchema — care field', () => {
+  it('validates a response WITH a care payload and preserves every field', () => {
+    const payload = { ...BASE_RESONANCE_PAYLOAD, care: FULL_CARE_RESPONSE };
+    const parsed = resonanceResponseSchema.parse(payload);
+    expect(parsed.care).not.toBeNull();
+    expect(parsed.care!.message).toBe(FULL_CARE_RESPONSE.message);
+    expect(parsed.care!.resources).toHaveLength(4);
+  });
+
+  it('validates a response WITHOUT the care field (ordinary resonance entry)', () => {
+    // Backend defaults to None → the field is absent on the wire.
+    const parsed = resonanceResponseSchema.parse(BASE_RESONANCE_PAYLOAD);
+    expect(parsed.care == null).toBe(true);
+  });
+
+  it('validates a response where care is explicitly null', () => {
+    const payload = { ...BASE_RESONANCE_PAYLOAD, care: null };
+    const parsed = resonanceResponseSchema.parse(payload);
+    expect(parsed.care).toBeNull();
+  });
+
+  it('still round-trips marginalia and suggestions alongside care', () => {
+    const marginaliaItem = {
+      id: 1,
+      journal_entry_id: 7,
+      kind: 'theme',
+      anchor_start: 0,
+      anchor_end: 4,
+      anchor_text: 'walk',
+      note: 'A beginning.',
+      essay: null,
+      essay_generated_at: null,
+      status: 'active',
+      created_at: '2026-06-01T00:00:00Z',
+      updated_at: '2026-06-01T00:00:00Z',
+    };
+    const payload = {
+      ...BASE_RESONANCE_PAYLOAD,
+      marginalia: [marginaliaItem],
+      care: FULL_CARE_RESPONSE,
+    };
+    const parsed = resonanceResponseSchema.parse(payload);
+    expect(parsed.marginalia).toHaveLength(1);
+    expect(parsed.marginalia[0]!.kind).toBe('theme');
+    expect(parsed.care!.resources[0]!.kind).toBe('hotline');
+  });
+
+  it('rejects a care object with an invalid kind inside resources', () => {
+    const badCare = {
+      message: 'Reach out.',
+      resources: [{ ...HOTLINE_RESOURCE, kind: 'robot' }],
+    };
+    expect(() =>
+      resonanceResponseSchema.parse({ ...BASE_RESONANCE_PAYLOAD, care: badCare }),
+    ).toThrow();
+  });
+
+  it('rejects a care object missing the message field', () => {
+    const badCare = { resources: [HOTLINE_RESOURCE] };
+    expect(() =>
+      resonanceResponseSchema.parse({ ...BASE_RESONANCE_PAYLOAD, care: badCare }),
+    ).toThrow();
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -18,10 +18,14 @@ import {
   practiceRecipeSchema,
   practiceTagSchema,
   promptListResponseSchema,
+  resonanceResponseSchema,
   stageIntroSchema,
   stageSchema,
   timezoneReadSchema,
   type AcceptSuggestionResultT,
+  type CareKindT,
+  type CareResourceT,
+  type CareResponseT,
   type CompletionSuggestionT,
   type CompletionTargetTypeT,
   type Page,
@@ -1110,6 +1114,13 @@ export interface Marginalia {
   updated_at: string;
 }
 
+/** One of the four non-clinical care routings (mirrors ``domain.care.CareKind``). */
+export type CareKind = CareKindT;
+/** One support pointer (mirrors the backend ``CareResourceResponse``). */
+export type CareResource = CareResourceT;
+/** The care surface (mirrors the backend ``CareResponse``); see ``CareSupportNote``. */
+export type CareResponse = CareResponseT;
+
 export interface ResonanceResponse {
   marginalia: Marginalia[];
   /** Completion suggestions detected on the same pass (#817); defaults to []. */
@@ -1117,6 +1128,12 @@ export interface ResonanceResponse {
   remaining_messages: number;
   remaining_balance: number;
   monthly_reset_date: string;
+  /**
+   * Human + professional support surface (NORTH-STAR §10). ``null`` on every
+   * ordinary entry; set only on an acute-distress signal. Additive — a response
+   * without it parses and behaves exactly as before.
+   */
+  care?: CareResponse | null;
 }
 
 export interface MarginaliaListResponse {
@@ -1203,6 +1220,7 @@ export const resonance = {
       method: 'POST',
       token,
       headers: byokHeaders(apiKey),
+      schema: resonanceResponseSchema as unknown as z.ZodType<ResonanceResponse>,
     });
   },
   /** List an entry's margin notes (ordered by anchor position). */

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -477,6 +477,76 @@ export type CompletionSuggestionT = z.infer<typeof completionSuggestionSchema>;
 export type AcceptSuggestionResultT = z.infer<typeof acceptSuggestionResultSchema>;
 
 // ---------------------------------------------------------------------------
+// Resonance + marginalia + care (journal-resonance #891)
+// ---------------------------------------------------------------------------
+
+export const marginaliaKindSchema = z.enum(['theme', 'connection', 'symbol']);
+export const marginaliaStatusSchema = z.enum(['active', 'stale']);
+
+/** One margin note (mirrors the backend ``MarginaliaResponse``). */
+export const marginaliaSchema = z.object({
+  id: z.number().int(),
+  journal_entry_id: z.number().int(),
+  kind: marginaliaKindSchema,
+  anchor_start: z.number().int(),
+  anchor_end: z.number().int(),
+  anchor_text: z.string(),
+  note: z.string(),
+  essay: z.string().nullable(),
+  essay_generated_at: z.string().nullable(),
+  status: marginaliaStatusSchema,
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+/**
+ * The four non-clinical care routings (mirrors ``domain.care.CareKind``):
+ * crisis ``hotline`` / ``text_line``, a trusted ``human``, and clinical
+ * ``professional`` support. Anything else is a contract drift and is rejected
+ * at the boundary so an unknown routing can never render an unlabelled card.
+ */
+export const careKindSchema = z.enum(['hotline', 'text_line', 'human', 'professional']);
+
+/** One support pointer (mirrors the backend ``CareResourceResponse``). */
+export const careResourceSchema = z.object({
+  kind: careKindSchema,
+  name: z.string(),
+  contact: z.string(),
+  what_it_is: z.string(),
+});
+
+/**
+ * The care surface returned only on an acute-distress signal (NORTH-STAR §10):
+ * a warm, non-shaming message plus the ordered human + professional resources.
+ * Mirrors the backend ``CareResponse``; ``null`` on every ordinary entry.
+ */
+export const careResponseSchema = z.object({
+  message: z.string(),
+  resources: z.array(careResourceSchema),
+});
+
+/**
+ * Result of a resonance pass (mirrors the backend ``ResonanceResponse``).
+ *
+ * ``care`` is additive: it is ``None`` on every ordinary entry — absent on the
+ * wire — so ``.nullish()`` keeps existing (no-care) responses validating and
+ * behaving exactly as before. It is set only on an elevated signal.
+ */
+export const resonanceResponseSchema = z.object({
+  marginalia: z.array(marginaliaSchema),
+  suggestions: z.array(completionSuggestionSchema),
+  remaining_messages: z.number().int(),
+  remaining_balance: z.number().int(),
+  monthly_reset_date: z.string(),
+  care: careResponseSchema.nullish(),
+});
+
+export type CareKindT = z.infer<typeof careKindSchema>;
+export type CareResourceT = z.infer<typeof careResourceSchema>;
+export type CareResponseT = z.infer<typeof careResponseSchema>;
+export type ResonanceResponseT = z.infer<typeof resonanceResponseSchema>;
+
+// ---------------------------------------------------------------------------
 // Lenient schemas for legacy endpoints (gradually tightened)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/features/Journal/CareSupportNote.tsx
+++ b/frontend/src/features/Journal/CareSupportNote.tsx
@@ -1,0 +1,184 @@
+/**
+ * ``CareSupportNote`` — the human + professional support surface shown when a
+ * resonance pass screens an entry as carrying an acute-distress signal
+ * (NORTH-STAR §10). It *accompanies* the reflection — it never replaces it — so a
+ * distressed person is pointed at people (988, Crisis Text Line, someone they
+ * trust) and clinical care rather than left alone with AI-generated text.
+ *
+ * Deliberately NOT a chatbot: there is no avatar, no sender, no reply, no Send.
+ * It is a warm, non-shaming panel — a header-role message plus an ordered list
+ * of resources. ``Dismiss`` collapses the list to a persistent ``Re-open``
+ * affordance rather than removing the surface entirely, so the user can never
+ * lose their way back to help. Presentational, reduced-motion-safe, tokens only
+ * (mirrors ``CompletionSuggestionNote``).
+ */
+import React, { useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import type { CareResource, CareResponse } from '@/api';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  editorialType,
+  ink,
+  paperShadow,
+  spacing,
+  surface,
+  touchTarget,
+} from '@/design/tokens';
+
+const DISMISS_LABEL = 'Dismiss';
+const REOPEN_LABEL = 'Show support options';
+const DISMISS_A11Y = 'Hide the support options';
+const REOPEN_A11Y = 'Show the support options again';
+
+/** Accessibility label combining a resource's name, contact, and description. */
+function resourceLabel(resource: CareResource): string {
+  return `${resource.name}. ${resource.contact}. ${resource.what_it_is}`;
+}
+
+export interface CareSupportNoteProps {
+  /** The care surface from the latest resonance pass; ``null`` hides everything. */
+  care: CareResponse | null;
+}
+
+/** One support pointer: name, how to reach it, and what it is. */
+function ResourceCard({ resource }: { resource: CareResource }): React.JSX.Element {
+  return (
+    <View
+      style={styles.resource}
+      testID={`care-resource-${resource.kind}`}
+      accessible
+      accessibilityLabel={resourceLabel(resource)}
+    >
+      <Text style={styles.resourceName}>{resource.name}</Text>
+      <Text style={styles.resourceContact}>{resource.contact}</Text>
+      <Text style={styles.resourceWhat}>{resource.what_it_is}</Text>
+    </View>
+  );
+}
+
+/** The collapsed state: a single affordance that restores the resource list. */
+function ReopenControl({ onPress }: { onPress: () => void }): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={styles.reopen}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={REOPEN_A11Y}
+      testID="care-reopen"
+    >
+      <Text style={styles.reopenText}>{REOPEN_LABEL}</Text>
+    </TouchableOpacity>
+  );
+}
+
+/** The expanded state: the ordered resources plus a dismiss affordance. */
+function ExpandedBody({
+  resources,
+  onDismiss,
+}: {
+  resources: CareResource[];
+  onDismiss: () => void;
+}): React.JSX.Element {
+  return (
+    <>
+      {resources.map((resource) => (
+        <ResourceCard key={resource.kind} resource={resource} />
+      ))}
+      <TouchableOpacity
+        style={styles.dismiss}
+        onPress={onDismiss}
+        accessibilityRole="button"
+        accessibilityLabel={DISMISS_A11Y}
+        testID="care-dismiss"
+      >
+        <Text style={styles.dismissText}>{DISMISS_LABEL}</Text>
+      </TouchableOpacity>
+    </>
+  );
+}
+
+function CareSupportNote({ care }: CareSupportNoteProps): React.JSX.Element | null {
+  const [expanded, setExpanded] = useState(true);
+  if (care == null) return null;
+  return (
+    <View style={styles.root} testID="care-support">
+      <Text style={styles.message} accessibilityRole="header">
+        {care.message}
+      </Text>
+      {expanded ? (
+        <ExpandedBody resources={care.resources} onDismiss={() => setExpanded(false)} />
+      ) : (
+        <ReopenControl onPress={() => setExpanded(true)} />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    margin: SPACING.lg,
+    padding: SPACING.lg,
+    borderRadius: BORDER_RADIUS.lg,
+    backgroundColor: surface.raised,
+    borderLeftWidth: 4,
+    borderLeftColor: accent.primary,
+    ...paperShadow.card,
+  },
+  message: {
+    ...editorialType.title,
+    color: ink.primary,
+    marginBottom: SPACING.md,
+  },
+  resource: {
+    paddingVertical: SPACING.sm,
+    borderTopWidth: 1,
+    borderTopColor: surface.hairline,
+  },
+  resourceName: {
+    ...editorialType.note,
+    fontWeight: '600',
+    color: ink.primary,
+  },
+  resourceContact: {
+    ...editorialType.note,
+    color: accent.strong,
+    marginTop: spacing(0.25),
+  },
+  resourceWhat: {
+    ...editorialType.caption,
+    color: ink.soft,
+    marginTop: spacing(0.25),
+  },
+  dismiss: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    alignSelf: 'flex-start',
+    paddingHorizontal: SPACING.md,
+    marginTop: SPACING.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dismissText: {
+    ...editorialType.note,
+    fontWeight: '600',
+    color: ink.soft,
+  },
+  reopen: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    alignSelf: 'flex-start',
+    paddingHorizontal: SPACING.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  reopenText: {
+    ...editorialType.note,
+    fontWeight: '600',
+    color: accent.primary,
+  },
+});
+
+export default CareSupportNote;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import CareSupportNote from './CareSupportNote';
 import CompletionSuggestionNote from './CompletionSuggestionNote';
 import EditConfirmDialog from './EditConfirmDialog';
 import GetResonanceButton, { shouldShowResonance } from './GetResonanceButton';
@@ -701,6 +702,10 @@ function JournalEntryScreen({
   const { editGate, modal } = ctl;
   return (
     <SafeAreaView style={styles.safeArea} testID="journal-screen">
+      {/* Screen-level care surface (NORTH-STAR §10): a sibling ABOVE the page,
+          never nested in the margin column — so on an acute-distress signal the
+          human + professional support reads as the page's own, not a margin note. */}
+      <CareSupportNote care={ctl.resonance.care} />
       <JournalPage ctl={ctl} bodyPlaceholder={bodyPlaceholder} />
       <GetResonanceButton
         visible={ctl.visible}

--- a/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
@@ -1,0 +1,261 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+/**
+ * RED tests for ``CareSupportNote`` (issue #891).
+ *
+ * These tests fail until the implementation-specialist creates
+ * ``frontend/src/features/Journal/CareSupportNote.tsx``.
+ *
+ * Design requirements from the architect:
+ * - Renders a warm ``message`` with ``accessibilityRole="header"``.
+ * - Lists every resource with name, contact, and what_it_is text visible.
+ * - Each resource has a descriptive accessibilityLabel (not just the kind slug).
+ * - A dismiss control collapses the resource list to a compact re-opener.
+ * - The re-opener brings resources back (not a dead-end).
+ * - Renders nothing when ``care`` is null.
+ * - Interactive elements meet the 44dp ``touchTarget.minimum``.
+ * - No chat/bot affordances (no sender, avatar, reply testIDs).
+ */
+import CareSupportNote from '../CareSupportNote';
+
+import type { CareResponse } from '@/api';
+import { touchTarget } from '@/design/tokens';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function carePayload(overrides: Partial<CareResponse> = {}): CareResponse {
+  return {
+    message: 'What you shared sounds heavy. Here are some people who can help right now.',
+    resources: [
+      {
+        kind: 'hotline',
+        name: '988 Suicide & Crisis Lifeline',
+        contact: '988',
+        what_it_is: 'Free, confidential crisis support — call or text anytime.',
+      },
+      {
+        kind: 'text_line',
+        name: 'Crisis Text Line',
+        contact: 'Text HOME to 741741',
+        what_it_is: 'Text-based crisis counselling, 24/7.',
+      },
+      {
+        kind: 'human',
+        name: 'Trusted person in your life',
+        contact: 'Call, text, or visit',
+        what_it_is: 'Someone who knows you — no professional training required.',
+      },
+      {
+        kind: 'professional',
+        name: 'Licensed therapist',
+        contact: 'Psychology Today directory',
+        what_it_is: 'An ongoing therapeutic relationship with a credentialed clinician.',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+/** Smallest of the flattened minHeight/minWidth on an interactive node. */
+function StyleSheetMin(node: { props: { style: unknown } }): number {
+  const { StyleSheet } = require('react-native');
+  const flat = StyleSheet.flatten(node.props.style) as {
+    minHeight?: number;
+    minWidth?: number;
+  };
+  return Math.min(flat.minHeight ?? 0, flat.minWidth ?? 0);
+}
+
+// ---------------------------------------------------------------------------
+// null guard
+// ---------------------------------------------------------------------------
+
+describe('CareSupportNote — null care', () => {
+  it('renders nothing when care is null', () => {
+    const { queryByTestId } = render(<CareSupportNote care={null} />);
+    expect(queryByTestId('care-support')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Initial render (expanded state)
+// ---------------------------------------------------------------------------
+
+describe('CareSupportNote — initial render', () => {
+  it('mounts the root container with testID "care-support"', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-support')).toBeTruthy();
+  });
+
+  it('renders the message text', () => {
+    const { getByText } = render(<CareSupportNote care={carePayload()} />);
+    expect(
+      getByText('What you shared sounds heavy. Here are some people who can help right now.'),
+    ).toBeTruthy();
+  });
+
+  it('gives the message element accessibilityRole="header"', () => {
+    const { getByText } = render(<CareSupportNote care={carePayload()} />);
+    const messageEl = getByText(
+      'What you shared sounds heavy. Here are some people who can help right now.',
+    );
+    expect(messageEl.props.accessibilityRole).toBe('header');
+  });
+
+  it('renders name text for all four resource kinds', () => {
+    const { getByText } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByText('988 Suicide & Crisis Lifeline')).toBeTruthy();
+    expect(getByText('Crisis Text Line')).toBeTruthy();
+    expect(getByText('Trusted person in your life')).toBeTruthy();
+    expect(getByText('Licensed therapist')).toBeTruthy();
+  });
+
+  it('renders contact text for all four resource kinds', () => {
+    const { getByText } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByText('988')).toBeTruthy();
+    expect(getByText('Text HOME to 741741')).toBeTruthy();
+    expect(getByText('Call, text, or visit')).toBeTruthy();
+    expect(getByText('Psychology Today directory')).toBeTruthy();
+  });
+
+  it('renders what_it_is text for all four resource kinds', () => {
+    const { getByText } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByText('Free, confidential crisis support — call or text anytime.')).toBeTruthy();
+    expect(getByText('Text-based crisis counselling, 24/7.')).toBeTruthy();
+    expect(getByText('Someone who knows you — no professional training required.')).toBeTruthy();
+    expect(
+      getByText('An ongoing therapeutic relationship with a credentialed clinician.'),
+    ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resource-level testIDs and accessibility
+// ---------------------------------------------------------------------------
+
+describe('CareSupportNote — per-resource testIDs', () => {
+  it('mounts "care-resource-hotline" for the hotline resource', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-resource-hotline')).toBeTruthy();
+  });
+
+  it('mounts "care-resource-text_line" for the text-line resource', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-resource-text_line')).toBeTruthy();
+  });
+
+  it('mounts "care-resource-human" for the human resource', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-resource-human')).toBeTruthy();
+  });
+
+  it('mounts "care-resource-professional" for the professional resource', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-resource-professional')).toBeTruthy();
+  });
+
+  it('each resource element has a non-empty, descriptive accessibilityLabel', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    const kinds = ['hotline', 'text_line', 'human', 'professional'] as const;
+    for (const kind of kinds) {
+      const el = getByTestId(`care-resource-${kind}`);
+      const label: unknown = el.props.accessibilityLabel;
+      expect(typeof label).toBe('string');
+      // The label must be descriptive enough — longer than just the kind slug.
+      expect((label as string).length).toBeGreaterThan(kind.length + 5);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dismiss → re-open (not a dead-end)
+// ---------------------------------------------------------------------------
+
+describe('CareSupportNote — dismiss and re-open', () => {
+  it('mounts a dismiss control with testID "care-dismiss"', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-dismiss')).toBeTruthy();
+  });
+
+  it('hides resource cards after pressing care-dismiss', () => {
+    const { getByTestId, queryByTestId } = render(<CareSupportNote care={carePayload()} />);
+    fireEvent.press(getByTestId('care-dismiss'));
+    // Resources should no longer be visible.
+    expect(queryByTestId('care-resource-hotline')).toBeNull();
+    expect(queryByTestId('care-resource-text_line')).toBeNull();
+  });
+
+  it('mounts a re-open control with testID "care-reopen" after dismissing', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    fireEvent.press(getByTestId('care-dismiss'));
+    // The component must NOT disappear entirely — a re-opener must be reachable.
+    expect(getByTestId('care-reopen')).toBeTruthy();
+  });
+
+  it('re-shows resources after pressing care-reopen (not a dead-end)', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    fireEvent.press(getByTestId('care-dismiss'));
+    fireEvent.press(getByTestId('care-reopen'));
+    // Resources reappear.
+    expect(getByTestId('care-resource-hotline')).toBeTruthy();
+    expect(getByTestId('care-resource-professional')).toBeTruthy();
+  });
+
+  it('dismiss control still carries the care-support root after dismissal', () => {
+    // The root container must survive dismiss — the user must never lose the
+    // surface entirely.
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    fireEvent.press(getByTestId('care-dismiss'));
+    expect(getByTestId('care-support')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Touch-target size
+// ---------------------------------------------------------------------------
+
+describe('CareSupportNote — touch-target requirements', () => {
+  it('dismiss control meets the 44dp minimum touch target', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    const dismiss = getByTestId('care-dismiss');
+    expect(StyleSheetMin(dismiss)).toBeGreaterThanOrEqual(touchTarget.minimum);
+  });
+
+  it('re-open control meets the 44dp minimum touch target', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    fireEvent.press(getByTestId('care-dismiss'));
+    const reopen = getByTestId('care-reopen');
+    expect(StyleSheetMin(reopen)).toBeGreaterThanOrEqual(touchTarget.minimum);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No chat/bot affordances
+// ---------------------------------------------------------------------------
+
+describe('CareSupportNote — no chat UI', () => {
+  it('does not render a sender testID', () => {
+    const { queryByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(queryByTestId('sender')).toBeNull();
+  });
+
+  it('does not render an avatar testID', () => {
+    const { queryByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+
+  it('does not render a reply testID', () => {
+    const { queryByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(queryByTestId('reply')).toBeNull();
+  });
+
+  it('does not render a "Send" text element', () => {
+    const { queryByText } = render(<CareSupportNote care={carePayload()} />);
+    expect(queryByText('Send')).toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenCare.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenCare.test.tsx
@@ -1,0 +1,299 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react-native';
+import React from 'react';
+
+/**
+ * RED tests for the JournalEntryScreen care-surface placement (issue #891).
+ *
+ * Requirements:
+ * - When a resonance pass yields ``care``, ``CareSupportNote`` (testID
+ *   ``"care-support"``) mounts at the SCREEN level — a direct sibling of
+ *   ``JournalPage`` inside ``journal-screen``, NOT anywhere inside
+ *   ``journal-margin-column`` or ``journal-sheet``.
+ * - On an ordinary pass (no care), ``care-support`` is absent entirely.
+ *
+ * These tests fail until the implementation-specialist wires ``care`` from
+ * ``useResonance`` into ``JournalEntryScreen``.
+ */
+import type { CareResponse, JournalMessage, ResonanceResponse } from '@/api';
+import { DEFAULT_IDLE_DELAY_MS } from '@/hooks/useIdle';
+
+// ---------------------------------------------------------------------------
+// API mocks — mirrors the shape in JournalEntryScreen.test.tsx exactly.
+// ---------------------------------------------------------------------------
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+const mockGenerate = jest.fn() as jest.MockedFunction<(_id: number) => Promise<ResonanceResponse>>;
+const mockRespond = jest.fn() as jest.MockedFunction<(_w: number, _b: string) => Promise<unknown>>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: {
+    respond: (...a: unknown[]) => (mockRespond as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: (...a: unknown[]) => (mockGenerate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  completionSuggestions: {
+    list: jest.fn(() => Promise.resolve({ items: [] })),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 7,
+    message: 'Today felt very dark.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'freeform' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'A heavy day',
+    status: 'draft',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function carePayload(): CareResponse {
+  return {
+    message: 'What you shared sounds heavy. Here are some people who can help right now.',
+    resources: [
+      {
+        kind: 'hotline',
+        name: '988 Suicide & Crisis Lifeline',
+        contact: '988',
+        what_it_is: 'Free, confidential crisis support — call or text anytime.',
+      },
+    ],
+  };
+}
+
+function resonancePayload(care: CareResponse | null = null): ResonanceResponse {
+  return {
+    marginalia: [],
+    suggestions: [],
+    remaining_messages: 48,
+    remaining_balance: 0,
+    monthly_reset_date: '2026-07-01T00:00:00Z',
+    care,
+  };
+}
+
+function renderScreen(
+  params?: {
+    entryId?: number;
+    weekNumber?: number;
+    promptQuestion?: string;
+    prefillTitle?: string;
+    practiceSessionId?: number;
+  },
+  extraProps: Record<string, unknown> = {},
+) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return {
+    ...render(<Screen navigation={navigation} route={route} {...extraProps} />),
+    navigation,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockGenerate.mockReset();
+  mockRespond.mockReset();
+  mockRespond.mockResolvedValue({});
+});
+
+// ---------------------------------------------------------------------------
+// Placement tests
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — care-support surface placement (issue #891)', () => {
+  it('does NOT render care-support on an ordinary resonance pass (no care)', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(resonancePayload(null));
+
+      const { getByTestId, queryByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A peaceful thought.');
+      // Advance autosave debounce: create fires, entry gets id=42.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      // Advance idle timer: isIdle flips true, visible=true, button is findable.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      // Trigger the resonance generate pass.
+      await act(async () => {
+        fireEvent.press(getByTestId('get-resonance-button'));
+        await Promise.resolve();
+      });
+
+      expect(queryByTestId('care-support')).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('mounts care-support when the resonance pass returns care', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(resonancePayload(carePayload()));
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'Today felt very dark.');
+      // Advance autosave debounce: create fires, entry gets id=42.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      // Advance idle timer: isIdle flips true, visible=true, button is findable.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId('get-resonance-button'));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(getByTestId('care-support')).toBeTruthy());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('care-support is a child of journal-screen, NOT of journal-margin-column', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(resonancePayload(carePayload()));
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'Today felt very dark.');
+      // Advance autosave debounce: create fires, entry gets id=42.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      // Advance idle timer: isIdle flips true, visible=true, button is findable.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId('get-resonance-button'));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(getByTestId('care-support')).toBeTruthy());
+
+      // The margin column must NOT contain care-support.
+      expect(within(getByTestId('journal-margin-column')).queryByTestId('care-support')).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('care-support is NOT a descendant of journal-sheet or journal-page', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(resonancePayload(carePayload()));
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'Today felt very dark.');
+      // Advance autosave debounce: create fires, entry gets id=42.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      // Advance idle timer: isIdle flips true, visible=true, button is findable.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId('get-resonance-button'));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(getByTestId('care-support')).toBeTruthy());
+
+      // Confirm care-support is NOT inside journal-sheet or journal-page.
+      expect(within(getByTestId('journal-sheet')).queryByTestId('care-support')).toBeNull();
+      expect(within(getByTestId('journal-page')).queryByTestId('care-support')).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('care-support IS a descendant of journal-screen (screen-level placement)', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(resonancePayload(carePayload()));
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'Today felt very dark.');
+      // Advance autosave debounce: create fires, entry gets id=42.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      // Advance idle timer: isIdle flips true, visible=true, button is findable.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId('get-resonance-button'));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(getByTestId('care-support')).toBeTruthy());
+
+      // care-support must live somewhere under journal-screen.
+      expect(within(getByTestId('journal-screen')).queryByTestId('care-support')).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/features/Journal/__tests__/useResonanceCare.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonanceCare.test.tsx
@@ -1,0 +1,212 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+/**
+ * RED tests for the ``care`` field threading through ``useResonance`` (issue #891).
+ *
+ * All tests fail until the implementation-specialist adds ``care`` to
+ * ``UseResonanceResult``, ``useGeneratePass``, and the hook's return value.
+ *
+ * The mock surface matches the existing ``useResonance.test.tsx`` exactly so
+ * the two files can be merged or colocated without conflict.
+ */
+import type { CareResponse, CompletionSuggestion, Marginalia, ResonanceResponse } from '@/api';
+
+const mockList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: Marginalia[] }>
+>;
+const mockGenerate = jest.fn() as jest.MockedFunction<(_id: number) => Promise<ResonanceResponse>>;
+const mockSugList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: CompletionSuggestion[] }>
+>;
+
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api') as Record<string, unknown>;
+  return {
+    ...actual,
+    resonance: {
+      list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+      generate: (...a: unknown[]) =>
+        (mockGenerate as unknown as (...x: unknown[]) => unknown)(...a),
+    },
+    completionSuggestions: {
+      list: (...a: unknown[]) => (mockSugList as unknown as (...x: unknown[]) => unknown)(...a),
+      accept: jest.fn(),
+      dismiss: jest.fn(),
+    },
+  };
+});
+
+const { useResonance } = require('../useResonance');
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function note(overrides: Partial<Marginalia> = {}): Marginalia {
+  return {
+    id: 1,
+    journal_entry_id: 7,
+    kind: 'theme',
+    anchor_start: 0,
+    anchor_end: 4,
+    anchor_text: 'walk',
+    note: 'A beginning.',
+    essay: null,
+    essay_generated_at: null,
+    status: 'active',
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function carePayload(): CareResponse {
+  return {
+    message: 'What you shared sounds heavy. Here are some people who can help right now.',
+    resources: [
+      {
+        kind: 'hotline',
+        name: '988 Suicide & Crisis Lifeline',
+        contact: '988',
+        what_it_is: 'Free, confidential crisis support — call or text anytime.',
+      },
+      {
+        kind: 'text_line',
+        name: 'Crisis Text Line',
+        contact: 'Text HOME to 741741',
+        what_it_is: 'Text-based crisis counselling, 24/7.',
+      },
+    ],
+  };
+}
+
+function resonancePayload(overrides: Partial<ResonanceResponse> = {}): ResonanceResponse {
+  return {
+    marginalia: [],
+    suggestions: [],
+    remaining_messages: 48,
+    remaining_balance: 0,
+    monthly_reset_date: '2026-07-01T00:00:00Z',
+    care: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockList.mockReset();
+  mockGenerate.mockReset();
+  mockSugList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockSugList.mockResolvedValue({ items: [] });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useResonance — care field threading (issue #891)', () => {
+  it('exposes care on the hook result when the generate pass returns a care payload', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue(resonancePayload({ care: carePayload() }));
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    // The hook must expose ``care`` — this fails until the field is added.
+    expect(result.current.care).not.toBeNull();
+    expect(result.current.care!.message).toBe(
+      'What you shared sounds heavy. Here are some people who can help right now.',
+    );
+    expect(result.current.care!.resources).toHaveLength(2);
+    expect(result.current.care!.resources[0]!.kind).toBe('hotline');
+  });
+
+  it('leaves care null when the generate pass returns care: null', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue(resonancePayload({ care: null }));
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(result.current.care).toBeNull();
+  });
+
+  it('leaves care null when the generate pass omits the care field', async () => {
+    const flush = jest.fn(async () => 42);
+    // Omit care entirely — the backend's default is None → absent from wire.
+    const payloadWithoutCare = { ...resonancePayload() };
+    delete (payloadWithoutCare as { care?: unknown }).care;
+    mockGenerate.mockResolvedValue(payloadWithoutCare as ResonanceResponse);
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(result.current.care == null).toBe(true);
+  });
+
+  it('clears stale care when a new requestResonance is started', async () => {
+    const flush = jest.fn(async () => 42);
+
+    // First pass: returns care.
+    mockGenerate.mockResolvedValueOnce(resonancePayload({ care: carePayload() }));
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+    expect(result.current.care).not.toBeNull(); // care is present after first pass
+
+    // Second pass: returns no care.
+    mockGenerate.mockResolvedValueOnce(resonancePayload({ care: null }));
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    // Stale care from the first pass must have been cleared.
+    expect(result.current.care).toBeNull();
+  });
+
+  it('never populates care from the load-on-open effect (marginalia list does not carry care)', async () => {
+    // The load-on-open path calls ``resonance.list`` (returns { items }), which
+    // has no care field — so care must stay null on mount regardless of what
+    // the marginalia list returns.
+    mockList.mockResolvedValue({ items: [note({ id: 1 })] });
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+
+    await waitFor(() => expect(result.current.marginalia).toHaveLength(1));
+
+    // care must not have been populated by the load-on-open path.
+    expect(result.current.care == null).toBe(true);
+  });
+
+  it('still merges marginalia and suggestions alongside care after a generate pass', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue(
+      resonancePayload({
+        marginalia: [note({ id: 5, journal_entry_id: 42 })],
+        care: carePayload(),
+      }),
+    );
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(result.current.marginalia).toHaveLength(1);
+    expect(result.current.care).not.toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -19,7 +19,7 @@ import {
 } from 'react';
 
 import { completionSuggestions, resonance } from '@/api';
-import type { CheckInResult, CompletionSuggestion, Marginalia } from '@/api';
+import type { CareResponse, CheckInResult, CompletionSuggestion, Marginalia } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 
 const EMPTY_BODY_MESSAGE = 'Write a little first, then ask for its resonance.';
@@ -37,6 +37,12 @@ export interface UseResonanceResult {
   suggestions: CompletionSuggestion[];
   /** Check-in (streak) per accepted suggestion id, for the confirmed card. */
   acceptedCheckIns: Record<number, CheckInResult | null>;
+  /**
+   * Human + professional support surface for the latest pass (NORTH-STAR §10).
+   * Always ``null`` (never ``undefined``) until a generate pass returns care; a
+   * new pass clears any stale care, and the load-on-open path never sets it.
+   */
+  care: CareResponse | null;
   loading: boolean;
   error: string | null;
   requestResonance: () => Promise<void>;
@@ -191,13 +197,17 @@ interface GeneratePass {
   requestResonance: () => Promise<void>;
 }
 
-/** The charged "generate" pass: flush, generate, merge notes + suggestions. */
-function useGeneratePass(
-  flush: () => Promise<number | null>,
-  setMarginalia: Dispatch<SetStateAction<Marginalia[]>>,
-  mergeFromGenerate: (_incoming: CompletionSuggestion[]) => void,
-  setError: Dispatch<SetStateAction<string | null>>,
-): GeneratePass {
+interface GeneratePassDeps {
+  flush: () => Promise<number | null>;
+  setMarginalia: Dispatch<SetStateAction<Marginalia[]>>;
+  mergeFromGenerate: (_incoming: CompletionSuggestion[]) => void;
+  setCare: Dispatch<SetStateAction<CareResponse | null>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+}
+
+/** The charged "generate" pass: flush, generate, merge notes + suggestions + care. */
+function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
+  const { flush, setMarginalia, mergeFromGenerate, setCare, setError } = deps;
   const [loading, setLoading] = useState(false);
   const inFlightRef = useRef(false);
 
@@ -206,6 +216,9 @@ function useGeneratePass(
     inFlightRef.current = true;
     setLoading(true);
     setError(null);
+    // Clear any care from a prior pass up front so a distressed-then-calm
+    // sequence never leaves a stale crisis surface on the page.
+    setCare(null);
     try {
       const entryId = await flush();
       if (entryId == null) {
@@ -215,29 +228,35 @@ function useGeneratePass(
       const result = await resonance.generate(entryId);
       setMarginalia((prev) => mergeById(prev, result.marginalia));
       mergeFromGenerate(result.suggestions);
+      // ``care`` is nullable/absent on ordinary entries — normalise to null.
+      setCare(result.care ?? null);
     } catch (err) {
       setError(formatApiError(err));
     } finally {
       inFlightRef.current = false;
       setLoading(false);
     }
-  }, [flush, setMarginalia, mergeFromGenerate, setError]);
+  }, [flush, setMarginalia, mergeFromGenerate, setCare, setError]);
 
   return { loading, requestResonance };
 }
 
 export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseResonanceResult {
   const [marginalia, setMarginalia] = useState<Marginalia[]>([]);
+  // Default null (never undefined): the load-on-open path never sets care, so
+  // the surface stays hidden until a generate pass returns one.
+  const [care, setCare] = useState<CareResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useLoadOnOpen(routeEntryId, resonance.list, setMarginalia);
   const sug = useSuggestions(routeEntryId, setError);
-  const { loading, requestResonance } = useGeneratePass(
+  const { loading, requestResonance } = useGeneratePass({
     flush,
     setMarginalia,
-    sug.mergeFromGenerate,
+    mergeFromGenerate: sug.mergeFromGenerate,
+    setCare,
     setError,
-  );
+  });
 
   const updateNote = useCallback((updated: Marginalia) => {
     setMarginalia((prev) => mergeById(prev, [updated]));
@@ -257,6 +276,7 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     marginalia,
     suggestions: sug.suggestions,
     acceptedCheckIns: sug.acceptedCheckIns,
+    care,
     loading,
     error,
     requestResonance,


### PR DESCRIPTION
## Summary

#891 (epic #887, NORTH-STAR §10): the frontend had no way to show support resources when the backend flags acute distress. Consume the #889 `care` payload and surface **human + professional** support prominently.

- `api/schemas.ts`/`index.ts`: `careKindSchema`/`careResourceSchema`/`careResponseSchema` + `care` on `resonanceResponseSchema` (`.nullish()`) + `CareResponse`/`CareResource`/`CareKind` types + `care?` on `ResonanceResponse`. Wired `resonanceResponseSchema` into `resonance.generate` (boundary validation / drift guard) — byte-for-byte match to the backend contract; ordinary (no-care) responses parse unchanged.
- `useResonance`: `care: CareResponse | null` (default null, cleared on each new request).
- New `CareSupportNote.tsx`: prominent warm panel (NOT a margin note, NOT a chatbot reply) — header-role message + ordered resource cards (per-resource a11y labels), dismiss → persistent re-opener (resources stay reachable — not a dead-end), ≥44dp, tokens-only.
- `JournalEntryScreen`: mounted Screen-level above `JournalPage` (under `journal-screen`, never in the margin column).

Worked under the conductor pipeline (architect → test → implementation → code-review-orchestrator).

## Test plan

Schema with/without/null care + bad kind; `useResonance` threading + clear-on-new-request; `CareSupportNote` render/a11y/dismiss-not-dead-end/null; Screen-level placement (via `within()` containment). `./scripts/frontend/check-all.sh` green; no `any`.

Closes #891
Refs #887
