### PR TITLE
feat(frontend): warm begin-again affordance + cycle indicator

### DIFF
--- a/frontend/src/api/__tests__/beginAgain-api.test.ts
+++ b/frontend/src/api/__tests__/beginAgain-api.test.ts
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { ApiValidationError, stages } from '../index';
+import type { StageProgressRecord } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+const VALID_RECORD: StageProgressRecord = {
+  id: 1,
+  user_id: 42,
+  current_stage: 1,
+  completed_stages: [],
+  cycle_number: 2,
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('stages.beginAgain', () => {
+  test('POSTs to /stages/begin-again (exact path, no trailing slash)', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(VALID_RECORD));
+    await stages.beginAgain();
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://test/stages/begin-again');
+    expect(init.method).toBe('POST');
+  });
+
+  test('returns a parsed StageProgressRecord with cycle_number', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(VALID_RECORD));
+    const result = await stages.beginAgain();
+
+    expect(result.cycle_number).toBe(2);
+    expect(result.current_stage).toBe(1);
+    expect(result.id).toBe(1);
+    expect(result.user_id).toBe(42);
+    expect(result.completed_stages).toEqual([]);
+  });
+
+  test('cycle_number increments: cycle 3 response parses correctly', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ ...VALID_RECORD, cycle_number: 3 }));
+    const result = await stages.beginAgain();
+    expect(result.cycle_number).toBe(3);
+  });
+
+  test('rejects a non-number cycle_number with ApiValidationError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ ...VALID_RECORD, cycle_number: 'not-a-number' }));
+    await expect(stages.beginAgain()).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('rejects a missing id field with ApiValidationError', async () => {
+    const { id: _omit, ...withoutId } = VALID_RECORD;
+    void _omit;
+    mockFetch.mockReturnValueOnce(jsonResponse(withoutId));
+    await expect(stages.beginAgain()).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('rejects a non-array completed_stages with ApiValidationError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ ...VALID_RECORD, completed_stages: 'nope' }));
+    await expect(stages.beginAgain()).rejects.toBeInstanceOf(ApiValidationError);
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -21,6 +21,7 @@ import {
   promptListResponseSchema,
   resonanceResponseSchema,
   stageIntroSchema,
+  stageProgressRecordSchema,
   stageSchema,
   timezoneReadSchema,
   wheelBalanceSchema,
@@ -33,6 +34,7 @@ import {
   type DepthPreferencesT,
   type Page,
   type PasswordResetAcceptedT,
+  type StageProgressRecordT,
   type SuggestionStatusT,
   type Tier,
   type TimezoneReadT,
@@ -1405,7 +1407,18 @@ export const stages = {
   history(stageNumber: number, token?: string): Promise<StageHistoryResponse> {
     return request<StageHistoryResponse>(`/stages/${stageNumber}/history`, { token });
   },
+  /** Open a fresh cycle through the arc; returns the reset progress record. */
+  beginAgain(token?: string): Promise<StageProgressRecordT> {
+    return request<StageProgressRecordT>('/stages/begin-again', {
+      method: 'POST',
+      token,
+      schema: stageProgressRecordSchema,
+    });
+  },
 };
+
+/** Public alias of the zod-inferred stage-progress type so consumers avoid a duplicate shape. */
+export type { StageProgressRecordT as StageProgressRecord } from './schemas';
 
 // Wheel-of-wholeness balance types and client (Map balance reading)
 

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -296,6 +296,17 @@ export const stageSchema = z.object({
   progress: z.number(),
 });
 
+/** A user's stage-progress record (mirrors the backend ``StageProgressRecord``). */
+export const stageProgressRecordSchema = z.object({
+  id: z.number(),
+  user_id: z.number(),
+  current_stage: z.number(),
+  completed_stages: z.array(z.number()),
+  cycle_number: z.number(),
+});
+
+export type StageProgressRecordT = z.infer<typeof stageProgressRecordSchema>;
+
 /** A catalog practice (mirrors ``PracticeItem``); exported for reuse (issue 06). */
 export const practiceItemSchema = z.object({
   id: z.number().int(),

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -241,6 +241,35 @@ const styles = StyleSheet.create({
     color: ink.primary,
     letterSpacing: 0.5,
   },
+  // Subtle "Cycle N" caption in the journey header (a wheel, not a rank).
+  cycleIndicator: {
+    fontFamily: editorialType.serif,
+    fontSize: 12,
+    color: ink.muted,
+    marginTop: spacing(0.25),
+    letterSpacing: 0.5,
+  },
+
+  // --- Begin-again affordance (end-of-arc, declinable) ----------------------
+  beginAgain: {
+    marginTop: spacing(1.5),
+    alignItems: CENTER,
+    gap: spacing(0.5),
+  },
+  beginAgainHeading: {
+    fontFamily: editorialType.serif,
+    fontSize: 16,
+    fontWeight: '700',
+    color: onShowcase.primary,
+    textAlign: CENTER,
+  },
+  beginAgainBody: {
+    fontFamily: editorialType.serif,
+    fontSize: 13,
+    lineHeight: 20,
+    color: onShowcase.soft,
+    textAlign: CENTER,
+  },
 
   // Wheel-of-wholeness balance read beneath the spiral (balance, not ladder).
   balanceSummary: {

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -24,21 +24,24 @@ import {
 } from '../../store/useProgramProgression';
 import {
   selectCurrentStage,
+  selectCycleNumber,
   selectStages,
   selectStagesError,
   selectStagesLoading,
   useStageStore,
 } from '../../store/useStageStore';
 
+import { BEGIN_AGAIN_COPY, cycleLabel } from './beginAgain';
 import { useWheelBalance } from './hooks/useWheelBalance';
 import { journeyRead, progressionSentence, rankedStats, unlockTimeline } from './journeyNarrative';
 import styles from './Map.styles';
 import { MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
-import { stageService, isStageUnlocked } from './services/stageService';
+import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
 import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
 import { BALANCE_COPY, emphasisStyle, FULLNESS_ALIVE_THRESHOLD, summaryFor } from './wheelBalance';
 
+import { Button } from '@/components/Button';
 import { Celebration } from '@/components/feedback/Celebration';
 import { colors } from '@/design/tokens';
 
@@ -639,15 +642,43 @@ const MapBackdrop = (): React.JSX.Element =>
     <View style={styles.backdrop} testID="map-background" pointerEvents="none" />
   );
 
+/** The first pass through the arc; cycles beyond it earn the subtle indicator. */
+const FIRST_CYCLE = 1;
+
+interface JourneyHeaderProps {
+  currentStage: number;
+  cycleNumber: number;
+}
+
 /** Compact momentum read at the top of the Map: "Stage N of 10 · Week W". */
-const JourneyHeader = ({ currentStage }: { currentStage: number }): React.JSX.Element => {
+const JourneyHeader = ({ currentStage, cycleNumber }: JourneyHeaderProps): React.JSX.Element => {
   const week = useDerivedCurrentWeek(1);
   return (
     <View style={styles.journeyHeader} testID="journey-read">
       <Text style={styles.journeyReadText}>{journeyRead(currentStage, week, STAGE_COUNT)}</Text>
+      {cycleNumber > FIRST_CYCLE ? (
+        <Text style={styles.cycleIndicator} testID="cycle-indicator">
+          {cycleLabel(cycleNumber)}
+        </Text>
+      ) : null}
     </View>
   );
 };
+
+/** End-of-arc "begin again" affordance: a gentle, declinable invitation the user chooses — never auto-invoked. */
+const BeginAgainBlock = ({ onBeginAgain }: { onBeginAgain: () => void }): React.JSX.Element => (
+  <View style={styles.beginAgain} testID="begin-again">
+    <Text style={styles.beginAgainHeading}>{BEGIN_AGAIN_COPY.heading}</Text>
+    <Text style={styles.beginAgainBody}>{BEGIN_AGAIN_COPY.body}</Text>
+    <Button
+      label={BEGIN_AGAIN_COPY.action}
+      variant="tertiary"
+      onPress={onBeginAgain}
+      testID="begin-again-button"
+      accessibilityLabel="Begin again — start a new cycle through the arc"
+    />
+  </View>
+);
 
 const MapGrid = ({
   lookup,
@@ -776,10 +807,13 @@ interface MapContentProps {
   lookup: StageLookup;
   fullnessByStage: FullnessLookup;
   currentStage: number;
+  cycleNumber: number;
+  showBeginAgain: boolean;
   showRefreshError: boolean;
   activeStage: StageData | null;
   celebration: CompletionCelebration;
   onRefresh: () => void;
+  onBeginAgain: () => void;
   onSelectStage: (_stage: StageData) => void;
   onCloseModal: () => void;
   onNavigate: (_screen: NavTarget, _stage: StageData) => void;
@@ -789,7 +823,7 @@ interface MapContentProps {
 const MapContent = (props: MapContentProps): React.JSX.Element => (
   <View style={styles.container}>
     <MapBackdrop />
-    <JourneyHeader currentStage={props.currentStage} />
+    <JourneyHeader currentStage={props.currentStage} cycleNumber={props.cycleNumber} />
     <MapGrid
       lookup={props.lookup}
       fullnessByStage={props.fullnessByStage}
@@ -797,6 +831,7 @@ const MapContent = (props: MapContentProps): React.JSX.Element => (
       onSelectStage={props.onSelectStage}
     />
     <BalanceSummary fullnessByStage={props.fullnessByStage} />
+    {props.showBeginAgain && <BeginAgainBlock onBeginAgain={props.onBeginAgain} />}
     {props.showRefreshError && <MapRefreshErrorBanner onRetry={props.onRefresh} />}
     <CelebrationBanner
       active={props.celebration.active}
@@ -816,6 +851,7 @@ const MapScreen = (): React.JSX.Element => {
   const loading = useStageStore(selectStagesLoading);
   const error = useStageStore(selectStagesError);
   const storeCurrentStage = useStageStore(selectCurrentStage);
+  const cycleNumber = useStageStore(selectCycleNumber);
   // Prefer the date-driven stage when the master anchor is set; the
   // server's count-based ``currentStage`` is the fallback for users who
   // haven't picked an anchor yet.
@@ -837,6 +873,7 @@ const MapScreen = (): React.JSX.Element => {
   }, [stages.length, loading]);
 
   const handleRefresh = useCallback(() => void stageService.loadStages(), []);
+  const handleBeginAgain = useCallback(() => void stageService.beginAgain(), []);
   const handleCloseModal = useCallback(() => setActiveStage(null), []);
   const handleNavigate = useStageNavigation(handleCloseModal);
   const celebration = useStageCompletionCelebration(stages, lookup);
@@ -849,10 +886,13 @@ const MapScreen = (): React.JSX.Element => {
       lookup={lookup}
       fullnessByStage={fullnessByStage}
       currentStage={currentStage}
+      cycleNumber={cycleNumber}
+      showBeginAgain={isEndOfCycle(lookup, currentStage)}
       showRefreshError={!!error && stages.length > 0}
       activeStage={activeStage}
       celebration={celebration}
       onRefresh={handleRefresh}
+      onBeginAgain={handleBeginAgain}
       onSelectStage={setActiveStage}
       onCloseModal={handleCloseModal}
       onNavigate={handleNavigate}

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../store/useStageStore';
 
 import { BEGIN_AGAIN_COPY, cycleLabel } from './beginAgain';
+import { useBeginAgainGuard } from './hooks/useBeginAgainGuard';
 import { useWheelBalance } from './hooks/useWheelBalance';
 import { journeyRead, progressionSentence, rankedStats, unlockTimeline } from './journeyNarrative';
 import styles from './Map.styles';
@@ -666,7 +667,13 @@ const JourneyHeader = ({ currentStage, cycleNumber }: JourneyHeaderProps): React
 };
 
 /** End-of-arc "begin again" affordance: a gentle, declinable invitation the user chooses — never auto-invoked. */
-const BeginAgainBlock = ({ onBeginAgain }: { onBeginAgain: () => void }): React.JSX.Element => (
+const BeginAgainBlock = ({
+  onBeginAgain,
+  beginning,
+}: {
+  onBeginAgain: () => void;
+  beginning: boolean;
+}): React.JSX.Element => (
   <View style={styles.beginAgain} testID="begin-again">
     <Text style={styles.beginAgainHeading}>{BEGIN_AGAIN_COPY.heading}</Text>
     <Text style={styles.beginAgainBody}>{BEGIN_AGAIN_COPY.body}</Text>
@@ -674,6 +681,9 @@ const BeginAgainBlock = ({ onBeginAgain }: { onBeginAgain: () => void }): React.
       label={BEGIN_AGAIN_COPY.action}
       variant="tertiary"
       onPress={onBeginAgain}
+      // Disable while the first POST is in flight so a double-press can't
+      // advance the cycle twice before ``loadStages`` hides this button.
+      disabled={beginning}
       testID="begin-again-button"
       accessibilityLabel="Begin again — start a new cycle through the arc"
     />
@@ -809,6 +819,7 @@ interface MapContentProps {
   currentStage: number;
   cycleNumber: number;
   showBeginAgain: boolean;
+  beginning: boolean;
   showRefreshError: boolean;
   activeStage: StageData | null;
   celebration: CompletionCelebration;
@@ -831,7 +842,9 @@ const MapContent = (props: MapContentProps): React.JSX.Element => (
       onSelectStage={props.onSelectStage}
     />
     <BalanceSummary fullnessByStage={props.fullnessByStage} />
-    {props.showBeginAgain && <BeginAgainBlock onBeginAgain={props.onBeginAgain} />}
+    {props.showBeginAgain && (
+      <BeginAgainBlock onBeginAgain={props.onBeginAgain} beginning={props.beginning} />
+    )}
     {props.showRefreshError && <MapRefreshErrorBanner onRetry={props.onRefresh} />}
     <CelebrationBanner
       active={props.celebration.active}
@@ -859,6 +872,7 @@ const MapScreen = (): React.JSX.Element => {
   // Additive overlay: a failed/loading read leaves the map empty so every Aspect reads thin.
   const { fullnessByStage } = useWheelBalance();
   const [activeStage, setActiveStage] = useState<StageData | null>(null);
+  const { beginning, handleBeginAgain } = useBeginAgainGuard();
 
   // Resolve each row's stage numbers to their loaded StageData once per change.
   const lookup = useMemo<StageLookup>(
@@ -873,7 +887,6 @@ const MapScreen = (): React.JSX.Element => {
   }, [stages.length, loading]);
 
   const handleRefresh = useCallback(() => void stageService.loadStages(), []);
-  const handleBeginAgain = useCallback(() => void stageService.beginAgain(), []);
   const handleCloseModal = useCallback(() => setActiveStage(null), []);
   const handleNavigate = useStageNavigation(handleCloseModal);
   const celebration = useStageCompletionCelebration(stages, lookup);
@@ -888,6 +901,7 @@ const MapScreen = (): React.JSX.Element => {
       currentStage={currentStage}
       cycleNumber={cycleNumber}
       showBeginAgain={isEndOfCycle(lookup, currentStage)}
+      beginning={beginning}
       showRefreshError={!!error && stages.length > 0}
       activeStage={activeStage}
       celebration={celebration}

--- a/frontend/src/features/Map/__tests__/MapHistory.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapHistory.test.tsx
@@ -72,6 +72,7 @@ const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
 const mockLoadStages = jest.fn();
 jest.mock('../services/stageService', () => ({
   stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+  isEndOfCycle: () => false,
   isStageUnlocked: (
     stage: { isUnlocked: boolean; stageNumber: number },
     currentStage: number | null,

--- a/frontend/src/features/Map/__tests__/MapJourney.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapJourney.test.tsx
@@ -86,6 +86,7 @@ let mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
 const mockLoadStages = jest.fn();
 jest.mock('../services/stageService', () => ({
   stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+  isEndOfCycle: () => false,
   isStageUnlocked: (
     stage: { isUnlocked: boolean; stageNumber: number },
     currentStage: number | null,

--- a/frontend/src/features/Map/__tests__/MapRetry.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapRetry.test.tsx
@@ -81,6 +81,7 @@ let mockError: string | null = null;
 
 jest.mock('../services/stageService', () => ({
   stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+  isEndOfCycle: () => false,
   isStageUnlocked: (
     stage: { isUnlocked: boolean; stageNumber: number },
     currentStage: number | null,

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -79,13 +79,24 @@ function mockMakeStage(stageNumber: number) {
 
 const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
 
+let mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
+  () => false,
+);
+let mockCycleNumber = 1;
+
 const mockLoadStages = jest.fn();
+const mockBeginAgain = jest.fn();
 jest.mock('../services/stageService', () => ({
-  stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+  stageService: {
+    loadStages: (...args: unknown[]) => mockLoadStages(...args),
+    beginAgain: (...args: unknown[]) => mockBeginAgain(...args),
+  },
   isStageUnlocked: (
     stage: { isUnlocked: boolean; stageNumber: number },
     currentStage: number | null,
   ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
+  isEndOfCycle: (stagesByNumber: Record<number, { progress: number }>, currentStage: number) =>
+    mockIsEndOfCycle(stagesByNumber, currentStage),
 }));
 
 const buildMockStageState = () => ({
@@ -95,11 +106,13 @@ const buildMockStageState = () => ({
   currentStage: 1,
   loading: false,
   error: null,
+  cycleNumber: mockCycleNumber,
   setStages: jest.fn(),
   setCurrentStage: jest.fn(),
   setLoading: jest.fn(),
   setError: jest.fn(),
   updateStageProgress: jest.fn(),
+  setCycleNumber: jest.fn(),
 });
 
 jest.mock('../../../store/useStageStore', () => ({
@@ -111,6 +124,7 @@ jest.mock('../../../store/useStageStore', () => ({
   selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
   selectStagesLoading: (s: { loading: unknown }) => s.loading,
   selectStagesError: (s: { error: unknown }) => s.error,
+  selectCycleNumber: (s: { cycleNumber: number }) => s.cycleNumber,
   selectStageByNumber:
     (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>
       n == null ? undefined : s.stagesByNumber[n],
@@ -134,6 +148,11 @@ describe('MapScreen', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
     mockLoadStages.mockClear();
+    mockBeginAgain.mockClear();
+    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
+      () => false,
+    );
+    mockCycleNumber = 1;
     mockDerivedStage = 1;
     mockDerivedWeek = 1;
     mockDaysUntilStage = null;
@@ -355,5 +374,56 @@ describe('MapScreen', () => {
     expect(hotspots.length).toBeGreaterThan(0);
     // No full-screen loader should obscure the grid.
     expect(() => tree.root.findByProps({ testID: 'map-loading' })).toThrow();
+  });
+
+  // --- begin-again affordance ---
+
+  it('shows begin-again-button at end of cycle', () => {
+    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(() => true);
+    const tree = create(<MapScreen />);
+    const btn = tree.root.findByProps({ testID: 'begin-again-button' });
+    expect(btn).toBeTruthy();
+  });
+
+  it('pressing begin-again-button calls stageService.beginAgain', () => {
+    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(() => true);
+    mockBeginAgain.mockResolvedValue(undefined);
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'begin-again-button' }).props.onPress();
+    });
+    expect(mockBeginAgain).toHaveBeenCalledTimes(1);
+  });
+
+  it('begin-again-button is absent mid-cycle', () => {
+    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
+      () => false,
+    );
+    const tree = create(<MapScreen />);
+    expect(
+      tree.root.findAll((n: TestNode) => n.props.testID === 'begin-again-button'),
+    ).toHaveLength(0);
+  });
+
+  // --- cycle-indicator ---
+
+  it('shows cycle-indicator with "Cycle 2" when cycleNumber is 2', () => {
+    mockCycleNumber = 2;
+    const tree = create(<MapScreen />);
+    const indicator = tree.root.findByProps({ testID: 'cycle-indicator' });
+    expect(indicator).toBeTruthy();
+    const flat = (indicator.props.children as unknown[]).flat
+      ? (indicator.props.children as unknown[]).flat(10)
+      : [indicator.props.children];
+    const text = flat.join('');
+    expect(text).toContain('Cycle 2');
+  });
+
+  it('cycle-indicator is absent when cycleNumber is 1', () => {
+    mockCycleNumber = 1;
+    const tree = create(<MapScreen />);
+    expect(tree.root.findAll((n: TestNode) => n.props.testID === 'cycle-indicator')).toHaveLength(
+      0,
+    );
   });
 });

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -13,6 +13,8 @@ jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
     cb();
     return { then: () => {}, done: () => {}, cancel: () => {} };
   },
+  createInteractionHandle: () => 1,
+  clearInteractionHandle: () => {},
 }));
 
 // Mock navigation so we can observe tab linking behaviour.
@@ -393,6 +395,31 @@ describe('MapScreen', () => {
       tree.root.findByProps({ testID: 'begin-again-button' }).props.onPress();
     });
     expect(mockBeginAgain).toHaveBeenCalledTimes(1);
+  });
+
+  it('double-pressing begin-again-button sends exactly one request', () => {
+    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(() => true);
+    // Never-resolving so the in-flight guard stays true across both presses;
+    // the second tap must be a no-op or a second POST would skip a cycle.
+    mockBeginAgain.mockReturnValue(new Promise<void>(() => {}));
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'begin-again-button' }).props.onPress();
+      tree.root.findByProps({ testID: 'begin-again-button' }).props.onPress();
+    });
+    expect(mockBeginAgain).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables begin-again-button while a begin-again request is in flight', () => {
+    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(() => true);
+    mockBeginAgain.mockReturnValue(new Promise<void>(() => {}));
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'begin-again-button' }).props.onPress();
+    });
+    const btn = tree.root.findByProps({ testID: 'begin-again-button' });
+    // The Button node carries the in-flight guard via its ``disabled`` prop.
+    expect(btn.props.disabled).toBe(true);
   });
 
   it('begin-again-button is absent mid-cycle', () => {

--- a/frontend/src/features/Map/__tests__/beginAgain.test.ts
+++ b/frontend/src/features/Map/__tests__/beginAgain.test.ts
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { BEGIN_AGAIN_COPY, cycleLabel } from '../beginAgain';
+
+const BANNED =
+  /\b(level|climb|ascend|higher|rank|altitude|ladder|streak|forever|fall behind|miss out|keep going|must|don.t lose)\b/i;
+
+describe('BEGIN_AGAIN_COPY', () => {
+  it('exports heading, body, and action keys', () => {
+    expect(typeof BEGIN_AGAIN_COPY.heading).toBe('string');
+    expect(typeof BEGIN_AGAIN_COPY.body).toBe('string');
+    expect(typeof BEGIN_AGAIN_COPY.action).toBe('string');
+    expect(Object.keys(BEGIN_AGAIN_COPY).sort()).toEqual(['action', 'body', 'heading'].sort());
+  });
+
+  it('heading contains no banned ladder/streak/FOMO vocabulary', () => {
+    expect(BANNED.test(BEGIN_AGAIN_COPY.heading)).toBe(false);
+  });
+
+  it('body contains no banned ladder/streak/FOMO vocabulary', () => {
+    expect(BANNED.test(BEGIN_AGAIN_COPY.body)).toBe(false);
+  });
+
+  it('action contains no banned ladder/streak/FOMO vocabulary', () => {
+    expect(BANNED.test(BEGIN_AGAIN_COPY.action)).toBe(false);
+  });
+
+  it('copy contains leaving-whole language (the word "whole")', () => {
+    const allCopy = Object.values(BEGIN_AGAIN_COPY).join(' ');
+    expect(/whole/i.test(allCopy)).toBe(true);
+  });
+});
+
+describe('cycleLabel', () => {
+  it('cycleLabel(2) returns "Cycle 2"', () => {
+    expect(cycleLabel(2)).toBe('Cycle 2');
+  });
+
+  it('cycleLabel(1) returns "Cycle 1"', () => {
+    expect(cycleLabel(1)).toBe('Cycle 1');
+  });
+
+  it('cycleLabel(10) returns "Cycle 10"', () => {
+    expect(cycleLabel(10)).toBe('Cycle 10');
+  });
+});

--- a/frontend/src/features/Map/beginAgain.ts
+++ b/frontend/src/features/Map/beginAgain.ts
@@ -1,0 +1,13 @@
+/** Warm "begin again" copy + cycle label for the end-of-arc affordance. */
+
+/** End-of-arc invitation: a declinable offer to walk again or rest here, whole — no ladder/streak/FOMO vocabulary. */
+export const BEGIN_AGAIN_COPY = {
+  heading: 'Begin again — or rest here, whole.',
+  body: "You've walked the full arc. You can carry what you've gathered into another pass, deepening each time — or set the practice down and simply be whole. Both are complete.",
+  action: 'Begin again',
+} as const;
+
+/** Subtle "Cycle N" caption naming which pass through the arc the user is on. */
+export function cycleLabel(n: number): string {
+  return `Cycle ${n}`;
+}

--- a/frontend/src/features/Map/hooks/useBeginAgainGuard.ts
+++ b/frontend/src/features/Map/hooks/useBeginAgainGuard.ts
@@ -1,0 +1,26 @@
+/** Ref-guarded single-flight begin-again: blocks same-tick double-press, state drives disabled UI. */
+
+import { useCallback, useRef, useState } from 'react';
+
+import { stageService } from '../services/stageService';
+
+/** Returns { beginning, handleBeginAgain } — one POST /stages/begin-again per in-flight window. */
+export function useBeginAgainGuard(): { beginning: boolean; handleBeginAgain: () => void } {
+  // In-flight guard: each POST increments cycle_number, so a double-press must
+  // send exactly one request until loadStages hides the button.
+  const [beginning, setBeginning] = useState(false);
+  const beginningRef = useRef(false);
+
+  const handleBeginAgain = useCallback(() => {
+    // Ref guard blocks a same-tick double-press; state drives the disabled UI.
+    if (beginningRef.current) return;
+    beginningRef.current = true;
+    setBeginning(true);
+    void stageService.beginAgain().finally(() => {
+      beginningRef.current = false;
+      setBeginning(false);
+    });
+  }, []);
+
+  return { beginning, handleBeginAgain };
+}

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it, beforeEach, jest } from '@jest/globals';
 import { act } from '@testing-library/react-native';
 
-import type { Stage } from '../../../../api';
+import type { Stage, StageProgressRecord } from '../../../../api';
 import { clampProgress, isStageUnlocked } from '../stageService';
 
 const mockList = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<Stage[]>>;
+const mockBeginAgainClient = jest.fn() as jest.MockedFunction<() => Promise<StageProgressRecord>>;
 jest.mock('../../../../api', () => ({
-  stages: { listAll: (...args: [string?]) => mockList(...args) },
+  stages: {
+    listAll: (...args: [string?]) => mockList(...args),
+    beginAgain: () => mockBeginAgainClient(),
+  },
 }));
 
 /** Build a fake API Stage response. */
@@ -34,12 +38,14 @@ describe('stageService', () => {
   beforeEach(() => {
     jest.resetModules();
     mockList.mockReset();
+    mockBeginAgainClient.mockReset();
     const { useStageStore } = require('../../../../store/useStageStore');
     act(() => {
       useStageStore.getState().setStages([]);
       useStageStore.getState().setCurrentStage(1);
       useStageStore.getState().setLoading(false);
       useStageStore.getState().setError(null);
+      useStageStore.getState().setCycleNumber(1);
     });
   });
 
@@ -267,6 +273,137 @@ describe('stageService', () => {
     it('falls back to the server flag when there is no calendar anchor', () => {
       expect(isStageUnlocked({ isUnlocked: false, stageNumber: 2 }, null)).toBe(false);
       expect(isStageUnlocked({ isUnlocked: true, stageNumber: 2 }, null)).toBe(true);
+    });
+  });
+
+  describe('isEndOfCycle', () => {
+    function makeStagesByNumber(
+      overrides: Record<number, Partial<{ progress: number }>>,
+    ): Record<number, { progress: number }> {
+      const map: Record<number, { progress: number }> = {};
+      for (let n = 1; n <= 10; n += 1) {
+        map[n] = { progress: overrides[n]?.progress ?? 0 };
+      }
+      return map;
+    }
+
+    it('returns true when currentStage is STAGE_COUNT and stage-10 progress >= 1', () => {
+      const { isEndOfCycle } = require('../stageService');
+      const stagesByNumber = makeStagesByNumber({ 10: { progress: 1 } });
+      expect(isEndOfCycle(stagesByNumber, 10)).toBe(true);
+    });
+
+    it('returns true when stage-10 progress is exactly 1.0 and currentStage is 10', () => {
+      const { isEndOfCycle } = require('../stageService');
+      const stagesByNumber = makeStagesByNumber({ 10: { progress: 1.0 } });
+      expect(isEndOfCycle(stagesByNumber, 10)).toBe(true);
+    });
+
+    it('returns false when currentStage is 10 but stage-10 progress < 1', () => {
+      const { isEndOfCycle } = require('../stageService');
+      const stagesByNumber = makeStagesByNumber({ 10: { progress: 0.9 } });
+      expect(isEndOfCycle(stagesByNumber, 10)).toBe(false);
+    });
+
+    it('returns false when stage-10 is complete but currentStage < STAGE_COUNT', () => {
+      const { isEndOfCycle } = require('../stageService');
+      const stagesByNumber = makeStagesByNumber({ 10: { progress: 1 } });
+      expect(isEndOfCycle(stagesByNumber, 5)).toBe(false);
+    });
+
+    it('returns false mid-cycle (currentStage 3, nothing complete)', () => {
+      const { isEndOfCycle } = require('../stageService');
+      const stagesByNumber = makeStagesByNumber({});
+      expect(isEndOfCycle(stagesByNumber, 3)).toBe(false);
+    });
+
+    it('returns false when stage-10 entry is absent from stagesByNumber', () => {
+      const { isEndOfCycle } = require('../stageService');
+      const stagesByNumber: Record<number, { progress: number }> = {};
+      for (let n = 1; n <= 9; n += 1) {
+        stagesByNumber[n] = { progress: 1 };
+      }
+      expect(isEndOfCycle(stagesByNumber, 10)).toBe(false);
+    });
+  });
+
+  describe('beginAgain action', () => {
+    function makeProgressRecord(cycleNumber: number): StageProgressRecord {
+      return {
+        id: 1,
+        user_id: 42,
+        current_stage: 1,
+        completed_stages: [],
+        cycle_number: cycleNumber,
+      };
+    }
+
+    it('calls stages.beginAgain() on the API client', async () => {
+      mockBeginAgainClient.mockResolvedValueOnce(makeProgressRecord(2));
+      mockList.mockResolvedValueOnce([makeApiStage(1)]);
+      const { stageService } = require('../stageService');
+
+      await act(async () => {
+        await stageService.beginAgain();
+      });
+
+      expect(mockBeginAgainClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets cycleNumber from the response record', async () => {
+      mockBeginAgainClient.mockResolvedValueOnce(makeProgressRecord(2));
+      mockList.mockResolvedValueOnce([makeApiStage(1)]);
+      const { stageService } = require('../stageService');
+      const { useStageStore } = require('../../../../store/useStageStore');
+
+      await act(async () => {
+        await stageService.beginAgain();
+      });
+
+      expect(useStageStore.getState().cycleNumber).toBe(2);
+    });
+
+    it('reloads stages after setting cycleNumber', async () => {
+      mockBeginAgainClient.mockResolvedValueOnce(makeProgressRecord(2));
+      mockList.mockResolvedValueOnce([makeApiStage(1)]);
+      const { stageService } = require('../stageService');
+
+      await act(async () => {
+        await stageService.beginAgain();
+      });
+
+      expect(mockList).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes a failed begin-again to the store error without rejecting', async () => {
+      mockBeginAgainClient.mockRejectedValueOnce(new Error('boom'));
+      const { stageService } = require('../stageService');
+      const { useStageStore } = require('../../../../store/useStageStore');
+
+      // The call site discards this promise, so a failure must not reject.
+      await act(async () => {
+        await expect(stageService.beginAgain()).resolves.toBeUndefined();
+      });
+
+      const state = useStageStore.getState();
+      expect(typeof state.error).toBe('string');
+      expect(state.error).toBe('boom');
+      // Failure short-circuits: no reload and no cycle bump from a bad response.
+      expect(mockList).not.toHaveBeenCalled();
+      expect(state.cycleNumber).toBe(1);
+    });
+
+    it('reflects cycle_number 3 when the server returns it', async () => {
+      mockBeginAgainClient.mockResolvedValueOnce(makeProgressRecord(3));
+      mockList.mockResolvedValueOnce([makeApiStage(1)]);
+      const { stageService } = require('../stageService');
+      const { useStageStore } = require('../../../../store/useStageStore');
+
+      await act(async () => {
+        await stageService.beginAgain();
+      });
+
+      expect(useStageStore.getState().cycleNumber).toBe(3);
     });
   });
 });

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -76,6 +76,13 @@ export const isStageUnlocked = (
   currentStage: number | null,
 ): boolean => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage);
 
+/** True only on the final stage with its progress complete — the gate for the declinable "begin again" affordance. */
+export const isEndOfCycle = (
+  stagesByNumber: Record<number, { progress: number } | undefined>,
+  currentStage: number,
+): boolean =>
+  currentStage === STAGE_COUNT && (stagesByNumber[STAGE_COUNT]?.progress ?? 0) >= FULLY_COMPLETE;
+
 /**
  * Snapshot captured by `prepareAdvanceStage` and consumed by
  * `applyAdvanceStage` / `rollbackAdvanceStage`. Holding the previous
@@ -177,6 +184,24 @@ export const stageService = {
    */
   rollbackAdvanceStage: (ctx: AdvanceStageContext): void => {
     useStageStore.getState().setCurrentStage(ctx.prev);
+  },
+
+  /**
+   * Open a fresh cycle: record the server's new cycle number, then reload
+   * stages so state resets from server truth. Mirrors `loadStages`'s
+   * error handling — a failed begin-again POST routes to `useStageStore.error`
+   * rather than rejecting unhandled, since the call site discards the promise.
+   */
+  beginAgain: async (token?: string): Promise<void> => {
+    try {
+      const record = await stagesApi.beginAgain(token);
+      useStageStore.getState().setCycleNumber(record.cycle_number);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to begin again';
+      useStageStore.getState().setError(message);
+      return;
+    }
+    await stageService.loadStages(token);
   },
 };
 

--- a/frontend/src/store/__tests__/useStageStore.test.ts
+++ b/frontend/src/store/__tests__/useStageStore.test.ts
@@ -138,4 +138,30 @@ describe('useStageStore', () => {
     act(() => resetAllStores());
     expect(useStageStore.getState().stages).toEqual([]);
   });
+
+  describe('cycleNumber', () => {
+    it('defaults to 1', () => {
+      const { useStageStore } = require('../useStageStore');
+      expect(useStageStore.getState().cycleNumber).toBe(1);
+    });
+
+    it('setCycleNumber(2) updates cycleNumber to 2', () => {
+      const { useStageStore } = require('../useStageStore');
+      act(() => useStageStore.getState().setCycleNumber(2));
+      expect(useStageStore.getState().cycleNumber).toBe(2);
+    });
+
+    it('selectCycleNumber reads cycleNumber from state', () => {
+      const { useStageStore, selectCycleNumber } = require('../useStageStore');
+      act(() => useStageStore.getState().setCycleNumber(3));
+      expect(selectCycleNumber(useStageStore.getState())).toBe(3);
+    });
+
+    it('reset() restores cycleNumber to 1', () => {
+      const { useStageStore } = require('../useStageStore');
+      act(() => useStageStore.getState().setCycleNumber(5));
+      act(() => useStageStore.getState().reset());
+      expect(useStageStore.getState().cycleNumber).toBe(1);
+    });
+  });
 });

--- a/frontend/src/store/useStageStore.ts
+++ b/frontend/src/store/useStageStore.ts
@@ -22,11 +22,14 @@ export interface StageStoreState {
   /** Derived array view. Kept in sync by actions. */
   stages: StageData[];
   currentStage: number;
+  /** Which pass through the arc the user is on; 1 on a first walk-through. */
+  cycleNumber: number;
   loading: boolean;
   error: string | null;
 
   setStages: (_stages: StageData[]) => void;
   setCurrentStage: (_stageNumber: number) => void;
+  setCycleNumber: (_cycleNumber: number) => void;
   setLoading: (_loading: boolean) => void;
   setError: (_error: string | null) => void;
   updateStageProgress: (_stageNumber: number, _progress: number) => void;
@@ -39,6 +42,7 @@ const INITIAL_STATE = {
   stageOrder: [] as number[],
   stages: [] as StageData[],
   currentStage: 1,
+  cycleNumber: 1,
   loading: false,
   error: null as string | null,
 };
@@ -70,6 +74,7 @@ export const useStageStore = create<StageStoreState>((set) => ({
 
   setStages: (stages) => set(normalizeStages(stages)),
   setCurrentStage: (currentStage) => set({ currentStage }),
+  setCycleNumber: (cycleNumber) => set({ cycleNumber }),
   setLoading: (loading) => set({ loading }),
   setError: (error) => set({ error }),
   updateStageProgress: (stageNumber, progress) =>
@@ -110,5 +115,6 @@ registerStoreReset(() => {
 
 export const selectStages = (state: StageStoreState): StageData[] => state.stages;
 export const selectCurrentStage = (state: StageStoreState): number => state.currentStage;
+export const selectCycleNumber = (state: StageStoreState): number => state.cycleNumber;
 export const selectStagesLoading = (state: StageStoreState): boolean => state.loading;
 export const selectStagesError = (state: StageStoreState): string | null => state.error;


### PR DESCRIPTION
## Summary
At the end of a cycle, warmly invites the next pass without pressure (NORTH-STAR §8), consuming the loop endpoint (#918) + `cycle_number` (#917).

- **api/store**: a zod-validated `stages.beginAgain()` (POST `/stages/begin-again`) + a `StageProgressRecord` type (zod-inferred re-export, no cast). The store gains a **write-sourced** `cycleNumber` (default 1, updated from the begin-again response — no GET carries it yet; cold-start display is tracked as **#1050**).
- **affordance**: a gentle "begin again" button shows **only at end-of-cycle** (`isEndOfCycle`: current stage is the last *and* complete) and is **user-chosen — never auto-forced** (no auto-nav, no timer). A subtle **"Cycle N"** caption appears only past cycle 1 (a first-cycle user sees no cycle chrome).
- **copy (§8)**: celebrates deepening AND explicitly welcomes leaving whole — *"…set the practice down and simply be whole. Both are complete."* A test guards the exported copy against ladder/FOMO/streak-shame vocabulary and positively asserts it stays whole-affirming.
- **robustness**: a failed begin-again surfaces through the store `error` (mirroring `loadStages`) rather than an unhandled rejection. Tokens-only; accessible (role + enriched label).

## Test plan
- 35 tests: client (POST no-slash, schema validation, `ApiValidationError`); store (`cycleNumber` default/set/reset); service (`isEndOfCycle` 6 cases; `beginAgain` happy + **error path** → store error, no reload); MapScreen (button only at end-of-cycle, press→action, absent mid-cycle; "Cycle 2" only when cycleNumber>1); copy banned-words + `/whole/` guard. The 3 sibling Map suites' `stageService` mocks gain `isEndOfCycle` (kept non-end-of-cycle).
- `scripts/frontend/check-all.sh` exits 0 (eslint zero-warning, tsc strict, prettier, all tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #919
Refs #916