### PR TITLE
docs: repoint Candle & Ink DESIGN.md pointer to implemented design doc

### DIFF
--- a/.claude/agents/shared/adepthood-constraints.md
+++ b/.claude/agents/shared/adepthood-constraints.md
@@ -10,8 +10,10 @@ Adepthood is a **journal-first PKM** built on **graduated engagement** — "you
 choose your depth." Nothing is gated or mandatory; deeper rings surface only as
 resonant, one-tap-declinable invitations. **No gamified pressure** — no
 streak-shame, no guilt mechanics, no dark patterns. The thesis lives in
-`NORTH-STAR.md`; the visual direction ("Candle & Ink") in `DESIGN.md`; the
-development philosophy in `AGENTS.md`. Build accordingly.
+`NORTH-STAR.md`; the visual direction ("Candle & Ink") and implemented design
+system in `frontend/src/design/DESIGN.md` (root `DESIGN.md` is the external
+inspiration reference — a marketing-site aesthetic analysis, not the build
+target); the development philosophy in `AGENTS.md`. Build accordingly.
 
 ## The stack
 


### PR DESCRIPTION
## Summary

`.claude/agents/shared/adepthood-constraints.md` pointed the "Candle & Ink" visual direction at root `DESIGN.md` — which is actually the external marketing-site aesthetic analysis, not the build target. This repoints it to `frontend/src/design/DESIGN.md` (the implemented design system) and reframes root `DESIGN.md` as the external inspiration reference, matching how `CLAUDE.md` already describes the distinction.

Surfaced during #905 (root DESIGN.md reconcile) but was out of that issue's stated scope, so it was split out here.

## Test plan

Docs-only change to a single Markdown pointer; no code behavior affected.
- Verified `frontend/src/design/DESIGN.md` exists as the canonical design doc.
- `pre-commit run` (hygiene/detect-secrets/commitlint) passes on the changed file.
- Gate 2.5 self-review (code-review-orchestrator): CLEAN.

Closes #1034
Refs #903, #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)