### PR TITLE
feat(backend): readiness-signal computation + non-repeating invitation generation

### DIFF
--- a/backend/src/domain/invitations.py
+++ b/backend/src/domain/invitations.py
@@ -1,0 +1,138 @@
+"""Pure readiness-signal computation — coordinates for resonant invitations.
+
+Given a snapshot of a user's cross-feature engagement (habit streaks, sustained
+practice weeks, active-day count in a rolling window), decide which deeper
+depths the moment invites the user to *consider*. The output is a list of
+plain coordinates — target ring, optional concrete target, and why the moment
+qualifies — that a later persistence pass turns into ``InvitationSignal`` rows.
+
+This module encodes NO shaming and NO FOMO: it never counts what the user
+*failed* to do, never compares them to anyone, and stays silent by default.
+An absent signal is the norm, not a deficiency. The thresholds below are
+deliberately conservative so an invitation only appears once a rhythm is
+genuinely established — the "you choose your depth" principle honoured before a
+single row is written.
+
+Pure by design: no session, no I/O, no clock. The caller gathers the
+aggregates (that is where the DB lives) and hands them in; this function is a
+deterministic map from a value object to a list of value objects, trivial to
+unit-test without fixtures.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from models.invitation_signal import InvitationKind, InvitationTargetType
+
+# A sustained habit rhythm: three unbroken weeks. Long enough that the streak
+# reflects an integrated habit rather than a burst of early enthusiasm, so the
+# consistency invitation lands as recognition, never nagging.
+SUSTAINED_HABIT_STREAK_DAYS = 21
+
+# A practice held for a full month of weeks. Mirrors the practice-cadence
+# "≥4 sessions/week" rule: four such weeks running is depth already reached,
+# which the mastery invitation acknowledges.
+SUSTAINED_PRACTICE_WEEKS = 4
+
+# Broad cross-feature engagement: active on 25 of the last 30 days. Set high
+# and outward-facing so the embodied-community invitation only surfaces for a
+# user whose practice is clearly part of daily life — never a nudge to do more.
+HIGH_ENGAGEMENT_ACTIVE_DAYS = 25
+
+# Rolling window over which active days are counted. Thirty days is a full
+# month of rhythm — wide enough to smooth over a missed day, narrow enough that
+# the signal reflects the present season, not a distant past.
+ENGAGEMENT_WINDOW_DAYS = 30
+
+# Reference the model enum *values* (not bare string literals) so the candidate
+# coordinates can never drift from the persisted vocabulary — the drift-guard
+# test asserts exactly this coupling.
+_HABIT = InvitationTargetType.HABIT.value
+_PRACTICE = InvitationTargetType.PRACTICE.value
+_EMBODIED_COMMUNITY = InvitationTargetType.EMBODIED_COMMUNITY.value
+_CONSISTENCY = InvitationKind.CONSISTENCY.value
+_MASTERY = InvitationKind.MASTERY.value
+_READINESS = InvitationKind.READINESS.value
+
+
+@dataclass(frozen=True)
+class InvitationCandidate:
+    """One coordinate for a resonant invitation, before it is persisted.
+
+    ``target_id`` is ``None`` for a ring-level (outward) invitation such as
+    embodied community, which has no concrete target within the ring.
+    """
+
+    target_type: str
+    target_id: int | None
+    kind: str
+
+
+@dataclass(frozen=True)
+class HabitSignal:
+    """A habit's current streak length, gathered from the persistence layer."""
+
+    habit_id: int
+    streak_days: int
+
+
+@dataclass(frozen=True)
+class PracticeSignal:
+    """A practice's count of consecutive weeks that met the cadence target."""
+
+    practice_id: int
+    sustained_weeks: int
+
+
+@dataclass(frozen=True)
+class ReadinessAggregates:
+    """A snapshot of one user's cross-feature engagement for candidate math."""
+
+    habits: list[HabitSignal]
+    practices: list[PracticeSignal]
+    active_days_in_window: int
+
+
+def _habit_candidates(habits: list[HabitSignal]) -> list[InvitationCandidate]:
+    """Emit a consistency candidate for each habit that cleared the streak floor."""
+    return [
+        InvitationCandidate(target_type=_HABIT, target_id=h.habit_id, kind=_CONSISTENCY)
+        for h in habits
+        if h.streak_days >= SUSTAINED_HABIT_STREAK_DAYS
+    ]
+
+
+def _practice_candidates(practices: list[PracticeSignal]) -> list[InvitationCandidate]:
+    """Emit a mastery candidate for each practice that held the cadence long enough."""
+    return [
+        InvitationCandidate(target_type=_PRACTICE, target_id=p.practice_id, kind=_MASTERY)
+        for p in practices
+        if p.sustained_weeks >= SUSTAINED_PRACTICE_WEEKS
+    ]
+
+
+def _community_candidates(active_days_in_window: int) -> list[InvitationCandidate]:
+    """Emit the outward, null-target readiness candidate when engagement is high."""
+    if active_days_in_window >= HIGH_ENGAGEMENT_ACTIVE_DAYS:
+        return [
+            InvitationCandidate(target_type=_EMBODIED_COMMUNITY, target_id=None, kind=_READINESS)
+        ]
+    return []
+
+
+def compute_invitation_candidates(
+    aggregates: ReadinessAggregates,
+) -> list[InvitationCandidate]:
+    """Map an engagement snapshot to the invitation coordinates it warrants.
+
+    Silent by default: aggregates below every threshold yield ``[]``. Each
+    source contributes independently — one candidate per qualifying habit, one
+    per qualifying practice, and at most one outward community candidate — so
+    the three signals coexist without interfering.
+    """
+    return [
+        *_habit_candidates(aggregates.habits),
+        *_practice_candidates(aggregates.practices),
+        *_community_candidates(aggregates.active_days_in_window),
+    ]

