### PR TITLE
feat(frontend): render the Map center column as a rising sine-wave

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -109,13 +109,13 @@ const styles = StyleSheet.create({
     justifyContent: CENTER,
     paddingHorizontal: spacing(0.5),
   },
-  // Gentle alternating band (replaces the old absolute grey half-bands): even
-  // (Divine-Feminine) stages get a recessed tint, odd stages stay on canvas.
+  // Polarity is now carried by the sine-wave overlay, so the center cells stay
+  // transparent and let the wave read through the whole column.
   cellFeminine: {
-    backgroundColor: surface.sunken,
+    backgroundColor: 'transparent',
   },
   cellMasculine: {
-    backgroundColor: surface.canvas,
+    backgroundColor: 'transparent',
   },
   // Brighter "you are here" current-stage marker: a thicker accent halo +
   // recessed warm fill so the live stage reads at a glance.
@@ -141,11 +141,6 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: colors.text.light,
     letterSpacing: 0.5,
-  },
-  arrowGlyph: {
-    fontSize: 22,
-    fontWeight: '700',
-    lineHeight: 26,
   },
   centerLabelRow: {
     flexDirection: 'row',

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -5,6 +5,7 @@ import {
   ActivityIndicator,
   Image,
   InteractionManager,
+  type LayoutChangeEvent,
   Modal,
   Pressable,
   ScrollView,
@@ -40,6 +41,7 @@ import { MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
 import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
+import { WaveOverlay } from './WaveOverlay';
 import { BALANCE_COPY, emphasisStyle, FULLNESS_ALIVE_THRESHOLD, summaryFor } from './wheelBalance';
 
 import { Button } from '@/components/Button';
@@ -62,9 +64,6 @@ const balanceLabelSuffix = (fullness: number): string =>
 /** Full a11y label for a stage node: persona/descriptor plus the balance read. */
 const stageNodeLabel = (display: StageDisplay, fullness: number): string =>
   `${display.persona} - ${display.descriptor} - ${balanceLabelSuffix(fullness)}`;
-/** Directional spiral glyphs — the Map reads with no background PNG (#766). */
-const ARROW_GLYPH_LEFT = '↩';
-const ARROW_GLYPH_RIGHT = '↪';
 
 // --- Sub-components ---
 //
@@ -135,14 +134,13 @@ const StageTextBlock = ({
   </TouchableOpacity>
 );
 
-// --- Center cell: directional glyph + label/title, lock, badge (the -1 tap) -
+// --- Center cell: label/title, lock, badge (the -1 tap); the wave overlay now
+// carries the directional/polarity read behind these cells ----------------
 
 const CenterContent = ({ display }: { display: StageDisplay }): React.JSX.Element => {
-  const glyph = isLeftReturning(display.stageNumber) ? ARROW_GLYPH_LEFT : ARROW_GLYPH_RIGHT;
   const title = TITLE_BY_STAGE[display.stageNumber];
   return (
     <>
-      <Text style={[styles.arrowGlyph, { color: display.textColor }]}>{glyph}</Text>
       {title ? (
         <Text style={styles.titleText}>{title}</Text>
       ) : display.arrowLabel ? (
@@ -690,25 +688,47 @@ const BeginAgainBlock = ({
   </View>
 );
 
+/** Measured pixel size of the grid; zero until the first layout pass reports it. */
+interface GridSize {
+  width: number;
+  height: number;
+}
+
+const EMPTY_GRID_SIZE: GridSize = { width: 0, height: 0 };
+
+/** Track the grid's measured size, updated on every layout pass. */
+const useGridSize = (): [GridSize, (_event: LayoutChangeEvent) => void] => {
+  const [size, setSize] = useState<GridSize>(EMPTY_GRID_SIZE);
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setSize({ width, height });
+  }, []);
+  return [size, onLayout];
+};
+
 const MapGrid = ({
   lookup,
   fullnessByStage,
   currentStage,
   onSelectStage,
-}: MapGridProps): React.JSX.Element => (
-  <View style={styles.grid}>
-    {MAP_ROWS.map((row) => (
-      <MapRowView
-        key={row.rightLabel}
-        row={row}
-        lookup={lookup}
-        fullnessByStage={fullnessByStage}
-        currentStage={currentStage}
-        onPress={onSelectStage}
-      />
-    ))}
-  </View>
-);
+}: MapGridProps): React.JSX.Element => {
+  const [size, onLayout] = useGridSize();
+  return (
+    <View style={styles.grid} testID="map-grid" onLayout={onLayout}>
+      <WaveOverlay width={size.width} height={size.height} />
+      {MAP_ROWS.map((row) => (
+        <MapRowView
+          key={row.rightLabel}
+          row={row}
+          lookup={lookup}
+          fullnessByStage={fullnessByStage}
+          currentStage={currentStage}
+          onPress={onSelectStage}
+        />
+      ))}
+    </View>
+  );
+};
 
 /**
  * Whole-wheel balance read shown beneath the spiral: one balance-not-ladder

--- a/frontend/src/features/Map/WaveOverlay.tsx
+++ b/frontend/src/features/Map/WaveOverlay.tsx
@@ -1,0 +1,70 @@
+// frontend/features/Map/WaveOverlay.tsx
+
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import Svg, { Path, Polygon } from 'react-native-svg';
+
+import { waveArrowheads, waveSegments } from './waveGeometry';
+
+/**
+ * Continuous sine-wave artwork for the Map's center column, rendered behind the
+ * per-stage tap cells. The wave rises upward like a struck tuning fork, wobbling
+ * left for even stages and right for odd ones and converging toward center at
+ * the top. Each segment and arrowhead carries its stage's textColor.
+ *
+ * The overlay is purely decorative: it is non-interactive and hidden from the
+ * accessibility tree so the stage hotspots remain the sole tap/read targets.
+ */
+
+/** Stroke thickness of each wave segment, in pixels. */
+const WAVE_STROKE_WIDTH = 3;
+
+/** Smallest positive layout extent worth drawing; below it there is no wave. */
+const MIN_DRAWABLE_EXTENT = 1;
+
+interface WaveOverlayProps {
+  /** Measured width of the grid the wave fills, in pixels. */
+  width: number;
+  /** Measured height of the grid the wave fills, in pixels. */
+  height: number;
+}
+
+/** SVG sine-wave overlay sized to the measured grid; null until measured. */
+export const WaveOverlay = ({ width, height }: WaveOverlayProps): React.JSX.Element | null => {
+  const smallerExtent = Math.min(width, height);
+  if (smallerExtent < MIN_DRAWABLE_EXTENT) return null;
+  const segments = waveSegments(width, height);
+  const arrowheads = waveArrowheads(width, height);
+  return (
+    <Svg
+      testID="map-wave"
+      width={width}
+      height={height}
+      style={StyleSheet.absoluteFill}
+      pointerEvents="none"
+      accessible={false}
+    >
+      {segments.map((segment) => (
+        <Path
+          key={segment.stageNumber}
+          d={segment.d}
+          stroke={segment.color}
+          fill="none"
+          strokeWidth={WAVE_STROKE_WIDTH}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ))}
+      {arrowheads.map((arrowhead) => (
+        <Polygon
+          key={arrowhead.stageNumber}
+          testID={`wave-arrow-${arrowhead.stageNumber}`}
+          points={arrowhead.points}
+          fill={arrowhead.color}
+        />
+      ))}
+    </Svg>
+  );
+};
+
+export default WaveOverlay;

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -453,4 +453,87 @@ describe('MapScreen', () => {
       0,
     );
   });
+
+  // --- sine-wave overlay (struck-tuning-fork) ---
+
+  const WAVE_LAYOUT_WIDTH = 300;
+  const WAVE_LAYOUT_HEIGHT = 600;
+  const MIN_WAVE_SEGMENTS = 9;
+
+  const fireGridLayout = (tree: ReturnType<typeof create>) => {
+    act(() => {
+      tree.root.findByProps({ testID: 'map-grid' }).props.onLayout({
+        nativeEvent: { layout: { width: WAVE_LAYOUT_WIDTH, height: WAVE_LAYOUT_HEIGHT } },
+      });
+    });
+  };
+
+  it('renders the wave overlay once the grid reports a non-zero layout size', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    expect(tree.root.findByProps({ testID: 'map-wave' })).toBeTruthy();
+  });
+
+  it('renders at least 9 wave path segments and arrowheads after layout', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    const paths = tree.root.findAll(
+      (node: TestNode) => typeof node.props.d === 'string' && node.props.d.length > 0,
+    );
+    expect(paths.length).toBeGreaterThanOrEqual(MIN_WAVE_SEGMENTS);
+    expect(tree.root.findByProps({ testID: 'wave-arrow-1' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'wave-arrow-5' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'wave-arrow-9' })).toBeTruthy();
+  });
+
+  it('does not render the wave overlay before the grid has reported a size', () => {
+    const tree = create(<MapScreen />);
+    expect(() => tree.root.findByProps({ testID: 'map-wave' })).toThrow();
+  });
+
+  it('no longer renders the old directional arrow glyphs', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    const glyphNodes = tree.root.findAll(
+      (node: TestNode) => node.props.children === '↩' || node.props.children === '↪',
+    );
+    expect(glyphNodes).toHaveLength(0);
+  });
+
+  it('keeps every stage-hotspot present after the wave overlay renders', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    const hotspots = tree.root.findAll(
+      (node: TestNode) =>
+        typeof node.props.testID === 'string' && node.props.testID.startsWith('stage-hotspot'),
+    );
+    const unique = new Set(hotspots.map((s: TestNode) => s.props.testID as string));
+    expect(unique.size).toBe(20);
+  });
+
+  it('keeps you-are-here present for the current stage after the wave overlay renders', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    expect(tree.root.findByProps({ testID: 'you-are-here' })).toBeTruthy();
+  });
+
+  it('keeps all six Aspect labels present after the wave overlay renders', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    const aspectLabels = ['Awareness', 'Being', 'Wisdom', 'Understanding', 'Love', 'Yes-And-Ness'];
+    for (const label of aspectLabels) {
+      expect(tree.root.findAll((n: TestNode) => n.props.children === label).length).toBeGreaterThan(
+        0,
+      );
+    }
+  });
+
+  it('renders the wave overlay independent of MAP_BACKGROUND_URI (MapBackdrop is a no-op)', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    // MapBackdrop still renders its placeholder testID regardless of the PNG,
+    // and the wave overlay renders alongside it with no dependency between them.
+    expect(tree.root.findByProps({ testID: 'map-background' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'map-wave' })).toBeTruthy();
+  });
 });

