### PR TITLE
feat(backend): compute per-Aspect wholeness and expose a wheel endpoint

### DIFF
--- a/backend/src/domain/wheel.py
+++ b/backend/src/domain/wheel.py
@@ -1,0 +1,64 @@
+"""Domain logic for the Wheel of Wholeness balance view.
+
+The wheel expresses per-Aspect *fullness*: for each of the ten stages, how
+engaged the user is (habits, practice, course), reusing the same
+``overall_progress`` signal the stage list already computes. Items are always
+returned in canonical stage order (1..10), never sorted by fullness, so the
+frontend can lay them out on a fixed wheel.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.constants import TOTAL_STAGES
+from domain.stage_progress import compute_stage_progress_batch
+from models.course_stage import CourseStage
+
+
+class WheelItem(TypedDict):
+    """One wheel item: its stage index, Aspect label, and fullness (0..1)."""
+
+    stage_number: int
+    aspect: str
+    fullness: float
+
+
+async def _aspect_labels_by_stage(
+    session: AsyncSession, stage_numbers: list[int]
+) -> dict[int, str]:
+    """Return ``{stage_number: aspect}`` for the given stages in one query."""
+    result = await session.execute(
+        select(CourseStage.stage_number, CourseStage.aspect).where(
+            col(CourseStage.stage_number).in_(stage_numbers)
+        )
+    )
+    return {row.stage_number: row.aspect for row in result.all()}
+
+
+async def compute_wheel_balance(session: AsyncSession, user_id: int) -> list[WheelItem]:
+    """Return per-Aspect fullness for all ten stages in canonical order.
+
+    Each item is ``{"stage_number", "aspect", "fullness"}``. ``fullness`` is the
+    stage's ``overall_progress`` from :func:`compute_stage_progress_batch` (a
+    single batched pass, no N+1); ``aspect`` is the stage's label from
+    ``CourseStage``. Stages with no engagement report ``0.0``. Ordering follows
+    ``stage_number`` ascending regardless of fullness.
+
+    ``aspect`` falls back to ``""`` only if a ``CourseStage`` row is absent for a
+    stage in 1..10 — a misconfigured-seed sentinel; the seeder guarantees all ten.
+    """
+    stage_numbers = list(range(1, TOTAL_STAGES + 1))
+    batch = await compute_stage_progress_batch(session, user_id, stage_numbers)
+    aspects = await _aspect_labels_by_stage(session, stage_numbers)
+    return [
+        {
+            "stage_number": stage_number,
+            "aspect": aspects.get(stage_number, ""),
+            "fullness": float(batch[stage_number]["overall_progress"]),
+        }
+        for stage_number in stage_numbers
+    ]

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -24,6 +24,7 @@ from domain.stage_progress import (
     is_stage_unlocked,
     stage_exists,
 )
+from domain.wheel import compute_wheel_balance
 from errors import bad_request, conflict, forbidden, not_found
 from models.course_stage import CourseStage
 from models.stage_progress import StageProgress
@@ -38,6 +39,7 @@ from schemas.stage import (
     StageProgressUpdate,
     StageResponse,
 )
+from schemas.wheel import WheelAspect, WheelBalanceResponse
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +154,21 @@ async def get_program_calendar(
         calendar_week=calendar_week(anchor),
         current_stage=progress.current_stage,
     )
+
+
+@router.get("/wheel", response_model=WheelBalanceResponse)
+async def get_wheel_balance(
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> WheelBalanceResponse:
+    """Per-Aspect fullness for all ten stages, in canonical stage order.
+
+    Registered ABOVE ``/{stage_number}`` so the static ``wheel`` path wins
+    route matching. Fullness reuses each stage's ``overall_progress`` signal;
+    a new user sees all zeros.
+    """
+    balance = await compute_wheel_balance(session, current_user)
+    return WheelBalanceResponse(aspects=[WheelAspect(**item) for item in balance])
 
 
 @router.get("/{stage_number}/progress", response_model=StageProgressResponse)

--- a/backend/src/schemas/wheel.py
+++ b/backend/src/schemas/wheel.py
@@ -1,0 +1,19 @@
+"""Response schemas for the Wheel of Wholeness balance view."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class WheelAspect(BaseModel):
+    """One Aspect's fullness at a stage, for the wheel layout."""
+
+    stage_number: int
+    aspect: str
+    fullness: float
+
+
+class WheelBalanceResponse(BaseModel):
+    """The ten Aspect fullness values in canonical stage order."""
+
+    aspects: list[WheelAspect]

