### PR TITLE
feat(ralph): make the fleet a non-blocking worker pool

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -20,7 +20,7 @@ sequential loop the orchestrator drives a single worker. Either way the spawn
 graph under a conductor is identical:
 
 ```
-ralph-tick (fleet ORCHESTRATOR — reconcile · serialized-merge · sync · monitor)
+ralph-tick (fleet ORCHESTRATOR — worker pool: reconcile · serialized-merge · lazy-sync · refill)
   └─ ralph-worker × up to 4 . L1  opus    per-issue CONDUCTOR in an isolated worktree
        ├─ chief-architect ..... L0  fable   plan + ordered dispatch list (no code)
        ├─ test-specialist ..... L2  sonnet  Gate 1 RED: failing tests          ─┐

--- a/.claude/commands/ralph-tick.md
+++ b/.claude/commands/ralph-tick.md
@@ -1,39 +1,49 @@
 ---
-description: One tick of the local Ralph loop for adepthood. Re-entrant — reads state from disk and drives a fleet of up to `max_workers` (default 4) parallel worktrees across the four gates (TDD → check-all → CI → review → merge).
+description: One tick of the local Ralph loop for adepthood. Re-entrant — reads state from disk and keeps a pool of up to `max_workers` (default 4) worktree lanes each moving INDEPENDENTLY through the four gates (TDD → check-all → CI → review → merge); the first lane to finish merges and its slot refills immediately.
 ---
 
-You are Ralph's brain for one tick of adepthood's local outer loop.
+You are Ralph's brain for one wake of adepthood's local outer loop.
 
 > Driven by `/loop /ralph-tick` in a caffeinated local Claude Code session at
-> the repo root (`Geoffe-Ga/adepthood`). The `/loop` skill fires you again
-> when your turn ends — either by a `Monitor` event or a `ScheduleWakeup`.
-> Be **re-entrant**: every tick reads state from disk, the live worktree fleet
-> (`git`), and PR state from GitHub, then figures out what to do. Never assume
-> continuity with the previous tick.
+> the repo root (`Geoffe-Ga/adepthood`). The `/loop` skill fires you again on
+> every wake — a background worker finishing, a PR webhook event, or a
+> `ScheduleWakeup`. Be **re-entrant**: each wake reads state from disk, the live
+> worktree fleet (`git`), and PR state from GitHub, then does whatever the
+> current state calls for. Never assume continuity with the previous wake.
 >
-> **You are a FLEET ORCHESTRATOR.** You can have up to `max_workers` (default 4)
-> issues in flight at once, each in its own git worktree, driven by a
-> `ralph-worker` subagent. You **manage** the fleet — reconcile, merge, sync,
-> dispatch workers, monitor — you do not write code yourself. The full design is
-> `scripts/ralph/FLEET.md`; read it if anything below is unclear.
+> **You are a FLEET ORCHESTRATOR running a WORKER POOL.** You keep up to
+> `max_workers` (default 4) **lanes** occupied. Each lane is one issue in its own
+> git worktree, moving through the four gates **independently, on its own clock**.
+> You never wait on the slowest lane: whichever lane is ready to merge merges
+> now, and the slot it frees refills immediately — the other lanes keep going
+> undisturbed. The full design is `scripts/ralph/FLEET.md`; read it if anything
+> below is unclear.
 >
 > **Do NOT use the Task tools (TaskCreate/TaskUpdate/…) to track this work.**
 > The GitHub issue is the only tracker. (User directive.)
 
 ## The core principle (this is what "responsibly" means)
 
-**Optimistic parallelism, pessimistic merge.** You *speculate* that the issues
-you pick are independent, but you never rely on that guess for correctness:
+**Optimistic parallelism, pessimistic merge — but never a barrier.**
 
-- Pick optimistically (`pick-next.sh` is parallel-aware), work each issue in an
-  isolated worktree through Gates 1–2.5.
-- **Merge exactly ONE PR per tick.** After merging, **sync** the new `main` into
-  every other worktree (`fleet.sh sync` — a merge, never a force-push) and make
-  each re-clear Gate 2 before it may merge. A sync conflict drops that worktree
-  to Gate 1.
+- **Optimistic pick.** `pick-next.sh` hands out issues that look independent, up
+  to the worker cap. Each is built in an isolated worktree through Gates 1–2.5.
+- **Independent lanes.** Lanes do not wait for each other. A fast lane at Gate 4
+  does not wait for a slow lane still at Gate 1. There is **no per-tick barrier**
+  and **no all-lanes Monitor** — you act on whichever lane a wake is about.
+- **Pessimistic, serialized merge.** Merges to `main` happen one at a time (the
+  single orchestrator session serializes them for free). A lane merges only when
+  it is `LGTM` + CI-green + **up-to-date with `main`**. If `main` moved since a
+  lane went green, that lane **syncs** first (`fleet.sh sync` — a merge, never a
+  force-push, so a plain push updates the PR and re-runs CI) and merges on a later
+  wake once green again. A sync conflict drops that lane to Gate 1.
+- **Immediate refill.** The instant a lane frees a slot (its PR merged, or it was
+  blocked/abandoned), refill that slot from the picker — up to the cap — without
+  waiting on any other lane.
 
-An imperfect independence guess therefore costs at most a sync — it can never
-merge broken or conflicting code.
+An imperfect independence guess therefore costs at most a sync; it can never
+merge broken or conflicting code, and it never makes a fast lane wait on a slow
+one.
 
 ## The four gates (and the drop-back rule)
 | Gate | Check | On pass | On fail |
@@ -41,225 +51,212 @@ merge broken or conflicting code.
 | 1 | **TDD** (Red→Green→Refactor, `stay-green`) | → Gate 2 | — |
 | 2 | **`./scripts/<side>/check-all.sh`** (backend and/or frontend) | → push → Gate 3 | **drop to Gate 1** |
 | 3 | **CI** all green | → Gate 4 | **drop to Gate 1** (via `ci-debugging`) |
-| 4 | **Claude review `Verdict:`** | `LGTM` → **merge + mark issue done** | **drop to Gate 1** (via `address-feedback`) |
+| 4 | **Claude review `Verdict:`** | `LGTM` + green + up-to-date → **merge + mark issue done + refill** | **drop to Gate 1** (via `address-feedback`) |
 
 "Drop to Gate 1" means: fix the root cause with a failing-test-first cycle, re-clear Gate 2 locally, push, and climb again. Never weaken a gate to pass it.
 
 ## The subagent taxonomy (workers are your conductors)
 
-You do not write code in the main loop. For each issue in flight you dispatch a
+You do not write code in the main loop. For each lane you dispatch a
 **`ralph-worker`** (`Agent`, `subagent_type: ralph-worker`) that works **inside
 that issue's worktree** and is itself the per-issue conductor: it spawns the
-`chief-architect` for the plan and runs the specialists in
-`.claude/agents/` (map + tiers in `.claude/agents/README.md`; shared rules in
-`.claude/agents/shared/adepthood-constraints.md`). The worker carries the issue
-through Gates 1–2.5 and opens its PR, then returns — it never merges, never
+`chief-architect` for the plan and runs the specialists in `.claude/agents/` (map
++ tiers in `.claude/agents/README.md`; shared rules in
+`.claude/agents/shared/adepthood-constraints.md`). A build worker carries the
+issue through Gates 1–2.5, opens its PR, and returns — it never merges, never
 touches `main`, never waits on CI.
 
-**Launch workers in parallel** (up to `max_workers`) by putting multiple
-`Agent(ralph-worker)` calls in a single message — but only when each targets a
-**different worktree**. Never run two workers against the same worktree. Within a
-worktree, its worker dispatches the taxonomy **sequentially** (one working tree
-per worker — no parallel edits) and invokes only the specialists the architect
-flagged; the per-agent map + model tiers live in `.claude/agents/README.md`.
+**Workers are BACKGROUND tasks — this is what makes the lanes independent.**
+Launch each `ralph-worker` with `run_in_background: true` (the default) and **do
+NOT await it**. You launch, then end your turn; each worker's completion is its
+own wake. **Never run a worker with `run_in_background: false`, and never launch a
+batch of workers expecting to collect all their reports in one turn** — that
+reintroduces the slowest-lane barrier you are here to remove. Within a worktree,
+its worker dispatches the taxonomy sequentially (one working tree per worker — no
+parallel edits) and invokes only the specialists the architect flagged.
 
 ---
 
-## Step 0 — Pause check, read state, reconcile the fleet
+## On each wake, do these in order, then end the turn
+
+### Step 0 — Pause check, reconcile, snapshot the pool
 ```bash
 if [ -f scripts/ralph/.paused ]; then echo "paused"; fi
