### PR TITLE
feat(frontend): "Choose your depths" Settings section (ring toggles)

### DIFF
--- a/frontend/src/features/Settings/ChooseDepthsSection.tsx
+++ b/frontend/src/features/Settings/ChooseDepthsSection.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect } from 'react';
+import { StyleSheet, Switch, Text, useWindowDimensions, View } from 'react-native';
+
+import type { DepthPreferencesUpdate } from '@/api';
+import { EditorialSection } from '@/components/layout/EditorialSection';
+import { useAuth } from '@/context/AuthContext';
+import { accent, ink, rhythm, surface, touchTarget, type as typeRamp } from '@/design/tokens';
+import {
+  load,
+  selectEnableCourse,
+  selectEnableHabits,
+  selectEnablePractices,
+  selectEnableSangha,
+  update,
+  useDepthPreferencesStore,
+} from '@/store/useDepthPreferencesStore';
+
+/**
+ * "Choose your depths" — the Settings surface for the you-choose-your-depth ring
+ * toggles. The journal floor is always on and is stated as text, never a switch:
+ * turning any of the four optional depths off is a valid choice, not a loss, so
+ * the copy stays invitational and free of streak-shame or pressure.
+ *
+ * State is read straight from the depth-preferences store (no local mirror) and
+ * loaded once on mount; each toggle dispatches a single-key partial update.
+ */
+
+const SECTION_TITLE = 'Choose your depths';
+
+/** The always-on journal floor — stated, never toggled (em dash U+2014). */
+const FLOOR_STATEMENT =
+  'Your journal is always here — the floor beneath everything. Nothing below is required.';
+
+/** Framing caption: turning a depth off is a choice, not a loss. */
+const FRAMING_CAPTION =
+  'Turn any depth on or off whenever it fits your life. Turning one off is a choice, not a loss.';
+
+/** One optional depth: its label, store key, and stable testID slug. */
+interface DepthDefinition {
+  key: 'habits' | 'practices' | 'course' | 'sangha';
+  label: string;
+  enableKey: keyof DepthPreferencesUpdate;
+}
+
+const DEPTHS: readonly DepthDefinition[] = [
+  { key: 'habits', label: 'Habits', enableKey: 'enable_habits' },
+  { key: 'practices', label: 'Practices', enableKey: 'enable_practices' },
+  { key: 'course', label: 'Course', enableKey: 'enable_course' },
+  { key: 'sangha', label: 'Sangha', enableKey: 'enable_sangha' },
+] as const;
+
+interface DepthToggleRowProps {
+  label: string;
+  value: boolean;
+  testID: string;
+  rowTestID: string;
+  onValueChange: (_value: boolean) => void;
+}
+
+/** A single ring row: a labelled switch on a >=44dp touch target. */
+const DepthToggleRow = ({
+  label,
+  value,
+  testID,
+  rowTestID,
+  onValueChange,
+}: DepthToggleRowProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const t = typeRamp(width);
+  return (
+    <View style={styles.row} testID={rowTestID}>
+      <Text style={[t.body, styles.rowLabel]}>{label}</Text>
+      <Switch
+        testID={testID}
+        accessibilityRole="switch"
+        accessibilityLabel={label}
+        accessibilityState={{ checked: value }}
+        value={value}
+        onValueChange={onValueChange}
+        trackColor={{ false: surface.hairline, true: accent.primary }}
+        thumbColor={surface.raised}
+      />
+    </View>
+  );
+};
+
+const ChooseDepthsSection = (): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const t = typeRamp(width);
+  const { token } = useAuth();
+
+  const enabled = {
+    habits: useDepthPreferencesStore(selectEnableHabits),
+    practices: useDepthPreferencesStore(selectEnablePractices),
+    course: useDepthPreferencesStore(selectEnableCourse),
+    sangha: useDepthPreferencesStore(selectEnableSangha),
+  };
+
+  useEffect(() => {
+    if (token) void load(token);
+  }, [token]);
+
+  return (
+    <EditorialSection title={SECTION_TITLE} testID="settings-group-depths">
+      <Text
+        style={[t.body, styles.floorLine]}
+        accessibilityRole="text"
+        testID="depths-floor-statement"
+      >
+        {FLOOR_STATEMENT}
+      </Text>
+      <Text style={[t.caption, styles.caption]}>{FRAMING_CAPTION}</Text>
+      {DEPTHS.map((depth) => (
+        <DepthToggleRow
+          key={depth.key}
+          label={depth.label}
+          value={enabled[depth.key]}
+          testID={`depth-toggle-${depth.key}`}
+          rowTestID={`depth-row-${depth.key}`}
+          onValueChange={(value) => void update({ [depth.enableKey]: value }, token ?? undefined)}
+        />
+      ))}
+    </EditorialSection>
+  );
+};
+
+const styles = StyleSheet.create({
+  floorLine: {
+    color: ink.primary,
+  },
+  caption: {
+    color: ink.soft,
+    marginTop: rhythm.blockGap / 3,
+    marginBottom: rhythm.blockGap,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: touchTarget.minimum,
+    paddingVertical: rhythm.blockGap,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: surface.hairline,
+  },
+  rowLabel: {
+    color: ink.primary,
+  },
+});
+
+export default ChooseDepthsSection;

