### PR TITLE
refactor(backend): remove unreachable claude-3-5-* rows from LLM pricing table

### DIFF
--- a/backend/src/services/llm_pricing.py
+++ b/backend/src/services/llm_pricing.py
@@ -74,8 +74,6 @@ MODEL_PRICING: dict[str, ModelPricing] = {
     # Anthropic — https://www.anthropic.com/pricing
     "claude-sonnet-4-20250514": _price("3.00", "15.00"),
     "claude-haiku-4-5-20251001": _price("1.00", "5.00"),
-    "claude-3-5-sonnet-20241022": _price("3.00", "15.00"),
-    "claude-3-5-haiku-20241022": _price("0.80", "4.00"),
     # Floating aliases (track the latest minor) — priced at the family's current
     # list price; the price follows the alias as Anthropic rolls it forward.
     "claude-opus-4-7": _price("15.00", "75.00"),

--- a/backend/tests/test_llm_pricing.py
+++ b/backend/tests/test_llm_pricing.py
@@ -143,6 +143,14 @@ class TestAllowlistPricingReconciliation:
         )
         assert unpriced == [], f"allowlisted models missing a price: {unpriced}"
 
+    def test_every_priced_model_is_allowlisted(self) -> None:
+        """A pricing row for a model on no provider allowlist is dead config."""
+        allowlisted_union = {
+            model for spec in PROVIDER_REGISTRY.values() for model in spec.allowed_models
+        }
+        orphaned = sorted(set(MODEL_PRICING) - allowlisted_union)
+        assert orphaned == [], f"priced but not allowlisted (dead config): {orphaned}"
+
     def test_allowlisted_models_estimate_a_real_cost(self) -> None:
         """A reachable allowlisted model never estimates cost as None."""
         for spec in PROVIDER_REGISTRY.values():


### PR DESCRIPTION
## Summary

Removes two dead-config rows from the LLM pricing table. The
`claude-3-5-sonnet-20241022` and `claude-3-5-haiku-20241022` entries in
`backend/src/services/llm_pricing.py` were unreachable: neither ID appears on any
provider allowlist in `services/botmason.py`, and `_get_model` raises
`RuntimeError` for any non-allowlisted model *before* pricing is ever consulted,
so `estimate_cost_usd` could never be called with them. A grep across the whole
repo (code, tests, docs, skills, JSON) confirmed the only references were the two
definition lines themselves.

After the deletion the 7 remaining priced rows exactly match the union of the two
provider allowlists (OpenAI: `gpt-4o-mini`, `gpt-4o`, `gpt-4-turbo`; Anthropic:
`claude-sonnet-4-20250514`, `claude-haiku-4-5-20251001`, `claude-opus-4-7`,
`claude-sonnet-4-6`) — no live/allowlisted row was touched, and the allowlist
itself is unchanged.

A new reverse-reconciliation regression guard,
`test_every_priced_model_is_allowlisted`, asserts every priced model appears on
some provider allowlist. It mirrors the existing forward guard
(`test_every_allowlisted_model_is_priced`), so the pricing table and the
allowlist union are now pinned as a bijection and dead rows cannot be
re-introduced silently.

## Test plan

- Added `test_every_priced_model_is_allowlisted` and confirmed it was RED before
  the deletion (failed naming exactly `claude-3-5-haiku-20241022` and
  `claude-3-5-sonnet-20241022`), GREEN after.
- Ran `./scripts/backend/check-all.sh` to exit 0: ruff lint + format, mypy
  `--strict`, bandit + pip-audit, radon + xenon complexity, 2050 tests passed
  (2 skipped), total coverage 96.07% (>= 90% gate). `llm_pricing.py` at 100%.
- All pre-commit hooks pass on commit.

Closes #1010
