### PR TITLE
feat(backend): get/update depth-preferences endpoints + schema

### DIFF
--- a/backend/src/domain/depth_preferences.py
+++ b/backend/src/domain/depth_preferences.py
@@ -1,0 +1,46 @@
+"""Domain logic for provisioning and reading user depth preferences."""
+
+from __future__ import annotations
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.user_depth_preferences import UserDepthPreferences
+
+
+async def _get_depth_preferences(
+    session: AsyncSession, user_id: int
+) -> UserDepthPreferences | None:
+    """Fetch the user's :class:`UserDepthPreferences` row, or ``None``."""
+    result = await session.execute(
+        select(UserDepthPreferences).where(col(UserDepthPreferences.user_id) == user_id)
+    )
+    return result.scalars().first()
+
+
+async def ensure_depth_preferences(session: AsyncSession, user_id: int) -> UserDepthPreferences:
+    """Return the user's depth preferences, provisioning an all-true row on first access.
+
+    Commits the new row before returning: a concurrent caller that loses the
+    SAVEPOINT race must re-read the winner's committed row, and ``get_session``
+    does not auto-commit. Because ``user_id`` is unique, a racing auto-provision
+    hits an ``IntegrityError`` and re-reads the winner's row. Mirrors
+    ``ensure_user_progress`` in ``stage_progress.py``.
+    """
+    preferences = await _get_depth_preferences(session, user_id)
+    if preferences is not None:
+        return preferences
+    preferences = UserDepthPreferences(user_id=user_id)
+    try:
+        async with session.begin_nested():
+            session.add(preferences)
+        await session.commit()
+        await session.refresh(preferences)
+    except IntegrityError as exc:
+        existing = await _get_depth_preferences(session, user_id)
+        if existing is None:
+            msg = "UserDepthPreferences creation lost the race but the winner's row is missing"
+            raise RuntimeError(msg) from exc
+        return existing
+    return preferences

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -31,6 +31,7 @@ from routers.admin import router as admin_router
 from routers.auth import router as auth_router
 from routers.botmason import router as botmason_router
 from routers.course import router as course_router
+from routers.depth_preferences import router as depth_preferences_router
 from routers.energy import router as energy_router
 from routers.goal_completions import router as goal_completion_router
 from routers.goal_groups import router as goal_groups_router
@@ -440,6 +441,7 @@ app.include_router(goal_groups_router)
 app.include_router(goals_router)
 app.include_router(stages_router)
 app.include_router(users_router)
+app.include_router(depth_preferences_router)
 
 
 # BUG-APP-004: separate liveness from readiness so the orchestrator can

--- a/backend/src/routers/depth_preferences.py
+++ b/backend/src/routers/depth_preferences.py
@@ -1,0 +1,68 @@
+"""Depth-preference endpoints for the optional program rings.
+
+A user records which self-chosen depths — habit scaffolding, the practice
+ramp, the course reading, and the Digital Sangha — they have enabled. Nothing
+is gated; these toggles simply let the user quiet rings they have not chosen.
+The caller is resolved from their JWT, so only that user's own row is read or
+mutated: no ``user_id`` is ever accepted from the body or path.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from domain.depth_preferences import ensure_depth_preferences
+from models.user_depth_preferences import UserDepthPreferences
+from routers.auth import get_current_user
+from schemas.depth_preferences import DepthPreferencesResponse, DepthPreferencesUpdate
+
+router = APIRouter(prefix="/depth-preferences", tags=["depth-preferences"])
+
+
+def _to_response(preferences: UserDepthPreferences) -> DepthPreferencesResponse:
+    """Project a stored row onto the four-boolean response DTO."""
+    return DepthPreferencesResponse(
+        enable_habits=preferences.enable_habits,
+        enable_practices=preferences.enable_practices,
+        enable_course=preferences.enable_course,
+        enable_sangha=preferences.enable_sangha,
+    )
+
+
+@router.get("", response_model=DepthPreferencesResponse)
+async def get_depth_preferences(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> DepthPreferencesResponse:
+    """Return the caller's depth preferences, provisioning all-true on first access.
+
+    Idempotent: repeated calls return the same state and never create a
+    duplicate row.
+    """
+    preferences = await ensure_depth_preferences(session, user_id)
+    return _to_response(preferences)
+
+
+@router.patch("", response_model=DepthPreferencesResponse)
+async def update_depth_preferences(
+    payload: DepthPreferencesUpdate,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> DepthPreferencesResponse:
+    """Partially update the caller's ring toggles and return the full new state.
+
+    Only the fields present in the request are applied; unspecified rings keep
+    their stored value. An empty body is rejected upstream (422) by
+    :class:`~schemas.depth_preferences.DepthPreferencesUpdate`.
+    """
+    preferences = await ensure_depth_preferences(session, user_id)
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(preferences, field, value)
+    session.add(preferences)
+    await session.commit()
+    await session.refresh(preferences)
+    return _to_response(preferences)

--- a/backend/src/schemas/depth_preferences.py
+++ b/backend/src/schemas/depth_preferences.py
@@ -1,0 +1,47 @@
+"""Depth-preference schemas for the optional program rings."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, model_validator
+
+
+class DepthPreferencesResponse(BaseModel):
+    """The four ring toggles returned to the caller.
+
+    ``user_id`` is intentionally excluded — the caller already knows its own
+    identity from the JWT, and surfacing surrogate keys aids enumeration.
+    """
+
+    enable_habits: bool
+    enable_practices: bool
+    enable_course: bool
+    enable_sangha: bool
+
+
+class DepthPreferencesUpdate(BaseModel):
+    """Partial update for the ring toggles (PATCH).
+
+    Every field is optional; an empty payload is rejected (422) so a no-op
+    PATCH cannot reach the database. Only the fields the caller sets are
+    applied — unspecified rings keep their stored value.
+    """
+
+    enable_habits: bool | None = None
+    enable_practices: bool | None = None
+    enable_course: bool | None = None
+    enable_sangha: bool | None = None
+
+    @model_validator(mode="after")
+    def _require_at_least_one_field(self) -> Self:
+        provided = (
+            self.enable_habits,
+            self.enable_practices,
+            self.enable_course,
+            self.enable_sangha,
+        )
+        if all(value is None for value in provided):
+            msg = "at least one field must be provided"
+            raise ValueError(msg)
+        return self

