### PR TITLE
feat(backend): descriptive contraction detection via a Higher Self reflection

### DIFF
--- a/backend/src/domain/contraction.py
+++ b/backend/src/domain/contraction.py
@@ -1,0 +1,190 @@
+"""Pure contraction detection — naming a natural ebb, never scoring a failure.
+
+Given a snapshot of how a user's habit *foundation* has behaved over a recent
+window, decide whether the moment warrants a warm, declinable Higher Self
+reflection that gently *names* a contraction — a season of easing off — and, for
+someone who has already travelled far, offers the optional five-week Return.
+
+This module encodes NO shaming and NO gamification. It never counts a "broken
+streak", never compares the user to anyone, never demotes, and stays silent by
+default. An absent signal is the expected, healthy case — not a deficiency. A
+contraction is framed exactly as the product philosophy frames it: *Contraction
+follows Expansion; it is ok to need a break from progress.* The thresholds below
+are deliberately long so a reflection only surfaces once a foundation has
+genuinely thinned for a sustained stretch, honoring "you choose your depth"
+before a single word is spoken.
+
+Pure by design: no session, no I/O, no clock. The caller gathers the aggregates
+(that is where the DB lives) and hands them in; every function here is a
+deterministic map from value objects to value objects, trivial to unit-test
+without fixtures.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from domain.constants import TOTAL_STAGES
+
+# How many consecutive days a scheduled goal can go *logged-but-unmet* (a
+# check-in recorded, but at zero units) before the foundation is named as
+# thinning. Two full weeks is long enough that this reads as a genuine season,
+# not a bad day or a busy week -- the reflection lands as recognition of a real
+# ebb, never as a nag after a single slip.
+FOUNDATION_UNMET_CONSECUTIVE_DAYS = 14
+
+# How many consecutive days an established goal can go entirely *unchecked* (no
+# check-in at all) before the same naming applies. Held equal to the unmet
+# window so the two paths agree on what "a sustained stretch" means; silence and
+# zero-effort days are treated with the same patience.
+FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS = 14
+
+# The highest stage a user must have *reached* before the reflection offers the
+# five-week Return rather than the simple ease-off. Orange (stage 5) reached
+# means Blue (stage 4) has been passed; Stage 4 itself stays just below the
+# threshold, so only someone who has integrated the earlier arc is invited into
+# the deeper, more structured Return.
+RETURN_MIN_HIGHEST_STAGE = 5
+
+# The ease-off invitation for someone still early on the path: no elaborate
+# structure, just permission to soften. Names the contraction plainly and hands
+# back agency -- smaller goals, fewer habits, or simple rest -- so the moment is
+# an open door, never a verdict. Deliberately avoids the word "return" so the
+# five-week Return remains the higher-stage variant's distinct offer.
+_SIMPLE_EASE_OFF_MESSAGE = (
+    "It looks like your foundation has grown quiet lately, and that is completely ok. "
+    "Contraction follows expansion as naturally as an out-breath follows an in-breath. "
+    "You might ease off for a while -- keep only the habits that still feel alive, shrink "
+    "a goal or two, or simply rest. Nothing here slips away when you take a break; the path "
+    "waits for you, exactly as it is."
+)
+
+# The Return offer for someone who has already travelled far: the same warm
+# naming, plus the specific, optional invitation to walk the gentle five-week
+# Return. The Return is named and offered only -- never built or assumed -- so
+# the user chooses whether to step into it.
+_RETURN_OFFER_MESSAGE = (
+    "It looks like your foundation has grown quiet lately, and after all the ground you have "
+    "covered, that is completely ok. Contraction follows expansion; it is ok to need a break "
+    "from progress. When it feels right, you are warmly invited to ease into the five-week "
+    "Return -- a slower, gentler arc back toward the practices that steadied you. It is here "
+    "whenever you want it, and just as welcome to set aside for now."
+)
+
+
+class ContractionVariant(StrEnum):
+    """Which warm reflection a flagged contraction warrants.
+
+    ``SIMPLE_EASE_OFF`` is for a user still early on the path -- a plain
+    invitation to soften. ``RETURN_OFFER`` is for a user who has reached
+    :data:`RETURN_MIN_HIGHEST_STAGE` or beyond, adding the optional five-week
+    Return as a declinable next step.
+    """
+
+    SIMPLE_EASE_OFF = "simple_ease_off"
+    RETURN_OFFER = "return_offer"
+
+
+@dataclass(frozen=True)
+class HabitFoundationSignal:
+    """One habit's recent foundation behavior, gathered from persistence.
+
+    ``consecutive_unmet_days`` counts days the goal was checked in at zero units;
+    ``consecutive_unchecked_days`` counts days with no check-in at all. Both are
+    measured from today backwards over a bounded window.
+    """
+
+    habit_id: int
+    consecutive_unmet_days: int
+    consecutive_unchecked_days: int
+
+
+@dataclass(frozen=True)
+class ContractionAggregates:
+    """A snapshot of one user's habit-foundation signals for detection."""
+
+    habits: list[HabitFoundationSignal]
+
+
+@dataclass(frozen=True)
+class ContractionSignal:
+    """A flagged contraction -- the marker that a warm reflection is warranted.
+
+    Carries the ids of the habits whose foundation crossed a window, purely as
+    useful context; detection callers only distinguish ``None`` (silent) from an
+    instance (flagged). Frozen and value-equal so repeated detection over the
+    same aggregates yields an equal signal.
+    """
+
+    flagged_habit_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class ContractionInvitation:
+    """The warm, declinable reflection copy chosen for a flagged contraction."""
+
+    variant: str
+    message: str
+
+
+def _habit_crosses_window(habit: HabitFoundationSignal) -> bool:
+    """Return True when either window is met exactly (window-1 stays silent)."""
+    return (
+        habit.consecutive_unmet_days >= FOUNDATION_UNMET_CONSECUTIVE_DAYS
+        or habit.consecutive_unchecked_days >= FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS
+    )
+
+
+def detect_contraction(aggregates: ContractionAggregates) -> ContractionSignal | None:
+    """Name a contraction when any habit's foundation has thinned for a full window.
+
+    Silent by default: empty or healthy aggregates return ``None``. A single
+    habit crossing either window (unmet *or* unchecked) is enough to flag, since
+    a thinning foundation is worth naming even when only one thread has gone
+    quiet. The boundary is exact -- one day short of a window never flags.
+    """
+    flagged = tuple(h.habit_id for h in aggregates.habits if _habit_crosses_window(h))
+    if not flagged:
+        return None
+    return ContractionSignal(flagged_habit_ids=flagged)
+
+
+def derive_highest_stage_reached(
+    current_stage: int,
+    completed_stages: list[int],
+    cycle_number: int,
+) -> int:
+    """Return the highest stage this user has ever reached.
+
+    Gating is by the *highest* stage reached, not the current one, so a user who
+    climbed high and later eased off is still met with the deeper Return offer.
+    Having looped the curriculum at least once (``cycle_number > 1``) means the
+    whole arc has been reached, so the full :data:`TOTAL_STAGES` applies.
+    """
+    if cycle_number > 1:
+        return TOTAL_STAGES
+    return max(current_stage, max(completed_stages, default=0))
+
+
+def build_contraction_invitation(
+    signal: ContractionSignal,
+    highest_stage_reached: int,
+) -> ContractionInvitation:
+    """Choose the warm reflection copy for a flagged contraction, gated by stage.
+
+    A user below :data:`RETURN_MIN_HIGHEST_STAGE` receives the simple ease-off
+    invitation; one who has reached it or beyond additionally receives the
+    optional five-week Return. ``signal`` is accepted so the gating stays a pure
+    function of a detected contraction plus the user's furthest reach.
+    """
+    del signal  # The copy depends only on the stage gate; the signal marks intent.
+    if highest_stage_reached >= RETURN_MIN_HIGHEST_STAGE:
+        return ContractionInvitation(
+            variant=ContractionVariant.RETURN_OFFER.value,
+            message=_RETURN_OFFER_MESSAGE,
+        )
+    return ContractionInvitation(
+        variant=ContractionVariant.SIMPLE_EASE_OFF.value,
+        message=_SIMPLE_EASE_OFF_MESSAGE,
+    )