--- a/frontend/src/features/Settings/SettingsHubScreen.tsx
+++ b/frontend/src/features/Settings/SettingsHubScreen.tsx
@@ -17,6 +17,7 @@ import { ScreenHeader } from '@/components/layout/ScreenHeader';
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { useAuth } from '@/context/AuthContext';
 import { accent, ink, rhythm, surface, touchTarget, type as typeRamp } from '@/design/tokens';
+import ChooseDepthsSection from '@/features/Settings/ChooseDepthsSection';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 /**
@@ -173,6 +174,7 @@ const SettingsHubScreen = (): React.JSX.Element => {
       />
       <AccountSection onApiKey={openApiKey} onTimezone={openTimezone} />
       <PrivacySection />
+      <ChooseDepthsSection />
       <SessionSection onLogout={onLogout} />
       <SupportSection onSupportCare={openSupportCare} />
     </ScreenScaffold>

--- a/frontend/src/features/Settings/__tests__/ChooseDepthsSection.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ChooseDepthsSection.test.tsx
@@ -1,0 +1,461 @@
+/* eslint-env jest */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { fireEvent, render, within } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+// ---------------------------------------------------------------------------
+// Store mock — returns selector values from a mutable state object.
+// All four rings default to true; individual tests override via setMockState.
+// ---------------------------------------------------------------------------
+
+const mockLoad = jest.fn<() => Promise<void>>(() => Promise.resolve());
+const mockUpdate = jest.fn<(partial: Record<string, boolean>, token?: string) => Promise<void>>(
+  () => Promise.resolve(),
+);
+
+type MockState = {
+  enable_habits: boolean;
+  enable_practices: boolean;
+  enable_course: boolean;
+  enable_sangha: boolean;
+  loading: boolean;
+  error: string | null;
+};
+
+let mockStoreState: MockState = {
+  enable_habits: true,
+  enable_practices: true,
+  enable_course: true,
+  enable_sangha: true,
+  loading: false,
+  error: null,
+};
+
+const setMockState = (patch: Partial<MockState>): void => {
+  mockStoreState = { ...mockStoreState, ...patch };
+};
+
+jest.mock('@/store/useDepthPreferencesStore', () => ({
+  useDepthPreferencesStore: jest.fn((selector: (_s: MockState) => unknown) =>
+    selector(mockStoreState),
+  ),
+  selectEnableHabits: (s: MockState): boolean => s.enable_habits,
+  selectEnablePractices: (s: MockState): boolean => s.enable_practices,
+  selectEnableCourse: (s: MockState): boolean => s.enable_course,
+  selectEnableSangha: (s: MockState): boolean => s.enable_sangha,
+  selectDepthPreferencesLoading: (s: MockState): boolean => s.loading,
+  selectDepthPreferencesError: (s: MockState): string | null => s.error,
+  // Expose actions on the store mock so the component can call them
+  get load() {
+    return mockLoad;
+  },
+  get update() {
+    return mockUpdate;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Auth mock — exposes token alongside the existing logout.
+// ---------------------------------------------------------------------------
+
+const mockToken = 'test-token-abc';
+const mockLogout = jest.fn<() => Promise<void>>(() => Promise.resolve());
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ logout: mockLogout, token: mockToken }),
+}));
+
+import ChooseDepthsSection from '../ChooseDepthsSection';
+
+import { touchTarget } from '@/design/tokens';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Read the flattened minHeight from a node's style prop. */
+function flatMinHeight(node: { props: { style: unknown } }): number {
+  const flat = StyleSheet.flatten(node.props.style) as { minHeight?: number };
+  return flat.minHeight ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Reset between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStoreState = {
+    enable_habits: true,
+    enable_practices: true,
+    enable_course: true,
+    enable_sangha: true,
+    loading: false,
+    error: null,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Section presence and copy
+// ---------------------------------------------------------------------------
+
+describe('ChooseDepthsSection — section-level copy', () => {
+  it('renders the section with testID "settings-group-depths"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('settings-group-depths')).toBeTruthy();
+  });
+
+  it('renders the section title "Choose your depths"', () => {
+    const { getByText } = render(<ChooseDepthsSection />);
+    expect(getByText('Choose your depths')).toBeTruthy();
+  });
+
+  it('renders the rings framing caption verbatim', () => {
+    const { getByText } = render(<ChooseDepthsSection />);
+    expect(
+      getByText(
+        'Turn any depth on or off whenever it fits your life. Turning one off is a choice, not a loss.',
+      ),
+    ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Floor statement
+// ---------------------------------------------------------------------------
+
+describe('ChooseDepthsSection — journal floor statement', () => {
+  it('renders testID "depths-floor-statement"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depths-floor-statement')).toBeTruthy();
+  });
+
+  it('the floor element carries accessibilityRole="text"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depths-floor-statement').props.accessibilityRole).toBe('text');
+  });
+
+  it('renders the floor line verbatim (em dash U+2014)', () => {
+    const { getByText } = render(<ChooseDepthsSection />);
+    expect(
+      getByText(
+        'Your journal is always here — the floor beneath everything. Nothing below is required.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('the floor statement is contained within the section', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    const section = getByTestId('settings-group-depths');
+    expect(within(section).getByTestId('depths-floor-statement')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ring row labels
+// ---------------------------------------------------------------------------
+
+describe('ChooseDepthsSection — ring row labels', () => {
+  it('renders the label "Habits"', () => {
+    const { getByText } = render(<ChooseDepthsSection />);
+    expect(getByText('Habits')).toBeTruthy();
+  });
+
+  it('renders the label "Practices"', () => {
+    const { getByText } = render(<ChooseDepthsSection />);
+    expect(getByText('Practices')).toBeTruthy();
+  });
+
+  it('renders the label "Course"', () => {
+    const { getByText } = render(<ChooseDepthsSection />);
+    expect(getByText('Course')).toBeTruthy();
+  });
+
+  it('renders the label "Sangha"', () => {
+    const { getByText } = render(<ChooseDepthsSection />);
+    expect(getByText('Sangha')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exactly four switch elements; no floor switch
+// ---------------------------------------------------------------------------
+
+describe('ChooseDepthsSection — switch count (journal floor is NOT a toggle)', () => {
+  it('renders exactly four elements with accessibilityRole="switch"', () => {
+    const { getAllByRole } = render(<ChooseDepthsSection />);
+    const switches = getAllByRole('switch');
+    expect(switches).toHaveLength(4);
+  });
+
+  it('does NOT render a switch with testID "depth-toggle-floor" or any floor-related switch', () => {
+    const { queryByTestId } = render(<ChooseDepthsSection />);
+    expect(queryByTestId('depth-toggle-floor')).toBeNull();
+  });
+
+  it('does NOT render a disabled switch (floor is text, not a greyed-out toggle)', () => {
+    const { getAllByRole } = render(<ChooseDepthsSection />);
+    const switches = getAllByRole('switch');
+    for (const sw of switches) {
+      expect(sw.props.accessibilityState?.disabled).not.toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Switch testIDs
+// ---------------------------------------------------------------------------
+
+describe('ChooseDepthsSection — switch testIDs', () => {
+  it('renders testID "depth-toggle-habits"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-habits')).toBeTruthy();
+  });
+
+  it('renders testID "depth-toggle-practices"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-practices')).toBeTruthy();
+  });
+
+  it('renders testID "depth-toggle-course"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-course')).toBeTruthy();
+  });
+
+  it('renders testID "depth-toggle-sangha"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-sangha')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UI reflects persisted store state (no local mirror)
+// ---------------------------------------------------------------------------
+
+describe('ChooseDepthsSection — renders store state, not local state', () => {
+  it('course switch is false when store reports enable_course: false', () => {
+    setMockState({ enable_course: false });
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    const courseSwitch = getByTestId('depth-toggle-course');
+    expect(courseSwitch.props.value).toBe(false);
+    expect(courseSwitch.props.accessibilityState.checked).toBe(false);
+  });
+
+  it('the other three switches remain true when only enable_course is false', () => {
+    setMockState({ enable_course: false });
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-habits').props.value).toBe(true);
+    expect(getByTestId('depth-toggle-practices').props.value).toBe(true);
+    expect(getByTestId('depth-toggle-sangha').props.value).toBe(true);
+  });
+
+  it('habits switch reflects enable_habits: false from store', () => {
+    setMockState({ enable_habits: false });
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-habits').props.value).toBe(false);
+    expect(getByTestId('depth-toggle-habits').props.accessibilityState.checked).toBe(false);
+  });
+
+  it('practices switch reflects enable_practices: false from store', () => {
+    setMockState({ enable_practices: false });
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-practices').props.value).toBe(false);
+    expect(getByTestId('depth-toggle-practices').props.accessibilityState.checked).toBe(false);
+  });
+
+  it('sangha switch reflects enable_sangha: false from store', () => {
+    setMockState({ enable_sangha: false });
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-sangha').props.value).toBe(false);
+    expect(getByTestId('depth-toggle-sangha').props.accessibilityState.checked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Load on mount
+// ---------------------------------------------------------------------------
+
+describe('ChooseDepthsSection — load on mount', () => {
+  it('calls store load(token) exactly once on mount', () => {
+    render(<ChooseDepthsSection />);
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+    expect(mockLoad).toHaveBeenCalledWith(mockToken);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-ring toggle dispatch
+// ---------------------------------------------------------------------------
+
+describe('ChooseDepthsSection — toggle dispatch: Habits', () => {
+  it('firing onValueChange(false) on the Habits switch calls update({ enable_habits: false }, token)', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    fireEvent(getByTestId('depth-toggle-habits'), 'valueChange', false);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith({ enable_habits: false }, mockToken);
+  });
+
+  it('firing onValueChange(true) on the Habits switch calls update({ enable_habits: true }, token)', () => {
+    setMockState({ enable_habits: false });
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    fireEvent(getByTestId('depth-toggle-habits'), 'valueChange', true);
+    expect(mockUpdate).toHaveBeenCalledWith({ enable_habits: true }, mockToken);
+  });
+});
+
+describe('ChooseDepthsSection — toggle dispatch: Practices', () => {
+  it('firing onValueChange(false) on the Practices switch calls update({ enable_practices: false }, token)', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    fireEvent(getByTestId('depth-toggle-practices'), 'valueChange', false);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith({ enable_practices: false }, mockToken);
+  });
+});
+
+describe('ChooseDepthsSection — toggle dispatch: Course', () => {
+  it('firing onValueChange(false) on the Course switch calls update({ enable_course: false }, token)', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    fireEvent(getByTestId('depth-toggle-course'), 'valueChange', false);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith({ enable_course: false }, mockToken);
+  });
+});
+
+describe('ChooseDepthsSection — toggle dispatch: Sangha', () => {
+  it('firing onValueChange(false) on the Sangha switch calls update({ enable_sangha: false }, token)', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    fireEvent(getByTestId('depth-toggle-sangha'), 'valueChange', false);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith({ enable_sangha: false }, mockToken);
+  });
+});
+
+describe('ChooseDepthsSection — toggle dispatch: key isolation', () => {
+  it('toggling Habits does NOT pass enable_practices key', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    fireEvent(getByTestId('depth-toggle-habits'), 'valueChange', false);
+    const calledWith = mockUpdate.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.keys(calledWith)).not.toContain('enable_practices');
+    expect(Object.keys(calledWith)).not.toContain('enable_course');
+    expect(Object.keys(calledWith)).not.toContain('enable_sangha');
+  });
+
+  it('toggling Sangha does NOT pass enable_habits key', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    fireEvent(getByTestId('depth-toggle-sangha'), 'valueChange', false);
+    const calledWith = mockUpdate.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.keys(calledWith)).not.toContain('enable_habits');
+    expect(Object.keys(calledWith)).not.toContain('enable_practices');
+    expect(Object.keys(calledWith)).not.toContain('enable_course');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accessibility — roles, labels, accessibilityState.checked, touch targets
+// ---------------------------------------------------------------------------
+
+describe('ChooseDepthsSection — accessibility: roles and labels', () => {
+  it('depth-toggle-habits has accessibilityRole="switch"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-habits').props.accessibilityRole).toBe('switch');
+  });
+
+  it('depth-toggle-practices has accessibilityRole="switch"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-practices').props.accessibilityRole).toBe('switch');
+  });
+
+  it('depth-toggle-course has accessibilityRole="switch"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-course').props.accessibilityRole).toBe('switch');
+  });
+
+  it('depth-toggle-sangha has accessibilityRole="switch"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-sangha').props.accessibilityRole).toBe('switch');
+  });
+
+  it('depth-toggle-habits has a non-empty accessibilityLabel containing "Habits"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    const label: string = getByTestId('depth-toggle-habits').props.accessibilityLabel;
+    expect(typeof label).toBe('string');
+    expect(label.length).toBeGreaterThan(0);
+    expect(label).toMatch(/Habits/);
+  });
+
+  it('depth-toggle-practices has a non-empty accessibilityLabel containing "Practices"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    const label: string = getByTestId('depth-toggle-practices').props.accessibilityLabel;
+    expect(label.length).toBeGreaterThan(0);
+    expect(label).toMatch(/Practices/);
+  });
+
+  it('depth-toggle-course has a non-empty accessibilityLabel containing "Course"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    const label: string = getByTestId('depth-toggle-course').props.accessibilityLabel;
+    expect(label.length).toBeGreaterThan(0);
+    expect(label).toMatch(/Course/);
+  });
+
+  it('depth-toggle-sangha has a non-empty accessibilityLabel containing "Sangha"', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    const label: string = getByTestId('depth-toggle-sangha').props.accessibilityLabel;
+    expect(label.length).toBeGreaterThan(0);
+    expect(label).toMatch(/Sangha/);
+  });
+});
+
+describe('ChooseDepthsSection — accessibility: accessibilityState.checked tracks value', () => {
+  it('checked is true for all four switches when all rings are on', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-habits').props.accessibilityState.checked).toBe(true);
+    expect(getByTestId('depth-toggle-practices').props.accessibilityState.checked).toBe(true);
+    expect(getByTestId('depth-toggle-course').props.accessibilityState.checked).toBe(true);
+    expect(getByTestId('depth-toggle-sangha').props.accessibilityState.checked).toBe(true);
+  });
+
+  it('checked matches value when all rings are off', () => {
+    setMockState({
+      enable_habits: false,
+      enable_practices: false,
+      enable_course: false,
+      enable_sangha: false,
+    });
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(getByTestId('depth-toggle-habits').props.accessibilityState.checked).toBe(false);
+    expect(getByTestId('depth-toggle-practices').props.accessibilityState.checked).toBe(false);
+    expect(getByTestId('depth-toggle-course').props.accessibilityState.checked).toBe(false);
+    expect(getByTestId('depth-toggle-sangha').props.accessibilityState.checked).toBe(false);
+  });
+});
+
+describe('ChooseDepthsSection — accessibility: touch targets ≥44dp', () => {
+  it('the Habits switch row meets the 44dp minimum touch target via minHeight', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(flatMinHeight(getByTestId('depth-row-habits'))).toBeGreaterThanOrEqual(
+      touchTarget.minimum,
+    );
+  });
+
+  it('the Practices switch row meets the 44dp minimum touch target via minHeight', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(flatMinHeight(getByTestId('depth-row-practices'))).toBeGreaterThanOrEqual(
+      touchTarget.minimum,
+    );
+  });
+
+  it('the Course switch row meets the 44dp minimum touch target via minHeight', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(flatMinHeight(getByTestId('depth-row-course'))).toBeGreaterThanOrEqual(
+      touchTarget.minimum,
+    );
+  });
+
+  it('the Sangha switch row meets the 44dp minimum touch target via minHeight', () => {
+    const { getByTestId } = render(<ChooseDepthsSection />);
+    expect(flatMinHeight(getByTestId('depth-row-sangha'))).toBeGreaterThanOrEqual(
+      touchTarget.minimum,
+    );
+  });
+});

