### PR TITLE
feat(backend): privacy classification tier on JournalEntry

### DIFF
--- a/backend/migrations/versions/d8e9f0a1b2c3_add_journalentry_classification.py
+++ b/backend/migrations/versions/d8e9f0a1b2c3_add_journalentry_classification.py
@@ -1,0 +1,62 @@
+"""add journalentry.classification privacy tier
+
+Revision ID: d8e9f0a1b2c3
+Revises: c5d6e7f8a9b0
+Create Date: 2026-06-30 00:00:00.000000
+
+Adds the privacy-tier column ``classification`` to ``journalentry``. ``upgrade``
+adds it ``NOT NULL`` with a temporary ``server_default='personal'`` so existing
+rows backfill to the default tier, then drops the server default (the app owns
+the default, keeping ``alembic check`` drift-free), then installs a CHECK
+pinning the value to {public, personal, intimate} — mirroring the constraint in
+the model's ``__table_args__``. ``downgrade`` drops the CHECK and the column.
+This is a data-model change only; routing/enforcement is issue #895.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d8e9f0a1b2c3"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "c5d6e7f8a9b0"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CLASSIFICATION_CHECK = "ck_journalentry_classification_valid"
+_CLASSIFICATION_CONDITION = "classification IN ('public', 'personal', 'intimate')"
+
+
+def upgrade() -> None:
+    """Add ``journalentry.classification`` (NOT NULL, backfilled 'personal') + CHECK."""
+    # Add with a server_default so the NOT NULL column backfills existing rows to
+    # the default tier ('personal').
+    op.add_column(
+        "journalentry",
+        sa.Column(
+            "classification",
+            sa.String(length=20),
+            nullable=False,
+            server_default="personal",
+        ),
+    )
+    # Drop the DB-level server_default (the app owns the default via the model's
+    # Field default, keeping ``alembic check`` drift-free) and install the CHECK
+    # in a single batch rebuild so SQLite (round-trip test) stays compatible.
+    with op.batch_alter_table("journalentry") as batch_op:
+        batch_op.alter_column(
+            "classification",
+            existing_type=sa.String(length=20),
+            existing_nullable=False,
+            server_default=None,
+        )
+        batch_op.create_check_constraint(_CLASSIFICATION_CHECK, _CLASSIFICATION_CONDITION)
+
+
+def downgrade() -> None:
+    """Drop the classification CHECK and column."""
+    # Batch mode keeps the downgrade SQLite-compatible (no ALTER/DROP CHECK there).
+    with op.batch_alter_table("journalentry") as batch_op:
+        batch_op.drop_constraint(_CLASSIFICATION_CHECK, type_="check")
+        batch_op.drop_column("classification")

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -2,7 +2,7 @@ import enum
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, DateTime, Index
+from sqlalchemy import CheckConstraint, Column, DateTime, Index
 from sqlmodel import Field, Relationship, SQLModel
 
 from services.journal_encryption import EncryptedString
@@ -40,6 +40,29 @@ class EntryStatus(enum.StrEnum):
     FINISHED = "finished"
 
 
+class JournalClassification(enum.StrEnum):
+    """Privacy tier of a journal entry — "you choose your depth" (issue #894).
+
+    ``public`` may be shared; ``personal`` is the default private tier;
+    ``intimate`` is the most sensitive tier (issue #895 will keep intimate
+    entries away from cloud LLMs). Stored as a plain string column with a DB
+    CHECK so the persisted set can't drift from this enum.
+    """
+
+    PUBLIC = "public"
+    PERSONAL = "personal"
+    INTIMATE = "intimate"
+
+
+def _classification_check() -> CheckConstraint:
+    """CHECK derived from ``JournalClassification`` so the DB set can't drift."""
+    quoted = ", ".join(f"'{c.value}'" for c in JournalClassification)
+    return CheckConstraint(
+        f"classification IN ({quoted})",
+        name="ck_journalentry_classification_valid",
+    )
+
+
 class JournalEntry(SQLModel, table=True):
     """Stores a chat message between the user and BotMason.
 
@@ -62,6 +85,7 @@ class JournalEntry(SQLModel, table=True):
     __table_args__ = (
         Index("ix_journalentry_deleted_at", "deleted_at"),
         Index("ix_journalentry_user_sender_deleted", "user_id", "sender", "deleted_at"),
+        _classification_check(),
     )
 
     id: int | None = Field(default=None, primary_key=True)
@@ -79,6 +103,9 @@ class JournalEntry(SQLModel, table=True):
     # ``message`` remains the body. ``updated_at`` tracks the last edit.
     title: str | None = Field(default=None, max_length=200)
     status: str = Field(default=EntryStatus.DRAFT, max_length=20)
+    # Privacy tier; defaults to ``personal``. The DB CHECK in ``__table_args__``
+    # pins the persisted value to the JournalClassification set.
+    classification: str = Field(default=JournalClassification.PERSONAL, max_length=20)
     sender: str = Field(max_length=10)  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     tag: str = Field(default=JournalTag.FREEFORM, max_length=50)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -259,17 +259,25 @@ async def get_journal_entry(
     return entry
 
 
+async def _apply_message_edit(
+    entry: JournalEntry, payload: JournalEntryUpdate, session: AsyncSession
+) -> None:
+    """Re-sanitize the body on edit and re-anchor marginalia + suggestions."""
+    if payload.message is None:
+        return
+    old_message = entry.message
+    new_message = _sanitize_message(payload.message)
+    if new_message != old_message:
+        entry.message = new_message
+        await reanchor_entry_marginalia(entry, old_message, new_message, session)
+        await reanchor_entry_suggestions(entry, new_message, session)
+
+
 async def _apply_entry_update(
     entry: JournalEntry, payload: JournalEntryUpdate, session: AsyncSession
 ) -> None:
     """Apply the provided fields to ``entry``, re-anchoring marginalia on a body edit."""
-    if payload.message is not None:
-        old_message = entry.message
-        new_message = _sanitize_message(payload.message)
-        if new_message != old_message:
-            entry.message = new_message
-            await reanchor_entry_marginalia(entry, old_message, new_message, session)
-            await reanchor_entry_suggestions(entry, new_message, session)
+    await _apply_message_edit(entry, payload, session)
     if payload.title is not None:
         entry.title = payload.title
     if payload.status is not None:

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -274,6 +274,8 @@ async def _apply_entry_update(
         entry.title = payload.title
     if payload.status is not None:
         entry.status = payload.status
+    if payload.classification is not None:
+        entry.classification = payload.classification
     # ``updated_at`` is bumped by the column's ``onupdate`` only when a value
     # actually changes, so a same-value PATCH doesn't move it.
 

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -7,7 +7,7 @@ from typing import Self
 
 from pydantic import BaseModel, Field, model_validator
 
-from models.journal_entry import EntryStatus, JournalTag
+from models.journal_entry import EntryStatus, JournalClassification, JournalTag
 
 JOURNAL_MESSAGE_MAX_LENGTH = 10_000
 
@@ -21,6 +21,7 @@ class JournalMessageCreate(BaseModel):
 
     message: str = Field(min_length=1, max_length=JOURNAL_MESSAGE_MAX_LENGTH)
     tag: JournalTag = JournalTag.FREEFORM
+    classification: JournalClassification = JournalClassification.PERSONAL
     practice_session_id: int | None = None
     user_practice_id: int | None = None
 
@@ -35,10 +36,16 @@ class JournalEntryUpdate(BaseModel):
     message: str | None = Field(default=None, min_length=1, max_length=JOURNAL_MESSAGE_MAX_LENGTH)
     title: str | None = Field(default=None, max_length=200)
     status: EntryStatus | None = None
+    classification: JournalClassification | None = None
 
     @model_validator(mode="after")
     def _require_at_least_one_field(self) -> Self:
-        if self.message is None and self.title is None and self.status is None:
+        if (
+            self.message is None
+            and self.title is None
+            and self.status is None
+            and self.classification is None
+        ):
             msg = "at least one field must be provided"
             raise ValueError(msg)
         return self
@@ -59,6 +66,7 @@ class JournalMessageResponse(BaseModel):
     timestamp: datetime
     updated_at: datetime
     tag: str
+    classification: JournalClassification
     practice_session_id: int | None
     user_practice_id: int | None
 

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -40,12 +40,8 @@ class JournalEntryUpdate(BaseModel):
 
     @model_validator(mode="after")
     def _require_at_least_one_field(self) -> Self:
-        if (
-            self.message is None
-            and self.title is None
-            and self.status is None
-            and self.classification is None
-        ):
+        provided = (self.message, self.title, self.status, self.classification)
+        if all(value is None for value in provided):
             msg = "at least one field must be provided"
             raise ValueError(msg)
         return self

--- a/backend/tests/test_journal_classification_endpoint.py
+++ b/backend/tests/test_journal_classification_endpoint.py
@@ -1,0 +1,158 @@
+"""Endpoint tests for the JournalClassification tier (issue #894).
+
+Scope: persistence and serialisation only.
+Routing / LLM behaviour for 'intimate' entries is issue #895 — not tested here.
+
+Covers:
+- POST /journal/ without classification → response.classification == "personal".
+- POST /journal/ with classification="intimate" → response.classification == "intimate".
+- PATCH /journal/{id} with classification="intimate" → response echoes "intimate".
+- PATCH /journal/{id} with classification="public" → response echoes "public".
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import cast
+
+import pytest
+from httpx import AsyncClient
+
+
+async def _signup(client: AsyncClient, username: str = "classif_ep") -> dict[str, str]:
+    """Create a user account and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create(
+    client: AsyncClient,
+    headers: dict[str, str],
+    *,
+    message: str = "A journal entry.",
+    **extra: object,
+) -> dict[str, object]:
+    """POST a journal entry and return the parsed response body."""
+    payload: dict[str, object] = {"message": message}
+    payload.update(extra)
+    resp = await client.post("/journal/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    return cast("dict[str, object]", resp.json())
+
+
+# ---------------------------------------------------------------------------
+# POST create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_without_classification_defaults_to_personal(
+    async_client: AsyncClient,
+) -> None:
+    """POST /journal/ omitting classification must return classification == 'personal'."""
+    headers = await _signup(async_client)
+    data = await _create(async_client, headers)
+    assert data["classification"] == "personal"
+
+
+@pytest.mark.asyncio
+async def test_create_with_intimate_echoes_intimate(async_client: AsyncClient) -> None:
+    """POST /journal/ with classification='intimate' must echo 'intimate' (persistence only).
+
+    NOTE: this test asserts only the stored value — #895 owns the routing
+    behaviour that intimate entries must never reach cloud LLMs.
+    """
+    headers = await _signup(async_client, "intimate_ep")
+    data = await _create(async_client, headers, classification="intimate")
+    assert data["classification"] == "intimate"
+
+
+@pytest.mark.asyncio
+async def test_create_with_public_echoes_public(async_client: AsyncClient) -> None:
+    """POST /journal/ with classification='public' must echo 'public'."""
+    headers = await _signup(async_client, "public_ep")
+    data = await _create(async_client, headers, classification="public")
+    assert data["classification"] == "public"
+
+
+@pytest.mark.asyncio
+async def test_create_with_invalid_classification_returns_422(async_client: AsyncClient) -> None:
+    """POST /journal/ with an invalid classification value must return 422."""
+    headers = await _signup(async_client, "invalid_ep")
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "Hello.", "classification": "secret"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ---------------------------------------------------------------------------
+# PATCH update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_classification_to_intimate(async_client: AsyncClient) -> None:
+    """PATCH /journal/{id} with classification='intimate' persists and echoes the value."""
+    headers = await _signup(async_client, "patch_intimate")
+    entry_id = (await _create(async_client, headers))["id"]
+
+    resp = await async_client.patch(
+        f"/journal/{entry_id}",
+        json={"classification": "intimate"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["classification"] == "intimate"
+
+
+@pytest.mark.asyncio
+async def test_patch_classification_to_public(async_client: AsyncClient) -> None:
+    """PATCH /journal/{id} with classification='public' persists and echoes the value."""
+    headers = await _signup(async_client, "patch_public")
+    entry_id = (await _create(async_client, headers))["id"]
+
+    resp = await async_client.patch(
+        f"/journal/{entry_id}",
+        json={"classification": "public"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["classification"] == "public"
+
+
+@pytest.mark.asyncio
+async def test_patch_classification_alone_is_not_422(async_client: AsyncClient) -> None:
+    """PATCH with only classification satisfies the at-least-one-field guard (not 422)."""
+    headers = await _signup(async_client, "patch_only_classif")
+    entry_id = (await _create(async_client, headers))["id"]
+
+    resp = await async_client.patch(
+        f"/journal/{entry_id}",
+        json={"classification": "personal"},
+        headers=headers,
+    )
+    # Must not be rejected as an empty payload.
+    assert resp.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_list_response_includes_classification(async_client: AsyncClient) -> None:
+    """GET /journal/ items must include the classification field."""
+    headers = await _signup(async_client, "list_classif")
+    await _create(async_client, headers, classification="intimate")
+
+    resp = await async_client.get("/journal/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    item = resp.json()["items"][0]
+    assert "classification" in item
+    assert item["classification"] == "intimate"

--- a/backend/tests/test_journal_classification_model.py
+++ b/backend/tests/test_journal_classification_model.py
@@ -1,0 +1,88 @@
+"""Data-layer tests for the JournalClassification tier (issue #894).
+
+Covers:
+- Default persistence to ``personal`` when classification is omitted.
+- Explicit ``intimate`` / ``public`` round-trips.
+- CHECK-constraint rejection of an invalid value.
+- Exact enum value set: {public, personal, intimate}.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import JournalClassification, JournalEntry
+from models.user import User
+
+
+async def _user(session: AsyncSession, email: str = "classif@example.com") -> int:
+    """Persist a minimal user and return its id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.flush()
+    assert user.id is not None
+    return user.id
+
+
+def _entry(user_id: int, **kwargs: object) -> JournalEntry:
+    """Build a JournalEntry with the given overrides (classification optional)."""
+    base: dict[str, object] = {
+        "sender": "user",
+        "user_id": user_id,
+        "message": "A private thought.",
+    }
+    base.update(kwargs)
+    return JournalEntry(**base)
+
+
+@pytest.mark.asyncio
+async def test_classification_defaults_to_personal(db_session: AsyncSession) -> None:
+    """A JournalEntry created without classification persists as 'personal'."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(JournalEntry))).scalar_one()
+    assert row.classification == JournalClassification.PERSONAL
+    assert row.classification == "personal"
+
+
+@pytest.mark.asyncio
+async def test_classification_intimate_persists_and_reads_back(db_session: AsyncSession) -> None:
+    """An explicit 'intimate' classification survives the round-trip."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, classification=JournalClassification.INTIMATE))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(JournalEntry))).scalar_one()
+    assert row.classification == JournalClassification.INTIMATE
+    assert row.classification == "intimate"
+
+
+@pytest.mark.asyncio
+async def test_classification_public_persists_and_reads_back(db_session: AsyncSession) -> None:
+    """An explicit 'public' classification survives the round-trip."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, classification=JournalClassification.PUBLIC))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(JournalEntry))).scalar_one()
+    assert row.classification == JournalClassification.PUBLIC
+    assert row.classification == "public"
+
+
+@pytest.mark.asyncio
+async def test_invalid_classification_raises_integrity_error(db_session: AsyncSession) -> None:
+    """A value outside the enum set violates the CHECK constraint at the DB layer."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, classification="secret"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+def test_classification_enum_value_set_is_exact() -> None:
+    """JournalClassification contains exactly {public, personal, intimate} — no more, no less."""
+    assert {c.value for c in JournalClassification} == {"public", "personal", "intimate"}

--- a/backend/tests/test_journal_classification_schema.py
+++ b/backend/tests/test_journal_classification_schema.py
@@ -1,0 +1,97 @@
+"""Schema-layer tests for the JournalClassification tier (issue #894).
+
+Covers:
+- JournalMessageCreate: omitted classification → default personal.
+- JournalMessageCreate: explicit valid value round-trips.
+- JournalMessageCreate: invalid value raises ValidationError.
+- JournalEntryUpdate: classification alone satisfies the at-least-one validator.
+- JournalEntryUpdate: empty {} still raises (the existing at-least-one guard).
+- JournalMessageResponse: classification field is present and serialised.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from models.journal_entry import JournalClassification
+from schemas.journal import JournalEntryUpdate, JournalMessageCreate, JournalMessageResponse
+
+
+class TestJournalMessageCreateClassification:
+    """JournalMessageCreate classification field behaviours."""
+
+    def test_omitted_classification_defaults_to_personal(self) -> None:
+        """A payload that omits classification should default to 'personal'."""
+        schema = JournalMessageCreate(message="Hello world.")
+        assert schema.classification == JournalClassification.PERSONAL
+        assert schema.classification.value == "personal"
+
+    def test_explicit_intimate_round_trips(self) -> None:
+        """An explicit 'intimate' value survives the parse/serialize cycle."""
+        schema = JournalMessageCreate(message="Private thought.", classification="intimate")
+        assert schema.classification == JournalClassification.INTIMATE
+
+    def test_explicit_public_round_trips(self) -> None:
+        """An explicit 'public' value survives the parse/serialize cycle."""
+        schema = JournalMessageCreate(message="Public thought.", classification="public")
+        assert schema.classification == JournalClassification.PUBLIC
+
+    def test_invalid_classification_raises_validation_error(self) -> None:
+        """A value not in the enum raises ValidationError (not a raw Python error)."""
+        with pytest.raises(ValidationError):
+            JournalMessageCreate(message="Oops.", classification="secret")
+
+
+class TestJournalEntryUpdateClassification:
+    """JournalEntryUpdate classification field behaviours."""
+
+    def test_classification_alone_satisfies_at_least_one_validator(self) -> None:
+        """Providing only classification should pass the at-least-one guard."""
+        schema = JournalEntryUpdate(classification="intimate")
+        assert schema.classification == JournalClassification.INTIMATE
+        # Confirm the other fields stayed None (not accidentally populated).
+        assert schema.message is None
+        assert schema.title is None
+        assert schema.status is None
+
+    def test_empty_payload_still_raises(self) -> None:
+        """An empty PATCH payload must still be rejected (the pre-existing guard)."""
+        with pytest.raises(ValidationError, match="at least one field"):
+            JournalEntryUpdate()
+
+    def test_classification_with_other_fields_is_valid(self) -> None:
+        """Classification can be combined with other fields without error."""
+        schema = JournalEntryUpdate(classification="public", title="A Title")
+        assert schema.classification == JournalClassification.PUBLIC
+        assert schema.title == "A Title"
+
+
+class TestJournalMessageResponseClassification:
+    """JournalMessageResponse must expose classification."""
+
+    def test_response_includes_classification_field(self) -> None:
+        """JournalMessageResponse model_fields must include 'classification'."""
+        assert "classification" in JournalMessageResponse.model_fields
+
+    def test_response_serialises_classification(self) -> None:
+        """A JournalMessageResponse built from attributes exposes classification as a string."""
+        now = datetime.now(UTC)
+        resp = JournalMessageResponse(
+            id=1,
+            title=None,
+            message="Hello.",
+            status="draft",
+            sender="user",
+            timestamp=now,
+            updated_at=now,
+            tag="freeform",
+            practice_session_id=None,
+            user_practice_id=None,
+            classification="intimate",
+        )
+        assert resp.classification.value == "intimate"
+        dumped = resp.model_dump()
+        assert dumped["classification"] == "intimate"

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1075,3 +1075,133 @@ def test_random_interval_bell_downgrade_refuses_with_existing_rows(
 
     with pytest.raises(RuntimeError, match="random_interval_bell"):
         command.downgrade(cfg, _RANDOM_INTERVAL_BELL_BASE_REVISION)
+
+
+# -- issue #894 journal_classification_tier migration round-trip ------------
+
+# These revision IDs are intentional placeholders that the implementer will
+# replace with the real IDs when writing the migration.  Until then the test
+# fails with ``CommandError`` (unknown revision) — which is the correct RED
+# failure mode: it forces the implementer to write the migration first.
+_JOURNAL_CLASSIFICATION_BASE_REVISION = "c5d6e7f8a9b0"  # pragma: allowlist secret
+# The implementer must set this to the real revision ID of the migration they
+# author for issue #894.
+_JOURNAL_CLASSIFICATION_REVISION = "d8e9f0a1b2c3"  # pragma: allowlist secret
+
+
+def _bootstrap_journalentry_table(sync_url: str) -> None:
+    """Pre-create a minimal ``journalentry`` table for the round-trip fixture.
+
+    Mirrors the schema in place just before the classification-tier migration,
+    without pulling in every preceding migration.  One existing row is seeded
+    so the upgrade backfill can be observed.
+    """
+    bootstrap_engine = create_engine(sync_url)
+    with bootstrap_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE journalentry ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " sender VARCHAR(10) NOT NULL,"
+                " message TEXT NOT NULL,"
+                " tag VARCHAR(50) NOT NULL DEFAULT 'freeform',"
+                " status VARCHAR(20) NOT NULL DEFAULT 'draft',"
+                " title VARCHAR(200),"
+                " deleted_at DATETIME,"
+                " updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                " timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO journalentry (id, user_id, sender, message)"
+                " VALUES (1, 1, 'user', 'Pre-migration entry.')"
+            )
+        )
+    bootstrap_engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_journal_classification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite Alembic config positioned just before the #894 migration.
+
+    Bootstraps a minimal ``journalentry`` table with one legacy row (no
+    ``classification`` column) and stamps the DB at the head revision just
+    before the new migration, so the round-trip exercises only the
+    classification-tier migration.
+    """
+    db_path = tmp_path / "journal_classification_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_journalentry_table(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _JOURNAL_CLASSIFICATION_BASE_REVISION)
+    return cfg
+
+
+def _journalentry_row(db_url: str, entry_id: int) -> dict[str, Any]:
+    """Fetch a single ``journalentry`` row as a dict."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text("SELECT id, classification FROM journalentry WHERE id = :id"),
+                    {"id": entry_id},
+                )
+                .mappings()
+                .first()
+            )
+            assert row is not None
+            return dict(row)
+    finally:
+        engine.dispose()
+
+
+def test_journal_classification_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_journal_classification: Config,
+) -> None:
+    """Round-trip the #894 migration: upgrade adds column + backfills; downgrade drops it.
+
+    Phase 1: upgrade adds ``classification`` NOT NULL DEFAULT 'personal' and
+    backfills the pre-existing legacy row to 'personal'.
+    Phase 2: downgrade removes the column.
+    Phase 3: re-upgrade is idempotent — the backfill re-runs cleanly.
+
+    This test will fail until the implementer authors the migration and sets
+    ``_JOURNAL_CLASSIFICATION_REVISION`` to its real revision ID.
+    """
+    cfg = alembic_sqlite_config_journal_classification
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade adds the classification column and backfills the legacy row.
+    command.upgrade(cfg, _JOURNAL_CLASSIFICATION_REVISION)
+    cols = _columns_of(db_url, "journalentry")
+    assert "classification" in cols
+
+    row = _journalentry_row(db_url, entry_id=1)
+    assert row["classification"] == "personal", (
+        "Upgrade must backfill pre-existing rows to 'personal' (the default tier)."
+    )
+
+    # Phase 2: downgrade removes the classification column.
+    command.downgrade(cfg, _JOURNAL_CLASSIFICATION_BASE_REVISION)
+    cols_after = _columns_of(db_url, "journalentry")
+    assert "classification" not in cols_after
+
+    # Phase 3: re-upgrade — backfill must reproduce the same value (idempotent).
+    command.upgrade(cfg, _JOURNAL_CLASSIFICATION_REVISION)
+    row_after = _journalentry_row(db_url, entry_id=1)
+    assert row_after["classification"] == "personal"