--- a/backend/src/services/invitations.py
+++ b/backend/src/services/invitations.py
@@ -1,0 +1,233 @@
+"""Generate persisted invitation signals from a user's readiness aggregates.
+
+This is the DB-aware companion to :mod:`domain.invitations`. It gathers a
+user's cross-feature engagement with a bounded, constant number of batched
+queries (never one-per-habit or one-per-practice), hands the snapshot to the
+pure candidate function, then persists only the candidates that do not already
+exist as an ``InvitationSignal`` row.
+
+Deduplication spans *all* prior rows — live and dismissed alike — so a declined
+invitation is never silently regenerated. A dismissed row is a present row and
+therefore blocks re-creation, honouring "you choose your depth" at the write
+boundary. A ``begin_nested`` SAVEPOINT plus an ``IntegrityError`` re-read makes
+the insert safe against a concurrent generation pass racing over the
+partial-unique indexes, mirroring ``ensure_user_progress`` and
+``ensure_depth_preferences``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.dates import now_in_tz, to_user_date_bucket
+from domain.invitations import (
+    ENGAGEMENT_WINDOW_DAYS,
+    HabitSignal,
+    InvitationCandidate,
+    PracticeSignal,
+    ReadinessAggregates,
+    compute_invitation_candidates,
+)
+from domain.practice_insights import build_insights
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.invitation_signal import InvitationSignal
+from models.journal_entry import JournalEntry
+from models.practice_session import PracticeSession
+from models.user_practice import UserPractice
+
+# Sentinel standing in for a ``None`` target_id in the dedup key, so the
+# outward (null-target) embodied-community candidate dedups against its prior
+# row even though SQL/Python treat two ``None`` targets as distinct.
+_NULL_TARGET = -1
+
+# Dedup / persisted-row identity: ``(target_type, target_id-or-sentinel, kind)``.
+type _SignalKey = tuple[str, int, str]
+
+
+def _signal_key(target_type: str, target_id: int | None, kind: str) -> _SignalKey:
+    """Build the dedup key, folding a null target onto the shared sentinel."""
+    return (target_type, target_id if target_id is not None else _NULL_TARGET, kind)
+
+
+async def _gather_habit_signals(session: AsyncSession, user_id: int) -> list[HabitSignal]:
+    """Read every habit's denormalized streak counter in one grouped query."""
+    result = await session.execute(
+        select(Habit.id, Habit.streak).where(col(Habit.user_id) == user_id)
+    )
+    return [HabitSignal(habit_id=habit_id, streak_days=streak) for habit_id, streak in result.all()]
+
+
+async def _gather_practice_signals(
+    session: AsyncSession, user_id: int, user_timezone: str
+) -> list[PracticeSignal]:
+    """Compute sustained weeks per practice from one session fetch (no per-practice query).
+
+    A single query pulls the user's sessions with the resolved ``practice_id``
+    (via ``PracticeSession.user_practice_id -> UserPractice.practice_id``); the
+    rows are grouped in memory and each group's consecutive-week count is
+    derived by reusing :func:`domain.practice_insights.build_insights`.
+    """
+    result = await session.execute(
+        select(UserPractice.practice_id, PracticeSession)
+        .join(UserPractice, col(PracticeSession.user_practice_id) == col(UserPractice.id))
+        .where(col(PracticeSession.user_id) == user_id)
+    )
+    sessions_by_practice: defaultdict[int, list[PracticeSession]] = defaultdict(list)
+    for practice_id, practice_session in result.all():
+        sessions_by_practice[practice_id].append(practice_session)
+    return [
+        PracticeSignal(
+            practice_id=practice_id,
+            sustained_weeks=build_insights(sessions, tz=user_timezone).streak_weeks,
+        )
+        for practice_id, sessions in sessions_by_practice.items()
+    ]
+
+
+async def _active_timestamps(
+    session: AsyncSession, user_id: int, since: datetime
+) -> list[datetime]:
+    """Fetch cross-feature activity timestamps since ``since`` in three grouped queries.
+
+    One query per source (goal completions, practice sessions, journal entries),
+    each already narrowed to the engagement window so the day-bucketing in
+    Python stays cheap regardless of history depth.
+    """
+    goal_rows = await session.execute(
+        select(GoalCompletion.timestamp).where(
+            col(GoalCompletion.user_id) == user_id,
+            col(GoalCompletion.timestamp) >= since,
+        )
+    )
+    practice_rows = await session.execute(
+        select(PracticeSession.timestamp).where(
+            col(PracticeSession.user_id) == user_id,
+            col(PracticeSession.timestamp) >= since,
+        )
+    )
+    journal_rows = await session.execute(
+        select(JournalEntry.timestamp).where(
+            col(JournalEntry.user_id) == user_id,
+            col(JournalEntry.deleted_at).is_(None),
+            col(JournalEntry.timestamp) >= since,
+        )
+    )
+    return [
+        *goal_rows.scalars().all(),
+        *practice_rows.scalars().all(),
+        *journal_rows.scalars().all(),
+    ]
+
+
+async def _gather_active_days(session: AsyncSession, user_id: int, user_timezone: str) -> int:
+    """Count distinct user-local calendar days with any activity in the window."""
+    # Normalize to UTC so the cutoff string shares the +00:00 offset of the
+    # stored timestamps: SQLite compares DateTime(timezone=True) lexically and
+    # is blind to the offset suffix, so a user-offset boundary would skew the
+    # window edge (see day_bounds_in_tz in domain.dates).
+    window_start = (now_in_tz(user_timezone) - timedelta(days=ENGAGEMENT_WINDOW_DAYS)).astimezone(
+        UTC
+    )
+    timestamps = await _active_timestamps(session, user_id, window_start)
+    return len({to_user_date_bucket(ts, user_timezone) for ts in timestamps})
+
+
+async def _gather_aggregates(
+    session: AsyncSession, user_id: int, user_timezone: str
+) -> ReadinessAggregates:
+    """Assemble the readiness snapshot from the batched per-source gathers."""
+    return ReadinessAggregates(
+        habits=await _gather_habit_signals(session, user_id),
+        practices=await _gather_practice_signals(session, user_id, user_timezone),
+        active_days_in_window=await _gather_active_days(session, user_id, user_timezone),
+    )
+
+
+async def _existing_signal_keys(session: AsyncSession, user_id: int) -> set[_SignalKey]:
+    """Pre-query the dedup keys of every prior row (live and dismissed) for the user."""
+    result = await session.execute(
+        select(
+            InvitationSignal.target_type,
+            InvitationSignal.target_id,
+            InvitationSignal.kind,
+        ).where(col(InvitationSignal.user_id) == user_id)
+    )
+    return {
+        _signal_key(target_type, target_id, kind) for target_type, target_id, kind in result.all()
+    }
+
+
+async def _persist_signal(session: AsyncSession, row: InvitationSignal) -> InvitationSignal | None:
+    """Insert one row inside a SAVEPOINT; return ``None`` if a race already wrote it.
+
+    The partial-unique indexes are the source of truth: an ``IntegrityError``
+    means a concurrent pass beat us to this coordinate, which is a safe no-op —
+    the winner's row already carries the invitation. Unlike ``ensure_*`` helpers
+    this variant deliberately omits the re-read: it discards the losing candidate
+    rather than returning the concurrently-written singleton.
+    """
+    try:
+        async with session.begin_nested():
+            session.add(row)
+        await session.commit()
+        await session.refresh(row)
+    except IntegrityError:
+        return None
+    else:
+        return row
+
+
+async def _insert_new_signals(
+    session: AsyncSession,
+    user_id: int,
+    candidates: list[InvitationCandidate],
+    existing: set[_SignalKey],
+) -> list[InvitationSignal]:
+    """Persist each candidate whose key is not already present; return the new rows.
+
+    ``existing`` is mutated as rows are inserted so two candidates that resolve
+    to the same coordinate within one pass can't both be written.
+    """
+    inserted: list[InvitationSignal] = []
+    for candidate in candidates:
+        key = _signal_key(candidate.target_type, candidate.target_id, candidate.kind)
+        if key in existing:
+            continue
+        existing.add(key)
+        row = InvitationSignal(
+            user_id=user_id,
+            target_type=candidate.target_type,
+            target_id=candidate.target_id,
+            kind=candidate.kind,
+        )
+        persisted = await _persist_signal(session, row)
+        if persisted is not None:
+            inserted.append(persisted)
+    return inserted
+
+
+async def generate_invitation_signals(
+    session: AsyncSession,
+    user_id: int,
+    user_timezone: str = "UTC",
+) -> list[InvitationSignal]:
+    """Detect readiness, persist the newly-warranted invitations, and return them.
+
+    Gathers the user's engagement with a constant number of batched queries,
+    computes candidates via the pure domain function, drops any candidate that
+    already exists as a signal (dismissed rows included), and inserts only the
+    survivors. Returns the rows created by this call — ``[]`` when nothing new
+    is warranted, making repeat calls idempotent.
+    """
+    aggregates = await _gather_aggregates(session, user_id, user_timezone)
+    candidates = compute_invitation_candidates(aggregates)
+    if not candidates:
+        return []
+    existing = await _existing_signal_keys(session, user_id)
+    return await _insert_new_signals(session, user_id, candidates, existing)

