### PR TITLE
fix(journal): surface classification PATCH failures on tier change (privacy divergence)

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -191,8 +191,12 @@ function useTimerCleanup(timerRef: React.MutableRefObject<ReturnType<typeof setT
 
 interface ClassificationPersist {
   classificationRef: React.MutableRefObject<JournalClassification>;
-  /** Record the tier for the next create and PATCH it when the entry exists. */
-  changeClassification: (_tier: JournalClassification) => void;
+  /**
+   * Record the tier for the next create and PATCH it when the entry exists.
+   * Resolves to the tier the UI should revert to when a PATCH fails and no later
+   * change has superseded it, else null.
+   */
+  changeClassification: (_tier: JournalClassification) => Promise<JournalClassification | null>;
 }
 
 /**
@@ -205,10 +209,21 @@ function useClassificationPersist(
 ): ClassificationPersist {
   const classificationRef = useRef<JournalClassification>(DEFAULT_CLASSIFICATION);
   const changeClassification = useCallback(
-    (tier: JournalClassification): void => {
+    async (tier: JournalClassification): Promise<JournalClassification | null> => {
+      const previous = classificationRef.current;
       classificationRef.current = tier;
-      if (entryIdRef.current != null) {
-        void journal.update(entryIdRef.current, { classification: tier });
+      // Create-time: the ref rides the next journal.create, nothing to PATCH yet.
+      if (entryIdRef.current == null) return null;
+      try {
+        await journal.update(entryIdRef.current, { classification: tier });
+        return null;
+      } catch {
+        // A rapid superseding change already owns the ref and the UI — leave both
+        // to it rather than reverting to this now-stale tier. Assumes one PATCH in
+        // flight at a time; ``previous`` is the optimistic ref, not last-persisted.
+        if (classificationRef.current !== tier) return null;
+        classificationRef.current = previous;
+        return previous;
       }
     },
     [entryIdRef],
@@ -302,7 +317,17 @@ function useDebouncedSave(
   const setTyping = useCallback(() => setSaveState('typing'), []);
   const { save, flush } = useSaveTimer(run, timerRef, entryIdRef, delayMs, setTyping);
 
-  return { saveState, save, flush, changeClassification };
+  // A failed classification PATCH surfaces the same error hint as a body save.
+  const persistClassification = useCallback(
+    async (tier: JournalClassification): Promise<JournalClassification | null> => {
+      const revertTo = await changeClassification(tier);
+      if (revertTo != null) setSaveState('error');
+      return revertTo;
+    },
+    [changeClassification],
+  );
+
+  return { saveState, save, flush, changeClassification: persistClassification };
 }
 
 type StrRef = React.MutableRefObject<string>;
@@ -418,11 +443,15 @@ function useJournalAutosave(
     () => flush(titleRef.current, bodyRef.current),
     [flush, titleRef, bodyRef],
   );
-  // Reflect the choice in the control, then persist it (create-time ref or PATCH).
+  // Reflect the choice optimistically, then persist it (create-time ref or PATCH);
+  // a failed PATCH resolves to the prior tier so the control reverts to the truth,
+  // unless a later change superseded it (then it resolves null and we keep that).
   const onChangeClassification = useCallback(
     (tier: PrivacyTier) => {
       setClassification(tier);
-      changeClassification(tier);
+      void changeClassification(tier).then((revertTo) => {
+        if (revertTo != null) setClassification(revertTo);
+      });
     },
     [changeClassification, setClassification],
   );

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
@@ -273,6 +273,101 @@ describe('JournalEntryScreen — classification on first create (#896)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 2c. Persistence — PATCH failure surfaces the error and reverts the selection
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — tier change PATCH failure', () => {
+  it('surfaces the save-error hint and reverts to the persisted tier when the PATCH rejects', async () => {
+    jest.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue(entry({ id: 7, classification: 'personal' }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+      mockUpdate.mockRejectedValueOnce(new Error('network'));
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(getByTestId('journal-save-hint').props.children).toBe(
+        "Couldn't save — keep writing, we'll retry",
+      );
+      const page = within(getByTestId('journal-page'));
+      expect(page.getByTestId('privacy-tier-personal').props.accessibilityState.selected).toBe(
+        true,
+      );
+      expect(page.getByTestId('privacy-tier-intimate').props.accessibilityState.selected).toBe(
+        false,
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps the new tier selected with no error hint when the PATCH succeeds', async () => {
+    jest.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue(entry({ id: 7, classification: 'personal' }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(
+        within(getByTestId('journal-page')).getByTestId('privacy-tier-intimate').props
+          .accessibilityState.selected,
+      ).toBe(true);
+      expect(getByTestId('journal-save-hint').props.children).not.toBe(
+        "Couldn't save — keep writing, we'll retry",
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not revert a superseding change when the earlier PATCH rejects', async () => {
+    jest.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue(entry({ id: 7, classification: 'personal' }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+      // First PATCH (intimate) rejects; the superseding one (public) resolves.
+      mockUpdate.mockRejectedValueOnce(new Error('network'));
+
+      const page = within(getByTestId('journal-page'));
+      fireEvent.press(page.getByTestId('privacy-tier-intimate'));
+      fireEvent.press(page.getByTestId('privacy-tier-public'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(page.getByTestId('privacy-tier-public').props.accessibilityState.selected).toBe(true);
+      expect(page.getByTestId('privacy-tier-personal').props.accessibilityState.selected).toBe(
+        false,
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 3. Load reflects server value
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Changing the privacy tier on an existing journal entry fired a fire-and-forget `journal.update(id, { classification })`. If that PATCH failed, the control kept showing the new tier (e.g. `intimate`) while the server retained the old one (e.g. `personal`) — a privacy divergence: on reload the entry reverts to the server value and could then surface in AI passes, with no error feedback (unlike the body-save path, which sets `saveState('error')`).

This makes `changeClassification` async and threads the result back through the existing autosave error surface:
- On PATCH failure it calls `setSaveState('error')`, reusing the same "Couldn't save…" hint the body-save path shows — the failure is no longer silently discarded.
- It resolves to the prior tier so `onChangeClassification` reverts the optimistic selection to the persisted truth — the control no longer misrepresents the server state.
- A superseding change is guarded: if a later tier change has already moved the ref, a stale earlier rejection resolves `null` and does not clobber the newer selection. The single-in-flight-PATCH assumption (and the deferred double-failure concurrency case) is documented inline.

Frontend-only; no backend, API, or dependency changes.

## Test plan
- New `JournalEntryScreenPrivacy` describe block "tier change PATCH failure":
  - rejected PATCH surfaces the error hint and reverts the control to the persisted tier;
  - successful PATCH keeps the new selection with no error hint;
  - a superseding change is not reverted when the earlier PATCH rejects.
- `scripts/frontend/check-all.sh` green (ESLint, prettier, tsc, 2734 tests).

Closes #1026
Refs #893, #896