### PR TITLE
refactor(frontend): unify PrivacyTier onto canonical JournalClassification

### DIFF
--- a/frontend/src/api/__tests__/privacySchemas.test.ts
+++ b/frontend/src/api/__tests__/privacySchemas.test.ts
@@ -2,20 +2,10 @@
 /* global describe, it, expect */
 
 /**
- * RED tests for the ``classification`` field on ``journalMessageSchema`` and
- * the ``private`` / ``private_message`` fields on ``resonanceResponseSchema``
- * (issue #896).
- *
- * These tests will fail until the implementation-specialist adds:
- * - ``classification`` (z.enum(['public','personal','intimate']).optional()) to
- *   ``journalMessageSchema`` in ``frontend/src/api/schemas.ts``.
- * - ``private`` (z.boolean().optional()) and
- *   ``private_message`` (z.string().nullish()) to ``resonanceResponseSchema``.
- * - The matching TypeScript fields on ``JournalMessage``, ``JournalMessageCreate``,
- *   ``JournalEntryUpdate``, and ``ResonanceResponse`` in ``frontend/src/api/index.ts``.
- *
- * The zod tests here are additive / non-breaking: a response WITHOUT the new
- * fields must still parse (backward-compat), and one WITH them must round-trip.
+ * Verifies that the ``classification`` field on ``journalMessageSchema`` and the
+ * ``private`` / ``private_message`` fields on ``resonanceResponseSchema`` parse
+ * correctly. The fields are backward-compatible: payloads without them still
+ * parse, and payloads with them round-trip.
  */
 import { journalMessageSchema, resonanceResponseSchema } from '../schemas';
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1090,6 +1090,7 @@ export type JournalTag = 'freeform' | 'stage_reflection' | 'practice_note' | 'ha
  * Privacy classification for a journal entry (mirrors the backend enum). An
  * ``intimate`` entry is never sent to AI: resonance is client-side gated off
  * for it. ``personal`` is the backend default; ``public`` is the most open.
+ * This is the canonical privacy-tier type; UI aliases (``PrivacyTier``) point here.
  */
 export type JournalClassification = 'public' | 'personal' | 'intimate';
 

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -28,7 +28,7 @@ import HighlightedBody from './HighlightedBody';
 import styles from './JournalEntry.styles';
 import MarginNote from './MarginNote';
 import { useSettleIn } from './motion';
-import PrivacyTierControl, { type PrivacyTier } from './PrivacyTierControl';
+import PrivacyTierControl, { DEFAULT_TIER } from './PrivacyTierControl';
 import ResonanceEssayModal from './ResonanceEssayModal';
 import { useResonance } from './useResonance';
 
@@ -52,9 +52,6 @@ export const AUTOSAVE_DELAY_MS = 1500;
 
 /** Below this width the margin column stacks under the writing column. */
 const NARROW_BREAKPOINT = 600;
-
-/** Backend default privacy tier for a fresh entry. */
-const DEFAULT_CLASSIFICATION: JournalClassification = 'personal';
 
 /** Fallback reason shown when resonance is gated off for an intimate entry. */
 const INTIMATE_RESONANCE_REASON = 'Intimate entries are kept private — resonance is paused.';
