### PR TITLE
feat(backend): add cycle_number to StageProgress + migration

### DIFF
--- a/backend/migrations/versions/f2a3b4c5d6e8_add_stageprogress_cycle_number.py
+++ b/backend/migrations/versions/f2a3b4c5d6e8_add_stageprogress_cycle_number.py
@@ -1,0 +1,63 @@
+"""Add stageprogress.cycle_number loop index.
+
+Revision ID: f2a3b4c5d6e8
+Revises: e2f3a4b5c6d8
+Create Date: 2026-07-01 00:00:00.000000
+
+Adds the loop-index column ``cycle_number`` to ``stageprogress``. ``upgrade``
+adds it ``NOT NULL`` with a temporary ``server_default='1'`` so existing rows
+backfill to the first cycle, then drops the server default (the app owns the
+default via the model's ``Field`` default, keeping ``alembic check`` drift-free),
+then installs a CHECK pinning the value to ``>= 1`` — mirroring the constraint
+in the model's ``__table_args__``. ``downgrade`` drops the CHECK and the column.
+This is a data-model change only; the progression/loop behaviour lands in a
+later issue.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f2a3b4c5d6e8"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "e2f3a4b5c6d8"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CYCLE_CHECK = "ck_stageprogress_cycle_number_positive"
+_CYCLE_CONDITION = "cycle_number >= 1"
+
+
+def upgrade() -> None:
+    """Add ``stageprogress.cycle_number`` (NOT NULL, backfilled 1) + CHECK."""
+    # Add with a server_default so the NOT NULL column backfills existing rows to
+    # the first cycle (1).
+    op.add_column(
+        "stageprogress",
+        sa.Column(
+            "cycle_number",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+        ),
+    )
+    # Drop the DB-level server_default (the app owns the default via the model's
+    # Field default, keeping ``alembic check`` drift-free) and install the CHECK
+    # in a single batch rebuild so SQLite (round-trip test) stays compatible.
+    with op.batch_alter_table("stageprogress") as batch_op:
+        batch_op.alter_column(
+            "cycle_number",
+            existing_type=sa.Integer(),
+            existing_nullable=False,
+            server_default=None,
+        )
+        batch_op.create_check_constraint(_CYCLE_CHECK, _CYCLE_CONDITION)
+
+
+def downgrade() -> None:
+    """Drop the cycle_number CHECK and column."""
+    # Batch mode keeps the downgrade SQLite-compatible (no ALTER/DROP CHECK there).
+    with op.batch_alter_table("stageprogress") as batch_op:
+        batch_op.drop_constraint(_CYCLE_CHECK, type_="check")
+        batch_op.drop_column("cycle_number")

--- a/backend/src/models/stage_progress.py
+++ b/backend/src/models/stage_progress.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, DateTime, Integer
+from sqlalchemy import CheckConstraint, Column, DateTime, Integer
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
 
 class StageProgress(SQLModel, table=True):
     """Tracks which stage a user is currently working on and which stages have been completed."""
+
+    __table_args__ = (
+        CheckConstraint("cycle_number >= 1", name="ck_stageprogress_cycle_number_positive"),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     current_stage: int
@@ -32,5 +36,7 @@ class StageProgress(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=True),
     )
+    # Loop index for the 36-week arc; progression/loop logic lands in a later issue.
+    cycle_number: int = Field(default=1, ge=1)
     user_id: int = Field(foreign_key="user.id", unique=True, ondelete="CASCADE")
     user: "User" = Relationship(back_populates="stage_progress")

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -216,6 +216,7 @@ def _bootstrap_record(existing: StageProgress) -> StageProgressRecord:
         user_id=existing.user_id,
         current_stage=existing.current_stage,
         completed_stages=existing.completed_stages,
+        cycle_number=existing.cycle_number,
     )
 
 
@@ -302,6 +303,7 @@ async def _advance_existing_progress(
         user_id=existing.user_id,
         current_stage=existing.current_stage,
         completed_stages=existing.completed_stages,
+        cycle_number=existing.cycle_number,
     )
 
 

--- a/backend/src/schemas/stage.py
+++ b/backend/src/schemas/stage.py
@@ -76,6 +76,7 @@ class StageProgressRecord(BaseModel):
     user_id: int
     current_stage: int
     completed_stages: list[int]
+    cycle_number: int = Field(default=1, ge=1)
 
 
 class PracticeHistoryItem(BaseModel):

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1213,6 +1213,11 @@ def test_journal_classification_migration_round_trip_on_sqlite(
 _USER_DEPTH_PREFS_BASE_REVISION = "d8e9f0a1b2c3"  # pragma: allowlist secret
 _USER_DEPTH_PREFS_REVISION = "e2f3a4b5c6d8"  # pragma: allowlist secret
 
+# stageprogress-01: add cycle_number column (NOT NULL, server_default=1, CHECK >= 1).
+_STAGEPROGRESS_CYCLE_BASE_REVISION = "e2f3a4b5c6d8"  # pragma: allowlist secret
+# The implementer must replace this with the real revision ID they author.
+_STAGEPROGRESS_CYCLE_REVISION = "f2a3b4c5d6e8"  # pragma: allowlist secret
+
 
 def _bootstrap_user_table_for_depth_prefs(sync_url: str) -> None:
     """Pre-create a minimal ``user`` table with two seeded rows.
