### PR TITLE
fix(frontend): harden the Markdown reader — defensive frontmatter strip + soft-wrap reflow

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -6,6 +6,7 @@ import { course as courseApi, type ContentBody } from '../../api';
 import { colors, SPACING } from '../../design/tokens';
 
 import styles, { markdownStyles } from './Course.styles';
+import { stripFrontmatter } from './stripFrontmatter';
 
 /**
  * Source descriptor for the reader.  ``kind`` decides which backend
@@ -64,6 +65,8 @@ const markdownRules = {
       />
     );
   },
+  // Render a CommonMark soft break as a space (the library default emits '\n'), so hard-wrapped prose reflows.
+  softbreak: (node: { key?: string }): React.ReactNode => <Text key={node.key}> </Text>,
 };
 
 interface HeaderProps {
@@ -183,7 +186,8 @@ function useContentBody(source: ChapterReaderSource): {
 }
 
 function renderBody(body: ContentBody): React.ReactElement {
-  if (body.body_markdown.trim() === '') {
+  const markdown = stripFrontmatter(body.body_markdown);
+  if (markdown.trim() === '') {
     return <EmptyView />;
   }
   return (
@@ -194,7 +198,7 @@ function renderBody(body: ContentBody): React.ReactElement {
     >
       <View style={styles.readerSheet}>
         <Markdown style={markdownStyles} rules={markdownRules} onLinkPress={handleLinkPress}>
-          {body.body_markdown}
+          {markdown}
         </Markdown>
       </View>
     </ScrollView>

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -184,7 +184,7 @@ describe('ChapterReader', () => {
     await findByText(/hasn['’]t been written yet/i);
   });
 
-  // RED: softbreak currently emits '\n'; the regex won't match across a newline.
+  // A single in-paragraph newline (soft break) must reflow to a space.
   it('reflows hard-wrapped lines within a paragraph into a single visual line', async () => {
     mockContentBody.mockResolvedValueOnce({
       title: 'Reflow Test',
@@ -229,7 +229,23 @@ describe('ChapterReader', () => {
     await findByText(/beta/);
   });
 
-  // RED: frontmatter is currently passed raw to the Markdown renderer.
+  // GREEN guard: a two-trailing-space hard break must NOT be collapsed to a space.
+  it('preserves a hard break (two trailing spaces) after the softbreak fix', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'Hard Break',
+      content_type: 'chapter',
+      body_markdown: 'line one  \nline two.\n',
+    });
+    const { findByText, queryByText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    await findByText(/line one/);
+    await findByText(/line two/);
+    // The hard break must keep them apart — not reflowed into one spaced run.
+    expect(queryByText(/line one line two/)).toBeNull();
+  });
+
+  // Defensive: raw frontmatter must never reach the Markdown renderer.
   it('does not render YAML frontmatter fields when body_markdown opens with a fence', async () => {
     mockContentBody.mockResolvedValueOnce({
       title: 'Frontmatter Test',

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -181,6 +181,68 @@ describe('ChapterReader', () => {
       <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
     );
     await findByTestId('reader-empty');
-    await findByText(/hasn’t been written yet/i);
+    await findByText(/hasn['’]t been written yet/i);
+  });
+
+  // RED: softbreak currently emits '\n'; the regex won't match across a newline.
+  it('reflows hard-wrapped lines within a paragraph into a single visual line', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'Reflow Test',
+      content_type: 'chapter',
+      body_markdown: 'a crash\ncourse in flow.\n',
+    });
+    const { findByText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    // Passes only when the softbreak between 'crash' and 'course' becomes a space.
+    await findByText(/crash course/);
+  });
+
+  // GREEN guard: blank-line paragraph boundaries must not be collapsed by the softbreak fix.
+  it('preserves blank-line paragraph boundaries after the softbreak fix', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'Para Boundary',
+      content_type: 'chapter',
+      body_markdown: 'para one.\n\npara two.\n',
+    });
+    const { findByText, queryByText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    await findByText(/para one/);
+    await findByText(/para two/);
+    // The two paragraphs must remain separate — not joined into one run of text.
+    expect(queryByText(/para one\.\s*para two/)).toBeNull();
+  });
+
+  // GREEN guard: list items must remain distinct after the softbreak fix.
+  it('renders list items as distinct nodes, not collapsed into one line', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'List Test',
+      content_type: 'chapter',
+      body_markdown: '- alpha\n- beta\n',
+    });
+    const { findByText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    // Both items must be independently queryable.
+    await findByText(/alpha/);
+    await findByText(/beta/);
+  });
+
+  // RED: frontmatter is currently passed raw to the Markdown renderer.
+  it('does not render YAML frontmatter fields when body_markdown opens with a fence', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'Frontmatter Test',
+      content_type: 'chapter',
+      body_markdown: '---\nslug: leak\ntitle: "T"\n---\n\n# Real\n\nProse.\n',
+    });
+    const { findByText, queryByText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    // Body text must appear once frontmatter is stripped.
+    await findByText(/Real/);
+    // Raw YAML keys must not appear anywhere in the rendered output.
+    expect(queryByText(/slug:/)).toBeNull();
+    expect(queryByText(/title:/)).toBeNull();
   });
 });

--- a/frontend/src/features/Course/__tests__/stripFrontmatter.test.ts
+++ b/frontend/src/features/Course/__tests__/stripFrontmatter.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 import { describe, expect, it } from '@jest/globals';
 
-// stripFrontmatter.ts does not exist yet — this import will fail (RED).
 import { stripFrontmatter } from '../stripFrontmatter';
 
 describe('stripFrontmatter', () => {
@@ -39,5 +38,12 @@ describe('stripFrontmatter', () => {
     const result = stripFrontmatter(input);
     // The leading blank means the --- is NOT on line 1; input returned unchanged.
     expect(result).toBe(input);
+  });
+
+  it('tolerates a leading UTF-8 BOM before the opening fence', () => {
+    const input = '﻿---\nslug: x\n---\n\n# Body\n';
+    const result = stripFrontmatter(input);
+    expect(result).not.toContain('slug:');
+    expect(result).toContain('# Body');
   });
 });

--- a/frontend/src/features/Course/__tests__/stripFrontmatter.test.ts
+++ b/frontend/src/features/Course/__tests__/stripFrontmatter.test.ts
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+import { describe, expect, it } from '@jest/globals';
+
+// stripFrontmatter.ts does not exist yet — this import will fail (RED).
+import { stripFrontmatter } from '../stripFrontmatter';
+
+describe('stripFrontmatter', () => {
+  it('strips a leading YAML frontmatter block', () => {
+    const input = '---\nslug: x\ntitle: "T"\nmedia: []\n---\n\n# Body\n\nProse.\n';
+    const result = stripFrontmatter(input);
+    expect(result).toContain('# Body');
+    expect(result).toContain('Prose.');
+    expect(result).not.toContain('slug:');
+    expect(result).not.toContain('title:');
+    expect(result).not.toContain('media:');
+    expect(result.startsWith('---')).toBe(false);
+  });
+
+  it('returns frontmatter-free input unchanged (exact equality)', () => {
+    const input = '# Heading\n\nProse.\n';
+    expect(stripFrontmatter(input)).toBe(input);
+  });
+
+  it('preserves a mid-body thematic break (--- not on line 1)', () => {
+    const input = '# H\n\nBefore.\n\n---\n\nAfter.\n';
+    const result = stripFrontmatter(input);
+    expect(result).toContain('---');
+    expect(result).toContain('Before.');
+    expect(result).toContain('After.');
+  });
+
+  it('returns an unterminated frontmatter block unchanged (exact equality)', () => {
+    const input = '---\nslug: x\nno close\n';
+    expect(stripFrontmatter(input)).toBe(input);
+  });
+
+  it('does not treat a fence preceded by a blank line as frontmatter', () => {
+    const input = '\n---\nslug: x\n---\n\n# Body\n';
+    const result = stripFrontmatter(input);
+    // The leading blank means the --- is NOT on line 1; input returned unchanged.
+    expect(result).toBe(input);
+  });
+});

--- a/frontend/src/features/Course/stripFrontmatter.ts
+++ b/frontend/src/features/Course/stripFrontmatter.ts
@@ -1,0 +1,28 @@
+/** Line that opens and closes a YAML frontmatter block: a lone triple-dash. */
+const FRONTMATTER_FENCE = '---';
+
+/** UTF-8 byte-order mark some editors prepend; tolerated before the fence. */
+const BOM = '﻿';
+
+/**
+ * Drop a leading ``---``-delimited YAML frontmatter block from Markdown,
+ * mirroring the backend algorithm: only a fence on line 1 (after an optional
+ * BOM) counts; a ``---`` after prose is a thematic break and is preserved.
+ * When there is no opening fence, or the block is never closed, the input is
+ * returned character-for-character so nothing is silently swallowed.
+ */
+export function stripFrontmatter(md: string): string {
+  const body = md.startsWith(BOM) ? md.slice(BOM.length) : md;
+  const lines = body.split('\n');
+  const firstLine = lines[0] ?? '';
+  if (firstLine.trimEnd() !== FRONTMATTER_FENCE) {
+    return md;
+  }
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line !== undefined && line.trimEnd() === FRONTMATTER_FENCE) {
+      return lines.slice(index + 1).join('\n');
+    }
+  }
+  return md;
+}


