### PR TITLE
refactor(backend): dedup tidy-up — ownership, pagination, overlaps, mode-config, botmason, dates

### DIFF
--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -87,18 +87,17 @@ async def require_owned_habit(
     return habit
 
 
-async def require_owned_goal(
-    goal_id: int,
-    current_user: Annotated[int, Depends(get_current_user)],
-    session: Annotated[AsyncSession, Depends(get_session)],
-) -> Goal:
-    """Resolve ``goal_id`` and verify the caller owns the parent habit.
+async def resolve_owned_goal_and_habit(
+    session: AsyncSession, goal_id: int, user_id: int
+) -> tuple[Goal, Habit]:
+    """Resolve ``goal_id`` to ``(goal, parent_habit)`` with enumeration-safe checks.
 
     Goal ownership rides on the parent habit's ``user_id`` -- the goal table
     itself has no ``user_id`` column.  We collapse "missing goal" and "not
-    yours" into a single 404 to deny enumeration (BUG-T7 / PR #265).  The
-    orphaned-FK branch (goal exists, parent habit gone) is a distinct
-    integrity-violation signal so it gets its own audit row.
+    yours" into a single 404 to deny enumeration.  The orphaned-FK branch
+    (goal exists, parent habit gone) is a distinct integrity-violation signal
+    so it gets its own audit row, but is still surfaced as 404.  Callers that
+    only need the goal (e.g. the goal-detail dependency) discard the habit.
     """
     goal = await session.get(Goal, goal_id)
     if goal is None:
@@ -107,12 +106,27 @@ async def require_owned_goal(
     if habit is None:
         logger.warning(
             "orphaned_goal_fk",
-            extra={"goal_id": goal_id, "habit_id": goal.habit_id, "user_id": current_user},
+            extra={"goal_id": goal_id, "habit_id": goal.habit_id, "user_id": user_id},
         )
         raise not_found("goal")
-    if habit.user_id != current_user:
-        log_ownership_denied("goal", goal_id, current_user)
+    if habit.user_id != user_id:
+        log_ownership_denied("goal", goal_id, user_id)
         raise not_found("goal")
+    return goal, habit
+
+
+async def require_owned_goal(
+    goal_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> Goal:
+    """Resolve ``goal_id`` and verify the caller owns the parent habit.
+
+    Delegates to :func:`resolve_owned_goal_and_habit` and returns just the
+    goal; the parent-habit ownership rule and the enumeration-safe 404s live
+    there so the goal-completions route and this dependency stay in lockstep.
+    """
+    goal, _habit = await resolve_owned_goal_and_habit(session, goal_id, current_user)
     return goal
 
 

--- a/backend/src/domain/course.py
+++ b/backend/src/domain/course.py
@@ -6,6 +6,8 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
+from domain.dates import ensure_aware
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,8 +16,7 @@ def compute_days_elapsed(stage_started_at: datetime) -> int:
     now = datetime.now(UTC)
     # SQLite drops tzinfo on round-trip, so coerce naive values to UTC
     # before subtraction to avoid TypeError under the test fixture.
-    if stage_started_at.tzinfo is None:
-        stage_started_at = stage_started_at.replace(tzinfo=UTC)
+    stage_started_at = ensure_aware(stage_started_at)
     delta = now - stage_started_at
     if delta.total_seconds() < 0:
         logger.warning(

--- a/backend/src/domain/dates.py
+++ b/backend/src/domain/dates.py
@@ -75,6 +75,18 @@ def _resolve_zone(user_or_tz: _HasTimezone | str | None) -> ZoneInfo:
         return ZoneInfo(_FALLBACK_TZ)
 
 
+def ensure_aware(value: datetime) -> datetime:
+    """Return ``value`` tagged as UTC when naive; pass aware values through.
+
+    SQLite (the test DB) drops ``tzinfo`` when round-tripping a column
+    declared timezone-aware, so a value written as ``datetime.now(UTC)``
+    reads back naive.  The stored instant is always the UTC one we wrote,
+    so re-anchoring UTC is correct rather than a band-aid.  Aware values
+    keep their own offset unchanged (identical object returned).
+    """
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
 def now_in_tz(user_or_tz: _HasTimezone | str | None) -> datetime:
     """Return ``datetime.now`` in the user's IANA timezone.
 
@@ -155,9 +167,5 @@ def to_user_date_bucket(ts: datetime | str, user_or_tz: _HasTimezone | str | Non
     storage. The single canonical owner of this coercion (was duplicated in the
     streak service and the subtractive domain).
     """
-    if isinstance(ts, datetime):
-        moment = ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
-    else:
-        parsed = datetime.fromisoformat(ts)
-        moment = parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
-    return to_user_date(user_or_tz, moment)
+    parsed = ts if isinstance(ts, datetime) else datetime.fromisoformat(ts)
+    return to_user_date(user_or_tz, ensure_aware(parsed))

--- a/backend/src/domain/detection.py
+++ b/backend/src/domain/detection.py
@@ -18,7 +18,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from domain.care import MEDICATION_GUARDRAIL
-from domain.resonance import ResonanceLLM, _quote_span
+from domain.resonance import ResonanceLLM, _overlaps, _quote_span
 from security import TextTooLongError, sanitize_user_text
 
 # Domain-level literals so this module stays free of DB/model imports (mirrors
@@ -150,11 +150,6 @@ def _anchor_hit(
         anchor_end=end,
         anchor_text=body[start:end],
     )
-
-
-def _overlaps(a: CompletionDetected, b: CompletionDetected) -> bool:
-    """True when two anchored spans intersect."""
-    return a.anchor_start < b.anchor_end and b.anchor_start < a.anchor_end
 
 
 def _is_duplicate(

--- a/backend/src/domain/practice_insights.py
+++ b/backend/src/domain/practice_insights.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 
-from domain.dates import to_user_date, today_in_tz
+from domain.dates import ensure_aware, to_user_date, today_in_tz
 from models.practice_session import PracticeSession
 
 # Weekly cadence the spec defines as "meeting the practice goal" (≥ 4 sessions
@@ -61,20 +61,6 @@ class PracticeInsights:
     last_insight: str | None
 
 
-def _as_utc_aware(moment: datetime) -> datetime:
-    """Return ``moment`` re-anchored as UTC if it arrived naive.
-
-    Production Postgres ``timestamptz`` columns yield tz-aware datetimes,
-    but SQLite (the test DB) silently drops the tzinfo on read.  The
-    stored value is always the UTC instant we wrote, so re-attaching UTC
-    is correct rather than a band-aid.  ``to_user_date`` raises on naive
-    input — funneling every session timestamp through this helper keeps
-    that strict guard intact without forcing every test fixture to know
-    the storage-layer quirk.
-    """
-    return moment.replace(tzinfo=UTC) if moment.tzinfo is None else moment
-
-
 def _monday_of(day: date) -> date:
     """Return the Monday on or before ``day``.
 
@@ -107,7 +93,7 @@ def _bucket_by_week(
             # Spec: partial sessions count toward weekly totals *iff* duration > 0.
             # Zero-duration aborts don't move the cadence needle.
             continue
-        local_day = to_user_date(tz, _as_utc_aware(session.timestamp))
+        local_day = to_user_date(tz, ensure_aware(session.timestamp))
         buckets[_monday_of(local_day)] += 1
     return buckets
 
@@ -138,7 +124,7 @@ def _is_in_30d_window(session: PracticeSession, today: date, tz: str | None) -> 
     Strict lower bound so the span is exactly ``ROLLING_30D_WINDOW_DAYS`` distinct
     calendar days (today-29 .. today); an inclusive lower bound would count 31.
     """
-    local_day = to_user_date(tz, _as_utc_aware(session.timestamp))
+    local_day = to_user_date(tz, ensure_aware(session.timestamp))
     return today - timedelta(days=ROLLING_30D_WINDOW_DAYS) < local_day <= today
 
 
@@ -184,7 +170,7 @@ def _last_insight(sessions: Iterable[PracticeSession]) -> str | None:
     with_insight = [s for s in sessions if s.insight is not None]
     if not with_insight:
         return None
-    latest = max(with_insight, key=lambda s: _as_utc_aware(s.timestamp))
+    latest = max(with_insight, key=lambda s: ensure_aware(s.timestamp))
     return latest.insight
 
 

--- a/backend/src/domain/resonance.py
+++ b/backend/src/domain/resonance.py
@@ -29,6 +29,25 @@ MAX_PRIOR_ENTRIES = 5
 _PRIOR_ENTRY_CHARS = 1000
 
 
+class _AnchoredSpan(Protocol):
+    """Structural type for anything carrying integer ``anchor_start`` / ``anchor_end``.
+
+    Lets :func:`_overlaps` serve both :class:`MarginaliaAnchored` and the
+    detection module's ``CompletionDetected`` without either importing the
+    other's concrete type -- the half-open span check is identical for both.
+    Both concrete types are frozen dataclasses, so the members are declared
+    read-only to stay structurally compatible under strict typing.
+    """
+
+    @property
+    def anchor_start(self) -> int:
+        """Inclusive start offset of the span in the source text."""
+
+    @property
+    def anchor_end(self) -> int:
+        """Exclusive end offset of the span in the source text."""
+
+
 @dataclass(frozen=True)
 class MarginaliaDraft:
     """A model-proposed note before anchoring: a kind, a verbatim quote, a note."""
@@ -151,7 +170,7 @@ def _anchor(body: str, draft: MarginaliaDraft) -> MarginaliaAnchored | None:
     )
 
 
-def _overlaps(a: MarginaliaAnchored, b: MarginaliaAnchored) -> bool:
+def _overlaps(a: _AnchoredSpan, b: _AnchoredSpan) -> bool:
     """True when two anchored spans intersect."""
     return a.anchor_start < b.anchor_end and b.anchor_start < a.anchor_end
 

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -33,7 +33,7 @@ from schemas.admin import (
     UsageStatsResponse,
     UserUsageBreakdown,
 )
-from schemas.pagination import count_query_total, paginate_query
+from schemas.pagination import count_query_total, page_has_more, paginate_query
 from services.energy import ENERGY_PLAN_RETENTION_DAYS, delete_expired_energy_plans
 
 # SQL ``SUM(NUMERIC)`` returns ``Decimal`` on Postgres but ``int`` (or
@@ -92,7 +92,7 @@ async def _fetch_per_user(
     has_more: bool | None = None
     if pagination.paginate:
         total = await count_query_total(session, query)
-        has_more = (pagination.offset + pagination.limit) < total
+        has_more = page_has_more(pagination.offset, pagination.limit, total)
         query = query.offset(pagination.offset).limit(pagination.limit)
     rows = (await session.execute(query)).all()
     breakdown = [
@@ -245,7 +245,7 @@ async def list_stage_progress_gaps(
             scanned_total=scanned_total,
             limit=pagination.limit,
             offset=pagination.offset,
-            has_more_rows=(pagination.offset + pagination.limit) < scanned_total,
+            has_more_rows=page_has_more(pagination.offset, pagination.limit, scanned_total),
         )
     all_rows = list((await session.execute(base_query)).scalars().all())
     gaps = _gaps_from_rows(all_rows)

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from domain.dates import ensure_aware
 from domain.timezone import normalize_timezone
 from errors import bad_request
 from models.login_attempt import LoginAttempt
@@ -733,19 +734,6 @@ def _coerce_iat_to_datetime(payload: dict[str, object]) -> datetime | None:
     return datetime.fromtimestamp(iat, tz=UTC)
 
 
-def _as_utc_aware(value: datetime) -> datetime:
-    """Tag a naive datetime as UTC; pass aware datetimes through unchanged.
-
-    SQLite (used in tests) drops timezone info on round-trip, so a column
-    written as ``datetime.now(UTC)`` returns naive on read.  Forcing UTC
-    here keeps the SPEC R7 comparison correct on both backends; on
-    PostgreSQL the column is already aware and the call is a no-op.
-    """
-    if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value
-
-
 def _token_predates_password_reset(
     token_iat: datetime | None,
     password_changed_at: datetime | None,
@@ -773,7 +761,7 @@ def _token_predates_password_reset(
     """
     if token_iat is None or password_changed_at is None:
         return False
-    return _as_utc_aware(token_iat) < _as_utc_aware(password_changed_at)
+    return ensure_aware(token_iat) < ensure_aware(password_changed_at)
 
 
 async def _check_user_active(

--- a/backend/src/routers/goal_completions.py
+++ b/backend/src/routers/goal_completions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import date
 from typing import Annotated
 
@@ -11,16 +10,11 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import get_session
-from dependencies.ownership import log_ownership_denied
+from dependencies.ownership import resolve_owned_goal_and_habit
 from dependencies.timezone import current_user_timezone
-from errors import not_found
-from models.goal import Goal
-from models.habit import Habit
 from routers.auth import get_current_user
 from schemas import CheckInResult
 from services.checkin import CheckInContext, record_goal_completion
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/goal_completions", tags=["goals"])
 
@@ -38,34 +32,6 @@ class GoalCompletionRequest(BaseModel):
     completed_on: date | None = None
 
 
-async def _get_owned_goal_and_habit(
-    session: AsyncSession, goal_id: int, user_id: int
-) -> tuple[Goal, Habit]:
-    """Fetch a goal + parent habit, verifying ownership."""
-    goal = await session.get(Goal, goal_id)
-    if goal is None:
-        raise not_found("goal")
-
-    habit = await session.get(Habit, goal.habit_id)
-    if habit is None:
-        # Orphaned FK (goal exists, parent habit gone) — a distinct integrity
-        # signal, but collapsed to 404 like a missing goal so it never acts as
-        # an enumeration oracle (matches dependencies.ownership.require_owned_goal).
-        logger.warning(
-            "orphaned_goal_fk",
-            extra={"goal_id": goal_id, "habit_id": goal.habit_id, "user_id": user_id},
-        )
-        raise not_found("goal")
-    if habit.user_id != user_id:
-        # Cross-tenant access is collapsed to 404 (not 403) so a prober cannot
-        # tell "exists but not yours" from "absent" — the enumeration-safe
-        # contract the goals router already enforces.
-        log_ownership_denied("goal", goal_id, user_id)
-        raise not_found("goal")
-
-    return goal, habit
-
-
 @router.post("/", response_model=CheckInResult)
 async def create_goal_completion(
     payload: GoalCompletionRequest,
@@ -80,7 +46,7 @@ async def create_goal_completion(
     (user, goal, day). The recording itself lives in ``services.checkin`` so the
     journal accept flow (#818) records through the identical path.
     """
-    goal, habit = await _get_owned_goal_and_habit(session, payload.goal_id, current_user)
+    goal, habit = await resolve_owned_goal_and_habit(session, payload.goal_id, current_user)
     ctx = CheckInContext(goal=goal, habit=habit, user_id=current_user, user_timezone=user_tz)
     return await record_goal_completion(
         session,

--- a/backend/src/routers/goal_groups.py
+++ b/backend/src/routers/goal_groups.py
@@ -133,10 +133,11 @@ async def create_goal_group(
     )
     session.add(group)
     await session.commit()
-    # Re-fetch with eager-loaded goals to avoid lazy-load greenlet errors
-    statement = select(GoalGroup).where(GoalGroup.id == group.id).options(GOAL_GROUP_WITH_GOALS)
-    result = await session.execute(statement)
-    refreshed = result.scalars().one()
+    await session.refresh(group)
+    # Re-fetch with eager-loaded goals (avoids lazy-load greenlet errors) via the
+    # shared helper, whose ``.first()`` + None-check turns a concurrent delete into
+    # a 404 rather than a ``NoResultFound`` 500.
+    refreshed = await _refetch_goal_group_with_goals(session, cast("int", group.id))
     logger.info(
         "goal_group_created", extra={"user_id": current_user, "goal_group_id": refreshed.id}
     )

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
-from sqlalchemy import ColumnElement, func
+from sqlalchemy import ColumnElement
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -38,6 +38,7 @@ from models.journal_entry import JournalClassification, JournalEntry, JournalTag
 from models.marginalia import Marginalia, MarginaliaStatus
 from models.practice import Practice
 from models.practice_session import PracticeSession
+from models.user import User
 from models.user_practice import UserPractice
 from rate_limit import limiter
 from routers.auth import get_current_user
@@ -61,6 +62,7 @@ from schemas.marginalia import (
     MarginaliaResponse,
     ResonanceResponse,
 )
+from schemas.pagination import count_query_total, page_has_more
 from security import TextTooLongError, sanitize_user_text
 from services import journal_encryption
 from services.botmason import LLMProviderError, resolve_chat_api_key
@@ -210,7 +212,7 @@ async def _encrypted_search_page(
     return JournalListResponse(
         items=[JournalMessageResponse.model_validate(e, from_attributes=True) for e in page],
         total=len(matched),
-        has_more=(filters.offset + filters.limit) < len(matched),
+        has_more=page_has_more(filters.offset, filters.limit, len(matched)),
     )
 
 
@@ -240,8 +242,7 @@ async def list_journal_entries(
     )
 
     # Count total before pagination
-    count_query = select(func.count()).select_from(query.subquery())
-    total = (await session.execute(count_query)).scalar() or 0
+    total = await count_query_total(session, query)
 
     # Fetch paginated results, newest first
     query = query.order_by(col(JournalEntry.id).desc()).offset(filters.offset).limit(filters.limit)
@@ -251,7 +252,7 @@ async def list_journal_entries(
     return JournalListResponse(
         items=[JournalMessageResponse.model_validate(e, from_attributes=True) for e in items],
         total=total,
-        has_more=(filters.offset + filters.limit) < total,
+        has_more=page_has_more(filters.offset, filters.limit, total),
     )
 
 
@@ -490,6 +491,33 @@ _INTIMATE_PRIVATE_MESSAGE = (
 )
 
 
+def _unspent_resonance(
+    user: User,
+    *,
+    care: CareResponse | None,
+    private: bool = False,
+    private_message: str | None = None,
+) -> ResonanceResponse:
+    """Build a no-reflection response over the caller's *unspent* wallet balances.
+
+    Shared skeleton for the two paths that return before any charge lands: the
+    intimate/private path and the care-only fallback when an elevated entry's
+    LLM pass fails. Both surface empty marginalia + suggestions
+    and read the wallet fresh (no ``preflight_deduction``), differing only in
+    the ``care`` payload and the private-message fields.
+    """
+    return ResonanceResponse(
+        marginalia=[],
+        suggestions=[],
+        remaining_messages=max(get_monthly_cap() - user.monthly_messages_used, 0),
+        remaining_balance=user.offering_balance,
+        monthly_reset_date=user.monthly_reset_date,
+        care=care,
+        private=private,
+        private_message=private_message,
+    )
+
+
 async def _private_response(session: AsyncSession, user_id: int) -> ResonanceResponse:
     """Resonance response for an intimate entry: no cloud call, no charge.
 
@@ -499,15 +527,8 @@ async def _private_response(session: AsyncSession, user_id: int) -> ResonanceRes
     with no ``preflight_deduction``), and the non-shaming private message.
     """
     user = await require_user_fresh(session, user_id)
-    return ResonanceResponse(
-        marginalia=[],
-        suggestions=[],
-        remaining_messages=max(get_monthly_cap() - user.monthly_messages_used, 0),
-        remaining_balance=user.offering_balance,
-        monthly_reset_date=user.monthly_reset_date,
-        care=None,
-        private=True,
-        private_message=_INTIMATE_PRIVATE_MESSAGE,
+    return _unspent_resonance(
+        user, care=None, private=True, private_message=_INTIMATE_PRIVATE_MESSAGE
     )
 
 
@@ -521,14 +542,7 @@ async def _care_only_response(
     depend on the LLM succeeding (NORTH-STAR §10).
     """
     user = await require_user_fresh(session, user_id)
-    return ResonanceResponse(
-        marginalia=[],
-        suggestions=[],
-        remaining_messages=max(get_monthly_cap() - user.monthly_messages_used, 0),
-        remaining_balance=user.offering_balance,
-        monthly_reset_date=user.monthly_reset_date,
-        care=care,
-    )
+    return _unspent_resonance(user, care=care)
 
 
 async def _resonance_pass_or_care(

--- a/backend/src/routers/practice_recipes.py
+++ b/backend/src/routers/practice_recipes.py
@@ -48,13 +48,13 @@ from models.user_practice import UserPractice
 from routers.auth import get_current_user
 from routers.user_practices import (
     EmbeddedSessionsParams,
+    _validate_mode_config_against_catalog,
     build_user_practice_detail,
     load_recent_sessions,
 )
 from schemas import Page, PaginationParams, build_page
 from schemas.pagination import paginate_query
 from schemas.practice import UserPracticeDetail
-from schemas.practice_mode_config import ModeConfigAdapter
 from schemas.practice_recipe import (
     PracticeRecipeCreate,
     PracticeRecipeOut,
@@ -335,24 +335,6 @@ async def delete_practice_recipe(
     logger.info("practice_recipe_deleted", extra={"recipe_id": recipe_id, "user_id": user_id})
 
 
-def _validate_materialised_against_catalog(
-    materialised: dict[str, Any], practice: Practice
-) -> None:
-    """Run the materialised config through the same gate the customise route uses.
-
-    Shared with ``user_practices.customize_user_practice`` in spirit:
-    both paths land in ``UserPractice.mode_config_override`` and both
-    must (a) parse cleanly under ``ModeConfigAdapter`` and (b) match
-    the catalog ``mode``.
-    """
-    try:
-        cfg = ModeConfigAdapter.validate_python(materialised)
-    except ValidationError as exc:
-        raise bad_request("recipe_invalid_for_mode") from exc
-    if cfg.mode != practice.mode:
-        raise bad_request("mode_mismatch")
-
-
 @router.post(
     "/{recipe_id}/apply-to/{user_practice_id}",
     response_model=UserPracticeDetail,
@@ -368,8 +350,11 @@ async def apply_recipe_to_user_practice(
 
     Re-uses ``require_owned_user_practice`` (the same dependency the
     customise endpoint uses) so the ownership rule for overrides is
-    enforced in exactly one place.  Mode mismatch returns ``400
-    mode_mismatch`` to mirror the customise endpoint's error shape.
+    enforced in exactly one place.  The materialised config runs through
+    ``_validate_mode_config_against_catalog`` -- literally the same gate
+    the customise route uses -- so a malformed config returns ``422`` with
+    structured per-field errors and a mode mismatch returns ``400
+    mode_mismatch``, identical to the customise endpoint's error shapes.
     """
     recipe = await _load_visible_recipe(recipe_id, user_id, session)
     steps = await _load_steps(recipe_id, session)
@@ -382,7 +367,7 @@ async def apply_recipe_to_user_practice(
     practice = practice_result.scalar_one_or_none()
     if practice is None:
         raise not_found("practice")
-    _validate_materialised_against_catalog(materialised, practice)
+    _validate_mode_config_against_catalog(materialised, practice)
 
     user_practice.mode_config_override = materialised
     session.add(user_practice)

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -20,6 +20,7 @@ from errors import conflict, forbidden, not_found, unprocessable
 from models.journal_entry import JournalEntry, JournalTag
 from models.prompt_response import PromptResponse
 from routers.auth import get_current_user
+from schemas.pagination import page_has_more
 from schemas.prompt import (
     PROMPT_RESPONSE_MAX_LENGTH,
     PromptDetail,
@@ -160,7 +161,7 @@ async def list_prompt_history(
     if total is not None:
         page_query = query.offset(filters.offset).limit(filters.limit)
         items = list((await session.execute(page_query)).scalars().all())
-        has_more = (filters.offset + filters.limit) < total
+        has_more = page_has_more(filters.offset, filters.limit, total)
     else:
         peek_query = query.offset(filters.offset).limit(filters.limit + 1)
         rows = list((await session.execute(peek_query)).scalars().all())

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -27,7 +27,7 @@ from models.user_practice import UserPractice
 from routers.auth import get_current_user
 from schemas import MAX_PAGE_SIZE, Page, PaginationParams, build_page
 from schemas.frequency import FrequencyResponse, render_banner_text
-from schemas.pagination import paginate_query
+from schemas.pagination import page_has_more, paginate_query
 from schemas.practice import (
     PracticeSessionSummary,
     UserPracticeCreate,
@@ -601,7 +601,7 @@ async def load_recent_sessions(
         limit=params.sessions_limit, offset=params.sessions_offset, paginate=True
     )
     sessions, total = await paginate_query(session, query, page_params)
-    has_more = (params.sessions_offset + params.sessions_limit) < total
+    has_more = page_has_more(params.sessions_offset, params.sessions_limit, total)
     return sessions, total, has_more
 
 
@@ -629,24 +629,26 @@ async def get_user_practice(
     )
 
 
-def _validate_override_against_catalog(override: dict[str, Any] | None, practice: Practice) -> None:
-    """Pre-flight validation: reject malformed or mode-mismatched overrides.
+def _validate_mode_config_against_catalog(
+    config: dict[str, Any] | None, practice: Practice
+) -> None:
+    """Pre-flight validation for a mode-config that will land in a UserPractice.
 
-    Raises ``HTTPException`` directly so the endpoint short-circuits
-    *before* persisting; without this guard, a bad override would land in
-    the DB and the post-write resolver would 500. Pydantic's
-    ``ValidationError`` is caught here and re-raised as a 422 with
-    structured error details so the client can show field-level messages.
-    Mode mismatch is mapped to a domain-meaningful 400.
+    The single gate shared by the customise route (per-user override) and the
+    recipe-apply route (materialised recipe): both write to
+    ``UserPractice.mode_config_override`` and both must (a) parse cleanly under
+    ``ModeConfigAdapter`` and (b) match the catalog ``mode``.  Runs *before*
+    persisting so a bad config never reaches the post-write resolver (which
+    would 500).  A ``ValidationError`` becomes a 422 carrying Pydantic's
+    structured per-field errors (``unprocessable()`` only takes a string
+    detail); a mode mismatch becomes a domain-meaningful 400.  ``None``
+    (the customise "clear the override" case) short-circuits.
     """
-    if override is None:
+    if config is None:
         return
     try:
-        cfg = ModeConfigAdapter.validate_python(override)
+        cfg = ModeConfigAdapter.validate_python(config)
     except ValidationError as exc:
-        # Preserve Pydantic's structured per-field errors so the client
-        # can render field-level messages — ``unprocessable()`` only
-        # accepts a string detail.
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=exc.errors(),
@@ -673,7 +675,7 @@ async def customize_user_practice(
     fields_set = payload.model_fields_set
 
     if "mode_config_override" in fields_set:
-        _validate_override_against_catalog(payload.mode_config_override, practice)
+        _validate_mode_config_against_catalog(payload.mode_config_override, practice)
         user_practice.mode_config_override = payload.mode_config_override
     if "custom_name" in fields_set:
         user_practice.custom_name = payload.custom_name

--- a/backend/src/schemas/pagination.py
+++ b/backend/src/schemas/pagination.py
@@ -68,6 +68,17 @@ class PaginationParams:
     )
 
 
+def page_has_more(offset: int, limit: int, total: int) -> bool:
+    """Return whether rows remain past the current ``offset`` + ``limit`` window.
+
+    The single source of truth for the ``has_more`` flag every paginated list
+    endpoint returns: ``True`` when the next page would contain at least one
+    row.  Equal ``offset + limit`` and ``total`` means the window ends exactly
+    at the last row, so there is no next page.
+    """
+    return (offset + limit) < total
+
+
 def build_page(items: list[T], total: int, params: PaginationParams) -> Page[T]:  # noqa: UP047
     """Construct a :class:`Page` envelope from sliced items + count + params."""
     return Page[T](
@@ -75,7 +86,7 @@ def build_page(items: list[T], total: int, params: PaginationParams) -> Page[T]:
         total=total,
         limit=params.limit,
         offset=params.offset,
-        has_more=(params.offset + params.limit) < total,
+        has_more=page_has_more(params.offset, params.limit, total),
     )
 
 

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -428,6 +428,29 @@ def _entry_message(entry: dict[str, str]) -> str:
     return entry.get("message", "")
 
 
+def _wrap_history(
+    conversation_history: list[dict[str, str]],
+    user_message: str,
+    nonce: str,
+) -> list[dict[str, str]]:
+    """Build the nonce-wrapped turn list: history followed by the new user turn.
+
+    Shared by the OpenAI and Anthropic message builders (BUG-BM-004): every
+    user-role content (prior turns and the new message) is nonce-wrapped so
+    the delimiter tags cannot be forged from a prior conversation, while
+    assistant turns pass through verbatim.  The system prompt is *not* part
+    of this list -- each caller places it where its provider expects.
+    """
+    messages: list[dict[str, str]] = []
+    for entry in conversation_history:
+        role = "assistant" if entry.get("sender") == "bot" else "user"
+        message = _entry_message(entry)
+        content = _wrap_user_input(message, nonce) if role == "user" else message
+        messages.append({"role": role, "content": content})
+    messages.append({"role": "user", "content": _wrap_user_input(user_message, nonce)})
+    return messages
+
+
 def _build_messages(
     user_message: str,
     conversation_history: list[dict[str, str]],
@@ -444,16 +467,8 @@ def _build_messages(
     """
     _check_prompt_injection(user_message)
     nonce = _make_nonce()
-    messages: list[dict[str, str]] = [
-        {"role": "system", "content": _augment_system_prompt(system_prompt, nonce)},
-    ]
-    for entry in conversation_history:
-        role = "assistant" if entry.get("sender") == "bot" else "user"
-        message = _entry_message(entry)
-        content = _wrap_user_input(message, nonce) if role == "user" else message
-        messages.append({"role": role, "content": content})
-    messages.append({"role": "user", "content": _wrap_user_input(user_message, nonce)})
-    return messages
+    system_turn = {"role": "system", "content": _augment_system_prompt(system_prompt, nonce)}
+    return [system_turn, *_wrap_history(conversation_history, user_message, nonce)]
 
 
 def _provider_default_model(provider: str) -> str:
@@ -506,13 +521,7 @@ def _build_anthropic_messages(
     """
     _check_prompt_injection(user_message)
     nonce = _make_nonce()
-    messages: list[dict[str, str]] = []
-    for entry in conversation_history:
-        role = "assistant" if entry.get("sender") == "bot" else "user"
-        message = _entry_message(entry)
-        content = _wrap_user_input(message, nonce) if role == "user" else message
-        messages.append({"role": role, "content": content})
-    messages.append({"role": "user", "content": _wrap_user_input(user_message, nonce)})
+    messages = _wrap_history(conversation_history, user_message, nonce)
     return messages, _augment_system_prompt(system_prompt, nonce)
 
 

--- a/backend/src/services/usage.py
+++ b/backend/src/services/usage.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime
 
+from domain.dates import ensure_aware
+
 # Default monthly cap when ``BOTMASON_MONTHLY_CAP`` is not set.  Chosen as a
 # conservative free-tier that covers a handful of reflections per day without
 # opening the door to sustained abuse before a purchase is required.
@@ -54,8 +56,7 @@ def compute_next_reset(now: datetime) -> datetime:
     is always timezone-aware (UTC) so it can be compared safely against
     ``datetime.now(UTC)`` in SQL WHERE clauses.
     """
-    aware = now if now.tzinfo is not None else now.replace(tzinfo=UTC)
-    utc = aware.astimezone(UTC)
+    utc = ensure_aware(now).astimezone(UTC)
     year, month = utc.year, utc.month
     if month == 12:  # noqa: PLR2004 - December rolls to January of next year
         return datetime(year + 1, 1, 1, tzinfo=UTC)

--- a/backend/tests/domain/test_dates.py
+++ b/backend/tests/domain/test_dates.py
@@ -22,6 +22,7 @@ import pytest
 
 from domain.dates import (
     day_bounds_in_tz,
+    ensure_aware,
     now_in_tz,
     to_user_date,
     today_in_tz,
@@ -202,6 +203,34 @@ class TestToUserDate:
 
 
 # ── Edge cases: year-boundary, leap-day ──────────────────────────────────
+
+
+class TestEnsureAware:
+    """ensure_aware tags naive datetimes UTC and passes aware ones through."""
+
+    def test_naive_datetime_is_tagged_utc(self) -> None:
+        naive = datetime(2026, 6, 15, 12, 0)  # noqa: DTZ001
+        result = ensure_aware(naive)
+        assert result.tzinfo is UTC
+
+    def test_naive_datetime_wall_clock_is_unchanged(self) -> None:
+        naive = datetime(2026, 6, 15, 12, 0)  # noqa: DTZ001
+        result = ensure_aware(naive)
+        assert result.replace(tzinfo=None) == naive
+
+    def test_aware_datetime_is_returned_unchanged(self) -> None:
+        zone = ZoneInfo("America/Los_Angeles")
+        aware = datetime(2026, 6, 15, 12, 0, tzinfo=zone)
+        result = ensure_aware(aware)
+        assert result == aware
+        assert result.tzinfo is aware.tzinfo
+
+    def test_aware_datetime_keeps_its_own_offset_not_utc(self) -> None:
+        zone = ZoneInfo("America/Los_Angeles")
+        aware = datetime(2026, 6, 15, 12, 0, tzinfo=zone)
+        result = ensure_aware(aware)
+        assert result.utcoffset() == aware.utcoffset()
+        assert result.utcoffset() != timedelta(0)
 
 
 class TestYearAndLeapBoundaries:

--- a/backend/tests/domain/test_overlaps_shared.py
+++ b/backend/tests/domain/test_overlaps_shared.py
@@ -1,0 +1,52 @@
+"""Pins domain.resonance._overlaps as the single shared span-overlap check."""
+
+from __future__ import annotations
+
+from domain.detection import CompletionDetected
+from domain.detection import _overlaps as _detection_overlaps
+from domain.resonance import MarginaliaAnchored, _overlaps
+
+
+def _marginalia(start: int, end: int) -> MarginaliaAnchored:
+    return MarginaliaAnchored(
+        kind="theme", anchor_start=start, anchor_end=end, anchor_text="x", note="n"
+    )
+
+
+def _completion(start: int, end: int) -> CompletionDetected:
+    return CompletionDetected(
+        target_type="habit",
+        target_id=1,
+        label="x",
+        anchor_start=start,
+        anchor_end=end,
+        anchor_text="x",
+    )
+
+
+def test_overlaps_true_for_overlapping_marginalia_spans() -> None:
+    assert _overlaps(_marginalia(0, 10), _marginalia(5, 15)) is True
+
+
+def test_overlaps_false_for_disjoint_marginalia_spans() -> None:
+    assert _overlaps(_marginalia(0, 5), _marginalia(10, 15)) is False
+
+
+def test_overlaps_false_for_adjacent_marginalia_spans() -> None:
+    assert _overlaps(_marginalia(0, 5), _marginalia(5, 10)) is False
+
+
+def test_overlaps_true_for_overlapping_completion_spans() -> None:
+    assert _overlaps(_completion(0, 10), _completion(5, 15)) is True
+
+
+def test_overlaps_false_for_disjoint_completion_spans() -> None:
+    assert _overlaps(_completion(0, 5), _completion(10, 15)) is False
+
+
+def test_overlaps_false_for_adjacent_completion_spans() -> None:
+    assert _overlaps(_completion(0, 5), _completion(5, 10)) is False
+
+
+def test_detection_module_imports_overlaps_from_resonance_not_duplicating_it() -> None:
+    assert _detection_overlaps is _overlaps

--- a/backend/tests/schemas/test_pagination.py
+++ b/backend/tests/schemas/test_pagination.py
@@ -1,0 +1,21 @@
+"""Unit tests for the shared page_has_more helper."""
+
+from __future__ import annotations
+
+from schemas.pagination import page_has_more
+
+
+def test_offset_plus_limit_equals_total_is_not_more() -> None:
+    assert page_has_more(offset=0, limit=10, total=10) is False
+
+
+def test_offset_plus_limit_less_than_total_has_more() -> None:
+    assert page_has_more(offset=0, limit=10, total=11) is True
+
+
+def test_offset_plus_limit_greater_than_total_is_not_more() -> None:
+    assert page_has_more(offset=8, limit=10, total=10) is False
+
+
+def test_zero_total_is_never_more() -> None:
+    assert page_has_more(offset=0, limit=10, total=0) is False

--- a/backend/tests/test_ownership_dependencies.py
+++ b/backend/tests/test_ownership_dependencies.py
@@ -1,0 +1,127 @@
+"""Direct contract tests for dependencies.ownership.resolve_owned_goal_and_habit."""
+
+from __future__ import annotations
+
+from datetime import date
+from http import HTTPStatus
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from dependencies.ownership import resolve_owned_goal_and_habit
+from models.goal import Goal
+from models.habit import Habit
+from models.user import User
+
+# Habit id that never exists; simulates an orphaned FK without ORM cascade-delete.
+_NONEXISTENT_HABIT_ID = 999_999
+
+
+async def _seed_user(db_session: AsyncSession, email: str) -> int:
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    assert user.id is not None
+    return user.id
+
+
+async def _seed_habit(db_session: AsyncSession, user_id: int) -> Habit:
+    habit = Habit(
+        name="Meditation",
+        icon="x",
+        start_date=date(2025, 1, 1),
+        energy_cost=10,
+        energy_return=20,
+        user_id=user_id,
+    )
+    db_session.add(habit)
+    await db_session.commit()
+    await db_session.refresh(habit)
+    return habit
+
+
+async def _seed_goal(db_session: AsyncSession, habit_id: int) -> Goal:
+    goal = Goal(
+        habit_id=habit_id,
+        title="Daily sit",
+        tier="clear",
+        target=10.0,
+        target_unit="minutes",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    db_session.add(goal)
+    await db_session.commit()
+    await db_session.refresh(goal)
+    return goal
+
+
+@pytest.mark.asyncio
+async def test_resolve_owned_goal_and_habit_returns_both_for_owned_goal(
+    db_session: AsyncSession,
+) -> None:
+    user_id = await _seed_user(db_session, "owner@example.com")
+    habit = await _seed_habit(db_session, user_id)
+    assert habit.id is not None
+    goal = await _seed_goal(db_session, habit.id)
+    assert goal.id is not None
+
+    resolved_goal, resolved_habit = await resolve_owned_goal_and_habit(db_session, goal.id, user_id)
+
+    assert resolved_goal.id == goal.id
+    assert resolved_habit.id == habit.id
+
+
+@pytest.mark.asyncio
+async def test_resolve_owned_goal_and_habit_missing_goal_raises_404(
+    db_session: AsyncSession,
+) -> None:
+    user_id = await _seed_user(db_session, "solo@example.com")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await resolve_owned_goal_and_habit(db_session, 999, user_id)
+
+    assert exc_info.value.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_resolve_owned_goal_and_habit_orphaned_fk_raises_404(
+    db_session: AsyncSession,
+) -> None:
+    user_id = await _seed_user(db_session, "orphan@example.com")
+    habit = await _seed_habit(db_session, user_id)
+    assert habit.id is not None
+    goal = await _seed_goal(db_session, habit.id)
+    assert goal.id is not None
+    # SQLite in tests does not enforce FKs, so this repoints habit_id directly.
+    await db_session.execute(
+        update(Goal).where(col(Goal.id) == goal.id).values(habit_id=_NONEXISTENT_HABIT_ID)
+    )
+    await db_session.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await resolve_owned_goal_and_habit(db_session, goal.id, user_id)
+
+    assert exc_info.value.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_resolve_owned_goal_and_habit_cross_tenant_raises_404(
+    db_session: AsyncSession,
+) -> None:
+    owner_id = await _seed_user(db_session, "alice_owner@example.com")
+    other_id = await _seed_user(db_session, "bob_other@example.com")
+    habit = await _seed_habit(db_session, owner_id)
+    assert habit.id is not None
+    goal = await _seed_goal(db_session, habit.id)
+    assert goal.id is not None
+
+    with pytest.raises(HTTPException) as exc_info:
+        await resolve_owned_goal_and_habit(db_session, goal.id, other_id)
+
+    assert exc_info.value.status_code == HTTPStatus.NOT_FOUND

--- a/backend/tests/test_practice_recipes_api.py
+++ b/backend/tests/test_practice_recipes_api.py
@@ -404,6 +404,58 @@ async def test_apply_mode_mismatch_400(async_client: AsyncClient, db_session: As
 
 
 @pytest.mark.asyncio
+async def test_apply_invalid_materialised_config_returns_422_with_structured_detail(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, user_id = await _signup(async_client)
+    catalog = await _seed_catalog_practice(
+        db_session,
+        mode="tallied_grounding",
+        mode_config={
+            "mode": "tallied_grounding",
+            "rounds": 1,
+            "categories": [{"key": "red", "label": "Red", "target_count": 1}],
+        },
+    )
+    up_id = await _setup_user_practice(async_client, db_session, headers, user_id, catalog)
+    # DB-seeded step bypasses create-time validation; its slug fails materialisation.
+    recipe = PracticeRecipe(
+        slug="apply_bad_key",
+        name="Bad Key Recipe",
+        description="",
+        owner_user_id=user_id,
+        mode="tallied_grounding",
+        rounds=1,
+    )
+    db_session.add(recipe)
+    await db_session.commit()
+    await db_session.refresh(recipe)
+    assert recipe.id is not None
+    db_session.add(
+        PracticeRecipeStep(
+            recipe_id=recipe.id,
+            position=0,
+            tag_slug="Not A Valid Slug!",
+            tag_label="Bad",
+            prompt_label="x",
+            target_count=1,
+        )
+    )
+    await db_session.commit()
+    recipe_id = recipe.id
+
+    resp = await async_client.post(
+        f"/practice-recipes/{recipe_id}/apply-to/{up_id}", headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, resp.text
+    detail = resp.json()["detail"]
+    assert isinstance(detail, list)
+    assert detail
+    assert all("loc" in item and "msg" in item for item in detail)
+
+
+@pytest.mark.asyncio
 async def test_apply_other_users_practice_forbidden(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:


### PR DESCRIPTION
## Summary

Backend dedup/cleanup tidy-up: consolidates eight independent duplications
across routers, domain, and services, each routed through an existing (or
newly extracted) canonical helper. Seven are behavior-preserving refactors;
one is a deliberate error-contract correction.

- **Ownership resolver** — extract `resolve_owned_goal_and_habit` in
  `dependencies/ownership.py`; `require_owned_goal` delegates to it and the
  forked `_get_owned_goal_and_habit` in `goal_completions.py` is deleted.
  Enumeration-safe 404 semantics (orphaned-FK warning, cross-tenant audit,
  never 403) preserved exactly.
- **Pagination `has_more`** — add `page_has_more(offset, limit, total)` in
  `schemas/pagination.py`; replace the inline `(offset + limit) < total`
  copies in the journal, admin, prompts, and user-practices list paths, and
  route the journal plaintext count through `count_query_total`.
- **Shared `_overlaps`** — generalize the span-overlap check over an
  anchored-span `Protocol` in `domain/resonance.py`; `domain/detection.py`
  imports it instead of duplicating the body.
- **Mode-config validation contract (fix)** — unify the recipe apply-to and
  customize routes on a single gate that returns **422** with structured
  `exc.errors()` on an invalid config (recipes previously returned a bare
  400 `recipe_invalid_for_mode`); `mode_mismatch` stays 400 on both.
- **Botmason `_wrap_history`** — fold the identical nonce-wrapping history
  loop out of the OpenAI and Anthropic message builders. Fresh nonce and
  prompt-injection check per call preserved in both paths.
- **`ensure_aware`** — add the naive→UTC coercion helper to `domain/dates.py`
  and route the copies in `course`, `practice_insights`, `usage`, and `auth`
  through it.
- **`_unspent_resonance`** — collapse the byte-identical unspent-wallet
  response skeleton shared by the private and care-only resonance paths.
- **`create_goal_group` refetch (fix)** — reuse the concurrent-delete-safe
  `_refetch_goal_group_with_goals` so a concurrent delete surfaces as a 404
  rather than a 500.

No endpoint paths or response shapes change apart from the recipe route's
400→422 correction. No schema/migration change.

## Test plan

- New RED-first tests: recipe apply-to returns 422 with structured detail on
  an invalid mode config (`mode_mismatch` still 400); `page_has_more`
  boundary cases; `ensure_aware` naive/aware handling; `resolve_owned_goal_and_habit`
  ownership contract incl. the previously-uncovered orphaned-FK branch;
  shared `_overlaps` identity across both dataclass types.
- Existing suites are the characterization net for the behavior-preserving
  items (journal/admin/prompts pagination, botmason wrapping, goal-group
  create, resonance/detection).
- Local gates green: `scripts/backend/check-all.sh` 7/7, mypy strict, ruff
  ALL, xenon A, radon MI ≥ B, interrogate 95.3%, full suite 2125 passed /
  2 skipped, 96.2% coverage.

Closes #1012
