### PR TITLE
feat(backend): surface local crisis care for intimate entries in acute distress

### DIFF
--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -490,13 +490,19 @@ _INTIMATE_PRIVATE_MESSAGE = (
 )
 
 
-async def _private_response(session: AsyncSession, user_id: int) -> ResonanceResponse:
+async def _private_response(
+    session: AsyncSession, user_id: int, care: CareResponse | None
+) -> ResonanceResponse:
     """Resonance response for an intimate entry: no cloud call, no charge.
 
     An ``intimate`` entry is never sent to a cloud LLM (issue #895), so this is
     returned *before* any wallet deduction or LLM construction: no marginalia,
     no suggestions, unspent balances (read fresh, like :func:`_care_only_response`,
     with no ``preflight_deduction``), and the non-shaming private message.
+
+    ``care`` is the locally-screened surface (never None-forced): a distressed
+    intimate entry still points to human/professional support, with no cloud
+    call, charge, or usage-log — the privacy floor never suppresses crisis care.
     """
     user = await require_user_fresh(session, user_id)
     return ResonanceResponse(
@@ -505,7 +511,7 @@ async def _private_response(session: AsyncSession, user_id: int) -> ResonanceRes
         remaining_messages=max(get_monthly_cap() - user.monthly_messages_used, 0),
         remaining_balance=user.offering_balance,
         monthly_reset_date=user.monthly_reset_date,
-        care=None,
+        care=care,
         private=True,
         private_message=_INTIMATE_PRIVATE_MESSAGE,
     )