--- a/backend/src/services/invitations.py
+++ b/backend/src/services/invitations.py
@@ -47,7 +47,7 @@ from models.user_practice import UserPractice
 _NULL_TARGET = -1
 
 # Dedup / persisted-row identity: ``(target_type, target_id-or-sentinel, kind)``.
-type _SignalKey = tuple[str, int, str]
+_SignalKey = tuple[str, int, str]
 
 
 def _signal_key(target_type: str, target_id: int | None, kind: str) -> _SignalKey:

--- a/backend/tests/domain/test_invitations.py
+++ b/backend/tests/domain/test_invitations.py
@@ -1,0 +1,254 @@
+"""Pure-domain tests for :mod:`domain.invitations` — readiness-signal computation.
+
+These tests FAIL on import until the implementation-specialist creates
+``backend/src/domain/invitations.py`` with the contracts pinned below.
+That is the correct RED state for Gate 1.
+
+Pinned public surface:
+  compute_invitation_candidates(aggregates: ReadinessAggregates) -> list[InvitationCandidate]
+  InvitationCandidate(target_type: str, target_id: int | None, kind: str)
+  HabitSignal(habit_id: int, streak_days: int)
+  PracticeSignal(practice_id: int, sustained_weeks: int)
+  ReadinessAggregates(habits: list[HabitSignal], practices: list[PracticeSignal],
+                      active_days_in_window: int)
+  SUSTAINED_HABIT_STREAK_DAYS = 21
+  SUSTAINED_PRACTICE_WEEKS   = 4
+  HIGH_ENGAGEMENT_ACTIVE_DAYS = 25
+  ENGAGEMENT_WINDOW_DAYS      = 30
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+
+import pytest
+
+from domain.invitations import (
+    HIGH_ENGAGEMENT_ACTIVE_DAYS,
+    SUSTAINED_HABIT_STREAK_DAYS,
+    SUSTAINED_PRACTICE_WEEKS,
+    HabitSignal,
+    InvitationCandidate,
+    PracticeSignal,
+    ReadinessAggregates,
+    compute_invitation_candidates,
+)
+from models.invitation_signal import InvitationKind, InvitationTargetType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EMPTY = ReadinessAggregates(habits=[], practices=[], active_days_in_window=0)
+
+
+def _agg(
+    *,
+    habit_id: int = 1,
+    streak: int = 0,
+    practice_id: int = 1,
+    weeks: int = 0,
+    active_days: int = 0,
+) -> ReadinessAggregates:
+    """Build a minimal aggregates object for a single-signal scenario."""
+    return ReadinessAggregates(
+        habits=[HabitSignal(habit_id=habit_id, streak_days=streak)] if streak else [],
+        practices=[PracticeSignal(practice_id=practice_id, sustained_weeks=weeks)] if weeks else [],
+        active_days_in_window=active_days,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Empty aggregates → silence by default
+# ---------------------------------------------------------------------------
+
+
+def test_empty_aggregates_returns_empty_list() -> None:
+    """No signals → no candidates (silence-by-default)."""
+    result = compute_invitation_candidates(_EMPTY)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Habit streak threshold boundary
+# ---------------------------------------------------------------------------
+
+
+def test_habit_streak_below_threshold_produces_no_candidate() -> None:
+    """A streak of threshold-1 must not generate a habit candidate."""
+    below = ReadinessAggregates(
+        habits=[HabitSignal(habit_id=7, streak_days=SUSTAINED_HABIT_STREAK_DAYS - 1)],
+        practices=[],
+        active_days_in_window=0,
+    )
+    candidates = compute_invitation_candidates(below)
+    assert not any(c.target_type == "habit" for c in candidates)
+
+
+def test_habit_streak_at_threshold_produces_one_candidate() -> None:
+    """A streak of exactly SUSTAINED_HABIT_STREAK_DAYS (21) triggers one candidate."""
+    at_threshold = ReadinessAggregates(
+        habits=[HabitSignal(habit_id=42, streak_days=SUSTAINED_HABIT_STREAK_DAYS)],
+        practices=[],
+        active_days_in_window=0,
+    )
+    candidates = compute_invitation_candidates(at_threshold)
+    assert len(candidates) == 1
+    assert candidates[0].target_type == "habit"
+    assert candidates[0].target_id == 42
+    assert candidates[0].kind == "consistency"
+
+
+# ---------------------------------------------------------------------------
+# 3. Practice sustained-weeks threshold boundary
+# ---------------------------------------------------------------------------
+
+
+def test_practice_weeks_below_threshold_produces_no_candidate() -> None:
+    """Sustained weeks below 4 must not generate a practice candidate."""
+    below = ReadinessAggregates(
+        habits=[],
+        practices=[PracticeSignal(practice_id=5, sustained_weeks=SUSTAINED_PRACTICE_WEEKS - 1)],
+        active_days_in_window=0,
+    )
+    candidates = compute_invitation_candidates(below)
+    assert not any(c.target_type == "practice" for c in candidates)
+
+
+def test_practice_weeks_at_threshold_produces_one_candidate() -> None:
+    """Exactly SUSTAINED_PRACTICE_WEEKS (4) weeks produces one mastery candidate."""
+    at_threshold = ReadinessAggregates(
+        habits=[],
+        practices=[PracticeSignal(practice_id=99, sustained_weeks=SUSTAINED_PRACTICE_WEEKS)],
+        active_days_in_window=0,
+    )
+    candidates = compute_invitation_candidates(at_threshold)
+    assert len(candidates) == 1
+    assert candidates[0].target_type == "practice"
+    assert candidates[0].target_id == 99
+    assert candidates[0].kind == "mastery"
+
+
+# ---------------------------------------------------------------------------
+# 4. Engagement / embodied-community threshold boundary
+# ---------------------------------------------------------------------------
+
+
+def test_active_days_below_threshold_produces_no_community_candidate() -> None:
+    """Active days below HIGH_ENGAGEMENT_ACTIVE_DAYS must not trigger the outward signal."""
+    below = ReadinessAggregates(
+        habits=[],
+        practices=[],
+        active_days_in_window=HIGH_ENGAGEMENT_ACTIVE_DAYS - 1,
+    )
+    candidates = compute_invitation_candidates(below)
+    assert not any(c.target_type == "embodied_community" for c in candidates)
+
+
+def test_active_days_at_threshold_produces_community_candidate_with_null_target() -> None:
+    """Exactly HIGH_ENGAGEMENT_ACTIVE_DAYS (25) active days yields the outward candidate."""
+    at_threshold = ReadinessAggregates(
+        habits=[],
+        practices=[],
+        active_days_in_window=HIGH_ENGAGEMENT_ACTIVE_DAYS,
+    )
+    candidates = compute_invitation_candidates(at_threshold)
+    assert len(candidates) == 1
+    assert candidates[0].target_type == "embodied_community"
+    assert candidates[0].target_id is None  # outward / no concrete target
+    assert candidates[0].kind == "readiness"
+
+
+# ---------------------------------------------------------------------------
+# 5. Combined signals: one candidate each, coexist correctly
+# ---------------------------------------------------------------------------
+
+
+def test_all_three_signals_produce_three_candidates() -> None:
+    """When all signals cross threshold, exactly three candidates are returned."""
+    combined = ReadinessAggregates(
+        habits=[HabitSignal(habit_id=10, streak_days=SUSTAINED_HABIT_STREAK_DAYS)],
+        practices=[PracticeSignal(practice_id=20, sustained_weeks=SUSTAINED_PRACTICE_WEEKS)],
+        active_days_in_window=HIGH_ENGAGEMENT_ACTIVE_DAYS,
+    )
+    candidates = compute_invitation_candidates(combined)
+    assert len(candidates) == 3
+    types = {c.target_type for c in candidates}
+    assert types == {"habit", "practice", "embodied_community"}
+
+
+def test_multiple_habits_above_threshold_produce_one_candidate_each() -> None:
+    """Each habit that clears the streak threshold gets its own candidate."""
+    two_habits = ReadinessAggregates(
+        habits=[
+            HabitSignal(habit_id=1, streak_days=SUSTAINED_HABIT_STREAK_DAYS),
+            HabitSignal(habit_id=2, streak_days=SUSTAINED_HABIT_STREAK_DAYS + 10),
+        ],
+        practices=[],
+        active_days_in_window=0,
+    )
+    candidates = compute_invitation_candidates(two_habits)
+    habit_candidates = [c for c in candidates if c.target_type == "habit"]
+    assert len(habit_candidates) == 2
+    assert {c.target_id for c in habit_candidates} == {1, 2}
+
+
+# ---------------------------------------------------------------------------
+# 6. Enum-drift guard: every candidate's fields are valid enum values
+# ---------------------------------------------------------------------------
+
+
+def test_all_candidate_values_are_valid_enum_members() -> None:
+    """All target_type / kind values in candidates are valid InvitationTargetType / InvitationKind.
+
+    Mirrors the drift guard pattern from domain.detection (VALID_TARGET_TYPES).
+    """
+    all_signals = ReadinessAggregates(
+        habits=[HabitSignal(habit_id=1, streak_days=SUSTAINED_HABIT_STREAK_DAYS)],
+        practices=[PracticeSignal(practice_id=2, sustained_weeks=SUSTAINED_PRACTICE_WEEKS)],
+        active_days_in_window=HIGH_ENGAGEMENT_ACTIVE_DAYS,
+    )
+    valid_types = {t.value for t in InvitationTargetType}
+    valid_kinds = {k.value for k in InvitationKind}
+
+    candidates = compute_invitation_candidates(all_signals)
+    for c in candidates:
+        assert c.target_type in valid_types, f"unexpected target_type: {c.target_type!r}"
+        assert c.kind in valid_kinds, f"unexpected kind: {c.kind!r}"
+
+
+# ---------------------------------------------------------------------------
+# 7. Purity: deterministic, no I/O, accepts only ReadinessAggregates
+# ---------------------------------------------------------------------------
+
+
+def test_calling_twice_with_same_input_returns_equal_output() -> None:
+    """Pure fn: same input always yields equal output (no hidden state)."""
+    agg = ReadinessAggregates(
+        habits=[HabitSignal(habit_id=3, streak_days=SUSTAINED_HABIT_STREAK_DAYS)],
+        practices=[PracticeSignal(practice_id=4, sustained_weeks=SUSTAINED_PRACTICE_WEEKS)],
+        active_days_in_window=HIGH_ENGAGEMENT_ACTIVE_DAYS,
+    )
+    first = compute_invitation_candidates(agg)
+    second = compute_invitation_candidates(agg)
+    assert first == second
+
+
+def test_function_signature_accepts_only_aggregates_not_a_session() -> None:
+    """The pure fn must accept ReadinessAggregates, not a session object (structural)."""
+    sig = inspect.signature(compute_invitation_candidates)
+    params = list(sig.parameters.keys())
+    # Exactly one positional parameter named 'aggregates'.
+    assert params == ["aggregates"], (
+        f"expected signature compute_invitation_candidates(aggregates), got {params}"
+    )
+
+
+def test_candidate_is_frozen_dataclass() -> None:
+    """InvitationCandidate is a frozen dataclass (immutable value object)."""
+    assert dataclasses.is_dataclass(InvitationCandidate), "InvitationCandidate must be a dataclass"
+    # frozen=True means __setattr__ raises FrozenInstanceError.
+    c = InvitationCandidate(target_type="habit", target_id=1, kind="consistency")
+    with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+        c.__setattr__("target_type", "mutated")

--- a/backend/tests/services/test_invitations_service.py
+++ b/backend/tests/services/test_invitations_service.py
@@ -1,0 +1,492 @@
+"""Integration tests for :mod:`services.invitations` — invitation-signal generation.
+
+These tests FAIL until both ``backend/src/services/invitations.py`` and
+``backend/src/domain/invitations.py`` exist.  That is the correct RED state.
+
+Pinned service contract:
+  generate_invitation_signals(session, user_id, user_timezone="UTC")
+      -> list[InvitationSignal]
+
+The function gathers readiness aggregates, calls the pure domain fn, deduplicates
+against ALL existing InvitationSignal rows (dismissed or live), inserts survivors,
+and returns only the newly inserted rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from conftest import test_engine
+from domain.dates import now_in_tz, to_user_date_bucket
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.invitation_signal import InvitationSignal
+from models.journal_entry import JournalEntry
+from models.practice import Practice
+from models.practice_session import PracticeSession
+from models.user import User
+from models.user_practice import UserPractice
+from services.invitations import generate_invitation_signals
+
+# ---------------------------------------------------------------------------
+# Shared fixture helpers
+# ---------------------------------------------------------------------------
+
+_SUSTAINED_STREAK = 21  # mirrors SUSTAINED_HABIT_STREAK_DAYS
+_SUSTAINED_WEEKS = 4  # mirrors SUSTAINED_PRACTICE_WEEKS
+_HIGH_ACTIVE_DAYS = 25  # mirrors HIGH_ENGAGEMENT_ACTIVE_DAYS
+_ENGAGEMENT_WINDOW_DAYS = 30  # mirrors ENGAGEMENT_WINDOW_DAYS
+_LA_TZ = "America/Los_Angeles"
+
+
+async def _make_user(session: AsyncSession, email: str = "inv@example.com") -> int:
+    """Insert a User row and return its id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    assert user.id is not None
+    return user.id
+
+
+async def _make_habit_with_streak(
+    session: AsyncSession,
+    user_id: int,
+    streak_days: int,
+    *,
+    name: str = "Meditate",
+) -> int:
+    """Seed a Habit with ``streak`` field set and the matching GoalCompletion rows.
+
+    Also sets ``Habit.streak`` directly so any service path that reads the
+    denormalized counter sees the right value.
+    """
+    habit = Habit(
+        name=name,
+        icon="flame",
+        start_date=datetime.now(UTC).date() - timedelta(days=streak_days),
+        stage="1",
+        streak=streak_days,
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    assert habit.id is not None
+
+    goal = Goal(
+        habit_id=habit.id,
+        title="Daily sit",
+        tier="clear",
+        target=1.0,
+        target_unit="minutes",
+        frequency=1.0,
+        frequency_unit="per_day",
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    assert goal.id is not None
+
+    now = datetime.now(UTC)
+    for days_ago in range(streak_days):
+        session.add(
+            GoalCompletion(
+                goal_id=goal.id,
+                user_id=user_id,
+                completed_units=goal.target,
+                timestamp=now - timedelta(days=days_ago),
+            )
+        )
+    await session.commit()
+    return habit.id
+
+
+async def _make_practice_with_sessions(
+    session: AsyncSession,
+    user_id: int,
+    *,
+    weeks: int,
+    name: str = "Morning sit",
+) -> int:
+    """Seed Practice + UserPractice + PracticeSession rows sufficient for ``weeks`` weeks."""
+    practice = Practice(
+        stage_number=1,
+        name=name,
+        description="x",
+        instructions="x",
+        default_duration_minutes=10.0,
+        mode="meditation_timer",
+        mode_config={"mode": "meditation_timer", "duration_minutes": 10},
+    )
+    session.add(practice)
+    await session.commit()
+    await session.refresh(practice)
+    assert practice.id is not None
+
+    start = datetime.now(UTC).date() - timedelta(weeks=weeks)
+    up = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=1,
+        start_date=start,
+    )
+    session.add(up)
+    await session.commit()
+    await session.refresh(up)
+    assert up.id is not None
+
+    # Four sessions per week spread evenly to satisfy any "active per week" check.
+    now = datetime.now(UTC)
+    for week in range(weeks):
+        for day_offset in (0, 2, 4, 6):
+            session.add(
+                PracticeSession(
+                    user_id=user_id,
+                    user_practice_id=up.id,
+                    duration_minutes=10.0,
+                    timestamp=now - timedelta(weeks=week, days=day_offset),
+                )
+            )
+    await session.commit()
+    return practice.id
+
+
+# ---------------------------------------------------------------------------
+# SELECT-count helper (mirrors test_completion_candidates.py pattern)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _count_selects() -> Iterator[list[str]]:
+    """Count SELECT statements run against the shared test engine."""
+    counter: list[str] = []
+
+    def _before(
+        _conn: object,
+        _cursor: object,
+        statement: str,
+        _params: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        if statement.lstrip().upper().startswith("SELECT"):
+            counter.append(statement)
+
+    sync_engine = test_engine.sync_engine
+    event.listen(sync_engine, "before_cursor_execute", _before)
+    try:
+        yield counter
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _before)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for asserting persisted rows
+# ---------------------------------------------------------------------------
+
+
+async def _signals_for(session: AsyncSession, user_id: int) -> list[InvitationSignal]:
+    """Return all InvitationSignal rows for user_id (dismissed or live)."""
+    result = await session.execute(
+        select(InvitationSignal).where(col(InvitationSignal.user_id) == user_id)
+    )
+    return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# 8. Persists new row when signal is triggered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generates_and_persists_habit_consistency_signal(
+    db_session: AsyncSession,
+) -> None:
+    """A habit streak at threshold causes one InvitationSignal row to be inserted."""
+    user_id = await _make_user(db_session)
+    habit_id = await _make_habit_with_streak(db_session, user_id, streak_days=_SUSTAINED_STREAK)
+
+    returned = await generate_invitation_signals(db_session, user_id)
+
+    assert len(returned) == 1
+    assert returned[0].target_type == "habit"
+    assert returned[0].target_id == habit_id
+    assert returned[0].kind == "consistency"
+
+    # Row must be persisted — verify via an independent query using col().
+    persisted = await _signals_for(db_session, user_id)
+    assert len(persisted) == 1
+    assert persisted[0].id is not None
+    assert persisted[0].target_type == "habit"
+    assert persisted[0].target_id == habit_id
+    assert persisted[0].kind == "consistency"
+    assert persisted[0].dismissed_at is None
+
+
+# ---------------------------------------------------------------------------
+# 9. Idempotent: second run inserts nothing, returns empty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_call_is_idempotent_and_returns_empty(
+    db_session: AsyncSession,
+) -> None:
+    """Running generate_invitation_signals twice inserts the row exactly once."""
+    user_id = await _make_user(db_session)
+    await _make_habit_with_streak(db_session, user_id, streak_days=_SUSTAINED_STREAK)
+
+    first = await generate_invitation_signals(db_session, user_id)
+    second = await generate_invitation_signals(db_session, user_id)
+
+    assert len(first) == 1
+    assert second == []
+
+    # Still exactly one row in the DB after two calls.
+    persisted = await _signals_for(db_session, user_id)
+    assert len(persisted) == 1
+
+
+# ---------------------------------------------------------------------------
+# 10. Dismissed row blocks regeneration (core acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dismissed_signal_is_never_regenerated(
+    db_session: AsyncSession,
+) -> None:
+    """A dismissed row blocks re-creation — the dedup covers live AND dismissed rows."""
+    user_id = await _make_user(db_session)
+    habit_id = await _make_habit_with_streak(db_session, user_id, streak_days=_SUSTAINED_STREAK)
+
+    # First call creates the row.
+    first_batch = await generate_invitation_signals(db_session, user_id)
+    assert len(first_batch) == 1
+    row = first_batch[0]
+    assert row.id is not None
+
+    # Dismiss the row (simulate user declining).
+    row.dismissed_at = datetime.now(UTC)
+    db_session.add(row)
+    await db_session.commit()
+
+    # Verify it is dismissed via col() query.
+    dismissed_rows = await db_session.execute(
+        select(InvitationSignal).where(
+            col(InvitationSignal.user_id) == user_id,
+            col(InvitationSignal.target_id) == habit_id,
+            col(InvitationSignal.kind) == "consistency",
+        )
+    )
+    dismissed_signal = dismissed_rows.scalars().one()
+    assert dismissed_signal.dismissed_at is not None
+
+    # Second call must return nothing and must not create a duplicate.
+    second_batch = await generate_invitation_signals(db_session, user_id)
+    assert second_batch == []
+
+    all_rows = await _signals_for(db_session, user_id)
+    assert len(all_rows) == 1  # the dismissed row, not a new one
+    assert all_rows[0].id == row.id
+
+
+# ---------------------------------------------------------------------------
+# 11. Null-target dedup: embodied_community not duplicated across runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_null_target_embodied_community_not_duplicated(
+    db_session: AsyncSession,
+) -> None:
+    """The null-target partial index dedups embodied_community across runs."""
+    # Seed a pre-existing row directly so we can test the dedup path in isolation.
+    user_id = await _make_user(db_session)
+    existing = InvitationSignal(
+        user_id=user_id,
+        target_type="embodied_community",
+        target_id=None,
+        kind="readiness",
+    )
+    db_session.add(existing)
+    await db_session.commit()
+    await db_session.refresh(existing)
+    assert existing.id is not None
+
+    # Now seed data that would normally generate the same signal.
+    now = datetime.now(UTC)
+    for day_offset in range(25):
+        db_session.add(
+            JournalEntry(
+                message=f"Entry {day_offset}",
+                sender="user",
+                user_id=user_id,
+                timestamp=now - timedelta(days=day_offset),
+            )
+        )
+    await db_session.commit()
+
+    result = await generate_invitation_signals(db_session, user_id)
+
+    # Dedup must block a second embodied_community row.
+    assert not any(r.target_type == "embodied_community" for r in result)
+
+    all_rows = await _signals_for(db_session, user_id)
+    community_rows = [r for r in all_rows if r.target_type == "embodied_community"]
+    assert len(community_rows) == 1
+    assert community_rows[0].id == existing.id
+
+
+# ---------------------------------------------------------------------------
+# 12. Below-threshold user → no rows inserted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_user_produces_no_signals(
+    db_session: AsyncSession,
+) -> None:
+    """A user with a streak of 1 generates no signals (silence-by-default)."""
+    user_id = await _make_user(db_session)
+    await _make_habit_with_streak(db_session, user_id, streak_days=1)
+
+    result = await generate_invitation_signals(db_session, user_id)
+
+    assert result == []
+    persisted = await _signals_for(db_session, user_id)
+    assert persisted == []
+
+
+# ---------------------------------------------------------------------------
+# 13. Bounded query count — no N+1 over habits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gather_does_not_produce_n_plus_one_queries(
+    db_session: AsyncSession,
+) -> None:
+    """Adding a second above-threshold habit must not add another round-trip.
+
+    A fixed SELECT budget is generous; the point is that scaling habits does
+    not scale queries.  If the gather uses a single aggregation query this
+    passes trivially; if it issues per-habit SELECTs it fails at >= 2 habits.
+    """
+    user_id = await _make_user(db_session)
+    await _make_habit_with_streak(
+        db_session, user_id, streak_days=_SUSTAINED_STREAK, name="Habit A"
+    )
+    await _make_habit_with_streak(
+        db_session, user_id, streak_days=_SUSTAINED_STREAK + 5, name="Habit B"
+    )
+
+    with _count_selects() as queries_one:
+        await generate_invitation_signals(db_session, user_id)
+
+    # Now add a third habit and check that the count does not grow proportionally.
+    # We can't re-run on the same session (dedup blocks inserts), so we measure
+    # relative growth: two habits must use the same or fewer queries than three.
+    user_id_2 = await _make_user(db_session, "inv2@example.com")
+    await _make_habit_with_streak(
+        db_session, user_id_2, streak_days=_SUSTAINED_STREAK, name="Habit X"
+    )
+    await _make_habit_with_streak(
+        db_session, user_id_2, streak_days=_SUSTAINED_STREAK, name="Habit Y"
+    )
+    await _make_habit_with_streak(
+        db_session, user_id_2, streak_days=_SUSTAINED_STREAK, name="Habit Z"
+    )
+
+    with _count_selects() as queries_two:
+        await generate_invitation_signals(db_session, user_id_2)
+
+    # Both runs should use the same number of SELECT round-trips (constant query count).
+    assert len(queries_two) <= len(queries_one) + 2, (
+        f"N+1 suspected: 2-habit run used {len(queries_one)} SELECTs, "
+        f"3-habit run used {len(queries_two)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 14. Non-UTC timezone: the active-days window boundary must be a true instant
+# ---------------------------------------------------------------------------
+
+
+async def _seed_journal_days(
+    session: AsyncSession, user_id: int, timestamps: list[datetime]
+) -> None:
+    """Seed one JournalEntry per supplied timestamp (a cross-feature activity row)."""
+    for index, ts in enumerate(timestamps):
+        session.add(
+            JournalEntry(
+                message=f"Entry {index}",
+                sender="user",
+                user_id=user_id,
+                timestamp=ts,
+            )
+        )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_active_days_window_boundary_uses_utc_instant_under_non_utc_tz(
+    db_session: AsyncSession,
+) -> None:
+    """The 30-day window boundary must compare instants, not the user's wall-clock offset.
+
+    ``America/Los_Angeles`` runs at ``-07:00``/``-08:00``.  SQLite stores the
+    activity timestamps as ``+00:00`` ISO strings and compares them *lexically*,
+    blind to the offset suffix, so a boundary carrying the user's offset skews the
+    window edge by that offset.  Here we seed exactly 24 distinct in-window local
+    days (below the 25-day threshold) plus one activity that is genuinely *outside*
+    the true UTC 30-day window but sits within one LA offset of the edge.  A
+    user-offset boundary wrongly pulls that stale row in — lifting the distinct-day
+    count to 25 and fabricating an ``embodied_community`` candidate.  The
+    UTC-normalized boundary excludes it, so the count stays 24 and no signal is
+    emitted.
+    """
+    user_id = await _make_user(db_session)
+    now_la = now_in_tz(_LA_TZ)
+
+    # 24 distinct in-window local days: comfortably inside the true UTC window
+    # (each anchored at local noon so day-bucketing is unambiguous).
+    in_window: list[datetime] = []
+    for days_ago in range(1, 25):
+        local_day = (now_la - timedelta(days=days_ago)).replace(
+            hour=12, minute=0, second=0, microsecond=0
+        )
+        in_window.append(local_day.astimezone(UTC))
+
+    # One activity 3 hours older than the true 30-day cutoff: excluded by a UTC
+    # instant boundary, but wrongly included by the LA-offset (buggy) boundary,
+    # which is over-inclusive at the trailing edge by the zone offset.
+    stale = now_la - timedelta(days=_ENGAGEMENT_WINDOW_DAYS, hours=3)
+    stale_utc = stale.astimezone(UTC)
+
+    await _seed_journal_days(db_session, user_id, [*in_window, stale_utc])
+
+    # The 24 in-window rows must bucket to 24 distinct LA days, and the stale row
+    # must fall on a distinct 25th LA day — otherwise the boundary flip can't move
+    # the count across the threshold and the guard would not exercise the bug.
+    in_window_days = {to_user_date_bucket(ts, _LA_TZ) for ts in in_window}
+    assert len(in_window_days) == 24
+    assert to_user_date_bucket(stale_utc, _LA_TZ) not in in_window_days
+
+    result = await generate_invitation_signals(db_session, user_id, user_timezone=_LA_TZ)
+
+    # True UTC-instant window counts 24 active days (< 25) → no community signal.
+    assert not any(r.target_type == "embodied_community" for r in result)
+    persisted = await _signals_for(db_session, user_id)
+    assert not any(r.target_type == "embodied_community" for r in persisted)


### PR DESCRIPTION
## Summary
Computes resonance-gated deepening invitations from a user's own behavior and generates them without ever recreating a declined one (NORTH-STAR §6). **Domain + service only — no endpoint/trigger yet (a later sub-issue).**

- **`domain/invitations.py` (pure, no I/O)**: `compute_invitation_candidates(ReadinessAggregates)` maps signals to zero-or-more candidates under **three conservative, documented thresholds** — a sustained habit streak (≥21d → `consistency`), a sustained practice cadence (≥4 weeks → `mastery`), and high cross-feature engagement (≥25 of 30 active days → an **outward `embodied_community`** invitation, honoring the chronically-online persona). **Silence by default**: below threshold yields nothing. No shaming/FOMO — coordinates only (target_type/target_id/kind), no copy.
- **`services/invitations.py`**: gathers aggregates with **one grouped query per source (no N+1)**, calls the pure fn, **dedups against ALL existing signals (dismissed or live)** so a declined invitation is never regenerated (including the null-target case), and persists survivors with a `begin_nested` + `IntegrityError` backstop over the #921 partial unique indexes. The active-day window boundary is **UTC-normalized** so SQLite's lexical timestamp comparison matches Postgres.

## Test plan
- 20 tests. **Pure (13)**: silence-by-default (empty→`[]`); each signal below/at threshold; the embodied-community null-target path; multi-signal coexistence; determinism/purity (no session); enum-value drift guard. **Service (7)**: persists new; idempotent (run-twice → one row); **dismissed never regenerated**; null-target dedup; below-threshold silence; a bounded-query (no-N+1) assertion; and a **non-UTC-timezone boundary** test (`America/Los_Angeles`) that fails against a user-offset window and passes with the UTC-normalized one.
- `scripts/backend/check-all.sh` exits 0 (7/7). **xenon** standalone → `src/` rank A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #922
Refs #920