### PR TITLE
feat(frontend): onboarding lands in the Journal after Welcome

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -136,7 +136,8 @@ function AuthNavigator() {
  * Program welcome gate (#836). On first run — once the persisted
  * ``hasSeenWelcome`` flag has resolved to unset — the editorial intro shows
  * above the app shell. Begin *or* Skip persists the flag, which flips
- * ``isFirstRun`` to false and lands the user on the already-mounted Today hub.
+ * ``isFirstRun`` to false and swaps to the app shell, which mounts at its
+ * ``Journal`` initial route — so both paths land the user on the Journal home.
  * Returning users (flag set) never see it; before hydration ``isFirstRun`` is
  * false, so the shell renders without a flash.
  */

--- a/frontend/src/__tests__/navigation/welcomeGate.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeGate.test.tsx
@@ -130,31 +130,10 @@ describe('WelcomeGate (issue #836)', () => {
   });
 });
 
-/**
- * Journal-shell regression locks (gate-level).
- *
- * This suite asserts the WelcomeGate→shell swap contract at the stub level:
- * ``root-stack`` (the RootStack stub) maps 1:1 to the authenticated shell
- * whose ``initialRouteName`` is Journal. The focused route-level assertion
- * (``getCurrentRoute().name === 'Journal'``) lives in the companion harness
- * ``welcomeLandsOnJournal.test.tsx`` which renders a real NavigationContainer
- * with a ref. Both suites must stay green; each catches a different class of
- * regression.
- *
- * These tests pass against the CURRENT correct implementation and would FAIL if:
- * - The WelcomeGate removed RootStack after Begin/Skip and replaced it with a
- *   different component (breaks ``root-stack`` presence assertion).
- * - The WelcomeScreen stopped invoking ``markSeen`` on Begin or Skip (breaks
- *   the swap: ``root-stack`` would never appear while Welcome is visible).
- */
+// Gate-level swap locks (stub RootStack = the Journal shell); the route-level
+// assertion lives in the companion welcomeLandsOnJournal.test.tsx harness.
 describe('WelcomeGate → Journal shell (regression locks)', () => {
-  /**
-   * Regression: if markSeen is no longer called by WelcomeScreen's Begin
-   * button, hasSeenWelcome stays false and the shell (root-stack) never
-   * mounts. The WelcomeScreen mock here does call onBegin+onComplete; if
-   * the real component diverges from that contract, WelcomeScreen.test.tsx
-   * will catch it.
-   */
+  // Fails if markSeen stops firing on Begin/Skip so the shell never mounts.
   it('returning user sees the shell (root-stack) that hosts Journal, not Welcome', () => {
     // Returning user: hasSeenWelcome already true (no Begin/Skip needed).
     act(() => useWelcomeStore.setState({ hasSeenWelcome: true }));
@@ -165,11 +144,7 @@ describe('WelcomeGate → Journal shell (regression locks)', () => {
     expect(queryByTestId('welcome-screen')).toBeNull();
   });
 
-  /**
-   * Regression: if the WelcomeGate is changed to show Welcome while
-   * hasSeenWelcome is null (pending hydration), returning users would see
-   * a flash of Welcome before the Journal shell renders.
-   */
+  // Fails if the gate showed Welcome while hasSeenWelcome is null (a flash).
   it('pre-hydration state shows the shell (root-stack) that hosts Journal, not Welcome', () => {
     // null = storage not yet read; no-flash contract: shell renders immediately.
     act(() => useWelcomeStore.setState({ hasSeenWelcome: null }));

--- a/frontend/src/__tests__/navigation/welcomeGate.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeGate.test.tsx
@@ -129,3 +129,52 @@ describe('WelcomeGate (issue #836)', () => {
     expect(queryByTestId('welcome-screen')).toBeNull();
   });
 });
+
+/**
+ * Journal-shell regression locks (gate-level).
+ *
+ * This suite asserts the WelcomeGate→shell swap contract at the stub level:
+ * ``root-stack`` (the RootStack stub) maps 1:1 to the authenticated shell
+ * whose ``initialRouteName`` is Journal. The focused route-level assertion
+ * (``getCurrentRoute().name === 'Journal'``) lives in the companion harness
+ * ``welcomeLandsOnJournal.test.tsx`` which renders a real NavigationContainer
+ * with a ref. Both suites must stay green; each catches a different class of
+ * regression.
+ *
+ * These tests pass against the CURRENT correct implementation and would FAIL if:
+ * - The WelcomeGate removed RootStack after Begin/Skip and replaced it with a
+ *   different component (breaks ``root-stack`` presence assertion).
+ * - The WelcomeScreen stopped invoking ``markSeen`` on Begin or Skip (breaks
+ *   the swap: ``root-stack`` would never appear while Welcome is visible).
+ */
+describe('WelcomeGate → Journal shell (regression locks)', () => {
+  /**
+   * Regression: if markSeen is no longer called by WelcomeScreen's Begin
+   * button, hasSeenWelcome stays false and the shell (root-stack) never
+   * mounts. The WelcomeScreen mock here does call onBegin+onComplete; if
+   * the real component diverges from that contract, WelcomeScreen.test.tsx
+   * will catch it.
+   */
+  it('returning user sees the shell (root-stack) that hosts Journal, not Welcome', () => {
+    // Returning user: hasSeenWelcome already true (no Begin/Skip needed).
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: true }));
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    // The shell embeds BottomTabs with initialRouteName="Journal".
+    // This testID presence is the gate-level proxy for "Journal is mounted".
+    expect(getByTestId('root-stack')).toBeTruthy();
+    expect(queryByTestId('welcome-screen')).toBeNull();
+  });
+
+  /**
+   * Regression: if the WelcomeGate is changed to show Welcome while
+   * hasSeenWelcome is null (pending hydration), returning users would see
+   * a flash of Welcome before the Journal shell renders.
+   */
+  it('pre-hydration state shows the shell (root-stack) that hosts Journal, not Welcome', () => {
+    // null = storage not yet read; no-flash contract: shell renders immediately.
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: null }));
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    expect(getByTestId('root-stack')).toBeTruthy();
+    expect(queryByTestId('welcome-screen')).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
@@ -1,25 +1,12 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
-/**
- * Regression-lock tests: after Welcome is dismissed via Begin or Skip, the
- * authenticated shell MUST open on the Journal tab (not Today). These tests
- * lock the journal-first initial route: ``initialRouteName="Journal"`` in
- * BottomTabs + ``TAB_CONFIGS[0] === Journal``.
- *
- * Mechanism: unlike ``welcomeGate.test.tsx`` (which stubs RootStack to a
- * plain testID marker), this harness keeps the REAL NavigationContainer,
- * RootStack, and BottomTabs so that ``NavigationContainerRef.getCurrentRoute()``
- * can witness which tab is focused. All individual tab *screens* and the
- * WelcomeScreen are mocked as lightweight stubs; the navigation plumbing is
- * genuine. ``saveHasSeenWelcome`` is a never-settling promise to prove the
- * shell swap does not await the async persist (no blank-frame regression).
- */
+// Regression locks for the journal-first landing: Welcome dismissal (Begin/Skip)
+// opens the shell on Journal, via a REAL NavigationContainer/RootStack/BottomTabs
+// harness (leaf screens stubbed) so getCurrentRoute() witnesses the focused tab.
 
 // ─── Screen stubs (keep the navigation plumbing real) ───────────────────────
 
-// The WelcomeScreen mock exposes two pressable testIDs so tests can trigger
-// the Begin path (onBegin + onComplete) and the Skip path (onComplete only),
-// matching the production WelcomeScreen surface contract.
+// WelcomeScreen stub: Begin fires onBegin+onComplete, Skip fires onComplete only.
 jest.mock('@/features/Welcome/WelcomeScreen', () => {
   const React = require('react');
   const { Pressable, Text, View } = require('react-native');
@@ -154,8 +141,7 @@ jest.mock('@/features/Journal/JournalEntryScreen', () => {
   return { __esModule: true, default: Stub };
 });
 
-// Habit modals referenced by HabitsScreen (indirectly via mocked HabitsScreen
-// above, but kept here for completeness in case BottomTabs imports them).
+// Habit modals BottomTabs may import.
 jest.mock('@/features/Habits/components/GoalModal', () => () => null);
 jest.mock('@/features/Habits/components/HabitSettingsModal', () => () => null);
 jest.mock('@/features/Habits/components/MissedDaysModal', () => () => null);
@@ -174,13 +160,8 @@ jest.mock('expo-notifications', () => ({
 
 jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
 
-// ─── Storage: never-settling persist to prove no-blank-frame guarantee ───────
-//
-// ``saveHasSeenWelcome`` returns a promise that never resolves/rejects.
-// ``markWelcomeSeen`` (Zustand) calls it as a fire-and-forget side-effect
-// AFTER setting state synchronously. If the implementation were changed to
-// await the persist before flipping ``hasSeenWelcome``, the Journal tab
-// would never appear while this mock is in play — proving the regression.
+// Never-settling persist: proves markWelcomeSeen flips state before (not after)
+// the fire-and-forget save — an awaited save would hang the shell render.
 jest.mock('@/storage/welcomeStorage', () => ({
   __esModule: true,
   loadHasSeenWelcome: jest.fn(() => new Promise<boolean>(() => undefined)),
@@ -217,12 +198,8 @@ import type { RootTabParamList } from '@/navigation/BottomTabs';
 import { navThemeFor } from '@/navigation/theme';
 import { useWelcomeStore } from '@/store/useWelcomeStore';
 
-// ─── Navigation state helper ──────────────────────────────────────────────────
-//
-// Resolves the effective first-tab name from the nav ref without embedding
-// the drill-down logic inline (keeps each waitFor arrow trivially simple).
-// Early-returns (rather than chained optionals) keep the branch count low:
-// resolve the tab navigator's first route, else fall back to the focused route.
+// Resolve the tab navigator's first route (else the focused route); early-returns
+// keep the branch count under the complexity limit.
 function firstTabName(
   navRef: React.RefObject<NavigationContainerRef<RootTabParamList>>,
 ): string | undefined {
@@ -254,13 +231,7 @@ function mockAuthenticated(): void {
   } as unknown as ReturnType<typeof AuthContextModule.useAuth>);
 }
 
-// ─── Focused harness ──────────────────────────────────────────────────────────
-//
-// Wraps RootNavigator in a REAL NavigationContainer with a ref so that
-// ``navRef.current.getCurrentRoute()`` and ``getRootState()`` are available.
-// The ``navThemeFor('light')`` call satisfies the theme shape that
-// NavigationContainer expects (same as AppShell in production).
-
+// Wrap RootNavigator in a REAL NavigationContainer + ref so getCurrentRoute() works.
 function renderWithNav(navRef: React.RefObject<NavigationContainerRef<RootTabParamList>>) {
   return render(
     <NavigationContainer theme={navThemeFor('light')} ref={navRef}>
@@ -279,19 +250,7 @@ beforeEach(() => {
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('Welcome → Journal landing', () => {
-  /**
-   * Test 1 — Begin path lands on Journal.
-   *
-   * First-run state (hasSeenWelcome=false) shows the WelcomeScreen stub.
-   * Pressing the Begin button calls onBegin then onComplete, both of which
-   * delegate to markSeen. markSeen sets hasSeenWelcome=true synchronously
-   * (BEFORE the never-settling saveHasSeenWelcome resolves), so WelcomeGate
-   * renders RootStack → BottomTabs immediately. The focused route MUST be
-   * Journal (initialRouteName="Journal" in BottomTabs).
-   *
-   * Regression: if initialRouteName reverts to "Today" this fails because
-   * getCurrentRoute().name would be "Today", not "Journal".
-   */
+  // Begin (onBegin+onComplete → markSeen) lands on Journal; fails if the initial route reverts.
   it('Begin path: focused route is Journal after Welcome is dismissed', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
     act(() => useWelcomeStore.setState({ hasSeenWelcome: false }));
@@ -316,15 +275,7 @@ describe('Welcome → Journal landing', () => {
     });
   });
 
-  /**
-   * Test 2 — Skip path lands on Journal.
-   *
-   * Skip calls onComplete only (onBegin is NOT called). Both paths call
-   * markSeen, so the landing tab must be the same: Journal.
-   *
-   * Regression: same as Test 1 — initialRouteName revert or an explicit
-   * navigate('Today') redirect introduced would break this.
-   */
+  // Skip (onComplete only → markSeen) lands on Journal, same as Begin.
   it('Skip path: focused route is Journal after Welcome is dismissed', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
     act(() => useWelcomeStore.setState({ hasSeenWelcome: false }));
@@ -344,17 +295,7 @@ describe('Welcome → Journal landing', () => {
     });
   });
 
-  /**
-   * Test 3 — No intermediate blank screen (persist non-blocking).
-   *
-   * ``saveHasSeenWelcome`` is mocked as a never-settling promise (it will
-   * never resolve during this test). After pressing Begin, the shell (with
-   * Journal as the focused route) must already be rendered — proving that
-   * markSeen flips state synchronously and the WelcomeGate swap does NOT
-   * await the persist. If the implementation were changed to await
-   * saveHasSeenWelcome before flipping hasSeenWelcome, this test would hang
-   * indefinitely inside the waitFor timeout.
-   */
+  // Shell mounts on Journal while the persist is still pending — no blank frame.
   it('shell renders Journal without awaiting the persist (no blank frame)', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
     act(() => useWelcomeStore.setState({ hasSeenWelcome: false }));
@@ -374,15 +315,7 @@ describe('Welcome → Journal landing', () => {
     });
   });
 
-  /**
-   * Test 4 — Returning user never sees Welcome; shell opens on Journal.
-   *
-   * hasSeenWelcome=true → WelcomeGate renders RootStack directly. The
-   * focused route must be Journal.
-   *
-   * Regression: if initialRouteName reverts to "Today" or an explicit
-   * navigate('Today') is added to the RootStack mount path, this fails.
-   */
+  // Returning user (hasSeenWelcome=true) skips Welcome and opens on Journal.
   it('returning user (hasSeenWelcome=true): shell opens on Journal without Welcome', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
     act(() => useWelcomeStore.setState({ hasSeenWelcome: true }));
@@ -397,17 +330,7 @@ describe('Welcome → Journal landing', () => {
     });
   });
 
-  /**
-   * Test 5 — Pre-hydration no-flash preserved; Journal is the initial route.
-   *
-   * hasSeenWelcome=null (storage not yet read) → WelcomeGate renders
-   * RootStack (isFirstRun is false). Shell must mount on Journal, and Welcome
-   * must never appear. This locks the no-flash guarantee alongside the
-   * journal-first landing change.
-   *
-   * Regression: if the gate logic is changed to show Welcome while null
-   * (adding a third truthy branch), this fails.
-   */
+  // Pre-hydration (hasSeenWelcome=null) shows the shell on Journal, no Welcome flash.
   it('pre-hydration (hasSeenWelcome=null): Journal renders without Welcome flash', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
     act(() => useWelcomeStore.setState({ hasSeenWelcome: null }));
@@ -421,17 +344,7 @@ describe('Welcome → Journal landing', () => {
     });
   });
 
-  /**
-   * Bonus — Journal is TAB_CONFIGS[0] (first in physical tab order).
-   *
-   * ``getRootState().routes[0].name`` is the first registered tab; it must
-   * be Journal so that the keyboard / accessibility order starts at Journal.
-   * Mirrors the assertion in BottomTabs.test.tsx ("Journal is the first tab
-   * in navigation order") but from the end-to-end Welcome→shell path.
-   *
-   * Regression: reordering TAB_CONFIGS so Journal is no longer index 0 would
-   * break this even if initialRouteName is still "Journal".
-   */
+  // Journal is TAB_CONFIGS[0] (physical tab order), end-to-end from the Welcome path.
   it('Journal is the first route in the tab bar (TAB_CONFIGS[0])', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
     act(() => useWelcomeStore.setState({ hasSeenWelcome: true }));

--- a/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
@@ -1,0 +1,445 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+/**
+ * Regression-lock tests: after Welcome is dismissed via Begin or Skip, the
+ * authenticated shell MUST open on the Journal tab (not Today). These tests
+ * lock the journal-first initial route: ``initialRouteName="Journal"`` in
+ * BottomTabs + ``TAB_CONFIGS[0] === Journal``.
+ *
+ * Mechanism: unlike ``welcomeGate.test.tsx`` (which stubs RootStack to a
+ * plain testID marker), this harness keeps the REAL NavigationContainer,
+ * RootStack, and BottomTabs so that ``NavigationContainerRef.getCurrentRoute()``
+ * can witness which tab is focused. All individual tab *screens* and the
+ * WelcomeScreen are mocked as lightweight stubs; the navigation plumbing is
+ * genuine. ``saveHasSeenWelcome`` is a never-settling promise to prove the
+ * shell swap does not await the async persist (no blank-frame regression).
+ */
+
+// ─── Screen stubs (keep the navigation plumbing real) ───────────────────────
+
+// The WelcomeScreen mock exposes two pressable testIDs so tests can trigger
+// the Begin path (onBegin + onComplete) and the Skip path (onComplete only),
+// matching the production WelcomeScreen surface contract.
+jest.mock('@/features/Welcome/WelcomeScreen', () => {
+  const React = require('react');
+  const { Pressable, Text, View } = require('react-native');
+  const WelcomeStub = ({ onComplete, onBegin }: { onComplete: () => void; onBegin: () => void }) =>
+    React.createElement(
+      View,
+      { testID: 'welcome-screen' },
+      React.createElement(
+        Pressable,
+        {
+          testID: 'welcome-begin',
+          onPress: () => {
+            onBegin();
+            onComplete();
+          },
+        },
+        React.createElement(Text, null, 'Begin'),
+      ),
+      React.createElement(
+        Pressable,
+        { testID: 'welcome-skip', onPress: onComplete },
+        React.createElement(Text, null, 'Skip'),
+      ),
+    );
+  return { __esModule: true, WelcomeScreen: WelcomeStub, default: WelcomeStub };
+});
+
+// Tab screens — minimal stubs with testIDs to allow containment checks.
+jest.mock('@/features/Journal/JournalShelfScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, { testID: 'journal-screen' }, 'Journal');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Today/TodayScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, { testID: 'today-screen' }, 'Today');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Habits/HabitsScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, { testID: 'habits-screen' }, 'Habits');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Practice/PracticeScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, { testID: 'practice-screen' }, 'Practice');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Course/CourseScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, { testID: 'course-screen' }, 'Course');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Map/MapScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, { testID: 'map-screen' }, 'Map');
+  return { __esModule: true, default: Stub };
+});
+
+// Modal screens that BottomTabs wraps via RootStack (Settings hub etc.)
+jest.mock('@/features/Settings/SettingsHubScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, { testID: 'settings-screen' }, 'Settings');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Settings/ApiKeySettingsScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, null, 'ApiKey');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Settings/TimezoneSettingsScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, null, 'Timezone');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Settings/SupportCareScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, null, 'Support');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Practice/screens/SharePreviewScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, null, 'Share');
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('@/features/Practice/screens/PracticeDetailScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, null, 'PracticeDetail');
+  return { __esModule: true, PracticeDetailScreen: Stub };
+});
+
+jest.mock('@/features/Practice/screens/CreatePracticeWizard', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, null, 'CreatePractice');
+  return { __esModule: true, CreatePracticeWizard: Stub };
+});
+
+jest.mock('@/features/Practice/screens/PracticeCatalogScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, null, 'Catalog');
+  return { __esModule: true, PracticeCatalogScreen: Stub };
+});
+
+jest.mock('@/features/Journal/JournalEntryScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Stub = () => React.createElement(Text, null, 'JournalEntry');
+  return { __esModule: true, default: Stub };
+});
+
+// Habit modals referenced by HabitsScreen (indirectly via mocked HabitsScreen
+// above, but kept here for completeness in case BottomTabs imports them).
+jest.mock('@/features/Habits/components/GoalModal', () => () => null);
+jest.mock('@/features/Habits/components/HabitSettingsModal', () => () => null);
+jest.mock('@/features/Habits/components/MissedDaysModal', () => () => null);
+jest.mock('@/features/Habits/components/OnboardingModal', () => () => null);
+jest.mock('@/features/Habits/components/ReorderHabitsModal', () => () => null);
+jest.mock('@/features/Habits/components/StatsModal', () => () => null);
+
+// Expo modules not available in Jest.
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn(),
+  getExpoPushTokenAsync: jest.fn().mockResolvedValue({ data: 'token' }),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+}));
+
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+// ─── Storage: never-settling persist to prove no-blank-frame guarantee ───────
+//
+// ``saveHasSeenWelcome`` returns a promise that never resolves/rejects.
+// ``markWelcomeSeen`` (Zustand) calls it as a fire-and-forget side-effect
+// AFTER setting state synchronously. If the implementation were changed to
+// await the persist before flipping ``hasSeenWelcome``, the Journal tab
+// would never appear while this mock is in play — proving the regression.
+jest.mock('@/storage/welcomeStorage', () => ({
+  __esModule: true,
+  loadHasSeenWelcome: jest.fn(() => new Promise<boolean>(() => undefined)),
+  saveHasSeenWelcome: jest.fn(() => new Promise<void>(() => undefined)),
+  clearHasSeenWelcome: jest.fn(() => Promise.resolve()),
+}));
+
+// ─── FeatureErrorBoundary — transparent pass-through ─────────────────────────
+jest.mock('@/components/FeatureErrorBoundary', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const Boundary = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(View, null, children);
+  return { __esModule: true, FeatureErrorBoundary: Boundary };
+});
+
+// ─── Hooks / stores that heavy screens would normally activate ────────────────
+jest.mock('@/store/useProgramStore', () => ({
+  __esModule: true,
+  useHydrateProgramStore: () => undefined,
+  useProgramStore: () => ({ currentStage: null }),
+}));
+
+// Static imports AFTER all jest.mock() hoisting ───────────────────────────────
+import type { NavigationContainerRef } from '@react-navigation/native';
+import { NavigationContainer } from '@react-navigation/native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import { RootNavigator } from '@/App';
+import * as AuthContextModule from '@/context/AuthContext';
+import type { AuthStatus } from '@/context/AuthContext';
+import type { RootTabParamList } from '@/navigation/BottomTabs';
+import { navThemeFor } from '@/navigation/theme';
+import { useWelcomeStore } from '@/store/useWelcomeStore';
+
+// ─── Navigation state helper ──────────────────────────────────────────────────
+//
+// Resolves the effective first-tab name from the nav ref without embedding
+// the drill-down logic inline (keeps each waitFor arrow trivially simple).
+// Early-returns (rather than chained optionals) keep the branch count low:
+// resolve the tab navigator's first route, else fall back to the focused route.
+function firstTabName(
+  navRef: React.RefObject<NavigationContainerRef<RootTabParamList>>,
+): string | undefined {
+  const container = navRef.current;
+  if (!container) return undefined;
+  const rootState = container.getRootState();
+  if (!rootState) return container.getCurrentRoute()?.name;
+  const tabRoute = rootState.routes.find((r) => r.name === 'Tabs') ?? rootState.routes[0];
+  const tabState = tabRoute?.state;
+  if (!tabState) return container.getCurrentRoute()?.name;
+  return tabState.routes[0]?.name as string | undefined;
+}
+
+// ─── Auth mock helper ─────────────────────────────────────────────────────────
+
+function mockAuthenticated(): void {
+  jest.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
+    token: 'jwt',
+    authStatus: 'authenticated' as AuthStatus,
+    isLoading: false,
+    userTimezone: 'UTC',
+    setUserTimezone: jest.fn(),
+    login: jest.fn(() => Promise.resolve()),
+    signup: jest.fn(() => Promise.resolve()),
+    logout: jest.fn(() => Promise.resolve()),
+    onUnauthorized: jest.fn(),
+    dismissReauth: jest.fn(() => Promise.resolve()),
+    confirmPasswordReset: jest.fn(() => Promise.resolve()),
+  } as unknown as ReturnType<typeof AuthContextModule.useAuth>);
+}
+
+// ─── Focused harness ──────────────────────────────────────────────────────────
+//
+// Wraps RootNavigator in a REAL NavigationContainer with a ref so that
+// ``navRef.current.getCurrentRoute()`` and ``getRootState()`` are available.
+// The ``navThemeFor('light')`` call satisfies the theme shape that
+// NavigationContainer expects (same as AppShell in production).
+
+function renderWithNav(navRef: React.RefObject<NavigationContainerRef<RootTabParamList>>) {
+  return render(
+    <NavigationContainer theme={navThemeFor('light')} ref={navRef}>
+      <RootNavigator />
+    </NavigationContainer>,
+  );
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  mockAuthenticated();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Welcome → Journal landing', () => {
+  /**
+   * Test 1 — Begin path lands on Journal.
+   *
+   * First-run state (hasSeenWelcome=false) shows the WelcomeScreen stub.
+   * Pressing the Begin button calls onBegin then onComplete, both of which
+   * delegate to markSeen. markSeen sets hasSeenWelcome=true synchronously
+   * (BEFORE the never-settling saveHasSeenWelcome resolves), so WelcomeGate
+   * renders RootStack → BottomTabs immediately. The focused route MUST be
+   * Journal (initialRouteName="Journal" in BottomTabs).
+   *
+   * Regression: if initialRouteName reverts to "Today" this fails because
+   * getCurrentRoute().name would be "Today", not "Journal".
+   */
+  it('Begin path: focused route is Journal after Welcome is dismissed', async () => {
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: false }));
+
+    const { getByTestId, queryByTestId } = renderWithNav(navRef);
+
+    // Welcome is showing before Begin is pressed.
+    expect(getByTestId('welcome-screen')).toBeTruthy();
+
+    // Dismiss via the Begin path (mirrors production: onBegin + onComplete).
+    act(() => {
+      fireEvent.press(getByTestId('welcome-begin'));
+    });
+
+    // Welcome is gone immediately (synchronous state flip, no persist await).
+    expect(queryByTestId('welcome-screen')).toBeNull();
+
+    // Navigation state commits asynchronously; waitFor drains the tab
+    // navigator's Animated update before asserting the route name.
+    await waitFor(() => {
+      expect(navRef.current?.getCurrentRoute()?.name).toBe('Journal');
+    });
+  });
+
+  /**
+   * Test 2 — Skip path lands on Journal.
+   *
+   * Skip calls onComplete only (onBegin is NOT called). Both paths call
+   * markSeen, so the landing tab must be the same: Journal.
+   *
+   * Regression: same as Test 1 — initialRouteName revert or an explicit
+   * navigate('Today') redirect introduced would break this.
+   */
+  it('Skip path: focused route is Journal after Welcome is dismissed', async () => {
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: false }));
+
+    const { getByTestId, queryByTestId } = renderWithNav(navRef);
+
+    expect(getByTestId('welcome-screen')).toBeTruthy();
+
+    act(() => {
+      fireEvent.press(getByTestId('welcome-skip'));
+    });
+
+    expect(queryByTestId('welcome-screen')).toBeNull();
+
+    await waitFor(() => {
+      expect(navRef.current?.getCurrentRoute()?.name).toBe('Journal');
+    });
+  });
+
+  /**
+   * Test 3 — No intermediate blank screen (persist non-blocking).
+   *
+   * ``saveHasSeenWelcome`` is mocked as a never-settling promise (it will
+   * never resolve during this test). After pressing Begin, the shell (with
+   * Journal as the focused route) must already be rendered — proving that
+   * markSeen flips state synchronously and the WelcomeGate swap does NOT
+   * await the persist. If the implementation were changed to await
+   * saveHasSeenWelcome before flipping hasSeenWelcome, this test would hang
+   * indefinitely inside the waitFor timeout.
+   */
+  it('shell renders Journal without awaiting the persist (no blank frame)', async () => {
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: false }));
+
+    const { getByTestId, queryByTestId } = renderWithNav(navRef);
+
+    act(() => {
+      fireEvent.press(getByTestId('welcome-begin'));
+    });
+
+    // Shell is already mounted (no blank frame) even though saveHasSeenWelcome
+    // never resolves — the persist is fire-and-forget.
+    expect(queryByTestId('welcome-screen')).toBeNull();
+
+    await waitFor(() => {
+      expect(navRef.current?.getCurrentRoute()?.name).toBe('Journal');
+    });
+  });
+
+  /**
+   * Test 4 — Returning user never sees Welcome; shell opens on Journal.
+   *
+   * hasSeenWelcome=true → WelcomeGate renders RootStack directly. The
+   * focused route must be Journal.
+   *
+   * Regression: if initialRouteName reverts to "Today" or an explicit
+   * navigate('Today') is added to the RootStack mount path, this fails.
+   */
+  it('returning user (hasSeenWelcome=true): shell opens on Journal without Welcome', async () => {
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: true }));
+
+    const { queryByTestId } = renderWithNav(navRef);
+
+    // Welcome must never appear for a returning user.
+    expect(queryByTestId('welcome-screen')).toBeNull();
+
+    await waitFor(() => {
+      expect(navRef.current?.getCurrentRoute()?.name).toBe('Journal');
+    });
+  });
+
+  /**
+   * Test 5 — Pre-hydration no-flash preserved; Journal is the initial route.
+   *
+   * hasSeenWelcome=null (storage not yet read) → WelcomeGate renders
+   * RootStack (isFirstRun is false). Shell must mount on Journal, and Welcome
+   * must never appear. This locks the no-flash guarantee alongside the
+   * journal-first landing change.
+   *
+   * Regression: if the gate logic is changed to show Welcome while null
+   * (adding a third truthy branch), this fails.
+   */
+  it('pre-hydration (hasSeenWelcome=null): Journal renders without Welcome flash', async () => {
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: null }));
+
+    const { queryByTestId } = renderWithNav(navRef);
+
+    expect(queryByTestId('welcome-screen')).toBeNull();
+
+    await waitFor(() => {
+      expect(navRef.current?.getCurrentRoute()?.name).toBe('Journal');
+    });
+  });
+
+  /**
+   * Bonus — Journal is TAB_CONFIGS[0] (first in physical tab order).
+   *
+   * ``getRootState().routes[0].name`` is the first registered tab; it must
+   * be Journal so that the keyboard / accessibility order starts at Journal.
+   * Mirrors the assertion in BottomTabs.test.tsx ("Journal is the first tab
+   * in navigation order") but from the end-to-end Welcome→shell path.
+   *
+   * Regression: reordering TAB_CONFIGS so Journal is no longer index 0 would
+   * break this even if initialRouteName is still "Journal".
+   */
+  it('Journal is the first route in the tab bar (TAB_CONFIGS[0])', async () => {
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: true }));
+
+    renderWithNav(navRef);
+
+    await waitFor(() => {
+      expect(firstTabName(navRef)).toBe('Journal');
+    });
+  });
+});

