### PR TITLE
fix(frontend): stop Practice Catalog empty-state cards overlapping and blocking taps

### DIFF
--- a/frontend/src/components/feedback/EmptyState.tsx
+++ b/frontend/src/components/feedback/EmptyState.tsx
@@ -3,6 +3,11 @@
  * an optional call-to-action slot. Replaces the bare one-line "nothing here yet"
  * text the Practice / Journal / Course screens each rolled by hand. Fades in via
  * ``useEntrance`` (static under reduced motion); token-only, AA on the canvas.
+ *
+ * Two layouts: the default full-screen centred surface, and a compact ``inline``
+ * variant (transparent, non-expanding, no settle offset) for use as an in-list
+ * block such as a ``SectionList`` footer, where the full-screen version would
+ * overlap and cover neighbouring rows.
  */
 import React from 'react';
 import {
@@ -28,6 +33,16 @@ interface EmptyStateProps {
   cta?: React.ReactNode;
   /** Extra container style — e.g. safe-area insets from the host screen. */
   style?: StyleProp<ViewStyle>;
+  /**
+   * When ``true``, render as a compact, transparent, non-expanding block that
+   * sits inline within a host list (e.g. a ``SectionList`` footer) rather than
+   * as its own full-screen surface. Also suppresses the entrance's upward
+   * settle so it doesn't read as floating over the content beneath it.
+   *
+   * Defaults to ``false``: the full-screen centered/opaque behavior the
+   * Today / Course / Journal / Practice screens rely on is preserved untouched.
+   */
+  inline?: boolean;
   testID?: string;
 }
 
@@ -37,12 +52,19 @@ export function EmptyState({
   body,
   cta,
   style,
+  inline = false,
   testID = 'empty-state',
 }: EmptyStateProps): React.JSX.Element {
   const t = type(useWindowDimensions().width);
   const entrance = useEntrance();
+  // Inline keeps the opacity fade but drops the upward settle so it reads as
+  // part of the list, not a surface floating in from below.
+  const entranceStyle = inline ? { opacity: entrance.opacity } : entrance;
   return (
-    <Animated.View style={[styles.container, style, entrance]} testID={testID}>
+    <Animated.View
+      style={[styles.container, inline && styles.inline, style, entranceStyle]}
+      testID={testID}
+    >
       <Text style={styles.glyph} accessibilityElementsHidden importantForAccessibility="no">
         {glyph}
       </Text>
@@ -63,6 +85,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: rhythm.screenPaddingH,
     gap: rhythm.blockGap,
     backgroundColor: surface.canvas,
+  },
+  inline: {
+    flex: 0,
+    alignItems: 'stretch',
+    justifyContent: 'flex-start',
+    backgroundColor: 'transparent',
   },
   glyph: { fontSize: GLYPH_SIZE },
   title: { color: ink.primary, textAlign: 'center' },

--- a/frontend/src/components/feedback/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/feedback/__tests__/EmptyState.test.tsx
@@ -40,9 +40,8 @@ describe('EmptyState', () => {
     expect(getByTestId('es')).toHaveStyle({ paddingTop: 47 });
   });
 
-  // Test 5: default-vs-inline guard.
-  // The default half (no inline prop) is a CHARACTERIZATION guard — must stay green.
-  // The inline half is RED until the prop is implemented.
+  // Default-vs-inline guard: the default half locks the full-screen contract the
+  // four full-screen consumers depend on; the inline half pins the compact variant.
   it('default mode keeps full-screen centered opaque container (characterization)', () => {
     const { getByTestId } = render(
       <EmptyState glyph="🧘" title="Full" body="Screen." testID="es-default" />,
@@ -56,7 +55,7 @@ describe('EmptyState', () => {
     expect(flat.backgroundColor).toBe(surface.canvas);
   });
 
-  it('inline mode uses flex:0, flex-start alignment, and transparent background (RED until prop exists)', () => {
+  it('inline mode uses flex:0, flex-start alignment, and transparent background', () => {
     const { getByTestId } = render(
       <EmptyState glyph="🪶" title="Inline" body="Footer." inline testID="es-inline" />,
     );

--- a/frontend/src/components/feedback/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/feedback/__tests__/EmptyState.test.tsx
@@ -2,9 +2,11 @@
 import { jest, describe, it, expect } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
 import { Button } from '@/components/Button';
 import { EmptyState } from '@/components/feedback/EmptyState';
+import { surface } from '@/design/tokens';
 
 describe('EmptyState', () => {
   it('renders the glyph, a header-role title, and the body', () => {
@@ -36,5 +38,35 @@ describe('EmptyState', () => {
       <EmptyState glyph="x" title="t" body="b" style={{ paddingTop: 47 }} testID="es" />,
     );
     expect(getByTestId('es')).toHaveStyle({ paddingTop: 47 });
+  });
+
+  // Test 5: default-vs-inline guard.
+  // The default half (no inline prop) is a CHARACTERIZATION guard — must stay green.
+  // The inline half is RED until the prop is implemented.
+  it('default mode keeps full-screen centered opaque container (characterization)', () => {
+    const { getByTestId } = render(
+      <EmptyState glyph="🧘" title="Full" body="Screen." testID="es-default" />,
+    );
+    const flat = StyleSheet.flatten(
+      getByTestId('es-default').props.style as Parameters<typeof StyleSheet.flatten>[0],
+    ) as { flex?: number; justifyContent?: string; backgroundColor?: string };
+    // These must never regress — Today/Course/Journal/Practice screens depend on them.
+    expect(flat.flex).toBe(1);
+    expect(flat.justifyContent).toBe('center');
+    expect(flat.backgroundColor).toBe(surface.canvas);
+  });
+
+  it('inline mode uses flex:0, flex-start alignment, and transparent background (RED until prop exists)', () => {
+    const { getByTestId } = render(
+      <EmptyState glyph="🪶" title="Inline" body="Footer." inline testID="es-inline" />,
+    );
+    const flat = StyleSheet.flatten(
+      getByTestId('es-inline').props.style as Parameters<typeof StyleSheet.flatten>[0],
+    ) as { flex?: number; justifyContent?: string; backgroundColor?: string };
+    // Must not be a full-screen block.
+    expect(flat.flex).not.toBe(1);
+    expect(flat.flex).toBe(0);
+    expect(flat.justifyContent).not.toBe('center');
+    expect(flat.backgroundColor).toBe('transparent');
   });
 });

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -111,7 +111,7 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
         keyExtractor={catalogKeyExtractor}
         renderItem={renderItem}
         renderSectionHeader={renderSectionHeader}
-        renderSectionFooter={makeSectionFooter(onCreate)}
+        renderSectionFooter={makeSectionFooter(onCreate, sections)}
         ListHeaderComponent={
           <CatalogHeader
             query={query}
@@ -264,13 +264,18 @@ const SECTION_EMPTY_COPY: Readonly<Record<Section, { title: string; body: string
 /**
  * An empty catalog section reads as an editorial empty state that points to the
  * create wizard, rather than the old passive "Nothing here yet." line.
+ *
+ * The empty-state footer only renders when the WHOLE visible catalog is empty:
+ * once any sibling section has rows, an empty section shows nothing so its
+ * footer can't stack over and swallow taps on the populated list.
  */
-/** A SectionList footer renderer that shows the empty state only for empty sections. */
 function makeSectionFooter(
   onCreate: () => void,
+  sections: readonly CatalogSection[],
 ): (info: { section: CatalogSection }) => React.JSX.Element | null {
+  const allEmpty = sections.every((s) => s.data.length === 0);
   return ({ section }) =>
-    section.data.length === 0 ? (
+    allEmpty && section.data.length === 0 ? (
       <SectionFooter section={section.section} onCreate={onCreate} />
     ) : null;
 }
@@ -279,6 +284,7 @@ const SectionFooter = ({ section, onCreate }: SectionFooterProps): React.JSX.Ele
   const copy = SECTION_EMPTY_COPY[section];
   return (
     <EmptyState
+      inline
       glyph="🪶"
       title={copy.title}
       body={copy.body}
@@ -726,7 +732,7 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     marginBottom: SPACING.sm,
   },
-  sectionEmpty: { flex: 0, alignItems: 'stretch', paddingVertical: SPACING.md, gap: SPACING.sm },
+  sectionEmpty: { paddingVertical: SPACING.md, gap: SPACING.sm },
   rowContainer: {
     flexDirection: 'row',
     alignItems: 'stretch',

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -459,7 +459,7 @@ const allEmptyLoad = jest.fn(async () => []) as jest.MockedFunction<
   (_stage: number) => Promise<PracticeItem[]>
 >;
 
-describe('PracticeCatalogScreen — footer suppression (RED until fix)', () => {
+describe('PracticeCatalogScreen — footer suppression', () => {
   // Test 1: empty sibling footers must be absent when any section is populated.
   it('hides drafts and imported empty-footers when presets are populated', async () => {
     const setActive = jest.fn(async () => undefined) as jest.MockedFunction<
@@ -476,7 +476,7 @@ describe('PracticeCatalogScreen — footer suppression (RED until fix)', () => {
       />,
     );
     await waitForLoad();
-    // Both of these must be absent — today they render → RED.
+    // Both empty-section footers must be absent while a sibling section has rows.
     expect(view.queryByTestId('practice-catalog-section-drafts-empty')).toBeNull();
     expect(view.queryByTestId('practice-catalog-section-imported-empty')).toBeNull();
   });
@@ -540,7 +540,7 @@ describe('PracticeCatalogScreen — footer suppression (RED until fix)', () => {
     const flat = StyleSheet.flatten(
       footer.props.style as Parameters<typeof StyleSheet.flatten>[0],
     ) as { flex?: number; justifyContent?: string; backgroundColor?: string };
-    // Must NOT be a full-screen block — today the base container contributes these → RED.
+    // Must NOT be a full-screen block: no expanding flex, centering, or opaque canvas.
     expect(flat.flex).not.toBe(1);
     expect(flat.justifyContent).not.toBe('center');
     expect(flat.backgroundColor).not.toBe(surface.canvas);

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
-import { Alert } from 'react-native';
+import { Alert, StyleSheet } from 'react-native';
 
 import type { PracticeItem } from '@/api';
+import { surface } from '@/design/tokens';
 
 // The catalog reads useSafeAreaInsets; stub it with non-zero insets (no
 // SafeAreaProvider in tests) so the safe-area padding is observable.
@@ -142,10 +143,16 @@ describe('PracticeCatalogScreen — sections', () => {
     });
   });
 
-  it('renders an empty Imported section because no share-token signal exists yet', async () => {
+  it('renders no Imported rows or footer when siblings are populated (no share-token signal yet)', async () => {
+    // Imported is structurally empty today (no share-token mechanism yet).
+    // When presets and drafts are populated the footer is suppressed so it
+    // cannot overlap and swallow taps on the populated list.
     const { view } = renderScreen();
     await waitForLoad();
-    expect(view.getByTestId('practice-catalog-section-imported-empty')).toBeTruthy();
+    // Section header is absent for empty sections (renderSectionHeader returns null).
+    expect(view.queryByTestId('practice-catalog-section-imported')).toBeNull();
+    // Empty-state footer must also be absent — suppressed while siblings have rows.
+    expect(view.queryByTestId('practice-catalog-section-imported-empty')).toBeNull();
   });
 
   it('shows a + Create button that fires the navigate callback', async () => {
@@ -348,14 +355,25 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
 });
 
 describe('PracticeCatalogScreen — empty sections', () => {
-  it('renders an editorial empty state with a Create CTA into the wizard', async () => {
-    const { view, navigateToCreate } = renderScreen();
+  it('renders an editorial empty state with a Create CTA into the wizard when the whole catalog is empty', async () => {
+    // The empty-state footer (with its Create CTA) shows only when every
+    // section is empty — that is the correct, non-overlapping contract.
+    const navigateToCreate = jest.fn();
+    const view = render(
+      <PracticeCatalogScreen
+        initialStage={1}
+        loadPractices={allEmptyLoad}
+        navigateToDetail={jest.fn()}
+        navigateToCreate={navigateToCreate}
+      />,
+    );
     await waitForLoad();
-    // The Imported section is always empty today — it shows the warm empty state
-    // (replacing the old passive "Nothing here yet." line) with a create CTA.
-    expect(view.getByTestId('practice-catalog-section-imported-empty')).toBeTruthy();
+    // All three section footers render under all-empty.
+    expect(view.getByTestId('practice-catalog-section-presets-empty')).toBeTruthy();
+    // Passive "Nothing here yet." copy must not appear in any footer.
     expect(view.queryByText('Nothing here yet.')).toBeNull();
-    fireEvent.press(view.getByTestId('practice-catalog-section-imported-create'));
+    // The Create CTA in the presets footer opens the wizard.
+    fireEvent.press(view.getByTestId('practice-catalog-section-presets-create'));
     expect(navigateToCreate).toHaveBeenCalled();
   });
 });
@@ -412,10 +430,11 @@ describe('PracticeCatalogScreen — virtualization parity', () => {
     const { view, navigateToDetail } = renderScreen();
     await waitForLoad();
 
-    // All three section headers render (the empty Imported section keeps its footer).
+    // Populated section headers render; the empty Imported section renders no header.
     expect(view.getByTestId('practice-catalog-section-presets')).toBeTruthy();
     expect(view.getByTestId('practice-catalog-section-drafts')).toBeTruthy();
-    expect(view.getByTestId('practice-catalog-section-imported-empty')).toBeTruthy();
+    // Footer suppression: Imported is empty but siblings are populated, so no footer.
+    expect(view.queryByTestId('practice-catalog-section-imported-empty')).toBeNull();
 
     // Rows from different sections all appear in the same windowed pass...
     expect(view.getByTestId('practice-catalog-row-1')).toBeTruthy();
@@ -425,5 +444,107 @@ describe('PracticeCatalogScreen — virtualization parity', () => {
     // ...and pressing a row still navigates (behavior unchanged by virtualization).
     fireEvent.press(view.getByTestId('practice-catalog-row-9'));
     expect(navigateToDetail).toHaveBeenCalledWith(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gate-1 RED: footer-suppression + inline-style contract
+// ---------------------------------------------------------------------------
+
+const presetsOnlyLoad = jest.fn(async () => [presetA, presetB]) as jest.MockedFunction<
+  (_stage: number) => Promise<PracticeItem[]>
+>;
+
+const allEmptyLoad = jest.fn(async () => []) as jest.MockedFunction<
+  (_stage: number) => Promise<PracticeItem[]>
+>;
+
+describe('PracticeCatalogScreen — footer suppression (RED until fix)', () => {
+  // Test 1: empty sibling footers must be absent when any section is populated.
+  it('hides drafts and imported empty-footers when presets are populated', async () => {
+    const setActive = jest.fn(async () => undefined) as jest.MockedFunction<
+      (id: number, stage: number) => Promise<void>
+    >;
+    presetsOnlyLoad.mockResolvedValue([presetA, presetB]);
+    const view = render(
+      <PracticeCatalogScreen
+        initialStage={1}
+        loadPractices={presetsOnlyLoad}
+        navigateToDetail={jest.fn()}
+        navigateToCreate={jest.fn()}
+        setActive={setActive}
+      />,
+    );
+    await waitForLoad();
+    // Both of these must be absent — today they render → RED.
+    expect(view.queryByTestId('practice-catalog-section-drafts-empty')).toBeNull();
+    expect(view.queryByTestId('practice-catalog-section-imported-empty')).toBeNull();
+  });
+
+  // Test 2: all-empty catalog MUST still show the presets empty footer (characterization guard).
+  it('shows the presets empty-footer when the whole catalog is empty', async () => {
+    allEmptyLoad.mockResolvedValue([]);
+    const view = render(
+      <PracticeCatalogScreen
+        initialStage={1}
+        loadPractices={allEmptyLoad}
+        navigateToDetail={jest.fn()}
+        navigateToCreate={jest.fn()}
+      />,
+    );
+    await waitForLoad();
+    // Must remain visible after the fix — suppression applies only to populated siblings.
+    expect(view.getByTestId('practice-catalog-section-presets-empty')).toBeTruthy();
+  });
+
+  // Test 3: Use button and row detail handler are reachable when presets are populated.
+  it('fires Use handler and detail handler on populated-preset rows', async () => {
+    const setActive = jest.fn(async () => undefined) as jest.MockedFunction<
+      (id: number, stage: number) => Promise<void>
+    >;
+    const navigateToDetail = jest.fn();
+    presetsOnlyLoad.mockResolvedValue([presetA, presetB]);
+    const view = render(
+      <PracticeCatalogScreen
+        initialStage={1}
+        loadPractices={presetsOnlyLoad}
+        navigateToDetail={navigateToDetail}
+        navigateToCreate={jest.fn()}
+        setActive={setActive}
+      />,
+    );
+    await waitForLoad();
+    // Use button must exist and fire the activate callback.
+    const useBtn = view.getByTestId('practice-catalog-row-1-use');
+    expect(useBtn).toBeTruthy();
+    fireEvent.press(useBtn);
+    await waitFor(() => expect(setActive).toHaveBeenCalledWith(1, 1));
+    // Row itself must open detail.
+    fireEvent.press(view.getByTestId('practice-catalog-row-1'));
+    expect(navigateToDetail).toHaveBeenCalledWith(1);
+  });
+
+  // Test 4: the inline empty-footer container must not carry full-screen styles.
+  it('section empty-footer has inline style contract (no full-screen canvas bg)', async () => {
+    allEmptyLoad.mockResolvedValue([]);
+    const view = render(
+      <PracticeCatalogScreen
+        initialStage={1}
+        loadPractices={allEmptyLoad}
+        navigateToDetail={jest.fn()}
+        navigateToCreate={jest.fn()}
+      />,
+    );
+    await waitForLoad();
+    const footer = view.getByTestId('practice-catalog-section-presets-empty');
+    const flat = StyleSheet.flatten(
+      footer.props.style as Parameters<typeof StyleSheet.flatten>[0],
+    ) as { flex?: number; justifyContent?: string; backgroundColor?: string };
+    // Must NOT be a full-screen block — today the base container contributes these → RED.
+    expect(flat.flex).not.toBe(1);
+    expect(flat.justifyContent).not.toBe('center');
+    expect(flat.backgroundColor).not.toBe(surface.canvas);
+    // Must positively declare itself as non-expanding.
+    expect(flat.flex).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
The Practice **Catalog** rendered each empty section's empty state with the full-screen `EmptyState` (`flex:1`, centered, opaque `surface.canvas`, upward settle) as an inline `SectionList` footer, so it **floated over the populated rows** above/below and — being opaque — **swallowed their touches**: the "Use" button and row tap target on covered rows became unreachable. Worse, all three sections were always emitted, so empty `drafts`/`imported` footers **stacked over a populated list**.

Fix (two parts):
- **`EmptyState` gains an `inline` prop** (default `false`, preserving the full-screen behavior every existing consumer relies on). When `true` it renders as a compact, **transparent, non-expanding** block with **no settle offset** — safe to drop into a list without covering neighbours.
- **Footer suppression:** the Catalog now renders an empty-section footer **only when the whole catalog is empty** (so the "Create a practice" affordance still appears on a truly empty screen); when any sibling section has rows, empty sections render **no footer at all**, so nothing overlaps or intercepts taps on real rows.

Chosen over softening a shared token because the `inline` default keeps the 4 full-screen consumers (Today / Course / Journal / Practice) byte-for-byte unchanged — zero blast radius.

## Test plan
- **Footer suppression:** populated presets + empty `drafts`/`imported` → those empty footers are absent (`queryByTestId(...-empty)` null).
- **Touch reachability:** with empty siblings present, the `Use` button exists and `fireEvent.press` fires `setActive(id, stage)`, and the row press fires the detail handler (RTL can't model z-index, so this + footer-absence is the structural proof the tap can land).
- **Inline style contract:** the empty footer's flattened style carries no `flex:1` / `justifyContent:'center'` / opaque `surface.canvas`, and does carry `flex:0`.
- **Shared regression guard (`EmptyState.test.tsx`):** default (no `inline`) keeps `flex:1`/centered/opaque; `inline` flips to `flex:0`/`flex-start`/transparent — locks the full-screen behavior for the 4 consumers.
- 3 pre-existing Catalog tests that encoded the old overlapping-footer behavior were reconciled to the fixed contract (intent preserved: imported-has-no-data, Create-CTA-reachable, virtualization-parity).
- `scripts/frontend/check-all.sh` exits 0 (2501 tests, ESLint zero-warning, prettier, tsc strict).

Self-review (Gate 2.5): **CLEAN** — shared change regression-safe, footer suppression correct (no off-by-one), legacy tests preserve intent, no suppression comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #930