### PR TITLE
fix(full-stack): let authors assign their own custom practices to a stage

### DIFF
--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -62,6 +62,28 @@ async def _resolve_practice(session: AsyncSession, practice_id: int) -> Practice
     return practice
 
 
+async def _resolve_selectable_practice(
+    session: AsyncSession, practice_id: int, current_user: int
+) -> Practice:
+    """Fetch a practice the caller is allowed to *select* for a stage.
+
+    Unlike :func:`_resolve_practice` (the read/customize path), this write
+    path permits an approved catalog practice **or** the caller's own draft:
+    ``practice.submitted_by_user_id == current_user`` clears an unapproved
+    row so an author can activate the practice they just submitted. A
+    non-owner selecting someone else's still-pending submission continues to
+    receive 400 ``practice_not_approved``; a missing row 404s exactly as the
+    read path does.
+    """
+    result = await session.execute(select(Practice).where(Practice.id == practice_id))
+    practice = result.scalars().first()
+    if practice is None:
+        raise not_found("practice")
+    if not (practice.approved or practice.submitted_by_user_id == current_user):
+        raise bad_request("practice_not_approved")
+    return practice
+
+
 async def _check_stage_eligibility(
     session: AsyncSession,
     current_user: int,
@@ -142,7 +164,7 @@ async def create_user_practice(
     reset ``start_date`` (the user-facing "I started this" label) or the
     streak math that hangs off it.
     """
-    practice = await _resolve_practice(session, payload.practice_id)
+    practice = await _resolve_selectable_practice(session, payload.practice_id, current_user)
     await _check_stage_eligibility(session, current_user, practice, payload.stage_number)
 
     # ``start_date`` is the user-facing "I started this practice today"

--- a/backend/tests/test_owner_practice_selection.py
+++ b/backend/tests/test_owner_practice_selection.py
@@ -1,0 +1,250 @@
+"""Tests for the ownership-aware practice-selection gate on POST /user-practices/.
+
+Covers three scenarios around the fix that adds an ownership carve-out to
+the unapproved-practice rejection:
+
+1. An author CAN select their own unapproved draft (RED — returns 400 today).
+2. A non-owner CANNOT select another user's unapproved draft (regression-guard).
+3. Any user CAN select an approved catalog practice (regression-guard for
+   the approved-normal path; see also test_select_practice in
+   test_user_practices_api.py which covers this with full assertions — we
+   keep this one for co-location and do not duplicate the heavy assertions).
+
+The read-path IDOR test (test_idor_practice_unapproved_returns_403 in
+tests/security/test_idor.py) guards GET /practices/{id} and is intentionally
+NOT modified here — it exercises a separate code path (require_visible_practice
+in dependencies/ownership.py) that this fix does not touch.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.practice import Practice
+from models.stage_progress import StageProgress
+from models.user_practice import UserPractice
+
+_PRACTICE_MODE_CONFIG: dict[str, object] = {
+    "mode": "meditation_timer",
+    "duration_minutes": 10,
+    "start_bell": True,
+    "halfway_bell": False,
+    "end_bell": True,
+}
+
+_PRACTICE_BASE: dict[str, object] = {
+    "stage_number": 1,
+    "name": "Quiet Breath",
+    "description": "Sit quietly",
+    "instructions": "Close your eyes and breathe",
+    "default_duration_minutes": 10,
+    "mode": "meditation_timer",
+    "mode_config": _PRACTICE_MODE_CONFIG,
+}
+
+
+async def _signup(client: AsyncClient, username: str) -> tuple[dict[str, str], int]:
+    """Sign up a user and return (auth headers, user_id)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+async def _unlock_stage(db_session: AsyncSession, user_id: int, stage: int = 1) -> None:
+    """Ensure the user has a StageProgress row that unlocks the given stage.
+
+    Stage 1 is always unlocked for a user who has any StageProgress row
+    with current_stage >= 1.  For stage N > 1 the completed_stages list
+    must contain all prior stages.  Mirrors the unlock seeding used in
+    tests/security/test_idor.py::_create_user_practice.
+    """
+    completed = list(range(1, stage))
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=stage,
+            completed_stages=completed,
+            stage_started_at=datetime.now(UTC),
+        )
+    )
+    await db_session.commit()
+
+
+async def _seed_unapproved_draft(
+    db_session: AsyncSession,
+    submitted_by_user_id: int,
+    stage_number: int = 1,
+) -> Practice:
+    """Insert an unapproved practice owned by submitted_by_user_id."""
+    practice = Practice(
+        **{
+            **_PRACTICE_BASE,
+            "stage_number": stage_number,
+            "name": f"Draft by {submitted_by_user_id}",
+            "approved": False,
+            "submitted_by_user_id": submitted_by_user_id,
+        }
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    return practice
+
+
+async def _seed_approved_practice(
+    db_session: AsyncSession,
+    stage_number: int = 1,
+) -> Practice:
+    """Insert an approved catalog practice (no owner)."""
+    practice = Practice(
+        **{
+            **_PRACTICE_BASE,
+            "stage_number": stage_number,
+            "name": "Approved Catalog Sit",
+            "approved": True,
+            "submitted_by_user_id": None,
+        }
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    return practice
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — RED: owner can select their own unapproved draft
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_can_select_own_unapproved_practice(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Author selecting their own unapproved draft must return 201.
+
+    Today this returns 400 practice_not_approved because _resolve_practice
+    rejects any unapproved row without an ownership check.  After the fix a
+    new resolver (_resolve_selectable_practice) allows the row when
+    practice.submitted_by_user_id == current_user.
+
+    RED: fails with 400 until the implementation is updated.
+    """
+    alice_headers, alice_id = await _signup(async_client, "alice_owner_select")
+    draft = await _seed_unapproved_draft(db_session, submitted_by_user_id=alice_id, stage_number=1)
+    await _unlock_stage(db_session, alice_id, stage=1)
+
+    resp = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": draft.id, "stage_number": 1},
+        headers=alice_headers,
+    )
+
+    # Must succeed — the author is allowed to activate their own draft.
+    assert resp.status_code == HTTPStatus.CREATED, (
+        f"Expected 201 for owner selecting own draft, got {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    assert body["practice_id"] == draft.id
+    assert body["stage_number"] == 1
+    assert body["end_date"] is None
+
+    # Confirm the UserPractice row exists in the DB for alice + this draft.
+    result = await db_session.execute(
+        select(UserPractice).where(
+            UserPractice.user_id == alice_id,
+            UserPractice.practice_id == draft.id,
+            col(UserPractice.end_date).is_(None),
+        )
+    )
+    row = result.scalars().first()
+    assert row is not None, "Expected an open UserPractice row for Alice's own draft"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — regression-guard: non-owner cannot select another user's draft
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_select_others_unapproved_practice(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A user who does not own the draft still receives 400 practice_not_approved.
+
+    This is the existing rejection behaviour for non-owners and must stay
+    green after the ownership carve-out is introduced.
+
+    regression-guard: must remain green before and after the fix.
+    """
+    _alice_headers, alice_id = await _signup(async_client, "alice_draft_owner")
+    bob_headers, bob_id = await _signup(async_client, "bob_non_owner")
+
+    draft = await _seed_unapproved_draft(db_session, submitted_by_user_id=alice_id, stage_number=1)
+    # Bob needs stage 1 unlocked so the stage-lock gate does not fire first.
+    await _unlock_stage(db_session, bob_id, stage=1)
+
+    resp = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": draft.id, "stage_number": 1},
+        headers=bob_headers,
+    )
+
+    assert resp.status_code == HTTPStatus.BAD_REQUEST, (
+        f"Expected 400 for non-owner selecting someone else's draft, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json()["detail"] == "practice_not_approved"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — regression-guard: approved catalog practice still returns 201
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_can_select_approved_catalog_practice(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Selecting an approved practice must return 201 after the ownership fix.
+
+    The ownership carve-out must not break the existing approved-practice path.
+    A similar happy-path test exists in test_user_practices_api.py::test_select_practice;
+    this copy lives here for co-location with the ownership-boundary tests.
+
+    regression-guard: must remain green before and after the fix.
+    """
+    headers, user_id = await _signup(async_client, "carol_approved_select")
+    practice = await _seed_approved_practice(db_session, stage_number=1)
+    await _unlock_stage(db_session, user_id, stage=1)
+
+    resp = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 1},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.CREATED, (
+        f"Expected 201 for selecting approved practice, got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json()["practice_id"] == practice.id
+
+
+# ---------------------------------------------------------------------------
+# Sentinel: test_idor_practice_unapproved_returns_403 in
+# tests/security/test_idor.py is NOT modified by this fix.  It guards
+# GET /practices/{id} via require_visible_practice (read path) which is
+# unchanged — Bob cannot read Alice's draft regardless of this fix.
+# ---------------------------------------------------------------------------

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -79,7 +79,7 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
     "You can't move to an earlier stage — APTITUDE is designed to progress forward only.",
   already_responded: "You've already answered this week's prompt. A new one unlocks each week.",
   practice_not_approved:
-    "That practice isn't available for selection yet. Pick one of the approved options for this stage.",
+    "This practice is still pending review, so it isn't available to select yet.",
   // --- Practice selection (BUG-PRACTICE-012) ---------------------------
   // ``stage_locked`` (403) and ``stage_number_mismatch`` (400) used to
   // fall through to the generic per-status copy ("You don't have access"

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -13,12 +13,15 @@
  *
  * On submit the wizard POSTs ``/practices/`` and, when the user pinned a
  * stage, follows with ``POST /user-practices/`` so the new draft is
- * already active for that stage. Successful submissions navigate to
- * ``PracticeDetail`` for the brand-new row.
+ * already active for that stage. Submissions navigate to ``PracticeDetail``
+ * for the brand-new row; if the stage-assign step fails the failure message
+ * is carried along in the ``assignError`` route param so the detail screen
+ * can surface it (the draft still exists, so the user retries there rather
+ * than staying stuck in the wizard).
  */
 
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -601,44 +604,108 @@ interface SubmitController {
   run: () => Promise<void>;
 }
 
+/**
+ * Create the catalog draft, or reuse the one minted on an earlier tap.
+ *
+ * ``stage_number`` is required on ``POST /practices/`` (catalog rows are
+ * stage-scoped), so a "Skip stage" choice mints the draft under
+ * FALLBACK_STAGE. The id is cached in ``draftIdRef`` so a retry after a
+ * failed stage-assign only re-tries the assign step instead of minting a
+ * second draft. See ``features/Practice/constants.ts`` for the rationale.
+ * Note: edits made after the draft is minted are not re-sent on retry — the
+ * cached row is reused as-is.
+ */
+async function createOrReuseDraft(
+  state: WizardState,
+  config: ModeConfig,
+  draftIdRef: React.MutableRefObject<number | null>,
+): Promise<number> {
+  if (draftIdRef.current !== null) return draftIdRef.current;
+  const created = await practices.create({
+    stage_number: state.stageNumber ?? FALLBACK_STAGE,
+    name: state.name.trim(),
+    description: state.description.trim(),
+    instructions: state.instructions.trim(),
+    default_duration_minutes: state.duration,
+    mode: config.mode,
+    mode_config: config,
+  });
+  draftIdRef.current = created.id;
+  return created.id;
+}
+
+/**
+ * Assign the draft as the active practice for the pinned stage.
+ *
+ * A stage-assign failure is recoverable — the draft already exists — so the
+ * error message is returned (not thrown) and carried to ``PracticeDetail``
+ * via the ``assignError`` route param, where the user retries rather than
+ * staying trapped in the wizard. Returns ``null`` on success (or when no
+ * stage was pinned); the caught message otherwise.
+ */
+async function tryAssign(
+  practiceId: number,
+  stageNumber: number | null,
+  draftIdRef: React.MutableRefObject<number | null>,
+): Promise<string | null> {
+  if (stageNumber === null) {
+    draftIdRef.current = null;
+    return null;
+  }
+  try {
+    await userPractices.create({ practice_id: practiceId, stage_number: stageNumber });
+    draftIdRef.current = null;
+    return null;
+  } catch (err) {
+    return formatApiError(err, { fallback: 'Could not assign practice to the stage.' });
+  }
+}
+
+function navigateToDetail(
+  props: CreatePracticeWizardProps,
+  practiceId: number,
+  assignError: string | null,
+): void {
+  if (assignError === null) {
+    props.navigation.replace('PracticeDetail', { practiceId });
+    return;
+  }
+  props.navigation.replace('PracticeDetail', { practiceId, assignError });
+}
+
 function useSubmitController(
   props: CreatePracticeWizardProps,
   state: WizardState,
 ): SubmitController {
   const [busy, setBusy] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
+  // Remembers the draft minted this wizard session so a retry after a failed
+  // stage-assign reuses it instead of creating a duplicate catalog row.
+  const draftIdRef = useRef<number | null>(null);
 
   const run = async () => {
     if (state.config === null) return;
     setBusy(true);
     setApiError(null);
+    let practiceId: number | null = null;
+    let assignError: string | null = null;
     try {
-      // ``stage_number`` is required on ``POST /practices/`` (catalog rows
-      // are stage-scoped), so a "Skip stage" choice mints the draft under
-      // FALLBACK_STAGE and skips the follow-up ``POST /user-practices``.
-      // The draft is then stored but not active for any stage; the user
-      // can assign it later from the detail screen. See
-      // ``features/Practice/constants.ts`` for the rationale.
-      const created = await practices.create({
-        stage_number: state.stageNumber ?? FALLBACK_STAGE,
-        name: state.name.trim(),
-        description: state.description.trim(),
-        instructions: state.instructions.trim(),
-        default_duration_minutes: state.duration,
-        mode: state.config.mode,
-        mode_config: state.config,
-      });
-      if (state.stageNumber !== null) {
-        await userPractices.create({
-          practice_id: created.id,
-          stage_number: state.stageNumber,
-        });
-      }
-      props.navigation.replace('PracticeDetail', { practiceId: created.id });
+      practiceId = await createOrReuseDraft(state, state.config, draftIdRef);
     } catch (err) {
       setApiError(formatApiError(err, { fallback: 'Could not save practice.' }));
-    } finally {
-      setBusy(false);
+    }
+    if (practiceId !== null) {
+      assignError = await tryAssign(practiceId, state.stageNumber, draftIdRef);
+    }
+    setBusy(false);
+    // The draft exists once ``createOrReuseDraft`` returns, so navigate even
+    // when the stage-assign failed. On failure the user lands on the detail
+    // screen with the message shown via the ``assignError`` route param, where
+    // they retry via "Use for stage" rather than staying stuck in the wizard.
+    // ``draftIdRef`` is only cleared on a successful assign (in ``tryAssign``),
+    // so a retry reuses the same draft instead of minting a duplicate.
+    if (practiceId !== null) {
+      navigateToDetail(props, practiceId, assignError);
     }
   };
 

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -47,11 +47,11 @@ interface ScreenState {
   assignedStage: number | null;
 }
 
-function initialState(): ScreenState {
+function initialState(actionError: string | null): ScreenState {
   return {
     practice: null,
     loadError: null,
-    actionError: null,
+    actionError,
     assigning: false,
     loading: true,
     pickerOpen: false,
@@ -120,14 +120,16 @@ function LoadedDetail({
 }
 
 export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JSX.Element {
-  const { practiceId } = props.route.params;
+  const { practiceId, assignError } = props.route.params;
   const { navigation } = props;
   // After a successful selection, pop back to the Practice screen (the tab is
   // the first route under the root stack; the catalog + this detail screen are
   // pushed on top), matching the catalog's one-tap "Use" which also returns the
   // user to where they can see the active practice.
   const onAssigned = useCallback(() => navigation.popToTop(), [navigation]);
-  const state = usePracticeDetail(practiceId, onAssigned);
+  // A wizard stage-assign that failed hands its message down via the route so
+  // the same banner used for this screen's own assign() failures surfaces it.
+  const state = usePracticeDetail(practiceId, onAssigned, assignError ?? null);
   if (state.loading) {
     return (
       <View style={styles.loading} testID="practice-detail-loading">
@@ -157,8 +159,25 @@ interface PracticeDetailHook {
   assign: (stageNumber: number) => Promise<void>;
 }
 
-function usePracticeDetail(practiceId: number, onAssigned?: () => void): PracticeDetailHook {
-  const [state, setState] = useState<ScreenState>(initialState);
+const withAssignSuccess = (prev: ScreenState, stageNumber: number): ScreenState => ({
+  ...prev,
+  assigning: false,
+  pickerOpen: false,
+  assignedStage: stageNumber,
+});
+
+const withAssignError = (prev: ScreenState, err: unknown): ScreenState => ({
+  ...prev,
+  assigning: false,
+  actionError: formatApiError(err, { fallback: 'Could not assign practice.' }),
+});
+
+function usePracticeDetail(
+  practiceId: number,
+  onAssigned?: () => void,
+  initialActionError: string | null = null,
+): PracticeDetailHook {
+  const [state, setState] = useState<ScreenState>(() => initialState(initialActionError));
 
   const runReload = useCallback(async () => {
     try {
@@ -193,21 +212,11 @@ function usePracticeDetail(practiceId: number, onAssigned?: () => void): Practic
       setState((prev) => ({ ...prev, assigning: true, actionError: null }));
       try {
         await userPractices.create({ practice_id: practiceId, stage_number: stageNumber });
-        setState((prev) => ({
-          ...prev,
-          assigning: false,
-          pickerOpen: false,
-          assignedStage: stageNumber,
-        }));
-        // Confirmation banner is set above for the brief moment before the
-        // screen pops; the callback returns the user to the Practice screen.
+        setState((prev) => withAssignSuccess(prev, stageNumber));
+        // The callback returns the user to the Practice screen after assigning.
         onAssigned?.();
       } catch (err) {
-        setState((prev) => ({
-          ...prev,
-          assigning: false,
-          actionError: formatApiError(err, { fallback: 'Could not assign practice.' }),
-        }));
+        setState((prev) => withAssignError(prev, err));
       }
     },
     [practiceId, onAssigned],

--- a/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/CreatePracticeWizard.test.tsx
@@ -313,6 +313,111 @@ describe('CreatePracticeWizard — prefill mode', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Ownership-aware select fix — submit idempotency and navigation contract
+//
+// Tests 5-7 cover three behaviours that are RED until the fix lands:
+//   5. Happy path — both API calls resolve → navigates to PracticeDetail,
+//      practices.create called exactly once.  (May be partially green already
+//      for the navigation assertion; the call-count assertion is the pin.)
+//   6. Select-failure navigates — practices.create resolves but
+//      userPractices.create rejects → wizard still navigates to PracticeDetail
+//      because the draft exists even when the select fails.  RED today: the
+//      throw from the catch block prevents navigation.
+//   7. Idempotent retry — userPractices.create rejects on tap 1; user taps
+//      Save again → practices.create must be called exactly ONCE across both
+//      taps (no duplicate draft).  RED today: every tap re-calls create.
+// ---------------------------------------------------------------------------
+
+describe('CreatePracticeWizard — submit idempotency + navigation contract', () => {
+  beforeEach(() => {
+    mockPracticesCreate.mockReset();
+    mockUserPracticesCreate.mockReset();
+  });
+
+  // Helper: navigate to the metadata step with stage 4 selected and a name
+  // filled in, then return the view + nav so the caller can trigger Save.
+  function navigateToReadyMetadata(navOverride?: NavMock) {
+    const { view, navigation } = renderScreen({}, navOverride);
+    fireEvent.press(view.getByTestId('create-practice-from-scratch'));
+    fireEvent.press(view.getByTestId('mode-picker-mode-random_interval_bell'));
+    fireEvent.press(view.getByTestId('create-practice-configure-next'));
+    fireEvent.changeText(view.getByTestId('create-practice-name'), 'Awareness bells');
+    fireEvent.press(view.getByTestId('create-practice-stage-4'));
+    return { view, navigation };
+  }
+
+  // Test 5 — happy path: both calls resolve → navigates with created id,
+  // practices.create called exactly once.
+  it('navigates to PracticeDetail when both API calls succeed', async () => {
+    mockPracticesCreate.mockResolvedValue(createdPractice);
+    mockUserPracticesCreate.mockResolvedValue(createdUserPractice);
+    const nav = makeNav();
+    const { view } = navigateToReadyMetadata(nav);
+
+    await act(async () => {
+      fireEvent.press(view.getByTestId('create-practice-submit'));
+      await flushPromises();
+    });
+
+    expect(mockPracticesCreate).toHaveBeenCalledTimes(1);
+    expect(nav.replace).toHaveBeenCalledWith('PracticeDetail', { practiceId: createdPractice.id });
+  });
+
+  // Test 6 — RED: select-failure must still navigate to PracticeDetail AND
+  // thread the assign-failure message so the detail screen can surface it.
+  // Today the wizard passes only { practiceId } (no assignError), so the
+  // objectContaining assertion below fails.
+  it('navigates to PracticeDetail with assignError when userPractices.create rejects', async () => {
+    mockPracticesCreate.mockResolvedValue(createdPractice);
+    mockUserPracticesCreate.mockRejectedValue(new Error('select_failed'));
+    const nav = makeNav();
+    const { view } = navigateToReadyMetadata(nav);
+
+    await act(async () => {
+      fireEvent.press(view.getByTestId('create-practice-submit'));
+      await flushPromises();
+    });
+
+    // The draft exists — navigate regardless of the select failure, and carry
+    // the error message so PracticeDetailScreen can render it on mount.
+    expect(nav.replace).toHaveBeenCalledWith(
+      'PracticeDetail',
+      expect.objectContaining({ practiceId: createdPractice.id, assignError: expect.any(String) }),
+    );
+  });
+
+  // Test 7 — RED: a second Save tap after a select failure must NOT call
+  // practices.create again.  The created practice id must be remembered
+  // within the submit attempt so a retry only re-tries the select step.
+  // Today the controller has no such memoisation, so the second tap calls
+  // practices.create a second time.
+  it('does not re-call practices.create on a retry after select failure', async () => {
+    mockPracticesCreate.mockResolvedValue(createdPractice);
+    // Reject on first call, resolve on second so the second tap can complete.
+    mockUserPracticesCreate
+      .mockRejectedValueOnce(new Error('select_failed'))
+      .mockResolvedValue(createdUserPractice);
+    const nav = makeNav();
+    const { view } = navigateToReadyMetadata(nav);
+
+    // First tap — practices.create resolves, userPractices.create rejects.
+    await act(async () => {
+      fireEvent.press(view.getByTestId('create-practice-submit'));
+      await flushPromises();
+    });
+
+    // Second tap — idempotent: must reuse the already-created practice id.
+    await act(async () => {
+      fireEvent.press(view.getByTestId('create-practice-submit'));
+      await flushPromises();
+    });
+
+    // practices.create must have been called exactly once across both taps.
+    expect(mockPracticesCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('CreatePracticeWizard — configurator dispatch (smoke)', () => {
   it.each([
     ['count_up', 'count-up-form'],

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -256,6 +256,36 @@ describe('PracticeDetailScreen — stage picker cancel', () => {
   });
 });
 
+describe('PracticeDetailScreen — assignError route param', () => {
+  beforeEach(() => {
+    mockPracticesGet.mockReset();
+    mockUserPracticesCreate.mockReset();
+  });
+
+  // RED: the screen currently reads only `practiceId` from route params and
+  // ignores `assignError`.  When the wizard threads the assign-failure message
+  // through navigation.replace, the detail screen must surface it via the
+  // existing `practice-detail-action-error` banner on mount.  Today that
+  // banner is only shown after the screen's own assign() call fails, so this
+  // assertion fails against current code.
+  it('renders the action-error banner on mount when assignError is in route params', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const navigation = makeNav();
+    const route = {
+      key: 'k',
+      name: 'PracticeDetail' as const,
+      params: { practiceId: 77, assignError: 'Stage assign failed — try again from this screen.' },
+    };
+    const Screen = PracticeDetailScreen as unknown as React.ComponentType<{
+      navigation: NavMock;
+      route: typeof route;
+    }>;
+    const { getByTestId } = render(<Screen navigation={navigation} route={route} />);
+    await waitForLoad();
+    expect(getByTestId('practice-detail-action-error')).toBeTruthy();
+  });
+});
+
 describe('PracticeDetailScreen — config summary variants', () => {
   it.each([
     [{ mode: 'meditation_timer', duration_minutes: 10 } as const],

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -46,7 +46,7 @@ export type RootStackParamList = {
   TimezoneSettings: undefined;
   SupportCare: undefined;
   SharePreview: { token: string };
-  PracticeDetail: { practiceId: number };
+  PracticeDetail: { practiceId: number; assignError?: string };
   CreatePractice: { prefill?: CreatePracticePrefill } | undefined;
   Catalog: { stageNumber?: number } | undefined;
   JournalEntry:


### PR DESCRIPTION
## Summary
A single `approved` boolean was overloaded for two different permissions — "available in the shared catalog" vs. "the owner may activate their own draft" — so the practice-**selection** write path (`POST /user-practices/`) rejected every unapproved practice with `practice_not_approved`. **A user could never activate the practice they just authored**, from the wizard *or* the detail screen; the entire custom-practices authoring flow dead-ended (and it contradicted "you choose your depth" — a user's own creation gated from their own use).

**Backend (primary):** new `_resolve_selectable_practice`, used only by `create_user_practice`, permits a practice when it is `approved` **OR** owned by the caller (`submitted_by_user_id == current_user`, keyed to the JWT — never a client field). A non-owner selecting someone else's still-pending submission still gets `400 practice_not_approved`. The separate IDOR read-path `403` gate and `submit_practice`'s `approved=False` posture (BUG-PRACTICE-002) are untouched; stage-eligibility still runs after resolution.

**Frontend (secondary):** the wizard submit is now idempotent — the minted draft id is held in a ref so a retry after a failed stage-assign reuses it instead of minting a duplicate draft — and it navigates to `PracticeDetail` even when the follow-up assign fails, carrying the failure message through a new optional `assignError` route param so the detail screen **surfaces it via its existing action-error banner** rather than trapping the user or failing silently.

**Copy (tertiary):** reworded `practice_not_approved` for the only case that can still hit it (selecting another user's pending submission).

## Security
Dedicated authz review — **PASS**: the owner carve-out is keyed to the JWT-derived `current_user` (no client influence), no cross-user draft selection (non-owner → 400), the IDOR read-path 403 test and `submit_practice` posture are intact, no new enumeration oracle, `submitted_by_user_id` is never echoed, and stage-eligibility is still enforced.

## Test plan
- **Backend** (`test_owner_practice_selection.py`): owner selects own unapproved draft → 201 + active row; non-owner selecting another's unapproved draft → 400 `practice_not_approved`; approved catalog practice → 201; the IDOR read-path 403 test is left untouched.
- **Frontend**: wizard navigates to `PracticeDetail` on success (exactly one `practices.create`); on assign-failure it still navigates **and** passes `assignError`, which the detail screen renders on mount; a failed-then-retried Save issues exactly **one** `practices.create` (no duplicate drafts).
- `scripts/backend/check-all.sh` + xenon rank A, and `scripts/frontend/check-all.sh` both exit 0 (backend 2035 tests @ 96% coverage; frontend 2505 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #931