### PR TITLE
feat(safety): always-available Support & care in Settings

### DIFF
--- a/frontend/src/components/care/CareResourceCard.tsx
+++ b/frontend/src/components/care/CareResourceCard.tsx
@@ -1,0 +1,64 @@
+/**
+ * ``CareResourceCard`` — one support pointer: a name, how to reach it, and what
+ * it is. Extracted from ``CareSupportNote`` (issue #891) so the same card can be
+ * reused both on the reactive journal care surface and the always-available
+ * Support & care settings screen, with one shared a11y formula and one set of
+ * styles. Purely presentational: it takes a ``CareResource`` and renders text —
+ * no chatbot chrome (no sender, avatar, reply, Send), tokens only.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import type { CareResource } from '@/api';
+import { SPACING, accent, editorialType, ink, spacing, surface } from '@/design/tokens';
+
+/** Accessibility label combining a resource's name, contact, and description. */
+export function resourceLabel(resource: CareResource): string {
+  return `${resource.name}. ${resource.contact}. ${resource.what_it_is}`;
+}
+
+export interface CareResourceCardProps {
+  /** The support pointer to render. */
+  resource: CareResource;
+}
+
+/** One support pointer: name, how to reach it, and what it is. */
+function CareResourceCard({ resource }: CareResourceCardProps): React.JSX.Element {
+  return (
+    <View
+      style={styles.resource}
+      testID={`care-resource-${resource.kind}`}
+      accessible
+      accessibilityLabel={resourceLabel(resource)}
+    >
+      <Text style={styles.resourceName}>{resource.name}</Text>
+      <Text style={styles.resourceContact}>{resource.contact}</Text>
+      <Text style={styles.resourceWhat}>{resource.what_it_is}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  resource: {
+    paddingVertical: SPACING.sm,
+    borderTopWidth: 1,
+    borderTopColor: surface.hairline,
+  },
+  resourceName: {
+    ...editorialType.note,
+    fontWeight: '600',
+    color: ink.primary,
+  },
+  resourceContact: {
+    ...editorialType.note,
+    color: accent.strong,
+    marginTop: spacing(0.25),
+  },
+  resourceWhat: {
+    ...editorialType.caption,
+    color: ink.soft,
+    marginTop: spacing(0.25),
+  },
+});
+
+export default CareResourceCard;

