### PR TITLE
feat(frontend): "How the Wavelength works" explainer on the Map

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -14,6 +14,7 @@ import {
   showcaseShadow,
   spacing,
   surface,
+  surfaceShadow,
   touchTarget,
 } from '../../design/tokens';
 
@@ -243,6 +244,57 @@ const styles = StyleSheet.create({
     color: ink.muted,
     marginTop: spacing(0.25),
     letterSpacing: 0.5,
+  },
+
+  // --- "How the Wavelength works" opt-in explainer -------------------------
+  // Gentle, declinable invitation in the journey header — never a demand.
+  explainerTrigger: {
+    marginTop: spacing(0.5),
+    paddingVertical: spacing(0.25),
+    paddingHorizontal: spacing(1),
+  },
+  explainerTriggerText: {
+    fontFamily: editorialType.serif,
+    fontSize: 13,
+    color: accent.primary,
+    letterSpacing: 0.25,
+  },
+  // Sheet body for the explainer modal, floating on the warm desk ground.
+  explainerSheet: {
+    width: '90%',
+    maxHeight: '82%',
+    backgroundColor: surface.canvas,
+    borderRadius: radius.lg,
+    paddingHorizontal: spacing(2.5),
+    paddingVertical: spacing(2.5),
+    borderTopWidth: 4,
+    borderTopColor: accent.primary,
+    ...surfaceShadow.card,
+  },
+  explainerScroll: {
+    paddingBottom: spacing(2),
+  },
+  explainerTitle: {
+    ...editorialType.title,
+    fontSize: 22,
+    color: ink.primary,
+    marginBottom: spacing(1),
+    paddingRight: spacing(3),
+  },
+  explainerClose: {
+    position: 'absolute',
+    top: spacing(1),
+    right: spacing(1),
+    minWidth: touchTarget.minimum,
+    minHeight: touchTarget.minimum,
+    alignItems: CENTER,
+    justifyContent: CENTER,
+    zIndex: 1,
+  },
+  explainerCloseText: {
+    fontSize: 22,
+    fontWeight: '600',
+    color: ink.soft,
   },
 
   // --- Begin-again affordance (end-of-arc, declinable) ----------------------

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -41,6 +41,7 @@ import { MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
 import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
+import WavelengthExplainer from './WavelengthExplainer';
 import { WaveOverlay } from './WaveOverlay';
 import { BALANCE_COPY, emphasisStyle, FULLNESS_ALIVE_THRESHOLD, summaryFor } from './wheelBalance';
 
@@ -647,10 +648,18 @@ const FIRST_CYCLE = 1;
 interface JourneyHeaderProps {
   currentStage: number;
   cycleNumber: number;
+  onOpenExplainer: () => void;
 }
 
+/** Warm, declinable copy inviting the reader into the Wavelength explainer. */
+const EXPLAINER_TRIGGER_LABEL = 'How the Wavelength works';
+
 /** Compact momentum read at the top of the Map: "Stage N of 10 · Week W". */
-const JourneyHeader = ({ currentStage, cycleNumber }: JourneyHeaderProps): React.JSX.Element => {
+const JourneyHeader = ({
+  currentStage,
+  cycleNumber,
+  onOpenExplainer,
+}: JourneyHeaderProps): React.JSX.Element => {
   const week = useDerivedCurrentWeek(1);
   return (
     <View style={styles.journeyHeader} testID="journey-read">
@@ -660,6 +669,15 @@ const JourneyHeader = ({ currentStage, cycleNumber }: JourneyHeaderProps): React
           {cycleLabel(cycleNumber)}
         </Text>
       ) : null}
+      <TouchableOpacity
+        testID="wavelength-explainer-trigger"
+        style={styles.explainerTrigger}
+        onPress={onOpenExplainer}
+        accessibilityRole="button"
+        accessibilityLabel={EXPLAINER_TRIGGER_LABEL}
+      >
+        <Text style={styles.explainerTriggerText}>{EXPLAINER_TRIGGER_LABEL}</Text>
+      </TouchableOpacity>
     </View>
   );
 };
@@ -843,18 +861,25 @@ interface MapContentProps {
   showRefreshError: boolean;
   activeStage: StageData | null;
   celebration: CompletionCelebration;
+  explainerVisible: boolean;
   onRefresh: () => void;
   onBeginAgain: () => void;
   onSelectStage: (_stage: StageData) => void;
   onCloseModal: () => void;
   onNavigate: (_screen: NavTarget, _stage: StageData) => void;
+  onOpenExplainer: () => void;
+  onCloseExplainer: () => void;
 }
 
 /** The rendered Map: spiral grid + balance overlay + banners + stage modal. */
 const MapContent = (props: MapContentProps): React.JSX.Element => (
   <View style={styles.container}>
     <MapBackdrop />
-    <JourneyHeader currentStage={props.currentStage} cycleNumber={props.cycleNumber} />
+    <JourneyHeader
+      currentStage={props.currentStage}
+      cycleNumber={props.cycleNumber}
+      onOpenExplainer={props.onOpenExplainer}
+    />
     <MapGrid
       lookup={props.lookup}
       fullnessByStage={props.fullnessByStage}
@@ -876,6 +901,7 @@ const MapContent = (props: MapContentProps): React.JSX.Element => (
       onClose={props.onCloseModal}
       onNavigate={props.onNavigate}
     />
+    <WavelengthExplainer visible={props.explainerVisible} onClose={props.onCloseExplainer} />
   </View>
 );
 
@@ -892,6 +918,8 @@ const MapScreen = (): React.JSX.Element => {
   // Additive overlay: a failed/loading read leaves the map empty so every Aspect reads thin.
   const { fullnessByStage } = useWheelBalance();
   const [activeStage, setActiveStage] = useState<StageData | null>(null);
+  // The explainer is a declinable door: it starts closed and is never auto-shown.
+  const [explainerVisible, setExplainerVisible] = useState<boolean>(false);
   const { beginning, handleBeginAgain } = useBeginAgainGuard();
 
   // Resolve each row's stage numbers to their loaded StageData once per change.
@@ -908,6 +936,8 @@ const MapScreen = (): React.JSX.Element => {
 
   const handleRefresh = useCallback(() => void stageService.loadStages(), []);
   const handleCloseModal = useCallback(() => setActiveStage(null), []);
+  const handleOpenExplainer = useCallback(() => setExplainerVisible(true), []);
+  const handleCloseExplainer = useCallback(() => setExplainerVisible(false), []);
   const handleNavigate = useStageNavigation(handleCloseModal);
   const celebration = useStageCompletionCelebration(stages, lookup);
 
@@ -925,11 +955,14 @@ const MapScreen = (): React.JSX.Element => {
       showRefreshError={!!error && stages.length > 0}
       activeStage={activeStage}
       celebration={celebration}
+      explainerVisible={explainerVisible}
       onRefresh={handleRefresh}
       onBeginAgain={handleBeginAgain}
       onSelectStage={setActiveStage}
       onCloseModal={handleCloseModal}
       onNavigate={handleNavigate}
+      onOpenExplainer={handleOpenExplainer}
+      onCloseExplainer={handleCloseExplainer}
     />
   );
 };

--- a/frontend/src/features/Map/WavelengthExplainer.tsx
+++ b/frontend/src/features/Map/WavelengthExplainer.tsx
@@ -1,5 +1,3 @@
-// frontend/features/Map/WavelengthExplainer.tsx
-
 import React from 'react';
 import { Modal, Pressable, ScrollView, Text } from 'react-native';
 import Markdown from 'react-native-markdown-display';
@@ -37,14 +35,7 @@ const ExplainerSheet = ({ onClose }: { onClose: () => void }): React.JSX.Element
   </Pressable>
 );
 
-/**
- * Opt-in "How the Wavelength works" explainer. It is a declinable door the user
- * chooses to open from the Map — never auto-shown, never gated behind, never a
- * demand. It only explains the model (torus, spiral, compression waves, rising
- * octaves, the chord); it never ranks or judges the reader. Closing it returns
- * the Map exactly as it was, matching the NORTH-STAR "you choose your depth"
- * framing.
- */
+/** Opt-in, declinable "How the Wavelength works" explainer — never auto-shown, never ranking. */
 export default function WavelengthExplainer({
   visible,
   onClose,

--- a/frontend/src/features/Map/WavelengthExplainer.tsx
+++ b/frontend/src/features/Map/WavelengthExplainer.tsx
@@ -1,0 +1,63 @@
+// frontend/features/Map/WavelengthExplainer.tsx
+
+import React from 'react';
+import { Modal, Pressable, ScrollView, Text } from 'react-native';
+import Markdown from 'react-native-markdown-display';
+
+import { markdownStyles } from '../Course/Course.styles';
+
+import styles from './Map.styles';
+import { WAVELENGTH_EXPLAINER } from './wavelengthExplainerContent';
+
+interface WavelengthExplainerProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+/** The explainer's inner sheet: title, close affordance, and the model copy. */
+const ExplainerSheet = ({ onClose }: { onClose: () => void }): React.JSX.Element => (
+  <Pressable style={styles.explainerSheet} onPress={() => {}} testID="wavelength-explainer-sheet">
+    <Pressable
+      testID="wavelength-explainer-close"
+      style={styles.explainerClose}
+      onPress={onClose}
+      accessibilityRole="button"
+      accessibilityLabel="Close"
+    >
+      <Text style={styles.explainerCloseText}>×</Text>
+    </Pressable>
+    <ScrollView
+      testID="wavelength-explainer"
+      contentContainerStyle={styles.explainerScroll}
+      showsVerticalScrollIndicator={false}
+    >
+      <Text style={styles.explainerTitle}>{WAVELENGTH_EXPLAINER.title}</Text>
+      <Markdown style={markdownStyles}>{WAVELENGTH_EXPLAINER.markdown}</Markdown>
+    </ScrollView>
+  </Pressable>
+);
+
+/**
+ * Opt-in "How the Wavelength works" explainer. It is a declinable door the user
+ * chooses to open from the Map — never auto-shown, never gated behind, never a
+ * demand. It only explains the model (torus, spiral, compression waves, rising
+ * octaves, the chord); it never ranks or judges the reader. Closing it returns
+ * the Map exactly as it was, matching the NORTH-STAR "you choose your depth"
+ * framing.
+ */
+export default function WavelengthExplainer({
+  visible,
+  onClose,
+}: WavelengthExplainerProps): React.JSX.Element {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable
+        style={styles.modalOverlay}
+        onPress={onClose}
+        testID="wavelength-explainer-overlay"
+      >
+        {visible ? <ExplainerSheet onClose={onClose} /> : null}
+      </Pressable>
+    </Modal>
+  );
+}

--- a/frontend/src/features/Map/__tests__/WavelengthExplainer.test.tsx
+++ b/frontend/src/features/Map/__tests__/WavelengthExplainer.test.tsx
@@ -1,0 +1,89 @@
+/* eslint-env jest */
+/* global describe, it, expect, jest */
+// Contract this test pins for the implementer (frontend/src/features/Map/):
+//   wavelengthExplainer.ts:
+//     export const WAVELENGTH_EXPLAINER = { title: string; markdown: string } as const;
+//   WavelengthExplainer.tsx:
+//     export default function WavelengthExplainer(props: { visible: boolean; onClose: () => void }): JSX.Element
+//     Renders a react-native Modal (transparent, animationType="slide", onRequestClose=onClose).
+//     Body content only mounts when visible is true.
+//     Scrollable content container: testID="wavelength-explainer".
+//     Close affordance: testID="wavelength-explainer-close", accessibilityRole="button".
+//     Renders WAVELENGTH_EXPLAINER.markdown via react-native-markdown-display,
+//     styled with markdownStyles from '../Course/Course.styles'.
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+
+import WavelengthExplainer from '../WavelengthExplainer';
+import { WAVELENGTH_EXPLAINER } from '../wavelengthExplainerContent';
+
+const SHAMING_LANGUAGE =
+  /\b(better than|worse than|higher\s+self\s+than|superior|inferior|failing|failure|you should|not enough|behind|fall short)\b/i;
+
+describe('WavelengthExplainer', () => {
+  it('renders nothing user-visible when not visible', () => {
+    const { queryByTestId } = render(<WavelengthExplainer visible={false} onClose={() => {}} />);
+    expect(queryByTestId('wavelength-explainer')).toBeNull();
+  });
+
+  it('renders the content container when visible', () => {
+    const { getByTestId } = render(<WavelengthExplainer visible onClose={() => {}} />);
+    expect(getByTestId('wavelength-explainer')).toBeTruthy();
+  });
+
+  it('renders the torus/auric-field concept', () => {
+    const { getAllByText } = render(<WavelengthExplainer visible onClose={() => {}} />);
+    expect(getAllByText(/torus/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the compression-wave concept', () => {
+    const { getAllByText } = render(<WavelengthExplainer visible onClose={() => {}} />);
+    expect(getAllByText(/compression/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the six-octaves concept', () => {
+    const { getAllByText } = render(<WavelengthExplainer visible onClose={() => {}} />);
+    expect(getAllByText(/octave/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the chord concept', () => {
+    const { getAllByText } = render(<WavelengthExplainer visible onClose={() => {}} />);
+    expect(getAllByText(/chord/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the spiral-growing-the-torus concept', () => {
+    const { getAllByText } = render(<WavelengthExplainer visible onClose={() => {}} />);
+    expect(getAllByText(/spiral/i).length).toBeGreaterThan(0);
+  });
+
+  it('calls onClose when the close affordance is pressed', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<WavelengthExplainer visible onClose={onClose} />);
+    fireEvent.press(getByTestId('wavelength-explainer-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes accessibilityRole="button" on the close affordance', () => {
+    const { getByTestId } = render(<WavelengthExplainer visible onClose={() => {}} />);
+    expect(getByTestId('wavelength-explainer-close').props.accessibilityRole).toBe('button');
+  });
+});
+
+describe('WAVELENGTH_EXPLAINER copy', () => {
+  it('has a non-empty title', () => {
+    expect(WAVELENGTH_EXPLAINER.title.length).toBeGreaterThan(0);
+  });
+
+  it('contains all five concept keywords in the markdown', () => {
+    const markdown = WAVELENGTH_EXPLAINER.markdown.toLowerCase();
+    expect(markdown).toMatch(/torus/);
+    expect(markdown).toMatch(/spiral/);
+    expect(markdown).toMatch(/compression/);
+    expect(markdown).toMatch(/octave/);
+    expect(markdown).toMatch(/chord/);
+  });
+
+  it('never contains shaming or ranking language', () => {
+    expect(SHAMING_LANGUAGE.test(WAVELENGTH_EXPLAINER.markdown)).toBe(false);
+  });
+});

--- a/frontend/src/features/Map/__tests__/WavelengthExplainerTrigger.test.tsx
+++ b/frontend/src/features/Map/__tests__/WavelengthExplainerTrigger.test.tsx
@@ -1,0 +1,162 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+// Pins the MapScreen JourneyHeader trigger contract: a TouchableOpacity with
+// testID="wavelength-explainer-trigger", accessibilityRole="button", and an
+// accessibilityLabel like "How the Wavelength works" that opens
+// WavelengthExplainer. The explainer must never be visible on initial render.
+import React from 'react';
+import { Image } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import MapScreen from '../MapScreen';
+
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
+  runAfterInteractions: (cb: () => void) => {
+    cb();
+    return { then: () => {}, done: () => {}, cancel: () => {} };
+  },
+  createInteractionHandle: () => 1,
+  clearInteractionHandle: () => {},
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('../../../navigation/hooks', () => ({
+  useAppNavigation: () => ({ navigate: mockNavigate }),
+}));
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: () => 0,
+}));
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+let mockWheelFullnessByStage: Record<number, number> = {};
+jest.mock('../hooks/useWheelBalance', () => ({
+  useWheelBalance: () => ({
+    fullnessByStage: mockWheelFullnessByStage,
+    loading: false,
+    error: null,
+  }),
+}));
+
+let mockDerivedStage = 1;
+jest.mock('../../../store/useProgramProgression', () => ({
+  useDerivedCurrentStage: (fallback: number) => mockDerivedStage ?? fallback,
+  useDerivedCurrentWeek: (fallback: number) => fallback,
+  useDaysUntilStage: () => null,
+}));
+
+function mockMakeStage(stageNumber: number) {
+  return {
+    id: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    stageNumber,
+    progress: 0,
+    color: '#aaa',
+    isUnlocked: stageNumber <= 2,
+    category: 'Test',
+    aspect: 'Aspect',
+    spiralDynamicsColor: 'Beige',
+    growingUpStage: 'Growing',
+    divineGenderPolarity: 'Polarity',
+    relationshipToFreeWill: 'Free Will',
+    freeWillDescription: 'Description of free will.',
+    overviewUrl: '',
+    hotspots: [
+      { top: (10 - stageNumber) * 8 + 4, left: 4, width: 32, height: 6 },
+      { top: (10 - stageNumber) * 8 + 4, left: 34, width: 40, height: 6 },
+    ],
+  };
+}
+
+const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+
+jest.mock('../services/stageService', () => ({
+  stageService: {
+    loadStages: jest.fn(),
+    beginAgain: jest.fn(),
+  },
+  isStageUnlocked: (
+    stage: { isUnlocked: boolean; stageNumber: number },
+    currentStage: number | null,
+  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
+  isEndOfCycle: () => false,
+}));
+
+const buildMockStageState = () => ({
+  stages: mockStages,
+  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
+  stageOrder: mockStages.map((s) => s.stageNumber),
+  currentStage: 1,
+  loading: false,
+  error: null,
+  cycleNumber: 1,
+  setStages: jest.fn(),
+  setCurrentStage: jest.fn(),
+  setLoading: jest.fn(),
+  setError: jest.fn(),
+  updateStageProgress: jest.fn(),
+  setCycleNumber: jest.fn(),
+});
+
+jest.mock('../../../store/useStageStore', () => ({
+  useStageStore: jest.fn((selector) => {
+    const mockState = buildMockStageState();
+    return selector ? selector(mockState) : mockState;
+  }),
+  selectStages: (s: { stages: unknown }) => s.stages,
+  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
+  selectStagesLoading: (s: { loading: unknown }) => s.loading,
+  selectStagesError: (s: { error: unknown }) => s.error,
+  selectCycleNumber: (s: { cycleNumber: number }) => s.cycleNumber,
+  selectStageByNumber:
+    (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>
+      n == null ? undefined : s.stagesByNumber[n],
+}));
+
+type TestNode = { props: Record<string, unknown> };
+
+describe('MapScreen wavelength explainer trigger', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockDerivedStage = 1;
+    mockWheelFullnessByStage = {};
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('does not show the explainer on initial render', () => {
+    const tree = create(<MapScreen />);
+    expect(
+      tree.root.findAll((n: TestNode) => n.props.testID === 'wavelength-explainer'),
+    ).toHaveLength(0);
+  });
+
+  it('renders the trigger in the journey header with an accessible label', () => {
+    const tree = create(<MapScreen />);
+    const trigger = tree.root.findByProps({ testID: 'wavelength-explainer-trigger' });
+    expect(trigger.props.accessibilityRole).toBe('button');
+    expect(trigger.props.accessibilityLabel).toMatch(/wavelength/i);
+  });
+
+  it('opens the explainer when the trigger is pressed', () => {
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'wavelength-explainer-trigger' }).props.onPress();
+    });
+    expect(tree.root.findByProps({ testID: 'wavelength-explainer' })).toBeTruthy();
+  });
+
+  it('dismisses the explainer when the close affordance is pressed', () => {
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'wavelength-explainer-trigger' }).props.onPress();
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'wavelength-explainer-close' }).props.onPress();
+    });
+    expect(
+      tree.root.findAll((n: TestNode) => n.props.testID === 'wavelength-explainer'),
+    ).toHaveLength(0);
+  });
+});

