### PR TITLE
docs(de-slopify): teach the detector to wire-in dead code, not only delete

### DIFF
--- a/.claude/skills/de-slopify/SKILL.md
+++ b/.claude/skills/de-slopify/SKILL.md
@@ -140,6 +140,14 @@ without **two independent signals, at least one concrete and reproducible.**
 Classify each survivor by family and assign a severity (Critical/High/Medium/
 Low) from the rubric. When corroboration is shaky, **downgrade or drop.**
 
+For **Family-3 (dead/orphaned/stubbed) survivors**, after corroboration classify
+the **remediation direction** — `delete` / `wire-in (+ e2e test)` /
+`decision-needed` — using the intent + completeness signals from
+`slop-taxonomy.md`. Wire-in requires **both** signals; the filed issue must then
+demand an e2e test proving the newly wired path works end to end. This does not
+loosen the two-signal corroboration gate above — it only decides what to
+recommend *after* a finding has already survived it.
+
 ### Step 6 — Cluster, then dedup against the backlog
 
 Group corroborated findings by area/theme. A cluster needing coordinated
@@ -210,6 +218,9 @@ narrowed to changed areas; that is a failed run, not a clean one.
 - Touch generated code, migrations, lockfiles, or justified suppressions.
 - Create duplicate issues, or flood the backlog with low-value nits.
 - File a stylistic opinion that contradicts CLAUDE.md/AGENTS.md conventions.
+- Recommend deleting orphaned/dead code without first checking the wire-in
+  signals (intent + completeness) — reflexively discarding finished, intended
+  work is itself slop.
 
 ## Examples
 
@@ -241,6 +252,22 @@ plaintext with no encrypt hook (signal 2). Corroborated and high-severity — th
 code advertises a guarantee it doesn't deliver. File an `audit-destub`-style
 epic to make it real (encrypt-on-write, key rotation, migration), mirroring the
 existing `prompts/github-issues/audit-destub-05b-*.md` precedent.
+
+### Example 4 — Orphaned-but-finished code (wire-in, not delete)
+
+grep on `export_journal()` in `backend/src/domain/journal_export.py`
+shows a typed, fully implemented, unit-tested function with zero inbound
+edges — no router calls it (signal 1, the orphaned-code tell). Reading the
+Settings screen's docstring finds a comment promising "export your journal as
+Markdown" and a roadmap reference in `prompts/github-issues/README.md` to the
+same feature (signal 2 = intent). Reading the function itself confirms it's
+complete and matches the house pattern (async, typed, follows the existing
+`domain/` conventions) — not a husk (completeness). Both signals hold, so this
+is **not** a deletion candidate: file a `de-slop`/`wire-in` Template A issue
+that requires wiring the intended Settings call site to the export endpoint
+**and** adding an e2e test (`async_client` hitting the real router) that proves
+the newly connected path returns the exported Markdown — not an issue to
+delete `journal_export.py`.
 
 ## Troubleshooting
 

--- a/.claude/skills/de-slopify/references/issue-templates.md
+++ b/.claude/skills/de-slopify/references/issue-templates.md
@@ -43,6 +43,7 @@ Create any that don't exist (`gh label create <name> --color <hex> --description
 | `backend` / `frontend` / `full-stack` | Scope | tool-matched |
 | `bug` | Family 0 / 12 correctness finding (has a reproducing test) | `#d73a4a` |
 | `dead-code` | Family 3 dispensable | `#cfd3d7` |
+| `wire-in` | Family 3 finding whose remedy is connect-it + e2e test (not delete) | `#0052cc` |
 | `refactor` | Bloaters / couplers / verbosity | `#fbca04` |
 | `tech-debt` | Architecture / change-preventers | `#e99695` |
 | `security` | Family 10 (work itself defers to the `security` skill) | `#b60205` |
@@ -50,13 +51,18 @@ Create any that don't exist (`gh label create <name> --color <hex> --description
 | `blocked` / `needs-spec` | Not ready for autonomous pickup | `#000000` |
 
 Keep labels minimal per issue: one severity + one scope + one category + `de-slop`.
+`wire-in` is **not** in `pick-next.sh`'s exclude list, so Ralph still picks
+these issues up like any other standalone finding.
 
 ---
 
 ## Template A — Standalone finding (single, atomic, Ralph-ready)
 
 Mirror the established `prompts/github-issues/*.md` shape so it's actionable
-without a single clarifying question. Title is imperative and specific.
+without a single clarifying question. Title is imperative and specific. For a
+wire-in finding, title it as a connect-it task, e.g. "Wire in orphaned
+`export_journal()` from Settings and cover it with an e2e test" — not as a
+removal.
 
 ```markdown
 # <imperative title> (e.g. "Remove dead `legacy_streak()` and its orphaned test")
@@ -64,6 +70,7 @@ without a single clarifying question. Title is imperative and specific.
 **Labels:** `de-slop`, `<scope>`, `<category>`, `priority-<level>`
 **Detected by:** weekly de-slopify run <YYYY-MM-DD>
 **Severity:** <Critical|High|Medium|Low>
+**Remediation:** <delete | wire-in (+ e2e test) | decision-needed>
 
 ## Problem
 <2-3 sentences. What's wrong, where. Cite file:line. State the taxonomy family.>
@@ -91,6 +98,9 @@ without a single clarifying question. Title is imperative and specific.
 |------|--------|
 | `path/to/file.py` | Modify / Delete / Create |
 ```
+
+For a wire-in issue, the Files table's Action column is Create/Modify — the
+wired call site plus the new e2e test file — not Delete.
 
 **Rule:** a standalone issue should be ~50–300 net LoC and touch ≤ ~5 files. If
 it's bigger, it's an epic.