### PR DESCRIPTION
## Summary

#894 (epic #893, NORTH-STAR §10): journal entries had no privacy classification, so the resonance pipeline couldn't tell an intimate entry from a shareable one. Adds the **data model** (routing/enforcement is #895).

- `models/journal_entry.py`: `JournalClassification` StrEnum (`public`|`personal`|`intimate`); `classification` column default `personal` + a CHECK in `__table_args__` (mirrors `completion_suggestion._status_check()`).
- `schemas/journal.py`: optional `classification` on create (default `personal`) + update (counted by `_require_at_least_one_field`) + response. Existing payloads without it still work.
- `routers/journal.py`: maps `classification` through create + `_apply_entry_update`; response echoes it.
- Migration `d8e9f0a1b2c3` (down_revision `c5d6e7f8a9b0`, single head): `server_default='personal'` to backfill existing rows, then drop the default (app owns it; drift-free) + the CHECK; `batch_alter_table` for the SQLite round-trip; real downgrade.

Default is `personal` at model + schema + migration. **No routing/LLM/resonance change** (`classification` appears in zero `domain/`/`services/` files — verified). Worked under the conductor pipeline (architect → test → implementation → code-review-orchestrator CLEAN).

## Test plan

Model default + CHECK rejection + enum set; schema omitted→default + invalid 422 + update-only-classification + empty-update 422; endpoint create/patch echo; migration backfill/downgrade round-trip. `./scripts/backend/check-all.sh` 7/7, xenon A, single alembic head.

Closes #894
Refs #893
