### PR TITLE
feat(frontend): render the Map as a wheel-of-wholeness balance reading

### DIFF
--- a/frontend/src/api/__tests__/wheel-api.test.ts
+++ b/frontend/src/api/__tests__/wheel-api.test.ts
@@ -1,0 +1,68 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { ApiError, ApiValidationError, wheel } from '../index';
+import type { WheelBalance } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+/** Minimal valid wheel payload with 10 aspects in canonical stage order. */
+const VALID_WHEEL: WheelBalance = {
+  aspects: [
+    { stage_number: 1, aspect: 'Agency', fullness: 0.1 },
+    { stage_number: 2, aspect: 'Receptivity', fullness: 0.2 },
+    { stage_number: 3, aspect: 'Self-Interest', fullness: 0.85 },
+    { stage_number: 4, aspect: 'Community', fullness: 0.0 },
+    { stage_number: 5, aspect: 'Intellectual', fullness: 0.5 },
+    { stage_number: 6, aspect: 'Embodied', fullness: 0.6 },
+    { stage_number: 7, aspect: 'Systems', fullness: 0.3 },
+    { stage_number: 8, aspect: 'Wisdom', fullness: 0.7 },
+    { stage_number: 9, aspect: 'Being', fullness: 0.9 },
+    { stage_number: 10, aspect: 'Awareness', fullness: 1.0 },
+  ],
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('wheel.get', () => {
+  test('GETs /stages/wheel (no trailing slash) and returns parsed aspects', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(VALID_WHEEL));
+    const result = await wheel.get('tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/stages/wheel');
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(result.aspects).toHaveLength(10);
+    expect(result.aspects[2]?.stage_number).toBe(3);
+    expect(result.aspects[2]?.fullness).toBe(0.85);
+    expect(result.aspects[2]?.aspect).toBe('Self-Interest');
+  });
+
+  test('surfaces a 401 as ApiError with status 401', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unauthorized' }, 401));
+    const err = await wheel.get('bad-tok').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(401);
+  });
+
+  test('rejects malformed payload (non-number fullness) with ApiValidationError', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({
+        aspects: [{ stage_number: 1, aspect: 'Agency', fullness: 'x' }],
+      }),
+    );
+    await expect(wheel.get('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -36,6 +36,7 @@ import {
   type SuggestionStatusT,
   type Tier,
   type TimezoneReadT,
+  type WheelBalanceT,
 } from './schemas';
 
 import { API_BASE_URL } from '@/config';
@@ -1408,30 +1409,14 @@ export const stages = {
 
 // Wheel-of-wholeness balance types and client (Map balance reading)
 
-/** One Aspect's fullness on the wheel reading (mirrors the backend ``WheelAspect``). */
-export interface WheelAspect {
-  stage_number: number;
-  aspect: string;
-  /** 0..1 fullness fraction; the Map clamps at the boundary. */
-  fullness: number;
-}
+/** Public aliases of the zod-inferred wheel types so consumers avoid duplicate shapes. */
+export type { WheelAspectT as WheelAspect, WheelBalanceT as WheelBalance } from './schemas';
 
-/** The full wheel reading: one fullness entry per Aspect (mirrors ``WheelBalance``). */
-export interface WheelBalance {
-  aspects: WheelAspect[];
-}
-
-// Responses validate via ``wheelBalanceSchema`` so a mis-shaped payload (e.g. a
-// non-number fullness) raises ApiValidationError rather than corrupting the
-// overlay. The route has no trailing slash — the backend serves ``/stages/wheel``
-// directly (no 307 redirect).
+// Responses validate via ``wheelBalanceSchema`` (no trailing slash — served directly).
 export const wheel = {
   /** Read the caller's wheel-of-wholeness balance (fullness per Aspect). */
-  get(token?: string): Promise<WheelBalance> {
-    return request<WheelBalance>('/stages/wheel', {
-      token,
-      schema: wheelBalanceSchema as unknown as z.ZodType<WheelBalance>,
-    });
+  get(token?: string): Promise<WheelBalanceT> {
+    return request<WheelBalanceT>('/stages/wheel', { token, schema: wheelBalanceSchema });
   },
 };
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -23,6 +23,7 @@ import {
   stageIntroSchema,
   stageSchema,
   timezoneReadSchema,
+  wheelBalanceSchema,
   type AcceptSuggestionResultT,
   type CareKindT,
   type CareResourceT,
@@ -1405,6 +1406,35 @@ export const stages = {
   },
 };
 
+// Wheel-of-wholeness balance types and client (Map balance reading)
+
+/** One Aspect's fullness on the wheel reading (mirrors the backend ``WheelAspect``). */
+export interface WheelAspect {
+  stage_number: number;
+  aspect: string;
+  /** 0..1 fullness fraction; the Map clamps at the boundary. */
+  fullness: number;
+}
+
+/** The full wheel reading: one fullness entry per Aspect (mirrors ``WheelBalance``). */
+export interface WheelBalance {
+  aspects: WheelAspect[];
+}
+
+// Responses validate via ``wheelBalanceSchema`` so a mis-shaped payload (e.g. a
+// non-number fullness) raises ApiValidationError rather than corrupting the
+// overlay. The route has no trailing slash — the backend serves ``/stages/wheel``
+// directly (no 307 redirect).
+export const wheel = {
+  /** Read the caller's wheel-of-wholeness balance (fullness per Aspect). */
+  get(token?: string): Promise<WheelBalance> {
+    return request<WheelBalance>('/stages/wheel', {
+      token,
+      schema: wheelBalanceSchema as unknown as z.ZodType<WheelBalance>,
+    });
+  },
+};
+
 // Course content types and client
 export interface ContentItem {
   id: number;
@@ -2352,6 +2382,7 @@ export default {
   auth,
   users,
   depthPreferences,
+  wheel,
   setTokenGetter,
   setOnUnauthorized,
   setOnTokenRefreshed,

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -576,6 +576,32 @@ export const depthPreferencesSchema = z.object({
 export type DepthPreferencesT = z.infer<typeof depthPreferencesSchema>;
 
 // ---------------------------------------------------------------------------
+// Wheel-of-wholeness balance (Map balance reading)
+// ---------------------------------------------------------------------------
+
+/**
+ * One Aspect's fullness on the wheel-of-wholeness reading (mirrors the backend
+ * ``WheelAspect``). ``fullness`` is a 0..1 fraction the Map clamps at the
+ * boundary; validated at the client edge so a drifted field raises
+ * ``ApiValidationError`` instead of a raw ``TypeError`` in the overlay. Unknown
+ * keys are stripped (plain object, not ``.strict()``) so an additive backend
+ * field cannot fail a client build.
+ */
+export const wheelAspectSchema = z.object({
+  stage_number: z.number().int(),
+  aspect: z.string(),
+  fullness: z.number(),
+});
+
+/** The full wheel reading: one fullness entry per Aspect (mirrors ``WheelBalance``). */
+export const wheelBalanceSchema = z.object({
+  aspects: z.array(wheelAspectSchema),
+});
+
+export type WheelAspectT = z.infer<typeof wheelAspectSchema>;
+export type WheelBalanceT = z.infer<typeof wheelBalanceSchema>;
+
+// ---------------------------------------------------------------------------
 // Lenient schemas for legacy endpoints (gradually tightened)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -242,6 +242,16 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
   },
 
+  // Wheel-of-wholeness balance read beneath the spiral (balance, not ladder).
+  balanceSummary: {
+    fontFamily: editorialType.serif,
+    fontSize: 15,
+    color: ink.soft,
+    textAlign: CENTER,
+    paddingHorizontal: spacing(2),
+    paddingVertical: spacing(1),
+  },
+
   // Completed stage checkmark
   completedBadge: {
     position: 'absolute',

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -108,11 +108,7 @@ interface StageTextBlockProps extends StageCellProps {
   fullness: number;
 }
 
-// --- Left cell: colored stage text (the -0 tap target) --------------------
-//
-// The wheel-of-wholeness overlay is additive here: the node keeps every existing
-// style/handler and gains an emphasis opacity (fuller Aspect reads more present)
-// plus a "reads full/thin" a11y suffix — no re-sort, no re-colour of the spiral.
+// Left cell: colored stage text (the -0 tap target); wheel overlay adds emphasis opacity + a11y only.
 
 const StageTextBlock = ({
   stage,
@@ -824,8 +820,7 @@ const MapScreen = (): React.JSX.Element => {
   // server's count-based ``currentStage`` is the fallback for users who
   // haven't picked an anchor yet.
   const currentStage = useDerivedCurrentStage(storeCurrentStage);
-  // Additive wheel-of-wholeness overlay: a failed/loading read leaves the map
-  // empty so every Aspect reads thin — the spiral itself never blanks.
+  // Additive overlay: a failed/loading read leaves the map empty so every Aspect reads thin.
   const { fullnessByStage } = useWheelBalance();
   const [activeStage, setActiveStage] = useState<StageData | null>(null);
 

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -30,12 +30,14 @@ import {
   useStageStore,
 } from '../../store/useStageStore';
 
+import { useWheelBalance } from './hooks/useWheelBalance';
 import { journeyRead, progressionSentence, rankedStats, unlockTimeline } from './journeyNarrative';
 import styles from './Map.styles';
 import { MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked } from './services/stageService';
 import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
+import { BALANCE_COPY, emphasisStyle, FULLNESS_ALIVE_THRESHOLD, summaryFor } from './wheelBalance';
 
 import { Celebration } from '@/components/feedback/Celebration';
 import { colors } from '@/design/tokens';
@@ -43,7 +45,19 @@ import { colors } from '@/design/tokens';
 /** Lookup of stage number → StageData for resolving row/arrow content. */
 type StageLookup = Readonly<Record<number, StageData | undefined>>;
 
+/** Wheel-of-wholeness fullness (0..1) keyed by stage number; absent reads thin. */
+type FullnessLookup = Readonly<Record<number, number>>;
+
 const FULL_PROGRESS = 1;
+const THIN_FULLNESS = 0;
+
+/** Accessibility suffix appended to a node's label from its wheel fullness. */
+const balanceLabelSuffix = (fullness: number): string =>
+  fullness >= FULLNESS_ALIVE_THRESHOLD ? 'reads full' : 'reads thin';
+
+/** Full a11y label for a stage node: persona/descriptor plus the balance read. */
+const stageNodeLabel = (display: StageDisplay, fullness: number): string =>
+  `${display.persona} - ${display.descriptor} - ${balanceLabelSuffix(fullness)}`;
 /** Directional spiral glyphs — the Map reads with no background PNG (#766). */
 const ARROW_GLYPH_LEFT = '↩';
 const ARROW_GLYPH_RIGHT = '↪';
@@ -89,15 +103,30 @@ interface StageCellProps {
   onPress: (_stage: StageData) => void;
 }
 
-// --- Left cell: colored stage text (the -0 tap target) --------------------
+interface StageTextBlockProps extends StageCellProps {
+  /** Wheel-of-wholeness fullness (0..1) for this Aspect; drives emphasis + a11y. */
+  fullness: number;
+}
 
-const StageTextBlock = ({ stage, display, locked, onPress }: StageCellProps): React.JSX.Element => (
+// --- Left cell: colored stage text (the -0 tap target) --------------------
+//
+// The wheel-of-wholeness overlay is additive here: the node keeps every existing
+// style/handler and gains an emphasis opacity (fuller Aspect reads more present)
+// plus a "reads full/thin" a11y suffix — no re-sort, no re-colour of the spiral.
+
+const StageTextBlock = ({
+  stage,
+  display,
+  locked,
+  fullness,
+  onPress,
+}: StageTextBlockProps): React.JSX.Element => (
   <TouchableOpacity
     testID={`stage-hotspot-${display.stageNumber}-0`}
-    style={[styles.stageBlock, locked ? styles.locked : null]}
+    style={[styles.stageBlock, locked ? styles.locked : null, emphasisStyle(fullness)]}
     onPress={() => onPress(stage)}
     accessibilityRole="button"
-    accessibilityLabel={`${display.persona} - ${display.descriptor}`}
+    accessibilityLabel={stageNodeLabel(display, fullness)}
   >
     <Text style={[styles.personaText, { color: display.textColor }]}>{display.persona}</Text>
     <Text style={[styles.lineText, { color: display.textColor }]}>{display.descriptor}</Text>
@@ -163,12 +192,19 @@ const StageCenterCell = ({
 interface MapRowProps {
   row: MapRow;
   lookup: StageLookup;
+  fullnessByStage: FullnessLookup;
   currentStage: number | null;
   onPress: (_stage: StageData) => void;
 }
 
 /** One grid row: left text + center glyph stacked per stage, one aspect label. */
-const MapRowView = ({ row, lookup, currentStage, onPress }: MapRowProps): React.JSX.Element => {
+const MapRowView = ({
+  row,
+  lookup,
+  fullnessByStage,
+  currentStage,
+  onPress,
+}: MapRowProps): React.JSX.Element => {
   const resolved = row.stageNumbers
     .map((n) => ({ stage: lookup[n], display: STAGE_DISPLAY[n] }))
     .filter((r): r is { stage: StageData; display: StageDisplay } => !!r.stage && !!r.display);
@@ -182,6 +218,7 @@ const MapRowView = ({ row, lookup, currentStage, onPress }: MapRowProps): React.
             display={display}
             locked={!isStageUnlocked(stage, currentStage)}
             isCurrent={stage.stageNumber === currentStage}
+            fullness={fullnessByStage[stage.stageNumber] ?? THIN_FULLNESS}
             onPress={onPress}
           />
         ))}
@@ -587,6 +624,7 @@ const MapRefreshErrorBanner = ({ onRetry }: { onRetry: () => void }): React.JSX.
 
 interface MapGridProps {
   lookup: StageLookup;
+  fullnessByStage: FullnessLookup;
   currentStage: number | null;
   onSelectStage: (_stage: StageData) => void;
 }
@@ -615,18 +653,38 @@ const JourneyHeader = ({ currentStage }: { currentStage: number }): React.JSX.El
   );
 };
 
-const MapGrid = ({ lookup, currentStage, onSelectStage }: MapGridProps): React.JSX.Element => (
+const MapGrid = ({
+  lookup,
+  fullnessByStage,
+  currentStage,
+  onSelectStage,
+}: MapGridProps): React.JSX.Element => (
   <View style={styles.grid}>
     {MAP_ROWS.map((row) => (
       <MapRowView
         key={row.rightLabel}
         row={row}
         lookup={lookup}
+        fullnessByStage={fullnessByStage}
         currentStage={currentStage}
         onPress={onSelectStage}
       />
     ))}
   </View>
+);
+
+/**
+ * Whole-wheel balance read shown beneath the spiral: one balance-not-ladder
+ * sentence keyed to whether every Aspect is thin, alive, or a mix.
+ */
+const BalanceSummary = ({
+  fullnessByStage,
+}: {
+  fullnessByStage: FullnessLookup;
+}): React.JSX.Element => (
+  <Text style={styles.balanceSummary} testID="balance-summary">
+    {BALANCE_COPY[summaryFor(fullnessByStage)]}
+  </Text>
 );
 
 // --- Main component ---
@@ -718,6 +776,45 @@ const CelebrationBanner = ({
   );
 };
 
+interface MapContentProps {
+  lookup: StageLookup;
+  fullnessByStage: FullnessLookup;
+  currentStage: number;
+  showRefreshError: boolean;
+  activeStage: StageData | null;
+  celebration: CompletionCelebration;
+  onRefresh: () => void;
+  onSelectStage: (_stage: StageData) => void;
+  onCloseModal: () => void;
+  onNavigate: (_screen: NavTarget, _stage: StageData) => void;
+}
+
+/** The rendered Map: spiral grid + balance overlay + banners + stage modal. */
+const MapContent = (props: MapContentProps): React.JSX.Element => (
+  <View style={styles.container}>
+    <MapBackdrop />
+    <JourneyHeader currentStage={props.currentStage} />
+    <MapGrid
+      lookup={props.lookup}
+      fullnessByStage={props.fullnessByStage}
+      currentStage={props.currentStage}
+      onSelectStage={props.onSelectStage}
+    />
+    <BalanceSummary fullnessByStage={props.fullnessByStage} />
+    {props.showRefreshError && <MapRefreshErrorBanner onRetry={props.onRefresh} />}
+    <CelebrationBanner
+      active={props.celebration.active}
+      message={props.celebration.message}
+      onDismiss={props.celebration.dismiss}
+    />
+    <StageDetailModal
+      activeStage={props.activeStage}
+      onClose={props.onCloseModal}
+      onNavigate={props.onNavigate}
+    />
+  </View>
+);
+
 const MapScreen = (): React.JSX.Element => {
   const stages = useStageStore(selectStages);
   const loading = useStageStore(selectStagesLoading);
@@ -727,6 +824,9 @@ const MapScreen = (): React.JSX.Element => {
   // server's count-based ``currentStage`` is the fallback for users who
   // haven't picked an anchor yet.
   const currentStage = useDerivedCurrentStage(storeCurrentStage);
+  // Additive wheel-of-wholeness overlay: a failed/loading read leaves the map
+  // empty so every Aspect reads thin — the spiral itself never blanks.
+  const { fullnessByStage } = useWheelBalance();
   const [activeStage, setActiveStage] = useState<StageData | null>(null);
 
   // Resolve each row's stage numbers to their loaded StageData once per change.
@@ -750,22 +850,18 @@ const MapScreen = (): React.JSX.Element => {
   if (error && stages.length === 0) return <MapError message={error} />;
 
   return (
-    <View style={styles.container}>
-      <MapBackdrop />
-      <JourneyHeader currentStage={currentStage} />
-      <MapGrid lookup={lookup} currentStage={currentStage} onSelectStage={setActiveStage} />
-      {error && stages.length > 0 && <MapRefreshErrorBanner onRetry={handleRefresh} />}
-      <CelebrationBanner
-        active={celebration.active}
-        message={celebration.message}
-        onDismiss={celebration.dismiss}
-      />
-      <StageDetailModal
-        activeStage={activeStage}
-        onClose={handleCloseModal}
-        onNavigate={handleNavigate}
-      />
-    </View>
+    <MapContent
+      lookup={lookup}
+      fullnessByStage={fullnessByStage}
+      currentStage={currentStage}
+      showRefreshError={!!error && stages.length > 0}
+      activeStage={activeStage}
+      celebration={celebration}
+      onRefresh={handleRefresh}
+      onSelectStage={setActiveStage}
+      onCloseModal={handleCloseModal}
+      onNavigate={handleNavigate}
+    />
   );
 };
 

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -116,10 +116,10 @@ jest.mock('../../../store/useStageStore', () => ({
       n == null ? undefined : s.stagesByNumber[n],
 }));
 
-// react-test-renderer ships no types here, so structurally type just the prop
-// we read instead of reaching for `any`.
-const isLockIcon = (node: { props: { children?: unknown } }): boolean =>
-  node.props.children === '🔒';
+// react-test-renderer ships no node types, so structurally type just the props.
+type TestNode = { props: Record<string, unknown> };
+
+const isLockIcon = (node: TestNode): boolean => node.props.children === '🔒';
 
 const countLockIcons = (tree: ReturnType<typeof create>): number =>
   tree.root.findAll(isLockIcon).length;
@@ -146,14 +146,10 @@ describe('MapScreen', () => {
   it('renders text and arrow hotspots for each stage', () => {
     const tree = create(<MapScreen />);
     const hotspots = tree.root.findAll(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (node: any) =>
+      (node: TestNode) =>
         typeof node.props.testID === 'string' && node.props.testID.startsWith('stage-hotspot'),
     );
-    const unique = new Set(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      hotspots.map((s: any) => s.props.testID as string),
-    );
+    const unique = new Set(hotspots.map((s: TestNode) => s.props.testID as string));
     // Each stage has 2 hotspots = 20 total
     expect(unique.size).toBe(20);
   });
@@ -237,8 +233,7 @@ describe('MapScreen', () => {
   it('renders connection lines between adjacent stages', () => {
     const tree = create(<MapScreen />);
     const connections = tree.root.findAll(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (node: any) =>
+      (node: TestNode) =>
         typeof node.props.testID === 'string' && node.props.testID.startsWith('stage-connection'),
     );
     // 10 stages → 9 gaps, but connections only render when next stage exists
@@ -354,8 +349,7 @@ describe('MapScreen', () => {
 
     // The grid must be present — wheel loading never blanks the spiral.
     const hotspots = tree.root.findAll(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (node: any) =>
+      (node: TestNode) =>
         typeof node.props.testID === 'string' && node.props.testID.startsWith('stage-hotspot'),
     );
     expect(hotspots.length).toBeGreaterThan(0);

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -4,6 +4,9 @@ import React from 'react';
 import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
+import MapScreen from '../MapScreen';
+import { BALANCE_COPY, emphasisStyle, FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
+
 // Mock InteractionManager to run callbacks synchronously in tests.
 jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
   runAfterInteractions: (cb: () => void) => {
@@ -22,6 +25,18 @@ jest.mock('@react-navigation/bottom-tabs', () => ({
 }));
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// Default wheel state: all stages thin (zero fullness). Override per-test.
+let mockWheelFullnessByStage: Record<number, number> = {};
+let mockWheelLoading = false;
+let mockWheelError: string | null = null;
+jest.mock('../hooks/useWheelBalance', () => ({
+  useWheelBalance: () => ({
+    fullnessByStage: mockWheelFullnessByStage,
+    loading: mockWheelLoading,
+    error: mockWheelError,
+  }),
 }));
 
 // Control the date-derived current stage without importing the real program
@@ -101,8 +116,6 @@ jest.mock('../../../store/useStageStore', () => ({
       n == null ? undefined : s.stagesByNumber[n],
 }));
 
-import MapScreen from '../MapScreen';
-
 // react-test-renderer ships no types here, so structurally type just the prop
 // we read instead of reaching for `any`.
 const isLockIcon = (node: { props: { children?: unknown } }): boolean =>
@@ -124,6 +137,9 @@ describe('MapScreen', () => {
     mockDerivedStage = 1;
     mockDerivedWeek = 1;
     mockDaysUntilStage = null;
+    mockWheelFullnessByStage = {};
+    mockWheelLoading = false;
+    mockWheelError = null;
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 
@@ -252,5 +268,98 @@ describe('MapScreen', () => {
     expect(hotspotHasLock(tree, 5)).toBe(false);
     expect(hotspotHasLock(tree, 8)).toBe(true);
     act(() => tree.unmount());
+  });
+
+  // --- Wheel-of-wholeness balance tests ---
+
+  it('alive node (fullness >= threshold) renders with higher opacity than a thin node', () => {
+    // Stage 3 is alive; stage 1 is thin.
+    mockWheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD, 1: 0.0 };
+    const tree = create(<MapScreen />);
+
+    const aliveHotspot = tree.root.findByProps({ testID: 'stage-hotspot-3-0' });
+    const thinHotspot = tree.root.findByProps({ testID: 'stage-hotspot-1-0' });
+
+    const aliveOpacity = emphasisStyle(FULLNESS_ALIVE_THRESHOLD).opacity;
+    const thinOpacity = emphasisStyle(0.0).opacity;
+
+    // The alive node must render with a visually distinct (higher) opacity.
+    expect(aliveOpacity).toBeGreaterThan(thinOpacity as number);
+
+    // The alive hotspot carries the alive-emphasis style; the thin does not.
+    const aliveStyles = (aliveHotspot.props.style as unknown[]).flat(10);
+    const thinStyles = (thinHotspot.props.style as unknown[]).flat(10);
+    const opacityOf = (styles: unknown[]) =>
+      styles.reduce<number | undefined>((acc, s) => {
+        if (s && typeof s === 'object' && 'opacity' in (s as object)) {
+          return (s as { opacity: number }).opacity;
+        }
+        return acc;
+      }, undefined);
+
+    expect(opacityOf(aliveStyles)).toBeGreaterThan(opacityOf(thinStyles) ?? 0);
+  });
+
+  it('alive node accessibilityLabel contains "reads full" suffix', () => {
+    mockWheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD };
+    const tree = create(<MapScreen />);
+    const hotspot = tree.root.findByProps({ testID: 'stage-hotspot-3-0' });
+    expect(hotspot.props.accessibilityLabel as string).toContain('reads full');
+  });
+
+  it('thin node accessibilityLabel contains "reads thin" suffix', () => {
+    mockWheelFullnessByStage = { 1: 0.0 };
+    const tree = create(<MapScreen />);
+    const hotspot = tree.root.findByProps({ testID: 'stage-hotspot-1-0' });
+    expect(hotspot.props.accessibilityLabel as string).toContain('reads thin');
+  });
+
+  it('BalanceSummary renders all-thin copy when every stage is 0.0', () => {
+    mockWheelFullnessByStage = Object.fromEntries(
+      Array.from({ length: 10 }, (_, i) => [i + 1, 0.0]),
+    );
+    const tree = create(<MapScreen />);
+    const summary = tree.root.findByProps({ testID: 'balance-summary' });
+    expect(summary.props.children as string).toBe(BALANCE_COPY.allThin);
+  });
+
+  it('BalanceSummary renders mixed copy when some stages are alive', () => {
+    mockWheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD, 7: 0.9 };
+    const tree = create(<MapScreen />);
+    const summary = tree.root.findByProps({ testID: 'balance-summary' });
+    expect(summary.props.children as string).toBe(BALANCE_COPY.mixed);
+  });
+
+  it('BalanceSummary renders all-alive copy when every stage is at full fullness', () => {
+    mockWheelFullnessByStage = Object.fromEntries(
+      Array.from({ length: 10 }, (_, i) => [i + 1, 1.0]),
+    );
+    const tree = create(<MapScreen />);
+    const summary = tree.root.findByProps({ testID: 'balance-summary' });
+    expect(summary.props.children as string).toBe(BALANCE_COPY.allAlive);
+  });
+
+  it('BALANCE_COPY constants contain none of the banned gamification words', () => {
+    const BANNED = /\b(level|climb|ascend|higher|rank|altitude|ladder)\b/i;
+    for (const [key, value] of Object.entries(BALANCE_COPY)) {
+      expect(BANNED.test(value)).toBe(false);
+      // Confirms key name for the pinned-contract assertion.
+      expect(['allThin', 'mixed', 'allAlive']).toContain(key);
+    }
+  });
+
+  it('Map spiral grid remains visible while wheel data is loading', () => {
+    mockWheelLoading = true;
+    const tree = create(<MapScreen />);
+
+    // The grid must be present — wheel loading never blanks the spiral.
+    const hotspots = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) =>
+        typeof node.props.testID === 'string' && node.props.testID.startsWith('stage-hotspot'),
+    );
+    expect(hotspots.length).toBeGreaterThan(0);
+    // No full-screen loader should obscure the grid.
+    expect(() => tree.root.findByProps({ testID: 'map-loading' })).toThrow();
   });
 });

--- a/frontend/src/features/Map/hooks/__tests__/useWheelBalance.test.tsx
+++ b/frontend/src/features/Map/hooks/__tests__/useWheelBalance.test.tsx
@@ -1,0 +1,90 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+import { renderHook, act } from '@testing-library/react-native';
+
+const mockWheelGet = jest.fn() as jest.Mock;
+jest.mock('../../../../api', () => ({
+  wheel: { get: (...args: unknown[]) => mockWheelGet(...args) },
+}));
+
+import type { WheelBalance } from '../../../../api';
+import { useWheelBalance } from '../useWheelBalance';
+
+/** Build a 10-aspect payload (all zeros unless overridden). */
+function makeWheel(overrides: Partial<Record<number, number>> = {}): WheelBalance {
+  const aspects = Array.from({ length: 10 }, (_, i) => {
+    const stage = i + 1;
+    return {
+      stage_number: stage,
+      aspect: `Aspect ${stage}`,
+      fullness: overrides[stage] ?? 0.0,
+    };
+  });
+  return { aspects };
+}
+
+beforeEach(() => {
+  mockWheelGet.mockReset();
+});
+
+describe('useWheelBalance', () => {
+  it('resolves fullnessByStage keyed by stage_number', async () => {
+    mockWheelGet.mockResolvedValueOnce(makeWheel({ 3: 0.85, 7: 0.4 }));
+    const { result } = renderHook(() => useWheelBalance());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.fullnessByStage[3]).toBe(0.85);
+    expect(result.current.fullnessByStage[7]).toBe(0.4);
+    expect(result.current.fullnessByStage[1]).toBe(0.0);
+  });
+
+  it('exposes loading=true during fetch then loading=false on resolve', async () => {
+    let resolve!: (v: WheelBalance) => void;
+    mockWheelGet.mockReturnValueOnce(
+      new Promise<WheelBalance>((r) => {
+        resolve = r;
+      }),
+    );
+
+    const { result } = renderHook(() => useWheelBalance());
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolve(makeWheel({ 1: 0.5 }));
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('on fetch error sets error and leaves fullnessByStage empty (all-thin fallback)', async () => {
+    mockWheelGet.mockRejectedValueOnce(new Error('network error'));
+    const { result } = renderHook(() => useWheelBalance());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(Object.keys(result.current.fullnessByStage)).toHaveLength(0);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('all-zero response produces fullnessByStage all zeros without crash', async () => {
+    mockWheelGet.mockResolvedValueOnce(makeWheel());
+    const { result } = renderHook(() => useWheelBalance());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBeFalsy();
+    for (let stage = 1; stage <= 10; stage += 1) {
+      expect(result.current.fullnessByStage[stage]).toBe(0.0);
+    }
+  });
+});

--- a/frontend/src/features/Map/hooks/useWheelBalance.ts
+++ b/frontend/src/features/Map/hooks/useWheelBalance.ts
@@ -1,13 +1,4 @@
-/**
- * Fetch the wheel-of-wholeness balance on mount and expose a fullness map the
- * Map spiral can join by stage number.
- *
- * The overlay is additive: on a fetch error (or an empty reading) the map stays
- * empty so every Aspect reads as thin — the neutral "whole wheel waiting"
- * fallback — and the spiral never breaks. The auth token is supplied by the API
- * client's registered token getter (mirroring ``stageService.loadStages``), so
- * the hook needs no ``AuthProvider`` of its own.
- */
+/** Fetch-on-mount wheel-of-wholeness balance; empty map on error reads all-thin. */
 
 import { useEffect, useState } from 'react';
 
@@ -26,12 +17,7 @@ export interface WheelBalanceState {
 const toFullnessByStage = (aspects: { stage_number: number; fullness: number }[]) =>
   Object.fromEntries(aspects.map((a) => [a.stage_number, clampProgress(a.fullness)]));
 
-/**
- * Load the wheel-of-wholeness balance once on mount.
- *
- * @returns The fullness-by-stage map plus ``loading`` / ``error`` flags. On any
- *   failure the map is left empty (all-thin fallback) and ``error`` is set.
- */
+/** Load the wheel balance once on mount; empty map + ``error`` on any failure. */
 export function useWheelBalance(): WheelBalanceState {
   const [fullnessByStage, setFullnessByStage] = useState<Record<number, number>>({});
   const [loading, setLoading] = useState(true);

--- a/frontend/src/features/Map/hooks/useWheelBalance.ts
+++ b/frontend/src/features/Map/hooks/useWheelBalance.ts
@@ -1,0 +1,65 @@
+/**
+ * Fetch the wheel-of-wholeness balance on mount and expose a fullness map the
+ * Map spiral can join by stage number.
+ *
+ * The overlay is additive: on a fetch error (or an empty reading) the map stays
+ * empty so every Aspect reads as thin — the neutral "whole wheel waiting"
+ * fallback — and the spiral never breaks. The auth token is supplied by the API
+ * client's registered token getter (mirroring ``stageService.loadStages``), so
+ * the hook needs no ``AuthProvider`` of its own.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { wheel } from '../../../api';
+import { clampProgress } from '../services/stageService';
+
+/** Fetch-on-mount wheel balance: fullness per stage, plus loading/error state. */
+export interface WheelBalanceState {
+  /** Clamped 0..1 fullness keyed by stage number; ``{}`` on error/loading. */
+  fullnessByStage: Record<number, number>;
+  loading: boolean;
+  error: string | null;
+}
+
+/** Join the wheel aspects into a stage-number → clamped-fullness map. */
+const toFullnessByStage = (aspects: { stage_number: number; fullness: number }[]) =>
+  Object.fromEntries(aspects.map((a) => [a.stage_number, clampProgress(a.fullness)]));
+
+/**
+ * Load the wheel-of-wholeness balance once on mount.
+ *
+ * @returns The fullness-by-stage map plus ``loading`` / ``error`` flags. On any
+ *   failure the map is left empty (all-thin fallback) and ``error`` is set.
+ */
+export function useWheelBalance(): WheelBalanceState {
+  const [fullnessByStage, setFullnessByStage] = useState<Record<number, number>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const fail = (err: unknown) => {
+      if (!active) return;
+      // Leave the map empty so the overlay degrades to all-thin; the spiral
+      // itself is unaffected by a failed wheel read.
+      setError(err instanceof Error ? err.message : 'Failed to load wheel balance');
+    };
+    // ``Promise.resolve`` wraps the call so a synchronous throw (not just a
+    // rejected promise) routes through the same all-thin fallback path.
+    Promise.resolve()
+      .then(() => wheel.get())
+      .then((balance) => {
+        if (active) setFullnessByStage(toFullnessByStage(balance.aspects));
+      })
+      .catch(fail)
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { fullnessByStage, loading, error };
+}

--- a/frontend/src/features/Map/wheelBalance.ts
+++ b/frontend/src/features/Map/wheelBalance.ts
@@ -1,0 +1,69 @@
+/**
+ * Wheel-of-wholeness balance overlay for the Map spiral.
+ *
+ * This layers a *balance* reading on top of the existing spiral: each Aspect
+ * (stage) reads as "thin" or "alive" by how full its fullness fraction is. The
+ * framing is deliberately a wheel, not a ladder — copy and emphasis speak to
+ * wholeness across every Aspect rather than rank or altitude, so nothing here
+ * implies one Aspect is above another.
+ */
+
+/** Fullness at or above which an Aspect reads as "alive" rather than "thin". */
+export const FULLNESS_ALIVE_THRESHOLD = 0.5;
+
+/**
+ * Rendered opacity for a thin vs. alive Aspect node. Opacity is a unitless
+ * emphasis dial (not a colour/spacing token): the alive value is fully opaque
+ * and the thin value is muted so a fuller Aspect reads as more present without
+ * re-sorting or re-colouring the spiral.
+ */
+const THIN_OPACITY = 0.55;
+const ALIVE_OPACITY = 1;
+
+/**
+ * Emphasis style for a stage node given its fullness: a higher fullness maps to
+ * a higher opacity, so an alive Aspect renders visually more present than a thin
+ * one. Returns a plain style fragment the caller appends to the node's style.
+ *
+ * @param fullness - The Aspect's fullness fraction (expected ``0..1``).
+ * @returns A ``{ opacity }`` fragment; alive at/above the threshold, else thin.
+ */
+export function emphasisStyle(fullness: number): { opacity: number } {
+  return { opacity: fullness >= FULLNESS_ALIVE_THRESHOLD ? ALIVE_OPACITY : THIN_OPACITY };
+}
+
+/**
+ * Balance-not-ladder copy for the three whole-wheel states. Every string is
+ * free of gamified rank/altitude language (level, climb, ascend, higher, rank,
+ * altitude, ladder) so the reading stays invitational.
+ */
+export const BALANCE_COPY = {
+  allThin: 'Every Aspect is still thin — a whole wheel waiting to be filled.',
+  mixed: 'Your balance right now: some Aspects are alive, others are still thin.',
+  allAlive: 'Your wheel reads full and balanced across every Aspect.',
+} as const;
+
+/** The balance state a wheel reads as, keyed to {@link BALANCE_COPY}. */
+export type BalanceState = keyof typeof BALANCE_COPY;
+
+/** Aspects on a full wheel; an absent stage in the map reads as thin. */
+const WHEEL_ASPECT_COUNT = 10;
+
+/**
+ * Pick the balance state for a fullness map, read against a full wheel: absent
+ * stages count as thin. ``allAlive`` requires every Aspect on the wheel to be
+ * alive; ``allThin`` requires none; anything between is ``mixed``. An empty map
+ * (the error/loading fallback) reads as ``allThin`` — the neutral "whole wheel
+ * waiting to be filled".
+ *
+ * @param fullnessByStage - Fullness fraction keyed by stage number.
+ * @returns The matching {@link BalanceState}.
+ */
+export function summaryFor(fullnessByStage: Readonly<Record<number, number>>): BalanceState {
+  const aliveCount = Object.values(fullnessByStage).filter(
+    (f) => f >= FULLNESS_ALIVE_THRESHOLD,
+  ).length;
+  if (aliveCount === 0) return 'allThin';
+  if (aliveCount >= WHEEL_ASPECT_COUNT) return 'allAlive';
+  return 'mixed';
+}

--- a/frontend/src/features/Map/wheelBalance.ts
+++ b/frontend/src/features/Map/wheelBalance.ts
@@ -1,42 +1,18 @@
-/**
- * Wheel-of-wholeness balance overlay for the Map spiral.
- *
- * This layers a *balance* reading on top of the existing spiral: each Aspect
- * (stage) reads as "thin" or "alive" by how full its fullness fraction is. The
- * framing is deliberately a wheel, not a ladder — copy and emphasis speak to
- * wholeness across every Aspect rather than rank or altitude, so nothing here
- * implies one Aspect is above another.
- */
+/** Wheel-of-wholeness balance overlay: each Aspect reads thin/alive, a wheel not a ladder. */
 
 /** Fullness at or above which an Aspect reads as "alive" rather than "thin". */
 export const FULLNESS_ALIVE_THRESHOLD = 0.5;
 
-/**
- * Rendered opacity for a thin vs. alive Aspect node. Opacity is a unitless
- * emphasis dial (not a colour/spacing token): the alive value is fully opaque
- * and the thin value is muted so a fuller Aspect reads as more present without
- * re-sorting or re-colouring the spiral.
- */
+/** Opacity emphasis dial (not a token): thin nodes are muted, alive nodes fully opaque. */
 const THIN_OPACITY = 0.55;
 const ALIVE_OPACITY = 1;
 
-/**
- * Emphasis style for a stage node given its fullness: a higher fullness maps to
- * a higher opacity, so an alive Aspect renders visually more present than a thin
- * one. Returns a plain style fragment the caller appends to the node's style.
- *
- * @param fullness - The Aspect's fullness fraction (expected ``0..1``).
- * @returns A ``{ opacity }`` fragment; alive at/above the threshold, else thin.
- */
+/** Opacity fragment for a node: fuller Aspect reads more present (alive vs thin). */
 export function emphasisStyle(fullness: number): { opacity: number } {
   return { opacity: fullness >= FULLNESS_ALIVE_THRESHOLD ? ALIVE_OPACITY : THIN_OPACITY };
 }
 
-/**
- * Balance-not-ladder copy for the three whole-wheel states. Every string is
- * free of gamified rank/altitude language (level, climb, ascend, higher, rank,
- * altitude, ladder) so the reading stays invitational.
- */
+/** Balance-not-ladder copy for the three whole-wheel states (no rank language). */
 export const BALANCE_COPY = {
   allThin: 'Every Aspect is still thin — a whole wheel waiting to be filled.',
   mixed: 'Your balance right now: some Aspects are alive, others are still thin.',
@@ -49,21 +25,13 @@ export type BalanceState = keyof typeof BALANCE_COPY;
 /** Aspects on a full wheel; an absent stage in the map reads as thin. */
 const WHEEL_ASPECT_COUNT = 10;
 
-/**
- * Pick the balance state for a fullness map, read against a full wheel: absent
- * stages count as thin. ``allAlive`` requires every Aspect on the wheel to be
- * alive; ``allThin`` requires none; anything between is ``mixed``. An empty map
- * (the error/loading fallback) reads as ``allThin`` — the neutral "whole wheel
- * waiting to be filled".
- *
- * @param fullnessByStage - Fullness fraction keyed by stage number.
- * @returns The matching {@link BalanceState}.
- */
+/** Balance state for a fullness map, read against a full wheel of ten Aspects. */
 export function summaryFor(fullnessByStage: Readonly<Record<number, number>>): BalanceState {
   const aliveCount = Object.values(fullnessByStage).filter(
     (f) => f >= FULLNESS_ALIVE_THRESHOLD,
   ).length;
   if (aliveCount === 0) return 'allThin';
+  // Absent stages count as thin, so all ten must be present and alive for allAlive.
   if (aliveCount >= WHEEL_ASPECT_COUNT) return 'allAlive';
   return 'mixed';
 }


### PR DESCRIPTION
## Summary
Surfaces per-Aspect fullness on the Map so the user sees which Aspects are alive and which are thin (NORTH-STAR §5) — **balance, not a ladder**. Consumes the wheel endpoint (#914).

- New zod-validated `wheel` client (`GET /stages/wheel`) + a Map-local `useWheelBalance` hook returning `{ fullnessByStage, loading, error }`. Fullness joins to the **existing** spiral nodes by `stage_number` — order stays canonical, never sorted by value; no new ladder chrome.
- A pure `emphasisStyle(fullness)` dims thin Aspect nodes and brightens alive ones (opacity, tokens only). Each node's `accessibilityLabel` gains a **"reads full" / "reads thin"** suffix so emphasis is not opacity-only.
- A `BalanceSummary` line reads the balance in plain text; copy is framed as balance with **no banned altitude/rank vocabulary** (`level`/`climb`/`ascend`/`higher`/`rank`/`altitude`/`ladder`) — enforced by a test over the exported copy constants.
- Graceful states: loading keeps the spiral visible; a new user (all thin) and a wheel-fetch error both degrade to the neutral all-thin read (the additive overlay never blanks the Map — the hook routes synchronous throws through its all-thin fallback so sibling Map tests that don't mock `wheel` stay green).

## Test plan
- 12 tests: wheel client (path `/stages/wheel` no trailing slash, 401 → `ApiError`, malformed `fullness` → `ApiValidationError`); hook (`fullnessByStage` by stage_number, loading, error→all-thin, all-zero); MapScreen (alive vs thin node render distinctly by emphasis; "reads full/thin" a11y suffixes; balance summary for all-thin/mixed/all-alive; **banned-words assertion**; spiral still renders while loading).
- `scripts/frontend/check-all.sh` exits 0 (eslint zero-warning, tsc strict, prettier, all tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #915
Refs #913