### PR TITLE
fix(frontend): make the Course landing scroll as one surface

### DIFF
--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -363,6 +363,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   contentListContent: {
+    flexGrow: 1,
     paddingTop: SPACING.sm,
     paddingBottom: SPACING.xl,
   },

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, FlatList, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -32,6 +32,10 @@ import StageIntroCard from './StageIntroCard';
 import StageSelector from './StageSelector';
 
 const DEFAULT_STAGE_NUMBER = 1;
+
+// Stable empty reference so the FlatList shows ListEmptyComponent while a stage
+// is loading or after a failed fetch, without churning the data prop's identity.
+const EMPTY_CONTENT: ContentItem[] = [];
 
 // --- Hook: load stages on mount ---
 
@@ -250,18 +254,29 @@ const CourseLoadingState = (): React.JSX.Element => (
   </SafeAreaView>
 );
 
+const ContentLoadingIndicator = (): React.JSX.Element => (
+  <View style={styles.loadingContainer}>
+    <ActivityIndicator testID="content-loading" size="small" />
+  </View>
+);
+
 interface ContentAreaProps {
   content: ContentItem[];
   loadingContent: boolean;
   error: boolean;
+  header: React.ReactElement;
   onContentPress: (_item: ContentItem) => void;
   onRetry: () => void;
 }
 
