### PR TITLE
refactor(backend): drop stale comments, vestigial param, and log-only COUNT queries

### DIFF
--- a/backend/src/domain/safety.py
+++ b/backend/src/domain/safety.py
@@ -5,8 +5,8 @@ reads text and returns a typed :class:`DistressSignal` saying whether the writin
 contains an **acute** distress signal (explicit suicidal intent, self-harm
 intent, medication cessation, or intent to harm another) and, if so, which
 category matched. Nothing here gives medical, medication, or treatment guidance;
-it only classifies. Later sub-issues wire the signal into a care surface — this
-module is wired into nothing.
+it only classifies. The signal is wired into the acute-distress care surface at
+the journal PATCH endpoint.
 
 Design — deliberately conservative
 ----------------------------------

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -117,7 +117,7 @@ def _items_to_raw_dicts(items: list[StageContent]) -> list[dict[str, object]]:
 async def _check_stage_unlocked(session: AsyncSession, user_id: int, stage_number: int) -> None:
     """Raise 403 if the given stage is locked for the user.
 
-    Used by endpoints that take ``stage_number`` directly (1..36 are
+    Used by endpoints that take ``stage_number`` directly (1..10 are
     public knowledge), so the 403 carries no enumeration risk.
     """
     progress = await get_user_progress(session, user_id)