-cat scripts/ralph/state.json                 # completed_since_groom, groom_interval, max_workers, parallel_enabled
-scripts/ralph/fleet.sh reconcile             # GC worktrees whose PR merged/closed
-scripts/ralph/fleet.sh list                  # active worktrees: <issue> <branch> <path>
-scripts/ralph/fleet.sh free                  # remaining worker capacity
+cat scripts/ralph/state.json                 # groom counters, max_workers, parallel_enabled
+scripts/ralph/fleet.sh reconcile             # GC worktrees whose PR merged/closed → frees slots
+scripts/ralph/fleet.sh list                  # occupied lanes: <issue> <branch> <path>
+scripts/ralph/fleet.sh free                  # open slots right now
 ```
 If `scripts/ralph/.paused` exists: `ScheduleWakeup` (~1800s, reason "ralph paused") and end the turn. Do not pick or work.
 
-Now snapshot **every in-flight Ralph PR** (case-insensitive `Closes/Fixes/Resolves #N`):
+Snapshot **every in-flight Ralph PR** with its mergeability, CI, and verdict:
 ```bash
-gh pr list --state open --author "@me" --json number,headRefName,body,mergeable \
+gh pr list --state open --author "@me" \
+  --json number,headRefName,body,mergeable,mergeStateStatus \
   --jq '.[] | select(.body | test("(?i)(closes|fixes|resolves)\\s+#[0-9]+"))'
 ```
-Each in-flight PR maps to a worktree branch (`issue/<N>-<slug>`). Together the
-worktrees and open PRs are your **active set**. Then work the phases below **in
-order**, doing the *next atomic action* and ending the turn — a tick may perform
-one merge, advance several workers, and fill a slot, but keep it bounded.
+Each in-flight PR is a lane in Gate 3/4; each occupied worktree without a PR yet
+is a lane still building (its worker is running in the background). Together they
+are the pool.
 
-**Mode A — all done.** If the active set is empty AND `pick-next.sh` prints
-nothing: announce "Backlog drained. Ralph is done." and call `/loop` to **stop**.
+**Mode A — all done.** If the pool is empty (no worktrees, no in-flight PRs) AND
+`pick-next.sh` prints nothing: announce "Backlog drained. Ralph is done." and
+call `/loop` to **stop**.
 
