### PR TITLE
feat(backend): vendor the Archetypal Wavelength curriculum as one source of truth

### DIFF
--- a/backend/src/curriculum/__init__.py
+++ b/backend/src/curriculum/__init__.py
@@ -1,0 +1,285 @@
+"""Typed loader for the vendored Archetypal Wavelength curriculum dataset.
+
+This package vendors a single source of truth for the per-Stage and per-phase
+copy of the Archetypal Wavelength (``archetypal_wavelength.json``) and exposes
+it as validated, frozen dataclasses.  The seeder and any other consumer read
+their Stage definitions from here rather than hardcoding them, so the copy
+cannot drift between call sites.
+
+The loader is strict: it rejects any dataset that is not exactly ten Stages
+(numbered one through ten, no duplicates), each carrying exactly the six
+canonical Wavelength phases in order, with every required string populated.
+Malformed JSON and every shape mismatch surface as :class:`CurriculumDataError`
+so callers never have to catch a raw ``json`` or ``KeyError``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from functools import cache
+from pathlib import Path
+from typing import Any, Final
+
+
+class WavelengthPhase(StrEnum):
+    """One of the six phases of the Archetypal Wavelength.
+
+    The values are the human-readable phase names exactly as they appear in
+    the dataset and the course copy, so the enum can be compared directly
+    against the JSON strings.
+    """
+
+    RISING = "Rising"
+    PEAKING = "Peaking"
+    WITHDRAWAL = "Withdrawal"
+    DIMINISHING = "Diminishing"
+    BOTTOMING_OUT = "Bottoming Out"
+    RESTORATION = "Restoration"
+
+
+#: The canonical order the six phases must appear in for every Stage.  The
+#: enum declaration order is authoritative, so we derive the tuple from it.
+CANONICAL_PHASE_ORDER: Final[tuple[WavelengthPhase, ...]] = tuple(WavelengthPhase)
+
+#: The Stage numbers the dataset must contain, exactly (one through ten).
+_EXPECTED_STAGE_COUNT: Final[int] = 10
+_EXPECTED_STAGE_NUMBERS: Final[frozenset[int]] = frozenset(
+    range(1, _EXPECTED_STAGE_COUNT + 1),
+)
+
+#: The vendored dataset ships alongside this module inside the package.
+_DEFAULT_DATASET_PATH: Final[Path] = Path(__file__).parent / "archetypal_wavelength.json"
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseExpression:
+    """One expression of a phase: an integrated (Rx) or shadow (OD) form."""
+
+    name: str
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseManifestation:
+    """How one Stage manifests in one Wavelength phase (integrated + shadow)."""
+
+    phase: WavelengthPhase
+    integrated: PhaseExpression
+    shadow: PhaseExpression
+
+
+@dataclass(frozen=True, slots=True)
+class StageCurriculum:
+    """The full curriculum record for one APTITUDE Stage.
+
+    Carries the Stage's identifying attributes plus its six phase
+    manifestations, in canonical phase order.
+    """
+
+    stage_number: int
+    title: str
+    subtitle: str
+    category: str
+    aspect: str
+    spiral_dynamics_color: str
+    growing_up_stage: str
+    divine_gender_polarity: str
+    relationship_to_free_will: str
+    free_will_description: str
+    manifestations: tuple[PhaseManifestation, ...]
+
+
+class CurriculumDataError(ValueError):
+    """The curriculum dataset is missing, malformed, or fails validation."""
+
+
+def _require_dict(obj: object, context: str) -> dict[str, Any]:
+    """Return ``obj`` as a dict, or raise :class:`CurriculumDataError`."""
+    if not isinstance(obj, dict):
+        msg = f"{context} must be a JSON object"
+        raise CurriculumDataError(msg)
+    return obj
+
+
+def _require_list(obj: object, context: str) -> list[Any]:
+    """Return ``obj`` as a list, or raise :class:`CurriculumDataError`."""
+    if not isinstance(obj, list):
+        msg = f"{context} must be a JSON array"
+        raise CurriculumDataError(msg)
+    return obj
+
+
+def _require_str(obj: dict[str, Any], key: str, context: str) -> str:
+    """Return a non-empty string at ``key``, or raise :class:`CurriculumDataError`."""
+    value = obj.get(key)
+    if not isinstance(value, str) or not value.strip():
+        msg = f"{context} field {key!r} must be a non-empty string"
+        raise CurriculumDataError(msg)
+    return value
+
+
+def _require_int(obj: dict[str, Any], key: str, context: str) -> int:
+    """Return an integer at ``key``, or raise :class:`CurriculumDataError`."""
+    value = obj.get(key)
+    # ``bool`` is an ``int`` subclass, so reject it explicitly.
+    if not isinstance(value, int) or isinstance(value, bool):
+        msg = f"{context} field {key!r} must be an integer"
+        raise CurriculumDataError(msg)
+    return value
+
+
+def _parse_expression(raw: object, context: str) -> PhaseExpression:
+    """Build a :class:`PhaseExpression` from a raw JSON object."""
+    obj = _require_dict(raw, context)
+    return PhaseExpression(
+        name=_require_str(obj, "name", context),
+        description=_require_str(obj, "description", context),
+    )
+
+
+def _parse_phase(raw: dict[str, Any], context: str) -> WavelengthPhase:
+    """Resolve the ``phase`` value to a :class:`WavelengthPhase` member."""
+    value = _require_str(raw, "phase", context)
+    try:
+        return WavelengthPhase(value)
+    except ValueError as exc:
+        msg = f"{context} has an unknown phase {value!r}"
+        raise CurriculumDataError(msg) from exc
+
+
+def _parse_manifestation(raw: object, context: str) -> PhaseManifestation:
+    """Build a :class:`PhaseManifestation` from a raw JSON object."""
+    obj = _require_dict(raw, context)
+    return PhaseManifestation(
+        phase=_parse_phase(obj, context),
+        integrated=_parse_expression(obj.get("integrated"), f"{context} integrated"),
+        shadow=_parse_expression(obj.get("shadow"), f"{context} shadow"),
+    )
+
+
+def _parse_manifestations(raw: object, context: str) -> tuple[PhaseManifestation, ...]:
+    """Parse and validate the six manifestations of one Stage, in order."""
+    entries = _require_list(raw, f"{context} manifestations")
+    manifestations = tuple(
+        _parse_manifestation(entry, f"{context} manifestation {index}")
+        for index, entry in enumerate(entries)
+    )
+    phases = tuple(m.phase for m in manifestations)
+    if phases != CANONICAL_PHASE_ORDER:
+        msg = f"{context} must list the six phases in canonical order"
+        raise CurriculumDataError(msg)
+    return manifestations
+
+
+def _parse_stage(raw: object) -> StageCurriculum:
+    """Build a :class:`StageCurriculum` from a raw JSON object."""
+    obj = _require_dict(raw, "stage")
+    stage_number = _require_int(obj, "stage_number", "stage")
+    context = f"stage {stage_number}"
+    return StageCurriculum(
+        stage_number=stage_number,
+        title=_require_str(obj, "title", context),
+        subtitle=_require_str(obj, "subtitle", context),
+        category=_require_str(obj, "category", context),
+        aspect=_require_str(obj, "aspect", context),
+        spiral_dynamics_color=_require_str(obj, "spiral_dynamics_color", context),
+        growing_up_stage=_require_str(obj, "growing_up_stage", context),
+        divine_gender_polarity=_require_str(obj, "divine_gender_polarity", context),
+        relationship_to_free_will=_require_str(
+            obj,
+            "relationship_to_free_will",
+            context,
+        ),
+        free_will_description=_require_str(obj, "free_will_description", context),
+        manifestations=_parse_manifestations(obj.get("manifestations"), context),
+    )
+
+
+def _validate_stages(stages: tuple[StageCurriculum, ...]) -> None:
+    """Enforce that the ten Stages are present, unique, and complete."""
+    if len(stages) != _EXPECTED_STAGE_COUNT:
+        msg = f"curriculum must define exactly {_EXPECTED_STAGE_COUNT} stages"
+        raise CurriculumDataError(msg)
+    numbers = {stage.stage_number for stage in stages}
+    if numbers != _EXPECTED_STAGE_NUMBERS:
+        msg = f"curriculum stage numbers must be exactly {sorted(_EXPECTED_STAGE_NUMBERS)}"
+        raise CurriculumDataError(msg)
+
+
+def _parse_dataset(payload: object) -> tuple[StageCurriculum, ...]:
+    """Parse the full dataset into an ordered, validated Stage tuple.
+
+    Accepts either the wrapped object shape (with a ``stages`` array) or a
+    bare array of Stage objects, so test fixtures can supply the minimal form.
+    """
+    entries: object = payload.get("stages") if isinstance(payload, dict) else payload
+    raw_stages = _require_list(entries, "curriculum stages")
+    stages = tuple(_parse_stage(raw) for raw in raw_stages)
+    _validate_stages(stages)
+    return tuple(sorted(stages, key=lambda stage: stage.stage_number))
+
+
+def _read_json(path: Path) -> object:
+    """Read and parse a JSON file, mapping every failure to a typed error."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        msg = f"curriculum dataset not found at {path}"
+        raise CurriculumDataError(msg) from exc
+    try:
+        parsed: object = json.loads(text)
+    except json.JSONDecodeError as exc:
+        msg = f"curriculum dataset at {path} is not valid JSON"
+        raise CurriculumDataError(msg) from exc
+    return parsed
+
+
+@cache
+def _load_default() -> tuple[StageCurriculum, ...]:
+    """Load and cache the vendored dataset from the default path."""
+    return _parse_dataset(_read_json(_DEFAULT_DATASET_PATH))
+
+
+def load_curriculum(path: Path | None = None) -> tuple[StageCurriculum, ...]:
+    """Load the curriculum, ordered by ``stage_number``.
+
+    With no ``path`` the vendored dataset is read once and cached; passing an
+    explicit ``path`` always parses fresh (used by tests to exercise
+    validation against fixtures).  Malformed data raises
+    :class:`CurriculumDataError`.
+    """
+    if path is None:
+        return _load_default()
+    return _parse_dataset(_read_json(path))
+
+
+def all_stages() -> tuple[StageCurriculum, ...]:
+    """Return every Stage's curriculum, ordered by ``stage_number``."""
+    return load_curriculum()
+
+
+def stage_curriculum(stage_number: int) -> StageCurriculum:
+    """Return the curriculum for ``stage_number``.
+
+    Raises :class:`CurriculumDataError` (not ``KeyError``) when unknown.
+    """
+    for stage in all_stages():
+        if stage.stage_number == stage_number:
+            return stage
+    msg = f"unknown stage_number {stage_number}"
+    raise CurriculumDataError(msg)
+
+
+def manifestation(stage_number: int, phase: WavelengthPhase) -> PhaseManifestation:
+    """Return one Stage's manifestation for ``phase``.
+
+    Raises :class:`CurriculumDataError` when the Stage or phase is unknown.
+    """
+    stage = stage_curriculum(stage_number)
+    for candidate in stage.manifestations:
+        if candidate.phase == phase:
+            return candidate
+    msg = f"stage {stage_number} has no manifestation for phase {phase!r}"
+    raise CurriculumDataError(msg)