@@ -143,11 +140,11 @@ interface AutosaveApi {
   setStatus: (_status: EntryStatus) => void;
   saveState: SaveState;
   /** The entry's privacy tier; drives the control and the resonance gate. */
-  classification: PrivacyTier;
+  classification: JournalClassification;
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
   /** Set the privacy tier: updates the control and persists (create/PATCH). */
-  onChangeClassification: (_tier: PrivacyTier) => void;
+  onChangeClassification: (_tier: JournalClassification) => void;
   /** Persist the latest text immediately and resolve to the entry id (or null). */
   flush: () => Promise<number | null>;
   /** Set when loading an existing entry failed; drives the banner + autosave gate. */
@@ -207,7 +204,7 @@ interface ClassificationPersist {
 function useClassificationPersist(
   entryIdRef: React.MutableRefObject<number | null>,
 ): ClassificationPersist {
-  const classificationRef = useRef<JournalClassification>(DEFAULT_CLASSIFICATION);
+  const classificationRef = useRef<JournalClassification>(DEFAULT_TIER);
   const changeClassification = useCallback(
     async (tier: JournalClassification): Promise<JournalClassification | null> => {
       const previous = classificationRef.current;
@@ -364,8 +361,8 @@ interface EntryState {
   body: string;
   status: EntryStatus;
   setStatus: (_status: EntryStatus) => void;
-  classification: PrivacyTier;
-  setClassification: (_tier: PrivacyTier) => void;
+  classification: JournalClassification;
+  setClassification: (_tier: JournalClassification) => void;
   setTitle: (_v: string) => void;
   setBody: (_v: string) => void;
   titleRef: StrRef;
@@ -379,7 +376,7 @@ function useEntryState(routeEntryId: number | null, initialTitle: string): Entry
   const [title, setTitle] = useState(initialTitle);
   const [body, setBody] = useState('');
   const [status, setStatus] = useState<EntryStatus>('draft');
-  const [classification, setClassification] = useState<PrivacyTier>(DEFAULT_CLASSIFICATION);
+  const [classification, setClassification] = useState<JournalClassification>(DEFAULT_TIER);
   const [loadError, setLoadError] = useState<string | null>(null);
   // Refs mirror the latest text so the change handlers stay referentially stable.
   const titleRef = useRef(initialTitle);
@@ -394,7 +391,7 @@ function useEntryState(routeEntryId: number | null, initialTitle: string): Entry
       setBody(bodyRef.current);
       setStatus(entry.status ?? 'draft');
       // Pre-select the server's tier so an intimate entry loads intimate.
-      setClassification(entry.classification ?? DEFAULT_CLASSIFICATION);
+      setClassification(entry.classification ?? DEFAULT_TIER);
     }, []),
     useCallback(() => setLoadError(LOAD_ERROR_MESSAGE), []),
   );
@@ -447,7 +444,7 @@ function useJournalAutosave(
   // a failed PATCH resolves to the prior tier so the control reverts to the truth,
   // unless a later change superseded it (then it resolves null and we keep that).
   const onChangeClassification = useCallback(
-    (tier: PrivacyTier) => {
+    (tier: JournalClassification) => {
       setClassification(tier);
       void changeClassification(tier).then((revertTo) => {
         if (revertTo != null) setClassification(revertTo);
@@ -475,10 +472,10 @@ interface WritingColumnProps {
   title: string;
   body: string;
   saveState: SaveState;
-  classification: PrivacyTier;
+  classification: JournalClassification;
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
-  onChangeClassification: (_tier: PrivacyTier) => void;
+  onChangeClassification: (_tier: JournalClassification) => void;
   onFinish?: () => void;
   bodyPlaceholder?: string;
 }
@@ -742,7 +739,7 @@ interface ResonanceGateArgs {
   isIdle: boolean;
   isLoading: boolean;
   body: string;
-  classification: PrivacyTier;
+  classification: JournalClassification;
   isPromptCompose: boolean;
   privateMessage: string | null;
 }

--- a/frontend/src/features/Journal/PrivacyTierControl.tsx
+++ b/frontend/src/features/Journal/PrivacyTierControl.tsx
@@ -15,11 +15,13 @@ import { Text, TouchableOpacity, View } from 'react-native';
 
 import styles from './JournalEntry.styles';
 
-/** Privacy tier for a journal entry (mirrors the backend classification enum). */
-export type PrivacyTier = 'public' | 'personal' | 'intimate';
+import type { JournalClassification } from '@/api';
 
-/** The backend default tier, used when no ``value`` is supplied. */
-const DEFAULT_TIER: PrivacyTier = 'personal';
+/** Privacy tier for a journal entry; alias of the canonical API type. */
+export type PrivacyTier = JournalClassification;
+
+/** The shared default privacy tier, used when no ``value`` is supplied. */
+export const DEFAULT_TIER: PrivacyTier = 'personal';
 
 /** One-line copy shown under the control when ``intimate`` is selected. */
 const INTIMATE_EXPLAINER = 'Intimate entries are never sent to AI.';

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
@@ -4,15 +4,10 @@ import { act, fireEvent, render, waitFor, within } from '@testing-library/react-
 import React from 'react';
 
 /**
- * RED tests for privacy classification control in JournalEntryScreen (#896).
- *
- * Failures until the implementation-specialist:
- * 1. Creates ``PrivacyTierControl`` and mounts it in ``WritingColumn``.
- * 2. Adds ``classification`` to ``JournalMessageCreate``, ``JournalEntryUpdate``,
- *    ``JournalMessage``, and ``ResonanceResponse`` in ``frontend/src/api/index.ts``.
- * 3. Passes ``classification`` through ``useJournalAutosave`` / ``writeEntry``.
- * 4. Wires ``GetResonanceButton disabled`` when ``classification === 'intimate'``
- *    and shows ``privacy-resonance-reason`` text.
+ * Verifies the privacy classification wiring in ``JournalEntryScreen``:
+ * ``PrivacyTierControl`` is mounted in the writing column, the chosen
+ * classification persists through autosave / create / update, and resonance is
+ * gated off for intimate entries.
  */
 import type { JournalMessage, ResonanceResponse } from '@/api';
 import { DEFAULT_IDLE_DELAY_MS } from '@/hooks/useIdle';

--- a/frontend/src/features/Journal/__tests__/PrivacyTierControl.test.tsx
+++ b/frontend/src/features/Journal/__tests__/PrivacyTierControl.test.tsx
@@ -8,12 +8,7 @@ import PrivacyTierControl, { type PrivacyTier } from '../PrivacyTierControl';
 import { touchTarget } from '@/design/tokens';
 
 /**
- * RED tests for ``PrivacyTierControl`` (issue #896).
- *
- * These tests fail until the implementation-specialist creates
- * ``frontend/src/features/Journal/PrivacyTierControl.tsx``.
- *
- * Design requirements (from the chief architect):
+ * Verifies ``PrivacyTierControl`` behavior:
  * - 3-option segmented control: public / personal / intimate.
  * - Default selection when no ``value`` is supplied is ``personal``.
  * - Each option exposes ``accessibilityState.selected`` truthily.


### PR DESCRIPTION
## Summary
Non-blocking follow-ups from the #1025 (#896) code review, frontend-only:

- **Unified the duplicate union type.** `PrivacyTierControl.tsx` previously
  redefined `PrivacyTier = 'public' | 'personal' | 'intimate'`, identical to
  `JournalClassification` in `api/index.ts`. `JournalClassification` is now the
  single canonical type (it mirrors the backend enum); `PrivacyTierControl`
  re-exports it as a type-only `PrivacyTier` alias, and `JournalEntryScreen`
  standardizes all its type references on `JournalClassification`.
- **Collapsed the duplicated default constant.** `DEFAULT_TIER`
  (`PrivacyTierControl.tsx`) and `DEFAULT_CLASSIFICATION`
  (`JournalEntryScreen.tsx`) — both `'personal'` — become a single exported
  `DEFAULT_TIER` shared by the control and the screen.
- **Refreshed stale RED-test doc-comment headers.** The "these tests will fail
  until the implementation-specialist adds…" headers in
  `JournalEntryScreenPrivacy.test.tsx`, `privacySchemas.test.ts`, and
  `PrivacyTierControl.test.tsx` now describe the behavior the (green) tests
  verify. The issue named the first two; the third carried the identical stale
  header and was folded in for consistency.

No runtime behavior changes.

## Test plan
- `scripts/frontend/check-all.sh` exits 0 (ESLint, Prettier, tsc, Jest).
- Full Jest suite: 273 suites / 2734 tests pass.
- `tsc --noEmit` clean; the `PrivacyTier` export name is preserved (type-only
  alias) so `PrivacyTierControl.test.tsx`'s import still resolves and existing
  `jest.mock('@/api', …)` mocks are unaffected.

Closes #1027
Refs #896, #893