--- a/backend/tests/test_depth_preferences_api.py
+++ b/backend/tests/test_depth_preferences_api.py
@@ -1,0 +1,209 @@
+"""Tests for GET /depth-preferences and PATCH /depth-preferences."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+_PREFS_URL = "/depth-preferences"
+
+# All four ring keys the response must carry.
+_RING_KEYS = ("enable_habits", "enable_practices", "enable_course", "enable_sangha")
+
+
+async def _signup(client: AsyncClient, username: str = "depthuser") -> dict[str, str]:
+    """Create an account and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# GET — auto-provision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_depth_prefs_auto_provisions_defaults(async_client: AsyncClient) -> None:
+    """Fresh user with no prefs row gets 200 with all four rings true."""
+    headers = await _signup(async_client)
+
+    resp = await async_client.get(_PREFS_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    for key in _RING_KEYS:
+        assert body[key] is True, f"expected {key}=True, got {body[key]}"
+
+
+@pytest.mark.asyncio
+async def test_get_depth_prefs_is_idempotent(async_client: AsyncClient) -> None:
+    """Calling GET twice returns identical all-true state (no duplicate/error)."""
+    headers = await _signup(async_client, "idem")
+
+    first = await async_client.get(_PREFS_URL, headers=headers)
+    second = await async_client.get(_PREFS_URL, headers=headers)
+
+    assert first.status_code == HTTPStatus.OK
+    assert second.status_code == HTTPStatus.OK
+    assert first.json() == second.json()
+    for key in _RING_KEYS:
+        assert second.json()[key] is True
+
+
+# ---------------------------------------------------------------------------
+# PATCH — partial update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_toggles_one_ring(async_client: AsyncClient) -> None:
+    """PATCH with one key flips that ring and leaves the other three true."""
+    headers = await _signup(async_client, "one_ring")
+
+    resp = await async_client.patch(
+        _PREFS_URL,
+        json={"enable_habits": False},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["enable_habits"] is False
+    assert body["enable_practices"] is True
+    assert body["enable_course"] is True
+    assert body["enable_sangha"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_partial_preserves_previous_toggles(async_client: AsyncClient) -> None:
+    """Second PATCH keeps the first ring flipped; only the new key changes."""
+    headers = await _signup(async_client, "two_patch")
+
+    first_patch = await async_client.patch(
+        _PREFS_URL,
+        json={"enable_habits": False},
+        headers=headers,
+    )
+    assert first_patch.status_code == HTTPStatus.OK
+
+    second_patch = await async_client.patch(
+        _PREFS_URL,
+        json={"enable_sangha": False},
+        headers=headers,
+    )
+
+    assert second_patch.status_code == HTTPStatus.OK
+    body = second_patch.json()
+    # First toggle must still be false.
+    assert body["enable_habits"] is False
+    # New toggle applied.
+    assert body["enable_sangha"] is False
+    # Untouched rings remain true.
+    assert body["enable_practices"] is True
+    assert body["enable_course"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_returns_all_four_ring_keys(async_client: AsyncClient) -> None:
+    """PATCH response always includes all four ring booleans."""
+    headers = await _signup(async_client, "full_resp")
+
+    resp = await async_client.patch(
+        _PREFS_URL,
+        json={"enable_course": False},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    for key in _RING_KEYS:
+        assert key in body, f"response missing key '{key}'"
+        assert isinstance(body[key], bool), f"expected bool for '{key}', got {type(body[key])}"
+
+
+# ---------------------------------------------------------------------------
+# Auth required
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_depth_prefs_requires_auth(async_client: AsyncClient) -> None:
+    """GET without a token returns 401."""
+    resp = await async_client.get(_PREFS_URL)
+
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_get_depth_prefs_invalid_token_returns_401(async_client: AsyncClient) -> None:
+    """GET with a malformed token returns 401."""
+    resp = await async_client.get(
+        _PREFS_URL,
+        headers={"Authorization": "Bearer not.a.valid.token"},
+    )
+
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_patch_depth_prefs_requires_auth(async_client: AsyncClient) -> None:
+    """PATCH without a token returns 401."""
+    resp = await async_client.patch(_PREFS_URL, json={"enable_habits": False})
+
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Caller-only isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_does_not_affect_other_user(async_client: AsyncClient) -> None:
+    """Toggling one user's ring leaves another user's prefs all-true."""
+    alice_headers = await _signup(async_client, "alice_dp")
+    bob_headers = await _signup(async_client, "bob_dp")
+
+    # Alice disables her habits ring.
+    patch = await async_client.patch(
+        _PREFS_URL,
+        json={"enable_habits": False},
+        headers=alice_headers,
+    )
+    assert patch.status_code == HTTPStatus.OK
+    assert patch.json()["enable_habits"] is False
+
+    # Bob's prefs are untouched; no user_id in the request body.
+    bob_resp = await async_client.get(_PREFS_URL, headers=bob_headers)
+    assert bob_resp.status_code == HTTPStatus.OK
+    for key in _RING_KEYS:
+        assert bob_resp.json()[key] is True, f"Bob's {key} was mutated by Alice's PATCH"
+
+    # Alice's state is her own; re-GET confirms persistence.
+    alice_resp = await async_client.get(_PREFS_URL, headers=alice_headers)
+    assert alice_resp.json()["enable_habits"] is False
+
+
+# ---------------------------------------------------------------------------
+# Empty-body rejection (mirrors JournalEntryUpdate at-least-one guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_empty_body_returns_422(async_client: AsyncClient) -> None:
+    """PATCH with no fields set is rejected so a no-op cannot reach the DB."""
+    headers = await _signup(async_client, "empty_dp")
+
+    resp = await async_client.patch(_PREFS_URL, json={}, headers=headers)
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## Summary
Exposes the opt-in ring preferences (#908) over a read/update API so the client can show and change which depths are enabled (NORTH-STAR §3).

- **`GET /depth-preferences`** returns the caller's four ring booleans, **auto-provisioning** an all-enabled row if absent. The get-or-create mirrors `ensure_user_progress` (nested SAVEPOINT + `IntegrityError` re-read) so concurrent first-access is race-safe given the `unique(user_id)` constraint.
- **`PATCH /depth-preferences`** applies a non-empty subset via `model_dump(exclude_unset=True)` so unspecified rings are **preserved** (an explicit `false` is applied; an omitted ring is untouched), and returns the full new state. An empty body is rejected **422** via an at-least-one-field validator (mirroring `JournalEntryUpdate`).
- **Caller-only:** `user_id` derives solely from `get_current_user` (the JWT) — there is no `user_id` in the body/path/query, so no IDOR/enumeration vector; unauthorized requests get **401**. The response DTO exposes only the four booleans (no surrogate keys).

## Test plan
- 10 async-client tests: GET auto-provisions defaults + idempotent; PATCH toggles one ring; partial update preserves others; PATCH returns all four keys; empty body → 422; missing/invalid token → 401 (GET + PATCH); caller-only isolation (user A's PATCH doesn't touch user B).
- `scripts/backend/check-all.sh` exits 0 (7/7). **xenon** standalone → `src/` rank A. mypy strict clean (incl. tests, via `col()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #909
Refs #907