--- a/frontend/src/features/Map/wavelengthExplainerContent.ts
+++ b/frontend/src/features/Map/wavelengthExplainerContent.ts
@@ -1,0 +1,71 @@
+// frontend/features/Map/wavelengthExplainerContent.ts
+//
+// Copy for the opt-in "How the Wavelength works" explainer. It describes the
+// model — the torus, the growing spiral, compression-wave emission, the rising
+// octaves, and the chord — in the course's warm, resonant voice. It never ranks
+// or shames the reader: it explains a shape of reality, not a scoreboard.
+
+export const WAVELENGTH_EXPLAINER = {
+  title: 'How the Wavelength works',
+  markdown: `# How the Wavelength works
+
+This is a picture, not a measurement. Nothing here is a ladder to climb or a
+score to beat — it is simply a way of seeing the shape of a life as it turns.
+Read it slowly, and take only what resonates.
+
+## Your torus — the auric field
+
+Picture the field around you as a torus: a doughnut of energy that flows up
+through you, blooms out around you, and folds back in to rise again. It is the
+living shape of your presence — the vibration you are already emitting, moment
+to moment.
+
+The torus is art, not a test. Don't judge the art. A torus can be small and
+quiet or wide and luminous, and neither is a verdict on you. It simply is what
+it is right now, and it is always in motion.
+
+## The spiral that grows it
+
+Around that torus turns a spiral. Every honest pass through experience — every
+practice, every reflection, every ordinary day met with a little more presence
+— winds the spiral one more turn. As it turns, it grows the torus wider and
+lifts it, opening you toward the higher Stages of the arc.
+
+The spiral never retraces the same circle. It rises. What returns comes back
+around at a new turn, carrying everything the last turn taught you.
+
+## Compression waves — how you touch other souls
+
+Each Stage of the spiral emits vibration outward as compression waves — tiny
+toruses rippling off the larger one, the way a struck string sends its note
+into the air. These waves travel. A steadier presence, a kinder word, a settled
+room: these are compression waves, and they can gently raise the vibration of
+the souls they reach.
+
+You are always emitting. The Wavelength simply names what your presence is
+already doing in the field around you.
+
+## The rising octaves
+
+The wave itself moves through six phases in every cycle — Rising, Peaking,
+Withdrawal, Diminishing, Bottoming Out, and Restoration — and then it turns
+again. As the spiral lifts through the Stages of the arc, the same six-phase
+wave sounds again at a higher octave: the same music, pitched higher, richer in
+overtones. The rising octaves are those lifting Stages — each one the familiar
+cycle sung anew.
+
+An octave up is not "more worthy." It is the same song, wider in range. Every
+octave is whole in itself.
+
+## The chord
+
+A single action can sound from more than one Stage at once — a chord rather than
+a single note. You might act, in one breath, from the Integrative Stage and the
+Conformist Stage and from something rooted deep in plain survival, all at the
+same time. That is not confusion; it is fullness. A chord is richer than any
+one note alone.
+
+To hear your own chord — the many notes ringing together in a single act — is
+simply to know yourself more completely. That is all the Wavelength ever asks:
+that you listen.`,
+} as const;

