### PR TITLE
docs: point Candle & Ink to the implemented design system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,11 @@ self-chosen **depths** — prompted journaling, habit scaffolding, a practice
 ramp, the course reading, and the Digital Sangha. Nothing is gated and nothing
 is mandatory: the governing principle is **"you choose your depth."** Deeper
 rings are offered only as resonant, declinable invitations — never gamified
-pressure. The product vision lives in `NORTH-STAR.md`; the visual north star
-("Candle & Ink") lives in `DESIGN.md`, with the implemented design system under
-`frontend/src/design/`.
+pressure. The product vision lives in `NORTH-STAR.md`; the "Candle & Ink" visual north
+star and implemented design system live in `frontend/src/design/DESIGN.md`
+(tokens under `frontend/src/design/`). Root `DESIGN.md` is an external
+inspiration reference — an analysis of the Anthropic / Claude.com
+marketing-site aesthetic that informed the Candle & Ink vocabulary.
 
 - **Frontend:** React Native with Expo (TypeScript, Zustand, React Navigation)
 - **Backend:** FastAPI with PostgreSQL (SQLModel, async, Alembic migrations)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -298,6 +298,15 @@ components:
     padding: 64px
 ---
 
+> **External inspiration reference — not Adepthood's design system.**
+> This document is an analysis of the Anthropic / Claude.com marketing-site visual
+> language. It captures the cream/coral/navy editorial aesthetic that informed the
+> vocabulary of the Candle & Ink design language, but it describes that external
+> site — not Adepthood's implemented design system.
+>
+> The canonical Candle & Ink reference for this codebase lives at
+> [`frontend/src/design/DESIGN.md`](./frontend/src/design/DESIGN.md).
+
 ## Overview
 
 Claude.com is the warmest, most editorial interface in the AI-product category. The base atmosphere is a **tinted cream canvas** (`{colors.canvas}` — #faf9f5) — distinctly warm, deliberately not the cool gray-white that every other AI brand uses. Headlines run a **slab-serif display** ("Copernicus" / Tiempos Headline) at weight 400 with negative letter-spacing, paired with **StyreneB / Inter** body sans. The combination feels like a literary publication, not a SaaS marketing page.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Adepthood is a React Native + FastAPI app whose floor is a **journal-first personal knowledge base** that, over time, becomes a _Higher Self_ — reflecting your own past reflections back to you in the language of the **APTITUDE** program and the Archetypal Wavelength. Arranged around that floor are optional, self-chosen **depths** — prompted journaling, habit scaffolding, a practice ramp, the course reading, and the Digital Sangha. Nothing is gated, nothing is mandatory, and there is no gamified pressure: **you choose your depth**. A single 36-week Archetypal Wavelength cadence (eight stages × 3 weeks + Unity & Emptiness × 6 weeks) paces whichever depths are turned on, and it loops — the Map reads as a wheel of wholeness, not a ladder to climb.
 
-See [`NORTH-STAR.md`](./NORTH-STAR.md) for the full product thesis ("Graduated Engagement") and [`DESIGN.md`](./DESIGN.md) for the "Candle & Ink" visual north star.
+See [`NORTH-STAR.md`](./NORTH-STAR.md) for the full product thesis ("Graduated Engagement") and [`frontend/src/design/DESIGN.md`](./frontend/src/design/DESIGN.md) for the "Candle & Ink" visual north star (the implemented design system). Root [`DESIGN.md`](./DESIGN.md) is an external inspiration reference — an analysis of the Anthropic / Claude.com marketing-site aesthetic that informed the Candle & Ink vocabulary.
 
 ## ✨ Features
 
@@ -37,10 +37,10 @@ See [`NORTH-STAR.md`](./NORTH-STAR.md) for the full product thesis ("Graduated E
 ├── scripts/       # Development and CI helper scripts
 ├── AGENTS.md      # Necessary instructions for AI collaborators
 ├── NORTH-STAR.md  # Product thesis — "Graduated Engagement"
-├── DESIGN.md      # Visual north star — the "Candle & Ink" design language
+├── DESIGN.md      # External inspiration reference — Anthropic/Claude.com marketing-site analysis
 ```
 
-The implemented design system (tokens, theme, and its own `DESIGN.md`) lives in
+The "Candle & Ink" design system (tokens, theme, and its own `DESIGN.md`) lives in
 `frontend/src/design/`.
 
 ## 🚀 Getting Started


### PR DESCRIPTION
## Summary
Resolves the DESIGN.md misdirection (chose **Option A** from the issue). Root `DESIGN.md` is actually a Claude.com/Anthropic marketing-site design analysis, but `README.md` and `CLAUDE.md` called it the "Candle & Ink" visual north star — misdirecting contributors away from the real implemented system.

- Added a clear header to root `DESIGN.md` marking it an **external inspiration reference** (the marketing-site analysis the Candle & Ink vocabulary drew from), not Adepthood's design system, with a pointer to the real one.
- Repointed `README.md` (intro + directory tree) and the `CLAUDE.md` project-overview paragraph to `frontend/src/design/DESIGN.md` as the implemented "Candle & Ink" system.
- Chose Option A over relocating because the implemented design doc is correctly co-located with the tokens under `frontend/src/design/`; moving it to root would only duplicate it.
- No token/code changes; `frontend/src/design/` is untouched.

## Test plan
- Docs-only. `pre-commit run --files DESIGN.md README.md CLAUDE.md` passes; the `frontend/src/design/DESIGN.md` links resolve.

## Follow-up
One more stale pointer exists in `.claude/agents/shared/adepthood-constraints.md:13` (agent-config, out of this issue's stated scope) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #905
Refs #903