@@ -671,13 +677,14 @@ async def run_resonance(
         raise not_found("journal_entry")
     # Privacy floor (issue #895): an intimate entry is NEVER sent to a cloud LLM.
     # Decided from the *persisted* classification (never client-supplied) and
-    # returned here — before any care screen, wallet charge, LLM construction, or
-    # usage-log write — so the cloud is provably unreachable for intimate entries.
-    if entry.classification == JournalClassification.INTIMATE:
-        return await _private_response(session, current_user)
-    # Screen first, with a pure/local check that can't fail the request, so the
-    # care surface is decided independently of the LLM (NORTH-STAR §10).
+    # returned here — before wallet charge, LLM construction, or usage-log write —
+    # so the cloud is provably unreachable for intimate entries. The LOCAL care
+    # screen (pure; no cloud/charge/log) still runs, so the privacy floor never
+    # suppresses crisis support (NORTH-STAR §10) — the same screen feeds both
+    # the intimate and non-intimate paths.
     care = _care_response(_care_for(entry.message))
+    if entry.classification == JournalClassification.INTIMATE:
+        return await _private_response(session, current_user, care)
     spent = await preflight_deduction(session, current_user)
     prior = await _recent_prior_bodies(session, current_user, entry_id)
     llm = BotmasonResonanceLLM(resolve_chat_api_key(x_llm_api_key))

--- a/backend/tests/test_intimate_privacy_guard.py
+++ b/backend/tests/test_intimate_privacy_guard.py
@@ -469,3 +469,139 @@ async def test_intimate_prior_body_excluded_from_resonance_prompt(
             "``_recent_prior_bodies`` is leaking intimate sibling bodies — "
             "the ``classification != INTIMATE`` filter is missing or not applied."
         )
+
+
+# ---------------------------------------------------------------------------
+# 9. Intimate entry + acute distress: local care must still surface, zero cloud
+# ---------------------------------------------------------------------------
+
+# A known elevated trigger for domain.safety.assess_distress.
+_DISTRESS_BODY = "I keep thinking I want to kill myself and end my life tonight."
+
+
+def _assert_local_care_shape(care: dict[str, object]) -> None:
+    """Assert the care payload carries the human + professional pointers."""
+    resources = care["resources"]
+    assert isinstance(resources, list)
+    kinds = {r["kind"] for r in resources if isinstance(r, dict)}
+    assert {"hotline", "text_line", "human", "professional"} <= kinds
+    blob = str(care).lower()
+    assert "988" in blob
+    assert "741741" in blob
+    assert "trust" in blob
+    assert "professional" in blob
+
+
+@pytest.mark.asyncio
+async def test_intimate_distress_surfaces_local_care_zero_cloud(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An intimate + distressed entry still gets the local care surface, zero cloud calls."""
+    spy = _SpyLLM()
+    monkeypatch.setattr(marginalia_service, "generate_response", spy)
+
+    headers, _ = await _signup(async_client, "intimate_distress_care")
+    entry_id = await _create_entry(
+        async_client, headers, classification="intimate", body=_DISTRESS_BODY
+    )
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK, resp.text
+
+    body = resp.json()
+    assert body["private"] is True
+    assert body["private_message"] == _INTIMATE_PRIVATE_MESSAGE
+    assert body["marginalia"] == []
+    assert body["suggestions"] == []
+    assert body["care"] is not None, "A distressed intimate entry must still surface local care."
+    _assert_local_care_shape(body["care"])
+    assert spy.calls == 0, (
+        f"Expected 0 cloud LLM calls for a distressed intimate entry; got {spy.calls}. "
+        "The care surface must be local-only and never route through the cloud."
+    )
+
+
+@pytest.mark.asyncio
+async def test_intimate_distress_care_no_wallet_charge_no_usage_log(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A distressed intimate entry's care surface still charges nothing and logs nothing."""
+    spy = _SpyLLM()
+    monkeypatch.setattr(marginalia_service, "generate_response", spy)
+
+    headers, email = await _signup(async_client, "intimate_distress_wallet")
+    entry_id = await _create_entry(
+        async_client, headers, classification="intimate", body=_DISTRESS_BODY
+    )
+
+    user_before = (
+        await db_session.execute(select(User).where(col(User.email) == email))
+    ).scalar_one()
+    messages_before = user_before.monthly_messages_used
+    balance_before = user_before.offering_balance
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    assert resp.json()["care"] is not None, "Care must surface even though nothing is charged."
+
+    await db_session.refresh(user_before)
+    assert user_before.monthly_messages_used == messages_before, (
+        "monthly_messages_used must not increase for a distressed intimate entry."
+    )
+    assert user_before.offering_balance == balance_before, (
+        "offering_balance must not decrease for a distressed intimate entry."
+    )
+
+    log_count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(LLMUsageLog)
+            .where(col(LLMUsageLog.journal_entry_id) == entry_id)
+        )
+    ).scalar_one()
+    assert log_count == 0, (
+        f"Expected 0 LLMUsageLog rows for distressed intimate entry {entry_id}; found {log_count}."
+    )
+
+
+@pytest.mark.asyncio
+async def test_intimate_denial_gets_no_care(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit denial in an intimate entry must not false-trigger the care surface."""
+    spy = _SpyLLM()
+    monkeypatch.setattr(marginalia_service, "generate_response", spy)
+
+    headers, _ = await _signup(async_client, "intimate_denial")
+    entry_id = await _create_entry(
+        async_client, headers, classification="intimate", body="I would never kill myself"
+    )
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK, resp.text
+
+    body = resp.json()
+    assert body["private"] is True
+    assert body["care"] is None, "A negated denial must not surface the care screen."
+    assert spy.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_intimate_non_distress_unchanged(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A calm intimate entry is unchanged: private stub, no care, exact copy."""
+    spy = _SpyLLM()
+    monkeypatch.setattr(marginalia_service, "generate_response", spy)
+
+    headers, _ = await _signup(async_client, "intimate_calm")
+    entry_id = await _create_entry(async_client, headers, classification="intimate")
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK, resp.text
+
+    body = resp.json()
+    assert body["private"] is True
+    assert body["care"] is None
+    assert body["private_message"] == _INTIMATE_PRIVATE_MESSAGE
+    assert spy.calls == 0


### PR DESCRIPTION
## Summary

An intimate journal entry short-circuits to `_private_response` in `run_resonance` *before* any cloud call, wallet charge, or usage-log write — the privacy floor from #895 (intimate entries are never sent to a cloud LLM). That short-circuit returned `care=None`, so a user in acute distress who marked their entry intimate got **no crisis-care surface** — a gap against NORTH-STAR §10 ("never leave someone alone in a crisis") on exactly the entries where distress is most likely to be written.

This wires the **pure, local** distress screen into the intimate path: `run_resonance` now computes `care = _care_response(_care_for(entry.message))` *before* the intimate short-circuit and passes it into `_private_response`, which attaches it to the private response on an `elevated` signal. The screen (`domain.safety.assess_distress`) is stdlib-only and negation-aware (per the merged #1005 fix — denials like "I would never kill myself" do not flag), and the care payload (`domain.care.build_care_payload`) is built from reviewable module constants and this entry alone.

The #895 privacy guarantee is fully preserved: no cloud is reachable, no wallet is charged, and no `LLMUsageLog` row is written for an intimate entry — the care surface is local-only. The same screen now feeds both the intimate and non-intimate paths.

## Test plan

Added 4 tests to `backend/tests/test_intimate_privacy_guard.py`:
- `test_intimate_distress_surfaces_local_care_zero_cloud` — distressed intimate entry returns the care surface (988 / 741741 / trusted-human / professional pointers) with `spy.calls == 0`.
- `test_intimate_distress_care_no_wallet_charge_no_usage_log` — care surfaces yet `monthly_messages_used` / `offering_balance` are unchanged and zero `LLMUsageLog` rows are written.
- `test_intimate_denial_gets_no_care` — an explicit denial does not false-trigger the care surface.
- `test_intimate_non_distress_unchanged` — a calm intimate entry is unchanged (private stub, no care, exact copy).

Full backend `check-all.sh` passes (2160 passed, 96% coverage, exit 0); xenon/radon A-grade; Gate 2.5 self-review verdict CLEAN.

Refs #895, #887, #891
Closes #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)