### PR TITLE
feat(full-stack): the "Return" — a declinable five-week Metta arc for a soft landing

### DIFF
--- a/backend/migrations/versions/c9d0e1f2a3b4_add_metta_return_arc.py
+++ b/backend/migrations/versions/c9d0e1f2a3b4_add_metta_return_arc.py
@@ -1,0 +1,60 @@
+"""add metta_return_arc table for the declinable Metta Return arc.
+
+Revision ID: c9d0e1f2a3b4
+Revises: b3c4d5e6f7a8
+Create Date: 2026-07-01 00:00:00.000000
+
+Purely additive: ``upgrade`` creates the ``mettareturnarc`` table (a user's
+opt-in, penalty-free five-week Return arc) with its owner FK (cascading), the
+partial unique index enforcing at most one active arc per user (``left_at IS
+NULL``), and the non-unique owner index. ``downgrade`` drops the indexes then
+the table. No ``ALTER`` / ``DROP`` against existing tables.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d0e1f2a3b4"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "b3c4d5e6f7a8"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``mettareturnarc`` table and its indexes."""
+    op.create_table(
+        "mettareturnarc",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("paused_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("left_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # Partial unique index: at most one active arc (``left_at IS NULL``) per
+    # user, while any number of previously-left arcs may coexist so leaving and
+    # restarting is always allowed.
+    op.create_index(
+        "ix_metta_return_arc_user_active",
+        "mettareturnarc",
+        ["user_id"],
+        unique=True,
+        postgresql_where=sa.text("left_at IS NULL"),
+        sqlite_where=sa.text("left_at IS NULL"),
+    )
+    op.create_index(
+        "ix_metta_return_arc_user_id",
+        "mettareturnarc",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``mettareturnarc`` indexes then the table."""
+    op.drop_index("ix_metta_return_arc_user_id", table_name="mettareturnarc")
+    op.drop_index("ix_metta_return_arc_user_active", table_name="mettareturnarc")
+    op.drop_table("mettareturnarc")

--- a/backend/src/domain/metta_return.py
+++ b/backend/src/domain/metta_return.py
@@ -1,0 +1,191 @@
+"""The Return — a declinable five-week Metta arc, offered as a skillful rest.
+
+The Return is an optional, self-chosen depth offered only once the program's
+Blue stage has been passed (highest stage reached >= ``RETURN_MINIMUM_STAGE``).
+Following the "Contraction follows Expansion" rhythm, it reframes a natural
+easing-off as a warm invitation to turn toward loving-kindness rather than a
+failure to keep pushing. Nothing here ranks, shames, or penalizes: eligibility
+is derived from advancement the user already earned, and the week the arc sits
+in is a gentle pacing hint, never a deadline.
+
+These helpers are pure: they read :class:`StageProgress` and datetimes and
+never mutate stage progress or any other state. The router that persists an arc
+lives alongside; this module owns only the sequence, the eligibility rule, and
+the elapsed-week math.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.stage_progress import StageProgress
+
+# The arc is exactly five weeks — one per focus of loving-kindness.
+RETURN_WEEK_COUNT = 5
+# Blue is stage 4; reaching stage 5 (Orange) means Blue was passed to get there.
+RETURN_MINIMUM_STAGE = 5
+DAYS_PER_WEEK = 7
+# A user mid-way through a second 10-stage cycle has, by definition, already
+# passed Blue in the prior cycle, so the arc is offered regardless of where the
+# current cycle sits.
+_SECOND_CYCLE = 2
+
+
+class MettaFocus(enum.StrEnum):
+    """The object of loving-kindness a Return week turns toward.
+
+    The progression widens the circle of care: from oneself, out through a
+    benefactor, a neutral stranger, and a difficult person, to all beings.
+    """
+
+    SELF = "self"
+    BENEFACTOR = "benefactor"
+    STRANGER = "stranger"
+    ANTAGONIST = "antagonist"
+    ALL_BEINGS = "all_beings"
+
+
+@dataclass(frozen=True)
+class ReturnWeek:
+    """One week of the Return arc: its focus and the warm framing that opens it.
+
+    Immutable so the shared :data:`RETURN_SEQUENCE` cannot be mutated by a
+    caller. ``title`` and ``framing`` are user-facing copy held to a strictly
+    non-shaming standard — a Return is a skillful rest, never a shortfall.
+    """
+
+    week_number: int
+    focus: MettaFocus
+    title: str
+    framing: str
+
+
+RETURN_SEQUENCE: tuple[ReturnWeek, ...] = (
+    ReturnWeek(
+        week_number=1,
+        focus=MettaFocus.SELF,
+        title="Turning kindness inward",
+        framing=(
+            "Contraction follows expansion, and resting here is its own kind of "
+            "practice. This week, offer yourself the warmth you so freely offer "
+            "others — you are welcome exactly as you are."
+        ),
+    ),
+    ReturnWeek(
+        week_number=2,
+        focus=MettaFocus.BENEFACTOR,
+        title="Someone who has held you",
+        framing=(
+            "Bring to mind someone whose care once steadied you. Let your "
+            "gratitude soften into a wish for their ease. Nothing is owed here — "
+            "only a quiet turning toward what has nourished you."
+        ),
+    ),
+    ReturnWeek(
+        week_number=3,
+        focus=MettaFocus.STRANGER,
+        title="A face you barely know",
+        framing=(
+            "Picture someone at the edge of your days — unremarkable, unknown. "
+            "This week, extend the same simple wish for their wellbeing, "
+            "widening the circle of care one gentle step at a time."
+        ),
+    ),
+    ReturnWeek(
+        week_number=4,
+        focus=MettaFocus.ANTAGONIST,
+        title="Meeting a hard heart with softness",
+        framing=(
+            "Hold someone who has been difficult for you, lightly and at your "
+            "own pace. There is no obligation to forgive — only an invitation to "
+            "wish them free of the suffering that hardens us all."
+        ),
+    ),
+    ReturnWeek(
+        week_number=5,
+        focus=MettaFocus.ALL_BEINGS,
+        title="The circle without an edge",
+        framing=(
+            "Let the warmth you have been growing spill past every boundary — "
+            "toward all beings, everywhere, without exception. However far it "
+            "reaches this week is exactly far enough."
+        ),
+    ),
+)
+
+
+def _highest_stage_reached(progress: StageProgress) -> int:
+    """Return the highest stage this user reached by advancement, not by calendar.
+
+    Advancement-granted stages are the current stage plus any historically
+    completed stages; the date-derived calendar unlock is deliberately excluded
+    so merely waiting can never confer eligibility.
+    """
+    return max({progress.current_stage, *progress.completed_stages})
+
+
+def is_return_eligible(progress: StageProgress | None) -> bool:
+    """Return True iff the user has passed Blue by advancement (never by calendar).
+
+    A user with no :class:`StageProgress` row has never advanced and is
+    ineligible. Otherwise eligibility holds when the highest stage reached by
+    advancement is at least :data:`RETURN_MINIMUM_STAGE`, or when the user is in
+    a second-or-later cycle (a full prior 10-stage cycle implies Blue was
+    passed, even mid-reset). This is a read-only check that never mutates
+    progress.
+    """
+    if progress is None:
+        return False
+    if progress.cycle_number >= _SECOND_CYCLE:
+        return True
+    return _highest_stage_reached(progress) >= RETURN_MINIMUM_STAGE
+
+
+def _normalize(moment: datetime) -> datetime:
+    """Strip tzinfo so naive (SQLite) and aware (Postgres) values compare.
+
+    Both dialects store UTC; only the tzinfo flag differs. Subtracting a mixed
+    naive/aware pair raises, so every elapsed-time computation funnels through
+    this, mirroring the program-calendar normalization.
+    """
+    return moment.replace(tzinfo=None) if moment.tzinfo else moment
+
+
+def _elapsed_days(anchor: datetime, now: datetime) -> int:
+    """Whole days since the anchor, floored at zero for clock skew."""
+    delta = _normalize(now) - _normalize(anchor)
+    return max(0, delta.days)
+
+
+def resumed_start(started_at: datetime, paused_at: datetime, now: datetime) -> datetime:
+    """Return ``started_at`` shifted forward by the elapsed pause duration.
+
+    Resuming a paused arc must not lose the frozen week: the time spent paused
+    is pushed onto the start so elapsed-since-start once again matches the
+    pre-pause elapsed. ``now`` and ``paused_at`` may carry different tzinfo
+    flags across SQLite (naive) and Postgres (aware), so both are normalized
+    before subtracting to form the pause duration, exactly as the elapsed-day
+    math does. The resulting timedelta is then added to the ORIGINAL
+    ``started_at`` — adding a timedelta preserves its tzinfo either way — so no
+    mixed naive/aware subtraction is ever performed.
+    """
+    paused_duration = _normalize(now) - _normalize(paused_at)
+    return started_at + paused_duration
+
+
+def active_return_week(started_at: datetime, paused_at: datetime | None, now: datetime) -> int:
+    """Return the 1-based Return week an arc sits in, clamped to the arc length.
+
+    Elapsed time is measured from ``started_at`` to the pause instant if the arc
+    is paused, otherwise to ``now`` — so a paused arc reports a frozen week that
+    ignores further elapsed time. The result is clamped to
+    ``[1, RETURN_WEEK_COUNT]`` so it never climbs past the arc. Mixed
+    naive/aware datetimes are normalized rather than raising.
+    """
+    reference = paused_at if paused_at is not None else now
+    week = _elapsed_days(started_at, reference) // DAYS_PER_WEEK + 1
+    return min(max(week, 1), RETURN_WEEK_COUNT)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -40,6 +40,7 @@ from routers.goals import router as goals_router
 from routers.habits import router as habits_router
 from routers.invitations import router as invitations_router
 from routers.journal import router as journal_router
+from routers.metta_return import router as metta_return_router
 from routers.practice_recipes import router as practice_recipes_router
 from routers.practice_sessions import router as practice_sessions_router
 from routers.practice_share import router as practice_share_router
@@ -444,6 +445,7 @@ app.include_router(stages_router)
 app.include_router(users_router)
 app.include_router(depth_preferences_router)
 app.include_router(invitations_router)
+app.include_router(metta_return_router)
 
 
 # BUG-APP-004: separate liveness from readiness so the orchestrator can

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -13,6 +13,7 @@ from .journal_entry import JournalEntry
 from .llm_usage_log import LLMUsageLog
 from .login_attempt import LoginAttempt
 from .marginalia import Marginalia
+from .metta_return_arc import MettaReturnArc
 from .password_reset_token import PasswordResetToken
 from .practice import Practice
 from .practice_recipe import PracticeRecipe, PracticeRecipeStep
@@ -43,6 +44,7 @@ __all__ = [
     "LLMUsageLog",
     "LoginAttempt",
     "Marginalia",
+    "MettaReturnArc",
     "PasswordResetToken",
     "Practice",
     "PracticeRecipe",

--- a/backend/src/models/metta_return_arc.py
+++ b/backend/src/models/metta_return_arc.py
@@ -1,0 +1,63 @@
+"""The persisted state of a user's Return arc — a declinable Metta rest.
+
+A ``MettaReturnArc`` row records that a user accepted the five-week Return
+(see :mod:`domain.metta_return`): when it started, whether it is currently
+paused, and when — if ever — the user left it. The arc is entirely opt-in and
+carries no penalty: pausing, resuming, and leaving are all first-class,
+never-shaming actions, and nothing in this table gates or mutates a user's
+stage progress.
+
+At most one *active* arc (``left_at IS NULL``) may exist per user, enforced by a
+partial unique index. Leaving sets ``left_at``, which frees that slot so a fresh
+arc can be started later. A non-unique owner index keeps "this user's arcs" a
+range scan.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Index
+from sqlmodel import Field, SQLModel
+
+# Bound at module scope so :class:`Index`'s ``*_where`` predicate can resolve the
+# column at table-creation time. Both Postgres and SQLite accept the same
+# ``IS NULL`` form, so the partial unique index renders on the test SQLite DB
+# via ``metadata.create_all`` and stays drift-free against the migration.
+_LEFT_AT_COLUMN = Column("left_at", DateTime(timezone=True), nullable=True)
+
+
+class MettaReturnArc(SQLModel, table=True):
+    """One user's Return arc lifecycle row.
+
+    The partial unique index ``ix_metta_return_arc_user_active`` on ``user_id``
+    WHERE ``left_at IS NULL`` guarantees a single live arc per user while
+    permitting any number of previously-left arcs, so leaving and restarting is
+    always allowed. Declaring the predicate with both ``postgresql_where`` and
+    ``sqlite_where`` keeps the metadata aligned with the migration so
+    ``alembic check`` sees no drift and ``metadata.create_all`` installs the
+    same constraint on the test SQLite DB.
+    """
+
+    __table_args__ = (
+        Index(
+            "ix_metta_return_arc_user_active",
+            "user_id",
+            unique=True,
+            postgresql_where=_LEFT_AT_COLUMN.is_(None),
+            sqlite_where=_LEFT_AT_COLUMN.is_(None),
+        ),
+        Index("ix_metta_return_arc_user_id", "user_id"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
+    started_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    paused_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    left_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )

--- a/backend/src/routers/metta_return.py
+++ b/backend/src/routers/metta_return.py
@@ -1,0 +1,214 @@
+"""The Return arc lifecycle endpoints (/metta-return).
+
+The Return is a declinable five-week Metta arc, offered only once Blue stage has
+been passed (see :func:`domain.metta_return.is_return_eligible`). Accepting it
+starts a guided arc the caller can pause, resume, or leave at any time with no
+penalty. Every action is scoped to the caller resolved from the JWT — no
+``user_id`` is ever accepted from the body or path, nor returned — and none of
+the lifecycle actions mutate :class:`StageProgress`.
+
+``GET`` is read-only: it reads (never provisions) stage progress to report
+eligibility and projects the caller's active arc, if any. The write handlers
+select the caller's active arc ``FOR UPDATE`` so concurrent lifecycle calls
+serialize, and an arc the caller does not own is indistinguishable from a
+missing one — both raise the same 404.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from database import get_session
+from domain.metta_return import (
+    RETURN_SEQUENCE,
+    active_return_week,
+    is_return_eligible,
+    resumed_start,
+)
+from domain.stage_progress import get_user_progress
+from errors import conflict, not_found
+from models.metta_return_arc import MettaReturnArc
+from routers.auth import get_current_user
+from schemas.metta_return import (
+    MettaReturnStateResponse,
+    ReturnArcResponse,
+    ReturnWeekResponse,
+)
+
+router = APIRouter(prefix="/metta-return", tags=["metta-return"])
+
+
+def _week_focus(week: int) -> str:
+    """Return the focus string for a 1-based Return week."""
+    return RETURN_SEQUENCE[week - 1].focus.value
+
+
+def _to_arc_response(arc: MettaReturnArc, now: datetime) -> ReturnArcResponse:
+    """Project an arc row onto its owner-key-free DTO with the current week."""
+    week = active_return_week(arc.started_at, arc.paused_at, now)
+    return ReturnArcResponse(
+        started_at=arc.started_at,
+        paused=arc.paused_at is not None,
+        week=week,
+        focus=_week_focus(week),
+    )
+
+
+def _sequence_response() -> list[ReturnWeekResponse]:
+    """Project the whole Return sequence onto its DTO list, in week order."""
+    return [
+        ReturnWeekResponse(
+            week_number=week.week_number,
+            focus=week.focus.value,
+            title=week.title,
+            framing=week.framing,
+        )
+        for week in RETURN_SEQUENCE
+    ]
+
+
+async def _active_arc_for_update(session: AsyncSession, user_id: int) -> MettaReturnArc | None:
+    """Return the caller's active (``left_at IS NULL``) arc under a row lock, or None.
+
+    Selecting by owner *and* active-ness in one ``FOR UPDATE`` query means a
+    caller can only ever lock their own arc: another user's arc is invisible
+    here, so cross-user lifecycle calls fall through to the same 404 as a
+    genuinely missing arc.
+    """
+    result = await session.execute(
+        select(MettaReturnArc)
+        .where(
+            col(MettaReturnArc.user_id) == user_id,
+            col(MettaReturnArc.left_at).is_(None),
+        )
+        .with_for_update()
+    )
+    return result.scalars().first()
+
+
+@router.get("", response_model=MettaReturnStateResponse)
+async def get_state(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> MettaReturnStateResponse:
+    """Return the caller's eligibility, the full week sequence, and their active arc.
+
+    Read-only: stage progress is fetched (never provisioned), so a brand-new
+    user's row is not created as a side effect. ``arc`` is the caller's active
+    arc projected to its current week, or ``None`` when there is none.
+    """
+    progress = await get_user_progress(session, user_id)
+    arc = await _active_arc_for_update(session, user_id)
+    now = datetime.now(UTC)
+    return MettaReturnStateResponse(
+        eligible=is_return_eligible(progress),
+        weeks=_sequence_response(),
+        arc=_to_arc_response(arc, now) if arc is not None else None,
+    )
+
+
+@router.post("/arc", status_code=status.HTTP_201_CREATED, response_model=ReturnArcResponse)
+async def start_arc(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ReturnArcResponse:
+    """Start a Return arc for an eligible caller, landing on week 1 (focus self).
+
+    Rejected with 409 when the caller has not passed Blue or already has an
+    active arc, so a duplicate is never created. On success a fresh arc is
+    inserted with ``started_at`` at the current UTC instant. Two truly
+    concurrent starts both clear the pre-check (there is no row to lock yet), so
+    the partial-unique active-arc index is the real guard: the loser's insert
+    raises ``IntegrityError``, which is caught and collapsed to the same 409 the
+    sequential path returns.
+    """
+    progress = await get_user_progress(session, user_id)
+    if not is_return_eligible(progress):
+        raise conflict("return_not_eligible")
+    if await _active_arc_for_update(session, user_id) is not None:
+        raise conflict("return_arc_already_active")
+    now = datetime.now(UTC)
+    arc = MettaReturnArc(user_id=user_id, started_at=now)
+    session.add(arc)
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise conflict("return_arc_already_active") from exc
+    await session.refresh(arc)
+    return _to_arc_response(arc, now)
+
+
+@router.post("/arc/pause", response_model=ReturnArcResponse)
+async def pause_arc(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ReturnArcResponse:
+    """Pause the caller's active arc, freezing its reported week; idempotent.
+
+    Raises 404 when the caller has no active arc. Pausing an already-paused arc
+    is a 200 no-op that keeps the original pause instant, so the frozen week
+    does not drift.
+    """
+    arc = await _active_arc_for_update(session, user_id)
+    if arc is None:
+        raise not_found("return_arc")
+    now = datetime.now(UTC)
+    if arc.paused_at is None:
+        arc.paused_at = now
+        session.add(arc)
+        await session.commit()
+        await session.refresh(arc)
+    return _to_arc_response(arc, now)
+
+
+@router.post("/arc/resume", response_model=ReturnArcResponse)
+async def resume_arc(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ReturnArcResponse:
+    """Resume the caller's paused arc so its week advances again; idempotent.
+
+    Raises 404 when the caller has no active arc. Resuming shifts ``started_at``
+    forward by the paused duration so no elapsed weeks are lost, then clears the
+    pause. Resuming an arc that is not paused is a 200 no-op.
+    """
+    arc = await _active_arc_for_update(session, user_id)
+    if arc is None:
+        raise not_found("return_arc")
+    now = datetime.now(UTC)
+    if arc.paused_at is not None:
+        arc.started_at = resumed_start(arc.started_at, arc.paused_at, now)
+        arc.paused_at = None
+        session.add(arc)
+        await session.commit()
+        await session.refresh(arc)
+    return _to_arc_response(arc, now)
+
+
+@router.post("/arc/leave", response_model=ReturnArcResponse)
+async def leave_arc(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ReturnArcResponse:
+    """Leave the caller's active arc, returning its final projected state.
+
+    Raises 404 when the caller has no active arc. Setting ``left_at`` frees the
+    partial-unique slot, so the arc no longer counts as active and a fresh arc
+    can be started afterward.
+    """
+    arc = await _active_arc_for_update(session, user_id)
+    if arc is None:
+        raise not_found("return_arc")
+    now = datetime.now(UTC)
+    arc.left_at = now
+    session.add(arc)
+    await session.commit()
+    await session.refresh(arc)
+    return _to_arc_response(arc, now)

--- a/backend/src/routers/metta_return.py
+++ b/backend/src/routers/metta_return.py
@@ -73,6 +73,24 @@ def _sequence_response() -> list[ReturnWeekResponse]:
     ]
 
 
+async def _active_arc(session: AsyncSession, user_id: int) -> MettaReturnArc | None:
+    """Return the caller's active (``left_at IS NULL``) arc, or None — no row lock.
+
+    Used by the read-only ``GET`` handler, which never writes: it must not take
+    the exclusive ``FOR UPDATE`` lock the write handlers use, or concurrent GETs
+    from one caller would serialize on that caller's arc row for no reason.
+    Selecting by owner *and* active-ness means another user's arc is invisible
+    here, mirroring :func:`_active_arc_for_update`.
+    """
+    result = await session.execute(
+        select(MettaReturnArc).where(
+            col(MettaReturnArc.user_id) == user_id,
+            col(MettaReturnArc.left_at).is_(None),
+        ),
+    )
+    return result.scalars().first()
+
+
 async def _active_arc_for_update(session: AsyncSession, user_id: int) -> MettaReturnArc | None:
     """Return the caller's active (``left_at IS NULL``) arc under a row lock, or None.
 
@@ -104,7 +122,7 @@ async def get_state(
     arc projected to its current week, or ``None`` when there is none.
     """
     progress = await get_user_progress(session, user_id)
-    arc = await _active_arc_for_update(session, user_id)
+    arc = await _active_arc(session, user_id)
     now = datetime.now(UTC)
     return MettaReturnStateResponse(
         eligible=is_return_eligible(progress),

--- a/backend/src/schemas/metta_return.py
+++ b/backend/src/schemas/metta_return.py
@@ -1,0 +1,53 @@
+"""Response schemas for the Return (Metta arc) endpoints.
+
+The Return is a declinable five-week arc offered as a skillful rest. These DTOs
+project the sequence, the caller's eligibility, and the caller's active arc.
+``user_id`` and the surrogate row ``id`` are intentionally excluded — the caller
+knows its own identity from the JWT, and surfacing the owner key would aid
+enumeration.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ReturnWeekResponse(BaseModel):
+    """One week of the Return arc projected for the caller.
+
+    Carries the focus of loving-kindness plus its warm, non-shaming title and
+    framing copy — a Return week is a gentle pacing hint, never a deadline.
+    """
+
+    week_number: int
+    focus: str
+    title: str
+    framing: str
+
+
+class ReturnArcResponse(BaseModel):
+    """The caller's active Return arc, without any owner key.
+
+    ``week`` is the arc's current (or, when paused, frozen) week; ``paused``
+    reflects whether the arc is resting. No ``user_id`` or row ``id`` is exposed.
+    """
+
+    started_at: datetime
+    paused: bool
+    week: int
+    focus: str
+
+
+class MettaReturnStateResponse(BaseModel):
+    """The full Return surface for the caller.
+
+    ``eligible`` gates whether the arc may be started, ``weeks`` is the whole
+    five-week sequence in order, and ``arc`` is the caller's active arc or
+    ``None`` when there is none.
+    """
+
+    eligible: bool
+    weeks: list[ReturnWeekResponse]
+    arc: ReturnArcResponse | None

--- a/backend/tests/domain/test_metta_return.py
+++ b/backend/tests/domain/test_metta_return.py
@@ -1,0 +1,280 @@
+"""Pure-domain tests for the Metta "Return" arc sequence and eligibility.
+
+These tests FAIL on import until the implementation-specialist creates
+``backend/src/domain/metta_return.py`` with the contracts pinned below.
+That is the correct RED state for Gate 1.
+
+Pinned public surface:
+  MettaFocus(StrEnum): self, benefactor, stranger, antagonist, all_beings
+  ReturnWeek(week_number: int, focus: MettaFocus, title: str, framing: str)
+  RETURN_SEQUENCE: tuple[ReturnWeek, ...]  (5 entries, ordered)
+  RETURN_WEEK_COUNT = 5
+  RETURN_MINIMUM_STAGE = 5
+  DAYS_PER_WEEK = 7
+  is_return_eligible(progress: StageProgress | None) -> bool
+  active_return_week(started_at, paused_at, now) -> int
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from domain.metta_return import (
+    DAYS_PER_WEEK,
+    RETURN_MINIMUM_STAGE,
+    RETURN_SEQUENCE,
+    RETURN_WEEK_COUNT,
+    MettaFocus,
+    ReturnWeek,
+    active_return_week,
+    is_return_eligible,
+    resumed_start,
+)
+from models.stage_progress import StageProgress
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_return_week_count_constant_matches_sequence_length() -> None:
+    """RETURN_WEEK_COUNT pins the arc to exactly five weeks."""
+    assert RETURN_WEEK_COUNT == 5
+    assert len(RETURN_SEQUENCE) == RETURN_WEEK_COUNT
+
+
+def test_return_minimum_stage_is_orange() -> None:
+    """RETURN_MINIMUM_STAGE pins eligibility to Stage 5 (Orange) or higher."""
+    assert RETURN_MINIMUM_STAGE == 5
+
+
+def test_days_per_week_constant() -> None:
+    """DAYS_PER_WEEK pins the week-length used by active_return_week."""
+    assert DAYS_PER_WEEK == 7
+
+
+# ---------------------------------------------------------------------------
+# RETURN_SEQUENCE shape
+# ---------------------------------------------------------------------------
+
+
+def test_return_sequence_has_five_entries_in_week_order() -> None:
+    """Weeks are numbered 1..5 in ascending, contiguous order."""
+    week_numbers = [week.week_number for week in RETURN_SEQUENCE]
+    assert week_numbers == [1, 2, 3, 4, 5]
+
+
+def test_return_sequence_focus_progression() -> None:
+    """The owner-specified focus progression: self, benefactor, stranger, antagonist, all beings."""
+    expected = [
+        MettaFocus.SELF,
+        MettaFocus.BENEFACTOR,
+        MettaFocus.STRANGER,
+        MettaFocus.ANTAGONIST,
+        MettaFocus.ALL_BEINGS,
+    ]
+    actual = [week.focus for week in RETURN_SEQUENCE]
+    assert actual == expected
+
+
+def test_return_sequence_titles_and_framings_are_non_empty() -> None:
+    """Every week carries a real title and framing string, not a placeholder."""
+    for week in RETURN_SEQUENCE:
+        assert week.title.strip() != ""
+        assert week.framing.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# Eligibility gate for offering the Return.
+# ---------------------------------------------------------------------------
+
+
+def test_eligibility_none_progress_is_ineligible() -> None:
+    """A user with no StageProgress row has never advanced — ineligible."""
+    assert is_return_eligible(None) is False
+
+
+def test_eligibility_stage_three_is_ineligible() -> None:
+    """Well below the Blue-passed threshold."""
+    progress = StageProgress(user_id=1, current_stage=3, completed_stages=[])
+    assert is_return_eligible(progress) is False
+
+
+def test_eligibility_stage_four_in_progress_is_ineligible() -> None:
+    """Currently working Blue (stage 4) — Blue has not yet been passed."""
+    progress = StageProgress(user_id=1, current_stage=4, completed_stages=[1, 2, 3])
+    assert is_return_eligible(progress) is False
+
+
+def test_eligibility_stage_five_current_is_eligible() -> None:
+    """Reaching Orange (stage 5) means Blue was passed to get there."""
+    progress = StageProgress(user_id=1, current_stage=5, completed_stages=[1, 2, 3, 4])
+    assert is_return_eligible(progress) is True
+
+
+def test_eligibility_completed_stages_containing_five_is_eligible() -> None:
+    """A historical completed_stages record of reaching stage 5+ counts."""
+    progress = StageProgress(user_id=1, current_stage=6, completed_stages=[1, 2, 3, 4, 5])
+    assert is_return_eligible(progress) is True
+
+
+def test_eligibility_second_cycle_counts_even_at_stage_one() -> None:
+    """A full prior cycle (cycle_number >= 2) implies Blue was passed, even mid-reset."""
+    progress = StageProgress(user_id=1, current_stage=1, completed_stages=[], cycle_number=2)
+    assert is_return_eligible(progress) is True
+
+
+# ---------------------------------------------------------------------------
+# Week derivation from elapsed and paused time.
+# ---------------------------------------------------------------------------
+
+
+def test_active_return_week_day_zero_is_week_one() -> None:
+    """No elapsed time — the arc starts in week 1."""
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    assert active_return_week(now, None, now) == 1
+
+
+def test_active_return_week_day_seven_rolls_to_week_two() -> None:
+    """A full seven days elapsed advances to week 2."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = started_at + timedelta(days=7)
+    assert active_return_week(started_at, None, now) == 2
+
+
+def test_active_return_week_day_eight_is_still_week_two() -> None:
+    """Eight elapsed days is within week 2, not yet week 3."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = started_at + timedelta(days=8)
+    assert active_return_week(started_at, None, now) == 2
+
+
+def test_active_return_week_day_thirty_four_is_week_five() -> None:
+    """Day 34 (weeks 5's interior) lands on week 5."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = started_at + timedelta(days=34)
+    assert active_return_week(started_at, None, now) == 5
+
+
+def test_active_return_week_clamps_past_five_weeks() -> None:
+    """Far beyond the arc length, the week clamps to 5 rather than climbing forever."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = started_at + timedelta(days=100)
+    assert active_return_week(started_at, None, now) == 5
+
+
+def test_active_return_week_paused_freezes_at_pause_time() -> None:
+    """A paused arc reports the week it was paused at, ignoring further elapsed time."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    paused_at = started_at + timedelta(days=10)  # inside week 2
+    now = started_at + timedelta(days=40)  # would otherwise be week 5+
+    assert active_return_week(started_at, paused_at, now) == 2
+
+
+def test_active_return_week_handles_naive_and_aware_datetime_mix() -> None:
+    """Mixed naive/aware inputs must not raise (mirrors program_calendar normalization)."""
+    started_at_naive = datetime(2026, 1, 1)  # noqa: DTZ001 - deliberately naive
+    now_aware = datetime(2026, 1, 8, tzinfo=UTC)
+    week = active_return_week(started_at_naive, None, now_aware)
+    assert week == 2
+
+
+# ---------------------------------------------------------------------------
+# resumed_start
+# ---------------------------------------------------------------------------
+
+
+def test_resumed_start_shifts_start_forward_by_pause_duration() -> None:
+    """Resuming pushes started_at forward by exactly the time spent paused.
+
+    With started_at = T, paused_at = T+2d and now = T+5d (three paused days),
+    the shifted start is T+3d, so elapsed-since-shifted-start at now equals the
+    two pre-pause days — the frozen week is preserved and ticks from there.
+    """
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    paused_at = started_at + timedelta(days=2)
+    now = started_at + timedelta(days=5)
+    resumed = resumed_start(started_at, paused_at, now)
+    assert resumed == started_at + timedelta(days=3)
+    # Elapsed since the shifted start equals the pre-pause elapsed (2 days).
+    assert active_return_week(resumed, None, now) == active_return_week(
+        started_at, paused_at, paused_at
+    )
+
+
+def test_resumed_start_preserves_frozen_week_after_resume() -> None:
+    """A week frozen at pause resumes at that same week and ticks onward.
+
+    Paused inside week 2 (day 10) then resumed a long time later, the arc still
+    reports week 2 immediately at resume, and advances one week after a further
+    seven days — no elapsed weeks are lost or gained across the pause.
+    """
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    paused_at = started_at + timedelta(days=10)  # inside week 2
+    now = started_at + timedelta(days=40)
+    resumed = resumed_start(started_at, paused_at, now)
+    assert active_return_week(resumed, None, now) == 2
+    assert active_return_week(resumed, None, now + timedelta(days=7)) == 3
+
+
+def test_resumed_start_handles_naive_and_aware_datetime_mix() -> None:
+    """Mixed naive/aware inputs must not raise and yield the same day-delta."""
+    started_at_naive = datetime(2026, 1, 1)  # noqa: DTZ001 - deliberately naive
+    paused_at_naive = datetime(2026, 1, 3)  # noqa: DTZ001 - deliberately naive
+    now_aware = datetime(2026, 1, 6, tzinfo=UTC)
+    resumed = resumed_start(started_at_naive, paused_at_naive, now_aware)
+    # Three paused days push the start to Jan 4; week stays frozen at week 1.
+    assert resumed == started_at_naive + timedelta(days=3)
+    assert active_return_week(resumed, None, now_aware) == 1
+
+
+# ---------------------------------------------------------------------------
+# Copy guard: the Return must never rank, shame, or penalize
+# ---------------------------------------------------------------------------
+
+# Words/phrases that would turn a declinable invitation into gamified
+# pressure or moral judgment. This is an intent rule, not a fragile literal
+# check: any future week copy is held to the same non-shaming standard the
+# product principle ("you choose your depth") requires.
+_BANNED_VOCABULARY: tuple[str, ...] = (
+    "fail",
+    "failure",
+    "shame",
+    "behind",
+    "penalty",
+    "penalized",
+    "rank",
+    "ranked",
+    "should have",
+    "catch up",
+    "fell",
+    "fell behind",
+    "lost",
+    "loser",
+    "weak",
+    "quitter",
+    "giving up",
+)
+
+_BANNED_PATTERN = re.compile(
+    "|".join(re.escape(word) for word in _BANNED_VOCABULARY),
+    re.IGNORECASE,
+)
+
+
+@pytest.mark.parametrize("week", RETURN_SEQUENCE, ids=lambda w: f"week_{w.week_number}")
+def test_return_week_copy_never_ranks_or_shames(week: ReturnWeek) -> None:
+    """No week's title or framing contains shaming, ranking, or penalty language.
+
+    The Return is an explicitly declinable invitation — pause/resume/leave
+    carry no penalty. Copy that implies falling behind, failing, or being
+    ranked would contradict that guarantee, so this guards the whole
+    banned-vocabulary surface rather than one hard-coded phrase.
+    """
+    assert _BANNED_PATTERN.search(week.title) is None, f"banned word found in title: {week.title!r}"
+    assert _BANNED_PATTERN.search(week.framing) is None, (
+        f"banned word found in framing: {week.framing!r}"
+    )

--- a/backend/tests/routers/test_metta_return.py
+++ b/backend/tests/routers/test_metta_return.py
@@ -1,0 +1,550 @@
+"""Tests for the Metta "Return" arc lifecycle endpoints (/metta-return).
+
+These tests FAIL on import/collection until the implementation-specialist
+creates ``backend/src/routers/metta_return.py`` (and the supporting model /
+schemas) and mounts the router in ``backend/src/main.py``. That is the
+correct RED state for Gate 1.
+
+The Return is a declinable five-week Metta arc, offered only after Blue
+Stage has been passed (highest stage reached >= 5). Accepting it starts a
+guided arc the user can pause/resume/leave at any time with no penalty, and
+none of the lifecycle actions ever mutate StageProgress.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.metta_return_arc import MettaReturnArc
+from models.stage_progress import StageProgress
+from models.user import User
+from routers import metta_return as metta_return_router
+
+_BASE_URL = "/metta-return"
+_START_URL = f"{_BASE_URL}/arc"
+_PAUSE_URL = f"{_BASE_URL}/arc/pause"
+_RESUME_URL = f"{_BASE_URL}/arc/resume"
+_LEAVE_URL = f"{_BASE_URL}/arc/leave"
+_FORBIDDEN_KEY = "user_id"
+_ELIGIBLE_STAGE = 5
+_INELIGIBLE_STAGE = 3
+
+
+# ---------------------------------------------------------------------------
+# Auth + seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _signup(client: AsyncClient, username: str) -> dict[str, str]:
+    """Create an account and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _get_user(session: AsyncSession, email: str) -> User:
+    """Look up a signed-up user row by email."""
+    result = await session.execute(select(User).where(col(User.email) == email))
+    return result.scalars().one()
+
+
+async def _seed_progress(
+    session: AsyncSession,
+    user_id: int,
+    *,
+    current_stage: int,
+    completed_stages: list[int] | None = None,
+    cycle_number: int = 1,
+) -> StageProgress:
+    """Insert a StageProgress row for a user at the given stage."""
+    progress = StageProgress(
+        user_id=user_id,
+        current_stage=current_stage,
+        completed_stages=completed_stages or [],
+        cycle_number=cycle_number,
+    )
+    session.add(progress)
+    await session.commit()
+    await session.refresh(progress)
+    return progress
+
+
+async def _seed_active_arc(
+    session: AsyncSession,
+    user_id: int,
+    *,
+    started_at: datetime,
+    paused_at: datetime | None = None,
+) -> MettaReturnArc:
+    """Insert an active (not-left) MettaReturnArc row directly."""
+    arc = MettaReturnArc(user_id=user_id, started_at=started_at, paused_at=paused_at)
+    session.add(arc)
+    await session.commit()
+    await session.refresh(arc)
+    return arc
+
+
+# ---------------------------------------------------------------------------
+# 1. Auth: 401 unauthenticated on all five routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_state_requires_auth(async_client: AsyncClient) -> None:
+    """GET /metta-return without a token returns 401."""
+    resp = await async_client.get(_BASE_URL)
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_start_arc_requires_auth(async_client: AsyncClient) -> None:
+    """POST /metta-return/arc without a token returns 401."""
+    resp = await async_client.post(_START_URL)
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_pause_arc_requires_auth(async_client: AsyncClient) -> None:
+    """POST /metta-return/arc/pause without a token returns 401."""
+    resp = await async_client.post(_PAUSE_URL)
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_resume_arc_requires_auth(async_client: AsyncClient) -> None:
+    """POST /metta-return/arc/resume without a token returns 401."""
+    resp = await async_client.post(_RESUME_URL)
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_leave_arc_requires_auth(async_client: AsyncClient) -> None:
+    """POST /metta-return/arc/leave without a token returns 401."""
+    resp = await async_client.post(_LEAVE_URL)
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# 2. GET shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_state_shape_no_active_arc(async_client: AsyncClient) -> None:
+    """GET returns eligible flag, the 5-week sequence in order, and a null arc."""
+    headers = await _signup(async_client, "mr_shape1")
+
+    resp = await async_client.get(_BASE_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert isinstance(body["eligible"], bool)
+    assert len(body["weeks"]) == 5
+    assert [w["week_number"] for w in body["weeks"]] == [1, 2, 3, 4, 5]
+    assert body["arc"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_state_never_exposes_user_id(async_client: AsyncClient) -> None:
+    """No response payload (top level, weeks, or arc) leaks a user_id key."""
+    headers = await _signup(async_client, "mr_noleak2")
+
+    resp = await async_client.get(_BASE_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert _FORBIDDEN_KEY not in body
+    for week in body["weeks"]:
+        assert _FORBIDDEN_KEY not in week
+    if body["arc"] is not None:
+        assert _FORBIDDEN_KEY not in body["arc"]
+
+
+@pytest.mark.asyncio
+async def test_get_state_does_not_provision_stage_progress(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET is read-only: a brand-new user's StageProgress row must not be created."""
+    headers = await _signup(async_client, "mr_noprovision3")
+    user = await _get_user(db_session, "mr_noprovision3@example.com")
+    assert user.id is not None
+    user_id = user.id
+
+    resp = await async_client.get(_BASE_URL, headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+    db_session.expire_all()
+    result = await db_session.execute(
+        select(StageProgress).where(col(StageProgress.user_id) == user_id)
+    )
+    assert result.scalars().first() is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Start: eligibility gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_arc_eligible_user_returns_week_one_self(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """An eligible user (stage 5+) starting an arc lands on week 1, focus self."""
+    headers = await _signup(async_client, "mr_start4")
+    user = await _get_user(db_session, "mr_start4@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+
+    resp = await async_client.post(_START_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.CREATED
+    body = resp.json()
+    assert body["week"] == 1
+    assert body["focus"] == "self"
+    assert body["paused"] is False
+    assert _FORBIDDEN_KEY not in body
+
+
+@pytest.mark.asyncio
+async def test_start_arc_ineligible_user_returns_409(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A user below the Blue-passed threshold cannot start the arc; no row persists."""
+    headers = await _signup(async_client, "mr_ineligible5")
+    user = await _get_user(db_session, "mr_ineligible5@example.com")
+    assert user.id is not None
+    user_id = user.id
+    await _seed_progress(db_session, user_id, current_stage=_INELIGIBLE_STAGE)
+
+    resp = await async_client.post(_START_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.CONFLICT
+
+    db_session.expire_all()
+    result = await db_session.execute(
+        select(MettaReturnArc).where(col(MettaReturnArc.user_id) == user_id)
+    )
+    assert result.scalars().first() is None
+
+
+@pytest.mark.asyncio
+async def test_start_arc_twice_while_active_returns_409(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A second start while an arc is already active is rejected, not duplicated."""
+    headers = await _signup(async_client, "mr_double6")
+    user = await _get_user(db_session, "mr_double6@example.com")
+    assert user.id is not None
+    user_id = user.id
+    await _seed_progress(db_session, user_id, current_stage=_ELIGIBLE_STAGE)
+
+    first = await async_client.post(_START_URL, headers=headers)
+    assert first.status_code == HTTPStatus.CREATED
+
+    second = await async_client.post(_START_URL, headers=headers)
+    assert second.status_code == HTTPStatus.CONFLICT
+
+    db_session.expire_all()
+    result = await db_session.execute(
+        select(MettaReturnArc).where(
+            col(MettaReturnArc.user_id) == user_id,
+            col(MettaReturnArc.left_at).is_(None),
+        )
+    )
+    assert len(list(result.scalars().all())) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_arc_losing_a_concurrent_race_returns_409(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When two starts race, the loser's insert hits the unique index and 409s.
+
+    The pre-check cannot lock a not-yet-existing row, so a truly concurrent
+    start can slip past it. Forcing the pre-check to see no active arc while one
+    already exists exercises the partial-unique-index guard: the insert raises
+    IntegrityError, which the handler collapses to the same 409, never a 500.
+    """
+    headers = await _signup(async_client, "mr_race16")
+    user = await _get_user(db_session, "mr_race16@example.com")
+    assert user.id is not None
+    user_id = user.id
+    await _seed_progress(db_session, user_id, current_stage=_ELIGIBLE_STAGE)
+    await _seed_active_arc(db_session, user_id, started_at=datetime.now(UTC))
+
+    async def _pretend_no_active_arc(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(metta_return_router, "_active_arc_for_update", _pretend_no_active_arc)
+
+    resp = await async_client.post(_START_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.CONFLICT
+    assert resp.json()["detail"] == "return_arc_already_active"
+
+
+# ---------------------------------------------------------------------------
+# 4. Pause / resume lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pause_freezes_week_and_resume_ticks_again(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Pausing an arc freezes the reported week; resuming lets it advance again."""
+    headers = await _signup(async_client, "mr_pauseresume7")
+    user = await _get_user(db_session, "mr_pauseresume7@example.com")
+    assert user.id is not None
+    user_id = user.id
+    await _seed_progress(db_session, user_id, current_stage=_ELIGIBLE_STAGE)
+
+    # Back-dated start: 10 days in, so unpaused week would be 2.
+    started_at = datetime.now(UTC) - timedelta(days=10)
+    await _seed_active_arc(db_session, user_id, started_at=started_at)
+
+    pause_resp = await async_client.post(_PAUSE_URL, headers=headers)
+    assert pause_resp.status_code == HTTPStatus.OK
+    assert pause_resp.json()["paused"] is True
+    frozen_week = pause_resp.json()["week"]
+
+    get_resp = await async_client.get(_BASE_URL, headers=headers)
+    assert get_resp.status_code == HTTPStatus.OK
+    assert get_resp.json()["arc"]["week"] == frozen_week
+    assert get_resp.json()["arc"]["paused"] is True
+
+    resume_resp = await async_client.post(_RESUME_URL, headers=headers)
+    assert resume_resp.status_code == HTTPStatus.OK
+    assert resume_resp.json()["paused"] is False
+
+
+@pytest.mark.asyncio
+async def test_pause_when_already_paused_is_idempotent_no_op(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Pausing an already-paused arc returns 200 without changing its frozen week."""
+    headers = await _signup(async_client, "mr_pauseidem8")
+    user = await _get_user(db_session, "mr_pauseidem8@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+
+    started_at = datetime.now(UTC) - timedelta(days=10)
+    paused_at = datetime.now(UTC) - timedelta(days=3)
+    await _seed_active_arc(db_session, user.id, started_at=started_at, paused_at=paused_at)
+
+    first = await async_client.post(_PAUSE_URL, headers=headers)
+    assert first.status_code == HTTPStatus.OK
+    second = await async_client.post(_PAUSE_URL, headers=headers)
+    assert second.status_code == HTTPStatus.OK
+    assert second.json()["week"] == first.json()["week"]
+    assert second.json()["paused"] is True
+
+
+@pytest.mark.asyncio
+async def test_resume_when_not_paused_is_idempotent_no_op(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Resuming an arc that is not paused returns 200 without altering its state."""
+    headers = await _signup(async_client, "mr_resumeidem9")
+    user = await _get_user(db_session, "mr_resumeidem9@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+
+    started_at = datetime.now(UTC) - timedelta(days=2)
+    await _seed_active_arc(db_session, user.id, started_at=started_at)
+
+    resp = await async_client.post(_RESUME_URL, headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["paused"] is False
+
+
+@pytest.mark.asyncio
+async def test_pause_without_active_arc_returns_404(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Pausing with no active arc returns 404."""
+    headers = await _signup(async_client, "mr_pause404_10")
+    user = await _get_user(db_session, "mr_pause404_10@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+
+    resp = await async_client.post(_PAUSE_URL, headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_resume_without_active_arc_returns_404(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Resuming with no active arc returns 404."""
+    headers = await _signup(async_client, "mr_resume404_11")
+    user = await _get_user(db_session, "mr_resume404_11@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+
+    resp = await async_client.post(_RESUME_URL, headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# 5. Leave lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_leave_removes_arc_from_get_and_blocks_further_lifecycle(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """After leaving, GET shows no arc and pause/resume/leave all 404."""
+    headers = await _signup(async_client, "mr_leave12")
+    user = await _get_user(db_session, "mr_leave12@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+    await _seed_active_arc(db_session, user.id, started_at=datetime.now(UTC))
+
+    leave_resp = await async_client.post(_LEAVE_URL, headers=headers)
+    assert leave_resp.status_code == HTTPStatus.OK
+
+    get_resp = await async_client.get(_BASE_URL, headers=headers)
+    assert get_resp.status_code == HTTPStatus.OK
+    assert get_resp.json()["arc"] is None
+
+    assert (await async_client.post(_PAUSE_URL, headers=headers)).status_code == (
+        HTTPStatus.NOT_FOUND
+    )
+    assert (await async_client.post(_RESUME_URL, headers=headers)).status_code == (
+        HTTPStatus.NOT_FOUND
+    )
+    assert (await async_client.post(_LEAVE_URL, headers=headers)).status_code == (
+        HTTPStatus.NOT_FOUND
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_again_after_leave_succeeds(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Leaving frees the partial-unique slot: a fresh arc can be started afterward."""
+    headers = await _signup(async_client, "mr_restart13")
+    user = await _get_user(db_session, "mr_restart13@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+    await _seed_active_arc(db_session, user.id, started_at=datetime.now(UTC))
+
+    leave_resp = await async_client.post(_LEAVE_URL, headers=headers)
+    assert leave_resp.status_code == HTTPStatus.OK
+
+    restart_resp = await async_client.post(_START_URL, headers=headers)
+    assert restart_resp.status_code == HTTPStatus.CREATED
+    assert restart_resp.json()["week"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. Cross-user isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_user_lifecycle_posts_return_404_never_mutate_other_arc(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """User B's pause/resume/leave never touches user A's active arc."""
+    alice_headers = await _signup(async_client, "mr_alice14")
+    bob_headers = await _signup(async_client, "mr_bob14")
+
+    alice = await _get_user(db_session, "mr_alice14@example.com")
+    bob = await _get_user(db_session, "mr_bob14@example.com")
+    assert alice.id is not None
+    assert bob.id is not None
+
+    await _seed_progress(db_session, alice.id, current_stage=_ELIGIBLE_STAGE)
+    await _seed_progress(db_session, bob.id, current_stage=_ELIGIBLE_STAGE)
+    await _seed_active_arc(db_session, alice.id, started_at=datetime.now(UTC))
+
+    assert (await async_client.post(_PAUSE_URL, headers=bob_headers)).status_code == (
+        HTTPStatus.NOT_FOUND
+    )
+    assert (await async_client.post(_RESUME_URL, headers=bob_headers)).status_code == (
+        HTTPStatus.NOT_FOUND
+    )
+    assert (await async_client.post(_LEAVE_URL, headers=bob_headers)).status_code == (
+        HTTPStatus.NOT_FOUND
+    )
+
+    # Alice's arc remains untouched: still active, unpaused.
+    alice_get = await async_client.get(_BASE_URL, headers=alice_headers)
+    assert alice_get.status_code == HTTPStatus.OK
+    assert alice_get.json()["arc"] is not None
+    assert alice_get.json()["arc"]["paused"] is False
+
+
+# ---------------------------------------------------------------------------
+# 7. No mutation of StageProgress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_lifecycle_never_mutates_stage_progress(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Start -> pause -> leave never touches current_stage/completed_stages/cycle_number."""
+    headers = await _signup(async_client, "mr_nomutate15")
+    user = await _get_user(db_session, "mr_nomutate15@example.com")
+    assert user.id is not None
+    user_id = user.id
+    progress = await _seed_progress(
+        db_session,
+        user_id,
+        current_stage=_ELIGIBLE_STAGE,
+        completed_stages=[1, 2, 3, 4],
+        cycle_number=1,
+    )
+    before_stage = progress.current_stage
+    before_completed = list(progress.completed_stages)
+    before_cycle = progress.cycle_number
+
+    start_resp = await async_client.post(_START_URL, headers=headers)
+    assert start_resp.status_code == HTTPStatus.CREATED
+
+    pause_resp = await async_client.post(_PAUSE_URL, headers=headers)
+    assert pause_resp.status_code == HTTPStatus.OK
+
+    leave_resp = await async_client.post(_LEAVE_URL, headers=headers)
+    assert leave_resp.status_code == HTTPStatus.OK
+
+    db_session.expire_all()
+    result = await db_session.execute(
+        select(StageProgress).where(col(StageProgress.user_id) == user_id)
+    )
+    refreshed = result.scalars().one()
+    assert refreshed.current_stage == before_stage
+    assert list(refreshed.completed_stages) == before_completed
+    assert refreshed.cycle_number == before_cycle

--- a/backend/tests/routers/test_metta_return.py
+++ b/backend/tests/routers/test_metta_return.py
@@ -194,6 +194,36 @@ async def test_get_state_does_not_provision_stage_progress(
     assert result.scalars().first() is None
 
 
+@pytest.mark.asyncio
+async def test_get_state_reads_active_arc_without_row_lock(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET projects the active arc via the lock-free reader, never ``FOR UPDATE``.
+
+    ``GET`` never writes, so it must use ``_active_arc`` (a plain ``select``) and
+    never ``_active_arc_for_update`` (``SELECT ... FOR UPDATE``), which would
+    serialize concurrent reads from one caller. Poison the write-lock reader so
+    any accidental call from the read path fails loudly.
+    """
+    headers = await _signup(async_client, "mr_getnolock5")
+    user = await _get_user(db_session, "mr_getnolock5@example.com")
+    assert user.id is not None
+    await _seed_active_arc(db_session, user.id, started_at=datetime.now(UTC))
+
+    def _forbidden(*_args: object, **_kwargs: object) -> None:
+        message = "GET must not acquire a row lock"
+        raise AssertionError(message)
+
+    monkeypatch.setattr(metta_return_router, "_active_arc_for_update", _forbidden)
+
+    resp = await async_client.get(_BASE_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["arc"] is not None
+
+
 # ---------------------------------------------------------------------------
 # 3. Start: eligibility gate
 # ---------------------------------------------------------------------------

--- a/backend/tests/routers/test_metta_return.py
+++ b/backend/tests/routers/test_metta_return.py
@@ -528,6 +528,11 @@ async def test_cross_user_lifecycle_posts_return_404_never_mutate_other_arc(
         HTTPStatus.NOT_FOUND
     )
 
+    # Bob's read path is isolated too: GET never surfaces Alice's active arc.
+    bob_get = await async_client.get(_BASE_URL, headers=bob_headers)
+    assert bob_get.status_code == HTTPStatus.OK
+    assert bob_get.json()["arc"] is None
+
     # Alice's arc remains untouched: still active, unpaused.
     alice_get = await async_client.get(_BASE_URL, headers=alice_headers)
     assert alice_get.status_code == HTTPStatus.OK

--- a/frontend/src/api/__tests__/mettaReturn.test.ts
+++ b/frontend/src/api/__tests__/mettaReturn.test.ts
@@ -1,0 +1,161 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { ApiValidationError, IDEMPOTENCY_KEY_HEADER, mettaReturn } from '../index';
+import type { MettaReturnState, ReturnArc, ReturnWeek } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function week(overrides: Partial<ReturnWeek> = {}): ReturnWeek {
+  return {
+    week_number: 1,
+    focus: 'self',
+    title: 'Toward yourself',
+    framing: 'Begin where you already are.',
+    ...overrides,
+  };
+}
+
+function fiveWeeks(): ReturnWeek[] {
+  return [
+    week({ week_number: 1, focus: 'self', title: 'Self' }),
+    week({ week_number: 2, focus: 'benefactor', title: 'Benefactor' }),
+    week({ week_number: 3, focus: 'stranger', title: 'Stranger' }),
+    week({ week_number: 4, focus: 'antagonist', title: 'Antagonist' }),
+    week({ week_number: 5, focus: 'all_beings', title: 'All beings' }),
+  ];
+}
+
+function arc(overrides: Partial<ReturnArc> = {}): ReturnArc {
+  return {
+    started_at: '2026-06-24T00:00:00Z',
+    paused: false,
+    week: 1,
+    focus: 'self',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('mettaReturn.state', () => {
+  test('GETs /metta-return and parses the full shape', async () => {
+    const payload: MettaReturnState = { eligible: true, weeks: fiveWeeks(), arc: null };
+    mockFetch.mockReturnValueOnce(jsonResponse(payload));
+    const result = await mettaReturn.state('tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/metta-return');
+    expect(init?.method ?? 'GET').toBe('GET');
+    expect(result.eligible).toBe(true);
+    expect(result.weeks).toHaveLength(5);
+    expect(result.arc).toBeNull();
+  });
+
+  test('parses an active arc when present', async () => {
+    const payload: MettaReturnState = {
+      eligible: true,
+      weeks: fiveWeeks(),
+      arc: arc({ week: 3, focus: 'stranger' }),
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(payload));
+    const result = await mettaReturn.state('tok');
+
+    expect(result.arc?.week).toBe(3);
+    expect(result.arc?.focus).toBe('stranger');
+  });
+
+  test('rejects a malformed payload missing a required field via Zod', async () => {
+    const { eligible: _omit, ...withoutEligible } = { eligible: true, weeks: [], arc: null };
+    void _omit;
+    mockFetch.mockReturnValueOnce(jsonResponse(withoutEligible));
+    await expect(mettaReturn.state('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('rejects a bad focus enum value via Zod', async () => {
+    const payload = {
+      eligible: true,
+      weeks: [week({ focus: 'not-a-real-focus' as ReturnWeek['focus'] })],
+      arc: null,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(payload));
+    await expect(mettaReturn.state('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+});
+
+describe('mettaReturn.start', () => {
+  test('POSTs /metta-return/arc with a deterministic idempotency key', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(arc()));
+    await mettaReturn.start('tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/metta-return/arc');
+    expect(init.method).toBe('POST');
+    expect(init.headers[IDEMPOTENCY_KEY_HEADER]).toBe('start-return');
+  });
+
+  test('the idempotency key is stable across repeated calls', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(arc())).mockReturnValueOnce(jsonResponse(arc()));
+    await mettaReturn.start('tok');
+    await mettaReturn.start('tok');
+    const calls = mockFetch.mock.calls as [string, { headers: Record<string, string> }][];
+    const keys = calls.map((c) => c[1].headers[IDEMPOTENCY_KEY_HEADER]);
+    expect(keys).toEqual(['start-return', 'start-return']);
+  });
+
+  test('resolves to week 1, focus self', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(arc({ week: 1, focus: 'self', paused: false })));
+    const result = await mettaReturn.start('tok');
+    expect(result.week).toBe(1);
+    expect(result.focus).toBe('self');
+    expect(result.paused).toBe(false);
+  });
+});
+
+describe('mettaReturn.pause', () => {
+  test('POSTs /metta-return/arc/pause and returns the paused arc', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(arc({ paused: true })));
+    const result = await mettaReturn.pause('tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/metta-return/arc/pause');
+    expect(init.method).toBe('POST');
+    expect(result.paused).toBe(true);
+  });
+});
+
+describe('mettaReturn.resume', () => {
+  test('POSTs /metta-return/arc/resume and returns the resumed arc', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(arc({ paused: false })));
+    const result = await mettaReturn.resume('tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/metta-return/arc/resume');
+    expect(init.method).toBe('POST');
+    expect(result.paused).toBe(false);
+  });
+});
+
+describe('mettaReturn.leave', () => {
+  test('POSTs /metta-return/arc/leave and returns the arc', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(arc()));
+    const result = await mettaReturn.leave('tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/metta-return/arc/leave');
+    expect(init.method).toBe('POST');
+    expect(result.week).toBe(1);
+  });
+});

--- a/frontend/src/api/__tests__/mettaReturn.test.ts
+++ b/frontend/src/api/__tests__/mettaReturn.test.ts
@@ -93,6 +93,30 @@ describe('mettaReturn.state', () => {
     mockFetch.mockReturnValueOnce(jsonResponse(payload));
     await expect(mettaReturn.state('tok')).rejects.toBeInstanceOf(ApiValidationError);
   });
+
+  test('rejects an out-of-range week_number via Zod', async () => {
+    const payload = { eligible: true, weeks: [week({ week_number: 6 })], arc: null };
+    mockFetch.mockReturnValueOnce(jsonResponse(payload));
+    await expect(mettaReturn.state('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('rejects a zero week_number via Zod', async () => {
+    const payload = { eligible: true, weeks: [week({ week_number: 0 })], arc: null };
+    mockFetch.mockReturnValueOnce(jsonResponse(payload));
+    await expect(mettaReturn.state('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('rejects a zero arc week via Zod', async () => {
+    const payload = { eligible: true, weeks: fiveWeeks(), arc: arc({ week: 0 }) };
+    mockFetch.mockReturnValueOnce(jsonResponse(payload));
+    await expect(mettaReturn.state('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('rejects an over-bound arc week via Zod', async () => {
+    const payload = { eligible: true, weeks: fiveWeeks(), arc: arc({ week: 6 }) };
+    mockFetch.mockReturnValueOnce(jsonResponse(payload));
+    await expect(mettaReturn.state('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
 });
 
 describe('mettaReturn.start', () => {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -13,6 +13,8 @@ import {
   invitationSchema,
   isTier,
   journalListResponseSchema,
+  mettaReturnStateSchema,
+  returnArcSchema,
   loginAuthResponseSchema,
   pageSchema,
   passwordResetAcceptedSchema,
@@ -34,7 +36,10 @@ import {
   type CompletionTargetTypeT,
   type DepthPreferencesT,
   type InvitationT,
+  type MettaReturnStateT,
   type Page,
+  type ReturnArcT,
+  type ReturnWeekT,
   type PasswordResetAcceptedT,
   type StageProgressRecordT,
   type SuggestionStatusT,
@@ -1328,6 +1333,57 @@ export const invitations = {
       method: 'POST',
       token,
       headers: { [IDEMPOTENCY_KEY_HEADER]: idempotencyKey('dismiss-invitation', id) },
+    });
+  },
+};
+
+// Metta Return client (the declinable five-week soft-landing arc)
+export type MettaReturnState = MettaReturnStateT;
+export type ReturnArc = ReturnArcT;
+export type ReturnWeek = ReturnWeekT;
+
+/**
+ * The declinable Return arc surface. ``state`` reports eligibility, the full
+ * week sequence, and the caller's active arc (or null) — safe to poll on load.
+ * ``start`` accepts the arc with a deterministic idempotency key so a double-tap
+ * cannot open two arcs; ``pause``/``resume``/``leave`` drive the lifecycle, each
+ * returning the arc projected to its current week. None of these mutate stage
+ * progress, and no ``user_id`` is ever sent or returned.
+ */
+export const mettaReturn = {
+  state(token?: string): Promise<MettaReturnState> {
+    return request<MettaReturnState>('/metta-return', {
+      token,
+      schema: mettaReturnStateSchema as unknown as z.ZodType<MettaReturnState>,
+    });
+  },
+  start(token?: string): Promise<ReturnArc> {
+    return request<ReturnArc>('/metta-return/arc', {
+      method: 'POST',
+      token,
+      headers: { [IDEMPOTENCY_KEY_HEADER]: idempotencyKey('start-return') },
+      schema: returnArcSchema as unknown as z.ZodType<ReturnArc>,
+    });
+  },
+  pause(token?: string): Promise<ReturnArc> {
+    return request<ReturnArc>('/metta-return/arc/pause', {
+      method: 'POST',
+      token,
+      schema: returnArcSchema as unknown as z.ZodType<ReturnArc>,
+    });
+  },
+  resume(token?: string): Promise<ReturnArc> {
+    return request<ReturnArc>('/metta-return/arc/resume', {
+      method: 'POST',
+      token,
+      schema: returnArcSchema as unknown as z.ZodType<ReturnArc>,
+    });
+  },
+  leave(token?: string): Promise<ReturnArc> {
+    return request<ReturnArc>('/metta-return/arc/leave', {
+      method: 'POST',
+      token,
+      schema: returnArcSchema as unknown as z.ZodType<ReturnArc>,
     });
   },
 };

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -518,6 +518,49 @@ export type InvitationKindT = z.infer<typeof invitationKindSchema>;
 export type InvitationT = z.infer<typeof invitationSchema>;
 
 // ---------------------------------------------------------------------------
+// Metta Return — the declinable five-week soft-landing arc. Mirrors the backend
+// MettaReturnStateResponse: an eligibility flag, the full week sequence, and the
+// caller's active arc (or null). No user_id is ever exposed.
+// ---------------------------------------------------------------------------
+
+/** The five classic Metta foci, one per Return week, in progression order. */
+export const mettaFocusSchema = z.enum([
+  'self',
+  'benefactor',
+  'stranger',
+  'antagonist',
+  'all_beings',
+]);
+
+/** One week of the Return sequence: its ordinal, focus, and warm framing copy. */
+export const returnWeekSchema = z.object({
+  week_number: z.number(),
+  focus: mettaFocusSchema,
+  title: z.string(),
+  framing: z.string(),
+});
+
+/** The caller's active arc projected to its current (possibly frozen) week. */
+export const returnArcSchema = z.object({
+  started_at: z.string(),
+  paused: z.boolean(),
+  week: z.number(),
+  focus: mettaFocusSchema,
+});
+
+/** Eligibility plus the full week sequence and the active arc, if any. */
+export const mettaReturnStateSchema = z.object({
+  eligible: z.boolean(),
+  weeks: z.array(returnWeekSchema),
+  arc: returnArcSchema.nullable(),
+});
+
+export type MettaFocusT = z.infer<typeof mettaFocusSchema>;
+export type ReturnWeekT = z.infer<typeof returnWeekSchema>;
+export type ReturnArcT = z.infer<typeof returnArcSchema>;
+export type MettaReturnStateT = z.infer<typeof mettaReturnStateSchema>;
+
+// ---------------------------------------------------------------------------
 // Resonance + marginalia + care (journal-resonance #891)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -532,9 +532,20 @@ export const mettaFocusSchema = z.enum([
   'all_beings',
 ]);
 
+/**
+ * The Return arc runs exactly five weeks, and the backend clamps every reported
+ * ordinal into ``[1, RETURN_WEEK_COUNT]`` (``domain.metta_return``). Pinning the
+ * bound here means an out-of-range week (``0``, ``-1``, ``999``) raises
+ * ``ApiValidationError`` at the client edge rather than rendering an undefined
+ * week card downstream.
+ */
+const RETURN_MIN_WEEK = 1;
+const RETURN_MAX_WEEK = 5;
+const returnWeekNumber = z.number().int().min(RETURN_MIN_WEEK).max(RETURN_MAX_WEEK);
+
 /** One week of the Return sequence: its ordinal, focus, and warm framing copy. */
 export const returnWeekSchema = z.object({
-  week_number: z.number(),
+  week_number: returnWeekNumber,
   focus: mettaFocusSchema,
   title: z.string(),
   framing: z.string(),
@@ -544,7 +555,7 @@ export const returnWeekSchema = z.object({
 export const returnArcSchema = z.object({
   started_at: z.string(),
   paused: z.boolean(),
-  week: z.number(),
+  week: returnWeekNumber,
   focus: mettaFocusSchema,
 });
 

--- a/frontend/src/features/Today/ReturnArcCard.tsx
+++ b/frontend/src/features/Today/ReturnArcCard.tsx
@@ -1,0 +1,212 @@
+/**
+ * ``ReturnArcCard`` — the active Return arc: this week's focus, a five-segment
+ * progress indicator, and the pause/resume/leave affordances. The person can
+ * rest (pause), continue (resume), or set the arc down (leave) at any time with
+ * no penalty. Presentational + reduced-motion-safe; tokens only.
+ */
+import React from 'react';
+import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import {
+  RETURN_ARC_LEAVE,
+  RETURN_ARC_LEAVE_A11Y,
+  RETURN_ARC_PAUSE,
+  RETURN_ARC_PAUSE_A11Y,
+  RETURN_ARC_RESUME,
+  RETURN_ARC_RESUME_A11Y,
+} from './returnCopy';
+
+import type { ReturnArc, ReturnWeek } from '@/api';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  paperShadow,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
+import { usePressScale } from '@/hooks/usePressScale';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+/** The Return runs five weeks — one Metta focus each. */
+export const RETURN_WEEK_COUNT = 5;
+
+/** Fixed segment indices so each elapsed week fills one visible block. */
+const SEGMENTS = Array.from({ length: RETURN_WEEK_COUNT }, (_, index) => index);
+
+const COMPLETED_LABEL = 'completed week';
+const REMAINING_LABEL = 'remaining week';
+
+export interface ReturnArcCardProps {
+  weeks: ReturnWeek[];
+  arc: ReturnArc;
+  onPause: () => void;
+  onResume: () => void;
+  onLeave: () => void;
+}
+
+/** The current week's focus copy, guarding against an out-of-range week. */
+function currentWeek(weeks: ReturnWeek[], week: number): ReturnWeek | undefined {
+  return weeks[week - 1];
+}
+
+interface PressHandlers {
+  onPressIn: () => void;
+  onPressOut: () => void;
+}
+
+/** The five-segment week indicator, filling one block per elapsed week. */
+function WeekSegments({ week }: { week: number }): React.JSX.Element {
+  return (
+    <View style={styles.segmentRow}>
+      {SEGMENTS.map((index) => {
+        const isFilled = index < week;
+        return (
+          <View
+            key={index}
+            style={[styles.segment, isFilled ? styles.segmentFilled : styles.segmentEmpty]}
+            accessibilityLabel={isFilled ? COMPLETED_LABEL : REMAINING_LABEL}
+            testID={`return-week-segment-${index}`}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+/** The pause-or-resume toggle: rest the arc, or continue it, depending on state. */
+function RestToggle({
+  paused,
+  onPause,
+  onResume,
+  press,
+}: {
+  paused: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  press: PressHandlers;
+}): React.JSX.Element {
+  const resumeMode = paused;
+  return (
+    <TouchableOpacity
+      style={styles.action}
+      onPress={resumeMode ? onResume : onPause}
+      onPressIn={press.onPressIn}
+      onPressOut={press.onPressOut}
+      accessibilityRole="button"
+      accessibilityLabel={resumeMode ? RETURN_ARC_RESUME_A11Y : RETURN_ARC_PAUSE_A11Y}
+      testID={resumeMode ? 'return-arc-resume' : 'return-arc-pause'}
+    >
+      <Text style={styles.actionText}>{resumeMode ? RETURN_ARC_RESUME : RETURN_ARC_PAUSE}</Text>
+    </TouchableOpacity>
+  );
+}
+
+function ReturnArcCard({
+  weeks,
+  arc,
+  onPause,
+  onResume,
+  onLeave,
+}: ReturnArcCardProps): React.JSX.Element {
+  const press = usePressScale(useReducedMotion());
+  const focusWeek = currentWeek(weeks, arc.week);
+  return (
+    <Animated.View style={{ transform: [{ scale: press.scale }] }}>
+      <View style={styles.card} testID="return-arc-card">
+        {focusWeek ? (
+          <>
+            <Text style={styles.title}>{focusWeek.title}</Text>
+            <Text style={styles.framing}>{focusWeek.framing}</Text>
+          </>
+        ) : null}
+        <WeekSegments week={arc.week} />
+        <View style={styles.actions}>
+          <RestToggle paused={arc.paused} onPause={onPause} onResume={onResume} press={press} />
+          <TouchableOpacity
+            style={styles.leave}
+            onPress={onLeave}
+            accessibilityRole="button"
+            accessibilityLabel={RETURN_ARC_LEAVE_A11Y}
+            testID="return-arc-leave"
+          >
+            <Text style={styles.leaveText}>{RETURN_ARC_LEAVE}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.paper.background,
+    borderLeftWidth: 3,
+    borderLeftColor: colors.tier.clear,
+    ...paperShadow.card,
+  },
+  title: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+  },
+  framing: {
+    ...editorialType.marginNote,
+    color: colors.paper.ink,
+    marginTop: spacing(1),
+  },
+  segmentRow: {
+    flexDirection: 'row',
+    marginTop: spacing(1.5),
+  },
+  segment: {
+    flex: 1,
+    height: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    marginRight: spacing(0.5),
+  },
+  segmentFilled: {
+    backgroundColor: colors.tier.clear,
+  },
+  segmentEmpty: {
+    backgroundColor: colors.paper.inkSoft,
+    opacity: 0.25,
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: spacing(1.5),
+  },
+  action: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.tier.clear,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  actionText: {
+    ...editorialType.caption,
+    color: colors.paper.background,
+  },
+  leave: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    marginLeft: spacing(1),
+    borderRadius: BORDER_RADIUS.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  leaveText: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+});
+
+export default ReturnArcCard;

--- a/frontend/src/features/Today/ReturnOfferCard.tsx
+++ b/frontend/src/features/Today/ReturnOfferCard.tsx
@@ -1,0 +1,123 @@
+/**
+ * ``ReturnOfferCard`` — a quiet paper card that offers the five-week Metta
+ * Return as a soft landing. It carries two affordances: accept (begin the arc)
+ * and decline (set it aside). The offer is the invitation; declining changes
+ * nothing. Presentational + reduced-motion-safe; tokens only.
+ */
+import React from 'react';
+import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import {
+  RETURN_OFFER_ACCEPT,
+  RETURN_OFFER_ACCEPT_A11Y,
+  RETURN_OFFER_BODY,
+  RETURN_OFFER_DISMISS,
+  RETURN_OFFER_DISMISS_A11Y,
+  RETURN_OFFER_HEADING,
+} from './returnCopy';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  paperShadow,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
+import { usePressScale } from '@/hooks/usePressScale';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+export interface ReturnOfferCardProps {
+  onAccept: () => void;
+  onDismiss: () => void;
+}
+
+function ReturnOfferCard({ onAccept, onDismiss }: ReturnOfferCardProps): React.JSX.Element {
+  const press = usePressScale(useReducedMotion());
+  return (
+    <Animated.View style={{ transform: [{ scale: press.scale }] }}>
+      <View style={styles.card} testID="return-offer-card">
+        <Text style={styles.heading}>{RETURN_OFFER_HEADING}</Text>
+        <Text style={styles.body}>{RETURN_OFFER_BODY}</Text>
+        <View style={styles.actions}>
+          <TouchableOpacity
+            style={styles.accept}
+            onPress={onAccept}
+            onPressIn={press.onPressIn}
+            onPressOut={press.onPressOut}
+            accessibilityRole="button"
+            accessibilityLabel={RETURN_OFFER_ACCEPT_A11Y}
+            testID="return-offer-accept"
+          >
+            <Text style={styles.acceptText}>{RETURN_OFFER_ACCEPT}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.dismiss}
+            onPress={onDismiss}
+            accessibilityRole="button"
+            accessibilityLabel={RETURN_OFFER_DISMISS_A11Y}
+            testID="return-offer-dismiss"
+          >
+            <Text style={styles.dismissText}>{RETURN_OFFER_DISMISS}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.paper.background,
+    borderLeftWidth: 3,
+    borderLeftColor: colors.tier.clear,
+    ...paperShadow.card,
+  },
+  heading: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+  },
+  body: {
+    ...editorialType.marginNote,
+    color: colors.paper.ink,
+    marginTop: spacing(1),
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: spacing(1.5),
+  },
+  accept: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: colors.tier.clear,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  acceptText: {
+    ...editorialType.caption,
+    color: colors.paper.background,
+  },
+  dismiss: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    marginLeft: spacing(1),
+    borderRadius: BORDER_RADIUS.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dismissText: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+});
+
+export default ReturnOfferCard;

--- a/frontend/src/features/Today/TodayScreen.tsx
+++ b/frontend/src/features/Today/TodayScreen.tsx
@@ -4,8 +4,11 @@ import React from 'react';
 import { Animated, Pressable, Text } from 'react-native';
 
 import InvitationNote from './InvitationNote';
+import ReturnArcCard from './ReturnArcCard';
+import ReturnOfferCard from './ReturnOfferCard';
 import { todayStyles as s } from './Today.styles';
 import { useInvitations } from './useInvitations';
+import { useMettaReturn } from './useMettaReturn';
 
 import { EmptyState } from '@/components/feedback/EmptyState';
 import { SkeletonCard } from '@/components/feedback/Skeleton';
@@ -148,6 +151,26 @@ const InvitationStack = (): React.JSX.Element | null => {
   );
 };
 
+/** The Return surface: the soft-landing offer when invited, or the active arc. */
+const ReturnStack = (): React.JSX.Element | null => {
+  const { weeks, arc, offerVisible, dismissOffer, start, pause, resume, leave } = useMettaReturn();
+  if (arc !== null) {
+    return (
+      <ReturnArcCard
+        weeks={weeks}
+        arc={arc}
+        onPause={() => void pause()}
+        onResume={() => void resume()}
+        onLeave={() => void leave()}
+      />
+    );
+  }
+  if (offerVisible) {
+    return <ReturnOfferCard onAccept={() => void start()} onDismiss={dismissOffer} />;
+  }
+  return null;
+};
+
 /** The editorial home tab: where am I in the journey, and what's next today. */
 const TodayScreen = (): React.JSX.Element => {
   const navigation = useNavigation<TodayNav>();
@@ -157,6 +180,7 @@ const TodayScreen = (): React.JSX.Element => {
   return (
     <ScreenScaffold scroll testID="today-screen">
       <TodayHero week={week} stage={stage} />
+      <ReturnStack />
       <InvitationStack />
       <HabitsBand index={1} onPress={() => navigation.navigate('Habits')} />
       <TodayBand

--- a/frontend/src/features/Today/__tests__/ReturnArcCard.test.tsx
+++ b/frontend/src/features/Today/__tests__/ReturnArcCard.test.tsx
@@ -1,0 +1,180 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+const mockPressIn = jest.fn();
+const mockPressOut = jest.fn();
+jest.mock('@/hooks/usePressScale', () => ({
+  usePressScale: () => ({ scale: 1, onPressIn: mockPressIn, onPressOut: mockPressOut }),
+}));
+
+import ReturnArcCard, { RETURN_WEEK_COUNT } from '../ReturnArcCard';
+
+import type { ReturnArc, ReturnWeek } from '@/api';
+
+function week(overrides: Partial<ReturnWeek> = {}): ReturnWeek {
+  return {
+    week_number: 1,
+    focus: 'self',
+    title: 'Self',
+    framing: 'Begin where you already are.',
+    ...overrides,
+  };
+}
+
+function fiveWeeks(): ReturnWeek[] {
+  return [
+    week({ week_number: 1, focus: 'self', title: 'Toward yourself', framing: 'Frame one.' }),
+    week({
+      week_number: 2,
+      focus: 'benefactor',
+      title: 'Toward a benefactor',
+      framing: 'Frame two.',
+    }),
+    week({
+      week_number: 3,
+      focus: 'stranger',
+      title: 'Toward a stranger',
+      framing: 'Frame three.',
+    }),
+    week({
+      week_number: 4,
+      focus: 'antagonist',
+      title: 'Toward a difficult person',
+      framing: 'Frame four.',
+    }),
+    week({
+      week_number: 5,
+      focus: 'all_beings',
+      title: 'Toward all beings',
+      framing: 'Frame five.',
+    }),
+  ];
+}
+
+function arc(overrides: Partial<ReturnArc> = {}): ReturnArc {
+  return {
+    started_at: '2026-06-24T00:00:00Z',
+    paused: false,
+    week: 1,
+    focus: 'self',
+    ...overrides,
+  };
+}
+
+const noop = () => undefined;
+
+describe('ReturnArcCard', () => {
+  it('week 1 renders the self focus title and framing', () => {
+    const { getByText } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc({ week: 1, focus: 'self' })}
+        onPause={noop}
+        onResume={noop}
+        onLeave={noop}
+      />,
+    );
+    expect(getByText('Toward yourself')).toBeTruthy();
+    expect(getByText('Frame one.')).toBeTruthy();
+  });
+
+  it('week 3 renders the stranger focus title and framing', () => {
+    const { getByText } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc({ week: 3, focus: 'stranger' })}
+        onPause={noop}
+        onResume={noop}
+        onLeave={noop}
+      />,
+    );
+    expect(getByText('Toward a stranger')).toBeTruthy();
+    expect(getByText('Frame three.')).toBeTruthy();
+  });
+
+  it('renders 5 week-indicator segments, filling up to the current week', () => {
+    const { getByTestId } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc({ week: 3 })}
+        onPause={noop}
+        onResume={noop}
+        onLeave={noop}
+      />,
+    );
+    expect(RETURN_WEEK_COUNT).toBe(5);
+    for (let i = 0; i < RETURN_WEEK_COUNT; i += 1) {
+      expect(getByTestId(`return-week-segment-${i}`)).toBeTruthy();
+    }
+    // Filled segments are 0,1,2 for week 3 (0-indexed, 3 filled of 5).
+    expect(getByTestId('return-week-segment-0').props.accessibilityLabel).toBe('completed week');
+    expect(getByTestId('return-week-segment-1').props.accessibilityLabel).toBe('completed week');
+    expect(getByTestId('return-week-segment-2').props.accessibilityLabel).toBe('completed week');
+    expect(getByTestId('return-week-segment-3').props.accessibilityLabel).toBe('remaining week');
+    expect(getByTestId('return-week-segment-4').props.accessibilityLabel).toBe('remaining week');
+  });
+
+  it('pause press calls onPause exactly once when not paused', () => {
+    const onPause = jest.fn();
+    const { getByTestId } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc({ paused: false })}
+        onPause={onPause}
+        onResume={noop}
+        onLeave={noop}
+      />,
+    );
+    fireEvent.press(getByTestId('return-arc-pause'));
+    expect(onPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('resume press calls onResume exactly once when paused', () => {
+    const onResume = jest.fn();
+    const { getByTestId } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc({ paused: true })}
+        onPause={noop}
+        onResume={onResume}
+        onLeave={noop}
+      />,
+    );
+    fireEvent.press(getByTestId('return-arc-resume'));
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('leave press calls onLeave exactly once', () => {
+    const onLeave = jest.fn();
+    const { getByTestId } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc()}
+        onPause={noop}
+        onResume={noop}
+        onLeave={onLeave}
+      />,
+    );
+    fireEvent.press(getByTestId('return-arc-leave'));
+    expect(onLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('leave affordance has accessibilityRole button and a non-empty label', () => {
+    const { getByTestId } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc()}
+        onPause={noop}
+        onResume={noop}
+        onLeave={noop}
+      />,
+    );
+    const leaveBtn = getByTestId('return-arc-leave');
+    expect(leaveBtn.props.accessibilityRole).toBe('button');
+    const label: string = leaveBtn.props.accessibilityLabel;
+    expect(label).toBeTruthy();
+    expect(label.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/features/Today/__tests__/ReturnOfferCard.test.tsx
+++ b/frontend/src/features/Today/__tests__/ReturnOfferCard.test.tsx
@@ -1,0 +1,73 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+const mockPressIn = jest.fn();
+const mockPressOut = jest.fn();
+jest.mock('@/hooks/usePressScale', () => ({
+  usePressScale: () => ({ scale: 1, onPressIn: mockPressIn, onPressOut: mockPressOut }),
+}));
+
+import { RETURN_OFFER_HEADING, RETURN_OFFER_BODY } from '../returnCopy';
+import ReturnOfferCard from '../ReturnOfferCard';
+
+import { touchTarget } from '@/design/tokens';
+
+/** Smallest of the flattened minHeight/minWidth on a pressable, for 44dp checks. */
+function styleSheetMin(node: { props: { style: unknown } }): number {
+  const { StyleSheet } = require('react-native');
+  const flat = StyleSheet.flatten(node.props.style) as { minHeight?: number; minWidth?: number };
+  return Math.min(flat.minHeight ?? 0, flat.minWidth ?? 0);
+}
+
+const noop = () => undefined;
+
+describe('ReturnOfferCard', () => {
+  it('renders the offer heading and body from returnCopy', () => {
+    const { getByTestId, getByText } = render(<ReturnOfferCard onAccept={noop} onDismiss={noop} />);
+    expect(getByTestId('return-offer-card')).toBeTruthy();
+    expect(getByText(RETURN_OFFER_HEADING)).toBeTruthy();
+    expect(getByText(RETURN_OFFER_BODY)).toBeTruthy();
+  });
+
+  it('accept press calls onAccept exactly once', () => {
+    const onAccept = jest.fn();
+    const { getByTestId } = render(<ReturnOfferCard onAccept={onAccept} onDismiss={noop} />);
+    fireEvent.press(getByTestId('return-offer-accept'));
+    expect(onAccept).toHaveBeenCalledTimes(1);
+  });
+
+  it('decline press calls onDismiss exactly once', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(<ReturnOfferCard onAccept={noop} onDismiss={onDismiss} />);
+    fireEvent.press(getByTestId('return-offer-dismiss'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('both affordances have accessibilityRole button and non-empty labels', () => {
+    const { getByTestId } = render(<ReturnOfferCard onAccept={noop} onDismiss={noop} />);
+    const accept = getByTestId('return-offer-accept');
+    const decline = getByTestId('return-offer-dismiss');
+
+    expect(accept.props.accessibilityRole).toBe('button');
+    expect(decline.props.accessibilityRole).toBe('button');
+
+    const acceptLabel: string = accept.props.accessibilityLabel;
+    const declineLabel: string = decline.props.accessibilityLabel;
+    expect(acceptLabel).toBeTruthy();
+    expect(acceptLabel.length).toBeGreaterThan(0);
+    expect(declineLabel).toBeTruthy();
+    expect(declineLabel.length).toBeGreaterThan(0);
+  });
+
+  it('both affordances meet the 44dp minimum touch target', () => {
+    const { getByTestId } = render(<ReturnOfferCard onAccept={noop} onDismiss={noop} />);
+    expect(styleSheetMin(getByTestId('return-offer-accept'))).toBeGreaterThanOrEqual(
+      touchTarget.minimum,
+    );
+    expect(styleSheetMin(getByTestId('return-offer-dismiss'))).toBeGreaterThanOrEqual(
+      touchTarget.minimum,
+    );
+  });
+});

--- a/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
+++ b/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
@@ -14,9 +14,31 @@ jest.mock('../useInvitations', () => ({
   useInvitations: () => ({ invitations: mockInvitations, dismiss: mockDismiss }),
 }));
 
+const mockDismissOffer = jest.fn();
+const mockStart = jest.fn();
+const mockPause = jest.fn();
+const mockResume = jest.fn();
+const mockLeave = jest.fn();
+let mockMettaReturn: {
+  eligible: boolean;
+  weeks: ReturnWeek[];
+  arc: ReturnArc | null;
+  offerVisible: boolean;
+};
+jest.mock('../useMettaReturn', () => ({
+  useMettaReturn: () => ({
+    ...mockMettaReturn,
+    dismissOffer: mockDismissOffer,
+    start: mockStart,
+    pause: mockPause,
+    resume: mockResume,
+    leave: mockLeave,
+  }),
+}));
+
 import TodayScreen from '../TodayScreen';
 
-import type { Invitation } from '@/api';
+import type { Invitation, ReturnArc, ReturnWeek } from '@/api';
 import type { Habit } from '@/features/Habits/Habits.types';
 import { useHabitStore } from '@/store/useHabitStore';
 import { useProgramStore } from '@/store/useProgramStore';
@@ -45,10 +67,30 @@ const makeHabit = (id: number, completedToday: boolean): Habit =>
       : [],
   }) as Habit;
 
+const makeWeek = (weekNumber: number): ReturnWeek => ({
+  week_number: weekNumber,
+  focus: 'self',
+  title: `Toward yourself, week ${weekNumber}`,
+  framing: 'Begin where you already are.',
+});
+
+const makeArc = (weekNumber: number): ReturnArc => ({
+  started_at: '2026-06-24T00:00:00Z',
+  paused: false,
+  week: weekNumber,
+  focus: 'self',
+});
+
 beforeEach(() => {
   mockNavigate.mockClear();
   mockDismiss.mockClear();
+  mockDismissOffer.mockClear();
+  mockStart.mockClear();
+  mockPause.mockClear();
+  mockResume.mockClear();
+  mockLeave.mockClear();
   mockInvitations = [];
+  mockMettaReturn = { eligible: false, weeks: [], arc: null, offerVisible: false };
   useProgramStore.setState({ programStartDate: new Date() });
   useHabitStore.setState({ habits: [], loading: false });
 });
@@ -106,5 +148,34 @@ describe('TodayScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('Practice');
     expect(mockNavigate).toHaveBeenCalledWith('Journal');
     expect(mockNavigate).toHaveBeenCalledWith('Course');
+  });
+
+  it('shows no Return offer card when offerVisible is false', () => {
+    mockMettaReturn = { eligible: true, weeks: [makeWeek(1)], arc: null, offerVisible: false };
+    const { queryByTestId } = render(<TodayScreen />);
+    expect(queryByTestId('return-offer-card')).toBeNull();
+  });
+
+  it('shows the Return offer card when offerVisible is true', () => {
+    mockMettaReturn = { eligible: true, weeks: [makeWeek(1)], arc: null, offerVisible: true };
+    const { getByTestId } = render(<TodayScreen />);
+    expect(getByTestId('return-offer-card')).toBeTruthy();
+  });
+
+  it('shows the Return arc card when an arc is active', () => {
+    mockMettaReturn = {
+      eligible: true,
+      weeks: [makeWeek(1)],
+      arc: makeArc(1),
+      offerVisible: false,
+    };
+    const { getByTestId } = render(<TodayScreen />);
+    expect(getByTestId('return-arc-card')).toBeTruthy();
+  });
+
+  it('shows no Return arc card when there is no active arc', () => {
+    mockMettaReturn = { eligible: true, weeks: [makeWeek(1)], arc: null, offerVisible: false };
+    const { queryByTestId } = render(<TodayScreen />);
+    expect(queryByTestId('return-arc-card')).toBeNull();
   });
 });

--- a/frontend/src/features/Today/__tests__/returnCopy.test.ts
+++ b/frontend/src/features/Today/__tests__/returnCopy.test.ts
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+import { RETURN_COPY_ENTRIES } from '../returnCopy';
+
+import { ranksOrShames } from '@/features/Map/__tests__/copyIntentRule';
+
+describe('returnCopy — balance-not-altitude intent rule', () => {
+  it('exposes at least one copy entry to sweep', () => {
+    expect(RETURN_COPY_ENTRIES.length).toBeGreaterThan(0);
+  });
+
+  it('no RETURN_COPY_ENTRIES entry ranks or shames the person', () => {
+    for (const entry of RETURN_COPY_ENTRIES) {
+      expect(ranksOrShames(entry)).toBe(false);
+    }
+  });
+});

--- a/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
+++ b/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
@@ -1,0 +1,232 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { MettaReturnState, ReturnArc, ReturnWeek } from '@/api';
+
+const mockState = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<MettaReturnState>>;
+const mockStart = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<ReturnArc>>;
+const mockPause = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<ReturnArc>>;
+const mockResume = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<ReturnArc>>;
+const mockLeave = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<ReturnArc>>;
+
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api') as Record<string, unknown>;
+  return {
+    ...actual,
+    mettaReturn: {
+      state: (...a: unknown[]) => (mockState as unknown as (...x: unknown[]) => unknown)(...a),
+      start: (...a: unknown[]) => (mockStart as unknown as (...x: unknown[]) => unknown)(...a),
+      pause: (...a: unknown[]) => (mockPause as unknown as (...x: unknown[]) => unknown)(...a),
+      resume: (...a: unknown[]) => (mockResume as unknown as (...x: unknown[]) => unknown)(...a),
+      leave: (...a: unknown[]) => (mockLeave as unknown as (...x: unknown[]) => unknown)(...a),
+    },
+  };
+});
+
+const mockIsContractionSignalActive = jest.fn() as jest.MockedFunction<() => boolean>;
+jest.mock('../contractionSignal', () => ({
+  isContractionSignalActive: () => mockIsContractionSignalActive(),
+}));
+
+const mockSaveDismissed = jest.fn() as jest.MockedFunction<() => Promise<void>>;
+const mockLoadDismissed = jest.fn() as jest.MockedFunction<() => Promise<boolean>>;
+jest.mock('@/storage/returnOfferStorage', () => ({
+  saveReturnOfferDismissed: (...a: unknown[]) =>
+    (mockSaveDismissed as unknown as (...x: unknown[]) => unknown)(...a),
+  loadReturnOfferDismissed: (...a: unknown[]) =>
+    (mockLoadDismissed as unknown as (...x: unknown[]) => unknown)(...a),
+}));
+
+const { useMettaReturn } = require('../useMettaReturn');
+
+function week(overrides: Partial<ReturnWeek> = {}): ReturnWeek {
+  return {
+    week_number: 1,
+    focus: 'self',
+    title: 'Toward yourself',
+    framing: 'Begin where you already are.',
+    ...overrides,
+  };
+}
+
+function fiveWeeks(): ReturnWeek[] {
+  return [1, 2, 3, 4, 5].map((n) => week({ week_number: n }));
+}
+
+function arc(overrides: Partial<ReturnArc> = {}): ReturnArc {
+  return {
+    started_at: '2026-06-24T00:00:00Z',
+    paused: false,
+    week: 1,
+    focus: 'self',
+    ...overrides,
+  };
+}
+
+function stateResult(overrides: Partial<MettaReturnState> = {}): MettaReturnState {
+  return { eligible: true, weeks: fiveWeeks(), arc: null, ...overrides };
+}
+
+beforeEach(() => {
+  mockState.mockReset();
+  mockStart.mockReset();
+  mockPause.mockReset();
+  mockResume.mockReset();
+  mockLeave.mockReset();
+  mockIsContractionSignalActive.mockReset();
+  mockSaveDismissed.mockReset();
+  mockLoadDismissed.mockReset();
+
+  mockState.mockResolvedValue(stateResult());
+  mockStart.mockResolvedValue(arc());
+  mockPause.mockResolvedValue(arc({ paused: true }));
+  mockResume.mockResolvedValue(arc({ paused: false }));
+  mockLeave.mockResolvedValue(arc());
+  mockIsContractionSignalActive.mockReturnValue(false);
+  mockSaveDismissed.mockResolvedValue(undefined);
+  mockLoadDismissed.mockResolvedValue(false);
+});
+
+describe('useMettaReturn', () => {
+  it('loads state on mount and exposes eligible/weeks/arc', async () => {
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    expect(result.current.eligible).toBe(true);
+    expect(result.current.weeks).toHaveLength(5);
+    expect(result.current.arc).toBeNull();
+  });
+
+  it('offerVisible is false when the contraction signal is inactive, even if eligible', async () => {
+    mockIsContractionSignalActive.mockReturnValue(false);
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    expect(result.current.offerVisible).toBe(false);
+  });
+
+  it('offerVisible is true when eligible, no arc, and the contraction signal is active', async () => {
+    mockIsContractionSignalActive.mockReturnValue(true);
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(result.current.offerVisible).toBe(true));
+  });
+
+  it('offerVisible is false when an arc already exists, even with an active signal', async () => {
+    mockIsContractionSignalActive.mockReturnValue(true);
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: arc() }));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    expect(result.current.offerVisible).toBe(false);
+    expect(result.current.arc).not.toBeNull();
+  });
+
+  it('dismissOffer hides the offer and persists the dismissal', async () => {
+    mockIsContractionSignalActive.mockReturnValue(true);
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(result.current.offerVisible).toBe(true));
+
+    await act(async () => {
+      result.current.dismissOffer();
+    });
+
+    expect(result.current.offerVisible).toBe(false);
+    expect(mockSaveDismissed).toHaveBeenCalledTimes(1);
+  });
+
+  it('a persisted dismissal keeps the offer hidden on reload', async () => {
+    mockIsContractionSignalActive.mockReturnValue(true);
+    mockLoadDismissed.mockResolvedValue(true);
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    expect(result.current.offerVisible).toBe(false);
+  });
+
+  it('start calls the API and updates arc to week 1, self', async () => {
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
+    mockStart.mockResolvedValue(arc({ week: 1, focus: 'self' }));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(mockStart).toHaveBeenCalledTimes(1);
+    expect(result.current.arc?.week).toBe(1);
+    expect(result.current.arc?.focus).toBe('self');
+  });
+
+  it('pause calls the API and updates arc.paused optimistically, reverting on error', async () => {
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: arc({ paused: false }) }));
+    mockPause.mockRejectedValue(new Error('network error'));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(result.current.arc).not.toBeNull());
+
+    await act(async () => {
+      await result.current.pause().catch(() => undefined);
+    });
+
+    expect(mockPause).toHaveBeenCalledTimes(1);
+    expect(result.current.arc?.paused).toBe(false);
+  });
+
+  it('resume calls the API and updates arc.paused', async () => {
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: arc({ paused: true }) }));
+    mockResume.mockResolvedValue(arc({ paused: false }));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(result.current.arc).not.toBeNull());
+
+    await act(async () => {
+      await result.current.resume();
+    });
+
+    expect(mockResume).toHaveBeenCalledTimes(1);
+    expect(result.current.arc?.paused).toBe(false);
+  });
+
+  it('leave calls the API and clears the local arc', async () => {
+    mockState.mockResolvedValue(stateResult({ eligible: true, arc: arc() }));
+    mockLeave.mockResolvedValue(arc());
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(result.current.arc).not.toBeNull());
+
+    await act(async () => {
+      await result.current.leave();
+    });
+
+    expect(mockLeave).toHaveBeenCalledTimes(1);
+    expect(result.current.arc).toBeNull();
+  });
+
+  it('silently swallows a state-load failure (no crash, defaults stay empty)', async () => {
+    mockState.mockRejectedValue(new Error('network error'));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    expect(result.current.eligible).toBe(false);
+    expect(result.current.weeks).toEqual([]);
+    expect(result.current.arc).toBeNull();
+  });
+
+  it('unmount guard: a late state resolution does not set state after unmount', async () => {
+    let resolveState: (_value: MettaReturnState) => void = () => {};
+    mockState.mockReturnValue(
+      new Promise<MettaReturnState>((resolve) => {
+        resolveState = resolve;
+      }),
+    );
+    const { result, unmount } = renderHook(() => useMettaReturn());
+    unmount();
+
+    await act(async () => {
+      resolveState(stateResult({ eligible: true, arc: null }));
+      await Promise.resolve();
+    });
+
+    // The hook must never flip eligible on a dead instance after unmount.
+    expect(result.current.eligible).toBe(false);
+  });
+});

--- a/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
+++ b/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
@@ -167,7 +167,7 @@ describe('useMettaReturn', () => {
     await waitFor(() => expect(result.current.arc).not.toBeNull());
 
     await act(async () => {
-      await result.current.pause().catch(() => undefined);
+      await expect(result.current.pause()).rejects.toThrow('network error');
     });
 
     expect(mockPause).toHaveBeenCalledTimes(1);

--- a/frontend/src/features/Today/contractionSignal.ts
+++ b/frontend/src/features/Today/contractionSignal.ts
@@ -1,0 +1,14 @@
+/**
+ * The seam that decides whether a contraction (a natural easing-off) is
+ * currently observed for the person. The Return offer is only ever surfaced
+ * when this returns true AND the person is eligible.
+ *
+ * It returns ``false`` for now: the descriptive contraction detector lands in a
+ * later slice, and until it does the offer stays quietly out of sight. Keeping
+ * the decision behind this single named function means wiring the real detector
+ * later is a one-line change, and every offer/accept path is already built and
+ * tested against it.
+ */
+export function isContractionSignalActive(): boolean {
+  return false;
+}

--- a/frontend/src/features/Today/returnCopy.ts
+++ b/frontend/src/features/Today/returnCopy.ts
@@ -1,0 +1,62 @@
+/**
+ * Microcopy for the Return — the declinable five-week Metta arc offered as a
+ * soft landing (NORTH-STAR "you choose your depth").
+ *
+ * Every line reads like a wise friend offering rest, never a verdict. Contraction
+ * follows expansion; a Return is a skillful pause, not a failure — so nothing
+ * here ranks, shames, or pressures. ``RETURN_COPY_ENTRIES`` enumerates every
+ * user-facing string for the balance-not-altitude sweep.
+ */
+
+/** The offer card heading — an invitation, softly phrased. */
+export const RETURN_OFFER_HEADING = 'A gentle Return, if you would like one';
+
+/** The offer card body — what the arc is, framed as rest rather than retreat. */
+export const RETURN_OFFER_BODY =
+  'Contraction follows expansion. If it feels right, there is a five-week Metta arc here — a soft landing you can begin, pause, or set down whenever you choose.';
+
+/** The accept affordance label. */
+export const RETURN_OFFER_ACCEPT = 'Begin the Return';
+
+/** The accessibility label for accepting the offer. */
+export const RETURN_OFFER_ACCEPT_A11Y = 'Begin the five-week Return';
+
+/** The decline affordance label. */
+export const RETURN_OFFER_DISMISS = 'Not now';
+
+/** The accessibility label for declining the offer. */
+export const RETURN_OFFER_DISMISS_A11Y = 'Set the Return offer aside for now';
+
+/** The pause affordance label on the active arc. */
+export const RETURN_ARC_PAUSE = 'Pause';
+
+/** The accessibility label for pausing the arc. */
+export const RETURN_ARC_PAUSE_A11Y = 'Pause the Return, resting where you are';
+
+/** The resume affordance label on a paused arc. */
+export const RETURN_ARC_RESUME = 'Resume';
+
+/** The accessibility label for resuming the arc. */
+export const RETURN_ARC_RESUME_A11Y = 'Resume the Return where you left off';
+
+/** The leave affordance label on the active arc. */
+export const RETURN_ARC_LEAVE = 'Set it down';
+
+/** The accessibility label for leaving the arc. */
+export const RETURN_ARC_LEAVE_A11Y = 'Set the Return down; nothing about your progress changes';
+
+/** Every user-facing Return string, gathered for the balance-not-altitude sweep. */
+export const RETURN_COPY_ENTRIES: readonly string[] = [
+  RETURN_OFFER_HEADING,
+  RETURN_OFFER_BODY,
+  RETURN_OFFER_ACCEPT,
+  RETURN_OFFER_ACCEPT_A11Y,
+  RETURN_OFFER_DISMISS,
+  RETURN_OFFER_DISMISS_A11Y,
+  RETURN_ARC_PAUSE,
+  RETURN_ARC_PAUSE_A11Y,
+  RETURN_ARC_RESUME,
+  RETURN_ARC_RESUME_A11Y,
+  RETURN_ARC_LEAVE,
+  RETURN_ARC_LEAVE_A11Y,
+];

--- a/frontend/src/features/Today/useMettaReturn.ts
+++ b/frontend/src/features/Today/useMettaReturn.ts
@@ -1,0 +1,127 @@
+/**
+ * ``useMettaReturn`` — loads the Return surface on mount and drives its
+ * lifecycle without ever nagging.
+ *
+ * Silent by default: a failed load leaves everything empty rather than crashing
+ * the tab, and the offer only becomes visible when the person is eligible, a
+ * contraction is currently observed, they have not already set the offer aside,
+ * and no arc is running. ``dismissOffer`` hides the offer and persists the
+ * decline; ``start``/``pause``/``resume``/``leave`` update the local arc
+ * optimistically and revert on error. An unmount guard keeps late resolutions
+ * from setting state on a dead hook.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
+
+import { isContractionSignalActive } from './contractionSignal';
+
+import { mettaReturn } from '@/api';
+import type { ReturnArc, ReturnWeek } from '@/api';
+import { loadReturnOfferDismissed, saveReturnOfferDismissed } from '@/storage/returnOfferStorage';
+
+export interface UseMettaReturnResult {
+  eligible: boolean;
+  weeks: ReturnWeek[];
+  arc: ReturnArc | null;
+  offerVisible: boolean;
+  dismissOffer: () => void;
+  start: () => Promise<void>;
+  pause: () => Promise<void>;
+  resume: () => Promise<void>;
+  leave: () => Promise<void>;
+}
+
+interface LoadedReturn {
+  eligible: boolean;
+  weeks: ReturnWeek[];
+  arc: ReturnArc | null;
+  dismissed: boolean;
+  setArc: (_arc: ReturnArc | null) => void;
+  setDismissed: (_dismissed: boolean) => void;
+  mountedRef: MutableRefObject<boolean>;
+}
+
+/** Own the Return state and load it (server state + persisted decline) once on mount. */
+function useLoadedReturn(): LoadedReturn {
+  const [eligible, setEligible] = useState(false);
+  const [weeks, setWeeks] = useState<ReturnWeek[]>([]);
+  const [arc, setArc] = useState<ReturnArc | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void loadReturnOfferDismissed()
+      .then((wasDismissed) => {
+        if (mountedRef.current) setDismissed(wasDismissed);
+      })
+      .catch(() => {
+        // A failed flag read stays silent — the offer simply is not suppressed.
+      });
+    void mettaReturn
+      .state()
+      .then((state) => {
+        if (!mountedRef.current) return;
+        setEligible(state.eligible);
+        setWeeks(state.weeks);
+        setArc(state.arc);
+      })
+      .catch(() => {
+        // A failed load stays silent — the Return must never nag or crash the tab.
+      });
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  return { eligible, weeks, arc, dismissed, setArc, setDismissed, mountedRef };
+}
+
+export function useMettaReturn(): UseMettaReturnResult {
+  const { eligible, weeks, arc, dismissed, setArc, setDismissed, mountedRef } = useLoadedReturn();
+  const arcRef = useRef<ReturnArc | null>(null);
+
+  // Mirror the committed arc into a ref so a lifecycle call can snapshot it
+  // synchronously for the revert branch when the API rejects immediately.
+  useEffect(() => {
+    arcRef.current = arc;
+  }, [arc]);
+
+  const dismissOffer = useCallback((): void => {
+    setDismissed(true);
+    void saveReturnOfferDismissed().catch(() => {
+      // A failed persist is harmless — the offer is already hidden this session.
+    });
+  }, [setDismissed]);
+
+  const start = useCallback(async (): Promise<void> => {
+    const started = await mettaReturn.start();
+    if (mountedRef.current) setArc(started);
+  }, [mountedRef, setArc]);
+
+  const runLifecycle = useCallback(
+    async (call: () => Promise<ReturnArc>): Promise<void> => {
+      const snapshot = arcRef.current;
+      try {
+        const updated = await call();
+        if (mountedRef.current) setArc(updated);
+      } catch (err) {
+        if (mountedRef.current) setArc(snapshot);
+        throw err;
+      }
+    },
+    [mountedRef, setArc],
+  );
+
+  const pause = useCallback(() => runLifecycle(() => mettaReturn.pause()), [runLifecycle]);
+  const resume = useCallback(() => runLifecycle(() => mettaReturn.resume()), [runLifecycle]);
+
+  const leave = useCallback(async (): Promise<void> => {
+    await mettaReturn.leave();
+    if (mountedRef.current) setArc(null);
+  }, [mountedRef, setArc]);
+
+  const offerVisible = eligible && isContractionSignalActive() && !dismissed && arc === null;
+
+  return { eligible, weeks, arc, offerVisible, dismissOffer, start, pause, resume, leave };
+}

--- a/frontend/src/storage/returnOfferStorage.ts
+++ b/frontend/src/storage/returnOfferStorage.ts
@@ -1,0 +1,20 @@
+// Persists the "the Return offer was set aside" flag so a decline is honoured
+// across launches — the offer stays quiet until the person chooses otherwise.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const RETURN_OFFER_DISMISSED_KEY = '@adepthood/return_offer_dismissed';
+const FLAG_TRUE = 'true';
+
+export async function saveReturnOfferDismissed(): Promise<void> {
+  await AsyncStorage.setItem(RETURN_OFFER_DISMISSED_KEY, FLAG_TRUE);
+}
+
+export async function loadReturnOfferDismissed(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(RETURN_OFFER_DISMISSED_KEY);
+    return raw === FLAG_TRUE;
+  } catch (err) {
+    console.warn('[returnOfferStorage] failed to load dismissal flag', err);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds **the Return**: a declinable five-week Metta arc (self, benefactor, stranger, antagonist, all beings) offered as a soft landing, only after Blue has been passed (highest stage reached >= Orange). Below eligibility it is never offered.
- The offer is always declinable and never shaming; accepting starts an arc the person can pause, resume, or set down at any time with no penalty. **Nothing mutates stage progress.**
- Backend exposes the sequence, eligibility, and the arc lifecycle under `/metta-return` (JWT-scoped, enumeration-safe, no `user_id` in DTOs). The frontend renders the offer and the weekly focus with Candle & Ink tokens, persists a decline locally, and keeps the offer hidden behind a contraction-signal seam that stays quiet until the descriptive contraction detector is wired in a later slice.

Eligibility is derived (there is no "highest reached" column): highest stage reached-by-advancement `>= 5`, or `cycle_number >= 2` (a full prior cycle). Calendar-unlock deliberately does not count — the antagonist / all-beings weeks assume real development.

### Deferred follow-ups (filed separately, out of scope here)
- Wire the offer to the live contraction signal once that detector lands.
- Server-persisted, per-episode dismissal (currently AsyncStorage-local).
- A warm completion state for a finished arc (currently rests at week 5 until set down).
- Launch a guided Metta session from the weekly focus.

## Test plan

- Backend: `./scripts/backend/check-all.sh` green (7/7). New domain + router tests cover eligibility (<= Red not offered; >= Orange offered; cycle>=2), five-week ordering, pause/resume clock math (tz-normalized), the partial-unique index allowing a fresh arc after leave, cross-user isolation, the concurrent-start race collapsing to 409, a no-shame copy sweep, and a snapshot proving start/pause/leave never touch `current_stage`/`completed_stages`/`cycle_number`. New modules: domain 96%, model/router/schema 100%. Ran xenon (A-grade) and radon MI (all A) separately; mypy strict + ruff ALL clean; alembic single head + migration tests pass.
- Frontend: `./scripts/frontend/check-all.sh` green (4/4; 2665 tests). New tests cover the api client (Zod validation), both cards (a11y roles/labels, 44dp targets, week-focus + 5-segment indicator), the hook (offer visibility gating, dismissal persistence, optimistic lifecycle with revert, unmount guard), the copy intent-rule sweep, and TodayScreen wiring. `tsc --noEmit` clean; ESLint zero-warning; prettier clean.

Closes #1003
Refs #943