----
-
-## Step 1 — Merge phase (serialized: at most ONE per tick)
+### Step 1 — Merge every ready lane (serialized, up-to-date only)
 
 Read each in-flight PR once:
 ```bash
-gh pr view "$PR_NUM" --comments --json state,mergeable,statusCheckRollup,comments
+gh pr view "$PR_NUM" --comments --json state,mergeable,mergeStateStatus,statusCheckRollup,comments
 ```
-Identify per PR: latest top-level `Verdict:` comment (from
-`claude-code-review.yml`), the CI status-check rollup, and PR state.
+For each PR, classify from the latest top-level `Verdict:` comment
+(`claude-code-review.yml`), the CI rollup, and `mergeStateStatus`:
 
-Collect the PRs that are **merge-ready** = `Verdict: LGTM` AND CI fully green AND
-still OPEN. If one or more are merge-ready, **merge only the lowest issue number
-this tick** (serializing keeps `main` conflicts impossible):
+- **Ready** = `Verdict: LGTM` AND CI fully green AND `mergeStateStatus` is `CLEAN`
+  (i.e. up-to-date with `main`). **Merge it now** — do not wait for any other
+  lane:
+  ```bash
+  gh pr merge "$PR_NUM" --squash --delete-branch
+  ISSUE_N=<issue this PR closed>
+  gh issue close "$ISSUE_N" --reason completed 2>/dev/null || true
+  git checkout main && git pull --ff-only
+  scripts/ralph/fleet.sh release "$ISSUE_N"        # frees the slot
+  python3 -c "import json;p='scripts/ralph/state.json';s=json.load(open(p));s['completed_since_groom']+=1;s['total_completed']+=1;s['last_completed_issue']=$ISSUE_N;json.dump(s,open(p,'w'),indent=2)"
+  ```
+  (Idempotent if `iteration-trigger.yml` or a prior wake already merged it — the
+  PR shows MERGED; do the same close + `release` + state bump.)
+- **Behind** = `LGTM` + green but `mergeStateStatus` is `BEHIND` (a sibling merged
+  after this lane went green). **Do not merge stale.** Sync it and let CI re-run:
+  ```bash
+  scripts/ralph/fleet.sh sync "$ISSUE_N" || echo "SYNC-CONFLICT $ISSUE_N"
+  ```
+  A clean sync → dispatch its `ralph-worker` to re-clear Gate 2 locally and push;
+  it re-merges on a later wake once green. `SYNC-CONFLICT` → that lane drops to
+  Gate 1 (worker resolves the conflict as a root-cause change, re-greens, pushes).
 
-```bash
-gh pr merge "$PR_NUM" --squash --delete-branch
-ISSUE_N=<issue this PR closed>
-gh issue close "$ISSUE_N" --reason completed 2>/dev/null || true
-git checkout main && git pull --ff-only
-scripts/ralph/fleet.sh release "$ISSUE_N"          # remove its worktree
-python3 -c "import json;p='scripts/ralph/state.json';s=json.load(open(p));s['completed_since_groom']+=1;s['total_completed']+=1;s['last_completed_issue']=$ISSUE_N;json.dump(s,open(p,'w'),indent=2)"
-```
-(If a prior tick or `iteration-trigger.yml` already merged it, the PR shows
-MERGED — do the same completion bookkeeping and `release`, idempotently.)
+You may merge more than one lane in a wake, but **re-check `mergeStateStatus`
+before each merge** — merging one lane can push the others `BEHIND`. Serialized,
+always up-to-date: correctness holds; a ready lane is never held back by a slow
+sibling.
 
-**Then re-baseline every OTHER active worktree against the new `main`:**
-```bash
-for M in $(scripts/ralph/fleet.sh active); do
-  scripts/ralph/fleet.sh sync "$M" || echo "SYNC-CONFLICT $M"   # exit 3 = conflict
-done
-```
-- **Clean sync** with new commits pulled in ⇒ that worktree must **re-clear Gate
-  2**: dispatch its `ralph-worker` to run the relevant `check-all.sh` and, if
-  anything changed or broke, fix (drop to Gate 1) and push. (A no-op sync needs
-  nothing.)
-- **`SYNC-CONFLICT M`** ⇒ that worktree **drops to Gate 1**: dispatch its
-  `ralph-worker` to resolve the conflict as a root-cause change, re-clear Gate 2,
-  and push (plain push — `sync` used a merge, so no force-push).
+If any merge happened, commit the `state.json` bump (state-only changes may go
+directly on `main`).
 
-Commit the `state.json` bump (state-only changes may go directly on `main`).
-Merge at most one PR per tick; other merge-ready PRs wait for the next tick (they
-will sync in this tick, so they stay current).
+### Step 2 — Advance failing lanes (per PR, independent)
 
----
+For each in-flight PR **not** merged, dispatch a **background** `ralph-worker`
+into that PR's worktree only if it needs a fix (re-attach a worktree with
+`scripts/ralph/fleet.sh assign "$N" "<slug>"` if reconcile removed it — `assign`
+reuses the existing branch):
 