--- a/backend/src/curriculum/archetypal_wavelength.json
+++ b/backend/src/curriculum/archetypal_wavelength.json
@@ -1,0 +1,451 @@
+{
+  "dataset_version": "1.0.0",
+  "provenance": {
+    "source": "Archetypal Wavelength spreadsheet, 'Expanded List' sheet",
+    "extracted_from": "in-repo vendored course markdown (backend/content/markdown/backup/ and *full-6-phase-wavelength-breakdown chapters)",
+    "refresh_doc": "docs/curriculum.md"
+  },
+  "phases": ["Rising", "Peaking", "Withdrawal", "Diminishing", "Bottoming Out", "Restoration"],
+  "stages": [
+    {
+      "stage_number": 1,
+      "title": "Survival",
+      "subtitle": "Active Yes-And-Ness",
+      "category": "Pre-personal",
+      "aspect": "Body",
+      "spiral_dynamics_color": "Beige",
+      "growing_up_stage": "Archaic",
+      "divine_gender_polarity": "Masculine",
+      "relationship_to_free_will": "Reactive",
+      "free_will_description": "Instinctual response to environment",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Commitment", "description": "A grounded promise to begin showing up."},
+          "shadow": {"name": "Over-commitment", "description": "Taking on too much too fast."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Diligence", "description": "Steady effort anchored in habit and presence."},
+          "shadow": {"name": "Thriving", "description": "Overextending in a rush of manic progress."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Steadiness", "description": "Returning to baseline without abandoning routine."},
+          "shadow": {"name": "Burnout", "description": "Energetic collapse from unsustainable output."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Security", "description": "Embracing contraction to restore safety and trust."},
+          "shadow": {"name": "Grasping", "description": "Clinging to momentum as it fades."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Stability", "description": "Deep stillness that anchors your nervous system."},
+          "shadow": {"name": "Overwhelm", "description": "Flooded by unmet needs or collapsing structure."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Next Habit", "description": "Humble return with a manageable new step."},
+          "shadow": {"name": "New Plan", "description": "Drastic overhaul to escape discomfort."}
+        }
+      ]
+    },
+    {
+      "stage_number": 2,
+      "title": "Magick",
+      "subtitle": "Receptive Yes-And-Ness",
+      "category": "Pre-personal",
+      "aspect": "Body",
+      "spiral_dynamics_color": "Purple",
+      "growing_up_stage": "Magic",
+      "divine_gender_polarity": "Feminine",
+      "relationship_to_free_will": "Receptive",
+      "free_will_description": "Surrender to tribal belonging",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Inspiration", "description": "Guided by subtle symbols, dreams, or intuitive nudges."},
+          "shadow": {"name": "Self-aggrandizement", "description": "Mistaking inspiration for spiritual superiority or specialness."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Attunement", "description": "In sync with feelings, symbols, and unseen rhythms."},
+          "shadow": {"name": "Intoxication", "description": "Overwhelmed by meaning, chasing mystical highs."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Introspectivity", "description": "Quiet inner reflection and gentle emotional processing."},
+          "shadow": {"name": "Anxiety", "description": "Flooded by feelings, uncertain what is real."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Coziness", "description": "Soft retreat into comfort, nesting, and gentle beauty."},
+          "shadow": {"name": "Self-doubt", "description": "Losing confidence, questioning intuition and worth."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Fallow state", "description": "Restful emptiness, receptive to future renewal."},
+          "shadow": {"name": "Self-loathing", "description": "Turning symbolic failure inward as shame."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Recuperation", "description": "Energy slowly returns; meaning begins to glimmer again."},
+          "shadow": {"name": "Selfishness", "description": "Hoarding vitality instead of rejoining the collective vibe."}
+        }
+      ]
+    },
+    {
+      "stage_number": 3,
+      "title": "Power",
+      "subtitle": "Self-Love",
+      "category": "Pre-personal",
+      "aspect": "Emotion",
+      "spiral_dynamics_color": "Red",
+      "growing_up_stage": "Power Gods",
+      "divine_gender_polarity": "Masculine",
+      "relationship_to_free_will": "Assertive",
+      "free_will_description": "Willful self-assertion",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Leading", "description": "Stepping forward with clarity and initiative."},
+          "shadow": {"name": "Dominating", "description": "Steamrolling others to feel safe or seen."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Power-With", "description": "Collaborating with others while staying in your strength."},
+          "shadow": {"name": "Power-Over", "description": "Asserting control to suppress difference or dissent."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Stepping Back", "description": "The courage to pause, reassess, and make room."},
+          "shadow": {"name": "Crumbling", "description": "Losing grip, collapsing under the weight of unmet needs."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Humility", "description": "Recognizing your limits without shame."},
+          "shadow": {"name": "Shame", "description": "Believing your worth depends on dominance or perfection."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Following", "description": "Willingly receiving leadership or guidance."},
+          "shadow": {"name": "Subjugation", "description": "Losing yourself in order to avoid conflict or rejection."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Assembling", "description": "Rallying the right team, tools, and timing to re-engage."},
+          "shadow": {"name": "Revenge", "description": "Re-entering the ring just to punish or prove."}
+        }
+      ]
+    },
+    {
+      "stage_number": 4,
+      "title": "Conformity",
+      "subtitle": "Universal Love",
+      "category": "Personal",
+      "aspect": "Emotion",
+      "spiral_dynamics_color": "Blue",
+      "growing_up_stage": "Mythic Order",
+      "divine_gender_polarity": "Feminine",
+      "relationship_to_free_will": "Obedient",
+      "free_will_description": "Submission to higher order",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Ambition", "description": "Reaching toward connection and community from fullness."},
+          "shadow": {"name": "Voraciousness", "description": "Compulsive hunger for connection that clings and overshares."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Attunement", "description": "The felt sense of being in harmony with others."},
+          "shadow": {"name": "Leprosy", "description": "Merging so fully you abandon yourself and burn out."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Discernment", "description": "Tuning in to your own truth about the relationship."},
+          "shadow": {"name": "Self-Medication", "description": "Pulling back to numb and escape rather than reflect."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Conviction", "description": "Staying true to what you value even when it costs you."},
+          "shadow": {"name": "Rage", "description": "Exploding and lashing out when you hit your limit."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Surrender", "description": "Releasing control and trusting the love is still there."},
+          "shadow": {"name": "Misery", "description": "The despairing belief that you have been abandoned."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Catharsis", "description": "Emotional release that clears the system for new energy."},
+          "shadow": {"name": "Self-Repression", "description": "Burying what needs release and restarting the cycle."}
+        }
+      ]
+    },
+    {
+      "stage_number": 5,
+      "title": "Achievist",
+      "subtitle": "Intellectual Understanding",
+      "category": "Personal",
+      "aspect": "Mind",
+      "spiral_dynamics_color": "Orange",
+      "growing_up_stage": "Scientific-Rational",
+      "divine_gender_polarity": "Masculine",
+      "relationship_to_free_will": "Strategic",
+      "free_will_description": "Calculated self-determination",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Hypothesize", "description": "Proposing a tentative answer and holding it lightly."},
+          "shadow": {"name": "Assert", "description": "Declaring the answer and shutting collaboration down."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Experiment", "description": "Willingly trying something to see what you can learn."},
+          "shadow": {"name": "Crusade", "description": "Evangelizing a hypothesis you have mistaken for truth."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Collect Data", "description": "Gathering the feedback and documenting what happened."},
+          "shadow": {"name": "Overlook Details", "description": "Cherry-picking data and ignoring contrary evidence."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Analyze", "description": "Sitting with complexity to draw tentative conclusions."},
+          "shadow": {"name": "Force It", "description": "Jamming the data into a conclusion that does not fit."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Synthesize", "description": "Integrating what you learned into a truer understanding."},
+          "shadow": {"name": "Fail", "description": "Giving up and reading the low point as inadequacy."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Question", "description": "Returning to fresh curiosity for the next cycle."},
+          "shadow": {"name": "Presume", "description": "Assuming you already know and skipping the inquiry."}
+        }
+      ]
+    },
+    {
+      "stage_number": 6,
+      "title": "Pluralist",
+      "subtitle": "Embodied Understanding",
+      "category": "Personal",
+      "aspect": "Mind",
+      "spiral_dynamics_color": "Green",
+      "growing_up_stage": "Sensitive Self",
+      "divine_gender_polarity": "Feminine",
+      "relationship_to_free_will": "Collaborative",
+      "free_will_description": "Co-creation through empathy",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Connection", "description": "Showing up authentically and letting yourself be seen."},
+          "shadow": {"name": "Oversharing", "description": "Trauma-dumping intensity mistaken for intimacy."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Belonging", "description": "Being fully yourself and fully accepted in community."},
+          "shadow": {"name": "Megalomania", "description": "Making the group special and exclusionary."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Retirement", "description": "Consciously pulling back to replenish and rest."},
+          "shadow": {"name": "Social Anxiety", "description": "Isolating from the fear of being seen and judged."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Unwinding", "description": "The natural release of tension after deep connection."},
+          "shadow": {"name": "Alienation", "description": "The story that no one understands you and you are alone."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Repose", "description": "Deep rest and sacred solitude that feels full."},
+          "shadow": {"name": "Isolation", "description": "The despairing belief that solitude is a sentence."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Vulnerability", "description": "Re-entering connection with open authenticity."},
+          "shadow": {"name": "Bitterness", "description": "Re-entering guarded and resentful from old wounds."}
+        }
+      ]
+    },
+    {
+      "stage_number": 7,
+      "title": "Integrative",
+      "subtitle": "Systems Wisdom",
+      "category": "Trans-personal",
+      "aspect": "Spirit",
+      "spiral_dynamics_color": "Yellow",
+      "growing_up_stage": "Integral",
+      "divine_gender_polarity": "Masculine",
+      "relationship_to_free_will": "Systemic",
+      "free_will_description": "Functional flow within systems",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Focus", "description": "Bringing awareness to what matters and sustaining it."},
+          "shadow": {"name": "Hyperfocus", "description": "Locking on so hard you lose peripheral awareness."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Concentration", "description": "Effortless unified absorption where the mind rests."},
+          "shadow": {"name": "Obsession", "description": "Addiction to peak states you chase and grasp at."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Adjustment", "description": "Noticing you have drifted and gently course-correcting."},
+          "shadow": {"name": "Stagnation", "description": "Awareness of being off course without any action."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Reorienting", "description": "Stepping back to reassess the approach and recalibrate."},
+          "shadow": {"name": "Dithering", "description": "Endlessly changing course without ever committing."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Settling", "description": "Deep rest that comes from releasing all striving."},
+          "shadow": {"name": "Depression", "description": "The hopeless belief that the low point is permanent."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Reset", "description": "Beginning again fresh without the last cycle's baggage."},
+          "shadow": {"name": "Addiction", "description": "Reaching for a compulsive fix instead of a clean start."}
+        }
+      ]
+    },
+    {
+      "stage_number": 8,
+      "title": "Nondual",
+      "subtitle": "Transcendent Wisdom",
+      "category": "Trans-personal",
+      "aspect": "Spirit",
+      "spiral_dynamics_color": "Turquoise",
+      "growing_up_stage": "Holistic",
+      "divine_gender_polarity": "Feminine",
+      "relationship_to_free_will": "Surrendered",
+      "free_will_description": "Alignment with universal flow",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Focus", "description": "Attention that gathers on its own, allowed not forced."},
+          "shadow": {"name": "Hyperfocus", "description": "A tight, straining grip that constricts the body."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Concentration", "description": "Unified awareness recognized rather than achieved."},
+          "shadow": {"name": "Obsession", "description": "The subtle grasp of preferring the state to continue."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Adjustment", "description": "Spontaneous return, since noticing itself is presence."},
+          "shadow": {"name": "Stagnation", "description": "The false refuge of drifting under the guise of acceptance."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Reorienting", "description": "Effortlessly letting awareness recalibrate the path."},
+          "shadow": {"name": "Dithering", "description": "Restlessly second-guessing without resting in any choice."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Settling", "description": "Resting as awareness itself with nothing to make happen."},
+          "shadow": {"name": "Depression", "description": "Settling that has lost trust the wave will turn upward."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Reset", "description": "Renewing presence spontaneously as energy returns."},
+          "shadow": {"name": "Addiction", "description": "Clinging to an old comfort instead of fresh re-engagement."}
+        }
+      ]
+    },
+    {
+      "stage_number": 9,
+      "title": "Effortless Being",
+      "subtitle": "Unity of Being",
+      "category": "Trans-personal",
+      "aspect": "Nondual",
+      "spiral_dynamics_color": "Ultraviolet",
+      "growing_up_stage": "Para-mind",
+      "divine_gender_polarity": "Integrated",
+      "relationship_to_free_will": "Effortless",
+      "free_will_description": "Spontaneous right action",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Ascending", "description": "The natural deepening that comes from sustained practice."},
+          "shadow": {"name": "Transcending", "description": "Spiritual bypass that escapes rather than includes life."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Clarity", "description": "Seeing reality as it is, as lived truth not concept."},
+          "shadow": {"name": "Superiority", "description": "Using realization as proof you are better than others."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Discernment", "description": "Precise seeing of distinctions held with compassion."},
+          "shadow": {"name": "Judgment", "description": "Using clarity to condemn, dismiss, and reject others."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Humility", "description": "Recognizing you are always the student before the mystery."},
+          "shadow": {"name": "Humiliation", "description": "Collapsing into shame that you are not enough."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Devotion", "description": "Practicing because the practice itself is sacred."},
+          "shadow": {"name": "Dogma", "description": "Mistaking your tradition for the one true path."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Recommitment", "description": "Choosing the path again out of love, not obligation."},
+          "shadow": {"name": "Righteousness", "description": "Wielding devotion as a badge to judge others."}
+        }
+      ]
+    },
+    {
+      "stage_number": 10,
+      "title": "Pure Awareness",
+      "subtitle": "Emptiness and Awareness",
+      "category": "Trans-personal",
+      "aspect": "Nondual",
+      "spiral_dynamics_color": "Clear Light",
+      "growing_up_stage": "Meta-mind",
+      "divine_gender_polarity": "Transcendent",
+      "relationship_to_free_will": "Witnessing",
+      "free_will_description": "Free will and determinism as one",
+      "manifestations": [
+        {
+          "phase": "Rising",
+          "integrated": {"name": "Riding", "description": "Letting momentum carry you while staying rooted."},
+          "shadow": {"name": "Grasping", "description": "Clutching at the returning energy and believing the hype."}
+        },
+        {
+          "phase": "Peaking",
+          "integrated": {"name": "Gratitude", "description": "Enjoying the flow fully and letting it pass in time."},
+          "shadow": {"name": "Attachment", "description": "Clinging to the peak instead of releasing it."}
+        },
+        {
+          "phase": "Withdrawal",
+          "integrated": {"name": "Trust", "description": "Letting go as the descent unfolds its natural rhythm."},
+          "shadow": {"name": "Collapse", "description": "Reading the natural ebb as failure and falling apart."}
+        },
+        {
+          "phase": "Diminishing",
+          "integrated": {"name": "Patience", "description": "Knowing this too shall pass, having been here before."},
+          "shadow": {"name": "Despair", "description": "Believing the trough is permanent and hopeless."}
+        },
+        {
+          "phase": "Bottoming Out",
+          "integrated": {"name": "Rest", "description": "Ceasing to fix it and letting the ground hold you."},
+          "shadow": {"name": "Fixing", "description": "Straining to repair the bottom instead of resting."}
+        },
+        {
+          "phase": "Restoration",
+          "integrated": {"name": "Recommitment", "description": "Returning to the same practice, path, and truth again."},
+          "shadow": {"name": "Novelty-Seeking", "description": "Chasing something new instead of the proven path."}
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/seed_stages.py
+++ b/backend/src/seed_stages.py
@@ -1,154 +1,47 @@
-"""Seed script for the 10 APTITUDE CourseStage definitions."""
+"""Seed script for the 10 APTITUDE CourseStage definitions.
+
+The Stage attributes are sourced from the vendored Archetypal Wavelength
+curriculum dataset (:mod:`curriculum`), the single source of truth for
+per-Stage copy.  The loader enforces that the ten Stages are present, unique,
+and complete, so this module maps that validated data into the seed dicts the
+ORM expects, adding the seeder-owned ``overview_url``.
+"""
 
 from __future__ import annotations
+
+from typing import Final
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+import curriculum
 from models.course_stage import CourseStage
 
-_STAGE_DEFINITIONS: list[dict[str, str | int]] = [
-    {
-        "stage_number": 1,
-        "title": "Survival",
-        "subtitle": "Active Yes-And-Ness",
-        "overview_url": "",
-        "category": "Pre-personal",
-        "aspect": "Body",
-        "spiral_dynamics_color": "Beige",
-        "growing_up_stage": "Archaic",
-        "divine_gender_polarity": "Masculine",
-        "relationship_to_free_will": "Reactive",
-        "free_will_description": "Instinctual response to environment",
-    },
-    {
-        "stage_number": 2,
-        "title": "Magick",
-        "subtitle": "Receptive Yes-And-Ness",
-        "overview_url": "",
-        "category": "Pre-personal",
-        "aspect": "Body",
-        "spiral_dynamics_color": "Purple",
-        "growing_up_stage": "Magic",
-        "divine_gender_polarity": "Feminine",
-        "relationship_to_free_will": "Receptive",
-        "free_will_description": "Surrender to tribal belonging",
-    },
-    {
-        "stage_number": 3,
-        "title": "Power",
-        "subtitle": "Self-Love",
-        "overview_url": "",
-        "category": "Pre-personal",
-        "aspect": "Emotion",
-        "spiral_dynamics_color": "Red",
-        "growing_up_stage": "Power Gods",
-        "divine_gender_polarity": "Masculine",
-        "relationship_to_free_will": "Assertive",
-        "free_will_description": "Willful self-assertion",
-    },
-    {
-        "stage_number": 4,
-        "title": "Conformity",
-        "subtitle": "Universal Love",
-        "overview_url": "",
-        "category": "Personal",
-        "aspect": "Emotion",
-        "spiral_dynamics_color": "Blue",
-        "growing_up_stage": "Mythic Order",
-        "divine_gender_polarity": "Feminine",
-        "relationship_to_free_will": "Obedient",
-        "free_will_description": "Submission to higher order",
-    },
-    {
-        "stage_number": 5,
-        "title": "Achievist",
-        "subtitle": "Intellectual Understanding",
-        "overview_url": "",
-        "category": "Personal",
-        "aspect": "Mind",
-        "spiral_dynamics_color": "Orange",
-        "growing_up_stage": "Scientific-Rational",
-        "divine_gender_polarity": "Masculine",
-        "relationship_to_free_will": "Strategic",
-        "free_will_description": "Calculated self-determination",
-    },
-    {
-        "stage_number": 6,
-        "title": "Pluralist",
-        "subtitle": "Embodied Understanding",
-        "overview_url": "",
-        "category": "Personal",
-        "aspect": "Mind",
-        "spiral_dynamics_color": "Green",
-        "growing_up_stage": "Sensitive Self",
-        "divine_gender_polarity": "Feminine",
-        "relationship_to_free_will": "Collaborative",
-        "free_will_description": "Co-creation through empathy",
-    },
-    {
-        "stage_number": 7,
-        "title": "Integrative",
-        "subtitle": "Systems Wisdom",
-        "overview_url": "",
-        "category": "Trans-personal",
-        "aspect": "Spirit",
-        "spiral_dynamics_color": "Yellow",
-        "growing_up_stage": "Integral",
-        "divine_gender_polarity": "Masculine",
-        "relationship_to_free_will": "Systemic",
-        "free_will_description": "Functional flow within systems",
-    },
-    {
-        "stage_number": 8,
-        "title": "Nondual",
-        "subtitle": "Transcendent Wisdom",
-        "overview_url": "",
-        "category": "Trans-personal",
-        "aspect": "Spirit",
-        "spiral_dynamics_color": "Turquoise",
-        "growing_up_stage": "Holistic",
-        "divine_gender_polarity": "Feminine",
-        "relationship_to_free_will": "Surrendered",
-        "free_will_description": "Alignment with universal flow",
-    },
-    {
-        "stage_number": 9,
-        "title": "Effortless Being",
-        "subtitle": "Unity of Being",
-        "overview_url": "",
-        "category": "Trans-personal",
-        "aspect": "Nondual",
-        "spiral_dynamics_color": "Ultraviolet",
-        "growing_up_stage": "Para-mind",
-        "divine_gender_polarity": "Integrated",
-        "relationship_to_free_will": "Effortless",
-        "free_will_description": "Spontaneous right action",
-    },
-    {
-        "stage_number": 10,
-        "title": "Pure Awareness",
-        "subtitle": "Emptiness and Awareness",
-        "overview_url": "",
-        "category": "Trans-personal",
-        "aspect": "Nondual",
-        "spiral_dynamics_color": "Clear Light",
-        "growing_up_stage": "Meta-mind",
-        "divine_gender_polarity": "Transcendent",
-        "relationship_to_free_will": "Witnessing",
-        "free_will_description": "Free will and determinism as one",
-    },
+#: The curriculum dataset does not carry per-Stage overview URLs; they are a
+#: seeder concern and default to empty until populated elsewhere.
+DEFAULT_OVERVIEW_URL: Final[str] = ""
+
+
+def _to_definition(stage: curriculum.StageCurriculum) -> dict[str, str | int]:
+    """Map a curriculum Stage to the ORM seed dict for :class:`CourseStage`."""
+    return {
+        "stage_number": stage.stage_number,
+        "title": stage.title,
+        "subtitle": stage.subtitle,
+        "overview_url": DEFAULT_OVERVIEW_URL,
+        "category": stage.category,
+        "aspect": stage.aspect,
+        "spiral_dynamics_color": stage.spiral_dynamics_color,
+        "growing_up_stage": stage.growing_up_stage,
+        "divine_gender_polarity": stage.divine_gender_polarity,
+        "relationship_to_free_will": stage.relationship_to_free_will,
+        "free_will_description": stage.free_will_description,
+    }
+
+
+STAGE_DEFINITIONS: list[dict[str, str | int]] = [
+    _to_definition(stage) for stage in curriculum.all_stages()
 ]
-
-# BUG-SEED-002: Assert uniqueness of stage_numbers at import time so a
-# duplicate definition is caught immediately, not silently ignored at runtime.
-_stage_numbers = [d["stage_number"] for d in _STAGE_DEFINITIONS]
-if len(set(_stage_numbers)) != len(_stage_numbers):
-    _dupes = sorted(n for n in _stage_numbers if _stage_numbers.count(n) > 1)
-    msg = f"Duplicate stage_number in STAGE_DEFINITIONS: {_dupes}"
-    raise ValueError(msg)
-
-STAGE_DEFINITIONS = _STAGE_DEFINITIONS
 
 
 async def seed_stages(session: AsyncSession) -> int:

--- a/backend/tests/test_curriculum.py
+++ b/backend/tests/test_curriculum.py
@@ -1,0 +1,290 @@
+"""Tests for the vendored Archetypal Wavelength curriculum dataset."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from curriculum import (
+    CurriculumDataError,
+    WavelengthPhase,
+    all_stages,
+    load_curriculum,
+    manifestation,
+    stage_curriculum,
+)
+
+CANONICAL_PHASE_ORDER = (
+    WavelengthPhase.RISING,
+    WavelengthPhase.PEAKING,
+    WavelengthPhase.WITHDRAWAL,
+    WavelengthPhase.DIMINISHING,
+    WavelengthPhase.BOTTOMING_OUT,
+    WavelengthPhase.RESTORATION,
+)
+
+
+def test_wavelength_phase_values_are_human_strings() -> None:
+    """Enum values are the human-readable phase names, not member names."""
+    assert WavelengthPhase.RISING.value == "Rising"
+    assert WavelengthPhase.PEAKING.value == "Peaking"
+    assert WavelengthPhase.WITHDRAWAL.value == "Withdrawal"
+    assert WavelengthPhase.DIMINISHING.value == "Diminishing"
+    assert WavelengthPhase.BOTTOMING_OUT.value == "Bottoming Out"
+    assert WavelengthPhase.RESTORATION.value == "Restoration"
+
+
+def test_all_stages_returns_ten_stages_in_order() -> None:
+    """all_stages() resolves exactly stage_numbers 1..10, in order."""
+    stages = all_stages()
+    assert len(stages) == 10
+    assert [s.stage_number for s in stages] == list(range(1, 11))
+
+
+def test_each_stage_has_six_phases_in_canonical_order() -> None:
+    """Every stage carries exactly six manifestations in canonical phase order."""
+    for stage in all_stages():
+        assert len(stage.manifestations) == 6
+        phases = tuple(m.phase for m in stage.manifestations)
+        assert phases == CANONICAL_PHASE_ORDER
+
+
+def test_each_manifestation_has_nonempty_integrated_and_shadow() -> None:
+    """Every manifestation's integrated/shadow expressions are fully populated."""
+    for stage in all_stages():
+        for phase_manifestation in stage.manifestations:
+            for expression in (
+                phase_manifestation.integrated,
+                phase_manifestation.shadow,
+            ):
+                assert expression.name != ""
+                assert expression.description != ""
+
+
+def test_all_ten_stages_and_six_phases_resolve_from_dataset() -> None:
+    """Headline seed assertion: all 10 stages x 6 phases fully resolve."""
+    stages = all_stages()
+    assert len(stages) == 10
+    for stage_number in range(1, 11):
+        resolved = stage_curriculum(stage_number)
+        assert resolved.stage_number == stage_number
+        for phase in CANONICAL_PHASE_ORDER:
+            found = manifestation(stage_number, phase)
+            assert found.phase == phase
+
+
+def test_stage_curriculum_returns_beige_survival() -> None:
+    """stage_curriculum(1) is Survival/Beige with known Rising Rx/OD values."""
+    stage = stage_curriculum(1)
+    assert stage.stage_number == 1
+    assert stage.title == "Survival"
+    assert stage.subtitle == "Active Yes-And-Ness"
+    assert stage.aspect == "Body"
+    assert stage.spiral_dynamics_color == "Beige"
+
+    rising = stage.manifestations[0]
+    assert rising.phase == WavelengthPhase.RISING
+    assert rising.integrated.name == "Commitment"
+    assert rising.shadow.name == "Over-commitment"
+
+
+def test_manifestation_returns_beige_rising() -> None:
+    """manifestation(1, RISING) matches the vendored Beige Rising Rx/OD."""
+    result = manifestation(1, WavelengthPhase.RISING)
+    assert result.phase == WavelengthPhase.RISING
+    assert result.integrated.name == "Commitment"
+    assert result.shadow.name == "Over-commitment"
+
+
+def test_stage_curriculum_unknown_stage_number_raises() -> None:
+    """An unknown stage_number raises CurriculumDataError, not KeyError."""
+    with pytest.raises(CurriculumDataError):
+        stage_curriculum(99)
+
+
+def test_load_curriculum_is_deterministic() -> None:
+    """Two default-path loads return equal data."""
+    first = load_curriculum()
+    second = load_curriculum()
+    assert first == second
+
+
+def _write_json(tmp_path: Path, name: str, payload: object) -> Path:
+    fixture_path = tmp_path / name
+    fixture_path.write_text(json.dumps(payload), encoding="utf-8")
+    return fixture_path
+
+
+def _valid_manifestations() -> list[dict[str, object]]:
+    return [
+        {
+            "phase": phase.value,
+            "integrated": {"name": "Name", "description": "Desc"},
+            "shadow": {"name": "ShadowName", "description": "ShadowDesc"},
+        }
+        for phase in CANONICAL_PHASE_ORDER
+    ]
+
+
+def _valid_stage(stage_number: int) -> dict[str, object]:
+    return {
+        "stage_number": stage_number,
+        "title": f"Stage {stage_number}",
+        "subtitle": "Subtitle",
+        "category": "Category",
+        "aspect": "Aspect",
+        "spiral_dynamics_color": "Color",
+        "growing_up_stage": "Growing",
+        "divine_gender_polarity": "Polarity",
+        "relationship_to_free_will": "Relationship",
+        "free_will_description": "Description",
+        "manifestations": _valid_manifestations(),
+    }
+
+
+def test_load_curriculum_rejects_wrong_stage_count(tmp_path: Path) -> None:
+    """A dataset with fewer or more than 10 stages is invalid."""
+    payload = [_valid_stage(n) for n in range(1, 10)]
+    fixture_path = _write_json(tmp_path, "nine_stages.json", payload)
+
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=fixture_path)
+
+
+def test_load_curriculum_rejects_duplicate_stage_number(tmp_path: Path) -> None:
+    """Duplicate stage_number values must be rejected (BUG-SEED-002 regression)."""
+    payload = [_valid_stage(n) for n in range(1, 10)]
+    payload.append(_valid_stage(1))
+    fixture_path = _write_json(tmp_path, "dupe_stage.json", payload)
+
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=fixture_path)
+
+
+def test_load_curriculum_rejects_missing_phase(tmp_path: Path) -> None:
+    """A stage with fewer than six phases (or the wrong phase set) is invalid."""
+    payload = [_valid_stage(n) for n in range(1, 11)]
+    payload[0]["manifestations"] = _valid_manifestations()[:-1]
+    fixture_path = _write_json(tmp_path, "missing_phase.json", payload)
+
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=fixture_path)
+
+
+def test_load_curriculum_rejects_empty_string_field(tmp_path: Path) -> None:
+    """An empty-string required field is invalid."""
+    payload = [_valid_stage(n) for n in range(1, 11)]
+    payload[0]["title"] = ""
+    fixture_path = _write_json(tmp_path, "empty_title.json", payload)
+
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=fixture_path)
+
+
+def test_load_curriculum_rejects_unknown_phase(tmp_path: Path) -> None:
+    """A manifestation naming a phase outside the canonical six is invalid."""
+    manifestations = _valid_manifestations()
+    manifestations[0]["phase"] = "Ascending"
+    first_stage = _valid_stage(1)
+    first_stage["manifestations"] = manifestations
+    payload = [first_stage, *(_valid_stage(n) for n in range(2, 11))]
+    fixture_path = _write_json(tmp_path, "unknown_phase.json", payload)
+
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=fixture_path)
+
+
+def test_load_curriculum_rejects_non_integer_stage_number(tmp_path: Path) -> None:
+    """A non-integer (or boolean) stage_number is invalid."""
+    payload = [_valid_stage(n) for n in range(1, 11)]
+    payload[0]["stage_number"] = "1"
+    fixture_path = _write_json(tmp_path, "str_stage_number.json", payload)
+
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=fixture_path)
+
+
+def test_load_curriculum_rejects_non_object_stage(tmp_path: Path) -> None:
+    """A stage entry that is not a JSON object is invalid."""
+    payload: list[object] = [_valid_stage(n) for n in range(1, 10)]
+    payload.append("not a stage")
+    fixture_path = _write_json(tmp_path, "scalar_stage.json", payload)
+
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=fixture_path)
+
+
+def test_load_curriculum_rejects_missing_file(tmp_path: Path) -> None:
+    """A path that does not exist raises the typed error, not OSError."""
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=tmp_path / "does_not_exist.json")
+
+
+def test_load_curriculum_rejects_object_without_stages(tmp_path: Path) -> None:
+    """A wrapped object missing its ``stages`` array raises the typed error."""
+    fixture_path = _write_json(tmp_path, "no_stages.json", {"provenance": {}})
+
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=fixture_path)
+
+
+def test_load_curriculum_rejects_malformed_json(tmp_path: Path) -> None:
+    """Syntactically invalid JSON raises CurriculumDataError, not a raw JSONDecodeError."""
+    fixture_path = tmp_path / "broken.json"
+    fixture_path.write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(CurriculumDataError):
+        load_curriculum(path=fixture_path)
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DATASET_PATH = (
+    Path(__file__).resolve().parents[1] / "src" / "curriculum" / "archetypal_wavelength.json"
+)
+
+
+def _dataset_payload() -> dict[str, object]:
+    data: object = json.loads(_DATASET_PATH.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _provenance() -> dict[str, object]:
+    provenance = _dataset_payload()["provenance"]
+    assert isinstance(provenance, dict)
+    return provenance
+
+
+def _refresh_doc() -> str:
+    refresh_doc = _provenance()["refresh_doc"]
+    assert isinstance(refresh_doc, str)
+    return refresh_doc
+
+
+def _require_nonempty_str(value: object) -> None:
+    assert isinstance(value, str)
+    assert value.strip()
+
+
+def test_dataset_carries_provenance_pointer() -> None:
+    """The vendored dataset records where its copy came from (source + extraction)."""
+    provenance = _provenance()
+    _require_nonempty_str(provenance["source"])
+    _require_nonempty_str(provenance["extracted_from"])
+    _require_nonempty_str(provenance["refresh_doc"])
+
+
+def test_provenance_refresh_doc_exists() -> None:
+    """The refresh-path doc named in provenance actually ships in the repo."""
+    refresh_doc = _refresh_doc()
+    resolved = _REPO_ROOT / refresh_doc
+    assert resolved.is_file(), f"refresh doc missing: {refresh_doc}"
+
+
+def test_refresh_doc_documents_the_dataset_and_path() -> None:
+    """The refresh doc points at the vendored dataset and its loader."""
+    text = (_REPO_ROOT / _refresh_doc()).read_text(encoding="utf-8")
+    assert "archetypal_wavelength.json" in text
+    assert "Archetypal Wavelength" in text

--- a/backend/tests/test_seed_stages.py
+++ b/backend/tests/test_seed_stages.py
@@ -53,3 +53,175 @@ async def test_seed_stages_definitions_valid() -> None:
     for defn in STAGE_DEFINITIONS:
         msg = f"Missing fields in stage {defn.get('stage_number')}"
         assert required_fields.issubset(defn.keys()), msg
+
+
+# Golden values pinned from the pre-refactor STAGE_DEFINITIONS literal so a
+# migration to a curriculum-backed source cannot silently change behavior.
+_GOLDEN_STAGE_DEFINITIONS: list[dict[str, str | int]] = [
+    {
+        "stage_number": 1,
+        "title": "Survival",
+        "subtitle": "Active Yes-And-Ness",
+        "overview_url": "",
+        "category": "Pre-personal",
+        "aspect": "Body",
+        "spiral_dynamics_color": "Beige",
+        "growing_up_stage": "Archaic",
+        "divine_gender_polarity": "Masculine",
+        "relationship_to_free_will": "Reactive",
+        "free_will_description": "Instinctual response to environment",
+    },
+    {
+        "stage_number": 2,
+        "title": "Magick",
+        "subtitle": "Receptive Yes-And-Ness",
+        "overview_url": "",
+        "category": "Pre-personal",
+        "aspect": "Body",
+        "spiral_dynamics_color": "Purple",
+        "growing_up_stage": "Magic",
+        "divine_gender_polarity": "Feminine",
+        "relationship_to_free_will": "Receptive",
+        "free_will_description": "Surrender to tribal belonging",
+    },
+    {
+        "stage_number": 3,
+        "title": "Power",
+        "subtitle": "Self-Love",
+        "overview_url": "",
+        "category": "Pre-personal",
+        "aspect": "Emotion",
+        "spiral_dynamics_color": "Red",
+        "growing_up_stage": "Power Gods",
+        "divine_gender_polarity": "Masculine",
+        "relationship_to_free_will": "Assertive",
+        "free_will_description": "Willful self-assertion",
+    },
+    {
+        "stage_number": 4,
+        "title": "Conformity",
+        "subtitle": "Universal Love",
+        "overview_url": "",
+        "category": "Personal",
+        "aspect": "Emotion",
+        "spiral_dynamics_color": "Blue",
+        "growing_up_stage": "Mythic Order",
+        "divine_gender_polarity": "Feminine",
+        "relationship_to_free_will": "Obedient",
+        "free_will_description": "Submission to higher order",
+    },
+    {
+        "stage_number": 5,
+        "title": "Achievist",
+        "subtitle": "Intellectual Understanding",
+        "overview_url": "",
+        "category": "Personal",
+        "aspect": "Mind",
+        "spiral_dynamics_color": "Orange",
+        "growing_up_stage": "Scientific-Rational",
+        "divine_gender_polarity": "Masculine",
+        "relationship_to_free_will": "Strategic",
+        "free_will_description": "Calculated self-determination",
+    },
+    {
+        "stage_number": 6,
+        "title": "Pluralist",
+        "subtitle": "Embodied Understanding",
+        "overview_url": "",
+        "category": "Personal",
+        "aspect": "Mind",
+        "spiral_dynamics_color": "Green",
+        "growing_up_stage": "Sensitive Self",
+        "divine_gender_polarity": "Feminine",
+        "relationship_to_free_will": "Collaborative",
+        "free_will_description": "Co-creation through empathy",
+    },
+    {
+        "stage_number": 7,
+        "title": "Integrative",
+        "subtitle": "Systems Wisdom",
+        "overview_url": "",
+        "category": "Trans-personal",
+        "aspect": "Spirit",
+        "spiral_dynamics_color": "Yellow",
+        "growing_up_stage": "Integral",
+        "divine_gender_polarity": "Masculine",
+        "relationship_to_free_will": "Systemic",
+        "free_will_description": "Functional flow within systems",
+    },
+    {
+        "stage_number": 8,
+        "title": "Nondual",
+        "subtitle": "Transcendent Wisdom",
+        "overview_url": "",
+        "category": "Trans-personal",
+        "aspect": "Spirit",
+        "spiral_dynamics_color": "Turquoise",
+        "growing_up_stage": "Holistic",
+        "divine_gender_polarity": "Feminine",
+        "relationship_to_free_will": "Surrendered",
+        "free_will_description": "Alignment with universal flow",
+    },
+    {
+        "stage_number": 9,
+        "title": "Effortless Being",
+        "subtitle": "Unity of Being",
+        "overview_url": "",
+        "category": "Trans-personal",
+        "aspect": "Nondual",
+        "spiral_dynamics_color": "Ultraviolet",
+        "growing_up_stage": "Para-mind",
+        "divine_gender_polarity": "Integrated",
+        "relationship_to_free_will": "Effortless",
+        "free_will_description": "Spontaneous right action",
+    },
+    {
+        "stage_number": 10,
+        "title": "Pure Awareness",
+        "subtitle": "Emptiness and Awareness",
+        "overview_url": "",
+        "category": "Trans-personal",
+        "aspect": "Nondual",
+        "spiral_dynamics_color": "Clear Light",
+        "growing_up_stage": "Meta-mind",
+        "divine_gender_polarity": "Transcendent",
+        "relationship_to_free_will": "Witnessing",
+        "free_will_description": "Free will and determinism as one",
+    },
+]
+
+_GOLDEN_FIELDS = (
+    "stage_number",
+    "title",
+    "subtitle",
+    "aspect",
+    "spiral_dynamics_color",
+    "category",
+    "growing_up_stage",
+    "divine_gender_polarity",
+    "relationship_to_free_will",
+    "free_will_description",
+    "overview_url",
+)
+
+
+def test_stage_definitions_match_golden_values() -> None:
+    """STAGE_DEFINITIONS must equal the pre-refactor literal, field for field.
+
+    Guards against behavior change if STAGE_DEFINITIONS is later derived from
+    the vendored curriculum dataset instead of the hardcoded literal.
+    """
+    assert len(STAGE_DEFINITIONS) == len(_GOLDEN_STAGE_DEFINITIONS)
+
+    actual_by_number = {d["stage_number"]: d for d in STAGE_DEFINITIONS}
+    for golden in _GOLDEN_STAGE_DEFINITIONS:
+        actual = actual_by_number[golden["stage_number"]]
+        for field in _GOLDEN_FIELDS:
+            msg = f"stage {golden['stage_number']} field {field!r} mismatch"
+            assert actual[field] == golden[field], msg
+
+
+def test_stage_definitions_overview_url_is_empty_for_all() -> None:
+    """overview_url golden value is the empty string for every stage."""
+    for defn in STAGE_DEFINITIONS:
+        assert defn["overview_url"] == ""

--- a/docs/curriculum.md
+++ b/docs/curriculum.md
@@ -1,0 +1,98 @@
+# The Archetypal Wavelength curriculum dataset
+
+The per-Stage and per-phase copy of *The Archetypal Wavelength* — the ten
+APTITUDE Stages and their six-phase manifestations (integrated `Rx` and shadow
+`OD` expressions) — is **vendored** into this repo as a single source of truth
+at `backend/src/curriculum/archetypal_wavelength.json`. Every consumer reads it
+through the typed loader in `backend/src/curriculum/__init__.py`; nothing
+hand-duplicates the prose. This mirrors the vendoring precedent set for course
+content (ADR 0001, `docs/content.md`): a checked-in, diff-reviewable data file
+refreshed by an explicit, documented step — never fetched at runtime.
+
+## Why one vendored file
+
+The same wavelength is described by three apps — adepthood,
+[`wavelength-demo`](https://github.com/Geoffe-Ga/wavelength-demo) (its
+`src/data/modes.ts`), and
+[`WavelengthWatch`](https://github.com/Geoffe-Ga/WavelengthWatch) (CSV/JSON
+fixtures under its `backend/data/`). If adepthood re-authored the manifestation
+copy by hand, the three would **drift** — the same Stage saying different things
+in different places. Vendoring the curriculum once and reading it everywhere
+removes that risk. (Decision recorded on issue #1021: option 1 — a checked-in
+data file with a strict loader — for the same reasons ADR 0001 chose vendoring
+over a submodule or a runtime fetch: deterministic, offline, diff-reviewable, no
+credentials surface.)
+
+## Where things live
+
+| What | File |
+| ---- | ---- |
+| Vendored dataset (10 Stages × 6 phases, integrated + shadow) | `backend/src/curriculum/archetypal_wavelength.json` |
+| Typed loader (validated, frozen dataclasses) | `backend/src/curriculum/__init__.py` |
+| Stage seeder (reads the dataset) | `backend/src/seed_stages.py` |
+| Loader + dataset tests | `backend/tests/test_curriculum.py` |
+| Seeder golden-value tests | `backend/tests/test_seed_stages.py` |
+
+## Provenance
+
+The dataset's top-level `provenance` block records where its copy came from:
+
+- `source` — *The Archetypal Wavelength* spreadsheet, "Expanded List" sheet
+  (the same sheet `wavelength-demo` and `WavelengthWatch` quote verbatim).
+- `extracted_from` — the in-repo vendored course markdown
+  (`backend/content/markdown/backup/*` and the per-stage
+  full-6-phase-wavelength-breakdown chapters), which already carries the
+  `Rising Rx: … / OD: …` lines verbatim from the sheet.
+- `refresh_doc` — a pointer back to this file.
+
+The `Rx`/`OD` copy in the JSON is quoted from that vendored markdown so the
+three apps stay in sync with the sheet without adepthood needing live access to
+the spreadsheet (privacy posture, #893).
+
+## What the loader guarantees
+
+`curriculum.load_curriculum()` (and the cached `all_stages()`) parse the JSON
+into frozen dataclasses and reject anything malformed with a single typed
+`CurriculumDataError` — never a raw `KeyError` or `json.JSONDecodeError`. The
+dataset is invalid unless it defines **exactly ten Stages** (numbered 1–10, no
+duplicates), each carrying **exactly the six canonical phases in order** (Rising
+→ Peaking → Withdrawal → Diminishing → Bottoming Out → Restoration), with every
+required string non-empty and each phase carrying a populated integrated and
+shadow expression. `stage_curriculum(n)` and `manifestation(n, phase)` resolve a
+single record; both raise `CurriculumDataError` for unknown keys.
+
+## Refreshing the dataset from the sheet (manual)
+
+The refresh is a deliberate, reviewable edit — there is no live pull:
+
+1. Open *The Archetypal Wavelength* spreadsheet, "Expanded List" sheet. For the
+   Stage(s) you are updating, read the per-phase `Rx` (integrated) and `OD`
+   (shadow) name + description. Cross-check against the vendored course markdown
+   under `backend/content/markdown/` so the wording matches what the reader
+   ships.
+2. Edit `backend/src/curriculum/archetypal_wavelength.json` in place, keeping
+   the shape: each Stage carries its identifying attributes plus a
+   `manifestations` array with the six phases **in canonical order**, each entry
+   `{ "phase", "integrated": {name, description}, "shadow": {name, description} }`.
+3. Bump `dataset_version` (semver: additive copy edits are a patch/minor;
+   changing the Stage/phase shape is a major) and, if the extraction source
+   changed, update the `provenance` block.
+4. Run the dataset tests — they enforce the shape, the golden Stage attributes,
+   and this doc's presence:
+
+   ```bash
+   cd backend && pytest tests/test_curriculum.py tests/test_seed_stages.py
+   ```
+
+5. Commit the JSON diff. Because the seeder derives `STAGE_DEFINITIONS` from the
+   dataset at import time, no seeder code change is needed; the golden-value
+   test in `test_seed_stages.py` will flag any unintended change to a Stage's
+   identifying attributes so a copy refresh cannot silently alter seeded rows.
+
+## Consumers
+
+The Stage seeder (`seed_stages.py`) already reads its definitions from the
+dataset. Downstream features that describe per-phase manifestations — medicinal
+/ toxic expressions (#1018), chord-journal Aspect labels (#1020), and the
+explainer (#948) — pull their copy from `curriculum` rather than re-authoring
+it, so the manifestation prose lives in exactly one place.


### PR DESCRIPTION
## Summary

Makes the shared *Archetypal Wavelength* curriculum data a **single vendored source of truth** so downstream per-phase copy cannot drift between adepthood and the sister apps (`wavelength-demo`, `WavelengthWatch`).

- **Vendored dataset** — `backend/src/curriculum/archetypal_wavelength.json` carries the ten APTITUDE Stages and their six-phase manifestations (integrated `Rx` and shadow `OD` name + description), quoted verbatim from the in-repo course markdown (`backend/content/markdown/backup/*`), plus a `provenance` block (source sheet, extraction source, refresh-doc pointer).
- **Strict typed loader** — the `curriculum` package parses the JSON into frozen, slotted dataclasses and rejects any malformed dataset (wrong Stage count, duplicate/ non-integer Stage number, missing/unknown/out-of-order phase, empty required field, missing file, malformed JSON) with a single `CurriculumDataError` — never a raw `KeyError`/`JSONDecodeError`. Public API: `all_stages()`, `stage_curriculum(n)`, `manifestation(n, phase)`, `load_curriculum(path=…)`.
- **Seeder consumes it** — `seed_stages.py` now derives `STAGE_DEFINITIONS` from `curriculum.all_stages()` instead of a hardcoded literal; the old import-time uniqueness guard moves into the loader's validation.
- **Refresh path documented** — `docs/curriculum.md` records provenance and the manual sheet → vendored-file refresh procedure, mirroring the vendoring precedent in ADR 0001 / `docs/content.md`.

Chosen approach: **option 1** (checked-in data file + small typed loader) per the in-thread decision — deterministic, offline, diff-reviewable, no credentials surface (privacy posture #893). Downstream consumers (#1018 medicinal/toxic, #1020 chord-journal Aspect labels, #948 explainer) are separate issues that will read from this dataset.

## Test plan

- `backend/tests/test_curriculum.py` — all ten Stages × six phases resolve from the vendored dataset; provenance pointer + refresh-doc presence/content; and the full set of validation-failure cases.
- `backend/tests/test_seed_stages.py` — golden-value pinning of all ten seeded Stages so the curriculum-backed refactor cannot silently change seeded rows; insert/idempotent behavior unchanged.
- `./scripts/backend/check-all.sh` exits 0 (2204 passed / 2 skipped, coverage 96.33%); xenon A/A/A and radon MI ≥ B on the new module.

Closes #1021
Refs #1004