@@ -1325,3 +1330,123 @@ def test_user_depth_prefs_migration_round_trip_on_sqlite(
     for row in rows_again:
         assert bool(row["enable_habits"]) is True
         assert bool(row["enable_sangha"]) is True
+
+
+# -- stageprogress-01 cycle_number column migration round-trip ----------------
+
+
+def _bootstrap_stageprogress_table(sync_url: str) -> None:
+    """Pre-create a minimal ``stageprogress`` table with one legacy row.
+
+    Mirrors the schema in place just before the cycle_number migration runs.
+    One existing row is seeded without cycle_number so the upgrade backfill
+    can be observed. The user FK is created as a standalone table; SQLite
+    FK enforcement is off by default so referential integrity is not the
+    concern here.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE user ( id INTEGER PRIMARY KEY, email VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(text("INSERT INTO user (id, email) VALUES (1, 'legacy@example.com')"))
+        conn.execute(
+            text(
+                "CREATE TABLE stageprogress ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL UNIQUE,"
+                " current_stage INTEGER NOT NULL,"
+                " completed_stages TEXT NOT NULL DEFAULT '[]',"
+                " stage_started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                " program_started_at DATETIME"
+                ")"
+            )
+        )
+        conn.execute(
+            text("INSERT INTO stageprogress (id, user_id, current_stage) VALUES (1, 1, 1)")
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_stageprogress_cycle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite Alembic config positioned just before the cycle_number migration.
+
+    Bootstraps a minimal ``stageprogress`` table with one legacy row (no
+    ``cycle_number`` column) and stamps the DB at ``e2f3a4b5c6d8`` (the
+    current chain head before this migration) so the round-trip exercises
+    only the new migration.
+    """
+    db_path = tmp_path / "stageprogress_cycle_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_stageprogress_table(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _STAGEPROGRESS_CYCLE_BASE_REVISION)
+    return cfg
+
+
+def _stageprogress_row(db_url: str, row_id: int) -> dict[str, Any]:
+    """Fetch a ``stageprogress`` row including the new cycle_number column."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        "SELECT id, current_stage, cycle_number FROM stageprogress WHERE id = :id"
+                    ),
+                    {"id": row_id},
+                )
+                .mappings()
+                .first()
+            )
+            assert row is not None
+            return dict(row)
+    finally:
+        engine.dispose()
+
+
+def test_stageprogress_cycle_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_stageprogress_cycle: Config,
+) -> None:
+    """Round-trip the cycle_number migration: upgrade adds column + backfills; downgrade drops it.
+
+    Phase 1: upgrade adds ``cycle_number`` NOT NULL and backfills the
+    pre-existing legacy row to 1.
+    Phase 2: downgrade removes the column.
+    Phase 3: re-upgrade is idempotent — the backfill re-runs cleanly.
+
+    This test fails until the implementer authors the migration and sets
+    ``_STAGEPROGRESS_CYCLE_REVISION`` to its real revision ID.
+    """
+    cfg = alembic_sqlite_config_stageprogress_cycle
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade adds the column and backfills the legacy row.
+    command.upgrade(cfg, _STAGEPROGRESS_CYCLE_REVISION)
+    cols = _columns_of(db_url, "stageprogress")
+    assert "cycle_number" in cols
+
+    row = _stageprogress_row(db_url, row_id=1)
+    assert row["cycle_number"] == 1, "Upgrade must backfill pre-existing rows to 1."
+
+    # Phase 2: downgrade drops the cycle_number column.
+    command.downgrade(cfg, _STAGEPROGRESS_CYCLE_BASE_REVISION)
+    cols_after = _columns_of(db_url, "stageprogress")
+    assert "cycle_number" not in cols_after
+
+    # Phase 3: re-upgrade — backfill must reproduce the same value.
+    command.upgrade(cfg, _STAGEPROGRESS_CYCLE_REVISION)
+    row_after = _stageprogress_row(db_url, row_id=1)
+    assert row_after["cycle_number"] == 1

--- a/backend/tests/test_stage_progress_model.py
+++ b/backend/tests/test_stage_progress_model.py
@@ -1,0 +1,74 @@
+"""Data-layer tests for StageProgress.cycle_number.
+
+Covers:
+- Default persistence to 1 when cycle_number is omitted.
+- CHECK-constraint rejection of cycle_number=0.
+- Named constraint is present on the mapped table.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import SQLModel
+
+from models.stage_progress import StageProgress
+from models.user import User
+
+
+async def _user(session: AsyncSession, email: str = "cycle@example.com") -> int:
+    """Persist a minimal user and return its id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.flush()
+    assert user.id is not None
+    return user.id
+
+
+def _progress(user_id: int, **kwargs: object) -> StageProgress:
+    """Build a StageProgress with sensible defaults and given overrides."""
+    base: dict[str, object] = {
+        "user_id": user_id,
+        "current_stage": 1,
+        "completed_stages": [],
+    }
+    base.update(kwargs)
+    return StageProgress(**base)
+
+
+@pytest.mark.asyncio
+async def test_cycle_number_defaults_to_one(db_session: AsyncSession) -> None:
+    """A StageProgress created without cycle_number persists with cycle_number == 1."""
+    user_id = await _user(db_session)
+    db_session.add(_progress(user_id))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(StageProgress))).scalar_one()
+    assert row.cycle_number == 1
+
+
+@pytest.mark.asyncio
+async def test_cycle_number_zero_violates_check_constraint(db_session: AsyncSession) -> None:
+    """Inserting cycle_number=0 must raise IntegrityError via the positive CHECK."""
+    user_id = await _user(db_session)
+    db_session.add(_progress(user_id, cycle_number=0))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_cycle_number_negative_violates_check_constraint(db_session: AsyncSession) -> None:
+    """Inserting a negative cycle_number must raise IntegrityError."""
+    user_id = await _user(db_session, email="cycle2@example.com")
+    db_session.add(_progress(user_id, cycle_number=-1))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+def test_check_constraint_name_is_present_on_table() -> None:
+    """The named CHECK constraint must exist on the stageprogress table."""
+    table = SQLModel.metadata.tables["stageprogress"]
+    names = {c.name for c in table.constraints}
+    assert "ck_stageprogress_cycle_number_positive" in names

--- a/backend/tests/test_stage_progress_schema.py
+++ b/backend/tests/test_stage_progress_schema.py
@@ -1,0 +1,78 @@
+"""Schema-layer tests for StageProgressRecord.cycle_number.
+
+Covers:
+- StageProgressRecord exposes cycle_number with default 1.
+- Constructing StageProgressRecord with cycle_number=0 raises ValidationError (ge=1).
+- Constructing StageProgressRecord with a negative cycle_number raises ValidationError.
+- cycle_number is serialised in model_dump output.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.stage import StageProgressRecord
+
+
+class TestStageProgressRecordCycleNumber:
+    """StageProgressRecord cycle_number field behaviours."""
+
+    def test_cycle_number_field_present(self) -> None:
+        """StageProgressRecord model_fields must include 'cycle_number'."""
+        assert "cycle_number" in StageProgressRecord.model_fields
+
+    def test_cycle_number_defaults_to_one(self) -> None:
+        """Omitting cycle_number produces a record with cycle_number == 1."""
+        record = StageProgressRecord(
+            id=1,
+            user_id=42,
+            current_stage=1,
+            completed_stages=[],
+        )
+        assert record.cycle_number == 1
+
+    def test_cycle_number_zero_raises_validation_error(self) -> None:
+        """cycle_number=0 must be rejected (ge=1 constraint)."""
+        with pytest.raises(ValidationError):
+            StageProgressRecord(
+                id=1,
+                user_id=42,
+                current_stage=1,
+                completed_stages=[],
+                cycle_number=0,
+            )
+
+    def test_cycle_number_negative_raises_validation_error(self) -> None:
+        """Negative cycle_number must be rejected (ge=1 constraint)."""
+        with pytest.raises(ValidationError):
+            StageProgressRecord(
+                id=1,
+                user_id=42,
+                current_stage=1,
+                completed_stages=[],
+                cycle_number=-5,
+            )
+
+    def test_cycle_number_one_is_valid(self) -> None:
+        """cycle_number=1 (the minimum) must be accepted."""
+        record = StageProgressRecord(
+            id=1,
+            user_id=42,
+            current_stage=1,
+            completed_stages=[],
+            cycle_number=1,
+        )
+        assert record.cycle_number == 1
+
+    def test_cycle_number_serialised_in_model_dump(self) -> None:
+        """model_dump must include cycle_number so the JSON response carries it."""
+        record = StageProgressRecord(
+            id=7,
+            user_id=3,
+            current_stage=2,
+            completed_stages=[1],
+        )
+        dumped = record.model_dump()
+        assert "cycle_number" in dumped
+        assert dumped["cycle_number"] == 1

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -633,6 +633,44 @@ _CONCURRENT_FIRST_ADVANCE_FANOUT = 5
 
 
 @pytest.mark.asyncio
+async def test_update_progress_response_includes_cycle_number(
+    async_client: AsyncClient,
+) -> None:
+    """PUT /stages/progress response JSON must include cycle_number == 1."""
+    headers, _user_id = await _signup(async_client, "cycleboot")
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 1},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert "cycle_number" in data
+    assert data["cycle_number"] == 1
+
+
+@pytest.mark.asyncio
+async def test_advancing_stage_does_not_change_cycle_number(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Advancing from stage 1 to 2 leaves cycle_number unchanged at 1."""
+    headers, user_id = await _signup(async_client, "cycleadvance")
+    progress = StageProgress(user_id=user_id, current_stage=1, completed_stages=[])
+    db_session.add(progress)
+    await db_session.commit()
+
+    resp = await async_client.put(
+        "/stages/progress",
+        json={"current_stage": 2},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data["cycle_number"] == 1
+
+
+@pytest.mark.asyncio
 @pytest.mark.usefixtures("disable_rate_limit")
 async def test_concurrent_first_advance_yields_one_progress_row(
     concurrent_async_client: AsyncClient,


### PR DESCRIPTION
## Summary
Gives `StageProgress` a loop index so the 36-week arc can eventually repeat (NORTH-STAR §8). **Field only — loop logic is the next issue (#918); no progression behavior change.**

- **Model**: `cycle_number` int, default `1`, `>= 1` — enforced both at the Pydantic boundary (`ge=1`) and the DB (a table CHECK `ck_stageprogress_cycle_number_positive`).
- **Migration `f2a3b4c5d6e8`** (down_revision `e2f3a4b5c6d8`, collision-checked, single head preserved): adds the column NOT NULL with `server_default '1'` to **backfill existing rows to 1**, then drops the server default and creates the CHECK via `batch_alter_table` (SQLite round-trip). The model owns `default=1`, so `alembic check` stays drift-free.
- **Serialization**: exposed additively (default `1`) in `StageProgressRecord` only, and carried through **unchanged** at both router construction sites — no client break, no mutation on advance.

## Test plan
- 13 tests: model default=1; `ge=1` rejects 0/negative; DB CHECK rejects `cycle_number=0` (`IntegrityError`); the named constraint is present; schema field present/default/serialized; migration round-trip (upgrade adds + backfills a legacy row to 1, downgrade drops, re-upgrade idempotent); `PUT /stages/progress` response includes `cycle_number`; advancing a stage leaves it unchanged.
- `scripts/backend/check-all.sh` exits 0 (7/7). **xenon** standalone → `src/` rank A. Single alembic head. Model↔migration parity is drift-free (CI's Postgres `migration-drift` job runs the authoritative `alembic check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #917
Refs #916