### PR TITLE
feat(frontend): surface privacy as a feature in Settings + onboarding

### DIFF
--- a/frontend/src/features/Settings/SettingsHubScreen.tsx
+++ b/frontend/src/features/Settings/SettingsHubScreen.tsx
@@ -6,6 +6,7 @@ import {
   KeyRound,
   LifeBuoy,
   LogOut,
+  ShieldCheck,
   type LucideIcon,
 } from 'lucide-react-native';
 import React, { useCallback } from 'react';
@@ -27,6 +28,14 @@ import type { RootStackParamList } from '@/navigation/RootStack';
 
 const ICON_SIZE = 22;
 const CHEVRON_SIZE = 20;
+
+/** Entry-visibility promise: the three privacy tiers are the user's choice. */
+const PRIVACY_VISIBILITY_LINE =
+  'You choose the privacy of every entry — Public, Personal, or Intimate.';
+/** The hard guarantee that Intimate entries are never shared with any model. */
+const PRIVACY_INTIMATE_LINE = 'Entries you mark Intimate are never sent to any AI.';
+/** Full-sentence a11y label so screen-reader users hear both promises at once. */
+const PRIVACY_A11Y_LABEL = `${PRIVACY_VISIBILITY_LINE} ${PRIVACY_INTIMATE_LINE}`;
 
 interface SettingsRowProps {
   icon: LucideIcon;
@@ -92,6 +101,33 @@ const AccountSection = ({ onApiKey, onTimezone }: AccountSectionProps): React.JS
   </EditorialSection>
 );
 
+/**
+ * Privacy group: a non-interactive, informational statement surfacing the
+ * entry-visibility tiers and the Intimate/AI guarantee as a first-class feature
+ * rather than a buried setting. Kept non-navigational — it makes a promise, it
+ * is not a destination.
+ */
+const PrivacySection = (): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const t = typeRamp(width);
+  return (
+    <EditorialSection title="Privacy" testID="settings-group-privacy">
+      <View
+        style={styles.privacyStatement}
+        accessibilityRole="text"
+        accessibilityLabel={PRIVACY_A11Y_LABEL}
+        testID="settings-privacy-statement"
+      >
+        <ShieldCheck color={accent.primary} size={ICON_SIZE} />
+        <View style={styles.privacyText}>
+          <Text style={[t.body, styles.privacyLine]}>{PRIVACY_VISIBILITY_LINE}</Text>
+          <Text style={[t.caption, styles.privacyLineSoft]}>{PRIVACY_INTIMATE_LINE}</Text>
+        </View>
+      </View>
+    </EditorialSection>
+  );
+};
+
 /** Session group: the destructive log-out action. */
 const SessionSection = ({ onLogout }: { onLogout: () => void }): React.JSX.Element => (
   <EditorialSection title="Session" testID="settings-group-session">
@@ -136,6 +172,7 @@ const SettingsHubScreen = (): React.JSX.Element => {
         lead="Manage how Adepthood works for you."
       />
       <AccountSection onApiKey={openApiKey} onTimezone={openTimezone} />
+      <PrivacySection />
       <SessionSection onLogout={onLogout} />
       <SupportSection onSupportCare={openSupportCare} />
     </ScreenScaffold>
@@ -159,6 +196,22 @@ const styles = StyleSheet.create({
     color: ink.primary,
   },
   rowDescription: {
+    color: ink.soft,
+    marginTop: rhythm.blockGap / 3,
+  },
+  privacyStatement: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: rhythm.blockGap,
+  },
+  privacyText: {
+    flex: 1,
+    marginLeft: rhythm.blockGap,
+  },
+  privacyLine: {
+    color: ink.primary,
+  },
+  privacyLineSoft: {
     color: ink.soft,
     marginTop: rhythm.blockGap / 3,
   },

--- a/frontend/src/features/Settings/__tests__/SettingsHubScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/SettingsHubScreen.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, within } from '@testing-library/react-native';
 import React from 'react';
 
 const mockNavigate = jest.fn();
@@ -91,5 +91,76 @@ describe('SettingsHubScreen — Support & care row (issue #892)', () => {
     expect(getByTestId('settings-row-api-key')).toBeTruthy();
     expect(getByTestId('settings-row-timezone')).toBeTruthy();
     expect(getByTestId('settings-row-logout')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #897 — Privacy section in Settings (RED — fails until impl exists)
+// ---------------------------------------------------------------------------
+
+describe('SettingsHubScreen — Privacy section (issue #897)', () => {
+  test('renders the Privacy group and statement block', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    expect(getByTestId('settings-group-privacy')).toBeTruthy();
+    expect(getByTestId('settings-privacy-statement')).toBeTruthy();
+  });
+
+  test('statement block is contained within the Privacy group', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+    const group = getByTestId('settings-group-privacy');
+
+    expect(within(group).getByTestId('settings-privacy-statement')).toBeTruthy();
+  });
+
+  test('renders the entry-visibility privacy statement verbatim', () => {
+    const { getByText } = render(<SettingsHubScreen />);
+
+    expect(
+      getByText('You choose the privacy of every entry — Public, Personal, or Intimate.'),
+    ).toBeTruthy();
+  });
+
+  test('renders the Intimate-entries AI statement verbatim', () => {
+    const { getByText } = render(<SettingsHubScreen />);
+
+    expect(getByText('Entries you mark Intimate are never sent to any AI.')).toBeTruthy();
+  });
+
+  test('statement block carries a non-empty accessibilityLabel and accessibilityRole="text"', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+    const block = getByTestId('settings-privacy-statement');
+
+    expect(typeof block.props.accessibilityLabel).toBe('string');
+    expect((block.props.accessibilityLabel as string).length).toBeGreaterThan(0);
+    expect(block.props.accessibilityRole).toBe('text');
+  });
+
+  test('accessibilityLabel is a full sentence, not a fragment', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+    const block = getByTestId('settings-privacy-statement');
+    const label = block.props.accessibilityLabel as string;
+
+    // A complete sentence ends with a full-stop or equivalent punctuation.
+    expect(label).toMatch(/[.!?]$/u);
+    // Must reference both key concepts so screen-reader users get the full picture.
+    expect(label.toLowerCase()).toContain('intimate');
+    expect(label.toLowerCase()).toContain('privacy');
+  });
+
+  test('NEGATIVE accuracy guard: does not claim "encrypted at rest"', () => {
+    const { queryByText } = render(<SettingsHubScreen />);
+
+    expect(queryByText(/encrypted at rest/iu)).toBeNull();
+  });
+
+  test('regression: existing sections and rows still render after Privacy addition', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    expect(getByTestId('settings-group-account')).toBeTruthy();
+    expect(getByTestId('settings-row-api-key')).toBeTruthy();
+    expect(getByTestId('settings-group-session')).toBeTruthy();
+    expect(getByTestId('settings-row-logout')).toBeTruthy();
+    expect(getByTestId('settings-group-support')).toBeTruthy();
   });
 });