-## Step 2 — Advance in-flight PRs (Gates 3 & 4, per PR)
+- **Gate 4 failed** (`CHANGES_REQUESTED`/`COMMENTS`): worker runs the
+  **`address-feedback`** flow in the worktree — triage, TDD fix loop dispatching
+  the specialist that owns each comment, re-clear Gate 2 + Gate 2.5, push, reply,
+  resolve threads.
+- **Gate 3 failed** (CI rollup has a failure): worker runs **`ci-debugging`** in
+  the worktree — reproduce locally, fix the root cause (failing test first),
+  re-clear Gate 2/2.5, push.
+- **In progress** (CI running, or verdict not yet posted): do nothing — this
+  lane's PR subscription (Step 5) wakes you when it changes.
+- **`dependencies` PRs** (from `dependabot-to-ralph-issue.yml`): the in-flight PR
+  is **Dependabot's own branch** (linked via `Closes`). Push Gate-1/Gate-3 fixes
+  **to that branch**, never a fresh branch or second PR. A breaking major is a
+  normal Gate-1 TDD adaptation — never pin back, suppress, or weaken a gate.
+  Dependabot stops rebasing once the PR carries a non-Dependabot commit. The three
+  SDK-tied pins (styleq, expo-av, expo-notifications) are deferred to the Expo SDK
+  53 epic (#885).
 
-For every open PR **not** merged this step, branch by its gate status. Where a
-fix is needed, dispatch its **`ralph-worker`** into that PR's worktree (re-attach
-one with `scripts/ralph/fleet.sh assign "$N" <slug>` if reconcile removed it —
-`assign` reuses the existing branch). Workers for **different** worktrees may be
-launched **in parallel in one message**.
+These fix-workers are background too — launch, don't await.
 
