### PR TITLE
refactor(backend): retire BotMason chatbot residue, reframe as reflection

### DIFF
--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -64,7 +64,9 @@ def _classification_check() -> CheckConstraint:
 
 
 class JournalEntry(SQLModel, table=True):
-    """Stores a chat message between the user and BotMason.
+    """Stores a user's journal reflection, optionally paired with an AI resonance response.
+
+    A ``sender`` of ``'bot'`` marks an AI resonance reply rather than a chat turn.
 
     Supports context tagging for stage reflections, practice notes, and
     habit-related thoughts.

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -30,7 +30,7 @@ class User(SQLModel, table=True):
     Tracks relationships to habits, journal entries, weekly responses,
     and APTITUDE stage progress.
 
-    BotMason access uses a two-bucket wallet:
+    AI resonance access uses a two-bucket wallet:
 
     * ``monthly_messages_used`` / ``monthly_reset_date`` — a free monthly
       allocation (see ``BOTMASON_MONTHLY_CAP``) that resets on the first of

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -28,16 +28,13 @@ logger = logging.getLogger(__name__)
 
 # Default system prompt used when no external prompt file is configured.
 _DEFAULT_SYSTEM_PROMPT = (
-    "You are BotMason, a Liminal Trickster Mystic guide for the APTITUDE "
-    "personal development program. You help users navigate the transition "
-    "from 'Liminal Creep' to 'Whole Adept' through the Archetypal Wavelength. "
-    "Respond with wisdom, warmth, and a touch of playful mysticism. "
-    "Reference the APTITUDE stages, habits, practices, and journaling when relevant."
+    "You are BotMason, a reflective mirror for the APTITUDE personal "
+    "development program. You do not advise or guide; you reflect the user's "
+    "own words and wisdom back to them, phrased in the language of the "
+    "APTITUDE stages and the Archetypal Wavelength. Draw only on what the user "
+    "has written — their habits, practices, and journal reflections — and echo "
+    "the resonance you find there rather than offering direction of your own."
 )
-
-# Maximum number of recent messages to include as conversation context.
-# Bumped from 20 to 50 so deeper reflections stay in context (BUG-JOURNAL-007).
-CONVERSATION_HISTORY_LIMIT = 50
 
 # Only allow prompt files from this directory to prevent path traversal.
 _ALLOWED_PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"


### PR DESCRIPTION
## Summary
Purges post-pivot chatbot residue (anti-guru, Rubric #9). Per-symbol disposition (grep-verified against the surviving resonance + wallet paths):

- **`_DEFAULT_SYSTEM_PROMPT` → reworded (not deleted).** It is still live — the resonance path resolves it via `get_system_prompt()` — so instead of removing it, its copy is reframed from the "Liminal Trickster Mystic guide" voice to a **reflection** framing: it echoes the user's own words and wisdom back in APTITUDE / Archetypal Wavelength language rather than advising. The `"BotMason"` and `"APTITUDE"` anchor substrings are preserved, so `test_system_prompt_default` stays green.
- **`CONVERSATION_HISTORY_LIMIT` → deleted.** Genuinely dead — repo-wide grep returned only its own definition line (zero call sites/imports/test refs).
- **`JournalEntry` + `User` docstrings → reworded** to describe a user's journal reflection optionally paired with an AI **resonance** response, and a **resonance-metered** two-bucket wallet — not BotMason chat logs. Wallet-bucket mechanics and the `BOTMASON_MONTHLY_CAP` identifier are kept verbatim.

No wallet/resonance **behavior** change; no signature, endpoint, `conversation_history` param, nonce/delimiter/medication-guardrail, or migration touched. The stale `load_recent_conversation` prose references stay in de-slop #873's lane (not duplicated here).

## Test plan
- `scripts/backend/check-all.sh` exits 0 (7/7: ruff, mypy strict, interrogate, pytest ≥90%/branch ≥80%, format). `test_botmason_api::test_system_prompt_default` and the wrapping tests stay green (anchor tokens + delimiter/nonce structure unaffected).
- **xenon** run standalone → rank A held; interrogate docstring coverage unchanged (rewords, no new undocumented symbols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #906
Refs #903
Related: #873