### PR TITLE
feat(backend): UserDepthPreferences model + migration (rings default on)

### DIFF
--- a/backend/migrations/versions/e2f3a4b5c6d8_add_user_depth_preferences.py
+++ b/backend/migrations/versions/e2f3a4b5c6d8_add_user_depth_preferences.py
@@ -1,0 +1,58 @@
+"""add user_depth_preferences table
+
+Revision ID: e2f3a4b5c6d8
+Revises: d8e9f0a1b2c3
+Create Date: 2026-06-30 00:00:00.000000
+
+Adds ``userdepthpreferences`` — one row per user recording which optional
+program rings (habits, practices, course, sangha) the user has enabled.
+``upgrade`` creates the table with all four boolean flags ``NOT NULL`` and a
+DB-level ``server_default`` of true (mirroring the model's ``server_default`` so
+``alembic check`` stays drift-free), a unique FK to ``user.id`` with
+``ON DELETE CASCADE``, then backfills every existing user with an all-True row.
+``downgrade`` drops the table.
+
+The revision ID ``e2f3a4b5c6d8`` was chosen because the id the test's
+placeholder originally named collided with an in-tree migration; the test
+constant ``_USER_DEPTH_PREFS_REVISION`` was updated to match this real id.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e2f3a4b5c6d8"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "d8e9f0a1b2c3"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE_NAME = "userdepthpreferences"
+_BACKFILL = sa.text(
+    "INSERT INTO userdepthpreferences"
+    " (user_id, enable_habits, enable_practices, enable_course, enable_sangha)"
+    ' SELECT id, true, true, true, true FROM "user"'
+)
+
+
+def upgrade() -> None:
+    """Create ``userdepthpreferences`` and backfill a row per existing user."""
+    op.create_table(
+        _TABLE_NAME,
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("enable_habits", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("enable_practices", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("enable_course", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("enable_sangha", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id"),
+    )
+    op.execute(_BACKFILL)
+
+
+def downgrade() -> None:
+    """Drop the ``userdepthpreferences`` table."""
+    op.drop_table(_TABLE_NAME)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -24,6 +24,7 @@ from .revoked_token import RevokedToken
 from .stage_content import StageContent
 from .stage_progress import StageProgress
 from .user import User
+from .user_depth_preferences import UserDepthPreferences
 from .user_practice import UserPractice
 from .wallet_audit import WalletAudit
 
@@ -53,6 +54,7 @@ __all__ = [
     "StageContent",
     "StageProgress",
     "User",
+    "UserDepthPreferences",
     "UserPractice",
     "WalletAudit",
 ]

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from .journal_entry import JournalEntry
     from .prompt_response import PromptResponse
     from .stage_progress import StageProgress
+    from .user_depth_preferences import UserDepthPreferences
 
 
 def _default_reset_date() -> datetime:
@@ -127,3 +128,7 @@ class User(SQLModel, table=True):
     journals: list["JournalEntry"] = Relationship(back_populates="user")
     responses: list["PromptResponse"] = Relationship(back_populates="user")
     stage_progress: Optional["StageProgress"] = Relationship(back_populates="user")
+    depth_preferences: Optional["UserDepthPreferences"] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs={"passive_deletes": True},
+    )

--- a/backend/src/models/user_depth_preferences.py
+++ b/backend/src/models/user_depth_preferences.py
@@ -1,0 +1,51 @@
+"""User depth-preference toggles for the optional program rings."""
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, Column
+from sqlmodel import Field, Relationship, SQLModel
+
+if TYPE_CHECKING:
+    from .user import User
+
+# Booleans default to enabled ("1") so a fresh user, and every legacy row the
+# migration backfills, starts with all optional depths opted-in. The
+# server_default mirrors the migration end-state, keeping ``alembic check``
+# drift-free.
+_ENABLED_SERVER_DEFAULT = "1"
+
+
+class UserDepthPreferences(SQLModel, table=True):
+    """Per-user opt-in flags for the optional program rings.
+
+    One row per user records which of the self-chosen depths — habit
+    scaffolding, the practice ramp, the course reading, and the Digital
+    Sangha — the user has enabled. Nothing is gated; these toggles simply
+    let the user quiet rings they have not chosen. Every flag defaults to
+    ``True`` so a new account starts fully opted-in and can decline depths
+    later.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    enable_habits: bool = Field(
+        default=True,
+        sa_column=Column(Boolean(), nullable=False, server_default=_ENABLED_SERVER_DEFAULT),
+    )
+    """Whether the habit-scaffolding ring is offered to this user."""
+    enable_practices: bool = Field(
+        default=True,
+        sa_column=Column(Boolean(), nullable=False, server_default=_ENABLED_SERVER_DEFAULT),
+    )
+    """Whether the practice-ramp ring is offered to this user."""
+    enable_course: bool = Field(
+        default=True,
+        sa_column=Column(Boolean(), nullable=False, server_default=_ENABLED_SERVER_DEFAULT),
+    )
+    """Whether the course-reading ring is offered to this user."""
+    enable_sangha: bool = Field(
+        default=True,
+        sa_column=Column(Boolean(), nullable=False, server_default=_ENABLED_SERVER_DEFAULT),
+    )
+    """Whether the Digital Sangha ring is offered to this user."""
+    user_id: int = Field(foreign_key="user.id", unique=True, ondelete="CASCADE")
+    user: "User" = Relationship(back_populates="depth_preferences")

