### PR TITLE
refactor(frontend): drop dead unknownRecord + wire 3 response schemas

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -67,6 +67,17 @@ describe('API client request composition', () => {
 
   it('creates practice session with POST /practice-sessions/', async () => {
     const session = { user_practice_id: 1, duration_minutes: 10 };
+    // create() validates against practiceSessionResponseSchema, so return that shape.
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 5,
+        user_practice_id: 1,
+        duration_minutes: 10,
+        timestamp: '2026-04-28T10:00:00.000Z',
+        reflection: null,
+      }),
+    });
     await api.practiceSessions.create(session);
     expect(fetch).toHaveBeenCalledWith(
       `${mockBaseUrl}/practice-sessions/`,

--- a/frontend/src/api/__tests__/goalGroups-api.test.ts
+++ b/frontend/src/api/__tests__/goalGroups-api.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
-import { goalGroups, ApiError } from '../index';
+import { goalGroups, ApiError, ApiValidationError } from '../index';
 
 const mockFetch = jest.fn() as jest.Mock;
 global.fetch = mockFetch;
@@ -53,5 +53,33 @@ describe('goalGroups API client', () => {
     );
 
     await expect(goalGroups.list('bad-token')).rejects.toThrow(ApiError);
+  });
+
+  test('goalGroups.list rejects a drifted row missing shared_template', async () => {
+    const drifted = [{ id: 1, name: 'Meditation Goals', goals: [] }];
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+
+    await expect(goalGroups.list('test-token')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('goalGroups.list rejects a row with a wrong-typed name', async () => {
+    const drifted = [{ id: 1, name: 123, shared_template: true, goals: [] }];
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+
+    await expect(goalGroups.list('test-token')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('goalGroups.get rejects a payload missing shared_template', async () => {
+    const drifted = { id: 1, name: 'Meditation Goals', goals: [] };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+
+    await expect(goalGroups.get(1, 'test-token')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('goalGroups.get rejects a payload with a wrong-typed name', async () => {
+    const drifted = { id: 1, name: 123, shared_template: true, goals: [] };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+
+    await expect(goalGroups.get(1, 'test-token')).rejects.toBeInstanceOf(ApiValidationError);
   });
 });

--- a/frontend/src/api/__tests__/practiceRecipes-api.test.ts
+++ b/frontend/src/api/__tests__/practiceRecipes-api.test.ts
@@ -161,6 +161,19 @@ describe('practiceRecipes.apply', () => {
     expect(url).toBe('http://test/practice-recipes/7/apply-to/99');
     expect(init.method).toBe('POST');
   });
+
+  test('raises ApiValidationError on a drifted UserPractice response', async () => {
+    const drifted = {
+      id: 99,
+      practice_id: 5,
+      stage_number: 1,
+      start_date: undefined,
+      end_date: null,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+
+    await expect(practiceRecipes.apply(7, 99)).rejects.toBeInstanceOf(ApiValidationError);
+  });
 });
 
 describe('practiceTags', () => {

--- a/frontend/src/api/__tests__/practiceSessions-api.test.ts
+++ b/frontend/src/api/__tests__/practiceSessions-api.test.ts
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { practiceSessions, ApiValidationError } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+const session = {
+  id: 9,
+  user_practice_id: 3,
+  duration_minutes: 10,
+  timestamp: '2026-03-01T10:30:00Z',
+  reflection: null,
+};
+
+const createPayload = {
+  user_practice_id: 3,
+  started_at: '2026-03-01T10:20:00Z',
+  ended_at: '2026-03-01T10:30:00Z',
+};
+
+describe('practiceSessions.create', () => {
+  test('POSTs the payload and parses a valid PracticeSessionResponse', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(session, 201));
+
+    const result = await practiceSessions.create(createPayload);
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practice-sessions/');
+    expect(init.method).toBe('POST');
+    expect(result).toEqual(session);
+  });
+
+  test('rejects a response with a non-ISO timestamp', async () => {
+    const drifted = { ...session, timestamp: 'oops' };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted, 201));
+
+    await expect(practiceSessions.create(createPayload)).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('rejects a response missing user_practice_id', async () => {
+    const drifted = { ...session, user_practice_id: undefined };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted, 201));
+
+    await expect(practiceSessions.create(createPayload)).rejects.toBeInstanceOf(ApiValidationError);
+  });
+});

--- a/frontend/src/api/__tests__/userPractices-api.test.ts
+++ b/frontend/src/api/__tests__/userPractices-api.test.ts
@@ -1,0 +1,79 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { userPractices, ApiValidationError } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+const userPractice = {
+  id: 3,
+  practice_id: 7,
+  stage_number: 2,
+  start_date: '2026-01-01',
+  end_date: null,
+};
+
+describe('userPractices.create', () => {
+  test('POSTs the payload and parses a valid UserPractice response', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(userPractice, 201));
+
+    const result = await userPractices.create({ practice_id: 7, stage_number: 2 });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/user-practices/');
+    expect(init.method).toBe('POST');
+    expect(result).toEqual(userPractice);
+  });
+
+  test('rejects a drifted response missing start_date', async () => {
+    const drifted = { ...userPractice, start_date: undefined };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted, 201));
+
+    await expect(userPractices.create({ practice_id: 7, stage_number: 2 })).rejects.toBeInstanceOf(
+      ApiValidationError,
+    );
+  });
+
+  test('rejects a response with a non-ISO start_date', async () => {
+    const drifted = { ...userPractice, start_date: 'not-a-date' };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted, 201));
+
+    await expect(userPractices.create({ practice_id: 7, stage_number: 2 })).rejects.toBeInstanceOf(
+      ApiValidationError,
+    );
+  });
+});
+
+describe('userPractices.list', () => {
+  test('GETs /user-practices/ and parses a valid array', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse([userPractice]));
+
+    const result = await userPractices.list('test-token');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/user-practices/');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer test-token' });
+    expect(result).toEqual([userPractice]);
+  });
+
+  test('rejects a drifted row with a non-ISO start_date', async () => {
+    const drifted = [{ ...userPractice, start_date: 'not-a-date' }];
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+
+    await expect(userPractices.list('test-token')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+});

--- a/frontend/src/api/__tests__/userPractices-customize.test.ts
+++ b/frontend/src/api/__tests__/userPractices-customize.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, test, expect, beforeEach, jest */
-import { userPractices } from '../index';
+import { userPractices, ApiValidationError } from '../index';
 
 const mockFetch = jest.fn() as jest.Mock;
 global.fetch = mockFetch;
@@ -53,12 +53,52 @@ describe('userPractices.customize', () => {
   });
 
   test('passes null overrides to clear server-side state', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({}));
+    const updated = {
+      id: 42,
+      practice_id: 9,
+      stage_number: 3,
+      start_date: '2026-05-01',
+      end_date: null,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(updated));
     await userPractices.customize(42, { custom_name: null, mode_config_override: null });
     const [, init] = mockFetch.mock.calls[0];
     expect(JSON.parse(init.body)).toEqual({
       custom_name: null,
       mode_config_override: null,
     });
+  });
+
+  test('accepts a valid UserPractice response', async () => {
+    const updated = {
+      id: 17,
+      practice_id: 9,
+      stage_number: 3,
+      start_date: '2026-05-01',
+      end_date: null,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(updated));
+
+    const result = await userPractices.customize(17, {
+      custom_name: 'My Sit',
+      mode_config_override: null,
+    });
+
+    expect(result).toEqual(updated);
+  });
+
+  test('rejects a drifted response with a non-ISO start_date', async () => {
+    const drifted = {
+      id: 17,
+      practice_id: 9,
+      stage_number: 3,
+      start_date: 'not-a-date',
+      end_date: null,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(drifted));
+
+    await expect(
+      userPractices.customize(17, { custom_name: 'My Sit', mode_config_override: null }),
+    ).rejects.toBeInstanceOf(ApiValidationError);
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { flattenGoalCompletions } from './flattenGoalCompletions';
 import {
+  apiGoalGroupSchema,
   authResponseSchema,
   contentItemSchema,
   acceptSuggestionResultSchema,
@@ -18,10 +19,12 @@ import {
   passwordResetAcceptedSchema,
   practiceItemSchema,
   practiceRecipeSchema,
+  practiceSessionResponseSchema,
   practiceTagSchema,
   promptListResponseSchema,
   resonanceResponseSchema,
   stageIntroSchema,
+  userPracticeSchema,
   stageProgressRecordSchema,
   stageSchema,
   timezoneReadSchema,
@@ -1060,10 +1063,16 @@ export const goals = {
 // Goal group client
 export const goalGroups = {
   list(token?: string): Promise<ApiGoalGroup[]> {
-    return request<ApiGoalGroup[]>('/goal-groups/', { token });
+    return request<ApiGoalGroup[]>('/goal-groups/', {
+      token,
+      schema: z.array(apiGoalGroupSchema) as unknown as z.ZodType<ApiGoalGroup[]>,
+    });
   },
   get(groupId: number, token?: string): Promise<ApiGoalGroup> {
-    return request<ApiGoalGroup>(`/goal-groups/${groupId}`, { token });
+    return request<ApiGoalGroup>(`/goal-groups/${groupId}`, {
+      token,
+      schema: apiGoalGroupSchema as unknown as z.ZodType<ApiGoalGroup>,
+    });
   },
 };
 
@@ -1869,10 +1878,18 @@ export const practices = {
 
 export const userPractices = {
   create(payload: UserPracticeCreate, token?: string): Promise<UserPractice> {
-    return request<UserPractice>('/user-practices/', { method: 'POST', body: payload, token });
+    return request<UserPractice>('/user-practices/', {
+      method: 'POST',
+      body: payload,
+      token,
+      schema: userPracticeSchema as unknown as z.ZodType<UserPractice>,
+    });
   },
   list(token?: string): Promise<UserPractice[]> {
-    return request<UserPractice[]>('/user-practices/', { token });
+    return request<UserPractice[]>('/user-practices/', {
+      token,
+      schema: z.array(userPracticeSchema) as unknown as z.ZodType<UserPractice[]>,
+    });
   },
   /**
    * PATCH the per-user overrides (custom name + mode_config_override).
@@ -1892,6 +1909,7 @@ export const userPractices = {
       method: 'PATCH',
       body: payload,
       token,
+      schema: userPracticeSchema as unknown as z.ZodType<UserPractice>,
     });
   },
 };
@@ -2044,6 +2062,7 @@ export const practiceRecipes = {
     return request<UserPractice>(`/practice-recipes/${recipeId}/apply-to/${userPracticeId}`, {
       method: 'POST',
       token,
+      schema: userPracticeSchema as unknown as z.ZodType<UserPractice>,
     });
   },
 };
@@ -2094,6 +2113,7 @@ export const practiceSessions = {
       method: 'POST',
       body: payload,
       token,
+      schema: practiceSessionResponseSchema as unknown as z.ZodType<PracticeSessionResponse>,
     });
   },
   weekCount(token?: string): Promise<WeekCountResponse> {

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -638,15 +638,3 @@ export const wheelBalanceSchema = z.object({
 
 export type WheelAspectT = z.infer<typeof wheelAspectSchema>;
 export type WheelBalanceT = z.infer<typeof wheelBalanceSchema>;
-
-// ---------------------------------------------------------------------------
-// Lenient schemas for legacy endpoints (gradually tightened)
-// ---------------------------------------------------------------------------
-
-/**
- * Gateway for callers that do not yet have a strict schema. The
- * ``.passthrough()`` means the return value is validated as an object but
- * unknown keys pass through — useful for partial contracts that will be
- * tightened in follow-ups without breaking the wire right now.
- */
-export const unknownRecord = z.record(z.unknown());


### PR DESCRIPTION
## Summary

Mixed de-slop of the frontend API layer (`api/schemas.ts` + `api/index.ts`).

**Deleted (dead):**
- `unknownRecord` — a lenient `z.record(z.unknown())` gateway plus its doc block and now-orphaned "Lenient schemas for legacy endpoints" section banner. Verified referenced nowhere under `frontend/src`.

**Wired in (defined-but-unused response schemas, now validating at the boundary):**
- `apiGoalGroupSchema` → `goalGroups.list` (array) and `goalGroups.get`
- `userPracticeSchema` → `userPractices.create`, `userPractices.list` (array), `userPractices.customize`, and `practiceRecipes.apply`
- `practiceSessionResponseSchema` → `practiceSessions.create`

Each was passed to `request()` via the established `... as unknown as z.ZodType<T>` cast — the same pattern every already-wired endpoint uses. Cross-checked against the backend Pydantic sources (`GoalGroupResponse`, `UserPracticeResponse`, `PracticeSessionResponse`): the schemas' `.nullish()`/`.optional()` fields correctly tolerate the `OwnedResourcePublic` `user_id` omission, so no real payload is rejected.

Note: the issue's stale line numbers referenced a since-resolved `checkInResultSchema` (already reachable via `acceptSuggestionResultSchema`); per the grooming comment it was dropped from the dead list, leaving `unknownRecord` as the only dead validator.

## Test plan

- New `userPractices-api.test.ts` and `practiceSessions-api.test.ts`, plus added drift cases in `goalGroups-api.test.ts`, `userPractices-customize.test.ts`, and `practiceRecipes-api.test.ts`: each wired endpoint accepts a realistic response and rejects a drifted one with `ApiValidationError`.
- Updated two composition-test fixtures (`api.test.ts` practice-session, and per-endpoint list rows) whose placeholder bodies would otherwise fail the newly-wired schemas.
- `./scripts/frontend/check-all.sh` → exit 0: ESLint zero-warning, `tsc` clean, 2635 Jest tests pass, prettier clean.

Closes #1009