--- a/frontend/src/features/Map/__tests__/waveGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/waveGeometry.test.ts
@@ -1,0 +1,116 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { STAGE_DISPLAY } from '../mapLayout';
+import { STAGE_COUNT, isLeftReturning } from '../stageData';
+import { arrowheadAt, stageWavePoint, waveSegments } from '../waveGeometry';
+
+const CENTER_X = 0.5;
+const CONVERGENCE_EPSILON = 0.05;
+const UNIT_MIN = 0;
+const UNIT_MAX = 1;
+const SEGMENT_COUNT = STAGE_COUNT - 1;
+const SMALL_WIDTH = 100;
+const SMALL_HEIGHT = 200;
+const LARGE_WIDTH = 200;
+const LARGE_HEIGHT = 400;
+const REPRESENTATIVE_STAGE = 4;
+
+describe('stageWavePoint', () => {
+  it('rises upward: y strictly decreases as stageNumber climbs from 1 to 10', () => {
+    const ys = Array.from({ length: STAGE_COUNT }, (_, i) => stageWavePoint(i + 1).y);
+    for (let stage = 2; stage <= STAGE_COUNT; stage += 1) {
+      expect(stageWavePoint(stage).y).toBeLessThan(stageWavePoint(stage - 1).y);
+    }
+    expect(ys).toHaveLength(STAGE_COUNT);
+  });
+
+  it('wobbles left for even (WE) stages and right for odd (I) stages, stages 1-8', () => {
+    for (let stage = 1; stage <= 8; stage += 1) {
+      const { x } = stageWavePoint(stage);
+      if (isLeftReturning(stage)) {
+        expect(x).toBeLessThan(CENTER_X);
+      } else {
+        expect(x).toBeGreaterThan(CENTER_X);
+      }
+    }
+  });
+
+  it('converges toward center for stages 9-10, tighter than stage 8', () => {
+    const offset8 = Math.abs(stageWavePoint(8).x - CENTER_X);
+    const offset9 = Math.abs(stageWavePoint(9).x - CENTER_X);
+    const offset10 = Math.abs(stageWavePoint(10).x - CENTER_X);
+    expect(offset10).toBeLessThan(offset9);
+    expect(offset9).toBeLessThan(offset8);
+    expect(offset10).toBeLessThan(CONVERGENCE_EPSILON);
+  });
+
+  it('keeps every stage point within unit space [0,1] for x and y', () => {
+    for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
+      const { x, y } = stageWavePoint(stage);
+      expect(x).toBeGreaterThanOrEqual(UNIT_MIN);
+      expect(x).toBeLessThanOrEqual(UNIT_MAX);
+      expect(y).toBeGreaterThanOrEqual(UNIT_MIN);
+      expect(y).toBeLessThanOrEqual(UNIT_MAX);
+    }
+  });
+
+  it('reports pole -1 for even stages and +1 for odd stages, 1-8', () => {
+    for (let stage = 1; stage <= 8; stage += 1) {
+      const expected = isLeftReturning(stage) ? -1 : 1;
+      expect(stageWavePoint(stage).pole).toBe(expected);
+    }
+  });
+
+  it('reports pole 0 at the converged top, stage 10', () => {
+    expect(stageWavePoint(10).pole).toBe(0);
+  });
+});
+
+describe('waveSegments', () => {
+  it('returns exactly STAGE_COUNT-1 segments', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    expect(segments).toHaveLength(SEGMENT_COUNT);
+  });
+
+  it('assigns each segment the lower stage number of the pair it connects', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    const stageNumbers = segments.map((s) => s.stageNumber).sort((a, b) => a - b);
+    expect(stageNumbers).toEqual(Array.from({ length: SEGMENT_COUNT }, (_, i) => i + 1));
+  });
+
+  it('colors each segment with the lower stage textColor from STAGE_DISPLAY', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    for (const segment of segments) {
+      expect(segment.color).toBe(STAGE_DISPLAY[segment.stageNumber]?.textColor);
+    }
+  });
+
+  it('produces a non-empty path string for every segment', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    for (const segment of segments) {
+      expect(segment.d.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('scales the path coordinates with width and height', () => {
+    const small = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    const large = waveSegments(LARGE_WIDTH, LARGE_HEIGHT);
+    for (let i = 0; i < small.length; i += 1) {
+      expect(large[i]?.d).not.toBe(small[i]?.d);
+    }
+  });
+});
+
+describe('arrowheadAt', () => {
+  it('points upward: apex y is above (smaller than) the base y in pixel space', () => {
+    const arrow = arrowheadAt(REPRESENTATIVE_STAGE, SMALL_WIDTH, SMALL_HEIGHT);
+    const coordinatePairs = arrow.points
+      .trim()
+      .split(' ')
+      .map((pair) => pair.split(',').map(Number));
+    const ys = coordinatePairs.map(([, y]) => y as number);
+    const apexY = Math.min(...ys);
+    const baseY = Math.max(...ys);
+    expect(apexY).toBeLessThan(baseY);
+  });
+});

--- a/frontend/src/features/Map/waveGeometry.ts
+++ b/frontend/src/features/Map/waveGeometry.ts
@@ -1,0 +1,220 @@
+// frontend/features/Map/waveGeometry.ts
+
+/**
+ * Pure geometry for the Map center column's continuous sine-wave (a
+ * struck-tuning-fork rising upward). Every helper works in unit space [0,1] or
+ * scales that unit space into pixel space; none of them touch React, so the wave
+ * math is testable in isolation from rendering.
+ *
+ * The wave wobbles left for even (Divine-Feminine / WE-returning) stages and
+ * right for odd (I-pointing) stages, then converges toward center at the top
+ * (stages 9-10) as the two poles resolve into the whole apex.
+ */
+
+import { STAGE_DISPLAY } from './mapLayout';
+import { STAGE_COUNT, isLeftReturning } from './stageData';
+
+/** Horizontal midline of the column in unit space; both poles swing around it. */
+const CENTER_X = 0.5;
+
+/**
+ * Vertical offset that centers each stage inside its own [0,1] band, so stage 1
+ * lands near the bottom (y ~ 0.95) and stage 10 near the top (y ~ 0.05).
+ */
+const Y_BAND_MIDPOINT = 0.5;
+
+/**
+ * Base horizontal swing from center for stages 1-8. Kept below 0.5 so a pole at
+ * full amplitude (x = CENTER_X +/- WAVE_AMPLITUDE) stays comfortably inside the
+ * unit column with margin for the arrowhead.
+ */
+const WAVE_AMPLITUDE = 0.32;
+
+/**
+ * Stage 9 begins the convergence: its swing is the base amplitude tapered by
+ * this ratio, so it sits inside stage 8 but outside the near-center apex.
+ */
+const TAPER_9 = 0.45;
+
+/**
+ * Stage 10 is the converged apex. A tiny non-zero offset keeps the path from
+ * degenerating to a vertical stub while staying visually centered; it must be
+ * smaller than every stage-9 swing so the wave reads as fully resolved.
+ */
+const CONVERGENCE_OFFSET = 0.01;
+
+/** Pole encoding: even stages return left, odd stages point right, apex neutral. */
+const POLE_LEFT = -1;
+const POLE_RIGHT = 1;
+const POLE_NEUTRAL = 0;
+
+/** Stages whose swing stays at full base amplitude (before convergence). */
+const FULL_AMPLITUDE_MAX_STAGE = 8;
+/** The lone taper stage that begins the convergence toward center. */
+const TAPER_STAGE = 9;
+
+/** Half-width of the arrowhead triangle base, in pixels. */
+const ARROWHEAD_HALF_WIDTH = 6;
+/** Distance from the arrowhead base up to its apex, in pixels. */
+const ARROWHEAD_HEIGHT = 10;
+
+/** Decimal places kept in emitted SVG coordinates (matches TierStar). */
+const COORD_PRECISION = 3;
+
+/** A stage's number paired with its exact textColor, sorted ascending. */
+interface StageColor {
+  stageNumber: number;
+  textColor: string;
+}
+
+/**
+ * Every stage's number + textColor, ascending. Derived from ``Object.entries``
+ * so the textColor values are non-optional (unlike numeric ``Record`` indexing
+ * under ``noUncheckedIndexedAccess``), giving callers exact colors with no
+ * never-taken fallback branch.
+ */
+const STAGE_COLORS: readonly StageColor[] = Object.entries(STAGE_DISPLAY)
+  .map(([stageNumber, display]) => ({
+    stageNumber: Number(stageNumber),
+    textColor: display.textColor,
+  }))
+  .sort((a, b) => a.stageNumber - b.stageNumber);
+
+/** A single stage's anchor point on the wave, plus which pole it swings to. */
+export interface WavePoint {
+  /** Horizontal position in unit space [0,1]. */
+  x: number;
+  /** Vertical position in unit space [0,1]; smaller means higher up. */
+  y: number;
+  /** -1 left pole (even), +1 right pole (odd), 0 at the converged apex. */
+  pole: -1 | 0 | 1;
+}
+
+/** Signed horizontal swing from center for a stage, in unit space. */
+const amplitudeFor = (stageNumber: number): number => {
+  if (stageNumber <= FULL_AMPLITUDE_MAX_STAGE) return WAVE_AMPLITUDE;
+  if (stageNumber === TAPER_STAGE) return WAVE_AMPLITUDE * TAPER_9;
+  return CONVERGENCE_OFFSET;
+};
+
+/** The pole a stage swings toward: left for even, right for odd, neutral at apex. */
+const poleFor = (stageNumber: number): -1 | 0 | 1 => {
+  if (stageNumber === STAGE_COUNT) return POLE_NEUTRAL;
+  return isLeftReturning(stageNumber) ? POLE_LEFT : POLE_RIGHT;
+};
+
+/**
+ * Anchor point for a stage on the rising wave, in unit space [0,1]. y strictly
+ * decreases as stageNumber climbs (the wave rises); x swings around center by
+ * the stage's amplitude toward its pole, converging near center at the top.
+ *
+ * The apex (stage 10) reports a neutral pole but its x still uses the left/right
+ * rule, so it lands a hair off dead-center (by CONVERGENCE_OFFSET) rather than
+ * degenerating into a vertical stub. This apparent mismatch is deliberate.
+ */
+export const stageWavePoint = (stageNumber: number): WavePoint => {
+  const y = (STAGE_COUNT - stageNumber + Y_BAND_MIDPOINT) / STAGE_COUNT;
+  const direction = isLeftReturning(stageNumber) ? POLE_LEFT : POLE_RIGHT;
+  const x = CENTER_X + amplitudeFor(stageNumber) * direction;
+  return { x, y, pole: poleFor(stageNumber) };
+};
+
+/** A rendered wave segment: its SVG path, stroke color, and lower stage number. */
+export interface WaveSegment {
+  /** SVG path data in pixel space connecting the two stage points. */
+  d: string;
+  /** Stroke color, taken from the lower stage's textColor. */
+  color: string;
+  /** The lower of the two stage numbers this segment connects (1..9). */
+  stageNumber: number;
+}
+
+/** Round a unit coordinate into a pixel coordinate string at fixed precision. */
+const toPixel = (unit: number, extent: number): string => (unit * extent).toFixed(COORD_PRECISION);
+
+/**
+ * A smooth cubic Bezier between two stage points. The control points sit at the
+ * vertical midpoint of the pair, each anchored to its own stage's x, giving the
+ * center column its continuous sine wobble rather than straight zig-zags.
+ */
+const segmentPath = (lower: WavePoint, upper: WavePoint, width: number, height: number): string => {
+  const midY = (lower.y + upper.y) / 2;
+  const x1 = toPixel(lower.x, width);
+  const y1 = toPixel(lower.y, height);
+  const x2 = toPixel(upper.x, width);
+  const y2 = toPixel(upper.y, height);
+  const midYPixel = toPixel(midY, height);
+  return `M ${x1} ${y1} C ${x1} ${midYPixel} ${x2} ${midYPixel} ${x2} ${y2}`;
+};
+
+/**
+ * The full wave as STAGE_COUNT-1 (9) segments in pixel space. Segment i connects
+ * stage i to stage i+1 and carries the lower stage's number and textColor.
+ * Coordinates scale with width and height, so a larger layout yields a larger
+ * wave.
+ */
+export const waveSegments = (width: number, height: number): readonly WaveSegment[] => {
+  const segments: WaveSegment[] = [];
+  STAGE_COLORS.reduce<StageColor | null>((previous, current) => {
+    if (previous !== null) {
+      const lower = stageWavePoint(previous.stageNumber);
+      const upper = stageWavePoint(current.stageNumber);
+      segments.push({
+        d: segmentPath(lower, upper, width, height),
+        color: previous.textColor,
+        stageNumber: previous.stageNumber,
+      });
+    }
+    return current;
+  }, null);
+  return segments;
+};
+
+/** An SVG polygon for a single stage's upward-pointing arrowhead. */
+export interface Arrowhead {
+  /** Space-separated "x,y" pixel coordinates for the triangle's three vertices. */
+  points: string;
+}
+
+/**
+ * An upward-pointing triangle centered on a stage's wave point, in pixel space.
+ * The apex sits ARROWHEAD_HEIGHT above the base (numerically smaller y) so the
+ * arrow leads toward the higher stages at the top of the wave.
+ */
+export const arrowheadAt = (stageNumber: number, width: number, height: number): Arrowhead => {
+  const point = stageWavePoint(stageNumber);
+  const cx = point.x * width;
+  const baseY = point.y * height;
+  const apexY = baseY - ARROWHEAD_HEIGHT;
+  const leftX = cx - ARROWHEAD_HALF_WIDTH;
+  const rightX = cx + ARROWHEAD_HALF_WIDTH;
+  const fmt = (value: number): string => value.toFixed(COORD_PRECISION);
+  const points = [
+    `${fmt(cx)},${fmt(apexY)}`,
+    `${fmt(leftX)},${fmt(baseY)}`,
+    `${fmt(rightX)},${fmt(baseY)}`,
+  ].join(' ');
+  return { points };
+};
+
+/** One stage's arrowhead polygon plus its stage number and fill color. */
+export interface WaveArrowhead {
+  /** Space-separated "x,y" pixel coordinates for the triangle's three vertices. */
+  points: string;
+  /** Fill color, the stage's exact textColor. */
+  color: string;
+  /** The stage this arrowhead marks (1..STAGE_COUNT). */
+  stageNumber: number;
+}
+
+/**
+ * Every stage's upward-pointing arrowhead in pixel space, each carrying the
+ * stage's exact textColor. Built from ``STAGE_COLORS`` so the colors are total
+ * (no optional-index fallback).
+ */
+export const waveArrowheads = (width: number, height: number): readonly WaveArrowhead[] =>
+  STAGE_COLORS.map(({ stageNumber, textColor }) => ({
+    points: arrowheadAt(stageNumber, width, height).points,
+    color: textColor,
+    stageNumber,
+  }));


### PR DESCRIPTION
## Summary

Renders the Map's center column as a **continuous SVG sine-wave rising upward** — a struck tuning fork wobbling between two poles as it ascends — replacing the old per-stage directional arrow glyphs (`↩`/`↪`).

- The wave rises from Stage 1 (bottom) to Stage 10 (top), wobbling **left for even (WE / Divine-Feminine) stages** and **right for odd (I) stages** per `isLeftReturning`, and **converging toward center** at the apex (stages 9–10).
- **Arrowheads lead upward** toward the higher stages, matching the course art.
- **Per-stage segment + arrowhead colors flow from `STAGE_DISPLAY`** (no hardcoded hex); the wave scales to the grid's measured layout, so it stays crisp, themeable (Candle & Ink), and **PNG-free** (no `MAP_BACKGROUND_URI` dependency).
- Every existing Map contract is preserved: 20 stage hotspots (pressable → stage-detail modal), the "YOU ARE HERE" marker, lock/unlock states, the six octave/Aspect labels (row-aligned by construction), and the balance summary.

Implementation shape:
- `waveGeometry.ts` — a **pure, fully-tested** module: `stageWavePoint` (unit-space anchor + pole), `waveSegments` (9 pixel-space Bézier segments), `arrowheadAt` / `waveArrowheads`.
- `WaveOverlay.tsx` — a small SVG component (TierStar house pattern) rendering the wave as a **non-interactive, screen-reader-hidden** layer behind the tap cells; returns `null` until the grid reports a size.
- `MapScreen.tsx` — measures the grid via `onLayout` and mounts the overlay; removes the arrow-glyph constants + render. `Map.styles.ts` — center cells go transparent so the wave reads through.

`react-native-svg` was already a dependency (15.15.4) — no new packages.

## Test plan

- `waveGeometry.test.ts` (new): y strictly decreases 1→10 (rising); even→left / odd→right for stages 1–8; convergence `|x(10)−0.5| < |x(9)−0.5| < |x(8)−0.5|` with the apex near center; all points within `[0,1]`; pole encoding; exactly 9 segments each colored by the lower stage's `STAGE_DISPLAY.textColor`; paths scale with width/height; arrowhead apex above base (upward).
- `MapScreen.test.tsx` (new blocks, existing tests untouched): fires the grid `onLayout`, then asserts `map-wave` renders, ≥9 wave segments + `wave-arrow-*` present, the old `↩`/`↪` glyphs are gone, and the 20 hotspots / you-are-here / six Aspect labels / no-`MAP_BACKGROUND_URI` contracts all still hold; the zero-size guard (overlay absent before layout) is covered.
- Gate 2 `./scripts/frontend/check-all.sh` exits 0 (ESLint zero-warning, prettier clean, `tsc --noEmit` clean, full Jest suite 2575 passing). New modules at 100% statement/branch/function/line coverage.

Closes #944
Refs #943