--- a/backend/tests/models/test_user_depth_preferences.py
+++ b/backend/tests/models/test_user_depth_preferences.py
@@ -1,0 +1,163 @@
+"""Data-layer tests for the UserDepthPreferences model (depth-prefs-01)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import JSON, func, select, text
+from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, col
+
+from models.user import User
+from models.user_depth_preferences import UserDepthPreferences
+
+
+def _swap_pg_arrays_to_json() -> None:
+    """Replace PostgreSQL ARRAY columns with JSON for SQLite compatibility."""
+    for table in SQLModel.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, PG_ARRAY):
+                column.type = JSON()
+
+
+async def _user(session: AsyncSession, email: str = "prefs@example.com") -> int:
+    """Insert a bare User and return its id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.flush()
+    assert user.id is not None
+    return user.id
+
+
+@pytest.mark.asyncio
+async def test_defaults_all_true_on_create(db_session: AsyncSession) -> None:
+    """All four booleans default to True when no value is supplied."""
+    user_id = await _user(db_session)
+    prefs = UserDepthPreferences(user_id=user_id)
+    db_session.add(prefs)
+    await db_session.commit()
+
+    row = (await db_session.execute(select(UserDepthPreferences))).scalar_one()
+    assert row.enable_habits is True
+    assert row.enable_practices is True
+    assert row.enable_course is True
+    assert row.enable_sangha is True
+
+
+@pytest.mark.asyncio
+async def test_explicit_false_round_trips(db_session: AsyncSession) -> None:
+    """An explicit False on one flag persists; the others remain True."""
+    user_id = await _user(db_session)
+    prefs = UserDepthPreferences(user_id=user_id, enable_sangha=False)
+    db_session.add(prefs)
+    await db_session.commit()
+
+    row = (await db_session.execute(select(UserDepthPreferences))).scalar_one()
+    assert row.enable_habits is True
+    assert row.enable_practices is True
+    assert row.enable_course is True
+    assert row.enable_sangha is False
+
+
+@pytest.mark.asyncio
+async def test_per_user_isolation(db_session: AsyncSession) -> None:
+    """Two users each have their own prefs row; mutating one does not touch the other."""
+    user_a = await _user(db_session, "a@example.com")
+    user_b = await _user(db_session, "b@example.com")
+    db_session.add(UserDepthPreferences(user_id=user_a))
+    db_session.add(UserDepthPreferences(user_id=user_b, enable_habits=False))
+    await db_session.commit()
+
+    row_a = (
+        await db_session.execute(
+            select(UserDepthPreferences).where(col(UserDepthPreferences.user_id) == user_a)
+        )
+    ).scalar_one()
+    row_b = (
+        await db_session.execute(
+            select(UserDepthPreferences).where(col(UserDepthPreferences.user_id) == user_b)
+        )
+    ).scalar_one()
+
+    assert row_a.enable_habits is True
+    assert row_b.enable_habits is False
+    # Mutate user_a's row and confirm user_b is unchanged.
+    row_a.enable_course = False
+    await db_session.commit()
+    await db_session.refresh(row_b)
+    assert row_b.enable_course is True
+
+
+@pytest.mark.asyncio
+async def test_unique_constraint_prevents_duplicate_for_same_user(
+    db_session: AsyncSession,
+) -> None:
+    """A second prefs row for the same user_id violates the unique constraint."""
+    user_id = await _user(db_session)
+    db_session.add(UserDepthPreferences(user_id=user_id))
+    await db_session.commit()
+
+    db_session.add(UserDepthPreferences(user_id=user_id))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_cascade_delete_on_user_delete() -> None:
+    """Deleting the parent user removes the prefs row via DB-level CASCADE.
+
+    Uses a dedicated in-memory engine so PRAGMA foreign_keys = ON is scoped
+    entirely to this test and never leaks to the shared test_engine used by
+    the rest of the suite.
+    """
+    _swap_pg_arrays_to_json()
+    isolated_engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    factory = async_sessionmaker(isolated_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with isolated_engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+            await conn.execute(text("PRAGMA foreign_keys = ON"))
+
+        async with factory() as session:
+            user = User(email="cascade@example.com", password_hash="x")  # pragma: allowlist secret
+            session.add(user)
+            await session.flush()
+            assert user.id is not None
+            session.add(UserDepthPreferences(user_id=user.id))
+            await session.commit()
+
+            await session.execute(text("PRAGMA foreign_keys = ON"))
+            loaded = await session.get(User, user.id)
+            assert loaded is not None
+            await session.delete(loaded)
+            await session.commit()
+
+            remaining = (
+                await session.execute(select(func.count()).select_from(UserDepthPreferences))
+            ).scalar_one()
+            assert remaining == 0
+    finally:
+        await isolated_engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_relationship_wiring(db_session: AsyncSession) -> None:
+    """user.depth_preferences loads the row; prefs.user back-references the user."""
+    user_id = await _user(db_session)
+    prefs = UserDepthPreferences(user_id=user_id)
+    db_session.add(prefs)
+    await db_session.commit()
+
+    loaded_user = await db_session.get(User, user_id)
+    assert loaded_user is not None
+    # Expire the cached attribute so the relationship is re-loaded from the DB.
+    await db_session.refresh(loaded_user, ["depth_preferences"])
+    assert loaded_user.depth_preferences is not None
+    assert loaded_user.depth_preferences.user_id == user_id
+
+    loaded_prefs = await db_session.get(UserDepthPreferences, prefs.id)
+    assert loaded_prefs is not None
+    await db_session.refresh(loaded_prefs, ["user"])
+    assert loaded_prefs.user is not None
+    assert loaded_prefs.user.id == user_id

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1205,3 +1205,123 @@ def test_journal_classification_migration_round_trip_on_sqlite(
     command.upgrade(cfg, _JOURNAL_CLASSIFICATION_REVISION)
     row_after = _journalentry_row(db_url, entry_id=1)
     assert row_after["classification"] == "personal"
+
+
+# -- depth-prefs-01 user_depth_preferences table migration round-trip -------
+
+# Revision anchors for the user_depth_preferences migration round-trip.
+_USER_DEPTH_PREFS_BASE_REVISION = "d8e9f0a1b2c3"  # pragma: allowlist secret
+_USER_DEPTH_PREFS_REVISION = "e2f3a4b5c6d8"  # pragma: allowlist secret
+
+
+def _bootstrap_user_table_for_depth_prefs(sync_url: str) -> None:
+    """Pre-create a minimal ``user`` table with two seeded rows.
+
+    Mirrors the schema the depth-prefs migration expects to find at
+    ``d8e9f0a1b2c3``.  Two rows are seeded so the backfill can be
+    verified for more than one user.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE user ( id INTEGER PRIMARY KEY, email VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(text("INSERT INTO user (id, email) VALUES (1, 'alice@example.com')"))
+        conn.execute(text("INSERT INTO user (id, email) VALUES (2, 'bob@example.com')"))
+    engine.dispose()
+
+
+def _depth_prefs_rows(db_url: str) -> list[dict[str, Any]]:
+    """Return all rows from ``userdepthpreferences`` as a list of dicts."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            rows = (
+                conn.execute(
+                    text(
+                        "SELECT user_id, enable_habits, enable_practices,"
+                        " enable_course, enable_sangha"
+                        " FROM userdepthpreferences ORDER BY user_id"
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            return [dict(r) for r in rows]
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_user_depth_prefs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite Alembic config positioned just before the depth-prefs migration.
+
+    Bootstraps a minimal ``user`` table with two pre-existing rows so the
+    backfill step can be verified for multiple users, then stamps the DB at
+    ``d8e9f0a1b2c3`` (the current chain head before this migration).
+    """
+    db_path = tmp_path / "user_depth_prefs_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_user_table_for_depth_prefs(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _USER_DEPTH_PREFS_BASE_REVISION)
+    return cfg
+
+
+def test_user_depth_prefs_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_user_depth_prefs: Config,
+) -> None:
+    """Round-trip the depth-prefs migration: upgrade creates table + backfills; downgrade drops.
+
+    Phase 1: upgrade creates ``userdepthpreferences`` and backfills both
+    pre-existing user rows with all-True flags.
+    Phase 2: downgrade drops the table.
+    Phase 3: re-upgrade is idempotent — the backfill reproduces the same rows.
+    """
+    cfg = alembic_sqlite_config_user_depth_prefs
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade creates the table and backfills pre-existing users.
+    command.upgrade(cfg, _USER_DEPTH_PREFS_REVISION)
+    assert _table_exists(db_url, "userdepthpreferences")
+    cols = _columns_of(db_url, "userdepthpreferences")
+    assert {
+        "id",
+        "user_id",
+        "enable_habits",
+        "enable_practices",
+        "enable_course",
+        "enable_sangha",
+    }.issubset(cols)
+
+    rows = _depth_prefs_rows(db_url)
+    assert len(rows) == 2, "Both pre-existing users must be backfilled."
+    for row in rows:
+        assert bool(row["enable_habits"]) is True
+        assert bool(row["enable_practices"]) is True
+        assert bool(row["enable_course"]) is True
+        assert bool(row["enable_sangha"]) is True
+
+    # Phase 2: downgrade drops the table entirely.
+    command.downgrade(cfg, _USER_DEPTH_PREFS_BASE_REVISION)
+    assert not _table_exists(db_url, "userdepthpreferences")
+
+    # Phase 3: re-upgrade reproduces the same backfill (idempotent cycle).
+    command.upgrade(cfg, _USER_DEPTH_PREFS_REVISION)
+    assert _table_exists(db_url, "userdepthpreferences")
+    rows_again = _depth_prefs_rows(db_url)
+    assert len(rows_again) == 2
+    for row in rows_again:
+        assert bool(row["enable_habits"]) is True
+        assert bool(row["enable_sangha"]) is True


### PR DESCRIPTION
## Summary
Adds the per-user data model for opt-in depth rings (NORTH-STAR §3) — the persistence foundation of the rings epic. **Data-model only; no endpoint/behavior wired** (that's #909).

- New dedicated 1:1 `UserDepthPreferences` table (mirrors the `StageProgress` sibling): `id` PK, four booleans `enable_habits`/`enable_practices`/`enable_course`/`enable_sangha` all defaulting **true** (existing users keep current behavior), `user_id` FK `unique=True, ondelete="CASCADE"`. Journal floor + Today hub are always-on and get no toggle.
- Migration `e2f3a4b5c6d8` (down_revision `d8e9f0a1b2c3`, the verified single head; new id collision-checked) creates the table and **backfills every existing user to all-enabled**.
- `User.depth_preferences` uses `passive_deletes=True` so an ORM user delete defers to the DB `ON DELETE CASCADE` rather than nulling the NOT-NULL `user_id`.

## Test plan
- 6 model tests (defaults-on-create, explicit-false round-trip, per-user isolation, 1:1 uniqueness `IntegrityError`, DB CASCADE on user delete, relationship wiring) + a migration round-trip test (upgrade creates+backfills, downgrade drops, re-upgrade idempotent).
- The CASCADE test uses a **dedicated isolated engine** so its `PRAGMA foreign_keys=ON` never leaks to the shared test engine (keeps the rest of the suite's SQLite default intact).
- `scripts/backend/check-all.sh` exits 0 (7/7: ruff, mypy strict, interrogate, pytest ≥90%/branch ≥80%, format). **xenon** run standalone → `src/` rank A. Single alembic head. Model↔migration `server_default` parity is drift-free (CI's Postgres `migration-drift` job runs the authoritative `alembic check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #908
Refs #907