### PR TITLE
refactor(frontend): extract shared Settings feedback-banner + form-state

### DIFF
--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -11,6 +12,9 @@ import {
 } from 'react-native';
 
 import { BYOK_PROVIDERS, providerForKey } from './byokProviders';
+import { SettingsFeedbackBanner } from './shared/SettingsFeedbackBanner';
+import type { SettingsFormState } from './shared/useSettingsForm';
+import { useSettingsFormState, useSettingsSubmit } from './shared/useSettingsForm';
 
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { useApiKey } from '@/context/ApiKeyContext';
@@ -154,29 +158,6 @@ function useRemoveConfirmation(performClear: () => Promise<void>): () => void {
   }, [performClear]);
 }
 
-interface FeedbackBannerProps {
-  error: string | null;
-  status: string | null;
-}
-
-const FeedbackBanner = ({ error, status }: FeedbackBannerProps): React.JSX.Element | null => {
-  if (error) {
-    return (
-      <Text style={styles.error} testID="api-key-error">
-        {error}
-      </Text>
-    );
-  }
-  if (status) {
-    return (
-      <Text style={styles.success} testID="api-key-status">
-        {status}
-      </Text>
-    );
-  }
-  return null;
-};
-
 interface ScreenBodyProps {
   apiKey: string | null;
   draft: string;
@@ -314,7 +295,7 @@ const ScreenBody = ({
       onToggleReveal={onToggleReveal}
     />
     <DetectedProvider draft={draft} />
-    <FeedbackBanner error={error} status={status} />
+    <SettingsFeedbackBanner idPrefix="api-key" error={error} status={status} />
     <ScreenFooter
       submitting={submitting}
       onSave={onSave}
@@ -324,71 +305,31 @@ const ScreenBody = ({
   </>
 );
 
-interface ApiKeyScreenState {
-  draft: string;
-  reveal: boolean;
-  submitting: boolean;
-  error: string | null;
-  status: string | null;
-  setDraft: React.Dispatch<React.SetStateAction<string>>;
-  setReveal: React.Dispatch<React.SetStateAction<boolean>>;
-  setSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
-  setError: React.Dispatch<React.SetStateAction<string | null>>;
-  setStatus: React.Dispatch<React.SetStateAction<string | null>>;
-}
-
-function useApiKeyScreenState(): ApiKeyScreenState {
-  const [draft, setDraft] = useState('');
-  const [reveal, setReveal] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<string | null>(null);
-  return {
-    draft,
-    reveal,
-    submitting,
-    error,
-    status,
-    setDraft,
-    setReveal,
-    setSubmitting,
-    setError,
-    setStatus,
-  };
-}
-
 function useSaveKeyHandler(
-  state: ApiKeyScreenState,
+  form: SettingsFormState,
+  setReveal: Dispatch<SetStateAction<boolean>>,
   saveApiKey: (_k: string) => Promise<void>,
 ): () => Promise<void> {
-  const { draft, setDraft, setReveal, setSubmitting, setError, setStatus } = state;
-  return useCallback(async () => {
-    setStatus(null);
-    const problem = validateUserApiKey(draft);
-    if (problem) {
-      setError(problem.message);
-      return;
-    }
-    setError(null);
-    setSubmitting(true);
-    try {
-      await saveApiKey(draft.trim());
-      setDraft('');
-      setReveal(false);
-      setStatus('API key saved on this device.');
-    } catch (err) {
-      setError((err as Error).message ?? 'Could not save the API key.');
-    } finally {
-      setSubmitting(false);
-    }
-  }, [draft, saveApiKey, setDraft, setReveal, setSubmitting, setError, setStatus]);
+  const { draft, setDraft, setStatus } = form;
+  const validate = useCallback(() => validateUserApiKey(draft)?.message ?? null, [draft]);
+  const perform = useCallback(async () => {
+    await saveApiKey(draft.trim());
+    setDraft('');
+    setReveal(false);
+    setStatus('API key saved on this device.');
+  }, [draft, saveApiKey, setDraft, setReveal, setStatus]);
+  const onError = useCallback(
+    (err: unknown) => (err as Error).message ?? 'Could not save the API key.',
+    [],
+  );
+  return useSettingsSubmit(form, { validate, perform, onError });
 }
 
 function useClearKeyHandler(
-  state: ApiKeyScreenState,
+  form: SettingsFormState,
   clearApiKey: () => Promise<void>,
 ): () => Promise<void> {
-  const { setStatus, setError, setSubmitting } = state;
+  const { setStatus, setError, setSubmitting } = form;
   return useCallback(async () => {
     setStatus(null);
     setSubmitting(true);
@@ -405,19 +346,21 @@ function useClearKeyHandler(
 
 export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.JSX.Element {
   const { apiKey, isLoading, saveApiKey, clearApiKey } = useApiKey();
-  const state = useApiKeyScreenState();
-  const handleSave = useSaveKeyHandler(state, saveApiKey);
-  const performClear = useClearKeyHandler(state, clearApiKey);
+  const form = useSettingsFormState('');
+  const [reveal, setReveal] = useState(false);
+  const handleSave = useSaveKeyHandler(form, setReveal, saveApiKey);
+  const performClear = useClearKeyHandler(form, clearApiKey);
   const handleRequestRemove = useRemoveConfirmation(performClear);
 
+  const { setDraft, setError } = form;
   const onChangeDraft = useCallback(
     (value: string) => {
-      state.setDraft(value);
-      state.setError(null);
+      setDraft(value);
+      setError(null);
     },
-    [state],
+    [setDraft, setError],
   );
-  const toggleReveal = useCallback(() => state.setReveal((prev) => !prev), [state]);
+  const toggleReveal = useCallback(() => setReveal((prev) => !prev), [setReveal]);
   const onBack = useMemo(
     () => (navigation?.goBack ? () => navigation.goBack?.() : undefined),
     [navigation],
@@ -439,11 +382,11 @@ export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.
     <ScreenScaffold scroll testID="api-key-settings-screen">
       <ScreenBody
         apiKey={apiKey}
-        draft={state.draft}
-        reveal={state.reveal}
-        submitting={state.submitting}
-        error={state.error}
-        status={state.status}
+        draft={form.draft}
+        reveal={reveal}
+        submitting={form.submitting}
+        error={form.error}
+        status={form.status}
         onChangeDraft={onChangeDraft}
         onToggleReveal={toggleReveal}
         onRequestRemove={handleRequestRemove}
@@ -528,8 +471,6 @@ const styles = StyleSheet.create({
     backgroundColor: surface.sunken,
   },
   revealButtonText: { fontSize: 14, color: ink.primary, fontWeight: '600' },
-  error: { color: colors.destructive.text, marginBottom: SPACING.md },
-  success: { color: colors.successText, marginBottom: SPACING.md },
   button: { borderRadius: BORDER_RADIUS.md, padding: SPACING.md + 2, alignItems: 'center' },
   primaryButton: { backgroundColor: accent.primary, marginTop: SPACING.xs },
   primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },

--- a/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
+++ b/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
@@ -1,5 +1,9 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+
+import { SettingsFeedbackBanner } from './shared/SettingsFeedbackBanner';
+import type { SettingsFormState } from './shared/useSettingsForm';
+import { useSettingsFormState, useSettingsSubmit } from './shared/useSettingsForm';
 
 import { ApiError, users } from '@/api';
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
@@ -56,77 +60,24 @@ const CurrentZoneCard = ({ zone }: { zone: string }): React.JSX.Element => (
   </View>
 );
 
-interface FeedbackBannerProps {
-  error: string | null;
-  status: string | null;
-}
-
-const FeedbackBanner = ({ error, status }: FeedbackBannerProps): React.JSX.Element | null => {
-  if (error) {
-    return (
-      <Text style={styles.error} testID="timezone-error">
-        {error}
-      </Text>
-    );
-  }
-  if (status) {
-    return (
-      <Text style={styles.success} testID="timezone-status">
-        {status}
-      </Text>
-    );
-  }
-  return null;
-};
-
-interface TimezoneScreenState {
-  draft: string;
-  submitting: boolean;
-  error: string | null;
-  status: string | null;
-  setDraft: React.Dispatch<React.SetStateAction<string>>;
-  setSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
-  setError: React.Dispatch<React.SetStateAction<string | null>>;
-  setStatus: React.Dispatch<React.SetStateAction<string | null>>;
-}
-
-function useTimezoneScreenState(initialZone: string): TimezoneScreenState {
-  const [draft, setDraft] = useState(initialZone);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<string | null>(null);
-  return { draft, submitting, error, status, setDraft, setSubmitting, setError, setStatus };
-}
-
 function useSaveTimezoneHandler(
-  state: TimezoneScreenState,
+  form: SettingsFormState,
   applyTimezone: (_timezone: string) => void,
 ): () => Promise<void> {
-  const { draft, setSubmitting, setError, setStatus } = state;
-  return useCallback(async () => {
-    setStatus(null);
-    const candidate = draft.trim();
-    if (!candidate) {
-      setError(EMPTY_ZONE_MESSAGE);
-      return;
-    }
-    setError(null);
-    setSubmitting(true);
-    try {
-      const result = await users.updateMyTimezone({ timezone: candidate });
-      applyTimezone(result.timezone);
-      setStatus('Time zone updated. Streaks and daily stats now use it.');
-    } catch (err: unknown) {
-      setError(saveErrorMessage(err, candidate));
-    } finally {
-      setSubmitting(false);
-    }
-  }, [draft, applyTimezone, setSubmitting, setError, setStatus]);
+  const { draft, setStatus } = form;
+  const validate = useCallback(() => (draft.trim() ? null : EMPTY_ZONE_MESSAGE), [draft]);
+  const perform = useCallback(async () => {
+    const result = await users.updateMyTimezone({ timezone: draft.trim() });
+    applyTimezone(result.timezone);
+    setStatus('Time zone updated. Streaks and daily stats now use it.');
+  }, [draft, applyTimezone, setStatus]);
+  const onError = useCallback((err: unknown) => saveErrorMessage(err, draft.trim()), [draft]);
+  return useSettingsSubmit(form, { validate, perform, onError });
 }
 
 interface ScreenBodyProps {
   currentZone: string;
-  state: TimezoneScreenState;
+  state: SettingsFormState;
   onChangeDraft: (_value: string) => void;
   onUseDeviceZone: () => void;
   onSave: () => void;
@@ -221,14 +172,14 @@ const ScreenBody = ({
       onChangeDraft={onChangeDraft}
       onUseDeviceZone={onUseDeviceZone}
     />
-    <FeedbackBanner error={state.error} status={state.status} />
+    <SettingsFeedbackBanner idPrefix="timezone" error={state.error} status={state.status} />
     <ScreenFooter submitting={state.submitting} onSave={onSave} onBack={onBack} />
   </ScreenScaffold>
 );
 
 export default function TimezoneSettingsScreen({ navigation }: Props = {}): React.JSX.Element {
   const { userTimezone, setUserTimezone } = useAuth();
-  const state = useTimezoneScreenState(userTimezone);
+  const state = useSettingsFormState(userTimezone);
   const handleSave = useSaveTimezoneHandler(state, setUserTimezone);
 
   // Depend on the stable useState setters, not ``state`` itself — the hook
@@ -322,8 +273,6 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.md,
   },
   secondaryButtonText: { fontSize: 14, color: ink.primary, fontWeight: '600' },
-  error: { color: colors.destructive.text, marginBottom: SPACING.md },
-  success: { color: colors.successText, marginBottom: SPACING.md },
   primaryButton: {
     borderRadius: BORDER_RADIUS.md,
     padding: SAVE_BUTTON_PADDING,

--- a/frontend/src/features/Settings/shared/SettingsFeedbackBanner.tsx
+++ b/frontend/src/features/Settings/shared/SettingsFeedbackBanner.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import { SPACING, colors } from '@/design/tokens';
+
+/**
+ * Shared error/status banner for Settings form screens.
+ *
+ * Renders the error message when present, otherwise the success status,
+ * otherwise nothing. The ``idPrefix`` keeps each screen's distinct testIDs
+ * (``api-key-error``/``api-key-status`` vs ``timezone-error``/``timezone-status``)
+ * from a single style + markup definition.
+ */
+
+interface SettingsFeedbackBannerProps {
+  idPrefix: string;
+  error: string | null;
+  status: string | null;
+}
+
+export const SettingsFeedbackBanner = ({
+  idPrefix,
+  error,
+  status,
+}: SettingsFeedbackBannerProps): React.JSX.Element | null => {
+  if (error) {
+    return (
+      <Text style={styles.error} testID={`${idPrefix}-error`}>
+        {error}
+      </Text>
+    );
+  }
+  if (status) {
+    return (
+      <Text style={styles.success} testID={`${idPrefix}-status`}>
+        {status}
+      </Text>
+    );
+  }
+  return null;
+};
+
+const styles = StyleSheet.create({
+  error: { color: colors.destructive.text, marginBottom: SPACING.md },
+  success: { color: colors.successText, marginBottom: SPACING.md },
+});

--- a/frontend/src/features/Settings/shared/useSettingsForm.ts
+++ b/frontend/src/features/Settings/shared/useSettingsForm.ts
@@ -1,0 +1,66 @@
+import { useCallback, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+/**
+ * Shared form-state scaffolding for Settings screens.
+ *
+ * Both the API-key and time-zone screens are the same small form: a text
+ * ``draft``, a ``submitting`` flag, and a mutually-exclusive ``error``/``status``
+ * banner pair. ``useSettingsFormState`` holds that state and ``useSettingsSubmit``
+ * wraps the validate → submit → try/catch/finally state-machine so neither
+ * screen has to re-derive it.
+ */
+
+export interface SettingsFormState<T = string> {
+  draft: T;
+  submitting: boolean;
+  error: string | null;
+  status: string | null;
+  setDraft: Dispatch<SetStateAction<T>>;
+  setSubmitting: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setStatus: Dispatch<SetStateAction<string | null>>;
+}
+
+export function useSettingsFormState<T = string>(initialDraft: T): SettingsFormState<T> {
+  const [draft, setDraft] = useState<T>(initialDraft);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  return { draft, submitting, error, status, setDraft, setSubmitting, setError, setStatus };
+}
+
+type SettingsSubmitState = Pick<SettingsFormState, 'setSubmitting' | 'setError' | 'setStatus'>;
+
+export interface SettingsSubmitConfig {
+  /** Return an error message to block the submit, or ``null`` to proceed. */
+  validate: () => string | null;
+  /** The async work run inside the try block (including success side effects). */
+  perform: () => Promise<void>;
+  /** Map a thrown value to the error message shown to the user. */
+  onError: (_err: unknown) => string;
+}
+
+export function useSettingsSubmit(
+  state: SettingsSubmitState,
+  { validate, perform, onError }: SettingsSubmitConfig,
+): () => Promise<void> {
+  const { setSubmitting, setError, setStatus } = state;
+  return useCallback(async () => {
+    setStatus(null);
+    const problem = validate();
+    if (problem) {
+      setError(problem);
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await perform();
+    } catch (err) {
+      setError(onError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [validate, perform, onError, setSubmitting, setError, setStatus]);
+}


### PR DESCRIPTION
## Summary
De-slop refactor: `ApiKeySettingsScreen` and `TimezoneSettingsScreen` had each independently grown a near-identical copy of one form pattern — a `FeedbackBanner` component, a `{draft, submitting, error, status}` form-state hook, a submit state-machine, and the `error`/`success` banner styles. This extracts that pattern into a Settings-local shared module and rewires both screens onto it.

- `frontend/src/features/Settings/shared/SettingsFeedbackBanner.tsx` — the shared error/status banner. An `idPrefix` prop preserves each screen's distinct testIDs (`api-key-error`/`api-key-status` vs `timezone-error`/`timezone-status`) from a single style + markup definition.
- `frontend/src/features/Settings/shared/useSettingsForm.ts` — `useSettingsFormState<T>()` (draft/submitting/error/status + setters) and `useSettingsSubmit(...)` encapsulating the validate → submit → try/catch/finally sequence.
- Both screens deleted their per-file duplicates and the duplicated `error`/`success` style blocks and now consume the shared primitives.

Behavior, validation, copy, and testIDs are unchanged. The ApiKey clear-key handler was intentionally left inline (it has no validate step and is not duplicated across files). Chosen a Settings-local module rather than a top-level shared location to avoid colliding with the sibling Practice dedup lane.

## Test plan
- `npx tsc --noEmit` — clean
- `npx eslint . --max-warnings=0` — clean
- `npx prettier -c .` — clean
- `npx jest` — 2727 tests pass (132 Settings tests unchanged); shared module 100% covered via the two screen suites
- Gate 2.5 self-review: CLEAN, line-by-line state-machine equivalence verified against the pre-refactor originals

Closes #1045