### PR TITLE
feat(frontend): warm first-prompt empty state for a new journal

### DIFF
--- a/frontend/src/features/Journal/JournalShelf.styles.ts
+++ b/frontend/src/features/Journal/JournalShelf.styles.ts
@@ -79,6 +79,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.xl,
     paddingTop: SPACING.xxl,
   },
+  emptyCtaGroup: {
+    alignItems: 'center',
+    gap: SPACING.sm,
+  },
   emptyText: {
     ...editorialType.body,
     color: ink.soft,

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -36,6 +36,9 @@ const WEEK_DAYS = 7;
 const MONTH_DAYS = 30;
 const WORDS_PER_MINUTE = 200;
 
+// A single curated opening invitation for a brand-new journal (no rotation).
+const FIRST_PROMPT = 'What brought you here?';
+
 type ShelfNavigation = NativeStackNavigationProp<RootStackParamList>;
 
 interface ShelfSection {
@@ -214,6 +217,7 @@ interface ShelfEmptyProps {
   error: string | null;
   searching: boolean;
   onNew: () => void;
+  onFirstPrompt: () => void;
 }
 
 /** Empty list: nothing while loading, the load error, a no-results line for an
@@ -223,6 +227,7 @@ function ShelfEmpty({
   error,
   searching,
   onNew,
+  onFirstPrompt,
 }: ShelfEmptyProps): React.JSX.Element | null {
   if (loading) return null;
   if (error != null) {
@@ -248,7 +253,18 @@ function ShelfEmpty({
       glyph="📖"
       title="Your shelf is empty"
       body="Start your first page — a quiet place to think out loud."
-      cta={<Button label="Start a page" onPress={onNew} testID="journal-empty-cta" />}
+      cta={
+        <View style={styles.emptyCtaGroup}>
+          <Button label="Start a page" onPress={onNew} testID="journal-empty-cta" />
+          <Button
+            label={FIRST_PROMPT}
+            variant="tertiary"
+            onPress={onFirstPrompt}
+            accessibilityLabel="Begin a first page from the question: What brought you here?"
+            testID="journal-empty-first-prompt"
+          />
+        </View>
+      }
       testID="journal-shelf-empty"
     />
   );
@@ -344,6 +360,7 @@ interface ShelfNav {
   openEntry: (_id: number) => void;
   newEntry: () => void;
   openPrompt: () => void;
+  openWithPrompt: () => void;
 }
 
 /** Memoized navigation callbacks for the shelf's three destinations. */
@@ -357,6 +374,10 @@ function useShelfNavigation(
     [navigation],
   );
   const newEntry = useCallback(() => navigation.navigate('JournalEntry'), [navigation]);
+  const openWithPrompt = useCallback(
+    () => navigation.navigate('JournalEntry', { promptQuestion: FIRST_PROMPT }),
+    [navigation],
+  );
   const openPrompt = useCallback(() => {
     if (!prompt) return;
     navigation.navigate('JournalEntry', {
@@ -365,7 +386,15 @@ function useShelfNavigation(
       prefillTitle: `Week ${week} Reflection`,
     });
   }, [navigation, prompt, week]);
-  return { openEntry, newEntry, openPrompt };
+  return { openEntry, newEntry, openPrompt, openWithPrompt };
+}
+
+function renderSectionHeader({
+  section,
+}: {
+  section: SectionListData<JournalMessage, ShelfSection>;
+}): React.JSX.Element {
+  return <SectionHeading title={section.title} />;
 }
 
 function JournalShelfScreen(): React.JSX.Element {
@@ -382,11 +411,6 @@ function JournalShelfScreen(): React.JSX.Element {
   const renderItem = ({ item }: SectionListRenderItemInfo<JournalMessage, ShelfSection>) => (
     <PageCard entry={item} onOpen={nav.openEntry} now={now} />
   );
-  const renderSectionHeader = ({
-    section,
-  }: {
-    section: SectionListData<JournalMessage, ShelfSection>;
-  }) => <SectionHeading title={section.title} />;
 
   return (
     <ScreenScaffold testID="journal-shelf">
@@ -410,7 +434,13 @@ function JournalShelfScreen(): React.JSX.Element {
           />
         }
         ListEmptyComponent={
-          <ShelfEmpty loading={loading} error={error} searching={searching} onNew={nav.newEntry} />
+          <ShelfEmpty
+            loading={loading}
+            error={error}
+            searching={searching}
+            onNew={nav.newEntry}
+            onFirstPrompt={nav.openWithPrompt}
+          />
         }
         onEndReached={hasMore ? loadMore : undefined}
         onEndReachedThreshold={0.4}

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react-native';
 import React from 'react';
 import { StyleSheet } from 'react-native';
 
@@ -253,5 +253,78 @@ describe('JournalShelfScreen', () => {
     const { findByTestId, queryByTestId } = render(<JournalShelfScreen />);
     await findByTestId('journal-shelf-empty');
     expect(queryByTestId('journal-weekly-prompt')).toBeNull();
+  });
+
+  // Warm first-prompt affordance — true-empty branch only.
+
+  it('renders the warm first-prompt affordance alongside the start-a-page CTA when the shelf is empty', async () => {
+    mockList.mockResolvedValue(page([]));
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-empty');
+    expect(getByTestId('journal-empty-first-prompt')).toBeTruthy();
+    expect(getByTestId('journal-empty-cta')).toBeTruthy();
+  });
+
+  it('shows the prompt copy "What brought you here?" on the warm affordance', async () => {
+    mockList.mockResolvedValue(page([]));
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-empty-first-prompt');
+    // Exact copy asserted verbatim — the implementation must match.
+    const affordance = getByTestId('journal-empty-first-prompt');
+    expect(within(affordance).getByText('What brought you here?')).toBeTruthy();
+  });
+
+  it('exposes accessibilityRole="button" and a non-empty accessibilityLabel on the warm affordance', async () => {
+    mockList.mockResolvedValue(page([]));
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-empty-first-prompt');
+    const affordance = getByTestId('journal-empty-first-prompt');
+    expect(affordance.props.accessibilityRole).toBe('button');
+    const label: string = affordance.props.accessibilityLabel ?? '';
+    expect(label.length).toBeGreaterThan(0);
+  });
+
+  it('navigates with the warm prompt question when the affordance is tapped', async () => {
+    mockList.mockResolvedValue(page([]));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    fireEvent.press(await findByTestId('journal-empty-first-prompt'));
+    // Exact nav params — implementation must match verbatim.
+    expect(mockNavigate).toHaveBeenCalledWith('JournalEntry', {
+      promptQuestion: 'What brought you here?',
+    });
+  });
+
+  it('hides the warm affordance when there is at least one journal entry', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { findByTestId, queryByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-card-1');
+    expect(queryByTestId('journal-empty-first-prompt')).toBeNull();
+  });
+
+  it('hides the warm affordance while the initial load is in flight', async () => {
+    // Never resolve so the component stays in the loading state.
+    mockList.mockReturnValue(new Promise<JournalListResponse>(() => undefined));
+    const { queryByTestId } = render(<JournalShelfScreen />);
+    expect(queryByTestId('journal-empty-first-prompt')).toBeNull();
+  });
+
+  it('hides the warm affordance when the initial load fails', async () => {
+    mockList.mockRejectedValue(new Error('network down'));
+    const { findByTestId, queryByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-error');
+    expect(queryByTestId('journal-empty-first-prompt')).toBeNull();
+  });
+
+  it('hides the warm affordance when a search returns no results', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { findByTestId, getByTestId, queryByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-card-1');
+
+    mockList.mockResolvedValue(page([]));
+    await act(async () => {
+      fireEvent.changeText(getByTestId('shelf-search'), 'zzz');
+    });
+    await findByTestId('journal-shelf-no-results');
+    expect(queryByTestId('journal-empty-first-prompt')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Lowers the barrier to the first entry (NORTH-STAR §11/§12). On a brand-new journal's empty state, a quiet second affordance sits beside "Start a page" and opens the editor seeded with a gentle opening prompt, **"What brought you here?"**

- Reuses the existing `promptQuestion`→`bodyPlaceholder` seam (the weekly-prompt flow), so the prompt renders as **placeholder guidance, not body text** — no blank-box freeze, trivially ignorable, and an untouched draft is never persisted (existing empty-draft guard).
- Appears **only on the true empty state**: absent while loading, on error, on a no-results search, and for any returning user with ≥1 entry.
- Gentle, never mandatory — a quiet tertiary affordance paired with (not replacing) "Start a page"; no badge, count, streak, or pressure copy.
- Tokens-only; `accessibilityRole="button"` + a descriptive label.

## Test plan
- 8 new RTL tests: empty journal renders `journal-empty-first-prompt` alongside the CTA with the copy "What brought you here?"; tapping navigates `('JournalEntry', { promptQuestion: 'What brought you here?' })`; the affordance is absent for returning users and in the loading/error/no-results-search branches; a11y role/label asserted.
- `scripts/frontend/check-all.sh` exits 0 (lint, tsc, prettier, all 2332 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #902
Refs #899