--- a/frontend/src/features/Map/wavelengthExplainerContent.ts
+++ b/frontend/src/features/Map/wavelengthExplainerContent.ts
@@ -1,10 +1,3 @@
-// frontend/features/Map/wavelengthExplainerContent.ts
-//
-// Copy for the opt-in "How the Wavelength works" explainer. It describes the
-// model — the torus, the growing spiral, compression-wave emission, the rising
-// octaves, and the chord — in the course's warm, resonant voice. It never ranks
-// or shames the reader: it explains a shape of reality, not a scoreboard.
-
 export const WAVELENGTH_EXPLAINER = {
   title: 'How the Wavelength works',
   markdown: `# How the Wavelength works


### PR DESCRIPTION
## Summary

Adds an opt-in, declinable **"How the Wavelength works"** explainer, reachable
from the Map's journey header. It presents the metaphysical model behind the Map
in the course's warm voice — the **torus / auric field** ("don't judge the
art"), the **spiral** that grows the torus and lifts it toward higher Stages,
**compression-wave** emission (each Stage rippling tiny toruses that can raise
other souls' vibration), the **six rising octaves**, and the **chord** (one
action sounding from more than one Stage at once).

- The explainer is **never auto-shown and never blocking** — a quiet door the
  user chooses to open, matching NORTH-STAR "you choose your depth" (§8).
- Copy lives in a **data-driven markdown module**
  (`wavelengthExplainerContent.ts`) so it can evolve without code changes, and is
  rendered through the **existing** `react-native-markdown-display` reader +
  `markdownStyles` — no new heavyweight reader.
- Candle & Ink tokens throughout; accessible trigger/close affordances.
- The copy **describes the model and never ranks or shames** the reader (intent-
  based copy rule) — it explicitly frames the model as "a picture, not a
  measurement… not a ladder to climb or a score to beat," and a copy-safety test
  guards against shaming/ranking strings.

Scoped to the smallest coherent slice per the issue's "lowest priority — ship
the wave first" guidance. Two follow-ups filed and deferred:
- #1077 — author the explainer as a vendored site resource in the content repo
  (the `backend/content/` tree is hand-edit-blocked by the `content-drift` CI
  gate, so the copy is frontend-local for now).
- #1076 — optional rich torus/spiral visual treatment.

## Test plan

- `frontend/src/features/Map/__tests__/WavelengthExplainer.test.tsx` — explainer
  renders nothing when `visible={false}`; renders the five concepts (torus,
  spiral, compression, octave, chord) when visible; close affordance calls
  `onClose`; a11y role on close; copy-safety guard against shaming/ranking
  language; all five concept keywords present.
- `frontend/src/features/Map/__tests__/WavelengthExplainerTrigger.test.tsx` —
  explainer not shown on initial Map render; trigger has an accessible label;
  pressing the trigger opens it; pressing close dismisses it.
- `./scripts/frontend/check-all.sh` exits 0 — ESLint zero-warning, prettier
  clean, `tsc --noEmit` clean, full Jest suite green (2612 tests).

Closes #948
Refs #943