--- a/backend/tests/domain/test_wheel.py
+++ b/backend/tests/domain/test_wheel.py
@@ -1,0 +1,337 @@
+"""Domain tests for the Wheel of Wholeness pure function: compute_wheel_balance."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, date, datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import JSON
+from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, col, select
+
+from domain.stage_progress import compute_stage_progress_batch
+from domain.wheel import compute_wheel_balance
+from models.content_completion import ContentCompletion
+from models.course_stage import CourseStage
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.practice import Practice
+from models.practice_session import PracticeSession
+from models.stage_content import StageContent
+from models.user_practice import UserPractice
+
+# Canonical ten Aspects in stage_number order (sourced from seed_stages.py)
+_CANONICAL_ASPECTS = [
+    "Body",  # stage 1
+    "Body",  # stage 2
+    "Emotion",  # stage 3
+    "Emotion",  # stage 4
+    "Mind",  # stage 5
+    "Mind",  # stage 6
+    "Spirit",  # stage 7
+    "Spirit",  # stage 8
+    "Nondual",  # stage 9
+    "Nondual",  # stage 10
+]
+
+_TOTAL_STAGES = 10
+_USER_A = 1
+_USER_B = 2
+
+
+def _replace_array_columns_for_sqlite() -> None:
+    """Swap PG ARRAY columns to JSON for SQLite test compatibility."""
+    for table in SQLModel.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, PG_ARRAY):
+                column.type = JSON()
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session, schema created fresh per test."""
+    _replace_array_columns_for_sqlite()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed_course_stage(s: AsyncSession, stage_number: int) -> CourseStage:
+    """Insert a CourseStage row so FK constraints and queries resolve."""
+    cs = CourseStage(
+        title=f"Stage {stage_number}",
+        subtitle="sub",
+        stage_number=stage_number,
+        overview_url="",
+        category="test",
+        aspect=_CANONICAL_ASPECTS[stage_number - 1],
+        spiral_dynamics_color="beige",
+        growing_up_stage="archaic",
+        divine_gender_polarity="masculine",
+        relationship_to_free_will="active",
+        free_will_description="desc",
+    )
+    s.add(cs)
+    await s.commit()
+    await s.refresh(cs)
+    return cs
+
+
+async def _seed_all_course_stages(s: AsyncSession) -> list[CourseStage]:
+    """Insert all ten CourseStage rows."""
+    return [await _seed_course_stage(s, n) for n in range(1, _TOTAL_STAGES + 1)]
+
+
+async def _seed_habit_with_completion(s: AsyncSession, user_id: int, stage_number: int) -> None:
+    """Seed one habit with one goal and one completion for the given stage."""
+    habit = Habit(
+        name=f"H-stage{stage_number}-user{user_id}",
+        icon="x",
+        start_date=date(2026, 1, 1),
+        energy_cost=1,
+        energy_return=1,
+        user_id=user_id,
+        stage=str(stage_number),
+        streak=0,
+    )
+    s.add(habit)
+    await s.commit()
+    await s.refresh(habit)
+    goal = Goal(
+        habit_id=habit.id,
+        title="g",
+        tier="t",
+        target=1,
+        target_unit="rep",
+        frequency=1,
+        frequency_unit="per_day",
+    )
+    s.add(goal)
+    await s.commit()
+    await s.refresh(goal)
+    s.add(GoalCompletion(goal_id=goal.id, user_id=user_id, completed_units=1))
+    await s.commit()
+
+
+async def _seed_practice_with_session(s: AsyncSession, user_id: int, stage_number: int) -> None:
+    """Seed a practice selection and one logged session for the given stage."""
+    practice = Practice(
+        stage_number=stage_number,
+        name=f"P-{stage_number}-{user_id}",
+        description="d",
+        instructions="i",
+        default_duration_minutes=5.0,
+        approved=True,
+    )
+    s.add(practice)
+    await s.commit()
+    await s.refresh(practice)
+    up = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=stage_number,
+        start_date=date(2026, 1, 1),
+    )
+    s.add(up)
+    await s.commit()
+    await s.refresh(up)
+    s.add(
+        PracticeSession(
+            user_id=user_id,
+            user_practice_id=up.id,
+            duration_minutes=5.0,
+            timestamp=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+    )
+    await s.commit()
+
+
+async def _seed_course_content_with_completion(
+    s: AsyncSession, user_id: int, stage_number: int
+) -> None:
+    """Seed one content item and mark it completed for the given stage."""
+    result = await s.execute(
+        select(CourseStage).where(col(CourseStage.stage_number) == stage_number)
+    )
+    cs = result.scalars().first()
+    if cs is None:
+        cs = await _seed_course_stage(s, stage_number)
+    content = StageContent(
+        course_stage_id=cs.id,
+        title="c1",
+        content_type="essay",
+        release_day=0,
+        url="u",
+    )
+    s.add(content)
+    await s.commit()
+    await s.refresh(content)
+    s.add(ContentCompletion(user_id=user_id, content_id=content.id))
+    await s.commit()
+
+
+# ── A. Domain tests ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wheel_empty_user_all_fullness_zero(session: AsyncSession) -> None:
+    """New user with no engagement → every Aspect fullness is 0.0."""
+    await _seed_all_course_stages(session)
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    assert len(result) == _TOTAL_STAGES
+    for item in result:
+        assert item["fullness"] == 0.0, f"stage {item['stage_number']} expected 0.0"
+
+
+@pytest.mark.asyncio
+async def test_wheel_single_aspect_engagement_isolates(session: AsyncSession) -> None:
+    """Engagement in exactly one stage → that Aspect > 0.0, the other nine = 0.0."""
+    await _seed_all_course_stages(session)
+    engaged_stage = 3
+    await _seed_habit_with_completion(session, _USER_A, engaged_stage)
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    assert len(result) == _TOTAL_STAGES
+    engaged_item = next(r for r in result if r["stage_number"] == engaged_stage)
+    assert engaged_item["fullness"] > 0.0
+    for item in result:
+        if item["stage_number"] != engaged_stage:
+            assert item["fullness"] == 0.0, (
+                f"stage {item['stage_number']} expected 0.0, got {item['fullness']}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_wheel_partial_engagement_reflects_batch_overall_progress(
+    session: AsyncSession,
+) -> None:
+    """Stages 2 and 5 engaged → their fullness matches batch overall_progress."""
+    await _seed_all_course_stages(session)
+    await _seed_habit_with_completion(session, _USER_A, 2)
+    await _seed_practice_with_session(session, _USER_A, 5)
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    stage2 = next(r for r in result if r["stage_number"] == 2)
+    stage5 = next(r for r in result if r["stage_number"] == 5)
+    assert stage2["fullness"] > 0.0
+    assert stage5["fullness"] > 0.0
+    # All other stages must remain at zero
+    for item in result:
+        if item["stage_number"] not in {2, 5}:
+            assert item["fullness"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_wheel_is_deterministic(session: AsyncSession) -> None:
+    """Same inputs produce identical output on repeated calls."""
+    await _seed_all_course_stages(session)
+    await _seed_habit_with_completion(session, _USER_A, 1)
+    await _seed_practice_with_session(session, _USER_A, 7)
+
+    first = await compute_wheel_balance(session, user_id=_USER_A)
+    second = await compute_wheel_balance(session, user_id=_USER_A)
+
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_wheel_order_is_canonical_not_by_fullness(session: AsyncSession) -> None:
+    """Items are ordered by stage_number 1..10 even when a later stage has higher fullness."""
+    await _seed_all_course_stages(session)
+    # Engage stage 8 (higher number) but not stage 1
+    await _seed_habit_with_completion(session, _USER_A, 8)
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    stage_numbers = [r["stage_number"] for r in result]
+    assert stage_numbers == list(range(1, _TOTAL_STAGES + 1)), (
+        f"expected canonical order 1..10, got {stage_numbers}"
+    )
+    # Stage 8 must have higher fullness than stage 1
+    s8 = next(r for r in result if r["stage_number"] == 8)
+    s1 = next(r for r in result if r["stage_number"] == 1)
+    assert s8["fullness"] > s1["fullness"]
+
+
+@pytest.mark.asyncio
+async def test_wheel_returns_exactly_ten_aspects(session: AsyncSession) -> None:
+    """The wheel always has exactly ten items, one per stage 1..10."""
+    await _seed_all_course_stages(session)
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    assert len(result) == _TOTAL_STAGES
+    stage_numbers = {r["stage_number"] for r in result}
+    assert stage_numbers == set(range(1, _TOTAL_STAGES + 1))
+
+
+@pytest.mark.asyncio
+async def test_wheel_items_carry_aspect_label(session: AsyncSession) -> None:
+    """Each result item exposes the aspect string from the CourseStage row."""
+    await _seed_all_course_stages(session)
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    for item in result:
+        expected_aspect = _CANONICAL_ASPECTS[item["stage_number"] - 1]
+        assert item["aspect"] == expected_aspect, (
+            f"stage {item['stage_number']}: expected aspect {expected_aspect!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_wheel_fullness_sourced_from_batch_overall_progress(
+    session: AsyncSession,
+) -> None:
+    """Fullness must equal the batch overall_progress (habits only = habit fraction)."""
+    await _seed_all_course_stages(session)
+    # Two habits for stage 4, one completed → habits_progress = 0.5
+    for i in range(2):
+        habit = Habit(
+            name=f"H4-{i}",
+            icon="x",
+            start_date=date(2026, 1, 1),
+            energy_cost=1,
+            energy_return=1,
+            user_id=_USER_A,
+            stage="4",
+            streak=0,
+        )
+        session.add(habit)
+        await session.commit()
+        await session.refresh(habit)
+        goal = Goal(
+            habit_id=habit.id,
+            title="g",
+            tier="t",
+            target=1,
+            target_unit="rep",
+            frequency=1,
+            frequency_unit="per_day",
+        )
+        session.add(goal)
+        await session.commit()
+        await session.refresh(goal)
+        if i == 0:
+            session.add(GoalCompletion(goal_id=goal.id, user_id=_USER_A, completed_units=1))
+            await session.commit()
+
+    batch = await compute_stage_progress_batch(session, _USER_A, list(range(1, 11)))
+    expected_stage4 = batch[4]["overall_progress"]
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+    stage4_item = next(r for r in result if r["stage_number"] == 4)
+
+    assert stage4_item["fullness"] == expected_stage4

--- a/backend/tests/test_wheel_api.py
+++ b/backend/tests/test_wheel_api.py
@@ -1,0 +1,267 @@
+"""Endpoint tests for GET /stages/wheel — Wheel of Wholeness balance."""
+
+from __future__ import annotations
+
+from datetime import date
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.course_stage import CourseStage
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+
+_TOTAL_STAGES = 10
+
+# Canonical aspect per stage (mirrors seed_stages.py)
+_CANONICAL_ASPECTS = [
+    "Body",
+    "Body",
+    "Emotion",
+    "Emotion",
+    "Mind",
+    "Mind",
+    "Spirit",
+    "Spirit",
+    "Nondual",
+    "Nondual",
+]
+
+
+def _stage_data(stage_number: int) -> dict[str, object]:
+    """Valid CourseStage fields for direct DB insertion."""
+    return {
+        "title": f"Stage {stage_number}",
+        "subtitle": "sub",
+        "stage_number": stage_number,
+        "overview_url": "",
+        "category": "test",
+        "aspect": _CANONICAL_ASPECTS[stage_number - 1],
+        "spiral_dynamics_color": "beige",
+        "growing_up_stage": "archaic",
+        "divine_gender_polarity": "masculine",
+        "relationship_to_free_will": "active",
+        "free_will_description": "desc",
+    }
+
+
+async def _signup(
+    client: AsyncClient,
+    username: str = "wheeluser",
+) -> tuple[dict[str, str], int]:
+    """Create a user and return (auth headers, user_id)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+async def _seed_all_stages(db_session: AsyncSession) -> None:
+    """Insert all ten CourseStage rows."""
+    for n in range(1, _TOTAL_STAGES + 1):
+        db_session.add(CourseStage(**_stage_data(n)))
+    await db_session.commit()
+
+
+async def _seed_habit_with_completion(
+    db_session: AsyncSession, user_id: int, stage_number: int
+) -> None:
+    """Seed one habit with one goal and one completion for the given stage."""
+    habit = Habit(
+        name=f"HW-{stage_number}-{user_id}",
+        icon="x",
+        start_date=date(2026, 1, 1),
+        energy_cost=1,
+        energy_return=1,
+        user_id=user_id,
+        stage=str(stage_number),
+        streak=0,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    goal = Goal(
+        habit_id=habit.id,
+        title="g",
+        tier="t",
+        target=1,
+        target_unit="rep",
+        frequency=1,
+        frequency_unit="per_day",
+    )
+    db_session.add(goal)
+    await db_session.commit()
+    await db_session.refresh(goal)
+    db_session.add(GoalCompletion(goal_id=goal.id, user_id=user_id, completed_units=1))
+    await db_session.commit()
+
+
+# ── B. Endpoint tests ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_requires_auth(async_client: AsyncClient) -> None:
+    """Missing token → 401."""
+    resp = await async_client.get("/stages/wheel")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_invalid_token_returns_401(async_client: AsyncClient) -> None:
+    """Invalid bearer token → 401."""
+    resp = await async_client.get(
+        "/stages/wheel", headers={"Authorization": "Bearer not-a-real-token"}
+    )
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_authed_returns_200(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Authenticated request → 200 with ten balance items."""
+    await _seed_all_stages(db_session)
+    headers, _uid = await _signup(async_client, "wheel_200")
+
+    resp = await async_client.get("/stages/wheel", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert "aspects" in data, f"response missing 'aspects' key: {data}"
+    assert len(data["aspects"]) == _TOTAL_STAGES
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_new_user_all_zero(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """New user → all ten fullness values are 0.0."""
+    await _seed_all_stages(db_session)
+    headers, _uid = await _signup(async_client, "wheel_newuser")
+
+    resp = await async_client.get("/stages/wheel", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    aspects = resp.json()["aspects"]
+    assert len(aspects) == _TOTAL_STAGES
+    for item in aspects:
+        assert item["fullness"] == 0.0, (
+            f"stage {item['stage_number']} expected 0.0 fullness, got {item['fullness']}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_canonical_stage_order(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Items are in stage_number 1..10 order, not sorted by fullness."""
+    await _seed_all_stages(db_session)
+    headers, user_id = await _signup(async_client, "wheel_order")
+    # Engage stage 9 so it has fullness > 0, earlier stages do not
+    await _seed_habit_with_completion(db_session, user_id, 9)
+
+    resp = await async_client.get("/stages/wheel", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    stage_numbers = [item["stage_number"] for item in resp.json()["aspects"]]
+    assert stage_numbers == list(range(1, _TOTAL_STAGES + 1))
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_response_schema_shape(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Each aspect item exposes exactly stage_number, aspect, and fullness fields."""
+    await _seed_all_stages(db_session)
+    headers, _uid = await _signup(async_client, "wheel_schema")
+
+    resp = await async_client.get("/stages/wheel", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    for item in resp.json()["aspects"]:
+        assert "stage_number" in item, f"missing stage_number: {item}"
+        assert "aspect" in item, f"missing aspect: {item}"
+        assert "fullness" in item, f"missing fullness: {item}"
+        assert isinstance(item["stage_number"], int)
+        assert isinstance(item["aspect"], str)
+        assert isinstance(item["fullness"], float)
+        assert 0.0 <= item["fullness"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_aspect_labels_match_stages(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Aspect strings in the response match the canonical stage-to-aspect mapping."""
+    await _seed_all_stages(db_session)
+    headers, _uid = await _signup(async_client, "wheel_aspect")
+
+    resp = await async_client.get("/stages/wheel", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    for item in resp.json()["aspects"]:
+        expected = _CANONICAL_ASPECTS[item["stage_number"] - 1]
+        assert item["aspect"] == expected, (
+            f"stage {item['stage_number']}: expected {expected!r}, got {item['aspect']!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_reflects_engagement(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Engaged stage shows fullness > 0.0; untouched stages remain 0.0."""
+    await _seed_all_stages(db_session)
+    headers, user_id = await _signup(async_client, "wheel_engagement")
+    engaged_stage = 6
+    await _seed_habit_with_completion(db_session, user_id, engaged_stage)
+
+    resp = await async_client.get("/stages/wheel", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    aspects = resp.json()["aspects"]
+    engaged = next(a for a in aspects if a["stage_number"] == engaged_stage)
+    assert engaged["fullness"] > 0.0
+    for item in aspects:
+        if item["stage_number"] != engaged_stage:
+            assert item["fullness"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_user_isolation(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """User A's engagement does not appear in User B's wheel response."""
+    await _seed_all_stages(db_session)
+    alice_headers, alice_id = await _signup(async_client, "wheel_alice")
+    bob_headers, _bob_id = await _signup(async_client, "wheel_bob")
+
+    # Only Alice engages stage 2
+    await _seed_habit_with_completion(db_session, alice_id, 2)
+
+    alice_resp = await async_client.get("/stages/wheel", headers=alice_headers)
+    bob_resp = await async_client.get("/stages/wheel", headers=bob_headers)
+
+    assert alice_resp.status_code == HTTPStatus.OK
+    assert bob_resp.status_code == HTTPStatus.OK
+
+    alice_stage2 = next(a for a in alice_resp.json()["aspects"] if a["stage_number"] == 2)
+    bob_stage2 = next(a for a in bob_resp.json()["aspects"] if a["stage_number"] == 2)
+    assert alice_stage2["fullness"] > 0.0
+    assert bob_stage2["fullness"] == 0.0


### PR DESCRIPTION
## Summary
The Map reads as **balance across the ten Aspects, not a ladder** (NORTH-STAR §5). Adds a per-Aspect fullness view built from existing engagement signals — **no new model, no migration**.

- `domain/wheel.py`: `compute_wheel_balance` reuses each stage's `overall_progress` (habits + practice + course) from `compute_stage_progress_batch` as its **fullness** (float 0..1), labelled with the stage's `CourseStage.aspect`. The ten items are always returned in **canonical stage order (1..10), never sorted by value** — balance, not ranking. **No N+1** (the batch's grouped queries + one aspect-label query = 4 queries, constant).
- `GET /stages/wheel` returns `{aspects: [...ten...]}` for the authenticated user, registered **above** `/{stage_number}` so the literal path wins route matching. A new user sees all fullness `0.0`; `user_id` comes only from the token (caller-only, 401 on unauth).
- Journal is intentionally omitted from fullness (no first-class per-stage journal linkage; a lossy join would mislead).

## Test plan
- 8 domain tests (empty → all 0.0; single-Aspect isolation; partial reflects batch `overall_progress`; determinism; canonical order even when a later stage has higher fullness; exactly ten) + 9 endpoint tests (shape, all ten in canonical order, new-user zeros, 401 missing/invalid token, caller-only isolation).
- `scripts/backend/check-all.sh` exits 0 (7/7). **xenon** standalone → `src/` rank A. mypy strict clean (via a `TypedDict` wheel item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #914
Refs #913