--- a/frontend/src/features/Welcome/WelcomeScreen.tsx
+++ b/frontend/src/features/Welcome/WelcomeScreen.tsx
@@ -142,7 +142,7 @@ const useWelcomePager = (): Pager => {
 export interface WelcomeScreenProps {
   /** Persist the flag and dismiss the welcome (called on Begin and Skip). */
   onComplete: () => void;
-  /** Land on the Today hub, optionally opening the first-habits step. */
+  /** Land on the Journal home, optionally opening the first-habits step. */
   onBegin: () => void;
 }
 
@@ -150,7 +150,7 @@ export interface WelcomeScreenProps {
  * The program welcome (#836): a swipeable editorial intro to the 36-week
  * journey. Paging works with or without animation (reduced-motion-safe), a
  * persistent Skip sits on every panel, and the final panel's Begin CTA lands
- * the user on Today.
+ * the user on the Journal home (the app shell's initial route).
  */
 export const WelcomeScreen = ({ onComplete, onBegin }: WelcomeScreenProps): React.JSX.Element => {
   const { page, width, scrollRef, onScroll, goNext } = useWelcomePager();

--- a/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
+++ b/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
@@ -52,7 +52,7 @@ describe('WelcomeScreen', () => {
     expect(queryByTestId('welcome-begin')).toBeNull();
   });
 
-  it('Begin completes (sets flag) and navigates to Today', () => {
+  it("Begin completes (sets flag) and lands on Journal (the app shell's initial route)", () => {
     const { getByTestId, onComplete, onBegin } = setup();
     // Page to the last panel via the pager scroll handler.
     const lastIndex = WELCOME_PANELS.length - 1;


### PR DESCRIPTION
## Summary
Guarantees the post-onboarding destination is the Journal (NORTH-STAR §11), building on #900.

The `WelcomeGate` is a synchronous conditional render swap: both Begin and Skip call `markSeen`, which flips first-run state before a fire-and-forget persist, then the app shell mounts at its `initialRouteName="Journal"`. There is no explicit `navigate('Today')`/`reset()` redirect and no awaited write — so both paths already land on Journal directly, with no blank intermediate frame and no forced re-onboarding for returning users.

The real deliverable is **locking that behavior** against regression, plus correcting two docstrings that still claimed the user lands on "Today".

## Test plan
- New regression-lock suite (`welcomeLandsOnJournal.test.tsx`) using a real `NavigationContainer` + `RootStack` + `BottomTabs` harness (leaf screens stubbed), asserting via `NavigationContainerRef.getCurrentRoute()`:
  - Begin path lands on Journal; Skip path lands on Journal.
  - The shell renders Journal with a **never-settling persist mock** — proving the swap doesn't await the write (no blank frame).
  - Returning user (`hasSeenWelcome=true`) opens straight on Journal, no Welcome.
  - Pre-hydration (`null`) shows the shell without a Welcome flash.
- `welcomeGate.test.tsx` extended with Journal-shell regression locks; the misnamed "navigates to Today" `WelcomeScreen` test retitled to reflect Journal-landing.
- `scripts/frontend/check-all.sh` exits 0 (lint, tsc, prettier, all tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #901
Refs #899