### PR TITLE
feat(design): dress the Markdown reader in candlelit tones + serif eyebrow/heading hierarchy

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -8,7 +8,12 @@ import { colors, SPACING } from '../../design/tokens';
 import styles, { markdownStyles } from './Course.styles';
 import { stripFrontmatter, stripLeadingTitleHeading } from './stripFrontmatter';
 
-/** Small-caps eyebrow shown above the sheet title, keyed by content type. */
+/**
+ * Small-caps eyebrow shown above the sheet title, keyed by content type.
+ * Only the types listed here map to a label; others (e.g. seeded ``essay`` /
+ * ``video`` / ``prompt`` chapters) resolve to ``undefined`` and render no
+ * eyebrow, which the sheet header handles gracefully.
+ */
 const READER_EYEBROWS: Record<string, string> = {
   chapter: 'Chapter',
   resource: 'Resource',

--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -6,7 +6,14 @@ import { course as courseApi, type ContentBody } from '../../api';
 import { colors, SPACING } from '../../design/tokens';
 
 import styles, { markdownStyles } from './Course.styles';
-import { stripFrontmatter } from './stripFrontmatter';
+import { stripFrontmatter, stripLeadingTitleHeading } from './stripFrontmatter';
+
+/** Small-caps eyebrow shown above the sheet title, keyed by content type. */
+const READER_EYEBROWS: Record<string, string> = {
+  chapter: 'Chapter',
+  resource: 'Resource',
+  introduction: 'Introduction',
+};
 
 /**
  * Source descriptor for the reader.  ``kind`` decides which backend
@@ -89,6 +96,24 @@ const ReaderHeader = ({ title, onBack }: HeaderProps): React.JSX.Element => (
       {title}
     </Text>
   </View>
+);
+
+interface SheetHeaderProps {
+  eyebrow: string | undefined;
+  title: string;
+}
+
+const ReaderSheetHeader = ({ eyebrow, title }: SheetHeaderProps): React.JSX.Element => (
+  <>
+    {eyebrow !== undefined && (
+      <Text testID="reader-sheet-eyebrow" style={styles.readerEyebrow}>
+        {eyebrow}
+      </Text>
+    )}
+    <Text testID="reader-sheet-title" style={styles.readerTitle}>
+      {title}
+    </Text>
+  </>
 );
 
 interface ErrorViewProps {
@@ -186,10 +211,11 @@ function useContentBody(source: ChapterReaderSource): {
 }
 
 function renderBody(body: ContentBody): React.ReactElement {
-  const markdown = stripFrontmatter(body.body_markdown);
-  if (markdown.trim() === '') {
+  const stripped = stripFrontmatter(body.body_markdown);
+  if (stripped.trim() === '') {
     return <EmptyView />;
   }
+  const markdown = stripLeadingTitleHeading(stripped, body.title);
   return (
     <ScrollView
       style={styles.readerScroll}
@@ -197,6 +223,7 @@ function renderBody(body: ContentBody): React.ReactElement {
       testID="reader-markdown"
     >
       <View style={styles.readerSheet}>
+        <ReaderSheetHeader eyebrow={READER_EYEBROWS[body.content_type]} title={body.title} />
         <Markdown style={markdownStyles} rules={markdownRules} onLinkPress={handleLinkPress}>
           {markdown}
         </Markdown>

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -380,8 +380,22 @@ const styles = StyleSheet.create({
     paddingTop: SPACING.sm,
     paddingBottom: SPACING.lg,
     borderRadius: radius.lg,
-    backgroundColor: surface.raised,
+    backgroundColor: surface.canvas,
     ...paperShadow.sheet,
+  },
+  // Small-caps eyebrow over the sheet title (mirrors sectionBandLabel).
+  readerEyebrow: {
+    ...editorialType.caption,
+    color: ink.muted,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginBottom: SPACING.xs,
+  },
+  // Serif editorial title heading the sheet; inherits its size from the token.
+  readerTitle: {
+    ...editorialType.title,
+    color: ink.primary,
+    marginBottom: SPACING.sm,
   },
   readerError: {
     flex: 1,
@@ -461,7 +475,6 @@ export const markdownStyles = StyleSheet.create({
     fontSize: 17,
     lineHeight: 26,
     color: ink.primary,
-    paddingTop: SPACING.md,
   },
   heading1: {
     ...editorialType.title,
@@ -524,7 +537,7 @@ export const markdownStyles = StyleSheet.create({
     marginVertical: SPACING.xs,
   },
   hr: {
-    backgroundColor: surface.hairline,
+    backgroundColor: accent.primary,
     marginVertical: SPACING.md,
   },
   contentImage: {

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -261,4 +261,81 @@ describe('ChapterReader', () => {
     expect(queryByText(/slug:/)).toBeNull();
     expect(queryByText(/title:/)).toBeNull();
   });
+
+  it('renders the manifest title in the reader sheet header', async () => {
+    const { findByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    const title = await findByTestId('reader-sheet-title');
+    expect(title.props.children).toBe('Chapter One');
+  });
+
+  it('labels the sheet eyebrow "Chapter" for content sources', async () => {
+    const { findByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    const eyebrow = await findByTestId('reader-sheet-eyebrow');
+    expect(eyebrow.props.children).toBe('Chapter');
+  });
+
+  it('labels the sheet eyebrow "Resource" for site-resource sources', async () => {
+    const { findByTestId } = render(
+      <ChapterReader
+        source={{ kind: 'resource', slug: 'philosophy' }}
+        fallbackTitle="x"
+        onBack={jest.fn()}
+      />,
+    );
+    const eyebrow = await findByTestId('reader-sheet-eyebrow');
+    expect(eyebrow.props.children).toBe('Resource');
+  });
+
+  it('labels the sheet eyebrow "Introduction" for intro sources', async () => {
+    const { findByTestId } = render(
+      <ChapterReader
+        source={{ kind: 'intro', stageNumber: 1 }}
+        fallbackTitle="x"
+        onBack={jest.fn()}
+      />,
+    );
+    const eyebrow = await findByTestId('reader-sheet-eyebrow');
+    expect(eyebrow.props.children).toBe('Introduction');
+  });
+
+  it('renders no eyebrow for an unmapped content_type', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'X',
+      content_type: 'mystery',
+      body_markdown: '# X\n\nbody.\n',
+    });
+    const { findByTestId, queryByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    await findByTestId('reader-sheet-title');
+    expect(queryByTestId('reader-sheet-eyebrow')).toBeNull();
+  });
+
+  it('dedupes a leading H1 that matches the manifest title', async () => {
+    const { findByTestId, getAllByText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    await findByTestId('reader-sheet-title');
+    // Only the viewer header and the sheet title render "Chapter One" -- the
+    // leading markdown H1 duplicate is stripped.
+    expect(getAllByText('Chapter One')).toHaveLength(2);
+  });
+
+  it('preserves a leading H1 that differs from the manifest title', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'Manifest Title',
+      content_type: 'chapter',
+      body_markdown: '# Different Heading\n\nbody.\n',
+    });
+    const { findByTestId, findByText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    const title = await findByTestId('reader-sheet-title');
+    expect(title.props.children).toBe('Manifest Title');
+    await findByText('Different Heading');
+  });
 });

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -65,7 +65,7 @@ describe('ChapterReader', () => {
       />,
     );
     expect(getByText('Loading…')).toBeTruthy();
-    // Header title + the markdown H1 both render the live title.
+    // The viewer header and the sheet title both render the live title.
     await findAllByText('Chapter One');
   });
 

--- a/frontend/src/features/Course/__tests__/Course.styles.test.ts
+++ b/frontend/src/features/Course/__tests__/Course.styles.test.ts
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+import { describe, expect, it } from '@jest/globals';
+import { StyleSheet } from 'react-native';
+
+import { accent, editorialType, ink, surface } from '../../../design/tokens';
+import styles, { markdownStyles } from '../Course.styles';
+
+describe('Course.styles reader sheet', () => {
+  it('grounds the reader sheet and scroll on the Candle & Ink surfaces', () => {
+    const readerSheet = StyleSheet.flatten(styles.readerSheet);
+    const readerScroll = StyleSheet.flatten(styles.readerScroll);
+    expect(readerSheet.backgroundColor).toBe(surface.canvas);
+    expect(readerSheet.backgroundColor).not.toBe('#ffffff');
+    expect(readerScroll.backgroundColor).toBe(surface.desk);
+  });
+
+  it('styles the sheet eyebrow with the muted caption face, uppercased', () => {
+    const eyebrow = StyleSheet.flatten(styles.readerEyebrow);
+    expect(eyebrow.color).toBe(ink.muted);
+    expect(eyebrow.textTransform).toBe('uppercase');
+    expect(eyebrow.fontFamily).toBe(editorialType.caption.fontFamily);
+  });
+
+  it('styles the sheet title with the serif editorial title face', () => {
+    const title = StyleSheet.flatten(styles.readerTitle);
+    expect(title.fontFamily).toBe(editorialType.title.fontFamily);
+    expect(title.fontSize).toBe(editorialType.title.fontSize);
+    expect(title.color).toBe(ink.primary);
+  });
+
+  it('draws markdown body and link text from the ink and accent tokens', () => {
+    const body = StyleSheet.flatten(markdownStyles.body);
+    const link = StyleSheet.flatten(markdownStyles.link);
+    expect(body.color).toBe(ink.primary);
+    expect(link.color).toBe(accent.primary);
+  });
+
+  it('draws the blockquote rule and hr from the accent token', () => {
+    const blockquote = StyleSheet.flatten(markdownStyles.blockquote);
+    const hr = StyleSheet.flatten(markdownStyles.hr);
+    expect(blockquote.borderLeftColor).toBe(accent.primary);
+    expect(hr.backgroundColor).toBe(accent.primary);
+  });
+});

--- a/frontend/src/features/Course/__tests__/stripFrontmatter.test.ts
+++ b/frontend/src/features/Course/__tests__/stripFrontmatter.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { describe, expect, it } from '@jest/globals';
 
-import { stripFrontmatter } from '../stripFrontmatter';
+import { stripFrontmatter, stripLeadingTitleHeading } from '../stripFrontmatter';
 
 describe('stripFrontmatter', () => {
   it('strips a leading YAML frontmatter block', () => {
@@ -45,5 +45,53 @@ describe('stripFrontmatter', () => {
     const result = stripFrontmatter(input);
     expect(result).not.toContain('slug:');
     expect(result).toContain('# Body');
+  });
+});
+
+describe('stripLeadingTitleHeading', () => {
+  it('strips a leading H1 that exactly matches the title', () => {
+    const input = '# Title\n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe('Prose.\n');
+  });
+
+  it('consumes the single blank line after the stripped heading', () => {
+    const input = '# Title\n\nProse.\n';
+    const result = stripLeadingTitleHeading(input, 'Title');
+    expect(result.startsWith('\n')).toBe(false);
+  });
+
+  it('preserves a differing heading unchanged (exact equality)', () => {
+    const input = '# Other\n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe(input);
+  });
+
+  it('returns whitespace-only input unchanged (exact equality)', () => {
+    const input = '\n   \n\t\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe(input);
+  });
+
+  it('preserves a body starting with an H2 unchanged (exact equality)', () => {
+    const input = '## Sub\n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe(input);
+  });
+
+  it('preserves a body starting with bare prose unchanged (exact equality)', () => {
+    const input = 'Just prose, no heading.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe(input);
+  });
+
+  it('skips leading blank lines to find and strip the matching H1', () => {
+    const input = '\n\n# Title\n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe('Prose.\n');
+  });
+
+  it('removes only the heading line when no blank line follows', () => {
+    const input = '# Title\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe('Prose.\n');
+  });
+
+  it('trims whitespace when comparing heading text to the title', () => {
+    const input = '# Title \n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe('Prose.\n');
   });
 });

--- a/frontend/src/features/Course/stripFrontmatter.ts
+++ b/frontend/src/features/Course/stripFrontmatter.ts
@@ -26,3 +26,34 @@ export function stripFrontmatter(md: string): string {
   }
   return md;
 }
+
+/** ATX H1 prefix: exactly one hash followed by a space. */
+const H1_PREFIX = '# ';
+
+/**
+ * Drop a leading ``# Heading`` line when its text exactly matches the manifest
+ * ``title`` — the reader already renders the title in its sheet header, so a
+ * duplicate H1 would read twice.  Only the first non-empty line is considered,
+ * it must be a single-hash ATX H1, and a differing heading is left untouched.
+ * A blank line immediately after the stripped heading is consumed too.
+ */
+export function stripLeadingTitleHeading(md: string, title: string): string {
+  const lines = md.split('\n');
+  const firstContentIndex = lines.findIndex((line) => line.trim() !== '');
+  if (firstContentIndex === -1) {
+    return md;
+  }
+  const heading = lines[firstContentIndex] ?? '';
+  if (!heading.startsWith(H1_PREFIX)) {
+    return md;
+  }
+  const headingText = heading.slice(H1_PREFIX.length).trim();
+  if (headingText !== title.trim()) {
+    return md;
+  }
+  let nextIndex = firstContentIndex + 1;
+  if (lines[nextIndex]?.trim() === '') {
+    nextIndex += 1;
+  }
+  return lines.slice(nextIndex).join('\n');
+}


### PR DESCRIPTION
## Summary

Dresses the course Markdown reader in the Candle & Ink design language so it
reads as a warm editorial surface rather than "any other AI tool":

- **Warm ground, not white.** `readerSheet` now floats on `surface.canvas`
  (warm paper) instead of pure `surface.raised` (#ffffff), keeping the soft
  `paperShadow.sheet` lift so it still reads as paper-on-desk.
- **Editorial header block.** A small-caps, letter-spaced eyebrow
  (`ink.muted`, derived from `content_type`) and a serif title
  (`editorialType.title`) now head the reading sheet, so the manifest metadata
  presents as a header + eyebrow instead of dumping raw into the body.
  Unmapped content types render no eyebrow (absent-safe).
- **Accent rule.** Markdown links already used `accent.primary`; the
  horizontal rule now does too (the blockquote keeps its terracotta left-rule).
- **Title dedupe.** A conservative pure helper (`stripLeadingTitleHeading`)
  drops a leading `# Heading` only when its text exactly equals the manifest
  title, so the title is not shown twice. A differing leading H1 is preserved.

All colors and sizes come from design tokens (`surface`/`ink`/`accent`/
`editorialType`/`SPACING`) — no magic hex, no raw font sizes. The
`semanticTokens` AA assertions are untouched (ink-on-canvas is exactly what
they verify).

## Test plan

- New `Course.styles.test.ts` asserts token identity for the reader surfaces,
  the new eyebrow/title styles, and the body/link/blockquote/hr colors (never
  hex literals).
- New `ChapterReader.test.tsx` cases cover the sheet title, the per-kind
  eyebrow label, the absent-safe unmapped case, and the title-dedupe strip +
  preserve paths. All 16 original reader tests remain green.
- New `stripFrontmatter.test.ts` cases cover the dedupe helper's edge cases.
- Local Gate 2 green: `./scripts/frontend/check-all.sh` (ESLint, Prettier,
  tsc, Jest 2567 pass) exit 0.

Refs #934
Closes #939
