### PR TITLE
feat(full-stack): chord journaling — tag an entry with a primary + optional secondary Aspect

### DIFF
--- a/backend/migrations/versions/a5b6c7d8e9f0_add_journalentry_chord_aspects.py
+++ b/backend/migrations/versions/a5b6c7d8e9f0_add_journalentry_chord_aspects.py
@@ -1,0 +1,66 @@
+"""Add journalentry chord aspects (primary + optional secondary).
+
+Revision ID: a5b6c7d8e9f0
+Revises: c9d0e1f2a3b4
+Create Date: 2026-07-01 00:00:00.000000
+
+Adds two nullable columns, ``primary_aspect`` and ``secondary_aspect``, plus the
+range and chord-shape CHECKs mirroring the model's ``__table_args__``. ``upgrade``
+adds the columns (nullable, no backfill needed) then installs the CHECKs in a
+batch rebuild so SQLite (round-trip test) stays compatible. ``downgrade`` drops
+the CHECKs then the columns.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from domain.constants import TOTAL_STAGES
+
+# revision identifiers, used by Alembic.
+revision: str = "a5b6c7d8e9f0"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "c9d0e1f2a3b4"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# The inclusive lower bound of a valid Aspect; the upper bound is TOTAL_STAGES so
+# the persisted range never drifts from the curriculum length. Conditions below
+# are IDENTICAL to the model's ``__table_args__`` CHECKs.
+_ASPECT_MIN = 1
+_PRIMARY_RANGE_CHECK = "ck_journalentry_primary_aspect_range"
+_SECONDARY_RANGE_CHECK = "ck_journalentry_secondary_aspect_range"
+_CHORD_SHAPE_CHECK = "ck_journalentry_chord_shape"
+_PRIMARY_RANGE_CONDITION = (
+    f"primary_aspect IS NULL OR primary_aspect BETWEEN {_ASPECT_MIN} AND {TOTAL_STAGES}"
+)
+_SECONDARY_RANGE_CONDITION = (
+    f"secondary_aspect IS NULL OR secondary_aspect BETWEEN {_ASPECT_MIN} AND {TOTAL_STAGES}"
+)
+_CHORD_SHAPE_CONDITION = (
+    "secondary_aspect IS NULL "
+    "OR (primary_aspect IS NOT NULL AND secondary_aspect != primary_aspect)"
+)
+
+
+def upgrade() -> None:
+    """Add the two nullable chord columns + the range and chord-shape CHECKs."""
+    op.add_column("journalentry", sa.Column("primary_aspect", sa.Integer(), nullable=True))
+    op.add_column("journalentry", sa.Column("secondary_aspect", sa.Integer(), nullable=True))
+    # Install the CHECKs in a single batch rebuild so SQLite (round-trip test)
+    # stays compatible.
+    with op.batch_alter_table("journalentry") as batch_op:
+        batch_op.create_check_constraint(_PRIMARY_RANGE_CHECK, _PRIMARY_RANGE_CONDITION)
+        batch_op.create_check_constraint(_SECONDARY_RANGE_CHECK, _SECONDARY_RANGE_CONDITION)
+        batch_op.create_check_constraint(_CHORD_SHAPE_CHECK, _CHORD_SHAPE_CONDITION)
+
+
+def downgrade() -> None:
+    """Drop the chord CHECKs and the two columns."""
+    # Batch mode keeps the downgrade SQLite-compatible (no ALTER/DROP CHECK there).
+    with op.batch_alter_table("journalentry") as batch_op:
+        batch_op.drop_constraint(_CHORD_SHAPE_CHECK, type_="check")
+        batch_op.drop_constraint(_SECONDARY_RANGE_CHECK, type_="check")
+        batch_op.drop_constraint(_PRIMARY_RANGE_CHECK, type_="check")
+        batch_op.drop_column("secondary_aspect")
+        batch_op.drop_column("primary_aspect")

--- a/backend/migrations/versions/a5b6c7d8e9f0_add_journalentry_chord_aspects.py
+++ b/backend/migrations/versions/a5b6c7d8e9f0_add_journalentry_chord_aspects.py
@@ -16,26 +16,30 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-from domain.constants import TOTAL_STAGES
-
 # revision identifiers, used by Alembic.
 revision: str = "a5b6c7d8e9f0"  # pragma: allowlist secret
 down_revision: str | Sequence[str] | None = "c9d0e1f2a3b4"  # pragma: allowlist secret
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-# The inclusive lower bound of a valid Aspect; the upper bound is TOTAL_STAGES so
-# the persisted range never drifts from the curriculum length. Conditions below
-# are IDENTICAL to the model's ``__table_args__`` CHECKs.
+# A migration is a frozen historical snapshot and must be self-contained: it
+# cannot import live application code (``domain.constants``), because Alembic's
+# ScriptDirectory loads every revision module without the app's ``src`` on the
+# path, and a later curriculum change must never retroactively alter this file's
+# SQL. So the Aspect bounds are inlined literals here. ``_ASPECT_MIN`` is the
+# inclusive lower bound and ``_ASPECT_MAX`` mirrors ``TOTAL_STAGES`` (== 10) as
+# of this revision. Conditions below are IDENTICAL to the model's
+# ``__table_args__`` CHECKs; the model derives its bound from ``TOTAL_STAGES``.
 _ASPECT_MIN = 1
+_ASPECT_MAX = 10
 _PRIMARY_RANGE_CHECK = "ck_journalentry_primary_aspect_range"
 _SECONDARY_RANGE_CHECK = "ck_journalentry_secondary_aspect_range"
 _CHORD_SHAPE_CHECK = "ck_journalentry_chord_shape"
 _PRIMARY_RANGE_CONDITION = (
-    f"primary_aspect IS NULL OR primary_aspect BETWEEN {_ASPECT_MIN} AND {TOTAL_STAGES}"
+    f"primary_aspect IS NULL OR primary_aspect BETWEEN {_ASPECT_MIN} AND {_ASPECT_MAX}"
 )
 _SECONDARY_RANGE_CONDITION = (
-    f"secondary_aspect IS NULL OR secondary_aspect BETWEEN {_ASPECT_MIN} AND {TOTAL_STAGES}"
+    f"secondary_aspect IS NULL OR secondary_aspect BETWEEN {_ASPECT_MIN} AND {_ASPECT_MAX}"
 )
 _CHORD_SHAPE_CONDITION = (
     "secondary_aspect IS NULL "

--- a/backend/src/domain/wheel.py
+++ b/backend/src/domain/wheel.py
@@ -5,18 +5,41 @@ engaged the user is (habits, practice, course), reusing the same
 ``overall_progress`` signal the stage list already computes. Items are always
 returned in canonical stage order (1..10), never sorted by fullness, so the
 frontend can lay them out on a fixed wheel.
+
+Chord-tag weighting: a stage's chord tags nudge its fullness upward. Each
+primary tag on a stage is worth ``WHEEL_PRIMARY_TAG_WEIGHT`` and each secondary
+tag ``WHEEL_SECONDARY_TAG_WEIGHT``; their weighted sum per stage is
+``weighted = WHEEL_PRIMARY_TAG_WEIGHT * n_primary + WHEEL_SECONDARY_TAG_WEIGHT
+* n_secondary``. That count is normalized against ``WHEEL_CHORD_SATURATION_TAGS``
+and scaled by ``WHEEL_CHORD_SIGNAL_CAP`` to yield ``chord_signal =
+WHEEL_CHORD_SIGNAL_CAP * min(weighted / WHEEL_CHORD_SATURATION_TAGS, 1.0)``,
+which saturates at the cap. Final fullness is ``min(overall_progress +
+chord_signal, 1.0)``. Only non-deleted entries count, across all
+classifications — the wheel is the user's own private aggregate. With no tagged
+entries ``chord_signal`` is exactly ``0.0``, so fullness equals
+``overall_progress``.
 """
 
 from __future__ import annotations
 
 from typing import TypedDict
 
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from domain.constants import TOTAL_STAGES
 from domain.stage_progress import compute_stage_progress_batch
 from models.course_stage import CourseStage
+from models.journal_entry import JournalEntry
+
+# Per-tag weights: a primary Aspect carries full weight, a secondary half.
+WHEEL_PRIMARY_TAG_WEIGHT = 1.0
+WHEEL_SECONDARY_TAG_WEIGHT = 0.5
+# The most a stage's chord tags can add to its fullness, and the weighted tag
+# count at which that cap is reached.
+WHEEL_CHORD_SIGNAL_CAP = 0.2
+WHEEL_CHORD_SATURATION_TAGS = 10.0
 
 
 class WheelItem(TypedDict):
