### PR TITLE
feat(journal): privacy tier control on the entry editor

### DIFF
--- a/frontend/src/api/__tests__/privacySchemas.test.ts
+++ b/frontend/src/api/__tests__/privacySchemas.test.ts
@@ -1,0 +1,157 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+
+/**
+ * RED tests for the ``classification`` field on ``journalMessageSchema`` and
+ * the ``private`` / ``private_message`` fields on ``resonanceResponseSchema``
+ * (issue #896).
+ *
+ * These tests will fail until the implementation-specialist adds:
+ * - ``classification`` (z.enum(['public','personal','intimate']).optional()) to
+ *   ``journalMessageSchema`` in ``frontend/src/api/schemas.ts``.
+ * - ``private`` (z.boolean().optional()) and
+ *   ``private_message`` (z.string().nullish()) to ``resonanceResponseSchema``.
+ * - The matching TypeScript fields on ``JournalMessage``, ``JournalMessageCreate``,
+ *   ``JournalEntryUpdate``, and ``ResonanceResponse`` in ``frontend/src/api/index.ts``.
+ *
+ * The zod tests here are additive / non-breaking: a response WITHOUT the new
+ * fields must still parse (backward-compat), and one WITH them must round-trip.
+ */
+import { journalMessageSchema, resonanceResponseSchema } from '../schemas';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+/** Minimal valid journal message without the new classification field. */
+const BASE_JOURNAL_MESSAGE = {
+  id: 1,
+  message: 'A page about rivers.',
+  sender: 'user' as const,
+  timestamp: '2026-06-01T00:00:00Z',
+  tag: 'freeform' as const,
+  practice_session_id: null,
+  user_practice_id: null,
+};
+
+/** Minimal valid resonance response without the new private fields. */
+const BASE_RESONANCE = {
+  marginalia: [],
+  suggestions: [],
+  remaining_messages: 48,
+  remaining_balance: 0,
+  monthly_reset_date: '2026-07-01T00:00:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// journalMessageSchema — classification field (additive)
+// ---------------------------------------------------------------------------
+
+describe('journalMessageSchema — classification field (issue #896)', () => {
+  it('still parses a message WITHOUT classification (backward-compat)', () => {
+    // Existing API responses that predate #896 omit this field; they must not fail.
+    expect(() => journalMessageSchema.parse(BASE_JOURNAL_MESSAGE)).not.toThrow();
+  });
+
+  it('parses a message with classification="personal"', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, classification: 'personal' };
+    expect(() => journalMessageSchema.parse(payload)).not.toThrow();
+  });
+
+  it('parses a message with classification="public"', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, classification: 'public' };
+    expect(() => journalMessageSchema.parse(payload)).not.toThrow();
+  });
+
+  it('parses a message with classification="intimate"', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, classification: 'intimate' };
+    expect(() => journalMessageSchema.parse(payload)).not.toThrow();
+  });
+
+  it('round-trips classification="intimate" exactly', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, classification: 'intimate' as const };
+    const parsed = journalMessageSchema.parse(payload);
+    expect(parsed.classification).toBe('intimate');
+  });
+
+  it('round-trips classification="personal" exactly', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, classification: 'personal' as const };
+    const parsed = journalMessageSchema.parse(payload);
+    expect(parsed.classification).toBe('personal');
+  });
+
+  it('round-trips classification="public" exactly', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, classification: 'public' as const };
+    const parsed = journalMessageSchema.parse(payload);
+    expect(parsed.classification).toBe('public');
+  });
+
+  it('rejects an unknown classification value (type drift)', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, classification: 'secret' };
+    expect(() => journalMessageSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects a numeric classification (type drift)', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, classification: 2 };
+    expect(() => journalMessageSchema.parse(payload)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resonanceResponseSchema — private + private_message fields (additive)
+// ---------------------------------------------------------------------------
+
+describe('resonanceResponseSchema — private / private_message fields (issue #896)', () => {
+  it('still parses a response WITHOUT private or private_message (backward-compat)', () => {
+    // All existing resonance responses omit these; they must continue to parse.
+    expect(() => resonanceResponseSchema.parse(BASE_RESONANCE)).not.toThrow();
+  });
+
+  it('parses a response with private=false and no private_message', () => {
+    const payload = { ...BASE_RESONANCE, private: false };
+    expect(() => resonanceResponseSchema.parse(payload)).not.toThrow();
+  });
+
+  it('parses a response with private=true and a private_message string', () => {
+    const payload = {
+      ...BASE_RESONANCE,
+      private: true,
+      private_message: 'This entry is intimate — resonance is paused.',
+    };
+    expect(() => resonanceResponseSchema.parse(payload)).not.toThrow();
+  });
+
+  it('parses a response with private=true and private_message=null', () => {
+    const payload = { ...BASE_RESONANCE, private: true, private_message: null };
+    expect(() => resonanceResponseSchema.parse(payload)).not.toThrow();
+  });
+
+  it('round-trips private=true exactly', () => {
+    const payload = { ...BASE_RESONANCE, private: true, private_message: 'Intimate entry.' };
+    const parsed = resonanceResponseSchema.parse(payload);
+    expect(parsed.private).toBe(true);
+  });
+
+  it('round-trips private_message string exactly', () => {
+    const msg = 'This entry is intimate — resonance is paused.';
+    const payload = { ...BASE_RESONANCE, private: true, private_message: msg };
+    const parsed = resonanceResponseSchema.parse(payload);
+    expect(parsed.private_message).toBe(msg);
+  });
+
+  it('round-trips private=false with no private_message', () => {
+    const payload = { ...BASE_RESONANCE, private: false };
+    const parsed = resonanceResponseSchema.parse(payload);
+    expect(parsed.private).toBe(false);
+  });
+
+  it('rejects a string value for the private field (type drift)', () => {
+    const payload = { ...BASE_RESONANCE, private: 'yes' };
+    expect(() => resonanceResponseSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects a numeric value for private_message (type drift)', () => {
+    const payload = { ...BASE_RESONANCE, private: true, private_message: 42 };
+    expect(() => resonanceResponseSchema.parse(payload)).toThrow();
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1062,11 +1062,20 @@ export const goalGroups = {
 // Journal types and client
 export type JournalTag = 'freeform' | 'stage_reflection' | 'practice_note' | 'habit_note';
 
+/**
+ * Privacy classification for a journal entry (mirrors the backend enum). An
+ * ``intimate`` entry is never sent to AI: resonance is client-side gated off
+ * for it. ``personal`` is the backend default; ``public`` is the most open.
+ */
+export type JournalClassification = 'public' | 'personal' | 'intimate';
+
 export interface JournalMessageCreate {
   message: string;
   tag?: JournalTag;
   practice_session_id?: number | null;
   user_practice_id?: number | null;
+  /** Privacy tier chosen at creation; the backend defaults to ``personal``. */
+  classification?: JournalClassification;
 }
 
 export type EntryStatus = 'draft' | 'finished';
@@ -1083,6 +1092,8 @@ export interface JournalMessage {
   title?: string | null;
   status?: EntryStatus;
   updated_at?: string;
+  /** Privacy tier; absent on older responses (defaults to ``personal``). */
+  classification?: JournalClassification;
 }
 
 /**
@@ -1094,6 +1105,8 @@ export interface JournalEntryUpdate {
   message?: string;
   title?: string | null;
   status?: EntryStatus;
+  /** Re-classify an existing entry's privacy tier. */
+  classification?: JournalClassification;
 }
 
 export type MarginaliaKind = 'theme' | 'connection' | 'symbol';
@@ -1134,6 +1147,13 @@ export interface ResonanceResponse {
    * without it parses and behaves exactly as before.
    */
   care?: CareResponse | null;
+  /**
+   * True when the pass was withheld because the entry is intimate.
+   * Absent on ordinary responses; additive — older responses parse unchanged.
+   */
+  private?: boolean;
+  /** Reason copy shown when ``private`` is true; ``null`` when unset. */
+  private_message?: string | null;
 }
 
 export interface MarginaliaListResponse {

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -256,6 +256,9 @@ export const journalMessageSchema = z.object({
   title: z.string().nullable().optional(),
   status: z.enum(['draft', 'finished']).optional(),
   updated_at: isoDateTime.optional(),
+  // Privacy tier. Optional so responses predating the column still
+  // validate; the enum rejects any value that drifts from the backend set.
+  classification: z.enum(['public', 'personal', 'intimate']).optional(),
 });
 
 /** Journal list envelope: ``{ items, total, has_more }`` (bespoke, not ``Page``). */
@@ -539,6 +542,11 @@ export const resonanceResponseSchema = z.object({
   remaining_balance: z.number().int(),
   monthly_reset_date: z.string(),
   care: careResponseSchema.nullish(),
+  // Privacy gate: ``private`` is true when the pass was withheld for an
+  // intimate entry, with optional reason copy. Additive/nullish so older
+  // responses (which omit both) still validate and behave as before.
+  private: z.boolean().optional(),
+  private_message: z.string().nullish(),
 });
 
 export type CareKindT = z.infer<typeof careKindSchema>;

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -8,6 +8,7 @@
 import { StyleSheet } from 'react-native';
 
 import {
+  BORDER_RADIUS,
   SPACING,
   colors,
   editorialType,
@@ -130,6 +131,50 @@ const styles = StyleSheet.create({
     ...editorialType.caption,
     color: colors.paper.inkSoft,
     paddingTop: spacing(2),
+  },
+  /** Privacy tier chooser block above the growing body. */
+  privacyTierControl: {
+    paddingBottom: spacing(1),
+  },
+  privacyTierRow: {
+    flexDirection: 'row',
+    gap: SPACING.xs,
+  },
+  /** Each tier option; both min dims hold the touch target at the 44dp floor. */
+  privacyTierOption: {
+    flex: 1,
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.paper.hairline,
+  },
+  privacyTierOptionSelected: {
+    backgroundColor: colors.paper.anchorHighlight,
+    borderColor: colors.paper.inkSoft,
+  },
+  privacyTierLabel: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+  privacyTierLabelSelected: {
+    color: colors.paper.ink,
+  },
+  privacyTierExplainer: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    paddingTop: spacing(1),
+  },
+  /** Reason line shown beside the disabled resonance button for intimate entries. */
+  privacyResonanceReason: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    textAlign: 'center',
+    paddingHorizontal: SPACING.xl,
+    paddingBottom: SPACING.sm,
   },
 });
 

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -27,6 +27,7 @@ import HighlightedBody from './HighlightedBody';
 import styles from './JournalEntry.styles';
 import MarginNote from './MarginNote';
 import { useSettleIn } from './motion';
+import PrivacyTierControl, { type PrivacyTier } from './PrivacyTierControl';
 import ResonanceEssayModal from './ResonanceEssayModal';
 import { useResonance } from './useResonance';
 
@@ -35,6 +36,7 @@ import type {
   CheckInResult,
   CompletionSuggestion,
   EntryStatus,
+  JournalClassification,
   JournalMessage,
   Marginalia,
 } from '@/api';
@@ -49,6 +51,12 @@ export const AUTOSAVE_DELAY_MS = 1500;
 
 /** Below this width the margin column stacks under the writing column. */
 const NARROW_BREAKPOINT = 600;
+
+/** Backend default privacy tier for a fresh entry. */
+const DEFAULT_CLASSIFICATION: JournalClassification = 'personal';
+
+/** Fallback reason shown when resonance is gated off for an intimate entry. */
+const INTIMATE_RESONANCE_REASON = 'Intimate entries are kept private — resonance is paused.';
 
 type SaveState = 'idle' | 'typing' | 'saving' | 'saved' | 'error';
 
@@ -76,14 +84,21 @@ export interface SaveContext {
   userPracticeId?: number;
 }
 
+interface WriteEntryRefs {
+  entryIdRef: React.MutableRefObject<number | null>;
+  respondedRef: React.MutableRefObject<boolean>;
+  /** Latest chosen privacy tier; carried on the first ``journal.create``. */
+  classificationRef: React.MutableRefObject<JournalClassification>;
+}
+
 /** Create on first save, then update; title is optional and saved separately. */
 async function writeEntry(
-  entryIdRef: React.MutableRefObject<number | null>,
+  refs: WriteEntryRefs,
   title: string,
   body: string,
   ctx: SaveContext,
-  respondedRef: React.MutableRefObject<boolean>,
 ): Promise<void> {
+  const { entryIdRef, respondedRef, classificationRef } = refs;
   // Weekly-prompt mode: the respond endpoint persists the entry itself, so we
   // submit exactly once and never pair it with journal.create (no double-create).
   if (ctx.weekNumber != null) {
@@ -95,9 +110,11 @@ async function writeEntry(
   const trimmedTitle = title.trim() ? title : null;
   if (entryIdRef.current == null) {
     // Only attach context keys when present, so a plain entry's payload stays
-    // exactly { message } rather than carrying explicit nulls.
+    // lean rather than carrying explicit nulls. ``classification`` always rides
+    // along so the entry's privacy tier is set at birth (defaults to personal).
     const created = await journal.create({
       message: body,
+      classification: classificationRef.current,
       ...(ctx.practiceSessionId != null && { practice_session_id: ctx.practiceSessionId }),
       ...(ctx.userPracticeId != null && { user_practice_id: ctx.userPracticeId }),
     });
@@ -116,8 +133,12 @@ interface AutosaveApi {
   status: EntryStatus;
   setStatus: (_status: EntryStatus) => void;
   saveState: SaveState;
+  /** The entry's privacy tier; drives the control and the resonance gate. */
+  classification: PrivacyTier;
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
+  /** Set the privacy tier: updates the control and persists (create/PATCH). */
+  onChangeClassification: (_tier: PrivacyTier) => void;
   /** Persist the latest text immediately and resolve to the entry id (or null). */
   flush: () => Promise<number | null>;
 }
@@ -154,6 +175,70 @@ function useTimerCleanup(timerRef: React.MutableRefObject<ReturnType<typeof setT
   );
 }
 
+interface ClassificationPersist {
+  classificationRef: React.MutableRefObject<JournalClassification>;
+  /** Record the tier for the next create and PATCH it when the entry exists. */
+  changeClassification: (_tier: JournalClassification) => void;
+}
+
+/**
+ * Owns the latest privacy tier: it rides the first ``journal.create`` via the
+ * ref, and on an existing entry a change is PATCHed immediately so a
+ * re-classification never waits on (or is lost to) the body-save debounce.
+ */
+function useClassificationPersist(
+  entryIdRef: React.MutableRefObject<number | null>,
+): ClassificationPersist {
+  const classificationRef = useRef<JournalClassification>(DEFAULT_CLASSIFICATION);
+  const changeClassification = useCallback(
+    (tier: JournalClassification): void => {
+      classificationRef.current = tier;
+      if (entryIdRef.current != null) {
+        void journal.update(entryIdRef.current, { classification: tier });
+      }
+    },
+    [entryIdRef],
+  );
+  return { classificationRef, changeClassification };
+}
+
+type TimerRef = React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+type RunSave = (_title: string, _body: string) => Promise<void>;
+
+interface SaveTimer {
+  save: (_title: string, _body: string) => void;
+  flush: (_title: string, _body: string) => Promise<number | null>;
+}
+
+/** Debounce (``save``) + immediate (``flush``) wrappers around the async writer. */
+function useSaveTimer(
+  run: RunSave,
+  timerRef: TimerRef,
+  entryIdRef: React.MutableRefObject<number | null>,
+  delayMs: number,
+  setTyping: () => void,
+): SaveTimer {
+  const save = useCallback(
+    (title: string, body: string): void => {
+      setTyping();
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => void run(title, body), delayMs);
+    },
+    [run, delayMs, timerRef, setTyping],
+  );
+  // Cancel any pending debounce and persist now; resolves to the entry id so a
+  // caller (e.g. resonance) can act on the just-saved entry.
+  const flush = useCallback(
+    async (title: string, body: string): Promise<number | null> => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (body.trim()) await run(title, body);
+      return entryIdRef.current;
+    },
+    [run, timerRef, entryIdRef],
+  );
+  return { save, flush };
+}
+
 /** Debounced create-then-update draft saver; tracks the save state. */
 function useDebouncedSave(
   routeEntryId: number | null,
@@ -167,6 +252,7 @@ function useDebouncedSave(
   // A weekly-prompt response is write-once; this guards against the debounce or
   // flush submitting it twice (the backend 409s on a duplicate week).
   const respondedRef = useRef(false);
+  const { classificationRef, changeClassification } = useClassificationPersist(entryIdRef);
   // Refs so non-memoised inputs don't churn the save callbacks below.
   const onSavedRef = useRef(onSaved);
   const ctxRef = useRef(ctx);
@@ -176,40 +262,27 @@ function useDebouncedSave(
   });
   useTimerCleanup(timerRef);
 
-  const run = useCallback(async (title: string, body: string): Promise<void> => {
-    if (!body.trim()) return; // never persist an empty draft
-    setSaveState('saving');
-    try {
-      await writeEntry(entryIdRef, title, body, ctxRef.current, respondedRef);
-      setSaveState('saved');
-      onSavedRef.current?.();
-    } catch {
-      // Surface a distinct error state so the hint isn't mistaken for "untouched".
-      setSaveState('error');
-    }
-  }, []);
-
-  const save = useCallback(
-    (title: string, body: string): void => {
-      setSaveState('typing');
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => void run(title, body), delayMs);
+  const run = useCallback<RunSave>(
+    async (title, body) => {
+      if (!body.trim()) return; // never persist an empty draft
+      setSaveState('saving');
+      const refs = { entryIdRef, respondedRef, classificationRef };
+      try {
+        await writeEntry(refs, title, body, ctxRef.current);
+        setSaveState('saved');
+        onSavedRef.current?.();
+      } catch {
+        // Surface a distinct error state so the hint isn't mistaken for "untouched".
+        setSaveState('error');
+      }
     },
-    [run, delayMs],
+    [classificationRef],
   );
 
-  // Cancel any pending debounce and persist now; resolves to the entry id so a
-  // caller (e.g. resonance) can act on the just-saved entry.
-  const flush = useCallback(
-    async (title: string, body: string): Promise<number | null> => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      if (body.trim()) await run(title, body);
-      return entryIdRef.current;
-    },
-    [run],
-  );
+  const setTyping = useCallback(() => setSaveState('typing'), []);
+  const { save, flush } = useSaveTimer(run, timerRef, entryIdRef, delayMs, setTyping);
 
-  return { saveState, save, flush };
+  return { saveState, save, flush, changeClassification };
 }
 
 type StrRef = React.MutableRefObject<string>;
@@ -241,21 +314,28 @@ function useFieldHandlers(
   return { onChangeTitle, onChangeBody };
 }
 
-/** Owns the entry's text + debounced draft autosave (create-then-update). */
-function useJournalAutosave(
-  routeEntryId: number | null,
-  delayMs: number,
-  ctx: SaveContext,
-  initialTitle: string,
-  onSaved?: () => void,
-): AutosaveApi {
+interface EntryState {
+  title: string;
+  body: string;
+  status: EntryStatus;
+  setStatus: (_status: EntryStatus) => void;
+  classification: PrivacyTier;
+  setClassification: (_tier: PrivacyTier) => void;
+  setTitle: (_v: string) => void;
+  setBody: (_v: string) => void;
+  titleRef: StrRef;
+  bodyRef: StrRef;
+}
+
+/** The entry's editable state (title/body/status/tier) + one-time load-on-open. */
+function useEntryState(routeEntryId: number | null, initialTitle: string): EntryState {
   const [title, setTitle] = useState(initialTitle);
   const [body, setBody] = useState('');
   const [status, setStatus] = useState<EntryStatus>('draft');
+  const [classification, setClassification] = useState<PrivacyTier>(DEFAULT_CLASSIFICATION);
   // Refs mirror the latest text so the change handlers stay referentially stable.
   const titleRef = useRef(initialTitle);
   const bodyRef = useRef('');
-  const { saveState, save, flush } = useDebouncedSave(routeEntryId, delayMs, ctx, onSaved);
 
   useEntryLoadEffect(
     routeEntryId,
@@ -265,26 +345,72 @@ function useJournalAutosave(
       setTitle(titleRef.current);
       setBody(bodyRef.current);
       setStatus(entry.status ?? 'draft');
+      // Pre-select the server's tier so an intimate entry loads intimate.
+      setClassification(entry.classification ?? DEFAULT_CLASSIFICATION);
     }, []),
   );
-
-  const { onChangeTitle, onChangeBody } = useFieldHandlers(
-    titleRef,
-    bodyRef,
-    save,
-    setTitle,
-    setBody,
-  );
-  const flushNow = useCallback(() => flush(titleRef.current, bodyRef.current), [flush]);
 
   return {
     title,
     body,
     status,
     setStatus,
+    classification,
+    setClassification,
+    setTitle,
+    setBody,
+    titleRef,
+    bodyRef,
+  };
+}
+
+/** Owns the entry's text + debounced draft autosave (create-then-update). */
+function useJournalAutosave(
+  routeEntryId: number | null,
+  delayMs: number,
+  ctx: SaveContext,
+  initialTitle: string,
+  onSaved?: () => void,
+): AutosaveApi {
+  const entry = useEntryState(routeEntryId, initialTitle);
+  const { titleRef, bodyRef, setClassification } = entry;
+  const { saveState, save, flush, changeClassification } = useDebouncedSave(
+    routeEntryId,
+    delayMs,
+    ctx,
+    onSaved,
+  );
+
+  const { onChangeTitle, onChangeBody } = useFieldHandlers(
+    titleRef,
+    bodyRef,
+    save,
+    entry.setTitle,
+    entry.setBody,
+  );
+  const flushNow = useCallback(
+    () => flush(titleRef.current, bodyRef.current),
+    [flush, titleRef, bodyRef],
+  );
+  // Reflect the choice in the control, then persist it (create-time ref or PATCH).
+  const onChangeClassification = useCallback(
+    (tier: PrivacyTier) => {
+      setClassification(tier);
+      changeClassification(tier);
+    },
+    [changeClassification, setClassification],
+  );
+
+  return {
+    title: entry.title,
+    body: entry.body,
+    status: entry.status,
+    setStatus: entry.setStatus,
     saveState,
+    classification: entry.classification,
     onChangeTitle,
     onChangeBody,
+    onChangeClassification,
     flush: flushNow,
   };
 }
@@ -293,8 +419,10 @@ interface WritingColumnProps {
   title: string;
   body: string;
   saveState: SaveState;
+  classification: PrivacyTier;
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
+  onChangeClassification: (_tier: PrivacyTier) => void;
   onFinish?: () => void;
   bodyPlaceholder?: string;
 }
@@ -317,8 +445,10 @@ function WritingColumn({
   title,
   body,
   saveState,
+  classification,
   onChangeTitle,
   onChangeBody,
+  onChangeClassification,
   onFinish,
   bodyPlaceholder = 'Begin writing…',
 }: WritingColumnProps) {
@@ -328,6 +458,7 @@ function WritingColumn({
       contentContainerStyle={styles.writingColumnContent}
       keyboardShouldPersistTaps="handled"
     >
+      <PrivacyTierControl value={classification} onChange={onChangeClassification} />
       <TextInput
         style={styles.titleInput}
         value={title}
@@ -542,17 +673,58 @@ function useBumpedHandlers(bump: () => void, autosave: AutosaveApi) {
   return { handleTitle, handleBody };
 }
 
-/** Compose the autosave + idle + resonance hooks into the screen's view-model. */
-function useJournalEntryController(
-  routeEntryId: number | null,
-  autosaveDelayMs: number,
-  navigation: ScreenNavigation,
-  ctx: SaveContext,
-  initialTitle: string,
-) {
+interface ResonanceGate {
+  /** Whether the resonance affordance is shown at all (hidden in prompt-compose). */
+  visible: boolean;
+  /** Shown-but-disabled: an intimate entry is never sent to AI. */
+  resonanceDisabled: boolean;
+  /** One-line reason accompanying a disabled/withheld resonance affordance. */
+  resonanceReason: string;
+}
+
+interface ResonanceGateArgs {
+  isIdle: boolean;
+  isLoading: boolean;
+  body: string;
+  classification: PrivacyTier;
+  isPromptCompose: boolean;
+  privateMessage: string | null;
+}
+
+/** Derive whether/how the resonance affordance shows, incl. the intimate gate. */
+function deriveResonanceGate(args: ResonanceGateArgs): ResonanceGate {
+  const hasContent = args.body.trim().length > 0;
+  // In weekly-prompt compose mode the entry is created by prompts.respond, which
+  // doesn't return a local id — so resonance can't run here. Hide the button; the
+  // reflection gains resonance normally once reopened from the shelf (with an id).
+  const visible =
+    !args.isPromptCompose &&
+    shouldShowResonance({ isIdle: args.isIdle, hasContent, isLoading: args.isLoading });
+  return {
+    visible,
+    // Client-side privacy gate: an intimate entry is never sent to AI, so the
+    // resonance affordance is shown-but-disabled with a visible reason.
+    resonanceDisabled: args.classification === 'intimate',
+    resonanceReason: args.privateMessage ?? INTIMATE_RESONANCE_REASON,
+  };
+}
+
+interface RefreshAfterEdit {
+  refreshRef: React.MutableRefObject<() => Promise<void>>;
+  /** Fires the deferred marginalia refresh after the first post-edit save. */
+  handleSaved: () => void;
+  /** Arms the deferred refresh when the user confirms an edit of a finished entry. */
+  onConfirmEdit: () => void;
+}
+
+/**
+ * A finished entry's notes re-anchor/stale on the first save after an edit, so
+ * the refresh is deferred: ``onConfirmEdit`` arms it and the next ``handleSaved``
+ * fires it once (via ``refreshRef``, wired to resonance.refresh by the caller).
+ */
+function useRefreshAfterEdit(): RefreshAfterEdit {
   const refreshRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const pendingRefreshRef = useRef(false);
-  // After the first save following an edit, re-read the (re-anchored/staled) notes.
   const handleSaved = useCallback(() => {
     if (!pendingRefreshRef.current) return;
     pendingRefreshRef.current = false;
@@ -561,6 +733,18 @@ function useJournalEntryController(
   const onConfirmEdit = useCallback(() => {
     pendingRefreshRef.current = true;
   }, []);
+  return { refreshRef, handleSaved, onConfirmEdit };
+}
+
+/** Compose the autosave + idle + resonance hooks into the screen's view-model. */
+function useJournalEntryController(
+  routeEntryId: number | null,
+  autosaveDelayMs: number,
+  navigation: ScreenNavigation,
+  ctx: SaveContext,
+  initialTitle: string,
+) {
+  const { refreshRef, handleSaved, onConfirmEdit } = useRefreshAfterEdit();
 
   const autosave = useJournalAutosave(
     routeEntryId,
@@ -584,31 +768,44 @@ function useJournalEntryController(
   });
 
   const { handleTitle, handleBody } = useBumpedHandlers(bump, autosave);
-  const hasContent = autosave.body.trim().length > 0;
-  // In weekly-prompt compose mode the entry is created by prompts.respond, which
-  // doesn't return a local id — so resonance can't run here. Hide the button; the
-  // reflection gains resonance normally once reopened from the shelf (with an id).
-  const isPromptCompose = ctx.weekNumber != null;
-  const visible =
-    !isPromptCompose && shouldShowResonance({ isIdle, hasContent, isLoading: resonance.loading });
+  const gate = deriveResonanceGate({
+    isIdle,
+    isLoading: resonance.loading,
+    body: autosave.body,
+    classification: autosave.classification,
+    isPromptCompose: ctx.weekNumber != null,
+    privateMessage: resonance.privateMessage,
+  });
 
-  return { autosave, resonance, isIdle, visible, handleTitle, handleBody, modal, editGate };
+  return {
+    autosave,
+    resonance,
+    isIdle,
+    visible: gate.visible,
+    resonanceDisabled: gate.resonanceDisabled,
+    resonanceReason: gate.resonanceReason,
+    handleTitle,
+    handleBody,
+    modal,
+    editGate,
+  };
 }
 
 type Controller = ReturnType<typeof useJournalEntryController>;
 
-/** The two-column page: the body (edit or read) + the margin. */
 /** The body column: the editable writing surface, or the read-mode highlighted view. */
 function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceholder: string }) {
-  const { title, body, saveState } = ctl.autosave;
+  const { title, body, saveState, classification } = ctl.autosave;
   const { editMode, canFinish, markFinished, requestEdit } = ctl.editGate;
   return editMode ? (
     <WritingColumn
       title={title}
       body={body}
       saveState={saveState}
+      classification={classification}
       onChangeTitle={ctl.handleTitle}
       onChangeBody={ctl.handleBody}
+      onChangeClassification={ctl.autosave.onChangeClassification}
       onFinish={canFinish ? markFinished : undefined}
       bodyPlaceholder={bodyPlaceholder}
     />
@@ -686,6 +883,25 @@ function readEntrypoint(params: RootStackParamList['JournalEntry']): EntryEntryp
   };
 }
 
+/**
+ * The one-line reason shown when resonance is gated off for an intimate entry.
+ * A sibling above the floating button so it reads as the button's own caption.
+ */
+function PrivacyResonanceReason({
+  visible,
+  reason,
+}: {
+  visible: boolean;
+  reason: string;
+}): React.JSX.Element | null {
+  if (!visible) return null;
+  return (
+    <Text style={styles.privacyResonanceReason} testID="privacy-resonance-reason">
+      {reason}
+    </Text>
+  );
+}
+
 function JournalEntryScreen({
   route,
   navigation,
@@ -707,9 +923,14 @@ function JournalEntryScreen({
           human + professional support reads as the page's own, not a margin note. */}
       <CareSupportNote care={ctl.resonance.care} />
       <JournalPage ctl={ctl} bodyPlaceholder={bodyPlaceholder} />
+      <PrivacyResonanceReason
+        visible={ctl.visible && ctl.resonanceDisabled}
+        reason={ctl.resonanceReason}
+      />
       <GetResonanceButton
         visible={ctl.visible}
         loading={ctl.resonance.loading}
+        disabled={ctl.resonanceDisabled}
         onPress={ctl.resonance.requestResonance}
       />
       <ResonanceEssayModal

--- a/frontend/src/features/Journal/PrivacyTierControl.tsx
+++ b/frontend/src/features/Journal/PrivacyTierControl.tsx
@@ -1,0 +1,106 @@
+/**
+ * ``PrivacyTierControl`` — the three-tier privacy chooser on the journal editor.
+ *
+ * A radio-like segmented control (public / personal / intimate) that lets the
+ * writer set how open an entry is. Choosing ``intimate`` reveals a one-line
+ * explainer that the entry is never sent to AI — the resonance affordance is
+ * gated off for intimate entries in the hosting screen. ``personal`` is the
+ * backend default and the selection when no ``value`` is supplied.
+ *
+ * Presentational and controlled: ``onChange`` is the only output; the host owns
+ * the tier and persists it (create/update).
+ */
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+
+import styles from './JournalEntry.styles';
+
+/** Privacy tier for a journal entry (mirrors the backend classification enum). */
+export type PrivacyTier = 'public' | 'personal' | 'intimate';
+
+/** The backend default tier, used when no ``value`` is supplied. */
+const DEFAULT_TIER: PrivacyTier = 'personal';
+
+/** One-line copy shown under the control when ``intimate`` is selected. */
+const INTIMATE_EXPLAINER = 'Intimate entries are never sent to AI.';
+
+interface TierOption {
+  tier: PrivacyTier;
+  label: string;
+  /** Screen-reader hint describing what the tier means. */
+  hint: string;
+}
+
+/** The three tiers, ordered most-open → most-private. */
+const TIER_OPTIONS: readonly TierOption[] = [
+  { tier: 'public', label: 'Public', hint: 'Most open — shareable with the Sangha.' },
+  { tier: 'personal', label: 'Personal', hint: 'Private to you; resonance may read it.' },
+  { tier: 'intimate', label: 'Intimate', hint: 'Never sent to AI; resonance is paused.' },
+];
+
+export interface PrivacyTierControlProps {
+  /** The currently-selected tier; defaults to ``personal`` when omitted. */
+  value?: PrivacyTier;
+  /** Called with the chosen tier when an option is pressed. */
+  onChange: (_tier: PrivacyTier) => void;
+}
+
+interface TierButtonProps {
+  option: TierOption;
+  selected: boolean;
+  onChange: (_tier: PrivacyTier) => void;
+}
+
+/** A single radio-like tier option; announces its selection state. */
+function TierButton({ option, selected, onChange }: TierButtonProps): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={[styles.privacyTierOption, selected && styles.privacyTierOptionSelected]}
+      onPress={() => onChange(option.tier)}
+      accessibilityRole="radio"
+      accessibilityLabel={option.label}
+      accessibilityHint={option.hint}
+      accessibilityState={{ selected }}
+      testID={`privacy-tier-${option.tier}`}
+    >
+      <Text style={[styles.privacyTierLabel, selected && styles.privacyTierLabelSelected]}>
+        {option.label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+/**
+ * The privacy tier segmented control plus its intimate-only explainer. Rendered
+ * in the writing column of {@link JournalEntryScreen}.
+ */
+function PrivacyTierControl({
+  value = DEFAULT_TIER,
+  onChange,
+}: PrivacyTierControlProps): React.JSX.Element {
+  return (
+    <View style={styles.privacyTierControl}>
+      <View
+        style={styles.privacyTierRow}
+        accessibilityRole="radiogroup"
+        accessibilityLabel="Entry privacy"
+      >
+        {TIER_OPTIONS.map((option) => (
+          <TierButton
+            key={option.tier}
+            option={option}
+            selected={option.tier === value}
+            onChange={onChange}
+          />
+        ))}
+      </View>
+      {value === 'intimate' ? (
+        <Text style={styles.privacyTierExplainer} testID="privacy-tier-explainer">
+          {INTIMATE_EXPLAINER}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+export default PrivacyTierControl;

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
@@ -1,0 +1,499 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react-native';
+import React from 'react';
+
+/**
+ * RED tests for privacy classification control in JournalEntryScreen (#896).
+ *
+ * Failures until the implementation-specialist:
+ * 1. Creates ``PrivacyTierControl`` and mounts it in ``WritingColumn``.
+ * 2. Adds ``classification`` to ``JournalMessageCreate``, ``JournalEntryUpdate``,
+ *    ``JournalMessage``, and ``ResonanceResponse`` in ``frontend/src/api/index.ts``.
+ * 3. Passes ``classification`` through ``useJournalAutosave`` / ``writeEntry``.
+ * 4. Wires ``GetResonanceButton disabled`` when ``classification === 'intimate'``
+ *    and shows ``privacy-resonance-reason`` text.
+ */
+import type { JournalMessage, ResonanceResponse } from '@/api';
+import { DEFAULT_IDLE_DELAY_MS } from '@/hooks/useIdle';
+
+// ---------------------------------------------------------------------------
+// API mock — mirrors JournalEntryScreen.test.tsx / JournalEntryScreenCare.test.tsx
+// ---------------------------------------------------------------------------
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+const mockGenerate = jest.fn() as jest.MockedFunction<(_id: number) => Promise<ResonanceResponse>>;
+const mockRespond = jest.fn() as jest.MockedFunction<(_w: number, _b: string) => Promise<unknown>>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: {
+    respond: (...a: unknown[]) => (mockRespond as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: (...a: unknown[]) => (mockGenerate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  completionSuggestions: {
+    list: jest.fn(() => Promise.resolve({ items: [] })),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+/** ``classification`` is not yet on the TS type — added by #896 implementation. */
+type EntryOverrides = Partial<JournalMessage> & {
+  classification?: 'public' | 'personal' | 'intimate';
+};
+
+function entry(overrides: EntryOverrides = {}): JournalMessage {
+  return {
+    id: 7,
+    message: 'A page about rivers.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'freeform' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'Rivers',
+    status: 'draft',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  } as JournalMessage;
+}
+
+function resonancePayload(overrides: Partial<ResonanceResponse> = {}): ResonanceResponse {
+  return {
+    marginalia: [],
+    suggestions: [],
+    remaining_messages: 48,
+    remaining_balance: 0,
+    monthly_reset_date: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderScreen(
+  params?: {
+    entryId?: number;
+    weekNumber?: number;
+    promptQuestion?: string;
+    prefillTitle?: string;
+    practiceSessionId?: number;
+  },
+  extraProps: Record<string, unknown> = {},
+) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return {
+    ...render(<Screen navigation={navigation} route={route} {...extraProps} />),
+    navigation,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockGenerate.mockReset();
+  mockRespond.mockReset();
+  mockRespond.mockResolvedValue({});
+});
+
+// ---------------------------------------------------------------------------
+// 1. Control renders; default is personal
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — privacy tier control renders (#896)', () => {
+  it('renders the PrivacyTierControl inside the writing column', () => {
+    const { getByTestId } = renderScreen();
+    // The writing column hosts the control; query by containment.
+    expect(within(getByTestId('journal-page')).getByTestId('privacy-tier-personal')).toBeTruthy();
+  });
+
+  it('defaults to personal (backend default) on a fresh entry', () => {
+    const { getByTestId } = renderScreen();
+    const personal = within(getByTestId('journal-page')).getByTestId('privacy-tier-personal');
+    expect(personal.props.accessibilityState.selected).toBe(true);
+  });
+
+  it('all three tier options are present on a fresh entry', () => {
+    const { getByTestId } = renderScreen();
+    const page = getByTestId('journal-page');
+    expect(within(page).getByTestId('privacy-tier-public')).toBeTruthy();
+    expect(within(page).getByTestId('privacy-tier-personal')).toBeTruthy();
+    expect(within(page).getByTestId('privacy-tier-intimate')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2a. Persistence — existing entry PATCH
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — tier persists via PATCH on existing entry (#896)', () => {
+  it('PATCHes classification when the tier changes on an existing entry', async () => {
+    jest.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue(entry({ id: 7, classification: 'personal' }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ classification: 'intimate' }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('PATCHes classification="public" when the public tier is chosen', async () => {
+    jest.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue(entry({ id: 7, classification: 'personal' }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-public'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ classification: 'public' }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2b. Persistence — new entry create carries classification
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — classification on first create (#896)', () => {
+  it('creates with classification="intimate" when intimate is chosen before first save', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      // Choose intimate before writing anything.
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate'));
+      // Now type to trigger the autosave.
+      fireEvent.changeText(getByTestId('journal-body-input'), 'An intimate reflection.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ classification: 'intimate' }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('creates with classification="personal" by default (no tier change)', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A personal reflection.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ classification: 'personal' }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('creates with classification="public" when public is chosen first', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-public'));
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A public reflection.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ classification: 'public' }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Load reflects server value
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — loads server classification into the control (#896)', () => {
+  it('pre-selects intimate when the loaded entry has classification="intimate"', async () => {
+    mockGet.mockResolvedValue(entry({ id: 7, classification: 'intimate' }));
+    const { getByTestId } = renderScreen({ entryId: 7 });
+
+    await waitFor(() => {
+      const intimate = within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate');
+      expect(intimate.props.accessibilityState.selected).toBe(true);
+    });
+  });
+
+  it('pre-selects public when the loaded entry has classification="public"', async () => {
+    mockGet.mockResolvedValue(entry({ id: 7, classification: 'public' }));
+    const { getByTestId } = renderScreen({ entryId: 7 });
+
+    await waitFor(() => {
+      const pub = within(getByTestId('journal-page')).getByTestId('privacy-tier-public');
+      expect(pub.props.accessibilityState.selected).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Intimate explainer shown in the editor
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — intimate explainer in the writing column (#896)', () => {
+  it('shows the explainer after choosing intimate', () => {
+    const { getByTestId } = renderScreen();
+    fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate'));
+    expect(within(getByTestId('journal-page')).getByTestId('privacy-tier-explainer')).toBeTruthy();
+  });
+
+  it('hides the explainer when personal is selected', () => {
+    const { queryByTestId } = renderScreen();
+    // Default is personal; explainer should not be present.
+    expect(queryByTestId('privacy-tier-explainer')).toBeNull();
+  });
+
+  it('hides the explainer after switching back from intimate to personal', () => {
+    const { getByTestId, queryByTestId } = renderScreen();
+    const page = getByTestId('journal-page');
+
+    fireEvent.press(within(page).getByTestId('privacy-tier-intimate'));
+    expect(within(page).getByTestId('privacy-tier-explainer')).toBeTruthy();
+
+    fireEvent.press(within(page).getByTestId('privacy-tier-personal'));
+    expect(queryByTestId('privacy-tier-explainer')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Resonance disabled with a visible reason for intimate entries
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — resonance disabled for intimate entries (#896)', () => {
+  it('shows resonance button disabled (not hidden) when classification=intimate after idle', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42, classification: 'intimate' }));
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      // Choose intimate before typing.
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate'));
+      fireEvent.changeText(getByTestId('journal-body-input'), 'An intimate page.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      // Button must be PRESENT but DISABLED (not hidden).
+      const btn = getByTestId('get-resonance-button');
+      expect(btn).toBeTruthy();
+      expect(btn.props.accessibilityState.disabled).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('shows a visible reason text when resonance is disabled for intimate', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42, classification: 'intimate' }));
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate'));
+      fireEvent.changeText(getByTestId('journal-body-input'), 'An intimate page.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      expect(getByTestId('privacy-resonance-reason')).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does NOT call resonance.generate when the disabled intimate button is tapped', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42, classification: 'intimate' }));
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate'));
+      fireEvent.changeText(getByTestId('journal-body-input'), 'An intimate page.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      fireEvent.press(getByTestId('get-resonance-button'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockGenerate).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('leaves resonance enabled for personal entries after idle', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(resonancePayload());
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A personal page.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      const btn = getByTestId('get-resonance-button');
+      expect(btn.props.accessibilityState.disabled).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('leaves resonance enabled for public entries after idle', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(resonancePayload());
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-public'));
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A public page.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      const btn = getByTestId('get-resonance-button');
+      expect(btn.props.accessibilityState.disabled).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Accessibility — control within the screen-level tree
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — privacy control a11y (#896)', () => {
+  it('all three tier touchables are inside journal-screen', () => {
+    const { getByTestId } = renderScreen();
+    const screen = getByTestId('journal-screen');
+    expect(within(screen).getByTestId('privacy-tier-public')).toBeTruthy();
+    expect(within(screen).getByTestId('privacy-tier-personal')).toBeTruthy();
+    expect(within(screen).getByTestId('privacy-tier-intimate')).toBeTruthy();
+  });
+
+  it('the resonance reason text is inside journal-screen when intimate is active', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42, classification: 'intimate' }));
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate'));
+      fireEvent.changeText(getByTestId('journal-body-input'), 'An intimate page.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+      });
+
+      expect(
+        within(getByTestId('journal-screen')).getByTestId('privacy-resonance-reason'),
+      ).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/features/Journal/__tests__/PrivacyTierControl.test.tsx
+++ b/frontend/src/features/Journal/__tests__/PrivacyTierControl.test.tsx
@@ -1,0 +1,185 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import PrivacyTierControl, { type PrivacyTier } from '../PrivacyTierControl';
+
+import { touchTarget } from '@/design/tokens';
+
+/**
+ * RED tests for ``PrivacyTierControl`` (issue #896).
+ *
+ * These tests fail until the implementation-specialist creates
+ * ``frontend/src/features/Journal/PrivacyTierControl.tsx``.
+ *
+ * Design requirements (from the chief architect):
+ * - 3-option segmented control: public / personal / intimate.
+ * - Default selection when no ``value`` is supplied is ``personal``.
+ * - Each option exposes ``accessibilityState.selected`` truthily.
+ * - Choosing ``intimate`` shows a one-line explainer; public/personal do not.
+ * - Pressing an option fires ``onChange`` with the new tier string.
+ * - All touch targets meet the 44dp ``touchTarget.minimum``.
+ * - testIDs: ``privacy-tier-public``, ``privacy-tier-personal``,
+ *   ``privacy-tier-intimate``, ``privacy-tier-explainer``.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Smallest of the flattened minHeight/minWidth on an interactive node. */
+function StyleSheetMin(node: { props: { style: unknown } }): number {
+  const { StyleSheet } = require('react-native') as {
+    StyleSheet: { flatten: (_s: unknown) => { minHeight?: number; minWidth?: number } };
+  };
+  const flat = StyleSheet.flatten(node.props.style);
+  return Math.min(flat.minHeight ?? 0, flat.minWidth ?? 0);
+}
+
+function renderControl(value?: PrivacyTier, onChange: (_tier: PrivacyTier) => void = jest.fn()) {
+  return render(<PrivacyTierControl value={value} onChange={onChange} />);
+}
+
+// ---------------------------------------------------------------------------
+// Default state
+// ---------------------------------------------------------------------------
+
+describe('PrivacyTierControl — default state (no value prop)', () => {
+  it('renders all three tier options', () => {
+    const { getByTestId } = renderControl();
+    expect(getByTestId('privacy-tier-public')).toBeTruthy();
+    expect(getByTestId('privacy-tier-personal')).toBeTruthy();
+    expect(getByTestId('privacy-tier-intimate')).toBeTruthy();
+  });
+
+  it('selects personal by default when no value is provided', () => {
+    const { getByTestId } = renderControl();
+    expect(getByTestId('privacy-tier-personal').props.accessibilityState.selected).toBe(true);
+    expect(getByTestId('privacy-tier-public').props.accessibilityState.selected).toBe(false);
+    expect(getByTestId('privacy-tier-intimate').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('does NOT show the intimate explainer when personal is selected by default', () => {
+    const { queryByTestId } = renderControl();
+    expect(queryByTestId('privacy-tier-explainer')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Controlled (value prop)
+// ---------------------------------------------------------------------------
+
+describe('PrivacyTierControl — controlled via value prop', () => {
+  it('selects public when value="public"', () => {
+    const { getByTestId } = renderControl('public');
+    expect(getByTestId('privacy-tier-public').props.accessibilityState.selected).toBe(true);
+    expect(getByTestId('privacy-tier-personal').props.accessibilityState.selected).toBe(false);
+    expect(getByTestId('privacy-tier-intimate').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('selects intimate when value="intimate"', () => {
+    const { getByTestId } = renderControl('intimate');
+    expect(getByTestId('privacy-tier-intimate').props.accessibilityState.selected).toBe(true);
+    expect(getByTestId('privacy-tier-personal').props.accessibilityState.selected).toBe(false);
+    expect(getByTestId('privacy-tier-public').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('selects personal when value="personal"', () => {
+    const { getByTestId } = renderControl('personal');
+    expect(getByTestId('privacy-tier-personal').props.accessibilityState.selected).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onChange wiring
+// ---------------------------------------------------------------------------
+
+describe('PrivacyTierControl — onChange', () => {
+  it('fires onChange("public") when the public option is pressed', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = renderControl('personal', onChange);
+    fireEvent.press(getByTestId('privacy-tier-public'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('public');
+  });
+
+  it('fires onChange("intimate") when the intimate option is pressed', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = renderControl('personal', onChange);
+    fireEvent.press(getByTestId('privacy-tier-intimate'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('intimate');
+  });
+
+  it('fires onChange("personal") when the personal option is pressed from public', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = renderControl('public', onChange);
+    fireEvent.press(getByTestId('privacy-tier-personal'));
+    expect(onChange).toHaveBeenCalledWith('personal');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Intimate explainer
+// ---------------------------------------------------------------------------
+
+describe('PrivacyTierControl — intimate explainer', () => {
+  it('shows the explainer when value="intimate"', () => {
+    const { getByTestId } = renderControl('intimate');
+    expect(getByTestId('privacy-tier-explainer')).toBeTruthy();
+  });
+
+  it('the explainer text mentions AI not receiving it', () => {
+    const { getByTestId } = renderControl('intimate');
+    const text: string = getByTestId('privacy-tier-explainer').props.children as string;
+    // The implementation-specialist must put copy about AI not accessing intimate entries.
+    expect(text.toLowerCase()).toMatch(/never sent to ai|not shared with ai|ai won.t|ai cannot/);
+  });
+
+  it('does NOT show the explainer when value="personal"', () => {
+    const { queryByTestId } = renderControl('personal');
+    expect(queryByTestId('privacy-tier-explainer')).toBeNull();
+  });
+
+  it('does NOT show the explainer when value="public"', () => {
+    const { queryByTestId } = renderControl('public');
+    expect(queryByTestId('privacy-tier-explainer')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accessibility — labels + selected state
+// ---------------------------------------------------------------------------
+
+describe('PrivacyTierControl — accessibility', () => {
+  it('each option carries a non-empty accessibilityLabel', () => {
+    const { getByTestId } = renderControl('personal');
+    const publicLabel: string = getByTestId('privacy-tier-public').props.accessibilityLabel;
+    const personalLabel: string = getByTestId('privacy-tier-personal').props.accessibilityLabel;
+    const intimateLabel: string = getByTestId('privacy-tier-intimate').props.accessibilityLabel;
+    expect(publicLabel.length).toBeGreaterThan(0);
+    expect(personalLabel.length).toBeGreaterThan(0);
+    expect(intimateLabel.length).toBeGreaterThan(0);
+  });
+
+  it('options carry role "radio" or "button" (segmented-control semantics)', () => {
+    const { getByTestId } = renderControl('personal');
+    const publicRole: string = getByTestId('privacy-tier-public').props.accessibilityRole;
+    // RNTL renders accessibilityRole as 'radio' or 'button' for segmented controls.
+    expect(['radio', 'button']).toContain(publicRole);
+  });
+
+  it('all touch targets meet the 44dp minimum', () => {
+    const { getByTestId } = renderControl('personal');
+    expect(StyleSheetMin(getByTestId('privacy-tier-public'))).toBeGreaterThanOrEqual(
+      touchTarget.minimum,
+    );
+    expect(StyleSheetMin(getByTestId('privacy-tier-personal'))).toBeGreaterThanOrEqual(
+      touchTarget.minimum,
+    );
+    expect(StyleSheetMin(getByTestId('privacy-tier-intimate'))).toBeGreaterThanOrEqual(
+      touchTarget.minimum,
+    );
+  });
+});

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -43,6 +43,12 @@ export interface UseResonanceResult {
    * new pass clears any stale care, and the load-on-open path never sets it.
    */
   care: CareResponse | null;
+  /**
+   * Reason copy from a pass that was withheld for an intimate entry.
+   * ``null`` until a generate pass returns a ``private_message``; the privacy
+   * gate falls back to its own default copy when this is null.
+   */
+  privateMessage: string | null;
   loading: boolean;
   error: string | null;
   requestResonance: () => Promise<void>;
@@ -202,12 +208,13 @@ interface GeneratePassDeps {
   setMarginalia: Dispatch<SetStateAction<Marginalia[]>>;
   mergeFromGenerate: (_incoming: CompletionSuggestion[]) => void;
   setCare: Dispatch<SetStateAction<CareResponse | null>>;
+  setPrivateMessage: Dispatch<SetStateAction<string | null>>;
   setError: Dispatch<SetStateAction<string | null>>;
 }
 
 /** The charged "generate" pass: flush, generate, merge notes + suggestions + care. */
 function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
-  const { flush, setMarginalia, mergeFromGenerate, setCare, setError } = deps;
+  const { flush, setMarginalia, mergeFromGenerate, setCare, setPrivateMessage, setError } = deps;
   const [loading, setLoading] = useState(false);
   const inFlightRef = useRef(false);
 
@@ -230,13 +237,15 @@ function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
       mergeFromGenerate(result.suggestions);
       // ``care`` is nullable/absent on ordinary entries — normalise to null.
       setCare(result.care ?? null);
+      // ``private_message`` is present only when the pass was withheld.
+      setPrivateMessage(result.private_message ?? null);
     } catch (err) {
       setError(formatApiError(err));
     } finally {
       inFlightRef.current = false;
       setLoading(false);
     }
-  }, [flush, setMarginalia, mergeFromGenerate, setCare, setError]);
+  }, [flush, setMarginalia, mergeFromGenerate, setCare, setPrivateMessage, setError]);
 
   return { loading, requestResonance };
 }
@@ -246,6 +255,8 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
   // Default null (never undefined): the load-on-open path never sets care, so
   // the surface stays hidden until a generate pass returns one.
   const [care, setCare] = useState<CareResponse | null>(null);
+  // Reason copy from a withheld (intimate) pass; null until one returns it.
+  const [privateMessage, setPrivateMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useLoadOnOpen(routeEntryId, resonance.list, setMarginalia);
@@ -255,6 +266,7 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     setMarginalia,
     mergeFromGenerate: sug.mergeFromGenerate,
     setCare,
+    setPrivateMessage,
     setError,
   });
 
@@ -277,6 +289,7 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     suggestions: sug.suggestions,
     acceptedCheckIns: sug.acceptedCheckIns,
     care,
+    privateMessage,
     loading,
     error,
     requestResonance,


### PR DESCRIPTION
## Summary
Adds a legible **public / personal / intimate** privacy tier selector to the journal entry editor, giving the writer direct control over an entry's depth (NORTH-STAR §10). Builds on the backend `classification` field and the intimate-never-to-cloud guard already shipped.

- New `PrivacyTierControl` — a token-styled radio group (public/personal/intimate) with an intimate-only one-line explainer ("Intimate entries are never sent to AI.").
- The choice **persists via the journal API**: new entries carry `classification` on create; changing the tier on an existing entry issues an immediate `PATCH { classification }` (disjoint from the debounced body save — no double-fire, no spurious request before first create).
- When an entry is `intimate`, the **Resonance affordance is clearly disabled with a visible reason** (client-side gate — the disabled button never fires the pass), mirroring the server-side intimate guard. Reason copy sources the server's `private_message` with a sane fallback.
- Frontend API types + zod gain additive `classification` (enum, optional) and `private` / `private_message` (optional/nullish) so older responses still validate — no drift from the backend enum.
- Accessible: `radiogroup`/`radio` roles, `accessibilityState.selected`, non-empty labels/hints, 44dp touch targets, `ink`/`paper` contrast tokens. Default tier is `personal` (matches the backend default).

## Test plan
- 54 new tests (Jest + RNTL): control renders + default `personal`; tier-change PATCHes `classification`; first-save create carries it; load pre-selects the server value; intimate explainer visible; intimate disables `get-resonance-button` with a reason and blocks the request; a11y labels/selected/44dp; additive-schema parse/round-trip/drift-rejection.
- `scripts/frontend/check-all.sh` exits 0 (lint zero-warning, tsc strict, prettier, all 2300 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #896
Refs #893