--- a/backend/src/domain/contraction.py
+++ b/backend/src/domain/contraction.py
@@ -102,9 +102,15 @@ class HabitFoundationSignal:
 
 @dataclass(frozen=True)
 class ContractionAggregates:
-    """A snapshot of one user's habit-foundation signals for detection."""
+    """A snapshot of one user's habit-foundation signals for detection.
 
-    habits: list[HabitFoundationSignal]
+    ``habits`` is a tuple so the value object is immutable by content, not just
+    by attribute binding: a frozen dataclass forbids reassigning the field but
+    would still let a caller mutate a list in place, which a pure snapshot must
+    not permit.
+    """
+
+    habits: tuple[HabitFoundationSignal, ...]
 
 
 @dataclass(frozen=True)
@@ -124,7 +130,7 @@ class ContractionSignal:
 class ContractionInvitation:
     """The warm, declinable reflection copy chosen for a flagged contraction."""
 
-    variant: str
+    variant: ContractionVariant
     message: str
 
 
@@ -167,24 +173,21 @@ def derive_highest_stage_reached(
     return max(current_stage, max(completed_stages, default=0))
 
 
-def build_contraction_invitation(
-    signal: ContractionSignal,
-    highest_stage_reached: int,
-) -> ContractionInvitation:
+def build_contraction_invitation(highest_stage_reached: int) -> ContractionInvitation:
     """Choose the warm reflection copy for a flagged contraction, gated by stage.
 
     A user below :data:`RETURN_MIN_HIGHEST_STAGE` receives the simple ease-off
     invitation; one who has reached it or beyond additionally receives the
-    optional five-week Return. ``signal`` is accepted so the gating stays a pure
-    function of a detected contraction plus the user's furthest reach.
+    optional five-week Return. The precondition is that a contraction has already
+    been detected (:func:`detect_contraction` returned a signal); the copy itself
+    depends only on the user's furthest reach, so the signal is not an input here.
     """
-    del signal  # The copy depends only on the stage gate; the signal marks intent.
     if highest_stage_reached >= RETURN_MIN_HIGHEST_STAGE:
         return ContractionInvitation(
-            variant=ContractionVariant.RETURN_OFFER.value,
+            variant=ContractionVariant.RETURN_OFFER,
             message=_RETURN_OFFER_MESSAGE,
         )
     return ContractionInvitation(
-        variant=ContractionVariant.SIMPLE_EASE_OFF.value,
+        variant=ContractionVariant.SIMPLE_EASE_OFF,
         message=_SIMPLE_EASE_OFF_MESSAGE,
     )

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -16,10 +16,16 @@ from database import get_session
 from dependencies.ownership import require_owned_journal_entry
 from dependencies.timezone import current_user_timezone
 from domain.care import CarePayload, build_care_payload
+from domain.contraction import (
+    build_contraction_invitation,
+    derive_highest_stage_reached,
+    detect_contraction,
+)
 from domain.detection import CompletionDetected, detect_completions
 from domain.practice_resolution import effective_config
 from domain.resonance import MarginaliaAnchored, generate_essay, generate_marginalia
 from domain.safety import assess_distress
+from domain.stage_progress import get_user_progress
 from errors import bad_gateway, conflict, not_found, unprocessable
 from models.completion_suggestion import (
     CompletionSuggestion,
@@ -50,6 +56,7 @@ from schemas.journal import (
 from schemas.marginalia import (
     CareResourceResponse,
     CareResponse,
+    ContractionReflectionResponse,
     MarginaliaListResponse,
     MarginaliaResponse,
     ResonanceResponse,
@@ -59,6 +66,7 @@ from services import journal_encryption
 from services.botmason import LLMProviderError, resolve_chat_api_key
 from services.checkin import CheckInContext, current_check_in, record_goal_completion
 from services.completion_candidates import gather_candidates
+from services.contraction import gather_contraction_aggregates
 from services.marginalia import (
     BotmasonResonanceLLM,
     reanchor_entry_marginalia,
@@ -66,6 +74,7 @@ from services.marginalia import (
 )
 from services.practice_session_idempotency import record_session, recorded_session_id
 from services.usage import get_monthly_cap
+from services.users import get_user_timezone
 from services.wallet import SpendResult, preflight_deduction, require_user_fresh
 
 
@@ -560,14 +569,63 @@ async def _persist_resonance(
     return rows, suggestions
 
 
+# A user with no StageProgress row yet is treated as the earliest reach: stage 1,
+# nothing completed, first cycle. This keeps the contraction gate on the simple
+# ease-off variant rather than the deeper Return, which is correct for someone
+# who has not begun the staged arc.
+_DEFAULT_CURRENT_STAGE = 1
+_DEFAULT_CYCLE_NUMBER = 1
+
+
+async def _contraction_reflection(
+    session: AsyncSession, user_id: int
+) -> ContractionReflectionResponse | None:
+    """Compute the warm, declinable contraction reflection, or ``None`` if healthy.
+
+    Read-only and deterministic: it gathers the user's habit-foundation signals,
+    detects a sustained contraction, and — only when flagged — gates the copy by
+    the highest stage the user has ever reached. It never writes and never touches
+    progression, so it is safe to run on the resonance happy path.
+    """
+    user_timezone = await get_user_timezone(session, user_id)
+    aggregates = await gather_contraction_aggregates(session, user_id, user_timezone)
+    signal = detect_contraction(aggregates)
+    if signal is None:
+        return None
+    progress = await get_user_progress(session, user_id)
+    if progress is None:
+        highest_stage = derive_highest_stage_reached(
+            _DEFAULT_CURRENT_STAGE, [], _DEFAULT_CYCLE_NUMBER
+        )
+    else:
+        highest_stage = derive_highest_stage_reached(
+            progress.current_stage, progress.completed_stages, progress.cycle_number
+        )
+    invitation = build_contraction_invitation(signal, highest_stage)
+    return ContractionReflectionResponse(variant=invitation.variant, message=invitation.message)
+
+
+@dataclass(frozen=True)
+class _ResonanceSurfaces:
+    """The optional reflection surfaces layered onto a resonance response.
+
+    ``care`` is the acute-distress support surface; ``contraction`` is the warm,
+    declinable naming of a thinned foundation. Both are ``None`` for an ordinary,
+    healthy pass, and bundling them keeps the response builder's signature small.
+    """
+
+    care: CareResponse | None
+    contraction: ContractionReflectionResponse | None = None
+
+
 def _resonance_response(
     rows: list[Marginalia],
     suggestions: list[CompletionSuggestion],
     spent: SpendResult,
     reset_date: datetime,
-    care: CareResponse | None,
+    surfaces: _ResonanceSurfaces,
 ) -> ResonanceResponse:
-    """Build the success response: notes, suggestions, refreshed balances, care."""
+    """Build the success response: notes, suggestions, refreshed balances, surfaces."""
     return ResonanceResponse(
         marginalia=[MarginaliaResponse.model_validate(r, from_attributes=True) for r in rows],
         suggestions=[
@@ -577,7 +635,8 @@ def _resonance_response(
         remaining_messages=max(get_monthly_cap() - spent.monthly_used, 0),
         remaining_balance=spent.offering_balance,
         monthly_reset_date=reset_date,
-        care=care,
+        care=surfaces.care,
+        contraction=surfaces.contraction,
     )
 
 
@@ -601,6 +660,11 @@ async def run_resonance(
     professional support) that accompanies — never replaces — the reflection, and
     is returned even if the LLM pass fails, so care never depends on the LLM
     (NORTH-STAR §10). An ordinary entry behaves exactly as before (``care`` None).
+
+    After the pass commits, a read-only, deterministic contraction check may add a
+    warm, declinable reflection when the habit foundation has thinned. It runs
+    only on this non-intimate happy path — never for an intimate entry, whose
+    privacy floor returns above — and never mutates progression.
     """
     entry = await _load_user_entry(session, entry_id, current_user)
     if entry is None:
@@ -630,7 +694,9 @@ async def run_resonance(
         "journal_resonance_generated",
         extra={"user_id": current_user, "entry_id": entry_id, "count": len(rows)},
     )
-    return _resonance_response(rows, suggestions, spent, spent_user.monthly_reset_date, care)
+    contraction = await _contraction_reflection(session, current_user)
+    surfaces = _ResonanceSurfaces(care=care, contraction=contraction)
+    return _resonance_response(rows, suggestions, spent, spent_user.monthly_reset_date, surfaces)
 
 
 @router.get("/{entry_id}/marginalia", response_model=MarginaliaListResponse)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -601,7 +601,7 @@ async def _contraction_reflection(
         highest_stage = derive_highest_stage_reached(
             progress.current_stage, progress.completed_stages, progress.cycle_number
         )
-    invitation = build_contraction_invitation(signal, highest_stage)
+    invitation = build_contraction_invitation(highest_stage)
     return ContractionReflectionResponse(variant=invitation.variant, message=invitation.message)
 
 

--- a/backend/src/schemas/marginalia.py
+++ b/backend/src/schemas/marginalia.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pydantic import BaseModel
 
 from domain.care import CareKind
+from domain.contraction import ContractionVariant
 from models.marginalia import MarginaliaKind, MarginaliaStatus
 from schemas.completion_suggestion import CompletionSuggestionResponse
 
@@ -68,7 +69,7 @@ class ContractionReflectionResponse(BaseModel):
     choose your depth." Present only when a sustained contraction is detected.
     """
 
-    variant: str
+    variant: ContractionVariant
     message: str
 
 

--- a/backend/src/schemas/marginalia.py
+++ b/backend/src/schemas/marginalia.py
@@ -59,6 +59,19 @@ class CareResponse(BaseModel):
     resources: list[CareResourceResponse]
 
 
+class ContractionReflectionResponse(BaseModel):
+    """A warm, declinable Higher Self reflection naming a foundation's contraction.
+
+    Mirrors :class:`domain.contraction.ContractionInvitation`: a ``variant`` drawn
+    from ``ContractionVariant`` and the deterministic ``message`` for it. Never a
+    demotion, never a broken-streak notice — a gentle naming that honors "you
+    choose your depth." Present only when a sustained contraction is detected.
+    """
+
+    variant: str
+    message: str
+
+
 class ResonanceResponse(BaseModel):
     """Result of a resonance pass: the new notes plus refreshed wallet balances.
 
@@ -75,6 +88,11 @@ class ResonanceResponse(BaseModel):
     and ``private_message`` carries the non-shaming explanation. Both fields are
     defaulted, so every existing (public/personal) response is byte-for-byte
     unchanged.
+
+    ``contraction`` is ``None`` for a healthy or new user; on a sustained thinning
+    of the habit foundation it carries a warm, declinable reflection. It is
+    computed locally (no LLM) and has zero side effects on progression, and — like
+    ``care`` / ``private`` — is defaulted so every existing response is unchanged.
     """
 
     marginalia: list[MarginaliaResponse]
@@ -85,6 +103,7 @@ class ResonanceResponse(BaseModel):
     care: CareResponse | None = None
     private: bool = False
     private_message: str | None = None
+    contraction: ContractionReflectionResponse | None = None
 
 
 class MarginaliaListResponse(BaseModel):

--- a/backend/src/services/contraction.py
+++ b/backend/src/services/contraction.py
@@ -1,0 +1,182 @@
+"""Read-only gathering of a user's habit-foundation signals for contraction math.
+
+The DB-aware companion to :mod:`domain.contraction`. It reads a user's habits,
+their additive goals, and the recent goal completions with a bounded, constant
+number of batched queries (never one-per-habit), buckets the completions into
+user-local days in memory, and derives each habit's consecutive unmet / unchecked
+day counts. The result is handed to the pure detection function.
+
+Strictly read-only: it issues ``SELECT`` statements only and never stages a
+write, so calling it during a resonance pass can have no side effect on
+progression or history.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, timedelta
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.contraction import (
+    FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS,
+    FOUNDATION_UNMET_CONSECUTIVE_DAYS,
+    ContractionAggregates,
+    HabitFoundationSignal,
+)
+from domain.dates import to_user_date_bucket, today_in_tz
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+
+# The furthest back the day-walk ever looks. It is the wider of the two windows:
+# once a walk reaches this many consecutive qualifying days the habit is already
+# flagged, so counting further would change no decision while lengthening the
+# query and the loop.
+_OBSERVATION_WINDOW_DAYS = max(
+    FOUNDATION_UNMET_CONSECUTIVE_DAYS, FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS
+)
+
+
+async def _gather_habit_goal_rows(
+    session: AsyncSession, user_id: int
+) -> list[tuple[int, int, date]]:
+    """Read ``(habit_id, goal_id, habit_start_date)`` for each additive goal, in one query.
+
+    Subtractive goals are excluded at the SQL layer: for them the absence of a
+    completion is success, so their silence must never read as a contraction.
+    """
+    result = await session.execute(
+        select(col(Habit.id), col(Goal.id), col(Habit.start_date))
+        .join(Goal, col(Goal.habit_id) == col(Habit.id))
+        .where(col(Habit.user_id) == user_id, col(Goal.is_additive).is_(True))
+    )
+    return [(habit_id, goal_id, start_date) for habit_id, goal_id, start_date in result.all()]
+
+
+async def _gather_completion_days(
+    session: AsyncSession,
+    goal_ids: list[int],
+    user_id: int,
+    user_timezone: str,
+    since: date,
+) -> dict[int, dict[date, float]]:
+    """Sum completion units per goal per user-local day, over one bounded query.
+
+    Keyed ``goal_id -> {local_day -> total_units}`` so the day-walk can ask, for
+    any day, both "was there a check-in?" (key present) and "did it meet the
+    goal?" (value > 0).
+    """
+    totals: dict[int, dict[date, float]] = defaultdict(lambda: defaultdict(float))
+    if not goal_ids:
+        return totals
+    result = await session.execute(
+        select(
+            GoalCompletion.goal_id, GoalCompletion.timestamp, GoalCompletion.completed_units
+        ).where(
+            col(GoalCompletion.user_id) == user_id,
+            col(GoalCompletion.goal_id).in_(goal_ids),
+        )
+    )
+    for goal_id, timestamp, units in result.all():
+        day = to_user_date_bucket(timestamp, user_timezone)
+        if day >= since:
+            totals[goal_id][day] += units
+    return totals
+
+
+def _consecutive_days(
+    day_totals: dict[date, float],
+    *,
+    today: date,
+    earliest: date,
+    unmet: bool,
+) -> int:
+    """Count consecutive qualifying days walking back from ``today`` to ``earliest``.
+
+    ``unmet=True`` counts days that carry a zero-unit check-in (logged but not
+    met); ``unmet=False`` counts days with no check-in at all. The walk stops at
+    the first non-qualifying day or once it crosses ``earliest`` (the habit's
+    start, so a brand-new habit can never accrue a long unchecked run).
+    """
+    streak = 0
+    cursor = today
+    while cursor >= earliest:
+        present = cursor in day_totals
+        qualifies = (present and day_totals[cursor] <= 0.0) if unmet else not present
+        if not qualifies:
+            break
+        streak += 1
+        cursor -= timedelta(days=1)
+    return streak
+
+
+def _build_signal(
+    habit_id: int,
+    day_totals: dict[date, float],
+    *,
+    today: date,
+    start_date: date,
+) -> HabitFoundationSignal:
+    """Derive one habit's unmet / unchecked consecutive-day counts."""
+    earliest = max(start_date, today - timedelta(days=_OBSERVATION_WINDOW_DAYS))
+    return HabitFoundationSignal(
+        habit_id=habit_id,
+        consecutive_unmet_days=_consecutive_days(
+            day_totals, today=today, earliest=earliest, unmet=True
+        ),
+        consecutive_unchecked_days=_consecutive_days(
+            day_totals, today=today, earliest=earliest, unmet=False
+        ),
+    )
+
+
+def _fold_by_habit(
+    habit_goal_rows: list[tuple[int, int, date]],
+    completion_days: dict[int, dict[date, float]],
+) -> tuple[dict[int, dict[date, float]], dict[int, date]]:
+    """Collapse goal-keyed day totals onto their habit and record each habit's start.
+
+    A habit reads as "checked" on any day any of its goals was logged, so each
+    goal's day totals are summed into the owning habit's totals.
+    """
+    per_habit_totals: dict[int, dict[date, float]] = defaultdict(lambda: defaultdict(float))
+    habit_start: dict[int, date] = {}
+    for habit_id, goal_id, start_date in habit_goal_rows:
+        habit_start[habit_id] = start_date
+        for day, units in completion_days.get(goal_id, {}).items():
+            per_habit_totals[habit_id][day] += units
+    return per_habit_totals, habit_start
+
+
+async def gather_contraction_aggregates(
+    session: AsyncSession,
+    user_id: int,
+    user_timezone: str = "UTC",
+) -> ContractionAggregates:
+    """Assemble a user's habit-foundation snapshot with two batched, read-only queries.
+
+    One query reads the user's additive goals (subtractive goals excluded), a
+    second reads their recent completions; the day-walk then runs purely in
+    memory. Multiple goals under one habit are folded into that habit's day
+    totals, so a habit reads as "checked" on any day any of its goals was logged.
+    """
+    today = today_in_tz(user_timezone)
+    since = today - timedelta(days=_OBSERVATION_WINDOW_DAYS)
+    habit_goal_rows = await _gather_habit_goal_rows(session, user_id)
+    if not habit_goal_rows:
+        return ContractionAggregates(habits=[])
+    goal_ids = [goal_id for _, goal_id, _ in habit_goal_rows]
+    completion_days = await _gather_completion_days(
+        session, goal_ids, user_id, user_timezone, since
+    )
+    per_habit_totals, habit_start = _fold_by_habit(habit_goal_rows, completion_days)
+    return ContractionAggregates(
+        habits=[
+            _build_signal(
+                habit_id, per_habit_totals[habit_id], today=today, start_date=habit_start[habit_id]
+            )
+            for habit_id in habit_start
+        ]
+    )

--- a/backend/src/services/contraction.py
+++ b/backend/src/services/contraction.py
@@ -25,7 +25,7 @@ from domain.contraction import (
     ContractionAggregates,
     HabitFoundationSignal,
 )
-from domain.dates import to_user_date_bucket, today_in_tz
+from domain.dates import day_bounds_in_tz, to_user_date_bucket, today_in_tz
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
@@ -66,17 +66,24 @@ async def _gather_completion_days(
 
     Keyed ``goal_id -> {local_day -> total_units}`` so the day-walk can ask, for
     any day, both "was there a check-in?" (key present) and "did it meet the
-    goal?" (value > 0).
+    goal?" (value > 0). The query is bounded on time as well as goals: it filters
+    at the SQL layer to rows on or after the UTC instant of local midnight on
+    ``since`` (:func:`day_bounds_in_tz`), so a long-lived user's whole completion
+    history is never loaded only to be discarded. The in-memory ``day >= since``
+    guard is retained as an exact-boundary backstop against any DST/edge skew
+    between the SQL bound and per-row user-local bucketing.
     """
     totals: dict[int, dict[date, float]] = defaultdict(lambda: defaultdict(float))
     if not goal_ids:
         return totals
+    since_utc, _ = day_bounds_in_tz(user_timezone, since)
     result = await session.execute(
         select(
             GoalCompletion.goal_id, GoalCompletion.timestamp, GoalCompletion.completed_units
         ).where(
             col(GoalCompletion.user_id) == user_id,
             col(GoalCompletion.goal_id).in_(goal_ids),
+            col(GoalCompletion.timestamp) >= since_utc,
         )
     )
     for goal_id, timestamp, units in result.all():
@@ -166,17 +173,17 @@ async def gather_contraction_aggregates(
     since = today - timedelta(days=_OBSERVATION_WINDOW_DAYS)
     habit_goal_rows = await _gather_habit_goal_rows(session, user_id)
     if not habit_goal_rows:
-        return ContractionAggregates(habits=[])
+        return ContractionAggregates(habits=())
     goal_ids = [goal_id for _, goal_id, _ in habit_goal_rows]
     completion_days = await _gather_completion_days(
         session, goal_ids, user_id, user_timezone, since
     )
     per_habit_totals, habit_start = _fold_by_habit(habit_goal_rows, completion_days)
     return ContractionAggregates(
-        habits=[
+        habits=tuple(
             _build_signal(
                 habit_id, per_habit_totals[habit_id], today=today, start_date=habit_start[habit_id]
             )
             for habit_id in habit_start
-        ]
+        )
     )

--- a/backend/tests/domain/test_contraction.py
+++ b/backend/tests/domain/test_contraction.py
@@ -9,13 +9,13 @@ Pinned public surface:
   FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS = 14
   RETURN_MIN_HIGHEST_STAGE = 5
   HabitFoundationSignal(habit_id, consecutive_unmet_days, consecutive_unchecked_days)
-  ContractionAggregates(habits: list[HabitFoundationSignal])
+  ContractionAggregates(habits: tuple[HabitFoundationSignal, ...])
   ContractionSignal (frozen; flagged marker, minimal fields)
-  ContractionInvitation(variant: str, message: str)  [frozen]
+  ContractionInvitation(variant: ContractionVariant, message: str)  [frozen]
   ContractionVariant(StrEnum): SIMPLE_EASE_OFF, RETURN_OFFER
   detect_contraction(aggregates) -> ContractionSignal | None
   derive_highest_stage_reached(current_stage, completed_stages, cycle_number) -> int
-  build_contraction_invitation(signal, highest_stage_reached) -> ContractionInvitation
+  build_contraction_invitation(highest_stage_reached) -> ContractionInvitation
 
 The detected condition is never framed as failure, a demotion, or a broken
 streak — it is a warm, declinable Higher Self reflection honoring
@@ -47,27 +47,20 @@ from domain.contraction import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-_EMPTY = ContractionAggregates(habits=[])
+_EMPTY = ContractionAggregates(habits=())
 
 
 def _agg(*, unmet: int = 0, unchecked: int = 0, habit_id: int = 1) -> ContractionAggregates:
     """Build a single-habit aggregates object for a scenario."""
     return ContractionAggregates(
-        habits=[
+        habits=(
             HabitFoundationSignal(
                 habit_id=habit_id,
                 consecutive_unmet_days=unmet,
                 consecutive_unchecked_days=unchecked,
-            )
-        ]
+            ),
+        )
     )
-
-
-def _flagged_signal() -> ContractionSignal:
-    """A clearly-flagged ContractionSignal, for invitation-building tests."""
-    signal = detect_contraction(_agg(unmet=FOUNDATION_UNMET_CONSECUTIVE_DAYS))
-    assert signal is not None
-    return signal
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +71,13 @@ def _flagged_signal() -> ContractionSignal:
 def test_empty_aggregates_returns_none() -> None:
     """No habits at all is a healthy/new-user state -- no contraction signal."""
     assert detect_contraction(_EMPTY) is None
+
+
+def test_flagged_signal_is_a_contraction_signal_with_habit_ids() -> None:
+    """A crossed window yields a ContractionSignal carrying the flagged habit ids."""
+    signal = detect_contraction(_agg(unmet=FOUNDATION_UNMET_CONSECUTIVE_DAYS, habit_id=7))
+    assert isinstance(signal, ContractionSignal)
+    assert signal.flagged_habit_ids == (7,)
 
 
 # ---------------------------------------------------------------------------
@@ -146,24 +146,19 @@ def test_highest_stage_reached_beyond_first_cycle_is_total_stages() -> None:
 
 def test_low_stage_yields_simple_ease_off_variant() -> None:
     """Highest stage reached <= 3 gets the simple ease-off invitation."""
-    signal = _flagged_signal()
-    invitation = build_contraction_invitation(signal, highest_stage_reached=3)
+    invitation = build_contraction_invitation(highest_stage_reached=3)
     assert invitation.variant == ContractionVariant.SIMPLE_EASE_OFF
 
 
 def test_blue_stage_itself_yields_simple_ease_off_variant() -> None:
     """Stage 4 (Blue) itself, not yet passed, still gets the simple variant."""
-    signal = _flagged_signal()
-    invitation = build_contraction_invitation(signal, highest_stage_reached=4)
+    invitation = build_contraction_invitation(highest_stage_reached=4)
     assert invitation.variant == ContractionVariant.SIMPLE_EASE_OFF
 
 
 def test_stage_at_return_threshold_yields_return_offer_variant() -> None:
     """Having reached RETURN_MIN_HIGHEST_STAGE or beyond offers the Return."""
-    signal = _flagged_signal()
-    invitation = build_contraction_invitation(
-        signal, highest_stage_reached=RETURN_MIN_HIGHEST_STAGE
-    )
+    invitation = build_contraction_invitation(highest_stage_reached=RETURN_MIN_HIGHEST_STAGE)
     assert invitation.variant == ContractionVariant.RETURN_OFFER
 
 
@@ -181,10 +176,9 @@ def test_detect_contraction_is_deterministic() -> None:
 
 
 def test_build_contraction_invitation_is_deterministic() -> None:
-    """Same signal + stage in -> equal ContractionInvitation out, every time."""
-    signal = _flagged_signal()
-    first = build_contraction_invitation(signal, highest_stage_reached=2)
-    second = build_contraction_invitation(signal, highest_stage_reached=2)
+    """Same stage in -> equal ContractionInvitation out, every time."""
+    first = build_contraction_invitation(highest_stage_reached=2)
+    second = build_contraction_invitation(highest_stage_reached=2)
     assert first == second
 
 
@@ -209,6 +203,18 @@ def test_contraction_invitation_is_frozen() -> None:
         invitation.message = "mutated"  # type: ignore[misc]
 
 
+def test_contraction_aggregates_habits_are_immutable_by_content() -> None:
+    """The ``habits`` tuple cannot be appended to -- a snapshot is immutable in full."""
+    aggregates = _agg(unmet=FOUNDATION_UNMET_CONSECUTIVE_DAYS)
+    assert isinstance(aggregates.habits, tuple)
+    with pytest.raises(AttributeError):
+        aggregates.habits.append(  # type: ignore[attr-defined]
+            HabitFoundationSignal(
+                habit_id=99, consecutive_unmet_days=0, consecutive_unchecked_days=0
+            )
+        )
+
+
 # ---------------------------------------------------------------------------
 # 9. Copy intent: warm, never shaming
 # ---------------------------------------------------------------------------
@@ -230,8 +236,7 @@ _FORBIDDEN_SUBSTRINGS = (
 
 def test_simple_ease_off_message_is_warm_and_non_shaming() -> None:
     """The ease-off message contains no shame/gamification language."""
-    signal = _flagged_signal()
-    invitation = build_contraction_invitation(signal, highest_stage_reached=1)
+    invitation = build_contraction_invitation(highest_stage_reached=1)
     assert invitation.message
     lowered = invitation.message.lower()
     for forbidden in _FORBIDDEN_SUBSTRINGS:
@@ -243,10 +248,7 @@ def test_simple_ease_off_message_is_warm_and_non_shaming() -> None:
 
 def test_return_offer_message_is_warm_and_non_shaming() -> None:
     """The Return-offer message contains no shame/gamification language."""
-    signal = _flagged_signal()
-    invitation = build_contraction_invitation(
-        signal, highest_stage_reached=RETURN_MIN_HIGHEST_STAGE
-    )
+    invitation = build_contraction_invitation(highest_stage_reached=RETURN_MIN_HIGHEST_STAGE)
     assert invitation.message
     lowered = invitation.message.lower()
     for forbidden in _FORBIDDEN_SUBSTRINGS:
@@ -264,6 +266,5 @@ def test_return_offer_message_is_warm_and_non_shaming() -> None:
 
 def test_simple_ease_off_message_does_not_mention_return() -> None:
     """The Return's specific wording is only emitted by the return variant."""
-    signal = _flagged_signal()
-    invitation = build_contraction_invitation(signal, highest_stage_reached=2)
+    invitation = build_contraction_invitation(highest_stage_reached=2)
     assert "return" not in invitation.message.lower()

--- a/backend/tests/domain/test_contraction.py
+++ b/backend/tests/domain/test_contraction.py
@@ -1,0 +1,269 @@
+"""Pure-domain tests for :mod:`domain.contraction` — warm contraction detection.
+
+These tests FAIL on import until the implementation-specialist creates
+``backend/src/domain/contraction.py`` with the contracts pinned below.
+That is the correct RED state for Gate 1.
+
+Pinned public surface:
+  FOUNDATION_UNMET_CONSECUTIVE_DAYS = 14
+  FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS = 14
+  RETURN_MIN_HIGHEST_STAGE = 5
+  HabitFoundationSignal(habit_id, consecutive_unmet_days, consecutive_unchecked_days)
+  ContractionAggregates(habits: list[HabitFoundationSignal])
+  ContractionSignal (frozen; flagged marker, minimal fields)
+  ContractionInvitation(variant: str, message: str)  [frozen]
+  ContractionVariant(StrEnum): SIMPLE_EASE_OFF, RETURN_OFFER
+  detect_contraction(aggregates) -> ContractionSignal | None
+  derive_highest_stage_reached(current_stage, completed_stages, cycle_number) -> int
+  build_contraction_invitation(signal, highest_stage_reached) -> ContractionInvitation
+
+The detected condition is never framed as failure, a demotion, or a broken
+streak — it is a warm, declinable Higher Self reflection honoring
+"you choose your depth."
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from domain.constants import TOTAL_STAGES
+from domain.contraction import (
+    FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS,
+    FOUNDATION_UNMET_CONSECUTIVE_DAYS,
+    RETURN_MIN_HIGHEST_STAGE,
+    ContractionAggregates,
+    ContractionInvitation,
+    ContractionSignal,
+    ContractionVariant,
+    HabitFoundationSignal,
+    build_contraction_invitation,
+    derive_highest_stage_reached,
+    detect_contraction,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EMPTY = ContractionAggregates(habits=[])
+
+
+def _agg(*, unmet: int = 0, unchecked: int = 0, habit_id: int = 1) -> ContractionAggregates:
+    """Build a single-habit aggregates object for a scenario."""
+    return ContractionAggregates(
+        habits=[
+            HabitFoundationSignal(
+                habit_id=habit_id,
+                consecutive_unmet_days=unmet,
+                consecutive_unchecked_days=unchecked,
+            )
+        ]
+    )
+
+
+def _flagged_signal() -> ContractionSignal:
+    """A clearly-flagged ContractionSignal, for invitation-building tests."""
+    signal = detect_contraction(_agg(unmet=FOUNDATION_UNMET_CONSECUTIVE_DAYS))
+    assert signal is not None
+    return signal
+
+
+# ---------------------------------------------------------------------------
+# 1. Empty aggregates -> silence by default
+# ---------------------------------------------------------------------------
+
+
+def test_empty_aggregates_returns_none() -> None:
+    """No habits at all is a healthy/new-user state -- no contraction signal."""
+    assert detect_contraction(_EMPTY) is None
+
+
+# ---------------------------------------------------------------------------
+# 2 & 3. Unmet-days boundary
+# ---------------------------------------------------------------------------
+
+
+def test_unmet_days_below_window_returns_none() -> None:
+    """One day short of the window must not flag a contraction."""
+    below = _agg(unmet=FOUNDATION_UNMET_CONSECUTIVE_DAYS - 1)
+    assert detect_contraction(below) is None
+
+
+def test_unmet_days_at_window_flags_contraction() -> None:
+    """Exactly the window of consecutive unmet days flags a contraction."""
+    at_window = _agg(unmet=FOUNDATION_UNMET_CONSECUTIVE_DAYS)
+    assert detect_contraction(at_window) is not None
+
+
+# ---------------------------------------------------------------------------
+# 4. Unchecked-days boundary (independent path)
+# ---------------------------------------------------------------------------
+
+
+def test_unchecked_days_at_window_flags_contraction() -> None:
+    """Exactly the window of consecutive unchecked days flags a contraction."""
+    at_window = _agg(unchecked=FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS)
+    assert detect_contraction(at_window) is not None
+
+
+def test_unchecked_days_below_window_returns_none() -> None:
+    """One day short of the unchecked window must not flag a contraction."""
+    below = _agg(unchecked=FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS - 1)
+    assert detect_contraction(below) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. derive_highest_stage_reached
+# ---------------------------------------------------------------------------
+
+
+def test_highest_stage_reached_prefers_completed_over_lower_current() -> None:
+    """Current stage 3 with completed [1, 2] in cycle 1 stays at 3 (max)."""
+    assert derive_highest_stage_reached(3, [1, 2], 1) == 3
+
+
+def test_highest_stage_reached_prefers_completed_when_higher() -> None:
+    """Completed stages above the current stage win the max."""
+    assert derive_highest_stage_reached(2, [1, 2, 3, 4], 1) == 4
+
+
+def test_highest_stage_reached_with_no_completed_stages() -> None:
+    """No completed stages at all: highest reached is just the current stage."""
+    assert derive_highest_stage_reached(1, [], 1) == 1
+
+
+def test_highest_stage_reached_beyond_first_cycle_is_total_stages() -> None:
+    """Having looped at least once means the full curriculum has been reached."""
+    assert derive_highest_stage_reached(2, [1], 2) == TOTAL_STAGES
+
+
+# ---------------------------------------------------------------------------
+# 6. Stage-gating via build_contraction_invitation
+# ---------------------------------------------------------------------------
+
+
+def test_low_stage_yields_simple_ease_off_variant() -> None:
+    """Highest stage reached <= 3 gets the simple ease-off invitation."""
+    signal = _flagged_signal()
+    invitation = build_contraction_invitation(signal, highest_stage_reached=3)
+    assert invitation.variant == ContractionVariant.SIMPLE_EASE_OFF
+
+
+def test_blue_stage_itself_yields_simple_ease_off_variant() -> None:
+    """Stage 4 (Blue) itself, not yet passed, still gets the simple variant."""
+    signal = _flagged_signal()
+    invitation = build_contraction_invitation(signal, highest_stage_reached=4)
+    assert invitation.variant == ContractionVariant.SIMPLE_EASE_OFF
+
+
+def test_stage_at_return_threshold_yields_return_offer_variant() -> None:
+    """Having reached RETURN_MIN_HIGHEST_STAGE or beyond offers the Return."""
+    signal = _flagged_signal()
+    invitation = build_contraction_invitation(
+        signal, highest_stage_reached=RETURN_MIN_HIGHEST_STAGE
+    )
+    assert invitation.variant == ContractionVariant.RETURN_OFFER
+
+
+# ---------------------------------------------------------------------------
+# 7. Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_detect_contraction_is_deterministic() -> None:
+    """Same aggregates in -> equal ContractionSignal out, every time."""
+    agg = _agg(unmet=FOUNDATION_UNMET_CONSECUTIVE_DAYS)
+    first = detect_contraction(agg)
+    second = detect_contraction(agg)
+    assert first == second
+
+
+def test_build_contraction_invitation_is_deterministic() -> None:
+    """Same signal + stage in -> equal ContractionInvitation out, every time."""
+    signal = _flagged_signal()
+    first = build_contraction_invitation(signal, highest_stage_reached=2)
+    second = build_contraction_invitation(signal, highest_stage_reached=2)
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# 8. Frozen dataclass guard
+# ---------------------------------------------------------------------------
+
+
+def test_habit_foundation_signal_is_frozen() -> None:
+    """HabitFoundationSignal cannot be mutated after construction."""
+    signal = HabitFoundationSignal(
+        habit_id=1, consecutive_unmet_days=0, consecutive_unchecked_days=0
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        signal.habit_id = 2  # type: ignore[misc]
+
+
+def test_contraction_invitation_is_frozen() -> None:
+    """ContractionInvitation cannot be mutated after construction."""
+    invitation = ContractionInvitation(variant=ContractionVariant.SIMPLE_EASE_OFF, message="Rest.")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        invitation.message = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 9. Copy intent: warm, never shaming
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_SUBSTRINGS = (
+    "streak",
+    "fail",
+    "failed",
+    "behind",
+    "lost",
+    "should",
+    "demot",
+    "rank",
+    "punish",
+    "worse",
+    "give up",
+)
+
+
+def test_simple_ease_off_message_is_warm_and_non_shaming() -> None:
+    """The ease-off message contains no shame/gamification language."""
+    signal = _flagged_signal()
+    invitation = build_contraction_invitation(signal, highest_stage_reached=1)
+    assert invitation.message
+    lowered = invitation.message.lower()
+    for forbidden in _FORBIDDEN_SUBSTRINGS:
+        assert forbidden not in lowered, (
+            f"forbidden word {forbidden!r} found in: {invitation.message!r}"
+        )
+    assert any(anchor in lowered for anchor in ("break", "ease", "rest"))
+
+
+def test_return_offer_message_is_warm_and_non_shaming() -> None:
+    """The Return-offer message contains no shame/gamification language."""
+    signal = _flagged_signal()
+    invitation = build_contraction_invitation(
+        signal, highest_stage_reached=RETURN_MIN_HIGHEST_STAGE
+    )
+    assert invitation.message
+    lowered = invitation.message.lower()
+    for forbidden in _FORBIDDEN_SUBSTRINGS:
+        assert forbidden not in lowered, (
+            f"forbidden word {forbidden!r} found in: {invitation.message!r}"
+        )
+    assert "return" in lowered
+    assert any(anchor in lowered for anchor in ("break", "ease", "rest"))
+
+
+# ---------------------------------------------------------------------------
+# 10. Variant-specific wording is not cross-contaminated
+# ---------------------------------------------------------------------------
+
+
+def test_simple_ease_off_message_does_not_mention_return() -> None:
+    """The Return's specific wording is only emitted by the return variant."""
+    signal = _flagged_signal()
+    invitation = build_contraction_invitation(signal, highest_stage_reached=2)
+    assert "return" not in invitation.message.lower()

--- a/backend/tests/routers/test_contraction_reflection.py
+++ b/backend/tests/routers/test_contraction_reflection.py
@@ -1,0 +1,317 @@
+"""Router tests -- contraction reflection riding the resonance endpoint.
+
+These tests FAIL until ``ResonanceResponse.contraction`` (schemas/marginalia.py)
+and its wiring into ``run_resonance`` (routers/journal.py) exist. That is the
+correct RED state for Gate 1.
+
+The reflection is a warm, declinable Higher Self surface -- never a demotion --
+and must never alter stage progression, never touch the intimate privacy floor,
+and never drift from the domain's ContractionVariant enum.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from http import HTTPStatus
+from types import SimpleNamespace
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from domain.contraction import FOUNDATION_UNMET_CONSECUTIVE_DAYS, ContractionVariant
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.journal_entry import JournalEntry
+from models.stage_progress import StageProgress
+from services import marginalia as marginalia_service
+
+_BODY = "I walked by the river and the willow bent without breaking."
+
+
+async def _signup(
+    client: AsyncClient, username: str = "contractionuser"
+) -> tuple[dict[str, str], int]:
+    """Create a user and return (auth headers, user_id)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+async def _create_entry(
+    client: AsyncClient,
+    headers: dict[str, str],
+    *,
+    body: str = _BODY,
+    classification: str | None = None,
+) -> int:
+    """POST a journal entry and return its id."""
+    payload: dict[str, str] = {"message": body}
+    if classification is not None:
+        payload["classification"] = classification
+    resp = await client.post("/journal/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+def _fake_llm(monkeypatch: pytest.MonkeyPatch, *notes: dict[str, str]) -> None:
+    """Patch the resonance LLM seam to return canned JSON notes."""
+    payload = json.dumps({"notes": list(notes)})
+
+    async def _complete(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> SimpleNamespace:
+        del prompt, history, system_prompt, api_key
+        return SimpleNamespace(text=payload)
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _complete)
+
+
+async def _make_flagged_habit(session: AsyncSession, user_id: int) -> None:
+    """Seed a habit whose goal has gone unmet for the full contraction window."""
+    habit = Habit(
+        name="Meditate",
+        icon="flame",
+        start_date=date(2020, 1, 1),
+        stage="1",
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    assert habit.id is not None
+
+    goal = Goal(
+        habit_id=habit.id,
+        title="Daily sit",
+        tier="clear",
+        target=1.0,
+        target_unit="minutes",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    assert goal.id is not None
+
+    now = datetime.now(UTC)
+    for days_ago in range(FOUNDATION_UNMET_CONSECUTIVE_DAYS):
+        session.add(
+            GoalCompletion(
+                goal_id=goal.id,
+                user_id=user_id,
+                completed_units=0.0,
+                timestamp=now - timedelta(days=days_ago),
+            )
+        )
+    await session.commit()
+
+
+async def _make_healthy_habit(session: AsyncSession, user_id: int) -> None:
+    """Seed a habit with recent positive completions -- no contraction signal."""
+    habit = Habit(
+        name="Meditate",
+        icon="flame",
+        start_date=date(2020, 1, 1),
+        stage="1",
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    assert habit.id is not None
+
+    goal = Goal(
+        habit_id=habit.id,
+        title="Daily sit",
+        tier="clear",
+        target=1.0,
+        target_unit="minutes",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    assert goal.id is not None
+
+    now = datetime.now(UTC)
+    for days_ago in range(3):
+        session.add(
+            GoalCompletion(
+                goal_id=goal.id,
+                user_id=user_id,
+                completed_units=1.0,
+                timestamp=now - timedelta(days=days_ago),
+            )
+        )
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# 1. Flagged user -> non-null contraction reflection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flagged_user_receives_contraction_reflection(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user in a flagged contraction condition gets a non-null contraction object."""
+    _fake_llm(monkeypatch, {"kind": "theme", "quote": "the willow bent", "note": "It holds."})
+    headers, user_id = await _signup(async_client, "flaggeduser")
+    await _make_flagged_habit(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers, classification="personal")
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+    assert body["contraction"] is not None
+    assert body["contraction"]["variant"]
+    assert body["contraction"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Healthy user -> contraction is null/absent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_healthy_user_has_no_contraction_reflection(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A healthy user's resonance response carries no contraction object."""
+    _fake_llm(monkeypatch, {"kind": "theme", "quote": "the willow bent", "note": "It holds."})
+    headers, user_id = await _signup(async_client, "healthyuser")
+    await _make_healthy_habit(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers, classification="personal")
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+    assert body.get("contraction") is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Intimate entry -> private path, contraction null, no cloud call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_intimate_entry_keeps_contraction_null_and_stays_private(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An intimate entry's resonance stays private: contraction is null, LLM untouched."""
+
+    class _SpyLLM:
+        """Counts calls; must never be reached for an intimate entry."""
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(
+            self, prompt: str, history: object, *, system_prompt: object, api_key: object
+        ) -> SimpleNamespace:
+            del prompt, history, system_prompt, api_key
+            self.calls += 1
+            return SimpleNamespace(text='{"notes":[]}')
+
+    spy = _SpyLLM()
+    monkeypatch.setattr(marginalia_service, "generate_response", spy)
+
+    headers, user_id = await _signup(async_client, "intimatecontraction")
+    await _make_flagged_habit(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers, classification="intimate")
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+    assert body.get("contraction") is None
+    assert body["private"] is True
+    assert spy.calls == 0, "the intimate privacy floor must hold even under a flagged contraction"
+
+
+# ---------------------------------------------------------------------------
+# 4. No side effects on progression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resonance_pass_does_not_mutate_progression(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A resonance pass under a flagged contraction never changes stage progress."""
+    _fake_llm(monkeypatch, {"kind": "theme", "quote": "the willow bent", "note": "It holds."})
+    headers, user_id = await _signup(async_client, "noprogressmutation")
+    await _make_flagged_habit(db_session, user_id)
+
+    progress = StageProgress(user_id=user_id, current_stage=2, completed_stages=[1])
+    db_session.add(progress)
+    await db_session.commit()
+
+    entries_before = (
+        await db_session.execute(select(func.count()).select_from(JournalEntry))
+    ).scalar_one()
+
+    entry_id = await _create_entry(async_client, headers, classification="personal")
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK, resp.text
+
+    refreshed = (
+        await db_session.execute(select(StageProgress).where(col(StageProgress.user_id) == user_id))
+    ).scalar_one()
+    assert refreshed.current_stage == 2
+    assert refreshed.completed_stages == [1]
+
+    # One new entry from _create_entry is expected; the resonance pass itself
+    # must not create any additional journal entries.
+    entries_after = (
+        await db_session.execute(select(func.count()).select_from(JournalEntry))
+    ).scalar_one()
+    assert entries_after == entries_before + 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Schema<->enum drift guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_contraction_variant_does_not_drift_from_domain_enum(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The variant returned by the endpoint is always a valid ContractionVariant value."""
+    _fake_llm(monkeypatch, {"kind": "theme", "quote": "the willow bent", "note": "It holds."})
+    headers, user_id = await _signup(async_client, "driftguard")
+    await _make_flagged_habit(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers, classification="personal")
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+    contraction = body.get("contraction")
+    assert contraction is not None
+    valid_variants = {v.value for v in ContractionVariant}
+    assert contraction["variant"] in valid_variants

--- a/backend/tests/services/test_contraction_service.py
+++ b/backend/tests/services/test_contraction_service.py
@@ -1,0 +1,221 @@
+"""Integration tests for :mod:`services.contraction` -- read-only aggregate gathering.
+
+These tests FAIL until ``backend/src/services/contraction.py`` exists with the
+contract pinned below. That is the correct RED state for Gate 1.
+
+Pinned service contract:
+  async def gather_contraction_aggregates(session, user_id, user_timezone="UTC")
+      -> ContractionAggregates
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain.contraction import (
+    FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS,
+    FOUNDATION_UNMET_CONSECUTIVE_DAYS,
+)
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.user import User
+from services.contraction import gather_contraction_aggregates
+
+_WINDOW = max(FOUNDATION_UNMET_CONSECUTIVE_DAYS, FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS)
+
+
+async def _make_user(session: AsyncSession, email: str = "contraction@example.com") -> int:
+    """Insert a User row and return its id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    assert user.id is not None
+    return user.id
+
+
+async def _make_habit(
+    session: AsyncSession,
+    user_id: int,
+    *,
+    name: str = "Meditate",
+    start_date: date | None = None,
+) -> int:
+    """Seed a Habit row (start_date well before the window) and return its id."""
+    habit = Habit(
+        name=name,
+        icon="flame",
+        start_date=start_date or (datetime.now(UTC).date() - timedelta(days=_WINDOW + 30)),
+        stage="1",
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    assert habit.id is not None
+    return habit.id
+
+
+async def _make_goal(session: AsyncSession, habit_id: int, *, is_additive: bool = True) -> int:
+    """Seed a Goal row for the given habit and return its id."""
+    goal = Goal(
+        habit_id=habit_id,
+        title="Daily sit",
+        tier="clear",
+        target=1.0,
+        target_unit="minutes",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=is_additive,
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    assert goal.id is not None
+    return goal.id
+
+
+async def _add_completions(
+    session: AsyncSession,
+    goal_id: int,
+    user_id: int,
+    *,
+    days: int,
+    completed_units: float,
+) -> None:
+    """Add one GoalCompletion row per day for the last ``days`` days."""
+    now = datetime.now(UTC)
+    for days_ago in range(days):
+        session.add(
+            GoalCompletion(
+                goal_id=goal_id,
+                user_id=user_id,
+                completed_units=completed_units,
+                timestamp=now - timedelta(days=days_ago),
+            )
+        )
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Unmet path: completions logged but at zero units, across the full window
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_habit_unmet_across_window_is_flagged(db_session: AsyncSession) -> None:
+    """A habit with zero-unit completions across the window is flagged unmet."""
+    user_id = await _make_user(db_session)
+    habit_id = await _make_habit(db_session, user_id)
+    goal_id = await _make_goal(db_session, habit_id)
+    await _add_completions(
+        db_session, goal_id, user_id, days=FOUNDATION_UNMET_CONSECUTIVE_DAYS, completed_units=0.0
+    )
+
+    aggregates = await gather_contraction_aggregates(db_session, user_id)
+
+    matching = [h for h in aggregates.habits if h.habit_id == habit_id]
+    assert matching
+    assert (
+        matching[0].consecutive_unmet_days >= FOUNDATION_UNMET_CONSECUTIVE_DAYS
+        or matching[0].consecutive_unchecked_days >= FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Healthy habit: recent positive completions -> not flagged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_healthy_habit_is_not_flagged(db_session: AsyncSession) -> None:
+    """A habit with recent positive completions has counts below the window."""
+    user_id = await _make_user(db_session)
+    habit_id = await _make_habit(db_session, user_id)
+    goal_id = await _make_goal(db_session, habit_id)
+    await _add_completions(db_session, goal_id, user_id, days=5, completed_units=1.0)
+
+    aggregates = await gather_contraction_aggregates(db_session, user_id)
+
+    matching = [h for h in aggregates.habits if h.habit_id == habit_id]
+    assert matching
+    assert matching[0].consecutive_unmet_days < FOUNDATION_UNMET_CONSECUTIVE_DAYS
+    assert matching[0].consecutive_unchecked_days < FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS
+
+
+# ---------------------------------------------------------------------------
+# Brand-new habit: too new to report as unchecked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_brand_new_habit_is_not_reported_unchecked(db_session: AsyncSession) -> None:
+    """A habit started within the window is excluded from the unchecked signal."""
+    user_id = await _make_user(db_session)
+    habit_id = await _make_habit(
+        db_session,
+        user_id,
+        start_date=datetime.now(UTC).date() - timedelta(days=2),
+    )
+    await _make_goal(db_session, habit_id)
+
+    aggregates = await gather_contraction_aggregates(db_session, user_id)
+
+    matching = [h for h in aggregates.habits if h.habit_id == habit_id]
+    assert matching
+    assert matching[0].consecutive_unchecked_days < FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS
+
+
+# ---------------------------------------------------------------------------
+# Subtractive goal: absence is success, must be excluded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subtractive_goal_is_excluded(db_session: AsyncSession) -> None:
+    """A subtractive goal with no completions is never reported as unmet/unchecked."""
+    user_id = await _make_user(db_session)
+    habit_id = await _make_habit(db_session, user_id)
+    await _make_goal(db_session, habit_id, is_additive=False)
+
+    aggregates = await gather_contraction_aggregates(db_session, user_id)
+
+    matching = [h for h in aggregates.habits if h.habit_id == habit_id]
+    assert not matching, "a subtractive goal's silence must not be treated as a contraction signal"
+
+
+# ---------------------------------------------------------------------------
+# Read-only: no session mutation, no row changes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gather_is_read_only(db_session: AsyncSession) -> None:
+    """gather_contraction_aggregates must not add/modify any rows."""
+    user_id = await _make_user(db_session)
+    habit_id = await _make_habit(db_session, user_id)
+    goal_id = await _make_goal(db_session, habit_id)
+    await _add_completions(
+        db_session, goal_id, user_id, days=FOUNDATION_UNMET_CONSECUTIVE_DAYS, completed_units=0.0
+    )
+
+    count_before = (
+        await db_session.execute(select(func.count()).select_from(GoalCompletion))
+    ).scalar_one()
+
+    await gather_contraction_aggregates(db_session, user_id)
+
+    assert not db_session.new
+    assert not db_session.dirty
+
+    count_after = (
+        await db_session.execute(select(func.count()).select_from(GoalCompletion))
+    ).scalar_one()
+    assert count_after == count_before


### PR DESCRIPTION
## Summary

When a user's habit foundation thins for a sustained window, the Higher Self now
gently *names* it with a warm, declinable reflection — never a demotion. This is
the natural contraction of the wave surfaced descriptively, honoring "you choose
your depth."

- **Pure detector** (`backend/src/domain/contraction.py`), mirroring the
  `domain/invitations.py` pattern: deterministic, silent-by-default, no I/O, with
  named-constant windows (`FOUNDATION_UNMET_CONSECUTIVE_DAYS`,
  `FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS`) and an exact boundary (window − 1 stays
  silent, window flags).
- **Stage-gated invitation**, keyed to the *highest stage reached* (not
  `current_stage`): below Orange (Blue included) offers a gentle ease-off (smaller
  goals / fewer habits / rest); Orange or beyond additionally offers the optional
  five-week Return as a declinable invitation. The Return is *named and offered
  only* — the Metta arc itself remains a separate sub-issue.
- **Read-only service** (`backend/src/services/contraction.py`) gathers the
  foundation signals with two batched queries (no N+1), excludes subtractive goals
  (absence is success there) and too-new habits, and never writes.
- **Delivery** rides the existing resonance path as a new defaulted
  `contraction` field on `ResonanceResponse`, computed locally with deterministic
  copy (no LLM), placed strictly *after* the intimate privacy floor.

Design guarantees, verified by tests:

- **No side effects on progression** — the whole path is read-only, so
  `current_stage`, `completed_stages`, journal history, and engagement are never
  modified.
- **Intimate privacy floor** — an intimate-tier entry returns before the
  contraction path, so it never triggers the reflection and the entry body never
  reaches an LLM.
- **No rank/shame language** — the copy carries no streak, failure, or demotion
  vocabulary.

No new dependencies, no migration.

## Test plan

- `backend/tests/domain/test_contraction.py` — detector boundaries (silent /
  flagged, unmet and unchecked paths independently), `derive_highest_stage_reached`
  (completed-stages max; `cycle_number > 1` → all stages), stage-gating at 3 / 4 / 5,
  determinism, frozen-dataclass guards, and copy intent-rule assertions.
- `backend/tests/services/test_contraction_service.py` — consecutive-day
  computation from seeded completions, healthy/new/subtractive exclusions, and a
  read-only assertion (no dirty/new session objects, row count unchanged).
- `backend/tests/routers/test_contraction_reflection.py` — flagged user surfaces
  `contraction`; healthy user gets `null`; intimate entry stays private with the LLM
  never called; no-mutation of `StageProgress` across the pass; schema↔enum drift
  guard.
- Gate 2: `./scripts/backend/check-all.sh` exit 0 (2071 passed, 96.07% coverage);
  xenon A-grade and radon MI = A on all changed source files.

Closes #946
Refs #943