--- a/.claude/skills/de-slopify/references/slop-taxonomy.md
+++ b/.claude/skills/de-slopify/references/slop-taxonomy.md
@@ -80,10 +80,12 @@ they cause incidents, not just friction.
 
 ---
 
-## Family 3 — Dispensables (code that should not exist)
+## Family 3 — Dispensables (code with no justified presence as written)
 
 This family is the heart of "de-slopping." It is where dead, stubbed, orphaned,
-and duplicated code lives.
+and duplicated code lives. Not everything here is destined for deletion — some
+orphaned code is finished work merely awaiting the connection it was written
+for; see the remediation note below the table.
 
 | Smell | The tell | Corroboration hint |
 |-------|----------|--------------------|
@@ -98,6 +100,21 @@ and duplicated code lives.
 | **Data class (anemic)** | a bag of fields with no behavior where behavior belongs | confirm logic is scattered across users. |
 | **Dead config / deps** | declared dependencies never imported; env vars never read; settings never used | grep usage of each; confirm zero references. |
 | **Redundant test** | tests asserting framework behavior, tautologies, `assert True`, snapshot-only with no logic | confirm it would survive a logic mutation (see mutation-testing). |
+
+**Remediation direction (delete vs. wire-in + e2e).** The default for
+Dead/Orphaned/Stubbed findings is still **delete** (git remembers) unless
+**both** hold: (a) **intent evidence** — a docstring/flag promise, a roadmap/
+epic/`NORTH-STAR.md` reference, or an adjacent call site that clearly meant to
+use it; and (b) **completeness evidence** — the orphaned code is a finished,
+coherent, house-pattern-consistent implementation, not a husk. Both present ⇒
+recommend **wire-in + an e2e test** that exercises the newly connected path
+(backend: through the real router via `async_client`; frontend: through the
+screen via RNTL). Intent without completeness is not this case — that is the
+existing **Fake/aspirational feature flag** row above, the `audit-destub`
+"make it real" pattern. Ambiguous ⇒ file as **decision-needed** rather than
+silently deleting finished work. Neither signal ⇒ delete. The detector only
+**files** the issue either way — it never wires anything in and never deletes
+anything itself.
 
 ---
 

--- a/.github/workflows/weekly-deslop.yml
+++ b/.github/workflows/weekly-deslop.yml
@@ -146,6 +146,12 @@ jobs:
               large coordinated work as an `epic`-labeled umbrella with
               decomposed sub-issues (Template B); use the `triage-and-plan`
               skill when an epic needs more than ~3 sub-issues.
+            - Orphaned/dead code that is complete AND has explicit intent
+              evidence may warrant WIRING IN (with an e2e test) instead of
+              deletion; classify each Family-3 finding's remediation
+              direction (delete / wire-in (+ e2e) / decision-needed) per
+              Template A, preferring decision-needed over silently deleting
+              finished work.
             - Create any missing labels first. Write issue bodies to files and
               file with `gh issue create --body-file`.
             - A run that files NOTHING because the code is clean is a SUCCESS.


### PR DESCRIPTION
## Summary

Teaches the `de-slopify` detector that some dead/orphaned code is not slop to
delete but finished, intended work that was simply never connected — for which
the right remedy is to **wire it in and add an e2e test**, not to discard it.

Every Family-3 (Dispensables) dead/orphaned/stubbed finding now carries an
explicit **remediation direction**: `delete` | `wire-in (+ e2e test)` |
`decision-needed`. Wire-in is the evidenced exception, not a new default — it
requires two signals: **intent** (a docstring/flag/roadmap/`NORTH-STAR.md`
reference, or an adjacent call site that clearly meant to use it) **and**
**completeness** (a finished, house-pattern-consistent implementation). Both
present → recommend wiring the intended call site plus an e2e test that proves
the newly connected path; intent-without-completeness → the existing
`audit-destub` "make it real" pattern; ambiguous → `decision-needed` rather than
silently deleting finished work. The two-signal corroboration gate and the
"detector only files issues, never implements" boundary are preserved verbatim.

Content-only change across the skill and its workflow — no application code:

- `slop-taxonomy.md` — softens the Family 3 header, adds a "Remediation
  direction (delete vs. wire-in + e2e)" note with the intent/completeness
  signals, cross-referencing the audit-destub precedent.
- `SKILL.md` — adds a Step 5 remediation-classification step and a worked
  wire-in Example 4 alongside the existing delete example; adds a "must never
  do" bullet against reflexive deletion of finished work.
- `issue-templates.md` — adds a `Remediation:` field to Template A, a wire-in
  title example, a Files-column note, and a `wire-in` label (documented as NOT
  in `pick-next.sh`'s exclude list, so Ralph still picks these up).
- `weekly-deslop.yml` — one bullet in the inline prompt so the detector
  classifies remediation direction and considers wiring-in over reflexive
  deletion.

## Test plan

- No application code or tests changed; the "e2e test" is guidance the detector
  now recommends in filed issues, not code authored here.
- `pre-commit run --files <changed>` — all applicable hooks pass (check-yaml,
  detect-secrets, whitespace/EOF, commitlint). No markdownlint hook exists in
  this repo; prettier is scoped to `frontend/` so these `.claude/` docs are
  untouched by it.
- Verified: straight ASCII quotes only, no leaked issue refs in content, the
  YAML change is additive-only inside the literal block (no `prompt:` reindent,
  no new `# shellcheck disable`), and the `wire-in`-not-excluded claim matches
  `scripts/ralph/pick-next.sh`.
- Gate 2.5 code-review-orchestrator over the diff: CLEAN, all five acceptance
  criteria met.

Closes #940
