### PR TITLE
feat(frontend): wire ritual haptics adapter into active sessions

### DIFF
--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -23,6 +23,7 @@
  *     `useWeeklyProgress` callbacks so the bar reconciles with server truth.
  *   - Activate keep-awake while the engine is `running` (not for the whole
  *     active-card lifetime).
+ *   - Inject the expo-haptics adapter so ritual cues emit tactile feedback.
  */
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -42,10 +43,12 @@ import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConf
 import type { PickedCard } from '@/features/Practice/data/resolveCard';
 import { buildCardMeditationMetadata, pickCard } from '@/features/Practice/data/resolveCard';
 import { cardForDayIndex } from '@/features/Practice/data/tarot';
+import { createExpoHapticsAdapter } from '@/features/Practice/engine/adapters/haptics';
 import { scheduledCues } from '@/features/Practice/engine/cues';
 import { totalSteps, totalStepsPerRound } from '@/features/Practice/engine/tallied';
 import type {
   CardMeditationConfig,
+  EngineDeps,
   IntervalBellConfig,
   MindfulAnchorMetadata,
   ModeConfig,
@@ -235,9 +238,14 @@ function useHarvestedMetadata(
   };
 }
 
+function useEngineDeps(tarotCardIndex: number): EngineDeps {
+  const [haptics] = useState(() => createExpoHapticsAdapter());
+  return useMemo(() => ({ startCardIndex: tarotCardIndex, haptics }), [tarotCardIndex, haptics]);
+}
+
 function useActiveSession(props: ActiveRitualSessionProps): ActiveSession {
   const tarotCardIndex = useTarotCardIndex(props);
-  const engineDeps = useMemo(() => ({ startCardIndex: tarotCardIndex }), [tarotCardIndex]);
+  const engineDeps = useEngineDeps(tarotCardIndex);
   const [state, controls] = useRitualEngine(props.effectiveConfig, engineDeps);
   useKeepAwakeWhileRunning(state.status);
   const window = useCompletionWindow(state.status);

--- a/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.haptics.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.haptics.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
+import React from 'react';
+
+import type { UserPractice } from '@/api';
+import ActiveRitualSession from '@/features/Practice/components/ActiveRitualSession';
+import type { MeditationTimerConfig } from '@/features/Practice/engine/types';
+
+const userPractice: UserPractice = {
+  id: 10,
+  practice_id: 1,
+  stage_number: 1,
+  start_date: '2026-04-12',
+  end_date: null,
+};
+
+const config: MeditationTimerConfig = {
+  mode: 'meditation_timer',
+  duration_minutes: 1,
+  halfway_bell: true,
+};
+
+function renderSession() {
+  return render(
+    <ActiveRitualSession
+      userPractice={userPractice}
+      effectiveName="Breath Awareness"
+      effectiveConfig={config}
+      userTimezone="UTC"
+      onSessionApply={jest.fn()}
+      onSessionRollback={jest.fn()}
+      onSessionCommitted={jest.fn()}
+      onUserPracticeUpdated={jest.fn()}
+      onWriteReflection={jest.fn()}
+    />,
+  );
+}
+
+describe('ActiveRitualSession haptics wiring', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    (Haptics.impactAsync as jest.Mock).mockClear();
+    (Haptics.notificationAsync as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fires a light impact for the start_bell cue when the session starts', () => {
+    const { getByTestId } = renderSession();
+
+    act(() => {
+      fireEvent.press(getByTestId('ritual-start'));
+    });
+
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+  });
+
+  it('fires a light impact for the halfway_bell cue at the midpoint', () => {
+    const { getByTestId } = renderSession();
+
+    act(() => {
+      fireEvent.press(getByTestId('ritual-start'));
+    });
+    (Haptics.impactAsync as jest.Mock).mockClear();
+
+    act(() => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+  });
+
+  it('fires a success notification for the end_bell cue on completion', () => {
+    const { getByTestId } = renderSession();
+
+    act(() => {
+      fireEvent.press(getByTestId('ritual-start'));
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+      Haptics.NotificationFeedbackType.Success,
+    );
+  });
+});

--- a/frontend/src/features/Practice/engine/adapters/__tests__/haptics.test.ts
+++ b/frontend/src/features/Practice/engine/adapters/__tests__/haptics.test.ts
@@ -1,19 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import * as Haptics from 'expo-haptics';
 
-import { createExpoHapticsAdapter, createNoopHapticsAdapter } from '../haptics';
+import { createExpoHapticsAdapter } from '../haptics';
 
 const impactMock = Haptics.impactAsync as jest.MockedFunction<typeof Haptics.impactAsync>;
 const notificationMock = Haptics.notificationAsync as jest.MockedFunction<
   typeof Haptics.notificationAsync
 >;
-
-describe('createNoopHapticsAdapter', () => {
-  it('returns an adapter that ignores cue calls', () => {
-    const adapter = createNoopHapticsAdapter();
-    expect(() => adapter.cue('start_bell')).not.toThrow();
-  });
-});
 
 describe('createExpoHapticsAdapter', () => {
   beforeEach(() => {

--- a/frontend/src/features/Practice/engine/adapters/haptics.ts
+++ b/frontend/src/features/Practice/engine/adapters/haptics.ts
@@ -5,11 +5,6 @@ import * as Haptics from 'expo-haptics';
 
 import type { CueKind, HapticsAdapter } from '../types';
 
-/** No-op adapter for tests and platforms without haptic hardware. */
-export function createNoopHapticsAdapter(): HapticsAdapter {
-  return { cue: () => undefined };
-}
-
 export function createExpoHapticsAdapter(): HapticsAdapter {
   return {
     cue: (kind) => {


### PR DESCRIPTION
## Summary

**Resolution: WIRED IN** (with a real integration test), per the wire-in-or-delete ADR.

The ritual-engine expo-haptics adapters were an aspirational feature shipped as complete: `createExpoHapticsAdapter` was fully unit-tested but **never reached a production code path**, so no user ever felt a haptic (dead code + coverage theater). The engine's cue-emit loop already calls `haptics.cue(cue.kind)`, but the single production caller (`ActiveRitualSession` → `useActiveSession`) only passed `{ startCardIndex }`, so the engine fell back to its inline `NOOP_HAPTICS`.

**Evidence the wire-in is correct and safe:**
- The composition-layer precedent already exists — `useBellAudio` in `RandomIntervalBellView` constructs `createExpoAudioAdapter()` once via `useState(() => ...)`. This change mirrors that pattern for haptics.
- No user-facing haptics on/off setting exists anywhere in `frontend/src` (verified by grep), so ungated injection is correct; a settings toggle would be new scope.

**What changed:**
- New `useEngineDeps(tarotCardIndex)` hook in `ActiveRitualSession` constructs `createExpoHapticsAdapter()` once and injects it into the engine deps. Every engine-cued mode now emits a haptic on start/halfway/interval/end cues (`metronome_tick` stays silent by design).
- Added an integration test that renders the **production** `ActiveRitualSession`, drives a `meditation_timer` ritual, and asserts the global `expo-haptics` mock fires on each struck cue — RED before the wiring, GREEN after.
- Deleted the now-orphaned `createNoopHapticsAdapter` and its unit tests (the engine keeps its own inline `NOOP_HAPTICS` default; the `haptics` DI seam is untouched), so no test exercises an unreachable adapter.

**Out of scope (per the issue):** the audio adapter and the engine's `haptics` DI seam are untouched. Note: the engine cue loop's *audio* path is also noop in production (audio reaches production only through `RandomIntervalBellView`); that asymmetry is explicitly out of scope here.

## Test plan

- New integration test `ActiveRitualSession.haptics.test.tsx` (3 cases: start_bell light impact, halfway_bell light impact, end_bell success notification) — confirmed to fail RED with "Number of calls: 0" before the wiring, pass GREEN after.
- `./scripts/frontend/check-all.sh` — all 4 checks pass: **2627 jest tests**, ESLint zero-warning, `tsc --noEmit` clean, prettier clean.
- No remaining test exercises a haptics adapter that no production path reaches; coverage stays ≥ 90%.

Closes #1006
