### PR TITLE
feat(backend): expose cycle_number on program-calendar for cold-start Map indicator

### DIFF
--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -147,7 +147,11 @@ async def get_program_calendar(
     progress = await get_user_progress(session, current_user)
     if progress is None:
         return ProgramCalendarResponse(
-            program_started_at=None, calendar_stage=1, calendar_week=1, current_stage=1
+            program_started_at=None,
+            calendar_stage=1,
+            calendar_week=1,
+            current_stage=1,
+            cycle_number=1,
         )
     anchor = resolve_program_anchor(progress)
     return ProgramCalendarResponse(
@@ -155,6 +159,7 @@ async def get_program_calendar(
         calendar_stage=calendar_stage(anchor),
         calendar_week=calendar_week(anchor),
         current_stage=progress.current_stage,
+        cycle_number=progress.cycle_number,
     )
 
 

--- a/backend/src/schemas/stage.py
+++ b/backend/src/schemas/stage.py
@@ -36,13 +36,15 @@ class ProgramCalendarResponse(BaseModel):
     are derived from ``program_started_at`` against the shared
     ``STAGE_DURATIONS_DAYS`` schedule; ``current_stage`` is the
     advancement-chain value.  Effective unlock is the max of the two —
-    the same reconciliation the gating endpoints apply.
+    the same reconciliation the gating endpoints apply.  ``cycle_number``
+    is exposed so the frontend can seed its "Cycle N" indicator on cold start.
     """
 
     program_started_at: datetime | None
     calendar_stage: int
     calendar_week: int
     current_stage: int
+    cycle_number: int = Field(default=1, ge=1)
 
 
 class StageProgressResponse(BaseModel):

--- a/backend/tests/test_program_gating.py
+++ b/backend/tests/test_program_gating.py
@@ -34,7 +34,11 @@ async def _signup(client: AsyncClient, username: str = "anchored") -> dict[str, 
 
 
 async def _plant_progress(
-    session: AsyncSession, *, days_into_program: int, current_stage: int = 1
+    session: AsyncSession,
+    *,
+    days_into_program: int,
+    current_stage: int = 1,
+    cycle_number: int = 1,
 ) -> StageProgress:
     """Create a StageProgress row anchored ``days_into_program`` days ago."""
     user = (await session.execute(select(User))).scalars().first()
@@ -47,6 +51,7 @@ async def _plant_progress(
         completed_stages=[],
         stage_started_at=anchor,
         program_started_at=anchor,
+        cycle_number=cycle_number,
     )
     session.add(progress)
     await session.commit()
@@ -139,6 +144,7 @@ async def test_program_calendar_endpoint_exposes_anchor_and_derivations(
     assert body["calendar_stage"] == 2
     assert body["calendar_week"] == 4
     assert body["current_stage"] == 1
+    assert body["cycle_number"] == 1
 
 
 @pytest.mark.asyncio
@@ -155,6 +161,21 @@ async def test_program_calendar_endpoint_day_zero_shape_without_progress(
     assert body["calendar_stage"] == 1
     assert body["calendar_week"] == 1
     assert body["current_stage"] == 1
+    assert body["cycle_number"] == 1
+
+
+@pytest.mark.asyncio
+async def test_program_calendar_endpoint_exposes_cycle_number_for_a_looper(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A returning looper on cycle 2 sees that cycle reflected on cold start."""
+    headers = await _signup(async_client, "loopercalendar")
+    await _plant_progress(db_session, days_into_program=1, cycle_number=2)
+
+    resp = await async_client.get("/stages/program-calendar", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["cycle_number"] == 2
 
 
 def test_is_stage_unlocked_accepts_an_explicit_now() -> None:

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -23,6 +23,7 @@ import {
   practiceRecipeSchema,
   practiceSessionResponseSchema,
   practiceTagSchema,
+  programCalendarSchema,
   promptListResponseSchema,
   resonanceResponseSchema,
   stageIntroSchema,
@@ -46,6 +47,7 @@ import {
   type ReturnArcT,
   type ReturnWeekT,
   type PasswordResetAcceptedT,
+  type ProgramCalendarT,
   type StageProgressRecordT,
   type SuggestionStatusT,
   type Tier,
@@ -1509,10 +1511,20 @@ export const stages = {
       schema: stageProgressRecordSchema,
     });
   },
+  /** The server's date-derived program calendar, including the cold-start cycle pass. */
+  programCalendar(token?: string): Promise<ProgramCalendarT> {
+    return request<ProgramCalendarT>('/stages/program-calendar', {
+      token,
+      schema: programCalendarSchema,
+    });
+  },
 };
 
 /** Public alias of the zod-inferred stage-progress type so consumers avoid a duplicate shape. */
 export type { StageProgressRecordT as StageProgressRecord } from './schemas';
+
+/** Public alias of the zod-inferred program-calendar type so consumers avoid a duplicate shape. */
+export type { ProgramCalendarT as ProgramCalendar } from './schemas';
 
 // Wheel-of-wholeness balance types and client (Map balance reading)
 

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -316,6 +316,17 @@ export const stageProgressRecordSchema = z.object({
 
 export type StageProgressRecordT = z.infer<typeof stageProgressRecordSchema>;
 
+/** The server's date-derived program calendar (mirrors ``ProgramCalendarResponse``). */
+export const programCalendarSchema = z.object({
+  program_started_at: z.string().nullable(),
+  calendar_stage: z.number(),
+  calendar_week: z.number(),
+  current_stage: z.number(),
+  cycle_number: z.number(),
+});
+
+export type ProgramCalendarT = z.infer<typeof programCalendarSchema>;
+
 /** A catalog practice (mirrors ``PracticeItem``); exported for reuse (issue 06). */
 export const practiceItemSchema = z.object({
   id: z.number().int(),

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -4,12 +4,25 @@ import { act } from '@testing-library/react-native';
 import type { Stage, StageProgressRecord } from '../../../../api';
 import { clampProgress, isStageUnlocked } from '../stageService';
 
+/** Minimal shape of the GET /stages/program-calendar payload. */
+interface ProgramCalendarPayload {
+  program_started_at: string | null;
+  calendar_stage: number;
+  calendar_week: number;
+  current_stage: number;
+  cycle_number: number;
+}
+
 const mockList = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<Stage[]>>;
 const mockBeginAgainClient = jest.fn() as jest.MockedFunction<() => Promise<StageProgressRecord>>;
+const mockProgramCalendar = jest.fn() as jest.MockedFunction<
+  (_token?: string) => Promise<ProgramCalendarPayload>
+>;
 jest.mock('../../../../api', () => ({
   stages: {
     listAll: (...args: [string?]) => mockList(...args),
     beginAgain: () => mockBeginAgainClient(),
+    programCalendar: (...args: [string?]) => mockProgramCalendar(...args),
   },
 }));
 
@@ -39,6 +52,14 @@ describe('stageService', () => {
     jest.resetModules();
     mockList.mockReset();
     mockBeginAgainClient.mockReset();
+    mockProgramCalendar.mockReset();
+    mockProgramCalendar.mockResolvedValue({
+      program_started_at: null,
+      calendar_stage: 1,
+      calendar_week: 1,
+      current_stage: 1,
+      cycle_number: 1,
+    });
     const { useStageStore } = require('../../../../store/useStageStore');
     act(() => {
       useStageStore.getState().setStages([]);
@@ -163,6 +184,69 @@ describe('stageService', () => {
     expect(mockList).toHaveBeenCalledWith('abc-token');
   });
 
+  describe('loadStages cycle-number sync', () => {
+    it('seeds cycleNumber from the program-calendar response', async () => {
+      mockList.mockResolvedValueOnce([makeApiStage(1)]);
+      mockProgramCalendar.mockResolvedValueOnce({
+        program_started_at: null,
+        calendar_stage: 1,
+        calendar_week: 1,
+        current_stage: 1,
+        cycle_number: 2,
+      });
+      const { stageService } = require('../stageService');
+      const { useStageStore } = require('../../../../store/useStageStore');
+
+      await act(async () => {
+        await stageService.loadStages();
+      });
+
+      expect(useStageStore.getState().cycleNumber).toBe(2);
+    });
+
+    it('sets cycleNumber to 1 when the calendar reports cycle_number 1', async () => {
+      mockList.mockResolvedValueOnce([makeApiStage(1)]);
+      mockProgramCalendar.mockResolvedValueOnce({
+        program_started_at: null,
+        calendar_stage: 1,
+        calendar_week: 1,
+        current_stage: 1,
+        cycle_number: 1,
+      });
+      const { stageService } = require('../stageService');
+      const { useStageStore } = require('../../../../store/useStageStore');
+      act(() => {
+        useStageStore.getState().setCycleNumber(4);
+      });
+
+      await act(async () => {
+        await stageService.loadStages();
+      });
+
+      expect(useStageStore.getState().cycleNumber).toBe(1);
+    });
+
+    it('leaves stages and cycleNumber intact when the program-calendar fetch rejects', async () => {
+      mockList.mockResolvedValueOnce([makeApiStage(1)]);
+      mockProgramCalendar.mockRejectedValueOnce(new Error('calendar down'));
+      const { stageService } = require('../stageService');
+      const { useStageStore } = require('../../../../store/useStageStore');
+      act(() => {
+        useStageStore.getState().setCycleNumber(3);
+      });
+
+      await act(async () => {
+        await stageService.loadStages();
+      });
+
+      expect(mockProgramCalendar).toHaveBeenCalledTimes(1);
+      const state = useStageStore.getState();
+      expect(state.stages).toHaveLength(1);
+      expect(state.error).toBeNull();
+      expect(state.cycleNumber).toBe(3);
+    });
+  });
+
   describe('clampProgress (BUG-FE-MAP-003)', () => {
     it('returns valid progress in [0, 1] unchanged', () => {
       expect(clampProgress(0)).toBe(0);
@@ -282,6 +366,14 @@ describe('stageService', () => {
     it('sets cycleNumber from the response record', async () => {
       mockBeginAgainClient.mockResolvedValueOnce(makeProgressRecord(2));
       mockList.mockResolvedValueOnce([makeApiStage(1)]);
+      // The reload's calendar fetch reports the same server-side cycle.
+      mockProgramCalendar.mockResolvedValueOnce({
+        program_started_at: null,
+        calendar_stage: 1,
+        calendar_week: 1,
+        current_stage: 1,
+        cycle_number: 2,
+      });
       const { stageService } = require('../stageService');
       const { useStageStore } = require('../../../../store/useStageStore');
 
@@ -325,6 +417,14 @@ describe('stageService', () => {
     it('reflects cycle_number 3 when the server returns it', async () => {
       mockBeginAgainClient.mockResolvedValueOnce(makeProgressRecord(3));
       mockList.mockResolvedValueOnce([makeApiStage(1)]);
+      // The reload's calendar fetch reports the same server-side cycle.
+      mockProgramCalendar.mockResolvedValueOnce({
+        program_started_at: null,
+        calendar_stage: 1,
+        calendar_week: 1,
+        current_stage: 1,
+        cycle_number: 3,
+      });
       const { stageService } = require('../stageService');
       const { useStageStore } = require('../../../../store/useStageStore');
 

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -83,6 +83,16 @@ export const isEndOfCycle = (
 ): boolean =>
   currentStage === STAGE_COUNT && (stagesByNumber[STAGE_COUNT]?.progress ?? 0) >= FULLY_COMPLETE;
 
+/** Seed the cycle indicator from the program calendar; a failure here must never break the stage list, so it is swallowed and the prior cycleNumber stands. */
+const seedCycleNumber = async (token?: string): Promise<void> => {
+  try {
+    const calendar = await stagesApi.programCalendar(token);
+    useStageStore.getState().setCycleNumber(calendar.cycle_number);
+  } catch {
+    // Non-fatal: cold-start cycle seeding is best-effort; keep the current value.
+  }
+};
+
 export const stageService = {
   /**
    * Fetch the stage list, map to StageData, and write it into the store. On
@@ -104,7 +114,9 @@ export const stageService = {
       const message = err instanceof Error ? err.message : 'Failed to load stages';
       useStageStore.getState().setError(message);
       useStageStore.getState().setLoading(false);
+      return;
     }
+    await seedCycleNumber(token);
   },
 
   /**


### PR DESCRIPTION
## Summary
The frontend "Cycle N" Map indicator was **write-sourced**: `cycleNumber` defaulted to 1 and only updated from the `POST /stages/begin-again` response, so a returning looper (already on cycle 2+) saw no cycle indicator on a **cold start** until they next looped.

This exposes `cycle_number` on the existing `GET /stages/program-calendar` (the semantically correct home — it already carries the user-global `current_stage`) and seeds the store from it on load. No DB/schema change: `StageProgress.cycle_number` already exists, so no migration.

- Backend: `ProgramCalendarResponse` gains `cycle_number: int` (default 1); `get_program_calendar` returns it in both the no-progress branch (1) and the progress branch (`progress.cycle_number`).
- Frontend: new `programCalendarSchema` + `stages.programCalendar(token?)` client; `stageService.loadStages` fetches it and seeds `cycleNumber` **non-fatally** — a calendar failure never breaks the stage list or sets the store error, leaving the prior cycle value in place.
- MapScreen needs no change — it already reads `selectCycleNumber` and calls `loadStages()` on mount.

## Test plan
- Backend (`test_program_gating.py`): `_plant_progress` gained a `cycle_number` kwarg; the day-zero and planted-progress endpoint tests assert `cycle_number == 1`; a new test plants cycle 2 and asserts the GET returns `cycle_number == 2`. Full backend `check-all.sh` green (96.21% coverage), xenon A-grade, radon ≥ B.
- Frontend (`stageService.test.ts`): new specs cover seeding `cycleNumber` from the calendar, a `cycle_number: 1` response, and the non-fatal path where the calendar fetch rejects (stages still load, `error` stays null, `cycleNumber` unchanged). Full frontend `check-all.sh` green (275 suites, 2748 tests), tsc clean.

Closes #1050
Refs #916, #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)