### PR TITLE
fix(backend): strip YAML frontmatter before serving chapter/resource/intro Markdown

### DIFF
--- a/backend/src/services/content_repository.py
+++ b/backend/src/services/content_repository.py
@@ -114,6 +114,31 @@ def _content_dir_from_env() -> Path:
     return Path(override) if override else _DEFAULT_CONTENT_DIR
 
 
+#: Line that opens and closes a YAML frontmatter block (a lone triple-dash).
+_FRONTMATTER_FENCE: Final[str] = "---"
+
+#: UTF-8 byte-order mark some editors prepend; tolerated before the fence.
+_BOM: Final[str] = "﻿"
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Drop a leading ``---``-delimited YAML frontmatter block from Markdown.
+
+    Only a fence on line 1 (after an optional UTF-8 BOM) counts; a ``---``
+    after prose is a thematic break and is preserved.  When there is no
+    opening fence, or the block is never closed, ``text`` is returned
+    byte-for-byte so nothing is silently swallowed.
+    """
+    body = text.removeprefix(_BOM)
+    lines = body.splitlines(keepends=True)
+    if not lines or lines[0].rstrip() != _FRONTMATTER_FENCE:
+        return text
+    for index in range(1, len(lines)):
+        if lines[index].rstrip() == _FRONTMATTER_FENCE:
+            return "".join(lines[index + 1 :])
+    return text
+
+
 def _parse_stamp_entries(text: str) -> dict[str, str]:
     """Parse ``key: value`` lines from a ``CONTENT_VERSION`` stamp."""
     entries: dict[str, str] = {}
@@ -269,7 +294,7 @@ class ContentRepository:
             msg = f"content path escapes the content directory: {rel_path!r}"
             raise ContentRepositoryError(msg)
         try:
-            return resolved.read_text()
+            return _strip_frontmatter(resolved.read_text())
         except FileNotFoundError as exc:
             msg = f"manifest references a missing file: {rel_path!r}"
             raise ContentRepositoryError(msg) from exc

--- a/backend/tests/test_content_repository.py
+++ b/backend/tests/test_content_repository.py
@@ -388,3 +388,94 @@ def test_lazy_singleton_builds_from_content_dir_env(
         assert [c.id for c in first.list_chapters()] == ["beige-1", "beige-2"]
     finally:
         reset_content_repository_for_tests()
+
+
+# ── Frontmatter stripping ───────────────────────────────────────────────
+
+
+def test_frontmatter_stripped_from_chapter_body(content_dir: Path) -> None:
+    # overwrite chapter file with YAML frontmatter before constructing the repo
+    md = content_dir / "markdown/01-beige/01-survival.md"
+    md.write_text("---\nslug: survival\ntitle: Survival\nmedia: x\n---\n\n# Survival\n\nBody.\n")
+    repo = ContentRepository(content_dir)
+    body = repo.read_body("beige-1").body
+    assert "# Survival" in body
+    assert "Body." in body
+    assert "slug:" not in body
+    assert "title:" not in body
+    assert "media:" not in body
+    assert not body.startswith("---")
+
+
+def test_no_frontmatter_body_returned_byte_for_byte(content_dir: Path) -> None:
+    # characterization guard: prose-first file must come back unchanged
+    raw = "# Heading\n\nProse.\n"
+    md = content_dir / "markdown/01-beige/01-survival.md"
+    md.write_text(raw)
+    repo = ContentRepository(content_dir)
+    assert repo.read_body("beige-1").body == raw
+
+
+def test_mid_body_thematic_break_survives(content_dir: Path) -> None:
+    # characterization guard: only a line-1 fence is stripped; mid-doc --- must survive
+    raw = "# H\n\nBefore.\n\n---\n\nAfter.\n"
+    md = content_dir / "markdown/01-beige/01-survival.md"
+    md.write_text(raw)
+    repo = ContentRepository(content_dir)
+    body = repo.read_body("beige-1").body
+    assert "---" in body
+    assert "Before." in body
+    assert "After." in body
+
+
+def test_frontmatter_value_containing_dashes_not_mistaken_for_fence(
+    content_dir: Path,
+) -> None:
+    # closing fence is the first lone --- line; a value like "a --- b" must not close it
+    md = content_dir / "markdown/01-beige/01-survival.md"
+    md.write_text('---\ntitle: "a --- b"\nnote: c:d\n---\n\nProse.\n')
+    repo = ContentRepository(content_dir)
+    body = repo.read_body("beige-1").body
+    assert "Prose." in body
+    assert "title:" not in body
+    assert "note:" not in body
+    assert not body.startswith("---")
+
+
+def test_frontmatter_stripped_across_all_three_read_paths(content_dir: Path) -> None:
+    # all three public read methods share _read_markdown; verify each strips frontmatter
+    chapter_md = content_dir / "markdown/01-beige/01-survival.md"
+    chapter_md.write_text("---\nslug: survival\n---\n\n# Survival body.\n")
+    resource_md = content_dir / "markdown/site/getting-started.md"
+    resource_md.write_text("---\nslug: getting-started\n---\n\n# Resource body.\n")
+    intro_md = content_dir / "markdown/01-beige/00-introduction.md"
+    intro_md.write_text("---\nstage: 1\n---\n\n# Intro body.\n")
+    repo = ContentRepository(content_dir)
+    chapter_body = repo.read_body("beige-1").body
+    assert "slug:" not in chapter_body
+    assert "# Survival body." in chapter_body
+    resource_body = repo.read_resource_body("getting-started").body
+    assert "slug:" not in resource_body
+    assert "# Resource body." in resource_body
+    intro_body = repo.read_intro_body(1).body
+    assert "stage:" not in intro_body
+    assert "# Intro body." in intro_body
+
+
+def test_bom_prefixed_frontmatter_is_stripped(content_dir: Path) -> None:
+    # UTF-8 BOM before the opening --- must still trigger stripping
+    md = content_dir / "markdown/01-beige/01-survival.md"
+    md.write_bytes("﻿---\nslug: x\n---\n\nProse.\n".encode())
+    repo = ContentRepository(content_dir)
+    body = repo.read_body("beige-1").body
+    assert "Prose." in body
+    assert "slug:" not in body
+
+
+def test_unterminated_frontmatter_returned_unchanged(content_dir: Path) -> None:
+    # defensive guard: no closing fence means the file is returned verbatim
+    raw = "---\nslug: x\nno closing fence here\n"
+    md = content_dir / "markdown/01-beige/01-survival.md"
+    md.write_text(raw)
+    repo = ContentRepository(content_dir)
+    assert repo.read_body("beige-1").body == raw


### PR DESCRIPTION
## Summary
The in-app reader rendered the raw `---`-delimited YAML frontmatter of every vendored Markdown file as a bold heading, because `ContentRepository._read_markdown` returned `read_text()` verbatim and markdown-it parses a text block immediately followed by a `---` line as a setext H2. The UI's `title`/`content_type` already come from the **manifest**, not the file body, so stripping the leading block is safe for the existing response shape.

Adds a pure module-level `_strip_frontmatter` and calls it at the single `_read_markdown` choke point, so all three body paths (chapter / resource / intro) return pure prose. **Conservative by design** — it only strips a `---` fence on **line 1** (after an optional UTF-8 BOM) through the next lone `---` line. Everything else is returned **byte-for-byte unchanged**:
- a file with no leading frontmatter,
- an **unterminated** block (no closing fence — never swallow the file),
- a **mid-document** `---` thematic break (only a line-1 block is frontmatter),
- and a frontmatter value containing `---`/`:` never closes the fence early (the closing fence is the next line that is *exactly* `---` when trimmed).

Line-based (no regex, no new deps — hand-rolled per the issue), kept xenon rank-A.

## Test plan
7 tests in `test_content_repository.py` (reusing the existing `content_dir` fixture, writing frontmatter into `.md` files before constructing the repo):
1. frontmatter stripped — body starts at the first prose line, no `slug:`/`title:`/`media:`/leading `---`;
2. no-frontmatter file returned **byte-for-byte** (`== raw`);
3. mid-document `---` thematic break survives;
4. a `title: "a --- b"` value isn't mistaken for the closing fence;
5. **all three read paths** (`read_body` / `read_resource_body` / `read_intro_body`) strip — proving the shared seam;
6. BOM-prefixed frontmatter is stripped;
7. unterminated frontmatter returned unchanged.
- `scripts/backend/check-all.sh` exits 0 (2042 tests, 96% coverage, ruff, mypy, interrogate); **xenon** standalone → `src/` rank A.

Self-review (Gate 2.5): **CLEAN** — correct against every AC (line-1-only fence, byte-exact passthrough, mid-doc-break survival, dashes-in-value, unterminated, BOM), no new deps, no suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #935
Refs #934