### PR TITLE
perf(backend): bound the practice-session gather in invitation generation

### DIFF
--- a/backend/src/services/invitations.py
+++ b/backend/src/services/invitations.py
@@ -27,6 +27,7 @@ from sqlmodel import col, select
 from domain.dates import now_in_tz, to_user_date_bucket
 from domain.invitations import (
     ENGAGEMENT_WINDOW_DAYS,
+    SUSTAINED_PRACTICE_WEEKS,
     HabitSignal,
     InvitationCandidate,
     PracticeSignal,
@@ -48,6 +49,16 @@ _NULL_TARGET = -1
 
 # Dedup / persisted-row identity: ``(target_type, target_id-or-sentinel, kind)``.
 _SignalKey = tuple[str, int, str]
+
+# Lower bound, in weeks, for the practice-session fetch. A streak needs only
+# the most recent SUSTAINED_PRACTICE_WEEKS calendar weeks of sessions, but
+# "N weeks ago" measured from *now* can land partway through the oldest of
+# those weeks -- the earliest instant a streak can still need is that week's
+# local Monday 00:00, which is strictly less than N*7 days before now. The
+# extra week is a calendar-alignment buffer, not slack for the streak logic
+# itself: it exists purely so a fetch anchored to the wall-clock "now" always
+# reaches back to the start of the oldest required week.
+_PRACTICE_SESSION_WINDOW_WEEKS = SUSTAINED_PRACTICE_WEEKS + 1
 
 
 def _signal_key(target_type: str, target_id: int | None, kind: str) -> _SignalKey:
@@ -71,12 +82,25 @@ async def _gather_practice_signals(
     A single query pulls the user's sessions with the resolved ``practice_id``
     (via ``PracticeSession.user_practice_id -> UserPractice.practice_id``); the
     rows are grouped in memory and each group's consecutive-week count is
-    derived by reusing :func:`domain.practice_insights.build_insights`.
+    derived by reusing :func:`domain.practice_insights.build_insights`. The
+    fetch itself is bounded to the trailing ``_PRACTICE_SESSION_WINDOW_WEEKS``
+    (UTC-normalized as in ``_gather_active_days``), so history far older than
+    the mastery threshold is never pulled in. Clamping the window is
+    semantically safe: the resulting ``sustained_weeks`` is only ever compared
+    against ``SUSTAINED_PRACTICE_WEEKS``, never persisted, and the required
+    weeks all sit fully inside the window, so the threshold comparison stays
+    exact even for streaks longer than the window.
     """
+    window_start = (
+        now_in_tz(user_timezone) - timedelta(weeks=_PRACTICE_SESSION_WINDOW_WEEKS)
+    ).astimezone(UTC)
     result = await session.execute(
         select(UserPractice.practice_id, PracticeSession)
         .join(UserPractice, col(PracticeSession.user_practice_id) == col(UserPractice.id))
-        .where(col(PracticeSession.user_id) == user_id)
+        .where(
+            col(PracticeSession.user_id) == user_id,
+            col(PracticeSession.timestamp) >= window_start,
+        )
     )
     sessions_by_practice: defaultdict[int, list[PracticeSession]] = defaultdict(list)
     for practice_id, practice_session in result.all():

--- a/backend/tests/services/test_invitations_service.py
+++ b/backend/tests/services/test_invitations_service.py
@@ -14,7 +14,7 @@ and returns only the newly inserted rows.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 
@@ -25,6 +25,9 @@ from sqlmodel import col, select
 
 from conftest import test_engine
 from domain.dates import now_in_tz, to_user_date_bucket
+from domain.invitations import SUSTAINED_PRACTICE_WEEKS
+from domain.practice_insights import PracticeInsights
+from domain.practice_insights import build_insights as _real_build_insights
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
@@ -490,3 +493,214 @@ async def test_active_days_window_boundary_uses_utc_instant_under_non_utc_tz(
     assert not any(r.target_type == "embodied_community" for r in result)
     persisted = await _signals_for(db_session, user_id)
     assert not any(r.target_type == "embodied_community" for r in persisted)
+
+
+# ---------------------------------------------------------------------------
+# 15. Pinning: an exact-threshold streak still yields the mastery candidate
+#     once the practice-session gather is bounded to a lower time window.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_practice_streak_at_exact_threshold_yields_mastery_candidate(
+    db_session: AsyncSession,
+) -> None:
+    """A practice held for exactly SUSTAINED_PRACTICE_WEEKS weeks yields a mastery signal.
+
+    Pins the happy path so a bounded fetch of the practice-session gather
+    cannot regress the ordinary case while it is being narrowed to a window.
+    Sessions are anchored to calendar (Monday-start) weeks so each of the four
+    required weeks reliably clears the cadence target regardless of the weekday
+    the suite runs on.
+    """
+    user_id = await _make_user(db_session)
+    practice = Practice(
+        stage_number=1,
+        name="Threshold sit",
+        description="x",
+        instructions="x",
+        default_duration_minutes=10.0,
+        mode="meditation_timer",
+        mode_config={"mode": "meditation_timer", "duration_minutes": 10},
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    assert practice.id is not None
+
+    now = datetime.now(UTC)
+    current_monday = (now - timedelta(days=now.weekday())).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    up = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=1,
+        start_date=(current_monday - timedelta(weeks=_SUSTAINED_WEEKS - 1)).date(),
+    )
+    db_session.add(up)
+    await db_session.commit()
+    await db_session.refresh(up)
+    assert up.id is not None
+
+    for week in range(_SUSTAINED_WEEKS):
+        week_monday = current_monday - timedelta(weeks=week)
+        for day_offset in (0, 1, 2, 3):
+            db_session.add(
+                PracticeSession(
+                    user_id=user_id,
+                    user_practice_id=up.id,
+                    duration_minutes=10.0,
+                    timestamp=week_monday + timedelta(days=day_offset),
+                )
+            )
+    await db_session.commit()
+
+    result = await generate_invitation_signals(db_session, user_id)
+
+    mastery = [r for r in result if r.target_type == "practice"]
+    assert len(mastery) == 1
+    assert mastery[0].target_id == practice.id
+    assert mastery[0].kind == "mastery"
+
+    persisted = await _signals_for(db_session, user_id)
+    persisted_mastery = [r for r in persisted if r.target_type == "practice"]
+    assert len(persisted_mastery) == 1
+    assert persisted_mastery[0].target_id == practice.id
+    assert persisted_mastery[0].kind == "mastery"
+
+
+# ---------------------------------------------------------------------------
+# 16. Boundary no-undercount: the oldest of the four required weeks sits at
+#     local Monday 00:00 under a non-UTC user timezone and must still count.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_practice_streak_oldest_week_at_local_midnight_still_counted_under_non_utc_tz(
+    db_session: AsyncSession,
+) -> None:
+    """A 4-week practice streak survives a bounded fetch under a non-UTC user timezone.
+
+    The oldest of the four required weeks is anchored at that week's local
+    Monday 00:00 -- the earliest instant a bounded fetch must still include.
+    A boundary derived from the user's wall-clock offset rather than the
+    UTC-normalized instant (mirroring ``_gather_active_days``) risks shaving
+    that week off the fetch and undercounting the streak.
+    """
+    user_id = await _make_user(db_session)
+    practice = Practice(
+        stage_number=1,
+        name="Boundary sit",
+        description="x",
+        instructions="x",
+        default_duration_minutes=10.0,
+        mode="meditation_timer",
+        mode_config={"mode": "meditation_timer", "duration_minutes": 10},
+    )
+    db_session.add(practice)
+    await db_session.commit()
+    await db_session.refresh(practice)
+    assert practice.id is not None
+
+    now_la = now_in_tz(_LA_TZ)
+    current_monday_la = (now_la - timedelta(days=now_la.weekday())).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+    up = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=1,
+        start_date=(current_monday_la - timedelta(weeks=3)).date(),
+    )
+    db_session.add(up)
+    await db_session.commit()
+    await db_session.refresh(up)
+    assert up.id is not None
+
+    # Four sessions per week for the current week plus the three prior weeks;
+    # the oldest week's sessions start exactly at its local Monday 00:00.
+    for week in range(_SUSTAINED_WEEKS):
+        week_monday_la = current_monday_la - timedelta(weeks=week)
+        for day_offset in (0, 1, 2, 3):
+            ts_la = week_monday_la + timedelta(days=day_offset)
+            db_session.add(
+                PracticeSession(
+                    user_id=user_id,
+                    user_practice_id=up.id,
+                    duration_minutes=10.0,
+                    timestamp=ts_la.astimezone(UTC),
+                )
+            )
+    await db_session.commit()
+
+    result = await generate_invitation_signals(db_session, user_id, user_timezone=_LA_TZ)
+
+    mastery = [r for r in result if r.target_type == "practice" and r.kind == "mastery"]
+    assert len(mastery) == 1
+    assert mastery[0].target_id == practice.id
+
+    persisted = await _signals_for(db_session, user_id)
+    persisted_mastery = [
+        r for r in persisted if r.target_type == "practice" and r.kind == "mastery"
+    ]
+    assert len(persisted_mastery) == 1
+    assert persisted_mastery[0].target_id == practice.id
+
+
+# ---------------------------------------------------------------------------
+# 17. Bound is applied: sessions older than the sustained-practice window are
+#     not fetched by _gather_practice_signals at all -- this is the actual
+#     behavior the bound must add over the current unbounded query.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_practice_gather_excludes_sessions_older_than_the_sustained_window(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The practice-session gather must not fetch rows outside its window.
+
+    A stale session placed comfortably beyond ``SUSTAINED_PRACTICE_WEEKS + 1``
+    weeks ago must never reach ``build_insights`` -- a spy wrapping the real
+    implementation records exactly how many session rows were handed to it.
+    Against the current unbounded gather the stale row is still fetched, so
+    this fails until the fetch carries a lower time bound.
+    """
+    user_id = await _make_user(db_session)
+    practice_id = await _make_practice_with_sessions(db_session, user_id, weeks=1)
+
+    up_result = await db_session.execute(
+        select(UserPractice.id).where(col(UserPractice.practice_id) == practice_id)
+    )
+    user_practice_id = up_result.scalar_one()
+
+    window_weeks = SUSTAINED_PRACTICE_WEEKS + 1
+    stale_offset_weeks = window_weeks + 5
+    now = datetime.now(UTC)
+    db_session.add(
+        PracticeSession(
+            user_id=user_id,
+            user_practice_id=user_practice_id,
+            duration_minutes=10.0,
+            timestamp=now - timedelta(weeks=stale_offset_weeks),
+        )
+    )
+    await db_session.commit()
+
+    fetched_counts: list[int] = []
+
+    def _spy(sessions: Iterable[PracticeSession], *, tz: str | None) -> PracticeInsights:
+        materialized = list(sessions)
+        fetched_counts.append(len(materialized))
+        return _real_build_insights(materialized, tz=tz)
+
+    monkeypatch.setattr("services.invitations.build_insights", _spy)
+
+    await generate_invitation_signals(db_session, user_id)
+
+    # _make_practice_with_sessions(weeks=1) seeds 4 rows in the current week;
+    # the stale row placed far outside the window must not be among them.
+    assert fetched_counts == [4]


### PR DESCRIPTION
## Summary
`_gather_practice_signals` (in `backend/src/services/invitations.py`) fetched **every** `PracticeSession` row for a user with no date lower bound, growing unboundedly with user tenure. The sustained-weeks streak check only needs the most recent few weeks of history.

This bounds the single-SELECT gather to a trailing `SUSTAINED_PRACTICE_WEEKS + 1` week window, UTC-normalized exactly like the existing `_gather_active_days` window (mirroring the #922 tz-boundary handling for SQLite's lexical `timestamptz` comparison). The `+1` week is a calendar-alignment buffer: "N weeks ago" measured from *now* can land partway through the oldest required week, whose earliest needed instant is that week's local Monday 00:00 (strictly `< N*7` days ago), so the buffer guarantees the oldest of the four required weeks is always fully fetched.

The bound is a pure performance change — no behavior change: `sustained_weeks` is only ever compared against `SUSTAINED_PRACTICE_WEEKS` (never persisted), and the four most-recent weeks stay fully inside the window, so the `>=` threshold decision remains exact even for streaks longer than the window. Query shape is unchanged (still one SELECT; no N+1).

## Test plan
- `test_practice_streak_at_exact_threshold_yields_mastery_candidate` — pins the happy path: an exactly-4-week calendar-aligned streak still yields the mastery candidate under the bounded fetch.
- `test_practice_streak_oldest_week_at_local_midnight_still_counted_under_non_utc_tz` — boundary no-undercount: under `America/Los_Angeles`, the oldest required week's sessions anchored at local Monday 00:00 are still counted (guards against a naive `SUSTAINED_PRACTICE_WEEKS`-week bound or a missing UTC normalization).
- `test_practice_gather_excludes_sessions_older_than_the_sustained_window` — proves the bound is applied: a spy on `build_insights` asserts stale sessions beyond the window never reach it (RED against the previously unbounded fetch).
- Full `./scripts/backend/check-all.sh` exits 0 (2227 passed, 2 skipped); xenon A-grade passes.

Closes #1054
Refs #920, #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)