### PR DESCRIPTION
## Summary
Two fixes to the Course reader (`ChapterReader`), pairing with the backend strip #935 as **defense in depth**.

### 1. Frontmatter leak (defensive)
`renderBody()` passed `body.body_markdown` straight into `<Markdown>`. Adds a pure `stripFrontmatter` helper (a mirror of the #935 backend algorithm) applied before rendering, so a single mis-vendored file can never splash raw `slug:/title:/media:` YAML across the reading surface even if it slips past the server strip. It only removes a leading `---`…`---` block on **line 1** (BOM-tolerant); frontmatter-free input, unterminated blocks, and mid-document thematic breaks are returned unchanged.

### 2. Paragraphs broken at every source line
The vendored files are hard-wrapped at prose width, and `react-native-markdown-display`'s **default `softbreak` render rule emits a literal newline**, so each physical source line became its own visual line. (`markdown-it` already tokenizes a single in-paragraph newline as a CommonMark **soft break** — `breaks` is already `false`, so a config change would do nothing; the render rule was the real cause.) The fix overrides the `softbreak` rule in the existing `markdownRules` to render a **space**, so hard-wrapped prose reflows. Hard breaks (two trailing spaces), blank-line paragraph boundaries, list items, and code fences are distinct tokens and are **untouched** — proven by guard tests.

**No new dependency** — the softbreak render-rule override is the whole reflow fix (no custom `markdown-it` instance).

## Test plan
- `stripFrontmatter.test.ts` (5 units): strips a leading block; frontmatter-free returned byte-for-byte; mid-body `---` survives; unterminated unchanged; non-line-1 fence not treated as frontmatter.
- `ChapterReader.test.tsx` (extended): **reflow** — hard-wrapped lines render contiguously (`/crash course/`); **frontmatter defense** — raw `slug:`/`title:` never render; **guards** — a blank-line boundary yields two separate paragraphs (not collapsed) and a bullet list keeps its items distinct.
- `scripts/frontend/check-all.sh` exits 0 (2549 tests, ESLint zero-warning, prettier, tsc strict).

Self-review (Gate 2.5): **CLEAN** — `stripFrontmatter` byte-exactly mirrors the backend; the `softbreak` override provably affects only soft breaks (verified against the library's render rules); the intentional-break guards are non-tautological.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #936
Refs #934