@@ -165,7 +165,7 @@ async def list_stage_content(
     # 404-then-403: missing stages return not_found regardless of caller so a
     # nonexistent stage_number can't be distinguished from a locked one by
     # response code (callers for this endpoint don't see a content_id oracle,
-    # so the existence of stages 1..36 is already public knowledge).
+    # so the existence of stages 1..10 is already public knowledge).
     stage = await _get_stage_by_number(session, stage_number)
     await _check_stage_unlocked(session, current_user, stage_number)
 

--- a/backend/src/routers/habits.py
+++ b/backend/src/routers/habits.py
@@ -307,17 +307,8 @@ async def delete_habit(
     session: Annotated[AsyncSession, Depends(get_session)],
     habit: Annotated[Habit, Depends(require_owned_habit)],
 ) -> Response:
-    """Delete a habit and cascade goals + completions; logs the cascade post-commit."""
+    """Delete a habit and cascade its goals + completions via the FK cascade."""
     habit_id = habit.id
-    cascade_goal_count = await session.scalar(
-        select(func.count()).select_from(Goal).where(Goal.habit_id == habit_id)
-    )
-    cascade_completion_count = await session.scalar(
-        select(func.count())
-        .select_from(GoalCompletion)
-        .join(Goal, col(Goal.id) == col(GoalCompletion.goal_id))
-        .where(Goal.habit_id == habit_id)
-    )
     await session.delete(habit)
     await session.commit()
     logger.info(
@@ -325,8 +316,6 @@ async def delete_habit(
         extra={
             "user_id": current_user,
             "habit_id": habit_id,
-            "cascade_goals": cascade_goal_count or 0,
-            "cascade_completions": cascade_completion_count or 0,
         },
     )
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -278,7 +278,7 @@ async def _apply_message_edit(
     new_message = _sanitize_message(payload.message)
     if new_message != old_message:
         entry.message = new_message
-        await reanchor_entry_marginalia(entry, old_message, new_message, session)
+        await reanchor_entry_marginalia(entry, new_message, session)
         await reanchor_entry_suggestions(entry, new_message, session)
 
 

--- a/backend/src/services/marginalia.py
+++ b/backend/src/services/marginalia.py
@@ -39,7 +39,6 @@ class BotmasonResonanceLLM:
 
 async def reanchor_entry_marginalia(
     entry: JournalEntry,
-    old_message: str,
     new_message: str,
     session: AsyncSession,
 ) -> None:
@@ -50,9 +49,6 @@ async def reanchor_entry_marginalia(
     nothing is deleted. Matching is on ``anchor_text`` (the snapshot), never on
     offsets alone, so the new body is the only input the logic needs.
     """
-    # The match is against the snapshot text in the new body, so the pre-edit
-    # body isn't consulted here.
-    del old_message
     result = await session.execute(
         select(Marginalia).where(Marginalia.journal_entry_id == entry.id)
     )

--- a/backend/tests/test_habits_api.py
+++ b/backend/tests/test_habits_api.py
@@ -505,37 +505,25 @@ async def test_habit_quota_caps_per_user(
 
 
 @pytest.mark.asyncio
-async def test_delete_habit_logs_cascade_counts(
+async def test_delete_habit_emits_audit_log(
     async_client: AsyncClient,
-    db_session: AsyncSession,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """``delete_habit`` emits a structured cascade-count audit row."""
+    """``delete_habit`` emits an audit log with user_id and habit_id, no cascade counts."""
     headers = await _signup(async_client, "cascade_user")
     create = await async_client.post("/habits/", json=sample_payload(), headers=headers)
     habit_id = create.json()["id"]
 
-    # Seed a goal so the cascade has something to count.
-    goal = Goal(
-        habit_id=habit_id,
-        title="g",
-        tier="clear",
-        target=1,
-        target_unit="glasses",
-        frequency=1,
-        frequency_unit="per_day",
-        is_additive=True,
-    )
-    db_session.add(goal)
-    await db_session.commit()
-
     with caplog.at_level(logging.INFO, logger="routers.habits"):
         resp = await async_client.delete(f"/habits/{habit_id}", headers=headers)
     assert resp.status_code == HTTPStatus.NO_CONTENT
-    cascade_logs = [r for r in caplog.records if r.message == "habit_deleted"]
-    assert cascade_logs, "expected a habit_deleted audit log entry"
-    # Three default goals (auto-seeded by POST /habits/) + one manually added.
-    assert getattr(cascade_logs[0], "cascade_goals", None) == 4
+    audit_logs = [r for r in caplog.records if r.message == "habit_deleted"]
+    assert audit_logs, "expected a habit_deleted audit log entry"
+    record = audit_logs[0]
+    assert getattr(record, "habit_id", None) == habit_id
+    assert getattr(record, "user_id", None) is not None
+    assert not hasattr(record, "cascade_goals")
+    assert not hasattr(record, "cascade_completions")
 
 
 @pytest.mark.asyncio

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -225,7 +225,7 @@ export interface SubtractiveStreakInput {
  *   - The walk stops at ``startDate`` so the streak can never exceed
  *     the habit's life.
  *
- * Mirrors backend ``services.streaks._compute_subtractive_streak``
+ * Mirrors backend ``domain.streaks.subtractive_current_streak``
  * so the stats overlay and the tile-displayed ``habit.streak`` (which
  * comes from the backend's ``compute_habit_streak``) agree.
  */


### PR DESCRIPTION
## Summary

Behavior-preserving backend de-slop bundling five independently-corroborated Low-severity tidy-ups. No endpoint response changes.

- **`routers/course.py`** — corrected two stale docstring/comment references from `1..36` to `1..10`; the curriculum has `TOTAL_STAGES = 10` and the `36` leaked the eradicated 36-week/10-stage conflation.
- **`domain/safety.py`** — the module docstring claimed the module "is wired into nothing," which is now false: `assess_distress` is imported and called in production at the journal PATCH endpoint. Updated the sentence to describe the real wiring.
- **`services/marginalia.py`** — removed the vestigial `old_message` parameter from `reanchor_entry_marginalia` (it was accepted only to be `del`'d); the sibling `reanchor_entry_suggestions` already does the same job without it. Updated the single caller in `routers/journal.py` (the `old_message` local there is retained for the `new_message != old_message` change-guard).
- **`routers/habits.py`** — `delete_habit` issued two `SELECT COUNT(*)` round-trips on every delete purely to populate a `logger.info` extra; the FK cascade does the actual deletion. Removed both queries and dropped `cascade_goals`/`cascade_completions` from the audit log.
- **`frontend/src/utils/dateUtils.ts`** — pointed a stale "Mirrors backend ..." comment at the real symbol `domain.streaks.subtractive_current_streak` (the referenced `_compute_subtractive_streak` never existed).

## Test plan

- Rewrote `test_delete_habit_logs_cascade_counts` → `test_delete_habit_emits_audit_log` to specify the new log contract: a `habit_deleted` record is emitted with `user_id`/`habit_id` and no longer carries `cascade_goals`/`cascade_completions`. Confirmed RED before the impl change, GREEN after.
- Backend `scripts/backend/check-all.sh`: exit 0 — 2106 passed, 2 skipped, 96% coverage.
- `xenon --max-absolute A --max-modules A --max-average A`: exit 0; `radon mi` on changed files: all A.
- Frontend `eslint`, `tsc --noEmit`, `prettier --check`: all exit 0.
- All pre-commit hooks pass.

Closes #1013
