### PR TITLE
feat(frontend): depth-preferences API client + store

### DIFF
--- a/frontend/src/api/__tests__/depthPreferences-api.test.ts
+++ b/frontend/src/api/__tests__/depthPreferences-api.test.ts
@@ -1,0 +1,115 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { ApiError, ApiValidationError, depthPreferences } from '../index';
+import type { DepthPreferences } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+const ALL_ON: DepthPreferences = {
+  enable_habits: true,
+  enable_practices: true,
+  enable_course: true,
+  enable_sangha: true,
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('depthPreferences.get', () => {
+  test('GETs /depth-preferences (no trailing slash) and returns four booleans', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(ALL_ON));
+    const result = await depthPreferences.get('tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/depth-preferences');
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(result.enable_habits).toBe(true);
+    expect(result.enable_practices).toBe(true);
+    expect(result.enable_course).toBe(true);
+    expect(result.enable_sangha).toBe(true);
+  });
+
+  test('surfaces a 401 as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unauthorized' }, 401));
+    const err = await depthPreferences.get('bad-tok').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(401);
+  });
+
+  test('rejects a malformed payload (non-boolean field) with ApiValidationError', async () => {
+    // Schema must reject a string where boolean is required
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({
+        enable_habits: 'yes',
+        enable_practices: true,
+        enable_course: true,
+        enable_sangha: true,
+      }),
+    );
+    await expect(depthPreferences.get('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+});
+
+describe('depthPreferences.update', () => {
+  test('PATCHes /depth-preferences with a partial body and returns the full state', async () => {
+    const fullResponse: DepthPreferences = {
+      enable_habits: true,
+      enable_practices: true,
+      enable_course: false,
+      enable_sangha: true,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(fullResponse));
+
+    const result = await depthPreferences.update({ enable_course: false }, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/depth-preferences');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body)).toEqual({ enable_course: false });
+    // Returns the server's FULL four-key response, not just the sent subset
+    expect(result.enable_habits).toBe(true);
+    expect(result.enable_practices).toBe(true);
+    expect(result.enable_course).toBe(false);
+    expect(result.enable_sangha).toBe(true);
+  });
+
+  test('partial in → full state out (multi-key subset)', async () => {
+    const fullResponse: DepthPreferences = {
+      enable_habits: false,
+      enable_practices: false,
+      enable_course: true,
+      enable_sangha: true,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(fullResponse));
+
+    const result = await depthPreferences.update(
+      { enable_habits: false, enable_practices: false },
+      'tok',
+    );
+
+    expect(result.enable_habits).toBe(false);
+    expect(result.enable_practices).toBe(false);
+    expect(result.enable_course).toBe(true);
+    expect(result.enable_sangha).toBe(true);
+  });
+
+  test('surfaces a 422 (empty body rejection) as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unprocessable_entity' }, 422));
+    await expect(depthPreferences.update({}, 'tok')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 422,
+    });
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -7,6 +7,7 @@ import {
   acceptSuggestionResultSchema,
   completionSuggestionListResponseSchema,
   completionSuggestionSchema,
+  depthPreferencesSchema,
   frequencyResponseSchema,
   habitWithGoalsSchema,
   isTier,
@@ -28,6 +29,7 @@ import {
   type CareResponseT,
   type CompletionSuggestionT,
   type CompletionTargetTypeT,
+  type DepthPreferencesT,
   type Page,
   type PasswordResetAcceptedT,
   type SuggestionStatusT,
@@ -2292,6 +2294,44 @@ export const users = {
   },
 };
 
+// Depth-preferences types and client (you-choose-your-depth ring toggles)
+
+/** The four optional-depth ring toggles (mirrors the backend response). */
+export type DepthPreferences = DepthPreferencesT;
+
+/** Partial update body — only the flipped rings are sent. */
+export type DepthPreferencesUpdate = Partial<DepthPreferences>;
+
+// Responses are validated via ``depthPreferencesSchema`` so a mis-shaped
+// payload (e.g. a non-boolean toggle) raises ApiValidationError rather than
+// silently corrupting a ring flag. The route has no trailing slash — the
+// backend serves ``/depth-preferences`` directly (no 307 redirect).
+const depthPreferencesResponseSchema =
+  depthPreferencesSchema as unknown as z.ZodType<DepthPreferences>;
+
+export const depthPreferences = {
+  /** Read the caller's current ring toggles. */
+  get(token?: string): Promise<DepthPreferences> {
+    return request<DepthPreferences>('/depth-preferences', {
+      token,
+      schema: depthPreferencesResponseSchema,
+    });
+  },
+  /**
+   * Flip one or more rings. The partial is sent verbatim; the server echoes
+   * the FULL four-key state back, so callers get the authoritative post-update
+   * snapshot rather than the subset they sent.
+   */
+  update(partial: DepthPreferencesUpdate, token?: string): Promise<DepthPreferences> {
+    return request<DepthPreferences>('/depth-preferences', {
+      method: 'PATCH',
+      body: partial,
+      token,
+      schema: depthPreferencesResponseSchema,
+    });
+  },
+};
+
 // Energy plan client
 export default {
   habits,
@@ -2311,6 +2351,7 @@ export default {
   practiceSessions,
   auth,
   users,
+  depthPreferences,
   setTokenGetter,
   setOnUnauthorized,
   setOnTokenRefreshed,

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -555,6 +555,27 @@ export type CareResponseT = z.infer<typeof careResponseSchema>;
 export type ResonanceResponseT = z.infer<typeof resonanceResponseSchema>;
 
 // ---------------------------------------------------------------------------
+// Depth preferences (you-choose-your-depth ring toggles)
+// ---------------------------------------------------------------------------
+
+/**
+ * The four optional-depth toggles (mirrors the backend ``DepthPreferences``).
+ * Each ring is on by default; a user opts *out* of a depth by flipping its
+ * flag false. Validated at the boundary so a mis-shaped payload (e.g. a
+ * stringly-typed "yes") raises ``ApiValidationError`` instead of quietly
+ * corrupting a boolean toggle. Unknown keys are stripped (plain object, not
+ * ``.strict()``) so an additive backend field cannot fail a client build.
+ */
+export const depthPreferencesSchema = z.object({
+  enable_habits: z.boolean(),
+  enable_practices: z.boolean(),
+  enable_course: z.boolean(),
+  enable_sangha: z.boolean(),
+});
+
+export type DepthPreferencesT = z.infer<typeof depthPreferencesSchema>;
+
+// ---------------------------------------------------------------------------
 // Lenient schemas for legacy endpoints (gradually tightened)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/store/__tests__/useDepthPreferencesStore.test.ts
+++ b/frontend/src/store/__tests__/useDepthPreferencesStore.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { act } from '@testing-library/react-native';
+
+import type { DepthPreferences, DepthPreferencesUpdate } from '../../api';
+
+// Mock the entire api module before any store import resolves
+jest.mock('../../api', () => ({
+  depthPreferences: {
+    get: jest.fn(() =>
+      Promise.resolve({
+        enable_habits: true,
+        enable_practices: true,
+        enable_course: true,
+        enable_sangha: true,
+      }),
+    ),
+    update: jest.fn(() =>
+      Promise.resolve({
+        enable_habits: true,
+        enable_practices: true,
+        enable_course: true,
+        enable_sangha: true,
+      }),
+    ),
+  },
+}));
+
+const mockApi = jest.requireMock('../../api') as {
+  depthPreferences: {
+    get: jest.Mock<(token?: string) => Promise<DepthPreferences>>;
+    update: jest.Mock<
+      (partial: DepthPreferencesUpdate, token?: string) => Promise<DepthPreferences>
+    >;
+  };
+};
+
+const ALL_ON = {
+  enable_habits: true,
+  enable_practices: true,
+  enable_course: true,
+  enable_sangha: true,
+};
+
+describe('useDepthPreferencesStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Restore all-on defaults between tests
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+    act(() => {
+      useDepthPreferencesStore.getState().reset();
+    });
+  });
+
+  it('initial state is all-on with loading false and error null', () => {
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+    const state = useDepthPreferencesStore.getState();
+
+    expect(state.enable_habits).toBe(true);
+    expect(state.enable_practices).toBe(true);
+    expect(state.enable_course).toBe(true);
+    expect(state.enable_sangha).toBe(true);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it('load() sets loading true during fetch then stores returned booleans', async () => {
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+
+    const serverResponse = {
+      enable_habits: true,
+      enable_practices: false,
+      enable_course: true,
+      enable_sangha: false,
+    };
+
+    // Single mock: captures mid-flight loading state AND resolves the response
+    let midFlightLoading: boolean | undefined;
+    mockApi.depthPreferences.get.mockImplementationOnce(
+      () =>
+        new Promise<DepthPreferences>((resolve) => {
+          // Record loading state synchronously before the promise settles
+          midFlightLoading = useDepthPreferencesStore.getState().loading;
+          resolve(serverResponse);
+        }),
+    );
+
+    await act(async () => {
+      await useDepthPreferencesStore.getState().load('tok');
+    });
+
+    // loading was true mid-flight
+    expect(midFlightLoading).toBe(true);
+
+    const state = useDepthPreferencesStore.getState();
+    expect(state.enable_habits).toBe(true);
+    expect(state.enable_practices).toBe(false);
+    expect(state.enable_course).toBe(true);
+    expect(state.enable_sangha).toBe(false);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it('load() calls depthPreferences.get with the supplied token', async () => {
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+    mockApi.depthPreferences.get.mockResolvedValueOnce(ALL_ON);
+
+    await act(async () => {
+      await useDepthPreferencesStore.getState().load('my-token');
+    });
+
+    expect(mockApi.depthPreferences.get).toHaveBeenCalledWith('my-token');
+  });
+
+  it('update() calls depthPreferences.update with the partial and sets RETURNED full state', async () => {
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+
+    const serverFull = {
+      enable_habits: true,
+      enable_practices: true,
+      enable_course: false,
+      enable_sangha: true,
+    };
+    mockApi.depthPreferences.update.mockResolvedValueOnce(serverFull);
+
+    // Confirm the value is NOT set before promise resolves
+    const stateBefore = useDepthPreferencesStore.getState().enable_course;
+    expect(stateBefore).toBe(true);
+
+    await act(async () => {
+      await useDepthPreferencesStore.getState().update({ enable_course: false }, 'tok');
+    });
+
+    expect(mockApi.depthPreferences.update).toHaveBeenCalledWith({ enable_course: false }, 'tok');
+    // State comes from the server response, not optimistic pre-set
+    const state = useDepthPreferencesStore.getState();
+    expect(state.enable_course).toBe(false);
+    expect(state.enable_habits).toBe(true);
+    expect(state.enable_practices).toBe(true);
+    expect(state.enable_sangha).toBe(true);
+  });
+
+  it('update() does NOT optimistically pre-set before the promise resolves', async () => {
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+
+    let stateWhileInFlight: boolean | undefined;
+
+    mockApi.depthPreferences.update.mockImplementationOnce(
+      () =>
+        new Promise<DepthPreferences>((resolve) => {
+          // Capture store state BEFORE the promise resolves
+          stateWhileInFlight = useDepthPreferencesStore.getState().enable_sangha;
+          resolve({ ...ALL_ON, enable_sangha: false });
+        }),
+    );
+
+    await act(async () => {
+      await useDepthPreferencesStore.getState().update({ enable_sangha: false }, 'tok');
+    });
+
+    // Still true mid-flight (no optimistic update)
+    expect(stateWhileInFlight).toBe(true);
+    // Now reflects the server response
+    expect(useDepthPreferencesStore.getState().enable_sangha).toBe(false);
+  });
+
+  it('load() error sets error string, restores loading to false, leaves defaults intact', async () => {
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+
+    mockApi.depthPreferences.get.mockRejectedValueOnce(new Error('network failure'));
+
+    await act(async () => {
+      await useDepthPreferencesStore.getState().load('tok');
+    });
+
+    const state = useDepthPreferencesStore.getState();
+    expect(typeof state.error).toBe('string');
+    expect(state.error).not.toBeNull();
+    expect(state.loading).toBe(false);
+    // Defaults remain all-on
+    expect(state.enable_habits).toBe(true);
+    expect(state.enable_practices).toBe(true);
+    expect(state.enable_course).toBe(true);
+    expect(state.enable_sangha).toBe(true);
+  });
+
+  it('update() error sets error string and restores loading to false', async () => {
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+
+    mockApi.depthPreferences.update.mockRejectedValueOnce(new Error('server error'));
+
+    await act(async () => {
+      await useDepthPreferencesStore.getState().update({ enable_habits: false }, 'tok');
+    });
+
+    const state = useDepthPreferencesStore.getState();
+    expect(typeof state.error).toBe('string');
+    expect(state.loading).toBe(false);
+  });
+
+  it('reset() returns state to the all-on defaults', () => {
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+
+    act(() => {
+      // Manually dirty the state to simulate a prior load
+      useDepthPreferencesStore.setState({
+        enable_habits: false,
+        enable_practices: false,
+        enable_course: false,
+        enable_sangha: false,
+        loading: true,
+        error: 'some error',
+      });
+    });
+
+    act(() => {
+      useDepthPreferencesStore.getState().reset();
+    });
+
+    const state = useDepthPreferencesStore.getState();
+    expect(state.enable_habits).toBe(true);
+    expect(state.enable_practices).toBe(true);
+    expect(state.enable_course).toBe(true);
+    expect(state.enable_sangha).toBe(true);
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it('selectors return their slices from state', () => {
+    const {
+      useDepthPreferencesStore,
+      selectEnableHabits,
+      selectEnablePractices,
+      selectEnableCourse,
+      selectEnableSangha,
+      selectDepthPreferencesLoading,
+      selectDepthPreferencesError,
+    } = require('../useDepthPreferencesStore');
+
+    act(() => {
+      useDepthPreferencesStore.setState({
+        enable_habits: true,
+        enable_practices: false,
+        enable_course: true,
+        enable_sangha: false,
+        loading: true,
+        error: 'oops',
+      });
+    });
+
+    const state = useDepthPreferencesStore.getState();
+    expect(selectEnableHabits(state)).toBe(true);
+    expect(selectEnablePractices(state)).toBe(false);
+    expect(selectEnableCourse(state)).toBe(true);
+    expect(selectEnableSangha(state)).toBe(false);
+    expect(selectDepthPreferencesLoading(state)).toBe(true);
+    expect(selectDepthPreferencesError(state)).toBe('oops');
+  });
+
+  it('registers its reset with the shared store registry', () => {
+    // Registry lets AuthContext.logout clear every store in one call
+    const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
+    const { resetAllStores } = require('../registry');
+
+    act(() => {
+      useDepthPreferencesStore.setState({ enable_habits: false, enable_sangha: false });
+    });
+    expect(useDepthPreferencesStore.getState().enable_habits).toBe(false);
+
+    act(() => resetAllStores());
+
+    expect(useDepthPreferencesStore.getState().enable_habits).toBe(true);
+    expect(useDepthPreferencesStore.getState().enable_sangha).toBe(true);
+  });
+});

--- a/frontend/src/store/useDepthPreferencesStore.ts
+++ b/frontend/src/store/useDepthPreferencesStore.ts
@@ -1,0 +1,106 @@
+import { create } from 'zustand';
+
+import { depthPreferences } from '../api';
+import type { DepthPreferences, DepthPreferencesUpdate } from '../api';
+
+import { registerStoreReset } from './registry';
+
+/**
+ * Depth-preferences store — the client-side mirror of the "you choose your
+ * depth" ring toggles. Every ring is on by default, matching the product
+ * principle that nothing is gated: a user opts *out* of a depth, never in.
+ *
+ * Unlike an optimistic toggle, ``update`` waits for the server's echoed full
+ * state before mutating: the four flags interact (a backend rule may force a
+ * dependent ring off), so the authoritative post-update snapshot is the only
+ * safe thing to store. A failed call leaves the current flags untouched and
+ * surfaces a string ``error`` for the UI to render.
+ */
+export interface DepthPreferencesStoreState {
+  enable_habits: boolean;
+  enable_practices: boolean;
+  enable_course: boolean;
+  enable_sangha: boolean;
+  loading: boolean;
+  error: string | null;
+
+  /** Fetch the current ring toggles and replace local state with the result. */
+  load: (_token?: string) => Promise<void>;
+  /** Flip one or more rings; stores the server's echoed full state on resolve. */
+  update: (_partial: DepthPreferencesUpdate, _token?: string) => Promise<void>;
+  /** Wipe every field back to the all-on defaults on logout. */
+  reset: () => void;
+}
+
+const INITIAL_STATE = {
+  enable_habits: true,
+  enable_practices: true,
+  enable_course: true,
+  enable_sangha: true,
+  loading: false,
+  error: null as string | null,
+};
+
+/** Narrow the four toggle flags out of a full API response. */
+const toToggles = (prefs: DepthPreferences) => ({
+  enable_habits: prefs.enable_habits,
+  enable_practices: prefs.enable_practices,
+  enable_course: prefs.enable_course,
+  enable_sangha: prefs.enable_sangha,
+});
+
+/** Human-readable message for an unknown rejection value. */
+const messageFor = (err: unknown): string =>
+  err instanceof Error ? err.message : 'Failed to load depth preferences';
+
+export const useDepthPreferencesStore = create<DepthPreferencesStoreState>((set) => ({
+  ...INITIAL_STATE,
+
+  load: async (token) => {
+    set({ loading: true, error: null });
+    try {
+      const prefs = await depthPreferences.get(token);
+      set({ ...toToggles(prefs), loading: false });
+    } catch (err: unknown) {
+      // Leave the existing flags intact — a failed read must not flip a ring.
+      set({ loading: false, error: messageFor(err) });
+    }
+  },
+
+  update: async (partial, token) => {
+    set({ loading: true, error: null });
+    try {
+      const prefs = await depthPreferences.update(partial, token);
+      // Non-optimistic: state comes only from the server's echoed full snapshot.
+      set({ ...toToggles(prefs), loading: false });
+    } catch (err: unknown) {
+      set({ loading: false, error: messageFor(err) });
+    }
+  },
+
+  reset: () => set({ ...INITIAL_STATE }),
+}));
+
+// Publish our reset to the shared registry so a single ``resetAllStores()``
+// call in AuthContext.logout clears every store, including this one.
+registerStoreReset(() => {
+  useDepthPreferencesStore.getState().reset();
+});
+
+// ---------------------------------------------------------------------------
+// Selectors — narrow state subscriptions. Zustand compares the returned value
+// with ``Object.is``, so components re-render only when their slice changes.
+// ---------------------------------------------------------------------------
+
+export const selectEnableHabits = (state: DepthPreferencesStoreState): boolean =>
+  state.enable_habits;
+export const selectEnablePractices = (state: DepthPreferencesStoreState): boolean =>
+  state.enable_practices;
+export const selectEnableCourse = (state: DepthPreferencesStoreState): boolean =>
+  state.enable_course;
+export const selectEnableSangha = (state: DepthPreferencesStoreState): boolean =>
+  state.enable_sangha;
+export const selectDepthPreferencesLoading = (state: DepthPreferencesStoreState): boolean =>
+  state.loading;
+export const selectDepthPreferencesError = (state: DepthPreferencesStoreState): string | null =>
+  state.error;


### PR DESCRIPTION
## Summary
Adds the frontend read/update path for the opt-in ring preferences (#909) so navigation and Settings can consume them (NORTH-STAR §3). **No UI yet** — client + store only (consumed by the next two issues).

- **api client**: a zod-validated `depthPreferences` object (`get(token)` / `update(partial, token)`) over the shared `request` helper, plus the `DepthPreferences` type — the four ring booleans matching the backend keys. `update` sends a partial subset and returns the full new state; a malformed response surfaces `ApiValidationError`.
- **store**: `useDepthPreferencesStore` (Zustand) initialises **all-on** so nothing flickers off before the first fetch resolves; `load()` and `update(partial)` set state from the returned response (**refetch/set-returned, not optimistic**); a `reset` is registered for logout-wipe; loading/error + selectors.

## Test plan
- 14 Jest tests: client (`get` path `/depth-preferences` no trailing slash + GET; `update` PATCHes the partial and returns full state; `ApiValidationError` on non-boolean) and store (all-on initial defaults; `load()` toggles loading + stores fetched state; `update()` non-optimistic set-from-response; load/update error → string error + loading false + defaults intact; `reset()`; selectors).
- `scripts/frontend/check-all.sh` exits 0 (eslint zero-warning, tsc strict, prettier, all tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #910
Refs #907