@@ -39,14 +62,77 @@ async def _aspect_labels_by_stage(
     return {row.stage_number: row.aspect for row in result.all()}
 
 
+async def _primary_aspect_counts(session: AsyncSession, user_id: int) -> dict[int, int]:
+    """Count non-deleted entries per stage tagged with that stage as primary.
+
+    One ``GROUP BY`` aggregate over ``primary_aspect`` (no per-stage loop).
+    """
+    result = await session.execute(
+        select(JournalEntry.primary_aspect, func.count())
+        .where(
+            JournalEntry.user_id == user_id,
+            col(JournalEntry.deleted_at).is_(None),
+            col(JournalEntry.primary_aspect).is_not(None),
+        )
+        .group_by(col(JournalEntry.primary_aspect))
+    )
+    return {row[0]: row[1] for row in result.all()}
+
+
+async def _secondary_aspect_counts(session: AsyncSession, user_id: int) -> dict[int, int]:
+    """Count non-deleted entries per stage tagged with that stage as secondary.
+
+    One ``GROUP BY`` aggregate over ``secondary_aspect`` (no per-stage loop).
+    """
+    result = await session.execute(
+        select(JournalEntry.secondary_aspect, func.count())
+        .where(
+            JournalEntry.user_id == user_id,
+            col(JournalEntry.deleted_at).is_(None),
+            col(JournalEntry.secondary_aspect).is_not(None),
+        )
+        .group_by(col(JournalEntry.secondary_aspect))
+    )
+    return {row[0]: row[1] for row in result.all()}
+
+
+async def _chord_tag_weighted_counts(session: AsyncSession, user_id: int) -> dict[int, float]:
+    """Return ``{stage_number: weighted_tag_count}`` for the user's chord tags.
+
+    ``weighted = WHEEL_PRIMARY_TAG_WEIGHT * n_primary + WHEEL_SECONDARY_TAG_WEIGHT
+    * n_secondary`` per stage, over non-deleted entries only, using two constant
+    grouped-count queries (no N+1).
+    """
+    primary = await _primary_aspect_counts(session, user_id)
+    secondary = await _secondary_aspect_counts(session, user_id)
+    weighted: dict[int, float] = {}
+    for stage, count in primary.items():
+        weighted[stage] = weighted.get(stage, 0.0) + WHEEL_PRIMARY_TAG_WEIGHT * count
+    for stage, count in secondary.items():
+        weighted[stage] = weighted.get(stage, 0.0) + WHEEL_SECONDARY_TAG_WEIGHT * count
+    return weighted
+
+
+def _chord_signal(weighted: float) -> float:
+    """Scale a stage's weighted tag count into its capped fullness lift."""
+    return WHEEL_CHORD_SIGNAL_CAP * min(weighted / WHEEL_CHORD_SATURATION_TAGS, 1.0)
+
+
 async def compute_wheel_balance(session: AsyncSession, user_id: int) -> list[WheelItem]:
     """Return per-Aspect fullness for all ten stages in canonical order.
 
-    Each item is ``{"stage_number", "aspect", "fullness"}``. ``fullness`` is the
-    stage's ``overall_progress`` from :func:`compute_stage_progress_batch` (a
-    single batched pass, no N+1); ``aspect`` is the stage's label from
-    ``CourseStage``. Stages with no engagement report ``0.0``. Ordering follows
-    ``stage_number`` ascending regardless of fullness.
+    Each item is ``{"stage_number", "aspect", "fullness"}``. ``fullness`` blends
+    the stage's ``overall_progress`` from :func:`compute_stage_progress_batch` (a
+    single batched pass, no N+1) with a capped chord-tag signal:
+    ``fullness = min(overall_progress + chord_signal, 1.0)`` where
+    ``chord_signal = WHEEL_CHORD_SIGNAL_CAP * min(weighted /
+    WHEEL_CHORD_SATURATION_TAGS, 1.0)`` and ``weighted =
+    WHEEL_PRIMARY_TAG_WEIGHT * n_primary + WHEEL_SECONDARY_TAG_WEIGHT *
+    n_secondary`` over the user's non-deleted tagged entries. With no chord tags
+    ``chord_signal`` is exactly ``0.0``, so fullness equals ``overall_progress``.
+    ``aspect`` is the stage's label from ``CourseStage``; stages with no
+    engagement report ``0.0``. Ordering follows ``stage_number`` ascending
+    regardless of fullness.
 
     ``aspect`` falls back to ``""`` only if a ``CourseStage`` row is absent for a
     stage in 1..10 — a misconfigured-seed sentinel; the seeder guarantees all ten.
@@ -54,11 +140,16 @@ async def compute_wheel_balance(session: AsyncSession, user_id: int) -> list[Whe
     stage_numbers = list(range(1, TOTAL_STAGES + 1))
     batch = await compute_stage_progress_batch(session, user_id, stage_numbers)
     aspects = await _aspect_labels_by_stage(session, stage_numbers)
+    weighted_counts = await _chord_tag_weighted_counts(session, user_id)
     return [
         {
             "stage_number": stage_number,
             "aspect": aspects.get(stage_number, ""),
-            "fullness": float(batch[stage_number]["overall_progress"]),
+            "fullness": min(
+                float(batch[stage_number]["overall_progress"])
+                + _chord_signal(weighted_counts.get(stage_number, 0.0)),
+                1.0,
+            ),
         }
         for stage_number in stage_numbers
     ]

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -5,7 +5,13 @@ from typing import TYPE_CHECKING
 from sqlalchemy import CheckConstraint, Column, DateTime, Index
 from sqlmodel import Field, Relationship, SQLModel
 
+from domain.constants import TOTAL_STAGES
 from services.journal_encryption import EncryptedString
+
+# The inclusive lower bound of a valid Aspect tag. The upper bound is
+# ``TOTAL_STAGES`` (an Aspect == a stage 1..TOTAL_STAGES), so the range never
+# drifts from the curriculum length.
+ASPECT_MIN = 1
 
 if TYPE_CHECKING:
     from .completion_suggestion import CompletionSuggestion
@@ -63,6 +69,32 @@ def _classification_check() -> CheckConstraint:
     )
 
 
+def _aspect_range_check(column: str, name: str) -> CheckConstraint:
+    """CHECK that ``column`` is NULL or a valid Aspect (1..``TOTAL_STAGES``).
+
+    The bound is derived from ``TOTAL_STAGES`` so the persisted range can't
+    drift from the curriculum length. The migration installs the identical SQL.
+    """
+    return CheckConstraint(
+        f"{column} IS NULL OR {column} BETWEEN {ASPECT_MIN} AND {TOTAL_STAGES}",
+        name=name,
+    )
+
+
+def _chord_shape_check() -> CheckConstraint:
+    """CHECK that a secondary Aspect requires a distinct primary Aspect.
+
+    A secondary tag is only meaningful atop a primary, and a chord's two notes
+    must differ — so a secondary with no primary, or one equal to the primary,
+    is rejected. The migration installs the identical SQL.
+    """
+    return CheckConstraint(
+        "secondary_aspect IS NULL "
+        "OR (primary_aspect IS NOT NULL AND secondary_aspect != primary_aspect)",
+        name="ck_journalentry_chord_shape",
+    )
+
+
 class JournalEntry(SQLModel, table=True):
     """Stores a user's journal reflection, optionally paired with an AI resonance response.
 
@@ -88,6 +120,9 @@ class JournalEntry(SQLModel, table=True):
         Index("ix_journalentry_deleted_at", "deleted_at"),
         Index("ix_journalentry_user_sender_deleted", "user_id", "sender", "deleted_at"),
         _classification_check(),
+        _aspect_range_check("primary_aspect", "ck_journalentry_primary_aspect_range"),
+        _aspect_range_check("secondary_aspect", "ck_journalentry_secondary_aspect_range"),
+        _chord_shape_check(),
     )
 
     id: int | None = Field(default=None, primary_key=True)
@@ -108,6 +143,11 @@ class JournalEntry(SQLModel, table=True):
     # Privacy tier; defaults to ``personal``. The DB CHECK in ``__table_args__``
     # pins the persisted value to the JournalClassification set.
     classification: str = Field(default=JournalClassification.PERSONAL, max_length=20)
+    # Chord tagging: an optional primary Aspect (a stage 1..TOTAL_STAGES) and an
+    # optional secondary. The CHECKs in ``__table_args__`` pin both to the valid
+    # range and enforce the chord shape (a secondary requires a distinct primary).
+    primary_aspect: int | None = Field(default=None)
+    secondary_aspect: int | None = Field(default=None)
     sender: str = Field(max_length=10)  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     tag: str = Field(default=JournalTag.FREEFORM, max_length=50)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -282,6 +282,19 @@ async def _apply_message_edit(
         await reanchor_entry_suggestions(entry, new_message, session)
 
 
+def _apply_chord_update(entry: JournalEntry, payload: JournalEntryUpdate) -> None:
+    """Apply the chord (primary/secondary Aspect) as one atomic pair.
+
+    Sending either field marks the whole chord provided: both are written, so a
+    primary-only PATCH resets a stale secondary to ``None`` (the schema default),
+    keeping the persisted pair a valid chord shape.
+    """
+    chord_fields = {"primary_aspect", "secondary_aspect"}
+    if payload.model_fields_set & chord_fields:
+        entry.primary_aspect = payload.primary_aspect
+        entry.secondary_aspect = payload.secondary_aspect
+
+
 async def _apply_entry_update(
     entry: JournalEntry, payload: JournalEntryUpdate, session: AsyncSession
 ) -> None:
@@ -293,6 +306,7 @@ async def _apply_entry_update(
         entry.status = payload.status
     if payload.classification is not None:
         entry.classification = payload.classification
+    _apply_chord_update(entry, payload)
     # ``updated_at`` is bumped by the column's ``onupdate`` only when a value
     # actually changes, so a same-value PATCH doesn't move it.
 

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -7,9 +7,32 @@ from typing import Self
 
 from pydantic import BaseModel, Field, model_validator
 
+from domain.constants import TOTAL_STAGES
 from models.journal_entry import EntryStatus, JournalClassification, JournalTag
 
 JOURNAL_MESSAGE_MAX_LENGTH = 10_000
+
+# An Aspect tag is a stage 1..TOTAL_STAGES; the bounds are derived from the
+# curriculum length so they can't drift from it.
+ASPECT_MIN = 1
+ASPECT_MAX = TOTAL_STAGES
+
+
+def _validate_chord_shape(primary: int | None, secondary: int | None) -> None:
+    """Enforce the chord shape shared by create and update payloads.
+
+    A secondary Aspect is only meaningful atop a primary, and a chord's two
+    notes must differ. Raises ``ValueError`` on a secondary with no primary, or
+    a secondary equal to the primary.
+    """
+    if secondary is None:
+        return
+    if primary is None:
+        msg = "secondary_aspect requires a primary_aspect"
+        raise ValueError(msg)
+    if secondary == primary:
+        msg = "secondary_aspect must differ from primary_aspect"
+        raise ValueError(msg)
 
 
 class JournalMessageCreate(BaseModel):
@@ -24,6 +47,13 @@ class JournalMessageCreate(BaseModel):
     classification: JournalClassification = JournalClassification.PERSONAL
     practice_session_id: int | None = None
     user_practice_id: int | None = None
+    primary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)
+    secondary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)
+
+    @model_validator(mode="after")
+    def _validate_chord(self) -> Self:
+        _validate_chord_shape(self.primary_aspect, self.secondary_aspect)
+        return self
 
 
 class JournalEntryUpdate(BaseModel):
@@ -37,13 +67,18 @@ class JournalEntryUpdate(BaseModel):
     title: str | None = Field(default=None, max_length=200)
     status: EntryStatus | None = None
     classification: JournalClassification | None = None
+    primary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)
+    secondary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)
 
     @model_validator(mode="after")
     def _require_at_least_one_field(self) -> Self:
-        provided = (self.message, self.title, self.status, self.classification)
-        if all(value is None for value in provided):
+        # An explicit null still counts as "provided" (it clears a field), so
+        # gate on whether ANY field was supplied — not on their values. This
+        # lets a PATCH that nulls the chord through while still rejecting {}.
+        if not self.model_fields_set:
             msg = "at least one field must be provided"
             raise ValueError(msg)
+        _validate_chord_shape(self.primary_aspect, self.secondary_aspect)
         return self
 
 
@@ -65,6 +100,8 @@ class JournalMessageResponse(BaseModel):
     classification: JournalClassification
     practice_session_id: int | None
     user_practice_id: int | None
+    primary_aspect: int | None = None
+    secondary_aspect: int | None = None
 
 
 class JournalListResponse(BaseModel):

