### PR TITLE
refactor(frontend): prune dead pagination ladder + MAP_STAGE_COLORS

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -57,10 +57,14 @@ describe('API client request composition', () => {
     );
   });
 
-  it('requests stage list with GET /stages', async () => {
-    await api.stages.list();
+  it('requests stage list with GET /stages via the paginated envelope', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [], total: 0, limit: 50, offset: 0, has_more: false }),
+    });
+    await api.stages.listAll();
     expect(fetch).toHaveBeenCalledWith(
-      `${mockBaseUrl}/stages`,
+      expect.stringContaining(`${mockBaseUrl}/stages?paginate=true`),
       expect.objectContaining(expectSignal),
     );
   });

--- a/frontend/src/api/__tests__/pagination-api.test.ts
+++ b/frontend/src/api/__tests__/pagination-api.test.ts
@@ -74,59 +74,13 @@ const validContentItem = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
-describe('paginated list endpoints (issue #221 — Page envelope)', () => {
-  test('practices.listPaginated opts into the envelope and forwards stage_number', async () => {
-    const envelope = page([validPractice()]);
-    mockFetch.mockReturnValueOnce(jsonResponse(envelope));
-
-    const result = await practices.listPaginated({ stageNumber: 3 }, 'tok');
-
-    const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/practices/?paginate=true&stage_number=3');
-    expect(init.method).toBeUndefined(); // GET
-    expect(init.headers).toMatchObject({ Authorization: 'Bearer tok' });
-    expect(result).toEqual(envelope);
-  });
-
-  test('practices.listPaginated forwards limit and offset when supplied', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse(page([], { total: 120, has_more: true })));
-
-    await practices.listPaginated({ stageNumber: 2, limit: 50, offset: 50 }, 'tok');
-
-    const [url] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/practices/?paginate=true&stage_number=2&limit=50&offset=50');
-  });
-
-  test('stages.listPaginated hits /stages (no trailing slash) with the envelope flag', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse(page([validStage()])));
-
-    await stages.listPaginated({}, 'tok');
-
-    const [url] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/stages?paginate=true');
-  });
-
-  test('course.stageContentPaginated targets the stage content path with the envelope flag', async () => {
-    const envelope = page([validContentItem()], {
-      total: 3,
-      has_more: true,
-    });
-    mockFetch.mockReturnValueOnce(jsonResponse(envelope));
-
-    const result = await course.stageContentPaginated(3, { limit: 50 }, 'tok');
-
-    const [url] = mockFetch.mock.calls[0];
-    expect(url).toBe('http://test/course/stages/3/content?paginate=true&limit=50');
-    expect(result.has_more).toBe(true);
-    expect(result.total).toBe(3);
-  });
-
+describe('paginated list endpoints (Page envelope)', () => {
   test('a malformed envelope (missing has_more) raises ApiValidationError', async () => {
     mockFetch.mockReturnValueOnce(
       jsonResponse({ items: [], total: 0, limit: 50, offset: 0 }), // no has_more
     );
 
-    await expect(stages.listPaginated({}, 'tok')).rejects.toThrow(ApiValidationError);
+    await expect(stages.listAll('tok')).rejects.toThrow(ApiValidationError);
   });
 
   test('a non-array items field raises ApiValidationError', async () => {
@@ -134,7 +88,7 @@ describe('paginated list endpoints (issue #221 — Page envelope)', () => {
       jsonResponse({ items: 'nope', total: 0, limit: 50, offset: 0, has_more: false }),
     );
 
-    await expect(stages.listPaginated({}, 'tok')).rejects.toThrow(ApiValidationError);
+    await expect(stages.listAll('tok')).rejects.toThrow(ApiValidationError);
   });
 });
 
@@ -217,26 +171,5 @@ describe('fetchAllPages + listAll helpers (issue #408 — screen adoption)', () 
     // whole page rather than being silently filtered (audit-contracts-04).
     mockFetch.mockReturnValueOnce(jsonResponse(page([validPractice(), { bogus: true }])));
     await expect(practices.listAll({ stageNumber: 3 })).rejects.toThrow(ApiValidationError);
-  });
-});
-
-describe('practices.list (bare array, audit-contracts-06)', () => {
-  test('round-trips every valid row intact', async () => {
-    const rows = [validPractice({ id: 1 }), validPractice({ id: 2 })];
-    mockFetch.mockReturnValueOnce(jsonResponse(rows));
-    const result = await practices.list({ stageNumber: 3 });
-    expect(result).toEqual(rows);
-  });
-
-  test('raises ApiValidationError on a drifted row instead of dropping it', async () => {
-    // A renamed field used to make the row silently fail the typeof guard and
-    // vanish from the catalog; it must now surface as a validation error.
-    const drifted = {
-      ...validPractice({ id: 2 }),
-      default_duration_minutes: undefined,
-      duration: 5,
-    };
-    mockFetch.mockReturnValueOnce(jsonResponse([validPractice({ id: 1 }), drifted]));
-    await expect(practices.list({ stageNumber: 3 })).rejects.toThrow(ApiValidationError);
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -889,37 +889,33 @@ const habitWithGoalsArraySchema = z.array(habitWithGoalsSchema);
 const habitPageSchema = pageSchema(habitWithGoalsSchema);
 
 /**
- * Standard ``limit`` / ``offset`` knobs every ``listPaginated`` helper accepts.
- * Both default to the server's values (limit 50, offset 0) when omitted.
+ * The single ``offset`` knob ``fetchAllPages`` threads through each page fetch.
+ * Defaults to the server's value (offset 0) when omitted.
  */
 export interface PaginationParams {
-  limit?: number;
   offset?: number;
 }
 
 /**
- * Build the query string shared by every ``listPaginated`` helper: always opt
+ * Build the query string shared by every ``listAll`` page fetch: always opt
  * into the ``Page`` envelope (``paginate=true``), append any endpoint-specific
- * filters (e.g. ``stage_number``), then ``limit`` / ``offset`` only when the
- * caller supplies them — mirroring ``habits.listPaginated`` above.
+ * filters (e.g. ``stage_number``), then ``offset`` only when the caller
+ * supplies one.
  */
 function pageQuery(extra: Record<string, string | number>, params: PaginationParams): string {
   const query = new URLSearchParams({ paginate: 'true' });
   for (const [key, value] of Object.entries(extra)) query.set(key, String(value));
-  if (params.limit != null) query.set('limit', String(params.limit));
   if (params.offset != null) query.set('offset', String(params.offset));
   return query.toString();
 }
 
 /**
- * Drain every page of a ``listPaginated``-style helper into one flat array.
+ * Drain every page of a paginated endpoint into one flat array.
  *
- * The screen-adoption path for the ``Page`` envelope (issue #408): every
- * list in the app is small today, so screens keep their whole-list render
- * while the wire contract moves to the envelope. A screen that later needs
- * true incremental loading calls its ``listPaginated`` helper directly with
- * offsets instead. The empty-page guard stops a buggy server from looping
- * forever on ``has_more: true``.
+ * The screen-adoption path for the ``Page`` envelope: every list in the app
+ * is small today, so screens keep their whole-list render while the wire
+ * contract moves to the envelope. The empty-page guard stops a buggy server
+ * from looping forever on ``has_more: true``.
  */
 export async function fetchAllPages<T>(
   fetchPage: (_params: PaginationParams) => Promise<Page<T>>,
@@ -942,33 +938,21 @@ export async function fetchAllPages<T>(
 // mobile web). Item-level URLs (`/habits/{id}`) are matched without the
 // trailing slash because their FastAPI routes are declared that way.
 export const habits = {
+  /** No production screen callers — screens use ``listAll``; retained as the request-machinery test vehicle and bare-array wire-contract guard. */
   list(token?: string): Promise<ApiHabitWithGoals[]> {
     return request<ApiHabitWithGoals[]>('/habits/', {
       token,
       schema: habitWithGoalsArraySchema as unknown as z.ZodType<ApiHabitWithGoals[]>,
     });
   },
-  /**
-   * Paginated habits list (BUG-INFRA-013). Opts into the server-side
-   * ``Page`` envelope introduced alongside the backend pagination change;
-   * callers that need ``total`` / ``has_more`` should prefer this over the
-   * bare-list variant above.
-   */
-  listPaginated(
-    params: { limit?: number; offset?: number } = {},
-    token?: string,
-  ): Promise<Page<ApiHabitWithGoals>> {
-    const query = new URLSearchParams({ paginate: 'true' });
-    if (params.limit != null) query.set('limit', String(params.limit));
-    if (params.offset != null) query.set('offset', String(params.offset));
-    return request<Page<ApiHabitWithGoals>>(`/habits/?${query.toString()}`, {
-      token,
-      schema: habitPageSchema as unknown as z.ZodType<Page<ApiHabitWithGoals>>,
-    });
-  },
-  /** Whole habits list via the ``Page`` envelope (issue #408). */
+  /** Whole habits list via the ``Page`` envelope. */
   listAll(token?: string): Promise<ApiHabitWithGoals[]> {
-    return fetchAllPages((params) => habits.listPaginated(params, token));
+    return fetchAllPages((params) =>
+      request<Page<ApiHabitWithGoals>>(`/habits/?${pageQuery({}, params)}`, {
+        token,
+        schema: habitPageSchema as unknown as z.ZodType<Page<ApiHabitWithGoals>>,
+      }),
+    );
   },
   create(payload: HabitCreatePayload, token?: string): Promise<ApiHabit> {
     return request<ApiHabit>('/habits/', { method: 'POST', body: payload, token });
@@ -1493,22 +1477,14 @@ export interface StageHistoryResponse {
 }
 
 export const stages = {
-  list(token?: string): Promise<Stage[]> {
-    return request<Stage[]>('/stages', { token });
-  },
-  /**
-   * Paginated stages list (BUG-INFRA-016). Opts into the ``Page`` envelope.
-   * Note the route has no trailing slash (``/stages``), matching the backend.
-   */
-  listPaginated(params: PaginationParams = {}, token?: string): Promise<Page<Stage>> {
-    return request<Page<Stage>>(`/stages?${pageQuery({}, params)}`, {
-      token,
-      schema: pageSchema(stageSchema),
-    });
-  },
-  /** Whole stages list via the ``Page`` envelope (issue #408). */
+  /** Whole stages list via the ``Page`` envelope (no trailing slash — matches the backend route). */
   listAll(token?: string): Promise<Stage[]> {
-    return fetchAllPages((params) => stages.listPaginated(params, token));
+    return fetchAllPages((params) =>
+      request<Page<Stage>>(`/stages?${pageQuery({}, params)}`, {
+        token,
+        schema: pageSchema(stageSchema),
+      }),
+    );
   },
   history(stageNumber: number, token?: string): Promise<StageHistoryResponse> {
     return request<StageHistoryResponse>(`/stages/${stageNumber}/history`, { token });
@@ -1589,29 +1565,14 @@ export interface StageIntro {
 }
 
 export const course = {
-  /**
-   * Paginated stage content (BUG-INFRA-018). Opts into the ``Page`` envelope.
-   *
-   * Caveat: pagination is applied *after* drip-feed filtering, so ``total``
-   * reflects only the items the user can currently see — it grows as content
-   * unlocks over time, without new database rows being added.
-   */
-  stageContentPaginated(
-    stageNumber: number,
-    params: PaginationParams = {},
-    token?: string,
-  ): Promise<Page<ContentItem>> {
-    return request<Page<ContentItem>>(
-      `/course/stages/${stageNumber}/content?${pageQuery({}, params)}`,
-      {
+  /** Whole stage-content list via the ``Page`` envelope. */
+  stageContentAll(stageNumber: number, token?: string): Promise<ContentItem[]> {
+    return fetchAllPages((params) =>
+      request<Page<ContentItem>>(`/course/stages/${stageNumber}/content?${pageQuery({}, params)}`, {
         token,
         schema: pageSchema(contentItemSchema) as unknown as z.ZodType<Page<ContentItem>>,
-      },
+      }),
     );
-  },
-  /** Whole stage-content list via the ``Page`` envelope (issue #408). */
-  stageContentAll(stageNumber: number, token?: string): Promise<ContentItem[]> {
-    return fetchAllPages((params) => course.stageContentPaginated(stageNumber, params, token));
   },
   markRead(contentId: number, token?: string): Promise<ContentCompletion> {
     return request<ContentCompletion>(`/course/content/${contentId}/mark-read`, {
@@ -1870,62 +1831,30 @@ export interface PracticeCreatePayload {
 
 export const practices = {
   /**
-   * List approved practices for a stage.
+   * Whole practices list for a stage via the ``Page`` envelope.
    *
    * ``includeMine`` opts in to the backend's ``?include_mine=true`` flag
-   * (custom-practices-07), which also returns the authenticated user's
-   * own unapproved drafts so the catalog can render a "My drafts"
-   * section. The default ``false`` preserves the legacy approved-only
-   * behaviour for existing callers (e.g. useActivePractice).
-   *
-   * The numeric overload retains the historic ``practices.list(stage)``
-   * signature so older call sites keep working without a churn pass.
-   */
-  async list(
-    options: { stageNumber: number; includeMine?: boolean } | number,
-    token?: string,
-  ): Promise<PracticeItem[]> {
-    const params = typeof options === 'number' ? { stageNumber: options } : options;
-    const query = new URLSearchParams();
-    query.set('stage_number', String(params.stageNumber));
-    if (params.includeMine === true) query.set('include_mine', 'true');
-    // Parse the array (don't filter): a drifted row now raises
-    // ApiValidationError instead of silently vanishing from the catalog.
-    return request<PracticeItem[]>(`/practices/?${query.toString()}`, {
-      token,
-      schema: z.array(practiceItemSchema) as unknown as z.ZodType<PracticeItem[]>,
-    });
-  },
-  /**
-   * Paginated practices list for a stage (BUG-INFRA-012). Opts into the
-   * ``Page`` envelope; ``stage_number`` is required (the backend route filters
-   * by stage). Prefer this over ``list`` when ``total`` / ``has_more`` matter.
-   */
-  listPaginated(
-    params: { stageNumber: number; includeMine?: boolean } & PaginationParams,
-    token?: string,
-  ): Promise<Page<PracticeItem>> {
-    const { stageNumber, includeMine, ...page } = params;
-    const extra: Record<string, string | number> = { stage_number: stageNumber };
-    if (includeMine === true) extra.include_mine = 'true';
-    return request<Page<PracticeItem>>(`/practices/?${pageQuery(extra, page)}`, {
-      token,
-      schema: pageSchema(practiceItemSchema) as unknown as z.ZodType<Page<PracticeItem>>,
-    });
-  },
-  /**
-   * Whole practices list via the ``Page`` envelope (issue #408). Items are
-   * validated per ``practiceItemSchema`` inside ``listPaginated``, so a
-   * malformed row rejects the page (``fetchAllPages`` propagates the
-   * ``ApiValidationError``) rather than being silently dropped.
+   * (custom-practices-07), which also returns the authenticated user's own
+   * unapproved drafts so the catalog can render a "My drafts" section; it
+   * defaults to the approved-only behaviour existing callers rely on. The
+   * numeric overload retains the historic ``practices.listAll(stage)``
+   * signature so older call sites keep working without a churn pass. Items are
+   * validated per ``practiceItemSchema``, so a malformed row rejects the page
+   * (``fetchAllPages`` propagates the ``ApiValidationError``) rather than
+   * being silently dropped.
    */
   async listAll(
     options: { stageNumber: number; includeMine?: boolean } | number,
     token?: string,
   ): Promise<PracticeItem[]> {
     const params = typeof options === 'number' ? { stageNumber: options } : options;
+    const extra: Record<string, string | number> = { stage_number: params.stageNumber };
+    if (params.includeMine === true) extra.include_mine = 'true';
     return fetchAllPages((pageParams) =>
-      practices.listPaginated({ ...params, ...pageParams }, token),
+      request<Page<PracticeItem>>(`/practices/?${pageQuery(extra, pageParams)}`, {
+        token,
+        schema: pageSchema(practiceItemSchema) as unknown as z.ZodType<Page<PracticeItem>>,
+      }),
     );
   },
   get(practiceId: number, token?: string): Promise<PracticeItem> {

--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -2,7 +2,6 @@
 /* global describe, it, expect */
 import {
   BORDER_RADIUS,
-  MAP_STAGE_COLORS,
   SPACING,
   STAGE_COLORS,
   STAGE_ORDER,
@@ -159,13 +158,6 @@ describe('design tokens', () => {
         return Math.max(...channels) - Math.min(...channels);
       };
       expect(spread(brightenColor('#6fa3d3'))).toBeGreaterThan(spread('#6fa3d3'));
-    });
-  });
-
-  describe('MAP_STAGE_COLORS', () => {
-    it('exports colors for the map spiral', () => {
-      expect(MAP_STAGE_COLORS).toHaveLength(10);
-      expect(MAP_STAGE_COLORS[0]).toBe('#7f1d1d');
     });
   });
 

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -224,20 +224,6 @@ export const brightenColor = (hex: string): string => {
   );
 };
 
-/** Colors for the map spiral visualization (indexed by stageNumber - 1). */
-export const MAP_STAGE_COLORS = [
-  '#7f1d1d',
-  '#9f1239',
-  '#c026d3',
-  '#6d28d9',
-  '#1d4ed8',
-  '#0ea5e9',
-  '#059669',
-  '#65a30d',
-  '#ca8a04',
-  '#ea580c',
-] as const;
-
 // ---------------------------------------------------------------------------
 // Spacing
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -192,7 +192,7 @@ function useContentBody(source: ChapterReaderSource): {
     // The API call omits the explicit token — ``api/index.ts``'s
     // ``request()`` helper falls back to the global ``tokenGetter``
     // (set by ``AuthContext`` at sign-in), so the bearer header is
-    // attached automatically.  Same pattern as ``stagesApi.list()``
+    // attached automatically.  Same pattern as ``stagesApi.listAll()``
     // and the other "no explicit token" callers in the codebase.
     const promise = fetchBody(source);
 

--- a/frontend/src/features/Course/SiteResourcesPanel.tsx
+++ b/frontend/src/features/Course/SiteResourcesPanel.tsx
@@ -34,7 +34,7 @@ const SiteResourcesPanel = ({ onSelect }: SiteResourcesPanelProps): React.JSX.El
     // ``siteResources()`` is called without an explicit token — the
     // shared ``request()`` helper in ``api/index.ts`` falls back to the
     // global ``tokenGetter`` set by ``AuthContext``, matching how
-    // ``stagesApi.list()`` and other no-explicit-token callers work.
+    // ``stagesApi.listAll()`` and other no-explicit-token callers work.
     courseApi
       .siteResources()
       .then((list) => {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -98,7 +98,7 @@ const toApiPayload = (h: Habit): HabitCreatePayload => ({
   stage: h.stage,
 });
 
-const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.list>>): Habit[] =>
+const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.listAll>>): Habit[] =>
   apiHabits.map((h) => ({
     id: h.id,
     stage: h.stage ?? '',
@@ -439,7 +439,7 @@ const rescheduleAndPersist = (habit: Habit): Promise<void> => {
 // ---------------------------------------------------------------------------
 
 const handleApiSuccess = async (
-  apiHabits: Awaited<ReturnType<typeof habitsApi.list>>,
+  apiHabits: Awaited<ReturnType<typeof habitsApi.listAll>>,
   hasCachedData: boolean,
 ): Promise<boolean> => {
   // Only seed FALLBACK when the user is truly fresh: no cache, no live store, no API.

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -272,7 +272,7 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
     mockRoute.params = undefined;
   });
 
-  it('calls practices.list with includeMine when no override is provided', async () => {
+  it('calls practices.listAll with includeMine when no override is provided', async () => {
     mockPracticesList.mockResolvedValueOnce([presetA]);
     render(<PracticeCatalogScreen initialStage={3} />);
     await waitForLoad();


### PR DESCRIPTION
## Summary

Collapses the dead three-rung pagination ladder in `frontend/src/api/index.ts` down to its only live path and removes two other unreferenced surfaces flagged by the 2026-07-01 de-slopify run.

- Inlined each `listPaginated` / `stageContentPaginated` body into its sole `listAll` / `stageContentAll` caller (habits, stages, practices, course), then deleted the now-unused intermediate methods. URLs and Zod `pageSchema` validation are unchanged — the inlines reuse the same `pageQuery` + `fetchAllPages` machinery.
- Deleted the zero-caller bare methods `stages.list` and `practices.list`.
- Pruned the now-dead `limit?` knob from `PaginationParams` and the `limit` branch from `pageQuery` (only `fetchAllPages` produces these params, and it passes `offset` only).
- Deleted the unrendered `MAP_STAGE_COLORS` design token and its test (the Map uses the name-keyed `STAGE_COLORS`).
- Repointed the `habitManager.ts` type alias to `habitsApi.listAll` and refreshed the two stale doc comments that named `stagesApi.list()`.

### Scope note (deliberate deviation from the issue's literal task list)
`habits.list` is **retained**, not deleted. The issue's Signal-1 grep used the production alias `habitsApi.`, which structurally cannot see test callers that import the module object as `habits`. In reality `habits.list()` is an active test vehicle at 13 call sites across `retryAndValidation.test.ts`, `token-refresh.test.ts`, and `unauthorizedReason.test.ts`, exercising the generic `request()` machinery (retry, timeout, 401-refresh-retry, concurrent-GET dedup) plus the habits bare-array wire-shape (`habitWithGoalsArraySchema`) contract guards. Deleting it would force converting all 13 sites to the Page-draining `listAll` — semantics-changing churn, not cleanup. It carries a one-line comment documenting that screens use `listAll` and it is kept as the machinery-test/wire-contract vehicle. The AC greps still return zero because tests call `habits.list(` (not `habitsApi.list(`) and the type alias has no invocation paren.

## Test plan

- `./scripts/frontend/check-all.sh` green: ESLint (zero warnings), Prettier, `tsc --noEmit` (strict), Jest **2727 passed / 273 suites**.
- AC greps return zero matches for `.listPaginated(`, `.stageContentPaginated(`, `MAP_STAGE_COLORS`, and `(habitsApi|stagesApi|practices).list(` invocations across `frontend/src`.
- The malformed-envelope / non-array-items → `ApiValidationError` error path is preserved by retargeting those tests from `stages.listPaginated` to `stages.listAll`; feature screens still load via `listAll` / `stageContentAll` (no behavior change).

Closes #1043