-- **2a — Gate 4 failed** (latest verdict `CHANGES_REQUESTED`/`COMMENTS`): dispatch
-  the worker to run the **`address-feedback`** flow in its worktree — parse the
-  verdict, triage blockers/problems/nits, run a TDD fix loop (Gate 1) dispatching
-  the specialist that owns each comment's dimension, re-clear Gate 2 and the Gate
-  2.5 self-review, commit, push, reply to and resolve threads.
-- **2b — Gate 3 failed** (CI rollup has a failure): dispatch the worker to run
-  **`ci-debugging`** in its worktree — reproduce locally, fix the root cause via
-  the owning specialist (failing test first), re-clear Gate 2/2.5, push.
-- **2c — In progress** (CI running, or verdict not yet posted): do nothing for
-  that PR; it will be watched in Step 4.
-- **2d — `dependencies` PRs** (filed by `dependabot-to-ralph-issue.yml`): the
-  in-flight PR is **Dependabot's own branch**, linked via `Closes`. Push Gate-1/
-  Gate-3 fixes **to that branch** (a worktree attached to it), never a fresh
-  branch or second PR. A breaking major (e.g. zod 3→4) is a normal Gate-1 TDD
-  adaptation: change the code, never pin back, suppress, or weaken a gate.
-  Dependabot stops rebasing once the PR carries a non-Dependabot commit. The
-  three SDK-tied pins (styleq, expo-av, expo-notifications) are deferred to the
-  Expo SDK 53 epic (#885).
+### Step 3 — Groom gate (every Nth completion)
 
----
-
-## Step 3 — Groom gate (every Nth completion)
-
-When `completed_since_groom >= groom_interval` (check after Step 1's bump):
-1. Invoke **`/backlog-grooming`** as a Skill; let it run its full pass. (Label/
-   close operations on issues are safe while workers build.)
+When `completed_since_groom >= groom_interval`:
+1. Invoke **`/backlog-grooming`** as a Skill (label/close ops are safe while lanes build).
 2. Reset the counter and stamp:
    ```bash
    python3 -c "import json,datetime;p='scripts/ralph/state.json';s=json.load(open(p));s['completed_since_groom']=0;s['last_groom_at']=datetime.datetime.now().isoformat();json.dump(s,open(p,'w'),indent=2)"
    ```
 3. Commit the state change (state-only changes may go directly on `main`).
 
----
+### Step 4 — Refill EVERY open slot now (up to `max_workers`)
 
-## Step 4 — Fill free worker slots (up to `max_workers`)
-
-While `scripts/ralph/fleet.sh free` > 0, pick the next **compatible** issue and
-launch a worker for it:
+Fill the pool back to full immediately — do not wait for other lanes to reach any
+particular gate:
 ```bash
 while [ "$(scripts/ralph/fleet.sh free)" -gt 0 ]; do
-  ISSUE_N=$(scripts/ralph/pick-next.sh)          # parallel-aware: excludes active worktrees + PRs, honors solo/epic
-  [ -z "$ISSUE_N" ] && break                     # nothing compatible with the current fleet
+  ISSUE_N=$(scripts/ralph/pick-next.sh)          # parallel-aware: excludes active lanes + PRs, honors solo/epic
+  [ -z "$ISSUE_N" ] && break                     # nothing compatible with the current pool
   SLUG=$(gh issue view "$ISSUE_N" --json title --jq .title)
-  WT=$(scripts/ralph/fleet.sh assign "$ISSUE_N" "$SLUG")   # creates worktree off origin/main
+  WT=$(scripts/ralph/fleet.sh assign "$ISSUE_N" "$SLUG")   # worktree off origin/main
   echo "assigned issue $ISSUE_N → $WT"
 done
 ```
-For each issue you just assigned (and any freshly re-attached worktree from Step
-2 that still needs its first build), dispatch a **`ralph-worker`**, passing
-`RALPH_ISSUE` and `RALPH_WORKTREE=<path>`. Its contract is
-`scripts/ralph/PROMPT.md` (fleet variant: branch/worktree already exist — skip
-branch creation, work inside the worktree, open the PR, return without waiting).
-**Batch all newly-launched workers into one message** so they run concurrently.
-Each worker returns a short report (`outcome: pr_opened | blocked | failed`).
+For **each** issue you just assigned, dispatch a **background** `ralph-worker`
+(`run_in_background: true`), passing `RALPH_ISSUE` and `RALPH_WORKTREE=<path>`.
+Its contract is `scripts/ralph/PROMPT.md` (fleet variant: branch/worktree already
+exist — skip branch creation, work inside the worktree, open the PR, return).
+**Launch and move on — never await a worker.** When a worker later finishes, that
+completion is its own wake; a `blocked`/`failed` worker has already commented +
+labelled, so `release` its worktree (`scripts/ralph/fleet.sh release "$N"`) so
+the slot refills on the next wake; a `pr_opened` worker leaves its worktree in
+Gate 3/4.
 
-- `blocked`/`failed` ⇒ the worker already commented + labelled; `release` its
-  worktree so the slot frees for the next tick:
-  `scripts/ralph/fleet.sh release "$ISSUE_N"`.
-- `pr_opened` ⇒ leave the worktree; Steps 1–2 will drive its Gates 3–4.
+### Step 5 — Arm per-lane wakes, then end the turn
 
-If `pick-next.sh` is empty and the active set is also empty ⇒ Mode A (stop).
+You want a wake the moment **any single lane** changes — not a barrier that waits
+for all of them. Arrange, in this order of preference:
 
----
+1. **Background workers** already wake you on their own completion — nothing to
+   arm for a lane that's still building.
+2. **Per-PR webhook subscriptions** for every in-flight PR, so any one PR's CI
+   failure or new review verdict wakes you independently:
+   ```
+   mcp__github__subscribe_pr_activity  (owner, repo, pullNumber)   # once per open PR
+   ```
+   Comment and CI-failure events arrive as `<github-webhook-activity>` and wake
+   this session; a verdict comment wakes you directly. Unsubscribe a PR once it
+   merges/closes.
+3. **`ScheduleWakeup` fallback** (~1200–1800s): webhooks do **not** deliver CI
+   *success*, `BEHIND→green` transitions, or merges, so keep one modest fallback
+   armed to re-poll Step 0–4 for any lane that quietly went green or up-to-date.
 
-## Step 5 — Arm the watch across ALL in-flight PRs, then end the turn
-
-After this tick's pushes/PR-opens, watch CI **and** the review verdict for **every
-open Ralph PR** with one Monitor that emits on any terminal signal and exits when
-all in-flight PRs are terminal (so silence never hides a crashed run). Then end
-the turn — the Monitor event wakes you and `/loop` re-enters Step 0.
-
-```bash
-# Combined CI + verdict watch across every open Ralph PR. Emits per-PR CI
-# completion and any new Verdict line; exits when all PRs are CI-terminal AND
-# each has a verdict, or on any CI failure.
-REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-mapfile -t PRS < <(gh pr list --state open --author "@me" --json number,body \
-  --jq '.[] | select(.body|test("(?i)(closes|fixes|resolves)\\s+#[0-9]+")) | .number')
-declare -A seen_verdict
-for _ in $(seq 1 60); do            # ~30 min at 30s; Monitor timeout_ms backstops
-  all_terminal=1
-  for PR in "${PRS[@]}"; do
-    roll=$(gh pr checks "$PR" 2>/dev/null) || true
-    cur=$(awk -F'\t' '$2!="pending"{print $1": "$2}' <<<"$roll" | sort)
-    if grep -qiE ': (fail|failure|error)' <<<"$cur"; then echo "CI: PR $PR FAILED — drop to Gate 1"; fi
-    v=$(gh pr view "$PR" -R "$REPO" --json comments \
-          --jq '[.comments[]|select(.body|test("Verdict"))]|last.body // empty' 2>/dev/null) || true
-    if [ -n "$v" ] && [ -z "${seen_verdict[$PR]:-}" ]; then
-      seen_verdict[$PR]=1
-      printf 'VERDICT: PR %s %s\n' "$PR" "$(grep -oiE 'Verdict:.*' <<<"$v" | head -1)"
-    fi
-    if [ -z "$cur" ] || grep -q ': pending' <<<"$roll" || [ -z "${seen_verdict[$PR]:-}" ]; then all_terminal=0; fi
-  done
-  [ "$all_terminal" = 1 ] && { echo "READY: all PRs terminal + verdicts present"; break; }
-  sleep 30
-done
-```
-Run it via the **Monitor** tool (e.g. `timeout_ms: 1800000`, `persistent: false`,
-description "fleet CI + verdicts"). A `CI: … FAILED` → next tick hits Step 2b; a
-`CHANGES_REQUESTED`/`COMMENTS` verdict → 2a; an `LGTM` + green → Step 1 merges it.
-If the Monitor times out with nothing terminal, `ScheduleWakeup` (~1800s) as the
-fallback heartbeat and end the turn.
+Then **end the turn.** Do not run a Monitor that waits for all lanes to be
+terminal — that is the barrier this design removes. Each independent wake re-runs
+Step 0 and merges/refills whatever is ready.
 
 ---
+
+## Worked example (why the slow lane never gates the fast one)
+
+Pool of 4: issues A, B, C, D building in parallel. B is a tiny fix, D is a large
+feature.
+1. B finishes Gate 2.5, opens its PR; CI + review pass → B is `LGTM`+green+`CLEAN`.
+2. A wake fires (B's verdict). Step 1 merges **B now** — A, C, D are untouched and
+   still mid-gate. Step 4 sees a free slot and assigns **E**, launching its worker.
+3. D is still at Gate 1. It never blocked B, and B's merge didn't wait for D.
+4. C later goes `LGTM`+green but is now `BEHIND` (B and E landed). Step 1 syncs C;
+   CI re-runs; C merges on the next wake once green. D keeps going the whole time.
+
+Continuous throughput, four lanes always busy, merges strictly serialized and
+always up-to-date.
 
 ## Sequential fallback
 
-Set `parallel_enabled: false` (or `max_workers: 1`) in `state.json` and the
-fleet collapses to one worker: `fleet.sh free` reports at most 1, so Step 4 fills
-a single slot and the loop behaves exactly like the classic one-issue-at-a-time
-Ralph — still worktree-isolated, same gates, same drop-backs.
+Set `parallel_enabled: false` (or `max_workers: 1`) in `state.json` and the pool
+collapses to one lane: `fleet.sh free` reports at most 1, so Step 4 fills a single
+slot and the loop behaves exactly like the classic one-issue-at-a-time Ralph —
+still worktree-isolated, same gates, same drop-backs.
 
 ## Hard rules (do not deviate)
-- **At most one merge per tick.** Sync every other worktree after it.
+- **Merges to `main` are serialized and always up-to-date.** Merge a lane only
+  when `LGTM` + green + `mergeStateStatus == CLEAN`; a `BEHIND` lane syncs first.
+- **Never make a fast lane wait on a slow one.** No per-tick barrier, no
+  all-lanes Monitor. Act on whichever lane a wake is about; refill freed slots
+  immediately.
+- **Workers are background; never await them.** `run_in_background: true`, launch
+  and end the turn.
 - **Never more than `max_workers` worktrees.** `fleet.sh` enforces the cap; do
-  not bypass it.
-- **One issue per worker; one worker per worktree.** Never two workers on one
-  worktree, never a worker on two issues.
+  not bypass it. **One issue per worker; one worker per worktree.**
 - **Never track these issues with the Task tools.** (User directive.)
 - **Never write to `main` directly** except `scripts/ralph/state.json`.
 - **Never force-push.** Integration is `fleet.sh sync` (a merge), never a rebase
@@ -267,9 +264,7 @@ Ralph — still worktree-isolated, same gates, same drop-backs.
 - **Never disable a CI check / pre-commit hook / lower a threshold.** Fix the
   root cause. If a tool is missing for an environmental reason, install it.
 - **Re-entrancy first.** Read `state.json`, `fleet.sh list`, and PR state at the
-  top of every tick; derive fleet state from live git + GitHub, never from memory.
-- **End the turn after each atomic action set.** Monitor is the preferred wake
-  signal; `ScheduleWakeup` (~30 min) is the fallback.
+  top of every wake; derive pool state from live git + GitHub, never from memory.
 - **On merge, mark the issue done** (Step 1) and bump `state.json`.
 
 ## Anti-bypass (verbatim, non-negotiable)

--- a/.claude/commands/ralph-tick.md
+++ b/.claude/commands/ralph-tick.md
@@ -139,8 +139,8 @@ before each merge** — merging one lane can push the others `BEHIND`. Serialize
 always up-to-date: correctness holds; a ready lane is never held back by a slow
 sibling.
 
-If any merge happened, commit the `state.json` bump (state-only changes may go
-directly on `main`).
+If any merge happened, commit the `state.json` bump **once** — a single commit
+covering every merge this wake (state-only changes may go directly on `main`).
 
 ### Step 2 — Advance failing lanes (per PR, independent)
 
@@ -214,8 +214,10 @@ for all of them. Arrange, in this order of preference:
    mcp__github__subscribe_pr_activity  (owner, repo, pullNumber)   # once per open PR
    ```
    Comment and CI-failure events arrive as `<github-webhook-activity>` and wake
-   this session; a verdict comment wakes you directly. Unsubscribe a PR once it
-   merges/closes.
+   this session; a verdict comment wakes you directly. `subscribe_pr_activity` is
+   **idempotent** — re-subscribing an already-watched PR every wake is safe and
+   does not stack subscriptions, so just (re)subscribe every open PR each wake.
+   Unsubscribe a PR once it merges/closes.
 3. **`ScheduleWakeup` fallback** (~1200–1800s): webhooks do **not** deliver CI
    *success*, `BEHIND→green` transitions, or merges, so keep one modest fallback
    armed to re-poll Step 0–4 for any lane that quietly went green or up-to-date.

--- a/scripts/ralph/FLEET.md
+++ b/scripts/ralph/FLEET.md
@@ -19,24 +19,30 @@ predict which files a change will touch before we make it. So the loop never
   `.ralph/worktrees/issue-<N>` on branch `issue/<N>-<slug>`, so concurrent edits
   never collide on disk. Each worktree runs the full four-gate pipeline exactly
   as the sequential loop does.
-- **Merge pessimistically.** Only **one PR merges to `main` per tick**. After a
-  merge, every surviving worktree **syncs the new `main` into its branch (by
-  merge, not rebase — so a plain push updates the PR, never a force-push) and
-  re-runs its local gate** (`check-all.sh`) before it is itself allowed to merge.
-  A worktree that cannot cleanly sync **drops to Gate 1** and fixes the conflict
-  as a root-cause, failing-test-first change.
+- **Merge pessimistically, but never with a barrier.** Merges to `main` are
+  **serialized** (one at a time — the single orchestrator session serializes them
+  for free) and each merge is **always up-to-date**: a lane merges only when it is
+  `LGTM` + CI-green + up-to-date with `main` (`mergeStateStatus == CLEAN`). If a
+  sibling merged after this lane went green, the lane is `BEHIND`; it **syncs the
+  new `main` into its branch (by merge, not rebase — a plain push updates the PR
+  and re-runs CI, never a force-push)** and merges on a later wake once green
+  again. A lane that cannot cleanly sync **drops to Gate 1**. This sync is **lazy**
+  — a lane only pays it when it is itself about to merge, not proactively every
+  time any sibling merges.
+- **Never wait on the slowest lane.** Whichever lane is ready merges immediately;
+  the slot it frees refills at once. A fast lane at Gate 4 never waits for a slow
+  lane at Gate 1.
 
-The result: an imperfect independence guess costs at most a sync (and, in the
-worst case, one worker redoing part of its work) — it can **never** merge broken
-or conflicting code, because the serialized-merge-then-sync step re-validates
-every worktree against the real, updated `main`.
+The result: an imperfect independence guess costs at most a sync — it can
+**never** merge broken or conflicting code (every merge is re-validated against
+the real, updated `main`), and it **never** stalls a ready lane behind a slow one.
 
 ```
-pick optimistically ──▶ work in parallel (isolated worktrees)
+pick optimistically ──▶ N lanes build in parallel (isolated worktrees)
         │
-   merge ONE PR/tick ──▶ sync new main into every other worktree (merge)
-        │            ──▶ re-run check-all in each
-    sync conflict?   ──▶ that worktree drops to Gate 1 (never a forced merge)
+   a lane goes LGTM+green ──▶ up-to-date (CLEAN)? ──▶ merge NOW, refill its slot
+        │                 ──▶ BEHIND? ── sync main in (lazy) ── re-green ── merge next wake
+   sync conflict?         ──▶ that lane drops to Gate 1 (never a forced merge)
 ```
 
 ## Why worktrees (not branches in one tree, not clones)
@@ -49,29 +55,41 @@ pick optimistically ──▶ work in parallel (isolated worktrees)
   "N isolated working copies of one repo" — the right primitive here.
 
 Ralph manages its **own persistent** worktrees rather than the `Agent` tool's
-ephemeral `isolation: "worktree"` because a worktree must **survive across ticks**:
-Gates 3–4 (CI + review) span multiple ticks, with the turn ending in between.
+ephemeral `isolation: "worktree"` because a worktree must **survive across wakes**:
+Gates 3–4 (CI + review) span many wakes, with the turn ending in between.
 
-## Execution model
+## Execution model — an event-driven worker pool
 
-One re-entrant orchestrator session (`/loop /ralph-tick`) remains the single
-brain. Each tick it:
+One re-entrant orchestrator session (`/loop /ralph-tick`) is the single brain. It
+runs a **worker pool**: up to `max_workers` **lanes**, each one issue in its own
+worktree moving through the four gates **independently, on its own clock**. There
+is **no per-tick barrier and no all-lanes Monitor** — the orchestrator is woken by
+*per-lane events* and acts on whichever lane the wake is about.
 
-1. **Reconciles** the fleet — releases worktrees whose PR merged/closed
-   (`fleet.sh reconcile`).
-2. **Merges at most one** LGTM+green PR, then syncs (merges main into) +
-   re-greens every other worktree (the pessimistic-merge step).
-3. **Advances** each active worker that needs a code action (Gate-1/2 fix, CI
-   fix, review feedback) by launching a `ralph-worker` subagent **in that
-   worktree** — up to `max_workers` in parallel, in one `Agent` message.
-4. **Fills** free slots: while `fleet.sh free > 0` and `pick-next.sh` yields a
-   compatible issue, assign a worktree and launch a `ralph-worker` for it.
-5. **Arms one Monitor** across all in-flight PRs and ends the turn.
+On each wake it:
 
-Workers never merge, never touch `main`, and never coordinate with each other —
-all cross-worker coordination (merge order, sync, slot allocation) is the
-orchestrator's job. This keeps the concurrency model simple: **fan-out for
-building, serialize for integrating.**
+1. **Reconciles** — releases worktrees whose PR merged/closed (`fleet.sh
+   reconcile`), freeing their slots.
+2. **Merges every ready lane** — any PR that is `LGTM` + green + up-to-date
+   (`mergeStateStatus == CLEAN`) merges *now*, serialized; a `BEHIND` lane lazily
+   syncs first and merges on a later wake. A ready lane never waits for a slow one.
+3. **Advances failing lanes** — a `ralph-worker` is dispatched into the worktree
+   of any PR that needs a fix (CI failure → `ci-debugging`; `CHANGES_REQUESTED` →
+   `address-feedback`).
+4. **Refills every open slot** — while `fleet.sh free > 0` and `pick-next.sh`
+   yields a compatible issue, assign a worktree and launch a `ralph-worker`.
+5. **Arms per-lane wakes** — background workers wake it on their own completion;
+   each in-flight PR is `subscribe_pr_activity`-subscribed so its CI/verdict wakes
+   it independently; a modest `ScheduleWakeup` backstops the CI-success /
+   `BEHIND→green` transitions the webhook doesn't deliver. Then it ends the turn.
+
+**Workers are background tasks.** Each `ralph-worker` is launched with
+`run_in_background: true` and **never awaited** — launch, end the turn, and let its
+completion be its own wake. Awaiting a batch of workers would re-introduce the
+slowest-lane barrier this design exists to avoid. Workers never merge, never touch
+`main`, and never coordinate with each other — all cross-lane coordination (merge
+serialization, lazy sync, slot allocation) is the orchestrator's job: **fan-out
+for building, serialize only the merge.**
 
 ## Which issues run in parallel (the safety gate)
 
@@ -91,7 +109,8 @@ filters and open-PR exclusion, it:
     ordered/overlapping). Toggle with `RALPH_RESPECT_EPICS=0`.
 
 These heuristics only reduce *sync churn*; they are **not** the correctness
-mechanism. Correctness is the serialized-merge + sync + re-green step above.
+mechanism. Correctness is the serialized, always-up-to-date merge (lazy sync +
+re-green when `BEHIND`) described above.
 
 ## Configuration (`scripts/ralph/state.json`)
 
@@ -141,8 +160,9 @@ bash scripts/ralph/test_pick_next.sh
 
 | Scenario | Handling |
 | --- | --- |
-| Two "independent" issues touch the same file | Second-to-merge syncs main in; conflict ⇒ drops to Gate 1. Never a broken merge. |
-| A worker crashes / abandons an issue | `reconcile` releases it once its PR closes; an un-PR'd stale worktree is re-detected and either resumed or released next tick. |
-| Fleet silts up with merged work | `reconcile` at the top of every tick GCs merged/closed worktrees. |
+| Two "independent" issues touch the same file | Whichever merges first wins; the other goes `BEHIND`, lazily syncs main in, re-greens, then merges. A sync conflict ⇒ drops to Gate 1. Never a broken merge. |
+| A slow lane would stall a fast one | It can't — lanes are independent; a ready lane merges immediately and its slot refills without waiting on any sibling. |
+| A worker crashes / abandons an issue | `reconcile` releases it once its PR closes; an un-PR'd stale worktree is re-detected and either resumed or released on the next wake. |
+| Fleet silts up with merged work | `reconcile` at the top of every wake GCs merged/closed worktrees. |
 | A genuinely serial issue | Label it `solo`; it runs alone and blocks fills until done. |
 | Want to disable parallelism | `parallel_enabled: false` in `state.json`. |

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -96,8 +96,9 @@ drives Gates 3–4. The taxonomy you dispatch is mapped in
     auto-closes the issue on merge), and `Refs #<parent-epic>` if the issue
     names one.
 11. **Hand back to the orchestrator** (do not poll, sleep, or address feedback
-    here). It watches CI (Gate 3) and the verdict (Gate 4) with the Monitor
-    tool.
+    here). It drives CI (Gate 3) and the verdict (Gate 4) via per-PR webhook
+    subscriptions plus your background-worker completion wake — one lane per
+    worktree, none waiting on another.
 
 ## Hard constraints
 - One issue per call. Never chain.


### PR DESCRIPTION
## Summary

Follow-up to #1066. The initial fleet worked but serialized on the slowest lane: the orchestrator batched all workers per tick, armed **one** Monitor that waited for *every* in-flight PR to be terminal, then merged one PR per tick — so a fast lane at Gate 4 waited on a slow lane still at Gate 1.

This reframes the orchestrator as an **event-driven worker pool** of up to `max_workers` (default 4) independent lanes, each moving through the four gates on its own clock:

- **Workers are background subagents, never awaited** — each worker's completion is its own wake, so a slow build never blocks a fast one.
- **No all-lanes Monitor** — each in-flight PR is watched via its own `subscribe_pr_activity` subscription; a modest `ScheduleWakeup` backstops the CI-success / `BEHIND→green` transitions webhooks don't deliver.
- **Merges stay serialized and always up-to-date** — a lane merges the instant it is `LGTM` + green + `mergeStateStatus == CLEAN`. A lane that went `BEHIND` **lazily** syncs `main` in (merge, no force-push), re-greens, and merges on a later wake — the sync is paid only by the lane about to merge, not fanned out to every sibling on every merge.
- **Freed slots refill immediately** (up to the cap), independent of other lanes.

Net: whichever lane finishes first merges first and its slot refills at once; the serialized, always-current merge invariant (the correctness guarantee) is unchanged.

## Changes

- `.claude/commands/ralph-tick.md` — rewritten as the worker-pool orchestrator (background workers, per-PR wakes, lazy up-to-date merges, immediate refill) with a worked example showing a slow lane never gating a fast one.
- `scripts/ralph/FLEET.md` — core-principle, execution-model, and failure-mode sections updated to the lane model.
- `.claude/agents/README.md`, `scripts/ralph/PROMPT.md` — consistency updates (orchestrator drives Gates 3–4 via per-PR subscriptions + background-worker wakes, not a Monitor).

Orchestration semantics only — no changes to `fleet.sh` / `pick-next.sh`.

## Test plan

- `bash scripts/ralph/test_fleet.sh` — green on the current base (unchanged).
- `bash scripts/ralph/test_pick_next.sh` — green on the current base (unchanged).
- Doc/prompt hygiene: trailing-whitespace / final-newline checks pass.
- No shell scripts changed, so no shellcheck delta; CI's `ralph-recap-tests` runs both suites.

Note: this is a fresh change on a branch restarted from `main` after #1066 merged — not a continuation of #1066.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaJTQxMErkaY2mUwFeqGtK)_