### PR TITLE
fix(course): fail seeding loudly + pin Stage 1 vendored-content regression

### DIFF
--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -13,6 +13,15 @@ Reconciliation is idempotent and never destructive: rows update in place
 when their fields drift, and nothing is ever deleted — rows referenced
 by ``ContentCompletion`` stay put.
 
+Seeding fails loudly when the manifest ships a stage that has no matching
+``CourseStage`` row: that mismatch means stages and content were seeded
+out of order (or a stage rollback left content orphaned), so we raise
+``SeedContentStageMissingError`` before touching the DB rather than
+silently dropping the stage's chapters.  ``_seed_startup_data`` catches
+it per seeder and surfaces it as ``seed_failed seeder=content`` in the
+boot logs.  Placeholder rows for stages the manifest does not cover keep
+skipping quietly — their ``CourseStage`` row may legitimately be absent.
+
 Editing happens in the content repo; see ``docs/content.md``.
 """
 
@@ -24,6 +33,11 @@ from sqlmodel import select
 from content_config import ChapterRecord, all_chapter_records
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
+
+
+class SeedContentStageMissingError(ValueError):
+    """Raised when a manifest stage has no matching ``CourseStage`` row."""
+
 
 # Placeholder rows for stages the content manifest does not cover yet.
 # Once the manifest ships a stage, its placeholders are suppressed
@@ -120,6 +134,13 @@ def desired_content_records() -> list[ChapterRecord]:
     return [*manifest_records, *_placeholder_records(covered)]
 
 
+def _unmapped_manifest_stages(stage_map: dict[int, int]) -> list[int]:
+    """Return sorted manifest stage numbers with no ``CourseStage`` row."""
+    return sorted(
+        {r.stage_number for r in all_chapter_records() if r.stage_number not in stage_map}
+    )
+
+
 async def _load_stage_map(session: AsyncSession) -> dict[int, int]:
     """Build a map of ``stage_number -> CourseStage.id`` from the DB."""
     result = await session.execute(select(CourseStage))
@@ -191,6 +212,29 @@ def _reconcile_one(
     return False, False
 
 
+def _guard_manifest_stages_mapped(stage_map: dict[int, int]) -> None:
+    """Raise loudly when a manifest stage has no ``CourseStage`` row."""
+    unmapped = _unmapped_manifest_stages(stage_map)
+    if unmapped:
+        message = f"Manifest stages have no CourseStage row: {unmapped}"
+        raise SeedContentStageMissingError(message)
+
+
+def _reconcile_all(
+    session: AsyncSession,
+    stage_map: dict[int, int],
+    existing: dict[tuple[int, str], StageContent],
+) -> tuple[int, bool]:
+    """Reconcile every desired record; return ``(inserted_count, dirty)``."""
+    inserted = 0
+    dirty = False
+    for record in desired_content_records():
+        was_inserted, was_dirty = _reconcile_one(session, record, stage_map, existing)
+        inserted += int(was_inserted)
+        dirty = dirty or was_dirty
+    return inserted, dirty
+
+
 async def seed_content(session: AsyncSession) -> int:
     """Reconcile ``StageContent`` rows with the declarative config.
 
