### PR TITLE
fix(ralph): make fleet picker worktree detection portable on macOS

### DIFF
--- a/scripts/ralph/pick-next.sh
+++ b/scripts/ralph/pick-next.sh
@@ -37,6 +37,9 @@
 # Exit codes:
 #   0 — issue number printed (or nothing if backlog empty / nothing compatible)
 #   2 — gh CLI not authenticated / missing
+#
+# Requires bash >= 4 (associative arrays `declare -A`, `${var,,}` lowercasing);
+# on macOS use /opt/homebrew/bin/bash (bash 5), not the system bash 3.2.
 set -euo pipefail
 
 if ! command -v gh >/dev/null 2>&1; then
@@ -105,8 +108,8 @@ if repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
   wt_dir="$repo_root/.ralph/worktrees"
   if [[ -d "$wt_dir" ]]; then
     worktree_issues=$(
-      find "$wt_dir" -maxdepth 1 -type d -name 'issue-*' -printf '%f\n' 2>/dev/null \
-        | sed 's/^issue-//' | sort -u || true
+      find "$wt_dir" -maxdepth 1 -type d -name 'issue-*' 2>/dev/null \
+        | sed 's#^.*/issue-##' | sort -u || true
     )
   fi
 fi

--- a/scripts/ralph/test_pick_next.sh
+++ b/scripts/ralph/test_pick_next.sh
@@ -147,6 +147,16 @@ check "epic guard off => same-epic candidate allowed" "11" \
 new_scenario drained
 check "empty candidate list => nothing" "" "$(run_pick)"
 
+# 10) A repo path segment matching "issue-<digits>" above .ralph/worktrees must not be mistaken for an active issue.
+new_scenario parent_path_issue_segment
+REPO2="$WORK/issue-777-fixture/repo"
+git init -q -b main "$REPO2"
+(cd "$REPO2" && git config user.email t@t.t && git config user.name t)
+candidate 10 ""; candidate 11 ""
+mkdir -p "$REPO2/.ralph/worktrees/issue-10"
+check "path segment matching issue-<n> above worktrees dir is ignored" "11" \
+  "$(cd "$REPO2" && PATH="$BIN:$PATH" "$PICK")"
+
 echo
 echo "pick-next tests: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- Fixes the parallel-Ralph fleet picker breaking on macOS/BSD: `scripts/ralph/pick-next.sh` used the GNU-only `find -printf`, which BSD/macOS find rejects. With `2>/dev/null` swallowing the error, `worktree_issues` was always empty on macOS, so the active-set exclusion collapsed and the orchestrator's slot-fill loop re-picked the same issue forever.
- Root-cause fix: replace `find ... -printf '%f\n' | sed 's/^issue-//'` with the portable `find ... | sed 's#^.*/issue-##'` (greedy strip through the last `/issue-`), which works on both BSD and GNU find and correctly handles a repo path that itself contains an `issue-<n>` segment. The downstream `grep -E '^[0-9]+$'` filter still sanitizes any non-numeric residue.
- Add a regression scenario pinning the parent-path `issue-<digits>` case, plus a header comment recording the `bash >= 4` requirement (`declare -A`, `${var,,}`) — use `/opt/homebrew/bin/bash` on macOS, not system bash 3.2.

## Test plan

Verified locally on macOS (BSD find, Homebrew bash 5):

- `bash scripts/ralph/test_pick_next.sh` → **12 passed, 0 failed** (was 5 passed / 6 failed before the fix; a 7th RED was added as the new regression scenario).
- `bash scripts/ralph/test_fleet.sh` → **25 passed, 0 failed**.
- `python -m pytest scripts/ralph -q` → **52 passed** (the `ralph-recap-tests` CI job).
- `pre-commit run shellcheck --all-files` → **Passed** (clean; no shellcheck disable added).

CI `ralph-recap-tests.yml` re-proves the shell suites + pytest on Ubuntu (GNU find), keeping the portable fix green on both platforms.

Closes #1068
Refs #1066
