### PR TITLE
refactor(backend): delete orphaned representative_goal() dead export

### DIFF
--- a/backend/src/services/completion_candidates.py
+++ b/backend/src/services/completion_candidates.py
@@ -34,29 +34,14 @@ _PRACTICE_TARGET = "practice"
 def _pick_representative(goals: list[Goal]) -> Goal | None:
     """Return the goal that stands for a habit: clear-tier, else first, else None.
 
-    The single source of truth for "which goal represents this habit", shared by
-    :func:`gather_candidates` (over eager-loaded goals) and
-    :func:`representative_goal` (querying), so the accept path checks off exactly
-    the goal detection matched.
+    The single source of truth for "which goal represents this habit", used by
+    :func:`gather_candidates` over each habit's eager-loaded goals so the accept
+    path checks off exactly the goal detection matched.
     """
     if not goals:
         return None
     clear = next((g for g in goals if g.tier == GoalTier.CLEAR), None)
     return clear if clear is not None else goals[0]
-
-
-async def representative_goal(session: AsyncSession, habit: Habit) -> Goal | None:
-    """The goal that represents ``habit`` for completion check-off.
-
-    Clear-tier goal preferred, else the first goal (by id), else ``None`` when the
-    habit has no goals. Exported so the accept path (#818/#820) targets the same
-    goal :func:`gather_candidates` offered. Queries the goals so it is safe on a
-    habit loaded without them.
-    """
-    result = await session.execute(
-        select(Goal).where(Goal.habit_id == habit.id).order_by(col(Goal.id)),
-    )
-    return _pick_representative(list(result.scalars().all()))
 
 
 def _habit_candidates(habits: list[Habit]) -> list[DetectionCandidate]:

--- a/backend/tests/services/test_completion_candidates.py
+++ b/backend/tests/services/test_completion_candidates.py
@@ -21,7 +21,6 @@ from models.user_practice import UserPractice
 from services.completion_candidates import (
     MAX_CANDIDATES,
     gather_candidates,
-    representative_goal,
 )
 
 _MAX_GATHER_QUERIES = 3  # habits + goals (selectinload) — constant in habit count
@@ -230,26 +229,6 @@ async def test_no_n_plus_one(db_session: AsyncSession) -> None:
     assert len(queries) <= _MAX_GATHER_QUERIES, (
         f"expected <= {_MAX_GATHER_QUERIES} SELECTs (no N+1), got {len(queries)}"
     )
-
-
-@pytest.mark.asyncio
-async def test_representative_goal_standalone(db_session: AsyncSession) -> None:
-    user_id = await _user(db_session)
-    with_clear = await _habit(db_session, user_id, "WithClear", tiers=("low", "clear"))
-    no_clear = await _habit(db_session, user_id, "NoClear", tiers=("low", "stretch"))
-    goalless = await _habit(db_session, user_id, "Goalless", tiers=())
-    assert with_clear.id is not None
-    assert no_clear.id is not None
-
-    clear_goal = await representative_goal(db_session, with_clear)
-    first_goal = await representative_goal(db_session, no_clear)
-    none_goal = await representative_goal(db_session, goalless)
-
-    assert clear_goal is not None
-    assert clear_goal.tier == "clear"
-    assert first_goal is not None
-    assert first_goal.tier == "low"  # first by id, no clear tier
-    assert none_goal is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
`representative_goal()` in `backend/src/services/completion_candidates.py` was a
public async function with **zero production callers** — only its own standalone
test imported it — and its docstring falsely claimed the accept path (#818/#820)
targets it. The parity it promised is actually delivered by the private
`_pick_representative` helper, while the accept path resolves the goal via
`session.get(Goal, suggestion.goal_id)` in `routers/journal.py`.

Per the issue's preferred resolution (delete as YAGNI; git remembers), this PR:
- Deletes the dead `representative_goal()` wrapper.
- Deletes its orphaned `test_representative_goal_standalone` test and drops the
  now-unused import.
- Corrects the `_pick_representative` docstring that referenced the removed
  function.

`_pick_representative` (the live shared helper), `gather_candidates`, and the
accept path are untouched — behavior is identical.

## Test plan
- `grep -rn representative_goal backend/src backend/tests` returns nothing.
- `./scripts/backend/check-all.sh` green: 2179 passed, 2 skipped, coverage 96.25%
  (≥90% gate held).
- xenon (`--max-absolute/modules/average A`) and radon (`mi -n B`) pass.
- Gate 2.5 self-review verdict: CLEAN, no blockers.

Closes #1046