### PR TITLE
feat(frontend): open the app into the Journal (initial route + tab order)

### DIFF
--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -89,11 +89,11 @@ const TAB_CONFIGS: ReadonlyArray<{
   component: React.ComponentType<object>;
   icon: LucideIcon;
 }> = [
+  { name: 'Journal', component: JournalTab, icon: NotebookPen },
   { name: 'Today', component: TodayTab, icon: Home },
   { name: 'Habits', component: HabitsTab, icon: Sprout },
   { name: 'Practice', component: PracticeTab, icon: Flower2 },
   { name: 'Course', component: CourseTab, icon: BookOpen },
-  { name: 'Journal', component: JournalTab, icon: NotebookPen },
   { name: 'Map', component: MapTab, icon: Compass },
 ];
 
@@ -134,7 +134,7 @@ const BottomTabs = (): React.JSX.Element => {
 
   return (
     <Tab.Navigator
-      initialRouteName="Today"
+      initialRouteName="Journal"
       screenOptions={{
         // Warm tab bar (#803): raised paper ground + hairline top edge; active
         // terracotta vs muted ink, both AA on the raised ground.

--- a/frontend/src/navigation/__tests__/BottomTabs.test.tsx
+++ b/frontend/src/navigation/__tests__/BottomTabs.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
-import { NavigationContainer } from '@react-navigation/native';
-import { render } from '@testing-library/react-native';
+import { NavigationContainer, type NavigationContainerRef } from '@react-navigation/native';
+import { render, waitFor } from '@testing-library/react-native';
 import {
   BookOpen,
   Compass,
@@ -30,7 +30,7 @@ jest.mock('@/features/Habits/components/ReorderHabitsModal', () => () => null);
 jest.mock('@/features/Habits/components/StatsModal', () => () => null);
 jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
 
-import BottomTabs from '../BottomTabs';
+import BottomTabs, { type RootTabParamList } from '../BottomTabs';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -83,5 +83,53 @@ describe('BottomTabs', () => {
 
     // LayoutGrid was the Catalog tab icon; it must be absent now (6 tabs).
     expect(UNSAFE_queryAllByType(LayoutGrid)).toHaveLength(0);
+  });
+
+  // Issue #900: Journal-first navigation — RED tests (fail until implementation).
+  // The fix sets initialRouteName="Journal" and moves Journal to TAB_CONFIGS[0].
+
+  it('opens into the Journal tab as the initial route (issue #900)', async () => {
+    // NavigationContainerRef exposes getCurrentRoute() after the navigation
+    // state commits. waitFor polls until the ref is populated, which also
+    // flushes the Animated(View) update that would otherwise surface as an
+    // act() warning.
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+
+    render(
+      <NavigationContainer ref={navRef}>
+        <BottomTabs />
+      </NavigationContainer>,
+    );
+
+    // getCurrentRoute() returns the leaf route that has focus. After mount with
+    // initialRouteName="Journal" this must be "Journal", not "Today".
+    await waitFor(() => {
+      expect(navRef.current?.getCurrentRoute()?.name).toBe('Journal');
+    });
+  });
+
+  it('Journal is the first tab in navigation order (issue #900)', async () => {
+    // getState() on NavigationContainerRef is not guaranteed to be populated
+    // synchronously at the point render() returns — the navigation state is
+    // committed asynchronously by @react-navigation/native. waitFor() polls
+    // until the assertion passes (or times out), giving the state time to
+    // commit. This also flushes pending Animated updates inside act(), so no
+    // act() warning is emitted.
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+
+    render(
+      <NavigationContainer ref={navRef}>
+        <BottomTabs />
+      </NavigationContainer>,
+    );
+
+    // getRootState() returns the committed root navigation state whose routes[]
+    // array reflects the physical left-to-right tab ordering (TAB_CONFIGS order).
+    // The container ref exposes getRootState() reliably (it backs
+    // getCurrentRoute()); a bare getState() can read undefined before commit.
+    // With TAB_CONFIGS[0] === Journal, routes[0].name must equal 'Journal'.
+    await waitFor(() => {
+      expect(navRef.current?.getRootState()?.routes?.[0]?.name).toBe('Journal');
+    });
   });
 });

--- a/frontend/src/navigation/__tests__/BottomTabs.test.tsx
+++ b/frontend/src/navigation/__tests__/BottomTabs.test.tsx
@@ -85,14 +85,7 @@ describe('BottomTabs', () => {
     expect(UNSAFE_queryAllByType(LayoutGrid)).toHaveLength(0);
   });
 
-  // Issue #900: Journal-first navigation — RED tests (fail until implementation).
-  // The fix sets initialRouteName="Journal" and moves Journal to TAB_CONFIGS[0].
-
-  it('opens into the Journal tab as the initial route (issue #900)', async () => {
-    // NavigationContainerRef exposes getCurrentRoute() after the navigation
-    // state commits. waitFor polls until the ref is populated, which also
-    // flushes the Animated(View) update that would otherwise surface as an
-    // act() warning.
+  it('opens into the Journal tab as the initial route', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
 
     render(
@@ -101,20 +94,14 @@ describe('BottomTabs', () => {
       </NavigationContainer>,
     );
 
-    // getCurrentRoute() returns the leaf route that has focus. After mount with
-    // initialRouteName="Journal" this must be "Journal", not "Today".
+    // waitFor: the navigation state commits asynchronously, and polling inside
+    // act() also drains the tab bar's Animated update (else an act() warning).
     await waitFor(() => {
       expect(navRef.current?.getCurrentRoute()?.name).toBe('Journal');
     });
   });
 
-  it('Journal is the first tab in navigation order (issue #900)', async () => {
-    // getState() on NavigationContainerRef is not guaranteed to be populated
-    // synchronously at the point render() returns — the navigation state is
-    // committed asynchronously by @react-navigation/native. waitFor() polls
-    // until the assertion passes (or times out), giving the state time to
-    // commit. This also flushes pending Animated updates inside act(), so no
-    // act() warning is emitted.
+  it('Journal is the first tab in navigation order', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
 
     render(
@@ -123,11 +110,8 @@ describe('BottomTabs', () => {
       </NavigationContainer>,
     );
 
-    // getRootState() returns the committed root navigation state whose routes[]
-    // array reflects the physical left-to-right tab ordering (TAB_CONFIGS order).
-    // The container ref exposes getRootState() reliably (it backs
-    // getCurrentRoute()); a bare getState() can read undefined before commit.
-    // With TAB_CONFIGS[0] === Journal, routes[0].name must equal 'Journal'.
+    // getRootState() (not a bare getState(), which can read undefined before
+    // commit) exposes routes[] in physical tab order; waitFor lets it commit.
     await waitFor(() => {
       expect(navRef.current?.getRootState()?.routes?.[0]?.name).toBe('Journal');
     });


### PR DESCRIPTION
## Summary
The journal is the floor (NORTH-STAR §1), so the authenticated app now opens directly into it instead of Today.

- `initialRouteName="Journal"` on the bottom-tab navigator — launching the authenticated app lands on `JournalShelfScreen`.
- Journal moved to the first position in `TAB_CONFIGS` for floor primacy.
- All six tabs retained (Today remains available; opt-in ring toggling is a separate epic, Refs #899). Tab order is purely a render concern — deep-link config, every `navigate('<Name>', params)` call, and `RootTabParamList` are all name-keyed, so the reorder can't break params or links.

## Test plan
- `BottomTabs.test.tsx` updated (not deleted): asserts the initial/focused route is `Journal` (`getCurrentRoute()`) and Journal is the first tab (`getRootState().routes[0].name`), both via `NavigationContainerRef` + `waitFor`. The existing six-icon and no-Catalog regression tests stay green, proving all tabs retained.
- `scripts/frontend/check-all.sh` exits 0 (lint, tsc — proving `RootTabParamList`/param-carrying navigate calls still type-check — prettier, all 2316 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #900
Refs #899