### PR TITLE
fix(frontend): calm the Practice tab's stacked umber showcase bands

### DIFF
--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -338,16 +338,17 @@ describe('PracticeScreen', () => {
     );
   });
 
-  it('wraps the running session mode view in the showcase SessionSurface (#859)', async () => {
-    // The active session provides the warm-dark showcase surface to the mode
-    // view, so the interior renders on the umber ground (not the light one).
+  it('wraps the running session mode view in the calm SessionSurface', async () => {
+    // The active session now provides the calm lifted-paper surface to the mode
+    // view, so the interior renders on the light raised ground; the deep umber
+    // is reserved for the single Begin hero accent.
     const { StyleSheet } = require('react-native');
-    const { showcase } = require('../../../design/tokens');
+    const { surface } = require('../../../design/tokens');
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId } = render(<PracticeScreen />);
     await waitFor(() => expect(getByTestId('meditation-timer-view')).toBeTruthy());
     const ground = StyleSheet.flatten(getByTestId('meditation-timer-view').props.style);
-    expect(ground.backgroundColor).toBe(showcase.canvas);
+    expect(ground.backgroundColor).toBe(surface.raised);
   });
 
   it('reflects a practice selected elsewhere once the screen regains focus', async () => {

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -35,15 +35,7 @@ import type {
 } from '@/api';
 import { practiceSessions } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import {
-  BORDER_RADIUS,
-  SPACING,
-  colors,
-  onShowcase,
-  showcase,
-  showcaseShadow,
-  surface,
-} from '@/design/tokens';
+import { BORDER_RADIUS, SPACING, colors, ink, surface, surfaceShadow } from '@/design/tokens';
 import { InsightCaptureModal } from '@/features/Practice/components/InsightCaptureModal';
 import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConfiguratorSheet';
 import type { PickedCard } from '@/features/Practice/data/resolveCard';
@@ -75,7 +67,7 @@ import MindfulAnchorView from '@/features/Practice/views/MindfulAnchorView';
 import RandomIntervalBellView from '@/features/Practice/views/RandomIntervalBellView';
 import RepCounterView from '@/features/Practice/views/RepCounterView';
 import SenseGroundingView from '@/features/Practice/views/SenseGroundingView';
-import { SHOWCASE_SURFACE, SessionSurfaceProvider } from '@/features/Practice/views/sessionSurface';
+import { CALM_SURFACE, SessionSurfaceProvider } from '@/features/Practice/views/sessionSurface';
 import TalliedGroundingView from '@/features/Practice/views/TalliedGroundingView';
 import TarotMeditationView from '@/features/Practice/views/TarotMeditationView';
 import { useOptimisticMutation } from '@/hooks/useOptimisticMutation';
@@ -420,13 +412,13 @@ interface SessionCardProps {
 }
 
 function SessionCard(props: SessionCardProps): React.JSX.Element {
-  // The session is fronted by a warm-dark showcase header band (practice name +
-  // Adjust on the umber ground) so a running practice reads as a focal moment
-  // rather than a settings form; the mode view renders below on its readable
+  // The session is fronted by a lifted-paper header band (practice name +
+  // Adjust on white raised paper) so a running practice reads as a focal moment
+  // rather than a settings form; the mode view renders below on the same calm
   // ground. The shared RitualControlsBar plays the completion Celebration.
   return (
     <View style={styles.card} testID="active-practice-card">
-      <View style={styles.headerBand}>
+      <View style={styles.headerBand} testID="active-practice-header-band">
         <View style={styles.cardHeader}>
           <TouchableOpacity
             accessibilityRole="button"
@@ -443,7 +435,7 @@ function SessionCard(props: SessionCardProps): React.JSX.Element {
           {props.effectiveName}
         </Text>
       </View>
-      <SessionSurfaceProvider value={SHOWCASE_SURFACE}>
+      <SessionSurfaceProvider value={CALM_SURFACE}>
         <ModeView
           config={props.config}
           state={props.state}
@@ -912,22 +904,22 @@ function repCounterSummary(config: RepCounterConfig, state: RitualState): ModeSu
 }
 
 const styles = StyleSheet.create({
-  // Flat session container; the warm-dark showcase header band sits at its top.
+  // Flat session container; the lifted-paper header band sits at its top.
   card: {
     paddingBottom: SPACING.lg,
     marginBottom: SPACING.lg,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: surface.hairline,
   },
-  // The showcase header band: the practice name + Adjust on the umber ground.
+  // The lifted-paper header band: the practice name + Adjust on white raised paper.
   headerBand: {
-    backgroundColor: showcase.canvas,
+    backgroundColor: surface.raised,
     borderRadius: BORDER_RADIUS.lg,
     paddingHorizontal: SPACING.lg,
     paddingBottom: SPACING.md,
     paddingTop: SPACING.xs,
     marginBottom: SPACING.lg,
-    ...showcaseShadow,
+    ...surfaceShadow.card,
   },
   cardHeader: {
     flexDirection: 'row',
@@ -943,12 +935,12 @@ const styles = StyleSheet.create({
     minHeight: 44,
     paddingHorizontal: SPACING.sm,
   },
-  gearText: { fontSize: 18, color: onShowcase.soft },
-  gearLabel: { fontSize: 14, fontWeight: '600', color: onShowcase.soft },
+  gearText: { fontSize: 18, color: ink.soft },
+  gearLabel: { fontSize: 14, fontWeight: '600', color: ink.soft },
   name: {
     fontSize: 20,
     fontWeight: '700',
-    color: onShowcase.primary,
+    color: ink.primary,
     marginBottom: SPACING.md,
   },
   error: {

--- a/frontend/src/features/Practice/views/__tests__/calmSurfaceMigration.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/calmSurfaceMigration.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * Gate 1 RED — pins the calm-surface migration contract for the Practice tab.
+ *
+ * Direction 2: only BeginHero stays on showcase.canvas; the session header band
+ * and all in-session mode views move to a new calm surface built from existing
+ * surface.raised / ink.* / accent.primary tokens.
+ *
+ * RED tests (fail until implementation lands):
+ *   A — mode view background is surface.raised in the live session wiring
+ *   A — mode view primary text is ink.primary in the live session wiring
+ *   B — header band background is surface.raised (requires testID on the band)
+ *   B — session name text is ink.primary (not onShowcase.primary)
+ *
+ * Characterization tests (GREEN today — lock regressions):
+ *   C — BeginHero stays on showcase.canvas
+ *   D — ink / accent tokens clear WCAG AA on surface.raised
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { fakeControls, fakeState } from './fixtures';
+
+import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
+import { accent, ink, onShowcase, showcase, surface } from '@/design/tokens';
+import MeditationTimerView from '@/features/Practice/views/MeditationTimerView';
+import { SessionSurfaceProvider } from '@/features/Practice/views/sessionSurface';
+
+// ---------------------------------------------------------------------------
+// Helpers — verbatim from sessionSurfaceMigration.test.tsx
+// ---------------------------------------------------------------------------
+
+const AA_NORMAL = 4.5;
+
+/** WCAG relative luminance of a #rrggbb colour. */
+const luminance = (hex: string): number => {
+  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
+  const channels = [match[1], match[2], match[3]].map((pair) => {
+    const c = Number.parseInt(pair!, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+};
+
+const contrast = (a: string, b: string): number => {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi! + 0.05) / (lo! + 0.05);
+};
+
+const flatColor = (style: unknown): string | undefined =>
+  (StyleSheet.flatten(style as never) as { color?: string }).color;
+
+const flatBackground = (style: unknown): string | undefined =>
+  (StyleSheet.flatten(style as never) as { backgroundColor?: string }).backgroundColor;
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — required by the PracticeScreen render path in A, B, C.
+// jest.mock calls are hoisted; factory closures run lazily on first import.
+// ---------------------------------------------------------------------------
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactMod = require('react') as typeof React;
+  const passthrough = ({ children }: { children: React.ReactNode }) =>
+    ReactMod.createElement(ReactMod.Fragment, null, children);
+  return {
+    SafeAreaProvider: passthrough,
+    SafeAreaView: passthrough,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('@react-navigation/native', () => {
+  const reactMod = jest.requireActual('react') as {
+    useEffect: (_cb: () => undefined | (() => void), _deps: unknown[]) => void;
+  };
+  return {
+    ...(jest.requireActual('@react-navigation/native') as object),
+    useNavigation: () => ({ navigate: jest.fn() }),
+    useFocusEffect: (cb: () => void | (() => void)) => {
+      reactMod.useEffect(() => {
+        const cleanup = cb();
+        return () => {
+          if (typeof cleanup === 'function') cleanup();
+        };
+      }, [cb]);
+    },
+  };
+});
+
+jest.mock('../../../../navigation/hooks', () => ({
+  useAppNavigation: () => ({ navigate: jest.fn() }),
+  useAppRoute: () => ({ key: 'Practice-test', name: 'Practice', params: {} }),
+}));
+
+jest.mock('../../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
+jest.mock('../../../../api', () => ({
+  practices: {
+    listAll: jest.fn<() => Promise<unknown>>().mockResolvedValue([
+      {
+        id: 1,
+        stage_number: 1,
+        name: 'Breath Awareness',
+        description: 'Focus on the breath.',
+        instructions: 'Sit comfortably.',
+        default_duration_minutes: 10,
+        submitted_by_user_id: null,
+        approved: true,
+        mode: 'meditation_timer',
+        mode_config: { mode: 'meditation_timer', duration_minutes: 10 },
+      },
+    ]),
+  },
+  userPractices: {
+    create: jest.fn(),
+    list: jest.fn<() => Promise<unknown>>().mockResolvedValue([
+      {
+        id: 10,
+        user_id: 1,
+        practice_id: 1,
+        stage_number: 1,
+        start_date: '2026-04-12',
+        end_date: null,
+      },
+    ]),
+    customize: jest.fn(),
+  },
+  practiceSessions: {
+    create: jest.fn(),
+    weekCount: jest.fn<() => Promise<unknown>>().mockResolvedValue({ count: 0 }),
+    insights: jest.fn<() => Promise<unknown>>().mockRejectedValue(new Error('unavailable')),
+  },
+  frequency: {
+    current: jest.fn<() => Promise<unknown>>().mockResolvedValue({
+      stage_number: 1,
+      color: 'Beige',
+      aspect: 'Body',
+      practice_name: 'Breath Awareness',
+      practice_id: 1,
+      user_practice_id: 10,
+      banner_text: 'You are in the Beige frequency.',
+    }),
+  },
+}));
+
+jest.mock('../../../../store/useProgramProgression', () => ({
+  useDerivedCurrentStage: (s: number) => s,
+}));
+
+jest.mock('../../../../store/useStageStore', () => ({
+  selectCurrentStage: (s: { currentStage: number }) => s.currentStage,
+  useStageStore: (sel: (_s: { currentStage: number; stages: unknown[] }) => unknown) =>
+    sel({ currentStage: 1, stages: [] }),
+}));
+
+jest.mock('../../../../features/Map/services/stageService', () => ({
+  stageService: { loadStages: jest.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Test A — mode view re-skins off umber (real wiring via PracticeScreen)
+// RED: ActiveRitualSession currently passes SHOWCASE_SURFACE to the provider,
+// so meditation-timer-view gets backgroundColor=showcase.canvas (#2a211a), not
+// surface.raised (#ffffff). Both assertions below fail today.
+// ---------------------------------------------------------------------------
+
+describe('A: mode view re-skins off umber (real ActiveRitualSession wiring)', () => {
+  it('meditation-timer-view ground resolves to surface.raised, not showcase.canvas', async () => {
+    const PracticeScreen = require('../../../../features/Practice/PracticeScreen')
+      .default as React.ComponentType;
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('meditation-timer-view')).toBeTruthy());
+    expect(flatBackground(getByTestId('meditation-timer-view').props.style)).toBe(surface.raised);
+    expect(flatBackground(getByTestId('meditation-timer-view').props.style)).not.toBe(
+      showcase.canvas,
+    );
+  });
+
+  it('meditation-time-remaining resolves to ink.primary, not onShowcase.primary', async () => {
+    const PracticeScreen = require('../../../../features/Practice/PracticeScreen')
+      .default as React.ComponentType;
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('meditation-time-remaining')).toBeTruthy());
+    expect(flatColor(getByTestId('meditation-time-remaining').props.style)).toBe(ink.primary);
+    expect(flatColor(getByTestId('meditation-time-remaining').props.style)).not.toBe(
+      onShowcase.primary,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test A-seam — standalone SessionSurfaceProvider seam (characterization)
+// GREEN today: confirms the seam itself works when provided a calm surface.
+// The real wiring (which surface ActiveRitualSession provides) is what A tests.
+// ---------------------------------------------------------------------------
+
+describe('A-seam: SessionSurfaceProvider forwards calm surface to mode views', () => {
+  const calmSurface = {
+    ground: surface.raised,
+    raised: surface.sunken,
+    text: ink.primary,
+    textSoft: ink.soft,
+    textMuted: ink.muted,
+    accent: accent.primary,
+  };
+
+  it('meditation-timer-view uses provided ground', () => {
+    const { getByTestId } = render(
+      <SessionSurfaceProvider value={calmSurface}>
+        <MeditationTimerView state={fakeState({ remainingMs: 0 })} controls={fakeControls()} />
+      </SessionSurfaceProvider>,
+    );
+    expect(flatBackground(getByTestId('meditation-timer-view').props.style)).toBe(surface.raised);
+  });
+
+  it('meditation-time-remaining uses provided text', () => {
+    const { getByTestId } = render(
+      <SessionSurfaceProvider value={calmSurface}>
+        <MeditationTimerView state={fakeState({ remainingMs: 0 })} controls={fakeControls()} />
+      </SessionSurfaceProvider>,
+    );
+    expect(flatColor(getByTestId('meditation-time-remaining').props.style)).toBe(ink.primary);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test B — session header band leaves umber (ActiveRitualSession)
+// RED:
+//   - active-practice-header-band testID does not exist on the headerBand View
+//     (element not found until the impl adds it).
+//   - active-practice-name static style sets color: onShowcase.primary today.
+// ---------------------------------------------------------------------------
+
+describe('B: session header band leaves umber (ActiveRitualSession)', () => {
+  it('header band background resolves to surface.raised', async () => {
+    // Implementation must add testID="active-practice-header-band" to the
+    // headerBand View and set its backgroundColor from the calm surface ground.
+    // RED today: element not found.
+    const PracticeScreen = require('../../../../features/Practice/PracticeScreen')
+      .default as React.ComponentType;
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+    const band = getByTestId('active-practice-header-band');
+    expect(flatBackground(band.props.style)).toBe(surface.raised);
+    expect(flatBackground(band.props.style)).not.toBe(showcase.canvas);
+  });
+
+  it('session name text resolves to ink.primary', async () => {
+    // active-practice-name static style uses onShowcase.primary today.
+    // RED: the assertion toBe(ink.primary) fails.
+    const PracticeScreen = require('../../../../features/Practice/PracticeScreen')
+      .default as React.ComponentType;
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('active-practice-name')).toBeTruthy());
+    expect(flatColor(getByTestId('active-practice-name').props.style)).toBe(ink.primary);
+    expect(flatColor(getByTestId('active-practice-name').props.style)).not.toBe(onShowcase.primary);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test C — BeginHero regression guard (characterization — GREEN today)
+// Locks the single retained showcase accent so the impl cannot over-flatten.
+// ---------------------------------------------------------------------------
+
+describe('C: BeginHero stays on showcase.canvas (regression guard)', () => {
+  it('ShowcaseCard renders with showcase.canvas background', () => {
+    // ShowcaseCard is what BeginHero uses; asserting on it directly avoids
+    // the full PracticeScreen mock stack while still pinning the contract.
+    const { getByTestId } = render(
+      <ShowcaseCard testID="hero-probe">
+        <></>
+      </ShowcaseCard>,
+    );
+    expect(flatBackground(getByTestId('hero-probe').props.style)).toBe(showcase.canvas);
+  });
+
+  it('practice-begin-hero in PracticeScreen renders on showcase.canvas', async () => {
+    // Belt-and-suspenders: verify the live wiring inside PracticeScreen too.
+    const PracticeScreen = require('../../../../features/Practice/PracticeScreen')
+      .default as React.ComponentType;
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('practice-begin-hero')).toBeTruthy());
+    expect(flatBackground(getByTestId('practice-begin-hero').props.style)).toBe(showcase.canvas);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test D — token AA guard for calm surface (characterization — GREEN today)
+// Asserts every ink / accent role used by the calm surface clears WCAG AA on
+// surface.raised. If any assertion FAILS here, stop — the chosen token fails
+// AA on the calm surface, which is a real design defect.
+// ---------------------------------------------------------------------------
+
+describe('D: calm surface tokens clear WCAG AA on surface.raised', () => {
+  it('ink.primary (text) clears AA on surface.raised', () => {
+    expect(contrast(ink.primary, surface.raised)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+
+  it('ink.soft (textSoft) clears AA on surface.raised', () => {
+    expect(contrast(ink.soft, surface.raised)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+
+  it('ink.muted (textMuted) clears AA on surface.raised', () => {
+    expect(contrast(ink.muted, surface.raised)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+
+  it('accent.primary clears AA on surface.raised', () => {
+    expect(contrast(accent.primary, surface.raised)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+});

--- a/frontend/src/features/Practice/views/sessionSurface.ts
+++ b/frontend/src/features/Practice/views/sessionSurface.ts
@@ -11,12 +11,13 @@
  * The default value is the original light palette, so any view rendered WITHOUT
  * a provider (e.g. the idle selector, existing unit tests) is byte-for-byte
  * unchanged. `ActiveRitualSession` wraps the live session in
- * {@link SessionSurfaceProvider} with {@link SHOWCASE_SURFACE} to flip the whole
- * mode view onto the umber ground with AA-clearing `onShowcase` cues.
+ * {@link SessionSurfaceProvider} with {@link CALM_SURFACE} to skin the whole
+ * mode view onto lifted white paper with AA-clearing `ink.*` cues, keeping the
+ * deep umber `showcase` ground for the single Begin hero accent.
  */
 import { createContext, useContext } from 'react';
 
-import { colors, onShowcase, showcase } from '@/design/tokens';
+import { accent, colors, ink, onShowcase, showcase, surface } from '@/design/tokens';
 
 export interface SessionSurface {
   /** The ground the session renders on. */
@@ -59,6 +60,22 @@ export const SHOWCASE_SURFACE: SessionSurface = {
   textSoft: onShowcase.soft,
   textMuted: onShowcase.muted,
   accent: onShowcase.primary,
+};
+
+/**
+ * The calm lifted-paper session surface — a running session rests on white
+ * `surface.raised` with the AA-clearing `ink.*` scale, recessed `surface.sunken`
+ * wells, and the terracotta `accent.primary`. The deep umber `showcase` ground
+ * is reserved for the single Begin hero accent, so a running practice reads as
+ * quiet lifted paper rather than a third stacked umber band.
+ */
+export const CALM_SURFACE: SessionSurface = {
+  ground: surface.raised,
+  raised: surface.sunken,
+  text: ink.primary,
+  textSoft: ink.soft,
+  textMuted: ink.muted,
+  accent: accent.primary,
 };
 
 const SessionSurfaceContext = createContext<SessionSurface>(LIGHT_SURFACE);


### PR DESCRIPTION
## Summary
The Practice tab stacked **three** deep-umber `showcase` bands — the Begin hero, the session header band, and the timer/mode-view ground — so a near-black brown (`showcase.canvas #2a211a`) dominated the light paper canvas (`surface.canvas #faf6ef`) and read as harsh rather than the calm, candlelit feel the rest of the app aims for. Text contrast was already fine; this was an **aesthetic / visual-weight** fix.

**Direction 2** (reduce how many showcase bands stack), via the existing `SessionSurface` context seam:

- Keep **only the Begin hero** on the deep umber, as a single deliberate accent.
- Add `CALM_SURFACE` to `sessionSurface.ts`: `surface.raised` ground, `surface.sunken` wells, `ink.*` text, `accent.primary` — composed entirely from existing AA-clearing semantic tokens (**no new or changed design token**).
- `ActiveRitualSession` points `SessionSurfaceProvider` at `CALM_SURFACE` and renders the header band on `surface.raised` (`ink` text, `surfaceShadow.card`); **every in-session mode view re-skins automatically** through `useSessionSurface()` — zero mode-view edits.
- The shared `showcase.canvas` token is **byte-for-byte untouched**, so `BeginHero` and the Today / Course / Map heroes are unaffected (zero blast radius — the reason direction 2 was chosen over softening the shared token).

## Test plan
Pinned via **token-consumption assertions** (not brittle pixel snapshots):
- `calmSurfaceMigration.test.tsx` (new): mode view + header band resolve to `surface.raised` / `ink.primary`; `BeginHero` still on `showcase.canvas` (over-flatten guard); the calm surface's `ink.*`/`accent.primary` clear WCAG AA (≥4.5:1) on `surface.raised`.
- `PracticeScreen.test.tsx`: the prior mode-view-on-showcase test updated to assert the intended calm-surface behavior.
- `showcaseTokens` / `semanticTokens` tests untouched and green (they guard the shared tokens we did not change).
- `scripts/frontend/check-all.sh` exits 0 (2495 tests, ESLint zero-warning, prettier, tsc strict).

Self-review (Gate 2.5): **CLEAN** — seam repoint verified (no mode view hardcodes umber), `CALM_SURFACE` shape correct, well-step reads as a correct recessed shade, shared token intact, AA holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #929