### PR TITLE
feat(scan): autonomous maintenance pipeline (full rollout)

### DIFF
--- a/.claude/skills/scan-issue-writer/SKILL.md
+++ b/.claude/skills/scan-issue-writer/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: scan-issue-writer
+description: >-
+  Run a named codebase maintenance scan and convert findings into
+  6-component, agent-ready GitHub issues. Use when a workflow or user says
+  "run the <name> scan", "create issues from this analysis", or passes a
+  prompts/scans/*.md file. Handles dedupe, priority labeling, and max-issue
+  caps so the Ralph loop never starves and never bloats. Do NOT use for
+  implementing fixes (use stay-green), reviewing PRs (use
+  comprehensive-pr-review), or closing/triaging existing issues (use
+  backlog-grooming).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Scan Issue Writer
+
+Turn scan findings into prioritized, deduplicated, agent-ready GitHub issues
+for the autonomous maintenance pipeline. The skill owns the *process*; each
+`prompts/scans/<name>.md` owns the *domain* of its scan.
+
+## Inputs
+
+The invoking workflow (or user) supplies:
+
+- **scan_name** — which scan to run; selects `prompts/scans/<scan_name>.md`.
+- **max_issues** — hard cap on issues created this run (default 5).
+- **priority** — `P0` | `P1` | `P2` | `P3`, applied to every issue filed.
+
+## Instructions
+
+### Step 1 — Load the scan definition
+Read `prompts/scans/<scan_name>.md`. It defines the tools to run, what counts
+as a finding, the severity rubric, and the title-slug prefix (`[scan:<name>]`).
+
+### Step 2 — Run the analysis (read-only)
+Execute the scan's tool commands. Never modify code. Record the current SHA
+with `git rev-parse HEAD` — every issue must cite it in its Context section.
+
+### Step 3 — Rank and cap
+Sort findings by the scan's severity rubric, highest first. Keep at most
+`max_issues`. Findings past the cut are NOT silently dropped: list them in a
+single run-summary comment (Step 6) so the next scheduled or hopper-dispatched
+run can pick them up. Never exceed the cap — the hopper controls volume.
+
+### Step 4 — Dedupe before every create
+For each surviving finding, derive its title slug and search open issues:
+
+```bash
+gh issue list --search 'in:title "<slug>"' --state open --json number,title
+```
+
+- **Exact match, finding still valid** → add a comment with fresh evidence
+  ("Still present at `<SHA>`; <tool> confidence …"). Do not create a duplicate.
+- **Exact match, evidence changed materially** → `gh issue edit` the body.
+- **No match** → proceed to Step 5.
+
+Duplicate issues inflate apparent queue depth with fake work — this step is the
+single most important behavior for keeping the hopper honest. Other scans may
+run concurrently, so re-run the dedupe search immediately before each create.
+
+### Step 5 — Write the issue
+Fill `references/issue-body-template.md` completely — all six components, no
+placeholders left. An issue missing any component gets `needs-triage` instead
+of `agent-ready`, and the grooming pass finishes it. Write the body to a file
+and create with:
+
+```bash
+gh issue create --title "[scan:<name>] <specific finding>" \
+  --body-file /tmp/scan-issue.md \
+  --label "<priority>,scan:<name>,agent-ready"
+```
+
+If any of the labels do not exist yet, create them first (see
+`scripts/setup-scan-labels.sh` for the canonical set), then retry.
+
+### Step 6 — Report
+Append a run summary to `$GITHUB_STEP_SUMMARY` (or print it, when run locally):
+findings found / created / deduped / capped-and-deferred, each with its issue
+number. A clean scan reports zero created and that is a success.
+
+## Examples
+
+### Example 1 — Perf scan finds an N+1
+Title: `[scan:perf] N+1 query loading marginalia in entries.list_for_user`
+Labels: `P2,scan:perf,agent-ready`. Body cites the SQLAlchemy echo log,
+`file:line` at the scanned SHA, and a `selectinload` before/after sketch.
+
+### Example 2 — Dedupe hit
+`[scan:dead-code] unused export parseFrequency in lib/wavelength.ts` is already
+open as #412 → add a comment: "Still present at `<SHA>`; vulture confidence
+100%." No new issue is created.
+
+## Troubleshooting
+
+### Scan tool exits nonzero with no findings
+Distinguish "tool crashed" from "clean scan." A genuine crash creates ONE `P1`
+issue about the broken tooling (with the command and stderr). A clean scan
+creates zero issues — that is success, not failure.
+
+### More findings than max_issues
+Never exceed the cap. Summarize the overflow in the Step 6 run summary so the
+next run picks it up. Raising throughput is the hopper's job (higher
+`max_issues`), not this skill's.

--- a/.claude/skills/scan-issue-writer/SKILL.md
+++ b/.claude/skills/scan-issue-writer/SKILL.md
@@ -61,10 +61,11 @@ single most important behavior for keeping the hopper honest. Other scans may
 run concurrently, so re-run the dedupe search immediately before each create.
 
 ### Step 5 — Write the issue
-Fill `references/issue-body-template.md` completely — all six components, no
-placeholders left. An issue missing any component gets `needs-triage` instead
-of `agent-ready`, and the grooming pass finishes it. Write the body to a file
-and create with:
+Fill the canonical `prompts/templates/scan-issue-body.md` completely — all six
+components, no placeholders left. (It is the single source of truth;
+`references/issue-body-template.md` just points at it.) An issue missing any
+component gets `needs-triage` instead of `agent-ready`, and the grooming pass
+finishes it. Write the body to a file and create with:
 
 ```bash
 gh issue create --title "[scan:<name>] <specific finding>" \

--- a/.claude/skills/scan-issue-writer/references/issue-body-template.md
+++ b/.claude/skills/scan-issue-writer/references/issue-body-template.md
@@ -1,0 +1,43 @@
+<!--
+  This is the operational copy the scan-issue-writer skill fills for every
+  issue it creates. It is kept identical to the canonical, doc-facing template
+  at prompts/templates/scan-issue-body.md — edit BOTH together (or edit the
+  canonical one and copy it here) so the two never drift.
+
+  Replace every [bracketed] placeholder. Leave no placeholder behind. An issue
+  missing any of the six components gets `needs-triage` instead of
+  `agent-ready`.
+-->
+
+## Role
+You are a [senior Python/FastAPI | senior React Native] engineer working in the
+adepthood codebase, following its existing conventions (TDD via stay-green,
+check-all.sh gates, ≥90% line / ≥80% branch backend coverage, ≥90% Jest
+frontend, zero lint/type suppressions).
+
+## Goal
+[One sentence. Specific, measurable, verifiable. e.g. "Eliminate the N+1 query
+in entries.list_for_user by eager-loading marginalia, verified by a query-count
+assertion test."]
+
+## Context
+- File(s): `path/to/file.py:120-164`
+- Scanned at commit: `<SHA>` — re-verify against HEAD before starting
+- Evidence: [tool output excerpt — the radon score, the audit finding, the
+  coverage gap, the query log, the grep hit with surrounding lines]
+- Related: [links to sibling issues from the same scan run, prior PRs]
+
+## Output Format
+A single PR that: (1) adds a failing test first, (2) makes it pass, (3) passes
+check-all.sh, (4) references this issue with "Closes #N".
+
+## Examples
+[One concrete before/after sketch — e.g. the current loop-with-query vs. the
+selectinload version. 5–15 lines. Enough to disambiguate, not a full spec.]
+
+## Constraints
+- Do not change public API signatures unless the Goal says so
+- No lint/type suppressions (max-quality-no-shortcuts): fix root causes
+- Scope: this issue only — file follow-up issues for adjacent problems
+- If the finding no longer reproduces at HEAD, close this issue with a comment
+  explaining what changed instead of forcing a PR

--- a/.claude/skills/scan-issue-writer/references/issue-body-template.md
+++ b/.claude/skills/scan-issue-writer/references/issue-body-template.md
@@ -1,43 +1,15 @@
 <!--
-  This is the operational copy the scan-issue-writer skill fills for every
-  issue it creates. It is kept identical to the canonical, doc-facing template
-  at prompts/templates/scan-issue-body.md — edit BOTH together (or edit the
-  canonical one and copy it here) so the two never drift.
+  NOT a copy — a pointer, to avoid the two-files-must-stay-in-sync drift risk.
 
-  Replace every [bracketed] placeholder. Leave no placeholder behind. An issue
-  missing any of the six components gets `needs-triage` instead of
-  `agent-ready`.
+  The canonical 6-component issue body template is the single source of truth at:
+
+      prompts/templates/scan-issue-body.md
+
+  Read that file and fill every one of its six components (Role / Goal / Context
+  / Output Format / Examples / Constraints). An issue missing any component gets
+  `needs-triage` instead of `agent-ready`, and the grooming pass finishes it.
+
+  Do not paste the template's contents back into this file — keeping the body in
+  one place is deliberate, so an edit can never land in one copy and miss the
+  other.
 -->
-
-## Role
-You are a [senior Python/FastAPI | senior React Native] engineer working in the
-adepthood codebase, following its existing conventions (TDD via stay-green,
-check-all.sh gates, ≥90% line / ≥80% branch backend coverage, ≥90% Jest
-frontend, zero lint/type suppressions).
-
-## Goal
-[One sentence. Specific, measurable, verifiable. e.g. "Eliminate the N+1 query
-in entries.list_for_user by eager-loading marginalia, verified by a query-count
-assertion test."]
-
-## Context
-- File(s): `path/to/file.py:120-164`
-- Scanned at commit: `<SHA>` — re-verify against HEAD before starting
-- Evidence: [tool output excerpt — the radon score, the audit finding, the
-  coverage gap, the query log, the grep hit with surrounding lines]
-- Related: [links to sibling issues from the same scan run, prior PRs]
-
-## Output Format
-A single PR that: (1) adds a failing test first, (2) makes it pass, (3) passes
-check-all.sh, (4) references this issue with "Closes #N".
-
-## Examples
-[One concrete before/after sketch — e.g. the current loop-with-query vs. the
-selectinload version. 5–15 lines. Enough to disambiguate, not a full spec.]
-
-## Constraints
-- Do not change public API signatures unless the Goal says so
-- No lint/type suppressions (max-quality-no-shortcuts): fix root causes
-- Scope: this issue only — file follow-up issues for adjacent problems
-- If the finding no longer reproduces at HEAD, close this issue with a comment
-  explaining what changed instead of forcing a PR

--- a/.github/workflows/_claude-scan.yml
+++ b/.github/workflows/_claude-scan.yml
@@ -1,0 +1,123 @@
+name: Claude Scan (reusable)
+
+# Reusable core for the autonomous maintenance pipeline. Each maintenance
+# scan (todo, deps, security, perf, …) is a ~20-line thin wrapper that calls
+# this workflow with a `scan_name`, a `priority`, and a `max_issues` cap. The
+# scan reads `prompts/scans/<scan_name>.md`, runs its read-only analysis, and
+# uses the `scan-issue-writer` skill to file deduplicated, 6-component,
+# agent-ready GitHub issues for the Ralph loop to consume.
+#
+# This mirrors the de-slop workflow's plumbing (auth, runner, permissions)
+# deliberately — see `.github/workflows/deslop.yml`. Scans NEVER push code:
+# the GITHUB_TOKEN is `contents: read` / `issues: write`, so the only durable
+# output is new issues. Code changes remain the Ralph loop's job.
+#
+# Required configuration:
+#   secret  CLAUDE_CODE_OAUTH_TOKEN  - same token the other Claude workflows use.
+
+on:
+  workflow_call:
+    inputs:
+      scan_name:
+        description: "Scan id — must match prompts/scans/<scan_name>.md (e.g. 'todo', 'perf')."
+        required: true
+        type: string
+      max_issues:
+        description: "Hard cap on issues created this run. The hopper controls volume."
+        required: false
+        type: number
+        default: 5
+      priority:
+        description: "Priority label applied to filed issues: P0 | P1 | P2 | P3."
+        required: true
+        type: string
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+  # OIDC token for the claude action's auth exchange (mirrors claude.yml / deslop.yml).
+  id-token: write
+
+# One scan at a time per scan type: never kill a run mid-issue-creation, and
+# never let a scheduled run race a hopper-dispatched run of the same scan.
+concurrency:
+  group: claude-scan-${{ inputs.scan_name }}
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: "Scan ${{ inputs.scan_name }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository (recent history for churn/bug analysis)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 50
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version-file: "frontend/.nvmrc"
+
+      - name: Install backend toolbox (read-only analyzers)
+        run: |
+          python -m venv .venv
+          # shellcheck disable=SC1091
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+          # Extra analyzers used by specific scans; failure here must not sink a
+          # scan that does not need them (e.g. the todo tracer needs only grep).
+          pip install pip-audit vulture mutmut || true
+
+      - name: Install frontend toolbox
+        run: |
+          cd frontend && npm ci
+
+      - name: Run Claude scan
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0  # v1.0.158
+        env:
+          # The scan-issue-writer skill files issues via gh; the action injects
+          # GITHUB_TOKEN, but gh reads GH_TOKEN — bind it to the job token whose
+          # scope is contents:read / issues:write.
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Surface the transcript in the run log so the scan is auditable: you
+          # can verify the skill was invoked and the cap respected. Safe on a
+          # private repo with read-only contents.
+          show_full_output: true
+
+          # --model opus: issue authoring is judgment-heavy (severity ranking,
+          #   dedupe decisions, 6-component prose). The action default (Sonnet)
+          #   files vaguer issues.
+          # --max-turns 40: one scan, bounded analysis + a capped set of creates.
+          claude_args: >-
+            --allowed-tools "Bash,Read,Grep,Glob,Write,Skill,Task"
+            --model opus
+            --max-turns 40
+
+          prompt: |
+            Use the `scan-issue-writer` skill and follow its instructions exactly.
+
+            Scan type: ${{ inputs.scan_name }}
+            Scan definition file: prompts/scans/${{ inputs.scan_name }}.md
+            Max issues to create this run: ${{ inputs.max_issues }}
+            Priority label for filed issues: ${{ inputs.priority }}
+
+            Read the scan definition first. Run its read-only analysis, rank and
+            cap the findings, dedupe against open issues before every create,
+            and file each surviving finding as a fully-populated 6-component
+            issue. A clean scan that files ZERO issues is a valid success — do
+            not invent work. End with the run summary the skill specifies,
+            appended to $GITHUB_STEP_SUMMARY.

--- a/.github/workflows/_claude-scan.yml
+++ b/.github/workflows/_claude-scan.yml
@@ -58,6 +58,24 @@ jobs:
         with:
           fetch-depth: 50
 
+      - name: Validate scan_name and locate its definition
+        env:
+          SCAN_NAME: ${{ inputs.scan_name }}
+        run: |
+          set -euo pipefail
+          # Charset guard: scan_name is interpolated into a file path and the
+          # Claude prompt. GitHub Actions inputs have no `pattern:` field, so we
+          # fail fast here instead. Blocks path-traversal / injection from any
+          # future wrapper that wires scan_name to a workflow_dispatch input.
+          if ! printf '%s' "$SCAN_NAME" | grep -qE '^[a-z][a-z0-9-]+$'; then
+            echo "::error::Invalid scan_name '$SCAN_NAME' — must match ^[a-z][a-z0-9-]+$"
+            exit 1
+          fi
+          if [ ! -f "prompts/scans/$SCAN_NAME.md" ]; then
+            echo "::error::No scan definition at prompts/scans/$SCAN_NAME.md"
+            exit 1
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -75,9 +93,17 @@ jobs:
           . .venv/bin/activate
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt -r backend/requirements-dev.txt
-          # Extra analyzers used by specific scans; failure here must not sink a
-          # scan that does not need them (e.g. the todo tracer needs only grep).
+          # Extra analyzers only some scans need (pip-audit→security,
+          # vulture→dead-code, mutmut→mutation). A failure here must not sink a
+          # scan that does not use them (the todo tracer needs only grep) — but
+          # it must be VISIBLE, not silent, so a scan that expected the tool and
+          # found it missing reports "tooling broken" (skill Troubleshooting)
+          # rather than a false "clean" result. Emit a ::warning:: per gap.
           pip install pip-audit vulture mutmut || true
+          for tool in pip-audit vulture mutmut; do
+            pip show "$tool" >/dev/null 2>&1 \
+              || echo "::warning::optional analyzer '$tool' is not installed; scans that rely on it should fail loudly, not report clean"
+          done
 
       - name: Install frontend toolbox
         run: |

--- a/.github/workflows/hopper.yml
+++ b/.github/workflows/hopper.yml
@@ -1,0 +1,73 @@
+name: "Hopper: queue-depth refill"
+
+# The never-runs-out guarantee for the Ralph loop. Fixed scan crons are a floor,
+# not a guarantee — repo entropy is bursty. This hourly guard measures the
+# agent-ready queue depth and, when runway drops below MIN_QUEUE, dispatches the
+# most-stale eligible producer scan off-schedule (with a raised max_issues cap).
+# When the queue is healthy it stands down; when it is bloated it also stands
+# down, letting the backlog drain rather than piling on more.
+#
+# No Claude token needed — pure gh + jq queue arithmetic.
+
+on:
+  schedule:
+    - cron: "23 * * * *"        # hourly, off the :00 mark to spread API load
+  workflow_dispatch:
+
+permissions:
+  issues: read
+  actions: write               # needed to dispatch scan workflows
+
+concurrency:
+  group: hopper
+  cancel-in-progress: false
+
+jobs:
+  check-and-refill:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      MIN_QUEUE: "12"           # ~6 hrs of runway at ~2 issues/hr
+      MAX_QUEUE: "80"           # above this, let the backlog drain
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Measure runway and refill if starving
+        run: |
+          set -euo pipefail
+          COUNT=$(gh issue list --label agent-ready --state open \
+                    --limit 300 --json number --jq 'length')
+          echo "Agent-ready queue depth: $COUNT" | tee -a "$GITHUB_STEP_SUMMARY"
+
+          if [ "$COUNT" -ge "$MAX_QUEUE" ]; then
+            echo "Queue bloated (>= $MAX_QUEUE) — standing down so it drains." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$COUNT" -ge "$MIN_QUEUE" ]; then
+            echo "Queue healthy (>= $MIN_QUEUE) — standing down." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Starving. Rotate through refill candidates, cheapest/highest-value
+          # first. Skips mutation (too expensive — schedule-only) and
+          # security/deps/bugs (already daily; not appropriate to spam here).
+          for WF in scan-complexity.yml scan-dead-code.yml scan-coverage.yml \
+                    scan-perf.yml scan-todo.yml scan-types.yml \
+                    scan-docs.yml scan-a11y.yml; do
+            LAST=$(gh run list --workflow "$WF" --limit 1 \
+                     --json createdAt --jq '.[0].createdAt // "1970-01-01T00:00:00Z"')
+            AGE=$(( $(date +%s) - $(date -d "$LAST" +%s) ))
+            if [ "$AGE" -gt 21600 ]; then   # don't re-dispatch within 6 hrs
+              echo "Runway low ($COUNT < $MIN_QUEUE); dispatching $WF (max_issues=8)." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+              gh workflow run "$WF" -f max_issues=8
+              exit 0
+            fi
+          done
+          echo "All refill candidates ran within 6 hrs; queue recovers on schedule." \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/labels-bootstrap.yml
+++ b/.github/workflows/labels-bootstrap.yml
@@ -1,0 +1,32 @@
+name: "Labels: bootstrap pipeline labels"
+
+# One-shot (manually dispatched) bootstrap that creates/updates the labels the
+# autonomous maintenance pipeline relies on: the P0–P3 priority tiers consumed
+# by scripts/ralph/pick-next.sh, the agent-ready gate, and the scan:<name>
+# provenance labels. Runs scripts/setup-scan-labels.sh, which is idempotent
+# (`gh label create --force`), so re-dispatching is safe drift correction.
+#
+# Run this once after merge (Actions → this workflow → Run workflow) before the
+# first scan files issues. Scans also create missing labels on demand, but this
+# makes the full set exist up front so pick-next.sh tiering is correct from run
+# one.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Create/update pipeline labels
+        run: bash scripts/setup-scan-labels.sh

--- a/.github/workflows/scan-a11y.yml
+++ b/.github/workflows/scan-a11y.yml
@@ -1,0 +1,28 @@
+name: "Scan: Accessibility audit"
+
+# Thin wrapper over the reusable _claude-scan.yml core. RN a11y props, touch-target sizes, contrast tokens, screen-reader flow through Journal.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 8 3 * *"       # monthly (3rd) 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "4"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: a11y
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '4') }}
+      priority: P2
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-bugs.yml
+++ b/.github/workflows/scan-bugs.yml
@@ -1,0 +1,28 @@
+name: "Scan: Bug harvest"
+
+# Thin wrapper over the reusable _claude-scan.yml core. Flaky/failing tests, revert commits, and error-handling gaps as RCA-ready issues.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 7 * * *"       # daily 07:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "4"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: bugs
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '4') }}
+      priority: P1
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-complexity.yml
+++ b/.github/workflows/scan-complexity.yml
@@ -1,0 +1,28 @@
+name: "Scan: Complexity refactor"
+
+# Thin wrapper over the reusable _claude-scan.yml core. radon/ruff C901/eslint hotspots that get a named refactor strategy.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 8 * * 2"       # weekly Tuesday 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "6"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: complexity
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '6') }}
+      priority: P2
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-coverage.yml
+++ b/.github/workflows/scan-coverage.yml
@@ -1,0 +1,28 @@
+name: "Scan: Coverage gaps"
+
+# Thin wrapper over the reusable _claude-scan.yml core. Modules under the >=90% line / >=80% branch (backend) and >=90% Jest (frontend) gates.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 8 * * 3"       # weekly Wednesday 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "6"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: coverage
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '6') }}
+      priority: P2
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-dead-code.yml
+++ b/.github/workflows/scan-dead-code.yml
@@ -1,0 +1,28 @@
+name: "Scan: Dead code"
+
+# Thin wrapper over the reusable _claude-scan.yml core. vulture + knip/ts-prune: unused exports, unreachable branches, orphaned files, unused deps.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"       # weekly Monday 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "6"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: dead-code
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '6') }}
+      priority: P3
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-deps.yml
+++ b/.github/workflows/scan-deps.yml
@@ -1,0 +1,28 @@
+name: "Scan: Dependencies"
+
+# Thin wrapper over the reusable _claude-scan.yml core. Groups compatible minor/patch Dependabot bumps into batch issues and writes a migration-plan issue per major bump.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"       # daily 06:00 UTC (Dependabot runs daily)
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "5"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: deps
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '5') }}
+      priority: P2
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-docs.yml
+++ b/.github/workflows/scan-docs.yml
@@ -1,0 +1,28 @@
+name: "Scan: Documentation drift"
+
+# Thin wrapper over the reusable _claude-scan.yml core. Docstring/README/NORTH-STAR claims that no longer match signatures or behavior.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 9 1,15 * *"       # biweekly (1st & 15th) 09:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "4"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: docs
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '4') }}
+      priority: P3
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-groom.yml
+++ b/.github/workflows/scan-groom.yml
@@ -1,0 +1,67 @@
+name: "Scan: Backlog grooming"
+
+# The backlog-grooming pass of the autonomous maintenance pipeline. Unlike the
+# producer scans (which route through _claude-scan.yml + scan-issue-writer),
+# groom is a CONSUMER: it closes resolved/stale scan issues, dedupes, and
+# promotes complete needs-triage issues to agent-ready via the backlog-grooming
+# skill. It therefore has its own thin workflow rather than the producer core,
+# but mirrors the same plumbing (auth, SHA-pinned actions, permissions).
+#
+# Runs daily at 04:00 UTC — BEFORE the day's producer scans (05:00+), so the
+# queue is deduped and trued-up against HEAD before new findings land.
+#
+# Required configuration:
+#   secret  CLAUDE_CODE_OAUTH_TOKEN  - same token the other Claude workflows use.
+
+on:
+  schedule:
+    - cron: "0 4 * * *"        # daily 04:00 UTC, before producer scans
+  workflow_dispatch:
+
+# issues: write covers close / comment / edit. No contents write: groom never
+# touches code, only the issue tracker.
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+concurrency:
+  group: claude-scan-groom
+  cancel-in-progress: false
+
+jobs:
+  groom:
+    name: Groom the Ralph backlog
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository (recent history to verify resolved findings)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 50
+
+      - name: Run backlog grooming
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0  # v1.0.158
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          # Bash carries gh issue close/comment/edit; issues:write is the scope.
+          claude_args: >-
+            --allowed-tools "Bash,Read,Grep,Glob,Skill,Task"
+            --model opus
+            --max-turns 40
+          prompt: |
+            Use the `backlog-grooming` skill and follow its instructions exactly.
+
+            Scan definition file: prompts/scans/groom.md
+
+            Reconcile the open issue backlog against current HEAD: close issues
+            resolved by merged PRs, close scan issues whose finding no longer
+            reproduces at HEAD, collapse duplicates (keep the oldest), and
+            promote fully-specified needs-triage scan issues to agent-ready.
+            Re-verify against HEAD before every close, and be conservative —
+            comment for confirmation rather than closing when "resolved/stale"
+            is uncertain. End with the run summary groom.md specifies, appended
+            to $GITHUB_STEP_SUMMARY.

--- a/.github/workflows/scan-mutation.yml
+++ b/.github/workflows/scan-mutation.yml
@@ -1,0 +1,28 @@
+name: "Scan: Mutation survivors"
+
+# Thin wrapper over the reusable _claude-scan.yml core. mutmut/Stryker survivors on the hottest modules, each with the killing assertion.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 8 8,22 * *"       # biweekly (8th & 22nd) 08:00 UTC — expensive, schedule-only (never hopper)
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "8"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: mutation
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '8') }}
+      priority: P3
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-perf.yml
+++ b/.github/workflows/scan-perf.yml
@@ -1,0 +1,28 @@
+name: "Scan: Performance sweep"
+
+# Thin wrapper over the reusable _claude-scan.yml core. N+1 queries, missing indexes, sync-in-async, unmemoized RN renders, bundle regressions.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 8 * * 4"       # weekly Thursday 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "5"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: perf
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '5') }}
+      priority: P2
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-security.yml
+++ b/.github/workflows/scan-security.yml
@@ -1,0 +1,28 @@
+name: "Scan: Security audit"
+
+# Thin wrapper over the reusable _claude-scan.yml core. pip-audit + npm audit + secret-pattern grep; one issue per actionable CVE.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 5 * * *"       # daily 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "5"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: security
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '5') }}
+      priority: P0
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-todo.yml
+++ b/.github/workflows/scan-todo.yml
@@ -1,0 +1,32 @@
+name: "Scan: TODO/FIXME harvest"
+
+# Thin wrapper over the reusable _claude-scan.yml core. Converts inline
+# TODO/FIXME/HACK/XXX markers into tracked, agent-ready GitHub issues.
+#
+# This is the tracer scan of the autonomous maintenance pipeline — the first
+# thread wired end-to-end. Clone this file for each additional scan, changing
+# only `name`, the cron, `scan_name`, `max_issues`, and `priority`.
+#
+# `workflow_dispatch` is REQUIRED on every scan wrapper: it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    # Weekly Friday 08:00 UTC, per the task table. (cron is UTC.)
+    - cron: "0 8 * * 5"
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "5"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: todo
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '5') }}
+      priority: P3
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/scan-types.yml
+++ b/.github/workflows/scan-types.yml
@@ -1,0 +1,28 @@
+name: "Scan: Type coverage"
+
+# Thin wrapper over the reusable _claude-scan.yml core. mypy --strict / tsc-strict delta: Any leaks, missing returns, type: ignore burn-down.
+#
+# Clone of scan-todo.yml; see it and _claude-scan.yml for the full rationale
+# (auth, permissions, SHA-pinned actions, the scan-issue-writer contract).
+# workflow_dispatch is REQUIRED on every scan wrapper — it is the hook the
+# queue-depth hopper uses to refill the Ralph backlog off-schedule.
+
+on:
+  schedule:
+    - cron: "0 8 1,15 * *"       # biweekly (1st & 15th) 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Hard cap on issues created this run."
+        required: false
+        default: "6"
+
+jobs:
+  run:
+    uses: ./.github/workflows/_claude-scan.yml
+    with:
+      scan_name: types
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '6') }}
+      priority: P3
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/prompts/scans/a11y.md
+++ b/prompts/scans/a11y.md
@@ -1,0 +1,77 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Accessibility audit of the adepthood frontend: find
+  missing or incorrect React Native a11y on the core journal + navigation
+  screens and hand each to the skill as a finding. Follows the same 6-component
+  framework as the issues it produces.
+-->
+
+## Role
+React Native accessibility engineer for the adepthood Expo frontend. You audit
+the app against WCAG 2.1 AA as it applies to RN, and hand each concrete a11y
+defect to the scan-issue-writer skill so it becomes a tracked, agent-ready fix.
+
+## Goal
+Surface missing or incorrect accessibility on the core journal and navigation
+screens so each becomes a tracked issue. Prefer a few well-evidenced,
+screen-reader-relevant findings over a long list of theoretical ones. A run that
+finds none is a valid, successful, zero-issue run.
+
+## Context
+- Title-slug prefix: `[scan:a11y]`
+- Priority label for this scan (workflow input): `P2`
+- Standard: WCAG 2.1 AA (RN adaptation).
+- Scan first-party frontend source only under `frontend/src/`; weight the core
+  Journal screens (`frontend/src/features/Journal`) and `navigation/` first.
+- Record the SHA with `git rev-parse HEAD` before scanning; every issue cites it.
+- What counts as a finding:
+  - **Missing a11y props on touchables** — a `Pressable` / `TouchableOpacity` /
+    `Button` with no `accessibilityLabel`, wrong or missing `accessibilityRole`,
+    or a control whose purpose is unclear to a screen reader without an
+    `accessibilityHint`.
+  - **Touch targets below 44×44** — an interactive element whose styled width or
+    height (or `hitSlop`-adjusted target) is under the 44px minimum.
+  - **Color contrast** — a foreground/background token pair from
+    `frontend/src/design/` whose contrast ratio falls below AA (4.5:1 body text,
+    3:1 large text / UI components). Cite the token names and the computed ratio.
+  - **Screen-reader flow** — reading order, focus traps, or decorative elements
+    not hidden with `accessibilityElementsHidden` / `importantForAccessibility`
+    on the core Journal screens.
+- Exclusions (NOT findings): generated code, `node_modules`, build output,
+  `__snapshots__`, tests; purely visual polish unrelated to a11y; and anything
+  already covered by an open `[scan:a11y]` issue (the skill dedupes).
+
+## Output Format
+Findings as a JSON list, one object per defect:
+
+```json
+{
+  "slug": "a11y-journal-entry-fab-no-label",
+  "title": "New-entry Pressable has no accessibilityLabel",
+  "severity": 3,
+  "file": "frontend/src/features/Journal/EntryListScreen.tsx",
+  "lines": "88-102",
+  "evidence": "the <Pressable onPress={createEntry}> citation — no accessibilityLabel/role/hint props",
+  "before_after_sketch": "add accessibilityRole=\"button\" accessibilityLabel=\"New journal entry\""
+}
+```
+
+Severity is 1–5. It orders findings against `max_issues`; the priority label
+comes from the workflow input.
+
+## Examples
+- A `Pressable` wrapping an icon with no `accessibilityLabel` — a screen reader
+  announces nothing actionable → severity 3; sketch adds role + label.
+- A tab-bar icon button styled 32×32 (under the 44px target) → severity 3;
+  sketch bumps the target or adds `hitSlop`.
+- A muted caption using `ink.faint` on `paper.base` measuring 3.1:1 (below the
+  4.5:1 body-text floor) → severity 3; sketch names an AA-passing token pair.
+
+## Constraints
+- Read-only analysis; never modify code.
+- Evidence must be reproducible: cite the component + props at file:line, and for
+  contrast findings show the token pair and the computed ratio from the values
+  in `frontend/src/design/`. No speculative "this may be hard to read" — if you
+  cannot cite it or compute it, it is not a finding.
+- Skip anything already covered by an open `[scan:a11y]` issue.
+- Respect `max_issues`; defer the overflow to the run summary.

--- a/prompts/scans/bugs.md
+++ b/prompts/scans/bugs.md
@@ -1,0 +1,52 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Bug harvest: flaky/failing tests, revert commits, and
+  error-handling gaps, filed as RCA-ready issues. Follows the 6-component
+  framework.
+-->
+
+## Role
+Senior engineer doing root-cause analysis in the adepthood monorepo (FastAPI +
+async SQLModel backend, React Native + Expo frontend). You surface latent bugs
+and hand each to scan-issue-writer as an RCA-ready finding.
+
+## Goal
+Find the highest-signal correctness defects at HEAD — flaky/failing tests,
+recently-reverted changes, and swallowed-error gaps — and file one RCA-ready
+issue each, with a reproducing-test idea.
+
+## Context
+- Title-slug prefix: `[scan:bugs]`. Priority `P1` (passed by the workflow).
+- Signals (read-only):
+  - **Flaky/failing tests**: scan recent CI history and re-run signals; grep
+    `backend/tests` and `frontend/src/**/__tests__` for `skip`/`xfail`/`todo`
+    markers hiding known failures.
+  - **Reverts**: `git log --grep=revert -i --since=90.days` — a revert often
+    marks a bug that was patched-around rather than fixed.
+  - **Swallowed errors**: bare `except:` / `except Exception: pass` /
+    `except Exception: ...` in `backend/src`; empty `catch {}` or
+    `.catch(() => {})` swallowing promise rejections in `frontend/src`.
+- Follow the repo's `bug-squashing-methodology`: every correctness claim needs a
+  reproduction. If a finding cannot be reproduced (even in principle by a named
+  test), DROP it — do not file speculation.
+
+## Output Format
+Findings as a JSON list, one object per finding:
+`{slug, title, severity(1-5), file, lines, evidence, repro_test, fix_strategy}`
+— `evidence` cites the failing test / revert commit / swallowed-error site;
+`repro_test` names the test that would fail today and pass after the fix.
+
+## Examples
+- `[scan:bugs] energy idempotency: double-apply on retry` — severity 4;
+  evidence = the code path; repro = a test posting the same event twice.
+- `[scan:bugs] swallowed DB error hides constraint violation in goals.py:88` —
+  severity 3; repro = a test asserting the error surfaces.
+
+## Constraints
+- Read-only analysis; never modify code.
+- Every finding must be reproducible from tool output, a commit, or a named
+  test — no "this looks risky" without a concrete failure mode.
+- Distinguish a genuine bug from a deliberate, documented convention (a
+  broad-except with a logged-and-reraised body is not a swallow).
+- Skip anything already covered by an open `[scan:bugs]` issue. Respect
+  `max_issues`; defer overflow to the run summary.

--- a/prompts/scans/complexity.md
+++ b/prompts/scans/complexity.md
@@ -1,0 +1,82 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Complexity refactor: named, targeted refactor strategies
+  for the worst cyclomatic hotspots. Follows the same 6-component framework as
+  the issues it produces. Priority P2.
+-->
+
+## Role
+Maintenance engineer for the adepthood monorepo (FastAPI + PostgreSQL backend,
+React Native + Expo frontend) doing targeted refactors. You find the functions
+that are hardest to reason about, name the refactor that would tame each, and
+hand every finding to the scan-issue-writer skill so the work is scheduled.
+
+## Goal
+Surface the worst-offending high-complexity functions in first-party source and
+attach a concrete, named refactor strategy to each. A run that finds none is a
+valid, successful, zero-issue run.
+
+## Context
+- Title-slug prefix: `[scan:complexity]`
+- Record the SHA with `git rev-parse HEAD` first.
+- Backend (Python), sorted worst-first:
+
+  ```bash
+  radon cc backend/src -s -o SCORE
+  ruff check backend/src --select C901
+  ```
+
+- Frontend (TS/RN):
+
+  ```bash
+  npx eslint frontend/src --rule '{"complexity": ["error", 8]}'
+  ```
+
+- IMPORTANT: complexity is already CI-gated — ruff C901, radon, and xenon
+  A-grade all block merges. A finding must therefore be something those gates do
+  **not** already reject: a function newly sitting at the edge of the threshold,
+  or a genuine cyclomatic hotspot worth a named refactor even though it currently
+  passes. Do not file a finding for anything already failing a gate (that is
+  caught at push, not here).
+- Exclusions (NOT findings): generated code, migrations, tests, vendored deps.
+- Skip anything already covered by an open `[scan:complexity]` issue.
+
+## Output Format
+Findings as a JSON list, one object per function:
+
+```json
+{
+  "slug": "complexity-resolve-stage-progress",
+  "title": "decompose resolve_stage_progress (radon C, CC 14)",
+  "severity": 4,
+  "file": "backend/src/domain/stage_progress.py",
+  "lines": "40-118",
+  "evidence": "radon cc -s: 'resolve_stage_progress' - C (14); one function, five branches on stage state",
+  "refactor_strategy": "strategy pattern: table of stage handlers keyed by StageState, replacing the if/elif ladder"
+}
+```
+
+`refactor_strategy` must name a specific technique — extract method, strategy
+pattern, early return / guard clauses, or decompose into helpers — not just
+"simplify". The skill turns each into a 6-component issue; priority label (`P2`)
+comes from the workflow input. Severity here orders findings against
+`max_issues`: rank by the metric score (higher CC = higher severity) and by how
+close a passing function sits to its gate.
+
+## Examples
+- `resolve_stage_progress` at radon C (CC 14), a five-way branch on stage state
+  → severity 4; strategy: strategy-pattern dispatch table keyed by state.
+- A FastAPI handler nesting three `try/except` blocks around validation → guard
+  clauses + extract-method for the validation, dropping nesting depth.
+- An RN reducer eslint flags at complexity 9 (threshold 8) → severity 2; strategy:
+  extract the per-action branches into named pure helpers.
+
+## Constraints
+- Read-only analysis; never modify code. The refactor PR is the Ralph loop's job.
+- Evidence must be reproducible from radon / ruff / eslint output — cite the
+  exact score and the function. No speculation, no "feels complex".
+- Do not file findings already failing a CI gate; those are handled at push.
+- Skip anything already covered by an open `[scan:complexity]` issue.
+- Respect `max_issues`; defer the overflow to the run summary.
+- No suppressions. The refactor must lower real complexity; never quiet the
+  checker with `# noqa: C901` / eslint-disable (max-quality-no-shortcuts).

--- a/prompts/scans/coverage.md
+++ b/prompts/scans/coverage.md
@@ -1,0 +1,51 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Test coverage gaps: modules under the repo's coverage
+  gates, with the SPECIFIC uncovered lines/branches. Follows the 6-component
+  framework.
+-->
+
+## Role
+Test engineer for the adepthood monorepo. You find the modules with the most
+valuable coverage gaps against the repo's gates and hand each to
+scan-issue-writer as a finding with the exact uncovered lines/branches.
+
+## Goal
+Produce one issue per under-covered module, naming the specific uncovered lines
+and branches and a concrete test plan to close them — measured against the
+≥90% line / ≥80% branch backend gate and the ≥90% Jest frontend gate.
+
+## Context
+- Title-slug prefix: `[scan:coverage]`. Priority `P2` (passed by the workflow).
+- Tools (read-only):
+  - Backend: `scripts/backend/coverage.sh` (or `pytest --cov=src
+    --cov-report=term-missing --cov-branch`) — parse the term-missing output for
+    modules below the gate and their uncovered line/branch ranges.
+  - Frontend: `npm test --prefix frontend -- --coverage` — parse the Jest
+    coverage summary for files below 90%.
+- Focus on modules whose uncovered code is BEHAVIORAL (domain logic, error
+  paths, branch conditions), not trivial getters — coverage is a means to catch
+  real regressions, not a number to game.
+
+## Output Format
+Findings as a JSON list, one object per finding:
+`{slug, title, severity(1-5), file, lines, evidence, test_plan}` — `evidence`
+is the coverage tool's term-missing / summary excerpt showing the exact
+uncovered lines/branches; `test_plan` names the cases (happy path, each error
+branch, boundary) that would cover them.
+
+## Examples
+- `[scan:coverage] domain/detection.py: 12 uncovered branches in the resonance
+  path` — severity 3; evidence = term-missing ranges; test_plan lists the
+  branch cases.
+- `[scan:coverage] features/Journal/useEntries.ts below 90% (error path
+  untested)` — severity 2; test_plan = a failing-fetch test.
+
+## Constraints
+- Read-only analysis; never modify code or tests.
+- Evidence must be the actual coverage report output — no guessing which lines
+  are uncovered.
+- Prefer branch coverage gaps over line gaps when both exist (branches catch
+  more real bugs); do not propose assertion-free "coverage theater" tests.
+- Skip anything already covered by an open `[scan:coverage]` issue. Respect
+  `max_issues`; defer overflow to the run summary.

--- a/prompts/scans/dead-code.md
+++ b/prompts/scans/dead-code.md
@@ -1,0 +1,92 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Dead-code elimination: unused exports, unreachable
+  branches, orphaned files, and unused dependencies. Follows the same
+  6-component framework as the issues it produces. Priority P3.
+-->
+
+## Role
+Maintenance engineer for the adepthood monorepo (FastAPI + PostgreSQL backend,
+React Native + Expo frontend) removing cruft. You find code and dependencies
+that nothing reaches, decide whether each should be deleted or wired in, and
+hand every finding to the scan-issue-writer skill so the cleanup is scheduled
+instead of rotting.
+
+## Goal
+Surface unused exports, unreachable branches, orphaned modules, and unused
+declared dependencies in first-party source — each with reproducible tool
+evidence and a classified remediation direction (delete / wire-in /
+decision-needed). A run that finds none is a valid, successful, zero-issue run.
+
+## Context
+- Title-slug prefix: `[scan:dead-code]`
+- First-party source only. Record the SHA with `git rev-parse HEAD` first.
+- Backend (Python), note vulture's confidence percentage per hit:
+
+  ```bash
+  vulture backend/src
+  ```
+
+- Frontend (TS/RN) unused exports, files, and dependencies:
+
+  ```bash
+  npx knip
+  npx ts-prune
+  ```
+
+- Dependencies: cross-check unused entries in `backend/requirements.txt`,
+  `backend/requirements-dev.txt`, and `frontend/package.json`.
+- Exclusions (NOT findings): generated code, migrations, lockfiles, vendored
+  deps, `node_modules`, build output, `__snapshots__`, and public API surface
+  intentionally exported for consumers (re-verify against `backend/src/main.py`
+  router mounting and `frontend/src/api/` before calling an export dead).
+- Skip anything already covered by an open `[scan:dead-code]` issue.
+- IMPORTANT nuance: some orphaned-but-complete code carries explicit intent
+  (a finished domain helper never imported, a screen not yet in navigation).
+  That warrants **wiring in** — with an e2e test proving the path — not
+  deletion. Classify every finding's `remediation` accordingly.
+
+## Output Format
+Findings as a JSON list, one object per finding (or tightly related cluster):
+
+```json
+{
+  "slug": "dead-code-unused-parse-frequency",
+  "title": "unused export parseFrequency in api/wavelength.ts",
+  "severity": 2,
+  "file": "frontend/src/api/wavelength.ts",
+  "lines": "58-74",
+  "evidence": "ts-prune: 'parseFrequency' (used in module) — no external ref; knip lists it unused",
+  "remediation": "delete",
+  "refactor_strategy": "remove the export and its now-orphaned helpers; run tsc + jest"
+}
+```
+
+`remediation` is one of `delete` | `wire-in` | `decision-needed`. For Python
+findings, include vulture's confidence in `evidence` (e.g. "vulture confidence
+90%"). The skill turns each into a 6-component issue; priority label (`P3`)
+comes from the workflow input. Severity here only orders findings against
+`max_issues` — orphaned intentful code needing a wire-in decision ranks above a
+trivially-dead private helper.
+
+## Examples
+- vulture flags `def _legacy_energy_curve` at 100% confidence, unimported
+  anywhere → severity 3, `remediation: delete`; strategy removes the function
+  and its test.
+- knip reports `features/Course/CourseReaderScreen.tsx` as an orphaned file, but
+  it is a complete screen absent from `navigation/` → severity 3,
+  `remediation: wire-in`; strategy adds the route + an e2e navigation test.
+- `httpx` present in `requirements.txt` but imported only in `backend/tests/` →
+  severity 2, `remediation: decision-needed` (move to `requirements-dev.txt`?).
+
+## Constraints
+- Read-only analysis; never modify code. The deletion/wiring PR is the Ralph
+  loop's job, not this scan's.
+- Evidence must be reproducible from vulture / knip / ts-prune output or a code
+  citation — no speculation. Do not call an export dead on a hunch: confirm no
+  dynamic reference (string import, registry lookup) before filing.
+- Skip anything already covered by an open `[scan:dead-code]` issue.
+- Respect `max_issues`; defer the overflow to the run summary.
+- No suppressions. The follow-up fix must address root cause (delete or wire in);
+  never silence a linter with `# noqa` / `type: ignore` / eslint-disable
+  (max-quality-no-shortcuts).

--- a/prompts/scans/deps.md
+++ b/prompts/scans/deps.md
@@ -1,0 +1,58 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Dependency triage: group compatible bumps, plan the
+  breaking ones. COMPLEMENTS .github/workflows/dependabot-to-ralph-issue.yml
+  (which already files one Ralph issue per individual Dependabot PR) — this scan
+  does the cross-PR work that per-PR automation cannot: batching and migration
+  planning. Follows the 6-component framework.
+-->
+
+## Role
+Release engineer for the adepthood monorepo (Python backend via
+`backend/requirements*.txt`, JS frontend via `frontend/package.json` +
+lockfile). You keep dependencies current without breaking the build.
+
+## Goal
+Turn the open Dependabot surface into a small number of high-signal issues:
+one batch issue grouping compatible minor/patch bumps, and one migration-plan
+issue per MAJOR bump (with breaking-change notes and the affected call sites in
+this repo). Hand each to scan-issue-writer as a finding.
+
+## Context
+- Title-slug prefix: `[scan:deps]`.
+- Do NOT duplicate `dependabot-to-ralph-issue.yml`, which already files a Ralph
+  issue per individual Dependabot PR. Your value is cross-PR: batching several
+  compatible bumps into one PR-sized issue, and deep migration planning for
+  majors. Dedupe against those per-PR issues too.
+- Inputs to read (read-only):
+  - Open Dependabot PRs/alerts: `gh pr list --label dependencies --state open
+    --json number,title,url`; `gh api repos/{owner}/{repo}/dependabot/alerts`.
+  - Manifests: `backend/requirements.txt`, `backend/requirements-dev.txt`,
+    `frontend/package.json`, `frontend/package-lock.json`.
+- Classify each bump: patch / minor / major (semver on the version delta).
+- Priority: the workflow passes a default (`P2`). Label MAJOR-bump migration
+  issues `P1` (they carry breaking risk) and minor/patch batches `P2` — state
+  the intended label per finding so scan-issue-writer applies it.
+
+## Output Format
+Findings as a JSON list, one object per finding:
+`{slug, title, severity(1-5), file, lines, evidence, fix_strategy,
+priority_override}` where `evidence` cites the Dependabot PR numbers / advisory
+and `fix_strategy` names the target versions and (for majors) the breaking
+changes + affected call sites.
+
+## Examples
+- Batch: `[scan:deps] batch 6 compatible minor/patch bumps (fastapi, httpx, …)`
+  — severity 2, one PR bumping all six, `P2`.
+- Major: `[scan:deps] migrate to Pydantic v3 (breaking: validators, Config)` —
+  severity 4, `P1`, evidence lists every `@validator`/`class Config` call site.
+
+## Constraints
+- Read-only analysis; never modify manifests or lockfiles.
+- Evidence must cite real Dependabot PRs/alerts or a concrete version delta —
+  no speculative "probably safe to bump."
+- Group ONLY bumps that are mutually compatible; never batch a major with
+  minors.
+- Skip anything already covered by an open `[scan:deps]` issue or an existing
+  per-PR Dependabot Ralph issue.
+- Respect `max_issues`; defer overflow to the run summary.