--- a/frontend/src/features/Settings/__tests__/SettingsHubScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/SettingsHubScreen.test.tsx
@@ -11,7 +11,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('@/context/AuthContext', () => ({
-  useAuth: () => ({ logout: mockLogout }),
+  useAuth: () => ({ logout: mockLogout, token: 'hub-test-token' }),
 }));
 
 import SettingsHubScreen from '../SettingsHubScreen';
@@ -161,6 +161,30 @@ describe('SettingsHubScreen — Privacy section (issue #897)', () => {
     expect(getByTestId('settings-row-api-key')).toBeTruthy();
     expect(getByTestId('settings-group-session')).toBeTruthy();
     expect(getByTestId('settings-row-logout')).toBeTruthy();
+    expect(getByTestId('settings-group-support')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "Choose your depths" section in the hub (RED — fails until impl exists)
+// ---------------------------------------------------------------------------
+
+describe('SettingsHubScreen — Choose your depths section', () => {
+  test('renders the depths section with testID "settings-group-depths"', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    // Fails until ChooseDepthsSection is mounted inside SettingsHubScreen.
+    expect(getByTestId('settings-group-depths')).toBeTruthy();
+  });
+
+  test('regression: all pre-existing sections and rows still render after depths addition', () => {
+    const { getByTestId } = render(<SettingsHubScreen />);
+
+    expect(getByTestId('settings-group-account')).toBeTruthy();
+    expect(getByTestId('settings-row-api-key')).toBeTruthy();
+    expect(getByTestId('settings-group-session')).toBeTruthy();
+    expect(getByTestId('settings-row-logout')).toBeTruthy();
+    expect(getByTestId('settings-group-privacy')).toBeTruthy();
     expect(getByTestId('settings-group-support')).toBeTruthy();
   });
 });

--- a/frontend/src/store/useDepthPreferencesStore.ts
+++ b/frontend/src/store/useDepthPreferencesStore.ts
@@ -88,6 +88,20 @@ registerStoreReset(() => {
 });
 
 // ---------------------------------------------------------------------------
+// Stable action exports — module-level bound references to the store actions so
+// a consumer can call them without subscribing (they never change identity,
+// making them safe dependency-free deps in a mount-only effect).
+// ---------------------------------------------------------------------------
+
+/** Fetch the current ring toggles and replace local state with the result. */
+export const load = (token?: string): Promise<void> =>
+  useDepthPreferencesStore.getState().load(token);
+
+/** Flip one or more rings; stores the server's echoed full state on resolve. */
+export const update = (partial: DepthPreferencesUpdate, token?: string): Promise<void> =>
+  useDepthPreferencesStore.getState().update(partial, token);
+
+// ---------------------------------------------------------------------------
 // Selectors — narrow state subscriptions. Zustand compares the returned value
 // with ``Object.is``, so components re-render only when their slice changes.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Gives users a calm, non-shaming control surface to opt rings in or out (NORTH-STAR §3), consuming the depth-preferences store (#910).

- A **"Choose your depths"** section in the Settings hub toggles **Habits / Practices / Course / Sangha** independently via four switches. Each `onValueChange` calls `update({ enable_X: value }, token)`; the switch's value/`checked` derives from the store selector, so changes **persist via the API and take effect without a restart** (the store refetch-sets from the server echo). The section calls `load(token)` on mount.
- The **journal floor** is presented as an always-on informational line — **never a toggle** (not even a disabled one), so it can't read as gate-able. Copy frames turning a depth off as "a choice, not a loss"; no streak-shame/guilt/pressure language.
- Tokens-only; accessible — `accessibilityRole="switch"`, per-ring labels, `accessibilityState.checked`, 44dp touch targets. A `DepthToggleRow` sub-component keeps functions ≤50 lines.
- The store gains stable module-level `load`/`update` wrappers (delegating to `getState()`) that the section imports.

## Test plan
- 45 RTL tests: per-ring toggle dispatches the correct single-key partial + token; the UI reflects persisted store state; the journal floor is a `text` element with exactly four switches (no floor switch, no disabled switch); load-on-mount; switch a11y (role/label/checked) + 44dp; verbatim non-shaming copy; hub mounts `settings-group-depths`.
- `scripts/frontend/check-all.sh` exits 0 (eslint zero-warning, tsc strict, prettier, all 2395 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #911
Refs #907