### PR TITLE
refactor(backend): fix two stale/lying docstrings (safety wiring, phantom sibling)

### DIFF
--- a/backend/src/domain/safety.py
+++ b/backend/src/domain/safety.py
@@ -5,8 +5,9 @@ reads text and returns a typed :class:`DistressSignal` saying whether the writin
 contains an **acute** distress signal (explicit suicidal intent, self-harm
 intent, medication cessation, or intent to harm another) and, if so, which
 category matched. Nothing here gives medical, medication, or treatment guidance;
-it only classifies. The signal is wired into the acute-distress care surface at
-the journal PATCH endpoint.
+it only classifies. The signal is consumed by the journal care path: the
+resonance endpoint (``POST /journal/{entry_id}/resonance``) screens the entry and,
+on an elevated signal, returns a care surface alongside the reflection.
 
 Design — deliberately conservative
 ----------------------------------

--- a/backend/src/services/practice_session_idempotency.py
+++ b/backend/src/services/practice_session_idempotency.py
@@ -1,11 +1,10 @@
 """DB-backed idempotency for practice-session creation.
 
 The read/insert primitives for the ``PracticeSessionSpend`` table that backs the
-``POST /practice-sessions`` ``Idempotency-Key`` dedup. Mirrors
-``services.chat_idempotency`` but is simpler: practice-session writes are fast and
-synchronous (no slow LLM call), so there is no in-flight tombstone window — the
-spend row is inserted in the same transaction as the session and always carries a
-real ``session_id``. Cross-worker serialisation comes from the
+``POST /practice-sessions`` ``Idempotency-Key`` dedup. Practice-session writes are
+fast and synchronous (no slow LLM call), so there is no in-flight tombstone
+window — the spend row is inserted in the same transaction as the session and
+always carries a real ``session_id``. Cross-worker serialisation comes from the
 ``UNIQUE(user_id, idem_key)`` constraint, not a process-local lock.
 """
 
@@ -26,7 +25,7 @@ def hash_idem_key(user_id: int, raw_key: str) -> str:
     The raw client header is never stored. Hashing keeps the column width
     bounded and one-way, and the ``user_id`` prefix keeps the hash space
     disjoint across users so a crafted key cannot collide into another user's
-    namespace (same scheme as ``services.chat_idempotency.hash_idem_key``).
+    namespace.
     """
     return hashlib.sha256(f"{user_id}:{raw_key}".encode()).hexdigest()
 


### PR DESCRIPTION
## Summary
Fixes two stale/lying backend docstrings flagged by the de-slopify run (taxonomy family 6 — naming & comment slop; the second also a family-12 hallucinated-sibling tell). Comment-only; both bodies of code are correct and unchanged.

- `backend/src/domain/safety.py` — the module docstring claimed the distress screen was "wired into the acute-distress care surface at the journal **PATCH** endpoint". That was false: `_care_for`/`_care_response` are invoked only at `routers/journal.py:713`, inside `run_resonance` (`@router.post("/{entry_id}/resonance")`). The docstring now accurately names the resonance endpoint. (The original issue also cited a "wired into nothing" sentence; that was already removed on `main` — only the endpoint claim remained inaccurate.)
- `backend/src/services/practice_session_idempotency.py` — two docstrings cross-referenced a `services.chat_idempotency` module that does not exist anywhere in the repo. Both references are removed and the SHA-256 + `user_id`-prefix scheme is now described self-contained.

## Test plan
- `grep -rn "wired into nothing" backend/src` → no matches
- `grep -rn "chat_idempotency" backend/` → no matches
- `./scripts/backend/check-all.sh` → exit 0 (2251 passed, coverage 96.4% ≥ 90%)
- `xenon --max-absolute A --max-modules A --max-average A` on both files → pass; `radon mi` → A/A
- `ruff check`, `ruff format --check`, `mypy` on both files → clean
- Gate 2.5 self-review (code-review-orchestrator) → CLEAN, no blockers

No behavior change: the diff touches docstring prose only; every function body is byte-identical.

Closes #1082