--- a/prompts/scans/docs.md
+++ b/prompts/scans/docs.md
@@ -1,0 +1,80 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Documentation-drift sweep of the adepthood monorepo:
+  find docs that no longer match the code at HEAD and hand each to the skill as
+  a finding. Follows the same 6-component framework as the issues it produces.
+-->
+
+## Role
+Technical writer / engineer for the adepthood monorepo (FastAPI + PostgreSQL
+backend, React Native + Expo frontend). You find where the prose lies — where a
+docstring, README, `NORTH-STAR.md`, or module doc claims behavior that no longer
+matches the code at HEAD — and hand each drift to the scan-issue-writer skill.
+
+## Goal
+Surface documentation that has drifted from the code so each becomes a tracked,
+agent-ready fix. Focus on ACCURACY, not presence: `interrogate` already gates
+docstring coverage at ≥85%, so a missing docstring is rarely the finding — a
+docstring that describes the wrong parameters, return type, or behavior is. A
+run that finds none is a valid, successful, zero-issue run.
+
+## Context
+- Title-slug prefix: `[scan:docs]`
+- Priority label for this scan (workflow input): `P3`
+- Record the SHA with `git rev-parse HEAD` before scanning; every issue cites it.
+- What counts as a finding:
+  - **Docstring drift** — a Python docstring in `backend/src/` whose documented
+    args, return type, raised exceptions, or described behavior contradicts the
+    actual function signature or body at HEAD.
+  - **Stale prose claims** — a concrete claim in `README.md`, `NORTH-STAR.md`, or
+    a module/design doc (an endpoint path, CLI command, file path, config key,
+    threshold number) that no longer matches the tree. Grep the claim, then
+    verify it against the actual file / route / script.
+  - **Undocumented public API** — an exported router endpoint, service, or public
+    frontend module with no docstring / TSDoc where its siblings have one.
+  - **Stale code examples** — a fenced code block in docs that would fail if run
+    (wrong import path, renamed symbol, changed argument order).
+- Useful commands (read-only):
+
+  ```bash
+  grep -rInE '(backend/src|frontend/src|scripts/)[A-Za-z0-9_./-]+' README.md NORTH-STAR.md
+  grep -rInE '"/[A-Za-z0-9_/{}.-]+"' backend/src/routers   # documented vs real routes
+  ```
+
+- Exclusions (NOT findings): generated code, migrations, lockfiles, vendored
+  deps, `node_modules`, build output, `__snapshots__`; pure formatting nits;
+  and anything already covered by an open `[scan:docs]` issue (the skill dedupes).
+
+## Output Format
+Findings as a JSON list, one object per drift:
+
+```json
+{
+  "slug": "docs-detection-docstring-drift",
+  "title": "detect_completion docstring documents removed `threshold` arg",
+  "severity": 3,
+  "file": "backend/src/domain/detection.py",
+  "lines": "48-72",
+  "evidence": "docstring lists args (entry, threshold); signature at HEAD is detect_completion(entry, plan) — threshold removed in <SHA>",
+  "before_after_sketch": "docstring Args section → match the real (entry, plan) signature and describe plan"
+}
+```
+
+Severity is 1–5. It orders findings against `max_issues`; the priority label
+comes from the workflow input.
+
+## Examples
+- A README quick-start that runs `uvicorn main:app` when the app moved to
+  `src.main:app` → severity 3; sketch corrects the command.
+- A `NORTH-STAR.md` claim of "six bottom tabs" when navigation now mounts seven →
+  severity 2; sketch names the actual tab set.
+- A service docstring promising `returns None on miss` when the code raises
+  `NotFoundError` → severity 3; sketch rewrites the Returns/Raises section.
+
+## Constraints
+- Read-only analysis; never modify code or docs.
+- Evidence must be reproducible: cite the doc line AND the contradicting code
+  line (file:line at the scanned SHA). No speculative "this looks outdated" — if
+  you cannot show both sides of the mismatch, it is not a finding.
+- Skip anything already covered by an open `[scan:docs]` issue.
+- Respect `max_issues`; defer the overflow to the run summary.

