### PR TITLE
feat(frontend): warm, declinable "tend your foundation" contraction reflection

### DIFF
--- a/frontend/src/api/__tests__/contractionSchemas.test.ts
+++ b/frontend/src/api/__tests__/contractionSchemas.test.ts
@@ -1,0 +1,85 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+
+/**
+ * RED tests for the ``contraction`` field on ``resonanceResponseSchema``.
+ *
+ * Backend delivers ``contraction: { variant, message } | null`` on the journal
+ * resonance-pass response, defaulted None (absent on the wire) for healthy or
+ * new users. ``variant`` is exactly one of ``simple_ease_off`` |
+ * ``return_offer``. This must be additive: a response omitting ``contraction``
+ * (all existing callers) still parses and behaves exactly as before.
+ */
+import { resonanceResponseSchema } from '../schemas';
+
+/** Minimal valid resonance response without the new contraction field. */
+const BASE_RESONANCE = {
+  marginalia: [],
+  suggestions: [],
+  remaining_messages: 48,
+  remaining_balance: 0,
+  monthly_reset_date: '2026-07-01T00:00:00Z',
+};
+
+describe('resonanceResponseSchema — contraction field (backward-compat)', () => {
+  it('still parses a response WITHOUT contraction', () => {
+    const parsed = resonanceResponseSchema.parse(BASE_RESONANCE);
+    expect(parsed.contraction == null).toBe(true);
+  });
+
+  it('parses a response with contraction: null', () => {
+    const payload = { ...BASE_RESONANCE, contraction: null };
+    const parsed = resonanceResponseSchema.parse(payload);
+    expect(parsed.contraction).toBeNull();
+  });
+});
+
+describe('resonanceResponseSchema — contraction field (round-trip)', () => {
+  it('round-trips a simple_ease_off contraction message exactly', () => {
+    const message = 'Your practice has eased off a little. No rush back.';
+    const payload = {
+      ...BASE_RESONANCE,
+      contraction: { variant: 'simple_ease_off', message },
+    };
+    const parsed = resonanceResponseSchema.parse(payload);
+    expect(parsed.contraction!.variant).toBe('simple_ease_off');
+    expect(parsed.contraction!.message).toBe(message);
+  });
+
+  it('round-trips a return_offer contraction message exactly', () => {
+    const message = 'It has been a while. A five-week Return is here whenever you want it.';
+    const payload = {
+      ...BASE_RESONANCE,
+      contraction: { variant: 'return_offer', message },
+    };
+    const parsed = resonanceResponseSchema.parse(payload);
+    expect(parsed.contraction!.variant).toBe('return_offer');
+    expect(parsed.contraction!.message).toBe(message);
+  });
+});
+
+describe('resonanceResponseSchema — contraction field (rejects drift)', () => {
+  it('rejects an unknown variant', () => {
+    const payload = {
+      ...BASE_RESONANCE,
+      contraction: { variant: 'demotion', message: 'Some copy.' },
+    };
+    expect(() => resonanceResponseSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects a contraction object missing message', () => {
+    const payload = {
+      ...BASE_RESONANCE,
+      contraction: { variant: 'simple_ease_off' },
+    };
+    expect(() => resonanceResponseSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects a non-string message', () => {
+    const payload = {
+      ...BASE_RESONANCE,
+      contraction: { variant: 'simple_ease_off', message: 42 },
+    };
+    expect(() => resonanceResponseSchema.parse(payload)).toThrow();
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -34,6 +34,8 @@ import {
   type CareResourceT,
   type CareResponseT,
   type CompletionSuggestionT,
+  type ContractionReflectionT,
+  type ContractionVariantT,
   type CompletionTargetTypeT,
   type DepthPreferencesT,
   type InvitationT,
@@ -1150,6 +1152,10 @@ export type CareKind = CareKindT;
 export type CareResource = CareResourceT;
 /** The care surface (mirrors the backend ``CareResponse``); see ``CareSupportNote``. */
 export type CareResponse = CareResponseT;
+/** One of the two contraction routings (``simple_ease_off`` | ``return_offer``). */
+export type ContractionVariant = ContractionVariantT;
+/** The contraction reflection surface; see ``ContractionReflectionNote``. */
+export type ContractionReflection = ContractionReflectionT;
 
 export interface ResonanceResponse {
   marginalia: Marginalia[];
@@ -1164,6 +1170,12 @@ export interface ResonanceResponse {
    * without it parses and behaves exactly as before.
    */
   care?: CareResponse | null;
+  /**
+   * Warm, declinable "tend your foundation" reflection. ``null`` on every
+   * healthy or new entry; set only when a pass senses a foundation easing off.
+   * Additive — a response without it parses and behaves exactly as before.
+   */
+  contraction?: ContractionReflection | null;
   /**
    * True when the pass was withheld because the entry is intimate.
    * Absent on ordinary responses; additive — older responses parse unchanged.

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -567,6 +567,25 @@ export const careResponseSchema = z.object({
 });
 
 /**
+ * The two contraction routings (mirrors the backend contraction variants): a
+ * gentle ``simple_ease_off`` nudge to tend a slipping foundation, and a warmer
+ * ``return_offer`` inviting a fresh Return. Anything else is contract drift and
+ * is rejected at the boundary so an unknown variant can never render untitled.
+ */
+export const contractionVariantSchema = z.enum(['simple_ease_off', 'return_offer']);
+
+/**
+ * The contraction surface returned when a pass senses a foundation easing off:
+ * a variant that keys warm, declinable "tend your foundation" copy plus the
+ * backend's own message. Mirrors the backend contraction reflection; ``null``
+ * on every healthy or new entry.
+ */
+export const contractionReflectionSchema = z.object({
+  variant: contractionVariantSchema,
+  message: z.string(),
+});
+
+/**
  * Result of a resonance pass (mirrors the backend ``ResonanceResponse``).
  *
  * ``care`` is additive: it is ``None`` on every ordinary entry — absent on the
@@ -580,6 +599,10 @@ export const resonanceResponseSchema = z.object({
   remaining_balance: z.number().int(),
   monthly_reset_date: z.string(),
   care: careResponseSchema.nullish(),
+  // Contraction reflection: a warm, declinable "tend your foundation" surface.
+  // Additive/nullish so it is ``None`` (absent on the wire) on healthy or new
+  // entries and older responses still validate and behave exactly as before.
+  contraction: contractionReflectionSchema.nullish(),
   // Privacy gate: ``private`` is true when the pass was withheld for an
   // intimate entry, with optional reason copy. Additive/nullish so older
   // responses (which omit both) still validate and behave as before.
@@ -590,6 +613,8 @@ export const resonanceResponseSchema = z.object({
 export type CareKindT = z.infer<typeof careKindSchema>;
 export type CareResourceT = z.infer<typeof careResourceSchema>;
 export type CareResponseT = z.infer<typeof careResponseSchema>;
+export type ContractionVariantT = z.infer<typeof contractionVariantSchema>;
+export type ContractionReflectionT = z.infer<typeof contractionReflectionSchema>;
 export type ResonanceResponseT = z.infer<typeof resonanceResponseSchema>;
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Journal/ContractionReflectionNote.tsx
+++ b/frontend/src/features/Journal/ContractionReflectionNote.tsx
@@ -1,0 +1,106 @@
+/**
+ * ``ContractionReflectionNote`` — a warm, declinable "tend your foundation"
+ * reflection shown when a resonance pass senses a foundation easing off. It
+ * mirrors ``CareSupportNote`` in shape but is deliberately gentler: it names a
+ * gentle nudge (``simple_ease_off``) or an open invitation (``return_offer``),
+ * never failure, demotion, or ranking. "You choose your depth" — a single tap
+ * sets it aside for good, and only a fresh pass's new reflection resurfaces it.
+ *
+ * Deliberately NOT a chatbot: no avatar, no sender, no reply, no Send. It is a
+ * header-role title, the backend's own message, and a one-tap dismiss.
+ * Presentational, reduced-motion-safe, tokens only.
+ */
+import React, { useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import type { ContractionReflection, ContractionVariant } from '@/api';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  editorialType,
+  ink,
+  paperShadow,
+  surface,
+  touchTarget,
+} from '@/design/tokens';
+
+/** Warm, declinable titles per contraction variant — never punishing copy. */
+const VARIANT_TITLES: Record<ContractionVariant, string> = {
+  simple_ease_off: 'Tend your foundation',
+  return_offer: 'The Return is open to you',
+};
+
+const DISMISS_LABEL = 'Not now';
+const DISMISS_A11Y = 'Set this reflection aside';
+/** The warm accent stripe width; matches the care surface's foundation cue. */
+const ACCENT_STRIPE_WIDTH = 4;
+
+export interface ContractionReflectionNoteProps {
+  /** The contraction surface from the latest pass; ``null`` hides everything. */
+  contraction: ContractionReflection | null;
+}
+
+function ContractionReflectionNote({
+  contraction,
+}: ContractionReflectionNoteProps): React.JSX.Element | null {
+  // Reference-identity dismissal: setting ``dismissedFor`` to the current object
+  // hides it for good, but a fresh pass hands a NEW object that never matches —
+  // so a later reflection resurfaces without a re-open affordance.
+  const [dismissedFor, setDismissedFor] = useState<ContractionReflection | null>(null);
+  if (contraction == null || dismissedFor === contraction) return null;
+  return (
+    <View style={styles.root} testID="contraction-reflection">
+      <Text style={styles.title} accessibilityRole="header" testID="contraction-reflection-title">
+        {VARIANT_TITLES[contraction.variant]}
+      </Text>
+      <Text style={styles.message}>{contraction.message}</Text>
+      <TouchableOpacity
+        style={styles.dismiss}
+        onPress={() => setDismissedFor(contraction)}
+        accessibilityRole="button"
+        accessibilityLabel={DISMISS_A11Y}
+        testID="contraction-dismiss"
+      >
+        <Text style={styles.dismissText}>{DISMISS_LABEL}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    margin: SPACING.lg,
+    padding: SPACING.lg,
+    borderRadius: BORDER_RADIUS.lg,
+    backgroundColor: surface.raised,
+    borderLeftWidth: ACCENT_STRIPE_WIDTH,
+    borderLeftColor: accent.primary,
+    ...paperShadow.card,
+  },
+  title: {
+    ...editorialType.title,
+    color: ink.primary,
+    marginBottom: SPACING.md,
+  },
+  message: {
+    ...editorialType.body,
+    color: ink.primary,
+  },
+  dismiss: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    alignSelf: 'flex-start',
+    paddingHorizontal: SPACING.md,
+    marginTop: SPACING.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dismissText: {
+    ...editorialType.note,
+    fontWeight: '600',
+    color: ink.soft,
+  },
+});
+
+export default ContractionReflectionNote;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -21,6 +21,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import CareSupportNote from './CareSupportNote';
 import CompletionSuggestionNote from './CompletionSuggestionNote';
+import ContractionReflectionNote from './ContractionReflectionNote';
 import EditConfirmDialog from './EditConfirmDialog';
 import GetResonanceButton, { shouldShowResonance } from './GetResonanceButton';
 import HighlightedBody from './HighlightedBody';
@@ -922,6 +923,10 @@ function JournalEntryScreen({
           never nested in the margin column — so on an acute-distress signal the
           human + professional support reads as the page's own, not a margin note. */}
       <CareSupportNote care={ctl.resonance.care} />
+      {/* Foundation reflection: a warm, declinable "tend your foundation"
+          sibling rendered AFTER the care surface so an acute-distress signal
+          always reads first. Hidden (renders nothing) on healthy passes. */}
+      <ContractionReflectionNote contraction={ctl.resonance.contraction} />
       <JournalPage ctl={ctl} bodyPlaceholder={bodyPlaceholder} />
       <PrivacyResonanceReason
         visible={ctl.visible && ctl.resonanceDisabled}

--- a/frontend/src/features/Journal/__tests__/ContractionReflectionNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ContractionReflectionNote.test.tsx
@@ -1,0 +1,200 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+/**
+ * RED tests for ``ContractionReflectionNote``.
+ *
+ * These tests fail until the implementation-specialist creates
+ * ``frontend/src/features/Journal/ContractionReflectionNote.tsx``: a warm,
+ * declinable "tend your foundation" reflection surface driven by the
+ * resonance-pass ``contraction`` field. It is not punitive copy — the note
+ * must never read as failure, demotion, or ranking language, and a dismiss
+ * always fully hides the surface (no forced re-open, unlike CareSupportNote).
+ */
+import ContractionReflectionNote from '../ContractionReflectionNote';
+
+import type { ContractionReflection } from '@/api';
+import { touchTarget } from '@/design/tokens';
+
+function contraction(overrides: Partial<ContractionReflection> = {}): ContractionReflection {
+  return {
+    variant: 'simple_ease_off',
+    message: 'Your practice has eased off a little. No rush back — pick it up when it calls.',
+    ...overrides,
+  };
+}
+
+function returnOfferContraction(
+  overrides: Partial<ContractionReflection> = {},
+): ContractionReflection {
+  return {
+    variant: 'return_offer',
+    message:
+      'It has been a while since you tended this. A five-week Return is here if you want it.',
+    ...overrides,
+  };
+}
+
+/** Smallest of the flattened minHeight/minWidth on an interactive node. */
+function StyleSheetMin(node: { props: { style: unknown } }): number {
+  const { StyleSheet } = require('react-native');
+  const flat = StyleSheet.flatten(node.props.style) as {
+    minHeight?: number;
+    minWidth?: number;
+  };
+  return Math.min(flat.minHeight ?? 0, flat.minWidth ?? 0);
+}
+
+describe('ContractionReflectionNote — null contraction', () => {
+  it('renders nothing when contraction is null', () => {
+    const { queryByTestId } = render(<ContractionReflectionNote contraction={null} />);
+    expect(queryByTestId('contraction-reflection')).toBeNull();
+  });
+});
+
+describe('ContractionReflectionNote — initial render', () => {
+  it('mounts the root container with testID "contraction-reflection"', () => {
+    const { getByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
+    expect(getByTestId('contraction-reflection')).toBeTruthy();
+  });
+
+  it('renders the backend message text', () => {
+    const { getByText } = render(<ContractionReflectionNote contraction={contraction()} />);
+    expect(
+      getByText('Your practice has eased off a little. No rush back — pick it up when it calls.'),
+    ).toBeTruthy();
+  });
+
+  it('gives the title element accessibilityRole="header"', () => {
+    const { getByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
+    const title = getByTestId('contraction-reflection-title');
+    expect(title.props.accessibilityRole).toBe('header');
+  });
+});
+
+describe('ContractionReflectionNote — variant-distinct titles', () => {
+  it('renders a different title for simple_ease_off vs return_offer, both with their message', () => {
+    const easeOff = render(<ContractionReflectionNote contraction={contraction()} />);
+    const easeOffTitle = textOf(easeOff.getByTestId('contraction-reflection-title'));
+    expect(
+      easeOff.getByText(
+        'Your practice has eased off a little. No rush back — pick it up when it calls.',
+      ),
+    ).toBeTruthy();
+
+    const returnOffer = render(
+      <ContractionReflectionNote contraction={returnOfferContraction()} />,
+    );
+    const returnTitle = textOf(returnOffer.getByTestId('contraction-reflection-title'));
+    expect(
+      returnOffer.getByText(
+        'It has been a while since you tended this. A five-week Return is here if you want it.',
+      ),
+    ).toBeTruthy();
+
+    expect(easeOffTitle).not.toBe(returnTitle);
+  });
+});
+
+describe('ContractionReflectionNote — dismiss', () => {
+  it('mounts a dismiss control with testID "contraction-dismiss"', () => {
+    const { getByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
+    expect(getByTestId('contraction-dismiss')).toBeTruthy();
+  });
+
+  it('gives the dismiss control accessibilityRole "button" and a non-empty accessibilityLabel', () => {
+    const { getByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
+    const dismiss = getByTestId('contraction-dismiss');
+    expect(dismiss.props.accessibilityRole).toBe('button');
+    const label: unknown = dismiss.props.accessibilityLabel;
+    expect(typeof label).toBe('string');
+    expect((label as string).length).toBeGreaterThan(0);
+  });
+
+  it('hides the whole surface after one tap on contraction-dismiss', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ContractionReflectionNote contraction={contraction()} />,
+    );
+    fireEvent.press(getByTestId('contraction-dismiss'));
+    expect(queryByTestId('contraction-reflection')).toBeNull();
+  });
+
+  it('re-shows the note when a NEW contraction object arrives after a prior dismissal', () => {
+    const { getByTestId, getByText, queryByTestId, rerender } = render(
+      <ContractionReflectionNote contraction={contraction()} />,
+    );
+    fireEvent.press(getByTestId('contraction-dismiss'));
+    expect(queryByTestId('contraction-reflection')).toBeNull();
+
+    const fresh = contraction({ message: 'A fresh reflection for a new pass.' });
+    rerender(<ContractionReflectionNote contraction={fresh} />);
+
+    expect(getByTestId('contraction-reflection')).toBeTruthy();
+    expect(getByText('A fresh reflection for a new pass.')).toBeTruthy();
+  });
+});
+
+describe('ContractionReflectionNote — touch-target requirements', () => {
+  it('dismiss control meets the 44dp minimum touch target', () => {
+    const { getByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
+    const dismiss = getByTestId('contraction-dismiss');
+    expect(StyleSheetMin(dismiss)).toBeGreaterThanOrEqual(touchTarget.minimum);
+  });
+});
+
+describe('ContractionReflectionNote — non-punitive intent', () => {
+  it('renders no failure/demotion/ranking language for simple_ease_off', () => {
+    const rendered = render(<ContractionReflectionNote contraction={contraction()} />);
+    expect(textOf(rendered.getByTestId('contraction-reflection'))).not.toMatch(
+      /fail|demot|fell behind|rank/i,
+    );
+  });
+
+  it('renders no failure/demotion/ranking language for return_offer', () => {
+    const rendered = render(<ContractionReflectionNote contraction={returnOfferContraction()} />);
+    expect(textOf(rendered.getByTestId('contraction-reflection'))).not.toMatch(
+      /fail|demot|fell behind|rank/i,
+    );
+  });
+});
+
+describe('ContractionReflectionNote — no chat UI', () => {
+  it('does not render a sender testID', () => {
+    const { queryByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
+    expect(queryByTestId('sender')).toBeNull();
+  });
+
+  it('does not render an avatar testID', () => {
+    const { queryByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+
+  it('does not render a reply testID', () => {
+    const { queryByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
+    expect(queryByTestId('reply')).toBeNull();
+  });
+
+  it('does not render a "Send" text element', () => {
+    const { queryByText } = render(<ContractionReflectionNote contraction={contraction()} />);
+    expect(queryByText('Send')).toBeNull();
+  });
+});
+
+/** Concatenates all visible text strings under a rendered element for a scan. */
+function textOf(node: { children: readonly unknown[] }): string {
+  const parts: string[] = [];
+  const walk = (n: unknown): void => {
+    if (typeof n === 'string') {
+      parts.push(n);
+      return;
+    }
+    if (n != null && typeof n === 'object' && 'children' in n) {
+      const withChildren = n as { children: readonly unknown[] };
+      for (const child of withChildren.children) walk(child);
+    }
+  };
+  walk(node);
+  return parts.join(' ');
+}

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenContraction.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenContraction.test.tsx
@@ -1,0 +1,218 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+/**
+ * RED tests for the JournalEntryScreen contraction-reflection surface.
+ *
+ * Requirements:
+ * - A resonance pass returning ``contraction`` mounts
+ *   ``ContractionReflectionNote`` (testID ``"contraction-reflection"``).
+ * - An ordinary pass (no contraction) renders nothing for it.
+ * - The care surface and the contraction surface can coexist on one pass.
+ *
+ * These tests fail until the implementation-specialist wires ``contraction``
+ * from ``useResonance`` into ``JournalEntryScreen``.
+ */
+import type { CareResponse, ContractionReflection, JournalMessage, ResonanceResponse } from '@/api';
+import { DEFAULT_IDLE_DELAY_MS } from '@/hooks/useIdle';
+
+// ---------------------------------------------------------------------------
+// API mocks — mirrors the shape in JournalEntryScreenCare.test.tsx exactly.
+// ---------------------------------------------------------------------------
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+const mockGenerate = jest.fn() as jest.MockedFunction<(_id: number) => Promise<ResonanceResponse>>;
+const mockRespond = jest.fn() as jest.MockedFunction<(_w: number, _b: string) => Promise<unknown>>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: {
+    respond: (...a: unknown[]) => (mockRespond as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: (...a: unknown[]) => (mockGenerate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  completionSuggestions: {
+    list: jest.fn(() => Promise.resolve({ items: [] })),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 7,
+    message: 'Today felt quiet.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'freeform' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'A quiet day',
+    status: 'draft',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function carePayload(): CareResponse {
+  return {
+    message: 'What you shared sounds heavy. Here are some people who can help right now.',
+    resources: [
+      {
+        kind: 'hotline',
+        name: '988 Suicide & Crisis Lifeline',
+        contact: '988',
+        what_it_is: 'Free, confidential crisis support — call or text anytime.',
+      },
+    ],
+  };
+}
+
+function contractionPayload(overrides: Partial<ContractionReflection> = {}): ContractionReflection {
+  return {
+    variant: 'simple_ease_off',
+    message: 'Your practice has eased off a little. No rush back.',
+    ...overrides,
+  };
+}
+
+function resonancePayload(overrides: Partial<ResonanceResponse> = {}): ResonanceResponse {
+  return {
+    marginalia: [],
+    suggestions: [],
+    remaining_messages: 48,
+    remaining_balance: 0,
+    monthly_reset_date: '2026-07-01T00:00:00Z',
+    care: null,
+    contraction: null,
+    ...overrides,
+  };
+}
+
+function renderScreen(
+  params?: {
+    entryId?: number;
+    weekNumber?: number;
+    promptQuestion?: string;
+    prefillTitle?: string;
+    practiceSessionId?: number;
+  },
+  extraProps: Record<string, unknown> = {},
+) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return {
+    ...render(<Screen navigation={navigation} route={route} {...extraProps} />),
+    navigation,
+  };
+}
+
+interface ScreenQueries {
+  getByTestId: (_id: string) => { props: Record<string, unknown> };
+}
+
+async function triggerResonancePass(screen: ScreenQueries): Promise<void> {
+  fireEvent.changeText(screen.getByTestId('journal-body-input'), 'Today felt quiet.');
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(100);
+  });
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
+  });
+  await act(async () => {
+    fireEvent.press(screen.getByTestId('get-resonance-button'));
+    await Promise.resolve();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockGenerate.mockReset();
+  mockRespond.mockReset();
+  mockRespond.mockResolvedValue({});
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — contraction-reflection surface', () => {
+  it('renders contraction-reflection when the resonance pass returns a contraction', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(resonancePayload({ contraction: contractionPayload() }));
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      await triggerResonancePass({ getByTestId });
+
+      await waitFor(() => expect(getByTestId('contraction-reflection')).toBeTruthy());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('renders nothing for contraction-reflection on an ordinary pass', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(resonancePayload());
+
+      const { getByTestId, queryByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      await triggerResonancePass({ getByTestId });
+
+      expect(queryByTestId('contraction-reflection')).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('renders both care-support and contraction-reflection when a pass returns both', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(entry({ id: 42 }));
+      mockGenerate.mockResolvedValue(
+        resonancePayload({ care: carePayload(), contraction: contractionPayload() }),
+      );
+
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      await triggerResonancePass({ getByTestId });
+
+      await waitFor(() => expect(getByTestId('care-support')).toBeTruthy());
+      expect(getByTestId('contraction-reflection')).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/features/Journal/__tests__/useResonanceContraction.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonanceContraction.test.tsx
@@ -1,0 +1,193 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+/**
+ * RED tests for the ``contraction`` field threading through ``useResonance``.
+ *
+ * All tests fail until the implementation-specialist adds ``contraction`` to
+ * ``UseResonanceResult``, ``useGeneratePass``, and the hook's return value.
+ *
+ * The mock surface matches ``useResonanceCare.test.tsx`` exactly so the two
+ * files can be merged or colocated without conflict.
+ */
+import type {
+  CompletionSuggestion,
+  ContractionReflection,
+  Marginalia,
+  ResonanceResponse,
+} from '@/api';
+
+const mockList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: Marginalia[] }>
+>;
+const mockGenerate = jest.fn() as jest.MockedFunction<(_id: number) => Promise<ResonanceResponse>>;
+const mockSugList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: CompletionSuggestion[] }>
+>;
+
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api') as Record<string, unknown>;
+  return {
+    ...actual,
+    resonance: {
+      list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+      generate: (...a: unknown[]) =>
+        (mockGenerate as unknown as (...x: unknown[]) => unknown)(...a),
+    },
+    completionSuggestions: {
+      list: (...a: unknown[]) => (mockSugList as unknown as (...x: unknown[]) => unknown)(...a),
+      accept: jest.fn(),
+      dismiss: jest.fn(),
+    },
+  };
+});
+
+const { useResonance } = require('../useResonance');
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function note(overrides: Partial<Marginalia> = {}): Marginalia {
+  return {
+    id: 1,
+    journal_entry_id: 7,
+    kind: 'theme',
+    anchor_start: 0,
+    anchor_end: 4,
+    anchor_text: 'walk',
+    note: 'A beginning.',
+    essay: null,
+    essay_generated_at: null,
+    status: 'active',
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function contractionPayload(overrides: Partial<ContractionReflection> = {}): ContractionReflection {
+  return {
+    variant: 'simple_ease_off',
+    message: 'Your practice has eased off a little. No rush back.',
+    ...overrides,
+  };
+}
+
+function resonancePayload(overrides: Partial<ResonanceResponse> = {}): ResonanceResponse {
+  return {
+    marginalia: [],
+    suggestions: [],
+    remaining_messages: 48,
+    remaining_balance: 0,
+    monthly_reset_date: '2026-07-01T00:00:00Z',
+    care: null,
+    contraction: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockList.mockReset();
+  mockGenerate.mockReset();
+  mockSugList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockSugList.mockResolvedValue({ items: [] });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useResonance — contraction field threading', () => {
+  it('is null before any generate pass', () => {
+    const flush = jest.fn(async () => 42);
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    expect(result.current.contraction).toBeNull();
+  });
+
+  it('never populates contraction from the load-on-open effect (marginalia list carries none)', async () => {
+    mockList.mockResolvedValue({ items: [note({ id: 1 })] });
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+
+    await waitFor(() => expect(result.current.marginalia).toHaveLength(1));
+
+    expect(result.current.contraction).toBeNull();
+  });
+
+  it('exposes contraction on the hook result when a generate pass returns one', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue(resonancePayload({ contraction: contractionPayload() }));
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(result.current.contraction).not.toBeNull();
+    expect(result.current.contraction!.variant).toBe('simple_ease_off');
+    expect(result.current.contraction!.message).toBe(
+      'Your practice has eased off a little. No rush back.',
+    );
+  });
+
+  it('normalizes undefined contraction (field omitted) to null', async () => {
+    const flush = jest.fn(async () => 42);
+    const payloadWithoutContraction = { ...resonancePayload() };
+    delete (payloadWithoutContraction as { contraction?: unknown }).contraction;
+    mockGenerate.mockResolvedValue(payloadWithoutContraction as ResonanceResponse);
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(result.current.contraction == null).toBe(true);
+  });
+
+  it('clears stale contraction at the start of a subsequent healthy pass', async () => {
+    const flush = jest.fn(async () => 42);
+
+    mockGenerate.mockResolvedValueOnce(
+      resonancePayload({ contraction: contractionPayload({ variant: 'return_offer' }) }),
+    );
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+    expect(result.current.contraction).not.toBeNull();
+
+    mockGenerate.mockResolvedValueOnce(resonancePayload({ contraction: null }));
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(result.current.contraction).toBeNull();
+  });
+
+  it('still merges marginalia and suggestions alongside contraction after a generate pass', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue(
+      resonancePayload({
+        marginalia: [note({ id: 5, journal_entry_id: 42 })],
+        contraction: contractionPayload(),
+      }),
+    );
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(result.current.marginalia).toHaveLength(1);
+    expect(result.current.contraction).not.toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -19,7 +19,13 @@ import {
 } from 'react';
 
 import { completionSuggestions, resonance } from '@/api';
-import type { CareResponse, CheckInResult, CompletionSuggestion, Marginalia } from '@/api';
+import type {
+  CareResponse,
+  CheckInResult,
+  CompletionSuggestion,
+  ContractionReflection,
+  Marginalia,
+} from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 
 const EMPTY_BODY_MESSAGE = 'Write a little first, then ask for its resonance.';
@@ -43,6 +49,13 @@ export interface UseResonanceResult {
    * new pass clears any stale care, and the load-on-open path never sets it.
    */
   care: CareResponse | null;
+  /**
+   * Warm, declinable "tend your foundation" reflection for the latest pass.
+   * Always ``null`` (never ``undefined``) until a generate pass returns one; a
+   * new pass clears any stale reflection, and the load-on-open path never sets
+   * it.
+   */
+  contraction: ContractionReflection | null;
   /**
    * Reason copy from a pass that was withheld for an intimate entry.
    * ``null`` until a generate pass returns a ``private_message``; the privacy
@@ -208,13 +221,15 @@ interface GeneratePassDeps {
   setMarginalia: Dispatch<SetStateAction<Marginalia[]>>;
   mergeFromGenerate: (_incoming: CompletionSuggestion[]) => void;
   setCare: Dispatch<SetStateAction<CareResponse | null>>;
+  setContraction: Dispatch<SetStateAction<ContractionReflection | null>>;
   setPrivateMessage: Dispatch<SetStateAction<string | null>>;
   setError: Dispatch<SetStateAction<string | null>>;
 }
 
 /** The charged "generate" pass: flush, generate, merge notes + suggestions + care. */
 function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
-  const { flush, setMarginalia, mergeFromGenerate, setCare, setPrivateMessage, setError } = deps;
+  const { flush, setMarginalia, mergeFromGenerate, setCare, setContraction } = deps;
+  const { setPrivateMessage, setError } = deps;
   const [loading, setLoading] = useState(false);
   const inFlightRef = useRef(false);
 
@@ -226,6 +241,9 @@ function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
     // Clear any care from a prior pass up front so a distressed-then-calm
     // sequence never leaves a stale crisis surface on the page.
     setCare(null);
+    // Likewise clear any prior contraction so an eased-then-healthy sequence
+    // never leaves a stale "tend your foundation" reflection on the page.
+    setContraction(null);
     try {
       const entryId = await flush();
       if (entryId == null) {
@@ -237,6 +255,8 @@ function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
       mergeFromGenerate(result.suggestions);
       // ``care`` is nullable/absent on ordinary entries — normalise to null.
       setCare(result.care ?? null);
+      // ``contraction`` is nullable/absent on healthy entries — normalise to null.
+      setContraction(result.contraction ?? null);
       // ``private_message`` is present only when the pass was withheld.
       setPrivateMessage(result.private_message ?? null);
     } catch (err) {
@@ -245,7 +265,15 @@ function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
       inFlightRef.current = false;
       setLoading(false);
     }
-  }, [flush, setMarginalia, mergeFromGenerate, setCare, setPrivateMessage, setError]);
+  }, [
+    flush,
+    setMarginalia,
+    mergeFromGenerate,
+    setCare,
+    setContraction,
+    setPrivateMessage,
+    setError,
+  ]);
 
   return { loading, requestResonance };
 }
@@ -255,6 +283,9 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
   // Default null (never undefined): the load-on-open path never sets care, so
   // the surface stays hidden until a generate pass returns one.
   const [care, setCare] = useState<CareResponse | null>(null);
+  // Default null (never undefined): the load-on-open path never sets it, so the
+  // reflection stays hidden until a generate pass returns one.
+  const [contraction, setContraction] = useState<ContractionReflection | null>(null);
   // Reason copy from a withheld (intimate) pass; null until one returns it.
   const [privateMessage, setPrivateMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -266,6 +297,7 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     setMarginalia,
     mergeFromGenerate: sug.mergeFromGenerate,
     setCare,
+    setContraction,
     setPrivateMessage,
     setError,
   });
@@ -289,6 +321,7 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
     suggestions: sug.suggestions,
     acceptedCheckIns: sug.acceptedCheckIns,
     care,
+    contraction,
     privateMessage,
     loading,
     error,


### PR DESCRIPTION
## Summary

Wires the real backend **contraction** signal into a warm, declinable "tend your foundation" affordance on the Journal resonance-pass flow, mirroring the existing acute-distress `care` surface.

When a resonance pass senses a foundation easing off, the backend returns a descriptive Higher Self reflection — `contraction: { variant, message } | null` — riding the resonance response (shipped by the reframed #946). This PR consumes that real shape:

- **Schema (`api/schemas.ts`, `api/index.ts`):** adds `contractionVariantSchema` (`simple_ease_off` | `return_offer`), `contractionReflectionSchema`, and an additive `.nullish()` `contraction` field on `resonanceResponseSchema`; exports the inferred types. Older responses (no `contraction`) validate and behave exactly as before.
- **Hook (`useResonance.ts`):** threads `contraction` state as a faithful mirror of `care` — defaults `null`, cleared at the start of every pass (no stale reflection), normalized `undefined -> null`, never set by the load-on-open path.
- **Component (`ContractionReflectionNote.tsx`, new):** a presentational, tokens-only surface. Variant-keyed warm titles ("Tend your foundation" / "The Return is open to you"), the backend `message` as the body under a header role, and a one-tap dismiss ("Not now"). Dismissal uses a reference-identity reset so a *new* pass's reflection re-surfaces without a `useEffect` or a forced re-open — appropriate for a non-crisis, declinable invitation.
- **Screen (`JournalEntryScreen.tsx`):** renders the note as a screen-level sibling immediately after `CareSupportNote`, so an acute-distress care surface always reads first.

Copy is warm, invitational, and non-punitive throughout — never "failed", "demoted", "fell behind", or ranking language — honoring "you choose your depth". Candle & Ink tokens only; accessible (header-role title, dismiss a11y label + button role, 44dp touch target, real `Text` message).

### Scope note: Map "route to Beige" overlay intentionally excluded

The original issue was written against a backend grounding contract (`foundation_thinning` + `route_to_beige` fields feeding a Map overlay) that was **never built**. Its dependency #946 shipped instead as the descriptive reflection consumed here. No endpoint delivers a contraction signal to the Map, so a geometric route-to-Beige overlay would require inventing a fictional backend contract. This PR implements the honest subset against the real signal. A Map visualization, if still wanted, needs a new backend contract first (suggest a follow-up issue referencing the #946 reframe).

## Test plan

- New `contractionSchemas.test.ts`: parses without `contraction` (backward compat), with `null`, and both variants; round-trips `message`; rejects unknown variant / missing / non-string message.
- New `ContractionReflectionNote.test.tsx` (100% coverage): null-hide, message + header-role title, variant-distinct titles, dismiss (a11y label, button role, one-tap full hide, fresh-object re-show), touch target ≥ 44dp, non-punitive intent regex for both variants, no chat chrome.
- New `useResonanceContraction.test.tsx`: null default, load-on-open never sets it, populated/cleared/normalized across passes, coexists with marginalia + suggestions.
- New `JournalEntryScreenContraction.test.tsx`: renders on a contraction-bearing pass, hidden otherwise, coexists with the care surface.
- `./scripts/frontend/check-all.sh` exits 0 (ESLint zero-warning, prettier clean, tsc strict clean, all 2667 jest tests pass).

Closes #947
Refs #943