@@ -200,15 +244,10 @@ async def seed_content(session: AsyncSession) -> int:
     second time.
     """
     stage_map = await _load_stage_map(session)
+    _guard_manifest_stages_mapped(stage_map)
     existing = await _load_existing_keys(session)
 
-    inserted = 0
-    dirty = False
-    for record in desired_content_records():
-        was_inserted, was_dirty = _reconcile_one(session, record, stage_map, existing)
-        if was_inserted:
-            inserted += 1
-        dirty = dirty or was_dirty
+    inserted, dirty = _reconcile_all(session, stage_map, existing)
 
     if dirty:
         await session.commit()

--- a/backend/tests/test_course_vendored_content.py
+++ b/backend/tests/test_course_vendored_content.py
@@ -1,0 +1,138 @@
+"""Integration tests against the REAL vendored content manifest.
+
+Stage 1 (Beige) went briefly blank in production because a pre-content
+deploy image seeded zero StageContent rows for it. These tests seed from
+the actual vendored ``backend/content`` tree via the real startup seeders
+and assert the production symptom over HTTP so the empty-stage-1 failure
+mode can never regress silently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from content_config import CONTENT_REF_SCHEME
+from models.course_stage import CourseStage
+from models.stage_content import StageContent
+from seed_content import seed_content
+from seed_stages import seed_stages
+from services.content_repository import (
+    ContentRepository,
+    reset_content_repository_for_tests,
+    set_content_repository_for_tests,
+)
+
+_VENDORED_CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
+
+#: Stage 1 (Beige) ships exactly 17 chapters in the vendored manifest.
+_STAGE_ONE_CHAPTER_COUNT = 17
+
+#: The first Beige chapter drips on day 0 (immediately visible at signup).
+_DAY_ZERO = 0
+
+_BEIGE_ONE_TITLE = "What is Beige?"
+
+
+@pytest_asyncio.fixture
+async def seeded_vendored_course(db_session: AsyncSession) -> AsyncIterator[None]:
+    """Seed all 10 stages and their content from the real vendored manifest."""
+    set_content_repository_for_tests(ContentRepository(_VENDORED_CONTENT_DIR))
+    await seed_stages(db_session)
+    await seed_content(db_session)
+    yield
+    reset_content_repository_for_tests()
+
+
+async def _signup(async_client: AsyncClient, username: str) -> dict[str, str]:
+    """Sign up a fresh user (no stage-progress pinning, so day 0 applies)."""
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("seeded_vendored_course")
+async def test_stage_one_progress_reflects_vendored_manifest(async_client: AsyncClient) -> None:
+    """Regression: a fresh signup sees all 17 vendored Beige chapters, none read."""
+    headers = await _signup(async_client, "fresh-adept")
+
+    resp = await async_client.get("/course/stages/1/progress", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["total_items"] == _STAGE_ONE_CHAPTER_COUNT
+    assert body["read_items"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("seeded_vendored_course")
+async def test_stage_one_day_zero_chapter_is_visible_at_signup(async_client: AsyncClient) -> None:
+    """The day-0 Beige chapter is unlocked immediately, not hidden behind a drip."""
+    headers = await _signup(async_client, "day-zero-reader")
+
+    resp = await async_client.get("/course/stages/1/content", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()
+    assert items
+    day_zero_items = [item for item in items if item["release_day"] == _DAY_ZERO]
+    assert day_zero_items
+    assert all(item["is_locked"] is False for item in day_zero_items)
+    assert any(item["title"] == _BEIGE_ONE_TITLE for item in day_zero_items)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("seeded_vendored_course")
+async def test_beige_one_body_has_frontmatter_stripped(async_client: AsyncClient) -> None:
+    """The served body for beige-1 excludes its YAML frontmatter block."""
+    headers = await _signup(async_client, "frontmatter-reader")
+    listing = await async_client.get("/course/stages/1/content", headers=headers)
+    assert listing.status_code == HTTPStatus.OK
+    beige_one = next(item for item in listing.json() if item["title"] == _BEIGE_ONE_TITLE)
+
+    resp = await async_client.get(f"/course/content/{beige_one['id']}/body", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    payload = resp.json()
+    stripped = payload["body_markdown"].lstrip()
+    assert not stripped.startswith("---")
+    assert stripped != ""
+    # The frontmatter carries an ``id:`` key; a stripped body must not leak it.
+    assert "id: beige-1" not in payload["body_markdown"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("seeded_vendored_course")
+async def test_stage_one_rows_carry_content_refs_not_urls(db_session: AsyncSession) -> None:
+    """Every seeded Stage 1 row uses a local content:// reference, never a URL."""
+    stage_one = (
+        (await db_session.execute(select(CourseStage).where(CourseStage.stage_number == 1)))
+        .scalars()
+        .one()
+    )
+    rows = (
+        (
+            await db_session.execute(
+                select(StageContent).where(StageContent.course_stage_id == stage_one.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(rows) == _STAGE_ONE_CHAPTER_COUNT
+    assert all(row.url.startswith(f"{CONTENT_REF_SCHEME}://") for row in rows)

--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -23,7 +23,11 @@ from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 from models.user import User
-from seed_content import desired_content_records, seed_content
+from seed_content import (
+    SeedContentStageMissingError,
+    desired_content_records,
+    seed_content,
+)
 from services.content_repository import (
     ContentRepository,
     reset_content_repository_for_tests,
@@ -36,6 +40,9 @@ _PLACEHOLDER_COUNT = 6
 # Resolved once at import (not inside async tests — pathlib in an async def trips
 # ASYNC240) so the real vendored content dir is reusable across tests.
 _VENDORED_CONTENT_DIR = Path(__file__).resolve().parent.parent / "content"
+
+# Stage 1 (Beige) ships exactly 17 chapters in the vendored manifest.
+_VENDORED_STAGE_ONE_CHAPTER_COUNT = 17
 
 
 def _chapter(
@@ -66,6 +73,17 @@ _MANIFEST: dict[str, Any] = {
         _chapter("beige-1", 1, "Survival", 0),
         _chapter("beige-2", 1, "Breath as Anchor", 3, content_type="essay"),
         _chapter("teal-1", 4, "Systems Sight", 0),
+    ],
+    "site_resources": [],
+}
+
+# Covers only stage 1 -- used to isolate "placeholder unmapped stays quiet"
+# from "manifest-mapped stage missing its CourseStage row raises loudly".
+_STAGE_ONE_ONLY_MANIFEST: dict[str, Any] = {
+    "schema_version": "1.0.0",
+    "chapters": [
+        _chapter("beige-1", 1, "Survival", 0),
+        _chapter("beige-2", 1, "Breath as Anchor", 3, content_type="essay"),
     ],
     "site_resources": [],
 }
@@ -184,9 +202,56 @@ async def test_seed_content_populates_stage_one_from_vendored_manifest(
             .scalars()
             .all()
         )
-        assert rows, "Stage 1 must seed real course content from the vendored manifest"
+        assert len(rows) == _VENDORED_STAGE_ONE_CHAPTER_COUNT
     finally:
         reset_content_repository_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_seed_content_raises_when_manifest_stage_has_no_course_stage_row(
+    db_session: AsyncSession,
+) -> None:
+    """A manifest stage with no matching CourseStage row must fail loudly, not silently."""
+    set_content_repository_for_tests(ContentRepository(_VENDORED_CONTENT_DIR))
+    try:
+        with pytest.raises(SeedContentStageMissingError, match=r"no CourseStage row: \[1"):
+            await seed_content(db_session)
+    finally:
+        reset_content_repository_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_seed_content_raises_naming_only_the_unmapped_manifest_stage(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """A partial seed raises for the missing manifest stage while mapped stages seed fine."""
+    install_manifest(_MANIFEST)  # ships stages 1 and 4
+    await _seed_stages(db_session, count=1)  # only stage 1 has a CourseStage row
+
+    with pytest.raises(SeedContentStageMissingError, match=r"no CourseStage row: \[4\]"):
+        await seed_content(db_session)
+
+    # The raise fires before any write, so stage 1's mapped chapters never land.
+    rows = (await db_session.execute(select(StageContent))).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_seed_content_placeholder_stages_stay_quiet_when_unmapped(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Unmapped placeholder stages (no manifest coverage) never raise, unlike manifest stages."""
+    install_manifest(_STAGE_ONE_ONLY_MANIFEST)
+    await _seed_stages(db_session, count=1)
+
+    inserted = await seed_content(db_session)
+
+    assert inserted == len(_STAGE_ONE_ONLY_MANIFEST["chapters"])
+    result = await db_session.execute(select(StageContent))
+    rows = result.scalars().all()
+    assert [r.title for r in rows] == ["Survival", "Breath as Anchor"]
 
 
 def test_content_ref_format() -> None:
@@ -226,13 +291,14 @@ async def test_seed_content_idempotent(
 
 
 @pytest.mark.asyncio
-async def test_seed_content_no_stages(
+async def test_seed_content_no_stages_raises_for_manifest_coverage(
     db_session: AsyncSession,
     install_manifest: Callable[[dict[str, Any]], None],
 ) -> None:
-    install_manifest(_MANIFEST)
-    inserted = await seed_content(db_session)
-    assert inserted == 0
+    """No CourseStage rows at all means every manifest stage is unmapped -- loud, not silent."""
+    install_manifest(_MANIFEST)  # ships stages 1 and 4
+    with pytest.raises(SeedContentStageMissingError, match=r"no CourseStage row: \[1, 4\]"):
+        await seed_content(db_session)
 
 
 @pytest.mark.asyncio

--- a/docs/content.md
+++ b/docs/content.md
@@ -87,7 +87,11 @@ The seeder never deletes rows (deletion would orphan
 simply stops being referenced; write a one-off migration if a row must
 actually go. Stages the manifest does not cover yet keep placeholder
 rows (`seed_content.py`); those suppress automatically once the
-manifest ships the stage.
+manifest ships the stage. If the manifest instead ships a stage with
+no matching `CourseStage` row (stages and content seeded out of
+order, or a stage rollback orphaned content), seeding fails loudly
+before writing anything, surfacing as `seed_failed seeder=content` in
+the boot logs; boot continues regardless.
 
 ## How the app serves it
 


### PR DESCRIPTION
## Summary

Stage 1 (Survival / Beige) rendered an empty chapter list — "0 of 0 read" on
the cover, "0/0 completed" on the progress bar, and no chapters — even though
the vendored manifest ships 17 Beige chapters.

**Root cause: a deploy/runtime image gap, not a gating or frontend bug.** The
runtime that seeded the live database predates the image fix that ships
`backend/content` (the Dockerfile now `COPY`s the content tree, guarded by
`test_dockerfile_ships_content.py`). On that older image the manifest was
absent, so `all_chapter_records()` raised, the startup seeder logged
`seed_failed seeder=content`, rolled back, and booted anyway by design —
leaving Stage 1 with **zero** `StageContent` rows. Because Stage 1 has no
placeholder fallback and the seeder is the only writer of its content, the
stage stayed empty until a content-bearing image rebooted. Gating is exonerated:
Stage 1 is always unlocked, `ensure_user_progress` provisions `current_stage=1`
for fresh users, and `total_items` counts rows directly — `0/0` reflected an
empty table, not a filtered list.

**No data fix is required:** the seeder is idempotent, so the live database
self-heals on the next content-bearing deploy. This PR closes the two gaps that
let the failure ship green and hide:

1. **Regression net** — a new HTTP integration suite seeds from the *real*
   vendored manifest via the *real* startup seeders and asserts the exact
   production symptom can never return: `GET /course/stages/1/progress` returns
   `total_items == 17`, the day-0 Beige chapter is visible and unlocked at
   signup, the served body has its YAML frontmatter stripped, and every seeded
   Stage 1 row carries a `content://` reference.
2. **Loud failure** — `seed_content` now raises `SeedContentStageMissingError`
   (before any DB write) when the manifest ships a stage that has no matching
   `CourseStage` row, instead of silently skipping it. `_seed_startup_data`
   surfaces it as `seed_failed seeder=content` in the boot logs. Placeholder
   rows for stages the manifest does not cover still skip quietly.

No schema change, no migration, no frontend change.

## Test plan

- `backend/tests/test_course_vendored_content.py` (new, real vendored manifest):
  - `test_stage_one_progress_reflects_vendored_manifest` — fresh signup →
    `total_items == 17`, `read_items == 0`.
  - `test_stage_one_day_zero_chapter_is_visible_at_signup` — day-0 chapter
    returned, `is_locked == false`, includes "What is Beige?".
  - `test_beige_one_body_has_frontmatter_stripped` — body 200, no leading `---`,
    no leaked frontmatter key.
  - `test_stage_one_rows_carry_content_refs_not_urls` — all 17 rows start with
    `content://`.
- `backend/tests/test_seed_content.py`:
  - Tightened the vendored Stage 1 seed test from truthy to `== 17`.
  - Added: manifest stage with no `CourseStage` row raises
    `SeedContentStageMissingError` naming the stage; partial seed raises naming
    only the unmapped stage while writing nothing; placeholder-only unmapped
    stages stay quiet; the no-stages case now asserts the loud contract.
- Gate 2: `./scripts/backend/check-all.sh` green (2050 tests, 96% coverage),
  plus `xenon` A-grade and `radon mi` A on `seed_content.py` (run separately —
  `check-all.sh` omits them).
- Gate 2.5: `code-review-orchestrator` verdict CLEAN (no blockers).

Refs #934
Closes #938