+/** The single scroll surface: the stage header and the chapter list share one
+ *  FlatList so the whole landing page scrolls together. Loading, error, and
+ *  empty states render in ``ListEmptyComponent`` below the pinned header. */
 const ContentArea = ({
   content,
   loadingContent,
   error,
+  header,
   onContentPress,
   onRetry,
 }: ContentAreaProps): React.JSX.Element => {
@@ -270,23 +285,11 @@ const ContentArea = ({
     [onContentPress],
   );
 
-  const renderEmpty = useCallback(() => {
-    if (loadingContent) return null;
+  const empty = useMemo(() => {
+    if (loadingContent) return <ContentLoadingIndicator />;
+    if (error) return <CourseErrorState onRetry={onRetry} />;
     return <CourseEmptyState />;
-  }, [loadingContent]);
-
-  if (loadingContent) {
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator testID="content-loading" size="small" />
-      </View>
-    );
-  }
-
-  // A failed content fetch shows error+retry, distinct from the empty state.
-  if (error) {
-    return <CourseErrorState onRetry={onRetry} />;
-  }
+  }, [loadingContent, error, onRetry]);
 
   return (
     <FlatList
@@ -296,7 +299,8 @@ const ContentArea = ({
       data={content}
       renderItem={renderContentItem}
       keyExtractor={(item) => String(item.id)}
-      ListEmptyComponent={renderEmpty}
+      ListHeaderComponent={header}
+      ListEmptyComponent={empty}
     />
   );
 };
@@ -396,8 +400,9 @@ interface StagePanelProps {
   viewer: ReturnType<typeof useCourseViewer>;
 }
 
-/** The selected stage's cover, metadata, progress, intro, and chapter list. */
-const StagePanel = ({
+/** The selected stage's cover, metadata, progress, and intro — the pinned
+ *  header that rides atop the shared chapter-list scroll surface. */
+const StageHeader = ({
   selectedStage,
   selectedStageData,
   stageContent,
@@ -424,15 +429,45 @@ const StagePanel = ({
     <View style={styles.sectionBand}>
       <Text style={styles.sectionBandLabel}>Chapters</Text>
     </View>
+  </>
+);
+
+/** The selected stage's cover, metadata, progress, intro, and chapter list,
+ *  all hosted in one FlatList so the landing page scrolls as a single surface. */
+const StagePanel = ({
+  selectedStage,
+  selectedStageData,
+  stageContent,
+  viewer,
+}: StagePanelProps): React.JSX.Element => {
+  const header = useMemo(
+    () => (
+      <StageHeader
+        selectedStage={selectedStage}
+        selectedStageData={selectedStageData}
+        stageContent={stageContent}
+        viewer={viewer}
+      />
+    ),
+    [selectedStage, selectedStageData, stageContent, viewer],
+  );
+
+  // While loading or after a failed fetch the list is empty so the header stays
+  // pinned and the loading/error state renders in ListEmptyComponent.
+  const items =
+    stageContent.loadingContent || stageContent.error ? EMPTY_CONTENT : stageContent.content;
+
+  return (
     <ContentArea
-      content={stageContent.content}
+      content={items}
       loadingContent={stageContent.loadingContent}
       error={stageContent.error}
+      header={header}
       onContentPress={viewer.handleContentPress}
       onRetry={stageContent.retry}
     />
-  </>
-);
+  );
+};
 
 const CourseScreen = (): React.JSX.Element => {
   const { allStages, selectedStage, setSelectedStage, loading, error, retry } = useStagesLoader();

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -153,7 +153,7 @@ jest.mock('react-native-safe-area-context', () => {
 });
 
 // eslint-disable-next-line import/order
-const { render, waitFor, fireEvent, act } = require('@testing-library/react-native');
+const { render, waitFor, fireEvent, act, within } = require('@testing-library/react-native');
 const CourseScreen = require('../CourseScreen').default;
 
 describe('CourseScreen', () => {
@@ -429,5 +429,78 @@ describe('CourseScreen', () => {
     await waitFor(() => {
       expect(mockStageIntro).toHaveBeenCalledWith(2);
     });
+  });
+});
+
+describe('single scroll surface', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStagesList.mockResolvedValue(sampleStages);
+    mockStageContent.mockResolvedValue(sampleContent);
+    mockStageProgress.mockResolvedValue(sampleProgress);
+    mockStageIntro.mockRejectedValue({ detail: 'content_not_found' });
+  });
+
+  it('hosts the stage header inside the chapter list', async () => {
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('content-list')).toBeTruthy();
+    });
+
+    const list = within(getByTestId('content-list'));
+    expect(list.getByTestId('stage-cover')).toBeTruthy();
+    expect(list.getByTestId('stage-metadata')).toBeTruthy();
+    expect(list.getByTestId('progress-bar')).toBeTruthy();
+    expect(list.getByText('Chapters')).toBeTruthy();
+  });
+
+  it('keeps a single scrollable surface with the cover when the stage is empty', async () => {
+    mockStageContent.mockResolvedValue([]);
+
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('content-list')).toBeTruthy();
+    });
+
+    const list = within(getByTestId('content-list'));
+    expect(list.getByTestId('stage-cover')).toBeTruthy();
+    expect(list.getByText('No Content Yet')).toBeTruthy();
+  });
+
+  it('keeps the header on the same surface when content fails, and recovers on retry', async () => {
+    mockStageContent.mockRejectedValueOnce(new Error('boom'));
+
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('content-list')).toBeTruthy();
+    });
+
+    const listOnError = within(getByTestId('content-list'));
+    expect(listOnError.getByTestId('course-error')).toBeTruthy();
+    expect(getByTestId('stage-cover')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(listOnError.getByTestId('course-retry'));
+    });
+
+    await waitFor(() => {
+      expect(within(getByTestId('content-list')).getByText('Welcome Essay')).toBeTruthy();
+    });
+    expect(within(getByTestId('content-list')).queryByTestId('course-error')).toBeNull();
+  });
+
+  it('renders both the header and chapter items in the same list', async () => {
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('content-list')).toBeTruthy();
+    });
+
+    const list = within(getByTestId('content-list'));
+    expect(list.getByText('Welcome Essay')).toBeTruthy();
+    expect(list.getByTestId('stage-cover')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Host the Course stage header (cover, site resources, metadata, progress bar, "Start here" intro, and the Chapters band) in the chapter `FlatList`'s `ListHeaderComponent`, so the whole landing page scrolls as one surface instead of only the list scrolling below a fixed header.
- Route loading / error / empty states into `ListEmptyComponent` (data forced empty while loading or erroring) so the header stays pinned, the list stays virtualized, and observable state behavior is preserved.
- Add `flexGrow: 1` to the list content container so those states center below the scrolled header.

## Test plan
- Added a "single scroll surface" describe block in `CourseScreen.test.tsx` proving the header (`stage-cover`, `stage-metadata`, `progress-bar`, "Chapters") is hosted inside `content-list` via `within()`, that the empty stage keeps a scrollable page with the cover, and that a content-fetch error keeps the header on the same surface and recovers on retry.
- `./scripts/frontend/check-all.sh` exits 0: Jest 2555/2555 (85/85 Course), `tsc --noEmit` clean, ESLint zero-warning. `CourseScreen.tsx` coverage 97.69% lines / 85.48% branch.
- Existing `CourseErrorStates.test.tsx` regression contract passes unchanged.

Closes #937
Refs #934