--- a/frontend/src/features/Welcome/Welcome.styles.ts
+++ b/frontend/src/features/Welcome/Welcome.styles.ts
@@ -57,6 +57,11 @@ export const welcomeStyles = StyleSheet.create({
     ...editorialType.body,
     color: onShowcase.soft,
   },
+  note: {
+    ...editorialType.caption,
+    color: onShowcase.muted,
+    marginTop: rhythm.blockGap,
+  },
   pillars: {
     gap: rhythm.blockGap,
     marginTop: rhythm.blockGap,

--- a/frontend/src/features/Welcome/WelcomeScreen.tsx
+++ b/frontend/src/features/Welcome/WelcomeScreen.tsx
@@ -36,6 +36,11 @@ const WelcomePanelView = ({ panel, index, width }: PanelProps): React.JSX.Elemen
             ))}
           </View>
         ) : null}
+        {panel.note ? (
+          <Text style={s.note} testID="welcome-privacy-note">
+            {panel.note}
+          </Text>
+        ) : null}
       </View>
     </ShowcaseCard>
   </View>

--- a/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
+++ b/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { jest, beforeEach, describe, it, expect } from '@jest/globals';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, within } from '@testing-library/react-native';
 import React from 'react';
 
 let mockReduced = false;
@@ -84,5 +84,81 @@ describe('WelcomeScreen', () => {
       },
     });
     expect(getByTestId('welcome-begin')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #897 — Privacy note in onboarding (RED — fails until impl exists)
+// ---------------------------------------------------------------------------
+
+// The privacy note rides the "Five pillars" panel (index 1) via a new optional
+// `note` field on WelcomePanel — NOT an additional panel.
+// WELCOME_PANELS.length must stay at 4 (the current count).
+const EXPECTED_PANEL_COUNT = 4;
+
+// Exact onboarding note copy (verbatim — em dash U+2014, curly apostrophe U+2019
+// in "entry’s", matching the apostrophe convention in welcomeContent.ts).
+const PRIVACY_NOTE =
+  'Your journal is yours — you choose each entry’s privacy, and anything you mark Intimate never leaves for AI.';
+
+// The privacy note lives on panel index 1 ("Five pillars"). Drive the pager
+// there before querying so the note is in the rendered tree.
+const scrollToPanelIndex = (
+  getByTestId: ReturnType<typeof render>['getByTestId'],
+  index: number,
+) => {
+  fireEvent(getByTestId('welcome-pager'), 'momentumScrollEnd', {
+    nativeEvent: {
+      contentOffset: { x: index * TEST_WIDTH },
+      layoutMeasurement: { width: TEST_WIDTH },
+    },
+  });
+};
+
+describe('WelcomeScreen — onboarding privacy note (issue #897)', () => {
+  it('WELCOME_PANELS.length is unchanged at 4 — no new panel was added', () => {
+    // If a new panel is added this fails, enforcing the "no gate/slowdown" rule.
+    expect(WELCOME_PANELS.length).toBe(EXPECTED_PANEL_COUNT);
+  });
+
+  it('renders the privacy note testID on the Five Pillars panel', () => {
+    const { getByTestId } = setup();
+    scrollToPanelIndex(getByTestId, 1);
+    const panel = getByTestId('welcome-panel-1');
+
+    expect(within(panel).getByTestId('welcome-privacy-note')).toBeTruthy();
+  });
+
+  it('renders the exact privacy note copy verbatim', () => {
+    const { getByTestId, getByText } = setup();
+    scrollToPanelIndex(getByTestId, 1);
+
+    expect(getByText(PRIVACY_NOTE)).toBeTruthy();
+  });
+
+  it('privacy note text is contained within the Five Pillars panel', () => {
+    const { getByTestId } = setup();
+    scrollToPanelIndex(getByTestId, 1);
+    const panel = getByTestId('welcome-panel-1');
+
+    expect(within(panel).getByText(PRIVACY_NOTE)).toBeTruthy();
+  });
+
+  it('Skip still fires onComplete without onBegin after privacy note added', () => {
+    const { getByTestId, onComplete, onBegin } = setup();
+    fireEvent.press(getByTestId('welcome-skip'));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onBegin).not.toHaveBeenCalled();
+  });
+
+  it('Begin on the last panel still fires both onComplete and onBegin after privacy note added', () => {
+    const { getByTestId, onComplete, onBegin } = setup();
+    const lastIndex = WELCOME_PANELS.length - 1;
+    scrollToPanelIndex(getByTestId, lastIndex);
+    fireEvent.press(getByTestId('welcome-begin'));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onBegin).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/features/Welcome/welcomeContent.ts
+++ b/frontend/src/features/Welcome/welcomeContent.ts
@@ -11,7 +11,17 @@ export interface WelcomePanel {
   title: string;
   body: string;
   pillars?: readonly WelcomePillar[];
+  /** Optional privacy reassurance rendered inline beneath the panel body. */
+  note?: string;
 }
+
+/**
+ * Onboarding privacy promise, surfaced inline on the Five-pillars panel so the
+ * "you choose your depth" ethos is visible before any entry is written — no
+ * extra panel, no gate.
+ */
+export const WELCOME_PRIVACY_NOTE =
+  'Your journal is yours — you choose each entry’s privacy, and anything you mark Intimate never leaves for AI.';
 
 /** The five APTITUDE pillars introduced on the second panel. */
 export const WELCOME_PILLARS: readonly WelcomePillar[] = [
@@ -34,6 +44,7 @@ export const WELCOME_PANELS: readonly WelcomePanel[] = [
     title: 'How the work holds together',
     body: 'Each week weaves the same five threads. Lean on whichever the day asks for.',
     pillars: WELCOME_PILLARS,
+    note: WELCOME_PRIVACY_NOTE,
   },
   {
     eyebrow: 'A week, lived',


### PR DESCRIPTION
## Summary
Makes the privacy model visible rather than buried in the plumbing (NORTH-STAR §9/§10), pairing with the per-entry classification control (#896).

- **Settings** — a non-navigational **Privacy** section stating plainly: you choose the privacy of every entry (Public/Personal/Intimate), and entries marked Intimate are never sent to any AI.
- **Onboarding** — one concise privacy line added to the existing "Five pillars" panel near the journal pillar. No new panel, no gate, no acknowledgement tap; the Skip/Next/Begin flow and panel count are unchanged.
- **Accuracy-first copy** — held true to shipped behavior (#894 field, #895 intimate-never-to-cloud, #896 per-entry control). It makes **no** "encrypted at rest" guarantee (encryption is opt-in/off-by-default via `JOURNAL_ENCRYPTION_KEYS`, so the frontend can't promise it per-deployment) and scopes the AI-withholding promise to **Intimate only** (Personal/Public still reach the LLM).
- Token-only styling; the statement block follows the tested house a11y pattern (`accessibilityRole="text"` + full-sentence label).

## Test plan
- 14 new tests (Jest + RNTL): Settings renders `settings-group-privacy`/`settings-privacy-statement` with the two verbatim statements + a11y role/label; a **negative guard** asserts "encrypted at rest" never renders; existing sections unaffected. Welcome renders `welcome-privacy-note` (verbatim copy) inside the Five-pillars panel; `WELCOME_PANELS.length` pinned at 4 (no new gate); Skip/Begin flow unchanged.
- `scripts/frontend/check-all.sh` exits 0 (lint zero-warning, tsc strict, prettier, all 2314 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #897
Refs #893