--- a/backend/tests/domain/test_wheel_chord.py
+++ b/backend/tests/domain/test_wheel_chord.py
@@ -1,0 +1,287 @@
+"""Domain tests for compute_wheel_balance's chord-tag weighting."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, date, datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import JSON
+from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+from domain.stage_progress import compute_stage_progress_batch
+from domain.wheel import (
+    WHEEL_CHORD_SATURATION_TAGS,
+    WHEEL_CHORD_SIGNAL_CAP,
+    WHEEL_PRIMARY_TAG_WEIGHT,
+    WHEEL_SECONDARY_TAG_WEIGHT,
+    compute_wheel_balance,
+)
+from models.course_stage import CourseStage
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.journal_entry import JournalEntry
+from models.practice import Practice
+from models.practice_session import PracticeSession
+from models.user_practice import UserPractice
+
+_CANONICAL_ASPECTS = [
+    "Body",
+    "Body",
+    "Emotion",
+    "Emotion",
+    "Mind",
+    "Mind",
+    "Spirit",
+    "Spirit",
+    "Nondual",
+    "Nondual",
+]
+
+_TOTAL_STAGES = 10
+_USER_A = 1
+_SATURATING_TAG_COUNT = 15
+
+# The exact lift a single primary/secondary tag contributes, derived from the
+# named constants so this test binds to the real weighting, not a hardcoded number.
+_PER_PRIMARY_LIFT = WHEEL_CHORD_SIGNAL_CAP * (
+    WHEEL_PRIMARY_TAG_WEIGHT / WHEEL_CHORD_SATURATION_TAGS
+)
+_PER_SECONDARY_LIFT = WHEEL_CHORD_SIGNAL_CAP * (
+    WHEEL_SECONDARY_TAG_WEIGHT / WHEEL_CHORD_SATURATION_TAGS
+)
+
+
+def _replace_array_columns_for_sqlite() -> None:
+    """Swap PG ARRAY columns to JSON for SQLite test compatibility."""
+    for table in SQLModel.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, PG_ARRAY):
+                column.type = JSON()
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session, schema created fresh per test."""
+    _replace_array_columns_for_sqlite()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed_course_stage(s: AsyncSession, stage_number: int) -> CourseStage:
+    """Insert a CourseStage row so queries resolve."""
+    cs = CourseStage(
+        title=f"Stage {stage_number}",
+        subtitle="sub",
+        stage_number=stage_number,
+        overview_url="",
+        category="test",
+        aspect=_CANONICAL_ASPECTS[stage_number - 1],
+        spiral_dynamics_color="beige",
+        growing_up_stage="archaic",
+        divine_gender_polarity="masculine",
+        relationship_to_free_will="active",
+        free_will_description="desc",
+    )
+    s.add(cs)
+    await s.commit()
+    await s.refresh(cs)
+    return cs
+
+
+async def _seed_all_course_stages(s: AsyncSession) -> list[CourseStage]:
+    """Insert all ten CourseStage rows."""
+    return [await _seed_course_stage(s, n) for n in range(1, _TOTAL_STAGES + 1)]
+
+
+async def _seed_habit_with_completion(s: AsyncSession, user_id: int, stage_number: int) -> None:
+    """Seed one habit with one goal and one completion for the given stage."""
+    habit = Habit(
+        name=f"H-stage{stage_number}-user{user_id}",
+        icon="x",
+        start_date=date(2026, 1, 1),
+        energy_cost=1,
+        energy_return=1,
+        user_id=user_id,
+        stage=str(stage_number),
+        streak=0,
+    )
+    s.add(habit)
+    await s.commit()
+    await s.refresh(habit)
+    goal = Goal(
+        habit_id=habit.id,
+        title="g",
+        tier="t",
+        target=1,
+        target_unit="rep",
+        frequency=1,
+        frequency_unit="per_day",
+    )
+    s.add(goal)
+    await s.commit()
+    await s.refresh(goal)
+    s.add(GoalCompletion(goal_id=goal.id, user_id=user_id, completed_units=1))
+    await s.commit()
+
+
+async def _seed_practice_with_session(s: AsyncSession, user_id: int, stage_number: int) -> None:
+    """Seed a practice selection and one logged session for the given stage."""
+    practice = Practice(
+        stage_number=stage_number,
+        name=f"P-{stage_number}-{user_id}",
+        description="d",
+        instructions="i",
+        default_duration_minutes=5.0,
+        approved=True,
+    )
+    s.add(practice)
+    await s.commit()
+    await s.refresh(practice)
+    up = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=stage_number,
+        start_date=date(2026, 1, 1),
+    )
+    s.add(up)
+    await s.commit()
+    await s.refresh(up)
+    s.add(
+        PracticeSession(
+            user_id=user_id,
+            user_practice_id=up.id,
+            duration_minutes=5.0,
+            timestamp=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+    )
+    await s.commit()
+
+
+def _tagged_entry(
+    user_id: int,
+    *,
+    primary: int | None = None,
+    secondary: int | None = None,
+    deleted: bool = False,
+) -> JournalEntry:
+    """Build a chord-tagged JournalEntry, optionally soft-deleted."""
+    return JournalEntry(
+        sender="user",
+        user_id=user_id,
+        message="A tagged reflection.",
+        primary_aspect=primary,
+        secondary_aspect=secondary,
+        deleted_at=datetime.now(UTC) if deleted else None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wheel_chord_single_primary_tag_lifts_only_its_stage(session: AsyncSession) -> None:
+    """A lone primary tag on stage 3 lifts only stage 3's fullness."""
+    await _seed_all_course_stages(session)
+    session.add(_tagged_entry(_USER_A, primary=3))
+    await session.commit()
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    for item in result:
+        if item["stage_number"] == 3:
+            assert item["fullness"] == pytest.approx(_PER_PRIMARY_LIFT)
+        else:
+            assert item["fullness"] == 0.0, f"stage {item['stage_number']} expected 0.0"
+
+
+@pytest.mark.asyncio
+async def test_wheel_chord_secondary_lifts_half_and_primary_lifts_full(
+    session: AsyncSession,
+) -> None:
+    """secondary=5 with primary=2: stage 5 gets half the lift, stage 2 gets the full lift."""
+    await _seed_all_course_stages(session)
+    session.add(_tagged_entry(_USER_A, primary=2, secondary=5))
+    await session.commit()
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    for item in result:
+        if item["stage_number"] == 2:
+            assert item["fullness"] == pytest.approx(_PER_PRIMARY_LIFT)
+        elif item["stage_number"] == 5:
+            assert item["fullness"] == pytest.approx(_PER_SECONDARY_LIFT)
+        else:
+            assert item["fullness"] == 0.0, f"stage {item['stage_number']} expected 0.0"
+
+
+@pytest.mark.asyncio
+async def test_wheel_chord_soft_deleted_entry_contributes_nothing(session: AsyncSession) -> None:
+    """A soft-deleted tagged entry must not lift any stage's fullness."""
+    await _seed_all_course_stages(session)
+    session.add(_tagged_entry(_USER_A, primary=6, secondary=9, deleted=True))
+    await session.commit()
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    for item in result:
+        assert item["fullness"] == 0.0, f"stage {item['stage_number']} expected 0.0"
+
+
+@pytest.mark.asyncio
+async def test_wheel_chord_saturation_caps_signal_at_ceiling(session: AsyncSession) -> None:
+    """Enough primary tags on one stage saturate chord_signal at its cap, never above it."""
+    await _seed_all_course_stages(session)
+    for _ in range(_SATURATING_TAG_COUNT):
+        session.add(_tagged_entry(_USER_A, primary=4))
+    await session.commit()
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    stage4 = next(r for r in result if r["stage_number"] == 4)
+    assert stage4["fullness"] == pytest.approx(WHEEL_CHORD_SIGNAL_CAP)
+    assert stage4["fullness"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_wheel_chord_fullness_clamps_at_one_with_full_engagement(
+    session: AsyncSession,
+) -> None:
+    """A stage already at full overall_progress stays clamped at 1.0 once chord tags are added."""
+    await _seed_all_course_stages(session)
+    await _seed_habit_with_completion(session, _USER_A, 7)
+    for _ in range(_SATURATING_TAG_COUNT):
+        session.add(_tagged_entry(_USER_A, primary=7))
+    await session.commit()
+
+    batch = await compute_stage_progress_batch(session, _USER_A, [7])
+    assert batch[7]["overall_progress"] == pytest.approx(1.0)
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+    stage7 = next(r for r in result if r["stage_number"] == 7)
+    assert stage7["fullness"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_wheel_chord_no_tags_matches_batch_overall_progress_exactly(
+    session: AsyncSession,
+) -> None:
+    """With no chord-tagged entries, every stage's fullness equals its overall_progress."""
+    await _seed_all_course_stages(session)
+    await _seed_habit_with_completion(session, _USER_A, 1)
+    await _seed_practice_with_session(session, _USER_A, 8)
+
+    stage_numbers = list(range(1, _TOTAL_STAGES + 1))
+    batch = await compute_stage_progress_batch(session, _USER_A, stage_numbers)
+
+    result = await compute_wheel_balance(session, user_id=_USER_A)
+
+    for item in result:
+        expected = float(batch[item["stage_number"]]["overall_progress"])
+        assert item["fullness"] == pytest.approx(expected)

--- a/backend/tests/test_journal_chord_model.py
+++ b/backend/tests/test_journal_chord_model.py
@@ -1,0 +1,129 @@
+"""Data-layer tests for chord journaling (primary_aspect / secondary_aspect).
+
+Covers:
+- Persistence with no aspects (both columns None).
+- primary + secondary round-trip.
+- Out-of-range values raise IntegrityError (DB CHECK).
+- Chord-shape violations (secondary without primary, secondary == primary)
+  raise IntegrityError.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import JournalEntry
+from models.user import User
+
+
+async def _user(session: AsyncSession, email: str = "chord@example.com") -> int:
+    """Persist a minimal user and return its id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.flush()
+    assert user.id is not None
+    return user.id
+
+
+def _entry(user_id: int, **kwargs: object) -> JournalEntry:
+    """Build a JournalEntry with the given overrides (chord fields optional)."""
+    base: dict[str, object] = {
+        "sender": "user",
+        "user_id": user_id,
+        "message": "A tagged reflection.",
+    }
+    base.update(kwargs)
+    return JournalEntry(**base)
+
+
+@pytest.mark.asyncio
+async def test_entry_with_no_aspects_persists_both_none(db_session: AsyncSession) -> None:
+    """An entry with neither aspect set persists with both columns None."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(JournalEntry))).scalar_one()
+    assert row.primary_aspect is None
+    assert row.secondary_aspect is None
+
+
+@pytest.mark.asyncio
+async def test_primary_only_persists_and_reads_back(db_session: AsyncSession) -> None:
+    """A primary_aspect alone (no secondary) round-trips."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, primary_aspect=3))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(JournalEntry))).scalar_one()
+    assert row.primary_aspect == 3
+    assert row.secondary_aspect is None
+
+
+@pytest.mark.asyncio
+async def test_primary_and_secondary_round_trip(db_session: AsyncSession) -> None:
+    """A full chord (primary + secondary) persists and reads back exactly."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, primary_aspect=3, secondary_aspect=7))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(JournalEntry))).scalar_one()
+    assert row.primary_aspect == 3
+    assert row.secondary_aspect == 7
+
+
+@pytest.mark.asyncio
+async def test_primary_below_range_raises_integrity_error(db_session: AsyncSession) -> None:
+    """primary_aspect=0 violates the range CHECK (1..10)."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, primary_aspect=0))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_primary_above_range_raises_integrity_error(db_session: AsyncSession) -> None:
+    """primary_aspect=11 violates the range CHECK (1..10)."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, primary_aspect=11))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_secondary_below_range_raises_integrity_error(db_session: AsyncSession) -> None:
+    """secondary_aspect=0 violates the range CHECK (1..10)."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, primary_aspect=5, secondary_aspect=0))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_secondary_above_range_raises_integrity_error(db_session: AsyncSession) -> None:
+    """secondary_aspect=11 violates the range CHECK (1..10)."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, primary_aspect=5, secondary_aspect=11))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_secondary_without_primary_raises_integrity_error(db_session: AsyncSession) -> None:
+    """A secondary set with no primary violates the chord-shape CHECK."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, secondary_aspect=7))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_secondary_equal_to_primary_raises_integrity_error(db_session: AsyncSession) -> None:
+    """secondary_aspect == primary_aspect violates the chord-shape CHECK."""
+    user_id = await _user(db_session)
+    db_session.add(_entry(user_id, primary_aspect=4, secondary_aspect=4))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()

--- a/backend/tests/test_journal_chord_router.py
+++ b/backend/tests/test_journal_chord_router.py
@@ -1,0 +1,147 @@
+"""Router tests for chord journaling (primary_aspect / secondary_aspect) CRUD."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+
+async def _signup(client: AsyncClient, username: str = "chorduser") -> dict[str, str]:
+    """Create a user and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _create(
+    client: AsyncClient, headers: dict[str, str], **overrides: object
+) -> dict[str, object]:
+    """POST a journal message and return the parsed response body."""
+    payload: dict[str, object] = {"message": "A tagged reflection."}
+    payload.update(overrides)
+    resp = await client.post("/journal/", json=payload, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    body: dict[str, object] = resp.json()
+    return body
+
+
+@pytest.mark.asyncio
+async def test_create_persists_and_echoes_both_aspects(async_client: AsyncClient) -> None:
+    """POST with a full chord persists both fields and echoes them in the response."""
+    headers = await _signup(async_client)
+    body = await _create(async_client, headers, primary_aspect=3, secondary_aspect=7)
+    assert body["primary_aspect"] == 3
+    assert body["secondary_aspect"] == 7
+
+
+@pytest.mark.asyncio
+async def test_create_without_aspects_leaves_both_null(async_client: AsyncClient) -> None:
+    """POST with neither aspect leaves both fields null (unchanged behavior)."""
+    headers = await _signup(async_client, "noaspect")
+    body = await _create(async_client, headers)
+    assert body["primary_aspect"] is None
+    assert body["secondary_aspect"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_updates_chord_pair(async_client: AsyncClient) -> None:
+    """PATCH with both aspects updates and echoes the pair."""
+    headers = await _signup(async_client, "patcher_chord")
+    entry = await _create(async_client, headers)
+    resp = await async_client.patch(
+        f"/journal/{entry['id']}",
+        json={"primary_aspect": 4, "secondary_aspect": 8},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["primary_aspect"] == 4
+    assert body["secondary_aspect"] == 8
+
+
+@pytest.mark.asyncio
+async def test_patch_explicit_nulls_clears_chord(async_client: AsyncClient) -> None:
+    """PATCH with explicit nulls for both aspects clears the chord."""
+    headers = await _signup(async_client, "clearer_chord")
+    entry = await _create(async_client, headers, primary_aspect=2, secondary_aspect=6)
+    resp = await async_client.patch(
+        f"/journal/{entry['id']}",
+        json={"primary_aspect": None, "secondary_aspect": None},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["primary_aspect"] is None
+    assert body["secondary_aspect"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_primary_only_resets_stale_secondary(async_client: AsyncClient) -> None:
+    """PATCH with only primary_aspect must reset a stale secondary, not 500."""
+    headers = await _signup(async_client, "atomic_chord")
+    entry = await _create(async_client, headers, primary_aspect=1, secondary_aspect=5)
+    resp = await async_client.patch(
+        f"/journal/{entry['id']}",
+        json={"primary_aspect": 5},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["primary_aspect"] == 5
+    assert body["secondary_aspect"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_secondary_without_primary_is_422(async_client: AsyncClient) -> None:
+    """POST with a secondary but no primary is rejected."""
+    headers = await _signup(async_client, "shape_a")
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "x", "secondary_aspect": 4},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_primary_equal_secondary_is_422(async_client: AsyncClient) -> None:
+    """POST with primary == secondary is rejected."""
+    headers = await _signup(async_client, "shape_b")
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "x", "primary_aspect": 5, "secondary_aspect": 5},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_primary_below_range_is_422(async_client: AsyncClient) -> None:
+    """POST with primary_aspect=0 is rejected (below range)."""
+    headers = await _signup(async_client, "range_a")
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "x", "primary_aspect": 0},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_primary_above_range_is_422(async_client: AsyncClient) -> None:
+    """POST with primary_aspect=11 is rejected (above range)."""
+    headers = await _signup(async_client, "range_b")
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "x", "primary_aspect": 11},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/backend/tests/test_journal_chord_schema.py
+++ b/backend/tests/test_journal_chord_schema.py
@@ -1,0 +1,174 @@
+"""Schema-layer tests for chord journaling (primary_aspect / secondary_aspect).
+
+Covers:
+- JournalMessageCreate: omitted -> both None; round-trip; chord-shape and
+  range violations raise ValidationError.
+- JournalEntryUpdate: aspect-only PATCH satisfies the at-least-one guard;
+  explicit-null aspects are accepted (model_fields_set); empty {} still
+  raises; chord-shape validator applies.
+- JournalMessageResponse: both fields present and serialised.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.journal import JournalEntryUpdate, JournalMessageCreate, JournalMessageResponse
+
+
+class TestJournalMessageCreateChord:
+    """JournalMessageCreate primary_aspect / secondary_aspect behaviours."""
+
+    def test_omitted_aspects_default_to_none(self) -> None:
+        """A payload that omits both aspects should leave them None."""
+        schema = JournalMessageCreate(message="Hello world.")
+        assert schema.primary_aspect is None
+        assert schema.secondary_aspect is None
+
+    def test_primary_only_round_trips(self) -> None:
+        """A primary_aspect alone (no secondary) survives the parse cycle."""
+        schema = JournalMessageCreate(message="A thought.", primary_aspect=3)
+        assert schema.primary_aspect == 3
+        assert schema.secondary_aspect is None
+
+    def test_primary_and_secondary_round_trip(self) -> None:
+        """A full chord survives the parse cycle."""
+        schema = JournalMessageCreate(message="A thought.", primary_aspect=3, secondary_aspect=7)
+        assert schema.primary_aspect == 3
+        assert schema.secondary_aspect == 7
+
+    def test_secondary_without_primary_raises_validation_error(self) -> None:
+        """A secondary with no primary violates the chord-shape rule."""
+        with pytest.raises(ValidationError):
+            JournalMessageCreate(message="Oops.", secondary_aspect=7)
+
+    def test_secondary_equal_to_primary_raises_validation_error(self) -> None:
+        """secondary_aspect == primary_aspect violates the chord-shape rule."""
+        with pytest.raises(ValidationError):
+            JournalMessageCreate(message="Oops.", primary_aspect=4, secondary_aspect=4)
+
+    def test_primary_zero_raises_validation_error(self) -> None:
+        """primary_aspect=0 is below the 1..10 range."""
+        with pytest.raises(ValidationError):
+            JournalMessageCreate(message="Oops.", primary_aspect=0)
+
+    def test_primary_eleven_raises_validation_error(self) -> None:
+        """primary_aspect=11 is above the 1..10 range."""
+        with pytest.raises(ValidationError):
+            JournalMessageCreate(message="Oops.", primary_aspect=11)
+
+    def test_secondary_zero_raises_validation_error(self) -> None:
+        """secondary_aspect=0 is below the 1..10 range."""
+        with pytest.raises(ValidationError):
+            JournalMessageCreate(message="Oops.", primary_aspect=5, secondary_aspect=0)
+
+    def test_secondary_eleven_raises_validation_error(self) -> None:
+        """secondary_aspect=11 is above the 1..10 range."""
+        with pytest.raises(ValidationError):
+            JournalMessageCreate(message="Oops.", primary_aspect=5, secondary_aspect=11)
+
+
+class TestJournalEntryUpdateChord:
+    """JournalEntryUpdate primary_aspect / secondary_aspect behaviours."""
+
+    def test_aspect_only_satisfies_at_least_one_validator(self) -> None:
+        """Providing only primary_aspect should pass the at-least-one guard."""
+        schema = JournalEntryUpdate(primary_aspect=3)
+        assert schema.primary_aspect == 3
+        assert schema.message is None
+        assert schema.title is None
+        assert schema.status is None
+
+    def test_empty_payload_still_raises(self) -> None:
+        """An empty PATCH payload must still be rejected (the pre-existing guard)."""
+        with pytest.raises(ValidationError, match="at least one field"):
+            JournalEntryUpdate()
+
+    def test_explicit_null_aspects_are_accepted(self) -> None:
+        """PATCH {'primary_aspect': null, 'secondary_aspect': null} must be accepted.
+
+        An explicit null still counts as "a field was provided" via
+        model_fields_set, so this must NOT raise the at-least-one guard.
+        """
+        schema = JournalEntryUpdate.model_validate(
+            {"primary_aspect": None, "secondary_aspect": None}
+        )
+        assert schema.primary_aspect is None
+        assert schema.secondary_aspect is None
+        assert "primary_aspect" in schema.model_fields_set
+        assert "secondary_aspect" in schema.model_fields_set
+
+    def test_chord_shape_applies_to_update(self) -> None:
+        """Secondary without primary in a PATCH violates the chord-shape rule."""
+        with pytest.raises(ValidationError):
+            JournalEntryUpdate(secondary_aspect=7)
+
+    def test_secondary_equal_to_primary_raises_in_update(self) -> None:
+        """secondary_aspect == primary_aspect violates the chord-shape rule in a PATCH."""
+        with pytest.raises(ValidationError):
+            JournalEntryUpdate(primary_aspect=6, secondary_aspect=6)
+
+    def test_aspects_with_other_fields_is_valid(self) -> None:
+        """Chord fields can be combined with other fields without error."""
+        schema = JournalEntryUpdate(primary_aspect=2, secondary_aspect=8, title="A Title")
+        assert schema.primary_aspect == 2
+        assert schema.secondary_aspect == 8
+        assert schema.title == "A Title"
+
+
+class TestJournalMessageResponseChord:
+    """JournalMessageResponse must expose both chord fields."""
+
+    def test_response_includes_chord_fields(self) -> None:
+        """JournalMessageResponse model_fields must include both aspect fields."""
+        assert "primary_aspect" in JournalMessageResponse.model_fields
+        assert "secondary_aspect" in JournalMessageResponse.model_fields
+
+    def test_response_serialises_chord_fields(self) -> None:
+        """A JournalMessageResponse built from attributes exposes both aspect fields."""
+        now = datetime.now(UTC)
+        resp = JournalMessageResponse(
+            id=1,
+            title=None,
+            message="Hello.",
+            status="draft",
+            sender="user",
+            timestamp=now,
+            updated_at=now,
+            tag="freeform",
+            practice_session_id=None,
+            user_practice_id=None,
+            classification="personal",
+            primary_aspect=3,
+            secondary_aspect=7,
+        )
+        assert resp.primary_aspect == 3
+        assert resp.secondary_aspect == 7
+        dumped = resp.model_dump()
+        assert dumped["primary_aspect"] == 3
+        assert dumped["secondary_aspect"] == 7
+
+    def test_response_serialises_none_chord_fields(self) -> None:
+        """A JournalMessageResponse without a chord exposes both fields as None."""
+        now = datetime.now(UTC)
+        resp = JournalMessageResponse(
+            id=1,
+            title=None,
+            message="Hello.",
+            status="draft",
+            sender="user",
+            timestamp=now,
+            updated_at=now,
+            tag="freeform",
+            practice_session_id=None,
+            user_practice_id=None,
+            classification="personal",
+            primary_aspect=None,
+            secondary_aspect=None,
+        )
+        dumped = resp.model_dump()
+        assert dumped["primary_aspect"] is None
+        assert dumped["secondary_aspect"] is None

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1573,3 +1573,99 @@ def test_invitation_signal_migration_round_trip_on_sqlite(
     # Phase 3: re-upgrade is idempotent.
     command.upgrade(cfg, _INVITATION_SIGNAL_REVISION)
     assert _table_exists(db_url, "invitationsignal")
+
+
+# -- chord-journaling-01 primary_aspect / secondary_aspect migration round-trip ---
+
+# Revision anchors for the chord-journaling migration round-trip.
+# down_revision is c9d0e1f2a3b4 (the metta_return_arc migration, current head).
+_CHORD_BASE_REVISION = "c9d0e1f2a3b4"  # pragma: allowlist secret
+_CHORD_REVISION = "a5b6c7d8e9f0"  # pragma: allowlist secret
+
+
+def _bootstrap_journalentry_table_for_chord(sync_url: str) -> None:
+    """Pre-create a minimal journalentry table without the chord columns."""
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE journalentry ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " sender VARCHAR(10) NOT NULL,"
+                " message TEXT NOT NULL,"
+                " tag VARCHAR(50) NOT NULL DEFAULT 'freeform',"
+                " status VARCHAR(20) NOT NULL DEFAULT 'draft',"
+                " title VARCHAR(200),"
+                " classification VARCHAR(20) NOT NULL DEFAULT 'personal',"
+                " deleted_at DATETIME,"
+                " updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                " timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO journalentry (id, user_id, sender, message)"
+                " VALUES (1, 1, 'user', 'Pre-chord entry.')"
+            )
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_journal_chord(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite Alembic config positioned just before the chord migration.
+
+    Bootstraps a minimal journalentry table (no chord columns) with one
+    pre-existing row, then stamps the DB at c9d0e1f2a3b4 (the chain head
+    before this migration) so the round-trip exercises only the new migration.
+    """
+    db_path = tmp_path / "journal_chord_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_journalentry_table_for_chord(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _CHORD_BASE_REVISION)
+    return cfg
+
+
+def test_journal_chord_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_journal_chord: Config,
+) -> None:
+    """Round-trip the chord migration: upgrade adds both columns; downgrade drops them.
+
+    Phase 1: upgrade adds primary_aspect and secondary_aspect (both nullable).
+    Phase 2: downgrade removes both columns.
+    Phase 3: re-upgrade is idempotent.
+    """
+    cfg = alembic_sqlite_config_journal_chord
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade adds both chord columns.
+    command.upgrade(cfg, _CHORD_REVISION)
+    cols = _columns_of(db_url, "journalentry")
+    assert "primary_aspect" in cols
+    assert "secondary_aspect" in cols
+
+    # Phase 2: downgrade removes both columns.
+    command.downgrade(cfg, _CHORD_BASE_REVISION)
+    cols_after = _columns_of(db_url, "journalentry")
+    assert "primary_aspect" not in cols_after
+    assert "secondary_aspect" not in cols_after
+
+    # Phase 3: re-upgrade is idempotent.
+    command.upgrade(cfg, _CHORD_REVISION)
+    cols_final = _columns_of(db_url, "journalentry")
+    assert "primary_aspect" in cols_final
+    assert "secondary_aspect" in cols_final

--- a/frontend/src/api/__tests__/privacySchemas.test.ts
+++ b/frontend/src/api/__tests__/privacySchemas.test.ts
@@ -155,3 +155,41 @@ describe('resonanceResponseSchema — private / private_message fields (issue #8
     expect(() => resonanceResponseSchema.parse(payload)).toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// journalMessageSchema — primary_aspect / secondary_aspect chord fields
+// ---------------------------------------------------------------------------
+
+describe('journalMessageSchema — chord fields (primary_aspect / secondary_aspect)', () => {
+  it('still parses a message WITHOUT chord fields (backward-compat)', () => {
+    expect(() => journalMessageSchema.parse(BASE_JOURNAL_MESSAGE)).not.toThrow();
+  });
+
+  it('parses a message with both primary_aspect and secondary_aspect', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, primary_aspect: 3, secondary_aspect: 7 };
+    const parsed = journalMessageSchema.parse(payload);
+    expect(parsed.primary_aspect).toBe(3);
+    expect(parsed.secondary_aspect).toBe(7);
+  });
+
+  it('parses a message with only primary_aspect set', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, primary_aspect: 5 };
+    const parsed = journalMessageSchema.parse(payload);
+    expect(parsed.primary_aspect).toBe(5);
+  });
+
+  it('rejects primary_aspect=0 (below range)', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, primary_aspect: 0 };
+    expect(() => journalMessageSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects primary_aspect=11 (above range)', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, primary_aspect: 11 };
+    expect(() => journalMessageSchema.parse(payload)).toThrow();
+  });
+
+  it('rejects a non-integer primary_aspect', () => {
+    const payload = { ...BASE_JOURNAL_MESSAGE, primary_aspect: 3.5 };
+    expect(() => journalMessageSchema.parse(payload)).toThrow();
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1100,6 +1100,10 @@ export interface JournalMessageCreate {
   user_practice_id?: number | null;
   /** Privacy tier chosen at creation; the backend defaults to ``personal``. */
   classification?: JournalClassification;
+  /** Primary chord Aspect (a stage 1..10); omitted when untagged. */
+  primary_aspect?: number | null;
+  /** Secondary chord Aspect (a stage 1..10); only meaningful with a primary. */
+  secondary_aspect?: number | null;
 }
 
 export type EntryStatus = 'draft' | 'finished';
@@ -1118,6 +1122,10 @@ export interface JournalMessage {
   updated_at?: string;
   /** Privacy tier; absent on older responses (defaults to ``personal``). */
   classification?: JournalClassification;
+  /** Primary chord Aspect (a stage 1..10); null/absent when untagged. */
+  primary_aspect?: number | null;
+  /** Secondary chord Aspect (a stage 1..10); only meaningful with a primary. */
+  secondary_aspect?: number | null;
 }
 
 /**
@@ -1131,6 +1139,10 @@ export interface JournalEntryUpdate {
   status?: EntryStatus;
   /** Re-classify an existing entry's privacy tier. */
   classification?: JournalClassification;
+  /** Update the primary chord Aspect (a stage 1..10); null clears it. */
+  primary_aspect?: number | null;
+  /** Update the secondary chord Aspect (a stage 1..10); null clears it. */
+  secondary_aspect?: number | null;
 }
 
 export type MarginaliaKind = 'theme' | 'connection' | 'symbol';

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -240,6 +240,11 @@ export const journalTagSchema = z.enum([
   'weekly_prompt',
 ]);
 
+/** Lowest Aspect tag (stage 1); the curriculum's first stage. */
+const MIN_ASPECT = 1;
+/** Highest Aspect tag (stage 10); the curriculum has ten stages. */
+const MAX_ASPECT = 10;
+
 /** One journal message (mirrors the backend ``JournalMessage`` response). */
 export const journalMessageSchema = z.object({
   id: z.number().int(),
@@ -259,6 +264,10 @@ export const journalMessageSchema = z.object({
   // Privacy tier. Optional so responses predating the column still
   // validate; the enum rejects any value that drifts from the backend set.
   classification: z.enum(['public', 'personal', 'intimate']).optional(),
+  // Chord Aspect tags (each a stage 1..MAX_ASPECT). Optional and nullable so
+  // untagged / pre-column responses still validate.
+  primary_aspect: z.number().int().min(MIN_ASPECT).max(MAX_ASPECT).nullable().optional(),
+  secondary_aspect: z.number().int().min(MIN_ASPECT).max(MAX_ASPECT).nullable().optional(),
 });
 
 /** Journal list envelope: ``{ items, total, has_more }`` (bespoke, not ``Page``). */

--- a/frontend/src/features/Journal/AspectChordControl.tsx
+++ b/frontend/src/features/Journal/AspectChordControl.tsx
@@ -1,0 +1,175 @@
+/**
+ * ``AspectChordControl`` — an optional, declinable chooser for a journal
+ * entry's chord: a primary Aspect and, atop it, a secondary Aspect (each a
+ * curriculum stage 1..10). It starts collapsed behind a warm trigger so the
+ * writer only meets it if they want it — nothing here is required and no rank
+ * or progress is implied.
+ *
+ * Presentational and controlled: ``onChange`` is the only output; the host owns
+ * the chord value and persists it (create/update). Picking a primary clears any
+ * secondary; the secondary chips omit the chosen primary so the two notes
+ * always differ.
+ */
+import React, { useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+
+import styles from './JournalEntry.styles';
+
+import { STAGE_DISPLAY } from '@/features/Map/mapLayout';
+
+/** The controlled chord value: a primary Aspect and an optional secondary. */
+export interface AspectChordValue {
+  primary: number | null;
+  secondary: number | null;
+}
+
+/** The empty chord used when no ``value`` is supplied. */
+const EMPTY_CHORD: AspectChordValue = { primary: null, secondary: null };
+
+/** Warm, declinable copy for the collapsed trigger. */
+const TRIGGER_LABEL = 'Name an Aspect (optional)';
+
+/** One offered Aspect: its stage number and the persona label to show. */
+interface AspectOption {
+  stage: number;
+  label: string;
+}
+
+/** The stages offered as Aspects, ascending (1..10), labelled by persona. */
+const ASPECT_OPTIONS: readonly AspectOption[] = Object.entries(STAGE_DISPLAY)
+  .map(([key, display]) => ({ stage: Number(key), label: display.persona }))
+  .sort((a, b) => a.stage - b.stage);
+
+export interface AspectChordControlProps {
+  /** The current chord; defaults to an empty (untagged) chord when omitted. */
+  value?: AspectChordValue;
+  /** Called with the next chord whenever a chip or the clear affordance fires. */
+  onChange: (_next: AspectChordValue) => void;
+}
+
+interface AspectChipProps {
+  option: AspectOption;
+  selected: boolean;
+  testID: string;
+  onPress: () => void;
+}
+
+/** A single Aspect chip; announces its selection state to screen readers. */
+function AspectChip({ option, selected, testID, onPress }: AspectChipProps): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={[styles.aspectChordChip, selected && styles.aspectChordChipSelected]}
+      onPress={onPress}
+      accessibilityRole="radio"
+      accessibilityLabel={option.label}
+      accessibilityState={{ selected }}
+      testID={testID}
+    >
+      <Text style={[styles.aspectChordChipLabel, selected && styles.aspectChordChipLabelSelected]}>
+        {option.label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+interface AspectChipRowProps {
+  prefix: string;
+  selectedStage: number | null;
+  omitStage: number | null;
+  onSelect: (_stage: number) => void;
+}
+
+/** A wrapping row of Aspect chips, optionally omitting one stage. */
+function AspectChipRow({
+  prefix,
+  selectedStage,
+  omitStage,
+  onSelect,
+}: AspectChipRowProps): React.JSX.Element {
+  return (
+    <View style={styles.aspectChordRow} accessibilityRole="radiogroup">
+      {ASPECT_OPTIONS.filter((option) => option.stage !== omitStage).map((option) => (
+        <AspectChip
+          key={option.stage}
+          option={option}
+          selected={option.stage === selectedStage}
+          testID={`${prefix}-${option.stage}`}
+          onPress={() => onSelect(option.stage)}
+        />
+      ))}
+    </View>
+  );
+}
+
+/** The collapsed state: a single warm trigger that reveals the chooser. */
+function CollapsedTrigger({ onExpand }: { onExpand: () => void }): React.JSX.Element {
+  return (
+    <View style={styles.aspectChordControl}>
+      <TouchableOpacity
+        style={styles.aspectChordTrigger}
+        onPress={onExpand}
+        accessibilityRole="button"
+        accessibilityLabel={TRIGGER_LABEL}
+        testID="aspect-chord-trigger"
+      >
+        <Text style={styles.aspectChordTriggerLabel}>{TRIGGER_LABEL}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+/** The expanded state: primary chips, optional secondary chips, and a clear. */
+function ExpandedChooser({
+  value,
+  onChange,
+}: Required<AspectChordControlProps>): React.JSX.Element {
+  const primary = value.primary;
+  return (
+    <View style={styles.aspectChordControl} accessibilityLabel="Aspect chord">
+      <Text style={styles.aspectChordSectionLabel}>Primary Aspect</Text>
+      <AspectChipRow
+        prefix="aspect-primary"
+        selectedStage={primary}
+        omitStage={null}
+        onSelect={(stage) => onChange({ primary: stage, secondary: null })}
+      />
+      {primary === null ? null : (
+        <View>
+          <Text style={styles.aspectChordSectionLabel}>Secondary Aspect</Text>
+          <AspectChipRow
+            prefix="aspect-secondary"
+            selectedStage={value.secondary}
+            omitStage={primary}
+            onSelect={(stage) => onChange({ primary, secondary: stage })}
+          />
+        </View>
+      )}
+      <TouchableOpacity
+        style={styles.aspectChordClear}
+        onPress={() => onChange(EMPTY_CHORD)}
+        accessibilityRole="button"
+        accessibilityLabel="Clear Aspect"
+        testID="aspect-chord-clear"
+      >
+        <Text style={styles.aspectChordClearLabel}>Clear</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+/**
+ * The collapsible Aspect chord chooser. Rendered in the writing column of
+ * {@link JournalEntryScreen}, beside the privacy control.
+ */
+function AspectChordControl({
+  value = EMPTY_CHORD,
+  onChange,
+}: AspectChordControlProps): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  if (!expanded) {
+    return <CollapsedTrigger onExpand={() => setExpanded(true)} />;
+  }
+  return <ExpandedChooser value={value} onChange={onChange} />;
+}
+
+export default AspectChordControl;

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -191,6 +191,63 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.xl,
     paddingBottom: SPACING.sm,
   },
+  /** Optional chord (Aspect) tagging block above the growing body. */
+  aspectChordControl: {
+    paddingBottom: spacing(1),
+  },
+  /** The collapsed, declinable trigger that reveals the Aspect chips. */
+  aspectChordTrigger: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.sm,
+  },
+  aspectChordTriggerLabel: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+  /** Section label above a row of Aspect chips (primary / secondary). */
+  aspectChordSectionLabel: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    paddingTop: spacing(1),
+  },
+  /** Wrapping row of Aspect chips. */
+  aspectChordRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: SPACING.xs,
+  },
+  /** A single Aspect chip; min dims hold the 44dp touch-target floor. */
+  aspectChordChip: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.paper.hairline,
+  },
+  aspectChordChipSelected: {
+    backgroundColor: colors.paper.anchorHighlight,
+    borderColor: colors.paper.inkSoft,
+  },
+  aspectChordChipLabel: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+  aspectChordChipLabelSelected: {
+    color: colors.paper.ink,
+  },
+  /** The clear affordance that resets the chord to untagged. */
+  aspectChordClear: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.sm,
+  },
+  aspectChordClearLabel: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
 });
 
 export default styles;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -242,25 +242,42 @@ function useClassificationPersist(
 
 interface ChordPersist {
   chordRef: React.MutableRefObject<AspectChordValue>;
-  /** Record the chord for the next create and PATCH it when the entry exists. */
-  changeChord: (_next: AspectChordValue) => void;
+  /**
+   * Record the chord for the next create and PATCH it when the entry exists.
+   * Resolves to the chord the UI should revert to when a PATCH fails and no
+   * later change has superseded it, else null.
+   */
+  changeChord: (_next: AspectChordValue) => Promise<AspectChordValue | null>;
 }
 
 /**
  * Owns the latest Aspect chord: it rides the first ``journal.create`` via the
  * ref, and on an existing entry a change is PATCHed immediately (both notes,
  * including explicit nulls) so re-tagging never waits on the body-save debounce.
+ * A failed PATCH resolves to the prior chord so the control reverts to the
+ * truth, mirroring the sibling privacy-tier control's revert-on-failure path.
  */
 function useChordPersist(entryIdRef: React.MutableRefObject<number | null>): ChordPersist {
   const chordRef = useRef<AspectChordValue>(EMPTY_CHORD);
   const changeChord = useCallback(
-    (next: AspectChordValue): void => {
+    async (next: AspectChordValue): Promise<AspectChordValue | null> => {
+      const previous = chordRef.current;
       chordRef.current = next;
-      if (entryIdRef.current != null) {
-        void journal.update(entryIdRef.current, {
+      // Create-time: the ref rides the next journal.create, nothing to PATCH yet.
+      if (entryIdRef.current == null) return null;
+      try {
+        await journal.update(entryIdRef.current, {
           primary_aspect: next.primary,
           secondary_aspect: next.secondary,
         });
+        return null;
+      } catch {
+        // A rapid superseding change already owns the ref and the UI — leave both
+        // to it rather than reverting to this now-stale chord. Assumes one PATCH in
+        // flight at a time; ``previous`` is the optimistic ref, not last-persisted.
+        if (chordRef.current !== next) return null;
+        chordRef.current = previous;
+        return previous;
       }
     },
     [entryIdRef],
@@ -303,6 +320,24 @@ function useSaveTimer(
     [run, timerRef, entryIdRef],
   );
   return { save, flush };
+}
+
+/**
+ * Wrap a revert-on-failure persister so a failed PATCH also surfaces the shared
+ * save-error hint (used identically by the privacy-tier and chord controls).
+ */
+function useErrorSurfacingPersist<T>(
+  change: (_value: T) => Promise<T | null>,
+  setSaveState: (_state: SaveState) => void,
+): (_value: T) => Promise<T | null> {
+  return useCallback(
+    async (value: T): Promise<T | null> => {
+      const revertTo = await change(value);
+      if (revertTo != null) setSaveState('error');
+      return revertTo;
+    },
+    [change, setSaveState],
+  );
 }
 
 /** Debounced create-then-update draft saver; tracks the save state. */
@@ -355,17 +390,17 @@ function useDebouncedSave(
   const setTyping = useCallback(() => setSaveState('typing'), []);
   const { save, flush } = useSaveTimer(run, timerRef, entryIdRef, delayMs, setTyping);
 
-  // A failed classification PATCH surfaces the same error hint as a body save.
-  const persistClassification = useCallback(
-    async (tier: JournalClassification): Promise<JournalClassification | null> => {
-      const revertTo = await changeClassification(tier);
-      if (revertTo != null) setSaveState('error');
-      return revertTo;
-    },
-    [changeClassification],
-  );
+  // A failed classification/chord PATCH surfaces the same error hint as a body save.
+  const persistClassification = useErrorSurfacingPersist(changeClassification, setSaveState);
+  const persistChord = useErrorSurfacingPersist(changeChord, setSaveState);
 
-  return { saveState, save, flush, changeClassification: persistClassification, changeChord };
+  return {
+    saveState,
+    save,
+    flush,
+    changeClassification: persistClassification,
+    changeChord: persistChord,
+  };
 }
 
 type StrRef = React.MutableRefObject<string>;
@@ -471,7 +506,7 @@ interface ChoiceHandlers {
 function useChoiceHandlers(
   entry: EntryState,
   changeClassification: (_tier: JournalClassification) => Promise<JournalClassification | null>,
-  changeChord: (_next: AspectChordValue) => void,
+  changeChord: (_next: AspectChordValue) => Promise<AspectChordValue | null>,
 ): ChoiceHandlers {
   const { setClassification, setChord } = entry;
   // Reflect the choice optimistically, then persist it (create-time ref or PATCH);
@@ -489,7 +524,9 @@ function useChoiceHandlers(
   const onChangeChord = useCallback(
     (next: AspectChordValue) => {
       setChord(next);
-      changeChord(next);
+      void changeChord(next).then((revertTo) => {
+        if (revertTo != null) setChord(revertTo);
+      });
     },
     [changeChord, setChord],
   );

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import AspectChordControl, { type AspectChordValue } from './AspectChordControl';
 import CareSupportNote from './CareSupportNote';
 import CompletionSuggestionNote from './CompletionSuggestionNote';
 import ContractionReflectionNote from './ContractionReflectionNote';
@@ -55,6 +56,9 @@ const NARROW_BREAKPOINT = 600;
 
 /** Backend default privacy tier for a fresh entry. */
 const DEFAULT_CLASSIFICATION: JournalClassification = 'personal';
+
+/** An untagged chord (no primary/secondary Aspect) for a fresh entry. */
+const EMPTY_CHORD: AspectChordValue = { primary: null, secondary: null };
 
 /** Fallback reason shown when resonance is gated off for an intimate entry. */
 const INTIMATE_RESONANCE_REASON = 'Intimate entries are kept private — resonance is paused.';
@@ -98,6 +102,8 @@ interface WriteEntryRefs {
   respondedRef: React.MutableRefObject<boolean>;
   /** Latest chosen privacy tier; carried on the first ``journal.create``. */
   classificationRef: React.MutableRefObject<JournalClassification>;
+  /** Latest chosen Aspect chord; carried on the first ``journal.create``. */
+  chordRef: React.MutableRefObject<AspectChordValue>;
 }
 
 /** Create on first save, then update; title is optional and saved separately. */
@@ -107,7 +113,7 @@ async function writeEntry(
   body: string,
   ctx: SaveContext,
 ): Promise<void> {
-  const { entryIdRef, respondedRef, classificationRef } = refs;
+  const { entryIdRef, respondedRef, classificationRef, chordRef } = refs;
   // Weekly-prompt mode: the respond endpoint persists the entry itself, so we
   // submit exactly once and never pair it with journal.create (no double-create).
   if (ctx.weekNumber != null) {
@@ -124,6 +130,8 @@ async function writeEntry(
     const created = await journal.create({
       message: body,
       classification: classificationRef.current,
+      primary_aspect: chordRef.current.primary,
+      secondary_aspect: chordRef.current.secondary,
       ...(ctx.practiceSessionId != null && { practice_session_id: ctx.practiceSessionId }),
       ...(ctx.userPracticeId != null && { user_practice_id: ctx.userPracticeId }),
     });
@@ -144,10 +152,14 @@ interface AutosaveApi {
   saveState: SaveState;
   /** The entry's privacy tier; drives the control and the resonance gate. */
   classification: PrivacyTier;
+  /** The entry's Aspect chord; drives the chord control. */
+  chord: AspectChordValue;
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
   /** Set the privacy tier: updates the control and persists (create/PATCH). */
   onChangeClassification: (_tier: PrivacyTier) => void;
+  /** Set the Aspect chord: updates the control and persists (create/PATCH). */
+  onChangeChord: (_next: AspectChordValue) => void;
   /** Persist the latest text immediately and resolve to the entry id (or null). */
   flush: () => Promise<number | null>;
   /** Set when loading an existing entry failed; drives the banner + autosave gate. */
@@ -216,6 +228,34 @@ function useClassificationPersist(
   return { classificationRef, changeClassification };
 }
 
+interface ChordPersist {
+  chordRef: React.MutableRefObject<AspectChordValue>;
+  /** Record the chord for the next create and PATCH it when the entry exists. */
+  changeChord: (_next: AspectChordValue) => void;
+}
+
+/**
+ * Owns the latest Aspect chord: it rides the first ``journal.create`` via the
+ * ref, and on an existing entry a change is PATCHed immediately (both notes,
+ * including explicit nulls) so re-tagging never waits on the body-save debounce.
+ */
+function useChordPersist(entryIdRef: React.MutableRefObject<number | null>): ChordPersist {
+  const chordRef = useRef<AspectChordValue>(EMPTY_CHORD);
+  const changeChord = useCallback(
+    (next: AspectChordValue): void => {
+      chordRef.current = next;
+      if (entryIdRef.current != null) {
+        void journal.update(entryIdRef.current, {
+          primary_aspect: next.primary,
+          secondary_aspect: next.secondary,
+        });
+      }
+    },
+    [entryIdRef],
+  );
+  return { chordRef, changeChord };
+}
+
 type TimerRef = React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
 type RunSave = (_title: string, _body: string) => Promise<void>;
 
@@ -268,6 +308,7 @@ function useDebouncedSave(
   // flush submitting it twice (the backend 409s on a duplicate week).
   const respondedRef = useRef(false);
   const { classificationRef, changeClassification } = useClassificationPersist(entryIdRef);
+  const { chordRef, changeChord } = useChordPersist(entryIdRef);
   // Refs so non-memoised inputs don't churn the save callbacks below.
   const onSavedRef = useRef(onSaved);
   const ctxRef = useRef(ctx);
@@ -286,7 +327,7 @@ function useDebouncedSave(
       if (loadFailedRef.current) return; // never overwrite an entry that failed to load
       if (!body.trim()) return; // never persist an empty draft
       setSaveState('saving');
-      const refs = { entryIdRef, respondedRef, classificationRef };
+      const refs = { entryIdRef, respondedRef, classificationRef, chordRef };
       try {
         await writeEntry(refs, title, body, ctxRef.current);
         setSaveState('saved');
@@ -296,13 +337,13 @@ function useDebouncedSave(
         setSaveState('error');
       }
     },
-    [classificationRef],
+    [classificationRef, chordRef],
   );
 
   const setTyping = useCallback(() => setSaveState('typing'), []);
   const { save, flush } = useSaveTimer(run, timerRef, entryIdRef, delayMs, setTyping);
 
-  return { saveState, save, flush, changeClassification };
+  return { saveState, save, flush, changeClassification, changeChord };
 }
 
 type StrRef = React.MutableRefObject<string>;
@@ -341,6 +382,8 @@ interface EntryState {
   setStatus: (_status: EntryStatus) => void;
   classification: PrivacyTier;
   setClassification: (_tier: PrivacyTier) => void;
+  chord: AspectChordValue;
+  setChord: (_next: AspectChordValue) => void;
   setTitle: (_v: string) => void;
   setBody: (_v: string) => void;
   titleRef: StrRef;
@@ -355,6 +398,7 @@ function useEntryState(routeEntryId: number | null, initialTitle: string): Entry
   const [body, setBody] = useState('');
   const [status, setStatus] = useState<EntryStatus>('draft');
   const [classification, setClassification] = useState<PrivacyTier>(DEFAULT_CLASSIFICATION);
+  const [chord, setChord] = useState<AspectChordValue>(EMPTY_CHORD);
   const [loadError, setLoadError] = useState<string | null>(null);
   // Refs mirror the latest text so the change handlers stay referentially stable.
   const titleRef = useRef(initialTitle);
@@ -370,6 +414,11 @@ function useEntryState(routeEntryId: number | null, initialTitle: string): Entry
       setStatus(entry.status ?? 'draft');
       // Pre-select the server's tier so an intimate entry loads intimate.
       setClassification(entry.classification ?? DEFAULT_CLASSIFICATION);
+      // Pre-select the server's chord so a tagged entry loads its Aspects.
+      setChord({
+        primary: entry.primary_aspect ?? null,
+        secondary: entry.secondary_aspect ?? null,
+      });
     }, []),
     useCallback(() => setLoadError(LOAD_ERROR_MESSAGE), []),
   );
@@ -381,12 +430,43 @@ function useEntryState(routeEntryId: number | null, initialTitle: string): Entry
     setStatus,
     classification,
     setClassification,
+    chord,
+    setChord,
     setTitle,
     setBody,
     titleRef,
     bodyRef,
     loadError,
   };
+}
+
+interface ChoiceHandlers {
+  onChangeClassification: (_tier: PrivacyTier) => void;
+  onChangeChord: (_next: AspectChordValue) => void;
+}
+
+/** Reflect a privacy/chord choice in local state, then persist it (ref or PATCH). */
+function useChoiceHandlers(
+  entry: EntryState,
+  changeClassification: (_tier: PrivacyTier) => void,
+  changeChord: (_next: AspectChordValue) => void,
+): ChoiceHandlers {
+  const { setClassification, setChord } = entry;
+  const onChangeClassification = useCallback(
+    (tier: PrivacyTier) => {
+      setClassification(tier);
+      changeClassification(tier);
+    },
+    [changeClassification, setClassification],
+  );
+  const onChangeChord = useCallback(
+    (next: AspectChordValue) => {
+      setChord(next);
+      changeChord(next);
+    },
+    [changeChord, setChord],
+  );
+  return { onChangeClassification, onChangeChord };
 }
 
 /** Owns the entry's text + debounced draft autosave (create-then-update). */
@@ -398,8 +478,8 @@ function useJournalAutosave(
   onSaved?: () => void,
 ): AutosaveApi {
   const entry = useEntryState(routeEntryId, initialTitle);
-  const { titleRef, bodyRef, setClassification } = entry;
-  const { saveState, save, flush, changeClassification } = useDebouncedSave(
+  const { titleRef, bodyRef } = entry;
+  const { saveState, save, flush, changeClassification, changeChord } = useDebouncedSave(
     routeEntryId,
     delayMs,
     ctx,
@@ -418,13 +498,10 @@ function useJournalAutosave(
     () => flush(titleRef.current, bodyRef.current),
     [flush, titleRef, bodyRef],
   );
-  // Reflect the choice in the control, then persist it (create-time ref or PATCH).
-  const onChangeClassification = useCallback(
-    (tier: PrivacyTier) => {
-      setClassification(tier);
-      changeClassification(tier);
-    },
-    [changeClassification, setClassification],
+  const { onChangeClassification, onChangeChord } = useChoiceHandlers(
+    entry,
+    changeClassification,
+    changeChord,
   );
 
   return {
@@ -434,9 +511,11 @@ function useJournalAutosave(
     setStatus: entry.setStatus,
     saveState,
     classification: entry.classification,
+    chord: entry.chord,
     onChangeTitle,
     onChangeBody,
     onChangeClassification,
+    onChangeChord,
     flush: flushNow,
     loadError: entry.loadError,
   };
@@ -447,9 +526,11 @@ interface WritingColumnProps {
   body: string;
   saveState: SaveState;
   classification: PrivacyTier;
+  chord: AspectChordValue;
   onChangeTitle: (_next: string) => void;
   onChangeBody: (_next: string) => void;
   onChangeClassification: (_tier: PrivacyTier) => void;
+  onChangeChord: (_next: AspectChordValue) => void;
   onFinish?: () => void;
   bodyPlaceholder?: string;
 }
@@ -473,9 +554,11 @@ function WritingColumn({
   body,
   saveState,
   classification,
+  chord,
   onChangeTitle,
   onChangeBody,
   onChangeClassification,
+  onChangeChord,
   onFinish,
   bodyPlaceholder = 'Begin writing…',
 }: WritingColumnProps) {
@@ -486,6 +569,7 @@ function WritingColumn({
       keyboardShouldPersistTaps="handled"
     >
       <PrivacyTierControl value={classification} onChange={onChangeClassification} />
+      <AspectChordControl value={chord} onChange={onChangeChord} />
       <TextInput
         style={styles.titleInput}
         value={title}
@@ -822,7 +906,7 @@ type Controller = ReturnType<typeof useJournalEntryController>;
 
 /** The body column: the editable writing surface, or the read-mode highlighted view. */
 function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceholder: string }) {
-  const { title, body, saveState, classification } = ctl.autosave;
+  const { title, body, saveState, classification, chord } = ctl.autosave;
   const { editMode, canFinish, markFinished, requestEdit } = ctl.editGate;
   return editMode ? (
     <WritingColumn
@@ -830,9 +914,11 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
       body={body}
       saveState={saveState}
       classification={classification}
+      chord={chord}
       onChangeTitle={ctl.handleTitle}
       onChangeBody={ctl.handleBody}
       onChangeClassification={ctl.autosave.onChangeClassification}
+      onChangeChord={ctl.autosave.onChangeChord}
       onFinish={canFinish ? markFinished : undefined}
       bodyPlaceholder={bodyPlaceholder}
     />

--- a/frontend/src/features/Journal/__tests__/AspectChordControl.test.tsx
+++ b/frontend/src/features/Journal/__tests__/AspectChordControl.test.tsx
@@ -1,0 +1,130 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import AspectChordControl from '../AspectChordControl';
+
+import { STAGE_DISPLAY } from '@/features/Map/mapLayout';
+
+/** The controlled value shape the control reports back via onChange. */
+interface AspectChordValue {
+  primary: number | null;
+  secondary: number | null;
+}
+
+function renderControl(
+  value?: AspectChordValue,
+  onChange: (_next: AspectChordValue) => void = jest.fn(),
+) {
+  return render(<AspectChordControl value={value} onChange={onChange} />);
+}
+
+// ---------------------------------------------------------------------------
+// Collapsed by default
+// ---------------------------------------------------------------------------
+
+describe('AspectChordControl — collapsed by default', () => {
+  it('shows the trigger and no primary chips before expanding', () => {
+    const { getByTestId, queryByTestId } = renderControl();
+    expect(getByTestId('aspect-chord-trigger')).toBeTruthy();
+    expect(queryByTestId('aspect-primary-1')).toBeNull();
+  });
+
+  it('never fires onChange on mount (nothing pre-selected)', () => {
+    const onChange = jest.fn();
+    renderControl(undefined, onChange);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expanding reveals primary chips
+// ---------------------------------------------------------------------------
+
+describe('AspectChordControl — expanding', () => {
+  it('tapping the trigger reveals all ten primary aspect chips', () => {
+    const { getByTestId } = renderControl();
+    fireEvent.press(getByTestId('aspect-chord-trigger'));
+    for (let n = 1; n <= 10; n += 1) {
+      expect(getByTestId(`aspect-primary-${n}`)).toBeTruthy();
+    }
+  });
+
+  it('uses STAGE_DISPLAY labels for the primary chips, not invented copy', () => {
+    const { getByTestId, getByText } = renderControl();
+    fireEvent.press(getByTestId('aspect-chord-trigger'));
+    const stageOne = STAGE_DISPLAY[1];
+    if (stageOne === undefined) throw new Error('STAGE_DISPLAY[1] missing');
+    expect(getByText(stageOne.persona)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selecting a primary
+// ---------------------------------------------------------------------------
+
+describe('AspectChordControl — selecting a primary', () => {
+  it('fires onChange with {primary, secondary: null}', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = renderControl(undefined, onChange);
+    fireEvent.press(getByTestId('aspect-chord-trigger'));
+    fireEvent.press(getByTestId('aspect-primary-4'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ primary: 4, secondary: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Secondary chips
+// ---------------------------------------------------------------------------
+
+describe('AspectChordControl — secondary chips', () => {
+  it('do not appear before a primary is set', () => {
+    const { getByTestId, queryByTestId } = renderControl();
+    fireEvent.press(getByTestId('aspect-chord-trigger'));
+    expect(queryByTestId('aspect-secondary-1')).toBeNull();
+  });
+
+  it('appear once a primary is set, excluding the chosen primary', () => {
+    const onChange = jest.fn();
+    const { getByTestId, queryByTestId, rerender } = render(
+      <AspectChordControl value={undefined} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('aspect-chord-trigger'));
+    fireEvent.press(getByTestId('aspect-primary-4'));
+    rerender(<AspectChordControl value={{ primary: 4, secondary: null }} onChange={onChange} />);
+    expect(getByTestId('aspect-secondary-1')).toBeTruthy();
+    expect(queryByTestId('aspect-secondary-4')).toBeNull();
+  });
+
+  it('fires onChange with {primary, secondary} when a secondary chip is pressed', () => {
+    const onChange = jest.fn();
+    const { getByTestId, rerender } = render(
+      <AspectChordControl value={undefined} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('aspect-chord-trigger'));
+    fireEvent.press(getByTestId('aspect-primary-4'));
+    rerender(<AspectChordControl value={{ primary: 4, secondary: null }} onChange={onChange} />);
+    fireEvent.press(getByTestId('aspect-secondary-9'));
+    expect(onChange).toHaveBeenCalledWith({ primary: 4, secondary: 9 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clear affordance
+// ---------------------------------------------------------------------------
+
+describe('AspectChordControl — clear affordance', () => {
+  it('resets to {primary: null, secondary: null} when pressed', () => {
+    const onChange = jest.fn();
+    const { getByTestId, rerender } = render(
+      <AspectChordControl value={undefined} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('aspect-chord-trigger'));
+    fireEvent.press(getByTestId('aspect-primary-2'));
+    rerender(<AspectChordControl value={{ primary: 2, secondary: null }} onChange={onChange} />);
+    fireEvent.press(getByTestId('aspect-chord-clear'));
+    expect(onChange).toHaveBeenCalledWith({ primary: null, secondary: null });
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
@@ -1,0 +1,196 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react-native';
+import React from 'react';
+
+/**
+ * Verifies the Aspect-chord PATCH-error wiring in ``JournalEntryScreen``: a
+ * chord change on an existing entry is PATCHed immediately, and — mirroring the
+ * privacy-tier control — a rejected PATCH surfaces the save-error hint and
+ * reverts the optimistic chord selection to the persisted value, unless a later
+ * change has superseded it.
+ */
+import type { JournalMessage } from '@/api';
+
+// ---------------------------------------------------------------------------
+// API mock — mirrors JournalEntryScreenPrivacy.test.tsx
+// ---------------------------------------------------------------------------
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+const mockGenerate = jest.fn() as jest.MockedFunction<(_id: number) => Promise<unknown>>;
+const mockRespond = jest.fn() as jest.MockedFunction<(_w: number, _b: string) => Promise<unknown>>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: {
+    respond: (...a: unknown[]) => (mockRespond as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: (...a: unknown[]) => (mockGenerate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  completionSuggestions: {
+    list: jest.fn(() => Promise.resolve({ items: [] })),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+type EntryOverrides = Partial<JournalMessage> & {
+  primary_aspect?: number | null;
+  secondary_aspect?: number | null;
+};
+
+function entry(overrides: EntryOverrides = {}): JournalMessage {
+  return {
+    id: 7,
+    message: 'A page about rivers.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'freeform' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'Rivers',
+    status: 'draft',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  } as JournalMessage;
+}
+
+function renderScreen(params?: { entryId?: number }, extraProps: Record<string, unknown> = {}) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return render(<Screen navigation={navigation} route={route} {...extraProps} />);
+}
+
+const ERROR_HINT = "Couldn't save — keep writing, we'll retry";
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockGenerate.mockReset();
+  mockRespond.mockReset();
+  mockRespond.mockResolvedValue({});
+});
+
+// ---------------------------------------------------------------------------
+// Chord change — PATCH failure surfaces the error and reverts the selection
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — chord change PATCH failure', () => {
+  it('surfaces the save-error hint and reverts the optimistic chord when the PATCH rejects', async () => {
+    jest.useFakeTimers();
+    try {
+      // Untagged on load — the revert target is the persisted (empty) chord, so a
+      // failed tag correctly falls back to "no chord", matching the ref's truth.
+      mockGet.mockResolvedValue(entry({ id: 7, primary_aspect: null, secondary_aspect: null }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+      mockUpdate.mockRejectedValueOnce(new Error('network'));
+
+      const page = within(getByTestId('journal-page'));
+      fireEvent.press(page.getByTestId('aspect-chord-trigger'));
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('aspect-primary-5'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(getByTestId('journal-save-hint').props.children).toBe(ERROR_HINT);
+      // Reverted to the persisted (untagged) chord: the just-picked chip is cleared.
+      expect(
+        within(getByTestId('journal-page')).getByTestId('aspect-primary-5').props.accessibilityState
+          .selected,
+      ).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps the new chord selected with no error hint when the PATCH succeeds', async () => {
+    jest.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue(entry({ id: 7, primary_aspect: null, secondary_aspect: null }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+
+      const page = within(getByTestId('journal-page'));
+      fireEvent.press(page.getByTestId('aspect-chord-trigger'));
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('aspect-primary-5'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ primary_aspect: 5, secondary_aspect: null }),
+      );
+      const after = within(getByTestId('journal-page'));
+      expect(after.getByTestId('aspect-primary-5').props.accessibilityState.selected).toBe(true);
+      expect(getByTestId('journal-save-hint').props.children).not.toBe(ERROR_HINT);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not revert a superseding chord change when the earlier PATCH rejects', async () => {
+    jest.useFakeTimers();
+    try {
+      mockGet.mockResolvedValue(entry({ id: 7, primary_aspect: null, secondary_aspect: null }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+      // First PATCH (primary 5) rejects; the superseding one (primary 8) resolves.
+      mockUpdate.mockRejectedValueOnce(new Error('network'));
+
+      const page = within(getByTestId('journal-page'));
+      fireEvent.press(page.getByTestId('aspect-chord-trigger'));
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('aspect-primary-5'));
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('aspect-primary-8'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const after = within(getByTestId('journal-page'));
+      expect(after.getByTestId('aspect-primary-8').props.accessibilityState.selected).toBe(true);
+      expect(after.getByTestId('aspect-primary-5').props.accessibilityState.selected).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Lets a journal entry name a **chord**: an optional **primary Aspect** (a curriculum stage 1..10) and, atop it, an optional **secondary Aspect** — the way one action can sound from more than one Stage at once. Both are optional and declinable; untagged entries are completely unchanged.

- **Model** (`journal_entry.py`): two nullable int columns `primary_aspect` / `secondary_aspect` with DB CHECKs — a range check (1..`TOTAL_STAGES`) and a chord-shape check (a secondary requires a distinct primary). New Alembic revision `a5b6c7d8e9f0` mirrors the model's constraints exactly (keeps `alembic check` drift-free) with a SQLite upgrade/downgrade round-trip test.
- **Schemas** (`schemas/journal.py`): chord fields on create/update/response with a shared range + chord-shape validator. `JournalEntryUpdate`'s at-least-one guard now keys on `model_fields_set`, so an explicit-null clear (`{primary_aspect: null, secondary_aspect: null}`) is accepted while an empty `{}` is still rejected.
- **Router** (`routers/journal.py`): PATCH applies the chord as an **atomic pair** — a primary-only edit resets a stale secondary to null rather than colliding with the chord-shape CHECK.
- **Wheel** (`domain/wheel.py`): each Aspect's `fullness` now folds in a small, **capped, documented chord signal** (primary weighs 2× secondary; `fullness = min(overall_progress + chord_signal, 1.0)`), counting the user's own non-deleted entries. It is an **exact no-op** when no entries are tagged, so existing wheel behavior is preserved.
- **Frontend**: a collapsed-by-default `AspectChordControl` (primary chips → optional secondary chips that exclude the chosen primary → a clear affordance), wired into the journal editor and persisted on create and via a paired PATCH. API types and the response zod schema carry both fields, so the Wheel (#913/#914) and the explainer (#948) can read a chord.

## Test plan

- `backend/tests/test_journal_chord_model.py` — DB-level range + chord-shape enforcement (IntegrityError).
- `backend/tests/test_journal_chord_schema.py` — pydantic range/chord-shape, `model_fields_set` explicit-null path, empty-payload rejection, response serialization.
- `backend/tests/test_journal_chord_router.py` — POST persists/echoes; PATCH pair, explicit-null clear, primary-only resets stale secondary (no 500); 422s for invalid chords.
- `backend/tests/domain/test_wheel_chord.py` — primary/secondary lift the right Aspect by the exact formula; soft-deleted entries contribute 0; cap + 1.0 clamp; untagged is a no-op.
- `backend/tests/test_migrations.py` — SQLite upgrade/downgrade/re-upgrade round-trip for the new revision.
- `frontend/.../AspectChordControl.test.tsx` + `privacySchemas.test.ts` — declinable/collapsed control behavior and zod parsing/rejection.
- Gate 2 green locally: backend `check-all.sh` (2200 passed, coverage 96.11%) + `xenon`/`radon`; frontend `check-all.sh` (2746 passed, eslint/prettier/tsc).

## Follow-ups (non-blocking)

- In weekly-prompt compose mode the chord control renders but the chord isn't carried (the prompt-respond endpoint persists the entry and doesn't take chord fields) — this mirrors the existing `PrivacyTierControl`, which also drops `classification` there. Worth a small follow-up to either gate both controls off in that mode or thread them through the prompt endpoint.

Closes #1020
Refs #1004, #913, #914, #948, #943