--- a/prompts/scans/groom.md
+++ b/prompts/scans/groom.md
@@ -1,0 +1,63 @@
+<!--
+  Grooming definition for the autonomous maintenance pipeline. Unlike the other
+  prompts/scans/*.md files, groom does NOT produce issues — it CONSUMES the
+  backlog: it closes resolved/stale scan issues, dedupes, and promotes complete
+  `needs-triage` issues to `agent-ready`. It runs before the day's producer
+  scans (daily 04:00 UTC) via .github/workflows/scan-groom.yml, which invokes
+  the `backlog-grooming` skill. Follows the same 6-component framework.
+-->
+
+## Role
+Backlog steward for the adepthood repo. You keep the Ralph queue honest: every
+open `agent-ready` issue should be real, current, and not a duplicate, so that
+queue depth reflects genuine runway rather than stale or phantom work.
+
+## Goal
+Reconcile the open issue backlog against current `main` (HEAD): close issues
+already resolved by merged PRs, close scan issues whose finding no longer
+reproduces at HEAD, collapse duplicates, and promote fully-specified
+`needs-triage` scan issues to `agent-ready`. Net effect is a queue that shrinks
+toward healthy rather than bloating.
+
+## Context
+- Invoke the `backlog-grooming` skill and follow it; this file is the scope.
+- Priority/label vocabulary: `P0`–`P3`, `agent-ready`, `needs-triage`, and the
+  `scan:<name>` provenance labels (see `scripts/setup-scan-labels.sh`).
+- Signals for action:
+  - **Resolved**: a merged PR body references `Closes|Fixes|Resolves #N`, or the
+    cited `file:line` change is already present at HEAD → close with a comment
+    linking the PR/commit.
+  - **Stale**: a `scan:*` issue whose evidence no longer reproduces at HEAD
+    (the code was refactored/removed) → close with a comment explaining what
+    changed, per the issue template's "close-if-stale beats implement-anyway"
+    constraint.
+  - **Duplicate**: two issues sharing a title slug → keep the oldest, close the
+    newer with a pointer comment.
+  - **Incomplete**: a `scan:*` issue missing any of the six body components →
+    it should already carry `needs-triage`; if it is now complete, promote it
+    to `agent-ready` (`gh issue edit --add-label agent-ready --remove-label
+    needs-triage`).
+- Re-verify against HEAD before every close — do not close on a stale read.
+
+## Output Format
+Take the actions directly via `gh` (`gh issue close`, `gh issue comment`,
+`gh issue edit`). Then append a run summary to `$GITHUB_STEP_SUMMARY`: counts of
+closed-resolved / closed-stale / deduped / promoted, each with issue numbers,
+and a net-change figure (issues removed from the queue this run).
+
+## Examples
+- `[scan:perf] N+1 in entries.list_for_user` cites `entries.py:142` but HEAD now
+  uses `selectinload` there → close: "Fixed at `<SHA>`; no longer reproduces."
+- Two open `[scan:dead-code] unused export parseFrequency` issues → keep #412,
+  close #588 as duplicate with a pointer to #412.
+- A `[scan:todo]` issue that was filed `needs-triage` for a missing Examples
+  section, since filled in by a later edit → promote to `agent-ready`.
+
+## Constraints
+- This scan is a NET CONSUMER: it must not create producer-style findings.
+- Be conservative: when "resolved/stale" is uncertain, COMMENT asking for
+  confirmation rather than closing. A wrongly-closed real issue is worse than a
+  stale one that survives one more grooming cycle.
+- Never delete labels or touch issues authored by Geoff that carry no `scan:*`
+  label unless they are provably resolved by a merged PR.
+- Read-only with respect to CODE; the only writes are issue close/comment/edit.

--- a/prompts/scans/mutation.md
+++ b/prompts/scans/mutation.md
@@ -1,0 +1,89 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Mutation testing: find surviving mutants that expose
+  weak assertions. EXPENSIVE — run on a schedule, never from the hopper.
+  Follows the same 6-component framework as the issues it produces. Priority P3.
+-->
+
+## Role
+Test-quality engineer for the adepthood monorepo (FastAPI + PostgreSQL backend,
+React Native + Expo frontend). You run mutation testing on the hottest modules,
+find the mutants the suite fails to kill, and hand each surviving cluster — with
+the exact assertion that would kill it — to the scan-issue-writer skill so the
+test hardening is scheduled.
+
+## Goal
+Surface clusters of surviving mutants in first-party source and, for each, name
+the precise logic-validating assertion (exact-value or boundary) that would kill
+them. A run that finds none — every mutant killed — is a valid, successful,
+zero-issue run.
+
+## Context
+- Title-slug prefix: `[scan:mutation]`
+- IMPORTANT: this scan is EXPENSIVE. Run it on a schedule, not from the hopper.
+  Record the SHA with `git rev-parse HEAD` first.
+- Backend (Python), the hottest modules only — mutants there are highest-value:
+
+  ```bash
+  mutmut run --paths-to-mutate backend/src/domain,backend/src/routers
+  mutmut results
+  ```
+
+- Frontend (TS/RN):
+
+  ```bash
+  cd frontend && npx stryker run
+  ```
+
+- Exclusions (NOT findings): mutants in generated code, migrations, or code
+  already slated for deletion by a `[scan:dead-code]` issue; equivalent mutants
+  (no test can distinguish them) — note these in the run summary rather than
+  filing churn.
+- Skip anything already covered by an open `[scan:mutation]` issue.
+- Follow the repo's mutation-testing skill philosophy: mutants die to
+  logic-validating assertions — exact-value and boundary checks — not to
+  `toBeTruthy()` / "it ran without throwing" smoke tests.
+
+## Output Format
+Findings as a JSON list, one object per surviving-mutant cluster:
+
+```json
+{
+  "slug": "mutation-streak-boundary-off-by-one",
+  "title": "surviving mutants in domain.streaks.is_streak_alive boundary",
+  "severity": 4,
+  "file": "backend/src/domain/streaks.py",
+  "lines": "31-38",
+  "evidence": "mutmut: mutant 47 survived — '<=' -> '<' at line 34; no test asserts the exact grace-window edge",
+  "kill_strategy": "add a boundary test asserting is_streak_alive is True at exactly grace_hours and False one second past it"
+}
+```
+
+`kill_strategy` must name the exact assertion (the value or boundary) that turns
+the surviving mutant red, and the module operator that survived. Cluster mutants
+that one new test would kill together into a single finding. The skill turns each
+into a 6-component issue; priority label (`P3`) comes from the workflow input.
+Severity here orders findings against `max_issues`: survivors in `domain/`
+logic and boundary/off-by-one operators outrank cosmetic string mutants.
+
+## Examples
+- `mutmut` reports `<=`→`<` surviving in a streak grace-window check → severity 4;
+  kill: boundary test asserting True at the edge and False one unit past it.
+- A survived arithmetic mutant (`+`→`-`) in energy computation with only a
+  "returns a number" test → severity 4; kill: exact-value assertion on a known
+  input/output pair.
+- Stryker reports a survived conditional in a reducer guarded only by
+  `toBeTruthy()` → severity 3; kill: assert the exact next-state object.
+
+## Constraints
+- Read-only analysis; never modify code. The test-hardening PR is the Ralph
+  loop's job, not this scan's.
+- Evidence must be reproducible from mutmut / Stryker output — cite the surviving
+  mutant id, the operator, and file:line. No speculation about which mutants
+  might survive; run the tool.
+- Skip anything already covered by an open `[scan:mutation]` issue.
+- Respect `max_issues`; defer the overflow to the run summary. Because the run is
+  expensive, prefer deferring low-value survivors over inflating the queue.
+- No suppressions. The fix must add real logic-validating assertions; never kill
+  a mutant by weakening or skipping a test, and never silence tooling with an
+  ignore comment (max-quality-no-shortcuts).

--- a/prompts/scans/perf.md
+++ b/prompts/scans/perf.md
@@ -1,0 +1,80 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Performance sweep of the adepthood monorepo: find the
+  highest-impact perf defects at HEAD and hand each to the skill as a finding.
+  Follows the same 6-component framework as the issues it produces.
+-->
+
+## Role
+Performance engineer for the adepthood monorepo — a FastAPI + async SQLModel
+(SQLAlchemy) + PostgreSQL backend and a React Native + Expo frontend. You find
+the perf defects that actually cost users latency or battery and hand each,
+with reproducible evidence, to the scan-issue-writer skill.
+
+## Goal
+Surface the highest-impact performance defects present at HEAD so each becomes a
+tracked, agent-ready issue. Prefer a few well-evidenced findings over a long
+speculative list. A run that finds none is a valid, successful, zero-issue run.
+
+## Context
+- Title-slug prefix: `[scan:perf]`
+- Priority label for this scan (workflow input): `P2`
+- First-party source only — backend `backend/src/`, frontend `frontend/src/`.
+- Record the SHA with `git rev-parse HEAD` before scanning; every issue cites it.
+- What counts as a finding:
+  - **N+1 queries** — `routers/` or `domain/` code that loops over ORM objects
+    and issues a per-item query inside the loop. Recommend `selectinload` /
+    `joinedload`. Evidence must be a query log (enable SQLAlchemy `echo`) or a
+    direct citation of the loop + the per-iteration query call.
+  - **Missing DB indexes** — frequently-filtered / joined columns in
+    `backend/src/models/` with no `index=True` and no composite index, where a
+    known-hot query filters on them.
+  - **Sync / blocking I/O in `async def`** — blocking file, network, or
+    subprocess calls (e.g. `open()`, `requests`, `time.sleep`, sync DB drivers)
+    inside an `async def` route handler, which stalls the event loop.
+  - **Unmemoized RN renders** — `FlatList` `renderItem` recreating closures each
+    render, list rows without `React.memo`, expensive derived values without
+    `useMemo`, callbacks passed to children without `useCallback`.
+  - **Bundle-size regressions** — a heavy dependency newly imported at the top of
+    a hot screen where a lighter or lazy import would do.
+- Known-hot paths to weight first: journal entry list, habit stats / streaks,
+  energy plan, resonance + completion-suggestion detection
+  (`backend/src/domain/detection.py`), the Map screen.
+- Exclusions (NOT findings): generated code, migrations, lockfiles, vendored
+  deps, `node_modules`, build output, `__snapshots__`, and anything already
+  covered by an open `[scan:perf]` issue (the skill dedupes).
+
+## Output Format
+Findings as a JSON list, one object per finding:
+
+```json
+{
+  "slug": "perf-entries-list-n-plus-one",
+  "title": "N+1 query loading marginalia in entries.list_for_user",
+  "severity": 4,
+  "file": "backend/src/routers/entries.py",
+  "lines": "142-160",
+  "evidence": "SQLAlchemy echo log showing one SELECT per entry, or the loop + per-iteration query.get(...) citation",
+  "before_after_sketch": "loop-with-query → single query using selectinload(Entry.marginalia)"
+}
+```
+
+Severity is 1–5. It orders findings against `max_issues`; the priority label
+comes from the workflow input.
+
+## Examples
+- A loop over `entries` that calls `session.get(Marginalia, ...)` per row →
+  severity 4; sketch shows the `selectinload` rewrite.
+- `open(path).read()` inside an `async def` export handler (blocks the loop) →
+  severity 4; sketch shows `run_in_threadpool` or an async file read.
+- A `FlatList` whose `renderItem={(item) => <Row onPress={() => ...} />}`
+  rebuilds the row + closure every render → severity 3; sketch shows a memoized
+  `Row` + `useCallback` handler.
+
+## Constraints
+- Read-only analysis; never modify code.
+- Evidence must be reproducible from tool output (a query log, a profile) or a
+  direct code citation. No speculative "this might be slow" — if you cannot show
+  the cost, it is not a finding.
+- Skip anything already covered by an open `[scan:perf]` issue.
+- Respect `max_issues`; defer the overflow to the run summary.

--- a/prompts/scans/security.md
+++ b/prompts/scans/security.md
@@ -1,0 +1,54 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Security audit: dependency CVEs + leaked secrets. This
+  is the P0 producer — its issues preempt all other work. Follows the
+  6-component framework.
+-->
+
+## Role
+Application security engineer for a FastAPI + PostgreSQL backend and a React
+Native (Expo) frontend. You find actionable, exploitable dependency
+vulnerabilities and secret leaks, and hand each to scan-issue-writer.
+
+## Goal
+Produce ONE issue per actionable CVE/advisory (or confirmed secret leak) with
+the affected dependency path(s) and a concrete, upgrade-first fix strategy.
+
+## Context
+- Title-slug prefix: `[scan:security]`. Priority is `P0` (passed by the
+  workflow) — these preempt everything.
+- Tools (read-only, installed by the core; verify they exist — a missing tool
+  is "tooling broken", NOT a clean result):
+  - Backend: `pip-audit -r backend/requirements.txt -r backend/requirements-dev.txt`
+  - Frontend: `npm audit --prefix frontend --json`
+  - Secrets: grep for high-signal patterns (AWS keys, private-key headers,
+    `password=`, bearer tokens) in tracked files — but the repo already runs
+    detect-secrets in pre-commit, so treat a hit as corroboration, not novelty.
+- Follow the repo's `cve-remediation` skill philosophy: the FIRST action is to
+  look up the current published version on the live registry (training data is
+  stale); prefer upgrade / override over suppression. Suppression is the last
+  resort and does not count as remediation.
+
+## Output Format
+Findings as a JSON list, one object per finding:
+`{slug, title, severity(1-5), file, lines, evidence, fix_strategy}` — `evidence`
+cites the CVE/GHSA id and the pip-audit / npm audit line; `fix_strategy` names
+the fixed version to upgrade to (verified against the live registry) or the
+override path if no fix is published.
+
+## Examples
+- `[scan:security] CVE-2025-XXXXX in <pkg> <ver> — upgrade to <fixed>` —
+  severity by CVSS; evidence = the pip-audit row; fix = pin `<fixed>`.
+- `[scan:security] hard-coded API token in backend/src/services/x.py:42` —
+  severity 5; fix = rotate + move to env/secret manager.
+
+## Constraints
+- Read-only analysis; never modify code or manifests.
+- File only ACTIONABLE findings — a CVE with no code path reachable in this repo
+  is documented in the run summary, not filed as a blocking P0.
+- Verify fixed versions against the live registry before naming them; never
+  recommend a suppression as the primary remedy.
+- Never paste a real secret value into an issue body — cite `file:line` and the
+  pattern class only.
+- Skip anything already covered by an open `[scan:security]` issue. Respect
+  `max_issues`; defer overflow to the run summary.

--- a/prompts/scans/todo.md
+++ b/prompts/scans/todo.md
@@ -1,0 +1,74 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. This is the tracer scan of the autonomous maintenance
+  pipeline: the cheapest and most deterministic, wired end-to-end first.
+  Follows the same 6-component framework as the issues it produces.
+-->
+
+## Role
+Maintenance engineer for the adepthood monorepo (FastAPI + PostgreSQL backend,
+React Native + Expo frontend). You convert inline deferred-work markers into
+tracked, agent-ready GitHub issues so the work is scheduled instead of rotting
+in a comment.
+
+## Goal
+Find every `TODO` / `FIXME` / `HACK` / `XXX` marker in first-party source and
+hand each — with its file:line and enough surrounding context to act on — to
+the scan-issue-writer skill as a finding. A run that finds none is a valid,
+successful, zero-issue run.
+
+## Context
+- Title-slug prefix: `[scan:todo]`
+- Search first-party source only:
+  - Backend: `backend/src/`
+  - Frontend: `frontend/src/`
+- Command (record the SHA with `git rev-parse HEAD` first):
+
+  ```bash
+  grep -rInE '\b(TODO|FIXME|HACK|XXX)\b' backend/src frontend/src
+  ```
+
+- Exclusions (NOT findings):
+  - Generated code, migrations, lockfiles, vendored deps, `node_modules`, build
+    output, `__snapshots__`.
+  - Markers inside test fixtures that deliberately assert on the literal string.
+  - Markers already tracked by an open `[scan:todo]` issue (the skill dedupes).
+- One marker that clearly belongs to a cluster of related markers in the same
+  module may be filed as a single issue covering the cluster, with every
+  file:line listed in Context.
+
+## Output Format
+Findings as a JSON list, one object per marker (or marker cluster):
+
+```json
+{
+  "slug": "todo-entries-list-eager-load",
+  "title": "TODO: eager-load marginalia in entries.list_for_user",
+  "severity": 3,
+  "file": "backend/src/routers/entries.py",
+  "lines": "142",
+  "marker": "TODO",
+  "evidence": "the grep hit plus 3–5 lines of surrounding code",
+  "goal": "one measurable sentence for the issue's Goal component"
+}
+```
+
+The skill turns each into a 6-component issue. Priority label comes from the
+workflow input (`P3` for this scan per the task table); severity here only
+orders the findings against `max_issues`.
+
+## Examples
+- `FIXME: this ignores the timezone` above a date-parse call → severity 4
+  (potential correctness bug); Goal names the timezone-correct fix + a test.
+- `TODO: extract this into a hook` in a large RN screen → severity 2
+  (maintainability); Goal names the hook and the components that consume it.
+- `XXX: remove after migration N lands` where migration N has already merged →
+  severity 3; Goal is to delete the dead branch and the marker.
+
+## Constraints
+- Read-only analysis; never modify code. (The follow-up PR that removes the
+  marker in favor of the issue link is the Ralph loop's job, not this scan's.)
+- Evidence must be a real grep hit with surrounding context — no speculative
+  markers, no markers you cannot cite by file:line.
+- Skip anything already covered by an open `[scan:todo]` issue.
+- Respect `max_issues`; defer the overflow to the run summary.

--- a/prompts/scans/types.md
+++ b/prompts/scans/types.md
@@ -1,0 +1,83 @@
+<!--
+  Scan definition consumed by the scan-issue-writer skill via the reusable
+  _claude-scan.yml core. Type coverage: burn down Any leaks, missing return
+  types, and existing ignore sites. Follows the same 6-component framework as
+  the issues it produces. Priority P3.
+-->
+
+## Role
+Typing engineer for the adepthood monorepo (FastAPI + PostgreSQL backend,
+React Native + Expo frontend). You find the gaps in static-type coverage —
+`Any` leaks, missing annotations, and existing escape hatches — and hand each,
+with reproducible checker evidence and a root-cause fix strategy, to the
+scan-issue-writer skill so the burn-down is scheduled.
+
+## Goal
+Surface untyped and weakly-typed surfaces in first-party source: `Any` leaks,
+missing return/parameter annotations, and every existing `type: ignore` /
+`@ts-ignore` / `as any` site to burn down. A run that finds none is a valid,
+successful, zero-issue run.
+
+## Context
+- Title-slug prefix: `[scan:types]`
+- Record the SHA with `git rev-parse HEAD` first.
+- Backend (Python), strict-mode delta on first-party source:
+
+  ```bash
+  mypy --strict backend/src
+  grep -rInE '# *type: *ignore' backend/src
+  ```
+
+- Frontend (TS/RN):
+
+  ```bash
+  cd frontend && npx tsc --noEmit
+  grep -rInE ':\s*any\b|as any|@ts-ignore|@ts-expect-error' frontend/src
+  ```
+
+- Exclusions (NOT findings): generated code, migrations, vendored deps,
+  `node_modules`, `__snapshots__`. A `type: ignore` that is genuinely
+  unavoidable at a third-party boundary is `decision-needed`, not an auto-fix —
+  but it still gets filed so a human ratifies it.
+- Skip anything already covered by an open `[scan:types]` issue.
+
+## Output Format
+Findings as a JSON list, one object per site (or tightly related cluster):
+
+```json
+{
+  "slug": "types-energy-any-leak",
+  "title": "Any leak in domain.energy.compute_curve return type",
+  "severity": 3,
+  "file": "backend/src/domain/energy.py",
+  "lines": "72",
+  "evidence": "mypy --strict: 'Returning Any from function declared to return \"float\"' [no-any-return]",
+  "fix_strategy": "type the dict payload with a TypedDict so the indexed access is float, not Any"
+}
+```
+
+`fix_strategy` must name the root-cause fix — add the annotation, introduce a
+TypedDict/Protocol/generic, narrow with a type guard, or type the third-party
+boundary with a stub. The skill turns each into a 6-component issue; priority
+label (`P3`) comes from the workflow input. Severity here orders findings
+against `max_issues`: an `Any` that propagates into public API or domain logic
+outranks a missing return type on a private helper; standing `type: ignore`
+sites outrank cosmetic gaps.
+
+## Examples
+- `mypy --strict` reports `[no-any-return]` in a domain function → severity 3;
+  fix: TypedDict the payload so the value is typed at the source.
+- An existing `# type: ignore[arg-type]` masking a real signature mismatch →
+  severity 4; fix: correct the caller/callee types so the ignore is removable.
+- `as any` casting an API response in `frontend/src/api/` → severity 3; fix:
+  give the response a proper interface and parse/validate at the boundary.
+
+## Constraints
+- Read-only analysis; never modify code. The typing PR is the Ralph loop's job.
+- Evidence must be reproducible from mypy / tsc output or a grep hit with the
+  exact ignore/`any` token cited by file:line — no speculation.
+- Skip anything already covered by an open `[scan:types]` issue.
+- Respect `max_issues`; defer the overflow to the run summary.
+- No suppressions — this scan exists to *remove* them. The fix must address the
+  root cause and delete the escape hatch; never add or keep a `type: ignore` /
+  `@ts-ignore` / `as any` to placate the checker (max-quality-no-shortcuts).

--- a/prompts/templates/scan-issue-body.md
+++ b/prompts/templates/scan-issue-body.md
@@ -1,0 +1,44 @@
+<!--
+  Canonical body template for every autonomous-maintenance scan issue.
+
+  Each scan issue is itself a prompt: it is consumed by the Ralph agent, so it
+  follows the 6-component framework (Role / Goal / Context / Output Format /
+  Examples / Constraints) exactly. The scan-issue-writer skill fills every
+  component verbatim — an issue missing any component is labeled `needs-triage`
+  instead of `agent-ready`, and the grooming pass finishes it.
+
+  Replace every [bracketed] placeholder. Leave no placeholder behind.
+-->
+
+## Role
+You are a [senior Python/FastAPI | senior React Native] engineer working in the
+adepthood codebase, following its existing conventions (TDD via stay-green,
+check-all.sh gates, ≥90% line / ≥80% branch backend coverage, ≥90% Jest
+frontend, zero lint/type suppressions).
+
+## Goal
+[One sentence. Specific, measurable, verifiable. e.g. "Eliminate the N+1 query
+in entries.list_for_user by eager-loading marginalia, verified by a query-count
+assertion test."]
+
+## Context
+- File(s): `path/to/file.py:120-164`
+- Scanned at commit: `<SHA>` — re-verify against HEAD before starting
+- Evidence: [tool output excerpt — the radon score, the audit finding, the
+  coverage gap, the query log, the grep hit with surrounding lines]
+- Related: [links to sibling issues from the same scan run, prior PRs]
+
+## Output Format
+A single PR that: (1) adds a failing test first, (2) makes it pass, (3) passes
+check-all.sh, (4) references this issue with "Closes #N".
+
+## Examples
+[One concrete before/after sketch — e.g. the current loop-with-query vs. the
+selectinload version. 5–15 lines. Enough to disambiguate, not a full spec.]
+
+## Constraints
+- Do not change public API signatures unless the Goal says so
+- No lint/type suppressions (max-quality-no-shortcuts): fix root causes
+- Scope: this issue only — file follow-up issues for adjacent problems
+- If the finding no longer reproduces at HEAD, close this issue with a comment
+  explaining what changed instead of forcing a PR

--- a/prompts/templates/scan-issue-body.md
+++ b/prompts/templates/scan-issue-body.md
@@ -30,7 +30,9 @@ assertion test."]
 
 ## Output Format
 A single PR that: (1) adds a failing test first, (2) makes it pass, (3) passes
-check-all.sh, (4) references this issue with "Closes #N".
+the relevant `./scripts/<side>/check-all.sh` — `scripts/backend/check-all.sh`
+for backend changes, `scripts/frontend/check-all.sh` for frontend changes, both
+if the change is cross-cutting — and (4) references this issue with "Closes #N".
 
 ## Examples
 [One concrete before/after sketch — e.g. the current loop-with-query vs. the

--- a/scripts/ralph/pick-next.sh
+++ b/scripts/ralph/pick-next.sh
@@ -23,6 +23,12 @@
 #                         epic-prefixed label with an active issue is skipped
 #                         (likely ordered/overlapping) unless it carries the
 #                         parallel label. Set "0" to disable the guard.
+#   RALPH_DEFAULT_PRIORITY_RANK  Priority tier (0=P0 … 3=P3) assumed for an
+#                         issue carrying no P-label. Default 1 (== P1). See the
+#                         priority-tiering block below.
+#
+# Priority ordering: candidates are walked by [priority tier, number ascending]
+# — P0 → P1 → P2 → P3, oldest-first within a tier (see the tiering block below).
 #
 # Parallel awareness (see scripts/ralph/FLEET.md):
 #   Issues already being worked — either an open PR (`Closes|Fixes|Resolves #N`)
@@ -53,13 +59,34 @@ SOLO_LABEL="${RALPH_SOLO_LABEL:-solo}"
 PARALLEL_LABEL="${RALPH_PARALLEL_LABEL:-parallelizable}"
 RESPECT_EPICS="${RALPH_RESPECT_EPICS:-1}"
 
+# Priority tiering (autonomous maintenance pipeline). Candidates are ordered by
+# priority tier first, then oldest-first WITHIN a tier: P0 (security/breakage)
+# preempts P1 (bugs + Geoff's feature issues) preempts P2 (quality) preempts P3
+# (hygiene). An issue with no P-label sorts at RALPH_DEFAULT_PRIORITY_RANK.
+#
+#   RALPH_DEFAULT_PRIORITY_RANK  Tier an unlabeled issue is treated as. Default
+#                                1 (== P1), so legacy/unlabeled feature work
+#                                keeps flowing at feature priority and only P2/P3
+#                                scan hygiene sorts behind it. With no P-labels
+#                                anywhere, every issue ranks equal and ordering
+#                                collapses to the previous oldest-first behavior
+#                                — this change is backward compatible.
+#
+# To enforce the pipeline's stricter "agent-ready required" gate (so ONLY fully
+# specified scan/feature issues are picked), set RALPH_REQUIRE_LABELS=agent-ready.
+# It is left empty by default to avoid starving an existing unlabeled backlog.
+DEFAULT_RANK="${RALPH_DEFAULT_PRIORITY_RANK:-1}"
+if ! printf '%s' "$DEFAULT_RANK" | grep -qE '^[0-9]+$'; then
+  DEFAULT_RANK=1
+fi
+
 # jq array literals from the space-separated env vars.
 require_json=$(printf '%s\n' $REQUIRE_LABELS | jq -R . | jq -s .)
 exclude_json=$(printf '%s\n' $EXCLUDE_LABELS | jq -R . | jq -s .)
 
-# All open issues as "<number>\t<comma-separated-labels>", ascending by number,
-# filtered by require/exclude labels. Fetched once; reused for candidates and
-# for looking up active issues' labels.
+# All open issues as "<number>\t<comma-separated-labels>", filtered by
+# require/exclude labels and ordered by [priority-tier, number ascending].
+# Fetched once; reused for candidates and for looking up active issues' labels.
 open_tsv=$(
   gh issue list \
     --state open \
@@ -68,14 +95,20 @@ open_tsv=$(
     --jq "
       ( $require_json | map(select(length>0)) ) as \$req
       | ( $exclude_json | map(select(length>0)) ) as \$exc
-      | sort_by(.number)
       | map(. as \$i | (\$i.labels | map(.name)) as \$names
           | select(
               ( \$req | all(. as \$r | \$names | index(\$r)) )
               and ( \$exc | any(. as \$x | \$names | index(\$x)) | not )
             )
-          | \"\(\$i.number)\t\(\$names | join(\",\"))\")
+          | { number: \$i.number, names: \$names,
+              rank: ( if   (\$names | index(\"P0\")) then 0
+                      elif (\$names | index(\"P1\")) then 1
+                      elif (\$names | index(\"P2\")) then 2
+                      elif (\$names | index(\"P3\")) then 3
+                      else $DEFAULT_RANK end ) })
+      | sort_by([.rank, .number])
       | .[]
+      | \"\(.number)\t\(.names | join(\",\"))\"
     "
 )
 

--- a/scripts/ralph/test_pick_next.sh
+++ b/scripts/ralph/test_pick_next.sh
@@ -44,7 +44,20 @@ cat > "$BIN/gh" <<'STUB'
 args="$*"
 case "$args" in
   *"issue list"*)
-    cat "$STUBDIR/issue_list.tsv" 2>/dev/null || true ;;
+    # Two modes. Default: emit the pre-jq'd TSV a scenario supplied (tests the
+    # bash walk logic). Opt-in JSON mode ($STUBDIR/issue_json present): apply the
+    # REAL --jq filter pick-next.sh passes to a JSON fixture, so the embedded
+    # filter/sort (require/exclude + priority tiering) is exercised end-to-end.
+    if [[ -f "$STUBDIR/issue_json" ]]; then
+      filter=""; prev=""
+      for a in "$@"; do
+        [[ "$prev" == "--jq" ]] && { filter="$a"; break; }
+        prev="$a"
+      done
+      jq -r "$filter" "$STUBDIR/issue_json"
+    else
+      cat "$STUBDIR/issue_list.tsv" 2>/dev/null || true
+    fi ;;
   *"pr list"*)
     cat "$STUBDIR/pr_bodies" 2>/dev/null || true ;;
   *"issue view"*)
@@ -74,6 +87,17 @@ set_labels() { printf '%s' "$2" > "$STUBDIR/labels/$1"; }                    # <
 pr_closes()  { printf 'Closes #%s\n' "$1" >> "$STUBDIR/pr_bodies"; }
 worktree()   { mkdir -p "$REPO/.ralph/worktrees/issue-$1"; }
 run_pick()   { (cd "$REPO" && PATH="$BIN:$PATH" "$PICK"); }
+
+# JSON-mode helpers: build the fixture the stub feeds to pick-next's REAL --jq
+# filter (mirrors `gh issue list --json number,labels`), so require/exclude
+# filtering AND the priority-tier sort are exercised, not bypassed.
+ij_add()      { # <num> <labels-csv>  — append one issue object
+  local names
+  names=$(jq -cn --arg s "$2" '$s | split(",") | map(select(length>0) | {name: .})')
+  jq -cn --argjson n "$1" --argjson l "$names" '{number:$n, labels:$l}' \
+    >> "$STUBDIR/issue_json.lines"
+}
+ij_finalize() { jq -s . "$STUBDIR/issue_json.lines" > "$STUBDIR/issue_json"; }
 
 # 1) First worker (empty fleet) gets the lowest candidate.
 new_scenario first
@@ -156,6 +180,44 @@ candidate 10 ""; candidate 11 ""
 mkdir -p "$REPO2/.ralph/worktrees/issue-10"
 check "path segment matching issue-<n> above worktrees dir is ignored" "11" \
   "$(cd "$REPO2" && PATH="$BIN:$PATH" "$PICK")"
+
+# --- priority tiering (JSON mode: exercises the real embedded --jq sort) ------
+
+# 11) P0 preempts a lower, older issue: #99 (P0) beats #10 (P3).
+new_scenario prio_p0_preempts
+ij_add 10 "P3,agent-ready"; ij_add 99 "P0,agent-ready"; ij_finalize
+check "P0 preempts older P3" "99" "$(run_pick)"
+
+# 12) Full tier order P0<P1<P2<P3, and oldest-first WITHIN a tier.
+new_scenario prio_full_order
+ij_add 40 "P3"; ij_add 30 "P2"; ij_add 21 "P1"; ij_add 20 "P1"; ij_add 10 "P0"
+ij_finalize
+check "lowest tier wins (P0)" "10" "$(run_pick)"
+
+new_scenario prio_within_tier
+ij_add 22 "P1"; ij_add 20 "P1"; ij_add 21 "P1"; ij_finalize
+check "oldest-first within a tier" "20" "$(run_pick)"
+
+# 13) Unlabeled issue defaults to rank 1 (== P1): it beats a P2 but loses to P0.
+new_scenario prio_default_rank
+ij_add 5 "P2"; ij_add 9 ""; ij_add 3 "P0"; ij_finalize
+check "unlabeled ranks as P1 (beats P2)" "3" \
+  "$(run_pick)"                                   # P0 #3 first
+new_scenario prio_default_beats_p2
+ij_add 5 "P2"; ij_add 9 ""; ij_finalize
+check "unlabeled (default P1) beats P2" "9" "$(run_pick)"
+
+# 14) RALPH_DEFAULT_PRIORITY_RANK override: push unlabeled to the back (rank 3).
+new_scenario prio_default_override
+ij_add 9 ""; ij_add 5 "P2"; ij_finalize
+check "default-rank override sends unlabeled behind P2" "5" \
+  "$(cd "$REPO" && PATH="$BIN:$PATH" RALPH_DEFAULT_PRIORITY_RANK=3 "$PICK")"
+
+# 15) require/exclude filtering still applies in JSON mode: agent-ready gate.
+new_scenario prio_require_gate
+ij_add 10 "P0"; ij_add 11 "P3,agent-ready"; ij_finalize
+check "require agent-ready filters out ungated P0" "11" \
+  "$(cd "$REPO" && PATH="$BIN:$PATH" RALPH_REQUIRE_LABELS=agent-ready "$PICK")"
 
 echo
 echo "pick-next tests: $PASS passed, $FAIL failed"

--- a/scripts/setup-scan-labels.sh
+++ b/scripts/setup-scan-labels.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/setup-scan-labels.sh
+#
+# Create (or update) the labels the autonomous maintenance pipeline relies on:
+# the priority tiers consumed by scripts/ralph/pick-next.sh, the `agent-ready`
+# gate, and one `scan:<name>` provenance label per scan type. Run once per repo;
+# safe to re-run — `--force` makes each label create-or-update, so this is
+# idempotent and can double as drift correction.
+#
+# Requires an authenticated `gh` CLI with `repo` scope. Usage:
+#   ./scripts/setup-scan-labels.sh
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "setup-scan-labels: gh CLI not found" >&2
+  exit 2
+fi
+
+# label <name> <color> <description>
+label() {
+  gh label create "$1" --color "$2" --description "$3" --force
+}
+
+echo "Priority tiers (consumed by pick-next.sh: P0 -> P1 -> P2 -> P3)…"
+label "P0" "B60205" "Security/breakage — preempts all work"
+label "P1" "D93F0B" "Bugs + Geoff feature issues"
+label "P2" "FBCA04" "Quality: refactor, coverage, perf, a11y"
+label "P3" "0E8A16" "Hygiene: dead code, types, docs, TODOs"
+
+echo "Consumption gate…"
+label "agent-ready" "1D76DB" "Fully specified; Ralph may pick up"
+
+echo "Scan provenance labels…"
+for scan in deps security bugs dead-code complexity coverage perf todo \
+            types mutation docs a11y; do
+  label "scan:${scan}" "C5DEF5" "Filed by the ${scan} maintenance scan"
+done
+
+echo "Done. Labels created/updated."


### PR DESCRIPTION
Stands up the **complete** autonomous maintenance pipeline from the 2026-07-01 spec — scaled out from the original tracer thread in this same branch.

## Consumption — `scripts/ralph/pick-next.sh`
- Priority-tier ordering: **P0 → P1 → P2 → P3**, oldest-first within a tier.
- Unlabeled issues take `RALPH_DEFAULT_PRIORITY_RANK` (default `1` == P1), so legacy/feature work keeps flowing and only P2/P3 hygiene sorts behind it.
- **Backward compatible**: with no P-labels present, ordering collapses to the prior oldest-first. `agent-ready` stays opt-in via `RALPH_REQUIRE_LABELS` so no existing backlog is starved.
- `test_pick_next.sh` gains a JSON-mode `gh` stub that exercises the **real** embedded `--jq` filter (not a pre-jq'd TSV) + 7 priority scenarios → **19/19 pass**.

## Producers — 12 scans
`deps, security, bugs, dead-code, complexity, coverage, perf, todo, types, mutation, docs, a11y` — each a `prompts/scans/*.md` 6-component definition (real repo paths) + a thin wrapper on the task-table cadence/priority. Every wrapper has `workflow_dispatch` for hopper refill. All route through the reusable `_claude-scan.yml` core + `scan-issue-writer` skill.

## Grooming — `scan-groom.yml`
Daily 04:00 (before producers); drives the `backlog-grooming` skill from `prompts/scans/groom.md` to close resolved/stale issues, dedupe, and promote `needs-triage` → `agent-ready`.

## Hopper — `hopper.yml`
Hourly; dispatches the most-stale cheap scan when the `agent-ready` queue drops below 12, stands down when healthy or bloated (>80). Pure `gh`+`jq`, no Claude token.

## Reusable-core hardening (the LGTM review's 🟢 LOW notes)
- Validate `scan_name` against `^[a-z][a-z0-9-]+$` + confirm the scan file exists (fail fast; blocks path traversal from any future dispatch input).
- Optional-analyzer install failures now emit a visible `::warning::` instead of failing silently, so a scan needing a missing tool reports broken tooling, not a false "clean."

## Bootstrap — `labels-bootstrap.yml`
Runs `scripts/setup-scan-labels.sh` to create the P0–P3 tiers, `agent-ready`, and `scan:<name>` labels.

Infrastructure + prompt/skill definitions only — no application source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)