--- a/frontend/src/components/care/__tests__/CareResourceCard.test.tsx
+++ b/frontend/src/components/care/__tests__/CareResourceCard.test.tsx
@@ -1,0 +1,172 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+/**
+ * RED tests for ``CareResourceCard`` (issue #892 — always-available Support &
+ * care in Settings).
+ *
+ * These tests fail until the implementation-specialist creates
+ * ``frontend/src/components/care/CareResourceCard.tsx``, which is the
+ * ``ResourceCard`` sub-component extracted from ``CareSupportNote`` so it can
+ * be reused in ``SupportCareScreen``.
+ *
+ * Design contract (from architect):
+ *   - Accepts a single ``resource: CareResource`` prop.
+ *   - Renders the resource's ``name``, ``contact``, and ``what_it_is`` as text.
+ *   - Sets ``testID={`care-resource-${resource.kind}`}``.
+ *   - Sets a combined, descriptive ``accessibilityLabel`` (same formula as the
+ *     existing ``resourceLabel`` helper in ``CareSupportNote``):
+ *     ``"{name}. {contact}. {what_it_is}"``.
+ */
+import CareResourceCard from '../CareResourceCard';
+
+import type { CareResource } from '@/api';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeResource(overrides: Partial<CareResource> = {}): CareResource {
+  return {
+    kind: 'hotline',
+    name: '988 Suicide & Crisis Lifeline',
+    contact: '988',
+    what_it_is: 'Free, confidential crisis support — call or text anytime.',
+    ...overrides,
+  };
+}
+
+const ALL_KINDS: CareResource['kind'][] = ['hotline', 'text_line', 'human', 'professional'];
+
+const KIND_FIXTURES: Record<CareResource['kind'], CareResource> = {
+  hotline: makeResource({ kind: 'hotline', name: '988 Lifeline', contact: '988' }),
+  text_line: makeResource({
+    kind: 'text_line',
+    name: 'Crisis Text Line',
+    contact: 'Text HOME to 741741',
+    what_it_is: 'Text-based crisis counselling, 24/7.',
+  }),
+  human: makeResource({
+    kind: 'human',
+    name: 'Trusted person in your life',
+    contact: 'Call, text, or visit',
+    what_it_is: 'Someone who knows you.',
+  }),
+  professional: makeResource({
+    kind: 'professional',
+    name: 'Licensed therapist',
+    contact: 'Psychology Today directory',
+    what_it_is: 'An ongoing therapeutic relationship with a credentialed clinician.',
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Rendering — name / contact / what_it_is text visible
+// ---------------------------------------------------------------------------
+
+describe('CareResourceCard — text content', () => {
+  it('renders the resource name as visible text', () => {
+    const resource = makeResource();
+    const { getByText } = render(<CareResourceCard resource={resource} />);
+    expect(getByText('988 Suicide & Crisis Lifeline')).toBeTruthy();
+  });
+
+  it('renders the resource contact as visible text', () => {
+    const resource = makeResource();
+    const { getByText } = render(<CareResourceCard resource={resource} />);
+    expect(getByText('988')).toBeTruthy();
+  });
+
+  it('renders the resource what_it_is as visible text', () => {
+    const resource = makeResource();
+    const { getByText } = render(<CareResourceCard resource={resource} />);
+    expect(getByText('Free, confidential crisis support — call or text anytime.')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// testID — care-resource-${kind} for each of the four kinds
+// ---------------------------------------------------------------------------
+
+describe('CareResourceCard — testID', () => {
+  for (const kind of ALL_KINDS) {
+    it(`mounts testID "care-resource-${kind}" for kind="${kind}"`, () => {
+      const resource = KIND_FIXTURES[kind];
+      const { getByTestId } = render(<CareResourceCard resource={resource} />);
+      expect(getByTestId(`care-resource-${kind}`)).toBeTruthy();
+    });
+  }
+
+  it('does NOT mount a card for a kind that was not rendered', () => {
+    const resource = makeResource({ kind: 'hotline' });
+    const { queryByTestId } = render(<CareResourceCard resource={resource} />);
+    // Other kinds must not appear when only "hotline" was rendered.
+    expect(queryByTestId('care-resource-text_line')).toBeNull();
+    expect(queryByTestId('care-resource-human')).toBeNull();
+    expect(queryByTestId('care-resource-professional')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// accessibilityLabel — combined descriptive label
+// ---------------------------------------------------------------------------
+
+describe('CareResourceCard — accessibilityLabel', () => {
+  it('sets a combined accessibilityLabel containing name, contact, and what_it_is', () => {
+    const resource = makeResource();
+    const { getByTestId } = render(<CareResourceCard resource={resource} />);
+    const card = getByTestId('care-resource-hotline');
+    const label: unknown = card.props.accessibilityLabel;
+    expect(typeof label).toBe('string');
+    // Must contain all three parts.
+    expect(label as string).toContain(resource.name);
+    expect(label as string).toContain(resource.contact);
+    expect(label as string).toContain(resource.what_it_is);
+  });
+
+  it('the accessibilityLabel is longer than just the resource name', () => {
+    const resource = makeResource();
+    const { getByTestId } = render(<CareResourceCard resource={resource} />);
+    const card = getByTestId('care-resource-hotline');
+    const label = card.props.accessibilityLabel as string;
+    expect(label.length).toBeGreaterThan(resource.name.length + 5);
+  });
+
+  it('the accessibilityLabel format matches "{name}. {contact}. {what_it_is}"', () => {
+    const resource = makeResource();
+    const { getByTestId } = render(<CareResourceCard resource={resource} />);
+    const card = getByTestId('care-resource-hotline');
+    const label = card.props.accessibilityLabel as string;
+    const expected = `${resource.name}. ${resource.contact}. ${resource.what_it_is}`;
+    expect(label).toBe(expected);
+  });
+
+  it('text_line card has a descriptive accessibilityLabel', () => {
+    const resource = KIND_FIXTURES['text_line'];
+    const { getByTestId } = render(<CareResourceCard resource={resource} />);
+    const card = getByTestId('care-resource-text_line');
+    const label = card.props.accessibilityLabel as string;
+    expect(label).toContain('Crisis Text Line');
+    expect(label).toContain('741741');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No chat/bot affordances
+// ---------------------------------------------------------------------------
+
+describe('CareResourceCard — no chat UI', () => {
+  it('does not render a "Send" text element', () => {
+    const resource = makeResource();
+    const { queryByText } = render(<CareResourceCard resource={resource} />);
+    expect(queryByText('Send')).toBeNull();
+  });
+
+  it('does not render testID "sender"', () => {
+    const resource = makeResource();
+    const { queryByTestId } = render(<CareResourceCard resource={resource} />);
+    expect(queryByTestId('sender')).toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/CareSupportNote.tsx
+++ b/frontend/src/features/Journal/CareSupportNote.tsx
@@ -16,6 +16,7 @@ import React, { useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { CareResource, CareResponse } from '@/api';
+import CareResourceCard from '@/components/care/CareResourceCard';
 import {
   BORDER_RADIUS,
   SPACING,
@@ -23,7 +24,6 @@ import {
   editorialType,
   ink,
   paperShadow,
-  spacing,
   surface,
   touchTarget,
 } from '@/design/tokens';
@@ -33,30 +33,9 @@ const REOPEN_LABEL = 'Show support options';
 const DISMISS_A11Y = 'Hide the support options';
 const REOPEN_A11Y = 'Show the support options again';
 
-/** Accessibility label combining a resource's name, contact, and description. */
-function resourceLabel(resource: CareResource): string {
-  return `${resource.name}. ${resource.contact}. ${resource.what_it_is}`;
-}
-
 export interface CareSupportNoteProps {
   /** The care surface from the latest resonance pass; ``null`` hides everything. */
   care: CareResponse | null;
-}
-
-/** One support pointer: name, how to reach it, and what it is. */
-function ResourceCard({ resource }: { resource: CareResource }): React.JSX.Element {
-  return (
-    <View
-      style={styles.resource}
-      testID={`care-resource-${resource.kind}`}
-      accessible
-      accessibilityLabel={resourceLabel(resource)}
-    >
-      <Text style={styles.resourceName}>{resource.name}</Text>
-      <Text style={styles.resourceContact}>{resource.contact}</Text>
-      <Text style={styles.resourceWhat}>{resource.what_it_is}</Text>
-    </View>
-  );
 }
 
 /** The collapsed state: a single affordance that restores the resource list. */
@@ -85,7 +64,7 @@ function ExpandedBody({
   return (
     <>
       {resources.map((resource) => (
-        <ResourceCard key={resource.kind} resource={resource} />
+        <CareResourceCard key={resource.kind} resource={resource} />
       ))}
       <TouchableOpacity
         style={styles.dismiss}
@@ -131,26 +110,6 @@ const styles = StyleSheet.create({
     ...editorialType.title,
     color: ink.primary,
     marginBottom: SPACING.md,
-  },
-  resource: {
-    paddingVertical: SPACING.sm,
-    borderTopWidth: 1,
-    borderTopColor: surface.hairline,
-  },
-  resourceName: {
-    ...editorialType.note,
-    fontWeight: '600',
-    color: ink.primary,
-  },
-  resourceContact: {
-    ...editorialType.note,
-    color: accent.strong,
-    marginTop: spacing(0.25),
-  },
-  resourceWhat: {
-    ...editorialType.caption,
-    color: ink.soft,
-    marginTop: spacing(0.25),
   },
   dismiss: {
     minHeight: touchTarget.minimum,

--- a/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
@@ -259,3 +259,46 @@ describe('CareSupportNote — no chat UI', () => {
     expect(queryByText('Send')).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #892 regression — care-resource-${kind} testIDs survive the
+// ResourceCard → CareResourceCard extraction.
+//
+// After issue #892 the inline ``ResourceCard`` function in ``CareSupportNote``
+// is extracted to ``components/care/CareResourceCard`` and re-imported.
+// These tests confirm that the testID contract on the reactive (journal)
+// surface is IDENTICAL after the refactor — the implementation-specialist
+// must NOT rename the testIDs or alter the accessibilityLabel formula.
+// ---------------------------------------------------------------------------
+
+describe('CareSupportNote — regression: care-resource testIDs after CareResourceCard extraction (issue #892)', () => {
+  it('still mounts "care-resource-hotline" after the extraction refactor', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-resource-hotline')).toBeTruthy();
+  });
+
+  it('still mounts "care-resource-text_line" after the extraction refactor', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-resource-text_line')).toBeTruthy();
+  });
+
+  it('still mounts "care-resource-human" after the extraction refactor', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-resource-human')).toBeTruthy();
+  });
+
+  it('still mounts "care-resource-professional" after the extraction refactor', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    expect(getByTestId('care-resource-professional')).toBeTruthy();
+  });
+
+  it('accessibilityLabel format is preserved: "{name}. {contact}. {what_it_is}"', () => {
+    const payload = carePayload();
+    const { getByTestId } = render(<CareSupportNote care={payload} />);
+    const hotlineResource = payload.resources.find((r) => r.kind === 'hotline');
+    if (!hotlineResource) throw new Error('fixture missing hotline resource');
+    const card = getByTestId('care-resource-hotline');
+    const expected = `${hotlineResource.name}. ${hotlineResource.contact}. ${hotlineResource.what_it_is}`;
+    expect(card.props.accessibilityLabel).toBe(expected);
+  });
+});

--- a/frontend/src/features/Settings/SettingsHubScreen.tsx
+++ b/frontend/src/features/Settings/SettingsHubScreen.tsx
@@ -1,6 +1,13 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { ChevronRight, Globe, KeyRound, LogOut, type LucideIcon } from 'lucide-react-native';
+import {
+  ChevronRight,
+  Globe,
+  KeyRound,
+  LifeBuoy,
+  LogOut,
+  type LucideIcon,
+} from 'lucide-react-native';
 import React, { useCallback } from 'react';
 import { StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
 
@@ -60,12 +67,65 @@ const SettingsRow = ({
   );
 };
 
+interface AccountSectionProps {
+  onApiKey: () => void;
+  onTimezone: () => void;
+}
+
+/** Account group: the bring-your-own-key and time-zone destinations. */
+const AccountSection = ({ onApiKey, onTimezone }: AccountSectionProps): React.JSX.Element => (
+  <EditorialSection title="Account" testID="settings-group-account">
+    <SettingsRow
+      icon={KeyRound}
+      label="API key"
+      description="Bring your own BotMason API key, stored on this device."
+      onPress={onApiKey}
+      testID="settings-row-api-key"
+    />
+    <SettingsRow
+      icon={Globe}
+      label="Time zone"
+      description="Set the zone streaks and daily stats count days in."
+      onPress={onTimezone}
+      testID="settings-row-timezone"
+    />
+  </EditorialSection>
+);
+
+/** Session group: the destructive log-out action. */
+const SessionSection = ({ onLogout }: { onLogout: () => void }): React.JSX.Element => (
+  <EditorialSection title="Session" testID="settings-group-session">
+    <SettingsRow
+      icon={LogOut}
+      label="Log out"
+      description="Sign out of Adepthood on this device."
+      onPress={onLogout}
+      testID="settings-row-logout"
+      destructive
+    />
+  </EditorialSection>
+);
+
+/** Always-available Support & care destination (issue #892). */
+const SupportSection = ({ onSupportCare }: { onSupportCare: () => void }): React.JSX.Element => (
+  <EditorialSection title="Support & care" testID="settings-group-support">
+    <SettingsRow
+      icon={LifeBuoy}
+      label="Support & care"
+      description="Reach a person — crisis lines and professional care, any time."
+      onPress={onSupportCare}
+      testID="settings-row-support"
+    />
+  </EditorialSection>
+);
+
 const SettingsHubScreen = (): React.JSX.Element => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { logout } = useAuth();
 
   const openApiKey = useCallback(() => navigation.navigate('ApiKeySettings'), [navigation]);
   const openTimezone = useCallback(() => navigation.navigate('TimezoneSettings'), [navigation]);
+  const openSupportCare = useCallback(() => navigation.navigate('SupportCare'), [navigation]);
   const onLogout = useCallback(() => void logout(), [logout]);
 
   return (
@@ -75,32 +135,9 @@ const SettingsHubScreen = (): React.JSX.Element => {
         title="Settings"
         lead="Manage how Adepthood works for you."
       />
-      <EditorialSection title="Account" testID="settings-group-account">
-        <SettingsRow
-          icon={KeyRound}
-          label="API key"
-          description="Bring your own BotMason API key, stored on this device."
-          onPress={openApiKey}
-          testID="settings-row-api-key"
-        />
-        <SettingsRow
-          icon={Globe}
-          label="Time zone"
-          description="Set the zone streaks and daily stats count days in."
-          onPress={openTimezone}
-          testID="settings-row-timezone"
-        />
-      </EditorialSection>
-      <EditorialSection title="Session" testID="settings-group-session">
-        <SettingsRow
-          icon={LogOut}
-          label="Log out"
-          description="Sign out of Adepthood on this device."
-          onPress={onLogout}
-          testID="settings-row-logout"
-          destructive
-        />
-      </EditorialSection>
+      <AccountSection onApiKey={openApiKey} onTimezone={openTimezone} />
+      <SessionSection onLogout={onLogout} />
+      <SupportSection onSupportCare={openSupportCare} />
     </ScreenScaffold>
   );
 };

--- a/frontend/src/features/Settings/SupportCareScreen.tsx
+++ b/frontend/src/features/Settings/SupportCareScreen.tsx
@@ -1,0 +1,54 @@
+/**
+ * ``SupportCareScreen`` — the always-available Support & care surface (issue
+ * #892), reachable any time from the Settings hub. It mirrors the resources of
+ * the reactive ``CareSupportNote`` but as a calm, standing invitation rather
+ * than a response to a distress signal: a header-role message, the four shared
+ * ``CareResourceCard``s, and a quiet care-boundary caption. Deliberately NOT a
+ * chatbot — no avatar, no sender, no reply, no Send. Tokens only.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { CARE_LIMITS_LINE, STANDING_CARE } from './careResources';
+
+import CareResourceCard from '@/components/care/CareResourceCard';
+import { ScreenHeader } from '@/components/layout/ScreenHeader';
+import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
+import { SPACING, editorialType, ink } from '@/design/tokens';
+
+const SupportCareScreen = (): React.JSX.Element => (
+  <ScreenScaffold scroll testID="support-care-screen">
+    <ScreenHeader
+      eyebrow="You are not alone"
+      title="Support & care"
+      lead="Support you can reach any time — not just when things are hard."
+    />
+    <Text style={styles.message} accessibilityRole="header">
+      {STANDING_CARE.message}
+    </Text>
+    <View style={styles.resources}>
+      {STANDING_CARE.resources.map((resource) => (
+        <CareResourceCard key={resource.kind} resource={resource} />
+      ))}
+    </View>
+    <Text style={styles.limits}>{CARE_LIMITS_LINE}</Text>
+  </ScreenScaffold>
+);
+
+const styles = StyleSheet.create({
+  message: {
+    ...editorialType.title,
+    color: ink.primary,
+    marginTop: SPACING.md,
+    marginBottom: SPACING.md,
+  },
+  resources: {
+    marginBottom: SPACING.lg,
+  },
+  limits: {
+    ...editorialType.caption,
+    color: ink.soft,
+  },
+});
+
+export default SupportCareScreen;

--- a/frontend/src/features/Settings/__tests__/SettingsHubScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/SettingsHubScreen.test.tsx
@@ -55,3 +55,41 @@ describe('SettingsHubScreen', () => {
     expect(mockLogout).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #892 — "Support & care" row additions (RED — fails until impl exists)
+// ---------------------------------------------------------------------------
+
+describe('SettingsHubScreen — Support & care row (issue #892)', () => {
+  test('renders the "Support & care" row with testID "settings-row-support"', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    // This row does not exist until the implementation-specialist adds it.
+    // The test will fail with "Unable to find an element with testID: settings-row-support".
+    expect(getByTestId('settings-row-support')).toBeTruthy();
+  });
+
+  test('the "Support & care" row has accessible label text "Support & care"', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+    const row = getByTestId('settings-row-support');
+    expect(row.props.accessibilityLabel).toBe('Support & care');
+  });
+
+  test('tapping "settings-row-support" navigates to SupportCare', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    fireEvent.press(getByTestId('settings-row-support'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('SupportCare');
+  });
+
+  test('the existing rows are unaffected by the new Support & care row', () => {
+    // Regression: the original three rows must still render after the new row
+    // is added to prevent accidental reordering or duplication.
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    expect(getByTestId('settings-row-api-key')).toBeTruthy();
+    expect(getByTestId('settings-row-timezone')).toBeTruthy();
+    expect(getByTestId('settings-row-logout')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Settings/__tests__/SupportCareScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/SupportCareScreen.test.tsx
@@ -1,0 +1,179 @@
+/* eslint-env jest */
+/* global jest */
+import { describe, it, expect } from '@jest/globals';
+import { render, within } from '@testing-library/react-native';
+
+/**
+ * RED tests for ``SupportCareScreen`` (issue #892 — always-available Support &
+ * care in Settings).
+ *
+ * These tests fail until the implementation-specialist creates
+ * ``frontend/src/features/Settings/SupportCareScreen.tsx``.
+ *
+ * Design contract:
+ *   - Renders all four care resource cards (testID ``care-resource-{kind}``).
+ *   - Renders a header-role message (``accessibilityRole="header"``).
+ *   - Renders the ``CARE_LIMITS_LINE`` text.
+ *   - Does NOT render any chatbot chrome (no sender, avatar, reply, Send).
+ *   - The four resources come from ``STANDING_CARE`` (static, not reactive).
+ */
+
+// Module-level mock for careResources so the screen resolves its imports even
+// before production files exist; the values it exposes are the canonical
+// fixtures so tests still fail on rendering gaps, not on mock gaps.
+jest.mock('../careResources', () => ({
+  STANDING_CARE: {
+    message: 'Support is available whenever you need it. Here are some people who can help.',
+    resources: [
+      {
+        kind: 'hotline',
+        name: '988 Suicide & Crisis Lifeline',
+        contact: '988',
+        what_it_is: 'Free, confidential crisis support — call or text anytime.',
+      },
+      {
+        kind: 'text_line',
+        name: 'Crisis Text Line',
+        contact: 'Text HOME to 741741',
+        what_it_is: 'Text-based crisis counselling, 24/7.',
+      },
+      {
+        kind: 'human',
+        name: 'Trusted person in your life',
+        contact: 'Call, text, or visit',
+        what_it_is: 'Someone who knows you — no professional training required.',
+      },
+      {
+        kind: 'professional',
+        name: 'Licensed therapist',
+        contact: 'Psychology Today directory',
+        what_it_is: 'An ongoing therapeutic relationship with a credentialed clinician.',
+      },
+    ],
+  },
+  CARE_LIMITS_LINE: 'This complements professional care — it does not replace it.',
+}));
+
+// CareResourceCard is the extracted shared component; mock it to a thin
+// pass-through so SupportCareScreen tests are isolated from CareResourceCard
+// rendering details. The testID contract is still asserted here because the
+// screen must pass correct props.
+jest.mock('@/components/care/CareResourceCard', () => {
+  const React = require('react');
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      resource,
+    }: {
+      resource: { kind: string; name: string; contact: string; what_it_is: string };
+    }) => (
+      <View
+        testID={`care-resource-${resource.kind}`}
+        accessibilityLabel={`${resource.name}. ${resource.contact}. ${resource.what_it_is}`}
+      >
+        <Text>{resource.name}</Text>
+        <Text>{resource.contact}</Text>
+        <Text>{resource.what_it_is}</Text>
+      </View>
+    ),
+  };
+});
+
+import SupportCareScreen from '../SupportCareScreen';
+
+// ---------------------------------------------------------------------------
+// Resource card presence
+// ---------------------------------------------------------------------------
+
+describe('SupportCareScreen — resource cards', () => {
+  it('renders testID "care-resource-hotline"', () => {
+    const { getByTestId } = render(<SupportCareScreen />);
+    expect(getByTestId('care-resource-hotline')).toBeTruthy();
+  });
+
+  it('renders testID "care-resource-text_line"', () => {
+    const { getByTestId } = render(<SupportCareScreen />);
+    expect(getByTestId('care-resource-text_line')).toBeTruthy();
+  });
+
+  it('renders testID "care-resource-human"', () => {
+    const { getByTestId } = render(<SupportCareScreen />);
+    expect(getByTestId('care-resource-human')).toBeTruthy();
+  });
+
+  it('renders testID "care-resource-professional"', () => {
+    const { getByTestId } = render(<SupportCareScreen />);
+    expect(getByTestId('care-resource-professional')).toBeTruthy();
+  });
+
+  it('renders the hotline name text within its card', () => {
+    const { getByTestId } = render(<SupportCareScreen />);
+    const hotlineCard = getByTestId('care-resource-hotline');
+    expect(within(hotlineCard).getByText('988 Suicide & Crisis Lifeline')).toBeTruthy();
+  });
+
+  it('renders the text_line contact within its card', () => {
+    const { getByTestId } = render(<SupportCareScreen />);
+    const textLineCard = getByTestId('care-resource-text_line');
+    expect(within(textLineCard).getByText('Text HOME to 741741')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Header-role message
+// ---------------------------------------------------------------------------
+
+describe('SupportCareScreen — header message', () => {
+  it('renders the STANDING_CARE message text', () => {
+    const { getByText } = render(<SupportCareScreen />);
+    expect(
+      getByText('Support is available whenever you need it. Here are some people who can help.'),
+    ).toBeTruthy();
+  });
+
+  it('the STANDING_CARE message element has accessibilityRole="header"', () => {
+    const { getByText } = render(<SupportCareScreen />);
+    const messageEl = getByText(
+      'Support is available whenever you need it. Here are some people who can help.',
+    );
+    expect(messageEl.props.accessibilityRole).toBe('header');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Limits line
+// ---------------------------------------------------------------------------
+
+describe('SupportCareScreen — limits line', () => {
+  it('renders the CARE_LIMITS_LINE text', () => {
+    const { getByText } = render(<SupportCareScreen />);
+    expect(getByText('This complements professional care — it does not replace it.')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No chatbot chrome
+// ---------------------------------------------------------------------------
+
+describe('SupportCareScreen — no chatbot chrome', () => {
+  it('does not render testID "sender"', () => {
+    const { queryByTestId } = render(<SupportCareScreen />);
+    expect(queryByTestId('sender')).toBeNull();
+  });
+
+  it('does not render testID "avatar"', () => {
+    const { queryByTestId } = render(<SupportCareScreen />);
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+
+  it('does not render testID "reply"', () => {
+    const { queryByTestId } = render(<SupportCareScreen />);
+    expect(queryByTestId('reply')).toBeNull();
+  });
+
+  it('does not render a "Send" text element', () => {
+    const { queryByText } = render(<SupportCareScreen />);
+    expect(queryByText('Send')).toBeNull();
+  });
+});

--- a/frontend/src/features/Settings/__tests__/careResources.test.ts
+++ b/frontend/src/features/Settings/__tests__/careResources.test.ts
@@ -1,0 +1,174 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+/**
+ * RED tests for ``careResources.ts`` (issue #892 — always-available Support &
+ * care in Settings).
+ *
+ * These tests fail until the implementation-specialist creates
+ * ``frontend/src/features/Settings/careResources.ts`` that exports:
+ *   - ``STANDING_CARE: CareResponse``  — the static, always-available payload
+ *   - ``CARE_LIMITS_LINE: string``     — the disclaimer about professional care
+ */
+import { STANDING_CARE, CARE_LIMITS_LINE } from '../careResources';
+
+import { careResponseSchema } from '@/api/schemas';
+
+// ---------------------------------------------------------------------------
+// Dynamic imports — fails immediately on missing module (RED signal)
+// ---------------------------------------------------------------------------
+
+// NOTE: we import with `await import(...)` in each test so the module-not-found
+// error is the RED reason (not a parse-time crash that swallows the test name).
+
+// ---------------------------------------------------------------------------
+// STANDING_CARE structural validity
+// ---------------------------------------------------------------------------
+
+describe('STANDING_CARE — Zod schema compliance', () => {
+  it('parses cleanly through careResponseSchema (structural identity)', () => {
+    const result = careResponseSchema.safeParse(STANDING_CARE);
+    expect(result.success).toBe(true);
+  });
+
+  it('has a non-empty message string', () => {
+    expect(typeof STANDING_CARE.message).toBe('string');
+    expect(STANDING_CARE.message.length).toBeGreaterThan(0);
+  });
+
+  it('contains exactly four resource entries', () => {
+    expect(STANDING_CARE.resources).toHaveLength(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STANDING_CARE — kind ordering: hotline → text_line → human → professional
+// ---------------------------------------------------------------------------
+
+describe('STANDING_CARE — resource ordering', () => {
+  it('the first resource has kind "hotline"', () => {
+    expect(STANDING_CARE.resources[0]?.kind).toBe('hotline');
+  });
+
+  it('the second resource has kind "text_line"', () => {
+    expect(STANDING_CARE.resources[1]?.kind).toBe('text_line');
+  });
+
+  it('the third resource has kind "human"', () => {
+    expect(STANDING_CARE.resources[2]?.kind).toBe('human');
+  });
+
+  it('the fourth resource has kind "professional"', () => {
+    expect(STANDING_CARE.resources[3]?.kind).toBe('professional');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STANDING_CARE — required contacts present
+// ---------------------------------------------------------------------------
+
+describe('STANDING_CARE — required crisis contacts', () => {
+  it('the hotline resource contains "988" in its contact field', () => {
+    const hotline = STANDING_CARE.resources.find((r) => r.kind === 'hotline');
+    expect(hotline).toBeDefined();
+    expect(hotline?.contact).toContain('988');
+  });
+
+  it('the text_line resource contains "741741" in its contact field', () => {
+    const textLine = STANDING_CARE.resources.find((r) => r.kind === 'text_line');
+    expect(textLine).toBeDefined();
+    expect(textLine?.contact).toContain('741741');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STANDING_CARE — each resource has non-empty name / contact / what_it_is
+// ---------------------------------------------------------------------------
+
+describe('STANDING_CARE — resource field completeness', () => {
+  const KINDS = ['hotline', 'text_line', 'human', 'professional'] as const;
+
+  for (const kind of KINDS) {
+    it(`"${kind}" resource has a non-empty name`, () => {
+      const resource = STANDING_CARE.resources.find((r) => r.kind === kind);
+      expect(resource).toBeDefined();
+      expect(resource?.name.length).toBeGreaterThan(0);
+    });
+
+    it(`"${kind}" resource has a non-empty contact`, () => {
+      const resource = STANDING_CARE.resources.find((r) => r.kind === kind);
+      expect(resource?.contact.length).toBeGreaterThan(0);
+    });
+
+    it(`"${kind}" resource has a non-empty what_it_is`, () => {
+      const resource = STANDING_CARE.resources.find((r) => r.kind === kind);
+      expect(resource?.what_it_is.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// CARE_LIMITS_LINE — present and contains the complementary-care idea
+// ---------------------------------------------------------------------------
+
+describe('CARE_LIMITS_LINE — content requirements', () => {
+  it('is a non-empty string', () => {
+    expect(typeof CARE_LIMITS_LINE).toBe('string');
+    expect(CARE_LIMITS_LINE.length).toBeGreaterThan(0);
+  });
+
+  it('conveys that this complements professional care', () => {
+    // Must contain the "complements" or "complement" root to convey the idea.
+    // Case-insensitive because capitalisation is a style choice.
+    expect(CARE_LIMITS_LINE.toLowerCase()).toMatch(/complement/);
+  });
+
+  it('conveys that this does not replace professional care', () => {
+    // Must contain "replace" (or "replaces") to convey the limiting idea.
+    expect(CARE_LIMITS_LINE.toLowerCase()).toMatch(/replace/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Safety gate — no diagnosis/medication wording anywhere in STANDING_CARE
+// ---------------------------------------------------------------------------
+
+describe('STANDING_CARE — prohibited clinical wording', () => {
+  const PROHIBITED = [/diagnos/i, /medic(at|ine)/i, /prescri/i, /disorder/i, /symptom/i];
+
+  it('no resource name contains prohibited clinical wording', () => {
+    for (const resource of STANDING_CARE.resources) {
+      for (const pattern of PROHIBITED) {
+        expect(resource.name).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('no resource contact contains prohibited clinical wording', () => {
+    for (const resource of STANDING_CARE.resources) {
+      for (const pattern of PROHIBITED) {
+        expect(resource.contact).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('no resource what_it_is contains prohibited clinical wording', () => {
+    for (const resource of STANDING_CARE.resources) {
+      for (const pattern of PROHIBITED) {
+        expect(resource.what_it_is).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('the message does not contain prohibited clinical wording', () => {
+    for (const pattern of PROHIBITED) {
+      expect(STANDING_CARE.message).not.toMatch(pattern);
+    }
+  });
+
+  it('CARE_LIMITS_LINE does not contain prohibited clinical wording', () => {
+    for (const pattern of PROHIBITED) {
+      expect(CARE_LIMITS_LINE).not.toMatch(pattern);
+    }
+  });
+});

--- a/frontend/src/features/Settings/careResources.ts
+++ b/frontend/src/features/Settings/careResources.ts
@@ -1,0 +1,76 @@
+/**
+ * ``STANDING_CARE`` — the always-available Support & care payload shown in
+ * Settings (issue #892). Unlike the reactive ``CareSupportNote`` (which appears
+ * only when a resonance pass screens an entry as carrying an acute-distress
+ * signal), this is a calm standing invitation: support that is reachable any
+ * time, not framed as a response to anything the user just wrote.
+ *
+ * Canonical source of the copy is ``backend/src/domain/care.py`` (§10 "Wellbeing
+ * and care boundaries"): the same four resources, in the same order, with the
+ * same non-shaming, non-clinical voice. These constants intentionally mirror
+ * that canon so reviewers can keep the two surfaces from drifting; if the canon
+ * changes, update both. As there, there is NO diagnosis, NO medication guidance,
+ * and NO treatment advice here — only pointers toward human and professional
+ * support.
+ */
+import type { CareResource, CareResponse } from '@/api';
+
+/**
+ * A warm, non-shaming standing invitation. It names reaching out to a person as
+ * a sign of strength and makes clear that support is here whenever it is wanted —
+ * a calm, always-on offer rather than a reaction to a distress signal.
+ */
+const STANDING_CARE_MESSAGE =
+  'Whenever you want it, support is here — and reaching out to a person is a ' +
+  'sign of strength, not weakness. You never have to carry a hard moment ' +
+  'alone. The people below are here for exactly this, any time, and so is ' +
+  'someone you trust.';
+
+/**
+ * The four standing support pointers, ordered to lead with the immediate crisis
+ * lines, then a trusted person, then ongoing professional care. Mirrors
+ * ``CARE_RESOURCES`` in ``backend/src/domain/care.py``.
+ */
+const STANDING_CARE_RESOURCES: CareResource[] = [
+  {
+    kind: 'hotline',
+    name: '988 Suicide & Crisis Lifeline',
+    contact: 'Call or text 988',
+    what_it_is:
+      'Free, confidential support from a trained human counselor, 24 hours a day, 7 days a week.',
+  },
+  {
+    kind: 'text_line',
+    name: 'Crisis Text Line',
+    contact: 'Text HOME to 741741',
+    what_it_is:
+      'Text back and forth with a trained volunteer crisis counselor, any time, for free.',
+  },
+  {
+    kind: 'human',
+    name: 'Someone you trust',
+    contact: 'Reach out to a friend, family member, or anyone you trust',
+    what_it_is:
+      "You don't have to explain it perfectly — telling one person you're struggling can make this moment less heavy.",
+  },
+  {
+    kind: 'professional',
+    name: 'A mental-health professional',
+    contact: 'Contact a therapist, counselor, or your doctor',
+    what_it_is:
+      'A professional can offer ongoing, personal support. This app builds skill and self-knowledge alongside that care — it never replaces it.',
+  },
+];
+
+/** The always-available Support & care surface (static, not resonance-driven). */
+export const STANDING_CARE: CareResponse = {
+  message: STANDING_CARE_MESSAGE,
+  resources: STANDING_CARE_RESOURCES,
+};
+
+/**
+ * Quiet caption stating the app's care boundary: it sits alongside professional
+ * care, never in place of it (§10). Kept as a separate constant so it can be
+ * rendered as a subdued footnote rather than mixed into the warm message.
+ */
+export const CARE_LIMITS_LINE = "Adepthood complements professional care; it doesn't replace it.";

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -9,6 +9,7 @@ import { PracticeDetailScreen } from '../features/Practice/screens/PracticeDetai
 import SharePreviewScreen from '../features/Practice/screens/SharePreviewScreen';
 import ApiKeySettingsScreen from '../features/Settings/ApiKeySettingsScreen';
 import SettingsHubScreen from '../features/Settings/SettingsHubScreen';
+import SupportCareScreen from '../features/Settings/SupportCareScreen';
 import TimezoneSettingsScreen from '../features/Settings/TimezoneSettingsScreen';
 
 import type { RootTabParamList } from './BottomTabs';
@@ -43,6 +44,7 @@ export type RootStackParamList = {
   Settings: undefined;
   ApiKeySettings: undefined;
   TimezoneSettings: undefined;
+  SupportCare: undefined;
   SharePreview: { token: string };
   PracticeDetail: { practiceId: number };
   CreatePractice: { prefill?: CreatePracticePrefill } | undefined;
@@ -61,15 +63,15 @@ export type RootStackParamList = {
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
+// Header background/border come from the warm navTheme; here we add the
+// editorial serif title + terracotta back/tint.
+const NAV_SCREEN_OPTIONS = {
+  headerTintColor: accent.primary,
+  headerTitleStyle: { fontFamily: fonts.serif, color: ink.primary },
+} as const;
+
 const RootStack = (): React.JSX.Element => (
-  // Header background/border come from the warm navTheme; here we add the
-  // editorial serif title + terracotta back/tint (#803).
-  <Stack.Navigator
-    screenOptions={{
-      headerTintColor: accent.primary,
-      headerTitleStyle: { fontFamily: fonts.serif, color: ink.primary },
-    }}
-  >
+  <Stack.Navigator screenOptions={NAV_SCREEN_OPTIONS}>
     <Stack.Screen name="Tabs" component={BottomTabs} options={{ headerShown: false }} />
     <Stack.Screen name="Settings" component={SettingsHubScreen} options={{ title: 'Settings' }} />
     <Stack.Screen
@@ -81,6 +83,11 @@ const RootStack = (): React.JSX.Element => (
       name="TimezoneSettings"
       component={TimezoneSettingsScreen}
       options={{ title: 'Time zone' }}
+    />
+    <Stack.Screen
+      name="SupportCare"
+      component={SupportCareScreen}
+      options={{ title: 'Support & care' }}
     />
     <Stack.Screen
       name="SharePreview"


### PR DESCRIPTION
## Summary

#892 (epic #887, NORTH-STAR §10): support resources were only reactive to a detected crisis. Add a standing "Support & care" entry so help is always reachable.

- New `features/Settings/careResources.ts`: `STANDING_CARE` (typed to the `@/api` `CareResponse` shape — structurally identical to the reactive payload) with a calm standing message + the four resources (988 → Crisis Text Line 741741 → trusted person → professional); `CARE_LIMITS_LINE`. Copy sourced from the backend `domain/care.py` §10 canon (anti-drift pointer); no diagnosis/medication wording.
- **Extracted `components/care/CareResourceCard.tsx`** from `CareSupportNote` (single-sources the visual treatment); `CareSupportNote` rewired — behavior + testIDs + a11y label identical (regression-pinned).
- New `features/Settings/SupportCareScreen.tsx` (`ScreenScaffold` + `ScreenHeader`): header-role message + cards + limits caption. Registered as RootStack `SupportCare`.
- `SettingsHubScreen`: a last "Support & care" row (`settings-row-support`) → `navigate('SupportCare')`.

Worked under the conductor pipeline (architect → test → implementation → code-review-orchestrator CLEAN). **Completes the wellbeing/care epic (#887).**

## Test plan

`STANDING_CARE` parses + ordered + contacts + no-clinical-wording; `CareResourceCard` render/a11y; `SupportCareScreen` cards + message + limits; hub row → nav; `CareSupportNote` extraction regression. `./scripts/frontend/check-all.sh` green; no `any`, tokens-only.

Closes #892
Refs #887
