### PR TITLE
fix(backend): make the acute-distress screen negation-aware

### DIFF
--- a/backend/src/domain/safety.py
+++ b/backend/src/domain/safety.py
@@ -21,6 +21,22 @@ human support (added later), while a false positive would shame someone in their
 darkness. The phrase lists below are explicit and auditable rather than clever;
 add to them only with a corresponding negative test guarding ordinary darkness.
 
+Negation is handled deterministically, not with a parser. Before matching, the
+Unicode curly apostrophe (U+2019) is folded to ASCII ``'`` so iOS smart
+punctuation matches the phrase lists. A candidate phrase match is suppressed only
+when a negator (e.g. "never", "not", "no plans to", "don't") appears in the
+window of :data:`_NEGATION_WINDOW_WORDS` whitespace tokens strictly *before* the
+match, within the same clause (the window is clipped at the last ``.``, ``!``,
+``?``, ``;``, or ``,``, so a negator in an earlier clause cannot suppress genuine
+intent in a later one). Logical negators ("never", "not", "don't", …) are counted
+by parity: an odd count negates, an even count (including zero) does not, so
+double negation ("I can't say I don't want to die") still flags. Temporal
+negators ("used to", "no longer") negate only when they directly abut the match,
+so a present-tense signal is never suppressed by a distant one ("more than I used
+to I want to die" still flags). Because the window is strictly before the match, a
+negator that is itself part of a positive phrase (the "don't" in "don't want to
+be alive anymore") can never suppress that phrase.
+
 Purity: no FastAPI, SQLModel, or network/LLM imports — only the standard library.
 """
 
@@ -114,6 +130,61 @@ _COMPILED: tuple[tuple[DistressCategory, re.Pattern[str]], ...] = tuple(
     for category, phrases in _PATTERNS
 )
 
+# Unicode curly apostrophe (iOS smart punctuation) folded to ASCII before matching.
+_CURLY_APOSTROPHE = "\N{RIGHT SINGLE QUOTATION MARK}"
+
+# Number of whitespace tokens before a match inspected for a negator.
+_NEGATION_WINDOW_WORDS = 5
+
+# Logical negators that invert intent wherever they sit in the preceding window;
+# counted by parity. Multi-word alternatives come first so they win over their
+# single-word prefixes. Bare "no" is excluded: it would negate "No. I want to
+# kill myself".
+_LOGICAL_NEGATORS = re.compile(
+    r"\b(?:no plans? to|no intention|no desire|never|not|cannot"
+    r"|don'?t|won'?t|wouldn'?t|couldn'?t|can'?t|didn'?t|doesn'?t|haven'?t"
+    r"|isn'?t|ain'?t)\b",
+    re.IGNORECASE,
+)
+
+# Temporal negators only negate when they directly abut the matched phrase
+# ("I used to cut myself"). A distant one must not suppress a present-tense signal
+# ("more than I used to I want to die" still flags), so they are matched only at
+# the very end of the window rather than counted anywhere in it.
+_TEMPORAL_NEGATOR = re.compile(r"\b(?:no longer|used to)\s*$", re.IGNORECASE)
+
+# Clause boundaries clip the preceding window. Commas count: a negator in an
+# earlier clause must not suppress genuine intent in a later one, so a mixed
+# statement ("I would never hurt myself, but I want to kill him") still flags.
+_CLAUSE_BOUNDARY = re.compile(r"[.!?;,]")
+
+
+def _tail_window(prefix: str) -> str:
+    """Return the last :data:`_NEGATION_WINDOW_WORDS` tokens of ``prefix``.
+
+    ``prefix`` is first clipped to the current clause — only the text after the
+    last clause-boundary character (``.``, ``!``, ``?``, ``;``, ``,``) is kept.
+    """
+    boundaries = list(_CLAUSE_BOUNDARY.finditer(prefix))
+    if boundaries:
+        prefix = prefix[boundaries[-1].end() :]
+    return " ".join(prefix.split()[-_NEGATION_WINDOW_WORDS:])
+
+
+def _is_negated(normalized: str, match_start: int) -> bool:
+    """Return whether the match at ``match_start`` is negated by preceding text.
+
+    Only text strictly before the match is inspected, so a negator that is part of
+    a positive phrase cannot self-suppress. An odd number of logical negators in
+    the window negates; an even number (including zero) does not, so double
+    negation still flags. A temporal negator negates only when it directly abuts
+    the match.
+    """
+    window = _tail_window(normalized[:match_start])
+    if _TEMPORAL_NEGATOR.search(window):
+        return True
+    return len(_LOGICAL_NEGATORS.findall(window)) % 2 == 1
+
 
 def assess_distress(text: str) -> DistressSignal:
     """Screen ``text`` for an acute-distress signal; return a typed result.
@@ -127,13 +198,17 @@ def assess_distress(text: str) -> DistressSignal:
     Matching is conservative by design (see the module docstring): it fires only
     on explicit intent/action phrasing and lets ordinary sadness, grief,
     emptiness, and "dark night" reflection pass through unflagged, so the app does
-    not pathologize ordinary darkness. This is a screen, not a diagnosis, and
-    introduces no medication, treatment, or medical advice.
+    not pathologize ordinary darkness. Explicit denials ("I would never kill
+    myself") are suppressed by preceding-window negation handling. This is a
+    screen, not a diagnosis, and introduces no medication, treatment, or medical
+    advice.
     """
-    normalized = re.sub(r"\s+", " ", text).strip().lower()
+    folded = text.replace(_CURLY_APOSTROPHE, "'")
+    normalized = re.sub(r"\s+", " ", folded).strip().lower()
     if not normalized:
         return _NONE
     for category, pattern in _COMPILED:
-        if pattern.search(normalized):
-            return DistressSignal(level="elevated", category=category)
+        for match in pattern.finditer(normalized):
+            if not _is_negated(normalized, match.start()):
+                return DistressSignal(level="elevated", category=category)
     return _NONE

--- a/backend/tests/domain/test_safety.py
+++ b/backend/tests/domain/test_safety.py
@@ -79,3 +79,57 @@ def test_matching_normalizes_internal_whitespace() -> None:
 def test_no_substring_false_positive_on_word_boundary() -> None:
     # "skill" contains "kill" but must not match "kill myself".
     assert assess_distress("I want to upskill myself professionally.").level == "none"
+
+
+# iOS smart punctuation emits this curly apostrophe; the screen must treat it like
+# a straight one. Built via a named escape so it reads unambiguously in source.
+_CURLY = "\N{RIGHT SINGLE QUOTATION MARK}"
+
+# Explicit denials of acute-distress phrasing. A negated statement must not flag
+# — matching only the negation-blind phrase would wrongly pathologize a denial.
+_NEGATED_DENIALS = [
+    "I would never kill myself",
+    "I do not want to die",
+    "I have no plans to kill myself",
+    "I am not going to hurt myself",
+    "I promised I would never cut myself again",
+    "I don't feel suicidal at all anymore",
+    "I won't hurt myself",
+    "I would never cut myself",
+    "I would never kill him",
+    "I don't want to hurt them",
+    "I'm not going to stop taking my meds",
+    "I would never quit my antidepressants",
+    "I no longer want to die",
+    "I used to cut myself",
+    f"I don{_CURLY}t want to die",
+]
+
+
+@pytest.mark.parametrize("text", _NEGATED_DENIALS)
+def test_negated_denials_do_not_flag(text: str) -> None:
+    assert assess_distress(text) == DistressSignal(level="none", category=DistressCategory.NONE)
+
+
+@pytest.mark.parametrize(
+    ("text", "category"),
+    [
+        ("I want to kill myself tonight", DistressCategory.SUICIDAL_INTENT),
+        ("I can't say I don't want to die", DistressCategory.SUICIDAL_INTENT),
+        (
+            "I would never hurt myself, but I want to kill him",
+            DistressCategory.INTENT_TO_HARM,
+        ),
+        (
+            "I said never before, but tonight I want to kill myself",
+            DistressCategory.SUICIDAL_INTENT,
+        ),
+        ("No. I want to kill myself tonight.", DistressCategory.SUICIDAL_INTENT),
+        ("I don't want to be alive anymore", DistressCategory.SUICIDAL_INTENT),
+        (f"I don{_CURLY}t want to be alive anymore", DistressCategory.SUICIDAL_INTENT),
+        ("Now more than I used to I want to die", DistressCategory.SUICIDAL_INTENT),
+        ("I am not okay and lonely and I want to die", DistressCategory.SUICIDAL_INTENT),
+    ],
+)
+def test_negation_does_not_suppress_genuine_signals(text: str, category: DistressCategory) -> None:
+    assert assess_distress(text) == DistressSignal(level="elevated", category=category)

--- a/backend/tests/test_resonance_endpoints.py
+++ b/backend/tests/test_resonance_endpoints.py
@@ -237,6 +237,25 @@ async def test_normal_entry_returns_no_care(
 
 
 @pytest.mark.asyncio
+async def test_denial_entry_returns_no_care(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit denial of distress is unchanged: care is None, marginalia intact."""
+    _fake_llm(
+        monkeypatch,
+        {"kind": "theme", "quote": "I would never kill myself", "note": "You are resolute."},
+    )
+    headers = await _signup(async_client, "denial")
+    entry_id = await _create_entry(async_client, headers, body="I would never kill myself")
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["care"] is None
+    assert len(body["marginalia"]) == 1
+
+
+@pytest.mark.asyncio
 async def test_distress_entry_returns_care_alongside_reflection(
     async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

The acute-distress / crisis screen (`domain/safety.assess_distress`) was
**negation-blind**: it matched its phrase regexes anywhere in the text with no
negation handling, so explicit *denials* returned `level="elevated"` and
surfaced the full crisis-care panel (988 / Crisis Text Line) via the journal
resonance path. That is the exact "shame someone in their darkness" outcome the
module's own docstring says it must avoid — a user journaling "I would never kill
myself" was shown the crisis surface.

This adds deterministic, auditable negation handling — no NLP libraries, no
network/LLM, still pure standard library:

- **Normalization** now folds the iOS curly apostrophe (U+2019) to ASCII `'`, so
  smart-punctuation text matches the phrase lists symmetrically (this also fixes
  a pre-existing silent true-positive miss on curly-apostrophe contractions).
- **Per-match screening:** `assess_distress` iterates `finditer` per category and
  a category fires only on a match that is **not** negated by its
  strictly-preceding clause window (last 5 tokens, clipped at `.!?;,`).
- **Logical negators** (`never`, `not`, `no plans to`, `don't`, …) count by
  **parity** — odd negates, even (incl. zero) does not — so double negation still
  flags. Bare "no" is deliberately excluded.
- **Temporal negators** (`used to`, `no longer`) negate **only when they directly
  abut the match**, so a distant one never suppresses a present-tense signal.
- Because the window is *strictly before* the match, a negator that is part of a
  positive phrase (the "don't" in "don't want to be alive anymore") can never
  self-suppress.

**Safety priority preserved:** a false negative (missing a real crisis) is far
worse than a false positive, so every true positive still flags — mixed,
double-negated, distant-negator, and prior-sentence-negator statements all
surface care. The router (`_care_for`) is unchanged: fixing the domain fixes the
panel.

## Test plan

New negation negative-battery in `backend/tests/domain/test_safety.py` — every
phrase asserts `level="none"`, `category=NONE`:

- All 6 reproduction phrases: "I would never kill myself", "I do not want to
  die", "I have no plans to kill myself", "I am not going to hurt myself",
  "I promised I would never cut myself again", "I don't feel suicidal at all
  anymore".
- Per-category denials: "I won't hurt myself", "I would never cut myself",
  "I would never kill him", "I don't want to hurt them", "I'm not going to stop
  taking my meds", "I would never quit my antidepressants".
- Temporal: "I no longer want to die", "I used to cut myself".
- Curly-apostrophe denial: "I don’t want to die".

New must-still-flag battery (the safety-critical assertions) — each asserts
`level="elevated"` with the correct category:

- "I want to kill myself tonight" → SUICIDAL_INTENT.
- Double negation: "I can't say I don't want to die" → SUICIDAL_INTENT.
- Mixed clause: "I would never hurt myself, but I want to kill him" →
  INTENT_TO_HARM.
- Distant negator: "I said never before, but tonight I want to kill myself" →
  SUICIDAL_INTENT.
- Prior-sentence negator + bare "no": "No. I want to kill myself tonight." →
  SUICIDAL_INTENT.
- Self-negating positive phrase: "I don't want to be alive anymore" (+ curly
  variant) → SUICIDAL_INTENT.
- Temporal-negator anti-suppression guards: "Now more than I used to I want to
  die" and "I am not okay and lonely and I want to die" → SUICIDAL_INTENT.

Plus a router regression in `backend/tests/test_resonance_endpoints.py`
(`test_denial_entry_returns_no_care`): a denial entry ("I would never kill
myself") returns `care is None` from `/journal/{id}/resonance`.

Verification (all foreground):

- `pytest tests/domain/test_safety.py tests/test_resonance_endpoints.py` — 71
  passed.
- `./scripts/backend/check-all.sh` — pass; total coverage 96%, `safety.py` at
  100% line + branch.
- `xenon --max-absolute A --max-modules A --max-average A src/domain/safety.py` —
  A-grade; `radon mi src/domain/safety.py` — A.
- `pre-commit` over the changed files — all hooks pass.

Existing `_ACUTE` positive and `_ORDINARY_DARKNESS` negative batteries are
unchanged and green.

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
